### PR TITLE
fix(embedding): forward proxy and timeout config

### DIFF
--- a/src/core/store/factory.test.ts
+++ b/src/core/store/factory.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import { createStoreBundle } from "./factory.js";
+
+const createEmbeddingServiceMock = vi.hoisted(() => vi.fn(() => ({
+  embed: vi.fn(),
+  embedBatch: vi.fn(),
+  getDimensions: vi.fn(() => 1024),
+  getProviderInfo: vi.fn(() => ({ provider: "qclaw", model: "bge-m3" })),
+  isReady: vi.fn(() => true),
+  startWarmup: vi.fn(),
+})));
+
+const VectorStoreMock = vi.hoisted(() => vi.fn(function VectorStore() {
+  return {
+    init: vi.fn(),
+    isDegraded: vi.fn(() => false),
+    getCapabilities: vi.fn(),
+    close: vi.fn(),
+    reindexAll: vi.fn(),
+  };
+}));
+
+vi.mock("./embedding.js", () => ({
+  createEmbeddingService: createEmbeddingServiceMock,
+  NoopEmbeddingService: class NoopEmbeddingService {},
+}));
+
+vi.mock("./sqlite.js", () => ({
+  VectorStore: VectorStoreMock,
+}));
+
+vi.mock("./tcvdb.js", () => ({
+  TcvdbMemoryStore: vi.fn(),
+}));
+
+vi.mock("./bm25-local.js", () => ({
+  createBM25Encoder: vi.fn(() => undefined),
+}));
+
+describe("createStoreBundle", () => {
+  it("forwards qclaw proxy and timeout embedding config to the remote embedding service", () => {
+    const cfg = parseConfig({
+      embedding: {
+        provider: "qclaw",
+        proxyUrl: "http://127.0.0.1:18080/embedding-proxy",
+        baseUrl: "https://embedding.example/v1",
+        apiKey: "test-key",
+        model: "bge-m3",
+        dimensions: 1024,
+        sendDimensions: false,
+        maxInputChars: 4096,
+        timeoutMs: 25_000,
+      },
+    });
+
+    createStoreBundle(cfg, { dataDir: "/tmp/memory-tdai-test" });
+
+    expect(createEmbeddingServiceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "qclaw",
+        proxyUrl: "http://127.0.0.1:18080/embedding-proxy",
+        baseUrl: "https://embedding.example/v1",
+        timeoutMs: 25_000,
+        sendDimensions: false,
+        maxInputChars: 4096,
+      }),
+      undefined,
+    );
+  });
+});

--- a/src/core/store/factory.ts
+++ b/src/core/store/factory.ts
@@ -99,7 +99,9 @@ export function createStoreBundle(
           model: config.embedding.model,
           dimensions: config.embedding.dimensions,
           sendDimensions: config.embedding.sendDimensions,
+          proxyUrl: config.embedding.proxyUrl,
           maxInputChars: config.embedding.maxInputChars,
+          timeoutMs: config.embedding.timeoutMs,
         }, logger);
       }
 


### PR DESCRIPTION
## Summary
- Forward `embedding.proxyUrl` into the remote embedding service so qclaw proxy mode uses the configured local proxy instead of silently calling the remote base URL directly.
- Forward `embedding.timeoutMs` into the embedding service so service-level default timeouts match user config when call sites do not pass an override.
- Add a focused store factory regression test for qclaw proxy + timeout config propagation.

## Root cause
`parseConfig()` exposes `embedding.proxyUrl` and `embedding.timeoutMs`, and `OpenAIEmbeddingService` supports both fields, but `createStoreBundle()` only forwarded provider/baseUrl/apiKey/model/dimensions/sendDimensions/maxInputChars. The factory boundary dropped proxy and timeout settings.

## Tests
- RED: `npm test -- src/core/store/factory.test.ts` failed because `createEmbeddingService()` received no `proxyUrl` or `timeoutMs`.
- GREEN: `npm test -- src/core/store/factory.test.ts`
- `npm test`
- `npm run build`