### PR TITLE
fix(pipeline): L2 runner 零记录时返回现有 cursor 而非 void

### DIFF
--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -466,7 +466,7 @@ export function createL2Runner(opts: {
         logger.debug?.(
           `${TAG} [L2] No new L1 records since cursor (session=${sessionKey}, updatedAfter=${cursor ?? "(full)"}), skipping scene extraction`,
         );
-        return;
+        return { latestCursor: cursor || undefined };
       }
 
       logger.debug?.(
@@ -497,7 +497,7 @@ export function createL2Runner(opts: {
 
       if (sessionRecords.length === 0) {
         logger.debug?.(`${TAG} [L2] No new L1 records found (JSONL fallback, session=${sessionKey}), skipping scene extraction`);
-        return;
+        return { latestCursor: cursor || undefined };
       }
 
       records = sessionRecords.map((r) => ({

--- a/src/utils/pipeline-manager.ts
+++ b/src/utils/pipeline-manager.ts
@@ -909,6 +909,11 @@ export class MemoryPipelineManager {
     // Advance cursor using the record timestamp returned by the runner
     if (result?.latestCursor) {
       state.last_extraction_updated_time = result.latestCursor;
+    } else if (!state.last_extraction_updated_time) {
+      // Runner returned void (zero records or extraction failed) and cursor
+      // is still empty.  Seed with current time so the next L2 run fetches
+      // incrementally instead of re-scanning all records.
+      state.last_extraction_updated_time = new Date().toISOString();
     }
 
     await this.persistStates();


### PR DESCRIPTION
## Summary

修复 L2 runner 在零记录/提取失败时不返回 cursor 导致 `last_extraction_updated_time` 永不推进的问题。

### 改动 1：`src/utils/pipeline-factory.ts`（runner 侧）

VectorStore 和 JSONL fallback 路径在 0 记录时返回 `{ latestCursor: cursor }` 而非 `void`，让 `runL2` 保留已有 cursor。提取失败路径保持 `void` 返回以保留重试语义。

### 改动 2：`src/utils/pipeline-manager.ts`（runL2 侧）

当 runner 返回 void 且 `last_extraction_updated_time` 仍为空字符串时，将其初始化为当前时间。这解决了 runner 侧改动无法覆盖的边界情况：首次运行时 cursor 为空，`cursor || undefined` 仍为 `undefined`，返回 `{ latestCursor: undefined }` 与 `return;` 效果相同。

## 各场景行为

| 场景 | cursor 初始值 | 最终 cursor | 行为 |
|------|--------------|-------------|------|
| 零记录 + cursor 为空 | `""` | 当前时间 | 不再全量扫描 ✓ |
| 零记录 + 已有 cursor | `"2024-01-01"` | `"2024-01-01"` | 保留不变 ✓ |
| 提取成功 | `""` | `max(updatedAt)` | 正常推进 ✓ |
| 提取失败 + 已有 cursor | `"2024-01-01"` | `"2024-01-01"` | 保留重试 ✓ |
| 提取失败 + cursor 为空 | `""` | 当前时间 | 避免永远全量扫描 |

## 与 PR #2 的区别

PR #2 将 `latestCursor` 计算移到 `if` 块外并无条件返回，导致提取失败（如 LLM 超时）时 cursor 也会推进到 `max(records.updatedAt)`，未成功提取的记录被永久跳过。本 PR 仅在零记录路径返回 cursor，提取失败时保留原始的重试语义。

## Test plan

- [x] 现有测试通过 (`npx vitest run`)
- [ ] 手动验证：首次 L2 运行（cursor 为空）后 cursor 不再为空
- [ ] 手动验证：提取失败 + 已有 cursor 时 cursor 不推进
- [ ] 手动验证：零记录 + 已有 cursor 时 cursor 保持不变

Closes #98