### PR TITLE
fix(store): sanitize FTS5 operators in buildFtsQuery to prevent query-semantics injection (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
 
 不动配置 = 行为完全不变。
 
+### 🐛 修复
+
+#### 安全 / 输入净化
+- **FTS5 操作符注入防护** ([#160](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160))：`buildFtsQuery()` 在分词前剥离用户输入中的 FTS5 特殊操作符（`AND` / `OR` / `NOT` / `NEAR`，大小写不敏感）和单引号 / 星号，避免用户输入改变查询语义或触发 FTS5 语法错误。原有的"每个 token 用双引号包裹"兜底仍然保留。`ANDROID` / `SCANNER` 等包含操作符子串的普通词不受影响（正则使用 `\b` 词边界）。新增 `src/core/store/sqlite.test.ts` 覆盖 5 类边界场景，全部通过。
+
 ---
 
 ## [0.3.6] - 2026-05-27

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for FTS5 query sanitization in buildFtsQuery() — issue #160.
+ *
+ * These tests run against the fallback (regex) tokenizer path. The jieba
+ * path is lazy-loaded and not available in this test environment, but the
+ * sanitize step runs before either tokenizer is selected, so the
+ * sanitization contract is the same for both paths.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildFtsQuery } from "./sqlite.js";
+
+/** Return the per-token quoted terms that buildFtsQuery() emits. */
+function quotedTerms(out: string): string[] {
+  return out.match(/"[^"]*"/g) ?? [];
+}
+
+describe("buildFtsQuery() — FTS5 operator sanitization (issue #160)", () => {
+  it("strips AND/OR/NOT/NEAR operators so they cannot alter query semantics", () => {
+    const out = buildFtsQuery("foo AND bar OR baz NOT qux NEAR hello");
+    expect(out).not.toBeNull();
+    // None of the operator keywords may appear as quoted tokens in the output.
+    // (The ` OR ` join separator is fine — we only care that the operator
+    // words from user input didn't survive tokenization.)
+    const tokens = quotedTerms(out!);
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"AND"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"OR"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"NOT"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"NEAR"');
+    // Real content terms survive
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+    expect(out).toContain('"qux"');
+    expect(out).toContain('"hello"');
+  });
+
+  it("strips operators case-insensitively", () => {
+    const out = buildFtsQuery("foo and bar Or baz not qux");
+    expect(out).not.toBeNull();
+    const tokens = quotedTerms(out!);
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"AND"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"OR"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"NOT"');
+  });
+
+  it("strips single quotes and asterisks (defense-in-depth)", () => {
+    const out = buildFtsQuery("foo's bar* baz");
+    expect(out).not.toBeNull();
+    expect(out).not.toContain("'");
+    expect(out).not.toContain("*");
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+  });
+
+  it("preserves normal Chinese / English text without operators", () => {
+    const out = buildFtsQuery("用户 喜欢 TypeScript 编程");
+    expect(out).not.toBeNull();
+    expect(out).toContain('"用户"');
+    expect(out).toContain('"喜欢"');
+    expect(out).toContain('"TypeScript"');
+    expect(out).toContain('"编程"');
+  });
+
+  it("does not treat operator substrings as operators (word-boundary)", () => {
+    // "ANDROID" contains "AND" but is a real word, not the FTS5 operator.
+    // The regex uses \b so it must NOT strip it.
+    const out = buildFtsQuery("ANDROID scanner");
+    expect(out).not.toBeNull();
+    expect(out).toContain('"ANDROID"');
+    expect(out).toContain('"scanner"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,6 +175,27 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * Strip FTS5 special operators and syntax from raw search input before
+ * tokenization (defense-in-depth for issue #160).
+ *
+ * The double-quoting in `buildFtsQuery()` already neutralizes most
+ * injection vectors — FTS5 operators like `AND`/`OR`/`NOT`/`NEAR` end up
+ * wrapped as literal string terms, which is harmless but means a user
+ * can still alter query semantics (e.g. by typing `NOT foo` to exclude
+ * results). Stripping them here ensures the resulting query is always a
+ * plain OR-of-terms, matching the documented behavior.
+ *
+ * Also strips single quotes (`'`) and the prefix wildcard (`*`) so they
+ * cannot leak through the jieba tokenizer (the regex fallback already
+ * drops them, but jieba may preserve them in rare cases).
+ */
+function sanitizeFtsRaw(raw: string): string {
+  return raw
+    .replace(/['*]/g, " ")                                  // strip single-quote + prefix wildcard
+    .replace(/\b(?:AND|OR|NOT|NEAR)\b/gi, " ");             // strip FTS5 boolean/positional operators
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -196,6 +217,10 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  // Issue #160: strip FTS5 operators / special chars from raw input before
+  // tokenization. Defense-in-depth on top of the per-token double-quoting
+  // already applied below.
+  const cleaned = sanitizeFtsRaw(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +228,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +243,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
## Description

Fix the FTS5 query-semantics injection issue reported in #160. `buildFtsQuery()` previously tokenized raw user input and joined the tokens with ` OR `. The double-quoting per token already neutralizes most injection vectors, but the FTS5 operator keywords (`AND` / `OR` / `NOT` / `NEAR`) survived tokenization as quoted literals — harmless, but letting users alter the documented query semantics. Single quotes (`'`), the prefix wildcard (`*`), and a few other special chars could also leak through the jieba tokenizer (the regex fallback already strips them).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code optimization

## Self-test Checklist

- [x] Verified locally — `npx vitest run src/core/store/sqlite.test.ts` → 5 passed (5)
- [x] No existing features affected — pure additive sanitization step before the existing tokenizer path; tokens that don't contain operators are untouched

## Implementation Details

### What changed

Added `sanitizeFtsRaw()` at the top of `buildFtsQuery()` (`src/core/store/sqlite.ts`):

```ts
function sanitizeFtsRaw(raw: string): string {
  return raw
    .replace(/['*]/g, " ")                                  // strip single-quote + prefix wildcard
    .replace(/\b(?:AND|OR|NOT|NEAR)\b/gi, " ");           // strip FTS5 boolean / positional operators
}
```

Both the jieba path (`cutForSearch(cleaned, true)`) and the regex fallback path (`cleaned.match(...)`) now operate on the cleaned input. The per-token double-quoting step is unchanged.

### Why this approach

- **Minimal diff**: ~10 lines of fix code, no API changes, no behavior change for inputs without FTS5 operators.
- **Word-boundary safety**: `\b` ensures `ANDROID` / `SCANNER` / `ORACLE` / `NEARBY` (real words containing operator substrings) are not stripped.
- **Defense-in-depth**: the existing double-quoting stays — it already protects against most edge cases; this fix tightens the few remaining ones.
- **Cheap**: two regex passes on a short query string, no allocation overhead beyond the intermediate strings.

## Test Coverage

5 new vitest tests in `src/core/store/sqlite.test.ts`:

| Test | What it verifies |
|------|-----------------|
| strips operators | `AND`/`OR`/`NOT`/`NEAR` from input do not appear as quoted tokens in output |
| case-insensitive | `and`/`Or`/`not` mixed-case input is also stripped |
| strips `'*` | single quotes and asterisks removed from output |
| preserves normal text | Chinese + English text without operators is unaffected |
| word-boundary safety | `ANDROID` and `SCANNER` are NOT stripped (contain operator substrings) |

## Out of scope (per issue's progressive verification levels)

- **Deep** ("before/after recall comparison") — not attempted; requires benchmark data, may be a follow-up.
- **Stretch** ("FTS5 query whitelist / parameterized queries") — much larger design change; not in scope for this minimal fix.

## CHANGELOG

Entry added under `[Unreleased] → 🐛 修复 → 安全 / 输入净化`.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)