### PR TITLE
fix(hermes): advertise memory tools before gateway init

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/hermes-plugin/memory/memory_tencentdb/README.md
@@ -288,10 +288,11 @@ aliases:
   specific path, set `MEMORY_TENCENTDB_GATEWAY_CMD` explicitly — it always
   wins over discovery.
 - **Search tools silently missing from the LLM**: `get_tool_schemas()`
-  returns `[]` until either the Gateway is reachable or one of
-  `MEMORY_TENCENTDB_GATEWAY_CMD` / `MEMORY_TENCENTDB_GATEWAY_PORT` is set
-  in the environment. Set the env var so the tools are advertised
-  optimistically at registration time.
+  advertises both search tools before Gateway startup, so Hermes should not
+  show this provider as `tools=0` in zero-config mode. If it still does,
+  verify Hermes is loading this provider checkout/version rather than a stale
+  copy in another plugin directory, then restart Hermes so it rebuilds the
+  provider routing table.
 - **"circuit breaker tripped"** warnings: five consecutive Gateway errors
   were observed. Calls are paused for 60 s; check Gateway health and logs.
 - **Capture backlog warnings**: Gateway is slow or hung — `sync_turn` is

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -729,10 +729,9 @@ class MemoryTencentdbProvider(MemoryProvider):
             results or no-ops — no data is lost because capture will
             succeed once the Gateway comes up and subsequent turns will
             work normally.
-          * ``get_tool_schemas`` already returns schemas optimistically
-            (gated on ``_initialized``, not ``_gateway_available``),
-            so the tools appear in the LLM surface even before the
-            Gateway is ready.
+          * ``get_tool_schemas`` already returns schemas unconditionally,
+            so the tools appear in the LLM surface even before the provider
+            and Gateway are initialized.
         """
         self._session_id = session_id
         self._user_id = kwargs.get("user_id", "default")
@@ -758,8 +757,10 @@ class MemoryTencentdbProvider(MemoryProvider):
             api_key=api_key,
         )
 
-        # Mark as initialized immediately so tools are registered
-        # (get_tool_schemas checks _initialized, not _gateway_available).
+        # Mark as initialized immediately so lifecycle hooks can distinguish
+        # pre-init from post-init state. Tool registration is intentionally
+        # independent from this flag because Hermes may build tool routing
+        # before calling initialize().
         self._initialized = True
 
         def _background_start():
@@ -984,17 +985,14 @@ class MemoryTencentdbProvider(MemoryProvider):
     # -- Tools ----------------------------------------------------------------
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        # Optimistically return tool schemas if Gateway is configured or running.
-        # This is critical because MemoryManager.add_provider() calls
-        # get_tool_schemas() BEFORE initialize() to build the _tool_to_provider
-        # routing table. If we return [] here, tools won't be routable
-        # even after initialize() succeeds (despite _refresh_tool_registration).
-        if self._gateway_available or self._initialized:
-            return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
-        # Pre-init: check if Gateway is likely to be available
-        if os.environ.get("MEMORY_TENCENTDB_GATEWAY_CMD") or os.environ.get("MEMORY_TENCENTDB_GATEWAY_PORT"):
-            return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
-        return []
+        # Always advertise the tool contract. Hermes builds its tool routing
+        # table before initialize() in some startup paths, so tying schemas to
+        # Gateway/env availability can permanently register this provider with
+        # tools=0 even though zero-config auto-discovery later starts the
+        # sidecar successfully. Runtime calls are still guarded in
+        # handle_tool_call(), which returns a transient unavailable error while
+        # the Gateway is starting or disconnected.
+        return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         # Lazy probe — gives tool-call path the same self-heal opportunity

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -183,6 +183,30 @@ def provider_with_fake_supervisor(monkeypatch, fast_watchdog):
 
 
 # ---------------------------------------------------------------------------
+# Tool schema registration
+# ---------------------------------------------------------------------------
+
+
+def test_tool_schemas_are_advertised_before_initialize_without_gateway_env(monkeypatch):
+    """Hermes may ask for schemas before initialize() builds the Gateway.
+
+    Zero-config auto-discovery happens later during initialize(), so schema
+    registration must not depend on Gateway env vars or runtime availability.
+    """
+    monkeypatch.delenv("MEMORY_TENCENTDB_GATEWAY_CMD", raising=False)
+    monkeypatch.delenv("MEMORY_TENCENTDB_GATEWAY_PORT", raising=False)
+
+    provider = MemoryTencentdbProvider()
+
+    assert provider._initialized is False
+    assert provider._gateway_available is False
+    assert [schema["name"] for schema in provider.get_tool_schemas()] == [
+        "memory_tencentdb_memory_search",
+        "memory_tencentdb_conversation_search",
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Supervisor.is_process_alive
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description | 描述
Advertise the Hermes `memory_tencentdb` search tool schemas before Gateway initialization so Hermes can build its tool routing table correctly in zero-config auto-discovery mode.

Runtime tool calls still go through the existing Gateway availability checks and return a transient unavailable error while the sidecar is starting or disconnected.

## Related Issue | 关联 Issue
Fix #219

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with:
- `npm test`
- `npm run build`
- Python smoke test for pre-initialize `get_tool_schemas()` with no Gateway env vars

`python3 -m pytest hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py` could not be run in this environment because `pytest` is not installed.
