### PR TITLE
fix(recall): preserve non-BMP characters when truncating recalled context

### DIFF
--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -782,11 +782,15 @@ function normalizeBudgetLimit(value: number | undefined): number | undefined {
 }
 
 function truncateRecallLine(line: string, maxChars: number): string {
-  if (line.length <= maxChars) return line;
+  // Count and slice by code point, not UTF-16 code unit, so a cut never lands
+  // between the halves of a surrogate pair (which would corrupt a non-BMP
+  // character to U+FFFD when the line is UTF-8 encoded for the request).
+  const cps = Array.from(line);
+  if (cps.length <= maxChars) return line;
   if (maxChars <= RECALL_TRUNCATION_SUFFIX.length) {
-    return line.slice(0, maxChars);
+    return cps.slice(0, maxChars).join("");
   }
-  return `${line.slice(0, maxChars - RECALL_TRUNCATION_SUFFIX.length).trimEnd()}${RECALL_TRUNCATION_SUFFIX}`;
+  return `${cps.slice(0, maxChars - RECALL_TRUNCATION_SUFFIX.length).join("").trimEnd()}${RECALL_TRUNCATION_SUFFIX}`;
 }
 
 /**


### PR DESCRIPTION
## Description | 描述
`truncateRecallLine` (`src/core/hooks/auto-recall.ts`) truncated recalled-memory lines by UTF-16 code unit (`line.length` / `line.slice`). A cap landing between the halves of a surrogate pair left a lone surrogate, which becomes U+FFFD when the line is UTF-8 encoded for the request, corrupting any non-BMP character (emoji, CJK Ext-B) in the injected context. Switched the count and slice to code points via `Array.from`. Both recall call sites (per-memory and total-budget) route through this one function. Same defect class as #30/#31 ("preserve non-BMP characters in sanitizeText"), reintroduced by the #71 budget path.

## Related Issue | 关联 Issue
Fix #108

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with Node on both branches of the function: a cap landing mid-pair produces U+FFFD before the change and an intact character after; ASCII/BMP input is byte-for-byte unchanged. CI has no test step and the repo currently ships no test files, so no test was added.
