### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ The Docker image bundles `hermes-agent` and the `memory_tencentdb` provider toge
 
 ```bash
 # ============ Configuration Parameters ============
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/tencentcloud-tencentdb-agent-memory)
+
 # MODEL_API_KEY    LLM API key (required) — replace with your own credential
 # MODEL_BASE_URL   LLM endpoint, defaults to Tencent Cloud LKE (Large Model Knowledge Engine)
 # MODEL_NAME       Model name, defaults to DeepSeek-V3.2


### PR DESCRIPTION
Hi! 👋 **TencentDB-Agent-Memory** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/tencentcloud-tencentdb-agent-memory

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building TencentDB-Agent-Memory! 🙏