### PR TITLE
fix(offload): honor backend timeout config

### DIFF
--- a/src/offload/backend-client.test.ts
+++ b/src/offload/backend-client.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BackendClient } from "./backend-client.js";
+import type { PluginLogger } from "./types.js";
+
+const httpMocks = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+vi.mock("node:http", () => ({
+  request: httpMocks.request,
+}));
+
+vi.mock("node:https", () => ({
+  request: httpMocks.request,
+}));
+
+const logger: PluginLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function makeSuccessfulRequest() {
+  const req = new EventEmitter() as EventEmitter & {
+    write: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+    destroy: (err?: Error) => void;
+  };
+  req.write = vi.fn();
+  req.end = vi.fn();
+  req.destroy = (err?: Error) => {
+    if (err) req.emit("error", err);
+  };
+  return req;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  httpMocks.request.mockImplementation((_opts, callback: (res: EventEmitter & { statusCode: number; statusMessage: string }) => void) => {
+    const req = makeSuccessfulRequest();
+    queueMicrotask(() => {
+      const res = new EventEmitter() as EventEmitter & {
+        statusCode: number;
+        statusMessage: string;
+      };
+      res.statusCode = 200;
+      res.statusMessage = "OK";
+      callback(res);
+      res.emit("data", Buffer.from(JSON.stringify({ entries: [], insertedId: "state-1" })));
+      res.emit("end");
+    });
+    return req;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BackendClient", () => {
+  it("uses the configured backend timeout for L1 backend calls", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const client = new BackendClient("http://backend.example", logger, undefined, 4_321);
+
+    await client.l1Summarize({ recentMessages: "hello", toolPairs: [] });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 4_321);
+  });
+
+  it("uses the configured backend timeout for state store uploads", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const client = new BackendClient("http://backend.example", logger, undefined, 4_321);
+
+    await client.storeState({ stage: "L3.report" });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 4_321);
+  });
+});

--- a/src/offload/backend-client.ts
+++ b/src/offload/backend-client.ts
@@ -106,8 +106,9 @@ export interface StoreStateResponse {
 export class BackendClient {
   private baseUrl: string;
   private apiKey: string | undefined;
-  /** Hardcoded timeout for all backend calls (L1/L1.5/L2/L4) */
-  private static readonly TIMEOUT_MS = 120_000;
+  /** Default timeout for backend calls when the caller does not provide one. */
+  private static readonly DEFAULT_TIMEOUT_MS = 120_000;
+  private readonly timeoutMs: number;
   private logger: PluginLogger;
   private sessionKeyFn: () => string | null;
   /** Resolves the value of the `X-User-Id` header sent on every call. */
@@ -119,13 +120,16 @@ export class BackendClient {
     baseUrl: string,
     logger: PluginLogger,
     apiKey?: string,
-    _defaultTimeoutMs?: number, // kept for backward compat, ignored
+    defaultTimeoutMs?: number,
     sessionKeyFn?: () => string | null,
     userIdFn?: () => string | null,
     taskIdFn?: () => string | null,
   ) {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
     this.apiKey = apiKey;
+    this.timeoutMs = typeof defaultTimeoutMs === "number" && Number.isFinite(defaultTimeoutMs) && defaultTimeoutMs > 0
+      ? defaultTimeoutMs
+      : BackendClient.DEFAULT_TIMEOUT_MS;
     this.logger = logger;
     this.sessionKeyFn = sessionKeyFn ?? (() => null);
     this.userIdFn = userIdFn ?? (() => null);
@@ -137,7 +141,7 @@ export class BackendClient {
     const pairNames = req.toolPairs.map((p) => `${p.toolName}(${p.toolCallId})`).join(", ");
     this.logger.debug?.(`[context-offload] L1 >>> summarize ${req.toolPairs.length} pairs: [${pairNames}]`);
     const startMs = Date.now();
-    const resp = await this.post<L1Response>("/offload/v1/l1/summarize", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L1Response>("/offload/v1/l1/summarize", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     const entryCount = resp.entries?.length ?? 0;
     const scores = resp.entries?.map((e) => `${e.tool_call_id}:score=${e.score}`).join(", ") ?? "";
@@ -165,7 +169,7 @@ export class BackendClient {
       `[context-offload] L1.5 >>> judge: currentMmd=${req.currentMmd?.filename ?? "null"}, availableMmds=${req.availableMmdMetas.length}, recentMessages=${req.recentMessages.length} chars`,
     );
     const startMs = Date.now();
-    const resp = await this.post<L15Response>("/offload/v1/l15/judge", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L15Response>("/offload/v1/l15/judge", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     this.logger.debug?.(
       `[context-offload] L1.5 <<< completed=${resp.taskCompleted}, continuation=${resp.isContinuation}, continuationFile=${resp.continuationMmdFile ?? "null"}, newLabel=${resp.newTaskLabel ?? "null"}, longTask=${resp.isLongTask}`,
@@ -193,7 +197,7 @@ export class BackendClient {
       `[context-offload] L2 >>> generate: task=${req.taskLabel}, prefix=${req.mmdPrefix}, entries=${req.newEntries.length} [${entryIds}], existingMmd=${req.existingMmd ? `${req.mmdCharCount} chars` : "null (new)"}`,
     );
     const startMs = Date.now();
-    const resp = await this.post<L2Response>("/offload/v1/l2/generate", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L2Response>("/offload/v1/l2/generate", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     const mappingCount = Object.keys(resp.nodeMapping ?? {}).length;
     const mappingStr = Object.entries(resp.nodeMapping ?? {}).map(([k, v]) => `${k}->${v}`).join(", ");
@@ -222,7 +226,7 @@ export class BackendClient {
       `[context-offload] L4 >>> generate: mmd=${req.mmdFilename}, entries=${req.offloadEntries.length}, skillFocus=${req.skillFocus ?? "null"}`,
     );
     const startMs = Date.now();
-    const resp = await this.post<L4Response>("/offload/v1/l4/generate", req, BackendClient.TIMEOUT_MS);
+    const resp = await this.post<L4Response>("/offload/v1/l4/generate", req, this.timeoutMs);
     const durationMs = Date.now() - startMs;
     this.logger.debug?.(
       `[context-offload] L4 <<< skill="${resp.skillName}", content=${resp.skillContent?.length ?? 0} chars`,
@@ -246,14 +250,13 @@ export class BackendClient {
   /**
    * Upload an arbitrary state payload to the backend `/offload/v1/store` endpoint.
    * Fire-and-forget style — the caller is expected to `.catch(...)` rejections.
-   * Uses a short timeout so reporting never blocks hook execution meaningfully.
+   * Uses the configured backend timeout so large report payloads can follow
+   * the same deployment-specific timeout budget as other backend calls.
    */
   async storeState(payload: StoreStatePayload): Promise<StoreStateResponse> {
-    // Short timeout — reporting must never stall the plugin
-    const timeoutMs = 10_000;
     const startMs = Date.now();
     try {
-      const resp = await this.post<StoreStateResponse>("/offload/v1/store", payload, timeoutMs);
+      const resp = await this.post<StoreStateResponse>("/offload/v1/store", payload, this.timeoutMs);
       const durationMs = Date.now() - startMs;
       this.logger.debug?.(
         `[context-offload] store <<< insertedId=${resp.insertedId ?? "?"} (${durationMs}ms)`,


### PR DESCRIPTION
## Summary
- store the `backendTimeoutMs` value passed into `BackendClient` instead of ignoring it
- use the configured timeout for L1/L1.5/L2/L4 backend calls and `/offload/v1/store` state uploads
- add regression tests proving the constructor timeout drives the actual HTTP request timer

## Why
`registerOffload()` already passes `offloadConfig.backendTimeoutMs` into `BackendClient`, but the constructor parameter was ignored. Backend-mode LLM calls always used a hardcoded 120s timeout, while state uploads always used a hardcoded 10s timeout, so user configuration could not tune slow or strict backend deployments.

## Tests
- `npm test -- src/offload/backend-client.test.ts`
- `npm test`
- `npm run build`
