### PR TITLE
fix(install): pin node absolute path in MEMORY_TENCENTDB_GATEWAY_CMD

### DIFF
--- a/scripts/install_hermes_memory_tencentdb.sh
+++ b/scripts/install_hermes_memory_tencentdb.sh
@@ -224,9 +224,34 @@ fi
 
 echo "[memory-tencentdb] Step 4: Setting up Gateway environment..."
 
+# 解析 node 绝对路径写入 GATEWAY_CMD。
+#
+# 为什么不直接用 `npx tsx ...` 这种依赖 PATH 的形式？
+#
+# 当 Hermes（或独立的 memory-tencentdb-gateway 服务）以 systemd service
+# 运行时，systemd 不会 source 任何 user shell rc 文件 —— nvm / asdf 用户
+# 装的 node 在 `~/.nvm/versions/node/v*/bin/`，而 systemd unit 默认 PATH
+# 只有 `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`。
+# 结果：交互 shell 里 `npx tsx ...` 能跑，systemd 服务里 fork-exec 就 fail
+# 在 `/usr/bin/env: 'node': No such file or directory`。详见 issue #19。
+#
+# 修复：在生成 GATEWAY_CMD 的当下解析 `node` 的绝对路径，并改用 Node 原生
+# 的 `--import tsx/esm` 形式（Node ≥ 20.6 起 stable）跳过 `npx`，让最终
+# 命令完全不依赖运行时 PATH。
+NODE_BIN="$(command -v node || true)"
+if [ -z "$NODE_BIN" ]; then
+    echo "[ERROR] 'node' not found in PATH; cannot generate Gateway start command." >&2
+    echo "[ERROR] If you installed Node via nvm/asdf, source the loader script for the install user before re-running:" >&2
+    echo "[ERROR]   source ~/.bashrc   # or `nvm use <version>`" >&2
+    exit 1
+fi
+echo "[memory-tencentdb] Resolved node: $NODE_BIN"
+
 # 构建 Gateway 启动命令
-# 使用 sh -c 包裹，先 cd 到插件目录再启动 Gateway（ESM 解析需要）
-GATEWAY_CMD="sh -c 'cd $TDAI_INSTALL_DIR && exec npx tsx src/gateway/server.ts'"
+# 使用 sh -c 包裹，先 cd 到插件目录再启动 Gateway（ESM 解析需要）。
+# `node --import tsx/esm` 替代 `npx tsx`：避免 systemd 环境下 PATH 不含
+# nvm bin 导致 `npx` 找不到 node 的问题（issue #19）。
+GATEWAY_CMD="sh -c 'cd $TDAI_INSTALL_DIR && exec \"$NODE_BIN\" --import tsx/esm src/gateway/server.ts'"
 
 # ── 4a: /etc/profile.d（SSH 交互式登录场景） ──
 # 写入 /etc/profile.d 持久化环境变量，供 SSH 手动执行 `hermes` 时使用。


### PR DESCRIPTION
## Summary | 摘要

修复 #19：install 脚本生成的 \`MEMORY_TENCENTDB_GATEWAY_CMD\` 用裸 \`npx\`，systemd 环境下 PATH 不含 nvm/asdf 装的 node → daemon spawn 失败、Hermes 反复日志 \"Gateway unreachable\"。改为 install 时 resolve node 绝对路径，并用 \`node --import tsx/esm\` 替代 \`npx tsx\`。

Fix #19: \`MEMORY_TENCENTDB_GATEWAY_CMD\` used bare \`npx\` which fails under systemd (nvm/asdf node not in systemd's minimal PATH). Now resolves node's absolute path at install time and uses Node-native \`--import tsx/esm\` to remove the runtime PATH dependency.

## Root cause

\`scripts/install_hermes_memory_tencentdb.sh:229\` (before):

\`\`\`bash
GATEWAY_CMD=\"sh -c 'cd \$TDAI_INSTALL_DIR && exec npx tsx src/gateway/server.ts'\"
\`\`\`

- 交互 shell：\`~/.bashrc\` 加载 nvm → PATH 含 \`~/.nvm/versions/node/v*/bin/\` → \`npx\` 找到 → OK
- systemd service：默认 PATH = \`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\`，**不 source** 任何 user shell rc → \`npx\` 找不到 → 日志：

\`\`\`text
/usr/bin/env: 'node': No such file or directory
\`\`\`

issue 报告者手动 workaround：systemd unit 显式写绝对 node 路径 + \`Environment=PATH=...\` 后 Gateway 正常启动。

## Fix

\`\`\`bash
NODE_BIN=\"\$(command -v node || true)\"
if [ -z \"\$NODE_BIN\" ]; then
    echo \"[ERROR] 'node' not found in PATH; cannot generate Gateway start command.\" >&2
    echo \"[ERROR] If you installed Node via nvm/asdf, source the loader script for the install user before re-running:\" >&2
    echo \"[ERROR]   source ~/.bashrc   # or 'nvm use <version>'\" >&2
    exit 1
fi
echo \"[memory-tencentdb] Resolved node: \$NODE_BIN\"

GATEWAY_CMD=\"sh -c 'cd \$TDAI_INSTALL_DIR && exec \\\"\$NODE_BIN\\\" --import tsx/esm src/gateway/server.ts'\"
\`\`\`

两点变化：

1. **绝对路径**：\`command -v node\` 在 install 时（user shell 已加载 nvm）resolve 出 \`/root/.nvm/versions/node/v25.8.2/bin/node\` 之类的绝对路径，写入 \`MEMORY_TENCENTDB_GATEWAY_CMD\`。systemd 直接 exec 该绝对路径，跳过 PATH 查找。
2. **去掉 npx**：用 Node 原生 \`--import tsx/esm\` loader 直接加载 tsx 作为 ESM register hook，跳过 \`npx tsx\` 这层间接（npx 自身也是个 node script，需要解析）。\`--import\` 在 Node ≥ 20.6 stable；脚本顶部已经声明 \`Node.js >= 22\` 前置条件，引入零新要求。

Install 时 \`node\` 不在 PATH 直接 fail-fast + 给出 nvm/asdf 用户的 hint，比生成一个不能跑的 \`GATEWAY_CMD\` 再等 runtime 报错好得多。

## Compatibility | 兼容性

| 场景 | 之前 | 修复后 |
| --- | --- | --- |
| 交互 shell（nvm \`~/.bashrc\` 已加载） | ✅ npx 跑通 | ✅ 直接 exec node 跑通 |
| 系统包管理 node（\`/usr/bin/node\`） | ✅ npx 跑通 | ✅ 绝对路径 \`/usr/bin/node\` 跑通 |
| systemd service + nvm node | ❌ npx 找不到（issue #19） | ✅ 绝对路径不依赖 PATH |
| Hermes \`hermes\` 命令（与 systemd 等价 spawn 模式） | ❌ 同上 | ✅ |

## Manual test plan

\`\`\`bash
# Before fix (重现 issue)：
# 1. nvm install node 22 + hermes 装好
# 2. 跑 install_hermes_memory_tencentdb.sh
# 3. cat /etc/profile.d/memory-tencentdb-env.sh → 看到裸 npx
# 4. 用 systemd unit 启动 → 日志 'node: No such file or directory'

# After fix：
# 1. 同上 1-2 步
# 3. cat /etc/profile.d/memory-tencentdb-env.sh → 看到绝对 node 路径
#    export MEMORY_TENCENTDB_GATEWAY_CMD=\"sh -c 'cd ... && exec \\\"/root/.nvm/.../node\\\" --import tsx/esm src/gateway/server.ts'\"
# 4. 用 systemd unit 启动 → curl http://127.0.0.1:8420/health 返回 200
\`\`\`

## Edge cases handled

- **node 不在 install 用户的 PATH**：fail-fast，明确报错 + nvm/asdf hint，不生成损坏的 GATEWAY_CMD。
- **node 路径含空格**：\`\\\"\$NODE_BIN\\\"\` 在 \`sh -c\` 内部用双引号保护，spaces in path 不会破坏 GATEWAY_CMD 语义（虽然 nvm/系统路径通常不含空格，但作为防御性 quoting）。

## Out of scope

- 不动 \`memory-tencentdb-ctl.sh\` 或 \`hermes-plugin/memory/memory_tencentdb/__init__.py\` 中的 \`_discover_gateway_cmd()\` —— 那是 fallback 路径，被 \`MEMORY_TENCENTDB_GATEWAY_CMD\` 优先级覆盖。如果腾讯团队希望 fallback 也走 absolute path，可以单独 follow-up。
- 不为 shell script 引入测试基础设施（项目暂无 bats / shellcheck CI）；手动验证步骤见上。

## DCO

Commit 带 \`Signed-off-by: 李冠辰 <liguanchen@xiaomi.com>\`。

Closes #19.