### PR TITLE
fix(offload): sanitize session storage paths

### DIFF
--- a/src/offload/session-registry.test.ts
+++ b/src/offload/session-registry.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SessionRegistry } from "./session-registry.js";
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "tdai-offload-registry-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function expectInside(parent: string, child: string): void {
+  const rel = relative(parent, child);
+  expect(rel).not.toBe("");
+  expect(rel.startsWith("..")).toBe(false);
+  expect(rel).not.toMatch(/^([A-Za-z]:)?[/\\]/);
+}
+
+describe("SessionRegistry", () => {
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("keeps host-provided session ids inside the agent storage directory", async () => {
+    const root = await makeTempRoot();
+    const registry = new SessionRegistry(root);
+
+    const entry = await registry.resolve("agent:main:safe-session", "../../../../escaped");
+
+    expectInside(root, entry.manager.ctx.dataDir);
+    expectInside(entry.manager.ctx.dataDir, entry.manager.ctx.offloadJsonl);
+    expect(entry.manager.ctx.offloadJsonl).toContain("offload-");
+    expect(entry.manager.ctx.offloadJsonl).not.toContain("../");
+  });
+
+  it("sanitizes fallback session keys before building storage paths", async () => {
+    const root = await makeTempRoot();
+    const registry = new SessionRegistry(root);
+
+    const entry = await registry.resolve("..");
+
+    expectInside(root, entry.manager.ctx.dataDir);
+    expect(entry.manager.ctx.agentName).not.toBe("..");
+  });
+});

--- a/src/offload/session-registry.ts
+++ b/src/offload/session-registry.ts
@@ -6,7 +6,7 @@
  * its own isolated OffloadStateManager + StorageContext.
  */
 import { OffloadStateManager } from "./state-manager.js";
-import { parseSessionKey } from "./storage.js";
+import { parseSessionKey, sanitizeStoragePath } from "./storage.js";
 
 /** Matches internal memory-pipeline sessions (e.g. memory-{taskId}-session-{ts}). */
 const INTERNAL_SESSION_RE = /memory-.*-session-\d+/;
@@ -68,8 +68,8 @@ export class SessionRegistry {
       // sessionKey doesn't match "agent:<name>:<id>" format.
       // Use a sanitized sessionKey as both agentName and sessionId
       // so ctx is always initialized (avoids "ctx not initialized" errors).
-      const fallbackName = sessionKey.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_").slice(0, 64) || "unknown";
-      const fallbackSessionId = realSessionId || `fallback-${Date.now()}`;
+      const fallbackName = sanitizeStoragePath(sessionKey).slice(0, 64) || "unknown";
+      const fallbackSessionId = sanitizeStoragePath(realSessionId || `fallback-${Date.now()}`);
       await mgr.init(this._dataRoot, fallbackName, fallbackSessionId);
     }
 

--- a/src/offload/storage.ts
+++ b/src/offload/storage.ts
@@ -40,24 +40,30 @@ export function createStorageContext(
   agentName: string,
   sessionId: string,
 ): StorageContext {
-  const dataDir = join(dataRoot, agentName);
+  const safeAgentName = sanitizeStoragePath(agentName);
+  const safeSessionId = sanitizeStoragePath(sessionId);
+  const dataDir = join(dataRoot, safeAgentName);
   return Object.freeze({
     dataRoot,
     dataDir,
     refsDir: join(dataDir, "refs"),
     mmdsDir: join(dataDir, "mmds"),
-    offloadJsonl: join(dataDir, `offload-${sessionId}.jsonl`),
+    offloadJsonl: join(dataDir, `offload-${safeSessionId}.jsonl`),
     stateFile: join(dataDir, "state.json"),
-    agentName,
-    sessionId,
+    agentName: safeAgentName,
+    sessionId: safeSessionId,
   });
 }
 
 // ─── SessionKey Parsing ──────────────────────────────────────────────────────
 
-/** Sanitize a string for use as a directory/file name */
-function sanitizePath(s: string): string {
-  return s.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_").replace(/\.{2,}/g, "_");
+/** Sanitize a string for use as a single directory/file-name segment. */
+export function sanitizeStoragePath(s: string, fallback = "unknown"): string {
+  const safe = String(s ?? "")
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, "_")
+    .replace(/\.{2,}/g, "_");
+  const trimmed = safe.trim();
+  return trimmed.length === 0 || trimmed === "." ? fallback : safe;
 }
 
 /**
@@ -84,8 +90,8 @@ export function parseSessionKey(
     agentName = `${agentName}-w${workerMatch[1]}`;
   }
   return {
-    agentName: sanitizePath(agentName),
-    sessionId: sanitizePath(sessionId),
+    agentName: sanitizeStoragePath(agentName),
+    sessionId: sanitizeStoragePath(sessionId),
   };
 }
 
@@ -117,9 +123,10 @@ export async function registerSession(
   } catch {
     /* corrupt file, start fresh */
   }
+  const safeSessionId = sanitizeStoragePath(realSessionId, ctx.sessionId);
   registry[sessionKey] = {
-    sessionId: realSessionId,
-    offloadFile: `offload-${realSessionId}.jsonl`,
+    sessionId: safeSessionId,
+    offloadFile: `offload-${safeSessionId}.jsonl`,
     updatedAt: new Date().toISOString(),
   };
   await writeFile(registryPath, JSON.stringify(registry, null, 2), "utf-8");


### PR DESCRIPTION
## Summary
- sanitize offload agent/session path segments at StorageContext creation
- reuse the same sanitizer for invalid session-key fallback routing
- store sanitized session ids/offload filenames in the session registry

## Why
Host-provided session ids are used in `offload-<sessionId>.jsonl`. Path separators or dot segments could escape the intended agent storage directory, and fallback session keys like `..` could point the agent directory outside the data root.

## Tests
- `npm test -- src/offload/session-registry.test.ts`
- `npm test -- src/offload/auth-profile-key.test.ts src/offload/session-registry.test.ts`
- `npm test -- src/utils/sanitize.test.ts src/offload/session-registry.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`