### PR TITLE
fix(search): sanitize FTS5 query tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **FTS5 查询输入净化** ([#160](https://github.com/Tencent/TencentDB-Agent-Memory/issues/160))：`buildFtsQuery()` 在 jieba 与 fallback 分词路径统一执行 NFKC 归一化、FTS5 语法剥离和安全 token 白名单过滤，防止 `AND` / `OR` / `NOT` / `NEAR` 等用户输入改变 MATCH 查询语义。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("keeps ordinary fallback tokens OR-joined as quoted phrases", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("旅行计划 API")).toBe('"旅行计划" OR "API"');
+  });
+
+  it("drops standalone FTS5 operators before building fallback queries", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta OR NOT gamma NEAR delta")).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta"',
+    );
+  });
+
+  it("filters operators case-insensitively without deleting containing words", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("android ordinary nearshore scanner Or NOT")).toBe(
+      '"android" OR "ordinary" OR "nearshore" OR "scanner"',
+    );
+  });
+
+  it("normalizes full-width operators and strips FTS5 syntax characters", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha＊ ＯＲ beta NEAR/5 'gamma' -content:delta")).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta"',
+    );
+  });
+
+  it("keeps NEAR group terms while discarding its distance argument", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("NEAR(alpha beta, 5)")).toBe('"alpha" OR "beta"');
+  });
+
+  it("returns null when input contains no searchable fallback tokens", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("AND OR NOT NEAR () * ''")).toBeNull();
+  });
+
+  it("applies the same sanitizer to jieba-produced tokens", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["alpha", "AND", "NEAR(beta", "C++", "的", "beta", "alpha"],
+    });
+
+    expect(buildFtsQuery("ignored raw input")).toBe('"alpha" OR "beta" OR "C"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,41 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function normalizeFtsText(raw: string): string {
+  return raw.normalize("NFKC");
+}
+
+function stripFtsSyntax(raw: string): string {
+  return raw
+    .replace(/\bNEAR\s*\(([^)]*)\)/gi, (_match, inner: string) => inner.replace(/,\s*\d+\s*$/, " "))
+    .replace(/\bNEAR\s*\/\s*\d+\b/gi, " ")
+    .replace(/(^|[\s(])-?[\p{L}_][\p{L}\p{N}_]*\s*:/gu, "$1");
+}
+
+function sanitizeFtsTokens(rawTokens: string[]): string[] {
+  const safeTokens: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawToken of rawTokens) {
+    const parts = stripFtsSyntax(normalizeFtsText(rawToken)).match(FTS5_TOKEN_RE) ?? [];
+    for (const part of parts) {
+      const token = part.trim();
+      if (!token) continue;
+      if (!/[\p{L}\p{N}]/u.test(token)) continue;
+      if (ZH_STOP_WORDS.has(token)) continue;
+      if (FTS5_RESERVED_OPERATORS.has(token.toUpperCase())) continue;
+      if (seen.has(token)) continue;
+      seen.add(token);
+      safeTokens.push(token);
+    }
+  }
+
+  return safeTokens;
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -197,31 +232,16 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const normalizedRaw = stripFtsSyntax(normalizeFtsText(raw));
 
   let tokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
-    // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
+    tokens = sanitizeFtsTokens(jieba.cutForSearch(normalizedRaw, true));
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    tokens = sanitizeFtsTokens(normalizedRaw.match(FTS5_TOKEN_RE) ?? []);
   }
 
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Description | 描述

Fixes the FTS5 query-semantics issue reported in #160 by making `buildFtsQuery()` construct MATCH expressions only from sanitized search tokens.

This PR keeps the existing recall strategy unchanged: safe tokens are still quoted and joined with `OR`, so normal keyword search behavior remains stable.

## What changed | 修改内容

- Add NFKC normalization before query tokenization to handle full-width operator variants.
- Strip FTS5 syntax forms such as `NEAR(...)`, `NEAR/5`, and column-filter-like prefixes before token extraction.
- Apply the same safe-token sanitizer to both jieba and regex fallback tokenization paths.
- Drop standalone FTS5 reserved operators: `AND`, `OR`, `NOT`, `NEAR`.
- Preserve ordinary words containing operator substrings, such as `android`, `ordinary`, `nearshore`, and `scanner`.
- Add focused tests for fallback and jieba-produced token paths.
- Add CHANGELOG entry for the security/input-sanitization fix.

## Related Issue | 关联 Issue

Fixes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Validated with Node.js v22.23.1:

```bash
npm test -- src/core/store/sqlite.test.ts
npm test
npm run build
```

Results:

- `src/core/store/sqlite.test.ts`: 7 passed
- Full test suite: 5 files passed, 74 tests passed
- Build: passed