### PR TITLE
docs(install): warn against caret-range upgrades in ~/.openclaw/npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,19 @@ graph LR
 ### 1.1 Install the plugin
 
 ```bash
-openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
+# Always pin an exact version — OpenClaw's plugin manager does not accept
+# semver ranges (^/~) in ~/.openclaw/npm/package.json and will silently
+# disable the plugin on the next update if it sees one. See issue #107.
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6
 openclaw gateway restart
 ```
+
+> **Upgrading?** Do *not* run `npm install @tencentdb-agent-memory/memory-tencentdb@latest`
+> inside `~/.openclaw/npm/` — npm will rewrite the spec to a caret range
+> (`"^0.3.6"`) which OpenClaw rejects with
+> `unsupported npm spec: use an exact version or dist-tag`. Re-run the
+> `openclaw plugins install …@<version>` command above (or `npm install
+> …@<version> --save-exact`) to keep the spec exact.
 
 ### 1.2 Zero-config to enable
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,9 +139,19 @@ graph LR
 ### 1.1 安装插件
 
 ```bash
-openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
+# 务必固定到具体版本号 —— OpenClaw 的插件管理器不接受 ~/.openclaw/npm/package.json
+# 里的 semver 区间（^/~），若检测到范围声明会在下一次更新时静默禁用插件。
+# 详情见 issue #107。
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6
 openclaw gateway restart
 ```
+
+> **升级注意**：**不要**在 `~/.openclaw/npm/` 目录里跑 `npm install
+> @tencentdb-agent-memory/memory-tencentdb@latest`——npm 默认会把版本
+> 改写成 caret 区间（`"^0.3.6"`），OpenClaw 启动时会以
+> `unsupported npm spec: use an exact version or dist-tag` 报错并禁用
+> 插件。请用上面的 `openclaw plugins install …@<version>`（或
+> `npm install …@<version> --save-exact`）来确保版本保持精确。
 
 ### 1.2 零配置启用
 


### PR DESCRIPTION
## Summary

Fixes #107 — OpenClaw silently disables `memory-tencentdb` on the next update with `unsupported npm spec: use an exact version or dist-tag (ranges are not allowed)` when its `~/.openclaw/npm/package.json` records a semver range. @fdefilippo reproduced and root-caused it: running `npm install @tencentdb-agent-memory/memory-tencentdb@latest` inside `~/.openclaw/npm/` rewrites the spec to `"^0.3.6"`, which OpenClaw's plugin manager refuses.

### Change

Docs-only — there is no code path inside this repo that controls what npm writes into a user's `~/.openclaw/npm/package.json`. The actionable fix is to keep users on the supported upgrade flow:

- `README.md` and `README_CN.md` install snippets now pin an explicit version (`@0.3.6`) instead of installing the bare name.
- Added an **Upgrading?** callout that names the failure mode in OpenClaw's own words and points at the supported upgrade commands (`openclaw plugins install …@<version>` or `npm install …@<version> --save-exact`).

### What's intentionally NOT in this PR

- No change to this repo's own `package.json` dependencies. Those caret ranges are normal for a publishable package — npm resolves them at install time and never round-trips them into `~/.openclaw/npm/package.json`. The bug is strictly about the spec OpenClaw records for the **plugin itself**, not its transitive deps.
- No postinstall script to rewrite the user's `package.json` — too invasive, and the docs fix is enough to dodge the foot-gun.

## Test plan

- [ ] On a fresh OpenClaw install, run `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6` → verify `~/.openclaw/npm/package.json` records `"0.3.6"` (no caret).
- [ ] Restart `openclaw gateway` → no `unsupported npm spec` error, plugin stays enabled.
- [ ] Try the bad path documented in the callout (`npm install …@latest` in `~/.openclaw/npm/`) → confirm it rewrites the spec to `"^0.3.6"` and that the next OpenClaw start disables the plugin, matching the bug report.