### PR TITLE
fix(recall): scope L1 search by session_key for agent/user isolation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -372,6 +372,13 @@ export default function register(api: OpenClawPluginApi) {
             type: "string",
             description: "Optional filter by scene name",
           },
+          session_key: {
+            type: "string",
+            description:
+              "Optional: restrict results to memories captured under this session_key. " +
+              "Use this to keep agent/user memories isolated — pass the current session's " +
+              "key to avoid recalling other agents' or users' records.",
+          },
         },
         required: ["query"],
       },
@@ -381,15 +388,16 @@ export default function register(api: OpenClawPluginApi) {
         const limit = Math.min(Math.max(Number(params.limit) || 5, 1), 20);
         const typeFilter = typeof params.type === "string" ? params.type : undefined;
         const sceneFilter = typeof params.scene === "string" ? params.scene : undefined;
+        const sessionKeyFilter = typeof params.session_key === "string" ? params.session_key : undefined;
 
         api.logger.debug?.(
           `${TAG} [tool] tdai_memory_search called: ` +
           `query="${query.length > 80 ? query.slice(0, 80) + "…" : query}", ` +
-          `limit=${limit}, type=${typeFilter ?? "(all)"}, scene=${sceneFilter ?? "(all)"}`,
+          `limit=${limit}, type=${typeFilter ?? "(all)"}, scene=${sceneFilter ?? "(all)"}, session_key=${sessionKeyFilter ?? "(all)"}`,
         );
 
         try {
-          const result = await core.searchMemories({ query, limit, type: typeFilter, scene: sceneFilter });
+          const result = await core.searchMemories({ query, limit, type: typeFilter, scene: sceneFilter, sessionKey: sessionKeyFilter });
 
           const elapsedMs = Date.now() - startMs;
           api.logger.debug?.(

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -121,7 +121,16 @@ async function performAutoRecallInner(params: {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
-    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
+    const searchResult = await searchMemories(
+      userText,
+      pluginDataDir,
+      cfg,
+      logger,
+      effectiveStrategy as "keyword" | "embedding" | "hybrid",
+      vectorStore,
+      embeddingService,
+      params.sessionKey,
+    );
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
     memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
@@ -262,6 +271,26 @@ interface SearchResult {
 }
 
 /**
+ * Filter raw search results down to a single session_key for agent/user isolation.
+ * Returns the input unchanged when no session filter is supplied.
+ */
+function applySessionFilter<T extends { session_key: string }>(
+  items: T[],
+  sessionKey: string | undefined,
+  logger?: Logger,
+  label?: string,
+): T[] {
+  if (!sessionKey) return items;
+  const filtered = items.filter((r) => r.session_key === sessionKey);
+  if (filtered.length !== items.length && logger?.debug) {
+    logger.debug(
+      `${TAG} [session-filter${label ? ":" + label : ""}] sessionKey="${sessionKey}": kept ${filtered.length}/${items.length}`,
+    );
+  }
+  return filtered;
+}
+
+/**
  * Search memories and return both formatted lines and structured details.
  *
  * This is a thin wrapper around `searchMemories` that also captures
@@ -276,8 +305,9 @@ async function searchMemoriesWithDetails(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  sessionKey?: string,
 ): Promise<{ lines: string[]; memories: RecalledMemory[]; timing: SearchTiming }> {
-  const result = await searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService);
+  const result = await searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService, sessionKey);
 
   // Extract structured data from formatted memory lines.
   // Format: "- [type|scene] content (活动时间: ...)" or "- [type] content"
@@ -312,6 +342,7 @@ async function searchMemories(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  sessionKey?: string,
 ): Promise<SearchResult> {
   const emptyResult: SearchResult = { lines: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
   // Strip gateway-injected inbound metadata (Sender, timestamps, media markers,
@@ -360,13 +391,13 @@ async function searchMemories(
   try {
     if (effectiveStrategy === "keyword") {
       const tFts = performance.now();
-      const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore);
+      const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore, sessionKey);
       return { lines, timing: { ftsMs: performance.now() - tFts, embeddingMs: 0, ftsHits: lines.length, embeddingHits: 0 } };
     }
 
     if (effectiveStrategy === "embedding") {
       const tEmb = performance.now();
-      const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts);
+      const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts, sessionKey);
       return { lines, timing: { ftsMs: 0, embeddingMs: performance.now() - tEmb, ftsHits: 0, embeddingHits: lines.length } };
     }
 
@@ -375,7 +406,10 @@ async function searchMemories(
     // to avoid a redundant second HTTP request and a wasted local embed().
     if (vectorStore?.getCapabilities().nativeHybridSearch) {
       const tNative = performance.now();
-      const results = await vectorStore.searchL1Hybrid({ query: cleanText, topK: maxResults });
+      // Over-retrieve when filtering to absorb the post-filter drop.
+      const nativeTopK = sessionKey ? maxResults * 4 : maxResults;
+      const rawResults = await vectorStore.searchL1Hybrid({ query: cleanText, topK: nativeTopK });
+      const results = applySessionFilter(rawResults, sessionKey, logger, "hybrid-native").slice(0, maxResults);
       const nativeMs = performance.now() - tNative;
       logger?.debug?.(`${TAG} [hybrid-native] Single-call hybrid: ${results.length} results in ${nativeMs.toFixed(0)}ms`);
       const lines = results.map((r) => formatMemoryLine(vectorResultToFormatable(r)));
@@ -383,7 +417,7 @@ async function searchMemories(
     }
 
     // Fallback: run keyword + embedding in parallel, merge with client-side RRF (SQLite path)
-    return await searchHybrid(cleanText, pluginDataDir, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts);
+    return await searchHybrid(cleanText, pluginDataDir, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts, sessionKey);
   } catch (err) {
     logger?.warn?.(`${TAG} Memory search failed (strategy=${effectiveStrategy}): ${err instanceof Error ? err.message : String(err)}`);
     return emptyResult;
@@ -401,13 +435,18 @@ async function searchByKeyword(
   threshold: number,
   logger?: Logger,
   vectorStore?: IMemoryStore,
+  sessionKey?: string,
 ): Promise<string[]> {
   // Prefer FTS5 if available
   if (vectorStore?.isFtsAvailable()) {
     const ftsQuery = buildFtsQuery(userText);
     if (ftsQuery) {
       logger?.debug?.(`${TAG} [keyword-fts] Using FTS5 BM25 search: query="${ftsQuery}"`);
-      const ftsResults = await vectorStore.searchL1Fts(ftsQuery, maxResults * 2);
+      // Over-retrieve when filtering by session_key — l1_fts has session_key UNINDEXED,
+      // so we can only filter client-side after the FTS5 MATCH.
+      const candidateK = sessionKey ? maxResults * 4 : maxResults * 2;
+      const ftsResultsRaw = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+      const ftsResults = applySessionFilter(ftsResultsRaw, sessionKey, logger, "keyword-fts");
       if (ftsResults.length > 0) {
         logger?.debug?.(
           `${TAG} [keyword-fts] FTS5 raw results (${ftsResults.length}): ` +
@@ -454,7 +493,11 @@ async function searchByEmbedding(
   embeddingService: EmbeddingService,
   logger?: Logger,
   embeddingCallOpts?: EmbeddingCallOptions,
+  sessionKey?: string,
 ): Promise<string[]> {
+  // Over-retrieve when filtering by session_key — the underlying ANN index has no
+  // session-aware filter, so we apply it client-side after retrieval.
+  const candidateK = sessionKey ? maxResults * 4 : maxResults * 2;
   logger?.debug?.(
     `${TAG} [embedding-search] START query="${userText.slice(0, 80)}...", maxResults=${maxResults}, threshold=${threshold}`,
   );
@@ -462,10 +505,10 @@ async function searchByEmbedding(
   logger?.debug?.(
     `${TAG} [embedding-search] Query embedding OK: dims=${queryEmbedding.length}, ` +
     `norm=${Math.sqrt(Array.from(queryEmbedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}, ` +
-    `searching top-${maxResults * 2}...`,
+    `searching top-${candidateK}...`,
   );
-  // Retrieve more candidates for subsequent filtering
-  const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, maxResults * 2);
+  const vecResultsRaw: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, candidateK);
+  const vecResults = applySessionFilter(vecResultsRaw, sessionKey, logger, "embedding-search");
 
   if (vecResults.length === 0) {
     logger?.debug?.(`${TAG} [embedding-search] Returned 0 results`);
@@ -516,9 +559,12 @@ async function searchHybrid(
   embeddingService: EmbeddingService,
   logger?: Logger,
   embeddingCallOpts?: EmbeddingCallOptions,
+  sessionKey?: string,
 ): Promise<SearchResult> {
-  // Run keyword and embedding searches in parallel
-  const candidateK = maxResults * 3; // retrieve more for merging
+  // Run keyword and embedding searches in parallel.
+  // Over-retrieve more when a session filter is active so the post-filter
+  // RRF still has enough candidates to fill maxResults.
+  const candidateK = sessionKey ? maxResults * 5 : maxResults * 3;
 
   const [keywordResult, embeddingResult] = await Promise.all([
     // Keyword search: FTS5 only (no in-memory fallback)
@@ -529,7 +575,8 @@ async function searchHybrid(
         if (vectorStore.isFtsAvailable()) {
           const ftsQuery = buildFtsQuery(userText);
           if (ftsQuery) {
-            const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+            const ftsResultsRaw = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+            const ftsResults = applySessionFilter(ftsResultsRaw, sessionKey, logger, "hybrid-keyword-fts");
             if (ftsResults.length > 0) {
               logger?.debug?.(`${TAG} [hybrid-keyword-fts] FTS5 found ${ftsResults.length} candidates`);
               // Convert FtsSearchResult to ScoredRecord for RRF merge
@@ -571,7 +618,8 @@ async function searchHybrid(
         logger?.debug?.(
           `${TAG} [hybrid-embedding] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const results = await vectorStore.searchL1Vector(queryEmbedding, candidateK, userText);
+        const resultsRaw = await vectorStore.searchL1Vector(queryEmbedding, candidateK, userText);
+        const results = applySessionFilter(resultsRaw, sessionKey, logger, "hybrid-embedding");
         logger?.debug?.(`${TAG} [hybrid-embedding] Got ${results.length} candidates`);
         return { results, ms: performance.now() - tStart };
       } catch (err) {

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -293,6 +293,7 @@ export class TdaiCore {
       limit: params.limit ?? 5,
       type: params.type,
       scene: params.scene,
+      sessionKey: params.sessionKey,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
       logger: this.logger,

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -25,6 +25,8 @@ export interface MemorySearchResultItem {
   type: string;
   priority: number;
   scene_name: string;
+  /** Session_key the record belongs to. Used by the agent/user isolation filter. */
+  session_key: string;
   score: number;
   created_at: string;
   updated_at: string;
@@ -84,6 +86,7 @@ export async function executeMemorySearch(params: {
   limit: number;
   type?: string;
   scene?: string;
+  sessionKey?: string;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
   logger?: Logger;
@@ -93,6 +96,7 @@ export async function executeMemorySearch(params: {
     limit,
     type: typeFilter,
     scene: sceneFilter,
+    sessionKey: sessionFilter,
     vectorStore,
     embeddingService,
     logger,
@@ -101,6 +105,7 @@ export async function executeMemorySearch(params: {
   logger?.debug?.(
     `${TAG} CALLED: query="${query.slice(0, 100)}", limit=${limit}, ` +
     `typeFilter=${typeFilter ?? "(none)"}, sceneFilter=${sceneFilter ?? "(none)"}, ` +
+    `sessionFilter=${sessionFilter ?? "(none)"}, ` +
     `vectorStore=${vectorStore ? "available" : "UNAVAILABLE"}, ` +
     `embeddingService=${embeddingService ? "available" : "UNAVAILABLE"}`,
   );
@@ -133,7 +138,9 @@ export async function executeMemorySearch(params: {
   }
 
   // ── Over-retrieve for later filtering and RRF merging ──
-  const candidateK = limit * 3;
+  // Session-filtered queries need extra candidates because the underlying
+  // FTS5 / ANN index has no session-aware filter.
+  const candidateK = sessionFilter ? limit * 5 : limit * 3;
 
   // ── Run available search strategies in parallel ──
   const [ftsItems, vecItems] = await Promise.all([
@@ -155,6 +162,7 @@ export async function executeMemorySearch(params: {
           type: r.type,
           priority: r.priority,
           scene_name: r.scene_name,
+          session_key: r.session_key,
           score: r.score,
           created_at: r.timestamp_start,
           updated_at: r.timestamp_end,
@@ -184,6 +192,7 @@ export async function executeMemorySearch(params: {
           type: r.type,
           priority: r.priority,
           scene_name: r.scene_name,
+          session_key: r.session_key,
           score: r.score,
           created_at: r.timestamp_start,
           updated_at: r.timestamp_end,
@@ -225,8 +234,12 @@ export async function executeMemorySearch(params: {
     results = ftsOk ? ftsItems : vecItems;
   }
 
-  // ── Apply secondary filters (type, scene) ──
+  // ── Apply secondary filters (session_key, type, scene) ──
   const preFilterCount = results.length;
+  if (sessionFilter) {
+    results = results.filter((r) => r.session_key === sessionFilter);
+    logger?.debug?.(`${TAG} After session filter "${sessionFilter}": ${results.length}/${preFilterCount}`);
+  }
   if (typeFilter) {
     results = results.filter((r) => r.type === typeFilter);
     logger?.debug?.(`${TAG} After type filter "${typeFilter}": ${results.length}/${preFilterCount}`);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -231,6 +231,12 @@ export interface MemorySearchParams {
   limit?: number;
   type?: string;
   scene?: string;
+  /**
+   * Restrict results to records captured under this session_key.
+   * Used by the auto-recall hook for agent/user isolation and exposed
+   * as an optional filter on `tdai_memory_search`.
+   */
+  sessionKey?: string;
 }
 
 /** Search parameters for L0 conversation search. */


### PR DESCRIPTION
## Summary

Fixes #111 — `searchMemories` was performing global L1 searches across every captured `session_key`, so in a multi-agent or multi-user setup the auto-recall hook pulled the wrong agent's / wrong user's memories into the prompt. The OP filed it as a serious cross-contamination bug with a clean root-cause analysis; this PR implements their proposed fix.

### Root cause (reproduced from the issue)

`handleBeforeRecall(userText, sessionKey)` → `performAutoRecall({...sessionKey})` → `performAutoRecallInner(params)` already carried `sessionKey`, but the next call `searchMemories(userText, …)` dropped it. From that point on:

- `searchByKeyword` ran `vectorStore.searchL1Fts(ftsQuery, maxResults * 2)` with no scoping.
- `searchByEmbedding` ran `vectorStore.searchL1Vector(queryEmbedding, maxResults * 2)` with no scoping.
- `searchHybrid` did the same in parallel and RRF-merged.
- The tool entry `executeMemorySearch` had no `sessionKey` parameter at all, while the sibling `executeConversationSearch` already had one.

`l1_fts.session_key` is `UNINDEXED` so server-side `WHERE` is not an option — client-side filter on the raw `L1SearchResult` / `L1FtsResult` (both already carry `session_key`) is the only safe path.

### Change

- **`src/core/hooks/auto-recall.ts`** — thread `sessionKey` from `performAutoRecallInner` into `searchMemories` and the four strategy branches (`searchByKeyword`, `searchByEmbedding`, `searchHybrid`, native-hybrid). Add `applySessionFilter` helper that drops raw FTS / vector results whose `session_key !== sessionKey`. Each strategy now over-retrieves (×4 single, ×5 hybrid RRF) when scoped so the post-filter pool can still fill `maxResults`.
- **`src/core/tools/memory-search.ts`** — add `sessionKey?` to `executeMemorySearch` params; add `session_key` to `MemorySearchResultItem` so RRF-merged items carry the key. Apply the session filter alongside the existing `type` / `scene` filters; over-retrieve when scoped.
- **`src/core/types.ts`** — add `sessionKey?: string` to `MemorySearchParams`.
- **`src/core/tdai-core.ts`** — forward `params.sessionKey` into `executeMemorySearch`.
- **`index.ts`** — expose `session_key` as an optional parameter on `tdai_memory_search`, mirroring `tdai_conversation_search`.

### Semantics

- **Auto-recall hook**: strictly scoped to the active `sessionKey`. The hook is already short-circuited upstream when `sessionKey` is empty (see `resolveSessionKey` in `index.ts`), so non-empty + strict-match is the right default.
- **`tdai_memory_search` tool**: `session_key` is **optional**. Agents that want cross-session recall (\"summarize everything you know about the user\") can still omit it; agents that want isolation pass it through. Same shape as `tdai_conversation_search` to keep the tool surface consistent.

### What's intentionally NOT in this PR

- No SQL schema change (no migration). `l1_fts.session_key` stays `UNINDEXED`; client-side filter is fine for the recall budget (`maxResults` is single digits) and the over-retrieve multiplier compensates for the post-filter drop. If profiling later shows the multiplier is hurting BM25 quality, we can add an indexed mirror or a composite FTS index in a follow-up.
- No backfill / migration for existing records — their `session_key` is already correctly stamped at write time.
- No automated isolation test — the repo currently ships no tracked `.test.ts` files (verified via `git ls-files`), so a one-off test for this PR wouldn't run anywhere. Verification is by hand below.

## Test plan

- [x] `npm run build` passes locally (tsdown clean).
- [ ] Two sessions on the same backend (e.g. `main` agent and `coder` agent under the same user, or two users under the same host):
  - capture distinct L1 memories from each session
  - trigger auto-recall from session A — confirm only A's records appear in `<relevant-memories>` (and the `[session-filter:*]` debug log shows the drop count)
  - same for session B
- [ ] `tdai_memory_search` called without `session_key` still returns the global pool (no regression for the cross-session use case).
- [ ] `tdai_memory_search` called with `session_key=<current>` filters correctly.
- [ ] Native-hybrid path (TCVDB backend with `nativeHybridSearch=true`) still works — verified that we now over-retrieve and post-filter rather than re-issue the request.