### PR TITLE
feat(offload): support OpenClaw auth-profiles for local-llm apiKey resolution

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -52,6 +52,7 @@ import type { OffloadConfig } from "../config.js";
 import type { PluginConfig, PluginLogger } from "./types.js";
 import { BackendClient } from "./backend-client.js";
 import { LocalLlmClient } from "./local-llm/index.js";
+import { resolveLocalLlmConfig } from "./local-llm/config-resolver.js";
 import type { L1Request, L15Request, L2Request } from "./backend-client.js";
 import { parseMmdMeta } from "./mmd-meta.js";
 import { sanitizeText, writeRefMd } from "./storage.js";
@@ -362,22 +363,24 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
     }
 
     if (resolvedModelRef) {
-      const modelParts = resolvedModelRef.split("/", 2);
-      const providerKey = modelParts[0];
-      const modelId = modelParts[1] ?? resolvedModelRef;
-      const models = (api.config as any)?.models;
-      const providerCfg = models?.providers?.[providerKey];
-      const baseUrl = providerCfg?.baseUrl ?? providerCfg?.baseURL;
-      const apiKey = providerCfg?.apiKey;
+      const resolved = resolveLocalLlmConfig(api, resolvedModelRef, logger);
 
-      if (baseUrl && apiKey) {
+      if (resolved) {
         backendClient = new LocalLlmClient(
-          { baseUrl, apiKey, model: modelId, temperature: offloadConfig.temperature, timeoutMs: offloadConfig.backendTimeoutMs },
+          {
+            baseUrl: resolved.baseUrl,
+            apiKey: resolved.apiKey,
+            model: resolved.modelId,
+            temperature: offloadConfig.temperature,
+            timeoutMs: offloadConfig.backendTimeoutMs,
+          },
           logger,
         );
       } else {
+        const providerKey = resolvedModelRef.split("/", 2)[0];
         logger.error(
-          `[context-offload] Local LLM mode failed: provider "${providerKey}" not found or missing baseUrl/apiKey in models.providers. ` +
+          `[context-offload] Local LLM mode failed: provider "${providerKey}" not found or missing baseUrl/apiKey. ` +
+          `Ensure either (1) models.providers.${providerKey}.apiKey is set, or (2) auth-profiles has credentials for "${providerKey}". ` +
           `L1/L1.5/L2 disabled.`,
         );
       }

--- a/src/offload/local-llm/config-resolver.ts
+++ b/src/offload/local-llm/config-resolver.ts
@@ -1,0 +1,81 @@
+/**
+ * Resolve LLM provider configuration for local-llm mode.
+ *
+ * Supports both direct config (models.providers) and OpenClaw auth-profiles.
+ * When auth-profiles is used, the apiKey is not injected into models.providers
+ * at runtime; we must call api.getAuthProviderCredential(providerKey) to retrieve it.
+ */
+import type { PluginLogger } from "../types.js";
+
+export interface LocalLlmResolvedConfig {
+  providerKey: string;
+  modelId: string;
+  baseUrl: string;
+  apiKey: string;
+}
+
+/**
+ * Parse a model reference string into provider key and model ID.
+ *
+ * Expected formats:
+ *   - "provider/model-id"  → { providerKey: "provider", modelId: "model-id" }
+ *   - "model-id"           → { providerKey: "model-id", modelId: "model-id" }
+ */
+export function parseModelRef(resolvedModelRef: string): {
+  providerKey: string;
+  modelId: string;
+} {
+  const modelParts = resolvedModelRef.split("/", 2);
+  const providerKey = modelParts[0];
+  const modelId = modelParts[1] ?? resolvedModelRef;
+  return { providerKey, modelId };
+}
+
+/**
+ * Resolve the full local-LLM configuration from the OpenClaw api object.
+ *
+ * Resolution order:
+ *   1. baseUrl from models.providers[providerKey].baseUrl (or .baseURL alias)
+ *   2. apiKey from models.providers[providerKey].apiKey (direct config)
+ *   3. If apiKey missing, fallback to api.getAuthProviderCredential(providerKey)
+ *
+ * Returns null if baseUrl or apiKey cannot be resolved.
+ */
+export function resolveLocalLlmConfig(
+  api: any,
+  resolvedModelRef: string,
+  logger?: PluginLogger,
+): LocalLlmResolvedConfig | null {
+  const { providerKey, modelId } = parseModelRef(resolvedModelRef);
+
+  const models = (api.config as any)?.models;
+  const providerCfg = models?.providers?.[providerKey];
+
+  const baseUrl = providerCfg?.baseUrl ?? providerCfg?.baseURL;
+
+  // 1. Try direct config first (backward compatible)
+  let apiKey: string | undefined = providerCfg?.apiKey;
+
+  // 2. Fallback to OpenClaw auth-profiles
+  if (!apiKey && typeof api.getAuthProviderCredential === "function") {
+    try {
+      const authCreds = api.getAuthProviderCredential(providerKey);
+      apiKey = authCreds?.apiKey ?? authCreds?.key;
+      if (apiKey) {
+        logger?.debug?.(
+          `[context-offload] Resolved apiKey for provider "${providerKey}" via auth-profiles`,
+        );
+      }
+    } catch (e) {
+      logger?.debug?.(
+        `[context-offload] getAuthProviderCredential failed for "${providerKey}": ${e}`,
+      );
+    }
+  }
+
+  if (!baseUrl || !apiKey) {
+    return null;
+  }
+
+  return { providerKey, modelId, baseUrl, apiKey };
+}


### PR DESCRIPTION
## Description | 描述

Add auth-profiles support for local-llm mode's apiKey resolution.

When `offload.model` is configured in `provider/model` format (e.g. `deepseek/deepseek-v4-flash`), the local-llm module previously only read `apiKey` from `models.providers`, which does not work when users manage credentials via OpenClaw auth-profiles — the auth-profiles mechanism does not inject apiKey into `models.providers` at runtime.

This change:

- Introduces `src/offload/local-llm/config-resolver.ts` with `resolveLocalLlmConfig()`, a unified resolver that supports both credential sources.
- **Direct config** (backward-compatible): reads `apiKey` from `models.providers[providerKey].apiKey`.
- **Auth-profiles fallback**: when `apiKey` is missing from direct config, calls `api.getAuthProviderCredential(providerKey)` to retrieve credentials from OpenClaw's auth-profiles store.
- Keeps full backward compatibility — existing setups with `models.providers.*.apiKey` continue to work unchanged.
- Error message now explicitly mentions both configuration options.

## Related Issue | 关联 Issue

Closes #90

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

cc @Maxwell-Code07