### PR TITLE
fix(pipeline): honor L2/L3 runner timeout config

### DIFF
--- a/src/core/persona/persona-generator.test.ts
+++ b/src/core/persona/persona-generator.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { PersonaGenerator } from "./persona-generator.js";
+import type { LLMRunParams, LLMRunner } from "../types.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("PersonaGenerator", () => {
+  it("lets an injected LLM runner use its configured timeout", async () => {
+    const dataDir = await makeTempDir("persona-generator-");
+    const calls: LLMRunParams[] = [];
+    const runner: LLMRunner = {
+      async run(params) {
+        calls.push(params);
+        await fs.writeFile(path.join(params.workspaceDir!, "persona.md"), "Prefers concise technical answers.", "utf-8");
+        return "";
+      },
+    };
+
+    const generator = new PersonaGenerator({
+      dataDir,
+      config: {},
+      llmRunner: runner,
+    });
+
+    const result = await generator.generateLocalPersona("test");
+
+    expect(result).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].timeoutMs).toBeUndefined();
+  });
+});

--- a/src/core/persona/persona-generator.ts
+++ b/src/core/persona/persona-generator.ts
@@ -24,12 +24,14 @@ export class PersonaGenerator {
   private logger: Logger | undefined;
   private backupCount: number;
   private instanceId: string | undefined;
+  private timeoutMs: number | undefined;
 
   constructor(opts: {
     dataDir: string;
     config: unknown;
     model?: string;
     backupCount?: number;
+    timeoutMs?: number;
     logger?: Logger;
     /** Plugin instance ID for metric reporting (optional) */
     instanceId?: string;
@@ -44,6 +46,7 @@ export class PersonaGenerator {
     this.logger = opts.logger;
     this.backupCount = opts.backupCount ?? 3;
     this.instanceId = opts.instanceId;
+    this.timeoutMs = opts.timeoutMs ?? (opts.llmRunner ? undefined : 180_000);
     // Use injected LLMRunner if available, otherwise fall back to CleanContextRunner
     this.runner = opts.llmRunner ?? new CleanContextRunner({
       config: opts.config,
@@ -150,7 +153,7 @@ export class PersonaGenerator {
         systemPrompt,
         prompt: userPrompt,
         taskId: "persona-generation",
-        timeoutMs: 180_000,
+        timeoutMs: this.timeoutMs,
         // maxTokens omitted → core uses the resolved model's maxTokens from catalog
         workspaceDir: this.dataDir,
       });

--- a/src/core/scene/scene-extractor.test.ts
+++ b/src/core/scene/scene-extractor.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SceneExtractor } from "./scene-extractor.js";
+import type { LLMRunParams, LLMRunner } from "../types.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("SceneExtractor", () => {
+  it("lets an injected LLM runner use its configured timeout", async () => {
+    const dataDir = await makeTempDir("scene-extractor-");
+    const calls: LLMRunParams[] = [];
+    const runner: LLMRunner = {
+      async run(params) {
+        calls.push(params);
+        return "";
+      },
+    };
+
+    const extractor = new SceneExtractor({
+      dataDir,
+      config: {},
+      llmRunner: runner,
+    });
+
+    const result = await extractor.extract([
+      {
+        id: "memory-1",
+        content: "User prefers quiet keyboards for late-night coding.",
+        created_at: "2026-06-29T00:00:00.000Z",
+      },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].timeoutMs).toBeUndefined();
+  });
+});

--- a/src/core/scene/scene-extractor.ts
+++ b/src/core/scene/scene-extractor.ts
@@ -87,7 +87,7 @@ export class SceneExtractor {
   private runner: LLMRunner;
   private maxScenes: number;
   private sceneBackupCount: number;
-  private timeoutMs: number;
+  private timeoutMs: number | undefined;
   private logger: ExtractorLogger | undefined;
   private instanceId: string | undefined;
 
@@ -95,7 +95,7 @@ export class SceneExtractor {
     this.dataDir = opts.dataDir;
     this.maxScenes = opts.maxScenes ?? 15;
     this.sceneBackupCount = opts.sceneBackupCount ?? 10;
-    this.timeoutMs = opts.timeoutMs ?? 300_000; // 5 min — LLM may do multiple tool calls
+    this.timeoutMs = opts.timeoutMs ?? (opts.llmRunner ? undefined : 300_000); // 5 min fallback for CleanContextRunner
     this.logger = opts.logger;
     this.instanceId = opts.instanceId;
 


### PR DESCRIPTION
## Summary
- stop L2 scene extraction from overriding injected LLM runner timeout with a hard-coded 300s default
- stop L3 persona generation from overriding injected LLM runner timeout with a hard-coded 180s default
- preserve the legacy CleanContextRunner fallback defaults when no runner is injected
- add regression tests for both L2 and L3 runner timeout forwarding

## Tests
- npm test -- src/core/scene/scene-extractor.test.ts src/core/persona/persona-generator.test.ts
- npm test
- npm run build