### PR TITLE
feat(recall): add show injected visibility option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { stripRelevantMemoriesFromContent } from "./src/utils/recall-visibility.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -624,30 +625,13 @@ export default function register(api: OpenClawPluginApi) {
 
     if (msg.role !== "user") return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+    const stripped = stripRelevantMemoriesFromContent(msg.content, {
+      showInjected: cfg.recall.showInjected,
+    });
+    if (!stripped.changed) return;
 
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
-    }
-
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
+    api.logger.debug?.(`${TAG} [before_message_write] Stripped recalled context: removed ${stripped.removedChars} chars`);
+    return { message: { ...event.message, content: stripped.content } as typeof event.message };
   });
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,8 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /** Preserve injected recall context in visible conversation history (default: false). */
+  showInjected: boolean;
 }
 
 /** Embedding service configuration for vector search. */
@@ -535,6 +537,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      showInjected: bool(recallGroup, "showInjected") ?? false,
     },
     embedding: {
       enabled: embeddingEnabled,

--- a/src/utils/recall-visibility.test.ts
+++ b/src/utils/recall-visibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "../config.js";
+import { stripRelevantMemoriesFromContent } from "./recall-visibility.js";
+
+describe("recall.showInjected", () => {
+  it("defaults to hiding injected recall context", () => {
+    expect(parseConfig({}).recall.showInjected).toBe(false);
+  });
+
+  it("can preserve injected recall context for visible history", () => {
+    expect(parseConfig({ recall: { showInjected: true } }).recall.showInjected).toBe(true);
+
+    const content = "hello\n<relevant-memories>\nremembered fact\n</relevant-memories>";
+    const result = stripRelevantMemoriesFromContent(content, { showInjected: true });
+
+    expect(result.changed).toBe(false);
+    expect(result.content).toBe(content);
+  });
+
+  it("strips injected recall context when visibility is disabled", () => {
+    const result = stripRelevantMemoriesFromContent(
+      "hello\n<relevant-memories>\nremembered fact\n</relevant-memories>",
+      { showInjected: false },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toBe("hello");
+    expect(result.removedChars).toBeGreaterThan(0);
+  });
+
+  it("strips injected recall context from text parts only", () => {
+    const result = stripRelevantMemoriesFromContent(
+      [
+        { type: "text", text: "hello\n<relevant-memories>x</relevant-memories>" },
+        { type: "image", imageUrl: "file://example.png" },
+      ],
+      { showInjected: false },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: "hello" },
+      { type: "image", imageUrl: "file://example.png" },
+    ]);
+  });
+});

--- a/src/utils/recall-visibility.ts
+++ b/src/utils/recall-visibility.ts
@@ -1,0 +1,59 @@
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+export interface StripRelevantMemoriesOptions {
+  showInjected: boolean;
+}
+
+export interface StripRelevantMemoriesResult<T = unknown> {
+  content: T;
+  changed: boolean;
+  removedChars: number;
+}
+
+export function stripRelevantMemoriesFromContent<T>(
+  content: T,
+  options: StripRelevantMemoriesOptions,
+): StripRelevantMemoriesResult<T> {
+  if (options.showInjected) {
+    return { content, changed: false, removedChars: 0 };
+  }
+
+  if (typeof content === "string") {
+    if (!content.includes("<relevant-memories>")) {
+      return { content, changed: false, removedChars: 0 };
+    }
+    const cleaned = content.replace(RELEVANT_MEMORIES_RE, "").trim();
+    return {
+      content: cleaned as T,
+      changed: cleaned !== content,
+      removedChars: content.length - cleaned.length,
+    };
+  }
+
+  if (Array.isArray(content)) {
+    let removedChars = 0;
+    const cleanedParts = content.map((part) => {
+      if (!isTextPart(part) || !part.text.includes("<relevant-memories>")) return part;
+      const cleaned = part.text.replace(RELEVANT_MEMORIES_RE, "").trim();
+      removedChars += part.text.length - cleaned.length;
+      return { ...part, text: cleaned };
+    });
+
+    return {
+      content: cleanedParts as T,
+      changed: removedChars > 0,
+      removedChars,
+    };
+  }
+
+  return { content, changed: false, removedChars: 0 };
+}
+
+function isTextPart(part: unknown): part is { type: string; text: string } {
+  return (
+    !!part &&
+    typeof part === "object" &&
+    (part as { type?: unknown }).type === "text" &&
+    typeof (part as { text?: unknown }).text === "string"
+  );
+}


### PR DESCRIPTION
## Summary
- add `recall.showInjected` config with a safe default of `false`
- preserve `<relevant-memories>` in visible user-message history when enabled
- extract the relevant-memory stripping logic into a tested helper for string and text-part content

Fixes #114
Refs #11

## Verification
- npm test -- src/utils/recall-visibility.test.ts
- npm test
- npm run build