### PR TITLE
test(recall): cover character budget guards

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall budget", () => {
+  it("defaults recall character budgets to disabled", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.maxCharsPerMemory).toBe(0);
+    expect(cfg.recall.maxTotalRecallChars).toBe(0);
+  });
+
+  it("reads recall character budget options", () => {
+    const cfg = parseConfig({
+      recall: {
+        maxCharsPerMemory: 800,
+        maxTotalRecallChars: 3000,
+      },
+    });
+
+    expect(cfg.recall.maxCharsPerMemory).toBe(800);
+    expect(cfg.recall.maxTotalRecallChars).toBe(3000);
+  });
+});

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseConfig } from "../../config.js";
+import type { IMemoryStore, L1FtsResult } from "../store/types.js";
+import { performAutoRecall } from "./auto-recall.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("performAutoRecall recall budget", () => {
+  it("limits each injected L1 memory by configured character count", async () => {
+    const dataDir = await makeTempDir();
+    const longContent = `alpha ${"x".repeat(240)}`;
+    const store = fakeFtsStore([
+      makeFtsResult("m1", longContent),
+    ]);
+    const cfg = parseConfig({
+      recall: {
+        strategy: "keyword",
+        maxResults: 1,
+        maxCharsPerMemory: 120,
+        maxTotalRecallChars: 0,
+      },
+    });
+
+    const result = await performAutoRecall({
+      userText: "alpha query",
+      actorId: "agent",
+      sessionKey: "session",
+      cfg,
+      pluginDataDir: dataDir,
+      vectorStore: store,
+    });
+
+    expect(result?.prependContext).toContain("已截断");
+    expect(result?.prependContext).not.toContain("x".repeat(180));
+    expect(result?.recalledL1Memories?.[0]?.content).toContain("已截断");
+  });
+
+  it("stops adding L1 memories after the total recall budget is exhausted", async () => {
+    const dataDir = await makeTempDir();
+    const store = fakeFtsStore([
+      makeFtsResult("m1", `alpha ${"a".repeat(160)}`),
+      makeFtsResult("m2", `beta ${"b".repeat(160)}`),
+    ]);
+    const cfg = parseConfig({
+      recall: {
+        strategy: "keyword",
+        maxResults: 2,
+        maxCharsPerMemory: 0,
+        maxTotalRecallChars: 150,
+      },
+    });
+
+    const result = await performAutoRecall({
+      userText: "alpha beta",
+      actorId: "agent",
+      sessionKey: "session",
+      cfg,
+      pluginDataDir: dataDir,
+      vectorStore: store,
+    });
+
+    expect(result?.prependContext).toContain("alpha");
+    expect(result?.prependContext).toContain("已截断");
+    expect(result?.prependContext).not.toContain("beta");
+    expect(result?.recalledL1Memories).toHaveLength(1);
+  });
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "tdai-auto-recall-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeFtsResult(recordId: string, content: string): L1FtsResult {
+  return {
+    record_id: recordId,
+    content,
+    type: "episodic",
+    priority: 50,
+    scene_name: "test scene",
+    score: 1,
+    timestamp_str: "",
+    timestamp_start: "",
+    timestamp_end: "",
+    session_key: "session",
+    session_id: "session-id",
+    metadata_json: "{}",
+  };
+}
+
+function fakeFtsStore(results: L1FtsResult[]): IMemoryStore {
+  return {
+    isFtsAvailable: () => true,
+    searchL1Fts: async (_query, limit) => results.slice(0, limit),
+    getCapabilities: () => ({
+      vectorSearch: false,
+      ftsSearch: true,
+      nativeHybridSearch: false,
+      sparseVectors: false,
+    }),
+  } as Partial<IMemoryStore> as IMemoryStore;
+}


### PR DESCRIPTION
## Description | 描述
Add focused regression coverage for the recall-time L1 character budget safeguards.

Latest `main` already includes `recall.maxCharsPerMemory`, `recall.maxTotalRecallChars`, and recall-time budget application. This PR protects that behavior with tests for:
- parsing the new recall budget config defaults and custom values
- truncating an oversized recalled L1 memory before injection
- stopping injected L1 memories once the total recall budget is exhausted

This keeps the PR deliberately narrow and avoids schema/status/supersede changes from the broader issue.

## Related Issue | 关联 Issue
Related to #70

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with `npx vitest run src/config.test.ts src/core/hooks/auto-recall.test.ts`, `npm test`, and `npm run build` using Node v24.15.0.
