### PR TITLE
fix(conversation): scope L0 search candidates by session

### DIFF
--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -32,6 +32,7 @@ import type {
   L1FtsResult,
   L0SearchResult,
   L0FtsResult,
+  L0SearchFilter,
 } from "./types.js";
 import type { Logger } from "../types.js";
 
@@ -397,6 +398,7 @@ export class VectorStore implements IMemoryStore {
   private stmtL0FtsInsert!: StatementSync;
   private stmtL0FtsDelete!: StatementSync;
   private stmtL0FtsSearch!: StatementSync;
+  private stmtL0FtsSearchBySessionKey!: StatementSync;
 
   /**
    * Create a VectorStore instance.
@@ -817,6 +819,15 @@ export class VectorStore implements IMemoryStore {
                bm25(l0_fts) AS rank
         FROM l0_fts
         WHERE l0_fts MATCH ?
+        ORDER BY rank ASC
+        LIMIT ?
+      `);
+
+      this.stmtL0FtsSearchBySessionKey = this.db.prepare(`
+        SELECT record_id, message_text_original AS message_text, session_key, session_id, role, recorded_at, timestamp,
+               bm25(l0_fts) AS rank
+        FROM l0_fts
+        WHERE l0_fts MATCH ? AND session_key = ?
         ORDER BY rank ASC
         LIMIT ?
       `);
@@ -1554,7 +1565,7 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL0Vector(queryEmbedding: Float32Array, topK = 5): L0VectorSearchResult[] {
+  searchL0Vector(queryEmbedding: Float32Array, topK = 5, _queryText?: string, filter?: L0SearchFilter): L0VectorSearchResult[] {
     if (this.degraded || !this.vecTablesReady) {
       if (this.degraded) this.logger?.warn(`${TAG} [L0-search] SKIPPED (degraded mode)`);
       return [];
@@ -1567,7 +1578,9 @@ export class VectorStore implements IMemoryStore {
       // in KNN results.
       // NOTE: "AND distance IS NOT NULL" is NOT usable because vec0 does not
       // support that constraint — it causes an empty result set.
-      const retrieveCount = topK + VectorStore.ZERO_VEC_BUFFER;
+      const retrieveCount = filter?.sessionKey
+        ? Math.max(topK * 20, topK + VectorStore.ZERO_VEC_BUFFER)
+        : topK + VectorStore.ZERO_VEC_BUFFER;
 
       this.logger?.debug?.(
         `${TAG} [L0-search] START topK=${topK}, retrieveCount=${retrieveCount}, ` +
@@ -1609,6 +1622,10 @@ export class VectorStore implements IMemoryStore {
 
         if (!meta) {
           this.logger?.warn(`${TAG} [L0-search] record_id=${record_id} has vector but NO metadata (orphan)`);
+          continue;
+        }
+
+        if (filter?.sessionKey && meta.session_key !== filter.sessionKey) {
           continue;
         }
 
@@ -2103,10 +2120,12 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL0Fts(ftsQuery: string, limit = VectorStore.FTS_DEFAULT_LIMIT): L0FtsSearchResult[] {
+  searchL0Fts(ftsQuery: string, limit = VectorStore.FTS_DEFAULT_LIMIT, filter?: L0SearchFilter): L0FtsSearchResult[] {
     if (this.degraded || !this.ftsAvailable) return [];
     try {
-      const rows = this.stmtL0FtsSearch.all(ftsQuery, limit) as Array<{
+      const rows = (filter?.sessionKey
+        ? this.stmtL0FtsSearchBySessionKey.all(ftsQuery, filter.sessionKey, limit)
+        : this.stmtL0FtsSearch.all(ftsQuery, limit)) as Array<{
         record_id: string;
         message_text: string;
         session_key: string;

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -23,6 +23,7 @@ import type {
   L1QueryFilter,
   L0SearchResult,
   L0FtsResult,
+  L0SearchFilter,
   L0QueryRow,
   L0SessionGroup,
   ProfileRecord,
@@ -96,6 +97,15 @@ function isoToEpochMs(iso: string): number {
 function epochMsToIso(ms: number): string {
   if (!ms || ms <= 0) return "";
   return new Date(ms).toISOString();
+}
+
+function escapeFilterLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}
+
+function buildL0SearchFilter(filter?: L0SearchFilter): string | undefined {
+  if (!filter?.sessionKey) return undefined;
+  return `session_key = "${escapeFilterLiteral(filter.sessionKey)}"`;
 }
 
 /**
@@ -967,18 +977,18 @@ export class TcvdbMemoryStore implements IMemoryStore {
 
   // ── L0 Search Operations ─────────────────────────────────
 
-  async searchL0Vector(_queryEmbedding: Float32Array, topK?: number, queryText?: string): Promise<L0SearchResult[]> {
+  async searchL0Vector(_queryEmbedding: Float32Array, topK?: number, queryText?: string, filter?: L0SearchFilter): Promise<L0SearchResult[]> {
     // TCVDB uses server-side embedding — delegate to hybrid search with text
     if (queryText) {
-      return this.searchL0HybridAsync({ queryText, topK });
+      return this.searchL0HybridAsync({ queryText, topK, filter });
     }
     return [];
   }
 
-  async searchL0Fts(ftsQuery: string, limit?: number): Promise<L0FtsResult[]> {
+  async searchL0Fts(ftsQuery: string, limit?: number, filter?: L0SearchFilter): Promise<L0FtsResult[]> {
     if (!ftsQuery) return [];
     // Use hybrid search; L0SearchResult and L0FtsResult have identical shapes
-    return this.searchL0HybridAsync({ queryText: ftsQuery, topK: limit });
+    return this.searchL0HybridAsync({ queryText: ftsQuery, topK: limit, filter });
   }
 
   /**
@@ -987,17 +997,20 @@ export class TcvdbMemoryStore implements IMemoryStore {
   async searchL0HybridAsync(params: {
     queryText: string;
     topK?: number;
+    filter?: L0SearchFilter;
   }): Promise<L0SearchResult[]> {
-    const { queryText, topK = 10 } = params;
+    const { queryText, topK = 10, filter } = params;
     if (!queryText) return [];
 
     try {
       await this._ensureInit();
       if (this.degraded) return [];
 
+      const filterExpr = buildL0SearchFilter(filter);
       const searchParams: Record<string, unknown> = {
         limit: topK,
         outputFields: L0_OUTPUT_FIELDS,
+        ...(filterExpr ? { filter: filterExpr } : {}),
       };
 
       // ann: use embedding field name "message_text" for L0 server-side embedding
@@ -1031,6 +1044,7 @@ export class TcvdbMemoryStore implements IMemoryStore {
           limit: topK,
           retrieveVector: false,
           outputFields: L0_OUTPUT_FIELDS,
+          ...(filterExpr ? { filter: filterExpr } : {}),
         };
         const resp = await this.client.search(this.l0Collection, denseSearch);
         return this._parseL0SearchResults(resp.documents);

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -75,6 +75,11 @@ export interface L1QueryFilter {
   updatedAfter?: string;
 }
 
+/** Filter options for L0 search operations. */
+export interface L0SearchFilter {
+  sessionKey?: string;
+}
+
 /** Row shape returned by L1 query methods. */
 export interface L1RecordRow {
   record_id: string;
@@ -292,8 +297,8 @@ export interface IMemoryStore {
 
   // ── L0 Search ────────────────────────────────────────────
 
-  searchL0Vector(queryEmbedding: Float32Array, topK?: number, queryText?: string): MaybePromise<L0SearchResult[]>;
-  searchL0Fts(ftsQuery: string, limit?: number): MaybePromise<L0FtsResult[]>;
+  searchL0Vector(queryEmbedding: Float32Array, topK?: number, queryText?: string, filter?: L0SearchFilter): MaybePromise<L0SearchResult[]>;
+  searchL0Fts(ftsQuery: string, limit?: number, filter?: L0SearchFilter): MaybePromise<L0FtsResult[]>;
 
   pullProfiles?(): Promise<ProfileRecord[]>;
   syncProfiles?(records: ProfileSyncRecord[]): Promise<void>;

--- a/src/core/tools/conversation-search.test.ts
+++ b/src/core/tools/conversation-search.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeConversationSearch } from "./conversation-search.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore, L0SearchResult } from "../store/types.js";
+
+type L0SearchFilter = { sessionKey?: string };
+
+function l0Result(id: string, sessionKey: string): L0SearchResult {
+  return {
+    record_id: id,
+    session_key: sessionKey,
+    session_id: "",
+    role: "user",
+    message_text: `message ${id}`,
+    score: 0.9,
+    recorded_at: "2026-06-24T00:00:00.000Z",
+    timestamp: 0,
+  };
+}
+
+describe("executeConversationSearch", () => {
+  it("pushes the session filter down to FTS search before candidate limiting", async () => {
+    const searchL0Fts = vi.fn(
+      (_query: string, _limit?: number, filter?: L0SearchFilter): L0SearchResult[] => {
+        if (filter?.sessionKey === "session-a") {
+          return [l0Result("target", "session-a")];
+        }
+        return [
+          l0Result("other-1", "session-b"),
+          l0Result("other-2", "session-b"),
+          l0Result("other-3", "session-b"),
+          l0Result("other-4", "session-b"),
+        ];
+      },
+    );
+
+    const store = {
+      isFtsAvailable: () => true,
+      searchL0Fts,
+    } as unknown as IMemoryStore;
+
+    const result = await executeConversationSearch({
+      query: "target",
+      limit: 1,
+      sessionKey: "session-a",
+      vectorStore: store,
+    });
+
+    expect(searchL0Fts).toHaveBeenCalledWith(expect.any(String), 4, { sessionKey: "session-a" });
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].id).toBe("target");
+  });
+
+  it("pushes the session filter down to vector search before candidate limiting", async () => {
+    const searchL0Vector = vi.fn(
+      (_embedding: Float32Array, _limit?: number, _query?: string, filter?: L0SearchFilter): L0SearchResult[] => {
+        if (filter?.sessionKey === "session-a") {
+          return [l0Result("target", "session-a")];
+        }
+        return [
+          l0Result("other-1", "session-b"),
+          l0Result("other-2", "session-b"),
+          l0Result("other-3", "session-b"),
+          l0Result("other-4", "session-b"),
+        ];
+      },
+    );
+
+    const store = {
+      isFtsAvailable: () => false,
+      searchL0Vector,
+    } as unknown as IMemoryStore;
+    const embeddingService = {
+      embed: vi.fn(async () => new Float32Array([1, 0])),
+    } as unknown as EmbeddingService;
+
+    const result = await executeConversationSearch({
+      query: "target",
+      limit: 1,
+      sessionKey: "session-a",
+      vectorStore: store,
+      embeddingService,
+    });
+
+    expect(searchL0Vector).toHaveBeenCalledWith(expect.any(Float32Array), 4, "target", { sessionKey: "session-a" });
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].id).toBe("target");
+  });
+});

--- a/src/core/tools/conversation-search.ts
+++ b/src/core/tools/conversation-search.ts
@@ -117,6 +117,7 @@ export async function executeConversationSearch(params: {
   // ── Determine available capabilities ──
   const hasEmbedding = !!embeddingService;
   const hasFts = vectorStore.isFtsAvailable();
+  const searchFilter = sessionFilter ? { sessionKey: sessionFilter } : undefined;
 
   if (!hasEmbedding && !hasFts) {
     logger?.warn?.(`${TAG} Neither EmbeddingService nor FTS5 available — cannot search`);
@@ -146,7 +147,7 @@ export async function executeConversationSearch(params: {
           return [];
         }
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 query: "${ftsQuery}"`);
-        const ftsResults = await vectorStore.searchL0Fts(ftsQuery, candidateK);
+        const ftsResults = await vectorStore.searchL0Fts(ftsQuery, candidateK, searchFilter);
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 returned ${ftsResults.length} candidates`);
         return ftsResults.map((r) => ({
           id: r.record_id,
@@ -173,7 +174,7 @@ export async function executeConversationSearch(params: {
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const vecResults: L0SearchResult[] = await vectorStore.searchL0Vector(queryEmbedding, candidateK, query);
+        const vecResults: L0SearchResult[] = await vectorStore.searchL0Vector(queryEmbedding, candidateK, query, searchFilter);
         logger?.debug?.(`${TAG} [hybrid-vec] Vector search returned ${vecResults.length} candidates`);
         return vecResults.map((r) => ({
           id: r.record_id,


### PR DESCRIPTION
## Summary
- pass the optional `sessionKey` from `tdai_conversation_search` down into L0 store searches before candidate limiting
- add L0 search filter support to the store interface, SQLite FTS/vector paths, and TCVDB L0 hybrid search
- keep the existing tool-level post-filter as a defensive final guard

## Root cause
`executeConversationSearch` accepted `sessionKey`, but searched global L0 candidates first and only filtered after FTS/vector results were already limited. If other sessions occupied the top candidates, the requested session could return no messages even when matching L0 rows existed.

## Verification
- `npx vitest run src/core/tools/conversation-search.test.ts` (RED before fix, green after)
- `npm test`
- `npm run build`
- `git diff --check`