### PR TITLE
fix(l1): honor runner timeout config

### DIFF
--- a/src/core/record/l1-dedup.test.ts
+++ b/src/core/record/l1-dedup.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { batchDedup } from "./l1-dedup.js";
+import type { LLMRunner } from "../types.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore } from "../store/types.js";
+
+describe("batchDedup", () => {
+  it("does not override the timeout of a host-neutral LLM runner", async () => {
+    const run = vi.fn(async () => JSON.stringify([
+      {
+        record_id: "new-1",
+        action: "store",
+        target_ids: [],
+      },
+    ]));
+    const llmRunner = { run } satisfies LLMRunner;
+    const embeddingService = {
+      embedBatch: vi.fn(async () => [new Float32Array([0.1, 0.2])]),
+    } as unknown as EmbeddingService;
+    const vectorStore = {
+      countL1: vi.fn(async () => 1),
+      isFtsAvailable: vi.fn(() => false),
+      searchL1Vector: vi.fn(async () => [
+        {
+          record_id: "existing-1",
+          content: "User likes concise TypeScript answers.",
+          type: "preference",
+          priority: 80,
+          scene_name: "preferences",
+          score: 0.9,
+          timestamp_str: "2026-01-01",
+          timestamp_start: "2026-01-01T00:00:00.000Z",
+          timestamp_end: "2026-01-01T00:00:00.000Z",
+          session_key: "session-1",
+          session_id: "session-1",
+          metadata_json: "{}",
+        },
+      ]),
+    } as unknown as IMemoryStore;
+
+    await batchDedup({
+      memories: [
+        {
+          record_id: "new-1",
+          content: "User prefers concise TypeScript explanations.",
+          type: "preference",
+          priority: 80,
+          source_message_ids: ["m1"],
+          metadata: {},
+          scene_name: "preferences",
+        },
+      ],
+      config: {},
+      vectorStore,
+      embeddingService,
+      llmRunner,
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0][0]).not.toHaveProperty("timeoutMs");
+  });
+});

--- a/src/core/record/l1-dedup.ts
+++ b/src/core/record/l1-dedup.ts
@@ -158,7 +158,6 @@ async function runLlmJudgment(
         prompt: userPrompt,
         systemPrompt: CONFLICT_DETECTION_SYSTEM_PROMPT,
         taskId: "l1-conflict-detection",
-        timeoutMs: 180_000,
       });
     } else {
       // Fallback: create CleanContextRunner (OpenClaw path)

--- a/src/core/record/l1-extractor.test.ts
+++ b/src/core/record/l1-extractor.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { extractL1Memories } from "./l1-extractor.js";
+import type { LLMRunner } from "../types.js";
+
+describe("extractL1Memories", () => {
+  it("does not override the timeout of a host-neutral LLM runner", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "tdai-l1-timeout-"));
+    const run = vi.fn(async () => JSON.stringify([
+      {
+        scene_name: "preferences",
+        message_ids: ["m1"],
+        memories: [
+          {
+            content: "User prefers concise TypeScript explanations.",
+            type: "preference",
+            priority: 80,
+            source_message_ids: ["m1"],
+            metadata: {},
+          },
+        ],
+      },
+    ]));
+    const llmRunner = { run } satisfies LLMRunner;
+
+    await extractL1Memories({
+      messages: [
+        {
+          id: "m1",
+          role: "user",
+          content: "Please remember that I prefer concise TypeScript explanations.",
+          timestamp: Date.now(),
+        },
+      ],
+      sessionKey: "session-1",
+      baseDir,
+      config: {},
+      options: {
+        enableDedup: false,
+        llmRunner,
+      },
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0][0]).not.toHaveProperty("timeoutMs");
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -324,7 +324,6 @@ async function callLlmExtraction(params: {
       prompt: userPrompt,
       systemPrompt: EXTRACT_MEMORIES_SYSTEM_PROMPT,
       taskId: "l1-extraction",
-      timeoutMs: 180_000,
     });
   } else {
     // Fallback: create CleanContextRunner (OpenClaw path)


### PR DESCRIPTION
## Summary
- stop passing hardcoded 180s timeouts to host-neutral L1 extraction and conflict-detection runners
- keep the existing 180s timeout only for the legacy CleanContextRunner fallback path
- add regression tests for extraction and dedup so configured runner timeouts are not overridden

## Why
Standalone/Gateway/OpenClaw standalone-LLM paths create `LLMRunner` instances with configured timeouts (`cfg.llm.timeoutMs`). L1 extraction and L1 dedup overrode those runner defaults with `180_000`, making shorter or longer user-configured LLM timeouts ineffective for those calls.

## Tests
- `npm test -- src/core/record/l1-extractor.test.ts src/core/record/l1-dedup.test.ts`
- `npm test`
- `npm run build`
