### PR TITLE
fix(offload): preserve non-BMP characters in sanitizeText

### DIFF
--- a/src/offload/storage.test.ts
+++ b/src/offload/storage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeText } from "./storage.js";
+
+describe("sanitizeText", () => {
+  it("preserves plain ASCII", () => {
+    expect(sanitizeText("hello world")).toBe("hello world");
+  });
+
+  it("preserves emoji and other non-BMP code points", () => {
+    // 🎉 = U+1F389, 𠮷 = U+20BB7 (CJK Extension B), 𝐀 = U+1D400 (math bold A).
+    // Each is a surrogate pair in UTF-16. Without the `u` flag, the
+    // [\uD800-\uDFFF] range in UNSAFE_CHAR_RE would strip each half
+    // independently and silently destroy these characters.
+    expect(sanitizeText("emoji \u{1F389} here")).toBe("emoji \u{1F389} here");
+    expect(sanitizeText("CJK ext-B \u{20BB7} here")).toBe(
+      "CJK ext-B \u{20BB7} here",
+    );
+    expect(sanitizeText("math bold \u{1D400} here")).toBe(
+      "math bold \u{1D400} here",
+    );
+  });
+
+  it("strips lone (malformed) surrogates", () => {
+    expect(sanitizeText("lone \uD800 surrogate")).toBe("lone  surrogate");
+    expect(sanitizeText("lone \uDC00 surrogate")).toBe("lone  surrogate");
+  });
+
+  it("strips C0 and C1 control characters", () => {
+    expect(sanitizeText("ctrlhere")).toBe("ctrlhere");
+    expect(sanitizeText("c1here")).toBe("c1here");
+  });
+
+  it("strips zero-width characters and BOM", () => {
+    expect(sanitizeText("a​b")).toBe("ab");
+    expect(sanitizeText("a﻿b")).toBe("ab");
+  });
+
+  it("returns non-string input unchanged", () => {
+    // Matches the existing typeof guard in sanitizeText.
+    expect(sanitizeText(42 as unknown as string)).toBe(42);
+  });
+});

--- a/src/offload/storage.ts
+++ b/src/offload/storage.ts
@@ -162,7 +162,7 @@ export async function listRegisteredSessions(
 // ─── JSONL Defense Layer ─────────────────────────────────────────────────────
 
 const UNSAFE_CHAR_RE =
-  /[\uFFFD\u0000-\u0008\u000B\u000C\u000E-\u001F\u0080-\u009F\uD800-\uDFFF\u200B-\u200F\u2028\u2029\uFEFF]/g;
+  /[\uFFFD\u0000-\u0008\u000B\u000C\u000E-\u001F\u0080-\u009F\uD800-\uDFFF\u200B-\u200F\u2028\u2029\uFEFF]/gu;
 
 /** Layer 0 — Source text sanitize. Strips unsafe characters from arbitrary text. */
 export function sanitizeText(text: string): string {


### PR DESCRIPTION
`UNSAFE_CHAR_RE` at `src/offload/storage.ts:165` includes the full surrogate range `[\uD800-\uDFFF]` but is not declared with the `u` flag. Without `u`, JS regexes treat strings as UTF-16 code units, so every well-formed non-BMP code point (emoji, CJK Extension B, math bold, etc.) is a surrogate pair whose halves get stripped individually. `sanitizeText`, `sanitizeJsonLine`, and `parseJsonlSafe` therefore silently destroy these characters in tool params, tool results, and ref-md archives.

Reproduction with the exact regex copied from the file:

```
$ node -e '
const re = /[�---\uD800-\uDFFF​-‏  ﻿]/g;
console.log(JSON.stringify("CJK ext-B \u{20BB7} here".replace(re, "")));'
"CJK ext-B  here"
```

The 𠮷 (U+20BB7) is gone. Same problem for 🎉, 𝐀, and every other supplementary character.

Fix: add the `u` flag. With `u`, the surrogate range only matches lone (malformed) surrogates, which is the original intent. Well-formed pairs are treated as single code points and pass through.

Other entries in the class (replacement char, C0/C1 controls, zero-width chars, line separators, BOM) keep their behavior.

Added `src/offload/storage.test.ts` with six cases:
- plain ASCII survives
- emoji, CJK Extension B, math bold survive
- lone surrogates still stripped
- C0 and C1 controls still stripped
- zero-width and BOM still stripped
- non-string input passes through (existing typeof guard)

On main the non-BMP test fails (`expected 'emoji  here' to be 'emoji 🎉 here'`); with the fix all six pass.

Files touched:
- `src/offload/storage.ts`: one-character change (`/g` -> `/gu`).
- `src/offload/storage.test.ts`: new file, no runtime/network/db dependency.

Closes #30
