### PR TITLE
Add Codex MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | Document | Contents |
 | :--- | :--- |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
+| [`integrations/codex/README.md`](./integrations/codex/README.md) | Codex MCP integration guide |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -348,6 +348,7 @@ docker exec -it hermes-memory hermes
 | 文档 | 内容 |
 | :--- | :--- |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
+| [`integrations/codex/README.md`](./integrations/codex/README.md) | Codex MCP 集成指南 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |
 

--- a/integrations/codex/AGENTS.md
+++ b/integrations/codex/AGENTS.md
@@ -1,0 +1,134 @@
+# Agent Operating Instructions
+
+## Memory System
+
+TencentDB Agent Memory is available through MCP tools:
+
+- `tdai_recall`
+- `tdai_memory_search`
+- `tdai_conversation_search`
+- `tdai_capture`
+- `tdai_session_end`
+
+Treat TencentDB Agent Memory as the primary long-term memory system for cross-session project knowledge, user preferences, repository conventions, implementation decisions, debugging history, and workflow constraints.
+
+Do not assume that prior context is already present in the current conversation. Use memory tools explicitly.
+
+## Session Key
+
+Use the current repository root path as the default `session_key`.
+
+If no repository is available, use the current working directory as `session_key`.
+
+Use the same `session_key` consistently for all memory operations within one task.
+
+## Start-of-Task Protocol
+
+At the beginning of every non-trivial task, before editing files or running commands:
+
+1. Call `tdai_recall`.
+2. Use the user's current request as the `query`.
+3. Use the repository root path as `session_key`.
+4. Read the returned memory before planning or modifying code.
+
+A task is non-trivial if it involves any of the following:
+
+- code changes
+- debugging
+- architecture decisions
+- dependency changes
+- test strategy
+- repository-specific conventions
+- deployment or build behavior
+- user preferences
+- multi-step investigation
+
+For trivial tasks, such as answering a simple question about visible code or formatting a short snippet, memory recall is optional.
+
+## Memory Search Protocol
+
+Use `tdai_memory_search` when looking for durable structured knowledge, including:
+
+- project conventions
+- previous architectural decisions
+- recurring user preferences
+- known pitfalls
+- preferred libraries or frameworks
+- testing/build/deployment commands
+- long-term repo-specific facts
+
+Use `tdai_conversation_search` when exact historical evidence is needed, including:
+
+- what was previously discussed
+- why a decision was made
+- prior debugging traces
+- previous commands or tool outputs
+- original wording from earlier sessions
+
+Prefer `tdai_recall` first. Use search tools only when recall is insufficient or when more precise evidence is needed.
+
+## During Work
+
+When memory conflicts with the current repository state, trust the repository state.
+
+When memory conflicts with explicit user instructions, trust the user's current instruction.
+
+When memory is stale, incomplete, or ambiguous, say so and proceed from current evidence.
+
+Do not blindly follow recalled memory. Validate it against files, tests, and current task requirements.
+
+## Capture Protocol
+
+At the end of every meaningful task, call `tdai_capture`.
+
+Store a concise but useful summary.
+
+The `user_content` should summarize what the user asked.
+
+The `assistant_content` should include:
+
+- what was changed
+- important files touched
+- commands run
+- tests run and results
+- bugs found
+- decisions made
+- constraints discovered
+- repository conventions learned
+- unresolved follow-ups
+- anything that would help a future Codex session continue efficiently
+
+Keep the capture factual and compact.
+
+Do not store noisy step-by-step logs unless they are diagnostically important.
+
+## Sensitive Information Policy
+
+Never store the following in memory:
+
+- API keys
+- access tokens
+- passwords
+- private keys
+- SSH keys
+- cookies
+- session tokens
+- secrets from `.env` files
+- personal identification data unless explicitly required and safe
+- proprietary credentials
+- raw production data
+- security-sensitive exploit details
+
+If a task involves secrets, store only a sanitized summary.
+
+Good example:
+
+```text
+Configured authentication flow. Secret values are stored in environment variables and were not recorded.
+```
+
+Bad example:
+
+```text
+Configured authentication using API key sk-...
+```

--- a/integrations/codex/DEPLOYMENT.md
+++ b/integrations/codex/DEPLOYMENT.md
@@ -1,0 +1,182 @@
+# TencentDB Agent Memory + Codex MCP Deployment
+
+This guide installs TencentDB Agent Memory as a local Gateway and connects it to
+Codex through MCP. It avoids hard-coded usernames and uses `$HOME`,
+`$CODEX_HOME`, and configurable environment variables.
+
+## Architecture
+
+```text
+Codex
+  -> tdai-memory MCP server
+    -> TencentDB Agent Memory Gateway http://127.0.0.1:8420
+      -> local SQLite/BM25 memory store
+      -> OpenAI-compatible LLM API for L1/L2/L3 extraction
+```
+
+## Variables
+
+```bash
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export TDAI_HOME="${TDAI_HOME:-$HOME/.memory-tencentdb}"
+export TDAI_SRC="${TDAI_SRC:-$HOME/Downloads/TencentDB-Agent-Memory}"
+export TDAI_CODEX_INTEGRATION="${TDAI_CODEX_INTEGRATION:-$TDAI_SRC/integrations/codex}"
+export NODE_VERSION="${NODE_VERSION:-v22.16.0}"
+export NODE_DIR="$HOME/.local/opt/node-$NODE_VERSION-linux-x64"
+```
+
+## 1. Clone TencentDB Agent Memory
+
+```bash
+mkdir -p "$(dirname "$TDAI_SRC")"
+git clone https://github.com/Tencent/TencentDB-Agent-Memory.git "$TDAI_SRC"
+cd "$TDAI_SRC"
+```
+
+If the repository already exists:
+
+```bash
+git -C "$TDAI_SRC" pull --ff-only
+```
+
+## 2. Install Node 22 Locally
+
+TencentDB Agent Memory requires Node `>=22.16.0`.
+
+```bash
+mkdir -p "$HOME/.local/opt" "$HOME/.local/bin"
+cd "$HOME/.local/opt"
+
+curl -fL "https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.xz" \
+  -o "node-$NODE_VERSION-linux-x64.tar.xz"
+
+tar -xJf "node-$NODE_VERSION-linux-x64.tar.xz"
+ln -sfn "$NODE_DIR" "$HOME/.local/opt/node-current"
+ln -sfn "$HOME/.local/opt/node-current/bin/node" "$HOME/.local/bin/node"
+ln -sfn "$HOME/.local/opt/node-current/bin/npm" "$HOME/.local/bin/npm"
+ln -sfn "$HOME/.local/opt/node-current/bin/npx" "$HOME/.local/bin/npx"
+```
+
+Verify:
+
+```bash
+PATH="$HOME/.local/bin:$PATH" node --version
+PATH="$HOME/.local/bin:$PATH" npm --version
+```
+
+## 3. Install Dependencies And Build
+
+```bash
+cd "$TDAI_SRC"
+PATH="$HOME/.local/bin:$PATH" npm install
+PATH="$HOME/.local/bin:$PATH" npm run build
+```
+
+## 4. Install Global Codex Instructions
+
+Install the supplied `AGENTS.md` into Codex's global instruction location:
+
+```bash
+mkdir -p "$CODEX_HOME"
+install -m 0644 "$TDAI_CODEX_INTEGRATION/AGENTS.md" "$CODEX_HOME/AGENTS.md"
+```
+
+This global file tells future Codex sessions to use TencentDB Agent Memory as
+the primary long-term memory system across repositories. A project-local
+`AGENTS.md` can still be useful as documentation, but the global copy is the
+important one for cross-project behavior.
+
+## 5. Configure The Gateway LLM
+
+Create a private environment file from the example:
+
+```bash
+mkdir -p "$TDAI_HOME"
+install -m 0600 "$TDAI_CODEX_INTEGRATION/env/gateway.env.example" "$TDAI_HOME/gateway.env"
+$EDITOR "$TDAI_HOME/gateway.env"
+```
+
+Use any OpenAI-compatible endpoint. Never commit or share `gateway.env`.
+
+## 6. Install Gateway Startup Script
+
+```bash
+mkdir -p "$TDAI_HOME" "$HOME/.local/bin"
+install -m 0755 "$TDAI_CODEX_INTEGRATION/scripts/start-gateway.sh" "$TDAI_HOME/start-gateway.sh"
+
+cat > "$HOME/.local/bin/tdai-memory-gateway" <<'EOF'
+#!/usr/bin/env bash
+exec "${TDAI_HOME:-$HOME/.memory-tencentdb}/start-gateway.sh" "$@"
+EOF
+chmod +x "$HOME/.local/bin/tdai-memory-gateway"
+```
+
+## 7. Install systemd User Service
+
+```bash
+mkdir -p "$HOME/.config/systemd/user"
+
+sed \
+  -e "s|%HOME%|$HOME|g" \
+  -e "s|%TDAI_HOME%|$TDAI_HOME|g" \
+  -e "s|%TDAI_SRC%|$TDAI_SRC|g" \
+  "$TDAI_CODEX_INTEGRATION/systemd/tdai-memory-gateway.service.template" \
+  > "$HOME/.config/systemd/user/tdai-memory-gateway.service"
+
+systemctl --user daemon-reload
+systemctl --user enable --now tdai-memory-gateway.service
+```
+
+Check status:
+
+```bash
+systemctl --user status tdai-memory-gateway.service
+journalctl --user -u tdai-memory-gateway.service -n 100 --no-pager
+curl -sS http://127.0.0.1:8420/health
+```
+
+## 8. Install Codex MCP Server
+
+The Python MCP server requires `mcp` and `httpx`:
+
+```bash
+python3 -m pip install --user -r "$TDAI_CODEX_INTEGRATION/mcp/tdai-memory/requirements.txt"
+mkdir -p "$CODEX_HOME/mcp/tdai-memory"
+install -m 0755 "$TDAI_CODEX_INTEGRATION/mcp/tdai-memory/server.py" \
+  "$CODEX_HOME/mcp/tdai-memory/server.py"
+```
+
+Register the MCP server in `$CODEX_HOME/config.toml`:
+
+```toml
+[mcp_servers.tdai-memory]
+command = "python3"
+args = ["/absolute/path/to/.codex/mcp/tdai-memory/server.py"]
+```
+
+Use the absolute path printed by:
+
+```bash
+printf '%s\n' "$CODEX_HOME/mcp/tdai-memory/server.py"
+```
+
+## 9. Verify From Codex
+
+Restart Codex and ask it to use the TencentDB Agent Memory tools. The MCP server
+should expose:
+
+```text
+tdai_recall
+tdai_memory_search
+tdai_conversation_search
+tdai_capture
+tdai_session_end
+```
+
+## Troubleshooting
+
+- `connection refused`: start or restart `tdai-memory-gateway.service`.
+- `No module named mcp`: install the Python dependencies for the same Python
+  executable used by Codex.
+- `HTTP 401` or extraction failures: check `$TDAI_HOME/gateway.env`, but never
+  paste or commit secret values.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,41 @@
+# Codex MCP Integration
+
+This directory contains a portable Codex integration for TencentDB Agent Memory.
+It runs TencentDB Agent Memory Gateway locally and exposes memory tools to Codex
+through a stdio MCP server.
+
+## Contents
+
+- `AGENTS.md`: recommended global Codex operating instructions.
+- `DEPLOYMENT.md`: end-to-end setup guide.
+- `mcp/tdai-memory/server.py`: Python MCP bridge for Codex.
+- `mcp/tdai-memory/requirements.txt`: Python dependencies for the MCP bridge.
+- `scripts/start-gateway.sh`: portable Gateway startup script.
+- `systemd/tdai-memory-gateway.service.template`: user systemd service template.
+- `env/gateway.env.example`: example LLM configuration without secrets.
+
+## Exposed MCP Tools
+
+- `tdai_recall`
+- `tdai_memory_search`
+- `tdai_conversation_search`
+- `tdai_capture`
+- `tdai_session_end`
+
+## Quick Agent Prompt
+
+```text
+Read integrations/codex/AGENTS.md and integrations/codex/DEPLOYMENT.md.
+Install TencentDB Agent Memory Gateway and register the tdai-memory MCP server
+with Codex. Install AGENTS.md globally at $CODEX_HOME/AGENTS.md. Use
+integrations/codex/env/gateway.env.example as a template, but never record or
+expose API keys.
+```
+
+## Do Not Distribute
+
+- Real `gateway.env` files.
+- API keys, access tokens, or private credentials.
+- `$CODEX_HOME/auth.json`.
+- Local memory data under `$TDAI_HOME/memory-tdai`.
+- `node_modules` or build output.

--- a/integrations/codex/env/gateway.env.example
+++ b/integrations/codex/env/gateway.env.example
@@ -1,0 +1,3 @@
+TDAI_LLM_API_KEY=replace_with_your_api_key
+TDAI_LLM_BASE_URL=https://api.lkeap.cloud.tencent.com/v1
+TDAI_LLM_MODEL=deepseek-v3.2

--- a/integrations/codex/mcp/tdai-memory/requirements.txt
+++ b/integrations/codex/mcp/tdai-memory/requirements.txt
@@ -1,0 +1,2 @@
+mcp
+httpx

--- a/integrations/codex/mcp/tdai-memory/server.py
+++ b/integrations/codex/mcp/tdai-memory/server.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""TencentDB Agent Memory MCP server for Codex."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+
+BASE = os.environ.get("TDAI_GATEWAY_URL", "http://127.0.0.1:8420").rstrip("/")
+DEFAULT_SESSION_KEY = os.environ.get("TDAI_SESSION_KEY") or str(Path.cwd())
+TOKEN = os.environ.get("TDAI_GATEWAY_TOKEN")
+TIMEOUT_SECONDS = float(os.environ.get("TDAI_GATEWAY_TIMEOUT", "30"))
+
+mcp = FastMCP(
+    "tdai-memory",
+    instructions=(
+        "Use tdai_recall before starting coding tasks when prior TencentDB "
+        "Agent Memory context may help."
+    ),
+    log_level=os.environ.get("FASTMCP_LOG_LEVEL", "ERROR"),
+)
+
+
+async def post(path: str, body: dict[str, Any]) -> Any:
+    headers = {"content-type": "application/json"}
+    if TOKEN:
+        headers["authorization"] = f"Bearer {TOKEN}"
+
+    async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+        response = await client.post(f"{BASE}{path}", headers=headers, json=body)
+
+    text = response.text
+    if response.status_code >= 400:
+        raise RuntimeError(f"{path} failed: HTTP {response.status_code} {text}")
+
+    if not text:
+        return {}
+
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return text
+
+
+def pretty(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, indent=2)
+
+
+@mcp.tool(
+    description="Recall relevant TencentDB Agent Memory context before starting a coding task.",
+    structured_output=False,
+)
+async def tdai_recall(query: str, session_key: str | None = None) -> str:
+    return pretty(
+        await post(
+            "/recall",
+            {
+                "query": query,
+                "session_key": session_key or DEFAULT_SESSION_KEY,
+            },
+        )
+    )
+
+
+@mcp.tool(
+    description="Search structured L1 memories.",
+    structured_output=False,
+)
+async def tdai_memory_search(
+    query: str,
+    limit: int | None = None,
+    type: str | None = None,
+    scene: str | None = None,
+) -> str:
+    body: dict[str, Any] = {"query": query}
+    if limit is not None:
+        body["limit"] = limit
+    if type is not None:
+        body["type"] = type
+    if scene is not None:
+        body["scene"] = scene
+    return pretty(await post("/search/memories", body))
+
+
+@mcp.tool(
+    description="Search raw L0 conversation history as evidence.",
+    structured_output=False,
+)
+async def tdai_conversation_search(
+    query: str,
+    limit: int | None = None,
+    session_key: str | None = None,
+) -> str:
+    body: dict[str, Any] = {
+        "query": query,
+        "session_key": session_key or DEFAULT_SESSION_KEY,
+    }
+    if limit is not None:
+        body["limit"] = limit
+    return pretty(await post("/search/conversations", body))
+
+
+@mcp.tool(
+    description="Store a concise user/assistant turn into TencentDB Agent Memory.",
+    structured_output=False,
+)
+async def tdai_capture(
+    user_content: str,
+    assistant_content: str,
+    session_key: str | None = None,
+    session_id: str | None = None,
+) -> str:
+    body: dict[str, Any] = {
+        "user_content": user_content,
+        "assistant_content": assistant_content,
+        "session_key": session_key or DEFAULT_SESSION_KEY,
+    }
+    if session_id is not None:
+        body["session_id"] = session_id
+    return pretty(await post("/capture", body))
+
+
+@mcp.tool(
+    description="Flush memory pipeline for the current session.",
+    structured_output=False,
+)
+async def tdai_session_end(session_key: str | None = None) -> str:
+    return pretty(
+        await post(
+            "/session/end",
+            {
+                "session_key": session_key or DEFAULT_SESSION_KEY,
+            },
+        )
+    )
+
+
+if __name__ == "__main__":
+    mcp.run("stdio")

--- a/integrations/codex/scripts/start-gateway.sh
+++ b/integrations/codex/scripts/start-gateway.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+export TDAI_HOME="${TDAI_HOME:-$HOME/.memory-tencentdb}"
+export TDAI_SRC="${TDAI_SRC:-$HOME/Downloads/TencentDB-Agent-Memory}"
+
+if [[ -f "$TDAI_HOME/gateway.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$TDAI_HOME/gateway.env"
+  set +a
+fi
+
+export TDAI_GATEWAY_HOST="${TDAI_GATEWAY_HOST:-127.0.0.1}"
+export TDAI_GATEWAY_PORT="${TDAI_GATEWAY_PORT:-8420}"
+export TDAI_DATA_DIR="${TDAI_DATA_DIR:-$TDAI_HOME/memory-tdai}"
+export TDAI_LLM_BASE_URL="${TDAI_LLM_BASE_URL:-https://api.lkeap.cloud.tencent.com/v1}"
+export TDAI_LLM_MODEL="${TDAI_LLM_MODEL:-deepseek-v3.2}"
+export TDAI_LLM_API_KEY="${TDAI_LLM_API_KEY:-${OPENAI_API_KEY:-}}"
+
+cd "$TDAI_SRC"
+exec node --import tsx src/gateway/server.ts

--- a/integrations/codex/systemd/tdai-memory-gateway.service.template
+++ b/integrations/codex/systemd/tdai-memory-gateway.service.template
@@ -1,0 +1,17 @@
+[Unit]
+Description=TencentDB Agent Memory Gateway
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%HOME%/.local/bin/tdai-memory-gateway
+WorkingDirectory=%TDAI_SRC%
+Restart=on-failure
+RestartSec=3
+Environment=PATH=%HOME%/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=TDAI_HOME=%TDAI_HOME%
+Environment=TDAI_SRC=%TDAI_SRC%
+EnvironmentFile=%TDAI_HOME%/gateway.env
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Description | 描述

Add a portable Codex MCP integration for TencentDB Agent Memory.

This PR adds:

- `integrations/codex/README.md`: Codex integration overview
- `integrations/codex/DEPLOYMENT.md`: end-to-end deployment guide
- `integrations/codex/AGENTS.md`: recommended global Codex memory instructions
- `integrations/codex/mcp/tdai-memory/server.py`: stdio MCP bridge for Codex
- `integrations/codex/mcp/tdai-memory/requirements.txt`: Python dependencies
- `integrations/codex/scripts/start-gateway.sh`: portable Gateway startup script
- `integrations/codex/systemd/tdai-memory-gateway.service.template`: systemd user service template
- `integrations/codex/env/gateway.env.example`: example LLM environment config
- README links in both English and Chinese documentation tables

The MCP bridge exposes:

- `tdai_recall`
- `tdai_memory_search`
- `tdai_conversation_search`
- `tdai_capture`
- `tdai_session_end`

## Related Issue | 关联 Issue

N/A

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Local verification:

- `python3 -m py_compile integrations/codex/mcp/tdai-memory/server.py`
- `git diff --check origin/main...HEAD`
- MCP client startup test confirmed all five expected tools are exposed
- Secret/path scan found no hard-coded personal paths or real credentials
- `PATH=/home/haoyi/.local/bin:$PATH npm test`

Result:

- 2 test files passed
- 8 tests passed