### PR TITLE
fix(runner): avoid duplicate system prompt

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -154,7 +154,7 @@ export default function register(api: OpenClawPluginApi) {
 
   // ─── Full / discovery mode: complete runtime initialization ───
   pluginStartTimestamp = Date.now();
-  setPreferredEmbeddedAgentRuntime(api.runtime.agent);
+  setPreferredEmbeddedAgentRuntime(api.runtime.agent, (api.runtime as any)?.version);
   // Reset reporter singleton so config changes take effect on hot-reload.
   resetReporter();
   const _require = createRequire(import.meta.url);

--- a/src/utils/clean-context-runner.test.ts
+++ b/src/utils/clean-context-runner.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CleanContextRunner,
+  setPreferredEmbeddedAgentRuntime,
+  shouldPassExtraSystemPrompt,
+} from "./clean-context-runner.js";
+
+function makeLogger() {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+describe("shouldPassExtraSystemPrompt", () => {
+  it("keeps the legacy fallback when the OpenClaw version is unknown", () => {
+    expect(shouldPassExtraSystemPrompt(undefined)).toBe(true);
+    expect(shouldPassExtraSystemPrompt("unknown")).toBe(true);
+  });
+
+  it("keeps the fallback for OpenClaw versions before 2026.4.7", () => {
+    expect(shouldPassExtraSystemPrompt("2026.4.6")).toBe(true);
+  });
+
+  it("omits the fallback for OpenClaw versions that support systemPromptOverride", () => {
+    expect(shouldPassExtraSystemPrompt("2026.4.7")).toBe(false);
+    expect(shouldPassExtraSystemPrompt("2026.4.7-beta.1")).toBe(false);
+    expect(shouldPassExtraSystemPrompt("2026.5.20")).toBe(false);
+  });
+});
+
+describe("CleanContextRunner system prompt compatibility", () => {
+  it("does not pass extraSystemPrompt on OpenClaw versions with systemPromptOverride support", async () => {
+    const calls: any[] = [];
+    const runtime = {
+      runEmbeddedPiAgent: async (args: any) => {
+        calls.push(args);
+        return { payloads: [{ text: "ok" }] };
+      },
+    };
+    setPreferredEmbeddedAgentRuntime(runtime, "2026.4.7");
+
+    const runner = new CleanContextRunner({
+      config: {},
+      agentRuntime: runtime,
+      logger: makeLogger(),
+    });
+
+    await runner.run({
+      prompt: "extract",
+      systemPrompt: "system-only-once",
+      taskId: "system-prompt-compat",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).not.toHaveProperty("extraSystemPrompt");
+    expect(calls[0].config.agents.defaults.systemPromptOverride).toBe("system-only-once");
+  });
+});

--- a/src/utils/clean-context-runner.ts
+++ b/src/utils/clean-context-runner.ts
@@ -18,6 +18,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { getEnv } from "./env.js";
 import { report } from "../core/report/reporter.js";
 import type { Logger } from "../core/types.js";
+import { compareVersionXYZ, parseVersionXYZ } from "./ensure-hook-policy.js";
 
 /**
  * Resolve a preferred temporary directory for memory-tdai operations.
@@ -61,11 +62,24 @@ export interface EmbeddedAgentRuntimeLike {
 }
 
 let _preferredAgentRuntime: EmbeddedAgentRuntimeLike | undefined;
+let _preferredOpenClawVersion: unknown;
+
+const SYSTEM_PROMPT_OVERRIDE_MIN_VERSION: readonly [number, number, number] = [
+  2026, 4, 7,
+];
 
 export function setPreferredEmbeddedAgentRuntime(
   agentRuntime: EmbeddedAgentRuntimeLike | undefined,
+  openClawVersion?: unknown,
 ): void {
   _preferredAgentRuntime = agentRuntime;
+  _preferredOpenClawVersion = openClawVersion;
+}
+
+export function shouldPassExtraSystemPrompt(openClawVersion: unknown): boolean {
+  const parsed = parseVersionXYZ(openClawVersion);
+  if (!parsed) return true;
+  return compareVersionXYZ(parsed, SYSTEM_PROMPT_OVERRIDE_MIN_VERSION) < 0;
 }
 
 function resolveInjectedRunEmbeddedPiAgent(
@@ -436,12 +450,15 @@ export class CleanContextRunner {
 
       // Phase 2: Embedded agent run (LLM call + tool calls)
       const agentStartMs = Date.now();
-      // extraSystemPrompt: fallback for openclaw < 2026.4.7 which does not support
-      // config.agents.defaults.systemPromptOverride. On newer versions the
-      // override takes precedence and this becomes a no-op append.
+      // extraSystemPrompt is only needed for OpenClaw builds that predate
+      // config.agents.defaults.systemPromptOverride. Newer builds append it
+      // after the override, duplicating the full extraction system prompt.
       const effectiveSystemPrompt =
         params.systemPrompt ||
         "You are a precise data extraction and generation assistant. Follow the user instructions exactly. Respond only with the requested output format.";
+      const extraSystemPrompt = shouldPassExtraSystemPrompt(_preferredOpenClawVersion)
+        ? effectiveSystemPrompt
+        : undefined;
       const result = await runEmbeddedPiAgent({
         sessionId,
         sessionFile,
@@ -459,7 +476,7 @@ export class CleanContextRunner {
         // If a provider (e.g. qwencode) rejects empty tools[], users should
         // switch to StandaloneLLMRunner via LLM configuration instead.
         disableTools: !this.options.enableTools,
-        extraSystemPrompt: effectiveSystemPrompt,
+        ...(extraSystemPrompt ? { extraSystemPrompt } : {}),
         streamParams: {
           maxTokens: params.maxTokens,
         },


### PR DESCRIPTION
## Summary

- Avoids passing `extraSystemPrompt` on OpenClaw versions that support `agents.defaults.systemPromptOverride`.
- Preserves the legacy `extraSystemPrompt` fallback for unknown or older OpenClaw versions.
- Captures `api.runtime.version` at plugin registration and adds regression coverage for the version gate plus the actual `CleanContextRunner.run()` embedded-agent call.

This is a fresh, mergeable replacement for the older conflicting PR #86.

## Verification

- `npx vitest run src/utils/clean-context-runner.test.ts`
- `npm test` (4 files, 51 tests)
- `npm run build`
- `git diff --check`
