### PR TITLE
fix(record): retry unparsable L1 extraction output

### DIFF
--- a/src/core/record/l1-extractor-retry.test.ts
+++ b/src/core/record/l1-extractor-retry.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { LLMRunner } from "../types.js";
+import { extractL1Memories } from "./l1-extractor.js";
+
+const tempDirs: string[] = [];
+
+describe("extractL1Memories retry", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("retries once when the first extraction response is unparsable", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-l1-retry-"));
+    tempDirs.push(baseDir);
+
+    const calls: Array<{ taskId: string; systemPrompt?: string }> = [];
+    const llmRunner: LLMRunner = {
+      async run(params) {
+        calls.push({ taskId: params.taskId, systemPrompt: params.systemPrompt });
+        if (calls.length === 1) {
+          return '[{"scene_name":"工程状态同步","message_ids":["msg-1"],"memories":[{"content":"broken quote}]}]';
+        }
+
+        return JSON.stringify([
+          {
+            scene_name: "工程状态同步",
+            message_ids: ["msg-1", "msg-2"],
+            memories: [
+              {
+                content: "用户偏好工程实现过程中的状态更新保持简洁。",
+                type: "instruction",
+                priority: 80,
+                source_message_ids: ["msg-1"],
+                metadata: {},
+              },
+            ],
+          },
+        ]);
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages: sampleMessages(),
+      sessionKey: "retry-session",
+      baseDir,
+      config: {},
+      options: { enableDedup: false, llmRunner },
+    });
+
+    expect(calls.map((c) => c.taskId)).toEqual(["l1-extraction", "l1-extraction-retry"]);
+    expect(calls[1]?.systemPrompt).toContain("Previous output was not valid JSON");
+    expect(result.extractedCount).toBe(1);
+    expect(result.storedCount).toBe(1);
+    expect(result.records[0]?.content).toBe("用户偏好工程实现过程中的状态更新保持简洁。");
+  });
+
+  it("does not retry a valid empty extraction array", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-l1-retry-"));
+    tempDirs.push(baseDir);
+
+    let calls = 0;
+    const llmRunner: LLMRunner = {
+      async run() {
+        calls++;
+        return "[]";
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages: sampleMessages(),
+      sessionKey: "empty-session",
+      baseDir,
+      config: {},
+      options: { enableDedup: false, llmRunner },
+    });
+
+    expect(calls).toBe(1);
+    expect(result.extractedCount).toBe(0);
+    expect(result.storedCount).toBe(0);
+  });
+});
+
+function sampleMessages(): ConversationMessage[] {
+  return [
+    {
+      id: "msg-1",
+      role: "user",
+      content: "以后工程实现过程中请给我简洁的状态更新。",
+      timestamp: Date.parse("2026-06-25T10:00:00+08:00"),
+    },
+    {
+      id: "msg-2",
+      role: "assistant",
+      content: "明白，后续工程状态更新会保持简洁。",
+      timestamp: Date.parse("2026-06-25T10:00:01+08:00"),
+    },
+  ];
+}

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -43,6 +43,11 @@ interface SceneSegment {
   }>;
 }
 
+interface ParsedExtractionResult {
+  scenes: SceneSegment[];
+  parseFailed: boolean;
+}
+
 export interface L1ExtractionResult {
   /** Whether extraction succeeded */
   success: boolean;
@@ -316,41 +321,54 @@ async function callLlmExtraction(params: {
     `${TAG} [l1-debug] ENTRY taskId=l1-extraction, newMsgs=${newMessages.length}, bgMsgs=${backgroundMessages.length}, userPromptLen=${userPrompt.length}, sysPromptLen=${EXTRACT_MEMORIES_SYSTEM_PROMPT.length}, model=${model ?? "(default)"}, previousSceneName=${previousSceneName ? JSON.stringify(previousSceneName) : "(none)"}, runnerKind=${llmRunner ? "llmRunner" : "CleanContextRunner"}`,
   );
 
-  let result: string;
+  let runner: CleanContextRunner | undefined;
+  const runAttempt = async (attempt: "initial" | "retry"): Promise<string> => {
+    const taskId = attempt === "initial" ? "l1-extraction" : "l1-extraction-retry";
+    const systemPrompt = attempt === "initial"
+      ? EXTRACT_MEMORIES_SYSTEM_PROMPT
+      : `${EXTRACT_MEMORIES_SYSTEM_PROMPT}\n\nPrevious output was not valid JSON. Return only the required JSON array, with no markdown or explanation.`;
 
-  if (llmRunner) {
-    // Use the host-neutral LLMRunner interface
-    result = await llmRunner.run({
-      prompt: userPrompt,
-      systemPrompt: EXTRACT_MEMORIES_SYSTEM_PROMPT,
-      taskId: "l1-extraction",
-      timeoutMs: 180_000,
-    });
-  } else {
-    // Fallback: create CleanContextRunner (OpenClaw path)
-    const runner = new CleanContextRunner({
+    if (llmRunner) {
+      // Use the host-neutral LLMRunner interface
+      return llmRunner.run({
+        prompt: userPrompt,
+        systemPrompt,
+        taskId,
+        timeoutMs: 180_000,
+      });
+    }
+
+    runner ??= new CleanContextRunner({
       config,
       modelRef: model,
       enableTools: false,
       logger,
     });
 
-    result = await runner.run({
+    return runner.run({
       prompt: userPrompt,
-      systemPrompt: EXTRACT_MEMORIES_SYSTEM_PROMPT,
-      taskId: "l1-extraction",
+      systemPrompt,
+      taskId,
       timeoutMs: 180_000,
     });
+  };
+
+  const result = await runAttempt("initial");
+  const parsed = parseExtractionResult(result, logger);
+  if (!parsed.parseFailed) {
+    return parsed.scenes;
   }
 
-  return parseExtractionResult(result, logger);
+  logger?.warn?.(`${TAG} Retrying L1 extraction once after unparsable model output`);
+  const retryResult = await runAttempt("retry");
+  return parseExtractionResult(retryResult, logger).scenes;
 }
 
 /**
  * Parse the LLM's JSON response into SceneSegment array.
  * Expected format: [{scene_name, message_ids, memories: [...]}]
  */
-function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
+function parseExtractionResult(raw: string, logger?: Logger): ParsedExtractionResult {
   try {
     // Strip markdown code block wrappers if present
     let cleaned = raw.trim();
@@ -367,7 +385,7 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       logger?.warn?.(
         `${TAG} [l1-debug] NO_JSON taskId=l1-extraction, rawLen=${raw.length}, cleanedLen=${cleaned.length}, rawFull=${JSON.stringify(rawPreview)}${raw.length > 2048 ? `…(+${raw.length - 2048})` : ""}`,
       );
-      return [];
+      return { scenes: [], parseFailed: true };
     }
 
     // Sanitize control characters inside JSON string literals that LLM may produce
@@ -376,7 +394,7 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
 
     if (!Array.isArray(parsed)) {
       logger?.warn?.(`${TAG} Extraction response is not an array`);
-      return [];
+      return { scenes: [], parseFailed: true };
     }
 
     const scenes: SceneSegment[] = [];
@@ -401,10 +419,10 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       });
     }
 
-    return scenes;
+    return { scenes, parseFailed: false };
   } catch (err) {
     logger?.warn?.(`${TAG} Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    return { scenes: [], parseFailed: true };
   }
 }
 


### PR DESCRIPTION
## Description | 描述
Retry L1 extraction once when the model returns output that cannot be parsed as the required JSON scene array.

This addresses the L1 parse-failure part of seed data loss in #115. Non-OpenAI-compatible models can produce structurally invalid JSON; previously `parseExtractionResult()` returned `[]`, so the batch ended as `extracted=0, stored=0` with no second attempt.

This PR:
- distinguishes parse failures from a valid empty extraction array
- retries exactly once on parse failure with a stricter JSON-only system instruction
- keeps valid `[]` responses as-is and does not retry them
- reuses the same runner instance on the CleanContextRunner path
- adds focused regression coverage for retry success and valid-empty no-retry behavior

## Related Issue | 关联 Issue
Fixes #115

## Verification | 验证
- RED: `npm test -- src/core/record/l1-extractor-retry.test.ts` failed because only `l1-extraction` ran once
- GREEN: `npm test -- src/core/record/l1-extractor-retry.test.ts`
- `npm test`
- `npm run build`
