### PR TITLE
fix(offload): honor local L2 timeout config

### DIFF
--- a/src/offload/local-llm/index.test.ts
+++ b/src/offload/local-llm/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { LocalLlmClient } from "./index.js";
+
+const llmMocks = vi.hoisted(() => ({
+  callLlm: vi.fn(async () => JSON.stringify({
+    file_action: "write",
+    mmd_content: "flowchart TD\n  A-->B",
+    node_mapping: {},
+  })),
+}));
+
+vi.mock("./llm-caller.js", () => ({
+  callLlm: llmMocks.callLlm,
+}));
+
+describe("LocalLlmClient", () => {
+  it("uses the configured timeout for L2 generation", async () => {
+    const client = new LocalLlmClient({
+      baseUrl: "https://llm.example/v1",
+      apiKey: "sk-test",
+      model: "provider/model",
+      timeoutMs: 4_321,
+    });
+
+    await client.l2Generate({
+      existingMmd: null,
+      newEntries: [],
+      recentHistory: null,
+      currentTurn: null,
+      taskLabel: "task",
+      mmdPrefix: "task",
+      mmdCharCount: 0,
+    });
+
+    const [config, opts] = llmMocks.callLlm.mock.calls[0];
+    const effectiveTimeoutMs = opts.timeoutMs ?? config.timeoutMs;
+    expect(effectiveTimeoutMs).toBe(4_321);
+  });
+});

--- a/src/offload/local-llm/index.ts
+++ b/src/offload/local-llm/index.ts
@@ -149,7 +149,6 @@ export class LocalLlmClient {
       systemPrompt: L2_SYSTEM_PROMPT,
       userPrompt,
       label: "L2",
-      timeoutMs: 120_000, // L2 may take longer due to complex prompts
       customFetch: this.customFetch,
     }, this.logger);
 


### PR DESCRIPTION
## Summary
- remove the hardcoded 120s timeout override from local-mode L2 generation
- let L2 use the same configured `timeoutMs` stored on `LocalLlmClient` as L1/L1.5
- add a regression test for the effective L2 timeout

## Why
`registerOffload()` passes `offload.backendTimeoutMs` into `LocalLlmClient` for local mode. L1 and L1.5 already inherit that config via `callLlm`, but L2 overrode it with `120_000`, so users could not shorten or lengthen local L2 calls consistently.

## Tests
- `npm test -- src/offload/local-llm/index.test.ts`
- `npm test`
- `npm run build`
