### PR TITLE
fix(hermes-plugin): fall back to agent_identity when no gateway user_id

### DIFF
--- a/hermes-plugin/conftest.py
+++ b/hermes-plugin/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest fixtures / sys.modules stubs for memory_tencentdb plugin tests.
+
+The plugin's ``__init__.py`` imports ``agent.memory_provider.MemoryProvider``,
+which only exists inside a hermes-agent checkout. When tests are run
+standalone from this plugin repo (e.g. plugin CI, contributor running
+``pytest`` from the plugin root), pytest's collection still imports the
+package's ``__init__.py`` to resolve ``tests`` as a sub-package — even when
+the individual test file itself doesn't touch ``MemoryProvider``.
+
+To let pure-function tests (like ``test_resolve_user_id``) run without a
+sibling hermes-agent checkout, we stub the ``agent.memory_provider`` module
+with a no-op placeholder *only when the real module is not already
+importable*. In a hermes-agent checkout (production / integration tests),
+the real ``MemoryProvider`` is on sys.path first and the stub is skipped.
+"""
+
+import sys
+
+try:
+    import agent.memory_provider  # noqa: F401
+except ImportError:
+    import types
+
+    _agent_module = types.ModuleType("agent")
+    _provider_module = types.ModuleType("agent.memory_provider")
+
+    # Bare base class is enough — pure-function tests don't instantiate the
+    # provider; integration tests that do should run against a real
+    # hermes-agent checkout where this stub is bypassed.
+    class _StubMemoryProvider:
+        pass
+
+    _provider_module.MemoryProvider = _StubMemoryProvider
+    _agent_module.memory_provider = _provider_module
+
+    sys.modules.setdefault("agent", _agent_module)
+    sys.modules.setdefault("agent.memory_provider", _provider_module)

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 
+from ._identity import resolve_user_id
 from .client import MemoryTencentdbSdkClient
 from .supervisor import GatewaySupervisor
 
@@ -702,7 +703,7 @@ class MemoryTencentdbProvider(MemoryProvider):
             Gateway is ready.
         """
         self._session_id = session_id
-        self._user_id = kwargs.get("user_id", "default")
+        self._user_id = resolve_user_id(kwargs)
 
         host = _resolve_gateway_host()
         port = _resolve_gateway_port()

--- a/hermes-plugin/memory/memory_tencentdb/_identity.py
+++ b/hermes-plugin/memory/memory_tencentdb/_identity.py
@@ -1,0 +1,43 @@
+"""Pure-Python identity resolution helpers for the memory-tencentdb provider.
+
+Kept in a standalone module so the helpers can be unit-tested without
+importing ``__init__.py`` (which depends on ``agent.memory_provider`` — only
+present inside a hermes-agent checkout).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def resolve_user_id(kwargs: Dict[str, Any]) -> str:
+    """Resolve the per-session ``user_id`` from Hermes ``initialize`` kwargs.
+
+    Hermes passes two relevant identity kwargs to memory providers:
+
+      * ``user_id`` — set by gateway-style integrations (Telegram, Discord, …)
+        where each end-user has their own scope.
+      * ``agent_identity`` — set by the CLI when a profile is in use, e.g.
+        ``hermes --profile work`` → ``agent_identity="work"``. See Hermes
+        ``run_agent.py`` (``_init_kwargs["agent_identity"] = _profile``).
+
+    Falling back to a single hardcoded ``"default"`` ignored ``agent_identity``
+    entirely, causing every CLI profile to share the same memory pool — see
+    https://github.com/Tencent/TencentDB-Agent-Memory/issues/15.
+
+    Priority (first non-empty wins, otherwise ``"default"``):
+
+      1. ``user_id`` — preserves the multi-user isolation already used by
+         gateway integrations.
+      2. ``agent_identity`` — new: gives ``--profile`` users separate scopes.
+      3. ``"default"`` — historical fallback for the bare CLI invocation.
+
+    Empty strings are treated as "not set" so a deliberate ``user_id=""`` from
+    a misconfigured gateway falls through to ``agent_identity`` rather than
+    silently overriding it.
+    """
+    return (
+        kwargs.get("user_id")
+        or kwargs.get("agent_identity")
+        or "default"
+    )

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_resolve_user_id.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_resolve_user_id.py
@@ -1,0 +1,85 @@
+"""Tests for ``resolve_user_id`` — the kwargs → user_id mapping used by
+``MemoryTencentdbProvider.initialize``.
+
+Verifies the fix for
+https://github.com/Tencent/TencentDB-Agent-Memory/issues/15: Hermes
+``--profile`` users were silently sharing one memory pool because the
+provider hardcoded ``kwargs.get("user_id", "default")`` and ignored
+``agent_identity``. The new resolver falls back to ``agent_identity`` when
+no gateway ``user_id`` is present.
+
+This is a pure-function test — no Gateway / Supervisor / network involved.
+
+We load ``_identity.py`` directly via ``importlib`` rather than ``import
+memory.memory_tencentdb._identity`` so that triggering the package's
+``__init__.py`` (which itself imports ``agent.memory_provider``) is not
+required — that module only exists inside a hermes-agent checkout, and we
+want this test to run standalone in the plugin repo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_identity_module():
+    here = pathlib.Path(__file__).resolve().parent
+    module_path = here.parent / "_identity.py"
+    spec = importlib.util.spec_from_file_location(
+        "memory_tencentdb_identity_under_test", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load _identity.py at {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_identity = _load_identity_module()
+resolve_user_id = _identity.resolve_user_id
+
+
+def test_empty_kwargs_returns_default():
+    """Bare CLI invocation (no profile, no gateway): historical fallback."""
+    assert resolve_user_id({}) == "default"
+
+
+def test_gateway_user_id_wins():
+    """Gateway integrations (Telegram, Discord, …) pass ``user_id`` — preserved."""
+    assert resolve_user_id({"user_id": "alice"}) == "alice"
+
+
+def test_agent_identity_used_when_no_user_id():
+    """``hermes --profile work`` → ``agent_identity="work"`` becomes the scope."""
+    assert resolve_user_id({"agent_identity": "work"}) == "work"
+
+
+def test_user_id_takes_priority_over_agent_identity():
+    """When both are present (gateway request from a profile session),
+    multi-user isolation must take priority over per-profile isolation."""
+    assert (
+        resolve_user_id({"user_id": "alice", "agent_identity": "work"})
+        == "alice"
+    )
+
+
+def test_empty_strings_fall_through():
+    """Empty strings are treated as 'not set' — a misconfigured gateway
+    sending ``user_id=""`` falls through to ``agent_identity`` rather than
+    silently masking the profile scope."""
+    assert resolve_user_id({"user_id": "", "agent_identity": "work"}) == "work"
+    assert resolve_user_id({"user_id": "", "agent_identity": ""}) == "default"
+
+
+def test_other_kwargs_ignored():
+    """Unrelated kwargs (``agent_workspace`` etc.) don't interfere with the
+    resolution. Hermes ``run_agent.py`` also passes ``agent_workspace`` and
+    other identity-adjacent kwargs that this resolver must ignore."""
+    assert (
+        resolve_user_id({"agent_workspace": "hermes", "agent_identity": "work"})
+        == "work"
+    )
+    assert resolve_user_id({"agent_workspace": "hermes"}) == "default"


### PR DESCRIPTION
## Summary | 摘要

修复 #15 报告的 Hermes `--profile` 用户共享单一记忆池的问题。memory_tencentdb 之前忽略 Hermes 传过来的 `agent_identity` kwarg，把所有非 gateway session 都 scope 到 `\"default\"`，导致 `hermes --profile work` 与 `--profile personal` 的 Persona / L1 / L2 数据互相污染。

Fix #15 — memory_tencentdb ignored Hermes' \`agent_identity\` kwarg and hardcoded the scope to \`\"default\"\` for all non-gateway sessions, so \`hermes --profile work\` and \`--profile personal\` silently shared one memory pool. Now falls back to \`agent_identity\` when \`user_id\` is absent.

## Root cause

Hermes \`run_agent.py\` 把当前 profile 名通过 kwargs 传给 memory provider：

\`\`\`python
# run_agent.py L1803-1808
_init_kwargs[\"agent_identity\"] = _profile
_init_kwargs[\"agent_workspace\"] = \"hermes\"
\`\`\`

但 memory_tencentdb 的 \`initialize()\` 只读 \`user_id\`：

\`\`\`python
# hermes-plugin/memory/memory_tencentdb/__init__.py:705 (before)
self._user_id = kwargs.get(\"user_id\", \"default\")
\`\`\`

→ 所有 CLI profile 的 \`user_id\` 都是 \`\"default\"\` → 一个记忆池。

## Fix

新的解析优先级（first non-empty wins，否则 \`\"default\"\`）：

1. **\`user_id\`** — gateway 集成（Telegram / Discord / …）传，保持现有多用户隔离。
2. **\`agent_identity\`** — Hermes CLI profile，**新加的 fallback 路径**。
3. **\`\"default\"\`** — bare CLI 调用的历史 fallback。

空字符串视为未设置（misconfigured gateway 发 \`user_id=\"\"\` 不再静默盖住 profile scope）。

## Compatibility | 兼容性

| 场景 | 之前 | 修复后 |
| --- | --- | --- |
| Bare CLI（无 profile，无 gateway） | \`\"default\"\` | \`\"default\"\`（不变）|
| \`hermes --profile work\` | \`\"default\"\`（污染！） | \`\"work\"\`（隔离） |
| \`hermes --profile personal\` | \`\"default\"\`（污染！） | \`\"personal\"\`（隔离） |
| Gateway（Telegram \`user_id=alice\`） | \`\"alice\"\` | \`\"alice\"\`（不变） |
| Gateway + profile（\`user_id=alice\` + \`agent_identity=work\`） | \`\"alice\"\` | \`\"alice\"\`（multi-user 优先）|

**已有 \`default\` 数据保留**，新 profile 从空白开始 —— 与 issue 报告者预期一致。

## Refactor

把 user_id resolution 抽到独立模块 \`hermes-plugin/memory/memory_tencentdb/_identity.py\`（纯函数 \`resolve_user_id(kwargs) -> str\`），让它可以脱离 \`__init__.py\` 中的 \`agent.memory_provider\` import 独立单测 —— \`agent\` 模块只在 hermes-agent 仓库里存在，plugin standalone 测试需要绕开它。

\`hermes-plugin/conftest.py\` 提供 stub for \`agent.memory_provider\`（仅当真模块不可用时启用，hermes-agent 环境下被 sys.path 上的真模块 shadow，不影响集成测试）。

## Tests

新建 \`hermes-plugin/memory/memory_tencentdb/tests/test_resolve_user_id.py\` — 6 cases：

| # | 场景 | 期望 |
| - | --- | --- |
| 1 | 空 kwargs | \`\"default\"\` |
| 2 | 仅 \`user_id=alice\` | \`\"alice\"\` |
| 3 | 仅 \`agent_identity=work\` | \`\"work\"\` |
| 4 | 同时 \`user_id\` + \`agent_identity\` | \`\"alice\"\`（gateway 优先） |
| 5 | \`user_id=\"\"\`（空字符串）+ \`agent_identity=work\` | \`\"work\"\`（fall-through） |
| 6 | 无关 kwargs（\`agent_workspace\` 等） | 不影响解析 |

\`\`\`
✓ pytest hermes-plugin/memory/memory_tencentdb/tests/test_resolve_user_id.py → 6/6 passed
\`\`\`

## DCO

Commit 带 \`Signed-off-by: 李冠辰 <liguanchen@xiaomi.com>\`。

Closes #15.