### PR TITLE
fix(core): scope L1 memory search in stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [Unreleased]
+
+### ✨ 改进
+
+- **L1 作用域过滤**：`searchMemories()` 支持 `sessionKey` / `sessionId`，Gateway `/search/memories` 支持 `session_key` / `session_id`，避免共享后端里的结构化记忆跨 session 召回。
+
+---
+
 ## [0.3.4] - 2026-05-12
 
 ### 🐛 修复

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -28,6 +28,7 @@ import type {
   IMemoryStore,
   StoreCapabilities,
   L0Record,
+  L1QueryFilter,
   L1SearchResult,
   L1FtsResult,
   L0SearchResult,
@@ -94,16 +95,6 @@ export interface L0RecordRow {
   message_text: string;
   recorded_at: string;
   timestamp: number;
-}
-
-/** Filter options for querying L1 records from SQLite. */
-export interface L1QueryFilter {
-  /** If provided, only return records for this session key (conversation channel). */
-  sessionKey?: string;
-  /** If provided, only return records for this session ID (single conversation instance). */
-  sessionId?: string;
-  /** If provided, only return records with updated_time strictly after this ISO 8601 UTC timestamp. */
-  updatedAfter?: string;
 }
 
 interface Logger {
@@ -300,6 +291,36 @@ export function bm25RankToScore(rank: number): number {
     return relevance / (1 + relevance);
   }
   return 1 / (1 + rank);
+}
+
+function hasL1ScopeFilter(filter?: L1QueryFilter): boolean {
+  return Boolean(filter?.sessionKey || filter?.sessionId);
+}
+
+function matchesL1ScopeFilter(
+  row: { session_key: string; session_id: string },
+  filter?: L1QueryFilter,
+): boolean {
+  if (filter?.sessionKey && row.session_key !== filter.sessionKey) return false;
+  if (filter?.sessionId && row.session_id !== filter.sessionId) return false;
+  return true;
+}
+
+function buildL1ScopeSql(filter?: L1QueryFilter): {
+  clauses: string[];
+  values: string[];
+} {
+  const clauses: string[] = [];
+  const values: string[] = [];
+  if (filter?.sessionKey) {
+    clauses.push("session_key = ?");
+    values.push(filter.sessionKey);
+  }
+  if (filter?.sessionId) {
+    clauses.push("session_id = ?");
+    values.push(filter.sessionId);
+  }
+  return { clauses, values };
 }
 
 /** FTS5 search result for L1 records. */
@@ -1109,7 +1130,12 @@ export class VectorStore implements IMemoryStore {
    * **Fault-tolerant**: returns an empty array on any error (e.g. dimension
    * mismatch, corrupted DB) so callers can fall back to keyword search.
    */
-  searchL1Vector(queryEmbedding: Float32Array, topK = 5): VectorSearchResult[] {
+  searchL1Vector(
+    queryEmbedding: Float32Array,
+    topK = 5,
+    _queryText?: string,
+    filter?: L1QueryFilter,
+  ): VectorSearchResult[] {
     if (this.degraded || !this.vecTablesReady) {
       if (this.degraded) this.logger?.warn(`${TAG} [L1-search] SKIPPED (degraded mode)`);
       return [];
@@ -1123,7 +1149,9 @@ export class VectorStore implements IMemoryStore {
       // NOTE: "AND distance IS NOT NULL" is NOT usable because vec0 does not
       // support that constraint — it causes an empty result set.
       const ZERO_VEC_BUFFER = 10;
-      const retrieveCount = topK + ZERO_VEC_BUFFER;
+      const retrieveCount = hasL1ScopeFilter(filter)
+        ? Math.max(this.countL1(), topK + ZERO_VEC_BUFFER)
+        : topK + ZERO_VEC_BUFFER;
 
       this.logger?.debug?.(
         `${TAG} [L1-search] START topK=${topK}, retrieveCount=${retrieveCount}, ` +
@@ -1171,6 +1199,7 @@ export class VectorStore implements IMemoryStore {
           this.logger?.warn(`${TAG} [L1-search] record_id=${record_id} has vector but NO metadata (orphan)`);
           continue;
         }
+        if (!matchesL1ScopeFilter(meta, filter)) continue;
 
         const score = 1.0 - distance;
         this.logger?.debug?.(
@@ -2026,10 +2055,25 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL1Fts(ftsQuery: string, limit = 20): FtsSearchResult[] {
+  searchL1Fts(ftsQuery: string, limit = 20, filter?: L1QueryFilter): FtsSearchResult[] {
     if (this.degraded || !this.ftsAvailable) return [];
     try {
-      const rows = this.stmtL1FtsSearch.all(ftsQuery, limit) as Array<{
+      const scopeSql = buildL1ScopeSql(filter);
+      const rows = (scopeSql.clauses.length === 0
+        ? this.stmtL1FtsSearch.all(ftsQuery, limit)
+        : this.db
+            .prepare(`
+              SELECT record_id, content_original AS content, type, priority, scene_name,
+                     session_key, session_id, timestamp_str, timestamp_start, timestamp_end,
+                     metadata_json,
+                     bm25(l1_fts) AS rank
+              FROM l1_fts
+              WHERE l1_fts MATCH ?
+                AND ${scopeSql.clauses.join(" AND ")}
+              ORDER BY rank ASC
+              LIMIT ?
+            `)
+            .all(ftsQuery, ...scopeSql.values, limit)) as Array<{
         record_id: string;
         content: string;
         type: string;

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -98,6 +98,25 @@ function epochMsToIso(ms: number): string {
   return new Date(ms).toISOString();
 }
 
+function escapeFilterString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function buildL1FilterExpression(filter?: L1QueryFilter): string | undefined {
+  const conditions: string[] = [];
+  if (filter?.sessionKey) {
+    conditions.push(`session_key = "${escapeFilterString(filter.sessionKey)}"`);
+  }
+  if (filter?.sessionId) {
+    conditions.push(`session_id = "${escapeFilterString(filter.sessionId)}"`);
+  }
+  if (filter?.updatedAfter) {
+    const afterMs = isoToEpochMs(filter.updatedAfter);
+    if (afterMs > 0) conditions.push(`updated_time_ms > ${afterMs}`);
+  }
+  return conditions.length > 0 ? conditions.join(" and ") : undefined;
+}
+
 /**
  * Extract agent ID from a sessionKey like `agent:<agentId>:<channel>`.
  * Returns empty string if the format doesn't match.
@@ -552,15 +571,7 @@ export class TcvdbMemoryStore implements IMemoryStore {
       await this._ensureInit();
       if (this.degraded) return [];
 
-      // Build TCVDB filter expression from L1QueryFilter
-      const conditions: string[] = [];
-      if (filter?.sessionKey) conditions.push(`session_key = "${filter.sessionKey}"`);
-      if (filter?.sessionId) conditions.push(`session_id = "${filter.sessionId}"`);
-      if (filter?.updatedAfter) {
-        const afterMs = isoToEpochMs(filter.updatedAfter);
-        if (afterMs > 0) conditions.push(`updated_time_ms > ${afterMs}`);
-      }
-      const filterExpr = conditions.length > 0 ? conditions.join(" and ") : undefined;
+      const filterExpr = buildL1FilterExpression(filter);
 
       const docs = await this._queryAllDocs(
         this.l1Collection,
@@ -615,21 +626,26 @@ export class TcvdbMemoryStore implements IMemoryStore {
 
   // ── L1 Search Operations ─────────────────────────────────
 
-  async searchL1Vector(_queryEmbedding: Float32Array, topK?: number, queryText?: string): Promise<L1SearchResult[]> {
+  async searchL1Vector(
+    _queryEmbedding: Float32Array,
+    topK?: number,
+    queryText?: string,
+    filter?: L1QueryFilter,
+  ): Promise<L1SearchResult[]> {
     // TCVDB uses server-side embedding — delegate to hybrid search with text
     if (queryText) {
-      return this.searchL1HybridAsync({ queryText, topK });
+      return this.searchL1HybridAsync({ queryText, topK, filter });
     }
     // No queryText and TCVDB can't use client embeddings directly via embeddingItems
     // Return empty — callers should pass queryText for TCVDB
     return [];
   }
 
-  async searchL1Fts(ftsQuery: string, limit?: number): Promise<L1FtsResult[]> {
+  async searchL1Fts(ftsQuery: string, limit?: number, filter?: L1QueryFilter): Promise<L1FtsResult[]> {
     // TCVDB has no pure FTS — use hybrid search with sparse-only path
     // The ftsQuery is raw text, use it as queryText for hybrid
     if (!ftsQuery) return [];
-    const results = await this.searchL1HybridAsync({ queryText: ftsQuery, topK: limit });
+    const results = await this.searchL1HybridAsync({ queryText: ftsQuery, topK: limit, filter });
     // L1SearchResult and L1FtsResult have identical shapes
     return results;
   }
@@ -637,12 +653,21 @@ export class TcvdbMemoryStore implements IMemoryStore {
   async searchL1Hybrid(params: {
     query?: string;
     queryEmbedding?: Float32Array;
+    sessionId?: string;
+    sessionKey?: string;
     sparseVector?: SparseVector;
     topK?: number;
   }): Promise<L1SearchResult[]> {
     const queryText = params.query;
     if (!queryText) return [];
-    return this.searchL1HybridAsync({ queryText, topK: params.topK });
+    return this.searchL1HybridAsync({
+      queryText,
+      topK: params.topK,
+      filter: {
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      },
+    });
   }
 
   /**
@@ -650,10 +675,11 @@ export class TcvdbMemoryStore implements IMemoryStore {
    * Call this directly from async contexts (hooks, tools).
    */
   async searchL1HybridAsync(params: {
+    filter?: L1QueryFilter;
     queryText: string;
     topK?: number;
   }): Promise<L1SearchResult[]> {
-    const { queryText, topK = 10 } = params;
+    const { filter, queryText, topK = 10 } = params;
     if (!queryText) return [];
 
     try {
@@ -665,6 +691,8 @@ export class TcvdbMemoryStore implements IMemoryStore {
         limit: topK,
         outputFields: L1_OUTPUT_FIELDS,
       };
+      const filterExpr = buildL1FilterExpression(filter);
+      if (filterExpr) searchParams.filter = filterExpr;
 
       // ann: use embedding field name "text" for server-side embedding
       // (per SDK: AnnSearch(field_name="text", data='query string'))
@@ -702,6 +730,7 @@ export class TcvdbMemoryStore implements IMemoryStore {
           retrieveVector: false,
           outputFields: L1_OUTPUT_FIELDS,
         };
+        if (filterExpr) denseSearch.filter = filterExpr;
         const resp = await this.client.search(this.l1Collection, denseSearch);
         return this._parseL1SearchResults(resp.documents);
       }

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -270,11 +270,18 @@ export interface IMemoryStore {
 
   // ── L1 Search ────────────────────────────────────────────
 
-  searchL1Vector(queryEmbedding: Float32Array, topK?: number, queryText?: string): MaybePromise<L1SearchResult[]>;
-  searchL1Fts(ftsQuery: string, limit?: number): MaybePromise<L1FtsResult[]>;
+  searchL1Vector(
+    queryEmbedding: Float32Array,
+    topK?: number,
+    queryText?: string,
+    filter?: L1QueryFilter,
+  ): MaybePromise<L1SearchResult[]>;
+  searchL1Fts(ftsQuery: string, limit?: number, filter?: L1QueryFilter): MaybePromise<L1FtsResult[]>;
   searchL1Hybrid?(params: {
     query?: string;
     queryEmbedding?: Float32Array;
+    sessionId?: string;
+    sessionKey?: string;
     sparseVector?: Array<[number, number]>;
     topK?: number;
   }): MaybePromise<L1SearchResult[]>;

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -291,6 +291,8 @@ export class TdaiCore {
     const result = await executeMemorySearch({
       query: params.query,
       limit: params.limit ?? 5,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
       type: params.type,
       scene: params.scene,
       vectorStore: this.vectorStore,

--- a/src/core/tools/memory-search.test.ts
+++ b/src/core/tools/memory-search.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore, L1FtsResult, L1SearchResult } from "../store/types.js";
+import { executeMemorySearch } from "./memory-search.js";
+
+function l1Result(params: {
+  content: string;
+  recordId: string;
+  sessionId?: string;
+  sessionKey: string;
+}): L1FtsResult {
+  return {
+    content: params.content,
+    metadata_json: "{}",
+    priority: 50,
+    record_id: params.recordId,
+    scene_name: "review",
+    score: 0.9,
+    session_id: params.sessionId ?? `${params.sessionKey}:sub`,
+    session_key: params.sessionKey,
+    timestamp_end: "2026-05-16T00:00:00.000Z",
+    timestamp_start: "2026-05-16T00:00:00.000Z",
+    timestamp_str: "2026-05-16",
+    type: "preference",
+  };
+}
+
+describe("memory search scope", () => {
+  it("filters L1 FTS results by sessionKey before formatting", async () => {
+    const vectorStore = {
+      isFtsAvailable: () => true,
+      searchL1Fts: async () => [
+        l1Result({
+          content: "Refresh project prefers strict code review.",
+          recordId: "refresh-review-style",
+          sessionKey: "refresh-project",
+        }),
+        l1Result({
+          content: "Other project prefers loose review.",
+          recordId: "other-review-style",
+          sessionKey: "other-project",
+        }),
+      ],
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const result = await executeMemorySearch({
+      limit: 5,
+      query: "review style",
+      sessionKey: "refresh-project",
+      vectorStore,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.results.map((item) => item.content)).toEqual([
+      "Refresh project prefers strict code review.",
+    ]);
+  });
+
+  it("passes scope to the L1 store so filtering happens before topK truncation", async () => {
+    let observedFilter: { sessionKey?: string; sessionId?: string } | undefined;
+    const vectorStore = {
+      isFtsAvailable: () => true,
+      searchL1Fts: async (
+        _ftsQuery: string,
+        _limit?: number,
+        filter?: { sessionKey?: string; sessionId?: string },
+      ) => {
+        observedFilter = filter;
+        if (filter?.sessionKey === "refresh-project") {
+          return [
+            l1Result({
+              content: "Refresh project keeps in-scope memory after store filtering.",
+              recordId: "refresh-store-scoped",
+              sessionKey: "refresh-project",
+            }),
+          ];
+        }
+        return Array.from({ length: 20 }, (_, index) =>
+          l1Result({
+            content: `Other project memory ${index}`,
+            recordId: `other-${index}`,
+            sessionKey: "other-project",
+          }),
+        );
+      },
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const result = await executeMemorySearch({
+      limit: 5,
+      query: "store scoped",
+      sessionKey: "refresh-project",
+      vectorStore,
+    });
+
+    expect(observedFilter).toEqual({ sessionKey: "refresh-project" });
+    expect(result.total).toBe(1);
+    expect(result.results[0]?.id).toBe("refresh-store-scoped");
+  });
+
+  it("passes scope to vector L1 search before vector topK truncation", async () => {
+    let observedFilter: { sessionKey?: string; sessionId?: string } | undefined;
+    const vectorStore = {
+      isFtsAvailable: () => false,
+      searchL1Vector: async (
+        _embedding: Float32Array,
+        _limit?: number,
+        _queryText?: string,
+        filter?: { sessionKey?: string; sessionId?: string },
+      ): Promise<L1SearchResult[]> => {
+        observedFilter = filter;
+        return filter?.sessionId === "sub-1"
+          ? [
+              l1Result({
+                content: "Refresh vector memory stays scoped by session id.",
+                recordId: "refresh-vector-scoped",
+                sessionId: "sub-1",
+                sessionKey: "refresh-project",
+              }),
+            ]
+          : [];
+      },
+    } as Partial<IMemoryStore> as IMemoryStore;
+    const embeddingService = {
+      embed: async () => new Float32Array([0.1, 0.2]),
+    } as Partial<EmbeddingService> as EmbeddingService;
+
+    const result = await executeMemorySearch({
+      embeddingService,
+      limit: 5,
+      query: "vector scoped",
+      sessionId: "sub-1",
+      vectorStore,
+    });
+
+    expect(observedFilter).toEqual({ sessionId: "sub-1" });
+    expect(result.total).toBe(1);
+    expect(result.results[0]?.id).toBe("refresh-vector-scoped");
+  });
+});

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -10,7 +10,7 @@
  * The tool is registered via `api.registerTool()` in index.ts.
  */
 
-import type { IMemoryStore, L1SearchResult } from "../store/types.js";
+import type { IMemoryStore, L1QueryFilter, L1SearchResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
 
@@ -45,6 +45,26 @@ export interface MemorySearchResult {
 }
 
 const TAG = "[memory-tdai][tdai_memory_search]";
+
+function matchesL1Scope(
+  item: { session_key?: string; session_id?: string },
+  sessionKey?: string,
+  sessionId?: string,
+): boolean {
+  if (sessionKey && item.session_key !== sessionKey) return false;
+  if (sessionId && item.session_id !== sessionId) return false;
+  return true;
+}
+
+function buildL1ScopeFilter(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): L1QueryFilter | undefined {
+  const filter: L1QueryFilter = {};
+  if (params.sessionKey) filter.sessionKey = params.sessionKey;
+  if (params.sessionId) filter.sessionId = params.sessionId;
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
 
 // ============================
 // RRF (Reciprocal Rank Fusion)
@@ -88,6 +108,8 @@ function rrfMergeL1(...lists: MemorySearchResultItem[][]): MemorySearchResultIte
 export async function executeMemorySearch(params: {
   query: string;
   limit: number;
+  sessionKey?: string;
+  sessionId?: string;
   type?: string;
   scene?: string;
   vectorStore?: IMemoryStore;
@@ -97,6 +119,8 @@ export async function executeMemorySearch(params: {
   const {
     query,
     limit,
+    sessionKey,
+    sessionId,
     type: typeFilter,
     scene: sceneFilter,
     vectorStore,
@@ -106,6 +130,7 @@ export async function executeMemorySearch(params: {
 
   logger?.debug?.(
     `${TAG} CALLED: query="${query.slice(0, 100)}", limit=${limit}, ` +
+    `sessionKey=${sessionKey ?? "(all)"}, sessionId=${sessionId ?? "(all)"}, ` +
     `typeFilter=${typeFilter ?? "(none)"}, sceneFilter=${sceneFilter ?? "(none)"}, ` +
     `vectorStore=${vectorStore ? "available" : "UNAVAILABLE"}, ` +
     `embeddingService=${embeddingService ? "available" : "UNAVAILABLE"}`,
@@ -124,6 +149,7 @@ export async function executeMemorySearch(params: {
   // ── Determine available capabilities ──
   const hasEmbedding = !!embeddingService;
   const hasFts = vectorStore.isFtsAvailable();
+  const scopeFilter = buildL1ScopeFilter({ sessionKey, sessionId });
 
   if (!hasEmbedding && !hasFts) {
     logger?.warn?.(`${TAG} Neither EmbeddingService nor FTS5 available — cannot search`);
@@ -153,9 +179,9 @@ export async function executeMemorySearch(params: {
           return [];
         }
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 query: "${ftsQuery}"`);
-        const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+        const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK, scopeFilter);
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 returned ${ftsResults.length} candidates`);
-        return ftsResults.map((r) => ({
+        return ftsResults.filter((r) => matchesL1Scope(r, sessionKey, sessionId)).map((r) => ({
           id: r.record_id,
           content: r.content,
           type: r.type,
@@ -182,9 +208,14 @@ export async function executeMemorySearch(params: {
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, candidateK, query);
+        const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(
+          queryEmbedding,
+          candidateK,
+          query,
+          scopeFilter,
+        );
         logger?.debug?.(`${TAG} [hybrid-vec] Vector search returned ${vecResults.length} candidates`);
-        return vecResults.map((r) => ({
+        return vecResults.filter((r) => matchesL1Scope(r, sessionKey, sessionId)).map((r) => ({
           id: r.record_id,
           content: r.content,
           type: r.type,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -229,6 +229,8 @@ export interface CaptureResult {
 export interface MemorySearchParams {
   query: string;
   limit?: number;
+  sessionKey?: string;
+  sessionId?: string;
   type?: string;
   scene?: string;
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -290,6 +290,8 @@ export class TdaiGateway {
     const result = await this.core.searchMemories({
       query: body.query,
       limit: body.limit,
+      sessionKey: body.session_key,
+      sessionId: body.session_id,
       type: body.type,
       scene: body.scene,
     });

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -66,6 +66,8 @@ export interface CaptureResponse {
 export interface MemorySearchRequest {
   query: string;
   limit?: number;
+  session_key?: string;
+  session_id?: string;
   type?: string;
   scene?: string;
 }


### PR DESCRIPTION
## Description | 描述

Make L1 memory search scope filters apply before result truncation:

- accept `sessionKey` / `sessionId` in `searchMemories()` and Gateway `/search/memories`
- pass scope filters through the L1 store interfaces
- apply SQLite FTS filters in SQL and vector filters before final topK results are returned
- apply TCVDB filters through the query filter expression
- keep a caller-side scope check as a final defense
- add regression coverage for vector and FTS paths where unscoped topK truncation could otherwise hide in-scope memories

This is a general shared-backend correctness fix. It is not tied to any specific downstream host.

## Related Issue | 关联 Issue

None.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Local verification:

- `npm test -- src/core/tools/memory-search.test.ts`
- `npm test`
- `npm run build:plugin`
- `git diff --cached --check` before commit
