### PR TITLE
fix(manifest): declare memory kind and register memory capability

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -154,6 +154,26 @@ export default function register(api: OpenClawPluginApi) {
   // ─── Full / discovery mode: complete runtime initialization ───
   pluginStartTimestamp = Date.now();
   setPreferredEmbeddedAgentRuntime(api.runtime.agent);
+
+  // Declare ourselves as the host's active memory plugin so `openclaw doctor`
+  // and the slot loader can see this plugin occupies the memory slot. Paired
+  // with `"kind": "memory"` in openclaw.plugin.json — the host rejects the
+  // call when manifest kind does not include "memory". Feature-detected for
+  // OpenClaw hosts older than the version that introduced this API.
+  // See issue #119.
+  const registerMemoryCapability = (api as unknown as {
+    registerMemoryCapability?: (capability: Record<string, unknown>) => void;
+  }).registerMemoryCapability;
+  if (typeof registerMemoryCapability === "function") {
+    try {
+      registerMemoryCapability.call(api, {});
+      api.logger.debug?.(`${TAG} Registered memory capability (slot declared)`);
+    } catch (err) {
+      api.logger.warn(
+        `${TAG} registerMemoryCapability failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
   // Reset reporter singleton so config changes take effect on hot-reload.
   resetReporter();
   const _require = createRequire(import.meta.url);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "memory-tencentdb",
   "name": "Memory (TencentDB)",
   "description": "Four-layer memory system — auto-captures, structures, and profiles conversational knowledge",
+  "kind": "memory",
   "commandAliases": ["memory-tdai"],
   "activation": {
     "onStartup": true


### PR DESCRIPTION
## Summary

Fixes #119 — `openclaw doctor` reports "memory slot plugin not found" even though memory-tencentdb is loaded and serving four-layer memory.

### Root cause

The host's slot loader matches memory plugins via `hasKind(record.kind, "memory")` and only accepts `registerMemoryCapability(...)` from plugins whose manifest declares that kind. memory-tencentdb's manifest never set `kind`, and the plugin never called `registerMemoryCapability`. So from the host's view the memory slot is empty — doctor surfaces that as the missing-slot warning.

### Change

- `openclaw.plugin.json`: add `"kind": "memory"` so the loader recognizes this plugin as a memory-kind candidate.
- `index.ts`: in `register()`, feature-detect `api.registerMemoryCapability` and call it with an empty capability `{}` to claim the slot. The slot loader requires `kind: "memory"` before accepting the call (verified against the bundled OpenClaw SDK).
  - Wrapped in `try/catch` and feature-detected via `typeof === "function"` so older OpenClaw hosts (before the API existed) still load the plugin without error.
  - Logged at `debug` (success) / `warn` (failure) — non-fatal either way.

Empty `{}` is sufficient for slot-occupancy. `promptBuilder` / `runtime` / `publicArtifacts` can be wired later if we want the host to drive prompt sections or flush plans through its own memory pipeline; that's a follow-up, not part of this fix.

## Test plan

- [ ] Build still passes (`npm run build`)
- [ ] On a fresh OpenClaw install, `openclaw doctor` no longer reports "memory slot plugin not found"
- [ ] On an OpenClaw host older than the `registerMemoryCapability` API, the plugin still loads and runtime hooks fire (feature detection skips the call)