### PR TITLE
fix(offload): resolve local-LLM api key via OpenClaw auth-profiles

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -368,16 +368,58 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
       const models = (api.config as any)?.models;
       const providerCfg = models?.providers?.[providerKey];
       const baseUrl = providerCfg?.baseUrl ?? providerCfg?.baseURL;
-      const apiKey = providerCfg?.apiKey;
+
+      // Resolve the API key in two steps:
+      //   1. OpenClaw's auth-profiles (api.resolveProviderAuth) — supports
+      //      api-key profiles, env vars, and OAuth without forcing users to
+      //      duplicate the key under `models.providers[*].apiKey`.
+      //   2. Plain `models.providers[providerKey].apiKey` — backwards-compat
+      //      path for hosts that don't expose resolveProviderAuth, and for
+      //      users who already configure the key inline.
+      // baseUrl is intentionally still read from `models.providers` only,
+      // since auth-profiles doesn't carry endpoint information.
+      // See issue #90.
+      let apiKey: string | undefined;
+      let apiKeySource = "models.providers";
+      const resolveAuth = (api as unknown as {
+        resolveProviderAuth?: (
+          providerId?: string,
+        ) => { apiKey?: string; source?: string; mode?: string } | undefined;
+      }).resolveProviderAuth;
+      if (typeof resolveAuth === "function") {
+        try {
+          const auth = resolveAuth.call(api, providerKey);
+          if (auth?.apiKey) {
+            apiKey = auth.apiKey;
+            apiKeySource = auth.source === "profile"
+              ? `auth-profile${auth.mode ? ":" + auth.mode : ""}`
+              : (auth.source ?? "auth-profile");
+          }
+        } catch (err) {
+          logger.debug?.(
+            `[context-offload] resolveProviderAuth("${providerKey}") failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      if (!apiKey) {
+        apiKey = providerCfg?.apiKey;
+      }
 
       if (baseUrl && apiKey) {
+        logger.debug?.(
+          `[context-offload] Local LLM provider="${providerKey}" model="${modelId}" apiKey source=${apiKeySource}`,
+        );
         backendClient = new LocalLlmClient(
           { baseUrl, apiKey, model: modelId, temperature: offloadConfig.temperature, timeoutMs: offloadConfig.backendTimeoutMs },
           logger,
         );
       } else {
+        const missing = [
+          baseUrl ? null : `baseUrl (set models.providers["${providerKey}"].baseUrl)`,
+          apiKey ? null : `apiKey (set an auth-profile for "${providerKey}", or models.providers["${providerKey}"].apiKey)`,
+        ].filter(Boolean).join(", ");
         logger.error(
-          `[context-offload] Local LLM mode failed: provider "${providerKey}" not found or missing baseUrl/apiKey in models.providers. ` +
+          `[context-offload] Local LLM mode failed: provider "${providerKey}" is missing ${missing}. ` +
           `L1/L1.5/L2 disabled.`,
         );
       }


### PR DESCRIPTION
## Summary

Fixes #90 — when `offload.model` is set in `provider/model` form, the local-LLM backend only reads `models.providers[providerKey].apiKey` from the runtime config. OpenClaw's auth-profiles deliberately *doesn't* propagate the key into that map (the host injects it into the model call out-of-band instead), so users on auth-profiles see:

```
[context-offload] Local LLM mode failed: provider "deepseek" not found or missing baseUrl/apiKey in models.providers. L1/L1.5/L2 disabled.
```

…and the L1 / L1.5 / L2 layers stay disabled even though the model works fine for agent calls.

### Change

`src/offload/index.ts` — resolve the key in two ordered steps:

1. **`api.resolveProviderAuth(providerKey)`** if exposed by the host (verified against the OpenClaw 2026.5.12 SDK — covers api-key profiles, env-var fallbacks, and the OAuth mode the host already uses for agent → model calls). Feature-detected via `typeof === \"function\"` so older hosts still load.
2. **`models.providers[providerKey].apiKey`** if step 1 returns nothing — keeps existing inline-config setups working unchanged.

`baseUrl` is still read exclusively from `models.providers`. `resolveProviderAuth` intentionally doesn't carry endpoint info (auth-profiles is for credentials, not routing).

Side-touches kept tight:
- The \"missing config\" error now spells out **which** field is missing and **where** to set it (`auth-profile for \"<provider>\"` vs `models.providers[*].apiKey` / `.baseUrl`), so triage doesn't need a second round-trip.
- Added a debug-level log line reporting the apiKey source (e.g. `apiKey source=auth-profile:api_key`) so `--debug` users can confirm which path fired.

### What's intentionally NOT in this PR

- No new config schema — relying on the host's standard auth-profile resolution; no plugin-side config required.
- No change to extraction/persona pipelines. They go through the host's `LLMRunner` and don't hit this code path, so they were never broken in the same way. Filing as a follow-up if it turns out other modules duplicate the inline-only pattern.

## Test plan

- [x] `npm run build` (tsdown) clean — verified locally.
- [ ] On OpenClaw with `offload.model: \"deepseek/deepseek-v4-flash\"` and the deepseek key registered **only** as an auth-profile (no `models.providers.deepseek.apiKey`): offload pipeline starts, debug log shows `apiKey source=auth-profile:*`, L1/L1.5/L2 fire normally.
- [ ] Same config but with the key set inline in `models.providers.deepseek.apiKey` (no auth-profile): still works, debug log shows `apiKey source=models.providers`.
- [ ] No `models.providers.deepseek.baseUrl` set: error message now reads `provider \"deepseek\" is missing baseUrl (set models.providers[\"deepseek\"].baseUrl)`.
- [ ] Older OpenClaw host without `resolveProviderAuth`: plugin still loads, falls through to the inline-config path, no exception.