### PR TITLE
fix(offload): preserve namespaced model ids

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -67,6 +67,7 @@ import { SessionRegistry } from "./session-registry.js";
 import { reclaimOffloadData } from "./reclaimer.js";
 import { buildL3TriggerReport, reportL3Trigger } from "./state-reporter.js";
 import { resolveUserId, getUserIdSource } from "./user-id.js";
+import { parseModelRef } from "../utils/model-ref.js";
 
 // ─── Module-level state ──────────────────────────────────────────────────────
 // OpenClaw calls registerOffload() multiple times during lifecycle.
@@ -362,10 +363,10 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
       }
     }
 
-    if (resolvedModelRef) {
-      const modelParts = resolvedModelRef.split("/", 2);
-      const providerKey = modelParts[0];
-      const modelId = modelParts[1] ?? resolvedModelRef;
+    const parsedModelRef = parseModelRef(resolvedModelRef);
+    if (parsedModelRef) {
+      const providerKey = parsedModelRef.provider;
+      const modelId = parsedModelRef.model;
       const models = (api.config as any)?.models;
       const providerCfg = models?.providers?.[providerKey];
       const baseUrl = providerCfg?.baseUrl ?? providerCfg?.baseURL;
@@ -385,6 +386,11 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
           `L1/L1.5/L2 disabled.`,
         );
       }
+    } else if (resolvedModelRef) {
+      logger.error(
+        `[context-offload] Local LLM mode failed: invalid model ref "${resolvedModelRef}". Expected "provider/model". ` +
+        `L1/L1.5/L2 disabled.`,
+      );
     } else {
       logger.warn("[context-offload] No model resolved (offload.model not set, agents.defaults.model not found). L1/L1.5/L2 disabled.");
     }
@@ -852,12 +858,14 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
       const models = config?.models;
       // 1. If we know the model, find its exact contextWindow from providers
       if (defaultModel && models) {
-        const [providerKey, modelId] = defaultModel.split("/", 2);
-        const provider = models.providers?.[providerKey];
-        if (provider?.models) {
-          const modelList = Array.isArray(provider.models) ? provider.models : [];
-          for (const m of modelList) {
-            if (m.id === modelId && typeof m.contextWindow === "number") return m.contextWindow;
+        const parsedModelRef = parseModelRef(defaultModel);
+        if (parsedModelRef) {
+          const provider = models.providers?.[parsedModelRef.provider];
+          if (provider?.models) {
+            const modelList = Array.isArray(provider.models) ? provider.models : [];
+            for (const m of modelList) {
+              if (m.id === parsedModelRef.model && typeof m.contextWindow === "number") return m.contextWindow;
+            }
           }
         }
       }

--- a/src/offload/model-ref.test.ts
+++ b/src/offload/model-ref.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { registerOffload } from "./index.js";
+
+function makeLogger() {
+  const messages: string[] = [];
+  const log = (message: string) => messages.push(message);
+
+  return {
+    logger: {
+      debug: log,
+      info: log,
+      warn: log,
+      error: log,
+    },
+    messages,
+  };
+}
+
+describe("offload local model resolution", () => {
+  it("preserves slash-delimited namespaces inside the model id", () => {
+    const { logger, messages } = makeLogger();
+
+    registerOffload({
+      logger,
+      config: {
+        models: {
+          providers: {
+            siliconflow: {
+              baseUrl: "https://api.siliconflow.example/v1",
+              apiKey: "sk-test",
+            },
+          },
+        },
+      },
+      on: () => {},
+      registerContextEngine: () => ({ ok: true }),
+    }, {
+      mode: "local",
+      model: "siliconflow/deepseek-ai/DeepSeek-V4-Flash",
+    } as any);
+
+    expect(messages).toContain(
+      "[context-offload] [local-llm] Initialized: model=deepseek-ai/DeepSeek-V4-Flash, baseUrl=https://api.siliconflow.example/v1",
+    );
+  });
+});

--- a/src/utils/clean-context-runner.ts
+++ b/src/utils/clean-context-runner.ts
@@ -18,6 +18,8 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { getEnv } from "./env.js";
 import { report } from "../core/report/reporter.js";
 import type { Logger } from "../core/types.js";
+import { parseModelRef, resolveModelFromMainConfig } from "./model-ref.js";
+export { parseModelRef, resolveModelFromMainConfig, type ModelRef } from "./model-ref.js";
 
 /**
  * Resolve a preferred temporary directory for memory-tdai operations.
@@ -179,91 +181,6 @@ function collectText(payloads: Array<{ text?: string; isError?: boolean }> | und
     .filter((p) => !p.isError && typeof p.text === "string")
     .map((p) => p.text ?? "");
   return texts.join("\n").trim();
-}
-
-// ── Model resolution utilities ──
-
-/** Parsed model reference: { provider, model } */
-export interface ModelRef {
-  provider: string;
-  model: string;
-}
-
-/**
- * Parse a "provider/model" string into its components.
- * Returns undefined if the input is empty or doesn't contain a "/".
- *
- * Examples:
- *   "azure/gpt-5.2-chat"          → { provider: "azure", model: "gpt-5.2-chat" }
- *   "custom-host/org/model-v2"    → { provider: "custom-host", model: "org/model-v2" }
- *   ""                            → undefined
- *   "bare-model-name"             → undefined (no "/" — may be an alias)
- */
-export function parseModelRef(raw: string | undefined): ModelRef | undefined {
-  if (!raw) return undefined;
-  const trimmed = raw.trim();
-  if (!trimmed) return undefined;
-
-  const slashIdx = trimmed.indexOf("/");
-  if (slashIdx <= 0 || slashIdx === trimmed.length - 1) return undefined;
-
-  return {
-    provider: trimmed.slice(0, slashIdx),
-    model: trimmed.slice(slashIdx + 1),
-  };
-}
-
-/**
- * Resolve the user's default model from the main OpenClaw config.
- *
- * Resolution order:
- * 1. Read `agents.defaults.model` (string or { primary })
- * 2. If the value contains "/", parse directly
- * 3. If not (may be an alias), look up in `agents.defaults.models` alias table
- * 4. Return undefined if nothing resolves — let the core use its built-in default
- */
-export function resolveModelFromMainConfig(config: unknown): ModelRef | undefined {
-  if (!config || typeof config !== "object") return undefined;
-
-  const cfg = config as Record<string, unknown>;
-  const agents = cfg.agents as Record<string, unknown> | undefined;
-  if (!agents || typeof agents !== "object") return undefined;
-
-  const defaults = agents.defaults as Record<string, unknown> | undefined;
-  if (!defaults || typeof defaults !== "object") return undefined;
-
-  // Step 1: extract raw model value (string | { primary?: string })
-  const modelCfg = defaults.model;
-  let raw: string | undefined;
-  if (typeof modelCfg === "string") {
-    raw = modelCfg.trim();
-  } else if (modelCfg && typeof modelCfg === "object") {
-    const primary = (modelCfg as Record<string, unknown>).primary;
-    raw = typeof primary === "string" ? primary.trim() : undefined;
-  }
-  if (!raw) return undefined;
-
-  // Step 2: try direct "provider/model" parse
-  const direct = parseModelRef(raw);
-  if (direct) return direct;
-
-  // Step 3: alias lookup — raw doesn't contain "/", check agents.defaults.models
-  const models = defaults.models as Record<string, unknown> | undefined;
-  if (!models || typeof models !== "object") return undefined;
-
-  const rawLower = raw.toLowerCase();
-  for (const [key, entry] of Object.entries(models)) {
-    if (!entry || typeof entry !== "object") continue;
-    const alias = (entry as Record<string, unknown>).alias;
-    if (typeof alias !== "string") continue;
-    if (alias.trim().toLowerCase() !== rawLower) continue;
-
-    // key is "provider/model" format
-    const resolved = parseModelRef(key);
-    if (resolved) return resolved;
-  }
-
-  return undefined;
 }
 
 export interface CleanContextRunnerOptions {

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -1,0 +1,72 @@
+/** Parsed model reference: { provider, model } */
+export interface ModelRef {
+  provider: string;
+  model: string;
+}
+
+/**
+ * Parse a "provider/model" string into its components.
+ * Model ids may contain additional "/" namespace separators.
+ */
+export function parseModelRef(raw: string | undefined): ModelRef | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+
+  const slashIdx = trimmed.indexOf("/");
+  if (slashIdx <= 0 || slashIdx === trimmed.length - 1) return undefined;
+
+  return {
+    provider: trimmed.slice(0, slashIdx),
+    model: trimmed.slice(slashIdx + 1),
+  };
+}
+
+/**
+ * Resolve the user's default model from the main OpenClaw config.
+ *
+ * Resolution order:
+ * 1. Read `agents.defaults.model` (string or { primary })
+ * 2. If the value contains "/", parse directly
+ * 3. If not (may be an alias), look up in `agents.defaults.models` alias table
+ * 4. Return undefined if nothing resolves
+ */
+export function resolveModelFromMainConfig(config: unknown): ModelRef | undefined {
+  if (!config || typeof config !== "object") return undefined;
+
+  const cfg = config as Record<string, unknown>;
+  const agents = cfg.agents as Record<string, unknown> | undefined;
+  if (!agents || typeof agents !== "object") return undefined;
+
+  const defaults = agents.defaults as Record<string, unknown> | undefined;
+  if (!defaults || typeof defaults !== "object") return undefined;
+
+  const modelCfg = defaults.model;
+  let raw: string | undefined;
+  if (typeof modelCfg === "string") {
+    raw = modelCfg.trim();
+  } else if (modelCfg && typeof modelCfg === "object") {
+    const primary = (modelCfg as Record<string, unknown>).primary;
+    raw = typeof primary === "string" ? primary.trim() : undefined;
+  }
+  if (!raw) return undefined;
+
+  const direct = parseModelRef(raw);
+  if (direct) return direct;
+
+  const models = defaults.models as Record<string, unknown> | undefined;
+  if (!models || typeof models !== "object") return undefined;
+
+  const rawLower = raw.toLowerCase();
+  for (const [key, entry] of Object.entries(models)) {
+    if (!entry || typeof entry !== "object") continue;
+    const alias = (entry as Record<string, unknown>).alias;
+    if (typeof alias !== "string") continue;
+    if (alias.trim().toLowerCase() !== rawLower) continue;
+
+    const resolved = parseModelRef(key);
+    if (resolved) return resolved;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Fixes #24 by parsing `provider/model` refs at the first `/` only, so model ids like `deepseek-ai/DeepSeek-V4-Flash` are preserved.
- Reuses the same parser for offload local LLM setup and context-window lookup.
- Moves the existing clean-context model-ref helpers into a lightweight shared utility and keeps the old exports for compatibility.
- Adds a regression test that exercises `registerOffload()` and verifies the initialized local LLM model id is not truncated.

This is a fresh, mergeable replacement for the older conflicting PR #33.

## Verification

- `npx vitest run src/offload/model-ref.test.ts`
- `npm test` (4 files, 48 tests)
- `npm run build`
- `git diff --check`
