### PR TITLE
[good first issue] docs: recommend exact version install for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,14 @@ graph LR
 ### 1.1 Install the plugin
 
 ```bash
-openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
 openclaw gateway restart
 ```
 
-For OpenClaw installs, use an exact package version. OpenClaw does not support
-npm semver ranges such as `^0.3.6`; if you install with npm directly, run
-`npm install --save-exact @tencentdb-agent-memory/memory-tencentdb@0.3.6`.
+> Please use the native OpenClaw command to upgrade the plugin. This approach prevents the plugin from being disabled caused by semantic version ranges.
+> ```bash
+> openclaw plugins update @tencentdb-agent-memory/memory-tencentdb
+> ```
 
 ### 1.2 Zero-config to enable
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,13 @@ graph LR
 ### 1.1 Install the plugin
 
 ```bash
-openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6
 openclaw gateway restart
 ```
+
+For OpenClaw installs, use an exact package version. OpenClaw does not support
+npm semver ranges such as `^0.3.6`; if you install with npm directly, run
+`npm install --save-exact @tencentdb-agent-memory/memory-tencentdb@0.3.6`.
 
 ### 1.2 Zero-config to enable
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,9 +139,13 @@ graph LR
 ### 1.1 安装插件
 
 ```bash
-openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6
 openclaw gateway restart
 ```
+
+OpenClaw 安装请使用精确版本。OpenClaw 不支持 `^0.3.6` 这类 npm semver
+范围；如果直接使用 npm 安装，请运行
+`npm install --save-exact @tencentdb-agent-memory/memory-tencentdb@0.3.6`。
 
 ### 1.2 零配置启用
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,13 +139,14 @@ graph LR
 ### 1.1 安装插件
 
 ```bash
-openclaw plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
 openclaw gateway restart
 ```
 
-OpenClaw 安装请使用精确版本。OpenClaw 不支持 `^0.3.6` 这类 npm semver
-范围；如果直接使用 npm 安装，请运行
-`npm install --save-exact @tencentdb-agent-memory/memory-tencentdb@0.3.6`。
+> 升级插件请优先使用 OpenClaw 原生更新命令，该方式可以避免因语义化版本范围导致插件禁用：
+> ```bash
+> openclaw plugins update @tencentdb-agent-memory/memory-tencentdb
+> ```
 
 ### 1.2 零配置启用
 


### PR DESCRIPTION
﻿## Description | 描述
Updates the OpenClaw installation docs to recommend installing `@tencentdb-agent-memory/memory-tencentdb` with an exact version. This avoids npm semver ranges such as `^0.3.6`, which OpenClaw does not support during plugin updates.

## Related Issue | 关联 Issue
Fix #107

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Validation performed:
- `npm install --ignore-scripts --no-package-lock`
- `npm test`
- `npm pack --dry-run`
- `git diff --check`
- `openclaw --profile codex-issue-107 plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6`
- `openclaw --profile codex-issue-107 --log-level debug plugins install @tencentdb-agent-memory/memory-tencentdb@0.3.6 --pin`
- `npm pack @tencentdb-agent-memory/memory-tencentdb@0.3.6`
- `tar -xzf tencentdb-agent-memory-memory-tencentdb-0.3.6.tgz`

Notes:
- Plain `npm install` failed on Windows because the existing postinstall command uses `bash ... || true`, and `true` is not available in the current Windows cmd environment. CI uses `npm install --ignore-scripts`, so this docs-only PR follows the CI install path.
- The OpenClaw exact-version install command was accepted and reached the download/extract step, but full installation was blocked on Windows by an existing OpenClaw extraction error: `failed to extract archive: Error: EINVAL: invalid argument, open '.../package/LICENSE'`. The npm tarball itself downloads and extracts successfully with system `tar`.
