### PR TITLE
feat: add ArtifactTrace HTTP gateway integration

### DIFF
--- a/src/core/seed/seed-runtime.ts
+++ b/src/core/seed/seed-runtime.ts
@@ -23,6 +23,7 @@ import { performAutoCapture } from "../hooks/auto-capture.js";
 import { createPipeline, createL2Runner, createL3Runner } from "../../utils/pipeline-factory.js";
 import type { PipelineInstance, PipelineLogger } from "../../utils/pipeline-factory.js";
 import { readManifest, writeManifest } from "../../utils/manifest.js";
+import { CheckpointManager } from "../../utils/checkpoint.js";
 import { StandaloneLLMRunnerFactory } from "../../adapters/standalone/llm-runner.js";
 import type { MemoryPipelineManager } from "../../utils/pipeline-manager.js";
 import type { LLMRunner } from "../types.js";
@@ -232,15 +233,31 @@ export async function executeSeed(
   let pipeline: PipelineInstance | undefined;
   let totalL0Recorded = 0;
   let roundsProcessed = 0;
+  let initialL1Count = 0;
 
   try {
+    try {
+      const checkpoint = new CheckpointManager(opts.outputDir, logger);
+      const cp = await checkpoint.read();
+      initialL1Count = cp.total_memories_extracted;
+    } catch (err) {
+      logger.warn(`${TAG} Failed to read initial L1 count: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
     // Create and start pipeline (returns both the pipeline instance and the
     // seed-optimized config so we don't need to parse config again)
     const seed = await createSeedPipeline(opts);
     pipeline = seed.pipeline;
     const seedCfg = seed.cfg;
 
-    pipeline.scheduler.start({});
+    try {
+      const checkpoint = new CheckpointManager(opts.outputDir, logger);
+      const cp = await checkpoint.read();
+      pipeline.scheduler.start(checkpoint.getAllPipelineStates(cp));
+    } catch (err) {
+      logger.warn(`${TAG} Failed to restore checkpoint states, starting seed scheduler fresh: ${err instanceof Error ? err.message : String(err)}`);
+      pipeline.scheduler.start({});
+    }
     logger.info(`${TAG} Pipeline started, processing ${input.sessions.length} session(s), ${input.totalRounds} round(s)`);
 
     // Seed-specific: use 0 so the cold-start guard in captureAtomically()
@@ -378,12 +395,21 @@ export async function executeSeed(
   }
 
   const durationMs = Date.now() - startTime;
+  let l1RecordedCount = 0;
+  try {
+    const checkpoint = new CheckpointManager(opts.outputDir, logger);
+    const cp = await checkpoint.read();
+    l1RecordedCount = Math.max(0, cp.total_memories_extracted - initialL1Count);
+  } catch (err) {
+    logger.warn(`${TAG} Failed to read final L1 count: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   const summary: SeedSummary = {
     sessionsProcessed: input.sessions.length,
     roundsProcessed,
     messagesProcessed: input.totalMessages,
     l0RecordedCount: totalL0Recorded,
+    l1RecordedCount,
     durationMs,
     outputDir: opts.outputDir,
   };
@@ -394,7 +420,8 @@ export async function executeSeed(
     logger.info(
       `${TAG} Seed complete: sessions=${summary.sessionsProcessed}, ` +
       `rounds=${summary.roundsProcessed}, messages=${summary.messagesProcessed}, ` +
-      `l0Recorded=${summary.l0RecordedCount}, duration=${(durationMs / 1000).toFixed(1)}s`,
+      `l0Recorded=${summary.l0RecordedCount}, l1Recorded=${summary.l1RecordedCount}, ` +
+      `duration=${(durationMs / 1000).toFixed(1)}s`,
     );
   }
 

--- a/src/core/seed/types.ts
+++ b/src/core/seed/types.ts
@@ -135,6 +135,7 @@ export interface SeedSummary {
   roundsProcessed: number;
   messagesProcessed: number;
   l0RecordedCount: number;
+  l1RecordedCount: number;
   durationMs: number;
   outputDir: string;
 }

--- a/src/gateway/markdown-files.ts
+++ b/src/gateway/markdown-files.ts
@@ -1,0 +1,384 @@
+/**
+ * Read-only Markdown file access for L2 scene blocks and L3 persona.
+ *
+ * This module owns the mapping between public file_id values and the actual
+ * memory-data files. Callers never pass or receive real filesystem paths.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parseSceneBlock } from "../core/scene/scene-format.js";
+import { readSceneIndex } from "../core/scene/scene-index.js";
+import type {
+  ListMarkdownFilesPayload,
+  MarkdownFileDetail,
+  MarkdownFileInfo,
+  MarkdownView,
+  UpdateMarkdownFileRequest,
+} from "./types.js";
+
+const PROFILE_FILE_ID = "profile_persona";
+const SCENE_FILE_ID_PREFIX = "scene_";
+const SCENE_NAV_HEADER = "---\n## 🗺️ Scene Navigation (Scene Index)";
+
+export class MarkdownFilesError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "MarkdownFilesError";
+  }
+}
+
+export async function listMarkdownFiles(
+  dataDir: string,
+  view: MarkdownView,
+): Promise<ListMarkdownFilesPayload> {
+  if (view === "domain") {
+    return { files: await listSceneFiles(dataDir) };
+  }
+
+  if (view === "profile") {
+    return { files: await listProfileFiles(dataDir) };
+  }
+
+  throw invalidView();
+}
+
+export async function getMarkdownFile(
+  dataDir: string,
+  fileId: string,
+): Promise<MarkdownFileDetail> {
+  if (fileId === PROFILE_FILE_ID) {
+    return readProfileFile(dataDir);
+  }
+
+  if (fileId.startsWith(SCENE_FILE_ID_PREFIX)) {
+    return readSceneFile(dataDir, fileId);
+  }
+
+  throw notFound(fileId);
+}
+
+export async function updateMarkdownFile(
+  dataDir: string,
+  fileId: string,
+  request: UpdateMarkdownFileRequest,
+): Promise<MarkdownFileDetail> {
+  if (fileId === PROFILE_FILE_ID) {
+    return updateProfileFile(dataDir, request);
+  }
+
+  if (fileId.startsWith(SCENE_FILE_ID_PREFIX)) {
+    throw readonly(fileId);
+  }
+
+  throw notFound(fileId);
+}
+
+function sceneFileId(filename: string): string {
+  return `${SCENE_FILE_ID_PREFIX}${base64UrlEncode(filename)}`;
+}
+
+function sceneFilenameFromId(fileId: string): string {
+  const encoded = fileId.slice(SCENE_FILE_ID_PREFIX.length);
+  if (!encoded) throw notFound(fileId);
+
+  let filename: string;
+  try {
+    filename = base64UrlDecode(encoded);
+  } catch {
+    throw notFound(fileId);
+  }
+
+  if (!isSafeSceneFilename(filename)) {
+    throw notFound(fileId);
+  }
+  return filename;
+}
+
+async function listSceneFiles(dataDir: string): Promise<MarkdownFileInfo[]> {
+  const entries = await readSceneEntries(dataDir);
+  const files: MarkdownFileInfo[] = [];
+
+  for (const entry of entries) {
+    if (!isSafeSceneFilename(entry.filename)) continue;
+
+    const filePath = safeScenePath(dataDir, entry.filename);
+    let raw = "";
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const block = parseSceneBlock(raw, entry.filename);
+    const updatedAt = block.meta.updated || entry.updated || await fileMtimeIso(filePath);
+    files.push({
+      file_id: sceneFileId(entry.filename),
+      view: "domain",
+      title: titleFromFilename(entry.filename),
+      summary: block.meta.summary || entry.summary || "",
+      heat: block.meta.heat || entry.heat || 0,
+      updated_at: updatedAt,
+      version: contentVersion(raw),
+    });
+  }
+
+  return files.sort((a, b) => {
+    const heatDiff = (b.heat ?? 0) - (a.heat ?? 0);
+    if (heatDiff !== 0) return heatDiff;
+    return (b.updated_at ?? "").localeCompare(a.updated_at ?? "");
+  });
+}
+
+async function listProfileFiles(dataDir: string): Promise<MarkdownFileInfo[]> {
+  const personaPath = path.join(dataDir, "persona.md");
+  let raw: string;
+  try {
+    raw = await fs.readFile(personaPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  return [{
+    file_id: PROFILE_FILE_ID,
+    view: "profile",
+    title: "用户画像",
+    updated_at: await fileMtimeIso(personaPath),
+    version: contentVersion(raw),
+  }];
+}
+
+async function readSceneFile(dataDir: string, fileId: string): Promise<MarkdownFileDetail> {
+  const filename = sceneFilenameFromId(fileId);
+  const filePath = safeScenePath(dataDir, filename);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch {
+    throw notFound(fileId);
+  }
+
+  const block = parseSceneBlock(raw, filename);
+  return {
+    file_id: fileId,
+    view: "domain",
+    title: titleFromFilename(filename),
+    summary: block.meta.summary,
+    heat: block.meta.heat,
+    created_at: block.meta.created || undefined,
+    updated_at: block.meta.updated || await fileMtimeIso(filePath),
+    content: block.content,
+    version: contentVersion(raw),
+  };
+}
+
+async function readProfileFile(dataDir: string): Promise<MarkdownFileDetail> {
+  const personaPath = path.join(dataDir, "persona.md");
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(personaPath, "utf-8");
+  } catch {
+    throw notFound(PROFILE_FILE_ID);
+  }
+
+  const { content, sceneNavigation } = splitSceneNavigation(raw);
+  return {
+    file_id: PROFILE_FILE_ID,
+    view: "profile",
+    title: "用户画像",
+    updated_at: await fileMtimeIso(personaPath),
+    content,
+    scene_navigation: sceneNavigation,
+    version: contentVersion(raw),
+  };
+}
+
+async function updateProfileFile(
+  dataDir: string,
+  request: UpdateMarkdownFileRequest,
+): Promise<MarkdownFileDetail> {
+  const personaPath = path.join(dataDir, "persona.md");
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(personaPath, "utf-8");
+  } catch {
+    throw notFound(PROFILE_FILE_ID);
+  }
+
+  const currentVersion = contentVersion(raw);
+  if (request.expected_version !== currentVersion) {
+    throw versionConflict(currentVersion);
+  }
+
+  if (request.content.includes(SCENE_NAV_HEADER)) {
+    throw invalidContent("Scene navigation is generated by the memory pipeline and cannot be edited here");
+  }
+
+  const { sceneNavigation } = splitSceneNavigation(raw);
+  const nextRaw = composeProfileFile(request.content, sceneNavigation);
+  await fs.writeFile(personaPath, nextRaw, "utf-8");
+
+  return readProfileFile(dataDir);
+}
+
+async function readSceneEntries(dataDir: string): Promise<Array<{
+  filename: string;
+  summary: string;
+  heat: number;
+  updated: string;
+}>> {
+  const indexed = await readSceneIndex(dataDir);
+  if (indexed.length > 0) return indexed;
+
+  const blocksDir = path.join(dataDir, "scene_blocks");
+  let filenames: string[];
+  try {
+    filenames = (await fs.readdir(blocksDir)).filter((name) => name.endsWith(".md"));
+  } catch {
+    return [];
+  }
+
+  const entries = [];
+  for (const filename of filenames) {
+    if (!isSafeSceneFilename(filename)) continue;
+    try {
+      const filePath = path.join(blocksDir, filename);
+      const raw = await fs.readFile(filePath, "utf-8");
+      const block = parseSceneBlock(raw, filename);
+      entries.push({
+        filename,
+        summary: block.meta.summary,
+        heat: block.meta.heat,
+        updated: block.meta.updated || await fileMtimeIso(filePath),
+      });
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
+function splitSceneNavigation(raw: string): { content: string; sceneNavigation?: string } {
+  const idx = raw.indexOf(SCENE_NAV_HEADER);
+  if (idx === -1) {
+    return { content: raw.trim() };
+  }
+
+  const prefix = raw.slice(0, idx).trimEnd();
+  const navigation = raw.slice(idx).trim();
+  return {
+    content: prefix,
+    sceneNavigation: navigation || undefined,
+  };
+}
+
+function composeProfileFile(content: string, sceneNavigation?: string): string {
+  const normalizedContent = content.replace(/\r\n/g, "\n").trim();
+  if (!sceneNavigation) {
+    return `${normalizedContent}\n`;
+  }
+
+  return `${normalizedContent}\n\n${sceneNavigation.trim()}\n`;
+}
+
+function safeScenePath(dataDir: string, filename: string): string {
+  if (!isSafeSceneFilename(filename)) {
+    throw notFound(filename);
+  }
+
+  const blocksDir = path.resolve(dataDir, "scene_blocks");
+  const filePath = path.resolve(blocksDir, filename);
+  if (!filePath.startsWith(`${blocksDir}${path.sep}`)) {
+    throw notFound(filename);
+  }
+  return filePath;
+}
+
+function isSafeSceneFilename(filename: string): boolean {
+  return (
+    filename.endsWith(".md") &&
+    filename.length > ".md".length &&
+    !filename.includes("/") &&
+    !filename.includes("\\") &&
+    path.basename(filename) === filename
+  );
+}
+
+function titleFromFilename(filename: string): string {
+  return filename.replace(/\.md$/i, "");
+}
+
+async function fileMtimeIso(filePath: string): Promise<string> {
+  try {
+    return (await fs.stat(filePath)).mtime.toISOString();
+  } catch {
+    return "";
+  }
+}
+
+function contentVersion(content: string): string {
+  const hash = crypto.createHash("sha256").update(content).digest("hex").slice(0, 16);
+  return `sha256:${hash}`;
+}
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function base64UrlDecode(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + (4 - normalized.length % 4) % 4, "=");
+  return Buffer.from(padded, "base64").toString("utf-8");
+}
+
+function invalidView(): MarkdownFilesError {
+  return new MarkdownFilesError(
+    "MEMORY_MARKDOWN_INVALID_VIEW",
+    "Invalid markdown view. Expected domain or profile",
+    400,
+  );
+}
+
+function notFound(fileId: string): MarkdownFilesError {
+  return new MarkdownFilesError(
+    "MEMORY_MARKDOWN_NOT_FOUND",
+    `Markdown file not found: ${fileId}`,
+    404,
+  );
+}
+
+function readonly(fileId: string): MarkdownFilesError {
+  return new MarkdownFilesError(
+    "MEMORY_MARKDOWN_READONLY",
+    `Markdown file is read-only in this version: ${fileId}`,
+    405,
+  );
+}
+
+function invalidContent(message: string): MarkdownFilesError {
+  return new MarkdownFilesError(
+    "MEMORY_MARKDOWN_INVALID_CONTENT",
+    message,
+    400,
+  );
+}
+
+function versionConflict(currentVersion: string): MarkdownFilesError {
+  return new MarkdownFilesError(
+    "MEMORY_MARKDOWN_VERSION_CONFLICT",
+    `Markdown file has changed. Refresh and try again. Current version: ${currentVersion}`,
+    409,
+  );
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -9,12 +9,16 @@
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
  *   POST /seed               — Batch seed historical conversations (L0 → L1)
+ *   GET  /api/memory/markdown-files — List L2/L3 Markdown files
+ *   GET  /api/memory/markdown-files/{file_id} — Read L2/L3 Markdown content
+ *   PATCH /api/memory/markdown-files/{file_id} — Update editable Markdown content
  *
  * Built with Node.js native `http` module — no Express/Fastify dependency.
  * Designed to run as a managed sidecar alongside Hermes.
  */
 
 import http from "node:http";
+import path from "node:path";
 import { URL } from "node:url";
 import { TdaiCore } from "../core/tdai-core.js";
 import { StandaloneHostAdapter } from "../adapters/standalone/host-adapter.js";
@@ -37,14 +41,24 @@ import type {
   SeedRequest,
   SeedResponse,
   GatewayErrorResponse,
+  ApiResponse,
+  MarkdownView,
+  UpdateMarkdownFileRequest,
 } from "./types.js";
 import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
+import {
+  getMarkdownFile,
+  listMarkdownFiles,
+  MarkdownFilesError,
+  updateMarkdownFile,
+} from "./markdown-files.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
+type SeedMode = NonNullable<SeedRequest["mode"]>;
 
 // ============================
 // Console logger (for standalone gateway — no OpenClaw logger available)
@@ -90,6 +104,53 @@ function sendJson(res: http.ServerResponse, status: number, body: unknown): void
 
 function sendError(res: http.ServerResponse, status: number, message: string): void {
   sendJson(res, status, { error: message } satisfies GatewayErrorResponse);
+}
+
+function sendApiSuccess<T>(res: http.ServerResponse, payload: T): void {
+  const body: ApiResponse<T> = {
+    success: true,
+    payload,
+    error: null,
+    timestamp: Date.now(),
+  };
+  sendJson(res, 200, body);
+}
+
+function sendApiError(
+  res: http.ServerResponse,
+  status: number,
+  code: string,
+  message: string,
+): void {
+  const body: ApiResponse<null> = {
+    success: false,
+    payload: null,
+    error: { code, message },
+    timestamp: Date.now(),
+  };
+  sendJson(res, status, body);
+}
+
+function parseSeedMode(value: unknown): SeedMode | null {
+  if (value == null || value === "") return "append";
+  if (value === "append" || value === "test") return value;
+  return null;
+}
+
+function parseMarkdownView(value: unknown): MarkdownView | null {
+  if (value === "domain" || value === "profile") return value;
+  return null;
+}
+
+function createSeedTestOutputDir(baseDir: string): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const ts =
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-` +
+    `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  const suffix = Math.random().toString(16).slice(2, 8);
+
+  return path.join(baseDir, "test-runs", `seed-${ts}-${suffix}`);
 }
 
 // ============================
@@ -175,7 +236,7 @@ export class TdaiGateway {
 
     // CORS headers (for development)
     res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
     if (method === "OPTIONS") {
@@ -185,6 +246,20 @@ export class TdaiGateway {
     }
 
     try {
+      if (method === "GET" && pathname === "/api/memory/markdown-files") {
+        return await this.handleListMarkdownFiles(url, res);
+      }
+
+      const markdownFilePrefix = "/api/memory/markdown-files/";
+      if (method === "GET" && pathname.startsWith(markdownFilePrefix)) {
+        const fileId = decodeURIComponent(pathname.slice(markdownFilePrefix.length));
+        return await this.handleGetMarkdownFile(fileId, res);
+      }
+      if (method === "PATCH" && pathname.startsWith(markdownFilePrefix)) {
+        const fileId = decodeURIComponent(pathname.slice(markdownFilePrefix.length));
+        return await this.handleUpdateMarkdownFile(req, fileId, res);
+      }
+
       switch (`${method} ${pathname}`) {
         case "GET /health":
           return this.handleHealth(res);
@@ -225,6 +300,83 @@ export class TdaiGateway {
       },
     };
     sendJson(res, 200, response);
+  }
+
+  private async handleListMarkdownFiles(url: URL, res: http.ServerResponse): Promise<void> {
+    const view = parseMarkdownView(url.searchParams.get("view") ?? "domain");
+    if (!view) {
+      sendApiError(
+        res,
+        400,
+        "MEMORY_MARKDOWN_INVALID_VIEW",
+        "Invalid markdown view. Expected domain or profile",
+      );
+      return;
+    }
+
+    try {
+      const payload = await listMarkdownFiles(this.config.data.baseDir, view);
+      sendApiSuccess(res, payload);
+    } catch (err) {
+      if (err instanceof MarkdownFilesError) {
+        sendApiError(res, err.status, err.code, err.message);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async handleGetMarkdownFile(fileId: string, res: http.ServerResponse): Promise<void> {
+    try {
+      const payload = await getMarkdownFile(this.config.data.baseDir, fileId);
+      sendApiSuccess(res, payload);
+    } catch (err) {
+      if (err instanceof MarkdownFilesError) {
+        sendApiError(res, err.status, err.code, err.message);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async handleUpdateMarkdownFile(
+    req: http.IncomingMessage,
+    fileId: string,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    let body: UpdateMarkdownFileRequest;
+    try {
+      body = await parseJsonBody<UpdateMarkdownFileRequest>(req);
+    } catch {
+      sendApiError(res, 400, "MEMORY_MARKDOWN_INVALID_BODY", "Invalid JSON body");
+      return;
+    }
+
+    if (
+      !body ||
+      typeof body.content !== "string" ||
+      typeof body.expected_version !== "string" ||
+      body.expected_version.length === 0
+    ) {
+      sendApiError(
+        res,
+        400,
+        "MEMORY_MARKDOWN_INVALID_BODY",
+        "Expected body with content and expected_version",
+      );
+      return;
+    }
+
+    try {
+      const payload = await updateMarkdownFile(this.config.data.baseDir, fileId, body);
+      sendApiSuccess(res, payload);
+    } catch (err) {
+      if (err instanceof MarkdownFilesError) {
+        sendApiError(res, err.status, err.code, err.message);
+        return;
+      }
+      throw err;
+    }
   }
 
   private async handleRecall(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
@@ -345,6 +497,12 @@ export class TdaiGateway {
       return;
     }
 
+    const mode = parseSeedMode(body.mode);
+    if (!mode) {
+      sendError(res, 400, 'Invalid seed mode. Expected "append" or "test".');
+      return;
+    }
+
     // Validate and normalize input (reuses seed CLI's validation layers 2-6)
     let input;
     try {
@@ -365,17 +523,17 @@ export class TdaiGateway {
     }
 
     this.logger.info(
-      `Seed request: ${input.sessions.length} session(s), ` +
+      `Seed request: mode=${mode}, ${input.sessions.length} session(s), ` +
       `${input.totalRounds} round(s), ${input.totalMessages} message(s)`,
     );
 
-    // Resolve output directory: use gateway's data dir with a timestamped subfolder
-    const now = new Date();
-    const pad = (n: number) => String(n).padStart(2, "0");
-    const ts =
-      `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-` +
-      `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-    const outputDir = `${this.config.data.baseDir}/seed-${ts}`;
+    // append: live memory-data; test: isolated throwaway run under memory-data/test-runs/.
+    const outputDir = mode === "test"
+      ? createSeedTestOutputDir(this.config.data.baseDir)
+      : this.config.data.baseDir;
+    if (mode === "test") {
+      this.logger.info(`Seed test mode outputDir=${outputDir}`);
+    }
 
     // Merge config overrides if provided
     // Start with the base memory config + inject llm config from gateway settings
@@ -420,14 +578,17 @@ export class TdaiGateway {
 
     this.logger.info(
       `Seed complete: sessions=${summary.sessionsProcessed}, rounds=${summary.roundsProcessed}, ` +
-      `l0=${summary.l0RecordedCount}, duration=${(summary.durationMs / 1000).toFixed(1)}s`,
+      `l0=${summary.l0RecordedCount}, l1=${summary.l1RecordedCount}, ` +
+      `duration=${(summary.durationMs / 1000).toFixed(1)}s`,
     );
 
     const response: SeedResponse = {
+      mode,
       sessions_processed: summary.sessionsProcessed,
       rounds_processed: summary.roundsProcessed,
       messages_processed: summary.messagesProcessed,
       l0_recorded: summary.l0RecordedCount,
+      l1_recorded: summary.l1RecordedCount,
       duration_ms: summary.durationMs,
       output_dir: summary.outputDir,
     };

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -11,6 +11,18 @@ export interface GatewayErrorResponse {
   code?: string;
 }
 
+export interface ApiResponse<T> {
+  success: boolean;
+  payload: T | null;
+  error: ApiError | null;
+  timestamp: number;
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+}
+
 // ============================
 // /health
 // ============================
@@ -92,6 +104,37 @@ export interface ConversationSearchResponse {
 }
 
 // ============================
+// /api/memory/markdown-files
+// ============================
+
+export type MarkdownView = "domain" | "profile";
+
+export interface ListMarkdownFilesPayload {
+  files: MarkdownFileInfo[];
+}
+
+export interface MarkdownFileInfo {
+  file_id: string;
+  view: MarkdownView;
+  title: string;
+  updated_at: string;
+  version: string;
+  summary?: string;
+  heat?: number;
+}
+
+export interface MarkdownFileDetail extends MarkdownFileInfo {
+  content: string;
+  created_at?: string;
+  scene_navigation?: string;
+}
+
+export interface UpdateMarkdownFileRequest {
+  expected_version: string;
+  content: string;
+}
+
+// ============================
 // /session/end
 // ============================
 
@@ -123,6 +166,12 @@ export interface SeedRequest {
    * This is the same structure accepted by `openclaw memory-tdai seed --input`.
    */
   data: unknown;
+  /**
+   * Seed target mode.
+   * - append: write into the live gateway memory-data directory (default)
+   * - test: write into an isolated memory-data/test-runs/seed-* directory
+   */
+  mode?: "append" | "test";
   /** Fallback session key when input sessions lack one. */
   session_key?: string;
   /** Require each round to have both user and assistant messages. */
@@ -134,10 +183,12 @@ export interface SeedRequest {
 }
 
 export interface SeedResponse {
+  mode: "append" | "test";
   sessions_processed: number;
   rounds_processed: number;
   messages_processed: number;
   l0_recorded: number;
+  l1_recorded: number;
   duration_ms: number;
   output_dir: string;
 }


### PR DESCRIPTION
## Summary

- Add `/seed` mode support: `append` and `test`
- Add L1 recorded count to seed response
- Restore checkpoint scheduler state during seed execution
- Add markdown files API for L2 scene blocks and L3 persona
- Support profile markdown update with version check

## Notes

This fork branch is used by ArtifactTrace as an external memory HTTP service.