### PR TITLE
fix: pass disableTools:true when enableTools=false in CleanContextRunner

### DIFF
--- a/src/utils/clean-context-runner.ts
+++ b/src/utils/clean-context-runner.ts
@@ -5,7 +5,7 @@
  * Guarantees:
  * 1. Blank conversation history (temporary session file)
  * 2. Independent system prompt (only the task prompt)
- * 3. No tool calls (tools restricted to minimal read-only set to avoid empty tools[] rejection by some providers)
+ * 3. No tool calls when enableTools=false (disableTools:true — no tool definitions sent to API)
  * 4. No contamination from the main agent's context
  */
 
@@ -390,10 +390,11 @@ export class CleanContextRunner {
         },
         tools: {
           ...((this.options.config as Record<string, unknown>)?.tools as Record<string, unknown> | undefined),
-          // When enableTools=false we still keep one lightweight read-only tool
-          // so that the tools array sent to the API is non-empty.
-          // Some providers (e.g. qwencode) reject tools:[] with minItems:1 validation.
-          allow: this.options.enableTools ? ["read", "write", "edit"] : ["read"],
+          // When enableTools=true, restrict to the minimal set needed for
+          // scene extraction (read/write/edit).
+          // When enableTools=false, pass an empty allow list — disableTools:true
+          // will prevent tools from being sent to the API entirely.
+          allow: this.options.enableTools ? ["read", "write", "edit"] : [],
         },
         // Override the full agent system prompt with the caller's extraction-specific
         // system prompt. This replaces OpenClaw's default system prompt (identity,
@@ -451,11 +452,13 @@ export class CleanContextRunner {
         runId,
         provider: this.resolvedProvider,
         model: this.resolvedModel,
-        // Do NOT pass disableTools:true — that produces tools:[] which some
-        // providers (qwencode) reject with "[] is too short - 'tools'".
-        // Instead rely on cleanConfig.tools.allow to restrict the tool set
-        // to a minimal read-only tool (when enableTools=false).
-        disableTools: false,
+        // When enableTools=false, pass disableTools:true so that no tool
+        // definitions are sent to the API. This avoids polluting the LLM
+        // context with tool schemas and prevents the model from attempting
+        // tool calls during pure text extraction tasks.
+        // If a provider (e.g. qwencode) rejects empty tools[], users should
+        // switch to StandaloneLLMRunner via LLM configuration instead.
+        disableTools: !this.options.enableTools,
         extraSystemPrompt: effectiveSystemPrompt,
         streamParams: {
           maxTokens: params.maxTokens,


### PR DESCRIPTION
## Summary

When `enableTools=false` (the default for L1 extraction / L1 dedup tasks), `CleanContextRunner` now passes `disableTools: true` to `runEmbeddedPiAgent`, ensuring no tool definitions are sent to the LLM API.

## Motivation

Previously, `disableTools` was hardcoded to `false` as a workaround for a specific provider (qwencode) that rejects an empty `tools[]` array. As a result, even pure text extraction tasks would include a `read_file` tool definition in the API request.

This caused two problems:

1. **Wasted tokens** — the tool schema occupies context space on every LLM call that never intends to use tools.
2. **Output quality degradation** — some models, upon seeing an available tool, may attempt tool calls instead of producing the expected direct text output.

## Changes

| File | Change |
|------|--------|
| `src/utils/clean-context-runner.ts` | 1. `disableTools` changed from `false` to `!this.options.enableTools`<br>2. `tools.allow` changed from `["read"]` to `[]` when `enableTools=false`<br>3. Updated file header comment to reflect new behavior |

## Migration Note

Users on providers that reject requests without a `tools` field or with an empty `tools[]` (e.g. qwencode) should switch to `StandaloneLLMRunner` via LLM configuration. `StandaloneLLMRunner` (powered by Vercel AI SDK) natively handles the `enableTools=false` case by simply omitting the `tools` parameter from the request.