### PR TITLE
fix(openclaw): tolerate uninitialized state dir resolver

### DIFF
--- a/src/utils/openclaw-state-dir.test.ts
+++ b/src/utils/openclaw-state-dir.test.ts
@@ -1,0 +1,51 @@
+import { homedir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveOpenClawStateDir } from "./openclaw-state-dir.js";
+
+describe("resolveOpenClawStateDir", () => {
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+
+  afterEach(() => {
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+  });
+
+  it("uses the runtime state directory when the host provides it", () => {
+    process.env.OPENCLAW_STATE_DIR = "/env/state";
+
+    const stateDir = resolveOpenClawStateDir({
+      resolveStateDir: () => " /runtime/state ",
+    });
+
+    expect(stateDir).toBe("/runtime/state");
+  });
+
+  it("falls back to OPENCLAW_STATE_DIR when runtime state is missing", () => {
+    process.env.OPENCLAW_STATE_DIR = " /env/state ";
+
+    expect(resolveOpenClawStateDir(undefined)).toBe("/env/state");
+  });
+
+  it("falls back to OPENCLAW_STATE_DIR when the runtime resolver is not initialized", () => {
+    process.env.OPENCLAW_STATE_DIR = "/env/state";
+
+    const stateDir = resolveOpenClawStateDir({
+      resolveStateDir: () => {
+        throw new Error("state runtime not initialized");
+      },
+    });
+
+    expect(stateDir).toBe("/env/state");
+  });
+
+  it("falls back to the default OpenClaw state directory when no source is available", () => {
+    delete process.env.OPENCLAW_STATE_DIR;
+
+    expect(resolveOpenClawStateDir(undefined)).toBe(path.join(homedir(), ".openclaw"));
+  });
+});

--- a/src/utils/openclaw-state-dir.ts
+++ b/src/utils/openclaw-state-dir.ts
@@ -27,8 +27,16 @@ export interface OpenClawRuntimeStateLike {
 export function resolveOpenClawStateDir(
   runtimeState: OpenClawRuntimeStateLike | undefined,
 ): string {
+  let runtimeStateDir: string | undefined;
+  try {
+    runtimeStateDir = runtimeState?.resolveStateDir?.()?.trim();
+  } catch {
+    // Some registration paths expose runtime.state before it is fully
+    // initialized. Falling back keeps plugin registration non-fatal.
+  }
+
   return (
-    runtimeState?.resolveStateDir?.() ||
+    runtimeStateDir ||
     getEnv("OPENCLAW_STATE_DIR")?.trim() ||
     path.join(homedir(), ".openclaw")
   );


### PR DESCRIPTION
## Summary
- make OpenClaw state-dir resolution tolerate an uninitialized or throwing runtime resolver during plugin registration
- trim runtime and environment fallback values while preserving the existing priority order
- add focused coverage for runtime, env, throwing resolver, and default fallback paths

## Verification
- npm test
- npm run build

Fixes #89
Related: #182