### PR TITLE
fix(offload): keep backend TLS verification enabled

### DIFF
--- a/src/offload/backend-client.test.ts
+++ b/src/offload/backend-client.test.ts
@@ -1,0 +1,69 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BackendClient } from "./backend-client.js";
+
+const mocks = vi.hoisted(() => ({
+  capturedOptions: [] as any[],
+  httpsRequest: vi.fn(),
+}));
+
+vi.mock("node:https", () => ({
+  request: mocks.httpsRequest,
+}));
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function mockHttpsResponse(body: unknown) {
+  mocks.httpsRequest.mockImplementation((options: any, callback?: (res: any) => void) => {
+    mocks.capturedOptions.push(options);
+
+    const req = new EventEmitter() as any;
+    req.write = vi.fn();
+    req.destroy = vi.fn((err?: Error) => req.emit("error", err ?? new Error("destroyed")));
+    req.end = vi.fn(() => {
+      const res = new EventEmitter() as any;
+      res.statusCode = 200;
+      res.statusMessage = "OK";
+      callback?.(res);
+      res.emit("data", Buffer.from(JSON.stringify(body)));
+      res.emit("end");
+    });
+    return req;
+  });
+
+  return mocks.capturedOptions;
+}
+
+describe("BackendClient", () => {
+  beforeEach(() => {
+    mocks.capturedOptions.length = 0;
+    mocks.httpsRequest.mockReset();
+  });
+
+  it("keeps TLS verification enabled and honors the configured backend timeout", async () => {
+    const logger = makeLogger();
+    const capturedOptions = mockHttpsResponse({ entries: [] });
+    const client = new BackendClient(
+      "https://memory-backend.example",
+      logger,
+      undefined,
+      12_345,
+    );
+
+    await client.l1Summarize({ recentMessages: "", toolPairs: [] });
+
+    expect(capturedOptions).toHaveLength(1);
+    expect(capturedOptions[0]).not.toHaveProperty("rejectUnauthorized", false);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("timeout=12345ms"),
+    );
+  });
+});

--- a/src/offload/backend-client.ts
+++ b/src/offload/backend-client.ts
@@ -106,8 +106,9 @@ export interface StoreStateResponse {
 export class BackendClient {
   private baseUrl: string;
   private apiKey: string | undefined;
-  /** Hardcoded timeout for all backend calls (L1/L1.5/L2/L4) */
-  private static readonly TIMEOUT_MS = 120_000;
+  /** Default timeout for backend LLM calls (L1/L1.5/L2/L4). */
+  private static readonly DEFAULT_TIMEOUT_MS = 120_000;
+  private timeoutMs: number;
   private logger: PluginLogger;
   private sessionKeyFn: () => string | null;
   /** Resolves the value of the `X-User-Id` header sent on every call. */
@@ -119,13 +120,16 @@ export class BackendClient {
     baseUrl: string,
     logger: PluginLogger,
     apiKey?: string,
-    _defaultTimeoutMs?: number, // kept for backward compat, ignored
+    defaultTimeoutMs?: number,
     sessionKeyFn?: () => string | null,
     userIdFn?: () => string | null,
     taskIdFn?: () => string | null,
   ) {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
     this.apiKey = apiKey;
+    this.timeoutMs = typeof defaultTimeoutMs === "number" && defaultTimeoutMs > 0
+      ? defaultTimeoutMs
+      : BackendClient.DEFAULT_TIMEOUT_MS;
     this.logger = logger;
     this.sessionKeyFn = sessionKeyFn ?? (() => null);
     this.userIdFn = userIdFn ?? (() => null);
@@ -137,7 +141,7 @@ export class BackendClient {
     const pairNames = req.toolPairs.map((p) => `${p.toolName}(${p.toolCallId})`).join(", ");
     this.logger.debug?.(`[context-offload] L1 >>> summarize ${req.toolPairs.length} pairs: [${pairNames}]`);
     const startMs = Date.now();
-    const resp = await this.post<L1Response>("/offload/v1/l1/summarize", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L1Response>("/offload/v1/l1/summarize", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     const entryCount = resp.entries?.length ?? 0;
     const scores = resp.entries?.map((e) => `${e.tool_call_id}:score=${e.score}`).join(", ") ?? "";
@@ -165,7 +169,7 @@ export class BackendClient {
       `[context-offload] L1.5 >>> judge: currentMmd=${req.currentMmd?.filename ?? "null"}, availableMmds=${req.availableMmdMetas.length}, recentMessages=${req.recentMessages.length} chars`,
     );
     const startMs = Date.now();
-    const resp = await this.post<L15Response>("/offload/v1/l15/judge", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L15Response>("/offload/v1/l15/judge", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     this.logger.debug?.(
       `[context-offload] L1.5 <<< completed=${resp.taskCompleted}, continuation=${resp.isContinuation}, continuationFile=${resp.continuationMmdFile ?? "null"}, newLabel=${resp.newTaskLabel ?? "null"}, longTask=${resp.isLongTask}`,
@@ -193,7 +197,7 @@ export class BackendClient {
       `[context-offload] L2 >>> generate: task=${req.taskLabel}, prefix=${req.mmdPrefix}, entries=${req.newEntries.length} [${entryIds}], existingMmd=${req.existingMmd ? `${req.mmdCharCount} chars` : "null (new)"}`,
     );
     const startMs = Date.now();
-    const resp = await this.post<L2Response>("/offload/v1/l2/generate", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L2Response>("/offload/v1/l2/generate", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     const mappingCount = Object.keys(resp.nodeMapping ?? {}).length;
     const mappingStr = Object.entries(resp.nodeMapping ?? {}).map(([k, v]) => `${k}->${v}`).join(", ");
@@ -222,7 +226,7 @@ export class BackendClient {
       `[context-offload] L4 >>> generate: mmd=${req.mmdFilename}, entries=${req.offloadEntries.length}, skillFocus=${req.skillFocus ?? "null"}`,
     );
     const startMs = Date.now();
-    const resp = await this.post<L4Response>("/offload/v1/l4/generate", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L4Response>("/offload/v1/l4/generate", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     this.logger.debug?.(
       `[context-offload] L4 <<< skill="${resp.skillName}", content=${resp.skillContent?.length ?? 0} chars`,
@@ -309,7 +313,6 @@ export class BackendClient {
           path: parsed.pathname + parsed.search,
           method: "POST",
           headers: reqHeaders,
-          ...(isHttps ? { rejectUnauthorized: false } : {}),
         },
         (res) => {
           let data = "";


### PR DESCRIPTION
## Summary

- Removes the hardcoded `rejectUnauthorized: false` from HTTPS backend requests so Node keeps TLS certificate verification enabled by default.
- Makes the `BackendClient` constructor timeout parameter actually apply to L1/L1.5/L2/L4 backend calls instead of always using 120s.
- Keeps `/offload/v1/store` on its existing short 10s timeout so reporting remains non-blocking.
- Adds a focused regression test that mocks `https.request` and verifies TLS is not disabled and the configured timeout is used.

This is a small standalone extraction from the larger, conflicting Codex integration PR #67, limited to backend HTTP safety and timeout behavior.

## Verification

- `npx vitest run src/offload/backend-client.test.ts`
- `npm test` (4 files, 48 tests)
- `npm run build`
- `git diff --check`
