### PR TITLE
fix(search): literalize FTS5 MATCH tokens to prevent query semantics injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,12 @@
 
 ### 🐛 修复 / 安全性
 
-- **FTS5 MATCH 表达式查询语义注入** ([#160](https://github.com/TencentDB/TencentDB-Agent-Memory/issues/160))：在 `src/core/store/sqlite.ts` 的 `buildFtsQuery()` 中引入纵深防御：
-  - 预分词层 `sanitizeFtsInput()`：先对原始文本做 NFKC 归一化（捕获全角 Unicode 变体 `ＡＮＤ` 等），再词边界剥离 FTS5 保留运算符 `AND` / `OR` / `NOT` / `NEAR`（大小写不敏感，保证 `ANDROID` / `ORACLE` / `NEARBY` / `SCANNER` 安全），最后剥离 FTS5 语法字符 `'`、`"`、`*`、`(`、`)` 与列过滤前缀 `content:` / `message:` / `session:` / `actor:` / `topic:` 等（含否定前缀 `-`）。
-  - 分词层层（jieba 或 regex 回退）后再过一遍 `sanitizeFtsToken()`：基于 `[\p{L}\p{N}_]` Unicode 白名单与保留操作符二次检查，jieba 注入的 `OR` 等也无法滑过；token 输出为 FTS5 phrase 形式并对内嵌 `"` 做标准 `""` 转义。
-  - 空查询返回 `null`，所有下游 `searchL1Fts()` / `searchL0Fts()` 路径只需检查 `null` 即可安全跳过 MATCH。
-  - Best-solution refinement: `buildFtsQuery()` now treats every user fragment as plain literal text; FTS5 operators (`AND` / `OR` / `NOT` / `NEAR`), column filters (`content:foo`), quotes, wildcards, and groups are token separators only and can no longer alter MATCH semantics or reduce recall by dropping user words.
-  - 新增 44 个测试（30 个单元测试 + 14 个真实 `node:sqlite` FTS5 fixture 集成测试覆盖 true MATCH 执行、recall 对比与 200 次 fuzz）；普通关键词查询的召回集保持不变或变好。
+- **FTS5 MATCH 表达式查询语义注入** ([#160](https://github.com/TencentDB/TencentDB-Agent-Memory/issues/160))：将 `buildFtsQuery()` 收敛为字面量 token 构造器，用户输入永远不能贡献 FTS5 查询结构：
+  - `sanitizeFtsInput()` 先对原始文本做 NFKC 归一化，再只提取 Unicode 字母、数字和下划线；FTS5 operators、列过滤、引号、通配符、括号和 `NEAR/5` 这类语法片段都会变成普通 token 分隔。
+  - jieba 分词或 regex 回退后，`sanitizeFtsToken()` 会再次对每个 tokenizer 输出做字面量提取，防止 tokenizer stub/native binding 返回带标点或查询片段的 token。
+  - 所有输出 token 都由代码包成 FTS5 phrase literal，再用代码生成的 `OR` 连接；下游 `searchL1Fts()` / `searchL0Fts()` 继续通过 `MATCH ?` 参数绑定执行。
+  - 与 #178 的窄修不同，本修复不会删除用户实际输入的 `AND` / `OR` / `NOT` / `NEAR` 等词，而是把它们转成 `"AND"` 等可搜索字面量，避免安全修复误伤召回。
+  - 新增 46 个测试（31 个单元测试 + 15 个真实 `node:sqlite` FTS5 fixture 集成测试覆盖 tokenizer 二次净化、true MATCH 执行、reserved-word 字面量召回、recall 对比与 200 次 fuzz）。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复 / 安全性
+
+- **FTS5 MATCH 表达式查询语义注入** ([#160](https://github.com/TencentDB/TencentDB-Agent-Memory/issues/160))：在 `src/core/store/sqlite.ts` 的 `buildFtsQuery()` 中引入纵深防御：
+  - 预分词层 `sanitizeFtsInput()`：先对原始文本做 NFKC 归一化（捕获全角 Unicode 变体 `ＡＮＤ` 等），再词边界剥离 FTS5 保留运算符 `AND` / `OR` / `NOT` / `NEAR`（大小写不敏感，保证 `ANDROID` / `ORACLE` / `NEARBY` / `SCANNER` 安全），最后剥离 FTS5 语法字符 `'`、`"`、`*`、`(`、`)` 与列过滤前缀 `content:` / `message:` / `session:` / `actor:` / `topic:` 等（含否定前缀 `-`）。
+  - 分词层层（jieba 或 regex 回退）后再过一遍 `sanitizeFtsToken()`：基于 `[\p{L}\p{N}_]` Unicode 白名单与保留操作符二次检查，jieba 注入的 `OR` 等也无法滑过；token 输出为 FTS5 phrase 形式并对内嵌 `"` 做标准 `""` 转义。
+  - 空查询返回 `null`，所有下游 `searchL1Fts()` / `searchL0Fts()` 路径只需检查 `null` 即可安全跳过 MATCH。
+  - 新增 44 个测试（30 个单元测试 + 14 个真实 `node:sqlite` FTS5 fixture 集成测试覆盖 true MATCH 执行、recall 对比与 200 次 fuzz）；普通关键词查询的召回集保持不变或变好。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   - 预分词层 `sanitizeFtsInput()`：先对原始文本做 NFKC 归一化（捕获全角 Unicode 变体 `ＡＮＤ` 等），再词边界剥离 FTS5 保留运算符 `AND` / `OR` / `NOT` / `NEAR`（大小写不敏感，保证 `ANDROID` / `ORACLE` / `NEARBY` / `SCANNER` 安全），最后剥离 FTS5 语法字符 `'`、`"`、`*`、`(`、`)` 与列过滤前缀 `content:` / `message:` / `session:` / `actor:` / `topic:` 等（含否定前缀 `-`）。
   - 分词层层（jieba 或 regex 回退）后再过一遍 `sanitizeFtsToken()`：基于 `[\p{L}\p{N}_]` Unicode 白名单与保留操作符二次检查，jieba 注入的 `OR` 等也无法滑过；token 输出为 FTS5 phrase 形式并对内嵌 `"` 做标准 `""` 转义。
   - 空查询返回 `null`，所有下游 `searchL1Fts()` / `searchL0Fts()` 路径只需检查 `null` 即可安全跳过 MATCH。
+  - Best-solution refinement: `buildFtsQuery()` now treats every user fragment as plain literal text; FTS5 operators (`AND` / `OR` / `NOT` / `NEAR`), column filters (`content:foo`), quotes, wildcards, and groups are token separators only and can no longer alter MATCH semantics or reduce recall by dropping user words.
   - 新增 44 个测试（30 个单元测试 + 14 个真实 `node:sqlite` FTS5 fixture 集成测试覆盖 true MATCH 执行、recall 对比与 200 次 fuzz）；普通关键词查询的召回集保持不变或变好。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）

--- a/src/core/store/sqlite.recall.test.ts
+++ b/src/core/store/sqlite.recall.test.ts
@@ -143,7 +143,9 @@ describe("buildFtsQuery — real FTS5 execution", () => {
   });
 
   it("returns null for input that becomes empty after sanitization", () => {
-    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBe(
+      '"AND" OR "OR" OR "NOT" OR "NEAR"',
+    );
     expect(buildFtsQuery("***(((")).toBeNull();
   });
 

--- a/src/core/store/sqlite.recall.test.ts
+++ b/src/core/store/sqlite.recall.test.ts
@@ -55,6 +55,7 @@ const FIXTURE: IndexedDoc[] = [
   { record_id: "r23", content: "Sanity check fixture record 23" },
   { record_id: "r24", content: "Sanity check fixture record 24" },
   { record_id: "r25", content: "Sanity check fixture record 25" },
+  { record_id: "r26", content: "Boolean operator words AND OR NOT NEAR" },
 ];
 
 /** Build the OLD pre-sanitization MATCH expression for comparison only. */
@@ -142,7 +143,7 @@ describe("buildFtsQuery — real FTS5 execution", () => {
     expect(() => queryIds(match!)).not.toThrow();
   });
 
-  it("returns null for input that becomes empty after sanitization", () => {
+  it("keeps operator words but returns null for pure syntax", () => {
     expect(buildFtsQuery("AND OR NOT NEAR")).toBe(
       '"AND" OR "OR" OR "NOT" OR "NEAR"',
     );
@@ -154,6 +155,12 @@ describe("buildFtsQuery — real FTS5 execution", () => {
     expect(match).not.toBeNull();
     // Should be a safe OR-of-terms query; must execute without throwing.
     expect(() => queryIds(match!)).not.toThrow();
+  });
+
+  it("keeps reserved words searchable as literal document text", () => {
+    const match = buildFtsQuery("AND OR NOT NEAR");
+    expect(match).toBe('"AND" OR "OR" OR "NOT" OR "NEAR"');
+    expect(queryIds(match!)).toContain("r26");
   });
 });
 

--- a/src/core/store/sqlite.recall.test.ts
+++ b/src/core/store/sqlite.recall.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Recall & true-FTS5 integration tests for the sanitization in
+ * `src/core/store/sqlite.ts`.
+ *
+ * Two angles are exercised here:
+ *
+ *   1. **True FTS5 execution** — we instantiate a real `node:sqlite`
+ *      database with an FTS5 virtual table, index a fixture, and run the
+ *      queries that `buildFtsQuery()` produces.  This proves the generated
+ *      MATCH expressions are syntactically valid AND that malicious inputs
+ *      cannot poison result semantics.
+ *
+ *   2. **Recall comparison** — we compare the result set size and top-K
+ *      contents between the new sanitized `buildFtsQuery()` and the old
+ *      raw-token form on a fixed 25-row corpus.  A regression on ordinary
+ *      keyword queries would surface here.
+ *
+ * The tests intentionally avoid `@node-rs/jieba` so they remain
+ * deterministic in CI environments without the optional native binding.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+
+import { _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+interface IndexedDoc {
+  record_id: string;
+  content: string;
+}
+
+const FIXTURE: IndexedDoc[] = [
+  { record_id: "r1", content: "TypeScript builds scalable web APIs" },
+  { record_id: "r2", content: "TencentDB memory plugin uses SQLite FTS5" },
+  { record_id: "r3", content: "Vector search with sqlite-vec extension" },
+  { record_id: "r4", content: "用户偏好简洁的 TypeScript 示例" },
+  { record_id: "r5", content: "Travel plan for Tokyo in May" },
+  { record_id: "r6", content: "Plan a trip to Japan and visit Tokyo Tower" },
+  { record_id: "r7", content: "OpenClaw integration guide for Hermes" },
+  { record_id: "r8", content: "ANDROID 12 release notes for programmers" },
+  { record_id: "r9", content: "ORACLE database administrator tutorial" },
+  { record_id: "r10", content: "NEARBY restaurants open after midnight" },
+  { record_id: "r11", content: "FTS5 reserved operators in attack samples" },
+  { record_id: "r12", content: "Content column filter syntax content:foo" },
+  { record_id: "r13", content: "Prefix wildcard example alpha*" },
+  { record_id: "r14", content: "Parenthesized group (alpha) OR (beta)" },
+  { record_id: "r15", content: "Phrase-quote injection alpha\" OR \"beta" },
+  { record_id: "r16", content: "Single quote escape alpha'beta" },
+  { record_id: "r17", content: "中文测试 分词 用户 编程 TypeScript" },
+  { record_id: "r18", content: "BM25 ranking comparison baseline" },
+  { record_id: "r19", content: "Plugin memory pipeline L0 L1 L2 L3" },
+  { record_id: "r20", content: "Empty match NULL semantics check" },
+  { record_id: "r21", content: "Sanity check fixture record 21" },
+  { record_id: "r22", content: "Sanity check fixture record 22" },
+  { record_id: "r23", content: "Sanity check fixture record 23" },
+  { record_id: "r24", content: "Sanity check fixture record 24" },
+  { record_id: "r25", content: "Sanity check fixture record 25" },
+];
+
+/** Build the OLD pre-sanitization MATCH expression for comparison only. */
+function legacyBuildFtsQuery(raw: string): string | null {
+  const tokens = raw.match(/[\p{L}\p{N}_]+/gu) ?? [];
+  if (tokens.length === 0) return null;
+  return tokens.map((t) => `"${t.replaceAll('"', "")}"`).join(" OR ");
+}
+
+/**
+ * Insert the fixture into a fresh in-memory FTS5 table.  Each describe
+ * block creates its own db (and closes it in `afterAll`) so tests are
+ * isolated across forks.
+ */
+function setupFts(): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec(`
+    CREATE VIRTUAL TABLE docs USING fts5(
+      record_id UNINDEXED,
+      content,
+      tokenize = 'unicode61 remove_diacritics 2'
+    )
+  `);
+  const insert = database.prepare(
+    "INSERT INTO docs (record_id, content) VALUES (?, ?)",
+  );
+  for (const doc of FIXTURE) insert.run(doc.record_id, doc.content);
+  return database;
+}
+
+describe("buildFtsQuery — real FTS5 execution", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    _setJiebaForTest(null);
+    db = setupFts();
+  });
+
+  afterAll(() => {
+    try {
+      db?.close();
+    } catch {
+      /* best effort */
+    }
+  });
+
+  /** Run a MATCH query and return the record_ids returned (BM25 order). */
+  function queryIds(matchExpr: string): string[] {
+    const rows = db
+      .prepare(
+        "SELECT record_id FROM docs WHERE docs MATCH ? ORDER BY bm25(docs)",
+      )
+      .all(matchExpr) as Array<{ record_id: string }>;
+    return rows.map((r) => r.record_id);
+  }
+
+  it("returns a syntactically valid MATCH for the happy path", () => {
+    const match = buildFtsQuery("TypeScript memory");
+    expect(match).not.toBeNull();
+    const ids = queryIds(match!);
+    expect(ids.length).toBeGreaterThan(0);
+  });
+
+  it("does not throw on column-filter abuse", () => {
+    const match = buildFtsQuery("content:foo");
+    expect(match).not.toBeNull();
+    expect(() => queryIds(match!)).not.toThrow();
+  });
+
+  it("does not throw on parenthesized group expression", () => {
+    const match = buildFtsQuery("(alpha) OR (beta)");
+    expect(match).not.toBeNull();
+    expect(() => queryIds(match!)).not.toThrow();
+  });
+
+  it("does not throw on prefix-wildcard syntax", () => {
+    const match = buildFtsQuery("alpha*");
+    expect(match).not.toBeNull();
+    expect(() => queryIds(match!)).not.toThrow();
+  });
+
+  it("does not throw on phrase-quote injection", () => {
+    const match = buildFtsQuery('alpha" OR "beta');
+    expect(match).not.toBeNull();
+    expect(() => queryIds(match!)).not.toThrow();
+  });
+
+  it("returns null for input that becomes empty after sanitization", () => {
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+    expect(buildFtsQuery("***(((")).toBeNull();
+  });
+
+  it("executes AND NOT beta cleanly as OR-of-tokens", () => {
+    const match = buildFtsQuery("alpha AND NOT beta");
+    expect(match).not.toBeNull();
+    // Should be a safe OR-of-terms query; must execute without throwing.
+    expect(() => queryIds(match!)).not.toThrow();
+  });
+});
+
+describe("buildFtsQuery — recall comparison vs. legacy", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    _setJiebaForTest(null);
+    db = setupFts();
+  });
+
+  afterAll(() => {
+    try {
+      db?.close();
+    } catch {
+      /* best effort */
+    }
+  });
+
+  function queryIds(matchExpr: string): string[] {
+    const rows = db
+      .prepare(
+        "SELECT record_id FROM docs WHERE docs MATCH ? ORDER BY bm25(docs)",
+      )
+      .all(matchExpr) as Array<{ record_id: string }>;
+    return rows.map((r) => r.record_id);
+  }
+
+  /**
+   * Sanitized recall must be a SUPERSET of legacy recall for benign queries:
+   * we drop only reserved words / syntax chars, never alphanumeric tokens.
+   */
+  const queries = [
+    "TypeScript memory",
+    "users prefer concise",
+    "TencentDB FTS5",
+    "Travel Tokyo",
+    "OpenClaw Hermes",
+    "Sanity check",
+  ];
+
+  for (const q of queries) {
+    it(`recall parity — "${q}"`, () => {
+      const legacy = legacyBuildFtsQuery(q);
+      const safe = buildFtsQuery(q);
+      expect(safe, `safe query for ${q}`).not.toBeNull();
+      if (safe === null) return;
+      const legacyIds = legacy ? new Set(queryIds(legacy)) : new Set<string>();
+      const safeIds = new Set(queryIds(safe));
+      for (const id of legacyIds) {
+        expect(
+          safeIds.has(id),
+          `${q}: legacy hit ${id} missing from safe`,
+        ).toBe(true);
+      }
+    });
+  }
+});
+
+describe("buildFtsQuery — fuzz: random adversarial inputs never throw", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    _setJiebaForTest(null);
+    db = setupFts();
+  });
+
+  afterAll(() => {
+    try {
+      db?.close();
+    } catch {
+      /* best effort */
+    }
+  });
+
+  function queryIds(matchExpr: string): string[] {
+    const rows = db
+      .prepare(
+        "SELECT record_id FROM docs WHERE docs MATCH ? ORDER BY bm25(docs)",
+      )
+      .all(matchExpr) as Array<{ record_id: string }>;
+    return rows.map((r) => r.record_id);
+  }
+
+  it("survives 200 randomized attack-style queries without throwing", () => {
+    const corpus = [
+      "alpha beta",
+      'alpha" OR "beta',
+      "alpha AND NOT beta",
+      "(NEAR/5 alpha beta)",
+      "alpha* OR beta",
+      "content:-foo",
+      "message:bar",
+      "ＡＮＤ OR NOT ＮＥＡＲ",
+      "*()*()",
+      "OR AND OR AND OR",
+      '"a" AND "b" OR "c" NOT "d"',
+      "user:-something",
+      "and AND aND AnD",
+    ];
+    let totalQueries = 0;
+    for (let i = 0; i < 200; i++) {
+      const n = 1 + (i % 3);
+      const fragments: string[] = [];
+      for (let j = 0; j < n; j++) {
+        fragments.push(corpus[(i * 7 + j * 13) % corpus.length]);
+      }
+      const input = fragments.join(" ");
+      const match = buildFtsQuery(input);
+      totalQueries++;
+      if (match !== null) {
+        expect(() => queryIds(match)).not.toThrow();
+      }
+    }
+    expect(totalQueries).toBe(200);
+  });
+});

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -12,12 +12,11 @@
  *      word-boundary safe substrings (ANDROID, ORACLE, NEARBY, SCANNER).
  *   3. Recall — exercised in `sqlite.recall.test.ts` with a real FTS5 table.
  *   4. Whitelist / parameterization — `sanitizeFtsToken()` is the per-token
- *      unicode-letter whitelist; downstream `searchL1Fts()` uses prepared
- *      statements with `MATCH ?` placeholder (verified in the recall suite).
+ *      unicode-letter whitelist; the recall suite executes generated MATCH
+ *      expressions through the same prepared `MATCH ?` shape as production.
  *
- * Golden outputs here were produced by inspecting `scripts/temp-probe.mjs` so
- * any change to `sanitizeFtsInput()` that affects whitespace counts will
- * surface as a failing test (and force a deliberate update of the fixture).
+ * Expected outputs here specify the public MATCH expression that callers rely
+ * on: user text may become literal search terms, but never query syntax.
  */
 
 import { describe, expect, it, beforeEach } from "vitest";
@@ -81,7 +80,9 @@ describe("sanitizeFtsInput (sanitization layer 1)", () => {
   });
 
   it("normalizes full-width Unicode variants via NFKC", () => {
-    expect(sanitizeFtsInput("alpha \uFF21\uFF2E\uFF24 beta")).toBe("alpha AND beta");
+    expect(sanitizeFtsInput("alpha \uFF21\uFF2E\uFF24 beta")).toBe(
+      "alpha AND beta",
+    );
     expect(sanitizeFtsInput("alpha \uFF21\uFF2E\uFF24ROID beta")).toBe(
       "alpha ANDROID beta",
     );
@@ -234,6 +235,38 @@ describe("buildFtsQuery (fallback mode)", () => {
         '"gamma"',
         '"NEAR"',
         '"hello"',
+      ].join(" OR "),
+    );
+  });
+
+  it("re-sanitizes tokenizer output before building MATCH", () => {
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        expect(text).toBe("用户 AND TypeScript alpha OR beta foo bar");
+        return [
+          "用户",
+          "AND",
+          "TypeScript",
+          'alpha" OR "beta',
+          "foo:bar",
+          "***",
+          "用户",
+        ];
+      },
+    });
+
+    expect(
+      buildFtsQuery('用户 ＡＮＤ TypeScript alpha" OR "beta foo:bar'),
+    ).toBe(
+      [
+        '"用户"',
+        '"AND"',
+        '"TypeScript"',
+        '"alpha"',
+        '"OR"',
+        '"beta"',
+        '"foo"',
+        '"bar"',
       ].join(" OR "),
     );
   });

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -45,11 +45,13 @@ describe("sanitizeFtsInput (sanitization layer 1)", () => {
     );
   });
 
-  it("strips word-boundary reserved operators (case-insensitive)", () => {
-    expect(sanitizeFtsInput("alpha AND beta")).toBe("alpha   beta");
-    expect(sanitizeFtsInput("alpha Or beta")).toBe("alpha   beta");
-    expect(sanitizeFtsInput("alpha not beta")).toBe("alpha   beta");
-    expect(sanitizeFtsInput("alpha Near beta")).toBe("alpha   beta");
+  it("preserves FTS5 reserved words as literal search text", () => {
+    expect(sanitizeFtsInput("alpha \uFF21\uFF2E\uFF24 beta")).toBe(
+      "alpha AND beta",
+    );
+    expect(sanitizeFtsInput("alpha Or beta")).toBe("alpha Or beta");
+    expect(sanitizeFtsInput("alpha not beta")).toBe("alpha not beta");
+    expect(sanitizeFtsInput("alpha Near beta")).toBe("alpha Near beta");
   });
 
   it("does NOT touch substrings that contain reserved words", () => {
@@ -61,36 +63,39 @@ describe("sanitizeFtsInput (sanitization layer 1)", () => {
   });
 
   it("strips FTS5 syntax chars: \" ' * ( )", () => {
-    // Each `"` and `(` `)` and `*` is converted to a single space;
-    // surrounding whitespace is preserved verbatim.
-    expect(sanitizeFtsInput('alpha "beta" gamma')).toBe("alpha  beta  gamma");
+    // Syntax characters become separators and are collapsed by token extraction.
+    expect(sanitizeFtsInput('alpha "beta" gamma')).toBe("alpha beta gamma");
     expect(sanitizeFtsInput("alpha'beta")).toBe("alpha beta");
     expect(sanitizeFtsInput("alpha*")).toBe("alpha");
-    expect(sanitizeFtsInput("(alpha) (beta)")).toBe("alpha   beta");
+    expect(sanitizeFtsInput("(alpha) (beta)")).toBe("alpha beta");
   });
 
-  it("strips column filter prefixes including negation", () => {
-    expect(sanitizeFtsInput("content:foo")).toBe("foo");
-    expect(sanitizeFtsInput("-content:foo")).toBe("- foo");
-    expect(sanitizeFtsInput("message:hello world")).toBe("hello world");
-    expect(sanitizeFtsInput("-session:abc")).toBe("- abc");
-    expect(sanitizeFtsInput("actor:user1 topic:food")).toBe("user1  food");
-  });
-
-  it("normalizes full-width Unicode variants via NFKC", () => {
-    expect(sanitizeFtsInput("alpha ＡＮＤ beta")).toBe("alpha   beta");
-    expect(sanitizeFtsInput("alpha ＡＮＤROID beta")).toBe("alpha ANDROID beta");
-  });
-
-  it("handles tricky mixed inputs", () => {
-    expect(sanitizeFtsInput('"alpha" OR "beta"')).toBe("alpha     beta");
-    expect(sanitizeFtsInput("(content:foo) OR (message:bar)")).toBe(
-      "foo      bar",
+  it("turns column-filter syntax into literal tokens", () => {
+    expect(sanitizeFtsInput("content:foo")).toBe("content foo");
+    expect(sanitizeFtsInput("-content:foo")).toBe("content foo");
+    expect(sanitizeFtsInput("message:hello world")).toBe("message hello world");
+    expect(sanitizeFtsInput("-session:abc")).toBe("session abc");
+    expect(sanitizeFtsInput("actor:user1 topic:food")).toBe(
+      "actor user1 topic food",
     );
   });
 
-  it("leaves contiguous whitespace untouched when no syntax is present", () => {
-    expect(sanitizeFtsInput("hello    world")).toBe("hello    world");
+  it("normalizes full-width Unicode variants via NFKC", () => {
+    expect(sanitizeFtsInput("alpha \uFF21\uFF2E\uFF24 beta")).toBe("alpha AND beta");
+    expect(sanitizeFtsInput("alpha \uFF21\uFF2E\uFF24ROID beta")).toBe(
+      "alpha ANDROID beta",
+    );
+  });
+
+  it("handles tricky mixed inputs", () => {
+    expect(sanitizeFtsInput('"alpha" OR "beta"')).toBe("alpha OR beta");
+    expect(sanitizeFtsInput("(content:foo) OR (message:bar)")).toBe(
+      "content foo OR message bar",
+    );
+  });
+
+  it("collapses separators into single spaces", () => {
+    expect(sanitizeFtsInput("hello    world")).toBe("hello world");
   });
 });
 
@@ -114,15 +119,15 @@ describe("sanitizeFtsToken (sanitization layer 2 — per-token)", () => {
     expect(sanitizeFtsToken("()")).toBeNull();
   });
 
-  it("drops FTS5 reserved words regardless of case", () => {
-    expect(sanitizeFtsToken("AND")).toBeNull();
-    expect(sanitizeFtsToken("or")).toBeNull();
-    expect(sanitizeFtsToken("Not")).toBeNull();
-    expect(sanitizeFtsToken("near")).toBeNull();
+  it("quotes FTS5 reserved words as ordinary phrase tokens", () => {
+    expect(sanitizeFtsToken("AND")).toBe('"AND"');
+    expect(sanitizeFtsToken("or")).toBe('"or"');
+    expect(sanitizeFtsToken("Not")).toBe('"Not"');
+    expect(sanitizeFtsToken("near")).toBe('"near"');
   });
 
   it("strips embedded punctuation but keeps word fragments", () => {
-    expect(sanitizeFtsToken("foo:bar")).toBe('"foobar"');
+    expect(sanitizeFtsToken("foo:bar")).toBe('"foo" OR "bar"');
     expect(sanitizeFtsToken("C++")).toBe('"C"');
   });
 
@@ -130,8 +135,8 @@ describe("sanitizeFtsToken (sanitization layer 2 — per-token)", () => {
     // Quotes are filtered out by the unicode-letter/number whitelist; only
     // the letters around them survive.  This is intentional — quotes do not
     // survive into the index token stream because they are FTS5 syntax.
-    expect(sanitizeFtsToken('a"b')).toBe('"ab"');
-    expect(sanitizeFtsToken('he said "hi"')).toBe('"hesaidhi"');
+    expect(sanitizeFtsToken('a"b')).toBe('"a" OR "b"');
+    expect(sanitizeFtsToken('he said "hi"')).toBe('"he" OR "said" OR "hi"');
   });
 });
 
@@ -147,18 +152,24 @@ describe("buildFtsQuery (fallback mode)", () => {
     expect(buildFtsQuery("(())")).toBeNull();
   });
 
-  it("returns null for input that is just reserved operators", () => {
-    expect(buildFtsQuery("AND")).toBeNull();
-    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  it("searches reserved operators as literal user terms", () => {
+    expect(buildFtsQuery("AND")).toBe('"AND"');
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBe(
+      '"AND" OR "OR" OR "NOT" OR "NEAR"',
+    );
   });
 
-  it("strips reserved operators and produces OR-of-terms", () => {
-    expect(buildFtsQuery("alpha AND NOT beta")).toBe('"alpha" OR "beta"');
-    expect(buildFtsQuery("alpha Or beta")).toBe('"alpha" OR "beta"');
+  it("quotes reserved operators instead of letting them control MATCH", () => {
+    expect(buildFtsQuery("alpha AND NOT beta")).toBe(
+      '"alpha" OR "AND" OR "NOT" OR "beta"',
+    );
+    expect(buildFtsQuery("alpha Or beta")).toBe('"alpha" OR "Or" OR "beta"');
   });
 
   it("escapes phrase-quote injection", () => {
-    expect(buildFtsQuery('alpha" OR "beta')).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery('alpha" OR "beta')).toBe(
+      '"alpha" OR "OR" OR "beta"',
+    );
   });
 
   it("neutralizes the prefix-wildcard abuse path", () => {
@@ -166,7 +177,9 @@ describe("buildFtsQuery (fallback mode)", () => {
   });
 
   it("neutralizes parenthesized group expressions", () => {
-    expect(buildFtsQuery("(alpha) OR (beta)")).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery("(alpha) OR (beta)")).toBe(
+      '"alpha" OR "OR" OR "beta"',
+    );
   });
 
   it("neutralizes column-filter syntax", () => {
@@ -175,12 +188,16 @@ describe("buildFtsQuery (fallback mode)", () => {
     // sanitizeFtsToken filters `content` back out ONLY when it is a
     // stand-alone token.  In this query `content:` is collapsed to a space
     // by `sanitizeFtsInput` so we only ever see `foo` and `bar`.
-    expect(buildFtsQuery("content:foo bar")).toBe('"foo" OR "bar"');
-    expect(buildFtsQuery("-content:foo")).toBe('"foo"');
+    expect(buildFtsQuery("content:foo bar")).toBe(
+      '"content" OR "foo" OR "bar"',
+    );
+    expect(buildFtsQuery("-content:foo")).toBe('"content" OR "foo"');
   });
 
   it("handles NFKC full-width operator variants", () => {
-    expect(buildFtsQuery("alpha ＡＮＤ beta")).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery("alpha \uFF21\uFF2E\uFF24 beta")).toBe(
+      '"alpha" OR "AND" OR "beta"',
+    );
   });
 
   it("does NOT over-strip benign substrings (word-boundary safe)", () => {
@@ -199,16 +216,25 @@ describe("buildFtsQuery (fallback mode)", () => {
     expect(buildFtsQuery("alpha alpha alpha")).toBe('"alpha"');
   });
 
-  it("drops reserved words even when surrounded by other tokens", () => {
+  it("preserves reserved words even when surrounded by other tokens", () => {
     expect(buildFtsQuery("foo AND bar AND baz")).toBe(
-      '"foo" OR "bar" OR "baz"',
+      '"foo" OR "AND" OR "bar" OR "baz"',
     );
   });
 
-  it("strips a long chain of mixed operators / syntax / junk", () => {
-    // All of these neutralize to OR-of-letter-tokens:
+  it("literalizes a long chain of mixed operators / syntax / junk", () => {
+    // All user text becomes quoted literal tokens; no FTS5 operator survives.
     expect(buildFtsQuery('alpha AND NOT "beta" OR (gamma) NEAR hello')).toBe(
-      '"alpha" OR "beta" OR "gamma" OR "hello"',
+      [
+        '"alpha"',
+        '"AND"',
+        '"NOT"',
+        '"beta"',
+        '"OR"',
+        '"gamma"',
+        '"NEAR"',
+        '"hello"',
+      ].join(" OR "),
     );
   });
 });

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for FTS5 sanitization in `src/core/store/sqlite.ts`.
+ *
+ * These tests exercise `sanitizeFtsInput()`, `sanitizeFtsToken()` and
+ * `buildFtsQuery()` (in fallback mode — jieba stubbed to null).
+ *
+ * The behavior under test corresponds to the four acceptance levels of
+ * issue #160:
+ *   1. Basic escape — special characters are neutralized.
+ *   2. Complete coverage — every FTS5 operator / syntax character / colset
+ *      abuse has an explicit test, including NFKC full-width variants and
+ *      word-boundary safe substrings (ANDROID, ORACLE, NEARBY, SCANNER).
+ *   3. Recall — exercised in `sqlite.recall.test.ts` with a real FTS5 table.
+ *   4. Whitelist / parameterization — `sanitizeFtsToken()` is the per-token
+ *      unicode-letter whitelist; downstream `searchL1Fts()` uses prepared
+ *      statements with `MATCH ?` placeholder (verified in the recall suite).
+ *
+ * Golden outputs here were produced by inspecting `scripts/temp-probe.mjs` so
+ * any change to `sanitizeFtsInput()` that affects whitespace counts will
+ * surface as a failing test (and force a deliberate update of the fixture).
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+
+import {
+  _setJiebaForTest,
+  buildFtsQuery,
+  sanitizeFtsInput,
+  sanitizeFtsToken,
+} from "./sqlite.js";
+
+beforeEach(() => {
+  // Force fallback (regex) tokenizer for determinism in this suite.
+  _setJiebaForTest(null);
+});
+
+describe("sanitizeFtsInput (sanitization layer 1)", () => {
+  it("returns empty string for empty input", () => {
+    expect(sanitizeFtsInput("")).toBe("");
+  });
+
+  it("preserves benign Chinese / English / digits", () => {
+    expect(sanitizeFtsInput("用户 编程 TypeScript 2026")).toBe(
+      "用户 编程 TypeScript 2026",
+    );
+  });
+
+  it("strips word-boundary reserved operators (case-insensitive)", () => {
+    expect(sanitizeFtsInput("alpha AND beta")).toBe("alpha   beta");
+    expect(sanitizeFtsInput("alpha Or beta")).toBe("alpha   beta");
+    expect(sanitizeFtsInput("alpha not beta")).toBe("alpha   beta");
+    expect(sanitizeFtsInput("alpha Near beta")).toBe("alpha   beta");
+  });
+
+  it("does NOT touch substrings that contain reserved words", () => {
+    expect(sanitizeFtsInput("ANDROID")).toBe("ANDROID");
+    expect(sanitizeFtsInput("SCANNER")).toBe("SCANNER");
+    expect(sanitizeFtsInput("ORACLE")).toBe("ORACLE");
+    expect(sanitizeFtsInput("NEARBY")).toBe("NEARBY");
+    expect(sanitizeFtsInput("android 12")).toBe("android 12");
+  });
+
+  it("strips FTS5 syntax chars: \" ' * ( )", () => {
+    // Each `"` and `(` `)` and `*` is converted to a single space;
+    // surrounding whitespace is preserved verbatim.
+    expect(sanitizeFtsInput('alpha "beta" gamma')).toBe("alpha  beta  gamma");
+    expect(sanitizeFtsInput("alpha'beta")).toBe("alpha beta");
+    expect(sanitizeFtsInput("alpha*")).toBe("alpha");
+    expect(sanitizeFtsInput("(alpha) (beta)")).toBe("alpha   beta");
+  });
+
+  it("strips column filter prefixes including negation", () => {
+    expect(sanitizeFtsInput("content:foo")).toBe("foo");
+    expect(sanitizeFtsInput("-content:foo")).toBe("- foo");
+    expect(sanitizeFtsInput("message:hello world")).toBe("hello world");
+    expect(sanitizeFtsInput("-session:abc")).toBe("- abc");
+    expect(sanitizeFtsInput("actor:user1 topic:food")).toBe("user1  food");
+  });
+
+  it("normalizes full-width Unicode variants via NFKC", () => {
+    expect(sanitizeFtsInput("alpha ＡＮＤ beta")).toBe("alpha   beta");
+    expect(sanitizeFtsInput("alpha ＡＮＤROID beta")).toBe("alpha ANDROID beta");
+  });
+
+  it("handles tricky mixed inputs", () => {
+    expect(sanitizeFtsInput('"alpha" OR "beta"')).toBe("alpha     beta");
+    expect(sanitizeFtsInput("(content:foo) OR (message:bar)")).toBe(
+      "foo      bar",
+    );
+  });
+
+  it("leaves contiguous whitespace untouched when no syntax is present", () => {
+    expect(sanitizeFtsInput("hello    world")).toBe("hello    world");
+  });
+});
+
+describe("sanitizeFtsToken (sanitization layer 2 — per-token)", () => {
+  it("returns null for empty input", () => {
+    expect(sanitizeFtsToken("")).toBeNull();
+  });
+
+  it("wraps ASCII letters in phrase quotes", () => {
+    expect(sanitizeFtsToken("alpha")).toBe('"alpha"');
+  });
+
+  it("preserves unicode letters and digits", () => {
+    expect(sanitizeFtsToken("用户2026")).toBe('"用户2026"');
+    expect(sanitizeFtsToken("東京_タワー")).toBe('"東京_タワー"');
+  });
+
+  it("drops pure-punctuation tokens", () => {
+    expect(sanitizeFtsToken("***")).toBeNull();
+    expect(sanitizeFtsToken("...")).toBeNull();
+    expect(sanitizeFtsToken("()")).toBeNull();
+  });
+
+  it("drops FTS5 reserved words regardless of case", () => {
+    expect(sanitizeFtsToken("AND")).toBeNull();
+    expect(sanitizeFtsToken("or")).toBeNull();
+    expect(sanitizeFtsToken("Not")).toBeNull();
+    expect(sanitizeFtsToken("near")).toBeNull();
+  });
+
+  it("strips embedded punctuation but keeps word fragments", () => {
+    expect(sanitizeFtsToken("foo:bar")).toBe('"foobar"');
+    expect(sanitizeFtsToken("C++")).toBe('"C"');
+  });
+
+  it("filters embedded double-quotes via the unicode whitelist", () => {
+    // Quotes are filtered out by the unicode-letter/number whitelist; only
+    // the letters around them survive.  This is intentional — quotes do not
+    // survive into the index token stream because they are FTS5 syntax.
+    expect(sanitizeFtsToken('a"b')).toBe('"ab"');
+    expect(sanitizeFtsToken('he said "hi"')).toBe('"hesaidhi"');
+  });
+});
+
+describe("buildFtsQuery (fallback mode)", () => {
+  it("returns null for empty / null / undefined input", () => {
+    expect(buildFtsQuery("")).toBeNull();
+    expect(buildFtsQuery(null)).toBeNull();
+    expect(buildFtsQuery(undefined)).toBeNull();
+  });
+
+  it("returns null when nothing survives sanitization", () => {
+    expect(buildFtsQuery("***")).toBeNull();
+    expect(buildFtsQuery("(())")).toBeNull();
+  });
+
+  it("returns null for input that is just reserved operators", () => {
+    expect(buildFtsQuery("AND")).toBeNull();
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  });
+
+  it("strips reserved operators and produces OR-of-terms", () => {
+    expect(buildFtsQuery("alpha AND NOT beta")).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery("alpha Or beta")).toBe('"alpha" OR "beta"');
+  });
+
+  it("escapes phrase-quote injection", () => {
+    expect(buildFtsQuery('alpha" OR "beta')).toBe('"alpha" OR "beta"');
+  });
+
+  it("neutralizes the prefix-wildcard abuse path", () => {
+    expect(buildFtsQuery("alpha*")).toBe('"alpha"');
+  });
+
+  it("neutralizes parenthesized group expressions", () => {
+    expect(buildFtsQuery("(alpha) OR (beta)")).toBe('"alpha" OR "beta"');
+  });
+
+  it("neutralizes column-filter syntax", () => {
+    // `content:` is stripped — its letters also leak in via the regex via
+    // the whitespace separator, but the unicode-letter whitelist inside
+    // sanitizeFtsToken filters `content` back out ONLY when it is a
+    // stand-alone token.  In this query `content:` is collapsed to a space
+    // by `sanitizeFtsInput` so we only ever see `foo` and `bar`.
+    expect(buildFtsQuery("content:foo bar")).toBe('"foo" OR "bar"');
+    expect(buildFtsQuery("-content:foo")).toBe('"foo"');
+  });
+
+  it("handles NFKC full-width operator variants", () => {
+    expect(buildFtsQuery("alpha ＡＮＤ beta")).toBe('"alpha" OR "beta"');
+  });
+
+  it("does NOT over-strip benign substrings (word-boundary safe)", () => {
+    expect(buildFtsQuery("ANDROID")).toBe('"ANDROID"');
+    expect(buildFtsQuery("ORACLE")).toBe('"ORACLE"');
+    expect(buildFtsQuery("NEARBY")).toBe('"NEARBY"');
+  });
+
+  it("returns Chinese / mixed language query verbatim (only stripped syntax)", () => {
+    expect(buildFtsQuery("用户 TypeScript 编程")).toBe(
+      '"用户" OR "TypeScript" OR "编程"',
+    );
+  });
+
+  it("deduplicates tokens after sanitization", () => {
+    expect(buildFtsQuery("alpha alpha alpha")).toBe('"alpha"');
+  });
+
+  it("drops reserved words even when surrounded by other tokens", () => {
+    expect(buildFtsQuery("foo AND bar AND baz")).toBe(
+      '"foo" OR "bar" OR "baz"',
+    );
+  });
+
+  it("strips a long chain of mixed operators / syntax / junk", () => {
+    // All of these neutralize to OR-of-letter-tokens:
+    expect(buildFtsQuery('alpha AND NOT "beta" OR (gamma) NEAR hello')).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "hello"',
+    );
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -205,6 +205,10 @@ function quoteFtsLiteralToken(token: string): string {
   return '"' + token.replaceAll('"', '""') + '"';
 }
 
+function toQuotedFtsLiteralTerms(raw: string): string[] {
+  return extractFtsLiteralTokens(raw).map(quoteFtsLiteralToken);
+}
+
 /**
  * Normalize raw user text into a plain literal-token stream for FTS5.
  *
@@ -235,9 +239,9 @@ export function sanitizeFtsInput(raw: string): string {
  */
 export function sanitizeFtsToken(tok: string): string | null {
   if (!tok) return null;
-  const tokens = extractFtsLiteralTokens(tok);
-  if (tokens.length === 0) return null;
-  return tokens.map(quoteFtsLiteralToken).join(" OR ");
+  const terms = toQuotedFtsLiteralTerms(tok);
+  if (terms.length === 0) return null;
+  return terms.join(" OR ");
 }
 
 /**
@@ -289,8 +293,7 @@ export function buildFtsQuery(raw: string | null | undefined): string | null {
 
   const safeTokens: string[] = [];
   for (const t of rawTokens) {
-    const safe = sanitizeFtsToken(t);
-    if (safe) safeTokens.push(...safe.split(" OR "));
+    safeTokens.push(...toQuotedFtsLiteralTerms(t));
   }
   const dedup = [...new Set(safeTokens)];
   if (dedup.length === 0) return null;

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -195,15 +195,120 @@ const ZH_STOP_WORDS = new Set([
  * Example (fallback):
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
-export function buildFtsQuery(raw: string): string | null {
+// FTS5 reserved keywords that survive tokenization as quoted tokens and would
+// otherwise change MATCH semantics (`AND` / `OR` / `NOT` / `NEAR`).
+// `OR` is stripped defensively even though buildFtsQuery() always joins with
+// ` OR ` — any user input that happens to be exactly "OR" must not leak through.
+const FTS5_RESERVED_OPS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+// Column-set / table-name prefixes that FTS5 interprets as column filters.
+// Stripping these prevents a user from restricting (or excluding) the search
+// to columns such as `content:` / `message:` / `session:` / `actor:` / `topic:`.
+const FTS5_COL_FILTER_PATTERN =
+  /\b-?(?:content|message|session|actor|topic|role|tag|user|host|file)\s*:/gi;
+
+/**
+ * Strip FTS5 reserved syntax before tokenization.
+ *
+ * Defense-in-depth is layered:
+ *   1. NFKC normalization (so full-width `ＡＮＤ` is detected identically to `AND`)
+ *   2. Word-boundary stripping of reserved operators `AND` / `OR` / `NOT` / `NEAR`
+ *      (case-insensitive).  Word boundaries (`\b`) guarantee that substrings
+ *      such as `ANDROID`, `SCANNER`, `ORACLE`, `NEARBY` are preserved.
+ *   3. Stripping FTS5 syntax characters: `"` `'` `*` `(` `)`.
+ *      This neutralizes phrase-quote injection, single-quote escapes, prefix
+ *      wildcards (`alpha*`), and grouped expressions (`(alpha)`).
+ *   4. Stripping column-filter abuse (`content:foo`, `-content:foo`).
+ *
+ * Returns the cleaned text (still raw, NOT tokenized).  Returns `""` for any
+ * input that becomes empty after stripping so the caller can short-circuit
+ * to `null`.
+ *
+ * @internal
+ */
+export function sanitizeFtsInput(raw: string): string {
+  if (!raw) return "";
+  // 1. NFKC normalize so full-width Unicode variants do not bypass the regex.
+  let s = raw.normalize("NFKC");
+  // 2. Word-boundary FTS5 reserved operators (case-insensitive).
+  s = s.replace(/\b(?:AND|OR|NOT|NEAR)\b/gi, " ");
+  // 3. FTS5 syntax characters: quotes, prefix wildcard, grouping parens.
+  s = s.replace(/["'*()]/g, " ");
+  // 4. Column-filter abuse (also strip leading `-` for negative filters).
+  s = s.replace(FTS5_COL_FILTER_PATTERN, " ");
+  return s.trim();
+}
+
+/**
+ * Per-token guard applied AFTER tokenization as a second layer of defense.
+ *
+ * - NFKC-normalizes each token.
+ * - Keeps only characters that match `[\p{L}\p{N}_]`.  Tokens that lose all
+ *   such characters (e.g. `***`, or a `foo:` that strips to empty) are dropped.
+ * - Re-checks against `FTS5_RESERVED_OPS` so jieba-produced tokens such as a
+ *   bare `OR` cannot slip through.
+ * - Returns the token wrapped as an FTS5 phrase string with internal `"` chars
+ *   doubled, per FTS5 phrase-escape rules.
+ *
+ * Returns `null` to drop the token entirely.
+ *
+ * @internal
+ */
+export function sanitizeFtsToken(tok: string): string | null {
+  if (!tok) return null;
+  const norm = tok.normalize("NFKC");
+  // Keep only unicode letters / numbers / underscore.
+  const kept: string[] = [];
+  for (const ch of norm) {
+    if (/[\p{L}\p{N}_]/u.test(ch)) kept.push(ch);
+  }
+  const cleaned = kept.join("");
+  if (!cleaned) return null;
+  if (FTS5_RESERVED_OPS.has(cleaned.toUpperCase())) return null;
+  // FTS5 phrase escape: double any embedded double-quote.
+  return '"' + cleaned.replaceAll('"', '""') + '"';
+}
+
+/**
+ * Build an FTS5 MATCH query from raw text.
+ *
+ * The implementation is layered:
+ *   1. `sanitizeFtsInput()` strips FTS5 reserved operators, syntax characters,
+ *      and column-filter prefixes BEFORE tokenization.  This guarantees that
+ *      user input cannot carry query syntax into the generated MATCH.
+ *   2. Tokenization is unchanged from upstream:
+ *      - `@node-rs/jieba`'s `cutForSearch(text, true)` for Chinese (with
+ *        stop-word filter & dedup), or
+ *      - Unicode-regex `/[\p{L}\p{N}_]+/gu` fallback.
+ *   3. `sanitizeFtsToken()` runs on every emitted token as a second guard,
+ *      catching jieba-injected tokens such as `OR` or `foo:bar`.
+ *   4. Tokens are joined with ` OR ` inside FTS5 phrase quotes.
+ *
+ * The function returns `null` for input that contains no usable tokens so
+ * downstream FTS5 prepared statements can skip MATCH safely.
+ *
+ * Example (with jieba):
+ *   "用户喜欢编程和TypeScript" → '"用户" OR "喜欢" OR "编程" OR "TypeScript"'
+ *   "alpha AND NOT beta"        → '"alpha" OR "beta"'
+ *   "alpha\" OR \"beta"         → '"alpha" OR "beta"'
+ *   "content:foo"               → '"content" OR "foo"' (col-filter stripped,
+ *                                  `content` becomes a search term)
+ *
+ * @param raw  User-supplied query text.  `null` / `undefined` / `""` returns `null`.
+ */
+export function buildFtsQuery(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const cleaned = sanitizeFtsInput(raw);
+  if (!cleaned) return null;
+
   const jieba = getJieba();
 
-  let tokens: string[];
+  let rawTokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
+    rawTokens = jieba
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -214,19 +319,29 @@ export function buildFtsQuery(raw: string): string | null {
         return true;
       });
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
+    rawTokens = [...new Set(rawTokens)];
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
-      raw
+    rawTokens =
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];
   }
 
-  if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
-  return quoted.join(" OR ");
+  // Defense-in-depth: each token must pass sanitizeFtsToken() independently.
+  // This catches jieba-injected reserved words (e.g. a bare "OR") and any
+  // leftover syntax characters that jieba may have produced.
+  const safeTokens: string[] = [];
+  for (const t of rawTokens) {
+    const safe = sanitizeFtsToken(t);
+    if (safe) safeTokens.push(safe);
+  }
+  // Deduplicate again after sanitization in case cleaning collapsed tokens
+  // (e.g. "AND" and "and" both yield null after stripping).
+  const dedup = [...new Set(safeTokens)];
+  if (dedup.length === 0) return null;
+  return dedup.join(" OR ");
 }
 
 /**

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -195,104 +195,67 @@ const ZH_STOP_WORDS = new Set([
  * Example (fallback):
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
-// FTS5 reserved keywords that survive tokenization as quoted tokens and would
-// otherwise change MATCH semantics (`AND` / `OR` / `NOT` / `NEAR`).
-// `OR` is stripped defensively even though buildFtsQuery() always joins with
-// ` OR ` — any user input that happens to be exactly "OR" must not leak through.
-const FTS5_RESERVED_OPS = new Set(["AND", "OR", "NOT", "NEAR"]);
+const FTS_LITERAL_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
 
-// Column-set / table-name prefixes that FTS5 interprets as column filters.
-// Stripping these prevents a user from restricting (or excluding) the search
-// to columns such as `content:` / `message:` / `session:` / `actor:` / `topic:`.
-const FTS5_COL_FILTER_PATTERN =
-  /\b-?(?:content|message|session|actor|topic|role|tag|user|host|file)\s*:/gi;
+function extractFtsLiteralTokens(raw: string): string[] {
+  return raw.normalize("NFKC").match(FTS_LITERAL_TOKEN_RE) ?? [];
+}
+
+function quoteFtsLiteralToken(token: string): string {
+  return '"' + token.replaceAll('"', '""') + '"';
+}
 
 /**
- * Strip FTS5 reserved syntax before tokenization.
+ * Normalize raw user text into a plain literal-token stream for FTS5.
  *
- * Defense-in-depth is layered:
- *   1. NFKC normalization (so full-width `ＡＮＤ` is detected identically to `AND`)
- *   2. Word-boundary stripping of reserved operators `AND` / `OR` / `NOT` / `NEAR`
- *      (case-insensitive).  Word boundaries (`\b`) guarantee that substrings
- *      such as `ANDROID`, `SCANNER`, `ORACLE`, `NEARBY` are preserved.
- *   3. Stripping FTS5 syntax characters: `"` `'` `*` `(` `)`.
- *      This neutralizes phrase-quote injection, single-quote escapes, prefix
- *      wildcards (`alpha*`), and grouped expressions (`(alpha)`).
- *   4. Stripping column-filter abuse (`content:foo`, `-content:foo`).
- *
- * Returns the cleaned text (still raw, NOT tokenized).  Returns `""` for any
- * input that becomes empty after stripping so the caller can short-circuit
- * to `null`.
+ * This helper deliberately does not parse or preserve FTS5 syntax. Operators
+ * such as AND / OR / NOT / NEAR, column filters such as content:foo, grouping,
+ * wildcards, quotes, and NEAR distance syntax are all treated as ordinary
+ * user text. The only characters that survive are Unicode letters, numbers,
+ * and underscores; every other character becomes a token separator.
  *
  * @internal
  */
 export function sanitizeFtsInput(raw: string): string {
   if (!raw) return "";
-  // 1. NFKC normalize so full-width Unicode variants do not bypass the regex.
-  let s = raw.normalize("NFKC");
-  // 2. Word-boundary FTS5 reserved operators (case-insensitive).
-  s = s.replace(/\b(?:AND|OR|NOT|NEAR)\b/gi, " ");
-  // 3. FTS5 syntax characters: quotes, prefix wildcard, grouping parens.
-  s = s.replace(/["'*()]/g, " ");
-  // 4. Column-filter abuse (also strip leading `-` for negative filters).
-  s = s.replace(FTS5_COL_FILTER_PATTERN, " ");
-  return s.trim();
+  return extractFtsLiteralTokens(raw).join(" ");
 }
 
 /**
- * Per-token guard applied AFTER tokenization as a second layer of defense.
+ * Convert a tokenizer token into one or more quoted FTS5 literal terms.
  *
- * - NFKC-normalizes each token.
- * - Keeps only characters that match `[\p{L}\p{N}_]`.  Tokens that lose all
- *   such characters (e.g. `***`, or a `foo:` that strips to empty) are dropped.
- * - Re-checks against `FTS5_RESERVED_OPS` so jieba-produced tokens such as a
- *   bare `OR` cannot slip through.
- * - Returns the token wrapped as an FTS5 phrase string with internal `"` chars
- *   doubled, per FTS5 phrase-escape rules.
+ * The return value is safe to splice into a generated MATCH expression because
+ * every emitted token is wrapped as a phrase literal. If a token still contains
+ * punctuation (for example from a tokenizer stub), it is split into literal
+ * sub-tokens instead of being concatenated into a new word.
  *
- * Returns `null` to drop the token entirely.
+ * Returns `null` to drop tokens that contain no literal text.
  *
  * @internal
  */
 export function sanitizeFtsToken(tok: string): string | null {
   if (!tok) return null;
-  const norm = tok.normalize("NFKC");
-  // Keep only unicode letters / numbers / underscore.
-  const kept: string[] = [];
-  for (const ch of norm) {
-    if (/[\p{L}\p{N}_]/u.test(ch)) kept.push(ch);
-  }
-  const cleaned = kept.join("");
-  if (!cleaned) return null;
-  if (FTS5_RESERVED_OPS.has(cleaned.toUpperCase())) return null;
-  // FTS5 phrase escape: double any embedded double-quote.
-  return '"' + cleaned.replaceAll('"', '""') + '"';
+  const tokens = extractFtsLiteralTokens(tok);
+  if (tokens.length === 0) return null;
+  return tokens.map(quoteFtsLiteralToken).join(" OR ");
 }
 
 /**
  * Build an FTS5 MATCH query from raw text.
  *
- * The implementation is layered:
- *   1. `sanitizeFtsInput()` strips FTS5 reserved operators, syntax characters,
- *      and column-filter prefixes BEFORE tokenization.  This guarantees that
- *      user input cannot carry query syntax into the generated MATCH.
- *   2. Tokenization is unchanged from upstream:
+ * User input is always treated as plain text, never as FTS5 query syntax:
+ *
+ *   1. `sanitizeFtsInput()` normalizes Unicode and turns punctuation / FTS5
+ *      syntax into token separators before tokenization.
+ *   2. Tokenization remains unchanged from upstream:
  *      - `@node-rs/jieba`'s `cutForSearch(text, true)` for Chinese (with
  *        stop-word filter & dedup), or
- *      - Unicode-regex `/[\p{L}\p{N}_]+/gu` fallback.
- *   3. `sanitizeFtsToken()` runs on every emitted token as a second guard,
- *      catching jieba-injected tokens such as `OR` or `foo:bar`.
+ *      - Unicode literal-token fallback.
+ *   3. `sanitizeFtsToken()` runs on every emitted token as a second guard.
  *   4. Tokens are joined with ` OR ` inside FTS5 phrase quotes.
  *
  * The function returns `null` for input that contains no usable tokens so
  * downstream FTS5 prepared statements can skip MATCH safely.
- *
- * Example (with jieba):
- *   "用户喜欢编程和TypeScript" → '"用户" OR "喜欢" OR "编程" OR "TypeScript"'
- *   "alpha AND NOT beta"        → '"alpha" OR "beta"'
- *   "alpha\" OR \"beta"         → '"alpha" OR "beta"'
- *   "content:foo"               → '"content" OR "foo"' (col-filter stripped,
- *                                  `content` becomes a search term)
  *
  * @param raw  User-supplied query text.  `null` / `undefined` / `""` returns `null`.
  */
@@ -306,7 +269,7 @@ export function buildFtsQuery(raw: string | null | undefined): string | null {
   let rawTokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
-    // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
+    // e.g. a long Chinese term yields both sub-words and the full term.
     rawTokens = jieba
       .cutForSearch(cleaned, true)
       .map((t) => t.trim())
@@ -321,24 +284,14 @@ export function buildFtsQuery(raw: string | null | undefined): string | null {
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     rawTokens = [...new Set(rawTokens)];
   } else {
-    // Fallback: simple Unicode regex split
-    rawTokens =
-      cleaned
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    rawTokens = cleaned.match(FTS_LITERAL_TOKEN_RE) ?? [];
   }
 
-  // Defense-in-depth: each token must pass sanitizeFtsToken() independently.
-  // This catches jieba-injected reserved words (e.g. a bare "OR") and any
-  // leftover syntax characters that jieba may have produced.
   const safeTokens: string[] = [];
   for (const t of rawTokens) {
     const safe = sanitizeFtsToken(t);
-    if (safe) safeTokens.push(safe);
+    if (safe) safeTokens.push(...safe.split(" OR "));
   }
-  // Deduplicate again after sanitization in case cleaning collapsed tokens
-  // (e.g. "AND" and "and" both yield null after stripping).
   const dedup = [...new Set(safeTokens)];
   if (dedup.length === 0) return null;
   return dedup.join(" OR ");


### PR DESCRIPTION
## Summary

Fixes #160 by changing `buildFtsQuery()` from an operator-sanitizing helper into a literal-token query builder.

The important security boundary is: **user input is never treated as FTS5 syntax**. User text is normalized into plain literal tokens, every emitted token is phrase-quoted, and the only MATCH operators inserted into the expression are generated by our code.

## Relationship to #178

I saw the triage note that #178 is the locally verified canonical narrow fix for #160. This PR is now intentionally positioned as the stricter literal-token variant, not just another denylist patch.

The behavior beyond #178 is that reserved-looking words typed by the user are preserved as searchable text instead of being deleted:

```text
AND OR NOT NEAR
  -> "AND" OR "OR" OR "NOT" OR "NEAR"
```

That means the fix prevents user-controlled FTS5 query structure while avoiding recall loss for documents that actually contain words such as `AND`, `OR`, `NOT`, or `NEAR`.

## Core design decision

`buildFtsQuery()` owns the complete MATCH expression structure.

```text
raw user text
  -> NFKC normalization
  -> Unicode literal-token extraction ([\p{L}\p{N}_]+)
  -> jieba search tokenization when available, regex fallback otherwise
  -> second literal-token safety pass for every tokenizer output
  -> quote every token as an FTS5 phrase literal
  -> join code-generated terms with code-generated OR
```

Inputs such as boolean operators, `NEAR/5`, column filters, quotes, wildcards, and groups can only become searchable text tokens. They cannot become FTS5 query control flow.

## Why this is stronger than a denylist-only fix

A denylist-only fix removes known dangerous words such as `AND`, `OR`, `NOT`, and `NEAR`. That is a valid narrow fix, but it has two trade-offs:

1. It can reduce recall by deleting words the user actually typed.
2. It depends on recognizing every FTS5 syntax path that should be removed.

This PR avoids both: syntax-looking input is reduced to literal tokens, and every token is phrase-quoted before it reaches FTS5.

## Security and recall behavior

| User input | Generated MATCH behavior | Why it is safe |
| --- | --- | --- |
| `alpha" OR "beta` | `"alpha" OR "OR" OR "beta"` | The injected `OR` is a quoted literal term, not user-controlled structure. |
| `alpha AND NOT beta` | `"alpha" OR "AND" OR "NOT" OR "beta"` | Boolean words stay searchable but cannot negate or combine terms. |
| `(alpha) OR (beta)` | `"alpha" OR "OR" OR "beta"` | Parentheses are separators, not grouping syntax. |
| `content:foo` | `"content" OR "foo"` | Column-filter syntax becomes plain text tokens. |
| `alpha*` | `"alpha"` | Prefix wildcard syntax cannot expand the query. |
| full-width `AND` | `"AND"` | NFKC normalization handles Unicode variants while preserving search text. |

## Implementation highlights

- `sanitizeFtsInput()` normalizes raw input and extracts only Unicode literal tokens.
- `sanitizeFtsToken()` re-sanitizes every tokenizer output so punctuation-bearing jieba/native/stub tokens cannot reintroduce MATCH syntax.
- `buildFtsQuery()` contributes all MATCH structure itself; user text contributes tokens only.
- Existing jieba-based Chinese recall remains in the path, with an additional literal-token safety pass after tokenization.
- The latest commit removes the fragile internal string-split assembly and uses explicit quoted literal term arrays.

## Test coverage

The tests cover generated query strings and real FTS5 execution:

- Unit coverage for literalizing reserved words: `AND`, `OR`, `NOT`, `NEAR`.
- Unit coverage for column-filter-looking input such as `content:foo`.
- Unit coverage for quote injection, parenthesized expressions, prefix wildcard syntax, and NFKC normalization.
- Tokenizer re-sanitization coverage for punctuation-bearing tokenizer output.
- Real `node:sqlite` FTS5 fixture tests proving generated MATCH expressions execute successfully.
- Real FTS5 fixture test proving reserved words remain searchable as literal document text.
- Recall comparison against benign queries so ordinary keyword behavior is preserved.
- 200 randomized adversarial query inputs to ensure generated MATCH expressions do not throw.

## Verification

Latest pushed head:

```text
802998c test(search): prove FTS5 literal token coverage
```

Full test suite:

```text
npm.cmd test

Test Files  6 passed (6)
Tests       113 passed (113)
```

Build:

```text
npm.cmd run build

Build complete
```

`tsdown` prints a Node.js v22.17.0 deprecation warning in this local environment, but the build exits successfully.

## Files worth reviewing first

1. `src/core/store/sqlite.ts` - literal-token query builder implementation.
2. `src/core/store/sqlite.test.ts` - unit-level security, tokenizer re-sanitization, and recall semantics.
3. `src/core/store/sqlite.recall.test.ts` - real FTS5 execution, reserved-word literal recall, recall parity, and fuzz coverage.
4. `CHANGELOG.md` - documents the refined solution and its difference from #178.