### PR TITLE
fix: remove duplicate system prompt in CleanContextRunner

### DIFF
--- a/src/utils/clean-context-runner.ts
+++ b/src/utils/clean-context-runner.ts
@@ -439,12 +439,9 @@ export class CleanContextRunner {
 
       // Phase 2: Embedded agent run (LLM call + tool calls)
       const agentStartMs = Date.now();
-      // extraSystemPrompt: fallback for openclaw < 2026.4.7 which does not support
-      // config.agents.defaults.systemPromptOverride. On newer versions the
-      // override takes precedence and this becomes a no-op append.
-      const effectiveSystemPrompt =
-        params.systemPrompt ||
-        "You are a precise data extraction and generation assistant. Follow the user instructions exactly. Respond only with the requested output format.";
+      // System prompt is fully handled via config.agents.defaults.systemPromptOverride.
+      // Do NOT pass extraSystemPrompt — it would cause the same prompt to appear
+      // twice in the final system message (once from override, once appended).
       const result = await runEmbeddedPiAgent({
         sessionId,
         sessionFile,
@@ -460,7 +457,6 @@ export class CleanContextRunner {
         // Instead rely on cleanConfig.tools.allow to restrict the tool set
         // to a minimal read-only tool (when enableTools=false).
         disableTools: false,
-        extraSystemPrompt: effectiveSystemPrompt,
         streamParams: {
           maxTokens: params.maxTokens,
         },


### PR DESCRIPTION
The CleanContextRunner was passing the system prompt via two paths simultaneously:
1. config.agents.defaults.systemPromptOverride (primary)
2. extraSystemPrompt parameter (legacy fallback)

On openclaw >= 2026.4.7, both paths are active, causing the same prompt to appear twice in the final system message, wasting tokens per LLM call.

Remove the extraSystemPrompt parameter since systemPromptOverride fully handles the system prompt injection. This fixes the duplication for all downstream consumers: L1 extraction, L1 dedup, L2 scene extraction, and L3 persona generation.

## Problem

`CleanContextRunner` passes the system prompt to `runEmbeddedPiAgent` via **two paths** simultaneously:

1. **`config.agents.defaults.systemPromptOverride`** — the primary path, which completely replaces the default agent system prompt
2. **`extraSystemPrompt` parameter** — a legacy fallback intended for older versions of openclaw

On current versions of openclaw, both paths are active. In `openclaw/src/agents/pi-embedded-runner/run/attempt-system-prompt.ts`, `buildAttemptSystemPrompt` processes them as follows:

```typescript
// openclaw/src/agents/pi-embedded-runner/run/attempt-system-prompt.ts
const baseSystemPrompt = params.systemPromptOverrideText
  ? appendModelIdentitySystemPrompt({
      systemPrompt: appendRuntimeExtraSystemPrompt({
        systemPrompt: params.systemPromptOverrideText,              // ← path A: override
        extraSystemPrompt: params.embeddedSystemPrompt.extraSystemPrompt,  // ← path B: appended!
        ...
      }),
      ...
    })
  : buildEmbeddedSystemPrompt(...);
```

When `systemPromptOverrideText` is present, `appendRuntimeExtraSystemPrompt` appends `extraSystemPrompt` after it. Since both contain the same content (e.g. `EXTRACT_MEMORIES_SYSTEM_PROMPT`), the final system message becomes:

```
{EXTRACT_MEMORIES_SYSTEM_PROMPT}          ← from systemPromptOverride

## Group Chat Context
{EXTRACT_MEMORIES_SYSTEM_PROMPT}          ← from extraSystemPrompt (duplicate!)

{model identity line}
```

This affects **all** modules that use `CleanContextRunner`:
- L1 memory extraction (`l1-extractor.ts`)
- L1 conflict detection / dedup (`l1-dedup.ts`)
- L2 scene extraction (`scene-extractor.ts`)
- L3 persona generation (`persona-generator.ts`)

## Impact

- **Extra tokens wasted per LLM call** (the full system prompt is sent twice)
- **Larger lantency**

## Fix

Remove the `extraSystemPrompt` parameter from the `runEmbeddedPiAgent` call in `CleanContextRunner.run()`. The system prompt is already fully handled via `config.agents.defaults.systemPromptOverride`.

After this fix, on openclaw < 2026.4.7, users should enable the LLM configuration item for the plugin, so as to use the StandaloneLLMRunner instead of CleanContextRunner.

## Changes

- `src/utils/clean-context-runner.ts`: Remove `effectiveSystemPrompt` variable and `extraSystemPrompt` parameter passed to `runEmbeddedPiAgent`