### PR TITLE
fix(checkpoint): recalibrate aggregate counters on startup to fix drift (#157)

### DIFF
--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -23,6 +23,7 @@ import { loadGatewayConfig } from "./config.js";
 import type { GatewayConfig } from "./config.js";
 import { initDataDirectories } from "../utils/pipeline-factory.js";
 import { SessionFilter } from "../utils/session-filter.js";
+import { CheckpointManager } from "../utils/checkpoint.js";
 import type {
   HealthResponse,
   RecallRequest,
@@ -147,6 +148,28 @@ export class TdaiGateway {
 
     // Initialize core
     await this.core.initialize();
+
+    // Recalibrate checkpoint counters (issue #157)
+    // total_memories_extracted / l0_conversations_count only ever increment
+    // inside CheckpointManager, so external cleanup (memory-cleaner, manual
+    // JSONL pruning) leaves them permanently drifted. Recompute from the
+    // authoritative storage before serving traffic. Non-fatal: any failure
+    // here is logged and the gateway still starts — drift will self-heal on
+    // the next startup.
+    try {
+      const cp = new CheckpointManager(this.config.data.baseDir, this.logger);
+      const vectorStore = this.core.getVectorStore();
+      const counts: { l1Memories?: number; l0Conversations?: number } = {};
+      if (vectorStore) {
+        try { counts.l1Memories = await vectorStore.countL1(); } catch { /* non-fatal */ }
+        try { counts.l0Conversations = await vectorStore.countL0(); } catch { /* non-fatal */ }
+      }
+      await cp.recalibrate(counts);
+    } catch (err) {
+      this.logger.warn(
+        `Checkpoint recalibration failed (non-fatal, counters may drift): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     // Create HTTP server
     this.server = http.createServer((req, res) => this.handleRequest(req, res));

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for CheckpointManager.recalibrate() — issue #157.
+ *
+ * Verifies that aggregate counters (`total_memories_extracted`,
+ * `l0_conversations_count`) can be re-aligned with authoritative storage
+ * after external cleanup leaves them drifted.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+let dataDir: string;
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-recalibrate-"));
+});
+
+afterEach(async () => {
+  await fs.rm(dataDir, { recursive: true, force: true });
+});
+
+/** Read the checkpoint file directly to assert on-disk state. */
+async function readCheckpointFile(): Promise<Record<string, unknown>> {
+  const file = path.join(dataDir, ".metadata", "recall_checkpoint.json");
+  const raw = await fs.readFile(file, "utf-8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("CheckpointManager.recalibrate() — issue #157", () => {
+  it("drifts counters up via markL1ExtractionComplete and captureAtomically", async () => {
+    const cm = new CheckpointManager(dataDir);
+    // Drift the counters to non-zero values
+    await cm.markL1ExtractionComplete("session-a", 50);
+    await cm.markL1ExtractionComplete("session-b", 30);
+    await cm.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 1000,
+      messageCount: 4,
+    }));
+    await cm.captureAtomically("session-b", undefined, async () => ({
+      maxTimestamp: 2000,
+      messageCount: 6,
+    }));
+
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(80);
+    expect(cp.l0_conversations_count).toBe(2);
+  });
+
+  it("recalibrate overwrites both counters when both drift", async () => {
+    const cm = new CheckpointManager(dataDir);
+    await cm.markL1ExtractionComplete("session-a", 50);
+    await cm.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 1000,
+      messageCount: 4,
+    }));
+    await cm.captureAtomically("session-b", undefined, async () => ({
+      maxTimestamp: 2000,
+      messageCount: 6,
+    }));
+
+    // Simulate external cleanup: real data is 42 L1 + 3 L0, checkpoint says 50/2
+    const report = await cm.recalibrate({ l1Memories: 42, l0Conversations: 3 });
+
+    expect(report.totalMemoriesExtracted.old).toBe(50);
+    expect(report.totalMemoriesExtracted.new).toBe(42);
+    expect(report.totalMemoriesExtracted.changed).toBe(true);
+    expect(report.l0ConversationsCount.old).toBe(2);
+    expect(report.l0ConversationsCount.new).toBe(3);
+    expect(report.l0ConversationsCount.changed).toBe(true);
+
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(3);
+  });
+
+  it("recalibrate to a HIGHER value works (e.g. backup restored)", async () => {
+    // Real-world: a backup restore could make authoritative count larger
+    // than the in-memory counter. recalibrate must accept that too.
+    const cm = new CheckpointManager(dataDir);
+    await cm.markL1ExtractionComplete("session-a", 10);
+
+    const report = await cm.recalibrate({ l1Memories: 100, l0Conversations: 5 });
+    expect(report.totalMemoriesExtracted.changed).toBe(true);
+    expect(report.l0ConversationsCount.changed).toBe(true);
+
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(100);
+    expect(cp.l0_conversations_count).toBe(5);
+  });
+
+  it("recalibrate leaves a counter untouched when undefined is passed", async () => {
+    const cm = new CheckpointManager(dataDir);
+    await cm.markL1ExtractionComplete("session-a", 25);
+    await cm.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 1000,
+      messageCount: 2,
+    }));
+
+    // Only fix L1; leave L0 alone.
+    const report = await cm.recalibrate({ l1Memories: 7 });
+
+    expect(report.totalMemoriesExtracted.old).toBe(25);
+    expect(report.totalMemoriesExtracted.new).toBe(7);
+    expect(report.totalMemoriesExtracted.changed).toBe(true);
+    expect(report.l0ConversationsCount.old).toBe(1);
+    expect(report.l0ConversationsCount.new).toBe(1);
+    expect(report.l0ConversationsCount.changed).toBe(false);
+
+    const cp = await cm.read();
+    expect(cp.l0_conversations_count).toBe(1);
+  });
+
+  it("recalibrate is a no-op when called with empty input", async () => {
+    const cm = new CheckpointManager(dataDir);
+    await cm.markL1ExtractionComplete("session-a", 11);
+
+    const report = await cm.recalibrate({});
+    expect(report.totalMemoriesExtracted.changed).toBe(false);
+    expect(report.l0ConversationsCount.changed).toBe(false);
+
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(11);
+    expect(cp.l0_conversations_count).toBe(0);
+  });
+
+  it("recalibrate creates a fresh checkpoint when none exists", async () => {
+    const cm = new CheckpointManager(dataDir);
+    // Don't write anything first; the file shouldn't exist yet.
+    await expect(fs.access(path.join(dataDir, ".metadata", "recall_checkpoint.json")))
+      .rejects.toThrow();
+
+    const report = await cm.recalibrate({ l1Memories: 5, l0Conversations: 2 });
+    expect(report.totalMemoriesExtracted.old).toBe(0);
+    expect(report.totalMemoriesExtracted.new).toBe(5);
+    expect(report.l0ConversationsCount.old).toBe(0);
+    expect(report.l0ConversationsCount.new).toBe(2);
+
+    // File must now exist on disk
+    const onDisk = await readCheckpointFile();
+    expect(onDisk.total_memories_extracted).toBe(5);
+    expect(onDisk.l0_conversations_count).toBe(2);
+  });
+
+  it("recalibrate persists across new CheckpointManager instances", async () => {
+    const cm1 = new CheckpointManager(dataDir);
+    await cm1.markL1ExtractionComplete("session-a", 99);
+
+    await cm1.recalibrate({ l1Memories: 7, l0Conversations: 3 });
+
+    // A fresh instance reads the recalibrated values, not the drifted ones.
+    const cm2 = new CheckpointManager(dataDir);
+    const cp = await cm2.read();
+    expect(cp.total_memories_extracted).toBe(7);
+    expect(cp.l0_conversations_count).toBe(3);
+  });
+
+  it("recalibrate preserves other checkpoint fields (persona state, per-session state)", async () => {
+    const cm = new CheckpointManager(dataDir);
+    await cm.markL1ExtractionComplete("session-a", 50);
+    await cm.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 5000,
+      messageCount: 3,
+    }));
+    await cm.markPersonaGenerated(50);
+
+    await cm.recalibrate({ l1Memories: 10, l0Conversations: 1 });
+
+    const cp = await cm.read();
+    // Counters are recalibrated
+    expect(cp.total_memories_extracted).toBe(10);
+    expect(cp.l0_conversations_count).toBe(1);
+    // Persona fields untouched
+    expect(cp.last_persona_at).toBe(50);
+    expect(cp.memories_since_last_persona).toBe(0);
+    // Per-session state preserved (last_captured_timestamp set by capture)
+    const rs = cp.runner_states["session-a"];
+    expect(rs).toBeDefined();
+    expect(rs.last_captured_timestamp).toBe(5000);
+  });
+
+  it("recalibrate rejects negative or non-finite inputs", async () => {
+    const cm = new CheckpointManager(dataDir);
+    await expect(cm.recalibrate({ l1Memories: -1 })).rejects.toThrow(TypeError);
+    await expect(cm.recalibrate({ l0Conversations: -1 })).rejects.toThrow(TypeError);
+    await expect(cm.recalibrate({ l1Memories: Number.NaN })).rejects.toThrow(TypeError);
+    await expect(cm.recalibrate({ l0Conversations: Number.POSITIVE_INFINITY })).rejects.toThrow(TypeError);
+  });
+
+  it("recalibrate is atomic under concurrent mutate calls (no torn writes)", async () => {
+    // Race: two concurrent mutates must not interleave. The file lock
+    // serializes them so the final state matches one of the two writes.
+    const cm = new CheckpointManager(dataDir);
+    await cm.markL1ExtractionComplete("session-a", 100);
+
+    const results = await Promise.all([
+      cm.recalibrate({ l1Memories: 10 }),
+      cm.recalibrate({ l1Memories: 20 }),
+      cm.recalibrate({ l1Memories: 30 }),
+    ]);
+
+    // One of the three values must have won; nothing in between.
+    const finalValues = results.map((r) => r.totalMemoriesExtracted.new).sort();
+    expect(finalValues).toEqual([10, 20, 30]);
+
+    const cp = await cm.read();
+    expect([10, 20, 30]).toContain(cp.total_memories_extracted);
+
+    // No torn write: file is valid JSON with the winning value.
+    const onDisk = await readCheckpointFile();
+    expect([10, 20, 30]).toContain(onDisk.total_memories_extracted);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -124,6 +124,15 @@ const DEFAULT_PIPELINE_STATE: PipelineSessionState = {
   l2_last_extraction_time: "",
 };
 
+/**
+ * Report returned by `CheckpointManager.recalibrate()` describing the
+ * before/after values of each recalibrated counter plus a `changed` flag.
+ */
+export interface RecalibrationReport {
+  totalMemoriesExtracted: { old: number; new: number; changed: boolean };
+  l0ConversationsCount: { old: number; new: number; changed: boolean };
+}
+
 const DEFAULT_CHECKPOINT: Checkpoint = {
   last_captured_timestamp: 0,
   total_processed: 0,
@@ -259,13 +268,15 @@ export class CheckpointManager {
    * Execute a mutating operation under the per-file lock.
    * `fn` receives the current checkpoint and may modify it in place;
    * the updated checkpoint is atomically written back.
+   * If `fn` returns a value, it is forwarded to the caller (used by
+   * `recalibrate()` to return a recalibration report).
    */
-  private async mutate(fn: (cp: Checkpoint) => void | Promise<void>): Promise<Checkpoint> {
+  private async mutate<R = Checkpoint>(fn: (cp: Checkpoint) => R | Promise<R>): Promise<R> {
     return withFileLock(this.filePath, async () => {
       const cp = await this.readRaw();
-      await fn(cp);
+      const result = await fn(cp);
       await this.writeRaw(cp);
-      return cp;
+      return result;
     });
   }
 
@@ -326,10 +337,12 @@ export class CheckpointManager {
   }
 
   async incrementScenesProcessed(): Promise<void> {
-    const cp = await this.mutate((cp) => {
+    let newValue = 0;
+    await this.mutate((cp) => {
       cp.scenes_processed += 1;
+      newValue = cp.scenes_processed;
     });
-    this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
+    this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${newValue}`);
   }
 
   // ============================
@@ -429,6 +442,64 @@ export class CheckpointManager {
       `extracted=${memoriesExtracted}, cursor=${cursorRecordedAtMs ?? "(unchanged)"}, ` +
       `lastScene="${lastSceneName ?? "(unchanged)"}"`,
     );
+  }
+
+  // ============================
+  // Recalibration (drift fix — issue #157)
+  // ============================
+
+  /**
+   * Recalibrate aggregate counters from authoritative storage.
+   *
+   * `total_memories_extracted` and `l0_conversations_count` only ever increment
+   * in this class. After any external cleanup (memory-cleaner, manual JSONL
+   * pruning, deletion of pipeline_states test data) the counters permanently
+   * overstate reality, which corrupts persona-generation thresholds
+   * (`cp.total_processed`, `cp.memories_since_last_persona`) and status
+   * reporting. This method re-reads the source-of-truth counts and overwrites
+   * the in-checkpoint values atomically.
+   *
+   * Pass `undefined` for any counter whose authoritative count is unavailable
+   * (e.g. VectorStore not initialized) — that counter is left untouched.
+   *
+   * @returns A report describing the recalibration (old/new values, drift).
+   */
+  async recalibrate(
+    counts: { l1Memories?: number; l0Conversations?: number },
+  ): Promise<RecalibrationReport> {
+    const l1 = counts.l1Memories;
+    const l0 = counts.l0Conversations;
+    if (l1 !== undefined && (!Number.isFinite(l1) || l1 < 0)) {
+      throw new TypeError(`recalibrate: l1Memories must be a non-negative finite number, got ${l1}`);
+    }
+    if (l0 !== undefined && (!Number.isFinite(l0) || l0 < 0)) {
+      throw new TypeError(`recalibrate: l0Conversations must be a non-negative finite number, got ${l0}`);
+    }
+
+    const report = await this.mutate((cp) => {
+      const oldL1 = cp.total_memories_extracted;
+      const oldL0 = cp.l0_conversations_count;
+      if (l1 !== undefined) cp.total_memories_extracted = Math.floor(l1);
+      if (l0 !== undefined) cp.l0_conversations_count = Math.floor(l0);
+      this.logger.info(
+        `[checkpoint] recalibrate: ` +
+        `total_memories_extracted ${oldL1} → ${cp.total_memories_extracted} (Δ=${cp.total_memories_extracted - oldL1}); ` +
+        `l0_conversations_count ${oldL0} → ${cp.l0_conversations_count} (Δ=${cp.l0_conversations_count - oldL0})`,
+      );
+      return {
+        totalMemoriesExtracted: {
+          old: oldL1,
+          new: cp.total_memories_extracted,
+          changed: l1 !== undefined && oldL1 !== cp.total_memories_extracted,
+        },
+        l0ConversationsCount: {
+          old: oldL0,
+          new: cp.l0_conversations_count,
+          changed: l0 !== undefined && oldL0 !== cp.l0_conversations_count,
+        },
+      };
+    });
+    return report;
   }
 
   // ============================


### PR DESCRIPTION
## Summary

Fix the counter drift described in #157. `total_memories_extracted` and `l0_conversations_count` in `recall_checkpoint.json` previously only ever incremented inside `CheckpointManager`, so external cleanup (memory-cleaner, manual JSONL pruning, deletion of test pipeline_states) left them permanently overstated. The drift corrupted persona-generation thresholds (`cp.total_processed`, `cp.memories_since_last_persona`) and status reporting.

## Changes

- **`CheckpointManager.recalibrate()`** (`src/utils/checkpoint.ts`)
  - New method that overwrites the two aggregate counters with authoritative counts.
  - Atomic: reuses the existing per-file lock + atomic tmp+rename write.
  - Returns a `RecalibrationReport` describing before/after values and whether each counter changed.
  - Accepts optional `{ l1Memories?, l0Conversations? }` so callers can recalibrate whichever counts they can obtain (VectorStore counts may not always be available).

- **`TdaiGateway.start()`** (`src/gateway/server.ts`)
  - After `core.initialize()`, runs recalibrate once using `vectorStore.countL1()` and `vectorStore.countL0()` before serving traffic.
  - Non-fatal: any failure is logged and the gateway still starts — drift will self-heal on the next startup.

- **`mutate()` generalized** to forward the callback's return value (used by `recalibrate()` to return its report). All existing callers still work; `incrementScenesProcessed()` updated to capture the new value inside the locked section.

- **Tests** (`src/utils/checkpoint.test.ts`, 10 new tests, all passing):
  - Counter drift reproduction
  - Overwrite lower (cleanup) and higher (backup restore) values
  - Partial recalibration (only one counter)
  - Empty input no-op
  - Fresh-checkpoint creation when none exists
  - Persistence across `new CheckpointManager()` instances
  - Preservation of unrelated fields (persona state, per-session state)
  - Input validation (rejects negative / non-finite)
  - Atomicity under concurrent `mutate()` calls

Closes #157