### PR TITLE
fix(offload): keep MMD files inside storage dir

### DIFF
--- a/src/offload/hooks/before-agent-start.test.ts
+++ b/src/offload/hooks/before-agent-start.test.ts
@@ -1,0 +1,71 @@
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { OffloadStateManager } from "../state-manager.js";
+import { writeMmd } from "../storage.js";
+import { handleTaskTransition } from "./before-agent-start.js";
+
+const tempRoots: string[] = [];
+
+async function makeStateManager(): Promise<{ root: string; manager: OffloadStateManager }> {
+  const root = await mkdtemp(join(tmpdir(), "tdai-offload-mmd-"));
+  tempRoots.push(root);
+  const manager = new OffloadStateManager();
+  await manager.init(root, "agent", "session");
+  return { root, manager };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function expectInside(parent: string, child: string): void {
+  const rel = relative(parent, child);
+  expect(rel).not.toBe("");
+  expect(rel.startsWith("..")).toBe(false);
+  expect(rel).not.toMatch(/^([A-Za-z]:)?[/\\]/);
+}
+
+describe("handleTaskTransition", () => {
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("sanitizes new task labels before creating MMD files", async () => {
+    const { manager } = await makeStateManager();
+
+    await handleTaskTransition(
+      manager,
+      {
+        taskCompleted: true,
+        isContinuation: false,
+        isLongTask: true,
+        newTaskLabel: "../../../../escaped",
+      },
+      {},
+    );
+
+    const activeMmd = manager.getActiveMmdFile();
+    expect(activeMmd).toBeTruthy();
+    expect(activeMmd).not.toContain("/");
+    expect(activeMmd).not.toContain("..");
+    expectInside(manager.ctx.mmdsDir, join(manager.ctx.mmdsDir, activeMmd!));
+  });
+
+  it("keeps direct MMD writes inside the mmds directory", async () => {
+    const { root, manager } = await makeStateManager();
+
+    await writeMmd(manager.ctx, "../../escaped.mmd", "flowchart TD\n");
+
+    expect(await exists(join(root, "escaped.mmd"))).toBe(false);
+    expect(await exists(join(manager.ctx.mmdsDir, "escaped.mmd"))).toBe(true);
+  });
+});

--- a/src/offload/hooks/before-agent-start.ts
+++ b/src/offload/hooks/before-agent-start.ts
@@ -8,6 +8,7 @@
 import { readMmd, writeMmd, deleteMmd, type StorageContext } from "../storage.js";
 import type { OffloadStateManager } from "../state-manager.js";
 import type { PluginLogger, TaskJudgment } from "../types.js";
+import { sanitizeMmdFilename, sanitizeMmdLabel } from "../mmd-path.js";
 
 /**
  * Normalize a raw L1.5 judgment response (from backend)
@@ -35,7 +36,8 @@ export async function handleTaskTransition(
   judgment: TaskJudgment,
   logger: PluginLogger,
 ): Promise<void> {
-  const currentMmd = stateManager.getActiveMmdFile();
+  const rawCurrentMmd = stateManager.getActiveMmdFile();
+  const currentMmd = rawCurrentMmd ? sanitizeMmdFilename(rawCurrentMmd) : null;
 
   const ctx = stateManager.ctx;
 
@@ -68,29 +70,31 @@ export async function handleTaskTransition(
   const createNewMmd = async (label: string) => {
     const num = await stateManager.nextMmdNumber();
     const paddedNum = String(num).padStart(3, "0");
-    const filename = `${paddedNum}-${label}.mmd`;
+    const safeLabel = sanitizeMmdLabel(label);
+    const filename = `${paddedNum}-${safeLabel}.mmd`;
     logger.debug?.(`[context-offload] L1.5: Creating new MMD: ${filename} (replacing ${currentMmd ?? "(none)"})`);
     await cleanupIfEmptyShell(currentMmd);
-    stateManager.setActiveMmd(filename, label);
-    const initialMmd = `flowchart TD\n    ${paddedNum}-N1["${label}"]\n`;
+    stateManager.setActiveMmd(filename, safeLabel);
+    const initialMmd = `flowchart TD\n    ${paddedNum}-N1["${safeLabel}"]\n`;
     await writeMmd(ctx, filename, initialMmd);
     logger.debug?.(`[context-offload] L1.5: New MMD created and activated: ${filename}`);
   };
 
   const reactivateMmd = async (contFile: string) => {
-    logger.debug?.(`[context-offload] L1.5: Reactivating MMD: ${contFile} (current=${currentMmd ?? "(none)"})`);
-    if (currentMmd && currentMmd !== contFile) {
+    const safeContFile = sanitizeMmdFilename(contFile);
+    logger.debug?.(`[context-offload] L1.5: Reactivating MMD: ${safeContFile} (current=${currentMmd ?? "(none)"})`);
+    if (currentMmd && currentMmd !== safeContFile) {
       await cleanupIfEmptyShell(currentMmd);
     }
-    const mmdId = contFile.replace(/^\d+-/, "").replace(/\.mmd$/, "");
-    stateManager.setActiveMmd(contFile, mmdId);
-    const existing = await readMmd(ctx, contFile);
+    const mmdId = sanitizeMmdLabel(safeContFile.replace(/^\d+-/, "").replace(/\.mmd$/, ""));
+    stateManager.setActiveMmd(safeContFile, mmdId);
+    const existing = await readMmd(ctx, safeContFile);
     if (existing === null) {
-      const prefixMatch = contFile.match(/^(\d+)-/);
+      const prefixMatch = safeContFile.match(/^(\d+)-/);
       const prefix = prefixMatch ? prefixMatch[1] : "000";
       const initialMmd = `flowchart TD\n    ${prefix}-N1["${mmdId}"]\n`;
-      await writeMmd(ctx, contFile, initialMmd);
-      logger.warn(`[context-offload] L1.5: Reactivated MMD file was missing, wrote initial template: ${contFile}`);
+      await writeMmd(ctx, safeContFile, initialMmd);
+      logger.warn(`[context-offload] L1.5: Reactivated MMD file was missing, wrote initial template: ${safeContFile}`);
     }
   };
 
@@ -99,11 +103,12 @@ export async function handleTaskTransition(
     if (judgment.isContinuation && judgment.continuationMmdFile) {
       await reactivateMmd(judgment.continuationMmdFile);
     } else if (judgment.isLongTask && judgment.newTaskLabel) {
+      const newTaskLabel = sanitizeMmdLabel(judgment.newTaskLabel);
       const currentLabel = currentMmd
         ? currentMmd.replace(/^\d+-/, "").replace(/\.mmd$/, "")
         : null;
-      if (currentLabel !== judgment.newTaskLabel) {
-        await createNewMmd(judgment.newTaskLabel);
+      if (currentLabel !== newTaskLabel) {
+        await createNewMmd(newTaskLabel);
       }
     } else if (judgment.isContinuation && !judgment.continuationMmdFile) {
       if (!currentMmd) {
@@ -120,11 +125,12 @@ export async function handleTaskTransition(
         await reactivateMmd(judgment.continuationMmdFile);
       }
     } else if (judgment.isLongTask && judgment.newTaskLabel) {
+      const newTaskLabel = sanitizeMmdLabel(judgment.newTaskLabel);
       const currentLabel = currentMmd
         ? currentMmd.replace(/^\d+-/, "").replace(/\.mmd$/, "")
         : null;
-      if (currentLabel !== judgment.newTaskLabel) {
-        await createNewMmd(judgment.newTaskLabel);
+      if (currentLabel !== newTaskLabel) {
+        await createNewMmd(newTaskLabel);
       }
     }
   }

--- a/src/offload/mmd-path.ts
+++ b/src/offload/mmd-path.ts
@@ -1,0 +1,20 @@
+import { basename } from "node:path";
+
+const UNSAFE_MMD_NAME_RE = /[<>:"/\\|?*\x00-\x1f]/g;
+
+/** Sanitize a task label before using it in Mermaid content or filenames. */
+export function sanitizeMmdLabel(label: string, fallback = "task"): string {
+  const safe = String(label ?? "")
+    .replace(UNSAFE_MMD_NAME_RE, "_")
+    .replace(/\.{2,}/g, "_")
+    .slice(0, 80);
+  const trimmed = safe.trim();
+  return trimmed.length === 0 || trimmed === "." ? fallback : safe;
+}
+
+/** Normalize a caller-provided MMD filename to a single safe `.mmd` segment. */
+export function sanitizeMmdFilename(filename: string, fallback = "task"): string {
+  const base = basename(String(filename ?? ""));
+  const stem = base.endsWith(".mmd") ? base.slice(0, -".mmd".length) : base;
+  return `${sanitizeMmdLabel(stem, fallback)}.mmd`;
+}

--- a/src/offload/storage.ts
+++ b/src/offload/storage.ts
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { homedir } from "node:os";
 import type { OffloadEntry, PluginLogger } from "./types.js";
+import { sanitizeMmdFilename } from "./mmd-path.js";
 
 /** Default root data directory (parent of all agent subdirectories) */
 export const DEFAULT_DATA_ROOT = join(homedir(), ".openclaw", "context-offload");
@@ -571,7 +572,7 @@ export async function writeMmd(
   filename: string,
   content: string,
 ): Promise<void> {
-  const filePath = join(ctx.mmdsDir, filename);
+  const filePath = join(ctx.mmdsDir, sanitizeMmdFilename(filename));
   await writeFile(filePath, content, "utf-8");
 }
 
@@ -581,8 +582,9 @@ export async function patchMmd(
   filename: string,
   blocks: MmdReplaceBlock[],
 ): Promise<boolean> {
-  const filePath = join(ctx.mmdsDir, filename);
-  const original = await readMmd(ctx, filename);
+  const safeFilename = sanitizeMmdFilename(filename);
+  const filePath = join(ctx.mmdsDir, safeFilename);
+  const original = await readMmd(ctx, safeFilename);
   if (original === null) return false;
   const lines = original.split("\n");
   let allValid = true;
@@ -615,7 +617,7 @@ export async function readMmd(
   ctx: StorageContext,
   filename: string,
 ): Promise<string | null> {
-  const filePath = join(ctx.mmdsDir, filename);
+  const filePath = join(ctx.mmdsDir, sanitizeMmdFilename(filename));
   if (!existsSync(filePath)) return null;
   return readFile(filePath, "utf-8");
 }
@@ -625,7 +627,7 @@ export async function deleteMmd(
   ctx: StorageContext,
   filename: string,
 ): Promise<boolean> {
-  const filePath = join(ctx.mmdsDir, filename);
+  const filePath = join(ctx.mmdsDir, sanitizeMmdFilename(filename));
   if (!existsSync(filePath)) return false;
   await unlink(filePath);
   return true;


### PR DESCRIPTION
## Summary
- normalize L1.5 task labels and continuation MMD filenames before activating/writing MMDs
- route MMD read/write/patch/delete through a safe single-segment `.mmd` filename
- add regression tests for unsafe labels and direct MMD writes escaping `mmds/`

## Why
L1.5 judgments come from the backend/LLM. A `newTaskLabel` or `continuationMmdFile` containing dot segments could make `writeMmd` operate outside the agent `mmds/` directory.

## Tests
- `npm test -- src/offload/hooks/before-agent-start.test.ts`
- `npm test -- src/offload/hooks/before-agent-start.test.ts src/offload/auth-profile-key.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`