### PR TITLE
perf: replace O(n²) splice with O(n) filter in filterHeartbeatMessages

### DIFF
--- a/src/offload/hooks/llm-input-l3.ts
+++ b/src/offload/hooks/llm-input-l3.ts
@@ -53,6 +53,14 @@ function getMessageRoleLocal(msg: any): string | undefined {
   return msg.role;
 }
 
+function setMessageContentLocal(msg: any, newContent: any[]): void {
+  if (msg.type === "message") {
+    msg.message.content = newContent;
+  } else {
+    msg.content = newContent;
+  }
+}
+
 function collectHeartbeatToolUseIds(msg: any): string[] {
   const role = getMessageRoleLocal(msg);
   if (role !== "assistant") return [];
@@ -71,27 +79,37 @@ export function filterHeartbeatMessages(messages: any[], logger: PluginLogger | 
     for (const id of collectHeartbeatToolUseIds(msg)) heartbeatIds.add(id);
   }
   if (heartbeatIds.size === 0) return 0;
+
   let removed = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
+  const kept: any[] = [];
+
+  for (const msg of messages) {
     const role = getMessageRoleLocal(msg);
+
     if (role === "toolResult" || role === "tool") {
       const tcId = msg.toolCallId ?? msg.tool_call_id ?? msg.message?.toolCallId ?? msg.message?.tool_call_id;
-      if (tcId && heartbeatIds.has(tcId)) { messages.splice(i, 1); removed++; continue; }
-    }
-    if (role === "assistant") {
-      const content = getMessageContentLocal(msg);
-      if (!Array.isArray(content)) continue;
-      const beforeLen = content.length;
-      for (let j = content.length - 1; j >= 0; j--) {
-        if (isHeartbeatToolUseBlock(content[j])) content.splice(j, 1);
-      }
-      if (content.length < beforeLen) {
+      if (tcId && heartbeatIds.has(tcId)) {
         removed++;
-        if (content.length === 0) messages.splice(i, 1);
+        continue;
+      }
+    } else if (role === "assistant") {
+      const content = getMessageContentLocal(msg);
+      if (Array.isArray(content)) {
+        const filtered = content.filter((block: any) => !isHeartbeatToolUseBlock(block));
+        if (filtered.length < content.length) {
+          removed++;
+          if (filtered.length === 0) continue;
+          setMessageContentLocal(msg, filtered);
+        }
       }
     }
+
+    kept.push(msg);
   }
+
+  messages.length = 0;
+  for (const msg of kept) messages.push(msg);
+
   return removed;
 }
 


### PR DESCRIPTION
## Summary

Replace two levels of `splice()` calls in `filterHeartbeatMessages` with a filter-then-rebuild approach, reducing time complexity from O(n²) to O(n).

The function filters heartbeat tool calls from the messages array before LLM input. Previously it used `messages.splice(i, 1)` in the outer loop and `content.splice(j, 1)` in the inner loop — both O(n) per call due to element shifting.

### Changes

- Add `setMessageContentLocal(msg, newContent)` helper for consistent content reassignment across `msg.type === "message"` and normal message shapes
- Outer loop: replace reverse iteration + `splice(i, 1)` → forward iteration into `kept[]` array, skipping removed messages via `continue`
- Inner loop: replace reverse iteration + `splice(j, 1)` → `content.filter(block => !isHeartbeatToolUseBlock(block))`
- Rebuild `messages` array in-place from `kept` list at the end

### Behavior

No functional change — same heartbeat detection, same count semantics, same in-place mutation contract:

| Aspect | Before | After |
|--------|--------|-------|
| Heartbeat ID collection | O(n) scan | O(n) scan (same) |
| Message removal | splice(i, 1), O(n) each | skip via continue, O(1) |
| Content block removal | splice(j, 1), O(n) each | filter, O(n) total |
| Overall time | O(n²) worst-case | O(n) |
| Removal count | 1 per message | 1 per message (same) |

## Test plan

- [x] `npx tsdown` builds successfully
- [x] Heartbeat ID collection unchanged
- [x] Same messages are removed (tool/toolResult by tcId, assistant by content blocks)
- [x] Content block filtering preserves non-heartbeat blocks
- [x] In-place mutation contract preserved (callers receive mutated array)
