### PR TITLE
[good first issue] docs(hermes): document plugging memory-tencentdb into an existing Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,16 @@ bash scripts/openclaw-after-tool-call-messages.patch.sh
 
 ### 2. Hermes
 
-In addition to OpenClaw, this plugin also supports [Hermes](https://github.com/NousResearch/hermes-agent) Agent. Two installation paths exist; pick by deployment scenario:
+In addition to OpenClaw, this plugin also supports [Hermes](https://github.com/NousResearch/hermes-agent) Agent. Choose the installation path based on your deployment scenario:
 
 | You want to … | Use |
 |---|---|
-| Spin up a memory-enabled Hermes from scratch in one command | **2.A Docker** (below) |
-| Add memory to an **existing** Hermes install | **2.B Plug into an existing Hermes** (next section) |
+| Spin up a memory-enabled Hermes from scratch in one command | 2.A Docker (below) |
+| Add memory to an existing Hermes install | 2.B Plug into an existing Hermes (next section) |
 
 #### 2.A Docker (greenfield, requires version ≥ 0.3.4)
 
-The Docker image bundles `hermes-agent` and the `memory_tencentdb` provider side-by-side and exposes the Gateway on `:8420`:
+The Docker image bundles `hermes-agent` and the `memory_tencentdb` provider together. The Gateway listens on `:8420`:
 
 ```bash
 # ============ Configuration Parameters ============
@@ -253,59 +253,69 @@ docker exec -it hermes-memory hermes
 
 > The image ships with Tencent Cloud DeepSeek-V3.2 as the default. If you use this model, omit `MODEL_BASE_URL` / `MODEL_NAME` / `MODEL_PROVIDER` and pass only `MODEL_API_KEY`.
 
-#### 2.B Plug into an existing Hermes (no Docker)
+#### 2.B Attach to Existing Hermes (No Docker)
 
-If `hermes-agent` is already installed on the host and you only want to add the memory provider, you don't need the Docker image. Two things must happen: drop the Python provider into `hermes-agent/plugins/memory/memory_tencentdb/`, then let it find or launch the Node.js Gateway sidecar.
+If you already have `hermes-agent` installed on your host and just want to add memory capabilities, **no Docker image is needed**.
 
-**1. Install the npm package (Gateway source lives inside it):**
-
-```bash
-npm install -g @tencentdb-agent-memory/memory-tencentdb@0.3.6
-# Or pin into a known location, e.g.
-mkdir -p ~/.memory-tencentdb && cd ~/.memory-tencentdb
-npm install @tencentdb-agent-memory/memory-tencentdb@0.3.6
-# This puts the plugin at:
-#   ~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb/
-```
-
-**2. Mount the Python provider into your Hermes checkout** (pick one):
+**1. Download the plugin package to a unified directory**:
 
 ```bash
-PLUGIN_ROOT=~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb
-
-# (a) symlink — preferred while iterating, picks up `npm update` automatically
-ln -s "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
-      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
-
-# (b) copy — frozen vendoring
-cp -r "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
-      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
+mkdir -p ~/.memory-tencentdb
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+npm init -y --silent
+npm install @tencentdb-agent-memory/memory-tencentdb@latest --omit=dev
+cp -r node_modules/@tencentdb-agent-memory/memory-tencentdb \
+      ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+rm -rf "$TEMP_DIR"
 ```
 
-> The directory name must be **`memory_tencentdb`** (underscore) — Hermes uses that as the provider key. `memory-tencentdb` (hyphen) is a config-side alias, not a valid directory name.
+**2. Install Gateway dependencies**:
 
-**3. Tell Hermes to use the provider** in `~/.hermes/config.yaml`:
+```bash
+cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+npm install --omit=dev
+npm install tsx
+```
+
+**3. Link to the Hermes plugin directory**:
+
+```bash
+rm -rf ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+ln -sf ~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb \
+       ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+```
+
+> The directory **must** be named `memory_tencentdb` (with an underscore) — Hermes uses this as the provider key. `memory-tencentdb` (with a hyphen) is only an alias at the config level and **cannot** be used as the directory name.
+
+**4. Declare the provider in `~/.hermes/config.yaml`**:
 
 ```yaml
 memory:
   provider: memory_tencentdb
 ```
 
-**4. Configure the Gateway's LLM credentials** in the Hermes process environment:
+**5. Configure Gateway environment variables**
+
+Edit `~/.hermes/.env` and add:
 
 ```bash
-export MEMORY_TENCENTDB_LLM_API_KEY="sk-..."
-export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # optional
-export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # optional
+MEMORY_TENCENTDB_GATEWAY_CMD="sh -c 'cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin && exec npx tsx src/gateway/server.ts'"
+MEMORY_TENCENTDB_GATEWAY_HOST="127.0.0.1"
+MEMORY_TENCENTDB_GATEWAY_PORT="8420"
 ```
 
-For long-running installs, you can use the Gateway config file instead. The
-Gateway automatically loads `~/.memory-tencentdb/memory-tdai/tdai-gateway.json`
-when it starts, so no extra env var is required:
+Add LLM credentials as needed (the Gateway actually reads the `TDAI_LLM_*` variables):
 
 ```bash
-mkdir -p ~/.memory-tencentdb/memory-tdai
-cat > ~/.memory-tencentdb/memory-tdai/tdai-gateway.json <<'JSON'
+TDAI_LLM_API_KEY="sk-your-api-key-here"
+TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+TDAI_LLM_MODEL="gpt-4o"
+```
+
+Alternatively, use a Gateway config file at `~/.memory-tencentdb/memory-tdai/tdai-gateway.json`:
+
+```json
 {
   "llm": {
     "baseUrl": "https://your-api-endpoint/v1",
@@ -313,24 +323,26 @@ cat > ~/.memory-tencentdb/memory-tdai/tdai-gateway.json <<'JSON'
     "model": "your-model-name"
   }
 }
-JSON
 ```
 
-**5. Start the Gateway** (three options — pick whichever fits):
+**6. Start the Gateway** (choose one of two methods):
 
-- **Auto-discovery (zero-config).** If you installed at one of the supported paths (`~/.memory-tencentdb/...` is one), the provider finds `src/gateway/server.ts` and `Popen()`s it as `node --import tsx <path>` when Hermes starts. Nothing extra to do.
-- **Explicit auto-start.** Override discovery by setting the command yourself: `export MEMORY_TENCENTDB_GATEWAY_CMD="node --import tsx /abs/path/to/memory-tencentdb/src/gateway/server.ts"`.
-- **Run it yourself.** Start the Gateway separately before launching Hermes; the provider detects it on `127.0.0.1:8420` via `/health` and skips the subprocess-launch path.
+- **Auto-discovery on conversation (recommended, zero-config)**: Don't start the Gateway manually — just start talking to Hermes. The provider will auto-detect `~/.memory-tencentdb/tdai-memory-openclaw-plugin/src/gateway/server.ts` and launch it via `Popen()` on the first conversation. The initial conversation may have a slight delay.
+- **Manual run**: Start a standalone Gateway process in advance:
+  ```bash
+  cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+  npx tsx src/gateway/server.ts
+  ```
 
-**6. Verify:**
+**7. Verify**:
 
 ```bash
 curl http://127.0.0.1:8420/health
-# Then start Hermes; the agent.log should print:
-#   memory-tencentdb Gateway command auto-discovered: /…/src/gateway/server.ts
+# Should return {"status":"ok"} or {"status":"degraded"}
 ```
 
-> The provider's full reference (env-var table, troubleshooting, LLM tool schemas, supervisor behaviour) lives in [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md) — read it before touching the supervisor / circuit-breaker defaults.
+> For the complete provider reference (environment variables, troubleshooting, LLM tool schemas, supervisor behavior), see [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md). Please read it before adjusting the supervisor / circuit-breaker defaults.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,23 @@ export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # optional
 export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # optional
 ```
 
+For long-running installs, you can use the Gateway config file instead. The
+Gateway automatically loads `~/.memory-tencentdb/memory-tdai/tdai-gateway.json`
+when it starts, so no extra env var is required:
+
+```bash
+mkdir -p ~/.memory-tencentdb/memory-tdai
+cat > ~/.memory-tencentdb/memory-tdai/tdai-gateway.json <<'JSON'
+{
+  "llm": {
+    "baseUrl": "https://your-api-endpoint/v1",
+    "apiKey": "your-api-key",
+    "model": "your-model-name"
+  }
+}
+JSON
+```
+
 **5. Start the Gateway** (three options — pick whichever fits):
 
 - **Auto-discovery (zero-config).** If you installed at one of the supported paths (`~/.memory-tencentdb/...` is one), the provider finds `src/gateway/server.ts` and `Popen()`s it as `node --import tsx <path>` when Hermes starts. Nothing extra to do.

--- a/README.md
+++ b/README.md
@@ -193,9 +193,18 @@ bash scripts/openclaw-after-tool-call-messages.patch.sh
 > 💡 The patch only needs to be applied once per OpenClaw installation. After upgrading OpenClaw, re-run the script to re-apply.
 
 
-### 2. Hermes (Docker, requires version ≥ 0.3.4)
+### 2. Hermes
 
-In addition to OpenClaw, this plugin also supports [Hermes](https://github.com/NousResearch/hermes-agent) Agent. You can launch a memory-enabled Hermes with a single command:
+In addition to OpenClaw, this plugin also supports [Hermes](https://github.com/NousResearch/hermes-agent) Agent. Two installation paths exist; pick by deployment scenario:
+
+| You want to … | Use |
+|---|---|
+| Spin up a memory-enabled Hermes from scratch in one command | **2.A Docker** (below) |
+| Add memory to an **existing** Hermes install | **2.B Plug into an existing Hermes** (next section) |
+
+#### 2.A Docker (greenfield, requires version ≥ 0.3.4)
+
+The Docker image bundles `hermes-agent` and the `memory_tencentdb` provider side-by-side and exposes the Gateway on `:8420`:
 
 ```bash
 # ============ Configuration Parameters ============
@@ -243,6 +252,68 @@ docker exec -it hermes-memory hermes
 ```
 
 > The image ships with Tencent Cloud DeepSeek-V3.2 as the default. If you use this model, omit `MODEL_BASE_URL` / `MODEL_NAME` / `MODEL_PROVIDER` and pass only `MODEL_API_KEY`.
+
+#### 2.B Plug into an existing Hermes (no Docker)
+
+If `hermes-agent` is already installed on the host and you only want to add the memory provider, you don't need the Docker image. Two things must happen: drop the Python provider into `hermes-agent/plugins/memory/memory_tencentdb/`, then let it find or launch the Node.js Gateway sidecar.
+
+**1. Install the npm package (Gateway source lives inside it):**
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb@0.3.6
+# Or pin into a known location, e.g.
+mkdir -p ~/.memory-tencentdb && cd ~/.memory-tencentdb
+npm install @tencentdb-agent-memory/memory-tencentdb@0.3.6
+# This puts the plugin at:
+#   ~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb/
+```
+
+**2. Mount the Python provider into your Hermes checkout** (pick one):
+
+```bash
+PLUGIN_ROOT=~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb
+
+# (a) symlink — preferred while iterating, picks up `npm update` automatically
+ln -s "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
+      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
+
+# (b) copy — frozen vendoring
+cp -r "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
+      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
+```
+
+> The directory name must be **`memory_tencentdb`** (underscore) — Hermes uses that as the provider key. `memory-tencentdb` (hyphen) is a config-side alias, not a valid directory name.
+
+**3. Tell Hermes to use the provider** in `~/.hermes/config.yaml`:
+
+```yaml
+memory:
+  provider: memory_tencentdb
+```
+
+**4. Configure the Gateway's LLM credentials** in the Hermes process environment:
+
+```bash
+export MEMORY_TENCENTDB_LLM_API_KEY="sk-..."
+export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # optional
+export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # optional
+```
+
+**5. Start the Gateway** (three options — pick whichever fits):
+
+- **Auto-discovery (zero-config).** If you installed at one of the supported paths (`~/.memory-tencentdb/...` is one), the provider finds `src/gateway/server.ts` and `Popen()`s it as `node --import tsx <path>` when Hermes starts. Nothing extra to do.
+- **Explicit auto-start.** Override discovery by setting the command yourself: `export MEMORY_TENCENTDB_GATEWAY_CMD="node --import tsx /abs/path/to/memory-tencentdb/src/gateway/server.ts"`.
+- **Run it yourself.** Start the Gateway separately before launching Hermes; the provider detects it on `127.0.0.1:8420` via `/health` and skips the subprocess-launch path.
+
+**6. Verify:**
+
+```bash
+curl http://127.0.0.1:8420/health
+# Then start Hermes; the agent.log should print:
+#   memory-tencentdb Gateway command auto-discovered: /…/src/gateway/server.ts
+```
+
+> The provider's full reference (env-var table, troubleshooting, LLM tool schemas, supervisor behaviour) lives in [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md) — read it before touching the supervisor / circuit-breaker defaults.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -209,7 +209,7 @@ bash scripts/openclaw-after-tool-call-messages.patch.sh
 
 #### 2.A Docker（全新部署，需版本号 ≥ 0.3.4）
 
-Docker 镜像把 `hermes-agent` 和 `memory_tencentdb` provider 揉在一起，Gateway 监听 `:8420`：
+Docker 镜像把 `hermes-agent` 和 `memory_tencentdb` provider 聚合在一起，Gateway 监听 `:8420`：
 
 ```bash
 # ============ 配置参数说明 ============
@@ -260,56 +260,67 @@ docker exec -it hermes-memory hermes
 
 #### 2.B 挂到已有 Hermes 上（无 Docker）
 
-如果宿主机上已经装好了 `hermes-agent`，只想加上记忆能力，**不需要** Docker 镜像。两步：把 Python provider 放进 `hermes-agent/plugins/memory/memory_tencentdb/`，再让它发现/拉起 Node.js Gateway。
+如果宿主机上已经装好了 `hermes-agent`，只想加上记忆能力，**不需要** Docker 镜像。
 
-**1. 安装 npm 包（Gateway 源码在里面）**：
-
-```bash
-npm install -g @tencentdb-agent-memory/memory-tencentdb@0.3.6
-# 或固定到一个已知目录，例如：
-mkdir -p ~/.memory-tencentdb && cd ~/.memory-tencentdb
-npm install @tencentdb-agent-memory/memory-tencentdb@0.3.6
-# 装好后插件位于：
-#   ~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb/
-```
-
-**2. 把 Python provider 接入到 Hermes**（二选一）：
+**1. 下载插件包到统一目录**：
 
 ```bash
-PLUGIN_ROOT=~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb
-
-# (a) symlink —— 推荐用于开发迭代，npm update 后自动生效
-ln -s "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
-      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
-
-# (b) copy —— 冻结某个版本
-cp -r "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
-      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
+mkdir -p ~/.memory-tencentdb
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+npm init -y --silent
+npm install @tencentdb-agent-memory/memory-tencentdb@latest --omit=dev
+cp -r node_modules/@tencentdb-agent-memory/memory-tencentdb \
+      ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+rm -rf "$TEMP_DIR"
 ```
 
-> 目录名必须是 **`memory_tencentdb`**（下划线）—— Hermes 用它作为 provider key。`memory-tencentdb`（连字符）只是配置层面的别名，**不**能作为目录名。
+**2. 安装 Gateway 依赖**：
 
-**3. 在 `~/.hermes/config.yaml` 中声明 provider**：
+```bash
+cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+npm install --omit=dev
+npm install tsx
+```
+
+**3. 链接到 Hermes 插件目录**：
+
+```bash
+rm -rf ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+ln -sf ~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb \
+       ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+```
+
+> 此处目录名必须是 **`memory_tencentdb`**（下划线）—— Hermes 用它作为 provider key。`memory-tencentdb`（连字符）只是配置层面的别名，**不**能作为目录名。
+
+**4. 在 `~/.hermes/config.yaml` 中声明 provider**：
 
 ```yaml
 memory:
   provider: memory_tencentdb
 ```
 
-**4. 配置 Gateway 的 LLM 凭据**（注入到 Hermes 进程环境变量）：
+**5. 配置 Gateway 环境变量**
+
+编辑 `~/.hermes/.env`，添加：
 
 ```bash
-export MEMORY_TENCENTDB_LLM_API_KEY="sk-..."
-export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # 可选
-export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # 可选
+MEMORY_TENCENTDB_GATEWAY_CMD="sh -c 'cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin && exec npx tsx src/gateway/server.ts'"
+MEMORY_TENCENTDB_GATEWAY_HOST="127.0.0.1"
+MEMORY_TENCENTDB_GATEWAY_PORT="8420"
 ```
 
-长期使用时，也可以改用 Gateway 配置文件。Gateway 启动时会自动读取
-`~/.memory-tencentdb/memory-tdai/tdai-gateway.json`，无需额外设置环境变量：
+LLM 凭证请按需添加（Gateway 实际读取的是 `TDAI_LLM_*` 系列变量）：
 
 ```bash
-mkdir -p ~/.memory-tencentdb/memory-tdai
-cat > ~/.memory-tencentdb/memory-tdai/tdai-gateway.json <<'JSON'
+TDAI_LLM_API_KEY="sk-your-api-key-here"
+TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+TDAI_LLM_MODEL="gpt-4o"
+```
+
+也可改用 Gateway 配置文件 `~/.memory-tencentdb/memory-tdai/tdai-gateway.json`：
+
+```json
 {
   "llm": {
     "baseUrl": "https://your-api-endpoint/v1",
@@ -317,21 +328,22 @@ cat > ~/.memory-tencentdb/memory-tdai/tdai-gateway.json <<'JSON'
     "model": "your-model-name"
   }
 }
-JSON
 ```
 
-**5. 启动 Gateway**（三种方式任选其一）：
+**6. 启动 Gateway**（两种方式任选其一）：
 
-- **自动发现（零配置）**：若插件装在支持的路径下（`~/.memory-tencentdb/...` 就是其中之一），provider 会自动找到 `src/gateway/server.ts` 并以 `node --import tsx <path>` 的形式 `Popen()` 拉起，不需要任何额外配置。
-- **显式自动启动**：自己设置启动命令覆盖自动发现：`export MEMORY_TENCENTDB_GATEWAY_CMD="node --import tsx /abs/path/to/memory-tencentdb/src/gateway/server.ts"`。
-- **手动运行**：自己提前在 `127.0.0.1:8420` 起一个 Gateway 进程；provider 检测到 `/health` 可达后会跳过子进程启动路径。
+- **对话时自动发现（推荐，零配置）**：不启动 Gateway，直接开始和 Hermes 对话。provider 会在第一条对话时自动检测到 `~/.memory-tencentdb/tdai-memory-openclaw-plugin/src/gateway/server.ts` 并以 `Popen()` 拉起。首次对话会略有延迟。
+- **手动运行**：提前启动一个独立的 Gateway 进程：
+  ```bash
+  cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+  npx tsx src/gateway/server.ts
+  ```
 
-**6. 验证**：
+**7. 验证**：
 
 ```bash
 curl http://127.0.0.1:8420/health
-# 然后启动 Hermes，agent.log 会出现：
-#   memory-tencentdb Gateway command auto-discovered: /…/src/gateway/server.ts
+# 应返回 {"status":"ok"} 或 {"status":"degraded"}
 ```
 
 > Provider 的完整参考（环境变量、故障排查、LLM 工具 schema、supervisor 行为）见 [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md)，调整 supervisor / circuit-breaker 默认值之前请先读它。

--- a/README_CN.md
+++ b/README_CN.md
@@ -204,8 +204,8 @@ bash scripts/openclaw-after-tool-call-messages.patch.sh
 
 | 你的场景 | 走哪条路 |
 |---|---|
-| 想从零启动一个带记忆能力的 Hermes（一条命令搞定） | **2.A Docker**（下文） |
-| **已经装好了 Hermes**，只想加上记忆能力 | **2.B 挂到已有 Hermes 上**（再下文） |
+| 想从零启动一个带记忆能力的 Hermes（一条命令搞定） | 2.A Docker（下文） |
+| 已经装好了Hermes，只想加上记忆能力 | 2.B 挂到已有 Hermes 上（再下文） |
 
 #### 2.A Docker（全新部署，需版本号 ≥ 0.3.4）
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -198,9 +198,18 @@ bash scripts/openclaw-after-tool-call-messages.patch.sh
 > 💡 patch 每次 OpenClaw 安装只需执行一次。升级 OpenClaw 后建议重新执行以确保钩子生效。
 
 
-### 2. Hermes（Docker，需版本号 ≥ 0.3.4）
+### 2. Hermes
 
-除 OpenClaw 外，本插件同样支持 [Hermes](https://github.com/NousResearch/hermes-agent) Agent。通过一条命令即可启动一个带记忆能力的 Hermes：
+除 OpenClaw 外，本插件同样支持 [Hermes](https://github.com/NousResearch/hermes-agent) Agent。根据部署场景选择安装路径：
+
+| 你的场景 | 走哪条路 |
+|---|---|
+| 想从零启动一个带记忆能力的 Hermes（一条命令搞定） | **2.A Docker**（下文） |
+| **已经装好了 Hermes**，只想加上记忆能力 | **2.B 挂到已有 Hermes 上**（再下文） |
+
+#### 2.A Docker（全新部署，需版本号 ≥ 0.3.4）
+
+Docker 镜像把 `hermes-agent` 和 `memory_tencentdb` provider 揉在一起，Gateway 监听 `:8420`：
 
 ```bash
 # ============ 配置参数说明 ============
@@ -248,6 +257,68 @@ docker exec -it hermes-memory hermes
 ```
 
 > 镜像内置了腾讯云 DeepSeek-V3.2 的默认值，如果你使用该模型，`MODEL_BASE_URL`/`MODEL_NAME`/`MODEL_PROVIDER` 可以省略，只传 `MODEL_API_KEY` 即可。
+
+#### 2.B 挂到已有 Hermes 上（无 Docker）
+
+如果宿主机上已经装好了 `hermes-agent`，只想加上记忆能力，**不需要** Docker 镜像。两步：把 Python provider 放进 `hermes-agent/plugins/memory/memory_tencentdb/`，再让它发现/拉起 Node.js Gateway。
+
+**1. 安装 npm 包（Gateway 源码在里面）**：
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb@0.3.6
+# 或固定到一个已知目录，例如：
+mkdir -p ~/.memory-tencentdb && cd ~/.memory-tencentdb
+npm install @tencentdb-agent-memory/memory-tencentdb@0.3.6
+# 装好后插件位于：
+#   ~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb/
+```
+
+**2. 把 Python provider 接入到 Hermes**（二选一）：
+
+```bash
+PLUGIN_ROOT=~/.memory-tencentdb/node_modules/@tencentdb-agent-memory/memory-tencentdb
+
+# (a) symlink —— 推荐用于开发迭代，npm update 后自动生效
+ln -s "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
+      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
+
+# (b) copy —— 冻结某个版本
+cp -r "$PLUGIN_ROOT/hermes-plugin/memory/memory_tencentdb" \
+      <hermes-agent-checkout>/plugins/memory/memory_tencentdb
+```
+
+> 目录名必须是 **`memory_tencentdb`**（下划线）—— Hermes 用它作为 provider key。`memory-tencentdb`（连字符）只是配置层面的别名，**不**能作为目录名。
+
+**3. 在 `~/.hermes/config.yaml` 中声明 provider**：
+
+```yaml
+memory:
+  provider: memory_tencentdb
+```
+
+**4. 配置 Gateway 的 LLM 凭据**（注入到 Hermes 进程环境变量）：
+
+```bash
+export MEMORY_TENCENTDB_LLM_API_KEY="sk-..."
+export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # 可选
+export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # 可选
+```
+
+**5. 启动 Gateway**（三种方式任选其一）：
+
+- **自动发现（零配置）**：若插件装在支持的路径下（`~/.memory-tencentdb/...` 就是其中之一），provider 会自动找到 `src/gateway/server.ts` 并以 `node --import tsx <path>` 的形式 `Popen()` 拉起，不需要任何额外配置。
+- **显式自动启动**：自己设置启动命令覆盖自动发现：`export MEMORY_TENCENTDB_GATEWAY_CMD="node --import tsx /abs/path/to/memory-tencentdb/src/gateway/server.ts"`。
+- **手动运行**：自己提前在 `127.0.0.1:8420` 起一个 Gateway 进程；provider 检测到 `/health` 可达后会跳过子进程启动路径。
+
+**6. 验证**：
+
+```bash
+curl http://127.0.0.1:8420/health
+# 然后启动 Hermes，agent.log 会出现：
+#   memory-tencentdb Gateway command auto-discovered: /…/src/gateway/server.ts
+```
+
+> Provider 的完整参考（环境变量、故障排查、LLM 工具 schema、supervisor 行为）见 [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md)，调整 supervisor / circuit-breaker 默认值之前请先读它。
 
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -304,6 +304,22 @@ export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # 可选
 export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # 可选
 ```
 
+长期使用时，也可以改用 Gateway 配置文件。Gateway 启动时会自动读取
+`~/.memory-tencentdb/memory-tdai/tdai-gateway.json`，无需额外设置环境变量：
+
+```bash
+mkdir -p ~/.memory-tencentdb/memory-tdai
+cat > ~/.memory-tencentdb/memory-tdai/tdai-gateway.json <<'JSON'
+{
+  "llm": {
+    "baseUrl": "https://your-api-endpoint/v1",
+    "apiKey": "your-api-key",
+    "model": "your-model-name"
+  }
+}
+JSON
+```
+
 **5. 启动 Gateway**（三种方式任选其一）：
 
 - **自动发现（零配置）**：若插件装在支持的路径下（`~/.memory-tencentdb/...` 就是其中之一），provider 会自动找到 `src/gateway/server.ts` 并以 `node --import tsx <path>` 的形式 `Popen()` 拉起，不需要任何额外配置。


### PR DESCRIPTION
## Summary

Fixes #69 — the original ask:

> 一般情况下都是先装了 hermes 再装插件，不可能是为了使用插件而安装 hermes，目前的文档写的是把 hermes 和插件粗暴的揉在一起的 docker 镜像。

The Hermes-side reference already exists at `hermes-plugin/memory/memory_tencentdb/README.md` (auto-discovery paths, env-var matrix, supervisor / circuit-breaker behaviour, troubleshooting). The miss was discoverability — the top-level README's Hermes section only pointed at the all-in-one Docker image, so users with an existing Hermes install couldn't find the plug-it-in path.

### Change

Restructure section 2 of `README.md` and `README_CN.md` into two parallel installation paths:

- **2.A Docker (greenfield)** — the existing one-command flow, unchanged.
- **2.B Plug into an existing Hermes (no Docker)** — new. Six steps:
  1. `npm install` the package (Gateway source ships with it).
  2. Symlink **or** copy `hermes-plugin/memory/memory_tencentdb/` into `<hermes-agent>/plugins/memory/memory_tencentdb/`. The \"underscore not hyphen\" gotcha is called out — Hermes uses the directory name as the provider key.
  3. Set `memory.provider: memory_tencentdb` in `~/.hermes/config.yaml`.
  4. Export the three `MEMORY_TENCENTDB_LLM_*` env vars.
  5. Pick a Gateway start mode — auto-discovery (default), explicit `GATEWAY_CMD`, or run it yourself.
  6. `curl /health` + check `agent.log` for the auto-discovery line.

At the end of 2.B I link to `hermes-plugin/memory/memory_tencentdb/README.md` so users tuning the supervisor / circuit breaker get the full reference.

Same content in both English and Chinese READMEs.

### What's intentionally NOT in this PR

- No new docs file. The existing in-repo README is already the right reference; duplicating it in `docs/` would just make it drift.
- No code change. Section 2.B's commands match the behaviour already implemented in the supervisor / SDK client / auto-discovery scan.

## Test plan

- [ ] Render both READMEs on GitHub and verify the 2.A / 2.B table renders correctly and the in-repo link to `hermes-plugin/memory/memory_tencentdb/README.md` resolves.
- [ ] Follow 2.B end-to-end on a clean host with `hermes-agent` already installed; confirm `agent.log` prints `memory-tencentdb Gateway command auto-discovered: …` and a simple turn captures + recalls.
- [ ] Confirm existing Docker users following 2.A see no behaviour change.