### PR TITLE
fix(offload): sanitize ref and skill paths

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -67,6 +67,7 @@ import { SessionRegistry } from "./session-registry.js";
 import { reclaimOffloadData } from "./reclaimer.js";
 import { buildL3TriggerReport, reportL3Trigger } from "./state-reporter.js";
 import { resolveUserId, getUserIdSource } from "./user-id.js";
+import { sanitizePathSegment } from "./path-segment.js";
 
 // ─── Module-level state ──────────────────────────────────────────────────────
 // OpenClaw calls registerOffload() multiple times during lifecycle.
@@ -825,11 +826,12 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
           // Write skill file locally
           const { mkdir, writeFile } = await import("node:fs/promises");
           const { join } = await import("node:path");
-          const skillsDir = join(stateManager.ctx.dataDir, "skills", resp.skillName);
+          const safeSkillName = sanitizePathSegment(resp.skillName, "skill");
+          const skillsDir = join(stateManager.ctx.dataDir, "skills", safeSkillName);
           await mkdir(skillsDir, { recursive: true });
           await writeFile(join(skillsDir, "SKILL.md"), resp.skillContent, "utf-8");
-          const resultPrompt = `<l4_skill_result>\n【Skill 生成完成】\n\n**Skill 名称:** ${resp.skillName}\n**描述:** ${resp.skillDescription}\n**文件路径:** ${join(skillsDir, "SKILL.md")}\n\n---\n${resp.skillContent}\n---\n</l4_skill_result>`;
-          return { appendSystemContext: resultPrompt, phase: "completed", skillName: resp.skillName };
+          const resultPrompt = `<l4_skill_result>\n【Skill 生成完成】\n\n**Skill 名称:** ${safeSkillName}\n**描述:** ${resp.skillDescription}\n**文件路径:** ${join(skillsDir, "SKILL.md")}\n\n---\n${resp.skillContent}\n---\n</l4_skill_result>`;
+          return { appendSystemContext: resultPrompt, phase: "completed", skillName: safeSkillName };
         }
       }
     } catch (err) {

--- a/src/offload/path-segment.ts
+++ b/src/offload/path-segment.ts
@@ -1,0 +1,11 @@
+const UNSAFE_PATH_SEGMENT_RE = /[<>:"/\\|?*\x00-\x1f]/g;
+
+/** Sanitize untrusted text before using it as one filesystem path segment. */
+export function sanitizePathSegment(value: string, fallback = "item"): string {
+  const safe = String(value ?? "")
+    .replace(UNSAFE_PATH_SEGMENT_RE, "_")
+    .replace(/\.{2,}/g, "_")
+    .slice(0, 120);
+  const trimmed = safe.trim();
+  return trimmed.length === 0 || trimmed === "." ? fallback : safe;
+}

--- a/src/offload/storage-ref.test.ts
+++ b/src/offload/storage-ref.test.ts
@@ -1,0 +1,50 @@
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createStorageContext, ensureDirs, readRefMd, writeRefMd } from "./storage.js";
+
+const tempRoots: string[] = [];
+
+async function makeContext() {
+  const root = await mkdtemp(join(tmpdir(), "tdai-offload-ref-"));
+  tempRoots.push(root);
+  const ctx = createStorageContext(root, "agent", "session");
+  await ensureDirs(ctx);
+  return { root, ctx };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("ref MD storage", () => {
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("keeps timestamp-derived ref files inside the refs directory", async () => {
+    const { root, ctx } = await makeContext();
+
+    const refPath = await writeRefMd(ctx, "../../escaped", "tool", "content");
+
+    expect(refPath).toMatch(/^refs\//);
+    expect(refPath).not.toContain("../");
+    expect(await exists(join(root, "escaped.md"))).toBe(false);
+    await expect(readRefMd(ctx, refPath)).resolves.toContain("content");
+  });
+
+  it("does not read ref paths outside the refs directory", async () => {
+    const { root, ctx } = await makeContext();
+    await writeFile(join(root, "secret.md"), "secret", "utf-8");
+
+    await expect(readRefMd(ctx, "../secret.md")).resolves.toBeNull();
+  });
+});

--- a/src/offload/storage.ts
+++ b/src/offload/storage.ts
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { homedir } from "node:os";
 import type { OffloadEntry, PluginLogger } from "./types.js";
+import { sanitizePathSegment } from "./path-segment.js";
 
 /** Default root data directory (parent of all agent subdirectories) */
 export const DEFAULT_DATA_ROOT = join(homedir(), ".openclaw", "context-offload");
@@ -525,7 +526,10 @@ export async function updateOffloadNodeIds(
 
 /** Convert ISO 8601 timestamp to a safe filename (replace special chars) */
 export function isoToFilename(iso: string): string {
-  return iso.replace(/:/g, "-").replace(/\./g, "-").replace(/\+/g, "p");
+  return sanitizePathSegment(
+    iso.replace(/:/g, "-").replace(/\./g, "-").replace(/\+/g, "p"),
+    "ref",
+  );
 }
 
 /** Write tool result content to a ref MD file, return relative path */
@@ -548,7 +552,8 @@ export async function readRefMd(
   ctx: StorageContext,
   refPath: string,
 ): Promise<string | null> {
-  const filePath = join(ctx.dataDir, refPath);
+  const rawRef = String(refPath ?? "").replace(/^refs[/\\]/, "");
+  const filePath = join(ctx.refsDir, sanitizePathSegment(rawRef, "ref"));
   if (!existsSync(filePath)) return null;
   return readFile(filePath, "utf-8");
 }


### PR DESCRIPTION
## Summary
- sanitize timestamp-derived ref filenames before writing `refs/*.md`
- resolve `readRefMd` only within the refs directory
- sanitize backend-provided L4 skill names before creating skill directories

## Why
Ref filenames and L4 skill names are string inputs that were joined into filesystem paths. Dot segments or separators could escape the intended offload storage subdirectories.

## Tests
- `npm test -- src/offload/storage-ref.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`