### PR TITLE
fix(l1): retry failed extraction outputs

### DIFF
--- a/src/core/record/l1-extractor.test.ts
+++ b/src/core/record/l1-extractor.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { extractL1Memories } from "./l1-extractor.js";
+import type { LLMRunner, Logger } from "../types.js";
+
+const noopLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+describe("extractL1Memories", () => {
+  it("treats provider content-filter refusals as failed extraction output", async () => {
+    const refusingRunner: LLMRunner = {
+      async run() {
+        return "你好，我无法给到相关内容。\nProvider finish_reason: content_filter";
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          content: "Please remember that project Atlas has a deployment freeze until Friday.",
+          timestamp: Date.now(),
+        },
+      ],
+      sessionKey: "session-a",
+      baseDir: "/tmp/tencentdb-agent-memory-test",
+      config: {},
+      options: {
+        enableDedup: false,
+        llmRunner: refusingRunner,
+      },
+      logger: noopLogger,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.extractedCount).toBe(0);
+    expect(result.storedCount).toBe(0);
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -367,7 +367,10 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       logger?.warn?.(
         `${TAG} [l1-debug] NO_JSON taskId=l1-extraction, rawLen=${raw.length}, cleanedLen=${cleaned.length}, rawFull=${JSON.stringify(rawPreview)}${raw.length > 2048 ? `…(+${raw.length - 2048})` : ""}`,
       );
-      return [];
+      if (cleaned.length === 0) {
+        return [];
+      }
+      throw new Error("Extraction response did not contain a JSON array");
     }
 
     // Sanitize control characters inside JSON string literals that LLM may produce
@@ -403,8 +406,7 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
 
     return scenes;
   } catch (err) {
-    logger?.warn?.(`${TAG} Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    throw new Error(`Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/utils/pipeline-factory.test.ts
+++ b/src/utils/pipeline-factory.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseConfig } from "../config.js";
+import { recordConversation } from "../core/conversation/l0-recorder.js";
+import type { LLMRunner, Logger } from "../core/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { createL1Runner } from "./pipeline-factory.js";
+
+const noopLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+describe("createL1Runner", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("does not advance the L1 cursor when extraction fails", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "tdai-l1-runner-"));
+    tempDirs.push(baseDir);
+
+    await recordConversation({
+      sessionKey: "session-a",
+      sessionId: "thread-a",
+      baseDir,
+      rawMessages: [
+        {
+          id: "msg_1",
+          role: "user",
+          content: "Please remember that project Atlas has a deployment freeze until Friday.",
+          timestamp: Date.now(),
+        },
+      ],
+      logger: noopLogger,
+    });
+
+    const failingRunner: LLMRunner = {
+      async run() {
+        throw new Error("Provider finish_reason: content_filter");
+      },
+    };
+
+    const runner = createL1Runner({
+      pluginDataDir: baseDir,
+      cfg: parseConfig({ extraction: { enableDedup: false } }),
+      openclawConfig: {},
+      vectorStore: undefined,
+      embeddingService: undefined,
+      logger: noopLogger,
+      llmRunner: failingRunner,
+    });
+
+    await expect(runner({ sessionKey: "session-a" })).rejects.toThrow(/L1 extraction failed/i);
+
+    const checkpoint = new CheckpointManager(baseDir, noopLogger);
+    const state = await checkpoint.read();
+
+    expect(state.runner_states["session-a"]?.last_l1_cursor ?? 0).toBe(0);
+    expect(state.total_memories_extracted).toBe(0);
+  });
+});

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -371,6 +371,13 @@ export function createL1Runner(opts: {
           instanceId: getInstanceId?.(),
         });
 
+        if (!l1Result.success) {
+          throw new Error(
+            `L1 extraction failed for session ${sessionKey}` +
+            (group.sessionId ? ` (sessionId=${group.sessionId})` : ""),
+          );
+        }
+
         totalExtracted += l1Result.extractedCount;
         totalStored += l1Result.storedCount;
         if (l1Result.lastSceneName) {


### PR DESCRIPTION
## Summary

- Treat non-empty, non-JSON L1 extraction responses (for example provider content-filter refusals) as extraction failures instead of empty successful results.
- Propagate `extractL1Memories().success === false` through the standard L1 runner so the pipeline does not advance the L1 checkpoint cursor after failed extraction.
- Add regression coverage for both the extractor classification and checkpoint-preservation path.

## Why

When a provider returns a refusal/content-filter message, the current parser returns an empty extraction. The L1 runner then marks the L0 cursor complete, so the affected messages are skipped permanently and later L2 runs have nothing to process. This matches the silent `extracted=0, stored=0` failure mode reported in #104.

## Tests

- `npm test -- src/core/record/l1-extractor.test.ts src/utils/pipeline-factory.test.ts`
- `npm test`
- `npm run build`

Closes #104