### PR TITLE
fix(docker): add --start-period to HEALTHCHECK to prevent startup kill

### DIFF
--- a/docker/opensource/Dockerfile.hermes
+++ b/docker/opensource/Dockerfile.hermes
@@ -79,7 +79,7 @@ ENV TDAI_DATA_DIR=/opt/data/tdai-memory
 ENV MEMORY_TENCENTDB_GATEWAY_HOST=127.0.0.1
 ENV MEMORY_TENCENTDB_GATEWAY_PORT=8420
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD curl -sf http://localhost:8420/health || exit 1
 
 EXPOSE 8420


### PR DESCRIPTION
## Description | 描述
Docker HEALTHCHECK without --start-period causes the container to be killed during startup when Gateway initialization takes longer than ~60 seconds (e.g. large vectors.db, slow embedding service init). 

Dockerfile.hermes 的 HEALTHCHECK 缺少 --start-period，导致 Gateway 启动慢时（如 vectors.db > 30MB）被 Docker 误杀。加上 --start-period=30s 后，给容器 30 秒热身时间，热身期间的失败不计入重试次数。

Signed-off-by: malygoss <malygoss@126.com>

## Related Issue | 关联 Issue
N/A

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
<!-- Optional | 可选 -->