### PR TITLE
fix(hermes): log provider startup semantics

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -249,6 +249,46 @@ def _discover_gateway_cmd() -> Optional[str]:
     return None
 
 
+def _log_provider_startup_state(
+    *,
+    host: str,
+    port: int,
+    gateway_cmd: Optional[str],
+    init_kwargs: Dict[str, Any],
+) -> None:
+    """Explain why the provider is running and what it will do.
+
+    Hermes loads this module when ``memory.provider`` is set to
+    ``memory_tencentdb``. Host-side fields named ``memory_enabled`` and
+    ``user_profile_enabled`` only affect Hermes prompt advertising in current
+    Hermes releases, so the provider needs to make that runtime state explicit.
+    """
+    gateway_mode = "managed sidecar" if gateway_cmd else "external Gateway only"
+    logger.info(
+        "memory-tencentdb provider loaded because Hermes "
+        "memory.provider=memory_tencentdb; memory.memory_enabled only controls "
+        "Hermes system-prompt advertising and does not disable this provider. "
+        "You can disable memory_tencentdb by clearing memory.provider. "
+        "Runtime: gateway=%s:%d, startup=%s, features=watchdog,gateway,recall,"
+        "capture,L1/L2/L3 pipeline.",
+        host,
+        port,
+        gateway_mode,
+    )
+
+    memory_enabled = init_kwargs.get("memory_enabled")
+    user_profile_enabled = init_kwargs.get("user_profile_enabled")
+    if memory_enabled is False or user_profile_enabled is False:
+        logger.warning(
+            "memory-tencentdb host config appears to pass memory_enabled=%r, "
+            "user_profile_enabled=%r. These Hermes fields only affect host "
+            "system-prompt advertising; the plugin still runs because "
+            "memory.provider=memory_tencentdb.",
+            memory_enabled,
+            user_profile_enabled,
+        )
+
+
 # Search tool limit bounds (shared by memory_search and conversation_search).
 _DEFAULT_SEARCH_LIMIT = 5
 _MAX_SEARCH_LIMIT = 20
@@ -750,6 +790,13 @@ class MemoryTencentdbProvider(MemoryProvider):
         # configure ``TDAI_GATEWAY_API_KEY`` / ``server.apiKey`` on the
         # Gateway side directly so both ends agree on the secret.
         api_key = _resolve_gateway_api_key()
+
+        _log_provider_startup_state(
+            host=host,
+            port=port,
+            gateway_cmd=gateway_cmd,
+            init_kwargs=kwargs,
+        )
 
         self._supervisor = GatewaySupervisor(
             host=host,

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -19,6 +19,7 @@ real Node processes nor open network sockets.
 
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 import sys
@@ -229,6 +230,36 @@ def test_reap_dead_process_keeps_alive_handle():
     sup._process = alive
     sup._reap_dead_process()
     assert sup._process is alive
+
+
+# ---------------------------------------------------------------------------
+# Startup observability
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_logs_why_provider_runs(monkeypatch, fast_watchdog, caplog):
+    import plugins.memory.memory_tencentdb as mod
+
+    fake = FakeSupervisor()
+
+    def _factory(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(mod, "GatewaySupervisor", _factory)
+    monkeypatch.setenv("MEMORY_TENCENTDB_GATEWAY_CMD", "fake-cmd")
+    caplog.set_level(logging.INFO, logger=mod.__name__)
+
+    provider = MemoryTencentdbProvider()
+    try:
+        provider.initialize(session_id="startup-banner-session", user_id="tester")
+        assert _wait_until(lambda: provider._gateway_available, timeout=2.0)
+
+        text = caplog.text
+        assert "memory-tencentdb provider loaded because Hermes memory.provider=memory_tencentdb" in text
+        assert "memory.memory_enabled only controls Hermes system-prompt advertising" in text
+        assert "disable memory_tencentdb by clearing memory.provider" in text
+    finally:
+        provider.shutdown()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- log a Hermes provider startup banner explaining that memory.provider loads memory_tencentdb
- clarify that memory_enabled/user_profile_enabled only affect host prompt advertising, not plugin execution
- warn if host config fields are passed through with disabled-looking values

Fixes #95

## Verification
- PYTHONPATH=/tmp/hermes-agent-stub HERMES_AGENT_ROOT=/tmp/hermes-agent-stub /tmp/tdai-memory-pytest-venv/bin/python -m pytest hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py -q
- npm test
- npm run build