### PR TITLE
fix(embedding): cap remote batch size at 10

### DIFF
--- a/src/core/store/embedding.test.ts
+++ b/src/core/store/embedding.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenAIEmbeddingService } from "./embedding.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("OpenAIEmbeddingService batching", () => {
+  it("splits remote embedding requests into batches of at most 10 texts", async () => {
+    const batchSizes: number[] = [];
+
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const input = body.input ?? [];
+      batchSizes.push(input.length);
+
+      if (input.length > 10) {
+        return new Response(JSON.stringify({ error: { message: "batch size is invalid" } }), {
+          status: 400,
+          statusText: "Bad Request",
+        });
+      }
+
+      return Response.json({
+        data: input.map((_text, index) => ({
+          index,
+          embedding: [index + 1, 0, 0],
+        })),
+      });
+    }));
+
+    const service = new OpenAIEmbeddingService({
+      provider: "dashscope",
+      baseUrl: "https://dashscope.example/v1",
+      apiKey: "test-key",
+      model: "text-embedding-v4",
+      dimensions: 3,
+      sendDimensions: false,
+    });
+
+    const embeddings = await service.embedBatch(Array.from({ length: 11 }, (_value, index) => `text-${index}`));
+
+    expect(embeddings).toHaveLength(11);
+    expect(batchSizes).toEqual([10, 1]);
+  });
+});

--- a/src/core/store/embedding.ts
+++ b/src/core/store/embedding.ts
@@ -362,8 +362,8 @@ export class LocalEmbeddingService implements EmbeddingService {
 // OpenAI-compatible implementation
 // ============================
 
-/** Max texts per batch (OpenAI limit is 2048, we use a safe value) */
-const MAX_BATCH_SIZE = 256;
+/** Max texts per remote embedding batch; Dashscope rejects batches larger than 10. */
+const MAX_BATCH_SIZE = 10;
 
 /** Max retries for API calls */
 const MAX_RETRIES = 0;


### PR DESCRIPTION
## Summary
- cap remote embedding batch size at 10 so Dashscope/Tencent-compatible APIs do not reject L0 background embedding batches
- keep existing chunking behavior for OpenAI-compatible and ZeroEntropy remote embedding services
- add a regression test that fails when 11 inputs are sent as one remote batch

Closes #236

## Test plan
- npx vitest run src/core/store/embedding.test.ts
- npm test
- npm run build

## Notes
- npm run test:cc-plugin -- --run currently fails because package.json has no test:cc-plugin script.