### PR TITLE
fix(offload): enable TLS verification by default; add env opt-out + CA path

### DIFF
--- a/src/offload/__tests__/backend-client-tls.test.ts
+++ b/src/offload/__tests__/backend-client-tls.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BackendClient } from "../backend-client.js";
+import type { PluginLogger } from "../types.js";
+
+function createSpyLogger(): {
+  logger: PluginLogger;
+  warnCalls: string[];
+  infoCalls: string[];
+  errorCalls: string[];
+  debugCalls: string[];
+} {
+  const warnCalls: string[] = [];
+  const infoCalls: string[] = [];
+  const errorCalls: string[] = [];
+  const debugCalls: string[] = [];
+  const logger: PluginLogger = {
+    debug: (msg: string) => debugCalls.push(msg),
+    info: (msg: string) => infoCalls.push(msg),
+    warn: (msg: string) => warnCalls.push(msg),
+    error: (msg: string) => errorCalls.push(msg),
+  };
+  return { logger, warnCalls, infoCalls, errorCalls, debugCalls };
+}
+
+// Reach into the private `tlsOptions` field for assertions.
+function tlsOptionsOf(client: BackendClient): { rejectUnauthorized?: boolean; ca?: Buffer } {
+  return (client as unknown as { tlsOptions: { rejectUnauthorized?: boolean; ca?: Buffer } })
+    .tlsOptions;
+}
+
+describe("BackendClient TLS options", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-tls-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("defaults to secure TLS (no opts injected) when neither env var is set", () => {
+    const { logger, warnCalls, infoCalls } = createSpyLogger();
+    const client = new BackendClient("https://backend.example.com", logger, "test-key");
+    const opts = tlsOptionsOf(client);
+
+    // No overrides means we let node:https default to its system-trust-store
+    // behaviour (rejectUnauthorized: true). We explicitly do NOT set the field
+    // — that way a caller that *also* wanted to override gets the most natural
+    // composition.
+    expect(opts.rejectUnauthorized).toBeUndefined();
+    expect(opts.ca).toBeUndefined();
+    expect(warnCalls).toHaveLength(0);
+    // No info either — silent secure default.
+    expect(infoCalls.filter((m) => m.includes("CA"))).toHaveLength(0);
+  });
+
+  it("disables verification when TDAI_OFFLOAD_INSECURE_TLS=1 and emits a loud warning", () => {
+    vi.stubEnv("TDAI_OFFLOAD_INSECURE_TLS", "1");
+    const { logger, warnCalls } = createSpyLogger();
+    const client = new BackendClient("https://backend.example.com", logger, "test-key");
+    const opts = tlsOptionsOf(client);
+
+    expect(opts.rejectUnauthorized).toBe(false);
+    expect(opts.ca).toBeUndefined();
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]).toMatch(/TDAI_OFFLOAD_INSECURE_TLS=1/);
+    expect(warnCalls[0]).toMatch(/DISABLED/);
+    // Steer the operator toward the safer alternative.
+    expect(warnCalls[0]).toMatch(/TDAI_OFFLOAD_CA_PEM_PATH/);
+  });
+
+  it("ignores TDAI_OFFLOAD_INSECURE_TLS values other than the literal '1'", () => {
+    for (const v of ["true", "yes", "0", "", "1 "]) {
+      vi.stubEnv("TDAI_OFFLOAD_INSECURE_TLS", v);
+      const { logger, warnCalls } = createSpyLogger();
+      const client = new BackendClient("https://backend.example.com", logger, "test-key");
+      const opts = tlsOptionsOf(client);
+      expect(opts.rejectUnauthorized, `value=${JSON.stringify(v)}`).toBeUndefined();
+      expect(warnCalls, `value=${JSON.stringify(v)}`).toHaveLength(0);
+    }
+  });
+
+  it("loads CA bytes when TDAI_OFFLOAD_CA_PEM_PATH points at a readable file", () => {
+    const caPath = path.join(tmpDir, "ca.pem");
+    const caBytes = Buffer.from(
+      "-----BEGIN CERTIFICATE-----\nFAKE_PEM_BYTES_FOR_TEST\n-----END CERTIFICATE-----\n",
+    );
+    fs.writeFileSync(caPath, caBytes);
+    vi.stubEnv("TDAI_OFFLOAD_CA_PEM_PATH", caPath);
+
+    const { logger, warnCalls, infoCalls } = createSpyLogger();
+    const client = new BackendClient("https://backend.example.com", logger, "test-key");
+    const opts = tlsOptionsOf(client);
+
+    expect(opts.ca?.equals(caBytes)).toBe(true);
+    expect(opts.rejectUnauthorized).toBeUndefined(); // CA load alone does NOT disable verification
+    expect(warnCalls).toHaveLength(0);
+    expect(infoCalls.some((m) => m.includes(caPath))).toBe(true);
+  });
+
+  it("warns but does not throw when TDAI_OFFLOAD_CA_PEM_PATH points at a missing file", () => {
+    const caPath = path.join(tmpDir, "does-not-exist.pem");
+    vi.stubEnv("TDAI_OFFLOAD_CA_PEM_PATH", caPath);
+
+    const { logger, warnCalls } = createSpyLogger();
+    // Construction must not throw — a misconfigured CA path should degrade
+    // gracefully to "use system trust store" rather than break the daemon.
+    expect(() => new BackendClient("https://backend.example.com", logger, "test-key")).not.toThrow();
+    const client = new BackendClient("https://backend.example.com", logger, "test-key");
+    const opts = tlsOptionsOf(client);
+
+    expect(opts.ca).toBeUndefined();
+    expect(warnCalls.some((m) => m.includes(caPath))).toBe(true);
+    expect(warnCalls.some((m) => m.includes("Falling back to system trust store"))).toBe(true);
+  });
+
+  it("combines INSECURE_TLS=1 and CA_PEM_PATH (insecure wins; CA still loaded for completeness)", () => {
+    const caPath = path.join(tmpDir, "ca.pem");
+    const caBytes = Buffer.from("PEM");
+    fs.writeFileSync(caPath, caBytes);
+    vi.stubEnv("TDAI_OFFLOAD_INSECURE_TLS", "1");
+    vi.stubEnv("TDAI_OFFLOAD_CA_PEM_PATH", caPath);
+
+    const { logger, warnCalls, infoCalls } = createSpyLogger();
+    const client = new BackendClient("https://backend.example.com", logger, "test-key");
+    const opts = tlsOptionsOf(client);
+
+    expect(opts.rejectUnauthorized).toBe(false);
+    expect(opts.ca?.equals(caBytes)).toBe(true);
+    // Both signals surface to the operator.
+    expect(warnCalls.some((m) => m.includes("TDAI_OFFLOAD_INSECURE_TLS"))).toBe(true);
+    expect(infoCalls.some((m) => m.includes(caPath))).toBe(true);
+  });
+
+  it("resolves TLS options once at construction (no per-request env re-read)", () => {
+    // No env set at construction time.
+    const { logger } = createSpyLogger();
+    const client = new BackendClient("https://backend.example.com", logger, "test-key");
+    expect(tlsOptionsOf(client).rejectUnauthorized).toBeUndefined();
+
+    // Later changes to env must NOT retroactively affect the existing instance.
+    // (Construction-time resolution gives a stable, auditable security posture
+    // for the lifetime of the daemon.)
+    vi.stubEnv("TDAI_OFFLOAD_INSECURE_TLS", "1");
+    expect(tlsOptionsOf(client).rejectUnauthorized).toBeUndefined();
+  });
+});

--- a/src/offload/backend-client.ts
+++ b/src/offload/backend-client.ts
@@ -12,6 +12,7 @@ import type { OffloadEntry, ToolPair, TaskJudgment, PluginLogger } from "./types
 import { traceOffloadModelIo } from "./opik-tracer.js";
 import * as https from "node:https";
 import * as http from "node:http";
+import * as fs from "node:fs";
 
 // ─── Request / Response Types ────────────────────────────────────────────────
 
@@ -114,6 +115,18 @@ export class BackendClient {
   private userIdFn: () => string | null;
   /** Resolves the value of the `X-Task-Id` header sent on every call (optional). */
   private taskIdFn: () => string | null;
+  /**
+   * TLS options for HTTPS requests, resolved once at construction. Defaults
+   * are *secure* (full chain validation against the system trust store).
+   * Two env-driven overrides:
+   *   - `TDAI_OFFLOAD_INSECURE_TLS=1`     → set `rejectUnauthorized: false`
+   *     (development / private self-signed backends only; a warning is logged
+   *     on construction so the operator notices it in stderr).
+   *   - `TDAI_OFFLOAD_CA_PEM_PATH=<path>` → load a custom CA certificate so
+   *     a self-signed backend can be trusted *without* disabling validation.
+   *     Mirrors the `caPemPath` option on `src/core/store/tcvdb-client.ts`.
+   */
+  private tlsOptions: { rejectUnauthorized?: boolean; ca?: Buffer };
 
   constructor(
     baseUrl: string,
@@ -130,6 +143,34 @@ export class BackendClient {
     this.sessionKeyFn = sessionKeyFn ?? (() => null);
     this.userIdFn = userIdFn ?? (() => null);
     this.taskIdFn = taskIdFn ?? (() => null);
+    this.tlsOptions = this.resolveTlsOptions();
+  }
+
+  private resolveTlsOptions(): { rejectUnauthorized?: boolean; ca?: Buffer } {
+    const opts: { rejectUnauthorized?: boolean; ca?: Buffer } = {};
+    if (process.env.TDAI_OFFLOAD_INSECURE_TLS === "1") {
+      opts.rejectUnauthorized = false;
+      this.logger.warn(
+        `[context-offload] TDAI_OFFLOAD_INSECURE_TLS=1: TLS certificate validation is DISABLED. ` +
+          `This is only safe for development against private/self-signed backends — never use in production. ` +
+          `Prefer TDAI_OFFLOAD_CA_PEM_PATH=<path-to-ca.pem> to trust a specific self-signed CA instead.`,
+      );
+    }
+    const caPath = process.env.TDAI_OFFLOAD_CA_PEM_PATH;
+    if (caPath) {
+      try {
+        opts.ca = fs.readFileSync(caPath);
+        this.logger.info(
+          `[context-offload] loaded CA certificate from TDAI_OFFLOAD_CA_PEM_PATH=${caPath}`,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `[context-offload] failed to load CA from TDAI_OFFLOAD_CA_PEM_PATH=${caPath}: ` +
+            `${err instanceof Error ? err.message : String(err)}. Falling back to system trust store.`,
+        );
+      }
+    }
+    return opts;
   }
 
   /** L1 Summarize — synchronous await (used by assemble flush + force trigger) */
@@ -309,7 +350,7 @@ export class BackendClient {
           path: parsed.pathname + parsed.search,
           method: "POST",
           headers: reqHeaders,
-          ...(isHttps ? { rejectUnauthorized: false } : {}),
+          ...(isHttps ? this.tlsOptions : {}),
         },
         (res) => {
           let data = "";


### PR DESCRIPTION
## Summary | 摘要

Fix CWE-295 (Improper Certificate Validation) in the offload backend client. Closes #8.

修复 #8 报告的 offload backend client TLS 校验绕过（CWE-295）。

## Background | 背景

`src/offload/backend-client.ts` 之前在每次 HTTPS 请求中无条件传入 `rejectUnauthorized: false`：

```typescript
// before
const req = transport.request(
  {
    hostname: parsed.hostname,
    port: parsed.port || (isHttps ? 443 : 80),
    path: parsed.pathname + parsed.search,
    method: "POST",
    headers: reqHeaders,
    ...(isHttps ? { rejectUnauthorized: false } : {}),
  },
```

任何在网络路径上的 MITM 都能：
- 读取 L1/L1.5/L2/L4 工具调用摘要 + 完整 task 历史
- 读取 `Authorization: Bearer <apiKey>` 头
- 读取 `X-User-Id` / `X-Task-Id` 身份头
- **篡改 backend 响应** —— L1/L2/L4 输出会被写入用户数据目录，构成 memory poisoning 向量

`src/core/store/tcvdb-client.ts` 已经做对了（用 `caPemPath` 加载自签 CA）—— backend-client 的 `rejectUnauthorized: false` 是历史遗留 oversight。

## Fix | 修复

将默认值回到 *secure*（用系统 trust store 做完整链校验），通过两个环境变量提供 opt-in：

| 环境变量 | 行为 |
|---|---|
| `TDAI_OFFLOAD_INSECURE_TLS=1` | 关闭 `rejectUnauthorized`。构造时打 loud warn，确保运维不会无意中带到生产。仅用于本地开发对接自签 backend。 |
| `TDAI_OFFLOAD_CA_PEM_PATH=<path>` | 加载自签 CA 证书，让自签 backend 在 **不关闭校验** 的前提下被信任。命名与 `tcvdb-client.ts` 的 `caPemPath` 一致。 |

两个值都在 `BackendClient` constructor 内解析一次并缓存到 `this.tlsOptions`，请求 hot path 不再读 env，daemon 生命周期内的 TLS 立场稳定可审计。

CA 文件不存在 / 读不了时退回系统 trust store + warn，**不会** 让 daemon 启动失败。

## Tests | 测试

新建 `src/offload/__tests__/backend-client-tls.test.ts`（7 cases）：

1. ✅ 默认（无 env）→ secure（不注入任何 TLS option）
2. ✅ `TDAI_OFFLOAD_INSECURE_TLS=1` → `rejectUnauthorized: false` + warn
3. ✅ `TDAI_OFFLOAD_INSECURE_TLS` 非 `"1"` 字面值（`"true"`/`"yes"`/`"0"`/空/带空格）→ 忽略，保持 secure
4. ✅ `TDAI_OFFLOAD_CA_PEM_PATH=<readable>` → 加载 CA 字节到 `tlsOptions.ca`，info 日志，不关校验
5. ✅ `TDAI_OFFLOAD_CA_PEM_PATH=<不存在>` → warn + 退回系统 trust store，构造不抛
6. ✅ 两个 env 同时设 → INSECURE 与 CA 都生效，操作员同时看到两条日志
7. ✅ 构造时解析（后续修改 env 不影响已 new 出来的实例）

```
✓ npx vitest run src/offload  → 7/7 passed
```

## Out of scope | 范围外

- 与 `tcvdb-client.ts` 的 TLS 处理风格统一（迁移到 undici Agent）—— 当前 backend-client 用原生 `https` 模块，重写 transport 风险大，保留原 transport 仅在 options 上加 TLS 字段
- 配置项走 `BackendClient` constructor 参数 —— constructor 签名是 positional，加参数破坏 backward compat，env 路径更稳

## DCO

Commit `de35946` 带 `Signed-off-by: 李冠辰 <liguanchen@xiaomi.com>`。