### PR TITLE
fix(config): align offload timeout default

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -163,7 +163,7 @@
           "mmdMaxTokenRatio": { "type": "number", "default": 0.2, "description": "MMD 注入 token 预算比例" },
           "backendUrl": { "type": "string", "description": "后端服务 URL（如 https://offload-api.example.com），配置后 L1/L1.5/L2/L4 走后端" },
           "backendApiKey": { "type": "string", "description": "后端 API 认证 token" },
-          "backendTimeoutMs": { "type": "number", "default": 10000, "description": "后端调用超时（毫秒）" }
+          "backendTimeoutMs": { "type": "number", "default": 120000, "description": "后端调用超时（毫秒）" }
         }
       }
     }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+function readManifestDefault(path: string[]): unknown {
+  const manifest = JSON.parse(
+    readFileSync(join(process.cwd(), "openclaw.plugin.json"), "utf8"),
+  ) as Record<string, unknown>;
+
+  let current: unknown = manifest;
+  for (const key of path) {
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+describe("parseConfig", () => {
+  it("keeps offload.backendTimeoutMs default aligned with the manifest schema", () => {
+    const cfg = parseConfig({});
+    const manifestDefault = readManifestDefault([
+      "configSchema",
+      "properties",
+      "offload",
+      "properties",
+      "backendTimeoutMs",
+      "default",
+    ]);
+
+    expect(manifestDefault).toBe(cfg.offload.backendTimeoutMs);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -264,7 +264,7 @@ export interface OffloadConfig {
   backendUrl?: string;
   /** Backend API authentication token */
   backendApiKey?: string;
-  /** Backend call timeout in milliseconds (default: 10000) */
+  /** Backend call timeout in milliseconds (default: 120000) */
   backendTimeoutMs: number;
   /**
    * Offload data retention days. Sessions/refs/mmds older than this are cleaned up.


### PR DESCRIPTION
## Summary
- align `openclaw.plugin.json` default for `offload.backendTimeoutMs` with the runtime `parseConfig({})` default
- update the `OffloadConfig` comment to the same 120000ms default
- add a regression test that compares the manifest schema default with the parsed runtime default

## Why
`parseConfig()` defaults `offload.backendTimeoutMs` to 120000ms, but the manifest schema advertised 10000ms. Hosts that materialize schema defaults can therefore override the runtime default and make backend L1/L1.5/L2/L4 calls time out after 10 seconds instead of the intended 120 seconds.

## Tests
- `npm test -- src/config.test.ts`
- `npm test`
- `npm run build`
