### PR TITLE
fix(search): sanitize FTS5 query tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 不动配置 = 行为完全不变。
 
+### 🐛 修复
+
+#### 安全 / 输入净化
+
+- **FTS5 查询语法注入防护** ([#160](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160))：`buildFtsQuery()` 现在会在构造 SQLite FTS5 `MATCH` 表达式前统一清洗 fallback / jieba 分词 token，过滤 `AND` / `OR` / `NOT` / `NEAR` 等保留操作符和 FTS5 语法字符，避免用户输入改变查询语义或触发语法错误。普通关键词搜索的 OR 召回策略保持不变，并新增真实 SQLite FTS5、VectorStore L1/L0 fallback 与普通召回对比测试。
+
 ---
 
 ## [0.3.6] - 2026-05-27

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("filters FTS5 boolean and NEAR operators in fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha OR beta AND NOT NEAR gamma")).toBe('"alpha" OR "beta" OR "gamma"');
+  });
+
+  it("removes FTS5 syntax characters while preserving searchable terms", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('("alpha"* OR beta)')).toBe('"alpha" OR "beta"');
+  });
+
+  it("returns null when input contains only FTS5 operators and syntax", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('" OR AND NOT NEAR ( ) *')).toBeNull();
+  });
+
+  it("keeps non-operator words that merely contain operator text", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("ordinary candy nearshore or")).toBe('"ordinary" OR "candy" OR "nearshore" OR "or"');
+  });
+
+  it("sanitizes jieba output before building the MATCH query", () => {
+    const fakeJieba: Parameters<typeof _setJiebaForTest>[0] = {
+      cutForSearch: () => ["alpha", "OR", "NEAR(beta", "beta", "的", "*", "nearshore"],
+    };
+    _setJiebaForTest(fakeJieba);
+
+    expect(buildFtsQuery("ignored raw text")).toBe('"alpha" OR "beta" OR "nearshore"');
+  });
+});

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,10 +1,22 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+import type { MemoryRecord } from "../record/l1-writer.js";
+import type { L0Record } from "./types.js";
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery, VectorStore } from "./sqlite.js";
 
 describe("buildFtsQuery", () => {
   afterEach(() => {
     _resetJiebaForTest();
+  });
+
+  it("builds deterministic OR queries for ordinary text in fallback mode", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("travel plan API")).toBe('"travel" OR "plan" OR "API"');
   });
 
   it("filters FTS5 boolean and NEAR operators in fallback tokenization", () => {
@@ -19,6 +31,32 @@ describe("buildFtsQuery", () => {
     expect(buildFtsQuery('("alpha"* OR beta)')).toBe('"alpha" OR "beta"');
   });
 
+  it.each([
+    { input: 'alpha" OR "beta', expected: '"alpha" OR "beta"' },
+    { input: "alpha' OR 'beta", expected: '"alpha" OR "beta"' },
+    { input: "(alpha) OR (beta)", expected: '"alpha" OR "beta"' },
+    { input: "alpha AND beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha OR beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha NOT beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha and beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha Or beta", expected: '"alpha" OR "beta"' },
+    { input: "alpha not beta", expected: '"alpha" OR "beta"' },
+    { input: "NEAR(alpha beta, 5)", expected: '"alpha" OR "beta" OR "5"' },
+    { input: "near(alpha beta, 5)", expected: '"alpha" OR "beta" OR "5"' },
+    { input: "alpha NEAR/5 beta", expected: '"alpha" OR "5" OR "beta"' },
+    { input: "alpha*", expected: '"alpha"' },
+    { input: "content:alpha", expected: '"content" OR "alpha"' },
+    { input: "-content:alpha", expected: '"content" OR "alpha"' },
+    { input: "near and or not", expected: null },
+    { input: "   *** ((())) :::   ", expected: null },
+    { input: "alpha alpha OR beta", expected: '"alpha" OR "beta"' },
+    { input: "foo_bar v2", expected: '"foo_bar" OR "v2"' },
+  ])("sanitizes FTS5 syntax in %#", ({ input, expected }) => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery(input)).toBe(expected);
+  });
+
   it("returns null when input contains only FTS5 operators and syntax", () => {
     _setJiebaForTest(null);
 
@@ -28,15 +66,191 @@ describe("buildFtsQuery", () => {
   it("keeps non-operator words that merely contain operator text", () => {
     _setJiebaForTest(null);
 
-    expect(buildFtsQuery("ordinary candy nearshore or")).toBe('"ordinary" OR "candy" OR "nearshore" OR "or"');
+    expect(buildFtsQuery("ordinary candy nearshore origin android scanner")).toBe(
+      '"ordinary" OR "candy" OR "nearshore" OR "origin" OR "android" OR "scanner"',
+    );
+  });
+
+  it("normalizes full-width operator text before filtering", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha ＯＲ beta ＡＮＤ gamma")).toBe('"alpha" OR "beta" OR "gamma"');
   });
 
   it("sanitizes jieba output before building the MATCH query", () => {
     const fakeJieba: Parameters<typeof _setJiebaForTest>[0] = {
-      cutForSearch: () => ["alpha", "OR", "NEAR(beta", "beta", "的", "*", "nearshore"],
+      cutForSearch: () => ["alpha", "OR", "NEAR(beta", "beta", "的", "*", "nearshore", "C++"],
     };
     _setJiebaForTest(fakeJieba);
 
-    expect(buildFtsQuery("ignored raw text")).toBe('"alpha" OR "beta" OR "nearshore"');
+    expect(buildFtsQuery("ignored raw text")).toBe('"alpha" OR "beta" OR "nearshore" OR "C"');
+  });
+
+  it("produces an executable FTS5 query whose semantics are not controlled by payload operators", () => {
+    _setJiebaForTest(null);
+    const db = new DatabaseSync(":memory:");
+
+    try {
+      db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+      const insert = db.prepare("INSERT INTO docs(rowid, content) VALUES (?, ?)");
+      insert.run(1, "alpha beta");
+      insert.run(2, "alpha");
+      insert.run(3, "beta");
+
+      const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+      const rows = db
+        .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+        .all(ftsQuery) as Array<{ rowid: number }>;
+
+      expect(rows.map((row) => row.rowid)).toEqual([1, 2, 3]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps ordinary recall comparable to the previous token OR strategy", () => {
+    _setJiebaForTest(null);
+    const db = createRecallFixtureDb();
+
+    try {
+      for (const query of [
+        "travel plan API",
+        "TypeScript memory",
+        "coffee beans",
+        "project roadmap",
+        "user programming TypeScript",
+      ]) {
+        const legacyIds = searchDocIds(db, buildLegacyUnsafeFtsQueryForTest(query));
+        const sanitized = buildFtsQuery(query);
+        expect(sanitized).not.toBeNull();
+
+        const sanitizedIds = searchDocIds(db, sanitized!);
+        expect(sanitizedIds).toEqual(legacyIds);
+      }
+    } finally {
+      db.close();
+    }
   });
 });
+
+describe("VectorStore FTS query sanitization", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("keeps L1 FTS fallback searches executable and operator-neutral", async () => {
+    _setJiebaForTest(null);
+    const tempDir = await mkdtemp(path.join(tmpdir(), "tdai-fts-l1-"));
+    const store = new VectorStore(path.join(tempDir, "memory.db"), 0);
+
+    try {
+      const init = store.init();
+      expect(init.needsReindex).toBe(false);
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL1(makeMemoryRecord("l1-alpha-beta", "alpha beta memory"), undefined)).toBe(true);
+      expect(store.upsertL1(makeMemoryRecord("l1-alpha", "alpha memory"), undefined)).toBe(true);
+      expect(store.upsertL1(makeMemoryRecord("l1-beta", "beta memory"), undefined)).toBe(true);
+
+      const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+      const ids = store.searchL1Fts(ftsQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+
+      expect(ids).toEqual(["l1-alpha", "l1-alpha-beta", "l1-beta"]);
+    } finally {
+      store.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps L0 FTS fallback searches executable and operator-neutral", async () => {
+    _setJiebaForTest(null);
+    const tempDir = await mkdtemp(path.join(tmpdir(), "tdai-fts-l0-"));
+    const store = new VectorStore(path.join(tempDir, "memory.db"), 0);
+
+    try {
+      const init = store.init();
+      expect(init.needsReindex).toBe(false);
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL0(makeL0Record("l0-alpha-beta", "alpha beta message"), undefined)).toBe(true);
+      expect(store.upsertL0(makeL0Record("l0-alpha", "alpha message"), undefined)).toBe(true);
+      expect(store.upsertL0(makeL0Record("l0-beta", "beta message"), undefined)).toBe(true);
+
+      const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+      const ids = store.searchL0Fts(ftsQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+
+      expect(ids).toEqual(["l0-alpha", "l0-alpha-beta", "l0-beta"]);
+    } finally {
+      store.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function makeMemoryRecord(id: string, content: string): MemoryRecord {
+  const now = "2026-06-30T00:00:00.000Z";
+  return {
+    id,
+    content,
+    type: "episodic",
+    priority: 50,
+    scene_name: "test",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [now],
+    createdAt: now,
+    updatedAt: now,
+    sessionKey: "test-session-key",
+    sessionId: "test-session-id",
+  };
+}
+
+function makeL0Record(id: string, messageText: string): L0Record {
+  return {
+    id,
+    sessionKey: "test-session-key",
+    sessionId: "test-session-id",
+    role: "user",
+    messageText,
+    recordedAt: "2026-06-30T00:00:00.000Z",
+    timestamp: Date.parse("2026-06-30T00:00:00.000Z"),
+  };
+}
+
+function buildLegacyUnsafeFtsQueryForTest(input: string): string {
+  return input.split(/\s+/).filter(Boolean).join(" OR ");
+}
+
+function createRecallFixtureDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  const insert = db.prepare("INSERT INTO docs(rowid, content) VALUES (?, ?)");
+
+  insert.run(1, "travel plan API itinerary hotel booking");
+  insert.run(2, "TypeScript memory search sqlite fts");
+  insert.run(3, "coffee beans espresso grinder");
+  insert.run(4, "project roadmap milestone release");
+  insert.run(5, "user programming TypeScript memory search");
+  insert.run(6, "unrelated cooking recipe");
+
+  return db;
+}
+
+function searchDocIds(db: DatabaseSync, ftsQuery: string): number[] {
+  const rows = db
+    .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+    .all(ftsQuery) as Array<{ rowid: number }>;
+  return rows.map((row) => row.rowid);
+}

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,26 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+const FTS5_SAFE_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+
+function sanitizeFtsTokens(rawTokens: string[]): string[] {
+  const tokens: string[] = [];
+
+  for (const rawToken of rawTokens) {
+    const parts = rawToken.match(FTS5_SAFE_TOKEN_RE) ?? [];
+    for (const part of parts) {
+      const token = part.trim();
+      if (!token) continue;
+      if (FTS5_RESERVED_OPERATORS.has(token)) continue;
+      if (ZH_STOP_WORDS.has(token)) continue;
+      tokens.push(token);
+    }
+  }
+
+  return [...new Set(tokens)];
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -198,34 +218,19 @@ const ZH_STOP_WORDS = new Set([
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
 
-  let tokens: string[];
+  let rawTokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
-    // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
+    rawTokens = jieba.cutForSearch(raw, true);
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    rawTokens = raw.match(FTS5_SAFE_TOKEN_RE) ?? [];
   }
 
+  const tokens = sanitizeFtsTokens(rawTokens);
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map((t) => `"${t.replaceAll('"', '""')}"`);
   return quoted.join(" OR ");
 }
 

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -181,11 +181,11 @@ function sanitizeFtsTokens(rawTokens: string[]): string[] {
   const tokens: string[] = [];
 
   for (const rawToken of rawTokens) {
-    const parts = rawToken.match(FTS5_SAFE_TOKEN_RE) ?? [];
+    const parts = rawToken.normalize("NFKC").match(FTS5_SAFE_TOKEN_RE) ?? [];
     for (const part of parts) {
       const token = part.trim();
       if (!token) continue;
-      if (FTS5_RESERVED_OPERATORS.has(token)) continue;
+      if (FTS5_RESERVED_OPERATORS.has(token.toUpperCase())) continue;
       if (ZH_STOP_WORDS.has(token)) continue;
       tokens.push(token);
     }


### PR DESCRIPTION
## 背景

`buildFtsQuery()` 会把用户输入转换成 SQLite FTS5 的 `MATCH` 查询，用于记忆检索的全文搜索 fallback。Issue #160 指出当前实现对输入 token 的安全边界不够明确：虽然最终会把 token 包进双引号，但 FTS5 的保留操作符和语法字符仍应在进入 `MATCH` 查询前被显式清理。

风险点主要有两个：

- 用户输入中出现 `AND` / `OR` / `NOT` / `NEAR` 这类 FTS5 保留操作符时，容易让查询语义变得不透明。
- 输入中混入括号、星号、引号、列过滤样式等 FTS5 语法字符时，应该只保留可搜索词项，避免把查询语法当成用户搜索内容继续传递。

本 PR 的目标是把 `buildFtsQuery()` 的输入处理收窄到“安全词项列表”，让 FTS5 查询构造路径更可预测。

## 修复策略

本 PR 没有改变现有的召回策略：最终查询仍然是多个安全 token 以 `OR` 连接，并继续依赖 BM25 对匹配更多 token 的结果进行排序。

本 PR 只在进入 FTS5 `MATCH` 查询前增加统一清洗步骤：

- 新增 `sanitizeFtsTokens()`，作为 fallback 分词和 jieba 分词后的共同清洗入口。
- 通过 Unicode 安全 token 正则只提取字母、数字和下划线组成的词项。
- 对 token 做 `NFKC` 归一化，避免全角操作符等 Unicode 变体绕过过滤。
- 过滤 FTS5 保留操作符 `AND` / `OR` / `NOT` / `NEAR`，大小写不敏感。
- 保留原有中文停用词过滤逻辑，避免引入额外噪音。
- 保留去重逻辑，避免 jieba `cutForSearch()` 产生重复 token 后放大查询。
- 对最终写入双引号短语的 token 做引号转义，进一步收紧 FTS5 查询构造边界。

## 实现细节

主要修改位于 `src/core/store/sqlite.ts`：

- 将 fallback 路径和 jieba 路径都先转换为 `rawTokens`。
- fallback 路径继续使用 Unicode token 提取，不引入新的分词依赖。
- jieba 路径继续使用 `cutForSearch(raw, true)`，保持中文搜索召回行为。
- 两条路径统一调用 `sanitizeFtsTokens(rawTokens)` 后再构造 FTS5 查询。
- 如果清洗后没有可搜索 token，继续返回 `null`，避免生成空的 `MATCH` 查询。

同时在 `CHANGELOG.md` 的 `[Unreleased]` 区块补充本安全修复说明，便于后续发版记录。

这个实现把“分词”和“安全清洗”拆开处理，后续如果需要扩展 FTS5 白名单或增加更多保留语法过滤，可以集中改 `sanitizeFtsTokens()`。

## 测试覆盖

新增并扩展 `src/core/store/sqlite.test.ts`，覆盖以下场景：

- 普通关键词搜索仍生成稳定的 OR 查询，例如 `travel plan API`。
- fallback 分词下过滤 `AND` / `OR` / `NOT` / `NEAR`。
- 操作符过滤大小写不敏感，例如 `and` / `Or` / `not` / `near(...)`。
- 全角操作符会先归一化再过滤，例如 `ＯＲ` / `ＡＮＤ`。
- 输入包含双引号、单引号、括号、星号、冒号、列过滤样式、负号等 FTS5 语法字符时，只保留正常搜索词。
- 输入只包含 FTS5 操作符和语法字符时返回 `null`。
- `ordinary` / `nearshore` / `android` / `scanner` 这类只包含操作符片段的普通词不会被误删。
- jieba 输出里混入 `OR`、`NEAR(beta`、中文停用词、`*`、`C++` 等 token 时，最终只保留安全可搜索 token。
- 使用真实 SQLite FTS5 表验证 `alpha AND NOT beta` 不再按 FTS5 boolean 表达式执行，而是变成普通 OR-of-terms 查询。
- 使用同一 SQLite FTS5 fixture 对比普通关键词的旧 token-OR 行为和新 sanitized quoted-token 行为，确认代表性普通查询结果集一致。
- 覆盖真实 `VectorStore` L1 FTS fallback 路径：`upsertL1()` 后通过 `searchL1Fts()` 验证操作符输入保持可执行且 operator-neutral。
- 覆盖真实 `VectorStore` L0 FTS fallback 路径：`upsertL0()` 后通过 `searchL0Fts()` 验证操作符输入保持可执行且 operator-neutral。

## 兼容性

- 不改变现有 public API。
- 不改变搜索索引写入逻辑。
- 不改变 FTS5 查询的 `OR` 召回策略。
- 不新增运行时依赖。
- 对普通关键词搜索保持原有行为，只移除 FTS5 查询语法相关噪音。

## 验证

- `git diff --check`
- `npx vitest run src/core/store/sqlite.test.ts`
  - 1 个 test file 通过
  - 30 个 tests 通过
- `npm test`
  - 5 个 test files 通过
  - 97 个 tests 通过
- `npm run build`
  - `tsdown` plugin build 通过
  - scripts TypeScript build 通过

Fixes #160.
