### PR TITLE
fix(sanitize): prevent looksLikePromptInjection from being tree-shaken

### DIFF
--- a/src/utils/sanitize-tree-shaking.test.ts
+++ b/src/utils/sanitize-tree-shaking.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('Tree-shaking Verification', () => {
+  it('should ensure looksLikePromptInjection is preserved in the final dist bundle', () => {
+    // 使用 process.cwd() 绝对能精准定位到项目根目录下的 dist/index.mjs
+    const distPath = path.resolve(process.cwd(), 'dist/index.mjs');
+
+    // 1. 验证构建产物文件确实存在
+    const fileExists = fs.existsSync(distPath);
+    expect(fileExists).toBe(true);
+
+    if (fileExists) {
+      // 2. 读取打包产物内容
+      const bundleContent = fs.readFileSync(distPath, 'utf8');
+
+      // 3. 断言最终产物中依然保留了 looksLikePromptInjection
+      expect(bundleContent).toContain('looksLikePromptInjection');
+    }
+  });
+});

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -150,7 +150,7 @@ export function shouldExtractL1(text: string): boolean {
   // ── Security filters ──
   // Reject prompt-injection payloads — prevent malicious content from being
   // persisted into structured memory and re-injected on future recalls.
-  // if (looksLikePromptInjection(text)) return false;
+   if (looksLikePromptInjection(text)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Description | 描述
1. Uncommented line 153 in `src/utils/sanitize.ts` to re-enable the `looksLikePromptInjection` call, restoring prompt injection detection.
2. Verified that the bundler (`tsdown`) properly preserves the function inside the build artifact (`dist/index.mjs`).
3. Added a build-time integration test `src/utils/sanitize-tree-shaking.test.ts` to assert that the function is not tree-shaken out of the final package.

1. 取消了 `src/utils/sanitize.ts` 第 153 行的注释，恢复对 `looksLikePromptInjection` 的正常调用，修复了原本存在的 prompt 注入检测失效 bug。
2. 确认在重新编译打包后，产物 `dist/index.mjs` 中已经正确保留并包含了该函数。
3. 新增了构建验证测试 `src/utils/sanitize-tree-shaking.test.ts`，防止后续因打包工具 Tree-shaking 机制导致此函数再次丢失。

## Related Issue | 关联 Issue
Fix #158

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化