### PR TITLE
fix(openclaw): tolerate missing state dir resolver

### DIFF
--- a/src/utils/openclaw-state-dir.test.ts
+++ b/src/utils/openclaw-state-dir.test.ts
@@ -1,0 +1,50 @@
+import { homedir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveOpenClawStateDir } from "./openclaw-state-dir.js";
+
+describe("resolveOpenClawStateDir", () => {
+  const originalEnv = process.env.OPENCLAW_STATE_DIR;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalEnv;
+    }
+  });
+
+  it("uses runtime state dir when available", () => {
+    process.env.OPENCLAW_STATE_DIR = "/env/state";
+
+    const stateDir = resolveOpenClawStateDir({
+      resolveStateDir: () => " /runtime/state ",
+    });
+
+    expect(stateDir).toBe("/runtime/state");
+  });
+
+  it("falls back to OPENCLAW_STATE_DIR when runtime state is missing", () => {
+    process.env.OPENCLAW_STATE_DIR = " /env/state ";
+
+    expect(resolveOpenClawStateDir(undefined)).toBe("/env/state");
+  });
+
+  it("falls back to OPENCLAW_STATE_DIR when runtime resolver throws", () => {
+    process.env.OPENCLAW_STATE_DIR = "/env/state";
+
+    const stateDir = resolveOpenClawStateDir({
+      resolveStateDir: () => {
+        throw new Error("state not initialized");
+      },
+    });
+
+    expect(stateDir).toBe("/env/state");
+  });
+
+  it("falls back to the default OpenClaw state dir when no source is available", () => {
+    delete process.env.OPENCLAW_STATE_DIR;
+
+    expect(resolveOpenClawStateDir(undefined)).toBe(path.join(homedir(), ".openclaw"));
+  });
+});

--- a/src/utils/openclaw-state-dir.ts
+++ b/src/utils/openclaw-state-dir.ts
@@ -27,8 +27,16 @@ export interface OpenClawRuntimeStateLike {
 export function resolveOpenClawStateDir(
   runtimeState: OpenClawRuntimeStateLike | undefined,
 ): string {
+  let runtimeStateDir: string | undefined;
+  try {
+    runtimeStateDir = runtimeState?.resolveStateDir?.()?.trim();
+  } catch {
+    // Some host registration paths expose `runtime.state` before it is fully
+    // initialized. Falling back keeps plugin registration non-fatal.
+  }
+
   return (
-    runtimeState?.resolveStateDir?.() ||
+    runtimeStateDir ||
     getEnv("OPENCLAW_STATE_DIR")?.trim() ||
     path.join(homedir(), ".openclaw")
   );


### PR DESCRIPTION
## Description | 描述
Harden OpenClaw state directory resolution during plugin registration.

When OpenClaw loads the plugin before `runtime.state` is fully initialized, state directory lookup should not make registration fail. This change keeps the existing priority order but makes it more defensive:

- use `runtime.state.resolveStateDir()` when available,
- fall back to `OPENCLAW_STATE_DIR` when the runtime state is missing, empty, or throws,
- fall back to `~/.openclaw` when no host-provided state directory is available.

Added focused tests for runtime, environment, throwing resolver, and default fallback paths.

## Related Issue | 关联 Issue
Fix #89

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with `npm test` and `npm run build` using Node v24.15.0.
