### PR TITLE
fix(search): sanitize fts query operators

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildFtsQuery, _resetJiebaForTest, _setJiebaForTest } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("strips FTS5 operators before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta OR NOT gamma NEAR delta")).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta"',
+    );
+  });
+
+  it("does not strip operator words embedded inside normal tokens", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("android origin notable nearby")).toBe(
+      '"android" OR "origin" OR "notable" OR "nearby"',
+    );
+  });
+
+  it("strips FTS5 operators before jieba tokenization", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        seen.push(text);
+        return text.split(/\s+/);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe(
+      '"用户" OR "TypeScript" OR "记忆"',
+    );
+    expect(seen).toEqual(["用户   TypeScript   记忆"]);
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,8 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATORS = /\b(?:AND|OR|NOT|NEAR)\b/gi;
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -196,6 +198,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = raw.replace(FTS5_OPERATORS, " ");
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +206,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +221,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
 ## Description | 描述
  Strip FTS5 boolean/proximity operators from raw search text before tokenization so user input cannot carry query syntax into the
  generated MATCH expression.

  ## Related Issue | 关联 Issue
  Fix #160

  ## Change Type | 修改类型
  - [x] Bug fix | Bug 修复
  - [ ] New feature | 新功能
  - [ ] Documentation update | 文档更新
  - [ ] Code optimization | 代码优化

  ## Self-test Checklist | 自测清单
  - [x] Verified locally | 本地验证通过
  - [x] No existing features affected | 无影响现有功能

  ## Additional Notes | 其他说明
  Verified with `npm test` and `npm run build` using Node v24.15.0.