### PR TITLE
feat: add PostgreSQL memory store backend with pgvector + pg_textsearch

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -20,9 +20,9 @@
       },
       "storeBackend": {
         "type": "string",
-        "enum": ["sqlite", "tcvdb"],
+        "enum": ["sqlite", "tcvdb", "postgres"],
         "default": "sqlite",
-        "description": "存储后端：sqlite（本地 SQLite + sqlite-vec）或 tcvdb（腾讯云向量数据库）"
+        "description": "存储后端：sqlite（本地 SQLite + sqlite-vec）、tcvdb（腾讯云向量数据库）或 postgres（PostgreSQL + pgvector + pg_textsearch）"
       },
       "capture": {
         "type": "object",
@@ -113,6 +113,24 @@
           "embeddingModel": { "type": "string", "default": "bge-large-zh", "description": "服务端 embedding 模型" },
           "timeout": { "type": "number", "default": 10000, "description": "请求超时（毫秒）" },
           "caPemPath": { "type": "string", "description": "CA 证书 PEM 文件路径（HTTPS 连接时使用）" }
+        }
+      },
+      "postgres": {
+        "type": "object",
+        "description": "PostgreSQL 记忆层配置（仅 storeBackend=postgres 时生效）",
+        "properties": {
+          "host": { "type": "string", "default": "127.0.0.1", "description": "PostgreSQL 主机" },
+          "port": { "type": "number", "default": 5432, "description": "PostgreSQL 端口" },
+          "database": { "type": "string", "default": "postgres", "description": "数据库名" },
+          "user": { "type": "string", "default": "postgres", "description": "数据库用户" },
+          "password": { "type": "string", "description": "数据库密码；trust/peer 认证可不填" },
+          "schema": { "type": "string", "default": "agent_memory", "description": "记忆表所在 schema" },
+          "ssl": { "type": "boolean", "default": false, "description": "是否启用 SSL" },
+          "poolMax": { "type": "number", "default": 5, "description": "连接池最大连接数" },
+          "statementTimeoutMs": { "type": "number", "default": 10000, "description": "SQL 语句超时（毫秒）" },
+          "textConfig": { "type": "string", "default": "simple", "description": "pg_textsearch BM25 索引用的文本搜索配置；默认 simple（无需额外扩展），中文分词可填 jieba（映射为 public.jiebacfg，需 pg_jieba 扩展），也可填任意已安装的 text search configuration" },
+          "vectorIndex": { "type": "string", "enum": ["none", "hnsw", "ivfflat", "diskann"], "default": "hnsw", "description": "向量索引类型；diskann 需要 vectorscale" },
+          "useVectorScale": { "type": "boolean", "default": true, "description": "vectorIndex=diskann 时尝试使用 vectorscale StreamingDiskANN" }
         }
       },
       "bm25": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "ai": "^6.0.164",
     "js-tiktoken": "^1.0.18",
     "json5": "^2.2.3",
+    "pg": "^8.16.3",
     "sqlite-vec": "0.1.7-alpha.2",
     "tsx": "^4.21.0",
     "undici": "^8.1.0",
@@ -118,6 +119,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
+    "@types/pg": "^8.15.6",
     "@vitest/coverage-v8": "^4.1.2",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.2",

--- a/scripts/migrate-sqlite-to-tcvdb/sqlite-to-tcvdb.ts
+++ b/scripts/migrate-sqlite-to-tcvdb/sqlite-to-tcvdb.ts
@@ -75,7 +75,7 @@ export interface MigrationPreflightSummary {
     l1Count: number;
     profileCount: number;
     manifestExists: boolean;
-    manifestStoreType: "sqlite" | "tcvdb" | null;
+    manifestStoreType: "sqlite" | "tcvdb" | "postgres" | null;
   };
   target: {
     url: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,8 +173,36 @@ export interface TcvdbConfig {
   caPemPath?: string;
 }
 
+/** PostgreSQL memory store configuration. */
+export interface PostgresConfig {
+  /** PostgreSQL host (default: 127.0.0.1) */
+  host: string;
+  /** PostgreSQL port (default: 5432) */
+  port: number;
+  /** Database name (default: postgres) */
+  database: string;
+  /** Database user (default: postgres) */
+  user: string;
+  /** Database password (optional; omit for trust/peer auth) */
+  password?: string;
+  /** Schema for memory tables (default: agent_memory) */
+  schema: string;
+  /** Enable TLS/SSL for PostgreSQL connection */
+  ssl: boolean;
+  /** Max connections in node-postgres pool */
+  poolMax: number;
+  /** Statement timeout in milliseconds */
+  statementTimeoutMs: number;
+  /** Text search configuration for pg_textsearch BM25 indexes */
+  textConfig: string;
+  /** Vector index strategy for pgvector/vectorscale */
+  vectorIndex: "none" | "hnsw" | "ivfflat" | "diskann";
+  /** Try vectorscale StreamingDiskANN index when vectorIndex="diskann" */
+  useVectorScale: boolean;
+}
+
 /** Storage backend type. */
-export type StoreBackend = "sqlite" | "tcvdb";
+export type StoreBackend = "sqlite" | "tcvdb" | "postgres";
 
 /** Report settings — controls metric/event reporting. */
 export interface ReportConfig {
@@ -304,10 +332,12 @@ export interface MemoryTdaiConfig {
   pipeline: PipelineTriggerConfig;
   recall: RecallConfig;
   embedding: EmbeddingConfig;
-  /** Storage backend: "sqlite" (default) or "tcvdb" */
+  /** Storage backend: "sqlite" (default), "tcvdb", or "postgres" */
   storeBackend: StoreBackend;
   /** Tencent Cloud VectorDB configuration (required when storeBackend = "tcvdb") */
   tcvdb: TcvdbConfig;
+  /** PostgreSQL memory store configuration (used when storeBackend = "postgres") */
+  postgres: PostgresConfig;
   /** BM25 sparse vector encoding (local @tencentdb-agent-memory/tcvdb-text) */
   bm25: BM25Config;
   /** Local JSONL cleanup settings */
@@ -454,10 +484,13 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
 
   // --- Store backend ---
   const storeBackendRaw = str(c, "storeBackend") ?? "sqlite";
-  const storeBackend: StoreBackend = storeBackendRaw === "tcvdb" ? "tcvdb" : "sqlite";
+  const storeBackend: StoreBackend = validateStoreBackend(storeBackendRaw);
 
   // --- TCVDB config ---
   const tcvdbGroup = obj(c, "tcvdb");
+
+  // --- PostgreSQL config ---
+  const postgresGroup = obj(c, "postgres");
 
   const memoryCleanup: MemoryCleanupConfig = {
     retentionDays,
@@ -564,6 +597,20 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       timeout: num(tcvdbGroup, "timeout") ?? 10000,
       caPemPath: str(tcvdbGroup, "caPemPath") || undefined,
     },
+    postgres: {
+      host: str(postgresGroup, "host") ?? "127.0.0.1",
+      port: num(postgresGroup, "port") ?? 5432,
+      database: str(postgresGroup, "database") ?? "postgres",
+      user: str(postgresGroup, "user") ?? "postgres",
+      password: optStr(postgresGroup, "password"),
+      schema: str(postgresGroup, "schema") ?? "agent_memory",
+      ssl: bool(postgresGroup, "ssl") ?? false,
+      poolMax: num(postgresGroup, "poolMax") ?? 5,
+      statementTimeoutMs: num(postgresGroup, "statementTimeoutMs") ?? 10000,
+      textConfig: normalizeTextConfig(str(postgresGroup, "textConfig")),
+      vectorIndex: validateVectorIndex(str(postgresGroup, "vectorIndex")) ?? "hnsw",
+      useVectorScale: bool(postgresGroup, "useVectorScale") ?? true,
+    },
     bm25: {
       enabled: bool(bm25Group, "enabled") ?? true,
       language: (str(bm25Group, "language") === "en" ? "en" : "zh") as "zh" | "en",
@@ -634,6 +681,8 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_STORE_BACKENDS: StoreBackend[] = ["sqlite", "tcvdb", "postgres"];
+const VALID_VECTOR_INDEXES: PostgresConfig["vectorIndex"][] = ["none", "hnsw", "ivfflat", "diskann"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -644,6 +693,34 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
     : undefined;
+}
+
+function validateStoreBackend(value: string | undefined): StoreBackend {
+  return VALID_STORE_BACKENDS.includes(value as StoreBackend)
+    ? (value as StoreBackend)
+    : "sqlite";
+}
+
+function validateVectorIndex(value: string | undefined): PostgresConfig["vectorIndex"] | undefined {
+  if (!value) return undefined;
+  return VALID_VECTOR_INDEXES.includes(value as PostgresConfig["vectorIndex"])
+    ? (value as PostgresConfig["vectorIndex"])
+    : undefined;
+}
+
+/**
+ * Normalize the pg_textsearch text search configuration.
+ *
+ * Defaults to "simple" (no extra extension required). The friendly alias
+ * "jieba" (case-insensitive) maps to "public.jiebacfg" for Chinese word
+ * segmentation via the pg_jieba extension. Any other value is passed through
+ * verbatim so users can reference custom/installed configurations directly.
+ */
+function normalizeTextConfig(value: string | undefined): string {
+  const v = value?.trim();
+  if (!v) return "simple";
+  if (v.toLowerCase() === "jieba") return "public.jiebacfg";
+  return v;
 }
 
 /**

--- a/src/core/store/factory.ts
+++ b/src/core/store/factory.ts
@@ -5,6 +5,7 @@
  * Supports:
  * - "sqlite" (default): local SQLite + sqlite-vec + FTS5
  * - "tcvdb": Tencent Cloud VectorDB (server-side embedding + hybridSearch)
+ * - "postgres": PostgreSQL + pgvector + pg_textsearch
  */
 
 import path from "node:path";
@@ -12,6 +13,7 @@ import type { MemoryTdaiConfig } from "../../config.js";
 import type { IMemoryStore, IEmbeddingService, StoreLogger } from "./types.js";
 import { VectorStore } from "./sqlite.js";
 import { TcvdbMemoryStore } from "./tcvdb.js";
+import { PgMemoryStore } from "./postgres.js";
 import { createEmbeddingService, NoopEmbeddingService } from "./embedding.js";
 import type { EmbeddingService } from "./embedding.js";
 import { createBM25Encoder } from "./bm25-local.js";
@@ -83,6 +85,42 @@ export function createStoreBundle(
           tcvdbUrl: tcvdbCfg.url,
           tcvdbDatabase: database,
           tcvdbAlias: tcvdbCfg.alias || undefined,
+        },
+      };
+    }
+
+    case "postgres": {
+      const pgCfg = config.postgres;
+      let embeddingService: EmbeddingService | undefined;
+      if (config.embedding.enabled && config.embedding.provider !== "local" && config.embedding.apiKey) {
+        embeddingService = createEmbeddingService({
+          provider: config.embedding.provider,
+          baseUrl: config.embedding.baseUrl,
+          apiKey: config.embedding.apiKey,
+          model: config.embedding.model,
+          dimensions: config.embedding.dimensions,
+          sendDimensions: config.embedding.sendDimensions,
+          maxInputChars: config.embedding.maxInputChars,
+        }, logger);
+      }
+
+      const store = new PgMemoryStore(pgCfg, config.embedding.dimensions, logger);
+      logger?.debug?.(
+        `${TAG} Store created: backend=postgres, host=${pgCfg.host}, port=${pgCfg.port}, ` +
+        `database=${pgCfg.database}, schema=${pgCfg.schema}, dimensions=${config.embedding.dimensions}, ` +
+        `embedding=${embeddingService ? "enabled" : "disabled"}`,
+      );
+
+      return {
+        store,
+        embedding: embeddingService as unknown as IEmbeddingService,
+        bm25Encoder,
+        storeSnapshot: {
+          type: "postgres",
+          postgresHost: pgCfg.host,
+          postgresPort: pgCfg.port,
+          postgresDatabase: pgCfg.database,
+          postgresSchema: pgCfg.schema,
         },
       };
     }

--- a/src/core/store/postgres-schema.ts
+++ b/src/core/store/postgres-schema.ts
@@ -1,0 +1,354 @@
+import type { Pool, PoolClient } from "pg";
+import type { EmbeddingProviderInfo } from "./embedding.js";
+import type { StoreLogger } from "./types.js";
+
+const TAG = "[memory-tdai][postgres-schema]";
+
+export interface PostgresSchemaOptions {
+  schema: string;
+  dimensions: number;
+  textConfig: string;
+  vectorIndex: "none" | "hnsw" | "ivfflat" | "diskann";
+  useVectorScale: boolean;
+  logger?: StoreLogger;
+}
+
+export interface PostgresSchemaInitResult {
+  vectorAvailable: boolean;
+  ftsAvailable: boolean;
+  needsReindex: boolean;
+  reason?: string;
+}
+
+interface EmbeddingMeta {
+  provider: string;
+  model: string;
+  dimensions: number;
+}
+
+export const POSTGRES_TABLES = {
+  embeddingMeta: "embedding_meta",
+  l1: "l1_records",
+  l0: "l0_conversations",
+  profiles: "profiles",
+} as const;
+
+export function quoteIdent(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+export function qualifiedName(schema: string, name: string): string {
+  return `${quoteIdent(schema)}.${quoteIdent(name)}`;
+}
+
+export function postgresIndexName(schema: string, name: string): string {
+  return `${schema}_${name}`.replace(/[^a-zA-Z0-9_]/g, "_").slice(0, 60);
+}
+
+export async function initPostgresSchema(
+  pool: Pool,
+  options: PostgresSchemaOptions,
+  providerInfo?: EmbeddingProviderInfo,
+): Promise<PostgresSchemaInitResult> {
+  const result = await initWithRetry(pool, options, providerInfo, 0);
+  return result;
+}
+
+/**
+ * Retry wrapper for schema init.
+ *
+ * PostgreSQL 18 changed CREATE … IF NOT EXISTS semantics under concurrency:
+ * two sessions racing to create the same object may see
+ * "duplicate key value violates unique constraint pg_type_typname_nsp_index"
+ * instead of silently skipping. We retry once after a short delay; the winner
+ * already created everything, so the second attempt will be a no-op.
+ */
+async function initWithRetry(
+  pool: Pool,
+  options: PostgresSchemaOptions,
+  providerInfo: EmbeddingProviderInfo | undefined,
+  attempt: number,
+): Promise<PostgresSchemaInitResult> {
+  const client = await pool.connect();
+  try {
+    return await initWithClient(client, options, providerInfo);
+  } catch (err) {
+    client.release();
+    const message = errorMessage(err);
+    const isConcurrencyConflict =
+      message.includes("pg_type_typname_nsp_index") ||
+      message.includes("pg_class_relname_nsp_index") ||
+      message.includes("pg_namespace_nspname_index");
+    if (isConcurrencyConflict && attempt < 3) {
+      options.logger?.warn?.(
+        `${TAG} schema init conflict (attempt ${attempt + 1}), retrying after winner commits: ${message}`,
+      );
+      // Wait a beat for the winning session to commit its tables.
+      await new Promise((r) => setTimeout(r, 500 + attempt * 500));
+      return initWithRetry(pool, options, providerInfo, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+async function initWithClient(
+  client: PoolClient,
+  options: PostgresSchemaOptions,
+  providerInfo?: EmbeddingProviderInfo,
+): Promise<PostgresSchemaInitResult> {
+  const schema = options.schema;
+  let vectorAvailable = false;
+  let ftsAvailable = false;
+
+  await client.query(`CREATE SCHEMA IF NOT EXISTS ${quoteIdent(schema)}`);
+  await client.query(`CREATE EXTENSION IF NOT EXISTS vector`);
+  vectorAvailable = true;
+
+  if (options.useVectorScale || options.vectorIndex === "diskann") {
+    try {
+      await client.query(`CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE`);
+    } catch (err) {
+      options.logger?.warn?.(`${TAG} vectorscale unavailable, falling back to pgvector indexes: ${errorMessage(err)}`);
+    }
+  }
+
+  try {
+    await client.query(`CREATE EXTENSION IF NOT EXISTS pg_textsearch`);
+    ftsAvailable = true;
+  } catch (err) {
+    options.logger?.warn?.(`${TAG} pg_textsearch unavailable; FTS search disabled: ${errorMessage(err)}`);
+  }
+
+  await createTables(client, options);
+  const reindex = await updateEmbeddingMeta(client, options, providerInfo);
+  await createIndexes(client, options, ftsAvailable);
+
+  return {
+    vectorAvailable: vectorAvailable && options.dimensions > 0,
+    ftsAvailable,
+    needsReindex: reindex.needsReindex,
+    reason: reindex.reason,
+  };
+}
+
+async function createTables(client: PoolClient, options: PostgresSchemaOptions): Promise<void> {
+  const s = options.schema;
+  await tryDdl(client, options, POSTGRES_TABLES.embeddingMeta, `
+    CREATE TABLE IF NOT EXISTS ${qualifiedName(s, POSTGRES_TABLES.embeddingMeta)} (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `);
+
+  await tryDdl(client, options, POSTGRES_TABLES.l1, `
+    CREATE TABLE IF NOT EXISTS ${qualifiedName(s, POSTGRES_TABLES.l1)} (
+      record_id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT DEFAULT '',
+      priority INTEGER DEFAULT 50,
+      scene_name TEXT DEFAULT '',
+      session_key TEXT DEFAULT '',
+      session_id TEXT DEFAULT '',
+      timestamp_str TEXT DEFAULT '',
+      timestamp_start TEXT DEFAULT '',
+      timestamp_end TEXT DEFAULT '',
+      created_time TEXT DEFAULT '',
+      updated_time TEXT DEFAULT '',
+      metadata_json JSONB DEFAULT '{}'::jsonb,
+      embedding vector
+    )
+  `);
+
+  await tryDdl(client, options, POSTGRES_TABLES.l0, `
+    CREATE TABLE IF NOT EXISTS ${qualifiedName(s, POSTGRES_TABLES.l0)} (
+      record_id TEXT PRIMARY KEY,
+      session_key TEXT NOT NULL,
+      session_id TEXT DEFAULT '',
+      role TEXT NOT NULL DEFAULT '',
+      message_text TEXT NOT NULL,
+      recorded_at TEXT DEFAULT '',
+      timestamp BIGINT DEFAULT 0,
+      embedding vector
+    )
+  `);
+
+  await tryDdl(client, options, POSTGRES_TABLES.profiles, `
+    CREATE TABLE IF NOT EXISTS ${qualifiedName(s, POSTGRES_TABLES.profiles)} (
+      record_id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      filename TEXT NOT NULL,
+      content TEXT NOT NULL,
+      content_md5 TEXT NOT NULL,
+      agent_id TEXT DEFAULT '',
+      version INTEGER NOT NULL DEFAULT 1,
+      created_at_ms BIGINT NOT NULL DEFAULT 0,
+      updated_at_ms BIGINT NOT NULL DEFAULT 0
+    )
+  `);
+}
+
+async function createIndexes(client: PoolClient, options: PostgresSchemaOptions, ftsAvailable: boolean): Promise<void> {
+  const s = options.schema;
+  const idx = (suffix: string) => quoteIdent(postgresIndexName(s, suffix));
+  const tbl = (table: string) => qualifiedName(s, table);
+
+  const indexes: Array<{ label: string; sql: string }> = [
+    { label: "l1_type", sql: `CREATE INDEX IF NOT EXISTS ${idx("l1_type_idx")} ON ${tbl(POSTGRES_TABLES.l1)} (type)` },
+    { label: "l1_session_key", sql: `CREATE INDEX IF NOT EXISTS ${idx("l1_session_key_idx")} ON ${tbl(POSTGRES_TABLES.l1)} (session_key)` },
+    { label: "l1_session_id", sql: `CREATE INDEX IF NOT EXISTS ${idx("l1_session_id_idx")} ON ${tbl(POSTGRES_TABLES.l1)} (session_id)` },
+    { label: "l1_scene", sql: `CREATE INDEX IF NOT EXISTS ${idx("l1_scene_idx")} ON ${tbl(POSTGRES_TABLES.l1)} (scene_name)` },
+    { label: "l1_session_updated", sql: `CREATE INDEX IF NOT EXISTS ${idx("l1_session_updated_idx")} ON ${tbl(POSTGRES_TABLES.l1)} (session_id, updated_time)` },
+    { label: "l1_sessionkey_updated", sql: `CREATE INDEX IF NOT EXISTS ${idx("l1_sessionkey_updated_idx")} ON ${tbl(POSTGRES_TABLES.l1)} (session_key, updated_time)` },
+
+    { label: "l0_session", sql: `CREATE INDEX IF NOT EXISTS ${idx("l0_session_idx")} ON ${tbl(POSTGRES_TABLES.l0)} (session_key)` },
+    { label: "l0_session_id", sql: `CREATE INDEX IF NOT EXISTS ${idx("l0_session_id_idx")} ON ${tbl(POSTGRES_TABLES.l0)} (session_id)` },
+    { label: "l0_recorded", sql: `CREATE INDEX IF NOT EXISTS ${idx("l0_recorded_idx")} ON ${tbl(POSTGRES_TABLES.l0)} (recorded_at)` },
+    { label: "l0_timestamp", sql: `CREATE INDEX IF NOT EXISTS ${idx("l0_timestamp_idx")} ON ${tbl(POSTGRES_TABLES.l0)} (timestamp)` },
+
+    { label: "profiles_type", sql: `CREATE INDEX IF NOT EXISTS ${idx("profiles_type_idx")} ON ${tbl(POSTGRES_TABLES.profiles)} (type)` },
+    { label: "profiles_filename", sql: `CREATE INDEX IF NOT EXISTS ${idx("profiles_filename_idx")} ON ${tbl(POSTGRES_TABLES.profiles)} (filename)` },
+  ];
+
+  for (const { label, sql } of indexes) {
+    await tryDdl(client, options, label, sql);
+  }
+
+  if (options.dimensions > 0 && options.vectorIndex !== "none") {
+    await createVectorIndex(client, options, POSTGRES_TABLES.l1, "l1_embedding_idx");
+    await createVectorIndex(client, options, POSTGRES_TABLES.l0, "l0_embedding_idx");
+  }
+
+  if (ftsAvailable) {
+    await createBm25Index(client, options, POSTGRES_TABLES.l1, "content", "l1_content_bm25_idx");
+    await createBm25Index(client, options, POSTGRES_TABLES.l0, "message_text", "l0_message_bm25_idx");
+  }
+}
+
+async function createVectorIndex(
+  client: PoolClient,
+  options: PostgresSchemaOptions,
+  table: string,
+  indexSuffix: string,
+): Promise<void> {
+  const method = options.vectorIndex === "diskann" ? "diskann" : options.vectorIndex;
+  const indexName = quoteIdent(postgresIndexName(options.schema, indexSuffix));
+  const tableName = qualifiedName(options.schema, table);
+  const dims = options.dimensions;
+  const expression = `((embedding::vector(${dims}))) vector_cosine_ops`;
+  const where = `embedding IS NOT NULL AND vector_dims(embedding) = ${dims}`;
+  const sql = `CREATE INDEX IF NOT EXISTS ${indexName} ON ${tableName} USING ${method} (${expression}) WHERE ${where}`;
+
+  await tryDdl(client, options, indexSuffix, sql);
+}
+
+async function createBm25Index(
+  client: PoolClient,
+  options: PostgresSchemaOptions,
+  table: string,
+  column: string,
+  indexSuffix: string,
+): Promise<void> {
+  const indexName = quoteIdent(postgresIndexName(options.schema, indexSuffix));
+  const tableName = qualifiedName(options.schema, table);
+  const textConfig = options.textConfig.replaceAll("'", "''");
+  const sql = `CREATE INDEX IF NOT EXISTS ${indexName} ON ${tableName} USING bm25 (${quoteIdent(column)}) WITH (text_config='${textConfig}')`;
+
+  await tryDdl(client, options, indexSuffix, sql);
+}
+
+async function updateEmbeddingMeta(
+  client: PoolClient,
+  options: PostgresSchemaOptions,
+  providerInfo?: EmbeddingProviderInfo,
+): Promise<{ needsReindex: boolean; reason?: string }> {
+  if (!providerInfo) return { needsReindex: false };
+
+  const table = qualifiedName(options.schema, POSTGRES_TABLES.embeddingMeta);
+  const row = await client.query<{ value: string }>(`SELECT value FROM ${table} WHERE key = $1`, ["embedding_provider_info"]);
+  const saved = parseEmbeddingMeta(row.rows[0]?.value);
+  const next: EmbeddingMeta = {
+    provider: providerInfo.provider,
+    model: providerInfo.model,
+    dimensions: options.dimensions,
+  };
+
+  let needsReindex = false;
+  let reason: string | undefined;
+  if (saved) {
+    const changes: string[] = [];
+    if (saved.provider !== next.provider) changes.push(`provider: ${saved.provider} → ${next.provider}`);
+    if (saved.model !== next.model) changes.push(`model: ${saved.model} → ${next.model}`);
+    if (saved.dimensions !== next.dimensions) changes.push(`dimensions: ${saved.dimensions} → ${next.dimensions}`);
+    if (changes.length > 0) {
+      needsReindex = true;
+      reason = changes.join(", ");
+      await client.query(`UPDATE ${qualifiedName(options.schema, POSTGRES_TABLES.l1)} SET embedding = NULL`);
+      await client.query(`UPDATE ${qualifiedName(options.schema, POSTGRES_TABLES.l0)} SET embedding = NULL`);
+    }
+  } else {
+    const counts = await client.query<{ cnt: string }>(`
+      SELECT
+        (SELECT COUNT(*) FROM ${qualifiedName(options.schema, POSTGRES_TABLES.l1)}) +
+        (SELECT COUNT(*) FROM ${qualifiedName(options.schema, POSTGRES_TABLES.l0)}) AS cnt
+    `);
+    if (Number(counts.rows[0]?.cnt ?? 0) > 0) {
+      needsReindex = true;
+      reason = "legacy PostgreSQL store without embedding_meta — cannot verify vector compatibility";
+    }
+  }
+
+  await client.query(
+    `INSERT INTO ${table} (key, value) VALUES ($1, $2)
+     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+    ["embedding_provider_info", JSON.stringify(next)],
+  );
+
+  return { needsReindex, reason };
+}
+
+function parseEmbeddingMeta(value: string | undefined): EmbeddingMeta | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<EmbeddingMeta>;
+    if (!parsed.provider || !parsed.model || typeof parsed.dimensions !== "number") return null;
+    return parsed as EmbeddingMeta;
+  } catch {
+    return null;
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Execute a DDL statement safely under concurrent init.
+ *
+ * PostgreSQL 18 may throw pg_type_typname_nsp_index / pg_class_relname_nsp_index
+ * when two sessions race on CREATE … IF NOT EXISTS for the same object.
+ * The winner created the object; we just skip past this DDL.
+ */
+async function tryDdl(
+  client: PoolClient,
+  options: PostgresSchemaOptions,
+  label: string,
+  sql: string,
+): Promise<void> {
+  try {
+    await client.query(sql);
+  } catch (err) {
+    const message = errorMessage(err);
+    if (
+      message.includes("pg_type_typname_nsp_index") ||
+      message.includes("pg_class_relname_nsp_index") ||
+      message.includes("pg_namespace_nspname_index")
+    ) {
+      // Object already exists — concurrent session won the race.
+      options.logger?.debug?.(
+        `${TAG} concurrent DDL skipped (${label}): ${message}`,
+      );
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/core/store/postgres.test.ts
+++ b/src/core/store/postgres.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+import { PgMemoryStore } from "./postgres.js";
+import type { PostgresConfig } from "../../config.js";
+
+const runPostgresTests = process.env.TDAI_POSTGRES_TEST === "1";
+const describePostgres = runPostgresTests ? describe : describe.skip;
+
+const schema = `agent_memory_test_${process.pid}`;
+const config: PostgresConfig = {
+  host: process.env.TDAI_PGHOST ?? "127.0.0.1",
+  port: Number(process.env.TDAI_PGPORT ?? 5432),
+  database: process.env.TDAI_PGDATABASE ?? "postgres",
+  user: process.env.TDAI_PGUSER ?? "postgres",
+  password: process.env.TDAI_PGPASSWORD,
+  schema,
+  ssl: false,
+  poolMax: 2,
+  statementTimeoutMs: 10000,
+  textConfig: "simple",
+  vectorIndex: "none",
+  useVectorScale: false,
+};
+
+describePostgres("PgMemoryStore", () => {
+  let store: PgMemoryStore;
+
+  beforeAll(async () => {
+    const pool = new Pool(config);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await pool.end();
+
+    store = new PgMemoryStore(config, 3);
+    const init = await store.init({ provider: "test", model: "unit" });
+    expect(store.isDegraded()).toBe(false);
+    expect(init.needsReindex).toBe(false);
+  });
+
+  afterAll(async () => {
+    store?.close();
+    const pool = new Pool(config);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await pool.end();
+  });
+
+  it("persists and searches L1 and L0 records", async () => {
+    await expect(store.upsertL1({
+      id: "l1-a",
+      content: "PostgreSQL stores durable agent memory",
+      type: "persona",
+      priority: 80,
+      scene_name: "database",
+      source_message_ids: [],
+      metadata: {},
+      timestamps: ["2026-01-01T00:00:00.000Z"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      sessionKey: "session-key",
+      sessionId: "session-id",
+    }, new Float32Array([1, 0, 0]))).resolves.toBe(true);
+
+    await expect(store.upsertL0({
+      id: "l0-a",
+      sessionKey: "session-key",
+      sessionId: "session-id",
+      role: "user",
+      messageText: "Please remember the PostgreSQL backend design",
+      recordedAt: "2026-01-01T00:00:01.000Z",
+      timestamp: 1767225601000,
+    }, new Float32Array([1, 0, 0]))).resolves.toBe(true);
+
+    await expect(store.countL1()).resolves.toBe(1);
+    await expect(store.countL0()).resolves.toBe(1);
+
+    const l1Vec = await store.searchL1Vector(new Float32Array([1, 0, 0]), 1);
+    expect(l1Vec[0]?.record_id).toBe("l1-a");
+
+    const l0Vec = await store.searchL0Vector(new Float32Array([1, 0, 0]), 1);
+    expect(l0Vec[0]?.record_id).toBe("l0-a");
+
+    if (store.isFtsAvailable()) {
+      const l1Fts = await store.searchL1Fts("PostgreSQL", 1);
+      expect(l1Fts[0]?.record_id).toBe("l1-a");
+
+      const l0Fts = await store.searchL0Fts("PostgreSQL", 1);
+      expect(l0Fts[0]?.record_id).toBe("l0-a");
+    }
+  });
+
+  it("syncs profiles with optimistic versions", async () => {
+    await store.syncProfiles([{
+      id: "profile:l3:test",
+      type: "l3",
+      filename: "persona.md",
+      content: "User prefers PostgreSQL-backed memory.",
+      contentMd5: "md5-a",
+      version: 0,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      baselineVersion: 0,
+    }]);
+
+    const profiles = await store.pullProfiles();
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0].version).toBe(1);
+  });
+});

--- a/src/core/store/postgres.ts
+++ b/src/core/store/postgres.ts
@@ -1,0 +1,996 @@
+import { Pool, type PoolClient } from "pg";
+import type { PostgresConfig } from "../../config.js";
+import type { MemoryRecord } from "../record/l1-writer.js";
+import type { EmbeddingProviderInfo } from "./embedding.js";
+import type {
+  IMemoryStore,
+  L0FtsResult,
+  L0QueryRow,
+  L0Record,
+  L0SearchResult,
+  L0SessionGroup,
+  L1FtsResult,
+  L1QueryFilter,
+  L1RecordRow,
+  L1SearchResult,
+  ProfileRecord,
+  ProfileSyncRecord,
+  StoreCapabilities,
+  StoreInitResult,
+  StoreLogger,
+} from "./types.js";
+import {
+  initPostgresSchema,
+  postgresIndexName,
+  POSTGRES_TABLES,
+  qualifiedName,
+  quoteIdent,
+} from "./postgres-schema.js";
+
+const TAG = "[memory-tdai][postgres]";
+const ZERO_VEC_BUFFER = 10;
+const FTS_DEFAULT_LIMIT = 20;
+const DELETE_RATIO_LIMIT = 0.8;
+
+export class PgMemoryStore implements IMemoryStore {
+  readonly supportsDeferredEmbedding = true;
+
+  private readonly pool: Pool;
+  private readonly config: PostgresConfig;
+  private readonly dimensions: number;
+  private readonly logger?: StoreLogger;
+  private degraded = false;
+  private closed = false;
+  private vectorAvailable = false;
+  private ftsAvailable = false;
+
+  constructor(config: PostgresConfig, dimensions: number, logger?: StoreLogger) {
+    this.config = config;
+    this.dimensions = dimensions;
+    this.logger = logger;
+    this.pool = new Pool({
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.user,
+      password: config.password,
+      ssl: config.ssl ? { rejectUnauthorized: false } : undefined,
+      max: config.poolMax,
+      statement_timeout: config.statementTimeoutMs,
+      application_name: "tencentdb-agent-memory",
+    });
+
+    this.pool.on("connect", (client) => {
+      void client.query(`SET search_path TO ${quoteIdent(config.schema)}, public`).catch((err: unknown) => {
+        this.logger?.warn?.(`${TAG} failed to set search_path: ${errorMessage(err)}`);
+      });
+    });
+  }
+
+  async init(providerInfo?: EmbeddingProviderInfo): Promise<StoreInitResult> {
+    try {
+      const result = await initPostgresSchema(
+        this.pool,
+        {
+          schema: this.config.schema,
+          dimensions: this.dimensions,
+          textConfig: this.config.textConfig,
+          vectorIndex: this.config.vectorIndex,
+          useVectorScale: this.config.useVectorScale,
+          logger: this.logger,
+        },
+        providerInfo,
+      );
+      this.vectorAvailable = result.vectorAvailable;
+      this.ftsAvailable = result.ftsAvailable;
+      this.degraded = false;
+      this.logger?.debug?.(
+        `${TAG} initialized: ${this.safeConnectionLabel()}, schema=${this.config.schema}, ` +
+        `vector=${this.vectorAvailable}, fts=${this.ftsAvailable}`,
+      );
+      return { needsReindex: result.needsReindex, reason: result.reason };
+    } catch (err) {
+      this.degraded = true;
+      const message = errorMessage(err);
+      this.logger?.error?.(`${TAG} init failed; entering degraded mode: ${message}`);
+      return { needsReindex: false, reason: message };
+    }
+  }
+
+  isDegraded(): boolean {
+    return this.degraded;
+  }
+
+  getCapabilities(): StoreCapabilities {
+    return {
+      vectorSearch: !this.degraded && this.vectorAvailable,
+      ftsSearch: !this.degraded && this.ftsAvailable,
+      nativeHybridSearch: !this.degraded && this.ftsAvailable && this.vectorAvailable,
+      sparseVectors: false,
+    };
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    void this.pool.end().catch((err: unknown) => {
+      this.logger?.warn?.(`${TAG} close failed: ${errorMessage(err)}`);
+    });
+  }
+
+  async upsertL1(record: MemoryRecord, embedding?: Float32Array): Promise<boolean> {
+    if (this.degraded) return false;
+    const tsStr = record.timestamps[0] ?? "";
+    const tsStart = record.timestamps.length > 0 ? record.timestamps.reduce((a, b) => (a < b ? a : b)) : tsStr;
+    const tsEnd = record.timestamps.length > 0 ? record.timestamps.reduce((a, b) => (a > b ? a : b)) : tsStr;
+    const vec = this.prepareVector(embedding);
+
+    try {
+      await this.pool.query(
+        `INSERT INTO ${this.table(POSTGRES_TABLES.l1)} (
+           record_id, content, type, priority, scene_name, session_key, session_id,
+           timestamp_str, timestamp_start, timestamp_end, created_time, updated_time,
+           metadata_json, embedding
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::jsonb,$14::vector)
+         ON CONFLICT (record_id) DO UPDATE SET
+           content = EXCLUDED.content,
+           type = EXCLUDED.type,
+           priority = EXCLUDED.priority,
+           scene_name = EXCLUDED.scene_name,
+           session_key = EXCLUDED.session_key,
+           session_id = EXCLUDED.session_id,
+           timestamp_str = EXCLUDED.timestamp_str,
+           timestamp_start = EXCLUDED.timestamp_start,
+           timestamp_end = EXCLUDED.timestamp_end,
+           updated_time = EXCLUDED.updated_time,
+           metadata_json = EXCLUDED.metadata_json,
+           embedding = COALESCE(EXCLUDED.embedding, ${this.table(POSTGRES_TABLES.l1)}.embedding)`,
+        [
+          record.id,
+          record.content,
+          record.type,
+          record.priority,
+          record.scene_name,
+          record.sessionKey,
+          record.sessionId,
+          tsStr,
+          tsStart,
+          tsEnd,
+          record.createdAt,
+          record.updatedAt,
+          JSON.stringify(record.metadata ?? {}),
+          vec,
+        ],
+      );
+      return true;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-upsert] FAILED id=${record.id}: ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  async upsertL1Batch(records: MemoryRecord[]): Promise<number> {
+    if (this.degraded || records.length === 0) return 0;
+    if (records.length === 1) return (await this.upsertL1(records[0])) ? 1 : 0;
+
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      let ok = 0;
+      for (const record of records) {
+        const tsStr = record.timestamps[0] ?? "";
+        const tsStart = record.timestamps.length > 0 ? record.timestamps.reduce((a, b) => (a < b ? a : b)) : tsStr;
+        const tsEnd = record.timestamps.length > 0 ? record.timestamps.reduce((a, b) => (a > b ? a : b)) : tsStr;
+        const vec = this.prepareVector(undefined);
+        await client.query(
+          `INSERT INTO ${this.table(POSTGRES_TABLES.l1)} (
+             record_id, content, type, priority, scene_name, session_key, session_id,
+             timestamp_str, timestamp_start, timestamp_end, created_time, updated_time,
+             metadata_json, embedding
+           ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::jsonb,$14::vector)
+           ON CONFLICT (record_id) DO UPDATE SET
+             content = EXCLUDED.content,
+             type = EXCLUDED.type,
+             priority = EXCLUDED.priority,
+             scene_name = EXCLUDED.scene_name,
+             session_key = EXCLUDED.session_key,
+             session_id = EXCLUDED.session_id,
+             timestamp_str = EXCLUDED.timestamp_str,
+             timestamp_start = EXCLUDED.timestamp_start,
+             timestamp_end = EXCLUDED.timestamp_end,
+             updated_time = EXCLUDED.updated_time,
+             metadata_json = EXCLUDED.metadata_json,
+             embedding = COALESCE(EXCLUDED.embedding, ${this.table(POSTGRES_TABLES.l1)}.embedding)`,
+          [
+            record.id, record.content, record.type, record.priority,
+            record.scene_name, record.sessionKey, record.sessionId,
+            tsStr, tsStart, tsEnd, record.createdAt, record.updatedAt,
+            JSON.stringify(record.metadata ?? {}), vec,
+          ],
+        );
+        ok++;
+      }
+      await client.query("COMMIT");
+      return ok;
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      this.logger?.warn?.(`${TAG} [L1-upsert-batch] FAILED (${records.length} records): ${errorMessage(err)}`);
+      return 0;
+    } finally {
+      client.release();
+    }
+  }
+
+  async deleteL1(recordId: string): Promise<boolean> {
+    if (this.degraded) return false;
+    try {
+      await this.pool.query(`DELETE FROM ${this.table(POSTGRES_TABLES.l1)} WHERE record_id = $1`, [recordId]);
+      return true;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-delete] FAILED id=${recordId}: ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  async deleteL1Batch(recordIds: string[]): Promise<boolean> {
+    if (this.degraded) return false;
+    if (recordIds.length === 0) return true;
+    try {
+      await this.pool.query(`DELETE FROM ${this.table(POSTGRES_TABLES.l1)} WHERE record_id = ANY($1::text[])`, [recordIds]);
+      return true;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-delete-batch] FAILED: ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  async deleteL1Expired(cutoffIso: string): Promise<number> {
+    return this.deleteExpired(POSTGRES_TABLES.l1, "updated_time", cutoffIso, "L1");
+  }
+
+  async countL1(): Promise<number> {
+    return this.countTable(POSTGRES_TABLES.l1);
+  }
+
+  async queryL1Records(filter?: L1QueryFilter): Promise<L1RecordRow[]> {
+    if (this.degraded) return [];
+    try {
+      const conditions: string[] = [];
+      const values: unknown[] = [];
+      if (filter?.sessionId) {
+        values.push(filter.sessionId);
+        conditions.push(`session_id = $${values.length}`);
+      } else if (filter?.sessionKey) {
+        values.push(filter.sessionKey);
+        conditions.push(`session_key = $${values.length}`);
+      }
+      if (filter?.updatedAfter) {
+        values.push(filter.updatedAfter);
+        conditions.push(`updated_time > $${values.length}`);
+      }
+      const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+      const rows = await this.pool.query<L1RecordRow>(`
+        SELECT ${this.l1Columns()}
+        FROM ${this.table(POSTGRES_TABLES.l1)}
+        ${where}
+        ORDER BY updated_time ASC
+      `, values);
+      return rows.rows;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-query] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async getAllL1Texts(): Promise<Array<{ record_id: string; content: string; updated_time: string }>> {
+    if (this.degraded) return [];
+    try {
+      const rows = await this.pool.query<{ record_id: string; content: string; updated_time: string }>(
+        `SELECT record_id, content, updated_time FROM ${this.table(POSTGRES_TABLES.l1)} ORDER BY record_id ASC`,
+      );
+      return rows.rows;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-all-texts] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async searchL1Vector(queryEmbedding: Float32Array, topK = 5): Promise<L1SearchResult[]> {
+    if (this.degraded || !this.vectorAvailable || !this.isValidQueryVector(queryEmbedding)) return [];
+    try {
+      const limit = topK + ZERO_VEC_BUFFER;
+      const rows = await this.pool.query<L1SearchResult>({
+        name: "search_l1_vector_v1",
+        text: `
+          SELECT ${this.l1SearchColumns()}, 1 - (embedding <=> $1::vector) AS score
+          FROM ${this.table(POSTGRES_TABLES.l1)}
+          WHERE embedding IS NOT NULL AND vector_dims(embedding) = $2
+          ORDER BY embedding <=> $1::vector
+          LIMIT $3
+        `,
+        values: [vectorToSql(queryEmbedding), this.dimensions, limit],
+      });
+      return rows.rows.slice(0, topK).map(normalizeL1Score);
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-vector] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async searchL1Fts(ftsQuery: string, limit = FTS_DEFAULT_LIMIT): Promise<L1FtsResult[]> {
+    if (this.degraded || !this.ftsAvailable) return [];
+    const query = normalizeBm25Query(ftsQuery);
+    if (!query) return [];
+    try {
+      const rows = await this.pool.query<L1FtsResult & { rank: number }>({
+        name: "search_l1_fts_v1",
+        text: `
+          SELECT ${this.l1SearchColumns()}, content <@> to_bm25query($1, $3) AS rank
+          FROM ${this.table(POSTGRES_TABLES.l1)}
+          WHERE content <@> to_bm25query($1, $3) > 0
+          ORDER BY content <@> to_bm25query($1, $3)
+          LIMIT $2
+        `,
+        values: [query, limit, postgresIndexName(this.config.schema, "l1_content_bm25_idx")],
+      });
+      return rows.rows.map((row) => ({ ...row, score: bm25RankToScore(Number(row.rank)) }));
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-fts] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async searchL1Hybrid(params: {
+    query?: string;
+    queryEmbedding?: Float32Array;
+    topK?: number;
+  }): Promise<L1SearchResult[]> {
+    const topK = params.topK ?? 5;
+
+    // Native single-SQL RRF only when BOTH modalities are usable; otherwise fall
+    // through to the parallel + client-side RRF path so a single available
+    // modality still degrades gracefully instead of returning empty.
+    const normalizedFts = params.query ? normalizeBm25Query(params.query) : undefined;
+    if (
+      normalizedFts &&
+      params.queryEmbedding &&
+      this.isValidQueryVector(params.queryEmbedding) &&
+      !this.degraded &&
+      this.ftsAvailable &&
+      this.vectorAvailable
+    ) {
+      return this.searchL1HybridNative(
+        normalizedFts,
+        vectorToSql(params.queryEmbedding),
+        topK,
+      );
+    }
+
+    // Fallback: parallel calls + client-side RRF (when only one modality available)
+    const [fts, vec] = await Promise.all([
+      params.query ? this.searchL1Fts(params.query, topK * 3) : Promise.resolve([]),
+      params.queryEmbedding ? this.searchL1Vector(params.queryEmbedding, topK * 3) : Promise.resolve([]),
+    ]);
+    return rrfMergeL1(fts, vec).slice(0, topK);
+  }
+
+  /**
+   * Single-SQL hybrid search: BM25 + vector with Reciprocal Rank Fusion (RRF).
+   *
+   * Optimizations over naive approach:
+   * - BM25 CTE filters score > 0 to exclude irrelevant results from fusion
+   * - Both CTEs carry full row data, eliminating the final JOIN back to the main table
+   * - COALESCE on FULL OUTER JOIN produces correct RRF even when a record only appears in one path
+   */
+  private async searchL1HybridNative(
+    ftsQuery: string,
+    vectorLiteral: string,
+    topK: number,
+  ): Promise<L1SearchResult[]> {
+    if (this.degraded || !this.ftsAvailable || !this.vectorAvailable) return [];
+    const candidateK = topK * 3;
+    const dims = this.dimensions;
+    const idxName = postgresIndexName(this.config.schema, "l1_content_bm25_idx");
+    const tbl = this.table(POSTGRES_TABLES.l1);
+    const cols = `record_id, content, type, priority, scene_name,
+      timestamp_str, timestamp_start, timestamp_end, session_key, session_id,
+      metadata_json::text AS metadata_json`;
+
+    try {
+      const rows = await this.pool.query<L1SearchResult>({
+        name: "l1_hybrid_native_v2",
+        text: `
+        WITH fts AS (
+          SELECT ${cols},
+                 row_number() OVER (ORDER BY content <@> to_bm25query($1, $2)) AS rnk
+          FROM ${tbl}
+          WHERE content <@> to_bm25query($1, $2) > 0
+          ORDER BY content <@> to_bm25query($1, $2)
+          LIMIT $3
+        ),
+        vec AS (
+          SELECT ${cols},
+                 row_number() OVER (ORDER BY embedding <=> $4::vector) AS rnk
+          FROM ${tbl}
+          WHERE embedding IS NOT NULL AND vector_dims(embedding) = $5
+          ORDER BY embedding <=> $4::vector
+          LIMIT $3
+        ),
+        fused AS (
+          SELECT COALESCE(fts.record_id, vec.record_id) AS record_id,
+                 COALESCE(fts.content, vec.content) AS content,
+                 COALESCE(fts.type, vec.type) AS type,
+                 COALESCE(fts.priority, vec.priority) AS priority,
+                 COALESCE(fts.scene_name, vec.scene_name) AS scene_name,
+                 COALESCE(fts.timestamp_str, vec.timestamp_str) AS timestamp_str,
+                 COALESCE(fts.timestamp_start, vec.timestamp_start) AS timestamp_start,
+                 COALESCE(fts.timestamp_end, vec.timestamp_end) AS timestamp_end,
+                 COALESCE(fts.session_key, vec.session_key) AS session_key,
+                 COALESCE(fts.session_id, vec.session_id) AS session_id,
+                 COALESCE(fts.metadata_json, vec.metadata_json) AS metadata_json,
+                 COALESCE(1.0 / (60 + fts.rnk), 0) + COALESCE(1.0 / (60 + vec.rnk), 0) AS score
+          FROM fts
+          FULL OUTER JOIN vec ON fts.record_id = vec.record_id
+        )
+        SELECT record_id, content, type, priority, scene_name,
+               timestamp_str, timestamp_start, timestamp_end, session_key, session_id,
+               metadata_json, score
+        FROM fused
+        ORDER BY score DESC
+        LIMIT $6
+      `,
+        values: [ftsQuery, idxName, candidateK, vectorLiteral, dims, topK],
+      });
+      return rows.rows.map(normalizeL1Score);
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L1-hybrid-native] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async upsertL0(record: L0Record, embedding?: Float32Array): Promise<boolean> {
+    if (this.degraded) return false;
+    const vec = this.prepareVector(embedding);
+    try {
+      await this.pool.query(
+        `INSERT INTO ${this.table(POSTGRES_TABLES.l0)} (
+           record_id, session_key, session_id, role, message_text, recorded_at, timestamp, embedding
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::vector)
+         ON CONFLICT (record_id) DO UPDATE SET
+           session_key = EXCLUDED.session_key,
+           session_id = EXCLUDED.session_id,
+           role = EXCLUDED.role,
+           message_text = EXCLUDED.message_text,
+           recorded_at = EXCLUDED.recorded_at,
+           timestamp = EXCLUDED.timestamp,
+           embedding = COALESCE(EXCLUDED.embedding, ${this.table(POSTGRES_TABLES.l0)}.embedding)`,
+        [record.id, record.sessionKey, record.sessionId, record.role, record.messageText, record.recordedAt, record.timestamp, vec],
+      );
+      return true;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-upsert] FAILED id=${record.id}: ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  async upsertL0Batch(records: L0Record[]): Promise<number> {
+    if (this.degraded || records.length === 0) return 0;
+    if (records.length === 1) return (await this.upsertL0(records[0])) ? 1 : 0;
+
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      let ok = 0;
+      for (const record of records) {
+        const vec = this.prepareVector(undefined);
+        await client.query(
+          `INSERT INTO ${this.table(POSTGRES_TABLES.l0)} (
+             record_id, session_key, session_id, role, message_text, recorded_at, timestamp, embedding
+           ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::vector)
+           ON CONFLICT (record_id) DO UPDATE SET
+             session_key = EXCLUDED.session_key,
+             session_id = EXCLUDED.session_id,
+             role = EXCLUDED.role,
+             message_text = EXCLUDED.message_text,
+             recorded_at = EXCLUDED.recorded_at,
+             timestamp = EXCLUDED.timestamp,
+             embedding = COALESCE(EXCLUDED.embedding, ${this.table(POSTGRES_TABLES.l0)}.embedding)`,
+          [record.id, record.sessionKey, record.sessionId, record.role, record.messageText, record.recordedAt, record.timestamp, vec],
+        );
+        ok++;
+      }
+      await client.query("COMMIT");
+      return ok;
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      this.logger?.warn?.(`${TAG} [L0-upsert-batch] FAILED (${records.length} records): ${errorMessage(err)}`);
+      return 0;
+    } finally {
+      client.release();
+    }
+  }
+
+  async updateL0Embedding(recordId: string, embedding: Float32Array): Promise<boolean> {
+    if (this.degraded || !this.vectorAvailable) return false;
+    const vec = this.prepareVector(embedding);
+    if (!vec) return false;
+    try {
+      await this.pool.query(`UPDATE ${this.table(POSTGRES_TABLES.l0)} SET embedding = $2::vector WHERE record_id = $1`, [recordId, vec]);
+      return true;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-update-embedding] FAILED id=${recordId}: ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  async deleteL0(recordId: string): Promise<boolean> {
+    if (this.degraded) return false;
+    try {
+      await this.pool.query(`DELETE FROM ${this.table(POSTGRES_TABLES.l0)} WHERE record_id = $1`, [recordId]);
+      return true;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-delete] FAILED id=${recordId}: ${errorMessage(err)}`);
+      return false;
+    }
+  }
+
+  async deleteL0Expired(cutoffIso: string): Promise<number> {
+    return this.deleteExpired(POSTGRES_TABLES.l0, "recorded_at", cutoffIso, "L0");
+  }
+
+  async countL0(): Promise<number> {
+    return this.countTable(POSTGRES_TABLES.l0);
+  }
+
+  async queryL0ForL1(sessionKey: string, afterRecordedAtMs?: number, limit = 50): Promise<L0QueryRow[]> {
+    if (this.degraded) return [];
+    try {
+      const values: unknown[] = [sessionKey];
+      let where = "session_key = $1";
+      if (afterRecordedAtMs && afterRecordedAtMs > 0) {
+        values.push(new Date(afterRecordedAtMs).toISOString());
+        where += ` AND recorded_at > $${values.length}`;
+      }
+      values.push(limit);
+      const rows = await this.pool.query<L0QueryRow>(`
+        SELECT record_id, session_key, session_id, role, message_text, recorded_at, timestamp::bigint AS timestamp
+        FROM ${this.table(POSTGRES_TABLES.l0)}
+        WHERE ${where}
+        ORDER BY recorded_at DESC
+        LIMIT $${values.length}
+      `, values);
+      return rows.rows.map(normalizeL0Row).reverse();
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-query] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async queryL0GroupedBySessionId(sessionKey: string, afterRecordedAtMs?: number, limit = 50): Promise<L0SessionGroup[]> {
+    const rows = await this.queryL0ForL1(sessionKey, afterRecordedAtMs, limit);
+    const groups = new Map<string, L0SessionGroup["messages"]>();
+    for (const row of rows) {
+      const group = groups.get(row.session_id) ?? [];
+      group.push({
+        id: row.record_id,
+        role: row.role,
+        content: row.message_text,
+        timestamp: row.timestamp,
+        recordedAtMs: row.recorded_at ? Date.parse(row.recorded_at) || 0 : 0,
+      });
+      groups.set(row.session_id, group);
+    }
+    return [...groups.entries()]
+      .map(([sessionId, messages]) => ({ sessionId, messages }))
+      .sort((a, b) => (a.messages[0]?.timestamp ?? 0) - (b.messages[0]?.timestamp ?? 0));
+  }
+
+  async getAllL0Texts(): Promise<Array<{ record_id: string; message_text: string; recorded_at: string }>> {
+    if (this.degraded) return [];
+    try {
+      const rows = await this.pool.query<{ record_id: string; message_text: string; recorded_at: string }>(
+        `SELECT record_id, message_text, recorded_at FROM ${this.table(POSTGRES_TABLES.l0)} ORDER BY record_id ASC`,
+      );
+      return rows.rows;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-all-texts] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async searchL0Vector(queryEmbedding: Float32Array, topK = 5): Promise<L0SearchResult[]> {
+    if (this.degraded || !this.vectorAvailable || !this.isValidQueryVector(queryEmbedding)) return [];
+    try {
+      const limit = topK + ZERO_VEC_BUFFER;
+      const rows = await this.pool.query<L0SearchResult>({
+        name: "search_l0_vector_v1",
+        text: `
+          SELECT record_id, session_key, session_id, role, message_text,
+                 1 - (embedding <=> $1::vector) AS score,
+                 recorded_at, timestamp::bigint AS timestamp
+          FROM ${this.table(POSTGRES_TABLES.l0)}
+          WHERE embedding IS NOT NULL AND vector_dims(embedding) = $2
+          ORDER BY embedding <=> $1::vector
+          LIMIT $3
+        `,
+        values: [vectorToSql(queryEmbedding), this.dimensions, limit],
+      });
+      return rows.rows.slice(0, topK).map(normalizeL0SearchRow);
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-vector] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async searchL0Fts(ftsQuery: string, limit = FTS_DEFAULT_LIMIT): Promise<L0FtsResult[]> {
+    if (this.degraded || !this.ftsAvailable) return [];
+    const query = normalizeBm25Query(ftsQuery);
+    if (!query) return [];
+    try {
+      const rows = await this.pool.query<L0FtsResult & { rank: number }>({
+        name: "search_l0_fts_v1",
+        text: `
+          SELECT record_id, session_key, session_id, role, message_text,
+                 message_text <@> to_bm25query($1, $3) AS rank,
+                 recorded_at, timestamp::bigint AS timestamp
+          FROM ${this.table(POSTGRES_TABLES.l0)}
+          WHERE message_text <@> to_bm25query($1, $3) > 0
+          ORDER BY message_text <@> to_bm25query($1, $3)
+          LIMIT $2
+        `,
+        values: [query, limit, postgresIndexName(this.config.schema, "l0_message_bm25_idx")],
+      });
+      return rows.rows.map((row) => ({ ...normalizeL0SearchRow(row), score: bm25RankToScore(Number(row.rank)) }));
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [L0-fts] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async pullProfiles(): Promise<ProfileRecord[]> {
+    if (this.degraded) return [];
+    try {
+      const rows = await this.pool.query<{
+        record_id: string;
+        type: "l2" | "l3";
+        filename: string;
+        content: string;
+        content_md5: string;
+        agent_id: string;
+        version: number;
+        created_at_ms: string;
+        updated_at_ms: string;
+      }>(`
+        SELECT record_id, type, filename, content, content_md5, agent_id, version,
+               created_at_ms::bigint AS created_at_ms, updated_at_ms::bigint AS updated_at_ms
+        FROM ${this.table(POSTGRES_TABLES.profiles)}
+        ORDER BY type ASC, filename ASC
+      `);
+      return rows.rows.map((row) => ({
+        id: row.record_id,
+        type: row.type === "l3" ? "l3" : "l2",
+        filename: row.filename,
+        content: row.content,
+        contentMd5: row.content_md5,
+        agentId: row.agent_id || undefined,
+        version: Number(row.version ?? 0),
+        createdAtMs: Number(row.created_at_ms ?? 0),
+        updatedAtMs: Number(row.updated_at_ms ?? 0),
+      }));
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [profiles-pull] FAILED: ${errorMessage(err)}`);
+      return [];
+    }
+  }
+
+  async syncProfiles(records: ProfileSyncRecord[]): Promise<void> {
+    if (this.degraded || records.length === 0) return;
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      for (const record of records) {
+        await this.syncProfile(client, record);
+      }
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      this.logger?.warn?.(`${TAG} [profiles-sync] FAILED: ${errorMessage(err)}`);
+    } finally {
+      client.release();
+    }
+  }
+
+  async deleteProfiles(recordIds: string[]): Promise<void> {
+    if (this.degraded || recordIds.length === 0) return;
+    try {
+      await this.pool.query(`DELETE FROM ${this.table(POSTGRES_TABLES.profiles)} WHERE record_id = ANY($1::text[])`, [recordIds]);
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [profiles-delete] FAILED: ${errorMessage(err)}`);
+    }
+  }
+
+  async reindexAll(
+    embedFn: (text: string) => Promise<Float32Array>,
+    onProgress?: (done: number, total: number, layer: "L1" | "L0") => void,
+  ): Promise<{ l1Count: number; l0Count: number }> {
+    if (this.degraded || !this.vectorAvailable) return { l1Count: 0, l0Count: 0 };
+    const BATCH_SIZE = 20;
+    const CONCURRENCY = 4;
+
+    const l1Count = await this.reindexLayer(
+      POSTGRES_TABLES.l1, "content", "L1", embedFn, onProgress, BATCH_SIZE, CONCURRENCY,
+    );
+    const l0Count = await this.reindexLayer(
+      POSTGRES_TABLES.l0, "message_text", "L0", embedFn, onProgress, BATCH_SIZE, CONCURRENCY,
+    );
+    return { l1Count, l0Count };
+  }
+
+  /**
+   * Reindex a single layer with batched embedding + batched UPDATE.
+   *
+   * Improvements over the naive serial approach:
+   * - Paginated cursor read (avoids loading all rows into memory)
+   * - Concurrent embedding calls (up to CONCURRENCY in flight)
+   * - Batched UPDATE via unnest (single round-trip per batch)
+   */
+  private async reindexLayer(
+    table: string,
+    textColumn: string,
+    label: "L1" | "L0",
+    embedFn: (text: string) => Promise<Float32Array>,
+    onProgress?: (done: number, total: number, layer: "L1" | "L0") => void,
+    batchSize = 20,
+    concurrency = 4,
+  ): Promise<number> {
+    const total = await this.countTable(table);
+    if (total === 0) return 0;
+
+    let done = 0;
+    let offset = 0;
+
+    while (true) {
+      const batch = await this.pool.query<{ record_id: string; text: string }>(
+        `SELECT record_id, ${quoteIdent(textColumn)} AS text FROM ${this.table(table)} ORDER BY record_id LIMIT $1 OFFSET $2`,
+        [batchSize, offset],
+      );
+      if (batch.rows.length === 0) break;
+
+      // Concurrent embedding with bounded parallelism
+      const embedResults: Array<{ id: string; vec: string | null }> = [];
+      for (let i = 0; i < batch.rows.length; i += concurrency) {
+        const chunk = batch.rows.slice(i, i + concurrency);
+        const results = await Promise.allSettled(
+          chunk.map(async (row) => {
+            const embedding = await embedFn(row.text);
+            return { id: row.record_id, vec: this.prepareVector(embedding) };
+          }),
+        );
+        for (const result of results) {
+          if (result.status === "fulfilled" && result.value.vec) {
+            embedResults.push(result.value);
+          } else if (result.status === "rejected") {
+            this.logger?.warn?.(`${TAG} [reindex-${label}] embed failed: ${errorMessage(result.reason)}`);
+          }
+        }
+      }
+
+      // Batched UPDATE via unnest (single SQL for entire batch)
+      if (embedResults.length > 0) {
+        const ids = embedResults.map((r) => r.id);
+        const vecs = embedResults.map((r) => r.vec!);
+        try {
+          await this.pool.query(
+            `UPDATE ${this.table(table)} AS t
+             SET embedding = data.vec::vector
+             FROM (SELECT unnest($1::text[]) AS rid, unnest($2::text[]) AS vec) AS data
+             WHERE t.record_id = data.rid`,
+            [ids, vecs],
+          );
+        } catch (err) {
+          this.logger?.warn?.(`${TAG} [reindex-${label}] batch update failed: ${errorMessage(err)}`);
+        }
+      }
+
+      done += batch.rows.length;
+      offset += batchSize;
+      onProgress?.(done, total, label);
+    }
+    return done;
+  }
+
+  isFtsAvailable(): boolean {
+    return !this.degraded && this.ftsAvailable;
+  }
+
+  private async syncProfile(client: PoolClient, record: ProfileSyncRecord): Promise<void> {
+    const current = await client.query<{ version: number; content_md5: string; created_at_ms: string }>(
+      `SELECT version, content_md5, created_at_ms::bigint AS created_at_ms FROM ${this.table(POSTGRES_TABLES.profiles)} WHERE record_id = $1 FOR UPDATE`,
+      [record.id],
+    );
+    const now = Date.now();
+    if (current.rows.length === 0) {
+      await client.query(
+        `INSERT INTO ${this.table(POSTGRES_TABLES.profiles)}
+         (record_id, type, filename, content, content_md5, agent_id, version, created_at_ms, updated_at_ms)
+         VALUES ($1,$2,$3,$4,$5,$6,1,$7,$8)`,
+        [record.id, record.type, record.filename, record.content, record.contentMd5, record.agentId ?? "", record.createdAtMs || now, now],
+      );
+      return;
+    }
+
+    const row = current.rows[0];
+    if (row.content_md5 === record.contentMd5) return;
+    const currentVersion = Number(row.version ?? 0);
+    if ((record.baselineVersion ?? 0) !== currentVersion) {
+      this.logger?.warn?.(`${TAG} [profiles-sync] conflict for ${record.filename}: remote version ${currentVersion}, baseline ${record.baselineVersion ?? 0}`);
+      return;
+    }
+
+    await client.query(
+      `UPDATE ${this.table(POSTGRES_TABLES.profiles)}
+       SET type=$2, filename=$3, content=$4, content_md5=$5, agent_id=$6,
+           version=$7, updated_at_ms=$8
+       WHERE record_id=$1`,
+      [record.id, record.type, record.filename, record.content, record.contentMd5, record.agentId ?? "", currentVersion + 1, now],
+    );
+  }
+
+  private async deleteExpired(table: string, column: string, cutoffIso: string, label: string): Promise<number> {
+    if (this.degraded) return 0;
+    try {
+      const total = await this.countTable(table);
+      if (total <= 0) return 0;
+      const expired = await this.pool.query<{ cnt: string }>(
+        `SELECT COUNT(*) AS cnt FROM ${this.table(table)} WHERE ${quoteIdent(column)} != '' AND ${quoteIdent(column)} < $1`,
+        [cutoffIso],
+      );
+      const expiredCount = Number(expired.rows[0]?.cnt ?? 0);
+      if (expiredCount <= 0) return 0;
+      if (expiredCount / total > DELETE_RATIO_LIMIT) {
+        this.logger?.warn?.(`${TAG} [${label}-delete-expired] blocked: would delete ${expiredCount}/${total}`);
+        return 0;
+      }
+      const result = await this.pool.query(
+        `DELETE FROM ${this.table(table)} WHERE ${quoteIdent(column)} != '' AND ${quoteIdent(column)} < $1`,
+        [cutoffIso],
+      );
+      const deleted = result.rowCount ?? expiredCount;
+
+      // After significant deletions, hint autovacuum to reclaim dead tuples.
+      // This prevents index bloat (especially DiskANN/HNSW) from degrading
+      // search performance over time. Fire-and-forget; non-blocking.
+      if (deleted > 50) {
+        void this.pool.query(`VACUUM ANALYZE ${this.table(table)}`).catch((vacErr: unknown) => {
+          this.logger?.debug?.(`${TAG} [${label}-vacuum] non-critical: ${errorMessage(vacErr)}`);
+        });
+      }
+
+      return deleted;
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [${label}-delete-expired] FAILED: ${errorMessage(err)}`);
+      return 0;
+    }
+  }
+
+  private async countTable(table: string): Promise<number> {
+    if (this.degraded) return 0;
+    try {
+      const rows = await this.pool.query<{ cnt: string }>(`SELECT COUNT(*) AS cnt FROM ${this.table(table)}`);
+      return Number(rows.rows[0]?.cnt ?? 0);
+    } catch (err) {
+      this.logger?.warn?.(`${TAG} [count:${table}] FAILED: ${errorMessage(err)}`);
+      return 0;
+    }
+  }
+
+  private prepareVector(embedding?: Float32Array): string | null {
+    if (!embedding || embedding.length === 0 || embedding.every((v) => v === 0)) return null;
+    if (this.dimensions <= 0 || embedding.length !== this.dimensions) {
+      this.logger?.warn?.(`${TAG} embedding dimension mismatch: got=${embedding.length}, expected=${this.dimensions}`);
+      return null;
+    }
+    return vectorToSql(embedding);
+  }
+
+  private isValidQueryVector(embedding: Float32Array): boolean {
+    return this.dimensions > 0 && embedding.length === this.dimensions && !embedding.every((v) => v === 0);
+  }
+
+  private table(name: string): string {
+    return qualifiedName(this.config.schema, name);
+  }
+
+  private l1Columns(): string {
+    return `record_id, content, type, priority, scene_name, session_key, session_id,
+      timestamp_str, timestamp_start, timestamp_end, created_time, updated_time,
+      metadata_json::text AS metadata_json`;
+  }
+
+  private l1SearchColumns(prefix = ""): string {
+    const p = prefix ? `${prefix}.` : "";
+    return `${p}record_id, ${p}content, ${p}type, ${p}priority, ${p}scene_name,
+      ${p}timestamp_str, ${p}timestamp_start, ${p}timestamp_end, ${p}session_key, ${p}session_id,
+      ${p}metadata_json::text AS metadata_json`;
+  }
+
+  private safeConnectionLabel(): string {
+    return `${this.config.host}:${this.config.port}/${this.config.database}`;
+  }
+}
+
+function vectorToSql(embedding: Float32Array): string {
+  return `[${Array.from(embedding, (value) => Number.isFinite(value) ? String(value) : "0").join(",")}]`;
+}
+
+// Common Chinese stopwords that are too generic for BM25 precision
+const ZH_STOPWORDS = new Set([
+  "的", "了", "在", "是", "我", "有", "和", "就", "不", "人",
+  "都", "一", "一个", "上", "也", "很", "到", "说", "要", "去",
+  "你", "会", "着", "没有", "看", "好", "自己", "这", "他", "她",
+  "它", "那", "这个", "那个", "什么", "怎么", "如何", "可以", "能",
+  "吗", "吧", "呢", "啊", "哦", "把", "被", "让", "给", "从",
+  "但", "而", "或", "与", "及", "等", "之", "所", "以", "因",
+  "为", "对", "于", "用", "来", "做", "中", "大", "小", "多",
+]);
+
+const MAX_BM25_TOKENS = 8;
+
+function normalizeBm25Query(ftsQuery: string): string {
+  const tokens = ftsQuery
+    .match(/[\p{L}\p{N}_-]+/gu)
+    ?.filter((token) => {
+      // Remove BM25 logical operators
+      if (/^(OR|AND|NOT)$/i.test(token)) return false;
+      // Remove single-character CJK tokens (too generic)
+      if (token.length === 1 && /\p{Script=Han}/u.test(token)) return false;
+      // Remove common Chinese stopwords
+      if (ZH_STOPWORDS.has(token)) return false;
+      return true;
+    }) ?? [];
+
+  // Deduplicate and cap at MAX_BM25_TOKENS to maintain precision
+  const unique = [...new Set(tokens)];
+  return unique.slice(0, MAX_BM25_TOKENS).join(" ");
+}
+
+function bm25RankToScore(rank: number): number {
+  if (!Number.isFinite(rank)) return 1 / 1000;
+  if (rank < 0) {
+    const relevance = -rank;
+    return relevance / (1 + relevance);
+  }
+  return 1 / (1 + rank);
+}
+
+function normalizeL1Score<T extends L1SearchResult>(row: T): T {
+  return { ...row, score: Number(row.score ?? 0) };
+}
+
+function normalizeL0Row<T extends L0QueryRow>(row: T): T {
+  return { ...row, timestamp: Number(row.timestamp ?? 0) };
+}
+
+function normalizeL0SearchRow<T extends L0SearchResult | L0FtsResult>(row: T): T {
+  return { ...row, score: Number(row.score ?? 0), timestamp: Number(row.timestamp ?? 0) };
+}
+
+function rrfMergeL1(fts: L1FtsResult[], vec: L1SearchResult[]): L1SearchResult[] {
+  const map = new Map<string, { item: L1SearchResult; score: number }>();
+  for (const list of [fts, vec]) {
+    for (let rank = 0; rank < list.length; rank++) {
+      const item = list[rank] as L1SearchResult;
+      const score = 1 / (60 + rank + 1);
+      const existing = map.get(item.record_id);
+      if (existing) existing.score += score;
+      else map.set(item.record_id, { item, score });
+    }
+  }
+  return [...map.values()]
+    .sort((a, b) => b.score - a.score)
+    .map(({ item, score }) => ({ ...item, score }));
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -20,7 +20,7 @@ import path from "node:path";
 // ============================
 
 export interface ManifestStoreInfo {
-  type: "sqlite" | "tcvdb";
+  type: "sqlite" | "tcvdb" | "postgres";
   sqlite?: {
     /** Relative path to the SQLite DB file (relative to dataDir). */
     path: string;
@@ -30,6 +30,12 @@ export interface ManifestStoreInfo {
     database: string;
     /** User-friendly alias (optional). */
     alias?: string;
+  };
+  postgres?: {
+    host: string;
+    port: number;
+    database: string;
+    schema: string;
   };
 }
 
@@ -101,11 +107,15 @@ export function writeManifest(dataDir: string, manifest: Manifest): void {
 // ============================
 
 export interface StoreConfigSnapshot {
-  type: "sqlite" | "tcvdb";
+  type: "sqlite" | "tcvdb" | "postgres";
   sqlitePath?: string;
   tcvdbUrl?: string;
   tcvdbDatabase?: string;
   tcvdbAlias?: string;
+  postgresHost?: string;
+  postgresPort?: number;
+  postgresDatabase?: string;
+  postgresSchema?: string;
 }
 
 /**
@@ -115,11 +125,18 @@ export function buildStoreInfo(snapshot: StoreConfigSnapshot): ManifestStoreInfo
   const info: ManifestStoreInfo = { type: snapshot.type };
   if (snapshot.type === "sqlite") {
     info.sqlite = { path: snapshot.sqlitePath ?? "vectors.db" };
-  } else {
+  } else if (snapshot.type === "tcvdb") {
     info.tcvdb = {
       url: snapshot.tcvdbUrl!,
       database: snapshot.tcvdbDatabase!,
       alias: snapshot.tcvdbAlias || undefined,
+    };
+  } else {
+    info.postgres = {
+      host: snapshot.postgresHost ?? "127.0.0.1",
+      port: snapshot.postgresPort ?? 5432,
+      database: snapshot.postgresDatabase ?? "postgres",
+      schema: snapshot.postgresSchema ?? "agent_memory",
     };
   }
   return info;
@@ -152,6 +169,21 @@ export function diffStoreBinding(
     }
     if (persisted.tcvdb?.database !== current.tcvdb?.database) {
       diffs.push(`tcvdb database changed: ${persisted.tcvdb?.database} → ${current.tcvdb?.database}`);
+    }
+  }
+
+  if (persisted.type === "postgres" && current.type === "postgres") {
+    if (persisted.postgres?.host !== current.postgres?.host) {
+      diffs.push(`postgres host changed: ${persisted.postgres?.host} → ${current.postgres?.host}`);
+    }
+    if (persisted.postgres?.port !== current.postgres?.port) {
+      diffs.push(`postgres port changed: ${persisted.postgres?.port} → ${current.postgres?.port}`);
+    }
+    if (persisted.postgres?.database !== current.postgres?.database) {
+      diffs.push(`postgres database changed: ${persisted.postgres?.database} → ${current.postgres?.database}`);
+    }
+    if (persisted.postgres?.schema !== current.postgres?.schema) {
+      diffs.push(`postgres schema changed: ${persisted.postgres?.schema} → ${current.postgres?.schema}`);
     }
   }
 


### PR DESCRIPTION
- Add PgMemoryStore implementing IMemoryStore interface
- Support L0/L1 CRUD, vector search, BM25 full-text search, hybrid RRF
- Add pgvector (HNSW/IVFFlat/DiskANN) and vectorscale StreamingDiskANN
- Add pg_textsearch BM25 index with configurable text configuration
- Add SQLite-to-PostgreSQL migration CLI tool
- Extend config.ts, factory.ts, manifest.ts for postgres backend
- Add openclaw.plugin.json schema for postgres config
- Add integration tests (opt-in via TDAI_POSTGRES_TEST=1)
- Update README.md and README_CN.md with PostgreSQL usage docs

## Description | 描述
<!-- Describe what this PR does | 请描述这个 PR 做了什么 -->

## Related Issue | 关联 Issue
<!-- Example: Fix #123 | 例如：Fix #123 -->

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
<!-- Optional | 可选 -->