### PR TITLE
fix(core): honor layer model config for runners

### DIFF
--- a/src/core/seed/seed-runtime.ts
+++ b/src/core/seed/seed-runtime.ts
@@ -91,8 +91,14 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
       },
       logger,
     });
-    l1LlmRunner = runnerFactory.createRunner({ enableTools: false });
-    l2l3LlmRunner = runnerFactory.createRunner({ enableTools: true });
+    l1LlmRunner = runnerFactory.createRunner({
+      enableTools: false,
+      ...(cfg.extraction.model ? { modelRef: cfg.extraction.model } : {}),
+    });
+    l2l3LlmRunner = runnerFactory.createRunner({
+      enableTools: true,
+      ...(cfg.persona.model ? { modelRef: cfg.persona.model } : {}),
+    });
     logger.info(`${TAG} Seed using standalone LLM: model=${cfg.llm.model}`);
   }
 

--- a/src/core/tdai-core.test.ts
+++ b/src/core/tdai-core.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "../config.js";
+import { TdaiCore } from "./tdai-core.js";
+import type {
+  HostAdapter,
+  LLMRunParams,
+  LLMRunner,
+  LLMRunnerCreateOptions,
+  Logger,
+} from "./types.js";
+
+const logger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+describe("TdaiCore", () => {
+  it("passes layer-specific model refs when creating standalone pipeline runners", () => {
+    const createRunnerCalls: Array<LLMRunnerCreateOptions | undefined> = [];
+    const runner: LLMRunner = {
+      async run(_params: LLMRunParams) {
+        return "";
+      },
+    };
+
+    const hostAdapter: HostAdapter = {
+      hostType: "standalone",
+      getLogger: () => logger,
+      getRuntimeContext: () => ({
+        userId: "user-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        platform: "standalone",
+        workspaceDir: "/tmp",
+        dataDir: "/tmp/memory-tdai-test",
+      }),
+      getLLMRunnerFactory: () => ({
+        createRunner(opts) {
+          createRunnerCalls.push(opts);
+          return runner;
+        },
+      }),
+    };
+
+    const cfg = parseConfig({
+      extraction: { model: "openai/l1-mini" },
+      persona: { model: "openai/persona-large" },
+      llm: { enabled: true, apiKey: "test-key" },
+    });
+
+    const core = new TdaiCore({ hostAdapter, config: cfg });
+    const coreInternals = core as unknown as {
+      scheduler: {
+        setL1Runner(runner: unknown): void;
+        setPersister(persister: unknown): void;
+        setL2Runner(runner: unknown): void;
+        setL3Runner(runner: unknown): void;
+      };
+      wirePipelineRunners(): void;
+    };
+    coreInternals.scheduler = {
+      setL1Runner() {},
+      setPersister() {},
+      setL2Runner() {},
+      setL3Runner() {},
+    };
+
+    coreInternals.wirePipelineRunners();
+
+    expect(createRunnerCalls).toEqual([
+      { enableTools: false, modelRef: "openai/l1-mini" },
+      { enableTools: true, modelRef: "openai/persona-large" },
+    ]);
+  });
+});

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -448,10 +448,16 @@ export class TdaiCore {
     }
 
     const l1LlmRunner = useStandaloneRunner
-      ? runnerFactory.createRunner({ enableTools: false })
+      ? runnerFactory.createRunner({
+          enableTools: false,
+          ...(this.cfg.extraction.model ? { modelRef: this.cfg.extraction.model } : {}),
+        })
       : undefined;
     const l2l3LlmRunner = useStandaloneRunner
-      ? runnerFactory.createRunner({ enableTools: true })
+      ? runnerFactory.createRunner({
+          enableTools: true,
+          ...(this.cfg.persona.model ? { modelRef: this.cfg.persona.model } : {}),
+        })
       : undefined;
 
     // L1 runner


### PR DESCRIPTION
## Summary
- pass extraction.model into standalone/host-neutral L1 runner creation
- pass persona.model into standalone/host-neutral L2/L3 runner creation
- apply the same mapping in seed runtime so seeded pipelines respect layer-specific model config
- add a TdaiCore regression test that captures runner factory options

## Tests
- npm test -- src/core/tdai-core.test.ts
- npm test
- npm run build