### PR TITLE
fix(hermes): inject recalled context into system prompt

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -816,7 +816,7 @@ class MemoryTencentdbProvider(MemoryProvider):
     def system_prompt_block(self) -> str:
         if not self._gateway_available:
             return ""
-        return (
+        block = (
             "# memory-tencentdb Memory\n"
             f"Active. User: {self._user_id}.\n"
             "Four-layer memory system (L0→L1→L2→L3) with automatic conversation "
@@ -824,6 +824,23 @@ class MemoryTencentdbProvider(MemoryProvider):
             "Use memory_tencentdb_memory_search to find specific memories, "
             "memory_tencentdb_conversation_search to search raw conversation history."
         )
+        if not self._client:
+            return block
+        try:
+            result = self._client.recall(
+                query="system prompt memory context",
+                session_key=self._session_id,
+                user_id=self._user_id,
+            )
+            self._record_success()
+            context = result.get("context", "")
+            if context:
+                return f"{block}\n\n## Recalled memory context\n{context}"
+        except Exception as e:
+            self._record_failure()
+            logger.debug("memory-tencentdb system_prompt_block recall failed: %s", e)
+            self._try_recover_gateway()
+        return block
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Synchronous recall — fetch memories in real-time for the current turn."""

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_system_prompt_block.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_system_prompt_block.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_HERMES_PLUGIN_ROOT = _THIS_FILE.parents[3]
+if str(_HERMES_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_HERMES_PLUGIN_ROOT))
+
+if "agent.memory_provider" not in sys.modules:
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+
+    class MemoryProvider:  # Minimal test stub for the Hermes interface.
+        pass
+
+    memory_provider_module.MemoryProvider = MemoryProvider
+    agent_module.memory_provider = memory_provider_module
+    sys.modules.setdefault("agent", agent_module)
+    sys.modules["agent.memory_provider"] = memory_provider_module
+
+from memory.memory_tencentdb import MemoryTencentdbProvider
+
+
+class SystemPromptBlockTest(unittest.TestCase):
+    def test_system_prompt_block_includes_recalled_persona_context(self) -> None:
+        provider = MemoryTencentdbProvider()
+        provider._gateway_available = True
+        provider._session_id = "session-1"
+        provider._user_id = "user-1"
+        provider._client = MagicMock()
+        provider._client.recall.return_value = {
+            "context": "<user-persona>\nPrefers concise answers.\n</user-persona>",
+        }
+
+        block = provider.system_prompt_block()
+
+        self.assertIn("Prefers concise answers.", block)
+        provider._client.recall.assert_called_once()
+        call_kwargs = provider._client.recall.call_args.kwargs
+        self.assertEqual(call_kwargs["session_key"], "session-1")
+        self.assertEqual(call_kwargs["user_id"], "user-1")
+        self.assertTrue(call_kwargs["query"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- have Hermes system_prompt_block fetch recall context from the Gateway when available
- append recalled persona/scene memory context to the static memory guide so L3 persona can reach the agent system prompt
- fall back to the static block and trigger existing recovery handling when recall fails
- add a unittest covering persona context injection

Closes #205

## Test plan
- python3 hermes-plugin/memory/memory_tencentdb/tests/test_system_prompt_block.py
- python3 -m py_compile hermes-plugin/memory/memory_tencentdb/__init__.py hermes-plugin/memory/memory_tencentdb/tests/test_system_prompt_block.py
- npm test
- npm run build

## Notes
- python3 -m pytest is unavailable in this local environment: No module named pytest. The added test uses stdlib unittest and is pytest-discoverable.
- npm run test:cc-plugin -- --run currently fails because package.json has no test:cc-plugin script.