### PR TITLE
fix(core): reliable L3 persona writes for weak tool-calling models + warn on silent embedding misconfig

### DIFF
--- a/src/adapters/standalone/llm-runner.ts
+++ b/src/adapters/standalone/llm-runner.ts
@@ -18,7 +18,7 @@
 
 import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { generateText, tool, stepCountIs, jsonSchema } from "ai";
+import { generateText, tool, stepCountIs, hasToolCall, jsonSchema } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 import { report } from "../../core/report/reporter.js";
 import type {
@@ -197,13 +197,35 @@ export class StandaloneLLMRunner implements LLMRunner {
       : undefined;
 
     try {
+      // Optionally force the model to write via the write_to_file tool (L3
+      // persona). toolChoice pins the first step to that tool, and stopWhen
+      // halts as soon as it is called — so there is no risk of a forced-tool
+      // loop. Only applies to tool-enabled runs that expose write_to_file.
+      const forceWrite =
+        this.enableTools && params.forceWriteTool === true && "write_to_file" in tools;
+      if (forceWrite) {
+        this.logger?.debug?.(`${TAG} Forcing write_to_file tool call (toolChoice + hasToolCall stop).`);
+      }
+
       const result = await generateText({
         model: provider.chat(this.model),
         system: params.systemPrompt,
         prompt: params.prompt,
         ...(tools ? { tools } : {}),
-        stopWhen: stepCountIs(this.enableTools ? MAX_TOOL_ITERATIONS : 1),
+        // "required" (force any tool) is honoured far more reliably by Moonshot
+        // for large prompts than a specific {type:"tool"} choice (measured: 3/3
+        // clean tool calls vs intermittent). The persona prompt only offers
+        // write-style tools and instructs write_to_file, so the model picks it;
+        // hasToolCall then stops the loop as soon as the write happens.
+        toolChoice: forceWrite ? "required" : undefined,
+        stopWhen: forceWrite
+          ? [stepCountIs(MAX_TOOL_ITERATIONS), hasToolCall("write_to_file")]
+          : stepCountIs(this.enableTools ? MAX_TOOL_ITERATIONS : 1),
         maxOutputTokens: maxTokens,
+        // Survive transient network blips (e.g. flaky DNS: getaddrinfo ENOTFOUND)
+        // with extra retry headroom. The AI SDK retries with exponential backoff;
+        // the abortSignal below still caps total wall-clock per run.
+        maxRetries: 4,
         abortSignal: AbortSignal.timeout(timeoutMs),
       });
 
@@ -214,9 +236,11 @@ export class StandaloneLLMRunner implements LLMRunner {
         `${TAG} run() completed: ${totalMs}ms, steps=${result.steps.length}, output=${text.length} chars`,
       );
 
-      // Log tool usage if any
-      if (result.steps.length > 1) {
-        const toolCalls = result.steps.flatMap((s) => s.toolCalls ?? []);
+      // Log tool usage if any. Do NOT gate on steps.length > 1: a forced tool
+      // call (forceWrite) stops the loop at step 1 via hasToolCall, so the call
+      // would otherwise go unlogged.
+      const toolCalls = result.steps.flatMap((s) => s.toolCalls ?? []);
+      if (toolCalls.length > 0) {
         this.logger?.debug?.(
           `${TAG} Tool calls: ${toolCalls.map((tc) => tc.toolName).join(", ")}`,
         );

--- a/src/core/persona/persona-generator.ts
+++ b/src/core/persona/persona-generator.ts
@@ -9,7 +9,7 @@ import { CleanContextRunner } from "../../utils/clean-context-runner.js";
 import { CheckpointManager } from "../../utils/checkpoint.js";
 import { readSceneIndex } from "../scene/scene-index.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
-import { buildPersonaPrompt } from "../prompts/persona-generation.js";
+import { buildPersonaPrompt, type PersonaToolDialect } from "../prompts/persona-generation.js";
 import { BackupManager } from "../../utils/backup.js";
 import { escapeXmlTags } from "../../utils/sanitize.js";
 import { report } from "../report/reporter.js";
@@ -30,6 +30,8 @@ export class PersonaGenerator {
   private logger: Logger | undefined;
   private backupCount: number;
   private instanceId: string | undefined;
+  /** Tool-name dialect for the persona prompt, derived from the active runner. */
+  private toolDialect: PersonaToolDialect;
 
   constructor(opts: {
     dataDir: string;
@@ -57,7 +59,12 @@ export class PersonaGenerator {
       enableTools: true,
       logger: opts.logger,
     });
-    this.logger?.debug?.(`${TAG} Generator created: model=${opts.model ?? "(default)"}, dataDir=${opts.dataDir}`);
+    // The injected runner is the host-neutral StandaloneLLMRunner (gateway/Hermes),
+    // whose file tools are write_to_file/replace_in_file. The fallback
+    // CleanContextRunner uses OpenClaw's write/edit. Tell the prompt which set to
+    // reference so the model can actually call the write tool (not emit raw text).
+    this.toolDialect = opts.llmRunner ? "standalone" : "openclaw";
+    this.logger?.debug?.(`${TAG} Generator created: model=${opts.model ?? "(default)"}, dataDir=${opts.dataDir}, toolDialect=${this.toolDialect}`);
   }
 
   /**
@@ -143,6 +150,7 @@ export class PersonaGenerator {
       triggerInfo: triggerReason,
       personaFilePath: personaPath,
       checkpointPath: path.join(this.dataDir, ".metadata", "recall_checkpoint.json"),
+      toolDialect: this.toolDialect,
     });
 
     // 7. Backup before LLM run (LLM writes persona.md via tools)
@@ -150,15 +158,19 @@ export class PersonaGenerator {
     await bm.backupFile(personaPath, "persona", `offset${cp.total_processed}`, this.backupCount);
 
     // 8. Run LLM agent (sandboxed to dataDir, tools enabled — LLM writes persona.md directly)
+    let runOutput = "";
     try {
       this.logger?.debug?.(`${TAG} Calling LLM for persona generation (timeout=180s, tools=enabled, workspaceDir=${this.dataDir})...`);
-      await this.runner.run({
+      runOutput = await this.runner.run({
         systemPrompt,
         prompt: userPrompt,
         taskId: "persona-generation",
         timeoutMs: 180_000,
         // maxTokens omitted → core uses the resolved model's maxTokens from catalog
         workspaceDir: this.dataDir,
+        // Standalone runner exposes write_to_file: force the model to write the
+        // file via tool (the OpenClaw runner ignores this flag and uses its own).
+        forceWriteTool: this.toolDialect === "standalone",
       });
       this.logger?.debug?.(`${TAG} LLM runner completed`);
     } catch (err) {
@@ -167,14 +179,24 @@ export class PersonaGenerator {
       return false;
     }
 
-    // 9. Read LLM-written persona.md and apply post-processing
+    // 9. Read the LLM-written persona.md and apply post-processing.
+    //    Fallback: OpenAI-compatible models with weak tool-calling (e.g.
+    //    Moonshot/Kimi) often emit the persona as assistant TEXT instead of
+    //    invoking the write_to_file tool. In that case persona.md is never
+    //    created and an otherwise-successful generation would be silently lost.
+    //    When the file is missing but the runner returned text, persist that
+    //    text as the persona so L3 is robust to tool-calling variance.
     let personaText: string;
     try {
       personaText = await fs.readFile(personaPath, "utf-8");
     } catch {
-      // LLM failed to write persona.md — treat as failure
-      this.logger?.error(`${TAG} LLM did not write persona.md — file not found after runner completed`);
-      return false;
+      if (runOutput && runOutput.trim()) {
+        this.logger?.warn(`${TAG} LLM did not call write_to_file; persisting returned assistant text as persona.md (${runOutput.length} chars)`);
+        personaText = runOutput;
+      } else {
+        this.logger?.error(`${TAG} LLM did not write persona.md and returned no text — treating as failure`);
+        return false;
+      }
     }
 
     // 10. Strip any navigation the LLM might have added + sanitize for safe injection

--- a/src/core/prompts/persona-generation.ts
+++ b/src/core/prompts/persona-generation.ts
@@ -19,6 +19,12 @@ export interface PersonaPromptParams {
   personaFilePath: string;
   /** @deprecated Kept for call-site compatibility; no longer used in prompt. */
   checkpointPath: string;
+  /**
+   * Which runner's file-tool names the prompt should instruct the model to use.
+   * "standalone" = gateway/Hermes (write_to_file / replace_in_file);
+   * "openclaw" = OpenClaw runtime (write / edit). Default "openclaw" (upstream).
+   */
+  toolDialect?: PersonaToolDialect;
 }
 
 export interface PersonaPromptResult {
@@ -27,10 +33,42 @@ export interface PersonaPromptResult {
 }
 
 // ============================
+// Tool dialects
+// ============================
+// The standalone gateway/Hermes runner exposes file tools named
+// `write_to_file` / `replace_in_file`; the OpenClaw runtime exposes `write` /
+// `edit` (with a different edit-param shape). The persona prompt MUST name the
+// tools the ACTIVE runner actually has — otherwise the model cannot call the
+// write tool and emits the persona as plain text instead of a file write.
+
+export type PersonaToolDialect = "openclaw" | "standalone";
+
+interface ToolNames {
+  write: string;
+  edit: string;
+  /** Chinese hint describing the edit tool's parameters. */
+  editParams: string;
+}
+
+const TOOL_DIALECTS: Record<PersonaToolDialect, ToolNames> = {
+  openclaw: {
+    write: "write",
+    edit: "edit",
+    editParams: "`path`=`persona.md`, `edits`=[{`oldText`: 旧内容片段, `newText`: 新内容片段}]",
+  },
+  standalone: {
+    write: "write_to_file",
+    edit: "replace_in_file",
+    editParams: "`path`=`persona.md`, `old_str`=旧内容片段, `new_str`=新内容片段",
+  },
+};
+
+// ============================
 // System Prompt (stable: role + constraints + logic + template)
 // ============================
 
-const PERSONA_SYSTEM_PROMPT = `# 🧬 Persona Architect - Incremental Evolution Protocol
+function personaSystemPrompt(t: ToolNames): string {
+  return `# 🧬 Persona Architect - Incremental Evolution Protocol
 
 **输出语言**：\`persona.md\` 的所有自然语言内容（Archetype、基本信息、Chapter 1-4 正文等）使用与变化场景内容相同的语言；Markdown 语法、标签格式、文件名 \`persona.md\` 保持英文。模板里 Chapter 标识保留作骨架，非中文输出时请改用目标语言的对照说明。
 
@@ -39,8 +77,8 @@ const PERSONA_SYSTEM_PROMPT = `# 🧬 Persona Architect - Incremental Evolution 
 ## ⛔ 文件操作约束（必须严格遵守）
 
 1. **必须使用文件工具将最终 persona 内容写入 \`persona.md\`**。当前工作目录已设为数据目录，直接使用文件名 \`persona.md\`。
-   - **首次生成 / 大幅重写**：使用 **write** 工具整体写入。参数：\`path\`=\`persona.md\`, \`content\`=完整内容
-   - **增量更新（局部修改）**：使用 **edit** 工具精确替换。参数：\`path\`=\`persona.md\`, \`edits\`=[{\`oldText\`: 旧内容片段, \`newText\`: 新内容片段}]
+   - **首次生成 / 大幅重写**：使用 **${t.write}** 工具整体写入。参数：\`path\`=\`persona.md\`, \`content\`=完整内容
+   - **增量更新（局部修改）**：使用 **${t.edit}** 工具精确替换。参数：${t.editParams}
 2. **只能操作 \`persona.md\` 这一个文件**，禁止读取或写入任何其他文件（包括 scene_blocks/、.metadata/ 等）。
 3. **写入的内容必须只包含最终的 persona 文档**，不要包含你的思考过程、分析步骤或任何非 persona 内容。
 4. **无需 read 工具**：当前 persona.md 的完整内容已在用户消息中提供，直接基于它进行更新即可。
@@ -85,7 +123,7 @@ const PERSONA_SYSTEM_PROMPT = `# 🧬 Persona Architect - Incremental Evolution 
 
 ## 📝 输出模板 (The Persona Template)
 
-请参考以下格式，使用 **write** 工具写入最终内容。可以做自主调整（信息不足时可以减少或新增 chapter）（**必须保持 Markdown 格式**）：
+请参考以下格式，使用 **${t.write}** 工具写入最终内容。可以做自主调整（信息不足时可以减少或新增 chapter）（**必须保持 Markdown 格式**）：
 
 \`\`\`\`markdown
 # User Narrative Profile
@@ -130,12 +168,13 @@ const PERSONA_SYSTEM_PROMPT = `# 🧬 Persona Architect - Incremental Evolution 
 ---
 
 ### ⚠️ 成功标准
-- ✅ **必须使用 write 或 edit 工具写入最终结果到 \`persona.md\`**
+- ✅ **必须使用 ${t.write} 或 ${t.edit} 工具写入最终结果到 \`persona.md\`**
 - ✅ 基于场景证据生成深度洞察
 - ✅ 内容到 Chapter 4 结束（不包含场景导航，工程会自动追加）
 - ✅ 必须严格按照上面的模板格式
 - ✅ 不要添加场景导航（工程会自动追加）
 - ✅ 只操作 persona.md，不要操作其他文件`;
+}
 
 // ============================
 // User Prompt builder (dynamic data)
@@ -186,8 +225,10 @@ ${changedScenesContent}
 ${existingPersonaSection}
 ${iterationGuide}`;
 
+  const tools = TOOL_DIALECTS[params.toolDialect ?? "openclaw"];
+
   return {
-    systemPrompt: PERSONA_SYSTEM_PROMPT,
+    systemPrompt: personaSystemPrompt(tools),
     userPrompt,
   };
 }

--- a/src/core/store/factory.ts
+++ b/src/core/store/factory.ts
@@ -101,6 +101,22 @@ export function createStoreBundle(
           sendDimensions: config.embedding.sendDimensions,
           maxInputChars: config.embedding.maxInputChars,
         }, logger);
+      } else if (config.embedding.provider !== "none" && config.embedding.provider !== "local") {
+        // A remote embedding provider was configured but the service was NOT
+        // created. The usual cause is an empty/unresolved apiKey (e.g.
+        // ${OPENAI_API_KEY} not present in the gateway process environment),
+        // which otherwise SILENTLY disables semantic search — hybrid search
+        // degrades to keyword-only with no error. Surface it at WARN so the
+        // misconfiguration is diagnosable instead of mysterious.
+        const why = !config.embedding.apiKey
+          ? "apiKey is empty (is the provider API key resolved in this process's environment?)"
+          : !config.embedding.enabled
+            ? "embedding.enabled=false (config validation failed)"
+            : "unknown reason";
+        logger?.warn?.(
+          `${TAG} Embedding provider '${config.embedding.provider}' is configured but the EmbeddingService was NOT initialised: ${why}. ` +
+          `Semantic search will fall back to keyword-only.`,
+        );
       }
 
       // dimensions from config (0 when provider="none" → vec0 deferred)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -81,6 +81,15 @@ export interface LLMRunParams {
   workspaceDir?: string;
   /** Plugin instance ID for metric reporting (optional). */
   instanceId?: string;
+  /**
+   * Force the model to write its result via the `write_to_file` tool instead of
+   * emitting it as plain text. Only honoured by tool-enabled standalone runs.
+   * Used by L3 persona generation: large prompts make some OpenAI-compatible
+   * models (e.g. Moonshot) prefer a text answer over a tool call; forcing the
+   * tool guarantees the file is written by the model, with the text fallback
+   * still acting as a safety net.
+   */
+  forceWriteTool?: boolean;
 }
 
 /**


### PR DESCRIPTION
Two small, independent core fixes I hit while running the standalone gateway with an OpenAI-compatible model (Moonshot/Kimi) for extraction.

## 1. L3 persona is silently dropped with weak tool-calling models

The persona prompt instructed the model to use the `write`/`edit` tools (OpenClaw names), but the standalone runner exposes `write_to_file`/`replace_in_file`. With a model that has weaker tool-calling, it returned the persona as plain text and called no tool, so the result was discarded and `persona.md` was never written.

This PR:
- makes the persona prompt **tool-dialect aware** (`openclaw`: write/edit — unchanged default; `standalone`: write_to_file/replace_in_file);
- optionally **forces the write tool** (`toolChoice: "required"` + stop on `write_to_file`) so reliable tool-calling is guaranteed when needed;
- adds a **text fallback**: if the model still returns the persona as text, it's persisted instead of lost.

The non-forced branch is unchanged; I preserved main's conditional `tools` spread in the merge.

## 2. Silent degradation when an embedding provider is misconfigured

When a remote embedding provider is configured but the service fails to initialize (e.g. an empty API key), search silently fell back to keyword-only with no signal. This adds a **WARN at startup** so the misconfiguration is visible instead of silent.

## Testing

Built against current `main` (build green). Verified the persona path writes `persona.md` via the tool (fallback count 0) and the WARN fires when the embedding key is missing.

Happy to adjust naming or split these into two PRs if you'd prefer.