### PR TITLE
fix: add missing api_key field for custom provider in Dockerfile.hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [Unreleased]
+
+### 🐛 修复
+
+- **Hermes Docker 镜像 `config.yaml` 缺少 `api_key` 字段**：`Dockerfile.hermes` 的 CMD 脚本将 API Key 写入了 `.env` 的 `OPENAI_API_KEY`，但未写入 `config.yaml` 的 `model.api_key`，导致 `provider: custom` 时 Hermes 无法找到认证凭据（报 401 Authentication Fails）。现修复为在 `config.yaml` 的 `model` 段同步写入 `api_key: "${MODEL_API_KEY}"`。
+
+---
+
 ## [0.3.5] - 2026-05-15
 
 ### 🐛 修复

--- a/docker/opensource/Dockerfile.hermes
+++ b/docker/opensource/Dockerfile.hermes
@@ -96,7 +96,7 @@ CMD ["bash", "-c", "\
   export TDAI_LLM_MODEL=\"${MODEL_NAME}\" && \
   export TDAI_LLM_BASE_URL=\"${MODEL_BASE_URL}\" && \
   export TDAI_LLM_API_KEY=\"${MODEL_API_KEY}\" && \
-  printf \"model:\\n  default: \\\"${MODEL_NAME}\\\"\\n  provider: \\\"${MODEL_PROVIDER}\\\"\\n  base_url: \\\"${MODEL_BASE_URL}\\\"\\n\\nmemory:\\n  provider: memory_tencentdb\\n\" > \"$CFG\" && \
+  printf \"model:\\n  default: \\\"${MODEL_NAME}\\\"\\n  provider: \\\"${MODEL_PROVIDER}\\\"\\n  base_url: \\\"${MODEL_BASE_URL}\\\"\\n  api_key: \\\"${MODEL_API_KEY}\\\"\\n\\nmemory:\\n  provider: memory_tencentdb\\n\" > \"$CFG\" && \
   printf \"OPENAI_API_KEY=${MODEL_API_KEY}\\n\" > \"$ENVFILE\" && \
   echo \"=== Config: model=${MODEL_NAME}, provider=${MODEL_PROVIDER}, url=${MODEL_BASE_URL} ===\" && \
   echo \"=== Gateway starting... ===\" && \


### PR DESCRIPTION
Closes #77

## 问题

Hermes Docker 镜像启动后，用户执行 `docker exec -it hermes-memory hermes` 进入对话时报错：

```
⚠️  API call failed (attempt 1/3): AuthenticationError [HTTP 401]
 🔌 Provider: custom  Model: deepseek-v4-pro
 🌐 Endpoint: https://api.deepseek.com/v1
 📝 Error: HTTP 401: Authentication Fails, Your api key: ****ired is invalid
```

**根因**：`Dockerfile.hermes` 的 CMD 脚本将 `MODEL_API_KEY` 写入了 `.env` 文件（`OPENAI_API_KEY=xxx`），但生成的 `config.yaml` 中 `model` 段缺少 `api_key` 字段。Hermes 对 `provider: custom` 从 `config.yaml` 的 `model.api_key` 读取凭据，不从 `.env` 的 `OPENAI_API_KEY` 读取，因此认证失败。

## 修复

在 `printf` 生成的 `config.yaml` 中增加 `api_key: "${MODEL_API_KEY}"` 字段。

**修改后的 config.yaml 内容**：
```yaml
model:
  default: "deepseek-v3.2"
  provider: "custom"
  base_url: "https://api.lkeap.cloud.tencent.com/v1"
  api_key: "sk-xxx"              # ← 新增

memory:
  provider: memory_tencentdb
```

## 变更文件

| 文件 | 变更 |
|------|------|
| `docker/opensource/Dockerfile.hermes` | 第 99 行 `printf` 增加 `api_key` 字段 |
| `CHANGELOG.md` | 添加 Unreleased 修复记录 |

## 验证

已在运行中的容器内直接修复 `config.yaml` 验证修复有效。用户使用修复后的 Dockerfile 重新构建镜像即可正常使用。