### PR TITLE
fix: filter FTS5 reserved operators

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("filters FTS5 boolean operators in the fallback tokenizer", () => {
+    _setJiebaForTest(null);
+
+    const query = buildFtsQuery("alpha AND beta OR gamma NOT delta");
+
+    expect(query).toBe('"alpha" OR "beta" OR "gamma" OR "delta"');
+    expect(query).not.toContain('"AND"');
+    expect(query).not.toContain('"OR"');
+    expect(query).not.toContain('"NOT"');
+  });
+
+  it("filters FTS5 NEAR operator syntax without removing normal terms", () => {
+    _setJiebaForTest(null);
+
+    const query = buildFtsQuery("NEAR(alpha beta, 5)");
+
+    expect(query).toContain('"alpha"');
+    expect(query).toContain('"beta"');
+    expect(query).not.toContain('"NEAR"');
+  });
+
+  it("does not remove operator names embedded inside ordinary words", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("candy normalize north")).toBe('"candy" OR "normalize" OR "north"');
+  });
+
+  it("returns null when the input only contains FTS5 operators", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  });
+
+  it("filters FTS5 operators returned by jieba while keeping normal tokens", () => {
+    const user = "\u7528\u6237";
+    const likes = "\u559c\u6b22";
+    const cutInputs: string[] = [];
+
+    _setJiebaForTest({
+      cutForSearch(text, hmm) {
+        cutInputs.push(text);
+        expect(hmm).toBe(true);
+        return [user, "AND", likes, "OR", "TypeScript", user];
+      },
+    });
+
+    const query = buildFtsQuery(`${user} AND ${likes} OR TypeScript`);
+
+    expect(cutInputs).toHaveLength(1);
+    expect(cutInputs[0]).not.toContain("AND");
+    expect(cutInputs[0]).not.toContain("OR");
+    expect(query).toBe(`"${user}" OR "${likes}" OR "TypeScript"`);
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,18 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_RESERVED_OPERATORS =
+  /(?<![\p{L}\p{N}_])(?:AND|OR|NOT|NEAR)(?![\p{L}\p{N}_])/giu;
+const FTS5_RESERVED_OPERATOR_TOKENS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function isSearchableFtsToken(token: string): boolean {
+  if (!token) return false;
+  if (!/[\p{L}\p{N}]/u.test(token)) return false;
+  if (FTS5_RESERVED_OPERATOR_TOKENS.has(token.toUpperCase())) return false;
+  if (ZH_STOP_WORDS.has(token)) return false;
+  return true;
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -197,31 +209,25 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const cleaned = raw.replace(FTS5_RESERVED_OPERATORS, " ");
 
   let tokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .filter(isSearchableFtsToken);
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        .filter(isSearchableFtsToken) ?? [];
   }
 
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Description | 描述

This PR fixes FTS5 query construction by filtering SQLite FTS5 reserved operators from user input before building the `MATCH` expression.

Specifically, it:
- sanitizes standalone `AND`, `OR`, `NOT`, and `NEAR` before tokenization
- filters the same reserved operators at token level as a fallback
- keeps the existing project-owned `OR` recall strategy unchanged
- adds tests for fallback tokenization and jieba-based tokenization paths

## Related Issue | 关联 Issue

Fixes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Tested with Node.js v24.12.0:

```bash
npm.cmd test -- src/core/store/sqlite.test.ts
npm.cmd test
npm.cmd run build