### PR TITLE
fix(record): harden L1 dedup JSON parsing

### DIFF
--- a/src/core/record/l1-dedup.test.ts
+++ b/src/core/record/l1-dedup.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBatchResult } from "./l1-dedup.js";
+import type { ExtractedMemory } from "./l1-writer.js";
+
+function memory(record_id: string): ExtractedMemory & { record_id: string } {
+  return {
+    record_id,
+    content: "用户在诊断场景要求 AI 只回复 OK",
+    type: "instruction",
+    priority: 75,
+    source_message_ids: ["m1"],
+    metadata: {},
+    scene_name: "诊断调试",
+  };
+}
+
+describe("parseBatchResult", () => {
+  it("ignores bracketed prose before and after the conflict decision JSON array", () => {
+    const raw = `可选动作包括 [store/update/merge/skip]，下面才是决策：
+[
+  {
+    "record_id": "new-1",
+    "action": "merge",
+    "target_ids": ["old-1"],
+    "merged_content": "用户只在诊断调试场景要求 AI 只回复 OK",
+    "merged_type": "instruction",
+    "merged_priority": 75,
+    "merged_timestamps": ["2026-06-25T00:00:00.000Z"]
+  }
+]
+解析完成：[ok]`;
+
+    expect(parseBatchResult(raw, [memory("new-1")])).toEqual([
+      {
+        record_id: "new-1",
+        action: "merge",
+        target_ids: ["old-1"],
+        merged_content: "用户只在诊断调试场景要求 AI 只回复 OK",
+        merged_type: "instruction",
+        merged_priority: 75,
+        merged_timestamps: ["2026-06-25T00:00:00.000Z"],
+      },
+    ]);
+  });
+
+  it("accepts object-wrapped decision arrays even when earlier fields contain arrays", () => {
+    const raw = JSON.stringify({
+      notes: ["store/update/merge/skip are valid actions"],
+      decisions: [
+        {
+          record_id: "new-2",
+          action: "skip",
+          target_ids: ["old-2"],
+        },
+      ],
+    });
+
+    expect(parseBatchResult(raw, [memory("new-2")])).toEqual([
+      {
+        record_id: "new-2",
+        action: "skip",
+        target_ids: ["old-2"],
+      },
+    ]);
+  });
+});

--- a/src/core/record/l1-dedup.ts
+++ b/src/core/record/l1-dedup.ts
@@ -307,7 +307,7 @@ const VALID_TYPES: MemoryType[] = ["persona", "episodic", "instruction"];
  *
  * Expected format: [{record_id, action, target_ids, merged_content, merged_type, merged_priority, merged_timestamps}]
  */
-function parseBatchResult(
+export function parseBatchResult(
   raw: string,
   memories: Array<ExtractedMemory & { record_id: string }>,
   logger?: Logger,
@@ -319,19 +319,9 @@ function parseBatchResult(
       cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "");
     }
 
-    // Extract JSON array
-    const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
-    if (!arrayMatch) {
-      logger?.warn?.(`${TAG} No JSON array found in conflict detection response`);
-      return fallbackStoreAll(memories);
-    }
-
-    // Sanitize control characters inside JSON string literals that LLM may produce
-    const sanitized = sanitizeJsonForParse(arrayMatch[0]);
-    const parsed = JSON.parse(sanitized) as unknown[];
-
-    if (!Array.isArray(parsed)) {
-      logger?.warn?.(`${TAG} Conflict detection response is not an array`);
+    const parsed = parseFirstDecisionPayload(cleaned);
+    if (!parsed) {
+      logger?.warn?.(`${TAG} No JSON decision payload found in conflict detection response`);
       return fallbackStoreAll(memories);
     }
 
@@ -384,6 +374,81 @@ function parseBatchResult(
     logger?.warn?.(`${TAG} Failed to parse conflict detection result: ${err instanceof Error ? err.message : String(err)}`);
     return fallbackStoreAll(memories);
   }
+}
+
+function parseFirstDecisionPayload(text: string): unknown[] | undefined {
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch !== "[" && ch !== "{") continue;
+
+    const candidate = readBalancedJsonValue(text, i);
+    if (!candidate) continue;
+
+    try {
+      const parsed = JSON.parse(sanitizeJsonForParse(candidate));
+      const decisions = normalizeDecisionPayload(parsed);
+      if (decisions) return decisions;
+    } catch {
+      // Keep scanning: LLM prose often contains bracketed non-JSON hints.
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeDecisionPayload(parsed: unknown): unknown[] | undefined {
+  if (Array.isArray(parsed)) return parsed;
+  if (!parsed || typeof parsed !== "object") return undefined;
+
+  const obj = parsed as Record<string, unknown>;
+  for (const key of ["decisions", "results", "actions"]) {
+    if (Array.isArray(obj[key])) return obj[key];
+  }
+
+  return undefined;
+}
+
+function readBalancedJsonValue(text: string, start: number): string | undefined {
+  const opener = text[start];
+  const closer = opener === "[" ? "]" : opener === "{" ? "}" : undefined;
+  if (!closer) return undefined;
+
+  const stack: string[] = [closer];
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start + 1; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (ch === "[" || ch === "{") {
+      stack.push(ch === "[" ? "]" : "}");
+      continue;
+    }
+
+    if (ch === "]" || ch === "}") {
+      if (stack[stack.length - 1] !== ch) return undefined;
+      stack.pop();
+      if (stack.length === 0) return text.slice(start, i + 1);
+    }
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Description | 描述
Harden L1 conflict-detection result parsing so noisy LLM output does not force every extracted memory down the fallback `store` path.

The old parser used a greedy `/\[[\s\S]*\]/` match, so bracketed prose such as `[store/update/merge/skip]` before the JSON decision array could make parsing fail and silently disable dedup for the batch.

This PR:
- scans for balanced JSON arrays/objects instead of using a greedy regex
- accepts object-wrapped decision arrays such as `{ "decisions": [...] }`
- keeps fallback-to-store behavior when no valid decision payload exists
- adds focused regression coverage for noisy bracketed prose and object-wrapped payloads

## Related Issue | 关联 Issue
Related to #110 (same L1 JSON robustness failure mode, on the conflict-detection path).

## Verification | 验证
- RED: `npm test -- src/core/record/l1-dedup.test.ts` failed with fallback `store` decisions
- GREEN: `npm test -- src/core/record/l1-dedup.test.ts`
- `npm test`
- `npm run build`
