### PR TITLE
feat(scripts): add Windows native Gateway launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,41 @@ docker exec -it hermes-memory hermes
 
 > The image ships with Tencent Cloud DeepSeek-V3.2 as the default. If you use this model, omit `MODEL_BASE_URL` / `MODEL_NAME` / `MODEL_PROVIDER` and pass only `MODEL_API_KEY`.
 
+### 3. Windows (native, no Docker)
+
+Two scripts under [`scripts/`](./scripts/) bring up the Gateway natively on Windows so you don't have to spin up Docker / WSL just to run the plugin. See issue [#113](https://github.com/Tencent/TencentDB-Agent-Memory/issues/113).
+
+**Prerequisites**
+
+- Windows 10 / 11 with PowerShell 5.1+ (built-in).
+- Node.js ≥ 22.16 — install from <https://nodejs.org/> and confirm `node -v` works in a new terminal.
+- The plugin's npm package on disk (see §1.1 — the Gateway entry lives at `<install>/src/gateway/server.ts`).
+
+**One-shot start**
+
+```cmd
+:: cmd.exe / double-click
+set MEMORY_TENCENTDB_LLM_API_KEY=sk-...
+scripts\memory-tencentdb-ctl.bat start
+```
+
+```powershell
+# PowerShell
+$env:MEMORY_TENCENTDB_LLM_API_KEY = "sk-..."
+.\scripts\memory-tencentdb-ctl.ps1 start
+```
+
+The script:
+
+1. **Resolves paths** — `MEMORY_TENCENTDB_ROOT` (default `%USERPROFILE%\.memory-tencentdb`), `TDAI_DATA_DIR`, log dir, install dir — using the same env-var names as the POSIX `ctl.sh`, so a shared config carries over.
+2. **Checks dependencies** — fails fast if `node` or `npx` is not on `PATH`.
+3. **Spawns the Gateway** detached (`Start-Process -WindowStyle Hidden`), redirects stdout/stderr to `gateway.stdout.log` / `gateway.stderr.log`, writes the PID to `gateway.pid`, and waits up to 15 s for `GET /health` to return `ok`.
+4. **Other subcommands**: `stop`, `restart`, `status`, `health`, `logs` (use `-NoFollow` for a one-shot dump). `help` prints the full env-var reference and resolved paths.
+
+Listening / killing uses `Get-NetTCPConnection` + `Stop-Process` (no need for `lsof` / `kill`), with a `netstat` fallback for older PowerShell hosts.
+
+> `MEMORY_TENCENTDB_GATEWAY_CMD` still overrides the auto-derived spawn command, mirroring the POSIX script's behaviour — handy if you want to run the bundled JavaScript build instead of `npx tsx`.
+
 ---
 
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -249,6 +249,40 @@ docker exec -it hermes-memory hermes
 
 > 镜像内置了腾讯云 DeepSeek-V3.2 的默认值，如果你使用该模型，`MODEL_BASE_URL`/`MODEL_NAME`/`MODEL_PROVIDER` 可以省略，只传 `MODEL_API_KEY` 即可。
 
+### 3. Windows 原生启动（无 Docker）
+
+[`scripts/`](./scripts/) 目录下提供两个脚本，专门用于在 Windows 上原生拉起 Gateway——不必再为了一个插件去装 Docker / WSL。详见 issue [#113](https://github.com/Tencent/TencentDB-Agent-Memory/issues/113)。
+
+**前置依赖**
+
+- Windows 10 / 11 + PowerShell 5.1+（系统内置）。
+- Node.js ≥ 22.16 —— 从 <https://nodejs.org/> 安装，确认新开终端里 `node -v` 可用。
+- 已经在磁盘上装好本插件的 npm 包（参考 §1.1，Gateway 入口在 `<install>/src/gateway/server.ts`）。
+
+**一键启动**
+
+```cmd
+:: cmd.exe / 双击
+set MEMORY_TENCENTDB_LLM_API_KEY=sk-...
+scripts\memory-tencentdb-ctl.bat start
+```
+
+```powershell
+# PowerShell
+$env:MEMORY_TENCENTDB_LLM_API_KEY = "sk-..."
+.\scripts\memory-tencentdb-ctl.ps1 start
+```
+
+脚本做的事：
+
+1. **解析路径** —— `MEMORY_TENCENTDB_ROOT`（默认 `%USERPROFILE%\.memory-tencentdb`）、`TDAI_DATA_DIR`、日志目录、install 目录，环境变量名与 POSIX 版 `ctl.sh` 完全一致，配置可在 Linux / Windows 之间复用。
+2. **依赖检查** —— 缺少 `node` 或 `npx` 立即报错退出。
+3. **后台启动 Gateway**（`Start-Process -WindowStyle Hidden`），把 stdout/stderr 重定向到 `gateway.stdout.log` / `gateway.stderr.log`，PID 写入 `gateway.pid`，最多等 15 秒直到 `GET /health` 返回 `ok`。
+4. **其他子命令**：`stop`、`restart`、`status`、`health`、`logs`（加 `-NoFollow` 只打印最后一段而不 tail）。`help` 会列出全部环境变量与解析后的路径。
+
+监听检测和进程结束用 `Get-NetTCPConnection` + `Stop-Process`（不需要 `lsof` / `kill`），老 PowerShell 主机会自动回退到 `netstat`。
+
+> `MEMORY_TENCENTDB_GATEWAY_CMD` 仍然可以覆盖自动生成的启动命令，行为与 POSIX 脚本一致——比如你想直接跑打包后的 JS 而不走 `npx tsx`。
 
 ---
 

--- a/scripts/memory-tencentdb-ctl.bat
+++ b/scripts/memory-tencentdb-ctl.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Thin .bat wrapper around memory-tencentdb-ctl.ps1 so users can launch
+REM the Gateway from cmd.exe or by double-clicking. All real logic lives
+REM in the PowerShell script next to this one.
+REM
+REM Examples:
+REM     memory-tencentdb-ctl.bat start
+REM     memory-tencentdb-ctl.bat status
+REM     memory-tencentdb-ctl.bat stop
+REM
+REM See scripts\memory-tencentdb-ctl.ps1 for the supported subcommands and
+REM the MEMORY_TENCENTDB_* env-var list.
+
+setlocal
+set "SCRIPT_DIR=%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%memory-tencentdb-ctl.ps1" %*
+exit /b %ERRORLEVEL%

--- a/scripts/memory-tencentdb-ctl.ps1
+++ b/scripts/memory-tencentdb-ctl.ps1
@@ -1,0 +1,333 @@
+<#
+.SYNOPSIS
+    Windows native control script for the memory-tencentdb Gateway.
+
+.DESCRIPTION
+    PowerShell equivalent of scripts/memory-tencentdb-ctl.sh, intended for
+    Windows users who don't want to run inside Docker or WSL. Supports
+    start / stop / restart / status / health / logs subcommands; reuses
+    the same MEMORY_TENCENTDB_* env-var names as the POSIX script so
+    config carries over.
+
+    See issue #113.
+
+.PARAMETER Command
+    Subcommand to run: start | stop | restart | status | health | logs | help.
+
+.PARAMETER NoFollow
+    For `logs`: print the existing log content and exit instead of tailing.
+
+.EXAMPLE
+    PS> .\scripts\memory-tencentdb-ctl.ps1 start
+
+.EXAMPLE
+    PS> $env:MEMORY_TENCENTDB_LLM_API_KEY = "sk-..."
+    PS> .\scripts\memory-tencentdb-ctl.ps1 restart
+
+.NOTES
+    Requires PowerShell 5.1+ (ships with Windows 10/11) and Node.js >= 22.16.
+    npx tsx is used to run the Gateway entry, identical to the POSIX path.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('start', 'stop', 'restart', 'status', 'health', 'logs', 'help', '')]
+    [string]$Command = 'help',
+
+    [switch]$NoFollow
+)
+
+$ErrorActionPreference = 'Stop'
+$ScriptName = 'memory-tencentdb-ctl'
+
+# ────────────────────────────────────────────────────────────────────
+# Path / port / env resolution — keep names in lock-step with ctl.sh
+# ────────────────────────────────────────────────────────────────────
+
+function Resolve-DefaultPath {
+    param([string]$EnvName, [string]$Fallback)
+    $value = [Environment]::GetEnvironmentVariable($EnvName)
+    if ([string]::IsNullOrWhiteSpace($value)) { return $Fallback }
+    return $value
+}
+
+$UserHome = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+$MemoryRoot = Resolve-DefaultPath 'MEMORY_TENCENTDB_ROOT' (Join-Path $UserHome '.memory-tencentdb')
+$DataDir    = Resolve-DefaultPath 'TDAI_DATA_DIR'        (Join-Path $MemoryRoot 'memory-tdai')
+$LogDir     = Resolve-DefaultPath 'MEMORY_TENCENTDB_LOG_DIR' (Join-Path $DataDir 'logs')
+$InstallDir = Resolve-DefaultPath 'TDAI_INSTALL_DIR'     (Join-Path $MemoryRoot 'tdai-memory-openclaw-plugin')
+
+$GatewayHost = Resolve-DefaultPath 'MEMORY_TENCENTDB_GATEWAY_HOST' '127.0.0.1'
+[int]$GatewayPort = [int](Resolve-DefaultPath 'MEMORY_TENCENTDB_GATEWAY_PORT' '8420')
+
+$PidFile    = Join-Path $LogDir 'gateway.pid'
+$StdoutLog  = Join-Path $LogDir 'gateway.stdout.log'
+$StderrLog  = Join-Path $LogDir 'gateway.stderr.log'
+$GatewayUrl = "http://${GatewayHost}:${GatewayPort}"
+
+# ────────────────────────────────────────────────────────────────────
+# Logging
+# ────────────────────────────────────────────────────────────────────
+
+function Write-Info  { param([string]$Msg) Write-Host "[$ScriptName] $Msg" }
+function Write-Warn2 { param([string]$Msg) Write-Host "[$ScriptName] WARN: $Msg" -ForegroundColor Yellow }
+function Write-Die   { param([string]$Msg) Write-Host "[$ScriptName] ERROR: $Msg" -ForegroundColor Red; exit 1 }
+
+# ────────────────────────────────────────────────────────────────────
+# Dependency / port helpers
+# ────────────────────────────────────────────────────────────────────
+
+function Test-CommandExists {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-ListeningPids {
+    param([int]$Port)
+    try {
+        $conns = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+        if (-not $conns) { return @() }
+        return @($conns | Select-Object -ExpandProperty OwningProcess -Unique)
+    } catch {
+        # Older PowerShell / restricted environments — fall back to netstat.
+        $lines = netstat -ano | Select-String -Pattern "LISTENING" |
+                 Select-String -Pattern ":$Port\b"
+        $foundPids = @()
+        foreach ($line in $lines) {
+            $parts = -split $line.ToString()
+            if ($parts.Length -ge 5) {
+                $candidate = [int]$parts[-1]
+                if ($candidate -gt 0) { $foundPids += $candidate }
+            }
+        }
+        return $foundPids | Sort-Object -Unique
+    }
+}
+
+function Test-GatewayHealth {
+    param([int]$TimeoutSec = 2)
+    try {
+        $resp = Invoke-RestMethod -Uri "$GatewayUrl/health" -TimeoutSec $TimeoutSec
+        if ($resp -and ($resp.status -eq 'ok' -or $resp.status -eq 'degraded')) {
+            return $true
+        }
+    } catch {
+        return $false
+    }
+    return $false
+}
+
+function Resolve-GatewayCommand {
+    if ($env:MEMORY_TENCENTDB_GATEWAY_CMD) {
+        return $env:MEMORY_TENCENTDB_GATEWAY_CMD
+    }
+    $entry = Join-Path $InstallDir 'src\gateway\server.ts'
+    if (-not (Test-Path $entry)) {
+        Write-Die "Gateway entry not found: $entry. Install the plugin first (npm install @tencentdb-agent-memory/memory-tencentdb@<version>) or set MEMORY_TENCENTDB_GATEWAY_CMD."
+    }
+    return @{
+        WorkingDirectory = $InstallDir
+        FilePath         = 'npx'
+        ArgumentList     = @('tsx', 'src/gateway/server.ts')
+    }
+}
+
+function Ensure-Paths {
+    foreach ($d in @($DataDir, $LogDir)) {
+        if (-not (Test-Path $d)) {
+            New-Item -ItemType Directory -Path $d -Force | Out-Null
+        }
+    }
+}
+
+# ────────────────────────────────────────────────────────────────────
+# Subcommands
+# ────────────────────────────────────────────────────────────────────
+
+function Invoke-Start {
+    Ensure-Paths
+
+    $existing = Get-ListeningPids -Port $GatewayPort
+    if ($existing.Count -gt 0) {
+        Write-Warn2 "Gateway already running on :$GatewayPort (pid=$($existing -join ','))"
+        return 0
+    }
+
+    foreach ($needed in @('node', 'npx')) {
+        if (-not (Test-CommandExists $needed)) {
+            Write-Die "$needed is not on PATH. Install Node.js >= 22.16 (https://nodejs.org/) and retry."
+        }
+    }
+
+    $cmd = Resolve-GatewayCommand
+    Write-Info "starting gateway: npx tsx src/gateway/server.ts  (cwd=$($cmd.WorkingDirectory))"
+    Write-Info "stdout -> $StdoutLog"
+    Write-Info "stderr -> $StderrLog"
+
+    $proc = Start-Process -FilePath $cmd.FilePath `
+                          -ArgumentList $cmd.ArgumentList `
+                          -WorkingDirectory $cmd.WorkingDirectory `
+                          -WindowStyle Hidden `
+                          -RedirectStandardOutput $StdoutLog `
+                          -RedirectStandardError  $StderrLog `
+                          -PassThru
+    Set-Content -Path $PidFile -Value $proc.Id -Encoding ascii
+    Write-Info "spawned pid=$($proc.Id)"
+
+    # Wait for the port to start listening + health probe (up to ~15 s).
+    for ($i = 0; $i -lt 30; $i++) {
+        Start-Sleep -Milliseconds 500
+        $listening = Get-ListeningPids -Port $GatewayPort
+        if ($listening.Count -gt 0 -and (Test-GatewayHealth -TimeoutSec 2)) {
+            Write-Info "gateway healthy on $GatewayUrl"
+            return 0
+        }
+    }
+    Write-Warn2 "gateway did not pass health check within 15 s; see $StderrLog"
+    return 1
+}
+
+function Invoke-Stop {
+    $portPids = Get-ListeningPids -Port $GatewayPort
+    if ($portPids.Count -eq 0) {
+        Write-Info "no gateway listening on :$GatewayPort"
+        if (Test-Path $PidFile) {
+            $wpid = (Get-Content $PidFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+            if ($wpid) {
+                try { Stop-Process -Id $wpid -ErrorAction SilentlyContinue } catch {}
+            }
+            Remove-Item $PidFile -ErrorAction SilentlyContinue
+        }
+        return 0
+    }
+
+    Write-Info "sending Stop-Process to: $($portPids -join ',')"
+    foreach ($p in $portPids) {
+        try { Stop-Process -Id $p -ErrorAction SilentlyContinue } catch {}
+    }
+
+    # Wait up to 5 s for clean shutdown, then force-kill leftovers.
+    for ($i = 0; $i -lt 10; $i++) {
+        Start-Sleep -Milliseconds 500
+        if ((Get-ListeningPids -Port $GatewayPort).Count -eq 0) {
+            Write-Info "gateway stopped"
+            Remove-Item $PidFile -ErrorAction SilentlyContinue
+            return 0
+        }
+    }
+    Write-Warn2 "gateway did not exit cleanly; sending force-kill"
+    foreach ($p in (Get-ListeningPids -Port $GatewayPort)) {
+        try { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue } catch {}
+    }
+    Remove-Item $PidFile -ErrorAction SilentlyContinue
+    return 0
+}
+
+function Invoke-Status {
+    $portPids = Get-ListeningPids -Port $GatewayPort
+    if ($portPids.Count -eq 0) {
+        Write-Info "gateway: NOT RUNNING (no listener on :$GatewayPort)"
+        return 1
+    }
+    Write-Info "gateway: RUNNING on $GatewayUrl (pid=$($portPids -join ','))"
+    if (Test-GatewayHealth -TimeoutSec 2) {
+        Write-Info "health : OK"
+    } else {
+        Write-Warn2 "health : FAILED (port open but /health did not respond)"
+    }
+    return 0
+}
+
+function Invoke-Health {
+    try {
+        $resp = Invoke-RestMethod -Uri "$GatewayUrl/health" -TimeoutSec 5
+        $resp | ConvertTo-Json -Depth 4
+        return 0
+    } catch {
+        Write-Die "health probe failed: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-Logs {
+    if (-not (Test-Path $StderrLog) -and -not (Test-Path $StdoutLog)) {
+        Write-Die "no log files yet at $LogDir; run 'start' first"
+    }
+    if ($NoFollow) {
+        if (Test-Path $StdoutLog) { Write-Info "==> $StdoutLog <=="; Get-Content $StdoutLog -Tail 100 }
+        if (Test-Path $StderrLog) { Write-Info "==> $StderrLog <=="; Get-Content $StderrLog -Tail 100 }
+        return 0
+    }
+    Write-Info "tailing logs (Ctrl-C to stop). Use -NoFollow for a one-shot dump."
+    # Tail both files concurrently. PowerShell's Get-Content -Wait blocks per file,
+    # so spawn a job for stdout and tail stderr in the foreground.
+    $stdoutJob = $null
+    if (Test-Path $StdoutLog) {
+        $stdoutJob = Start-Job -ScriptBlock {
+            param($p) Get-Content $p -Wait -Tail 50 | ForEach-Object { "[stdout] $_" }
+        } -ArgumentList $StdoutLog
+    }
+    try {
+        if (Test-Path $StderrLog) {
+            Get-Content $StderrLog -Wait -Tail 50 | ForEach-Object { "[stderr] $_" }
+        }
+    } finally {
+        if ($stdoutJob) {
+            Stop-Job -Job $stdoutJob -ErrorAction SilentlyContinue | Out-Null
+            Remove-Job -Job $stdoutJob -Force -ErrorAction SilentlyContinue | Out-Null
+        }
+    }
+    return 0
+}
+
+function Invoke-Help {
+    @"
+$ScriptName — control script for the memory-tencentdb Gateway on Windows.
+
+Usage:
+    .\scripts\memory-tencentdb-ctl.ps1 <command> [-NoFollow]
+
+Commands:
+    start     Launch the Gateway in the background, redirect stdout/stderr
+              to $StdoutLog and $StderrLog, and wait for /health to respond.
+    stop      Send Stop-Process to whatever is listening on :$GatewayPort,
+              then force-kill if it does not exit within 5 s.
+    restart   stop && start.
+    status    Print whether the Gateway is listening and whether /health passes.
+    health    Curl /health once and print the JSON response.
+    logs      Tail stdout + stderr logs. Use -NoFollow for a one-shot dump.
+    help      This message.
+
+Environment variables (override any of these in the calling shell):
+    MEMORY_TENCENTDB_ROOT        $MemoryRoot
+    TDAI_INSTALL_DIR             $InstallDir
+    TDAI_DATA_DIR                $DataDir
+    MEMORY_TENCENTDB_LOG_DIR     $LogDir
+    MEMORY_TENCENTDB_GATEWAY_HOST $GatewayHost
+    MEMORY_TENCENTDB_GATEWAY_PORT $GatewayPort
+    MEMORY_TENCENTDB_GATEWAY_CMD (optional override for the spawn command)
+    MEMORY_TENCENTDB_LLM_API_KEY, MEMORY_TENCENTDB_LLM_BASE_URL, MEMORY_TENCENTDB_LLM_MODEL
+                                 (consumed by the Gateway sidecar, not this script)
+
+Hosts older than PowerShell 5.1 are not supported; the script falls back to
+netstat / parsing when Get-NetTCPConnection is unavailable, but that path is
+best-effort.
+"@
+    return 0
+}
+
+# ────────────────────────────────────────────────────────────────────
+# Dispatch
+# ────────────────────────────────────────────────────────────────────
+
+switch ($Command) {
+    'start'   { exit (Invoke-Start) }
+    'stop'    { exit (Invoke-Stop) }
+    'restart' {
+        Invoke-Stop  | Out-Null
+        exit (Invoke-Start)
+    }
+    'status'  { exit (Invoke-Status) }
+    'health'  { exit (Invoke-Health) }
+    'logs'    { exit (Invoke-Logs) }
+    default   { exit (Invoke-Help) }
+}


### PR DESCRIPTION
## Summary

Fixes #113 — Windows users had no native path to run the plugin. The existing `scripts/memory-tencentdb-ctl.sh` is POSIX-only, so getting the Gateway up meant either Docker or WSL. This PR adds a PowerShell control script and a thin `.bat` wrapper that bring up the Gateway directly on Windows.

### What ships

- **`scripts/memory-tencentdb-ctl.ps1`** — the real launcher. Subcommands: `start` / `stop` / `restart` / `status` / `health` / `logs` (with `-NoFollow` for one-shot dumps) / `help`.
  - Same `MEMORY_TENCENTDB_*` and `TDAI_*` env-var names as the POSIX `ctl.sh`, so a shared config carries over between Linux and Windows.
  - Path/port detection via `Get-NetTCPConnection` + `Stop-Process`, with a `netstat`-parsing fallback for older / restricted PowerShell hosts.
  - Spawns the Gateway detached (`Start-Process -WindowStyle Hidden`), redirects stdout/stderr to `gateway.stdout.log` / `gateway.stderr.log`, writes `gateway.pid`, and waits up to 15 s for `GET /health` to return `ok` before reporting success.
  - `MEMORY_TENCENTDB_GATEWAY_CMD` still overrides the auto-derived spawn command — same behaviour as the POSIX script.

- **`scripts/memory-tencentdb-ctl.bat`** — `.bat` wrapper that invokes the `.ps1` with `-NoProfile -ExecutionPolicy Bypass`, so users on a default `RemoteSigned` policy can launch via `cmd.exe` or by double-clicking without touching the global execution policy.

- **README.md / README_CN.md** — new **Windows (native, no Docker)** section under Quick Start. Lists prereqs (PowerShell 5.1, Node ≥ 22.16), shows both `cmd` and PowerShell launch snippets, and points at the env-var-driven knobs.

### Acceptance criteria from #113

| # | Criterion | Where |
|---|---|---|
| 1 | One-click Windows startup script (`.bat`) | `scripts/memory-tencentdb-ctl.bat` |
| 2 | Dependency check + env-var setup + process startup | `ps1` checks `node` / `npx`, resolves the seven `MEMORY_TENCENTDB_*` / `TDAI_*` env vars, then `Start-Process` |
| 3 | Windows install instructions in README | New \"Windows (native, no Docker)\" section in both READMEs |

### What's intentionally NOT in this PR

- I left the install / `config llm` / `enable-hermes-memory` and ~22 other subcommands of the POSIX `ctl.sh` out. They're install-flow plumbing the typical Windows runner doesn't need on day one — happy to grow the `.ps1` if Windows users start asking for them.
- No systemd / Windows-service registration. Most users land here wanting to *try* the plugin, not deploy it as a service. The PID file + `restart` subcommand cover the day-to-day case.

## Test plan

- [ ] On Windows 11 with Node 22.16: `scripts\memory-tencentdb-ctl.bat start` brings the Gateway up, `\health` returns `ok`, `gateway.pid` is written, double-running `start` warns rather than spawning twice.
- [ ] `scripts\memory-tencentdb-ctl.bat stop` shuts it down cleanly within ~5 s.
- [ ] On a host where `Get-NetTCPConnection` is unavailable (e.g. Server Core), the `netstat` fallback still finds the listener.
- [ ] `logs` tails both stdout and stderr; `-NoFollow` dumps and exits.
- [ ] `MEMORY_TENCENTDB_LLM_API_KEY` exported in the parent shell is inherited by the spawned `npx tsx` process (no extra plumbing needed).