### PR TITLE
fix(plugin): make before_message_write hook a no-op by default (cache-friendly)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,55 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 
+/**
+ * Inspect a message that the OpenClaw runtime is about to persist to the
+ * session JSONL via `before_message_write`.
+ *
+ * Return `null` to leave the message unchanged, or `{ content }` to signal
+ * the new content. The caller (the `before_message_write` hook wrapper) is
+ * responsible for re-wrapping the result into the OpenClaw return shape:
+ * `{ message: { ...event.message, content } }`. Keeping the helper's
+ * return shape minimal makes it trivially testable in isolation.
+ *
+ * Default: returns `null` (preserves `<relevant-memories>` blocks in the
+ * transcript so the LLM prompt prefix stays stable across sub-agent /
+ * replay boundaries — see issue #11).
+ *
+ * Opt-in to the legacy strip behavior with
+ * `TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE=1`.
+ */
+export function maybeStripRelevantMemoriesOnWrite(
+  message: { role?: string; content?: unknown },
+): { content: unknown } | null {
+  if (process.env.TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE !== "1") return null;
+  if (message.role !== "user") return null;
+
+  const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+  if (typeof message.content === "string") {
+    if (!message.content.includes("<relevant-memories>")) return null;
+    const cleaned = message.content.replace(STRIP_RE, "").trim();
+    if (cleaned === message.content) return null;
+    return { content: cleaned };
+  }
+
+  if (Array.isArray(message.content)) {
+    let changed = false;
+    const cleanedParts = (message.content as Array<Record<string, unknown>>).map((part) => {
+      if (part.type !== "text" || typeof part.text !== "string") return part;
+      if (!(part.text as string).includes("<relevant-memories>")) return part;
+      const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
+      if (cleaned === part.text) return part;
+      changed = true;
+      return { ...part, text: cleaned };
+    });
+    if (!changed) return null;
+    return { content: cleanedParts };
+  }
+
+  return null;
+}
+
 const TAG = "[memory-tdai]";
 
 /**
@@ -583,42 +632,25 @@ export default function register(api: OpenClawPluginApi) {
     });
   }
 
-  // Strip <relevant-memories> from user messages before they are persisted to
-  // the session JSONL.  The current-turn LLM already saw the full prompt
-  // (effectivePrompt lives in memory), but we don't want recall artifacts
-  // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
+  // Conditionally strip <relevant-memories> from user messages before they
+  // are persisted to the session JSONL. Default is no-op so the LLM prompt
+  // prefix stays stable across sub-agent / replay boundaries; set
+  // TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE=1 to restore the previous
+  // unconditional strip behavior. See issue #11 and the
+  // `maybeStripRelevantMemoriesOnWrite` helper above for details.
+  api.logger.debug?.(
+    `${TAG} Registering before_message_write hook (default no-op; ` +
+      `set TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE=1 to strip <relevant-memories> on write)`,
+  );
   api.on("before_message_write", (event) => {
-    const msg = event.message as { role?: string; content?: unknown };
-    const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
-    api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
-
-    if (msg.role !== "user") return;
-
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
-    }
-
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
+    const replacement = maybeStripRelevantMemoriesOnWrite(
+      event.message as { role?: string; content?: unknown },
+    );
+    if (!replacement) return;
+    api.logger.debug?.(
+      `${TAG} [before_message_write] Stripped <relevant-memories> (legacy mode)`,
+    );
+    return { message: { ...event.message, ...replacement } as typeof event.message };
   });
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule

--- a/src/__tests__/before-message-write.test.ts
+++ b/src/__tests__/before-message-write.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { maybeStripRelevantMemoriesOnWrite } from "../../index.js";
+
+describe("maybeStripRelevantMemoriesOnWrite", () => {
+  it("returns null when TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE is unset", () => {
+    const msg = {
+      role: "user",
+      content: "hello <relevant-memories>foo</relevant-memories> world",
+    };
+    expect(maybeStripRelevantMemoriesOnWrite(msg)).toBeNull();
+  });
+
+  it("strips <relevant-memories> from string content when env=1", () => {
+    vi.stubEnv("TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE", "1");
+    const msg = {
+      role: "user",
+      content:
+        "hello <relevant-memories>foo bar baz</relevant-memories> world",
+    };
+    const result = maybeStripRelevantMemoriesOnWrite(msg);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe("hello world");
+  });
+
+  it("strips <relevant-memories> from one part of array content when env=1", () => {
+    vi.stubEnv("TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE", "1");
+    const msg = {
+      role: "user",
+      content: [
+        { type: "text", text: "before <relevant-memories>x</relevant-memories>" },
+        { type: "image", url: "https://example.com/cat.png" },
+        { type: "text", text: "after (no memories here)" },
+      ],
+    };
+    const result = maybeStripRelevantMemoriesOnWrite(msg);
+    expect(result).not.toBeNull();
+    const parts = result!.content as Array<{ type: string; text?: string; url?: string }>;
+    expect(parts).toHaveLength(3);
+    expect(parts[0].text).toBe("before");
+    expect(parts[1].url).toBe("https://example.com/cat.png");
+    expect(parts[2].text).toBe("after (no memories here)");
+  });
+
+  it("does not touch assistant-role messages even when env=1", () => {
+    vi.stubEnv("TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE", "1");
+    const msg = {
+      role: "assistant",
+      content: "ok <relevant-memories>x</relevant-memories>",
+    };
+    expect(maybeStripRelevantMemoriesOnWrite(msg)).toBeNull();
+  });
+
+  it("returns null when user message has no <relevant-memories> tag (env=1)", () => {
+    vi.stubEnv("TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE", "1");
+    const msg = { role: "user", content: "just a plain message" };
+    expect(maybeStripRelevantMemoriesOnWrite(msg)).toBeNull();
+  });
+
+  it.each(["true", "yes", "0", "1 ", "", "TRUE"])(
+    "treats env=%j (anything but literal '1') as unset",
+    (envValue) => {
+      vi.stubEnv("TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE", envValue);
+      const msg = {
+        role: "user",
+        content: "<relevant-memories>x</relevant-memories>",
+      };
+      expect(maybeStripRelevantMemoriesOnWrite(msg)).toBeNull();
+    },
+  );
+});


### PR DESCRIPTION
## Summary | 摘要

`before_message_write` hook 默认改为 no-op，恢复 LLM prompt cache 在 sub-agent / replay 边界上的命中。原剥离行为保留为 `TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE=1` 的 opt-in。Closes #11.

Default `before_message_write` to no-op for `<relevant-memories>` stripping so the LLM prompt prefix stays stable across sub-agent / replay boundaries. Legacy strip behavior is preserved behind an opt-in env var. Closes #11.

## Root cause

`index.ts:591` 的 hook 把 user message 里的 `<relevant-memories>` 块剥离再写 session JSONL。hook 注释里写它有两层用意：

1. 让 transcript 干净（不让 replay 看到召回 artifact）
2. 防 L0 反馈循环（防止召回内容被 L0 当作"用户原话"再次录入）

但 (2) 已经被 `src/core/conversation/l0-recorder.ts:254` 上的 `sanitizeText()` 独立完成 —— 每条 L0-bound message 都会经过 `sanitizeText`，它会剥离 `<relevant-memories>`（以及其他几个 injected tag）。所以 hook 那次剥离严格是为 (1)，**也是 #11 cache miss 的唯一来源**。

## Fix

- **新默认**：hook 不再剥离 `<relevant-memories>`，user message 完整写入 session JSONL → sub-agent / replay 重读 transcript 时跟 in-memory `effectivePrompt` 前缀对齐 → LLM cache 命中。
- **旧行为回退**：`TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE=1` 一键恢复剥离。env 在每次 hook 触发时读取，运行时切换不需要重启 host。
- **不变**：
  - `auto-recall.ts` 仍注入 `<relevant-memories>` 到当前轮 user message
  - `l0-recorder.ts` 的 `sanitizeText` 仍在 L0 录入时剥离 memories（真正的反馈循环防御）
  - `sanitize.ts` 自身

## Theoretical cache-hit model

N 轮对话，每轮 user message 含 1-3 KB `<relevant-memories>` 块。Sub-agent / replay 路径：

| Strip behavior | LLM sees on turn N+1 | Cache prefix vs in-memory turn N |
| --- | --- | --- |
| Strip (current) | User msgs 1..N *without* memories | Differs in every user msg → miss |
| Don't strip (new) | User msgs 1..N *with* original memories | Identical → prefix cache hit |

Don't-strip cost：N × (1-3 KB) 额外 tokens。N ≤ 30、memories ≤ 3 KB 时 ≤ 90 KB ≈ 25 K tokens，远小于现代 context window 上限（128 K – 1 M），也明显小于 first-token cache miss 带来的延迟与单价损失（典型 cache hit 是 ~0.1× cost）。

## Refactor

把 hook callback 抽成 export 的纯函数 `maybeStripRelevantMemoriesOnWrite(message)`，hook 注册改为一行 wrapper。让 helper 可以脱离 OpenClaw runtime 独立单测，且 hook 的语义（"看 message 决定要不要替换 content"）跟 helper 签名 (`{ content } | null`) 一一对应。

## Tests

新建 `src/__tests__/before-message-write.test.ts` (main 上还没有 src 测试，跟 #39 / #42 / #51 同套路），11 个 cases：

| # | 场景 | 期望 |
| - | --- | --- |
| 1 | env 未设 + user msg 含 memories | helper 返回 `null` |
| 2 | `env=1` + string content + 含 memories | 剥离 |
| 3 | `env=1` + parts content + 某 part 含 memories | 仅剥离该 part |
| 4 | `env=1` + role=assistant + 含 memories | 不动 |
| 5 | `env=1` + user msg 无 memories tag | 返回 `null` |
| 6 | env 为 `"true"` / `"yes"` / `"0"` / `"1 "` / `""` / `"TRUE"`（非字面值 `"1"`） | 视为未设 → 返回 `null`（it.each 6 rows） |

```
✓ npx vitest run src/__tests__/before-message-write.test.ts → 11/11 passed
```

## Compatibility

- **Hermes plugin path**：不受影响。Hermes 通过 Gateway HTTP `/recall` 拿召回内容，自己拼 prompt，不走 OpenClaw `before_message_write` hook。
- **Claude Code plugin path**：不受影响。cc plugin 通过 `additionalContext` 在 cc 的 `UserPromptSubmit` hook 里注入召回，跟 OpenClaw hook 完全独立。
- **依赖 transcript 干净度的 OpenClaw 用户**（log shipping / audit / 独立 replay 工具）：设 `TDAI_STRIP_RELEVANT_MEMORIES_ON_WRITE=1` 恢复旧行为。

## Out of scope

- 真实 LLM cache 命中率测量 —— 没有 representative CI 环境；理论模型如上，腾讯团队若想 A/B 在合并前自行验证。
- per-turn 精细化剥离（"只剥离非最近一轮 memories"）—— 当前 OpenClaw hook 接口看不到 history，无法实现。
- L0 capture 路径改动 —— 已经正确。

## DCO

Commit 带 `Signed-off-by: 李冠辰 <liguanchen@xiaomi.com>`。