### PR TITLE
fix(hermes): install durable user plugin link

### DIFF
--- a/scripts/install_hermes_memory_tencentdb.sh
+++ b/scripts/install_hermes_memory_tencentdb.sh
@@ -50,7 +50,7 @@ USER_HOME=$(eval echo ~$USERNAME)
 NPM_PACKAGE="@tencentdb-agent-memory/memory-tencentdb@latest"
 
 # Hermes 路径
-HERMES_HOME="$USER_HOME/.hermes"
+HERMES_HOME="${HERMES_HOME:-$USER_HOME/.hermes}"
 # HERMES_AGENT_DIR（fix: issue #18）
 # 用户通过环境变量传什么就用什么；未设置时 fallback 到传统路径。
 # 如果目录不存在，后续前置检查会统一报错。
@@ -209,16 +209,48 @@ echo "[memory-tencentdb] Gateway dependencies installed"
 
 echo "[memory-tencentdb] Step 2.5: Linking plugin into hermes plugins directory..."
 
-HERMES_PLUGIN_DIR="$HERMES_AGENT_DIR/plugins/memory/memory_tencentdb"
 PLUGIN_SRC_DIR="$TDAI_INSTALL_DIR/hermes-plugin/memory/memory_tencentdb"
+HERMES_CHECKOUT_PLUGIN_DIR="$HERMES_AGENT_DIR/plugins/memory/memory_tencentdb"
+HERMES_USER_PLUGIN_DIR="$HERMES_HOME/plugins/memory_tencentdb"
 
-# 移除旧链接/目录
-rm -rf "$HERMES_PLUGIN_DIR"
+MISSING_SRC=0
+for f in __init__.py plugin.yaml client.py supervisor.py; do
+    if [ ! -f "$PLUGIN_SRC_DIR/$f" ]; then
+        echo "[ERROR] Missing hermes plugin source file: $PLUGIN_SRC_DIR/$f" >&2
+        MISSING_SRC=1
+    fi
+done
+if [ "$MISSING_SRC" -ne 0 ]; then
+    exit 1
+fi
 
-# 创建 symlink 使 hermes 能发现插件
-ln -sf "$PLUGIN_SRC_DIR" "$HERMES_PLUGIN_DIR"
+link_plugin_dir() {
+    local target="$1"
+    local source="$2"
+    local label="$3"
 
-echo "[memory-tencentdb] Plugin linked: $HERMES_PLUGIN_DIR -> $PLUGIN_SRC_DIR"
+    mkdir -p "$(dirname "$target")"
+
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        echo "[ERROR] $label target exists and is not a symlink: $target" >&2
+        echo "[ERROR] Refusing to overwrite it. Please move it aside and re-run the installer." >&2
+        exit 1
+    fi
+
+    ln -sfn "$source" "$target"
+
+    if [ ! -f "$target/plugin.yaml" ] || [ ! -f "$target/__init__.py" ]; then
+        echo "[ERROR] $label link verification failed: plugin.yaml or __init__.py not readable through $target" >&2
+        exit 1
+    fi
+
+    echo "[memory-tencentdb] $label plugin linked: $target -> $(readlink "$target")"
+}
+
+# Keep the checkout-tree link for compatibility with bundled Hermes installs,
+# and add the durable user-scope provider link that survives checkout updates.
+link_plugin_dir "$HERMES_CHECKOUT_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes checkout"
+link_plugin_dir "$HERMES_USER_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes user"
 
 # ---------- Step 3: 提示用户手动开启 memory_tencentdb（不自动修改 config） ----------
 
@@ -325,6 +357,29 @@ echo "  Env file:       $ENVFILE"
 echo ""
 echo "  Installed files in tdai dir:"
 ls -la "$TDAI_INSTALL_DIR"/ 2>/dev/null | head -20 || echo "  (none)"
+echo ""
+
+print_plugin_link_summary() {
+    local target="$1"
+    local expected="$2"
+    local label="$3"
+
+    if [ ! -L "$target" ]; then
+        echo "  [WARN] $label plugin link missing: $target"
+        return
+    fi
+
+    local actual
+    actual="$(readlink "$target")"
+    if [ "$actual" = "$expected" ]; then
+        echo "  [OK] $label plugin link: $target -> $actual"
+    else
+        echo "  [WARN] $label plugin link points to unexpected target: $actual (expected: $expected)"
+    fi
+}
+
+print_plugin_link_summary "$HERMES_CHECKOUT_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes checkout"
+print_plugin_link_summary "$HERMES_USER_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes user"
 echo ""
 
 # 验证 hermes 插件文件存在（在解压目录中）

--- a/src/install-hermes.test.ts
+++ b/src/install-hermes.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, lstatSync, mkdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+describe("install_hermes_memory_tencentdb.sh", () => {
+  it("links the Hermes provider into both checkout and user plugin directories", () => {
+    const root = mkdtempSync(join(tmpdir(), "memory-tencentdb-install-"));
+    try {
+      const fakeBin = join(root, "bin");
+      const installDir = join(root, "tdai-memory-openclaw-plugin");
+      const dataDir = join(root, "memory-tdai");
+      const hermesHome = join(root, ".hermes");
+      const hermesAgentDir = join(hermesHome, "hermes-agent");
+      const sudoSink = join(root, "sudo-tee-output");
+      mkdirSync(fakeBin, { recursive: true });
+      mkdirSync(hermesAgentDir, { recursive: true });
+
+      writeExecutable(
+        join(fakeBin, "npm"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"@tencentdb-agent-memory/memory-tencentdb@latest"* ]]; then
+  pkg="node_modules/@tencentdb-agent-memory/memory-tencentdb"
+  mkdir -p "$pkg/hermes-plugin/memory/memory_tencentdb" "$pkg/src/gateway"
+  touch "$pkg/hermes-plugin/memory/memory_tencentdb/__init__.py"
+  touch "$pkg/hermes-plugin/memory/memory_tencentdb/client.py"
+  touch "$pkg/hermes-plugin/memory/memory_tencentdb/supervisor.py"
+  printf 'name: memory_tencentdb\\n' > "$pkg/hermes-plugin/memory/memory_tencentdb/plugin.yaml"
+  touch "$pkg/src/gateway/server.ts"
+fi
+exit 0
+`,
+      );
+      writeExecutable(join(fakeBin, "npx"), "#!/usr/bin/env bash\nexit 0\n");
+      writeExecutable(
+        join(fakeBin, "sed"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "-i" ]]; then
+  expr="$2"
+  file="$3"
+  key=""
+  if [[ "$expr" =~ ^/\\^#\\ \\*([A-Za-z0-9_]+)=/d$ ]]; then
+    key="\${BASH_REMATCH[1]}"
+    grep -Ev "^# *\${key}=" "$file" > "$file.tmp" || true
+    mv "$file.tmp" "$file"
+    exit 0
+  fi
+  if [[ "$expr" =~ ^/\\^([A-Za-z0-9_]+)=/d$ ]]; then
+    key="\${BASH_REMATCH[1]}"
+    grep -Ev "^\${key}=" "$file" > "$file.tmp" || true
+    mv "$file.tmp" "$file"
+    exit 0
+  fi
+fi
+exec /usr/bin/sed "$@"
+`,
+      );
+      writeExecutable(
+        join(fakeBin, "sudo"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "tee" ]]; then
+  cat > "${sudoSink}"
+  exit 0
+fi
+exit 1
+`,
+      );
+
+      const script = resolve("scripts/install_hermes_memory_tencentdb.sh");
+      const result = spawnSync("bash", [script], {
+        cwd: root,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          INSTALL_AS_USER: "memory_tencentdb_test_user",
+          MEMORY_TENCENTDB_ROOT: root,
+          TDAI_INSTALL_DIR: installDir,
+          TDAI_DATA_DIR: dataDir,
+          HERMES_HOME: hermesHome,
+          HERMES_AGENT_DIR: hermesAgentDir,
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+
+      const pluginSource = join(installDir, "hermes-plugin/memory/memory_tencentdb");
+      const checkoutLink = join(hermesAgentDir, "plugins/memory/memory_tencentdb");
+      const userLink = join(hermesHome, "plugins/memory_tencentdb");
+
+      expect(lstatSync(checkoutLink).isSymbolicLink()).toBe(true);
+      expect(lstatSync(userLink).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(checkoutLink)).toBe(pluginSource);
+      expect(readlinkSync(userLink)).toBe(pluginSource);
+      expect(statSync(join(hermesHome, ".env")).isFile()).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fixes #167 by installing `memory_tencentdb` into both Hermes discovery locations
- keeps the existing checkout-tree link for compatibility and adds the durable `$HERMES_HOME/plugins/memory_tencentdb` user-scope link
- honors `HERMES_HOME` overrides and verifies provider source files before linking
- refuses to overwrite non-symlink plugin targets and prints link summaries after install

## Why
The installer previously linked only into `$HERMES_AGENT_DIR/plugins/memory/memory_tencentdb`. Hermes checkout updates can remove that tree while `memory.provider: memory_tencentdb` remains configured, silently detaching TencentDB memory. This PR is a clean, tested replacement for the older unstable #170.

## Verification
- `npx vitest run src/install-hermes.test.ts` (RED before fix, green after)
- `bash -n scripts/install_hermes_memory_tencentdb.sh`
- `npm test`
- `npm run build`
- `git diff --check`