### PR TITLE
feat(hermes): pass full messages (incl. tool calls) to Gateway capture endpoint

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -862,7 +862,7 @@ class MemoryTencentdbProvider(MemoryProvider):
         """No-op — recall is done synchronously in prefetch()."""
         pass
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", messages: list | None = None) -> None:
         """Send the turn to Gateway for capture (non-blocking).
 
         Threading model:
@@ -895,6 +895,7 @@ class MemoryTencentdbProvider(MemoryProvider):
                     assistant_content=assistant_content,
                     session_key=effective_session,
                     user_id=self._user_id,
+                    messages=messages,
                 )
                 self._record_success()
             except Exception as e:

--- a/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/hermes-plugin/memory/memory_tencentdb/client.py
@@ -126,6 +126,7 @@ class MemoryTencentdbSdkClient:
         session_key: str,
         session_id: str = "",
         user_id: str = "",
+        messages: list | None = None,
     ) -> Dict[str, Any]:
         """Capture a conversation turn (sync_turn)."""
         body: Dict[str, Any] = {
@@ -137,6 +138,8 @@ class MemoryTencentdbSdkClient:
             body["session_id"] = session_id
         if user_id:
             body["user_id"] = user_id
+        if messages:
+            body["messages"] = messages
         return self._post("/capture", body)
 
     def search_memories(self, query: str, limit: int = 5, type_filter: str = "", scene: str = "") -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

The Hermes sync_turn integration only sends user_content and assistant_content as plain text. Tool call names, arguments, results, and success/failure status are stripped.

This means L0 has no tool call records, L1 extraction operates on incomplete context, and the offload pipeline cannot function.

## Root Cause

Hermes MemoryManager.sync_all() already supports passing the full messages list (including tool_call, tool_result roles) to providers via inspect.signature detection. But memory-tencentdb providers sync_turn signature only declares user_content, assistant_content, and session_id.

## Fix

Add messages: list | None = None to sync_turn signature and forward to client.capture(). The Gateway /capture endpoint already accepts and processes messages (server.ts:932).

No Hermes core changes needed.

## Changes

- __init__.py: Add messages to sync_turn signature, pass to client.capture()
- client.py: Add messages to capture() signature, include in request body