### PR TITLE
fix(tcvdb): escape session filter literals

### DIFF
--- a/src/core/store/tcvdb.test.ts
+++ b/src/core/store/tcvdb.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { TcvdbMemoryStore } from "./tcvdb.js";
+
+function createStoreWithCapturedQueryFilters(): {
+  store: TcvdbMemoryStore;
+  filters: string[];
+} {
+  const filters: string[] = [];
+  const store = new TcvdbMemoryStore({
+    url: "http://127.0.0.1",
+    username: "root",
+    apiKey: "test-key",
+    database: "testdb",
+    embeddingModel: "bge-large-zh",
+    timeout: 1000,
+  });
+
+  Object.assign(store as unknown as Record<string, unknown>, {
+    client: {
+      query: async (_collection: string, params: Record<string, unknown>) => {
+        filters.push(String(params.filter ?? ""));
+        return { documents: [] };
+      },
+    },
+    _initPromise: Promise.resolve(),
+  });
+
+  return { store, filters };
+}
+
+describe("TcvdbMemoryStore filter expressions", () => {
+  it("escapes session string literals before building query filters", async () => {
+    const { store, filters } = createStoreWithCapturedQueryFilters();
+    const sessionKey = 'alpha" or session_key = "beta';
+    const sessionId = 'sid\\quote" or session_id = "other';
+    const updatedAfter = "2026-01-02T03:04:05.000Z";
+
+    await store.queryL1Records({ sessionKey, sessionId, updatedAfter });
+    await store.queryL0ForL1(sessionKey, 123);
+
+    expect(filters).toEqual([
+      `session_key = "alpha\\" or session_key = \\"beta" and session_id = "sid\\\\quote\\" or session_id = \\"other" and updated_time_ms > ${Date.parse(updatedAfter)}`,
+      `session_key = "alpha\\" or session_key = \\"beta" and recorded_at_ms > 123`,
+    ]);
+  });
+});

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -98,6 +98,10 @@ function epochMsToIso(ms: number): string {
   return new Date(ms).toISOString();
 }
 
+function tcvdbStringLiteral(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}"`;
+}
+
 /**
  * Extract agent ID from a sessionKey like `agent:<agentId>:<channel>`.
  * Returns empty string if the format doesn't match.
@@ -573,8 +577,8 @@ export class TcvdbMemoryStore implements IMemoryStore {
 
       // Build TCVDB filter expression from L1QueryFilter
       const conditions: string[] = [];
-      if (filter?.sessionKey) conditions.push(`session_key = "${filter.sessionKey}"`);
-      if (filter?.sessionId) conditions.push(`session_id = "${filter.sessionId}"`);
+      if (filter?.sessionKey) conditions.push(`session_key = ${tcvdbStringLiteral(filter.sessionKey)}`);
+      if (filter?.sessionId) conditions.push(`session_id = ${tcvdbStringLiteral(filter.sessionId)}`);
       if (filter?.updatedAfter) {
         const afterMs = isoToEpochMs(filter.updatedAfter);
         if (afterMs > 0) conditions.push(`updated_time_ms > ${afterMs}`);
@@ -873,7 +877,7 @@ export class TcvdbMemoryStore implements IMemoryStore {
       await this._ensureInit();
       if (this.degraded) return [];
 
-      const conditions: string[] = [`session_key = "${sessionKey}"`];
+      const conditions: string[] = [`session_key = ${tcvdbStringLiteral(sessionKey)}`];
       if (afterRecordedAtMs && afterRecordedAtMs > 0) {
         conditions.push(`recorded_at_ms > ${afterRecordedAtMs}`);
       }


### PR DESCRIPTION
## Summary
- Escape backslashes and double quotes before interpolating `session_key` / `session_id` into TCVDB filter expressions.
- Add a regression test that captures generated L1/L0 query filters for injection-shaped session values.

## Verification
- `npm test -- --run`
- `npm run build`