### PR TITLE
fix(search): honor recall embedding timeout

### DIFF
--- a/src/core/tdai-core.test.ts
+++ b/src/core/tdai-core.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { TdaiCore } from "./tdai-core.js";
+import type { HostAdapter, Logger } from "./types.js";
+import type { IMemoryStore } from "./store/types.js";
+import type { EmbeddingService } from "./store/embedding.js";
+import type { MemoryTdaiConfig } from "../config.js";
+
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function makeHostAdapter(): HostAdapter {
+  return {
+    hostType: "standalone",
+    getLogger: () => logger,
+    getRuntimeContext: () => ({
+      userId: "user-1",
+      sessionId: "session-1",
+      sessionKey: "session-key-1",
+      platform: "standalone",
+      workspaceDir: "/tmp/workspace",
+      dataDir: "/tmp/data",
+    }),
+    getLLMRunnerFactory: () => ({
+      createRunner: () => ({
+        run: async () => "",
+      }),
+    }),
+  };
+}
+
+function makeEmbeddingService() {
+  return {
+    embed: vi.fn(async () => new Float32Array([0.1, 0.2])),
+  } as unknown as EmbeddingService & {
+    embed: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeVectorStore() {
+  return {
+    isFtsAvailable: vi.fn(() => false),
+    searchL1Vector: vi.fn(async () => [
+      {
+        record_id: "memory-1",
+        content: "prefers short recall timeouts",
+        type: "preference",
+        priority: 80,
+        scene_name: "global",
+        score: 0.91,
+        timestamp_str: "2026-01-01",
+        timestamp_start: "2026-01-01T00:00:00.000Z",
+        timestamp_end: "2026-01-01T00:00:00.000Z",
+        session_key: "session-key-1",
+        session_id: "session-1",
+        metadata_json: "{}",
+      },
+    ]),
+    searchL0Vector: vi.fn(async () => [
+      {
+        record_id: "turn-1",
+        session_key: "session-key-1",
+        session_id: "session-1",
+        role: "user",
+        message_text: "conversation search should use recall timeout",
+        score: 0.89,
+        recorded_at: "2026-01-01T00:00:00.000Z",
+        timestamp: 1767225600000,
+      },
+    ]),
+  } as unknown as IMemoryStore;
+}
+
+function makeCore(config: unknown) {
+  const core = new TdaiCore({
+    hostAdapter: makeHostAdapter(),
+    config: config as MemoryTdaiConfig,
+  });
+  const embeddingService = makeEmbeddingService();
+  const vectorStore = makeVectorStore();
+
+  (core as unknown as { embeddingService: EmbeddingService }).embeddingService = embeddingService;
+  (core as unknown as { vectorStore: IMemoryStore }).vectorStore = vectorStore;
+
+  return { core, embeddingService };
+}
+
+describe("TdaiCore search tools", () => {
+  it("uses embedding.recallTimeoutMs for tdai_memory_search embeddings", async () => {
+    const { core, embeddingService } = makeCore({
+      embedding: {
+        timeoutMs: 10_000,
+        recallTimeoutMs: 2_000,
+      },
+    });
+
+    await core.searchMemories({ query: "recall timeout query", limit: 1 });
+
+    expect(embeddingService.embed).toHaveBeenCalledWith(
+      "recall timeout query",
+      { timeoutMs: 2_000 },
+    );
+  });
+
+  it("falls back to embedding.timeoutMs for tdai_conversation_search embeddings", async () => {
+    const { core, embeddingService } = makeCore({
+      embedding: {
+        timeoutMs: 7_500,
+      },
+    });
+
+    await core.searchConversations({ query: "conversation timeout query", limit: 1 });
+
+    expect(embeddingService.embed).toHaveBeenCalledWith(
+      "conversation timeout query",
+      { timeoutMs: 7_500 },
+    );
+  });
+});

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -295,6 +295,7 @@ export class TdaiCore {
       scene: params.scene,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
+      embeddingTimeoutMs: this.cfg.embedding.recallTimeoutMs ?? this.cfg.embedding.timeoutMs,
       logger: this.logger,
     });
 
@@ -316,6 +317,7 @@ export class TdaiCore {
       sessionKey: params.sessionKey,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
+      embeddingTimeoutMs: this.cfg.embedding.recallTimeoutMs ?? this.cfg.embedding.timeoutMs,
       logger: this.logger,
     });
 

--- a/src/core/tools/conversation-search.ts
+++ b/src/core/tools/conversation-search.ts
@@ -12,7 +12,7 @@
 
 import type { IMemoryStore, L0SearchResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
-import type { EmbeddingService } from "../store/embedding.js";
+import type { EmbeddingCallOptions, EmbeddingService } from "../store/embedding.js";
 import type { Logger } from "../types.js";
 
 // ============================
@@ -86,6 +86,7 @@ export async function executeConversationSearch(params: {
   sessionKey?: string;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  embeddingTimeoutMs?: number;
   logger?: Logger;
 }): Promise<ConversationSearchResult> {
   const {
@@ -94,6 +95,7 @@ export async function executeConversationSearch(params: {
     sessionKey: sessionFilter,
     vectorStore,
     embeddingService,
+    embeddingTimeoutMs,
     logger,
   } = params;
 
@@ -133,6 +135,8 @@ export async function executeConversationSearch(params: {
 
   // ── Over-retrieve for later filtering and RRF merging ──
   const candidateK = sessionFilter ? limit * 4 : limit * 3;
+  const embeddingCallOpts: EmbeddingCallOptions | undefined =
+    typeof embeddingTimeoutMs === "number" ? { timeoutMs: embeddingTimeoutMs } : undefined;
 
   // ── Run available search strategies in parallel ──
   const [ftsItems, vecItems] = await Promise.all([
@@ -169,7 +173,9 @@ export async function executeConversationSearch(params: {
       if (!hasEmbedding) return [];
       try {
         logger?.debug?.(`${TAG} [hybrid-vec] Generating query embedding...`);
-        const queryEmbedding = await embeddingService!.embed(query);
+        const queryEmbedding = embeddingCallOpts
+          ? await embeddingService!.embed(query, embeddingCallOpts)
+          : await embeddingService!.embed(query);
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -12,7 +12,7 @@
 
 import type { IMemoryStore, L1SearchResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
-import type { EmbeddingService } from "../store/embedding.js";
+import type { EmbeddingCallOptions, EmbeddingService } from "../store/embedding.js";
 import type { Logger } from "../types.js";
 
 // ============================
@@ -86,6 +86,7 @@ export async function executeMemorySearch(params: {
   scene?: string;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  embeddingTimeoutMs?: number;
   logger?: Logger;
 }): Promise<MemorySearchResult> {
   const {
@@ -95,6 +96,7 @@ export async function executeMemorySearch(params: {
     scene: sceneFilter,
     vectorStore,
     embeddingService,
+    embeddingTimeoutMs,
     logger,
   } = params;
 
@@ -134,6 +136,8 @@ export async function executeMemorySearch(params: {
 
   // ── Over-retrieve for later filtering and RRF merging ──
   const candidateK = limit * 3;
+  const embeddingCallOpts: EmbeddingCallOptions | undefined =
+    typeof embeddingTimeoutMs === "number" ? { timeoutMs: embeddingTimeoutMs } : undefined;
 
   // ── Run available search strategies in parallel ──
   const [ftsItems, vecItems] = await Promise.all([
@@ -172,7 +176,9 @@ export async function executeMemorySearch(params: {
       if (!hasEmbedding) return [];
       try {
         logger?.debug?.(`${TAG} [hybrid-vec] Generating query embedding...`);
-        const queryEmbedding = await embeddingService!.embed(query);
+        const queryEmbedding = embeddingCallOpts
+          ? await embeddingService!.embed(query, embeddingCallOpts)
+          : await embeddingService!.embed(query);
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );


### PR DESCRIPTION
## Summary
- pass `embedding.recallTimeoutMs ?? embedding.timeoutMs` from `TdaiCore` into both agent search tools
- forward the timeout to query embedding calls in `tdai_memory_search` and `tdai_conversation_search`
- add regression coverage for recall override and timeout fallback

## Why
`recallTimeoutMs` is already documented as the user-facing recall-path embedding timeout and auto-recall honors it, but the agent-callable search tools still called `embed(query)` without per-call options. A slow embedding provider could therefore ignore the shorter recall timeout during interactive tool search.

## Tests
- `npm test -- src/core/tdai-core.test.ts`
- `npm test`
- `npm run build`
