### PR TITLE
feat: per-agent data isolation for multi-agent deployments

### DIFF
--- a/docs/agent-isolation-plan.md
+++ b/docs/agent-isolation-plan.md
@@ -1,0 +1,201 @@
+# TDAI 按 Agent 隔离改造方案
+
+## 一、问题根因
+
+`memory-tencentdb` 插件在 `~/.openclaw/memory-tdai/` 下维护**单一数据目录**，所有 agent 共享：
+- `persona.md` — 统一用户画像
+- `conversations/` — 所有 agent 的对话记录
+- `scene_blocks/` — 所有场景记忆
+- `vectors.db` — 统一向量库
+
+插件在 `before_prompt_build` 阶段（`performAutoRecall`）将 persona + scene_navigation 注入到**每个 agent 的 system prompt**，不区分 agentId。
+
+### 污染链路
+```
+所有agent对话 → 同一个 conversations/ → 统一 L1 提取 → 统一 persona.md → 注入所有agent
+```
+
+## 二、改造目标
+
+**每个 agent 只能访问自己搭档用户的数据**：
+- persona.md 按 agent 隔离
+- conversations/ 按 agent 隔离
+- scene_blocks/ 按 agent 隔离
+- records/ 按 agent 隔离
+- vectors.db 按 agent 隔离（或按 agentId 分表）
+
+## 三、改造方案
+
+### 方案：per-agent 数据目录
+
+#### 3.1 数据目录结构
+
+**现状：**
+```
+~/.openclaw/memory-tdai/
+├── persona.md
+├── conversations/
+├── scene_blocks/
+├── records/
+└── vectors.db
+```
+
+**改造后：**
+```
+~/.openclaw/memory-tdai/
+├── agents/
+│   ├── duoduo/
+│   │   ├── persona.md
+│   │   ├── conversations/
+│   │   ├── scene_blocks/
+│   │   ├── records/
+│   │   └── vectors.db
+│   ├── sugarbaby/
+│   │   ├── persona.md
+│   │   ├── conversations/
+│   │   ├── scene_blocks/
+│   │   ├── records/
+│   │   └── vectors.db
+│   ├── miumiu/
+│   ├── jelly/
+│   ├── der/
+│   └── zhumi/
+└── shared/              ← 保留共享知识（跨agent经验等）
+    └── ...
+```
+
+#### 3.2 插件代码改动点
+
+##### 改动1：`pluginDataDir` 按 agentId 解析
+
+**文件**：`dist/index.mjs` 第 16969 行
+
+**现状**：
+```js
+const pluginDataDir = path.join(api.runtime.state.resolveStateDir(), "memory-tdai");
+```
+
+**改为**：
+```js
+// 基础目录
+const tdaiBaseDir = path.join(api.runtime.state.resolveStateDir(), "memory-tdai");
+// 在 capture/recall 时按 agentId 动态解析子目录
+```
+
+**关键**：不能在 register 时固定 agentId，因为一个插件实例服务所有 agent。需要在每次 capture/recall 时从 sessionKey 中提取 agentId。
+
+##### 改动2：L0 capture 按 agentId 分目录
+
+**文件**：`dist/index.mjs` 第 8013 行 `recordConversation`
+
+**现状**：
+```js
+const outDir = path.join(baseDir, "conversations");
+```
+
+**改为**：
+```js
+// 从 sessionKey 提取 agentId
+const agentId = extractAgentId(sessionKey);
+const outDir = path.join(baseDir, "agents", agentId, "conversations");
+```
+
+##### 改动3：L0 读取按 agentId 过滤
+
+**文件**：`dist/index.mjs` 第 8040 行 `readConversationRecords`
+
+**现状**：读取 `baseDir/conversations/` 下所有文件，按 sessionKey 过滤
+
+**改为**：读取 `baseDir/agents/{agentId}/conversations/`
+
+##### 改动4：L1 records 按 agentId 分目录
+
+所有 `records/` 的读写路径加上 `agents/{agentId}/` 前缀
+
+##### 改动5：persona.md 按 agentId 隔离
+
+**文件**：persona 生成（L3）和读取（recall）时
+
+**现状**：
+```js
+const personaPath = path.join(pluginDataDir, "persona.md");
+```
+
+**改为**：
+```js
+const personaPath = path.join(pluginDataDir, "agents", agentId, "persona.md");
+```
+
+##### 改动6：scene_blocks 按 agentId 隔离
+
+所有 scene_blocks 路径加上 `agents/{agentId}/` 前缀
+
+##### 改动7：vectors.db 按 agentId 隔离
+
+每个 agent 独立的 `vectors.db`，避免向量搜索跨 agent 召回
+
+##### 改动8：recall 时按 agentId 限定搜索范围
+
+**文件**：`performAutoRecall` 函数
+
+在 recall 时从 sessionKey 提取 agentId，只搜索该 agent 的数据目录
+
+#### 3.3 辅助函数
+
+`extractAgentId(sessionKey)` 已存在（第 11551 行），从 `agent:duoduo:feishu:xxx` 格式提取 `duoduo`。
+
+新增：
+```js
+function resolveAgentDataDir(baseDir, sessionKey) {
+    const agentId = extractAgentId(sessionKey);
+    if (!agentId) return baseDir; // fallback
+    const agentDir = path.join(baseDir, "agents", agentId);
+    mkdirSync(agentDir, { recursive: true });
+    return agentDir;
+}
+```
+
+#### 3.4 数据迁移
+
+已有数据需要拆分：
+
+```bash
+# 按 sessionKey 中的 agentId 拆分 conversations
+# 按 records 中的 agent_id 字段拆分 records
+# persona.md 和 scene_blocks 需要重新生成（按 agent）
+```
+
+## 四、改动量评估
+
+| 模块 | 改动文件 | 难度 | 说明 |
+|------|----------|------|------|
+| 数据目录路由 | index.mjs（多处） | 中 | 加 agentId 子路径 |
+| L0 capture | recordConversation | 低 | 改 outDir |
+| L0 read | readConversationRecords | 低 | 改读取路径 |
+| L1 records | 多处读写 | 中 | 加前缀 |
+| L2 scene | scene 相关函数 | 中 | 加前缀 |
+| L3 persona | persona 读写 | 低 | 改路径 |
+| vectors.db | 初始化/搜索 | 中 | 按 agent 分 db |
+| recall | performAutoRecall | 中 | 限定搜索范围 |
+| 数据迁移 | 新增脚本 | 低 | 一次性 |
+
+**总改动量**：约 20-30 处路径修改，核心逻辑不变
+
+## 五、风险
+
+1. **插件更新覆盖**：memory-tencentdb 更新后会覆盖改动 → 需要 fork 或提 PR
+2. **数据迁移**：现有数据需要正确拆分，否则历史记忆丢失
+3. **shared-knowledge**：跨 agent 共享经验目前也在 tdai 里，拆分后需要单独处理
+
+## 六、建议执行路径
+
+1. **Fork memory-tencentdb** → 建独立仓库
+2. **实现 per-agent 数据目录** → 按上面改动点修改
+3. **写数据迁移脚本** → 拆分现有 conversations/records
+4. **persona 重新生成** → 每个 agent 基于 L0 重新提炼
+5. **测试验证** → 确认糖宝不再读到其他人的数据
+6. **持续跟进上游** → 给腾讯提 PR，合入官方版本
+
+---
+
+生成时间：2026-05-20

--- a/patches/agent-isolation.patch
+++ b/patches/agent-isolation.patch
@@ -1,0 +1,172 @@
+11558a11559,11576
+> }
+> /**
+>  * Per-agent data directory resolver.
+>  * Routes pluginDataDir to agents/{agentId}/ subdirectory based on sessionKey.
+>  * Falls back to baseDir if agentId cannot be extracted.
+>  * Patched 2026-05-20: cross-agent memory isolation.
+>  */
+> const _agentDirCache = /* @__PURE__ */ new Map();
+> function resolveAgentDataDir(baseDir, sessionKey, logger) {
+> 	const agentId = extractAgentId(sessionKey);
+> 	if (!agentId) return baseDir;
+> 	const cacheKey = baseDir + "/" + agentId;
+> 	if (_agentDirCache.has(cacheKey)) return _agentDirCache.get(cacheKey);
+> 	const agentDir = path.join(baseDir, "agents", agentId);
+> 	initDataDirectories(agentDir);
+> 	_agentDirCache.set(cacheKey, agentDir);
+> 	logger?.debug?.(`[memory-tdai] [agent-isolation] sessionKey=${sessionKey} → dataDir=${agentDir}`);
+> 	return agentDir;
+15623c15641
+< 		const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy, vectorStore, embeddingService);
+---
+> 		const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy, vectorStore, embeddingService, extractAgentId(params.sessionKey) || void 0);
+15700c15718
+< async function searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService) {
+---
+> async function searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService, _filterAgentId) {
+15730c15748
+< 			const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore);
+---
+> 			const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore, _filterAgentId);
+15743c15761
+< 			const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore, embeddingService, logger, embeddingCallOpts);
+---
+> 			const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore, embeddingService, logger, embeddingCallOpts, _filterAgentId);
+15772c15790
+< 		return await searchHybrid(cleanText, pluginDataDir, maxResults, threshold, vectorStore, embeddingService, logger, embeddingCallOpts);
+---
+> 		return await searchHybrid(cleanText, pluginDataDir, maxResults, threshold, vectorStore, embeddingService, logger, embeddingCallOpts, _filterAgentId);
+15778c15796
+< async function searchByKeyword(userText, _pluginDataDir, maxResults, threshold, logger, vectorStore) {
+---
+> async function searchByKeyword(userText, _pluginDataDir, maxResults, threshold, logger, vectorStore, _filterAgentId) {
+15783c15801,15802
+< 			const ftsResults = await vectorStore.searchL1Fts(ftsQuery, maxResults * 2);
+---
+> 			let ftsResults = await vectorStore.searchL1Fts(ftsQuery, maxResults * 2);
+> 			if (_filterAgentId) ftsResults = ftsResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+15802c15821
+< async function searchByEmbedding(userText, maxResults, threshold, vectorStore, embeddingService, logger, embeddingCallOpts) {
+---
+> async function searchByEmbedding(userText, maxResults, threshold, vectorStore, embeddingService, logger, embeddingCallOpts, _filterAgentId) {
+15806c15825,15826
+< 	const vecResults = await vectorStore.searchL1Vector(queryEmbedding, maxResults * 2);
+---
+> 	let vecResults = await vectorStore.searchL1Vector(queryEmbedding, maxResults * 2);
+> 	if (_filterAgentId) vecResults = vecResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+15831c15851
+< async function searchHybrid(userText, _pluginDataDir, maxResults, _threshold, vectorStore, embeddingService, logger, embeddingCallOpts) {
+---
+> async function searchHybrid(userText, _pluginDataDir, maxResults, _threshold, vectorStore, embeddingService, logger, embeddingCallOpts, _filterAgentId) {
+15839c15859,15860
+< 					const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+---
+> 					let ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+> 					if (_filterAgentId) ftsResults = ftsResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+15889c15910,15911
+< 			const results = await vectorStore.searchL1Vector(queryEmbedding, candidateK, userText);
+---
+> 			let results = await vectorStore.searchL1Vector(queryEmbedding, candidateK, userText);
+> 			if (_filterAgentId) results = results.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+16069c16091
+< 	const { query, limit, type: typeFilter, scene: sceneFilter, vectorStore, embeddingService, logger } = params;
+---
+> 	const { query, limit, type: typeFilter, scene: sceneFilter, vectorStore, embeddingService, logger, _filterAgentId } = params;
+16108c16130,16131
+< 			const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+---
+> 			let ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+> 			if (_filterAgentId) ftsResults = ftsResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+16118c16141,16142
+< 				updated_at: r.timestamp_end
+---
+> 				updated_at: r.timestamp_end,
+> 				session_key: r.session_key
+16130c16154,16155
+< 			const vecResults = await vectorStore.searchL1Vector(queryEmbedding, candidateK, query);
+---
+> 			let vecResults = await vectorStore.searchL1Vector(queryEmbedding, candidateK, query);
+> 			if (_filterAgentId) vecResults = vecResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+16140c16165,16166
+< 				updated_at: r.timestamp_end
+---
+> 				updated_at: r.timestamp_end,
+> 				session_key: r.session_key
+16228c16254
+< 	const { query, limit, sessionKey: sessionFilter, vectorStore, embeddingService, logger } = params;
+---
+> 	const { query, limit, sessionKey: sessionFilter, vectorStore, embeddingService, logger, _filterAgentId } = params;
+16267c16293,16294
+< 			const ftsResults = await vectorStore.searchL0Fts(ftsQuery, candidateK);
+---
+> 			let ftsResults = await vectorStore.searchL0Fts(ftsQuery, candidateK);
+> 			if (_filterAgentId) ftsResults = ftsResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+16287c16314,16315
+< 			const vecResults = await vectorStore.searchL0Vector(queryEmbedding, candidateK, query);
+---
+> 			let vecResults = await vectorStore.searchL0Vector(queryEmbedding, candidateK, query);
+> 			if (_filterAgentId) vecResults = vecResults.filter(r => { const a = extractAgentId(r.session_key || ''); return !a || a === _filterAgentId; });
+16428a16457,16459
+> 		const _agentDir = resolveAgentDataDir(this.dataDir, sessionKey, this.logger);
+> 		// Phase 2: track current agent for search filtering
+> 		this._lastRecallAgentId = extractAgentId(sessionKey) || void 0;
+16434c16465
+< 			pluginDataDir: this.dataDir,
+---
+> 			pluginDataDir: _agentDir,
+16446a16478
+> 		const _agentDir = resolveAgentDataDir(this.dataDir, turn.sessionKey, this.logger);
+16452c16484
+< 			pluginDataDir: this.dataDir,
+---
+> 			pluginDataDir: _agentDir,
+16475c16507,16508
+< 			logger: this.logger
+---
+> 			logger: this.logger,
+> 			_filterAgentId: this._lastRecallAgentId
+16494c16527,16528
+< 			logger: this.logger
+---
+> 			logger: this.logger,
+> 			_filterAgentId: this._lastRecallAgentId
+16593,16602c16627,16639
+< 		this.scheduler.setL1Runner(createL1Runner({
+< 			pluginDataDir: this.dataDir,
+< 			cfg: this.cfg,
+< 			openclawConfig,
+< 			vectorStore: this.vectorStore,
+< 			embeddingService: this.embeddingService,
+< 			logger: this.logger,
+< 			getInstanceId: () => this.instanceId,
+< 			llmRunner: l1LlmRunner
+< 		}));
+---
+> 		this.scheduler.setL1Runner(async ({ sessionKey }) => {
+> 			const _agentDir = resolveAgentDataDir(this.dataDir, sessionKey, this.logger);
+> 			return createL1Runner({
+> 				pluginDataDir: _agentDir,
+> 				cfg: this.cfg,
+> 				openclawConfig,
+> 				vectorStore: this.vectorStore,
+> 				embeddingService: this.embeddingService,
+> 				logger: this.logger,
+> 				getInstanceId: () => this.instanceId,
+> 				llmRunner: l1LlmRunner
+> 			})({ sessionKey });
+> 		});
+16604a16642
+> 			const _agentDir = resolveAgentDataDir(this.dataDir, sessionKey, this.logger);
+16606c16644
+< 				pluginDataDir: this.dataDir,
+---
+> 				pluginDataDir: _agentDir,
+16615a16654
+> 			// L3 runner iterates all sessions; route each to its agent dir
+16623c16662,16664
+< 				llmRunner: l2l3LlmRunner
+---
+> 				llmRunner: l2l3LlmRunner,
+> 				// Pass agent resolver for per-agent persona generation
+> 				agentDataDirResolver: (sk) => resolveAgentDataDir(this.dataDir, sk, this.logger)

--- a/scripts/migrate_per_agent.py
+++ b/scripts/migrate_per_agent.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+TDAI 数据迁移脚本 - 按 agentId 拆分
+将 conversations/ 和 records/ 从统一目录拆分到 agents/{agentId}/ 下
+scene_blocks 和 persona.md 不拆分（混合内容无法拆，由插件重新生成）
+
+用法: python3 migrate_per_agent.py [--dry-run]
+"""
+
+import os
+import sys
+import json
+import shutil
+from pathlib import Path
+
+BASE_DIR = Path(os.path.expanduser("~/.openclaw/memory-tdai"))
+AGENTS_DIR = BASE_DIR / "agents"
+CONVERSATIONS_DIR = BASE_DIR / "conversations"
+RECORDS_DIR = BASE_DIR / "records"
+
+KNOWN_AGENTS = ["duoduo", "sugarbaby", "miumiu", "jelly", "der", "zhumi"]
+
+dry_run = "--dry-run" in sys.argv
+
+
+def ensure_agent_dirs():
+    """为每个已知 agent 创建子目录结构"""
+    for agent in KNOWN_AGENTS:
+        for sub in ["conversations", "records", "scene_blocks", ".metadata"]:
+            d = AGENTS_DIR / agent / sub
+            if not dry_run:
+                d.mkdir(parents=True, exist_ok=True)
+            else:
+                print(f"  [dry-run] mkdir {d}")
+
+
+def extract_agent_from_session_key(session_key: str) -> str:
+    """从 sessionKey 提取 agentId
+    格式: agent:duoduo:feishu:direct:ou_xxx 或 agent:duoduo:feishu:direct:ou_xxx:active-memory:xxx
+    """
+    if not session_key or not session_key.startswith("agent:"):
+        return None
+    parts = session_key.split(":")
+    if len(parts) >= 2:
+        return parts[1]
+    return None
+
+
+def extract_agent_from_source_id(source_id: str) -> str:
+    """从 record 的 source_message_ids 提取 agentId
+    格式: l0_agent:duoduo:feishu:...
+    """
+    if not source_id:
+        return None
+    parts = source_id.split(":")
+    if len(parts) >= 2 and parts[0] == "l0_agent":
+        return parts[1]
+    return None
+
+
+def migrate_conversations():
+    """拆分 conversations/ 按 agentId"""
+    print("\n=== 迁移 conversations ===")
+    if not CONVERSATIONS_DIR.exists():
+        print("  conversations 目录不存在，跳过")
+        return
+
+    stats = {}
+    unknown_count = 0
+
+    for jsonl_file in sorted(CONVERSATIONS_DIR.glob("*.jsonl")):
+        print(f"\n  处理: {jsonl_file.name}")
+
+        # 按agent分组读取
+        agent_lines = {a: [] for a in KNOWN_AGENTS}
+        agent_lines["unknown"] = []
+
+        with open(jsonl_file, "r", encoding="utf-8") as f:
+            for line_no, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    agent_id = extract_agent_from_session_key(rec.get("sessionKey", ""))
+                    if agent_id and agent_id in KNOWN_AGENTS:
+                        agent_lines[agent_id].append(line)
+                        stats[agent_id] = stats.get(agent_id, 0) + 1
+                    else:
+                        agent_lines["unknown"].append(line)
+                        unknown_count += 1
+                        if unknown_count <= 5:
+                            print(f"    ⚠ unknown agent: sessionKey={rec.get('sessionKey', 'N/A')[:80]}")
+                except json.JSONDecodeError:
+                    agent_lines["unknown"].append(line)
+                    unknown_count += 1
+
+        # 写入各 agent 目录
+        for agent_id, lines in agent_lines.items():
+            if not lines:
+                continue
+            target_dir = AGENTS_DIR / agent_id / "conversations"
+            target_file = target_dir / jsonl_file.name
+            if not dry_run:
+                target_dir.mkdir(parents=True, exist_ok=True)
+                with open(target_file, "w", encoding="utf-8") as out:
+                    out.write("\n".join(lines) + "\n")
+            else:
+                print(f"    [dry-run] {agent_id}: {len(lines)} lines → {target_file}")
+
+    print(f"\n  conversations 迁移统计:")
+    for a in sorted(stats):
+        print(f"    {a}: {stats[a]} 条")
+    if unknown_count:
+        print(f"    unknown: {unknown_count} 条")
+
+
+def migrate_records():
+    """拆分 records/ 按 agentId"""
+    print("\n=== 迁移 records ===")
+    if not RECORDS_DIR.exists():
+        print("  records 目录不存在，跳过")
+        return
+
+    stats = {}
+
+    for jsonl_file in sorted(RECORDS_DIR.glob("*.jsonl")):
+        print(f"\n  处理: {jsonl_file.name}")
+
+        agent_lines = {a: [] for a in KNOWN_AGENTS}
+        agent_lines["unknown"] = []
+
+        with open(jsonl_file, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    # 从 source_message_ids 提取 agentId
+                    agent_id = None
+                    src_ids = rec.get("source_message_ids", [])
+                    if src_ids:
+                        agent_id = extract_agent_from_source_id(src_ids[0])
+                    # fallback: 从 sessionKey 提取
+                    if not agent_id:
+                        agent_id = extract_agent_from_session_key(rec.get("sessionKey", ""))
+
+                    if agent_id and agent_id in KNOWN_AGENTS:
+                        agent_lines[agent_id].append(line)
+                        stats[agent_id] = stats.get(agent_id, 0) + 1
+                    else:
+                        agent_lines["unknown"].append(line)
+                except json.JSONDecodeError:
+                    agent_lines["unknown"].append(line)
+
+        for agent_id, lines in agent_lines.items():
+            if not lines:
+                continue
+            target_dir = AGENTS_DIR / agent_id / "records"
+            target_file = target_dir / jsonl_file.name
+            if not dry_run:
+                target_dir.mkdir(parents=True, exist_ok=True)
+                with open(target_file, "w", encoding="utf-8") as out:
+                    out.write("\n".join(lines) + "\n")
+            else:
+                print(f"    [dry-run] {agent_id}: {len(lines)} lines → {target_file}")
+
+    print(f"\n  records 迁移统计:")
+    for a in sorted(stats):
+        print(f"    {a}: {stats[a]} 条")
+
+
+def verify_migration():
+    """验证迁移结果"""
+    print("\n=== 验证迁移结果 ===")
+    for agent in KNOWN_AGENTS:
+        conv_dir = AGENTS_DIR / agent / "conversations"
+        rec_dir = AGENTS_DIR / agent / "records"
+
+        conv_count = 0
+        if conv_dir.exists():
+            for f in conv_dir.glob("*.jsonl"):
+                with open(f) as fh:
+                    conv_count += sum(1 for l in fh if l.strip())
+
+        rec_count = 0
+        if rec_dir.exists():
+            for f in rec_dir.glob("*.jsonl"):
+                with open(f) as fh:
+                    rec_count += sum(1 for l in fh if l.strip())
+
+        print(f"  {agent}: conversations={conv_count}, records={rec_count}")
+
+    # 检查 unknown
+    unknown_dir = AGENTS_DIR / "unknown"
+    if unknown_dir.exists():
+        for sub in ["conversations", "records"]:
+            d = unknown_dir / sub
+            if d.exists():
+                count = sum(1 for f in d.glob("*.jsonl") for _ in open(f) if _.strip())
+                if count > 0:
+                    print(f"  ⚠ unknown/{sub}: {count} 条需要人工检查")
+
+
+def main():
+    if dry_run:
+        print("🔍 DRY RUN - 不写入文件\n")
+
+    print(f"数据目录: {BASE_DIR}")
+    print(f"目标目录: {AGENTS_DIR}")
+
+    # 统计原始数据
+    print("\n=== 原始数据统计 ===")
+    if CONVERSATIONS_DIR.exists():
+        total_conv = sum(1 for f in CONVERSATIONS_DIR.glob("*.jsonl") for _ in open(f) if _.strip())
+        print(f"  conversations: {total_conv} 条")
+    if RECORDS_DIR.exists():
+        total_rec = sum(1 for f in RECORDS_DIR.glob("*.jsonl") for _ in open(f) if _.strip())
+        print(f"  records: {total_rec} 条")
+
+    ensure_agent_dirs()
+    migrate_conversations()
+    migrate_records()
+
+    if not dry_run:
+        verify_migration()
+        print("\n✅ 迁移完成！")
+        print("⚠️ 旧数据保留在原位置，确认无误后可手动删除")
+        print("⚠️ persona.md 和 scene_blocks 需要由插件重新生成（按agent独立提炼）")
+    else:
+        print("\n🔍 DRY RUN 完成 - 加 --dry-run 参数可查看实际写入")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Per-Agent Data Isolation

### Problem
When multiple agents share a single `memory-tdai` data directory, they cross-contaminate:
- Persona/scene blocks from one user get injected into other users sessions
- Search results return data from all agents, leaking private information
- Cron tasks with wrong agentId send data to wrong users

### Solution
A `resolveAgentDataDir()` function that routes all data paths through `agents/{agentId}/` subdirectories:

**Phase 1 — Data Isolation**
- Physical data split: conversations/records migrated to `agents/{agentId}/` subdirs
- `handleBeforeRecall` and `handleTurnCommitted` route to agent-specific dirs
- L1/L2/L3 pipeline runners use per-agent pluginDataDir
- persona.md and scene_blocks per-agent (each agent only sees own user's data)

**Phase 2 — Search Isolation**
- `_lastRecallAgentId` tracking via handleBeforeRecall
- `executeMemorySearch` filters FTS/vector/hybrid results by agentId
- `executeConversationSearch` filters L0 search results by agentId
- Internal `searchByKeyword`/`searchByEmbedding`/`searchHybrid` all support `_filterAgentId`
- `performAutoRecall` passes agentId to internal search for context injection

### Files in this PR
- `patches/agent-isolation.patch` — Full patch against dist/index.mjs (can be applied directly for hotfix)
- `scripts/migrate_per_agent.py` — Migration script to split existing data by agentId
- `docs/agent-isolation-plan.md` — Design document

### Migration
Existing data is preserved. The migration script:
1. Reads all conversations/records JSONL files
2. Extracts agentId from sessionKey (format: `agent:{agentId}:feishu:...`)
3. Copies files to `agents/{agentId}/conversations/` and `agents/{agentId}/records/`
4. Original data left in place for manual cleanup after verification

### Testing
- Deployed in production with 6 agents (duoduo, sugarbaby, miumiu, jelly, der, zhumi)
- Verified: sugarbaby no longer reads other agents user data
- Verified: search results filtered by agentId correctly
- Verified: L1 pipeline processes per-agent directories

### Notes
This PR provides the patch against `dist/index.mjs` as an immediate hotfix. A proper TypeScript source-level change would require cloning and building the repo. The patch approach allows users to apply the fix immediately.

We plan to follow up with a source-level implementation after running this in production for stability verification.