### PR TITLE
fix(openclaw-patch): clean no-op backups, skip 5.22 inline-spread, harden filters

### DIFF
--- a/scripts/openclaw-after-tool-call-messages.patch.sh
+++ b/scripts/openclaw-after-tool-call-messages.patch.sh
@@ -176,6 +176,7 @@ SKIPPED=0
 FAILED=0
 
 # ─── 对每个候选文件尝试多种策略 ──────────────────────────────────
+if [[ ${#CANDIDATE_FILES[@]} -gt 0 ]]; then
 for f in "${CANDIDATE_FILES[@]}"; do
     fname="$(basename "$f")"
     relpath="${f#$DIST_DIR/}"
@@ -300,6 +301,7 @@ for f in "${CANDIDATE_FILES[@]}"; do
         fi
     fi
 done
+fi
 
 # ─── 结果报告 ────────────────────────────────────────────────────
 echo ""

--- a/scripts/openclaw-after-tool-call-messages.patch.sh
+++ b/scripts/openclaw-after-tool-call-messages.patch.sh
@@ -159,10 +159,17 @@ backup_file() {
 }
 
 # ─── 查找所有候选文件 ────────────────────────────────────────────
-# 收集所有包含 after_tool_call 的 JS 文件（不限子目录深度）
+# 收集所有包含 after_tool_call 的 JS 文件（不限子目录深度）。
+# 再要求出现 runAfterToolCall 调用点：去除仅在 schema/test-contract 中
+# 以字面量形式出现 "after_tool_call" 的非运行时文件，避免后续策略对其
+# 留下空操作备份。
 CANDIDATE_FILES=()
 while IFS= read -r candidate_file; do
-    CANDIDATE_FILES+=("$candidate_file")
+    if grep -q 'runAfterToolCall' "$candidate_file" 2>/dev/null; then
+        CANDIDATE_FILES+=("$candidate_file")
+    else
+        debug "${candidate_file#$DIST_DIR/} — 无 runAfterToolCall 调用点（仅含字面量 \"after_tool_call\"），不作为候选"
+    fi
 done < <(grep -rl 'after_tool_call' "$DIST_DIR" --include='*.js' 2>/dev/null || true)
 
 if [[ ${#CANDIDATE_FILES[@]} -eq 0 ]]; then
@@ -174,6 +181,7 @@ info "找到 ${#CANDIDATE_FILES[@]} 个候选文件"
 PATCHED=0
 SKIPPED=0
 FAILED=0
+CLEANED=0
 
 # ─── 对每个候选文件尝试多种策略 ──────────────────────────────────
 if [[ ${#CANDIDATE_FILES[@]} -gt 0 ]]; then
@@ -198,6 +206,20 @@ for f in "${CANDIDATE_FILES[@]}"; do
     # 确认 durationMs 附近有 after_tool_call 上下文（避免误匹配 before_compaction 等）
     if ! perl -0777 -ne 'exit(0) if /after_tool_call[\s\S]{0,2000}durationMs/; exit(1)' "$f" 2>/dev/null; then
         debug "$relpath — durationMs 不在 after_tool_call 上下文中，跳过"
+        ((SKIPPED++)) || true
+        continue
+    fi
+
+    # OpenClaw 5.22+ 内联展开形态检测：durationMs 仅出现在条件展开
+    # (...cond ? { durationMs: ... } : {}) 中，调用点没有 hookEvent 字面量、
+    # 函数作用域也没有 ctx（只有 params）。当前注入文本 ctx.params.session?.messages
+    # 在该作用域下会触发 ReferenceError，且 params 上也没有 session 字段，
+    # patch script 无法在此位置完成注入 —— 需要 OpenClaw 上游把 session.messages
+    # 透传进 runAgentHarnessAfterToolCallHook 的函数签名。提前显式跳过，
+    # 避免后续策略空跑并留下误导性的 .pre-offload-patch.bak。
+    if perl -0777 -ne 'exit(0) if /\.\.\.\s*\w+\s*\.\s*startedAt\s*!=\s*null\s*\?\s*\{\s*durationMs\s*:/; exit(1)' "$f" 2>/dev/null \
+       && ! grep -qE '(^|\W)(hookEvent|hook_event)(\W|$)' "$f" 2>/dev/null; then
+        info "$relpath — OpenClaw 5.22+ 内联展开形态（调用点无 ctx 作用域），跳过；该位置需 OpenClaw 上游修改才能注入 messages"
         ((SKIPPED++)) || true
         continue
     fi
@@ -303,13 +325,29 @@ for f in "${CANDIDATE_FILES[@]}"; do
 done
 fi
 
+# ─── 空操作备份清理 ──────────────────────────────────────────────
+# 全局扫描 $DIST_DIR 下所有 .pre-offload-patch.bak：若与当前文件字节
+# 相等，说明本次或历史某次执行未真正改动文件（perl regex 未命中、
+# 策略 4 已恢复、或候选过滤新版本剔除了该文件）。保留这种 .bak 会让
+# 用户误以为 patch 改过文件并怀疑它导致系统异常（实际我们今天就遇到
+# 过）。统一在末尾做一次清理，让 ".bak 存在" 与 "脚本确实改动了文件"
+# 严格等价。
+while IFS= read -r bak; do
+    src="${bak%.pre-offload-patch.bak}"
+    if [[ -f "$src" ]] && cmp -s "$src" "$bak"; then
+        rm -f "$bak"
+        debug "${src#$DIST_DIR/} — 清理空备份 (no-op .pre-offload-patch.bak)"
+        ((CLEANED++)) || true
+    fi
+done < <(find "$DIST_DIR" -name '*.pre-offload-patch.bak' 2>/dev/null)
+
 # ─── 结果报告 ────────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}═══════════════════════════════════════════════════════${NC}"
 echo -e "${GREEN}  Patch 完成  (OpenClaw $VERSION)${NC}"
 echo -e "${GREEN}═══════════════════════════════════════════════════════${NC}"
 echo ""
-echo -e "  成功: ${GREEN}${PATCHED}${NC}  跳过: ${YELLOW}${SKIPPED}${NC}  失败: ${RED}${FAILED}${NC}"
+echo -e "  成功: ${GREEN}${PATCHED}${NC}  跳过: ${YELLOW}${SKIPPED}${NC}  失败: ${RED}${FAILED}${NC}  清理空备份: ${CYAN}${CLEANED}${NC}"
 echo ""
 if [[ $PATCHED -gt 0 ]]; then
     echo -e "  ${CYAN}重启 OpenClaw 后生效。${NC}"

--- a/scripts/openclaw-after-tool-call-messages.patch.sh
+++ b/scripts/openclaw-after-tool-call-messages.patch.sh
@@ -120,7 +120,7 @@ fi
 info "OpenClaw 目录: $OPENCLAW_DIR"
 
 # ─── 检测 OpenClaw 版本 ──────────────────────────────────────────
-VERSION=$(grep -oP '"version"\s*:\s*"\K[^"]+' "$OPENCLAW_DIR/package.json" 2>/dev/null || echo "unknown")
+VERSION=$(node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); console.log(pkg.version || 'unknown');" "$OPENCLAW_DIR/package.json" 2>/dev/null || echo "unknown")
 info "检测到 OpenClaw 版本: $VERSION"
 
 # ─── 已 patch 检测 ───────────────────────────────────────────────
@@ -160,7 +160,10 @@ backup_file() {
 
 # ─── 查找所有候选文件 ────────────────────────────────────────────
 # 收集所有包含 after_tool_call 的 JS 文件（不限子目录深度）
-mapfile -t CANDIDATE_FILES < <(grep -rl 'after_tool_call' "$DIST_DIR" --include='*.js' 2>/dev/null || true)
+CANDIDATE_FILES=()
+while IFS= read -r candidate_file; do
+    CANDIDATE_FILES+=("$candidate_file")
+done < <(grep -rl 'after_tool_call' "$DIST_DIR" --include='*.js' 2>/dev/null || true)
 
 if [[ ${#CANDIDATE_FILES[@]} -eq 0 ]]; then
     warn "在 $DIST_DIR 下未找到包含 after_tool_call 的 JS 文件"
@@ -187,17 +190,19 @@ for f in "${CANDIDATE_FILES[@]}"; do
     # 确认文件中有 durationMs（hookEvent 的标志字段）
     if ! grep -q 'durationMs' "$f" 2>/dev/null; then
         debug "$relpath — 不含 durationMs，非 patch 目标，跳过"
+        ((SKIPPED++)) || true
         continue
     fi
 
     # 确认 durationMs 附近有 after_tool_call 上下文（避免误匹配 before_compaction 等）
     if ! perl -0777 -ne 'exit(0) if /after_tool_call[\s\S]{0,2000}durationMs/; exit(1)' "$f" 2>/dev/null; then
         debug "$relpath — durationMs 不在 after_tool_call 上下文中，跳过"
+        ((SKIPPED++)) || true
         continue
     fi
 
-    backup_file "$f"
     applied=false
+    edit_attempted=false
 
     # ── 策略 1: hookEvent 对象中 durationMs 是最后一个字段 ────────
     # 匹配: durationMs<换行><空白>};<换行><空白>hookRunnerAfter
@@ -206,6 +211,8 @@ for f in "${CANDIDATE_FILES[@]}"; do
     if [[ "$applied" == "false" ]]; then
         if perl -0777 -ne 'exit(0) if /durationMs\s*\n(\s*)\};\s*\n\s*(hookRunnerAfter|await\s+\S*hookRunner\S*\.runAfterToolCall|hookRunner\S*\.runAfterToolCall)/; exit(1)' "$f" 2>/dev/null; then
             debug "$relpath — 命中策略1 (hookRunnerAfter 锚点)"
+            backup_file "$f"
+            edit_attempted=true
             perl -0777 -i -pe 's/(durationMs)\s*\n(\s*\};\s*\n\s*(?:hookRunnerAfter|await\s+\S*hookRunner\S*\.runAfterToolCall|hookRunner\S*\.runAfterToolCall))/$1,\n\t\t\tmessages: ctx.params.session?.messages\n$2/' "$f"
             if verify_patch "$f"; then
                 ok "[策略1] $relpath — patch 成功"
@@ -217,11 +224,13 @@ for f in "${CANDIDATE_FILES[@]}"; do
 
     # ── 策略 2: 旧版 dispatch-*.js — durationMs 行末独占 ─────────
     if [[ "$applied" == "false" ]]; then
-        if echo "$relpath" | grep -qP 'dispatch-.*\.js' 2>/dev/null; then
+        if echo "$relpath" | grep -Eq 'dispatch-.*\.js' 2>/dev/null; then
             # 匹配行末独占的 durationMs（前面是空白）
-            if grep -qP '^\s+durationMs\s*$' "$f" 2>/dev/null; then
+            if grep -Eq '^[[:space:]]+durationMs[[:space:]]*$' "$f" 2>/dev/null; then
                 debug "$relpath — 命中策略2 (旧版 dispatch)"
-                sed -i -E 's/^(\s+)(durationMs)\s*$/\1\2,\n\1messages: ctx.params.session?.messages/' "$f"
+                backup_file "$f"
+                edit_attempted=true
+                perl -i -pe 's/^([ \t]+)(durationMs)[ \t]*$/$1$2,\n$1messages: ctx.params.session?.messages/' "$f"
                 if verify_patch "$f"; then
                     ok "[策略2] $relpath — patch 成功"
                     ((PATCHED++)) || true
@@ -239,6 +248,8 @@ for f in "${CANDIDATE_FILES[@]}"; do
         if perl -0777 -ne 'exit(0) if /after_tool_call[\s\S]{0,800}durationMs\s*\n(\s*)\};/; exit(1)' "$f" 2>/dev/null; then
             debug "$relpath — 命中策略3 (durationMs→}; 邻近 after_tool_call)"
             # 只替换 after_tool_call 上下文附近的 durationMs → };
+            backup_file "$f"
+            edit_attempted=true
             perl -0777 -i -pe 's/(after_tool_call[\s\S]{0,800}durationMs)\s*\n(\s*\};)/$1,\n\t\t\tmessages: ctx.params.session?.messages\n$2/' "$f"
             if verify_patch "$f"; then
                 ok "[策略3] $relpath — patch 成功"
@@ -258,6 +269,8 @@ for f in "${CANDIDATE_FILES[@]}"; do
         if perl -0777 -ne 'exit(0) if /after_tool_call[\s\S]{0,2000}?(?:hookEvent|hook_event)[\s\S]{0,500}?durationMs/; exit(1)' "$f" 2>/dev/null; then
             debug "$relpath — 命中策略4 (通用 fallback)"
             # 在 durationMs 后追加 (仅首次匹配)
+            backup_file "$f"
+            edit_attempted=true
             perl -0777 -i -pe '
                 my $done = 0;
                 s/(after_tool_call[\s\S]{0,2000}?(?:hookEvent|hook_event)[\s\S]{0,500}?durationMs)\s*\n(\s*)(\};)/
@@ -278,8 +291,13 @@ for f in "${CANDIDATE_FILES[@]}"; do
 
     # ── 无策略命中 ───────────────────────────────────────────────
     if [[ "$applied" == "false" ]]; then
-        debug "$relpath — 无策略命中"
-        ((FAILED++)) || true
+        if [[ "$edit_attempted" == "true" ]]; then
+            debug "$relpath — patch 后验证失败"
+            ((FAILED++)) || true
+        else
+            debug "$relpath — 无策略命中，非 patch 目标，跳过"
+            ((SKIPPED++)) || true
+        fi
     fi
 done
 
@@ -295,7 +313,7 @@ if [[ $PATCHED -gt 0 ]]; then
     echo -e "  ${CYAN}重启 OpenClaw 后生效。${NC}"
     echo -e "  ${CYAN}备份文件: *.pre-offload-patch.bak${NC}"
 elif [[ $SKIPPED -gt 0 && $FAILED -eq 0 ]]; then
-    echo -e "  ${YELLOW}所有目标文件已 patch，无需重复操作。${NC}"
+    echo -e "  ${YELLOW}未发现需要修改的目标文件；已 patch 或非目标候选已跳过。${NC}"
 elif [[ $FAILED -gt 0 ]]; then
     echo -e "  ${RED}部分文件未能 patch。可能需要手动检查或更新 patch 脚本。${NC}"
     echo -e "  ${RED}提示：设置 DEBUG=1 运行以查看详细匹配过程：${NC}"


### PR DESCRIPTION
## Summary

Three improvements to `scripts/openclaw-after-tool-call-messages.patch.sh`, plus two prior local-only fixes that ride along (all three commits touch only that one file).

The motivating incident: after running the patch script against OpenClaw 2026.5.22, two `.pre-offload-patch.bak` files remained next to the live `dist/` files, byte-identical to their sources. This made it look like the script had modified those files and broken the gateway. Investigation showed the gateway breakage was unrelated (a wrapper-plist + secret-broker config issue), but the misleading backups were a real UX bug worth fixing.

## Platform support

The script is **verified on macOS** (and remains compatible with Linux). The portability commit `6067d6d` was made specifically to make the script run on the default macOS shell + utility set:

| macOS default | Behavior the script no longer relies on |
|---|---|
| `bash 3.2.57(1)-release` (arm64-apple-darwin25), `/bin/bash` | `mapfile -t` (bash 4+) — replaced with a portable `while IFS= read -r` loop |
| BSD `grep 2.6.0-FreeBSD` | `grep -oP` (GNU PCRE) for version parse — replaced with a `node -e` JSON read |
| BSD `grep` | `grep -qP` (PCRE) inside strategies — replaced with `grep -Eq` (POSIX ERE) and `perl` |
| BSD `sed -i` | `sed -i -E` inline edit (BSD `sed -i` requires a backup-suffix arg) — replaced with `perl -i -pe` |

My new changes (commit `547874f`) intentionally use only macOS-portable primitives: `find ... -name`, `cmp -s`, `grep -qE`, `grep -q`, and `perl -0777 -ne` — all available on a vanilla macOS install with the system shell.

Test environment for this PR:

```
ProductName:    macOS
ProductVersion: 26.5
BuildVersion:   25F71
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
grep (BSD grep, GNU compatible) 2.6.0-FreeBSD
OpenClaw 2026.5.22
```

## Fixed points, one by one

### 1. Tighten candidate filter (commit 547874f)

Require `runAfterToolCall` (the actual hook call site) **in addition to** the literal string `after_tool_call`. Excludes schema/test-contract files such as `plugin-sdk/agent-runtime-test-contracts.js` and `command-registration-*.js`, which only mention `"after_tool_call"` as event-name data.

Before: 5 candidates → 3 with backups created speculatively.
After:  3 candidates → no speculative backups on non-runtime files.

### 2. Detect OpenClaw 5.22+ inline-spread shape and skip cleanly (commit 547874f)

`native-hook-relay-CKQJJkrR.js` in 5.22 was refactored to pass the hook event as an inline object to `runAfterToolCall(...)`, with `durationMs` wrapped in a conditional spread:

```js
await hookRunner.runAfterToolCall({
    toolName: params.toolName,
    ...
    ...params.startedAt != null ? { durationMs: Date.now() - params.startedAt } : {}
}, { /* second arg */ });
```

Two structural reasons this site cannot be patched by the current script:

| Structural issue | Consequence |
|---|---|
| No `hookEvent` literal identifier | Strategies 1, 3, 4 cannot anchor |
| No `ctx` in function scope (only `params`) | The injection text `ctx.params.session?.messages` would `ReferenceError` at runtime |
| `params` has no `session` field either | A `params.session?.messages` rewrite would always be `undefined` |

Patching this site needs an **upstream OpenClaw change** to thread `session.messages` into the function signature. Until then, the new detection emits an explicit INFO line:

```
[INFO] native-hook-relay-CKQJJkrR.js — OpenClaw 5.22+ 内联展开形态（调用点无 ctx 作用域），跳过；该位置需 OpenClaw 上游修改才能注入 messages
```

This replaces the silent debug-level skip + leftover backup, so future readers see *why* and *what's needed*.

The main runtime path `selection-hR-AeOeU.js:2490` still has `ctx` in scope and still gets patched successfully — context-offload's L1/L1.5 pipeline keeps receiving `messages` from that site.

### 3. Global no-op backup cleanup pass at end of run (commit 547874f)

Walk `$DIST_DIR` and drop any `.pre-offload-patch.bak` byte-identical to its source. Catches:

- regex matched nothing → file unchanged but backup left behind
- strategy 4 restored from backup → backup now identical to file
- legacy backups from prior runs that the new candidate filter no longer considers

The script's effect on disk now matches its summary: `.bak exists` ⇔ `script actually modified that file`. The summary line surfaces a `清理空备份` counter so the cleanup is visible without `DEBUG=1`.

### 4. macOS / portability fixes (commit 6067d6d, pre-existing on fork)

Detailed in the **Platform support** table above. In short: removes every GNU-only / bash-4+ dependency the script used to have, so it runs on a vanilla macOS install. Also moves `backup_file` *inside* each strategy so backups are only created when a strategy actually attempts an edit, and adds `edit_attempted` tracking so "no strategy matched" becomes `SKIPPED++` instead of `FAILED++`.

### 5. Empty candidate list guard (commit de98071, pre-existing on fork)

Guards the per-file loop with `if [[ ${#CANDIDATE_FILES[@]} -gt 0 ]]` so an empty `dist/` produces a clean summary instead of iterating empty.

## Test plan

- [x] `bash -n scripts/openclaw-after-tool-call-messages.patch.sh` — syntax OK on macOS `bash 3.2.57`.
- [x] First run against live OpenClaw 2026.5.22 install with `DEBUG=1`:
  - 3 candidates (down from 5; test-contract + command-registration excluded by filter)
  - `selection-hR-AeOeU.js` → already-patched, skip
  - `native-hook-relay-CKQJJkrR.js` → 5.22 inline-spread skip with explicit INFO
  - `hook-runner-global-BkXXy1ub.js` → no `durationMs`, skip
  - 2 no-op backups cleaned up
  - Final summary: `成功: 0  跳过: 3  失败: 0  清理空备份: 2`
- [x] Second run for idempotence: same skip counts, `清理空备份: 0`, no `.pre-offload-patch.bak` left in `dist/`.
- [x] `selection-hR-AeOeU.js:2490` confirmed to still carry `messages: ctx.params.session?.messages` after the cleanup pass.
- [x] Live end-to-end with a gateway tool call: `[context-offload] [local-llm] L1 <<< 4506ms, output=317 chars` and `[context-offload] [local-llm] L1.5 <<< 2765ms, output=132 chars` — context-offload still fully operational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)