### PR TITLE
docs(troubleshooting): explain Linux ENOENT noise from OpenClaw probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,39 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 ---
 
+## Troubleshooting
+
+### Linux: `ENOENT` errors for macOS or `/home/user/` paths
+
+If your logs show repeated `ENOENT` for paths like
+`/Users/<name>/Library/Application Support/Claude/...`,
+`/home/user/agent_memory/memory.json`, or
+`/home/user/data/agent_memory/config/user_profile.yaml`, the source is **not**
+this plugin. Those paths are not referenced anywhere in the plugin's source
+tree — they come from the OpenClaw host's own startup probes (e.g. searching
+for a Claude Desktop config file). On Linux they will always miss, but they
+don't affect any memory-tencentdb functionality.
+
+How memory-tencentdb resolves paths is platform-aware:
+
+| Path | Resolution order |
+|---|---|
+| Plugin state dir | `runtime.state.resolveStateDir()` (OpenClaw API) → `$OPENCLAW_STATE_DIR` → `~/.openclaw` |
+| Gateway data dir | `$TDAI_DATA_DIR` → `$HOME`/`$USERPROFILE` → `/tmp` (then `…/.memory-tencentdb/memory-tdai`) |
+| Hook policy config | `$TDAI_GATEWAY_CONFIG` → `$CWD/openclaw.json` → `~/.openclaw/openclaw.json` |
+
+All three use `os.homedir()` plus an `existsSync` guard before reading,
+so a missing file is a silent fall-through, not an error.
+
+**To suppress the host's noise**: upgrade the OpenClaw host (newer versions
+short-circuit the Claude Desktop probe on non-macOS platforms), or
+filter `ENOENT` lines whose path matches `Library/Application Support` or
+`/home/user/` at the log-collector level. See issue
+[#103](https://github.com/Tencent/TencentDB-Agent-Memory/issues/103) for
+context.
+
+---
+
 ## Community & Contributing
 
 We welcome every kind of contribution — bug reports, feature ideas, doc fixes, benchmark reproductions, ecosystem integrations, or a Pull Request. Agent memory is far from a solved problem, and we'd love to figure it out together.

--- a/README_CN.md
+++ b/README_CN.md
@@ -407,6 +407,31 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |
 
 ---
+
+## 故障排查
+
+### Linux 下出现 macOS 或 `/home/user/` 路径的 `ENOENT` 报错
+
+若日志中反复出现以下路径的 `ENOENT`：
+- `/Users/<name>/Library/Application Support/Claude/...`
+- `/home/user/agent_memory/memory.json`
+- `/home/user/data/agent_memory/config/user_profile.yaml`
+
+它们都**不**来自本插件的源码（仓库内 grep 不到这些路径），而是 OpenClaw 宿主在启动时尝试探测 Claude Desktop 配置等的内部路径。在 Linux 上它们必然不存在，但**不会**影响 memory-tencentdb 的任何记忆能力。
+
+本插件的路径解析在所有平台都做了适配：
+
+| 路径 | 解析顺序 |
+|---|---|
+| 插件状态目录 | `runtime.state.resolveStateDir()`（OpenClaw API）→ `$OPENCLAW_STATE_DIR` → `~/.openclaw` |
+| Gateway 数据目录 | `$TDAI_DATA_DIR` → `$HOME` / `$USERPROFILE` → `/tmp`（拼接 `…/.memory-tencentdb/memory-tdai`） |
+| Hook 策略配置 | `$TDAI_GATEWAY_CONFIG` → `$CWD/openclaw.json` → `~/.openclaw/openclaw.json` |
+
+三处都用 `os.homedir()` 兜底，并在读取前 `existsSync` 守卫——文件缺失时静默回退，不会产生 error 日志。
+
+**抑制宿主噪声的两种方法**：升级 OpenClaw（新版本在非 macOS 平台会跳过 Claude Desktop 探测）；或在日志收集层过滤路径中包含 `Library/Application Support` 或 `/home/user/` 的 `ENOENT` 行。详见 issue [#103](https://github.com/Tencent/TencentDB-Agent-Memory/issues/103)。
+
+---
 ## 社区与贡献
 
 我们欢迎一切形式的贡献——Bug 反馈、功能建议、文档勘误、Benchmark 复现、生态集成，或者一个 Pull Request 都可以。Agent 记忆这件事远未有定论，希望和大家一起把它做出来。


### PR DESCRIPTION
## Summary

Closes #103 — clarifies that the `ENOENT` log noise reported on Linux is **not from this plugin** and points users at the actionable workarounds.

### What I verified

Grep'd the entire repo for the three reported paths:

| Reported path | Found in repo? |
|---|---|
| `/Users/<name>/Library/Application Support/Claude/...` | ❌ no match |
| `/home/user/agent_memory/memory.json` | ❌ no match (\"agent_memory\" only appears as a TCVDB database-name example in migration scripts) |
| `/home/user/data/agent_memory/config/user_profile.yaml` | ❌ no match |

The plugin's own path resolution is already platform-aware:

| Path | Resolution chain | Source |
|---|---|---|
| Plugin state dir | `runtime.state.resolveStateDir()` → `$OPENCLAW_STATE_DIR` → `~/.openclaw` | `src/utils/openclaw-state-dir.ts` |
| Gateway data dir | `$TDAI_DATA_DIR` → `$HOME` / `$USERPROFILE` → `/tmp` | `src/gateway/config.ts` |
| Hook policy config | `$TDAI_GATEWAY_CONFIG` → `$CWD/openclaw.json` → `~/.openclaw/openclaw.json` | `src/utils/ensure-hook-policy.ts` |

All three guard reads with `existsSync` and fall through silently on miss; nothing logs at `error` level for a missing file. The repro paths come from the **OpenClaw host's** own startup probes (e.g. searching for a Claude Desktop config) — that scan is unconditional on the host, so it always misses on Linux.

The issue's acceptance criteria — \"path checking supports Linux standard paths\", \"no repeated ENOENT logs\", \"add Linux test cases\" — are already met for the plugin's own paths. The visible noise needs a host-side fix or a log-filter on the user's collector.

### Change

Docs-only:

- `README.md` and `README_CN.md` gain a **Troubleshooting** section between **Documentation** and **Community & Contributing**.
- The new section names the three reported paths, confirms they're host-side not plugin-side, documents the plugin's three-tier path resolution so users can audit, and lists the two actionable workarounds (upgrade OpenClaw, or filter the noise at the log collector).

### What's intentionally NOT in this PR

- No code change. The plugin's path handling is already what the acceptance criteria asks for; adding a redundant `pathExistsCache` or warn-once wrapper inside the plugin wouldn't silence the host's probe and would add tech debt for nothing.
- No test file. The repo currently doesn't ship tracked `.test.ts` (verified via `git ls-files`), so a one-off Linux path test would have no harness to run in.

## Test plan

- [ ] Verify rendering of the new section in both READMEs.
- [ ] On a fresh Linux container with OpenClaw 2026.5.12 + this plugin, confirm the documented resolution chain is what actually runs (`echo $OPENCLAW_STATE_DIR`, `ls ~/.openclaw/memory-tdai`).
- [ ] Confirm the documented log-filter pattern (`Library/Application Support` and `/home/user/`) matches the format the host emits, so users can drop it straight into a Loki/grep rule.