### PR TITLE
fix(hermes): mirror builtin memory writes through on_memory_write

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -1047,10 +1047,43 @@ class MemoryTencentdbProvider(MemoryProvider):
     # -- Optional hooks -------------------------------------------------------
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
-        """Mirror built-in memory writes to memory-tencentdb for indexing."""
-        # TODO: Implement mirroring of Hermes builtin MEMORY.md/USER.md writes
-        # to memory-tencentdb's recall index for conflict suppression and dedup.
-        pass
+        """Mirror built-in memory writes to memory-tencentdb for indexing.
+
+        Hermes fires this hook when its built-in memory layer (the one
+        that writes to ``MEMORY.md`` / ``USER.md``) records a new
+        entry. The intent is to feed that write into the L1 index so
+        the dedup layer can suppress duplicates and the L3 persona
+        builder can see the user's stated preferences. Without this
+        mirror, the two memory systems run in parallel with no
+        cross-pollination — the user pays the L1/L2/L3 compute while
+        the builtin write stays invisible to it.
+
+        Implementation: encode the write as a synthetic turn and call
+        ``/capture``. The L1 extractor sees the content, the dedup
+        layer can match against it, and L3 picks it up on the next
+        persona refresh — all without blocking the caller. The
+        ``(memory_write …)`` prefix lets a future LLM-side filter
+        recognize and skip these synthetic entries during scene
+        extraction if the natural-turn framing becomes a problem.
+        """
+        if not self._client or not self._gateway_available:
+            return
+        try:
+            self._client.capture(
+                user_content=f"(memory_write action={action} target={target}) {content}",
+                assistant_content="(builtin memory write recorded)",
+                session_key=self._session_id,
+                session_id=self._session_id,
+                user_id=self._user_id,
+            )
+        except Exception as e:
+            # Mirror failures must never propagate. The builtin write
+            # already succeeded in Hermes's own store; failing to
+            # mirror it is a soft-loss of cross-system visibility,
+            # not a write failure, and the next sync_turn() in the
+            # same session will eventually re-surface the same
+            # content through normal conversation capture.
+            logger.debug("memory-tencentdb on_memory_write mirror failed: %s", e)
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Trigger session-level flush on the Gateway."""

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_on_memory_write_mirror.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_on_memory_write_mirror.py
@@ -1,0 +1,178 @@
+"""Tests for the built-in memory write mirror in on_memory_write().
+
+Regression coverage for #205 sub-bullet 1: the Hermes provider
+declared the ``on_memory_write`` hook in ``plugin.yaml`` but the
+method was a ``pass`` no-op with a TODO. The intent — feed
+``MEMORY.md`` / ``USER.md`` writes into the L1 index so dedup and
+L3 persona building can see them — was scaffolded and abandoned.
+
+The fix encodes the builtin write as a synthetic ``/capture`` turn
+so the L1 extractor sees it. These tests are mock-only: they assert
+that the provider calls ``client.capture`` with the right shape and
+that the hook tolerates a missing or failing client without
+propagating exceptions to the caller (Hermes's builtin layer is the
+authority for these writes; a mirror failure must not look like a
+write failure).
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mirror the sys.path injection used by the sibling test files
+# (test_l3_persona_injection.py, test_memory_tencentdb_recovery.py):
+# the provider can live either under the plugin repo or under a
+# hermes-agent checkout, so try both before skipping.
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_HERE = _THIS_FILE.parent
+for candidate in (
+    _HERE.parents[3] if len(_HERE.parents) >= 4 else None,    # plugin repo
+    _HERE.parents[4] if len(_HERE.parents) >= 5 else None,    # hermes-agent root
+    _HERE.parents[2] if len(_HERE.parents) >= 3 else None,    # fallback
+):
+    if candidate is not None and (candidate / "plugins").is_dir():
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+_hermes_root = os.environ.get("HERMES_AGENT_ROOT")
+if not _hermes_root:
+    sibling = _HERE.parents[4] / "hermes-agent" if len(_HERE.parents) >= 5 else None
+    if sibling is not None and (sibling / "agent").is_dir():
+        _hermes_root = str(sibling)
+if _hermes_root and _hermes_root not in sys.path:
+    sys.path.insert(0, _hermes_root)
+
+try:
+    from plugins.memory.memory_tencentdb import MemoryTencentdbProvider
+except ImportError as e:  # pragma: no cover — env-dependent
+    pytest.skip(
+        f"memory_tencentdb provider not importable ({e}); set "
+        "HERMES_AGENT_ROOT to a hermes-agent checkout if running from "
+        "the plugin repo.",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_provider(*, gateway_available: bool = True) -> MemoryTencentdbProvider:
+    """Construct a provider with the Gateway stubbed.
+
+    Bypasses ``initialize()`` the same way the L3 test does: the
+    on_memory_write hook only touches ``_client``, ``_gateway_available``,
+    ``_session_id``, and ``_user_id``, so we set those and skip the
+    rest of the lifecycle.
+    """
+    p = MemoryTencentdbProvider.__new__(MemoryTencentdbProvider)
+    p._gateway_available = gateway_available
+    p._client = MagicMock()
+    p._session_id = "test-session"
+    p._user_id = "test-user"
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Core behaviour
+# ---------------------------------------------------------------------------
+
+class TestOnMemoryWriteMirror:
+    def test_writes_are_forwarded_to_capture(self):
+        """A builtin memory write must reach client.capture() with the expected shape."""
+        p = _make_provider()
+        p.on_memory_write(
+            action="append",
+            target="USER.md",
+            content="User prefers concise answers.",
+        )
+        p._client.capture.assert_called_once()
+        kwargs = p._client.capture.call_args.kwargs
+        # The user_content must encode action + target so the L1
+        # extractor has enough signal to treat this as a memory
+        # write (and not a natural conversation turn).
+        assert "memory_write" in kwargs["user_content"]
+        assert "action=append" in kwargs["user_content"]
+        assert "target=USER.md" in kwargs["user_content"]
+        assert "concise answers" in kwargs["user_content"]
+        # The session/user context must be threaded through.
+        assert kwargs["session_key"] == "test-session"
+        assert kwargs["session_id"] == "test-session"
+        assert kwargs["user_id"] == "test-user"
+        # A non-empty assistant_content signals to the L1 pipeline
+        # that this is a complete turn, not a half-written one.
+        assert kwargs["assistant_content"]
+
+    def test_no_capture_when_gateway_unavailable(self):
+        """If the Gateway is down, the hook must not try to capture.
+
+        A builtin write already succeeded in Hermes's own store; we
+        would rather skip the mirror than raise. The user will see
+        the write land in USER.md regardless; the L1 index will
+        catch up via the next normal sync_turn() that re-surfaces
+        the same content.
+        """
+        p = _make_provider(gateway_available=False)
+        # Must not raise.
+        p.on_memory_write(action="append", target="USER.md", content="x")
+        p._client.capture.assert_not_called()
+
+    def test_no_capture_when_client_is_none(self):
+        """If _client is None (e.g. supervisor never started), skip silently."""
+        p = _make_provider()
+        p._client = None
+        # Must not raise.
+        p.on_memory_write(action="append", target="USER.md", content="x")
+
+    def test_capture_failure_is_swallowed(self):
+        """A failed capture must not propagate to the caller.
+
+        The builtin write already succeeded; a mirror failure is a
+        soft-loss of cross-system visibility, not a write failure.
+        Raising would make Hermes think the write itself failed
+        and (depending on host wiring) retry or surface an error
+        to the user. Both are wrong: the user only ever asked
+        Hermes to remember, and Hermes did remember.
+        """
+        p = _make_provider()
+        p._client.capture.side_effect = ConnectionError("Gateway down")
+        # Must not raise.
+        p.on_memory_write(action="append", target="USER.md", content="x")
+        p._client.capture.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Negative control: pre-fix behaviour would have been a no-op
+# ---------------------------------------------------------------------------
+
+class TestNegativeControl:
+    def test_pre_fix_hook_did_nothing(self):
+        """Sanity check: before this PR, on_memory_write was a pass statement.
+
+        This test simply confirms the hook *now* has observable
+        behaviour. If a future refactor reverts it to a no-op
+        (whether deliberately or by accident), the assertion above
+        (``test_writes_are_forwarded_to_capture``) will fail. The
+        negative control here documents the *shape* of the
+        regression: a no-op means the L1 extractor never sees the
+        builtin write, and the dedup layer cannot suppress a
+        duplicate of a preference the user already wrote down.
+        """
+        p = _make_provider()
+        p.on_memory_write(
+            action="append",
+            target="USER.md",
+            content="NEGATIVE_CONTROL_SENTINEL_PREFERENCE_42",
+        )
+        # The capture call must have happened with the sentinel
+        # verbatim in the user_content. If the hook is reverted to
+        # a no-op, this assertion fails — that's the whole point of
+        # the negative control.
+        assert p._client.capture.called
+        kwargs = p._client.capture.call_args.kwargs
+        assert "NEGATIVE_CONTROL_SENTINEL_PREFERENCE_42" in kwargs["user_content"]


### PR DESCRIPTION
## Description

The provider's `on_memory_write` hook was a no-op with a TODO. The intent — feed Hermes's builtin `MEMORY.md` / `USER.md` writes into the L1 index so dedup and L3 persona building can see them — was scaffolded but never wired. The two memory systems ran in parallel with no cross-pollination.

This routes the builtin write through `client.capture()` as a synthetic turn. The L1 extractor sees the content, the dedup layer can match against it, and L3 picks it up on the next persona refresh.

Refs #205 (sub-bullet 1 only; sub-bullet 2 is out of scope)

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code optimization

## Root Cause

`plugin.yaml` advertises two hooks:

```yaml
hooks:
  - on_memory_write
  - on_session_end
```

The provider's `on_session_end` is implemented (it calls `client.end_session()` to flush the L1/L2/L3 pipeline on session end). The provider's `on_memory_write` was:

```python
def on_memory_write(self, action: str, target: str, content: str) -> None:
    """Mirror built-in memory writes to memory-tencentdb for indexing."""
    # TODO: Implement mirroring of Hermes builtin MEMORY.md/USER.md writes
    # to memory-tencentdb's recall index for conflict suppression and dedup.
    pass
```

The TODO comment is the giveaway — unfinished work, not a deliberate "do nothing." The hook was scaffolded and abandoned. Effect:

- A user preference Hermes writes to `USER.md` is **invisible** to the TencentDB L1 index.
- The L1 dedup layer cannot catch a duplicate ("did we already record this preference?").
- The L3 persona generator never sees the preference, because L3 is built from L1.
- A user who repeats the same preference the next day gets a full LLM call instead of a recall.

So paying the L1/L2/L3 compute while the built-in memory layer is also writing means the two systems run in parallel with no cross-pollination — worst of both worlds. Same issue reporter flagged this as sub-bullet 1 of #205.

## Changes

- `hermes-plugin/memory/memory_tencentdb/__init__.py` — replace the `pass` body with a fire-and-forget call to `client.capture()`. The write is encoded as a synthetic turn with a `(memory_write action=… target=…)` prefix on `user_content`, which gives the L1 extractor enough signal to treat it as a memory write and a future LLM-side filter a marker to recognize and skip these entries during scene extraction.
- `hermes-plugin/memory/memory_tencentdb/tests/test_on_memory_write_mirror.py` — 5 new tests:
  - `test_writes_are_forwarded_to_capture` — happy path: action, target, and content all reach `client.capture()` in the right shape, with session/user context threaded through
  - `test_no_capture_when_gateway_unavailable` — Gateway down → no call, no exception
  - `test_no_capture_when_client_is_none` — supervisor never started → no call, no exception
  - `test_capture_failure_is_swallowed` — capture raises → caller never sees the exception
  - `test_pre_fix_hook_did_nothing` — negative control: the test would have failed on `main` because a `pass` body never calls `client.capture()`

No new public API surface. No client-side change (the existing `client.capture()` is the right primitive). No gateway-side change. No new dependencies.

## Defensive shape

The hook is fire-and-forget for two reasons:

1. **It is an event sink, not a request handler.** Hermes's builtin layer is the authority for these writes — it has already updated `MEMORY.md` / `USER.md` by the time the hook fires. We are mirroring, not replicating. A mirror failure is a soft-loss of cross-system visibility, not a write failure.
2. **Raising would mislead the caller.** If `on_memory_write` raises, Hermes's host wiring may surface an error to the user, or retry, or roll back the builtin write. None of those are right — the user only ever asked Hermes to remember, and Hermes did remember.

The fallback is automatic: the same content will re-surface through normal `sync_turn()` capture the next time it comes up in conversation, and the L1 extractor will dedup or extend as appropriate.

## Self-test Checklist

- [x] Verified locally
- [x] No existing features affected

```
hermes-plugin/memory/memory_tencentdb/tests/test_on_memory_write_mirror.py .....  5 passed
hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py   16 passed
```

`test_gateway_shutdown_leak.py` was not run in this branch — pre-existing failures on `main` are unrelated to this hook (they concern supervisor teardown, not the L1 mirror path). Same scope discipline as #206.

## Additional Notes

**On the `(memory_write …)` prefix:** The L1 extractor runs on the natural-turn framing by default. A synthetic entry with no marker could pollute the L1 store with what looks like a real conversation. The prefix gives downstream code a stable string to grep on if the natural-turn framing ever needs to be filtered out — e.g. if the L2 scene extractor starts grouping synthetic turns into scene blocks in unwanted ways. None of that filtering is implemented today; the marker is just future-proofing.

**On skipping the L3 inference cost:** This PR does not call `/recall` from `on_memory_write`. That is intentional. The L1 dedup / extraction pipeline runs on a schedule (`pipeline.everyNConversations`, default every 5 turns), and L3 runs every 50 new L1 memories. The write goes into L1 immediately on capture; L3 picks it up on its own schedule. Calling `/recall` here would burn an LLM call per write with no benefit, since L3 has its own trigger.

**On the test pattern:** The test file mirrors the sys.path injection used by `test_l3_persona_injection.py` and `test_memory_tencentdb_recovery.py` — it works under a hermes-agent checkout and skips cleanly in a plugin-only repo. Five focused tests, all mock-based, no real network or process spawning.
