### PR TITLE
refactor: unify duplicate Logger interfaces into single canonical type

### DIFF
--- a/src/core/conversation/l0-recorder.ts
+++ b/src/core/conversation/l0-recorder.ts
@@ -18,6 +18,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import crypto from "node:crypto";
 import { sanitizeText, stripCodeBlocks, shouldCaptureL0 } from "../../utils/sanitize.js";
+import type { Logger } from "../types.js";
 
 // ============================
 // Types
@@ -61,13 +62,6 @@ export interface L0ConversationRecord {
   recordedAt: string; // ISO timestamp
   messageCount: number;
   messages: ConversationMessage[];
-}
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
 }
 
 const TAG = "[memory-tdai][l0]";

--- a/src/core/hooks/auto-capture.ts
+++ b/src/core/hooks/auto-capture.ts
@@ -19,14 +19,9 @@ import type { ConversationMessage } from "../conversation/l0-recorder.js";
 import type { IMemoryStore, L0Record } from "../store/types.js";
 import type { EmbeddingService } from "../store/embedding.js";
 
-const TAG = "[memory-tdai] [capture]";
+import type { Logger } from "../types.js";
 
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+const TAG = "[memory-tdai] [capture]";
 
 export interface AutoCaptureResult {
   /** Whether the scheduler was notified (conversation count incremented) */

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -20,6 +20,7 @@ import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.j
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
+import type { Logger } from "../types.js";
 
 const TAG = "[memory-tdai] [recall]";
 
@@ -41,13 +42,6 @@ const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
 - 首次搜索无结果时，可换关键词或换工具重试，但总调用次数不要超过 3 次。
 - 若 3 次搜索后仍无结果，说明该信息不在记忆中，请直接根据已有信息回复用户，不要继续搜索。
 </memory-tools-guide>`
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 /** A single recalled L1 memory with its search score and type. */
 export interface RecalledMemory {

--- a/src/core/persona/persona-generator.ts
+++ b/src/core/persona/persona-generator.ts
@@ -13,16 +13,9 @@ import { buildPersonaPrompt } from "../prompts/persona-generation.js";
 import { BackupManager } from "../../utils/backup.js";
 import { escapeXmlTags } from "../../utils/sanitize.js";
 import { report } from "../report/reporter.js";
-import type { LLMRunner } from "../types.js";
+import type { LLMRunner, Logger } from "../types.js";
 
 const TAG = "[memory-tdai] [persona]";
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 export class PersonaGenerator {
   private dataDir: string;

--- a/src/core/persona/persona-trigger.ts
+++ b/src/core/persona/persona-trigger.ts
@@ -8,14 +8,11 @@ import path from "node:path";
 import { CheckpointManager } from "../../utils/checkpoint.js";
 import { stripSceneNavigation } from "../scene/scene-navigation.js";
 
+import type { Logger } from "../types.js";
+
 const TAG = "[memory-tdai] [trigger]";
 
-interface TriggerLogger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+type TriggerLogger = Logger;
 
 export interface TriggerResult {
   should: boolean;

--- a/src/core/profile/profile-sync.ts
+++ b/src/core/profile/profile-sync.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { IMemoryStore, ProfileRecord, ProfileSyncRecord } from "../store/types.js";
 import { readSceneIndex, syncSceneIndex } from "../scene/scene-index.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
+import type { Logger } from "../types.js";
 
 const PROFILE_SCOPE = "global";
 
@@ -11,13 +12,6 @@ const PROFILE_SCOPE = "global";
 function isRenameRaceError(err: unknown): boolean {
   const code = (err as NodeJS.ErrnoException)?.code;
   return code === "ENOTEMPTY" || code === "EEXIST";
-}
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
 }
 
 export interface ProfileBaseline {

--- a/src/core/record/l1-dedup.ts
+++ b/src/core/record/l1-dedup.ts
@@ -19,14 +19,7 @@ import { sanitizeJsonForParse } from "../../utils/sanitize.js";
 import type { IMemoryStore } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
-import type { LLMRunner } from "../types.js";
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+import type { LLMRunner, Logger } from "../types.js";
 
 const TAG = "[memory-tdai][l1-dedup]";
 

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -22,14 +22,7 @@ import { sanitizeJsonForParse, shouldExtractL1 } from "../../utils/sanitize.js";
 import type { IMemoryStore } from "../store/types.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import { report } from "../report/reporter.js";
-import type { LLMRunner } from "../types.js";
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+import type { LLMRunner, Logger } from "../types.js";
 
 const TAG = "[memory-tdai][l1-extractor]";
 

--- a/src/core/record/l1-reader.ts
+++ b/src/core/record/l1-reader.ts
@@ -19,13 +19,7 @@ import type { IMemoryStore, L1RecordRow, L1QueryFilter } from "../store/types.js
 // Re-export types that readers need
 export type { MemoryRecord, MemoryType, EpisodicMetadata } from "./l1-writer.js";
 export type { L1QueryFilter } from "../store/types.js";
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+import type { Logger } from "../types.js";
 
 const TAG = "[memory-tdai] [l1-reader]";
 

--- a/src/core/record/l1-writer.ts
+++ b/src/core/record/l1-writer.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import type { IMemoryStore } from "../store/types.js";
 import type { EmbeddingService } from "../store/embedding.js";
+import type { Logger } from "../types.js";
 
 // ============================
 // Types
@@ -108,13 +109,6 @@ export interface DedupDecision {
   merged_priority?: number;
   /** Union of all related timestamps (for update/merge) */
   merged_timestamps?: string[];
-}
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
 }
 
 const TAG = "[memory-tdai][l1-writer]";

--- a/src/core/scene/scene-extractor.ts
+++ b/src/core/scene/scene-extractor.ts
@@ -27,16 +27,11 @@ import { parseSceneBlock } from "../scene/scene-format.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
 import { buildSceneExtractionPrompt } from "../prompts/scene-extraction.js";
 import { report } from "../report/reporter.js";
-import type { LLMRunner } from "../types.js";
+import type { LLMRunner, Logger } from "../types.js";
 
 const TAG = "[memory-tdai] [extractor]";
 
-interface ExtractorLogger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+type ExtractorLogger = Logger;
 
 export interface ExtractionResult {
   memoriesProcessed: number;

--- a/src/core/store/bm25-client.ts
+++ b/src/core/store/bm25-client.ts
@@ -13,19 +13,14 @@
  * check health to dynamically downgrade to pure semantic search.
  */
 
+import type { Logger } from "../types.js";
+
 // ============================
 // Types
 // ============================
 
 /** Sparse vector: array of [token_hash, weight] pairs. */
 export type SparseVector = Array<[number, number]>;
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 export interface BM25ClientConfig {
   /** Sidecar service URL (default: "http://127.0.0.1:8084") */

--- a/src/core/store/bm25-local.ts
+++ b/src/core/store/bm25-local.ts
@@ -11,15 +11,9 @@
 
 import { BM25Encoder } from "@tencentdb-agent-memory/tcvdb-text";
 import type { SparseVector } from "@tencentdb-agent-memory/tcvdb-text";
+import type { Logger } from "../types.js";
 
 export type { SparseVector };
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 export interface BM25LocalConfig {
   /** Whether BM25 sparse encoding is enabled (default: true) */

--- a/src/core/store/embedding.ts
+++ b/src/core/store/embedding.ts
@@ -13,6 +13,8 @@
  * - Throws on failure; callers decide fallback strategy.
  */
 
+import type { Logger } from "../types.js";
+
 // ============================
 // Types
 // ============================
@@ -95,17 +97,6 @@ export class EmbeddingNotReadyError extends Error {
     super(message ?? "Local embedding model is not ready yet (still downloading or loading)");
     this.name = "EmbeddingNotReadyError";
   }
-}
-
-// ============================
-// Logger interface
-// ============================
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
 }
 
 const TAG = "[memory-tdai][embedding]";

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -33,6 +33,7 @@ import type {
   L0SearchResult,
   L0FtsResult,
 } from "./types.js";
+import type { Logger } from "../types.js";
 
 // ============================
 // Types
@@ -104,13 +105,6 @@ export interface L1QueryFilter {
   sessionId?: string;
   /** If provided, only return records with updated_time strictly after this ISO 8601 UTC timestamp. */
   updatedAfter?: string;
-}
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
 }
 
 const TAG = "[memory-tdai][sqlite]";

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -17,6 +17,7 @@
 
 import type { MemoryRecord } from "../record/l1-writer.js";
 import type { EmbeddingProviderInfo } from "./embedding.js";
+import type { Logger } from "../types.js";
 
 // Re-export so consumers can import everything from types.ts
 export type { MemoryRecord, EmbeddingProviderInfo };
@@ -26,12 +27,7 @@ export type { MemoryRecord, EmbeddingProviderInfo };
 // ============================
 
 /** Minimal logger interface accepted by store implementations. */
-export interface StoreLogger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+export type StoreLogger = Logger;
 
 // ============================
 // L1 Types (Structured Memories)

--- a/src/core/tools/conversation-search.ts
+++ b/src/core/tools/conversation-search.ts
@@ -13,17 +13,11 @@
 import type { IMemoryStore, L0SearchResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
+import type { Logger } from "../types.js";
 
 // ============================
 // Types
 // ============================
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 export interface ConversationSearchResultItem {
   id: string;

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -13,17 +13,11 @@
 import type { IMemoryStore, L1SearchResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
+import type { Logger } from "../types.js";
 
 // ============================
 // Types
 // ============================
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 export interface MemorySearchResultItem {
   id: string;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,10 +15,10 @@
 // ============================
 
 /**
- * Minimal logger interface used throughout TDAI Core.
+ * Canonical logger interface used across all TDAI modules.
  *
- * Matches the existing `StoreLogger` and `RunnerLogger` interfaces
- * already used in the codebase — no migration needed for existing callers.
+ * Named variants (StoreLogger, PluginLogger, etc.) are type aliases
+ * of this interface, kept for backward compatibility.
  */
 export interface Logger {
   debug?: (message: string) => void;

--- a/src/offload/types.ts
+++ b/src/offload/types.ts
@@ -3,6 +3,8 @@
  * Ported from context-offload-plugin with updated runtime defaults.
  */
 
+import type { Logger } from "../core/types.js";
+
 // ============================
 // Data types
 // ============================
@@ -212,12 +214,7 @@ export interface PluginConfig {
 // ============================
 
 /** Logger interface used by offload plugin components */
-export interface PluginLogger {
-  info: (msg: string) => void;
-  warn: (msg: string) => void;
-  error: (msg: string) => void;
-  debug?: (msg: string) => void;
-}
+export type PluginLogger = Logger;
 
 // ============================
 // Plugin defaults

--- a/src/utils/clean-context-runner.ts
+++ b/src/utils/clean-context-runner.ts
@@ -17,6 +17,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { getEnv } from "./env.js";
 import { report } from "../core/report/reporter.js";
+import type { Logger } from "../core/types.js";
 
 /**
  * Resolve a preferred temporary directory for memory-tdai operations.
@@ -49,12 +50,7 @@ function resolveOpenClawTmpDir(): string {
 
 const TAG = "[memory-tdai] [runner]";
 
-interface RunnerLogger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+type RunnerLogger = Logger;
 
 // Dynamic import type — runEmbeddedPiAgent is an internal API
 // Prefer the public plugin runtime signature so host-injected runtimes stay assignable.

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -3,13 +3,7 @@ import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+import type { Logger } from "../core/types.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -36,6 +36,7 @@ import { SceneExtractor } from "../core/scene/scene-extractor.js";
 import { PersonaTrigger } from "../core/persona/persona-trigger.js";
 import { PersonaGenerator } from "../core/persona/persona-generator.js";
 import { pullProfilesToLocal, syncLocalProfilesToStore } from "../core/profile/profile-sync.js";
+import type { Logger } from "../core/types.js";
 
 const TAG = "[memory-tdai] [pipeline-factory]";
 
@@ -47,12 +48,8 @@ function supportsProfileSyncWrite(store?: IMemoryStore): boolean {
 // Logger interface
 // ============================
 
-export interface PipelineLogger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
+/** @deprecated Use `Logger` from `../core/types.js` directly. */
+export type PipelineLogger = Logger;
 
 // ============================
 // Factory options

--- a/src/utils/pipeline-manager.ts
+++ b/src/utils/pipeline-manager.ts
@@ -81,17 +81,11 @@ import { SessionFilter } from "./session-filter.js";
 import { ManagedTimer } from "./managed-timer.js";
 import { SerialQueue } from "./serial-queue.js";
 import { report } from "../core/report/reporter.js";
+import type { Logger } from "../core/types.js";
 
 // ============================
 // Types
 // ============================
-
-interface Logger {
-  debug?: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
-  error: (message: string) => void;
-}
 
 /** A single captured message ready for L1 processing. */
 export interface CapturedMessage {


### PR DESCRIPTION
## Summary

23 files had local `Logger`/`StoreLogger`/`PluginLogger`/`PipelineLogger`/`RunnerLogger`/`ExtractorLogger`/`TriggerLogger` interface definitions with identical shapes (`{debug?, info, warn, error}`). This PR replaces all duplicates with imports from the canonical `Logger` in `src/core/types.ts`.

### Changes

- **17 files**: local `interface Logger` removed → `import type { Logger }` from `../types.js`
- **6 files**: named variants replaced with type aliases for backward compatibility:
  - `StoreLogger` → `type StoreLogger = Logger` (exported, used by tcvdb-client/factory)
  - `PluginLogger` → `type PluginLogger = Logger` (exported, used by offload/*)
  - `PipelineLogger` → `type PipelineLogger = Logger` (exported, used by seed-runtime)
  - `RunnerLogger` → `type RunnerLogger = Logger`
  - `ExtractorLogger` → `type ExtractorLogger = Logger`
  - `TriggerLogger` → `type TriggerLogger = Logger`

### Preserved as-is (different contract)

- `CheckpointLogger` in `checkpoint.ts` — only `info` + optional `warn` (no `error`)
- `Logger` in `ensure-hook-policy.ts` — only `info`, `warn`, `debug?` (no `error`)

### Impact

- **-128 lines** (35 insertions, 163 deletions)
- Zero behavioral change — type-only refactor
- All named variants preserved as type aliases for backward compatibility
- Build verified: `npx tsdown` passes (714.61 kB, no errors)
- No circular dependencies: `core/types.ts` has zero imports

## Test plan

- [x] `npx tsdown` builds successfully
- [x] No circular dependency chains
- [x] All `import type` paths verified correct (relative to each file)
- [x] Named type aliases (`StoreLogger`, `PluginLogger`, etc.) remain importable from original modules
- [x] No runtime behavior changes (type-only refactor)
