### PR TITLE
docs: fix OpenClaw context engine slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Add the `slots` field so OpenClaw routes context-offload requests to this plugin
 {
   "plugins": {
     "slots": {
-      "contextEngine": "openclaw-context-offload"
+      "contextEngine": "memory-tencentdb"
     }
   }
 }

--- a/README_CN.md
+++ b/README_CN.md
@@ -180,7 +180,7 @@ openclaw gateway restart
 {
   "plugins": {
     "slots": {
-      "contextEngine": "openclaw-context-offload"
+      "contextEngine": "memory-tencentdb"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update OpenClaw short-term compression setup to use `memory-tencentdb` for `plugins.slots.contextEngine`
- Apply the same fix to README_CN.md

## Why
`src/offload/index.ts` checks `CE_PLUGIN_ID = "memory-tencentdb"` before registering the context engine. The previous README value `openclaw-context-offload` is the internal engine info id, not the plugin slot id, and causes offload registration to be rejected.

## Validation
- `git diff --check`
- Verified the old README slot value no longer appears in README.md / README_CN.md
- Verified README slot value matches `CE_PLUGIN_ID` in `src/offload/index.ts`