### PR TITLE
feat(core): add explicit memory write tool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -434,6 +434,113 @@ export default function register(api: OpenClawPluginApi) {
     { name: "tdai_memory_search" },
   );
 
+  // tdai_memory_write — Agent-callable explicit L1 memory write tool
+  api.registerTool(
+    {
+      name: "tdai_memory_write",
+      label: "Memory Write",
+      description:
+        "Write a concise, explicit long-term memory supplied by the user or agent. " +
+        "Use only when the user asks you to remember something, or when you need to store a verified note from a subagent. " +
+        "This bypasses automatic L1 extraction and conflict detection, so do not use it for guesses or inferred preferences.",
+      parameters: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: "The exact memory content to store",
+          },
+          type: {
+            type: "string",
+            enum: ["persona", "episodic", "instruction"],
+            description: "Memory type: persona (identity/preferences), episodic (events/activities), instruction (user rules/commands). Defaults to episodic.",
+          },
+          scene_name: {
+            type: "string",
+            description: "Optional scene name for this memory. Defaults to manual.",
+          },
+          priority: {
+            type: "number",
+            description: "Optional importance score from 0 to 100. Defaults by type.",
+          },
+          session_key: {
+            type: "string",
+            description: "Optional session key to scope the memory. Defaults to manual-tool-write when unavailable.",
+          },
+          session_id: {
+            type: "string",
+            description: "Optional conversation session ID for traceability.",
+          },
+        },
+        required: ["content"],
+      },
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const startMs = Date.now();
+        const content = String(params.content ?? "");
+        const type = typeof params.type === "string" ? params.type : undefined;
+        const sceneName = typeof params.scene_name === "string" ? params.scene_name : undefined;
+        const priority = typeof params.priority === "number" ? params.priority : undefined;
+        const sessionKey = typeof params.session_key === "string" ? params.session_key : undefined;
+        const sessionId = typeof params.session_id === "string" ? params.session_id : undefined;
+
+        api.logger.debug?.(
+          `${TAG} [tool] tdai_memory_write called: ` +
+          `contentLen=${content.length}, type=${type ?? "(default)"}, ` +
+          `scene=${sceneName ?? "(default)"}, sessionKey=${sessionKey ?? "(default)"}`,
+        );
+
+        try {
+          const result = await core.writeMemory({
+            content,
+            type,
+            sceneName,
+            priority,
+            sessionKey,
+            sessionId,
+          });
+
+          const elapsedMs = Date.now() - startMs;
+          api.logger.debug?.(
+            `${TAG} [tool] tdai_memory_write completed (${elapsedMs}ms): ` +
+            `id=${result.record.id}, type=${result.record.type}, sessionKey=${result.record.sessionKey}`,
+          );
+          report("tool_call", {
+            tool: "tdai_memory_write",
+            type: result.record.type,
+            sceneName: result.record.scene_name,
+            sessionKey: result.record.sessionKey,
+            durationMs: elapsedMs,
+            success: true,
+          });
+          return {
+            content: [{ type: "text" as const, text: result.text }],
+            details: {
+              id: result.record.id,
+              type: result.record.type,
+              priority: result.record.priority,
+              sessionKey: result.record.sessionKey,
+            },
+          };
+        } catch (err) {
+          const elapsedMs = Date.now() - startMs;
+          const errMsg = err instanceof Error ? err.message : String(err);
+          api.logger.error(`${TAG} [tool] tdai_memory_write failed (${elapsedMs}ms): ${errMsg}`);
+          report("tool_call", {
+            tool: "tdai_memory_write",
+            durationMs: elapsedMs,
+            success: false,
+            error: errMsg,
+          });
+          return {
+            content: [{ type: "text" as const, text: `Memory write failed: ${errMsg}` }],
+            details: { error: errMsg },
+          };
+        }
+      },
+    },
+    { name: "tdai_memory_write" },
+  );
+
   // tdai_conversation_search — Agent-callable L0 conversation search tool
   // TODO: implement hard per-turn call limit via before_tool_call hook + execute early-return (方案 D)
   api.registerTool(
@@ -516,7 +623,7 @@ export default function register(api: OpenClawPluginApi) {
     { name: "tdai_conversation_search" },
   );
   } else {
-    api.logger.debug?.(`${TAG} Memory tools (tdai_memory_search, tdai_conversation_search) not registered — memory features disabled`);
+    api.logger.debug?.(`${TAG} Memory tools (tdai_memory_search, tdai_memory_write, tdai_conversation_search) not registered — memory features disabled`);
   }
 
   // ============================

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -36,6 +36,7 @@ import { performAutoRecall } from "./hooks/auto-recall.js";
 import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
+import { executeMemoryWrite } from "./tools/memory-write.js";
 import {
   initDataDirectories,
   initStores,
@@ -323,6 +324,32 @@ export class TdaiCore {
       text: formatConversationSearchResponse(result),
       total: result.total,
     };
+  }
+
+  /**
+   * Write an explicit L1 memory.
+   * Maps to: `tdai_memory_write` tool.
+   */
+  async writeMemory(params: {
+    content: string;
+    type?: string;
+    sceneName?: string;
+    priority?: number;
+    sessionKey?: string;
+    sessionId?: string;
+  }): Promise<Awaited<ReturnType<typeof executeMemoryWrite>>> {
+    await this.storeReady?.catch(() => {});
+
+    const runtime = this.hostAdapter.getRuntimeContext();
+    return executeMemoryWrite({
+      ...params,
+      baseDir: this.dataDir,
+      sessionKey: params.sessionKey ?? runtime.sessionKey,
+      sessionId: params.sessionId ?? runtime.sessionId,
+      vectorStore: this.vectorStore,
+      embeddingService: this.embeddingService,
+      logger: this.logger,
+    });
   }
 
   /**

--- a/src/core/tools/memory-write.test.ts
+++ b/src/core/tools/memory-write.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readMemoryRecords } from "../record/l1-reader.js";
+import { executeMemoryWrite } from "./memory-write.js";
+
+describe("executeMemoryWrite", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("stores an explicit memory through the L1 writer", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "tdai-memory-write-"));
+    tempDirs.push(baseDir);
+
+    const result = await executeMemoryWrite({
+      baseDir,
+      sessionKey: "subagent-alpha",
+      sessionId: "thread-1",
+      content: "User prefers concise TypeScript examples with focused tests.",
+      type: "instruction",
+      sceneName: "manual subagent note",
+      priority: 88,
+    });
+
+    expect(result.record.content).toBe("User prefers concise TypeScript examples with focused tests.");
+    expect(result.record.type).toBe("instruction");
+    expect(result.record.priority).toBe(88);
+    expect(result.record.scene_name).toBe("manual subagent note");
+    expect(result.record.sessionKey).toBe("subagent-alpha");
+    expect(result.record.sessionId).toBe("thread-1");
+    expect(result.text).toContain(result.record.id);
+
+    const records = await readMemoryRecords("subagent-alpha", baseDir);
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe(result.record.id);
+  });
+
+  it("rejects empty content and invalid memory types", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "tdai-memory-write-invalid-"));
+    tempDirs.push(baseDir);
+
+    await expect(executeMemoryWrite({
+      baseDir,
+      sessionKey: "subagent-alpha",
+      content: "   ",
+    })).rejects.toThrow(/content/i);
+
+    await expect(executeMemoryWrite({
+      baseDir,
+      sessionKey: "subagent-alpha",
+      content: "Remember this explicit note.",
+      type: "temporary",
+    })).rejects.toThrow(/type/i);
+  });
+});

--- a/src/core/tools/memory-write.ts
+++ b/src/core/tools/memory-write.ts
@@ -1,0 +1,128 @@
+/**
+ * memory_write tool: Agent-callable explicit L1 memory writer.
+ *
+ * This is intentionally narrow: callers provide the final memory content.
+ * The tool does not summarize, infer, deduplicate, or resolve conflicts.
+ */
+
+import { generateMemoryId, writeMemory } from "../record/l1-writer.js";
+import type { ExtractedMemory, MemoryRecord, MemoryType } from "../record/l1-writer.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore } from "../store/types.js";
+import type { Logger } from "../types.js";
+
+export interface MemoryWriteResult {
+  record: MemoryRecord;
+  text: string;
+}
+
+export interface ExecuteMemoryWriteParams {
+  content: string;
+  baseDir: string;
+  type?: string;
+  sceneName?: string;
+  priority?: number;
+  sessionKey?: string;
+  sessionId?: string;
+  vectorStore?: IMemoryStore;
+  embeddingService?: EmbeddingService;
+  logger?: Logger;
+}
+
+const TAG = "[memory-tdai][tdai_memory_write]";
+const MAX_CONTENT_CHARS = 5000;
+const VALID_TYPES: MemoryType[] = ["persona", "episodic", "instruction"];
+
+export async function executeMemoryWrite(params: ExecuteMemoryWriteParams): Promise<MemoryWriteResult> {
+  const content = normalizeContent(params.content);
+  const type = normalizeType(params.type);
+  const priority = normalizePriority(params.priority, type);
+  const sceneName = normalizeOptionalString(params.sceneName) ?? "manual";
+  const sessionKey = normalizeOptionalString(params.sessionKey) ?? "manual-tool-write";
+  const sessionId = normalizeOptionalString(params.sessionId) ?? "";
+  const recordId = generateMemoryId();
+
+  const memory: ExtractedMemory = {
+    content,
+    type,
+    priority,
+    scene_name: sceneName,
+    source_message_ids: [`tool:${recordId}`],
+    metadata: {},
+  };
+
+  const record = await writeMemory({
+    memory,
+    decision: {
+      record_id: recordId,
+      action: "store",
+      target_ids: [],
+    },
+    baseDir: params.baseDir,
+    sessionKey,
+    sessionId,
+    logger: params.logger,
+    vectorStore: params.vectorStore,
+    embeddingService: params.embeddingService,
+  });
+
+  if (!record) {
+    throw new Error("Memory write was skipped unexpectedly");
+  }
+
+  params.logger?.debug?.(
+    `${TAG} stored id=${record.id}, type=${record.type}, priority=${record.priority}, ` +
+    `sessionKey=${record.sessionKey}, contentLen=${record.content.length}`,
+  );
+
+  return {
+    record,
+    text: formatMemoryWriteResponse(record),
+  };
+}
+
+export function formatMemoryWriteResponse(record: MemoryRecord): string {
+  return [
+    `Stored memory ${record.id}.`,
+    `Type: ${record.type}`,
+    `Priority: ${record.priority}`,
+    `Scene: ${record.scene_name}`,
+    `Content: ${record.content}`,
+  ].join("\n");
+}
+
+function normalizeContent(raw: string): string {
+  const content = raw.trim();
+  if (!content) {
+    throw new Error("Memory content is required");
+  }
+  if (content.length > MAX_CONTENT_CHARS) {
+    throw new Error(`Memory content is too long (max ${MAX_CONTENT_CHARS} characters)`);
+  }
+  return content;
+}
+
+function normalizeType(raw: string | undefined): MemoryType {
+  const type = normalizeOptionalString(raw) ?? "episodic";
+  if (!VALID_TYPES.includes(type as MemoryType)) {
+    throw new Error(`Invalid memory type "${type}". Expected one of: ${VALID_TYPES.join(", ")}`);
+  }
+  return type as MemoryType;
+}
+
+function normalizePriority(raw: number | undefined, type: MemoryType): number {
+  if (raw == null) {
+    if (type === "instruction") return 80;
+    if (type === "persona") return 70;
+    return 60;
+  }
+  if (!Number.isFinite(raw) || raw < 0 || raw > 100) {
+    throw new Error("Memory priority must be a finite number between 0 and 100");
+  }
+  return Math.round(raw);
+}
+
+function normalizeOptionalString(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  return value ? value : undefined;
+}


### PR DESCRIPTION
## Summary

- Adds `tdai_memory_write` for explicit long-term memory writes from agent/subagent contexts.
- Reuses the existing L1 `writeMemory()` path so writes append JSONL and dual-write to the vector store when available.
- Validates content, type, priority, and stores traceable manual source IDs without adding LLM inference or automatic conflict resolution.

## Scope

This is intentionally conservative because direct writes bypass the automatic L1 extraction/dedup pipeline. The tool only stores caller-provided explicit memory content and its description tells agents not to use it for guesses or inferred preferences.

## Tests

- `npm test -- src/core/tools/memory-write.test.ts`
- `npm test`
- `npm run build`

Closes #66