### PR TITLE
fix(l1): drop ungrounded extracted memories

### DIFF
--- a/src/core/record/l1-extractor.test.ts
+++ b/src/core/record/l1-extractor.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { extractL1Memories } from "./l1-extractor.js";
+import { readMemoryRecords } from "./l1-reader.js";
+import type { LLMRunner, Logger } from "../types.js";
+
+const noopLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+describe("extractL1Memories", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("drops LLM memories that are not grounded in source messages", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "tdai-l1-validation-"));
+    tempDirs.push(baseDir);
+
+    const llmRunner: LLMRunner = {
+      async run() {
+        return JSON.stringify([
+          {
+            scene_name: "typescript examples",
+            message_ids: ["msg_1"],
+            memories: [
+              {
+                content: "User prefers concise TypeScript examples.",
+                type: "instruction",
+                priority: 80,
+                source_message_ids: ["msg_1"],
+                metadata: {},
+              },
+              {
+                content: "User is a professional violinist living in Berlin.",
+                type: "persona",
+                priority: 90,
+                source_message_ids: ["msg_1"],
+                metadata: {},
+              },
+            ],
+          },
+        ]);
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          content: "Please remember that I prefer concise TypeScript examples.",
+          timestamp: Date.now(),
+        },
+      ],
+      sessionKey: "session-a",
+      sessionId: "thread-a",
+      baseDir,
+      config: {},
+      options: {
+        enableDedup: false,
+        llmRunner,
+      },
+      logger: noopLogger,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.extractedCount).toBe(1);
+    expect(result.storedCount).toBe(1);
+    expect(result.records[0].content).toBe("User prefers concise TypeScript examples.");
+
+    const records = await readMemoryRecords("session-a", baseDir);
+    expect(records.map((record) => record.content)).toEqual([
+      "User prefers concise TypeScript examples.",
+    ]);
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -191,7 +191,25 @@ export async function extractL1Memories(params: {
 
   logger?.debug?.(`${TAG} Total extracted memories: ${allExtracted.length} across ${scenes.length} scene(s)`);
 
-  if (allExtracted.length === 0) {
+  const validatedExtracted = allExtracted.filter((memory) => {
+    const sourceText = getMemorySourceText(memory, qualifiedMessages);
+    const accepted = passesPostLlmValidation(memory, sourceText);
+    if (!accepted) {
+      logger?.warn?.(
+        `${TAG} Dropping low-confidence memory not grounded in source messages: ` +
+        `"${memory.content.slice(0, 100)}${memory.content.length > 100 ? "…" : ""}"`,
+      );
+    }
+    return accepted;
+  });
+
+  if (validatedExtracted.length < allExtracted.length) {
+    logger?.debug?.(
+      `${TAG} Post-LLM validation: ${allExtracted.length} → ${validatedExtracted.length} memories`,
+    );
+  }
+
+  if (validatedExtracted.length === 0) {
     return {
       success: true,
       extractedCount: 0,
@@ -203,7 +221,7 @@ export async function extractL1Memories(params: {
   }
 
   // Limit per session
-  let extracted = allExtracted;
+  let extracted = validatedExtracted;
   if (extracted.length > maxMemoriesPerSession) {
     logger?.debug?.(`${TAG} Limiting from ${extracted.length} to ${maxMemoriesPerSession} memories per session`);
     extracted = extracted.slice(0, maxMemoriesPerSession);
@@ -526,3 +544,58 @@ function normalizeType(raw: string): MemoryType | null {
   if (lower === "preference") return "persona"; // fold preference into persona
   return null;
 }
+
+function getMemorySourceText(memory: ExtractedMemory, messages: ConversationMessage[]): string {
+  const byId = new Map(messages.map((m) => [m.id, m.content]));
+  const matchedSourceText = memory.source_message_ids
+    .map((id) => byId.get(id))
+    .filter((content): content is string => typeof content === "string" && content.length > 0)
+    .join("\n");
+
+  return matchedSourceText || messages.map((m) => m.content).join("\n");
+}
+
+function passesPostLlmValidation(memory: ExtractedMemory, sourceText: string): boolean {
+  const content = memory.content.trim();
+  if (!content) return false;
+
+  const significantTokens = extractSignificantTokens(content);
+  if (significantTokens.length === 0) return false;
+
+  const normalizedSource = normalizeForMatching(sourceText);
+  const matched = significantTokens.filter((token) => normalizedSource.includes(token));
+  return matched.length / significantTokens.length >= 0.3;
+}
+
+function extractSignificantTokens(text: string): string[] {
+  const normalized = normalizeForMatching(text);
+  const tokens = new Set<string>();
+
+  for (const word of normalized.match(/[a-z0-9]{4,}/g) ?? []) {
+    if (!ENGLISH_STOPWORDS.has(word)) tokens.add(word);
+  }
+
+  const cjkChars = Array.from(normalized.match(/[\u4e00-\u9fff]/g) ?? []);
+  for (let i = 0; i < cjkChars.length - 1; i++) {
+    tokens.add(`${cjkChars[i]}${cjkChars[i + 1]}`);
+  }
+
+  return [...tokens];
+}
+
+function normalizeForMatching(text: string): string {
+  return text.toLowerCase().normalize("NFKC");
+}
+
+const ENGLISH_STOPWORDS = new Set([
+  "about",
+  "after",
+  "also",
+  "assistant",
+  "because",
+  "from",
+  "that",
+  "this",
+  "user",
+  "with",
+]);


### PR DESCRIPTION
## Summary

- Adds a conservative post-LLM validation pass for L1 extraction output.
- Drops extracted memories whose significant tokens have too little overlap with their source messages, preventing obvious hallucinated facts from reaching L1 storage.
- Keeps normal paraphrases/rewrites by using a low overlap threshold and falling back to the whole qualified batch when source IDs are missing.

## Why

Issue #82 notes that LLM extraction output currently goes directly to dedup/storage without quality validation. A model can emit plausible but unsupported persona/instruction facts, and those facts then become durable memory. This PR adds a narrow source-grounding gate before dedup/write.

## Tests

- `npm test -- src/core/record/l1-extractor.test.ts`
- `npm test`
- `npm run build`

Refs #82