### PR TITLE
fix(gateway): reject invalid and oversized JSON bodies

### DIFF
--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseConfig } from "../config.js";
+import { TdaiGateway } from "./server.js";
+import type { GatewayConfig } from "./config.js";
+
+const dataDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(dataDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTestGateway(): Promise<TdaiGateway> {
+  const dataDir = await mkdtemp(path.join(os.tmpdir(), "tdai-gateway-test-"));
+  dataDirs.push(dataDir);
+
+  const config: Partial<GatewayConfig> = {
+    server: {
+      port: 0,
+      host: "127.0.0.1",
+      apiKey: "test-token",
+      corsOrigins: [],
+    },
+    data: { baseDir: dataDir },
+    llm: {
+      baseUrl: "http://127.0.0.1/v1",
+      apiKey: "test-llm-key",
+      model: "test-model",
+      maxTokens: 16,
+      timeoutMs: 100,
+    },
+    memory: parseConfig({
+      extraction: { enabled: false },
+      recall: { strategy: "keyword", timeoutMs: 100 },
+      embedding: { provider: "none" },
+    }),
+  };
+
+  return new TdaiGateway(config);
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    "authorization": "Bearer test-token",
+    "content-type": "application/json",
+  };
+}
+
+class FakeResponse {
+  statusCode = 200;
+  body = "";
+  readonly headers = new Map<string, string | number | readonly string[]>();
+
+  setHeader(name: string, value: string | number | readonly string[]): this {
+    this.headers.set(name.toLowerCase(), value);
+    return this;
+  }
+
+  writeHead(statusCode: number, headers?: Record<string, string | number>): this {
+    this.statusCode = statusCode;
+    if (headers) {
+      for (const [name, value] of Object.entries(headers)) {
+        this.setHeader(name, value);
+      }
+    }
+    return this;
+  }
+
+  end(chunk?: string | Buffer): this {
+    if (chunk) {
+      this.body += Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : chunk;
+    }
+    return this;
+  }
+}
+
+async function invokeGateway(
+  gateway: TdaiGateway,
+  params: { method: string; url: string; headers?: Record<string, string>; body?: string },
+): Promise<{ status: number; json: unknown }> {
+  const req = Readable.from(params.body ? [Buffer.from(params.body)] : []) as unknown as {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+  };
+  req.method = params.method;
+  req.url = params.url;
+  req.headers = {
+    host: "localhost",
+    ...(params.headers ?? {}),
+  };
+
+  const res = new FakeResponse();
+  await (gateway as unknown as {
+    handleRequest: (req: unknown, res: unknown) => Promise<void>;
+  }).handleRequest(req, res);
+
+  return { status: res.statusCode, json: JSON.parse(res.body) as unknown };
+}
+
+describe("TdaiGateway HTTP request parsing", () => {
+  it("returns 400 for malformed JSON request bodies", async () => {
+    const gateway = await createTestGateway();
+
+    const response = await invokeGateway(gateway, {
+      method: "POST",
+      url: "/recall",
+      headers: authHeaders(),
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.json).toEqual({ error: "Invalid JSON body" });
+  });
+
+  it("returns 413 before routing when the JSON body exceeds the gateway limit", async () => {
+    const gateway = await createTestGateway();
+    const oversizedBody = JSON.stringify({
+      query: "x".repeat(8 * 1024 * 1024 + 1),
+      session_key: "session-1",
+    });
+
+    const response = await invokeGateway(gateway, {
+      method: "POST",
+      url: "/recall",
+      headers: authHeaders(),
+      body: oversizedBody,
+    });
+
+    expect(response.status).toBe(413);
+    expect(response.json).toEqual({ error: "Request body too large" });
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -46,6 +46,17 @@ import type { SeedProgress } from "../core/seed/types.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
+const MAX_JSON_BODY_BYTES = 8 * 1024 * 1024;
+
+class GatewayRequestError extends Error {
+  constructor(
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GatewayRequestError";
+  }
+}
 
 // ============================
 // Console logger (for standalone gateway — no OpenClaw logger available)
@@ -66,17 +77,46 @@ function createConsoleLogger(): Logger {
 
 async function parseJsonBody<T>(req: http.IncomingMessage): Promise<T> {
   return new Promise((resolve, reject) => {
+    const lengthHeader = req.headers["content-length"];
+    const contentLength = typeof lengthHeader === "string" ? Number.parseInt(lengthHeader, 10) : NaN;
+    if (Number.isFinite(contentLength) && contentLength > MAX_JSON_BODY_BYTES) {
+      req.resume();
+      reject(new GatewayRequestError(413, "Request body too large"));
+      return;
+    }
+
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let totalBytes = 0;
+    let settled = false;
+
+    const rejectOnce = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      req.resume();
+      reject(err);
+    };
+
+    req.on("data", (chunk: Buffer | string) => {
+      if (settled) return;
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buf.byteLength;
+      if (totalBytes > MAX_JSON_BODY_BYTES) {
+        rejectOnce(new GatewayRequestError(413, "Request body too large"));
+        return;
+      }
+      chunks.push(buf);
+    });
     req.on("end", () => {
+      if (settled) return;
+      settled = true;
       try {
         const body = Buffer.concat(chunks).toString("utf-8");
         resolve(JSON.parse(body) as T);
       } catch (err) {
-        reject(new Error("Invalid JSON body"));
+        reject(new GatewayRequestError(400, "Invalid JSON body"));
       }
     });
-    req.on("error", reject);
+    req.on("error", (err) => rejectOnce(err));
   });
 }
 
@@ -277,6 +317,10 @@ export class TdaiGateway {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      if (err instanceof GatewayRequestError) {
+        sendError(res, err.statusCode, msg);
+        return;
+      }
       this.logger.error(`Request error [${method} ${pathname}]: ${msg}`);
       sendError(res, 500, msg);
     }


### PR DESCRIPTION
## Summary
- return HTTP 400 for malformed JSON request bodies instead of treating them as server errors
- cap gateway JSON request bodies at 8 MiB using both Content-Length and streamed byte counting
- add gateway regression tests for malformed and oversized request bodies

## Test plan
- npx vitest run src/gateway
- npm test
- npm run build

## Notes
- npm run test:cc-plugin -- --run currently fails because package.json has no test:cc-plugin script.