### PR TITLE
fix(install): prevent infinite su recursion when running as root

### DIFF
--- a/scripts/install_hermes_memory_tencentdb.sh
+++ b/scripts/install_hermes_memory_tencentdb.sh
@@ -33,8 +33,17 @@
 
 set -e
 
-# 动态获取当前执行用户及 HOME 目录
-USERNAME=$(whoami)
+# 动态获取目标安装用户及其 HOME 目录。
+# 优先级：
+#   1. 显式 ``INSTALL_AS_USER`` 环境变量（管理员脚本场景：root 跑安装但
+#      想为另一个用户配置）
+#   2. ``SUDO_USER``（被 ``sudo`` 调用时，切回原用户而不是 root）
+#   3. ``whoami`` —— 当前 EUID 对应的用户
+#
+# 注意：当 root 直接 ssh 登录跑（非 sudo）时，前两个都不会被设置，
+# ``whoami`` 返回 ``root``。下面的 ``id -u`` == 0 分支会识别这种"目标
+# 就是 root"的情况、跳过 ``su - root`` 递归。
+USERNAME="${INSTALL_AS_USER:-${SUDO_USER:-$(whoami)}}"
 USER_HOME=$(eval echo ~$USERNAME)
 
 # npm 包名
@@ -62,10 +71,14 @@ LEGACY_INSTALL_DIR="$USER_HOME/tdai-memory-openclaw-plugin"
 LEGACY_DATA_DIR="$USER_HOME/memory-tdai"
 
 # ==================== root → 自动切换到目标用户 ====================
-# 与 install_hermes_ubuntu.sh 保持一致：如果以 root 执行，自动 su 切到
-# 目标用户运行实际安装逻辑。也可以直接以目标用户身份执行，跳过此段。
+# 与 install_hermes_ubuntu.sh 保持一致：如果以 root 执行且目标用户不是
+# root，自动 su 切到目标用户运行实际安装逻辑。
+#
+# 如果当前是 root 且目标用户也是 root（``USERNAME=root``，例如直接 ssh
+# 登录 root 跑安装），跳过 ``su - root`` —— 否则会无限递归（``su - root``
+# 进入的仍是 root，又走到这个分支，再次 su，永远停不下来）。见 issue #20。
 
-if [ "$(id -u)" -eq 0 ]; then
+if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
     echo "[memory-tencentdb] Running as root, switching to $USERNAME for installation..."
 
     # 验证前置条件
@@ -88,6 +101,10 @@ if [ "$(id -u)" -eq 0 ]; then
     rm -f "$TEMP_SCRIPT"
     echo "[memory-tencentdb] Installation completed successfully"
     exit 0
+elif [ "$(id -u)" -eq 0 ]; then
+    # 当前是 root 且目标用户也是 root：直接以 root 跑后续安装逻辑，
+    # 不再走 ``su -`` 切换（避免 #20 的递归）。
+    echo "[memory-tencentdb] Running as root; target user is also root — installing in place."
 fi
 
 # ==================== 用户阶段（核心安装逻辑） ====================


### PR DESCRIPTION
## Summary | 摘要

修复 #20：root 用户直接跑 \`install_hermes_memory_tencentdb.sh\` 会触发 \`su - root\` 无限递归。改为只在目标用户非 root 时 \`su -\` 切换；如果当前 root 且目标也是 root，直接以 root 跑安装。顺带支持 \`SUDO_USER\` 与 \`INSTALL_AS_USER\` env override，让 sudo 场景与管理员场景都正确。

Fix #20: running \`install_hermes_memory_tencentdb.sh\` as root triggered \`su - root\` infinite recursion. Now only \`su\`-switches when the target user is not root; if both are root, installs in place. Also honors \`SUDO_USER\` and \`INSTALL_AS_USER\` env overrides so \`sudo\` and admin scenarios pick the right target.

## Root cause

\`scripts/install_hermes_memory_tencentdb.sh\` (before):

\`\`\`bash
USERNAME=\$(whoami)               # → \"root\" when invoked by root
...
if [ \"\$(id -u)\" -eq 0 ]; then
    echo \"Running as root, switching to \$USERNAME for installation...\"
    su - \$USERNAME -c \"bash \$TEMP_SCRIPT\"   # → su - root → loops
fi
\`\`\`

\`su - root\` 进入一个新 root shell 重新跑这个脚本，新 shell 看到 \`id -u == 0\` 又 \`su -\`，永远停不下来。Issue 报告者 @cuiweiyou 的现象：

\`\`\`
[memory-tencentdb] Running as root, switching to root for installation...
[memory-tencentdb] Running as root, switching to root for installation...
...   （只能 Ctrl+C）
\`\`\`

## Fix

### 1. USERNAME 解析优先级链

\`\`\`bash
USERNAME=\"\${INSTALL_AS_USER:-\${SUDO_USER:-\$(whoami)}}\"
\`\`\`

- \`INSTALL_AS_USER\` —— 管理员显式 override（"我以 root 跑但想给 bar 用户安装"）
- \`SUDO_USER\` —— \`sudo bash install.sh\` 调用时 sudo 自动设置，让我们切回原用户而不是 root
- \`whoami\` —— 兜底（裸跑、无 sudo 也无 override）

### 2. 把 \`if\` 拆成两条分支

\`\`\`bash
if [ \"\$(id -u)\" -eq 0 ] && [ \"\$USERNAME\" != \"root\" ]; then
    # 当前 root + 目标非 root → su 切换（原有逻辑）
    ...
elif [ \"\$(id -u)\" -eq 0 ]; then
    # 当前 root + 目标也是 root → 直接 inline 安装，不 su（避免 #20 递归）
    echo \"Running as root; target user is also root — installing in place.\"
fi
\`\`\`

第二条 \`elif\` 故意让控制流落到下方 \"用户阶段（核心安装逻辑）\"，以 root 身份直接跑剩下的安装步骤。

## Compatibility | 兼容性

Dry-run 模拟 5 个场景行为：

| 场景 | 分支 | USERNAME |
| --- | --- | --- |
| root SSH 直接跑（#20 复现路径） | INLINE | root |
| 普通用户直接跑 | NORMAL（fall through） | <user> |
| \`sudo bash install.sh\` 从 user \`foo\` | SU | foo |
| root + \`INSTALL_AS_USER=bar\` | SU | bar |
| root + \`INSTALL_AS_USER=root\`（显式 admin） | INLINE | root |

dry-run 脚本见 PR description 之外的本地验证（见 commit message）。

\`INSTALL_AS_USER\` / \`SUDO_USER\` 是**新**的输入；既有用户没设这两个的情况下，\`USERNAME\` 仍然 fall back 到 \`whoami\` —— 即所有非 root 用户的现有行为完全不变。

## Manual test plan

\`\`\`bash
# Before fix（复现 #20）：
sudo su -    # root shell
bash scripts/install_hermes_memory_tencentdb.sh
# → 反复输出 \"Running as root, switching to root...\" 直到 Ctrl+C

# After fix:
sudo su -
bash scripts/install_hermes_memory_tencentdb.sh
# → 输出 \"Running as root; target user is also root — installing in place.\"
# → 继续正常安装

# sudo 场景（顺带改进）：
sudo bash scripts/install_hermes_memory_tencentdb.sh
# → 输出 \"Running as root, switching to <original-user> for installation...\"
# → 之前会以 root 安装；现在会切回原用户安装
\`\`\`

## Out of scope

- 不动 \`install_hermes_ubuntu.sh\`（它有同样模式但是另一个仓库的 issue），虽然脚本顶部注释提到"与 install_hermes_ubuntu.sh 保持一致"。腾讯团队若同意，可以同步那边。
- 不引入 shell test 框架（bats）；用 dry-run 验证 + manual test plan 覆盖。

## DCO

Commit 带 \`Signed-off-by: 李冠辰 <liguanchen@xiaomi.com>\`。

Closes #20.