### PR TITLE
fix(record): harden L1 parsing and embedding timeout

### DIFF
--- a/src/core/record/l1-extractor.test.ts
+++ b/src/core/record/l1-extractor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseExtractionResult } from "./l1-extractor.js";
+
+describe("parseExtractionResult", () => {
+  it("ignores non-JSON bracketed text before the extraction array", () => {
+    const raw = `
+[姓名]）在 [时间] 这类说明不是 JSON。
+[
+  {
+    "scene_name": "排障",
+    "message_ids": ["m1"],
+    "memories": [
+      {
+        "content": "用户使用 ollama nomic-embed-text 作为 embedding 模型",
+        "type": "episodic",
+        "priority": 60,
+        "source_message_ids": ["m1"],
+        "metadata": {}
+      }
+    ]
+  }
+]
+补充说明：以上为提取结果。
+`;
+
+    const scenes = parseExtractionResult(raw);
+
+    expect(scenes).toHaveLength(1);
+    expect(scenes[0]?.scene_name).toBe("排障");
+    expect(scenes[0]?.memories[0]?.content).toBe("用户使用 ollama nomic-embed-text 作为 embedding 模型");
+  });
+
+  it("accepts object-wrapped scene arrays with trailing text", () => {
+    const raw = `{"scenes":[{"scene_name":"配置","message_ids":["m1"],"memories":[]}]} trailing text`;
+
+    const scenes = parseExtractionResult(raw);
+
+    expect(scenes).toHaveLength(1);
+    expect(scenes[0]?.scene_name).toBe("配置");
+  });
+
+  it("skips unrelated JSON before the scene payload", () => {
+    const raw = `{"note":"not the extraction payload"}\n[{"scene_name":"召回","message_ids":[],"memories":[]}]`;
+
+    const scenes = parseExtractionResult(raw);
+
+    expect(scenes).toHaveLength(1);
+    expect(scenes[0]?.scene_name).toBe("召回");
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -241,13 +241,14 @@ export async function extractL1Memories(params: {
         logger,
         vectorStore: options.vectorStore,
         embeddingService: options.embeddingService,
+        embeddingTimeoutMs: options.embeddingTimeoutMs,
       });
     } catch (err) {
       logger?.warn?.(`${TAG} Batch dedup failed, storing all as new: ${err instanceof Error ? err.message : String(err)}`);
-      storedRecords = await storeAllDirectly(memoriesWithIds, baseDir, sessionKey, sessionId, logger, options.vectorStore, options.embeddingService);
+      storedRecords = await storeAllDirectly(memoriesWithIds, baseDir, sessionKey, sessionId, logger, options.vectorStore, options.embeddingService, options.embeddingTimeoutMs);
     }
   } else {
-    storedRecords = await storeAllDirectly(memoriesWithIds, baseDir, sessionKey, sessionId, logger, options.vectorStore, options.embeddingService);
+    storedRecords = await storeAllDirectly(memoriesWithIds, baseDir, sessionKey, sessionId, logger, options.vectorStore, options.embeddingService, options.embeddingTimeoutMs);
   }
 
   logger?.info(`${TAG} Extraction complete: extracted=${extracted.length}, stored=${storedRecords.length}`);
@@ -350,7 +351,7 @@ async function callLlmExtraction(params: {
  * Parse the LLM's JSON response into SceneSegment array.
  * Expected format: [{scene_name, message_ids, memories: [...]}]
  */
-function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
+export function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
   try {
     // Strip markdown code block wrappers if present
     let cleaned = raw.trim();
@@ -358,9 +359,8 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "");
     }
 
-    // Try to extract JSON array
-    const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
-    if (!arrayMatch) {
+    const scenePayload = parseFirstScenePayload(cleaned);
+    if (!scenePayload) {
       logger?.warn?.(`${TAG} No JSON array found in extraction response`);
       // [l1-debug] NO_JSON — dump the full raw so we can see what the LLM actually said
       const rawPreview = raw.slice(0, 2048);
@@ -370,17 +370,8 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       return [];
     }
 
-    // Sanitize control characters inside JSON string literals that LLM may produce
-    const sanitized = sanitizeJsonForParse(arrayMatch[0]);
-    const parsed = JSON.parse(sanitized) as unknown[];
-
-    if (!Array.isArray(parsed)) {
-      logger?.warn?.(`${TAG} Extraction response is not an array`);
-      return [];
-    }
-
     const scenes: SceneSegment[] = [];
-    for (const item of parsed) {
+    for (const item of scenePayload) {
       if (!item || typeof item !== "object") continue;
       const s = item as Record<string, unknown>;
 
@@ -408,6 +399,84 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
   }
 }
 
+function parseFirstScenePayload(text: string): unknown[] | null {
+  for (let start = 0; start < text.length; start++) {
+    const first = text[start];
+    if (first !== "[" && first !== "{") continue;
+
+    const candidate = readBalancedJsonValue(text, start);
+    if (!candidate) continue;
+
+    try {
+      const parsed = JSON.parse(sanitizeJsonForParse(candidate));
+      const scenePayload = normalizeScenePayload(parsed);
+      if (scenePayload) {
+        return scenePayload;
+      }
+    } catch {
+      // Keep scanning: model output may contain non-JSON bracketed text
+      // before the actual payload, e.g. "[姓名]）在 [时间] ...".
+    }
+  }
+
+  return null;
+}
+
+function readBalancedJsonValue(text: string, start: number): string | null {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (ch === "[" || ch === "{") {
+      stack.push(ch === "[" ? "]" : "}");
+      continue;
+    }
+
+    if (ch === "]" || ch === "}") {
+      if (stack.length === 0 || stack[stack.length - 1] !== ch) {
+        return null;
+      }
+      stack.pop();
+      if (stack.length === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function normalizeScenePayload(parsed: unknown): unknown[] | null {
+  if (Array.isArray(parsed)) return parsed;
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const obj = parsed as Record<string, unknown>;
+  for (const key of ["scenes", "scene_segments", "segments", "results", "memories"]) {
+    if (Array.isArray(obj[key])) return obj[key] as unknown[];
+  }
+
+  return null;
+}
+
 // ============================
 // Write helpers
 // ============================
@@ -424,8 +493,9 @@ async function applyDecisions(params: {
   logger?: Logger;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  embeddingTimeoutMs?: number;
 }): Promise<MemoryRecord[]> {
-  const { memoriesWithIds, decisions, baseDir, sessionKey, sessionId, logger, vectorStore, embeddingService } = params;
+  const { memoriesWithIds, decisions, baseDir, sessionKey, sessionId, logger, vectorStore, embeddingService, embeddingTimeoutMs } = params;
   const storedRecords: MemoryRecord[] = [];
 
   // Build a map from record_id → decision
@@ -451,6 +521,7 @@ async function applyDecisions(params: {
         logger,
         vectorStore,
         embeddingService,
+        embeddingTimeoutMs,
       });
 
       if (record) {
@@ -477,6 +548,7 @@ async function storeAllDirectly(
   logger?: Logger,
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  embeddingTimeoutMs?: number,
 ): Promise<MemoryRecord[]> {
   const storedRecords: MemoryRecord[] = [];
 
@@ -495,6 +567,7 @@ async function storeAllDirectly(
         logger,
         vectorStore,
         embeddingService,
+        embeddingTimeoutMs,
       });
       if (record) {
         storedRecords.push(record);

--- a/src/core/record/l1-writer.test.ts
+++ b/src/core/record/l1-writer.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { EmbeddingCallOptions, EmbeddingProviderInfo, EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore } from "../store/types.js";
+import { writeMemory } from "./l1-writer.js";
+import type { ExtractedMemory } from "./l1-writer.js";
+
+describe("writeMemory", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+    tempDirs = [];
+  });
+
+  it("passes capture embedding timeout to vector dual-write embedding calls", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-l1-writer-"));
+    tempDirs.push(baseDir);
+
+    let seenOptions: EmbeddingCallOptions | undefined;
+    let seenEmbedding: Float32Array | undefined;
+
+    const embeddingService: EmbeddingService = {
+      async embed(_text: string, options?: EmbeddingCallOptions): Promise<Float32Array> {
+        seenOptions = options;
+        return new Float32Array([1, 0]);
+      },
+      async embedBatch(): Promise<Float32Array[]> {
+        throw new Error("not used");
+      },
+      getDimensions(): number {
+        return 2;
+      },
+      getProviderInfo(): EmbeddingProviderInfo {
+        return { provider: "test", model: "fake" };
+      },
+      isReady(): boolean {
+        return true;
+      },
+      startWarmup(): void {
+        // no-op
+      },
+    };
+
+    const vectorStore = {
+      async upsertL1(_record, embedding) {
+        seenEmbedding = embedding;
+        return true;
+      },
+    } as Pick<IMemoryStore, "upsertL1"> as IMemoryStore;
+
+    const memory: ExtractedMemory = {
+      content: "用户的 CPU embedding 请求需要更长超时",
+      type: "episodic",
+      priority: 50,
+      source_message_ids: ["m1"],
+      metadata: {},
+      scene_name: "排障",
+    };
+
+    const record = await writeMemory({
+      memory,
+      decision: { record_id: "m_test", action: "store", target_ids: [] },
+      baseDir,
+      sessionKey: "session-a",
+      vectorStore,
+      embeddingService,
+      embeddingTimeoutMs: 15_000,
+    });
+
+    expect(record?.id).toBe("m_test");
+    expect(seenOptions).toEqual({ timeoutMs: 15_000 });
+    expect(seenEmbedding).toEqual(new Float32Array([1, 0]));
+  });
+});

--- a/src/core/record/l1-writer.ts
+++ b/src/core/record/l1-writer.ts
@@ -147,8 +147,10 @@ export async function writeMemory(params: {
   vectorStore?: IMemoryStore;
   /** Optional embedding service (required when vectorStore is provided) */
   embeddingService?: EmbeddingService;
+  /** Override embedding timeout for capture-path calls (milliseconds) */
+  embeddingTimeoutMs?: number;
 }): Promise<MemoryRecord | null> {
-  const { memory, decision, baseDir, sessionKey, sessionId, logger, vectorStore, embeddingService } = params;
+  const { memory, decision, baseDir, sessionKey, sessionId, logger, vectorStore, embeddingService, embeddingTimeoutMs } = params;
 
   if (decision.action === "skip") {
     logger?.debug?.(`${TAG} Skipping memory: ${memory.content.slice(0, 50)}...`);
@@ -231,7 +233,10 @@ export async function writeMemory(params: {
 
       if (embeddingService) {
         try {
-          embedding = await embeddingService.embed(record.content);
+          embedding = await embeddingService.embed(
+            record.content,
+            embeddingTimeoutMs ? { timeoutMs: embeddingTimeoutMs } : undefined,
+          );
           logger?.debug?.(
             `${TAG} [vec-dual-write] Embedding OK: dims=${embedding.length}, ` +
             `norm=${Math.sqrt(Array.from(embedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}`,


### PR DESCRIPTION
## Description | 描述
Harden the L1 extraction path against non-strict LLM JSON output and ensure capture-path embedding timeout configuration reaches vector dual-write calls.

- Parse the first valid scene payload instead of greedily matching from the first `[` to the last `]`, so explanatory text like `[姓名]）在 [时间]` no longer poisons extraction.
- Accept object-wrapped scene arrays such as `{ "scenes": [...] }` while still ignoring unrelated JSON before the actual scene payload.
- Forward `embedding.captureTimeoutMs` / capture embedding timeout through `writeMemory()` so slow CPU embedding providers are not limited by the default embedding timeout during L1 vector writes.

## Related Issue | 关联 Issue
Fix #110

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with `npm test` and `npm run build` using Node v24.15.0.
