### PR TITLE
fix: support linux config paths with unified home resolution

### DIFF
--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 import { getEnv } from "../utils/env.js";
+import { candidateAppConfigFiles, optionalConfigFileExists, resolveHomeDir } from "../utils/config-paths.js";
 import { parseConfig as parseMemoryConfig } from "../config.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import { normalizeDisableThinking } from "../utils/no-think-fetch.js";
@@ -78,8 +79,9 @@ export interface GatewayConfig {
  * Resolution order for config file:
  * 1. `TDAI_GATEWAY_CONFIG` env var (explicit path)
  * 2. `./tdai-gateway.yaml` or `./tdai-gateway.json` in CWD
- * 3. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
- * 4. Pure environment-variable config (no file)
+ * 3. Linux/macOS/Windows app config dir (`~/.config/memory-tencentdb/` on Linux)
+ * 4. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
+ * 5. Pure environment-variable config (no file)
  */
 export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
   let fileConfig: Record<string, unknown> = {};
@@ -122,7 +124,7 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   // Data config (expand leading ~ to $HOME so Node.js fs/path can resolve it)
   const dataConfig = obj(fileConfig, "data");
   const rawBaseDir = env("TDAI_DATA_DIR") ?? str(dataConfig, "baseDir") ?? resolveDefaultDataDir();
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+  const home = resolveHomeDir();
   const baseDir = rawBaseDir.startsWith("~/") ? path.join(home, rawBaseDir.slice(2)) : rawBaseDir;
 
   // LLM config
@@ -169,26 +171,33 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
 function resolveConfigPath(): string | null {
   // 1. Explicit env var
   const explicit = getEnv("TDAI_GATEWAY_CONFIG")?.trim();
-  if (explicit && fs.existsSync(explicit)) return explicit;
+  if (explicit && optionalConfigFileExists(explicit, { missingLogLevel: "silent" })) return explicit;
 
   // 2. CWD
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(process.cwd(), name);
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p, { missingLogLevel: "silent" })) return p;
   }
 
-  // 3. Default data dir
+  // 3. Standard per-user config dir. On Linux this is
+  //    $XDG_CONFIG_HOME/memory-tencentdb or ~/.config/memory-tencentdb.
+  const home = resolveHomeDir();
+  for (const p of candidateAppConfigFiles("memory-tencentdb", ["tdai-gateway.yaml", "tdai-gateway.json"], home)) {
+    if (optionalConfigFileExists(p, { missingLogLevel: "silent" })) return p;
+  }
+
+  // 4. Default data dir
   const dataDir = resolveDefaultDataDir();
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(dataDir, name);
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p, { missingLogLevel: "silent" })) return p;
   }
 
   return null;
 }
 
 function resolveDefaultDataDir(): string {
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+  const home = resolveHomeDir();
 
   // New canonical location: everything related to standalone/Hermes-mode TDAI
   // is collected under ~/.memory-tencentdb/ to avoid scattering top-level dirs

--- a/src/utils/config-paths.test.ts
+++ b/src/utils/config-paths.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const osState = vi.hoisted(() => ({
+  homedirMock: vi.fn<typeof import("node:os").homedir>(),
+  userInfoMock: vi.fn<typeof import("node:os").userInfo>(),
+  actualHomedir: null as typeof import("node:os").homedir | null,
+  actualUserInfo: null as typeof import("node:os").userInfo | null,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  osState.actualHomedir = actual.homedir;
+  osState.actualUserInfo = actual.userInfo;
+  osState.homedirMock.mockImplementation(actual.homedir);
+  osState.userInfoMock.mockImplementation(actual.userInfo);
+  return {
+    ...actual,
+    homedir: osState.homedirMock,
+    userInfo: osState.userInfoMock,
+  };
+});
+
+import { loadGatewayConfig } from "../gateway/config.js";
+import {
+  _resetConfigPathWarningsForTest,
+  candidateAppConfigFiles,
+  optionalConfigFileExists,
+  resolveHomeDir,
+} from "./config-paths.js";
+import { ensurePluginHookPolicy } from "./ensure-hook-policy.js";
+import { resolveOpenClawStateDir } from "./openclaw-state-dir.js";
+
+describe("config path helpers", () => {
+  const originalCwd = process.cwd();
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.unstubAllEnvs();
+    _resetConfigPathWarningsForTest();
+    if (osState.actualHomedir) osState.homedirMock.mockImplementation(osState.actualHomedir);
+    if (osState.actualUserInfo) osState.userInfoMock.mockImplementation(osState.actualUserInfo);
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses XDG_CONFIG_HOME for Linux app config paths", () => {
+    vi.stubEnv("XDG_CONFIG_HOME", "/tmp/xdg-config");
+
+    expect(candidateAppConfigFiles("memory-tencentdb", ["tdai-gateway.json"], "/home/alice", "linux")).toEqual([
+      path.join("/tmp/xdg-config", "memory-tencentdb", "tdai-gateway.json"),
+    ]);
+  });
+
+  it("falls back to ~/.config for Linux app config paths", () => {
+    vi.stubEnv("XDG_CONFIG_HOME", "");
+
+    expect(candidateAppConfigFiles("memory-tencentdb", ["tdai-gateway.yaml"], "/home/alice", "linux")).toEqual([
+      path.join("/home/alice", ".config", "memory-tencentdb", "tdai-gateway.yaml"),
+    ]);
+  });
+
+  it("resolveHomeDir prefers os.homedir when HOME and USERPROFILE are unset", () => {
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", "");
+    osState.homedirMock.mockReturnValue("/home/alice");
+
+    expect(resolveHomeDir()).toBe("/home/alice");
+  });
+
+  it("resolveHomeDir prefers USERPROFILE when HOME is unset", () => {
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", "/profile/home");
+    osState.homedirMock.mockReturnValue("/passwd/home");
+
+    expect(resolveHomeDir()).toBe("/profile/home");
+  });
+
+  it("resolveHomeDir falls back to /tmp when homedir and userInfo are empty", () => {
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", "");
+    osState.homedirMock.mockReturnValue("");
+    osState.userInfoMock.mockImplementation(() => {
+      throw new Error("no passwd entry");
+    });
+
+    expect(resolveHomeDir()).toBe("/tmp");
+  });
+
+  it("loadGatewayConfig keeps config and data under the same resolved home", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "memory-tdai-home-consistency-"));
+    tempDirs.push(root);
+
+    const cwd = path.join(root, "cwd");
+    const home = path.join(root, "home");
+    const configDir = path.join(home, ".config", "memory-tencentdb");
+    fs.mkdirSync(cwd, { recursive: true });
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 9462 }, llm: { model: "from-xdg-config" } }),
+      "utf-8",
+    );
+
+    process.chdir(cwd);
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", "");
+    vi.stubEnv("XDG_CONFIG_HOME", "");
+    vi.stubEnv("TDAI_DATA_DIR", undefined as unknown as string);
+    vi.stubEnv("TDAI_GATEWAY_CONFIG", undefined as unknown as string);
+    vi.stubEnv("MEMORY_TENCENTDB_ROOT", undefined as unknown as string);
+    osState.homedirMock.mockReturnValue(home);
+
+    const cfg = loadGatewayConfig();
+
+    expect(cfg.server.port).toBe(9462);
+    expect(cfg.llm.model).toBe("from-xdg-config");
+    expect(cfg.data.baseDir).toBe(path.join(home, ".memory-tencentdb", "memory-tdai"));
+  });
+
+  it("can warn only once for missing optional config files", () => {
+    const missing = path.join(os.tmpdir(), `memory-tdai-missing-${Date.now()}`, "missing.json");
+    const warnings: string[] = [];
+
+    expect(optionalConfigFileExists(missing, {
+      missingLogLevel: "warn",
+      logger: { warn: (msg) => warnings.push(msg) },
+    })).toBe(false);
+    expect(optionalConfigFileExists(missing, {
+      missingLogLevel: "warn",
+      logger: { warn: (msg) => warnings.push(msg) },
+    })).toBe(false);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("optional config file missing, skipped");
+  });
+
+  it("loads gateway config from the Linux XDG config directory", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "memory-tdai-xdg-"));
+    tempDirs.push(root);
+
+    const cwd = path.join(root, "cwd");
+    const home = path.join(root, "home");
+    const xdg = path.join(root, "xdg");
+    const configDir = path.join(xdg, "memory-tencentdb");
+    fs.mkdirSync(cwd, { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 9461 }, llm: { model: "from-xdg-config" } }),
+      "utf-8",
+    );
+
+    process.chdir(cwd);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("XDG_CONFIG_HOME", xdg);
+    vi.stubEnv("TDAI_DATA_DIR", undefined as unknown as string);
+    vi.stubEnv("TDAI_GATEWAY_CONFIG", undefined as unknown as string);
+
+    const cfg = loadGatewayConfig();
+
+    expect(cfg.server.port).toBe(9461);
+    expect(cfg.llm.model).toBe("from-xdg-config");
+  });
+
+  it("reuses USERPROFILE fallback for OpenClaw config and state paths", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "memory-tdai-openclaw-profile-"));
+    tempDirs.push(root);
+
+    const profile = path.join(root, "profile");
+    const openclawDir = path.join(profile, ".openclaw");
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.mkdirSync(openclawDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}", "utf-8");
+
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", profile);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "");
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
+
+    ensurePluginHookPolicy({
+      rootConfig: {},
+      logger: {
+        info: () => {},
+        warn: () => {},
+      },
+    });
+
+    const patched = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(patched.plugins.entries["memory-tencentdb"].hooks.allowConversationAccess).toBe(true);
+    expect(resolveOpenClawStateDir(undefined)).toBe(openclawDir);
+  });
+});

--- a/src/utils/config-paths.ts
+++ b/src/utils/config-paths.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import { homedir, userInfo } from "node:os";
+import path from "node:path";
+import { getEnv } from "./env.js";
+
+interface ConfigPathLogger {
+  debug?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+type MissingConfigFileLogLevel = "silent" | "debug" | "warn";
+
+interface OptionalConfigFileOptions {
+  logger?: ConfigPathLogger;
+  missingLogLevel?: MissingConfigFileLogLevel;
+}
+
+const missingConfigFileWarnings = new Set<string>();
+
+/** Single home-directory resolver for all config path lookups. */
+export function resolveHomeDir(): string {
+  const fromEnv = getEnv("HOME")?.trim() || getEnv("USERPROFILE")?.trim();
+  if (fromEnv) return fromEnv;
+
+  const fromOs = homedir().trim();
+  if (fromOs) return fromOs;
+
+  try {
+    const fromPasswd = userInfo().homedir?.trim();
+    if (fromPasswd) return fromPasswd;
+  } catch {
+    // UID-only containers may lack a passwd entry.
+  }
+
+  return "/tmp";
+}
+
+function resolveLinuxConfigDir(home = resolveHomeDir()): string {
+  return getEnv("XDG_CONFIG_HOME")?.trim() || path.join(home, ".config");
+}
+
+function resolveAppConfigDir(appName: string, home = resolveHomeDir(), platform = process.platform): string {
+  if (platform === "linux") {
+    return path.join(resolveLinuxConfigDir(home), appName);
+  }
+  if (platform === "darwin") {
+    return path.join(home, "Library", "Application Support", appName);
+  }
+  if (platform === "win32") {
+    return path.join(getEnv("APPDATA")?.trim() || path.join(home, "AppData", "Roaming"), appName);
+  }
+  return path.join(home, `.${appName}`);
+}
+
+export function candidateAppConfigFiles(appName: string, fileNames: readonly string[], home = resolveHomeDir(), platform = process.platform): string[] {
+  const base = resolveAppConfigDir(appName, home, platform);
+  return fileNames.map((fileName) => path.join(base, fileName));
+}
+
+export function optionalConfigFileExists(filePath: string, options: OptionalConfigFileOptions = {}): boolean {
+  try {
+    const exists = fs.existsSync(filePath);
+    if (!exists) logMissingConfigFileOnce(filePath, options);
+    return exists;
+  } catch (err) {
+    if (isMissingPathError(err)) {
+      logMissingConfigFileOnce(filePath, options);
+      return false;
+    }
+    throw err;
+  }
+}
+
+function isMissingPathError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function logMissingConfigFileOnce(filePath: string, options: OptionalConfigFileOptions): void {
+  const level = options.missingLogLevel ?? "debug";
+  if (level === "silent" || missingConfigFileWarnings.has(filePath)) return;
+  missingConfigFileWarnings.add(filePath);
+
+  const message = `[memory-tdai] optional config file missing, skipped: ${filePath}`;
+  if (level === "warn") {
+    options.logger?.warn?.(message);
+  } else {
+    options.logger?.debug?.(message);
+  }
+}
+
+export function _resetConfigPathWarningsForTest(): void {
+  missingConfigFileWarnings.clear();
+}

--- a/src/utils/ensure-hook-policy.ts
+++ b/src/utils/ensure-hook-policy.ts
@@ -8,6 +8,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { optionalConfigFileExists, resolveHomeDir } from "./config-paths.js";
 import { getEnv } from "./env.js";
 import JSON5 from "json5";
 
@@ -142,20 +143,19 @@ function isGatewayStart(): boolean {
 function resolveConfigPath(): string | null {
   // 1. OPENCLAW_CONFIG_PATH env override (same as core uses)
   const envPath = getEnv("OPENCLAW_CONFIG_PATH")?.trim();
-  if (envPath && fs.existsSync(envPath)) return envPath;
+  if (envPath && optionalConfigFileExists(envPath)) return envPath;
 
   // 2. OPENCLAW_STATE_DIR override
   const stateDir = getEnv("OPENCLAW_STATE_DIR")?.trim();
   if (stateDir) {
     const p = path.join(stateDir, "openclaw.json");
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
   // 3. Standard location: ~/.openclaw/openclaw.json
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "";
-  if (!home) return null;
+  const home = resolveHomeDir();
   const p = path.join(home, ".openclaw", "openclaw.json");
-  return fs.existsSync(p) ? p : null;
+  return optionalConfigFileExists(p) ? p : null;
 }
 
 function hasPolicyAlready(root: unknown): boolean {

--- a/src/utils/openclaw-state-dir.ts
+++ b/src/utils/openclaw-state-dir.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os";
 import path from "node:path";
+import { resolveHomeDir } from "./config-paths.js";
 import { getEnv } from "./env.js";
 
 export interface OpenClawRuntimeStateLike {
@@ -30,6 +30,6 @@ export function resolveOpenClawStateDir(
   return (
     runtimeState?.resolveStateDir?.() ||
     getEnv("OPENCLAW_STATE_DIR")?.trim() ||
-    path.join(homedir(), ".openclaw")
+    path.join(resolveHomeDir(), ".openclaw")
   );
 }


### PR DESCRIPTION
## Description | 描述
<!-- Describe what this PR does | 请描述这个 PR 做了什么 -->
- checks the per-user app config directory before falling back to the data dir
  - Linux: `$XDG_CONFIG_HOME/memory-tencentdb` or `~/.config/memory-tencentdb`
  - macOS/Windows paths are supported by the same helper
- uses one shared home fallback chain for config lookup and default data dir:
  `HOME -> USERPROFILE -> os.homedir() -> userInfo().homedir -> /tmp`
- keeps missing optional config candidates silent, avoiding repeated missing-path noise
- adds regression tests for Linux config paths and home-resolution consistency

## Related Issue | 关联 Issue
Fix #103

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

