### PR TITLE
fix(cleaner): allow one-day retention cutoff

### DIFF
--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { _resetTimeModuleForTest, initTimeModule } from "./time.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeShard(baseDir: string, dirName: string, fileName: string): Promise<string> {
+  const dir = path.join(baseDir, dirName);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, fileName);
+  await fs.writeFile(filePath, "{}\n", "utf-8");
+  return filePath;
+}
+
+afterEach(async () => {
+  _resetTimeModuleForTest();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalMemoryCleaner", () => {
+  it("allows one-day retention to delete shards before local today", async () => {
+    initTimeModule({ timezone: "UTC" });
+    const baseDir = await makeTempDir("memory-cleaner-");
+
+    const oldConversationShard = await writeShard(baseDir, "conversations", "2026-06-29.jsonl");
+    const todayConversationShard = await writeShard(baseDir, "conversations", "2026-06-30.jsonl");
+    const oldRecordShard = await writeShard(baseDir, "records", "2026-06-29.jsonl");
+    const todayRecordShard = await writeShard(baseDir, "records", "2026-06-30.jsonl");
+
+    const errors: string[] = [];
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 1,
+      cleanTime: "03:00",
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: (msg) => errors.push(msg),
+      },
+    });
+
+    await cleaner.runOnce(Date.parse("2026-06-30T12:00:00.000Z"));
+
+    expect(errors).toEqual([]);
+    expect(await exists(oldConversationShard)).toBe(false);
+    expect(await exists(oldRecordShard)).toBe(false);
+    expect(await exists(todayConversationShard)).toBe(true);
+    expect(await exists(todayRecordShard)).toBe(true);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -336,16 +336,19 @@ function computeCutoffMsByLocalDay(nowMs: number, retentionDays: number): number
   const todayStartMs = startOfLocalDay(now);
   const cutoffMs = todayStartMs - (retentionDays - 1) * 24 * 60 * 60 * 1000;
 
-  // Sanity check: cutoff must be strictly in the past
-  if (cutoffMs >= nowMs) {
+  // Sanity check: cutoff must not be in the future. Equality is valid at
+  // local midnight, especially for one-day retention.
+  if (cutoffMs > nowMs) {
     throw new Error(
-      `cutoff sanity failed: cutoff (${cutoffMs}) >= now (${nowMs}), ` +
+      `cutoff sanity failed: cutoff (${cutoffMs}) > now (${nowMs}), ` +
       `possible clock skew or invalid retentionDays=${retentionDays}`,
     );
   }
-  // Sanity check: gap between now and cutoff must be at least 24h
+  // Sanity check: for multi-day retention, the gap between now and cutoff
+  // must be at least 24h. One-day retention intentionally uses today's
+  // local midnight as cutoff, so its gap is less than 24h for most of the day.
   const MIN_GAP_MS = 24 * 60 * 60 * 1000;
-  if (nowMs - cutoffMs < MIN_GAP_MS) {
+  if (retentionDays > 1 && nowMs - cutoffMs < MIN_GAP_MS) {
     throw new Error(
       `cutoff sanity failed: gap ${nowMs - cutoffMs}ms < 24h, ` +
       `retentionDays=${retentionDays}, possible clock skew`,


### PR DESCRIPTION
## Summary
- allow one-day L0/L1 retention to use local midnight as the cutoff without tripping the 24h sanity check
- keep the multi-day cutoff sanity guard for retention periods above one day
- add a regression test proving yesterday's shards are deleted while today's shards are retained

## Tests
- npm test
- npm run build