### PR TITLE
docs: fix config comments to match actual defaults

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export interface ExtractionConfig {
 export interface PersonaConfig {
   /** Trigger persona generation every N new memories (default: 50) */
   triggerEveryN: number;
-  /** Max scene blocks (default: 20) */
+  /** Max scene blocks (default: 15) */
   maxScenes: number;
   /** Persona backup count (default: 3) */
   backupCount: number;
@@ -64,7 +64,7 @@ export interface PipelineTriggerConfig {
   enableWarmup: boolean;
   /** L1 idle timeout: trigger L1 after this many seconds of inactivity (default: 600) */
   l1IdleTimeoutSeconds: number;
-  /** L2 delay after L1: wait this many seconds after L1 completes before triggering L2 (default: 90) */
+  /** L2 delay after L1: wait this many seconds after L1 completes before triggering L2 (default: 10) */
   l2DelayAfterL1Seconds: number;
   /** L2 min interval: minimum seconds between L2 runs per session (default: 900 = 15 min) */
   l2MinIntervalSeconds: number;
@@ -175,7 +175,7 @@ export type StoreBackend = "sqlite" | "tcvdb";
 
 /** Report settings — controls metric/event reporting. */
 export interface ReportConfig {
-  /** Enable reporting (default: true) */
+  /** Enable reporting (default: false) */
   enabled: boolean;
   /** Reporter type: "local" logs structured JSON via logger (default: "local") */
   type: string;


### PR DESCRIPTION
Closes #161

Three config field comments disagreed with actual code defaults:

| Field | Comment said | Actual default |
|---|---|---|
| `maxScenes` | 20 | 15 |
| `l2DelayAfterL1Seconds` | 90 | 10 |
| `report.enabled` | true | false |

The most impactful discrepancy is `l2DelayAfterL1Seconds` which was off by 9x — comment claimed 90 seconds but code uses 10 seconds, giving users an incorrect mental model of pipeline timing.