### PR TITLE
fix(store): sanitize SQLite FTS5 MATCH queries

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,226 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { MemoryRecord } from "../record/l1-writer.js";
+import type { L0Record } from "./types.js";
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery, VectorStore } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("builds deterministic OR queries for ordinary text in fallback mode", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("travel plan API")).toBe('"travel" OR "plan" OR "API"');
+  });
+
+  it("removes FTS5 operators and special syntax from fallback tokens", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('"alpha" OR (beta*) NOT NEAR(gamma delta, 5)')).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta" OR "5"',
+    );
+  });
+
+  it.each([
+    { input: 'alpha" OR "beta', expected: '"alpha" OR "beta"' },
+    { input: "alpha' OR 'beta", expected: '"alpha" OR "beta"' },
+    { input: "(alpha) OR (beta)", expected: '"alpha" OR "beta"' },
+    { input: "alpha AND beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha OR beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha NOT beta", expected: '"alpha" OR "beta"' },
+    { input: "NEAR(alpha beta, 5)", expected: '"alpha" OR "beta" OR "5"' },
+    { input: "alpha NEAR/5 beta", expected: '"alpha" OR "5" OR "beta"' },
+    { input: "alpha*", expected: '"alpha"' },
+    { input: "content:alpha", expected: '"content" OR "alpha"' },
+    { input: "-content:alpha", expected: '"content" OR "alpha"' },
+    { input: "near and or not", expected: null },
+    { input: "   *** ((())) :::   ", expected: null },
+    { input: "alpha alpha OR beta", expected: '"alpha" OR "beta"' },
+    { input: "foo_bar v2", expected: '"foo_bar" OR "v2"' },
+  ])("sanitizes FTS5 syntax in %j", ({ input, expected }) => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery(input)).toBe(expected);
+  });
+
+  it("returns null when input contains only FTS5 syntax and operators", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('AND OR NOT NEAR * ^ : " \' ( )')).toBeNull();
+  });
+
+  it("applies the same sanitizer to jieba-produced tokens", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["foo:bar", " ", "AND", "C++", "的", "用户", "NEAR"],
+    });
+
+    expect(buildFtsQuery("ignored by fake jieba")).toBe('"foo" OR "bar" OR "C" OR "用户"');
+  });
+
+  it("produces an executable FTS5 query whose semantics are not controlled by payload operators", () => {
+    _setJiebaForTest(null);
+    const db = new DatabaseSync(":memory:");
+
+    db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+    const insert = db.prepare("INSERT INTO docs(rowid, content) VALUES (?, ?)");
+    insert.run(1, "alpha beta");
+    insert.run(2, "alpha");
+    insert.run(3, "beta");
+
+    const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+    expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+    const rows = db
+      .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+      .all(ftsQuery) as Array<{ rowid: number }>;
+
+    expect(rows.map((row) => row.rowid)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps ordinary recall comparable to the previous token OR strategy", () => {
+    _setJiebaForTest(null);
+    const db = createRecallFixtureDb();
+    const ordinaryQueries = [
+      "travel plan API",
+      "TypeScript memory",
+      "coffee beans",
+      "project roadmap",
+      "用户 编程 TypeScript",
+    ];
+
+    for (const query of ordinaryQueries) {
+      const legacyIds = searchDocIds(db, buildLegacyUnsafeFtsQueryForTest(query));
+      const sanitized = buildFtsQuery(query);
+      expect(sanitized).not.toBeNull();
+
+      const sanitizedIds = searchDocIds(db, sanitized!);
+      expect(sanitizedIds).toEqual(legacyIds);
+    }
+  });
+});
+
+describe("VectorStore FTS query sanitization", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("keeps L1 FTS fallback searches executable and operator-neutral", async () => {
+    _setJiebaForTest(null);
+    const tempDir = await mkdtemp(path.join(tmpdir(), "tdai-fts-l1-"));
+    const store = new VectorStore(path.join(tempDir, "memory.db"), 0);
+
+    try {
+      const init = store.init();
+      expect(init.needsReindex).toBe(false);
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL1(makeMemoryRecord("l1-alpha-beta", "alpha beta memory"), undefined)).toBe(true);
+      expect(store.upsertL1(makeMemoryRecord("l1-alpha", "alpha memory"), undefined)).toBe(true);
+      expect(store.upsertL1(makeMemoryRecord("l1-beta", "beta memory"), undefined)).toBe(true);
+
+      const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+      const ids = store.searchL1Fts(ftsQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+
+      expect(ids).toEqual(["l1-alpha", "l1-alpha-beta", "l1-beta"]);
+    } finally {
+      store.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps L0 FTS fallback searches executable and operator-neutral", async () => {
+    _setJiebaForTest(null);
+    const tempDir = await mkdtemp(path.join(tmpdir(), "tdai-fts-l0-"));
+    const store = new VectorStore(path.join(tempDir, "memory.db"), 0);
+
+    try {
+      const init = store.init();
+      expect(init.needsReindex).toBe(false);
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL0(makeL0Record("l0-alpha-beta", "alpha beta message"), undefined)).toBe(true);
+      expect(store.upsertL0(makeL0Record("l0-alpha", "alpha message"), undefined)).toBe(true);
+      expect(store.upsertL0(makeL0Record("l0-beta", "beta message"), undefined)).toBe(true);
+
+      const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+      const ids = store.searchL0Fts(ftsQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+
+      expect(ids).toEqual(["l0-alpha", "l0-alpha-beta", "l0-beta"]);
+    } finally {
+      store.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function makeMemoryRecord(id: string, content: string): MemoryRecord {
+  const now = "2026-06-30T00:00:00.000Z";
+  return {
+    id,
+    content,
+    type: "episodic",
+    priority: 50,
+    scene_name: "test",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [now],
+    createdAt: now,
+    updatedAt: now,
+    sessionKey: "test-session-key",
+    sessionId: "test-session-id",
+  };
+}
+
+function makeL0Record(id: string, messageText: string): L0Record {
+  return {
+    id,
+    sessionKey: "test-session-key",
+    sessionId: "test-session-id",
+    role: "user",
+    messageText,
+    recordedAt: "2026-06-30T00:00:00.000Z",
+    timestamp: Date.parse("2026-06-30T00:00:00.000Z"),
+  };
+}
+
+function buildLegacyUnsafeFtsQueryForTest(input: string): string {
+  return input.split(/\s+/).filter(Boolean).join(" OR ");
+}
+
+function createRecallFixtureDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  const insert = db.prepare("INSERT INTO docs(rowid, content) VALUES (?, ?)");
+
+  insert.run(1, "travel plan API itinerary hotel booking");
+  insert.run(2, "TypeScript memory search sqlite fts");
+  insert.run(3, "coffee beans espresso grinder");
+  insert.run(4, "project roadmap milestone release");
+  insert.run(5, "用户 编程 TypeScript 记忆 搜索");
+  insert.run(6, "unrelated cooking recipe");
+
+  return db;
+}
+
+function searchDocIds(db: DatabaseSync, ftsQuery: string): number[] {
+  const rows = db
+    .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+    .all(ftsQuery) as Array<{ rowid: number }>;
+  return rows.map((row) => row.rowid);
+}

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,6 +175,35 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * FTS5 query operators that must never be forwarded as user-controlled syntax.
+ * They are filtered out instead of quoted because users often type them as
+ * natural-language glue words, and keeping them would add noisy recall terms.
+ */
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+const FTS5_SAFE_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+
+function sanitizeFtsQueryTokens(rawTokens: string[]): string[] {
+  const sanitized: string[] = [];
+
+  for (const rawToken of rawTokens) {
+    const parts = rawToken.normalize("NFKC").match(FTS5_SAFE_TOKEN_RE) ?? [];
+    for (const part of parts) {
+      if (!part) continue;
+      if (ZH_STOP_WORDS.has(part)) continue;
+      if (FTS5_RESERVED_OPERATORS.has(part.toUpperCase())) continue;
+      sanitized.push(part);
+    }
+  }
+
+  return [...new Set(sanitized)];
+}
+
+function quoteFtsPhraseToken(token: string): string {
+  return `"${token}"`;
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -190,6 +219,11 @@ const ZH_STOP_WORDS = new Set([
  * significantly improved — especially for longer queries and when running
  * in FTS-only fallback mode (no embedding available).
  *
+ * User-controlled FTS5 syntax is removed before quoting. This keeps MATCH
+ * expressions deterministic: characters like `"`, `'`, `(`, `)`, `:`, `*`,
+ * and reserved words such as `AND` / `OR` / `NOT` / `NEAR` cannot change the
+ * boolean structure of the query or trigger syntax errors.
+ *
  * Example (with jieba):
  *   "用户喜欢编程和TypeScript" → '"用户" OR "喜欢" OR "编程" OR "TypeScript"'
  * Example (fallback):
@@ -198,34 +232,23 @@ const ZH_STOP_WORDS = new Set([
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
 
-  let tokens: string[];
+  let rawTokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
-    // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
+    rawTokens = jieba.cutForSearch(raw, true).map((t) => t.trim());
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
+    rawTokens =
       raw
-        .match(/[\p{L}\p{N}_]+/gu)
+        .match(FTS5_SAFE_TOKEN_RE)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];
   }
 
+  const tokens = sanitizeFtsQueryTokens(rawTokens);
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map(quoteFtsPhraseToken);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

This PR addresses SQLite FTS5 operator injection in `buildFtsQuery()`.

Issue #160 points out that user input may contain FTS5 query syntax such as `"`, `'`, `(`, `)`, `AND`, `OR`, `NOT`, `NEAR`, and `*`. If these tokens are forwarded into an FTS5 `MATCH` expression as user-controlled syntax, they can change search semantics or cause syntax errors.

This PR changes `buildFtsQuery()` to build SQLite FTS5 `MATCH` expressions from sanitized tokens only:

- Split or remove FTS5 syntax characters before constructing the query.
- Drop reserved FTS5 operators: `AND`, `OR`, `NOT`, `NEAR`.
- Keep only safe query tokens: Unicode letters, numbers, and `_`.
- Quote each sanitized token before joining with `OR`.
- Apply the same sanitizer to both jieba segmentation output and fallback regex tokenization.

Example:

```text
alpha AND NOT beta
```

is now converted to:

```text
"alpha" OR "beta"
```

rather than allowing `AND NOT` to control FTS5 query semantics.

## Related Issue | 关联 Issue

Fix #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Acceptance Criteria Coverage | 验收标准对应

### 基础：对 FTS5 特殊字符进行转义，普通用户搜索不受影响

Completed.

This PR sanitizes FTS5 syntax characters and reserved operators before building the `MATCH` expression.

Covered inputs include:

- `"`
- `'`
- `(`
- `)`
- `AND`
- `OR`
- `NOT`
- `NEAR`
- `*`

Ordinary keyword search remains supported. For example:

```text
travel plan API
```

still becomes:

```text
"travel" OR "plan" OR "API"
```

### 进阶：编写完整的安全测试用例，覆盖所有 FTS5 操作符和边界情况

Completed.

Added table-driven tests for issue-listed operators and common boundary cases, including:

- quote injection: `alpha" OR "beta`
- single-quote input: `alpha' OR 'beta`
- parentheses: `(alpha) OR (beta)`
- boolean operators: `alpha AND beta`, `alpha OR beta`, `alpha NOT beta`
- NEAR syntax: `NEAR(alpha beta, 5)`, `alpha NEAR/5 beta`
- prefix syntax: `alpha*`
- column-filter-like syntax: `content:alpha`, `-content:alpha`
- pure operators: `AND OR NOT NEAR`
- pure punctuation
- duplicated tokens
- jieba-produced mixed tokens such as `foo:bar` and `C++`

Also added an executable SQLite FTS5 test to verify that a payload such as:

```text
alpha AND NOT beta
```

does not behave as an FTS5 boolean expression after sanitization.

### 深入：对比转义前后 recall 效果，确认无明显退化

Completed.

Added a recall comparison fixture that compares:

- the previous token-OR behavior, simulated by `input.split(/\s+/).join(" OR ")`
- the new sanitized quoted-token behavior from `buildFtsQuery()`

The test runs both query forms against the same SQLite FTS5 fixture and verifies that representative ordinary keyword queries return the same result set.

Covered ordinary queries include:

```text
travel plan API
TypeScript memory
coffee beans
project roadmap
用户 编程 TypeScript
```

### 拓展：考虑 FTS5 查询白名单或参数化查询方案

Addressed through a whitelist-based FTS5 query builder.

SQLite execution already uses prepared statements with `MATCH ?`, which protects SQL syntax. However, FTS5 still parses the bound value as a `MATCH` query expression, so this PR adds a whitelist before constructing that expression.

The whitelist allows only:

```text
Unicode letters, Unicode numbers, _
```

to become FTS5 query tokens. FTS5 syntax characters and reserved operators are removed before SQLite receives the `MATCH` expression.

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

- [x] `buildFtsQuery()` keeps ordinary keyword search behavior
  - Verified that normal input such as `travel plan API` is converted to `"travel" OR "plan" OR "API"`.

- [x] FTS5 special characters are sanitized
  - Covered `"`, `'`, `(`, `)`, `:`, `*`, `-`, and pure punctuation input.
  - Verified that syntax-like input is split or removed before constructing the final `MATCH` expression.

- [x] FTS5 reserved operators cannot control query semantics
  - Covered `AND`, `OR`, `NOT`, `NEAR`, lowercase variants, `NEAR(...)`, and `NEAR/5`.
  - Verified that `alpha AND NOT beta` becomes `"alpha" OR "beta"`.

- [x] Sanitization works for both fallback tokenization and jieba-produced tokens
  - Forced fallback tokenization in tests with `_setJiebaForTest(null)`.
  - Added a fake jieba token test to verify mixed tokens such as `foo:bar`, `C++`, `AND`, and `NEAR` go through the same sanitizer.

- [x] Sanitized queries execute correctly in real SQLite FTS5
  - Created an in-memory FTS5 table with `node:sqlite`.
  - Verified that the payload `alpha AND NOT beta` does not behave as a boolean `AND NOT` expression after sanitization.

- [x] Real `VectorStore` L1 FTS fallback path works
  - Initialized a temporary SQLite-backed `VectorStore`.
  - Inserted records through `upsertL1()`.
  - Queried through `searchL1Fts()`.
  - Verified operator-neutral results for `alpha AND NOT beta`.

- [x] Real `VectorStore` L0 FTS fallback path works
  - Initialized a temporary SQLite-backed `VectorStore`.
  - Inserted records through `upsertL0()`.
  - Queried through `searchL0Fts()`.
  - Verified operator-neutral results for `alpha AND NOT beta`.

- [x] Recall comparison shows no obvious regression for ordinary keyword queries
  - Compared the previous token-OR behavior with the new sanitized quoted-token behavior on the same SQLite FTS5 fixture.
  - Verified identical result sets for:
    - `travel plan API`
    - `TypeScript memory`
    - `coffee beans`
    - `project roadmap`
    - `用户 编程 TypeScript`

- [x] Full test suite passes

```bash
npx vitest run src/core/store/sqlite.test.ts
```

```text
1 test file passed
23 tests passed
```

```bash
npm test
```

```text
5 test files passed
90 tests passed
```

```bash
npm run build
```

```text
passed
```
