### PR TITLE
docs(gateway): add process isolation troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,28 @@ curl http://127.0.0.1:8420/health
 # Should return {"status":"ok"} or {"status":"degraded"}
 ```
 
+**8. Troubleshoot unexpected recall data**
+
+If `/recall` returns another user's persona, scene paths, or data while your
+own data directory is empty, first confirm which Gateway process is actually
+serving port `8420`. On shared machines, WSL hosts, Docker hosts, SSH tunnels,
+or port-forwarded environments, `127.0.0.1:8420` may point to an older process
+or another user's sidecar.
+
+```bash
+sudo lsof -iTCP:8420 -sTCP:LISTEN -nP
+PID=$(sudo lsof -tiTCP:8420 -sTCP:LISTEN | head -1)
+sudo readlink /proc/$PID/cwd
+sudo tr '\0' '\n' < /proc/$PID/environ | grep -E '^(HOME|USER|TDAI_DATA_DIR)='
+sudo lsof -p $PID | grep memory-tencentdb
+```
+
+If the `cwd`, `HOME`, `USER`, or `TDAI_DATA_DIR` values point to another user
+or checkout, stop that Gateway or run your instance on a different port. Common
+causes are a previous process surviving a restart, two users sharing the same
+host port, Docker publishing `8420` only once per host, or an SSH/nginx/kubectl
+forward targeting the wrong process.
+
 > For the complete provider reference (environment variables, troubleshooting, LLM tool schemas, supervisor behavior), see [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md). Please read it before adjusting the supervisor / circuit-breaker defaults.
 
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -351,6 +351,26 @@ curl http://127.0.0.1:8420/health
 # 应返回 {"status":"ok"} 或 {"status":"degraded"}
 ```
 
+**8. 排查异常 recall 数据**
+
+如果 `/recall` 返回了其他用户的 persona、scene 路径或记忆数据，而你自己的
+dataDir 是空的，先确认 `8420` 端口实际命中了哪个 Gateway 进程。在共享机器、
+WSL、Docker、SSH 隧道或端口转发环境中，`127.0.0.1:8420` 可能仍然指向旧进程
+或其他用户的 sidecar。
+
+```bash
+sudo lsof -iTCP:8420 -sTCP:LISTEN -nP
+PID=$(sudo lsof -tiTCP:8420 -sTCP:LISTEN | head -1)
+sudo readlink /proc/$PID/cwd
+sudo tr '\0' '\n' < /proc/$PID/environ | grep -E '^(HOME|USER|TDAI_DATA_DIR)='
+sudo lsof -p $PID | grep memory-tencentdb
+```
+
+如果 `cwd`、`HOME`、`USER` 或 `TDAI_DATA_DIR` 指向其他用户或其他 checkout，
+请先停止那个 Gateway，或把你自己的实例换到不同端口。常见原因包括：旧进程在
+restart 后仍存活、多人共用同一个宿主机端口、Docker 的 `8420` 端口只能被一个
+容器发布、SSH/nginx/kubectl 转发到了错误进程。
+
 > Provider 的完整参考（环境变量、故障排查、LLM 工具 schema、supervisor 行为）见 [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md)，调整 supervisor / circuit-breaker 默认值之前请先读它。
 
 


### PR DESCRIPTION
## Description | 描述
Add README troubleshooting steps for unexpected `/recall` data that appears to come from another user.

The new note tells operators to verify which Gateway process owns port `8420`, inspect its `cwd`, `HOME`, `USER`, `TDAI_DATA_DIR`, and open memory-tencentdb files, then distinguish a real isolation problem from hitting an older or different sidecar process.

This is documentation-only and does not change runtime behavior.

## Related Issue | 关联 Issue
Related to #62

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with `npm test` and `npm run build` using Node v24.15.0.
