### PR TITLE
docs: add seed (historical conversation import) section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,95 @@ docker exec -it hermes-memory hermes
 
 ---
 
+### 3. Importing historical conversations (seed)
+
+Starting from v0.1.4, TencentDB Agent Memory ships with a `seed` command that processes historical conversations through the full L0→L1→L2→L3 pipeline, so previously exchanged conversations can produce structured memories, scene blocks, and persona refinements just like new ones.
+
+#### When to use seed
+
+- You installed the plugin after days of usage and want it to learn from past context.
+- You are migrating from another memory system.
+- You want to backfill selected high-value conversations.
+
+#### Input format
+
+Seed accepts two formats:
+
+**Format A (preferred):**
+```json
+{
+  "sessions": [
+    {
+      "sessionKey": "my-agent-session",
+      "conversations": [
+        [
+          { "role": "user", "content": "What's our project status?", "timestamp": 1770000000000 },
+          { "role": "assistant", "content": "We shipped v2.1 yesterday.", "timestamp": 1770000001000 }
+        ],
+        [
+          { "role": "user", "content": "Let's review the Q4 plan." },
+          { "role": "assistant", "content": "Here's the roadmap…" }
+        ]
+      ]
+    }
+  ]
+}
+```
+
+**Format B (top-level array):**
+```json
+[
+  {
+    "sessionKey": "my-agent-session",
+    "conversations": [ … ]
+  }
+]
+```
+
+Each `conversations` entry is a **round** — an ordered array of `{"role", "content"}` objects (typically a user turn followed by an assistant reply). Timestamps are optional; missing values are auto-filled on seed.
+
+#### CLI usage
+
+```bash
+# Standalone / Hermes mode
+openclaw memory-tdai seed --input ./conversations.json
+
+# With options
+openclaw memory-tdai seed \
+  --input ./conversations.json \
+  --config ./seed-config.json \
+  --yes
+```
+
+Options:
+
+| Flag | Description |
+| :--- | :--- |
+| `--input <file>` | Path to JSON file (Required) |
+| `--output-dir <dir>` | Seed output directory (auto-generated if omitted) |
+| `--session-key <key>` | Fallback session key when input lacks one |
+| `--config <file>` | Plugin config override file (JSON, deep-merged) |
+| `--strict-round-role` | Require both user and assistant per round |
+| `--yes` | Skip interactive confirmations |
+
+#### What happens during seed
+
+1. Each session's conversations are captured as L0 raw records (same path as real-time capture).
+2. The L1 memory extractor processes each session — the same LLM extraction pipeline that runs on new conversations.
+3. If configured, L2 scene blocks and L3 persona refinements are generated as new memories accumulate.
+4. All data is written to the same `vectors.db`, `records/`, `scene_blocks/` storage — no separate migration step needed.
+
+> 💡 When running seed in standalone mode, point `--output-dir` at your existing plugin data directory to write directly into the active memory store.
+
+#### Best practices
+
+- **Don't seed everything.** Only import conversations that contain decisions, preferences, project context, or instructive exchanges. Cron logs and debugging noise degrade extraction quality.
+- **Use a focused time window first.** Try the last 7–14 days before backfilling months of history.
+- **Monitor L1 output.** Check `~/.openclaw/memory-tdai/records/` and the l1_records SQLite table to assess extraction quality.
+- **Extraction requires a capable LLM.** If you experience `NO_JSON` or empty extractions, enable the standalone LLM (`plugin.config.llm`) with a model that handles structured JSON output well (e.g., DeepSeek V4 Pro, GPT-5.5).
+
+---
+
 
 ## 🔧 Configurable Parameters
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -250,6 +250,72 @@ docker exec -it hermes-memory hermes
 
 ---
 
+### 3. 历史对话导入（seed）
+
+从 v0.1.4 开始，TencentDB Agent Memory 内置了 `seed` 命令，可以将历史对话数据送入完整的 L0→L1→L2→L3 管线处理，让之前的对话也能产生结构化记忆、场景块和用户画像。
+
+#### 适用场景
+
+- 插件安装较晚，希望它学习安装前的对话上下文。
+- 从其他记忆系统迁移。
+- 希望精选导入高价值历史对话。
+
+#### 输入格式
+
+支持两种格式：
+
+**Format A（推荐）：**
+```json
+{
+  "sessions": [
+    {
+      "sessionKey": "my-agent-session",
+      "conversations": [
+        [
+          { "role": "user", "content": "项目进度怎么样了？", "timestamp": 1770000000000 },
+          { "role": "assistant", "content": "v2.1 昨天上线了。", "timestamp": 1770000001000 }
+        ]
+      ]
+    }
+  ]
+}
+```
+
+**Format B（顶层数组）：**
+```json
+[
+  {
+    "sessionKey": "my-agent-session",
+    "conversations": [ … ]
+  }
+]
+```
+
+#### CLI 用法
+
+```bash
+openclaw memory-tdai seed --input ./conversations.json
+openclaw memory-tdai seed --input ./conversations.json --config ./seed-config.json --yes
+```
+
+参数说明：`--input`（必填）、`--output-dir`、`--session-key`、`--config`、`--strict-round-role`、`--yes`。
+
+#### Seed 过程
+
+1. 每个会话的对话被记录为 L0 原始记录（与实时捕获路径一致）。
+2. L1 提取器对每个会话进行处理——与新对话运行相同的 LLM 抽取管线。
+3. 所有数据写入同一个 `vectors.db`、`records/`、`scene_blocks/`——无需迁移步骤。
+
+> 💡 将 `--output-dir` 指向已有插件数据目录，直接写入活跃记忆存储。
+
+#### 最佳实践
+
+- **不要全部导入。** 只导入包含决策、偏好、项目上下文的对话。Cron 日志和调试流水会降低抽取质量。
+- **先从短时间窗口开始。** 试最近 7-14 天再决定是否回溯更多。
+- **抽取需要强 LLM。** 遇到 `NO_JSON` 时启用独立 LLM（`plugin.config.llm`），选择能稳定输出 JSON 的模型。
+
+---
+
 ## 🔧 可调参数
 
 **所有字段均有合理默认值，零配置即可跑。** 如果要调优，可以按使用深度逐层展开。


### PR DESCRIPTION
### Summary

Documents the existing `seed` CLI command for importing historical conversations through the L0→L1→L2→L3 pipeline. The seed mechanism was implemented in `src/cli/commands/seed.ts` and `src/core/seed/` but had no user-facing documentation.

### What this adds

- **When to use seed** — backfill historical context after plugin install, migration from other systems
- **Input format** — Format A (`{ sessions: [...] }`) and Format B (top-level array) with examples
- **CLI usage** — command flags and options reference table
- **Seed pipeline** — what happens during execution (L0 capture → L1 extraction → storage)
- **Best practices** — selective import, start small, monitor L1 quality, LLM recommendations

Both English (README.md) and Chinese (README_CN.md) are updated.

### Related

The `memory-tencentdb-ctl` script also supports seed operations in Hermes mode. See `scripts/README.memory-tencentdb-ctl.md`.

---

Closes: (no related issue — this addresses an existing documentation gap)