### PR TITLE
fix(offload): invalidate token cache after stripping deleted tool_use blocks

### DIFF
--- a/src/offload/hooks/before-prompt-build.ts
+++ b/src/offload/hooks/before-prompt-build.ts
@@ -8,7 +8,7 @@
  */
 import { PLUGIN_DEFAULTS } from "../types.js";
 import { readOffloadEntries, markOffloadStatus } from "../storage.js";
-import { buildTiktokenContextSnapshot } from "../context-token-tracker.js";
+import { buildTiktokenContextSnapshot, invalidateTokenCache } from "../context-token-tracker.js";
 import { traceOffloadDecision } from "../opik-tracer.js";
 import { injectMmdIntoMessages, findHistoryMmdInsertionPoint } from "../mmd-injector.js";
 import { createL3TokenCounter } from "../l3-token-counter.js";
@@ -101,15 +101,18 @@ export function createBeforePromptBuildHandler(
         if (hasDeleted && isAssistantMessageWithToolUse(msg) && !isOnlyToolUseAssistant(msg)) {
           const content = msg.type === "message" ? msg.message?.content : msg.content;
           if (Array.isArray(content)) {
+            let stripped = false;
             for (let j = content.length - 1; j >= 0; j--) {
               const block = content[j] as any;
               if ((block.type === "tool_use" || block.type === "toolCall") && block.id) {
                 const blockIdNorm = normalizeToolCallIdForLookup(block.id);
                 if (stateManager.deletedOffloadIds.has(block.id) || stateManager.deletedOffloadIds.has(blockIdNorm)) {
                   content.splice(j, 1);
+                  stripped = true;
                 }
               }
             }
+            if (stripped) invalidateTokenCache(msg);
           }
         }
         if (msg._offloaded) continue;

--- a/src/offload/hooks/llm-input-l3.ts
+++ b/src/offload/hooks/llm-input-l3.ts
@@ -1369,15 +1369,18 @@ async function fastPathReApply(messages: any[], stateManager: OffloadStateManage
     if (hasDeleted && isAssistantMessageWithToolUse(msg) && !isOnlyToolUseAssistant(msg)) {
       const content = msg.type === "message" ? msg.message?.content : msg.content;
       if (Array.isArray(content)) {
+        let stripped = false;
         for (let j = content.length - 1; j >= 0; j--) {
           const block = content[j] as any;
           if ((block.type === "tool_use" || block.type === "toolCall") && block.id) {
             const blockIdNorm = normalizeToolCallIdForLookup(block.id);
             if (stateManager.deletedOffloadIds.has(block.id) || stateManager.deletedOffloadIds.has(blockIdNorm)) {
               content.splice(j, 1);
+              stripped = true;
             }
           }
         }
+        if (stripped) invalidateTokenCache(msg);
       }
     }
     if (msg._offloaded) continue;


### PR DESCRIPTION
## Description | 描述

`context-token-tracker.ts` caches per-message token counts in a WeakMap keyed on message identity plus `_offloaded`. Two offload hooks strip deleted `tool_use` blocks out of mixed assistant messages in place with `content.splice(...)` but never call `invalidateTokenCache(msg)` and never set `_offloaded`:

- `before-prompt-build.ts` (splice at line 109)
- `llm-input-l3.ts` (splice at line 1377)

So the next `buildTiktokenContextSnapshot` returns the stale pre-strip count, and since the strip runs just before the guard and emergency snapshots, the inflated total can cross the thresholds and over-delete real messages. Every other in-place mutation already invalidates the cache (`l3-helpers.ts:219/257/302`, `llm-input-l3.ts:1019`); these two were the only ones that skipped it. This calls `invalidateTokenCache(msg)` after each strip loop, only when a block was actually removed, and adds the import to `before-prompt-build.ts`.

## Related Issue | 关联 Issue

Closes #233

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Reproduced against the real `context-token-tracker.ts`: seed the cache, strip a deleted `tool_use` block in place, snapshot again.

Before:

    after strip, no inval : 537
    ground truth (fresh)  : 18
    drift                 : 519

After (invalidate following the splice): 18, drift 0.

`npm test` -> 47 passed. No new test added: the strip loops live in non-exported hook closures, so a unit test cannot drive them without a mocking harness the repo does not have. The runtime repro above is the evidence.
