### PR TITLE
fix(record): persist L1 extraction failure diagnostics

### DIFF
--- a/src/core/record/l1-extractor-diagnostics.test.ts
+++ b/src/core/record/l1-extractor-diagnostics.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { LLMRunner } from "../types.js";
+import { extractL1Memories } from "./l1-extractor.js";
+
+const tempDirs: string[] = [];
+
+describe("extractL1Memories diagnostics", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("persists the raw LLM response when extraction returns content-filter prose instead of JSON", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-l1-diagnostics-"));
+    tempDirs.push(baseDir);
+
+    const messages: ConversationMessage[] = [
+      {
+        id: "msg-1",
+        role: "user",
+        content: "请持续追踪这个敏感新闻话题。",
+        timestamp: Date.parse("2026-06-25T09:00:00+08:00"),
+      },
+      {
+        id: "msg-2",
+        role: "assistant",
+        content: "你好，我无法给到相关内容。",
+        timestamp: Date.parse("2026-06-25T09:00:01+08:00"),
+      },
+    ];
+
+    const llmRunner: LLMRunner = {
+      async run() {
+        return "你好，我无法给到相关内容。\nProvider finish_reason: content_filter";
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages,
+      sessionKey: "hermes:user-a",
+      sessionId: "session-1",
+      baseDir,
+      config: {},
+      options: { llmRunner, model: "tokenhub/glm" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.extractedCount).toBe(0);
+
+    const diagnosticPath = path.join(baseDir, ".metadata", "l1-extraction-failures.jsonl");
+    const diagnosticLines = (await fs.readFile(diagnosticPath, "utf-8")).trim().split("\n");
+    expect(diagnosticLines).toHaveLength(1);
+
+    const entry = JSON.parse(diagnosticLines[0]!) as Record<string, unknown>;
+    expect(entry.reason).toBe("no_json_array");
+    expect(entry.sessionKey).toBe("hermes:user-a");
+    expect(entry.sessionId).toBe("session-1");
+    expect(entry.model).toBe("tokenhub/glm");
+    expect(entry.newMessageIds).toEqual(["msg-1", "msg-2"]);
+    expect(entry.rawResponse).toContain("content_filter");
+    expect(entry.rawResponseLength).toBe("你好，我无法给到相关内容。\nProvider finish_reason: content_filter".length);
+    expect(entry.rawResponseTruncated).toBe(false);
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -12,6 +12,9 @@
  * 4. Write to L1 JSONL files
  */
 
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
 import type { ConversationMessage } from "../conversation/l0-recorder.js";
 import { EXTRACT_MEMORIES_SYSTEM_PROMPT, formatExtractionPrompt } from "../prompts/l1-extraction.js";
 import { batchDedup } from "./l1-dedup.js";
@@ -41,6 +44,16 @@ interface SceneSegment {
     source_message_ids: string[];
     metadata: Record<string, unknown>;
   }>;
+}
+
+type ExtractionFailureReason = "empty_response" | "no_json_array" | "parse_error";
+
+interface ParsedExtractionResult {
+  scenes: SceneSegment[];
+  failure?: {
+    reason: ExtractionFailureReason;
+    message: string;
+  };
 }
 
 export interface L1ExtractionResult {
@@ -156,6 +169,9 @@ export async function extractL1Memories(params: {
       backgroundMessages,
       previousSceneName: options.previousSceneName,
       config,
+      baseDir,
+      sessionKey,
+      sessionId,
       logger,
       model: options.model,
       llmRunner: options.llmRunner,
@@ -298,12 +314,15 @@ async function callLlmExtraction(params: {
   backgroundMessages: ConversationMessage[];
   previousSceneName?: string;
   config: unknown;
+  baseDir: string;
+  sessionKey: string;
+  sessionId?: string;
   logger?: Logger;
   model?: string;
   /** Host-neutral LLM runner — when provided, used instead of CleanContextRunner. */
   llmRunner?: LLMRunner;
 }): Promise<SceneSegment[]> {
-  const { newMessages, backgroundMessages, previousSceneName, config, logger, model, llmRunner } = params;
+  const { newMessages, backgroundMessages, previousSceneName, config, baseDir, sessionKey, sessionId, logger, model, llmRunner } = params;
 
   const userPrompt = formatExtractionPrompt({
     newMessages,
@@ -343,17 +362,40 @@ async function callLlmExtraction(params: {
     });
   }
 
-  return parseExtractionResult(result, logger);
+  const parsed = parseExtractionResult(result, logger);
+  if (parsed.failure) {
+    await writeExtractionFailureDiagnostic({
+      baseDir,
+      sessionKey,
+      sessionId,
+      reason: parsed.failure.reason,
+      message: parsed.failure.message,
+      rawResponse: result,
+      newMessages,
+      backgroundMessages,
+      model,
+      previousSceneName,
+      logger,
+    });
+  }
+
+  return parsed.scenes;
 }
 
 /**
  * Parse the LLM's JSON response into SceneSegment array.
  * Expected format: [{scene_name, message_ids, memories: [...]}]
  */
-function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
+function parseExtractionResult(raw: string, logger?: Logger): ParsedExtractionResult {
   try {
     // Strip markdown code block wrappers if present
     let cleaned = raw.trim();
+    if (!cleaned) {
+      const message = "LLM returned an empty extraction response";
+      logger?.warn?.(`${TAG} ${message}`);
+      return { scenes: [], failure: { reason: "empty_response", message } };
+    }
+
     if (cleaned.startsWith("```")) {
       cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "");
     }
@@ -361,13 +403,14 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
     // Try to extract JSON array
     const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
     if (!arrayMatch) {
-      logger?.warn?.(`${TAG} No JSON array found in extraction response`);
+      const message = "No JSON array found in extraction response";
+      logger?.warn?.(`${TAG} ${message}`);
       // [l1-debug] NO_JSON — dump the full raw so we can see what the LLM actually said
       const rawPreview = raw.slice(0, 2048);
       logger?.warn?.(
         `${TAG} [l1-debug] NO_JSON taskId=l1-extraction, rawLen=${raw.length}, cleanedLen=${cleaned.length}, rawFull=${JSON.stringify(rawPreview)}${raw.length > 2048 ? `…(+${raw.length - 2048})` : ""}`,
       );
-      return [];
+      return { scenes: [], failure: { reason: "no_json_array", message } };
     }
 
     // Sanitize control characters inside JSON string literals that LLM may produce
@@ -375,8 +418,9 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
     const parsed = JSON.parse(sanitized) as unknown[];
 
     if (!Array.isArray(parsed)) {
-      logger?.warn?.(`${TAG} Extraction response is not an array`);
-      return [];
+      const message = "Extraction response is not an array";
+      logger?.warn?.(`${TAG} ${message}`);
+      return { scenes: [], failure: { reason: "parse_error", message } };
     }
 
     const scenes: SceneSegment[] = [];
@@ -401,10 +445,58 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       });
     }
 
-    return scenes;
+    return { scenes };
   } catch (err) {
-    logger?.warn?.(`${TAG} Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    const message = `Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`;
+    logger?.warn?.(`${TAG} ${message}`);
+    return { scenes: [], failure: { reason: "parse_error", message } };
+  }
+}
+
+async function writeExtractionFailureDiagnostic(params: {
+  baseDir: string;
+  sessionKey: string;
+  sessionId?: string;
+  reason: ExtractionFailureReason;
+  message: string;
+  rawResponse: string;
+  newMessages: ConversationMessage[];
+  backgroundMessages: ConversationMessage[];
+  model?: string;
+  previousSceneName?: string;
+  logger?: Logger;
+}): Promise<void> {
+  const diagnosticsDir = path.join(params.baseDir, ".metadata");
+  const filePath = path.join(diagnosticsDir, "l1-extraction-failures.jsonl");
+  const rawResponseLimit = 20_000;
+  const rawResponseTruncated = params.rawResponse.length > rawResponseLimit;
+  const entry = {
+    id: `l1fail_${Date.now()}_${crypto.randomBytes(4).toString("hex")}`,
+    timestamp: new Date().toISOString(),
+    reason: params.reason,
+    message: params.message,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId ?? "",
+    model: params.model ?? "",
+    previousSceneName: params.previousSceneName ?? "",
+    newMessageIds: params.newMessages.map((m) => m.id),
+    backgroundMessageIds: params.backgroundMessages.map((m) => m.id),
+    rawResponse: params.rawResponse.slice(0, rawResponseLimit),
+    rawResponseLength: params.rawResponse.length,
+    rawResponseTruncated,
+  };
+
+  try {
+    await fs.mkdir(diagnosticsDir, { recursive: true });
+    await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
+    params.logger?.warn?.(
+      `${TAG} Wrote L1 extraction failure diagnostic: ${filePath} ` +
+      `(reason=${params.reason}, rawLen=${params.rawResponse.length})`,
+    );
+  } catch (err) {
+    params.logger?.warn?.(
+      `${TAG} Failed to write L1 extraction failure diagnostic: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Description | 描述
Persist L1 extraction failure diagnostics when the extraction model returns empty output, content-filter prose, or malformed JSON instead of the expected scene array.

Before this change, `parseExtractionResult()` returned an empty array for these failures and the pipeline reported `extracted=0`, leaving operators with no durable evidence of what the model actually returned. This matches the failure mode in #104, where content filtering made L1 appear to silently stop.

This PR:
- records failed L1 extraction parses to `.metadata/l1-extraction-failures.jsonl`
- includes failure reason/message, session identifiers, model, source message ids, previous scene, raw response length, truncation flag, and a capped raw response
- preserves existing extraction semantics: parse failures still return zero scenes/memories and do not block the pipeline
- adds focused regression coverage using a content-filter style model response

## Related Issue | 关联 Issue
Fixes #104

## Verification | 验证
- RED: `npm test -- src/core/record/l1-extractor-diagnostics.test.ts` failed with missing diagnostics file
- GREEN: `npm test -- src/core/record/l1-extractor-diagnostics.test.ts`
- `npm test`
- `npm run build`
