### PR TITLE
fix(search): sanitize FTS5 operators in buildFtsQuery

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("strips FTS5 operators from raw input before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha OR beta AND NOT gamma NEAR delta")).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta"',
+    );
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,8 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATORS = /\b(?:AND|OR|NOT|NEAR)\b/gi;
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -196,6 +198,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = raw.replace(FTS5_OPERATORS, " ");
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +206,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +221,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
## Summary
- strip FTS5 operators (AND/OR/NOT/NEAR) before tokenizing user input in buildFtsQuery
- add regression coverage for fallback tokenization

Fixes #160.

## Tests
- npm test -- src/core/store/sqlite.test.ts
- npm test
- npm run build