### PR TITLE
feat(core): expose host-neutral library controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [Unreleased]
+
+### ✨ 改进
+
+- **Library mode L1 作用域过滤**：`searchMemories()` 支持 `sessionKey` / `sessionId`，Gateway `/search/memories` 支持 `session_key` / `session_id`，避免共享后端里的结构化记忆跨 session 召回。
+
+---
+
 ## [0.3.4] - 2026-05-12
 
 ### 🐛 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### ✨ 改进
 
-- **Library mode L1 作用域过滤**：`searchMemories()` 支持 `sessionKey` / `sessionId`，Gateway `/search/memories` 支持 `session_key` / `session_id`，避免共享后端里的结构化记忆跨 session 召回。
+- **Library mode L1 作用域过滤**：`searchMemories()` 支持 `sessionKey` / `sessionId`，Gateway `/search/memories` 支持 `session_key` / `session_id`，并把作用域下推到 SQLite / TCVDB store 查询阶段，避免共享后端里的结构化记忆跨 session 召回或被 topK 截断漏召回。
+- **Library mode 文档示例**：README 示例改为通过 `HostAdapter.getLLMRunnerFactory()` 提供模型执行器，避免展示 `TdaiCore` 不支持的构造参数。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ import { TdaiCore, parseConfig } from "@tencentdb-agent-memory/memory-tencentdb/
 import type {
   CompletedTurn,
   HostAdapter,
-  LLMRunnerFactory,
 } from "@tencentdb-agent-memory/memory-tencentdb/core"
 
 const config = parseConfig({
@@ -356,11 +355,14 @@ const config = parseConfig({
 
 const core = new TdaiCore({
   hostAdapter,
-  llmRunnerFactory,
   config,
 })
 await core.initialize()
 ```
+
+`TdaiCore` obtains model execution through
+`HostAdapter.getLLMRunnerFactory()`, so the constructor only needs the adapter
+and parsed config.
 
 For configuration-only integrations, import the parser from
 `@tencentdb-agent-memory/memory-tencentdb/config`.

--- a/README.md
+++ b/README.md
@@ -380,6 +380,17 @@ const l1OnlyConfig = parseConfig({
 })
 ```
 
+When a host stores memories for multiple agents or workspaces in one backend,
+pass `sessionKey` or `sessionId` to `searchMemories()` to keep L1 recall scoped:
+
+```ts
+await core.searchMemories({
+  query: "review style",
+  sessionKey: "workspace:/repo/refresh",
+  limit: 5,
+})
+```
+
 ---
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ docker exec -it hermes-memory hermes
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `pipeline.everyNConversations` | `5` | Trigger an L1 memory extraction every N turns |
+| `pipeline.enableL2` | `true` | Enable L2 scene extraction after L1 |
+| `pipeline.enableL3` | `true` | Enable L3 persona generation after L2 |
 | `extraction.maxMemoriesPerSession` | `20` | Max memories extracted per L1 pass |
 | `persona.triggerEveryN` | `50` | Generate the user persona every N new memories |
 | `offload.enabled` | `false` | Whether to enable short-term compression |
@@ -362,6 +364,21 @@ await core.initialize()
 
 For configuration-only integrations, import the parser from
 `@tencentdb-agent-memory/memory-tencentdb/config`.
+
+Hosts that want L1 extraction without L2 scene extraction or L3 persona
+generation can keep capture/extraction enabled and explicitly disable the
+downstream pipeline stages:
+
+```ts
+const l1OnlyConfig = parseConfig({
+  capture: { enabled: true },
+  extraction: { enabled: true },
+  pipeline: {
+    enableL2: false,
+    enableL3: false,
+  },
+})
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,35 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | Hybrid retrieval | BM25 + vector + RRF — supports both keyword and semantic recall |
 | Agent tools | `tdai_memory_search` / `tdai_conversation_search` |
 
+### Library Mode for Non-OpenClaw Hosts
+
+OpenClaw remains the default plugin entry point, but host-neutral embedders can
+use the same core without depending on OpenClaw runtime APIs:
+
+```ts
+import { TdaiCore, parseConfig } from "@tencentdb-agent-memory/memory-tencentdb/core"
+import type {
+  CompletedTurn,
+  HostAdapter,
+  LLMRunnerFactory,
+} from "@tencentdb-agent-memory/memory-tencentdb/core"
+
+const config = parseConfig({
+  capture: { enabled: true },
+  extraction: { enabled: false },
+})
+
+const core = new TdaiCore({
+  hostAdapter,
+  llmRunnerFactory,
+  config,
+})
+await core.initialize()
+```
+
+For configuration-only integrations, import the parser from
+`@tencentdb-agent-memory/memory-tencentdb/config`.
+
 ---
 
 ## Documentation

--- a/README_CN.md
+++ b/README_CN.md
@@ -352,7 +352,6 @@ import { TdaiCore, parseConfig } from "@tencentdb-agent-memory/memory-tencentdb/
 import type {
   CompletedTurn,
   HostAdapter,
-  LLMRunnerFactory,
 } from "@tencentdb-agent-memory/memory-tencentdb/core"
 
 const config = parseConfig({
@@ -362,11 +361,13 @@ const config = parseConfig({
 
 const core = new TdaiCore({
   hostAdapter,
-  llmRunnerFactory,
   config,
 })
 await core.initialize()
 ```
+
+`TdaiCore` 通过 `HostAdapter.getLLMRunnerFactory()` 获取模型执行器，
+所以构造函数只需要 adapter 和解析后的 config。
 
 如果只需要配置解析，可以从
 `@tencentdb-agent-memory/memory-tencentdb/config` 导入 `parseConfig`。

--- a/README_CN.md
+++ b/README_CN.md
@@ -340,6 +340,35 @@ docker exec -it hermes-memory hermes
 | 混合检索 | BM25 + 向量 + RRF，兼顾关键词和语义召回 |
 | Agent 工具 | `tdai_memory_search` / `tdai_conversation_search` |
 
+### 非 OpenClaw 宿主的 Library Mode
+
+OpenClaw 仍然是默认插件入口，但其他宿主可以复用同一套
+host-neutral core，而不需要依赖 OpenClaw runtime API：
+
+```ts
+import { TdaiCore, parseConfig } from "@tencentdb-agent-memory/memory-tencentdb/core"
+import type {
+  CompletedTurn,
+  HostAdapter,
+  LLMRunnerFactory,
+} from "@tencentdb-agent-memory/memory-tencentdb/core"
+
+const config = parseConfig({
+  capture: { enabled: true },
+  extraction: { enabled: false },
+})
+
+const core = new TdaiCore({
+  hostAdapter,
+  llmRunnerFactory,
+  config,
+})
+await core.initialize()
+```
+
+如果只需要配置解析，可以从
+`@tencentdb-agent-memory/memory-tencentdb/config` 导入 `parseConfig`。
+
 ---
 
 ## 文档

--- a/README_CN.md
+++ b/README_CN.md
@@ -385,6 +385,17 @@ const l1OnlyConfig = parseConfig({
 })
 ```
 
+如果宿主把多个 agent 或 workspace 的记忆放在同一个后端里，调用
+`searchMemories()` 时传入 `sessionKey` 或 `sessionId`，让 L1 召回保持作用域隔离：
+
+```ts
+await core.searchMemories({
+  query: "review style",
+  sessionKey: "workspace:/repo/refresh",
+  limit: 5,
+})
+```
+
 ---
 
 ## 文档

--- a/README_CN.md
+++ b/README_CN.md
@@ -263,6 +263,8 @@ docker exec -it hermes-memory hermes
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `pipeline.everyNConversations` | `5` | 每 N 轮对话触发一次 L1 记忆提取 |
+| `pipeline.enableL2` | `true` | L1 后是否启用 L2 场景提取 |
+| `pipeline.enableL3` | `true` | L2 后是否启用 L3 画像生成 |
 | `extraction.maxMemoriesPerSession` | `20` | 单次 L1 最多提取多少条 |
 | `persona.triggerEveryN` | `50` | 每 N 条新记忆触发用户画像生成 |
 | `offload.enabled` | `false` | 是否启用短期记忆压缩 |
@@ -368,6 +370,20 @@ await core.initialize()
 
 如果只需要配置解析，可以从
 `@tencentdb-agent-memory/memory-tencentdb/config` 导入 `parseConfig`。
+
+如果宿主只希望启用 L1 抽取，不希望继续运行 L2 场景提取或 L3
+画像生成，可以保留 capture/extraction，并显式关闭下游 pipeline：
+
+```ts
+const l1OnlyConfig = parseConfig({
+  capture: { enabled: true },
+  extraction: { enabled: true },
+  pipeline: {
+    enableL2: false,
+    enableL3: false,
+  },
+})
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,6 @@
   "type": "module",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
-  "bin": {
-    "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
-    "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
@@ -28,16 +23,9 @@
     }
   },
   "scripts": {
-    "build": "npm run build:plugin && npm run build:scripts",
+    "build": "npm run build:plugin",
     "build:plugin": "tsdown",
-    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
     "prepack": "npm run build",
-    "build:migrate-sqlite-to-vdb": "tsc -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false",
-    "migrate-sqlite-to-tcvdb": "node ./bin/migrate-sqlite-to-tcvdb.mjs",
-    "build:export-tencent-vdb": "tsc --project scripts/export-tencent-vdb/tsconfig.json",
-    "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
-    "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
-    "read-local-memory": "node ./bin/read-local-memory.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -45,18 +33,13 @@
   },
   "files": [
     "dist/",
-    "bin/",
-    "index.ts",
-    "scripts/migrate-sqlite-to-tcvdb/dist/",
-    "scripts/export-tencent-vdb/dist/",
-    "scripts/read-local-memory/dist/",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",
     "scripts/README.memory-tencentdb-ctl.md",
-    "src/",
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "!hermes-plugin/**/tests/",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
@@ -113,7 +96,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.mjs"
     ],
     "compat": {
       "pluginApi": ">=2026.3.13",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Four-layer local memory system plugin for OpenClaw — auto-captures, structures, and profiles conversational knowledge using local LLM + SQLite vector search (L0→L1→L2→L3 pipeline)",
   "type": "module",
   "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
@@ -11,8 +12,19 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./core": {
+      "types": "./dist/core/index.d.mts",
+      "import": "./dist/core/index.mjs",
+      "default": "./dist/core/index.mjs"
+    },
+    "./config": {
+      "types": "./dist/config.d.mts",
+      "import": "./dist/config.mjs",
+      "default": "./dist/config.mjs"
     }
   },
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,10 @@ export interface PipelineTriggerConfig {
   everyNConversations: number;
   /** Enable warm-up: start threshold at 1, double after each L1 (1→2→4→...→everyN) (default: true) */
   enableWarmup: boolean;
+  /** Enable L2 scene extraction scheduling after L1 completes (default: true) */
+  enableL2: boolean;
+  /** Enable L3 persona generation after L2 completes (default: true) */
+  enableL3: boolean;
   /** L1 idle timeout: trigger L1 after this many seconds of inactivity (default: 600) */
   l1IdleTimeoutSeconds: number;
   /** L2 delay after L1: wait this many seconds after L1 completes before triggering L2 (default: 90) */
@@ -477,6 +481,8 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     pipeline: {
       everyNConversations: num(pipelineGroup, "everyNConversations") ?? 5,
       enableWarmup: bool(pipelineGroup, "enableWarmup") ?? true,
+      enableL2: bool(pipelineGroup, "enableL2") ?? true,
+      enableL3: bool(pipelineGroup, "enableL3") ?? true,
       l1IdleTimeoutSeconds: num(pipelineGroup, "l1IdleTimeoutSeconds") ?? 600,
       l2DelayAfterL1Seconds: num(pipelineGroup, "l2DelayAfterL1Seconds") ?? 90,
       l2MinIntervalSeconds: num(pipelineGroup, "l2MinIntervalSeconds") ?? 900,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,3 +24,21 @@ export type {
 // TdaiCore service facade
 export { TdaiCore } from "./tdai-core.js";
 export type { TdaiCoreOptions } from "./tdai-core.js";
+
+// Configuration parser used by host-neutral embedders.
+export { parseConfig } from "../config.js";
+export type {
+  CaptureConfig,
+  EmbeddingConfig,
+  ExtractionConfig,
+  MemoryTdaiConfig,
+  BM25Config,
+  MemoryCleanupConfig,
+  OffloadConfig,
+  PersonaConfig,
+  PipelineTriggerConfig,
+  RecallConfig,
+  ReportConfig,
+  StandaloneLLMOverrideConfig,
+  TcvdbConfig,
+} from "../config.js";

--- a/src/core/package-metadata.test.ts
+++ b/src/core/package-metadata.test.ts
@@ -1,0 +1,25 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import packageJson from "../../package.json" with { type: "json" };
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+describe("npm package metadata", () => {
+  it("does not reference missing command-line binaries", () => {
+    for (const target of Object.values(packageJson.bin ?? {})) {
+      expect(existsSync(resolve(repoRoot, target))).toBe(true);
+    }
+  });
+
+  it("builds the publishable runtime without missing script tsconfigs", () => {
+    expect(packageJson.scripts.build).toBe("npm run build:plugin");
+    expect(packageJson.scripts["build:scripts"]).toBeUndefined();
+  });
+
+  it("publishes compiled runtime artifacts instead of duplicating source", () => {
+    expect(packageJson.files).toContain("dist/");
+    expect(packageJson.files).not.toContain("src/");
+    expect(packageJson.openclaw.extensions).toEqual(["./dist/index.mjs"]);
+  });
+});

--- a/src/core/pipeline-controls.test.ts
+++ b/src/core/pipeline-controls.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseConfig, TdaiCore } from "./index.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "memory-tdai-pipeline-controls-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createHostAdapter(dataDir: string, runnerCalls: Array<{ enableTools: boolean }>) {
+  return {
+    hostType: "standalone" as const,
+    getLLMRunnerFactory: () => ({
+      createRunner: (options: { enableTools?: boolean } = {}) => {
+        runnerCalls.push({ enableTools: options.enableTools ?? false });
+        return { run: async () => "" };
+      },
+    }),
+    getLogger: () => ({
+      debug: () => {},
+      error: () => {},
+      info: () => {},
+      warn: () => {},
+    }),
+    getRuntimeContext: () => ({
+      dataDir,
+      platform: "vitest",
+      sessionId: "session-1",
+      sessionKey: "chat-1:session-1",
+      userId: "user-1",
+      workspaceDir: "/tmp/workspace",
+    }),
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("pipeline controls", () => {
+  it("defaults L2 and L3 pipeline stages to enabled", () => {
+    const config = parseConfig({});
+
+    expect(config.pipeline.enableL2).toBe(true);
+    expect(config.pipeline.enableL3).toBe(true);
+  });
+
+  it("can enable L1 extraction without creating tool-enabled L2/L3 runners", async () => {
+    const runnerCalls: Array<{ enableTools: boolean }> = [];
+    const config = parseConfig({
+      extraction: { enabled: true },
+      pipeline: {
+        enableL2: false,
+        enableL3: false,
+        enableWarmup: false,
+      },
+    });
+    const core = new TdaiCore({
+      config,
+      hostAdapter: createHostAdapter(makeTempDir(), runnerCalls),
+    });
+
+    await core.initialize();
+    await core.destroy();
+
+    expect(runnerCalls).toEqual([{ enableTools: false }]);
+    expect(core.getScheduler()?.getQueueSizes()).toMatchObject({
+      l2: 0,
+      l2Pending: false,
+      l3: 0,
+      l3Pending: false,
+    });
+  });
+});

--- a/src/core/public-exports.test.ts
+++ b/src/core/public-exports.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../../package.json" with { type: "json" };
+import { parseConfig, TdaiCore } from "./index.js";
+
+describe("library mode public exports", () => {
+  it("exposes host-neutral core and config subpaths", () => {
+    expect(packageJson.exports).toMatchObject({
+      "./core": {
+        import: "./dist/core/index.mjs",
+        types: "./dist/core/index.d.mts",
+      },
+      "./config": {
+        import: "./dist/config.mjs",
+        types: "./dist/config.d.mts",
+      },
+    });
+  });
+
+  it("keeps TdaiCore and parseConfig available from the core barrel", () => {
+    expect(typeof TdaiCore).toBe("function");
+    expect(typeof parseConfig).toBe("function");
+    expect(parseConfig({ extraction: { enabled: false } }).extraction.enabled).toBe(false);
+  });
+});

--- a/src/core/public-exports.test.ts
+++ b/src/core/public-exports.test.ts
@@ -1,6 +1,10 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import packageJson from "../../package.json" with { type: "json" };
 import { parseConfig, TdaiCore } from "./index.js";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
 
 describe("library mode public exports", () => {
   it("exposes host-neutral core and config subpaths", () => {
@@ -20,5 +24,15 @@ describe("library mode public exports", () => {
     expect(typeof TdaiCore).toBe("function");
     expect(typeof parseConfig).toBe("function");
     expect(parseConfig({ extraction: { enabled: false } }).extraction.enabled).toBe(false);
+  });
+
+  it("documents TdaiCore construction through the HostAdapter contract", () => {
+    const readme = readFileSync(resolve(repoRoot, "README.md"), "utf8");
+    const readmeCn = readFileSync(resolve(repoRoot, "README_CN.md"), "utf8");
+
+    expect(readme).not.toContain("llmRunnerFactory,");
+    expect(readmeCn).not.toContain("llmRunnerFactory,");
+    expect(readme).toContain("HostAdapter.getLLMRunnerFactory()");
+    expect(readmeCn).toContain("HostAdapter.getLLMRunnerFactory()");
   });
 });

--- a/src/core/seed/seed-runtime.ts
+++ b/src/core/seed/seed-runtime.ts
@@ -91,7 +91,9 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
       logger,
     });
     l1LlmRunner = runnerFactory.createRunner({ enableTools: false });
-    l2l3LlmRunner = runnerFactory.createRunner({ enableTools: true });
+    if (cfg.pipeline.enableL2 || cfg.pipeline.enableL3) {
+      l2l3LlmRunner = runnerFactory.createRunner({ enableTools: true });
+    }
     logger.info(`${TAG} Seed using standalone LLM: model=${cfg.llm.model}`);
   }
 
@@ -105,24 +107,28 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
   });
 
   // Wire L2 runner via shared factory (same logic as index.ts live runtime)
-  pipeline.scheduler.setL2Runner(createL2Runner({
-    pluginDataDir: outputDir,
-    cfg,
-    openclawConfig,
-    vectorStore: pipeline.vectorStore,
-    logger,
-    llmRunner: l2l3LlmRunner,
-  }));
+  if (cfg.pipeline.enableL2) {
+    pipeline.scheduler.setL2Runner(createL2Runner({
+      pluginDataDir: outputDir,
+      cfg,
+      openclawConfig,
+      vectorStore: pipeline.vectorStore,
+      logger,
+      llmRunner: l2l3LlmRunner,
+    }));
+  }
 
   // Wire L3 runner via shared factory (same logic as index.ts live runtime)
-  pipeline.scheduler.setL3Runner(createL3Runner({
-    pluginDataDir: outputDir,
-    cfg,
-    openclawConfig,
-    vectorStore: pipeline.vectorStore,
-    logger,
-    llmRunner: l2l3LlmRunner,
-  }));
+  if (cfg.pipeline.enableL3) {
+    pipeline.scheduler.setL3Runner(createL3Runner({
+      pluginDataDir: outputDir,
+      cfg,
+      openclawConfig,
+      vectorStore: pipeline.vectorStore,
+      logger,
+      llmRunner: l2l3LlmRunner,
+    }));
+  }
 
   return { pipeline, cfg };
 }

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -28,6 +28,7 @@ import type {
   IMemoryStore,
   StoreCapabilities,
   L0Record,
+  L1QueryFilter,
   L1SearchResult,
   L1FtsResult,
   L0SearchResult,
@@ -94,16 +95,6 @@ export interface L0RecordRow {
   message_text: string;
   recorded_at: string;
   timestamp: number;
-}
-
-/** Filter options for querying L1 records from SQLite. */
-export interface L1QueryFilter {
-  /** If provided, only return records for this session key (conversation channel). */
-  sessionKey?: string;
-  /** If provided, only return records for this session ID (single conversation instance). */
-  sessionId?: string;
-  /** If provided, only return records with updated_time strictly after this ISO 8601 UTC timestamp. */
-  updatedAfter?: string;
 }
 
 interface Logger {
@@ -300,6 +291,36 @@ export function bm25RankToScore(rank: number): number {
     return relevance / (1 + relevance);
   }
   return 1 / (1 + rank);
+}
+
+function hasL1ScopeFilter(filter?: L1QueryFilter): boolean {
+  return Boolean(filter?.sessionKey || filter?.sessionId);
+}
+
+function matchesL1ScopeFilter(
+  row: { session_key: string; session_id: string },
+  filter?: L1QueryFilter,
+): boolean {
+  if (filter?.sessionKey && row.session_key !== filter.sessionKey) return false;
+  if (filter?.sessionId && row.session_id !== filter.sessionId) return false;
+  return true;
+}
+
+function buildL1ScopeSql(filter?: L1QueryFilter): {
+  clauses: string[];
+  values: string[];
+} {
+  const clauses: string[] = [];
+  const values: string[] = [];
+  if (filter?.sessionKey) {
+    clauses.push("session_key = ?");
+    values.push(filter.sessionKey);
+  }
+  if (filter?.sessionId) {
+    clauses.push("session_id = ?");
+    values.push(filter.sessionId);
+  }
+  return { clauses, values };
 }
 
 /** FTS5 search result for L1 records. */
@@ -1109,7 +1130,12 @@ export class VectorStore implements IMemoryStore {
    * **Fault-tolerant**: returns an empty array on any error (e.g. dimension
    * mismatch, corrupted DB) so callers can fall back to keyword search.
    */
-  searchL1Vector(queryEmbedding: Float32Array, topK = 5): VectorSearchResult[] {
+  searchL1Vector(
+    queryEmbedding: Float32Array,
+    topK = 5,
+    _queryText?: string,
+    filter?: L1QueryFilter,
+  ): VectorSearchResult[] {
     if (this.degraded || !this.vecTablesReady) {
       if (this.degraded) this.logger?.warn(`${TAG} [L1-search] SKIPPED (degraded mode)`);
       return [];
@@ -1123,7 +1149,9 @@ export class VectorStore implements IMemoryStore {
       // NOTE: "AND distance IS NOT NULL" is NOT usable because vec0 does not
       // support that constraint — it causes an empty result set.
       const ZERO_VEC_BUFFER = 10;
-      const retrieveCount = topK + ZERO_VEC_BUFFER;
+      const retrieveCount = hasL1ScopeFilter(filter)
+        ? Math.max(this.countL1(), topK + ZERO_VEC_BUFFER)
+        : topK + ZERO_VEC_BUFFER;
 
       this.logger?.debug?.(
         `${TAG} [L1-search] START topK=${topK}, retrieveCount=${retrieveCount}, ` +
@@ -1171,6 +1199,7 @@ export class VectorStore implements IMemoryStore {
           this.logger?.warn(`${TAG} [L1-search] record_id=${record_id} has vector but NO metadata (orphan)`);
           continue;
         }
+        if (!matchesL1ScopeFilter(meta, filter)) continue;
 
         const score = 1.0 - distance;
         this.logger?.debug?.(
@@ -2026,10 +2055,25 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL1Fts(ftsQuery: string, limit = 20): FtsSearchResult[] {
+  searchL1Fts(ftsQuery: string, limit = 20, filter?: L1QueryFilter): FtsSearchResult[] {
     if (this.degraded || !this.ftsAvailable) return [];
     try {
-      const rows = this.stmtL1FtsSearch.all(ftsQuery, limit) as Array<{
+      const scopeSql = buildL1ScopeSql(filter);
+      const rows = (scopeSql.clauses.length === 0
+        ? this.stmtL1FtsSearch.all(ftsQuery, limit)
+        : this.db
+            .prepare(`
+              SELECT record_id, content_original AS content, type, priority, scene_name,
+                     session_key, session_id, timestamp_str, timestamp_start, timestamp_end,
+                     metadata_json,
+                     bm25(l1_fts) AS rank
+              FROM l1_fts
+              WHERE l1_fts MATCH ?
+                AND ${scopeSql.clauses.join(" AND ")}
+              ORDER BY rank ASC
+              LIMIT ?
+            `)
+            .all(ftsQuery, ...scopeSql.values, limit)) as Array<{
         record_id: string;
         content: string;
         type: string;

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -98,6 +98,25 @@ function epochMsToIso(ms: number): string {
   return new Date(ms).toISOString();
 }
 
+function escapeFilterString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function buildL1FilterExpression(filter?: L1QueryFilter): string | undefined {
+  const conditions: string[] = [];
+  if (filter?.sessionKey) {
+    conditions.push(`session_key = "${escapeFilterString(filter.sessionKey)}"`);
+  }
+  if (filter?.sessionId) {
+    conditions.push(`session_id = "${escapeFilterString(filter.sessionId)}"`);
+  }
+  if (filter?.updatedAfter) {
+    const afterMs = isoToEpochMs(filter.updatedAfter);
+    if (afterMs > 0) conditions.push(`updated_time_ms > ${afterMs}`);
+  }
+  return conditions.length > 0 ? conditions.join(" and ") : undefined;
+}
+
 /**
  * Extract agent ID from a sessionKey like `agent:<agentId>:<channel>`.
  * Returns empty string if the format doesn't match.
@@ -552,15 +571,7 @@ export class TcvdbMemoryStore implements IMemoryStore {
       await this._ensureInit();
       if (this.degraded) return [];
 
-      // Build TCVDB filter expression from L1QueryFilter
-      const conditions: string[] = [];
-      if (filter?.sessionKey) conditions.push(`session_key = "${filter.sessionKey}"`);
-      if (filter?.sessionId) conditions.push(`session_id = "${filter.sessionId}"`);
-      if (filter?.updatedAfter) {
-        const afterMs = isoToEpochMs(filter.updatedAfter);
-        if (afterMs > 0) conditions.push(`updated_time_ms > ${afterMs}`);
-      }
-      const filterExpr = conditions.length > 0 ? conditions.join(" and ") : undefined;
+      const filterExpr = buildL1FilterExpression(filter);
 
       const docs = await this._queryAllDocs(
         this.l1Collection,
@@ -615,21 +626,26 @@ export class TcvdbMemoryStore implements IMemoryStore {
 
   // ── L1 Search Operations ─────────────────────────────────
 
-  async searchL1Vector(_queryEmbedding: Float32Array, topK?: number, queryText?: string): Promise<L1SearchResult[]> {
+  async searchL1Vector(
+    _queryEmbedding: Float32Array,
+    topK?: number,
+    queryText?: string,
+    filter?: L1QueryFilter,
+  ): Promise<L1SearchResult[]> {
     // TCVDB uses server-side embedding — delegate to hybrid search with text
     if (queryText) {
-      return this.searchL1HybridAsync({ queryText, topK });
+      return this.searchL1HybridAsync({ queryText, topK, filter });
     }
     // No queryText and TCVDB can't use client embeddings directly via embeddingItems
     // Return empty — callers should pass queryText for TCVDB
     return [];
   }
 
-  async searchL1Fts(ftsQuery: string, limit?: number): Promise<L1FtsResult[]> {
+  async searchL1Fts(ftsQuery: string, limit?: number, filter?: L1QueryFilter): Promise<L1FtsResult[]> {
     // TCVDB has no pure FTS — use hybrid search with sparse-only path
     // The ftsQuery is raw text, use it as queryText for hybrid
     if (!ftsQuery) return [];
-    const results = await this.searchL1HybridAsync({ queryText: ftsQuery, topK: limit });
+    const results = await this.searchL1HybridAsync({ queryText: ftsQuery, topK: limit, filter });
     // L1SearchResult and L1FtsResult have identical shapes
     return results;
   }
@@ -637,12 +653,21 @@ export class TcvdbMemoryStore implements IMemoryStore {
   async searchL1Hybrid(params: {
     query?: string;
     queryEmbedding?: Float32Array;
+    sessionId?: string;
+    sessionKey?: string;
     sparseVector?: SparseVector;
     topK?: number;
   }): Promise<L1SearchResult[]> {
     const queryText = params.query;
     if (!queryText) return [];
-    return this.searchL1HybridAsync({ queryText, topK: params.topK });
+    return this.searchL1HybridAsync({
+      queryText,
+      topK: params.topK,
+      filter: {
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      },
+    });
   }
 
   /**
@@ -650,10 +675,11 @@ export class TcvdbMemoryStore implements IMemoryStore {
    * Call this directly from async contexts (hooks, tools).
    */
   async searchL1HybridAsync(params: {
+    filter?: L1QueryFilter;
     queryText: string;
     topK?: number;
   }): Promise<L1SearchResult[]> {
-    const { queryText, topK = 10 } = params;
+    const { filter, queryText, topK = 10 } = params;
     if (!queryText) return [];
 
     try {
@@ -665,6 +691,8 @@ export class TcvdbMemoryStore implements IMemoryStore {
         limit: topK,
         outputFields: L1_OUTPUT_FIELDS,
       };
+      const filterExpr = buildL1FilterExpression(filter);
+      if (filterExpr) searchParams.filter = filterExpr;
 
       // ann: use embedding field name "text" for server-side embedding
       // (per SDK: AnnSearch(field_name="text", data='query string'))
@@ -702,6 +730,7 @@ export class TcvdbMemoryStore implements IMemoryStore {
           retrieveVector: false,
           outputFields: L1_OUTPUT_FIELDS,
         };
+        if (filterExpr) denseSearch.filter = filterExpr;
         const resp = await this.client.search(this.l1Collection, denseSearch);
         return this._parseL1SearchResults(resp.documents);
       }

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -270,11 +270,18 @@ export interface IMemoryStore {
 
   // ── L1 Search ────────────────────────────────────────────
 
-  searchL1Vector(queryEmbedding: Float32Array, topK?: number, queryText?: string): MaybePromise<L1SearchResult[]>;
-  searchL1Fts(ftsQuery: string, limit?: number): MaybePromise<L1FtsResult[]>;
+  searchL1Vector(
+    queryEmbedding: Float32Array,
+    topK?: number,
+    queryText?: string,
+    filter?: L1QueryFilter,
+  ): MaybePromise<L1SearchResult[]>;
+  searchL1Fts(ftsQuery: string, limit?: number, filter?: L1QueryFilter): MaybePromise<L1FtsResult[]>;
   searchL1Hybrid?(params: {
     query?: string;
     queryEmbedding?: Float32Array;
+    sessionId?: string;
+    sessionKey?: string;
     sparseVector?: Array<[number, number]>;
     topK?: number;
   }): MaybePromise<L1SearchResult[]>;

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -291,6 +291,8 @@ export class TdaiCore {
     const result = await executeMemorySearch({
       query: params.query,
       limit: params.limit ?? 5,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
       type: params.type,
       scene: params.scene,
       vectorStore: this.vectorStore,

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -449,7 +449,8 @@ export class TdaiCore {
     const l1LlmRunner = useStandaloneRunner
       ? runnerFactory.createRunner({ enableTools: false })
       : undefined;
-    const l2l3LlmRunner = useStandaloneRunner
+    const needsToolRunner = this.cfg.pipeline.enableL2 || this.cfg.pipeline.enableL3;
+    const l2l3LlmRunner = useStandaloneRunner && needsToolRunner
       ? runnerFactory.createRunner({ enableTools: true })
       : undefined;
 
@@ -469,32 +470,36 @@ export class TdaiCore {
     this.scheduler.setPersister(createPersister(this.dataDir, this.logger));
 
     // L2 runner
-    this.scheduler.setL2Runner(async (sessionKey: string, cursor?: string) => {
-      const l2Runner = createL2Runner({
-        pluginDataDir: this.dataDir,
-        cfg: this.cfg,
-        openclawConfig,
-        vectorStore: this.vectorStore,
-        logger: this.logger,
-        instanceId: this.instanceId,
-        llmRunner: l2l3LlmRunner,
+    if (this.cfg.pipeline.enableL2) {
+      this.scheduler.setL2Runner(async (sessionKey: string, cursor?: string) => {
+        const l2Runner = createL2Runner({
+          pluginDataDir: this.dataDir,
+          cfg: this.cfg,
+          openclawConfig,
+          vectorStore: this.vectorStore,
+          logger: this.logger,
+          instanceId: this.instanceId,
+          llmRunner: l2l3LlmRunner,
+        });
+        return l2Runner(sessionKey, cursor);
       });
-      return l2Runner(sessionKey, cursor);
-    });
+    }
 
     // L3 runner
-    this.scheduler.setL3Runner(async () => {
-      const l3Runner = createL3Runner({
-        pluginDataDir: this.dataDir,
-        cfg: this.cfg,
-        openclawConfig,
-        vectorStore: this.vectorStore,
-        logger: this.logger,
-        instanceId: this.instanceId,
-        llmRunner: l2l3LlmRunner,
+    if (this.cfg.pipeline.enableL3) {
+      this.scheduler.setL3Runner(async () => {
+        const l3Runner = createL3Runner({
+          pluginDataDir: this.dataDir,
+          cfg: this.cfg,
+          openclawConfig,
+          vectorStore: this.vectorStore,
+          logger: this.logger,
+          instanceId: this.instanceId,
+          llmRunner: l2l3LlmRunner,
+        });
+        await l3Runner();
       });
-      await l3Runner();
-    });
+    }
 
     this.logger.debug?.(`${TAG} Pipeline runners wired`);
   }

--- a/src/core/tools/memory-search.test.ts
+++ b/src/core/tools/memory-search.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { IMemoryStore, L1FtsResult } from "../store/types.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore, L1FtsResult, L1SearchResult } from "../store/types.js";
 import { executeMemorySearch } from "./memory-search.js";
 
 function l1Result(params: {
   content: string;
   recordId: string;
+  sessionId?: string;
   sessionKey: string;
 }): L1FtsResult {
   return {
@@ -14,7 +16,7 @@ function l1Result(params: {
     record_id: params.recordId,
     scene_name: "review",
     score: 0.9,
-    session_id: `${params.sessionKey}:sub`,
+    session_id: params.sessionId ?? `${params.sessionKey}:sub`,
     session_key: params.sessionKey,
     timestamp_end: "2026-05-16T00:00:00.000Z",
     timestamp_start: "2026-05-16T00:00:00.000Z",
@@ -52,5 +54,86 @@ describe("memory search scope", () => {
     expect(result.results.map((item) => item.content)).toEqual([
       "Refresh project prefers strict code review.",
     ]);
+  });
+
+  it("passes scope to the L1 store so filtering happens before topK truncation", async () => {
+    let observedFilter: { sessionKey?: string; sessionId?: string } | undefined;
+    const vectorStore = {
+      isFtsAvailable: () => true,
+      searchL1Fts: async (
+        _ftsQuery: string,
+        _limit?: number,
+        filter?: { sessionKey?: string; sessionId?: string },
+      ) => {
+        observedFilter = filter;
+        if (filter?.sessionKey === "refresh-project") {
+          return [
+            l1Result({
+              content: "Refresh project keeps in-scope memory after store filtering.",
+              recordId: "refresh-store-scoped",
+              sessionKey: "refresh-project",
+            }),
+          ];
+        }
+        return Array.from({ length: 20 }, (_, index) =>
+          l1Result({
+            content: `Other project memory ${index}`,
+            recordId: `other-${index}`,
+            sessionKey: "other-project",
+          }),
+        );
+      },
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const result = await executeMemorySearch({
+      limit: 5,
+      query: "store scoped",
+      sessionKey: "refresh-project",
+      vectorStore,
+    });
+
+    expect(observedFilter).toEqual({ sessionKey: "refresh-project" });
+    expect(result.total).toBe(1);
+    expect(result.results[0]?.id).toBe("refresh-store-scoped");
+  });
+
+  it("passes scope to vector L1 search before vector topK truncation", async () => {
+    let observedFilter: { sessionKey?: string; sessionId?: string } | undefined;
+    const vectorStore = {
+      isFtsAvailable: () => false,
+      searchL1Vector: async (
+        _embedding: Float32Array,
+        _limit?: number,
+        _queryText?: string,
+        filter?: { sessionKey?: string; sessionId?: string },
+      ): Promise<L1SearchResult[]> => {
+        observedFilter = filter;
+        return filter?.sessionId === "sub-1"
+          ? [
+              l1Result({
+                content: "Refresh vector memory stays scoped by session id.",
+                recordId: "refresh-vector-scoped",
+                sessionId: "sub-1",
+                sessionKey: "refresh-project",
+              }),
+            ]
+          : [];
+      },
+    } as Partial<IMemoryStore> as IMemoryStore;
+    const embeddingService = {
+      embed: async () => new Float32Array([0.1, 0.2]),
+    } as Partial<EmbeddingService> as EmbeddingService;
+
+    const result = await executeMemorySearch({
+      embeddingService,
+      limit: 5,
+      query: "vector scoped",
+      sessionId: "sub-1",
+      vectorStore,
+    });
+
+    expect(observedFilter).toEqual({ sessionId: "sub-1" });
+    expect(result.total).toBe(1);
+    expect(result.results[0]?.id).toBe("refresh-vector-scoped");
   });
 });

--- a/src/core/tools/memory-search.test.ts
+++ b/src/core/tools/memory-search.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { IMemoryStore, L1FtsResult } from "../store/types.js";
+import { executeMemorySearch } from "./memory-search.js";
+
+function l1Result(params: {
+  content: string;
+  recordId: string;
+  sessionKey: string;
+}): L1FtsResult {
+  return {
+    content: params.content,
+    metadata_json: "{}",
+    priority: 50,
+    record_id: params.recordId,
+    scene_name: "review",
+    score: 0.9,
+    session_id: `${params.sessionKey}:sub`,
+    session_key: params.sessionKey,
+    timestamp_end: "2026-05-16T00:00:00.000Z",
+    timestamp_start: "2026-05-16T00:00:00.000Z",
+    timestamp_str: "2026-05-16",
+    type: "preference",
+  };
+}
+
+describe("memory search scope", () => {
+  it("filters L1 FTS results by sessionKey before formatting", async () => {
+    const vectorStore = {
+      isFtsAvailable: () => true,
+      searchL1Fts: async () => [
+        l1Result({
+          content: "Refresh project prefers strict code review.",
+          recordId: "refresh-review-style",
+          sessionKey: "refresh-project",
+        }),
+        l1Result({
+          content: "Other project prefers loose review.",
+          recordId: "other-review-style",
+          sessionKey: "other-project",
+        }),
+      ],
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const result = await executeMemorySearch({
+      limit: 5,
+      query: "review style",
+      sessionKey: "refresh-project",
+      vectorStore,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.results.map((item) => item.content)).toEqual([
+      "Refresh project prefers strict code review.",
+    ]);
+  });
+});

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -46,6 +46,16 @@ export interface MemorySearchResult {
 
 const TAG = "[memory-tdai][tdai_memory_search]";
 
+function matchesL1Scope(
+  item: { session_key?: string; session_id?: string },
+  sessionKey?: string,
+  sessionId?: string,
+): boolean {
+  if (sessionKey && item.session_key !== sessionKey) return false;
+  if (sessionId && item.session_id !== sessionId) return false;
+  return true;
+}
+
 // ============================
 // RRF (Reciprocal Rank Fusion)
 // ============================
@@ -88,6 +98,8 @@ function rrfMergeL1(...lists: MemorySearchResultItem[][]): MemorySearchResultIte
 export async function executeMemorySearch(params: {
   query: string;
   limit: number;
+  sessionKey?: string;
+  sessionId?: string;
   type?: string;
   scene?: string;
   vectorStore?: IMemoryStore;
@@ -97,6 +109,8 @@ export async function executeMemorySearch(params: {
   const {
     query,
     limit,
+    sessionKey,
+    sessionId,
     type: typeFilter,
     scene: sceneFilter,
     vectorStore,
@@ -106,6 +120,7 @@ export async function executeMemorySearch(params: {
 
   logger?.debug?.(
     `${TAG} CALLED: query="${query.slice(0, 100)}", limit=${limit}, ` +
+    `sessionKey=${sessionKey ?? "(all)"}, sessionId=${sessionId ?? "(all)"}, ` +
     `typeFilter=${typeFilter ?? "(none)"}, sceneFilter=${sceneFilter ?? "(none)"}, ` +
     `vectorStore=${vectorStore ? "available" : "UNAVAILABLE"}, ` +
     `embeddingService=${embeddingService ? "available" : "UNAVAILABLE"}`,
@@ -155,7 +170,7 @@ export async function executeMemorySearch(params: {
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 query: "${ftsQuery}"`);
         const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 returned ${ftsResults.length} candidates`);
-        return ftsResults.map((r) => ({
+        return ftsResults.filter((r) => matchesL1Scope(r, sessionKey, sessionId)).map((r) => ({
           id: r.record_id,
           content: r.content,
           type: r.type,
@@ -184,7 +199,7 @@ export async function executeMemorySearch(params: {
         );
         const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, candidateK, query);
         logger?.debug?.(`${TAG} [hybrid-vec] Vector search returned ${vecResults.length} candidates`);
-        return vecResults.map((r) => ({
+        return vecResults.filter((r) => matchesL1Scope(r, sessionKey, sessionId)).map((r) => ({
           id: r.record_id,
           content: r.content,
           type: r.type,

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -10,7 +10,7 @@
  * The tool is registered via `api.registerTool()` in index.ts.
  */
 
-import type { IMemoryStore, L1SearchResult } from "../store/types.js";
+import type { IMemoryStore, L1QueryFilter, L1SearchResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
 
@@ -54,6 +54,16 @@ function matchesL1Scope(
   if (sessionKey && item.session_key !== sessionKey) return false;
   if (sessionId && item.session_id !== sessionId) return false;
   return true;
+}
+
+function buildL1ScopeFilter(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): L1QueryFilter | undefined {
+  const filter: L1QueryFilter = {};
+  if (params.sessionKey) filter.sessionKey = params.sessionKey;
+  if (params.sessionId) filter.sessionId = params.sessionId;
+  return Object.keys(filter).length > 0 ? filter : undefined;
 }
 
 // ============================
@@ -139,6 +149,7 @@ export async function executeMemorySearch(params: {
   // ── Determine available capabilities ──
   const hasEmbedding = !!embeddingService;
   const hasFts = vectorStore.isFtsAvailable();
+  const scopeFilter = buildL1ScopeFilter({ sessionKey, sessionId });
 
   if (!hasEmbedding && !hasFts) {
     logger?.warn?.(`${TAG} Neither EmbeddingService nor FTS5 available — cannot search`);
@@ -168,7 +179,7 @@ export async function executeMemorySearch(params: {
           return [];
         }
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 query: "${ftsQuery}"`);
-        const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+        const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK, scopeFilter);
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 returned ${ftsResults.length} candidates`);
         return ftsResults.filter((r) => matchesL1Scope(r, sessionKey, sessionId)).map((r) => ({
           id: r.record_id,
@@ -197,7 +208,12 @@ export async function executeMemorySearch(params: {
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, candidateK, query);
+        const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(
+          queryEmbedding,
+          candidateK,
+          query,
+          scopeFilter,
+        );
         logger?.debug?.(`${TAG} [hybrid-vec] Vector search returned ${vecResults.length} candidates`);
         return vecResults.filter((r) => matchesL1Scope(r, sessionKey, sessionId)).map((r) => ({
           id: r.record_id,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -229,6 +229,8 @@ export interface CaptureResult {
 export interface MemorySearchParams {
   query: string;
   limit?: number;
+  sessionKey?: string;
+  sessionId?: string;
   type?: string;
   scene?: string;
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -290,6 +290,8 @@ export class TdaiGateway {
     const result = await this.core.searchMemories({
       query: body.query,
       limit: body.limit,
+      sessionKey: body.session_key,
+      sessionId: body.session_id,
       type: body.type,
       scene: body.scene,
     });

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -66,6 +66,8 @@ export interface CaptureResponse {
 export interface MemorySearchRequest {
   query: string;
   limit?: number;
+  session_key?: string;
+  session_id?: string;
   type?: string;
   scene?: string;
 }

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -664,6 +664,8 @@ export function createPipelineManager(
     {
       everyNConversations: cfg.pipeline.everyNConversations,
       enableWarmup: cfg.pipeline.enableWarmup,
+      enableL2: cfg.pipeline.enableL2,
+      enableL3: cfg.pipeline.enableL3,
       l1: { idleTimeoutSeconds: cfg.pipeline.l1IdleTimeoutSeconds },
       l2: {
         delayAfterL1Seconds: cfg.pipeline.l2DelayAfterL1Seconds,

--- a/src/utils/pipeline-manager.test.ts
+++ b/src/utils/pipeline-manager.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { MemoryPipelineManager, type PipelineConfig } from "./pipeline-manager.js";
+
+function baseConfig(overrides: Partial<PipelineConfig> = {}): PipelineConfig {
+  return {
+    enableL2: true,
+    enableL3: true,
+    enableWarmup: false,
+    everyNConversations: 1,
+    l1: { idleTimeoutSeconds: 60 },
+    l2: {
+      delayAfterL1Seconds: 0,
+      maxIntervalSeconds: 60,
+      minIntervalSeconds: 0,
+      sessionActiveWindowHours: 24,
+    },
+    ...overrides,
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("condition not met");
+}
+
+describe("MemoryPipelineManager stage controls", () => {
+  it("does not schedule L2 or L3 when both stages are disabled", async () => {
+    const manager = new MemoryPipelineManager(baseConfig({
+      enableL2: false,
+      enableL3: false,
+    }));
+    let l1Calls = 0;
+    let l2Calls = 0;
+    let l3Calls = 0;
+
+    manager.setL1Runner(async () => {
+      l1Calls += 1;
+    });
+    manager.setL2Runner(async () => {
+      l2Calls += 1;
+    });
+    manager.setL3Runner(async () => {
+      l3Calls += 1;
+    });
+    manager.start({});
+
+    await manager.notifyConversation("session-1", [
+      { role: "user", content: "remember this", timestamp: new Date().toISOString() },
+    ]);
+    await waitFor(() => l1Calls === 1);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(l2Calls).toBe(0);
+    expect(l3Calls).toBe(0);
+    expect(manager.getQueueSizes()).toMatchObject({
+      l2: 0,
+      l2Pending: false,
+      l3: 0,
+      l3Pending: false,
+    });
+
+    await manager.destroy();
+  });
+});

--- a/src/utils/pipeline-manager.ts
+++ b/src/utils/pipeline-manager.ts
@@ -120,6 +120,12 @@ export interface PipelineConfig {
    */
   enableWarmup: boolean;
 
+  /** Enable downstream L2 scene extraction after L1 succeeds. */
+  enableL2: boolean;
+
+  /** Enable downstream L3 persona generation after L2 succeeds. */
+  enableL3: boolean;
+
   l1: {
     /** Idle timeout before triggering L1 (seconds, default: 60) */
     idleTimeoutSeconds: number;
@@ -198,6 +204,8 @@ export class MemoryPipelineManager {
   private readonly l1IdleTimeoutMs: number;
   private readonly everyNConversations: number;
   private readonly enableWarmup: boolean;
+  private readonly enableL2: boolean;
+  private readonly enableL3: boolean;
   private readonly l2DelayAfterL1Ms: number;
   private readonly l2MinIntervalMs: number;
   private readonly l2MaxIntervalMs: number;
@@ -255,6 +263,8 @@ export class MemoryPipelineManager {
     this.l1IdleTimeoutMs = config.l1.idleTimeoutSeconds * 1000;
     this.everyNConversations = config.everyNConversations;
     this.enableWarmup = config.enableWarmup;
+    this.enableL2 = config.enableL2;
+    this.enableL3 = config.enableL3;
     this.l2DelayAfterL1Ms = config.l2.delayAfterL1Seconds * 1000;
     this.l2MinIntervalMs = config.l2.minIntervalSeconds * 1000;
     this.l2MaxIntervalMs = config.l2.maxIntervalSeconds * 1000;
@@ -265,6 +275,8 @@ export class MemoryPipelineManager {
     this.logger?.debug?.(
       `${TAG} Initialized: everyNConversations=${config.everyNConversations}, ` +
       `warmup=${config.enableWarmup ? "enabled" : "disabled"}, ` +
+      `l2=${config.enableL2 ? "enabled" : "disabled"}, ` +
+      `l3=${config.enableL3 ? "enabled" : "disabled"}, ` +
       `l1IdleTimeout=${config.l1.idleTimeoutSeconds}s, ` +
       `l2DelayAfterL1=${config.l2.delayAfterL1Seconds}s, ` +
       `l2MinInterval=${config.l2.minIntervalSeconds}s, ` +
@@ -686,11 +698,11 @@ export class MemoryPipelineManager {
 
     if (!this.l1Runner) {
       this.logger?.warn(`${TAG} [${sessionKey}] No L1 runner set, skipping`);
-      state.l2_pending_l1_count = state.conversation_count;
+      state.l2_pending_l1_count = this.enableL2 ? state.conversation_count : 0;
       state.conversation_count = 0;
       this.advanceWarmupThreshold(state);
       await this.persistStates();
-      this.advanceL2Timer(sessionKey);
+      if (this.enableL2) this.advanceL2Timer(sessionKey);
       return;
     }
 
@@ -738,13 +750,13 @@ export class MemoryPipelineManager {
     // Success: reset retry count and advance state
     const timers = this.getOrCreateTimers(sessionKey);
     timers.l1RetryCount = 0;
-    state.l2_pending_l1_count = state.conversation_count;
+    state.l2_pending_l1_count = this.enableL2 ? state.conversation_count : 0;
     state.conversation_count = 0;
     this.advanceWarmupThreshold(state);
     await this.persistStates();
 
     // Advance the L2 timer (downward-only) to fire after delay, respecting minInterval
-    this.advanceL2Timer(sessionKey);
+    if (this.enableL2) this.advanceL2Timer(sessionKey);
   }
 
   // ============================
@@ -762,6 +774,7 @@ export class MemoryPipelineManager {
    */
   private advanceL2Timer(sessionKey: string): void {
     if (this.destroyed) return;
+    if (!this.enableL2) return;
 
     const timers = this.getOrCreateTimers(sessionKey);
     const now = Date.now();
@@ -796,6 +809,7 @@ export class MemoryPipelineManager {
    */
   private armL2MaxInterval(sessionKey: string): void {
     if (this.destroyed) return;
+    if (!this.enableL2) return;
 
     const timers = this.getOrCreateTimers(sessionKey);
     const fireAt = Date.now() + this.l2MaxIntervalMs;
@@ -819,6 +833,8 @@ export class MemoryPipelineManager {
    * - "max-interval": periodic timer — apply cold check normally.
    */
   private onL2TimerFired(sessionKey: string, source: "delay-after-l1" | "max-interval"): void {
+    if (!this.enableL2) return;
+
     const state = this.sessionStates.get(sessionKey);
     if (!state) return;
 
@@ -844,6 +860,8 @@ export class MemoryPipelineManager {
   // ============================
 
   private enqueueL2(sessionKey: string, trigger: string): void {
+    if (!this.enableL2) return;
+
     const timers = this.getOrCreateTimers(sessionKey);
 
     // Cancel any pending L2 timer (we're about to run L2)
@@ -919,7 +937,7 @@ export class MemoryPipelineManager {
     this.armL2MaxInterval(sessionKey);
 
     // Trigger L3
-    this.triggerL3();
+    if (this.enableL3) this.triggerL3();
   }
 
   // ============================
@@ -928,6 +946,7 @@ export class MemoryPipelineManager {
 
   private triggerL3(): void {
     if (this.destroyed) return;
+    if (!this.enableL3) return;
 
     if (this.l3Running) {
       // L3 is in progress — mark pending so it runs again after current finishes
@@ -1096,6 +1115,8 @@ export class MemoryPipelineManager {
    * because the pipeline may be starting during management commands.
    */
   private recoverPendingSessions(): void {
+    if (!this.enableL2) return;
+
     for (const [sessionKey, state] of this.sessionStates) {
       if (state.conversation_count === 0 && state.l2_pending_l1_count === 0) continue;
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,13 +11,17 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: {
+    index: "./index.ts",
+    "core/index": "./src/core/index.ts",
+    config: "./src/config.ts",
+  },
   outDir: "./dist",
   format: "esm",
   platform: "node",
   clean: true,
   fixedExtension: true,
-  dts: false,
+  dts: true,
   sourcemap: false,
   deps: {
     neverBundle: (id) => {


### PR DESCRIPTION
## Description | 描述
Add stable host-neutral library usage for non-OpenClaw integrations:

- `@tencentdb-agent-memory/memory-tencentdb/core` exports `TdaiCore`, host adapter contracts, `parseConfig`, and config types.
- `@tencentdb-agent-memory/memory-tencentdb/config` exports the config parser for configuration-only integrations.
- `pipeline.enableL2` and `pipeline.enableL3` allow hosts to run L0/L1 without starting downstream scene/persona stages.
- TDAI core and seed runtime no longer create tool-enabled runners when both L2 and L3 are disabled.
- `searchMemories()` and Gateway `/search/memories` support `sessionKey` / `sessionId` scope filters, with SQLite and TCVDB store-level filtering so shared backends neither return another session's L1 memories nor miss in-scope memories after topK truncation.
- English and Chinese READMEs document library mode, pipeline stage controls, scoped L1 search, and the `HostAdapter.getLLMRunnerFactory()` construction contract.

OpenClaw remains the default plugin entry point. This change only makes existing core behavior consumable through public package subpaths and gives hosts a general way to opt out of L2/L3 work or scope L1 recall.

## Related Issue | 关联 Issue
None.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Local verification:

- `npm test -- src/core/tools/memory-search.test.ts src/core/public-exports.test.ts`
- `npm test`
- `npm run build:plugin`
- `npm pack --dry-run --ignore-scripts`
- `npm pack --ignore-scripts` produced a 281.3 kB tarball, under the 512 kB CI size guard.
