### PR TITLE
fix(prompts): replace hardcoded zh scene headers with placeholders

### DIFF
--- a/src/core/prompts/scene-extraction.ts
+++ b/src/core/prompts/scene-extraction.ts
@@ -44,7 +44,23 @@ export interface SceneExtractionPromptResult {
 function buildSceneSystemPrompt(maxScenes: number): string {
   return `# Memory Consolidation Architect
 
-**输出语言**：\`.md\` 场景文件的所有自然语言内容（文件名、章节标题、正文）使用与"New Memories List"中记忆相同的语言；META 字段名（created/updated/summary/heat）和 \`[DELETED]\` 等标记保持英文。模板中给出的中文章节标题（\`## 用户核心特征\` 等）作为结构骨架——非中文输出时请用目标语言的等价表达替换。
+## 🌐 Output Language & Header Localization (MUST FOLLOW)
+
+The natural-language content of every scene \`.md\` (filenames, section headers, body text) MUST be written in the **same language as the items in "New Memories List"** — including English, German, Japanese, etc. META field names (\`created\`/\`updated\`/\`summary\`/\`heat\`) and markers like \`[DELETED]\` stay in English.
+
+The template below uses \`{{HEADER_*}}\` placeholders for section titles. **NEVER output the literal placeholder string**. Replace every placeholder with a proper section header in the user's primary language. Suggested translations:
+
+| Placeholder | zh (Chinese) | en (English) |
+|---|---|---|
+| \`{{HEADER_BASIC_INFO}}\` | 用户基础信息 | User Basic Information |
+| \`{{HEADER_CORE_TRAITS}}\` | 用户核心特征 | User Core Traits |
+| \`{{HEADER_PREFERENCES}}\` | 用户偏好 | User Preferences |
+| \`{{HEADER_IMPLICIT_SIGNALS}}\` | 隐性信号 | Implicit Signals |
+| \`{{HEADER_CORE_NARRATIVE}}\` | 核心叙事 | Core Narrative |
+| \`{{HEADER_EVOLUTION}}\` | 演变轨迹 | Evolution Trajectory |
+| \`{{HEADER_PENDING}}\` | 待确认/矛盾点 | Pending / Contradictions |
+
+For languages not in the table (German, French, Japanese, Korean, …), translate the English variant into that language. The same rule applies to the bracketed example text inside the template — it is illustrative and MUST be rewritten in the user's language; never copy the Chinese phrasing verbatim.
 
 ## 角色定义 (Role Definition)
 你是记忆整合架构师。你的目标是为用户构建一个"数字第二大脑"。你不仅仅是在记录数据，你更像是一位人类学家和心理学家，负责分析原始记忆，从中提取核心特征、捕捉隐性信号，并构建不断演变的叙事。
@@ -185,7 +201,7 @@ function buildSceneSystemPrompt(maxScenes: number): string {
 
 请你参考这个模板输出 .md 文件的内容或基于已有md进行更新，每个md控制在1500字符内。不要把模板本身放在 Markdown 代码块中，只需直接输出要写入文件的原始文本。
 
-> 模板中的中文章节标题（\`## 用户核心特征\` 等）和示例文本仅作为**结构骨架**参考；**实际章节标题与正文必须按上述输出语言书写**（例如英文场景：\`## User Core Traits\`、\`## User Preferences\`、\`## Implicit Signals\`、\`## Core Narrative\` 等）。
+> **Critical**: every \`{{HEADER_*}}\` token below is a placeholder, NOT the literal header to emit. Resolve each one to a section header in the user's primary language using the localization table at the top of this prompt. The bracketed Chinese example text inside each section is illustrative and MUST be rewritten in the user's language too — copying the example verbatim is a bug.
 
 \`\`\`markdown
 -----META-START-----
@@ -195,37 +211,37 @@ summary: [30-40 words concise summary for indexing]
 heat: [Integer]
 -----META-END-----
 
-## 用户基础信息
+## {{HEADER_BASIC_INFO}}
 [可为空，如果没有可不写这节，可按照需求添加更多点，合并和更新方式尽量叠加，有冲突则覆盖]
    -姓名：
    -职业：
    -居住地：
    - ……
 
-## 用户核心特征
+## {{HEADER_CORE_TRAITS}}
 [这里不是列表！是一段连贯的描述。你细心推断出来最核心的用户特征，宁缺毋滥，**控制在100字以内**]
 [示例: 用户在后端开发方面表现出对 Python 的强烈偏好，特别是异步框架。近期（2026-02）开始关注 Rust 的所有权机制，这表明用户有向系统级编程转型的意图。]
 
-## 用户偏好
+## {{HEADER_PREFERENCES}}
 [这里可以是列表！**如果没有可以为不写这节**，记录用户明确的偏好信息（显性偏好），注意不要重复信息，不要流水账，偏好要可复用，更新时可以动态整合甚至重写]
 [示例：用户喜欢吃苹果]
 
-## 隐性信号
+## {{HEADER_IMPLICIT_SIGNALS}}
 [这是给人类学家看的，记录那些"没明说但很重要"的事，和显性偏好不一样，一定是你推断出来的，需要深思熟虑后再生成，可以为空，宁缺毋滥。你可以随时更新/删除/修改这里的信息]
 
-## 核心叙事
+## {{HEADER_CORE_NARRATIVE}}
 [这里不是列表！是一段连贯的描述，**控制在400字以内**，注意不要重复信息，不要流水账，可以动态整合甚至重写]
 *(这里记录连贯的故事，必须包含 Trigger -> Action -> Result)*
 
 [ 示例：本周用户主要集中在后端重构上。初期因为旧代码的耦合度高感到沮丧（**情绪点**），但他拒绝了"打补丁"的建议，坚持进行彻底解耦（**决策点**）。他在此过程中频繁查阅架构设计模式，表现出对"代码洁癖"的执着。]
 
 
-## 演变轨迹
+## {{HEADER_EVOLUTION}}
 > [注意] 可以为空，仅记录【用户偏好/性格/重大观念】转变，不记录琐碎、日常更新。当发生冲突时，不要直接覆盖，要记录变化轨迹。
 - [2026-01-10]: 从 "反对加班" 转向 "接受弹性工作"，原因：创业压力（记忆ID: #987）
 
 
-## 待确认/矛盾点
+## {{HEADER_PENDING}}
 - [记录当前无法整合的矛盾信息，等待未来记忆澄清]
 
 \`\`\`


### PR DESCRIPTION
## Summary

Fixes #122 — non-Chinese users (German in the bug report, but the issue applies to every language) see Chinese section headers (`## 用户基础信息`, `## 用户核心特征`, …) leak into their scene `.md` files, and from there into the recall context.

### Root cause

The system prompt in `src/core/prompts/scene-extraction.ts` carries an output template whose markdown headers are written in Chinese. v0.3.6 already added a one-line `**输出语言**` instruction telling the LLM to swap them for the user's language, but on weaker models (e.g. Qwen 3.6 27B in the report) that wasn't enough — the model treated the Chinese template as authoritative and copied the headers verbatim.

### Change

Two reinforcing steps in `src/core/prompts/scene-extraction.ts`:

1. **Replace the seven Chinese headers in the template with `{{HEADER_*}}` placeholders.** A token like `{{HEADER_BASIC_INFO}}` cannot plausibly be emitted as a markdown header, so the model is forced to resolve it before writing the file.
2. **Add a top-of-prompt localization table.** Each placeholder is given zh/en reference translations and an explicit fallback rule (\"translate the English variant\") for languages outside the table. The pre-template warning was also rewritten in English and now calls out the bracketed example text — which was previously another leak path.

| Placeholder | zh | en |
|---|---|---|
| `{{HEADER_BASIC_INFO}}` | 用户基础信息 | User Basic Information |
| `{{HEADER_CORE_TRAITS}}` | 用户核心特征 | User Core Traits |
| `{{HEADER_PREFERENCES}}` | 用户偏好 | User Preferences |
| `{{HEADER_IMPLICIT_SIGNALS}}` | 隐性信号 | Implicit Signals |
| `{{HEADER_CORE_NARRATIVE}}` | 核心叙事 | Core Narrative |
| `{{HEADER_EVOLUTION}}` | 演变轨迹 | Evolution Trajectory |
| `{{HEADER_PENDING}}` | 待确认/矛盾点 | Pending / Contradictions |

### What's intentionally NOT in this PR

- `persona-generation.ts` Chapter 1–4 headers are English-primary (`## Chapter 1: Context & Current State (全景语境)`) and the existing 输出语言 instruction is generally honored. The bug report didn't cite leakage there, so I'm not touching it to keep this PR's blast radius small. Happy to do a follow-up if reports come in.
- No code grep finds anything parsing these headers programmatically (only README mentions in docs), so the rename is safe for downstream.

## Test plan

- [ ] `npm run build` passes (verified locally — same dist size, no type errors)
- [ ] On a German-only conversation with Qwen 3.6 27B, scene_blocks/*.md now use German headers (e.g. `## Grundinformationen` instead of `## 用户基础信息`)
- [ ] On a Chinese conversation, scene_blocks/*.md still use Chinese headers (the localization table's zh column should be picked by the LLM)
- [ ] Existing scene files generated under v0.3.6 with Chinese headers can still be UPDATE'd in place — the LLM should follow the existing file's language when modifying, not force a switch to the new placeholder language