### PR TITLE
[good first issue] fix(embedding): enable retry backoff for embedding API calls

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -96,7 +96,7 @@
           "sendDimensions": { "type": "boolean", "default": true, "description": "是否在请求体中携带 dimensions 字段。默认 true（兼容 OpenAI text-embedding-3-* 的 Matryoshka 截断）。当目标服务为 BGE-M3 等不支持自定义维度的固定维度模型时，请设为 false，否则会被服务端以 HTTP 400 拒绝（'does not support matryoshka representation'）。" },
           "conflictRecallTopK": { "type": "number", "default": 5, "description": "冲突检测时召回 Top-K 数" },
           "maxInputChars": { "type": "number", "default": 5000, "description": "Embedding 输入文本最大字符数，超出时截断并打印警告日志（默认 5000，适合大多数模型的 token 上限）" },
-          "timeoutMs": { "type": "number", "default": 10000, "description": "单次 embedding API 调用超时（毫秒），超时后该次请求中止且不重试" },
+          "timeoutMs": { "type": "number", "default": 10000, "description": "单次 embedding API 调用超时（毫秒），超时后会自动重试（最多 3 次）" },
           "recallTimeoutMs": { "type": "number", "description": "recall 路径 embedding 超时（毫秒），覆盖 timeoutMs。用户等待中，建议设短一些（如 3000）" },
           "captureTimeoutMs": { "type": "number", "description": "capture 路径 embedding 超时（毫秒），覆盖 timeoutMs。后台运行，可设长一些（如 15000）" }
         }

--- a/src/core/store/embedding.ts
+++ b/src/core/store/embedding.ts
@@ -365,8 +365,11 @@ export class LocalEmbeddingService implements EmbeddingService {
 /** Max texts per batch (OpenAI limit is 2048, we use a safe value) */
 const MAX_BATCH_SIZE = 256;
 
-/** Max retries for API calls */
-const MAX_RETRIES = 0;
+/**
+ * Max retries for embedding API calls (transient errors: network, 429, DNS).
+ * Total attempts = MAX_RETRIES + 1. Exponential backoff: 500ms × attempt.
+ */
+const MAX_RETRIES = 3;
 /** Default timeout per API call in milliseconds */
 const DEFAULT_API_TIMEOUT_MS = 10_000;
 


### PR DESCRIPTION
## Summary

Fixes #159

`MAX_RETRIES` was hardcoded to `0` in `src/core/store/embedding.ts`, making the existing exponential backoff retry logic dead code. Transient errors (network jitter, 429 rate limits, DNS failures) caused immediate embedding failure.

## Changes

- Changed `MAX_RETRIES` from `0` to `3` in `src/core/store/embedding.ts`
- Updated comment to document the retry strategy
- Updated `timeoutMs` description in `openclaw.plugin.json` to reflect retry behavior

## Retry behavior (after fix)

| Attempt | Delay | Description |
|---------|-------|-------------|
| 0 | 0ms | Initial request |
| 1 | 500ms | 1st retry |
| 2 | 1000ms | 2nd retry |
| 3 | 1500ms | 3rd retry |

- **4xx (except 429)**: throw immediately, no retry
- **5xx / 429 / network errors**: trigger retry with exponential backoff

This matches the retry strategy already used by `tcvdb-client.ts` (`MAX_RETRIES = 2`).

## Verification

- ✅ `npm run build` — passed
- ✅ `npm test` — 38 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)