### PR TITLE
fix(store): strip FTS5 special chars from user query tokens

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  // ── Normal behavior (no regression) ──
+
+  it("splits English words and OR-joins them as quoted phrases", () => {
+    expect(buildFtsQuery("hello world")).toBe('"hello" OR "world"');
+  });
+
+  it("handles Unicode (Chinese) text via the fallback regex", () => {
+    expect(buildFtsQuery("AI 智能 记忆")).toBe('"AI" OR "智能" OR "记忆"');
+  });
+
+  it("returns null for empty input", () => {
+    expect(buildFtsQuery("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only input", () => {
+    expect(buildFtsQuery("   ")).toBeNull();
+  });
+
+  it("handles numbers and underscores in tokens", () => {
+    expect(buildFtsQuery("test_123 v2.0")).toBe('"test_123" OR "v2" OR "0"');
+  });
+
+  // ── FTS5 special character sanitization ──
+  //
+  // The regex /["'()*]/g strips these from every token before quoting.
+  // In the fallback path, the tokenizer /[\p{L}\p{N}_]+/gu already
+  // excludes these characters — sanitization is a no-op for
+  // fallback-produced tokens (belt-and-suspenders).
+  // On the jieba path, these characters may pass through jieba's
+  // segmenter and are removed here — the same sanitize logic applies.
+
+  it("removes asterisk to prevent FTS5 prefix matching", () => {
+    expect(buildFtsQuery("hello*")).toBe('"hello"');
+    expect(buildFtsQuery("**test**")).toBe('"test"');
+    expect(buildFtsQuery("*")).toBeNull();
+    expect(buildFtsQuery("a* b c*")).toBe('"a" OR "b" OR "c"');
+  });
+
+  it("handles double quotes in input", () => {
+    // Fallback regex excludes " so it acts as a word boundary
+    expect(buildFtsQuery('he"llo')).toBe('"he" OR "llo"');
+    // Surrounding quotes are naturally stripped by the regex match
+    expect(buildFtsQuery('"admin"')).toBe('"admin"');
+  });
+
+  it("handles single quotes in input", () => {
+    // Fallback regex excludes ' so it acts as a word boundary
+    expect(buildFtsQuery("he'llo")).toBe('"he" OR "llo"');
+    // Surrounding quotes are naturally stripped by the regex match
+    expect(buildFtsQuery("'alone'")).toBe('"alone"');
+  });
+
+  it("handles parentheses in input", () => {
+    // Fallback regex excludes ( ) so they act as word boundaries
+    expect(buildFtsQuery("test(query)here")).toBe('"test" OR "query" OR "here"');
+    expect(buildFtsQuery("(alone)")).toBe('"alone"');
+  });
+
+  it("removes all FTS5 special characters in combination", () => {
+    const result = buildFtsQuery('hello "*world*" \'(test)\'');
+    expect(result).toBe('"hello" OR "world" OR "test"');
+  });
+
+  it("returns null when input contains only special characters", () => {
+    expect(buildFtsQuery('"()*\'"')).toBeNull();
+    expect(buildFtsQuery("***")).toBeNull();
+  });
+
+  // ── FTS5 keyword operators (protected by quoting) ──
+  // AND, OR, NOT, NEAR, +, - are only operators outside double quotes.
+  // Since every token is wrapped in "..." they are treated as literal text.
+
+  it("treats AND/OR/NOT as literal words inside quoted strings", () => {
+    expect(buildFtsQuery("cat OR dog NOT mouse")).toBe(
+      '"cat" OR "OR" OR "dog" OR "NOT" OR "mouse"',
+    );
+  });
+
+  it("treats NEAR as a literal word inside quoted strings", () => {
+    expect(buildFtsQuery("NEAR match")).toBe('"NEAR" OR "match"');
+  });
+
+  it("handles + and - prefix operators (inert inside quotes)", () => {
+    // + and - are not matched by the fallback regex, so they naturally drop out
+    expect(buildFtsQuery("+include -exclude")).toBe('"include" OR "exclude"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -190,6 +190,13 @@ const ZH_STOP_WORDS = new Set([
  * significantly improved — especially for longer queries and when running
  * in FTS-only fallback mode (no embedding available).
  *
+ * **Security**: FTS5 special characters (`"`, `'`, `(`, `)`, `*`) are
+ * stripped from each token before quotation.  These characters retain
+ * special meaning inside double-quoted strings (notably `*` for prefix
+ * matching) and could alter query semantics or cause syntax errors.
+ * The remaining FTS5 operators (`AND`, `OR`, `NOT`, `NEAR`, `+`, `-`)
+ * are inert inside quotes and require no escaping.
+ *
  * Example (with jieba):
  *   "用户喜欢编程和TypeScript" → '"用户" OR "喜欢" OR "编程" OR "TypeScript"'
  * Example (fallback):
@@ -224,8 +231,15 @@ export function buildFtsQuery(raw: string): string | null {
         .filter(Boolean) ?? [];
   }
 
-  if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  // Sanitize: strip FTS5 special chars that retain meaning inside double-quoted strings
+  //   *  — prefix wildcard: "hello*" matches "helloworld" (unexpected recall expansion)
+  //   "  — string terminator (balanced quotes already caught above; strip for safety)
+  //   ' ( ) — grouping / column-ref syntax; not meaningful in user search intent
+  const sanitized = tokens
+    .map((t) => t.replace(/["'()*]/g, ""))
+    .filter(Boolean);
+  if (sanitized.length === 0) return null;
+  const quoted = sanitized.map((t) => `"${t}"`);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

This PR sanitizes user query tokens before constructing SQLite FTS5 queries.

- Strip FTS5 special characters (`*`, `"`, `'`, `(`, `)`) from query tokens before wrapping them in double quotes.
- Preserve existing query behavior by continuing to join sanitized tokens with `OR`.
- Add test cases covering:
  - normal query construction
  - FTS5 special characters
  - empty/pure-special-character input
  - keyword operators (`AND`, `OR`, `NOT`, `NEAR`) treated as literal terms

## Related Issue | 关联 Issue

Fix #<issue-number>

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

None.