### PR TITLE
fix(hermes): split recall context for prefetch

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -375,6 +375,7 @@ class MemoryTencentdbProvider(MemoryProvider):
         self._user_id = ""
         self._gateway_available = False
         self._initialized = False  # Track if initialize() has been called
+        self._latest_system_context = ""
 
         # Background sync threads.
         # We allow at most _MAX_INFLIGHT_SYNCS in-flight sync threads at any
@@ -816,7 +817,7 @@ class MemoryTencentdbProvider(MemoryProvider):
     def system_prompt_block(self) -> str:
         if not self._gateway_available:
             return ""
-        return (
+        block = (
             "# memory-tencentdb Memory\n"
             f"Active. User: {self._user_id}.\n"
             "Four-layer memory system (L0→L1→L2→L3) with automatic conversation "
@@ -824,6 +825,9 @@ class MemoryTencentdbProvider(MemoryProvider):
             "Use memory_tencentdb_memory_search to find specific memories, "
             "memory_tencentdb_conversation_search to search raw conversation history."
         )
+        if self._latest_system_context:
+            block = f"{block}\n\n{self._latest_system_context}"
+        return block
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Synchronous recall — fetch memories in real-time for the current turn."""
@@ -844,7 +848,11 @@ class MemoryTencentdbProvider(MemoryProvider):
                 session_key=effective_session,
                 user_id=self._user_id,
             )
-            context = result.get("context", "")
+            system_context = result.get("system_context", "")
+            if system_context:
+                self._latest_system_context = system_context
+
+            context = result.get("prepend_context") or result.get("context", "")
             self._record_success()
             if context:
                 return f"## memory-tencentdb Memory\n{context}"

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -357,6 +357,36 @@ def test_prefetch_recovers_when_stuck_false_and_breaker_closed(
     assert fake.ensure_running_calls >= 1
 
 
+def test_prefetch_uses_dynamic_recall_and_caches_system_context(
+    provider_with_fake_supervisor,
+):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+    fake.client.recall.return_value = {
+        "context": "legacy combined context",
+        "system_context": "<user-persona>stable persona</user-persona>",
+        "prepend_context": "<relevant-memories>L1 fact</relevant-memories>",
+    }
+
+    result = provider.prefetch(query="hello", session_id="test-session")
+
+    assert "<relevant-memories>L1 fact</relevant-memories>" in result
+    assert "legacy combined context" not in result
+    assert "<user-persona>stable persona</user-persona>" in provider.system_prompt_block()
+
+
+def test_prefetch_falls_back_to_legacy_context(
+    provider_with_fake_supervisor,
+):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+    fake.client.recall.return_value = {"context": "legacy context only"}
+
+    result = provider.prefetch(query="hello", session_id="test-session")
+
+    assert "legacy context only" in result
+
+
 def test_prefetch_respects_open_breaker(provider_with_fake_supervisor):
     """Breaker should still take precedence — the lazy probe must not
     turn every request into a respawn attempt during a confirmed outage."""

--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1,0 +1,71 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { TdaiGateway } from "./server.js";
+
+function jsonRequest(body: unknown): Readable {
+  const req = new Readable({
+    read() {
+      this.push(JSON.stringify(body));
+      this.push(null);
+    },
+  });
+  return req;
+}
+
+function jsonResponse() {
+  let status = 0;
+  let payload = "";
+
+  return {
+    response: {
+      writeHead(nextStatus: number) {
+        status = nextStatus;
+      },
+      end(chunk: string) {
+        payload = chunk;
+      },
+    },
+    get status() {
+      return status;
+    },
+    get body() {
+      return JSON.parse(payload) as Record<string, unknown>;
+    },
+  };
+}
+
+describe("TdaiGateway recall", () => {
+  it("returns split system and prepend contexts with a backward-compatible context", async () => {
+    const gateway = new TdaiGateway();
+    (gateway as unknown as { core: unknown }).core = {
+      handleBeforeRecall: async () => ({
+        appendSystemContext: "<user-persona>stable persona</user-persona>",
+        prependContext: "<relevant-memories>L1 fact</relevant-memories>",
+        recallStrategy: "hybrid",
+        recalledL1Memories: [{ id: "m1" }, { id: "m2" }],
+      }),
+    };
+
+    const res = jsonResponse();
+
+    await (
+      gateway as unknown as {
+        handleRecall(req: Readable, res: typeof res.response): Promise<void>;
+      }
+    ).handleRecall(
+      jsonRequest({ query: "hello", session_key: "test-session" }),
+      res.response,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      context:
+        "<user-persona>stable persona</user-persona>\n\n" +
+        "<relevant-memories>L1 fact</relevant-memories>",
+      system_context: "<user-persona>stable persona</user-persona>",
+      prepend_context: "<relevant-memories>L1 fact</relevant-memories>",
+      strategy: "hybrid",
+      memory_count: 2,
+    });
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -380,10 +380,19 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    const systemContext = result.appendSystemContext ?? "";
+    const prependContext = result.prependContext ?? "";
+    const context = [systemContext, prependContext].filter(Boolean).join("\n\n");
+
+    this.logger.info(
+      `Recall completed in ${elapsed}ms: ` +
+      `system_context=${systemContext.length} chars, prepend_context=${prependContext.length} chars`,
+    );
 
     const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
+      context,
+      system_context: systemContext,
+      prepend_context: prependContext,
       strategy: result.recallStrategy,
       memory_count: result.recalledL1Memories?.length ?? 0,
     };

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -36,7 +36,12 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Backward-compatible combined context for older clients. */
   context: string;
+  /** Stable persona / scene / tool guidance context for system prompt injection. */
+  system_context?: string;
+  /** Dynamic L1 recall context for per-turn prefetch injection. */
+  prepend_context?: string;
   strategy?: string;
   memory_count?: number;
 }


### PR DESCRIPTION
## Description | 描述
Split Gateway recall responses into stable system context and dynamic L1 prefetch context for Hermes.

This fixes the Hermes path where `/recall` only returned `appendSystemContext`, so L1 memories recalled by auto-recall were not injected through `prefetch()`. The Gateway now returns:
- `system_context` for persona / scene navigation / tool guidance
- `prepend_context` for dynamic L1 memories
- `context` as a backward-compatible combined field for older clients

The Hermes provider prefers `prepend_context` in `prefetch()` and caches `system_context` for `system_prompt_block()`, while still falling back to the legacy `context` response.

## Related Issue | 关联 Issue
Fix #101

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with `npx vitest run src/gateway/server.test.ts`, `npm test`, and `npm run build` using Node v24.15.0.
Also ran `python3 -m py_compile` for the Hermes provider files. `pytest` is not installed in this environment, so the Python pytest suite could not be executed here.
