### PR TITLE
fix(cleaner): preserve local day in negative timezones

### DIFF
--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { _resetTimeModuleForTest, initTimeModule } from "./time.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeShard(baseDir: string, dirName: string, fileName: string): Promise<string> {
+  const dir = path.join(baseDir, dirName);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, fileName);
+  await fs.writeFile(filePath, "{}\n", "utf-8");
+  return filePath;
+}
+
+afterEach(async () => {
+  _resetTimeModuleForTest();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalMemoryCleaner", () => {
+  it("keeps the previous local day for negative UTC offsets", async () => {
+    initTimeModule({ timezone: "America/New_York" });
+    const baseDir = await makeTempDir("memory-cleaner-");
+
+    const expiredShard = await writeShard(baseDir, "records", "2026-06-28.jsonl");
+    const previousLocalDayShard = await writeShard(baseDir, "records", "2026-06-29.jsonl");
+    const todayShard = await writeShard(baseDir, "records", "2026-06-30.jsonl");
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    });
+
+    await cleaner.runOnce(Date.parse("2026-06-30T12:00:00.000Z"));
+
+    expect(await exists(expiredShard)).toBe(false);
+    expect(await exists(previousLocalDayShard)).toBe(true);
+    expect(await exists(todayShard)).toBe(true);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
-import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { formatLocalDateTime, startOfLocalDate, startOfLocalDay } from "./time.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -315,9 +315,15 @@ function extractShardDateFromFileName(
 }
 
 function localDayEndMs(year: number, month: number, day: number): number {
-  // End of day = start of next day minus 1ms (in configured timezone)
+  // End of day = start of next local calendar day minus 1ms.
+  // Add by UTC calendar components only to normalize month/year rollover;
+  // the resulting date components are still interpreted as local calendar date.
   const nextDay = new Date(Date.UTC(year, month - 1, day + 1));
-  const nextDayStartMs = startOfLocalDay(nextDay);
+  const nextDayStartMs = startOfLocalDate(
+    nextDay.getUTCFullYear(),
+    nextDay.getUTCMonth() + 1,
+    nextDay.getUTCDate(),
+  );
   return nextDayStartMs - 1;
 }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -115,10 +115,20 @@ export function formatLocalDateTime(d: Date = new Date()): string {
 export function startOfLocalDay(d: Date = new Date()): number {
   // Get the local date components in the configured timezone
   const dateStr = formatLocalDate(d);
-  // Parse as midnight in the configured timezone
-  // Use a trick: format "YYYY-MM-DDT00:00:00" and find the UTC equivalent
-  const midnightLocal = new Date(`${dateStr}T00:00:00`);
+  return startOfLocalDateString(dateStr);
+}
 
+/** Compute local midnight for an explicit local calendar date. */
+export function startOfLocalDate(year: number, month: number, day: number): number {
+  const dateStr = [
+    String(year).padStart(4, "0"),
+    String(month).padStart(2, "0"),
+    String(day).padStart(2, "0"),
+  ].join("-");
+  return startOfLocalDateString(dateStr);
+}
+
+function startOfLocalDateString(dateStr: string): number {
   // We need to find the UTC instant that corresponds to midnight in _resolvedTz.
   // Approach: binary search isn't needed — we can use the timezone offset.
   const formatter = new Intl.DateTimeFormat("en-US", {


### PR DESCRIPTION
## Summary
- compute shard day ends from explicit local calendar dates instead of UTC instants
- add a shared startOfLocalDate helper for timezone-aware local midnight calculation
- add a regression test for America/New_York where retentionDays=2 must keep the previous local day

## Tests
- npm test
- npm run build