### PR TITLE
fix(gateway): normalize capture request timestamps

### DIFF
--- a/src/gateway/capture-request.test.ts
+++ b/src/gateway/capture-request.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGatewayCaptureTurn } from "./capture-request.js";
+
+describe("buildGatewayCaptureTurn", () => {
+  it("adds timestamps when HTTP clients omit raw messages", () => {
+    const turn = buildGatewayCaptureTurn({
+      user_content: "remember the Hermes issue marker",
+      assistant_content: "acknowledged",
+      session_key: "capture-session-1",
+    }, 1_000);
+
+    expect(turn.startedAt).toBe(1_000);
+    expect(turn.messages).toEqual([
+      { role: "user", content: "remember the Hermes issue marker", timestamp: 1_001 },
+      { role: "assistant", content: "acknowledged", timestamp: 1_002 },
+    ]);
+  });
+
+  it("keeps synthetic timestamps increasing across rapid lightweight turns", () => {
+    const first = buildGatewayCaptureTurn({
+      user_content: "first user",
+      assistant_content: "first assistant",
+      session_key: "rapid-session",
+    }, 2_000);
+    const second = buildGatewayCaptureTurn({
+      user_content: "second user",
+      assistant_content: "second assistant",
+      session_key: "rapid-session",
+    }, 2_000);
+
+    const firstAssistant = first.messages[1] as { timestamp: number };
+    const secondUser = second.messages[0] as { timestamp: number };
+    const secondAssistant = second.messages[1] as { timestamp: number };
+
+    expect(secondUser.timestamp).toBeGreaterThan(firstAssistant.timestamp);
+    expect(secondAssistant.timestamp).toBeGreaterThan(secondUser.timestamp);
+  });
+
+  it("continues synthetic timestamps after client-provided messages in the same session", () => {
+    buildGatewayCaptureTurn({
+      user_content: "fallback user",
+      assistant_content: "fallback assistant",
+      session_key: "mixed-session",
+      messages: [
+        { role: "user", content: "raw user", timestamp: 20_000 },
+        { role: "assistant", content: "raw assistant", timestamp: 20_100 },
+      ],
+    }, 2_000);
+
+    const next = buildGatewayCaptureTurn({
+      user_content: "lightweight user",
+      assistant_content: "lightweight assistant",
+      session_key: "mixed-session",
+    }, 2_000);
+
+    const user = next.messages[0] as { timestamp: number };
+    const assistant = next.messages[1] as { timestamp: number };
+
+    expect(user.timestamp).toBe(20_101);
+    expect(assistant.timestamp).toBe(20_102);
+  });
+
+  it("sets raw-message capture start before the payload timestamps", () => {
+    const messages = [
+      { role: "user", content: "original", timestamp: 2_000 },
+      { role: "assistant", content: "reply", timestamp: 2_100 },
+    ];
+
+    const turn = buildGatewayCaptureTurn({
+      user_content: "fallback user",
+      assistant_content: "fallback assistant",
+      session_key: "raw-session",
+      messages,
+    }, 5_000);
+
+    expect(turn.startedAt).toBe(1_999);
+    expect(turn.messages).toBe(messages);
+  });
+
+  it("uses a pre-request start time for raw messages without timestamps", () => {
+    const messages = [
+      { role: "user", content: "original" },
+      { role: "assistant", content: "reply" },
+    ];
+
+    const turn = buildGatewayCaptureTurn({
+      user_content: "fallback user",
+      assistant_content: "fallback assistant",
+      session_key: "raw-without-timestamp-session",
+      messages,
+    }, 5_000);
+
+    expect(turn.startedAt).toBe(4_999);
+    expect(turn.messages).toBe(messages);
+  });
+});

--- a/src/gateway/capture-request.ts
+++ b/src/gateway/capture-request.ts
@@ -1,0 +1,49 @@
+import type { CaptureRequest } from "./types.js";
+
+const syntheticCaptureTimestampsBySession = new Map<string, number>();
+
+export function buildGatewayCaptureTurn(body: CaptureRequest, now = Date.now()): {
+  messages: unknown[];
+  startedAt: number;
+} {
+  if (Array.isArray(body.messages)) {
+    const timestampRange = messageTimestampRange(body.messages);
+    if (timestampRange) {
+      const lastTimestamp = syntheticCaptureTimestampsBySession.get(body.session_key) ?? 0;
+      if (timestampRange.max > lastTimestamp) {
+        syntheticCaptureTimestampsBySession.set(body.session_key, timestampRange.max);
+      }
+    }
+    const floorBase = timestampRange ? Math.min(now, timestampRange.min) : now;
+    return { messages: body.messages, startedAt: floorBase - 1 };
+  }
+
+  const lastTimestamp = syntheticCaptureTimestampsBySession.get(body.session_key) ?? 0;
+  const baseTimestamp = Math.max(now, lastTimestamp);
+  const userTimestamp = baseTimestamp + 1;
+  const assistantTimestamp = baseTimestamp + 2;
+  syntheticCaptureTimestampsBySession.set(body.session_key, assistantTimestamp);
+
+  return {
+    messages: [
+      { role: "user", content: body.user_content, timestamp: userTimestamp },
+      { role: "assistant", content: body.assistant_content, timestamp: assistantTimestamp },
+    ],
+    startedAt: now,
+  };
+}
+
+function messageTimestampRange(messages: unknown[]): { min: number; max: number } | undefined {
+  let maxTimestamp: number | undefined;
+  let minTimestamp: number | undefined;
+  for (const message of messages) {
+    if (!message || typeof message !== "object") continue;
+    const timestamp = (message as Record<string, unknown>).timestamp;
+    if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) continue;
+    maxTimestamp = maxTimestamp == null ? timestamp : Math.max(maxTimestamp, timestamp);
+    minTimestamp = minTimestamp == null ? timestamp : Math.min(minTimestamp, timestamp);
+  }
+  return minTimestamp == null || maxTimestamp == null
+    ? undefined
+    : { min: minTimestamp, max: maxTimestamp };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -43,6 +43,7 @@ import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
+import { buildGatewayCaptureTurn } from "./capture-request.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
@@ -399,15 +400,14 @@ export class TdaiGateway {
     }
 
     const startMs = Date.now();
+    const turn = buildGatewayCaptureTurn(body, startMs);
     const result = await this.core.handleTurnCommitted({
       userText: body.user_content,
       assistantText: body.assistant_content,
-      messages: body.messages ?? [
-        { role: "user", content: body.user_content },
-        { role: "assistant", content: body.assistant_content },
-      ],
+      messages: turn.messages,
       sessionKey: body.session_key,
       sessionId: body.session_id,
+      startedAt: turn.startedAt,
     });
     const elapsed = Date.now() - startMs;
 


### PR DESCRIPTION
## Description | 描述

This PR narrows #318 to a focused Gateway capture compatibility fix found during real Gateway-based adapter testing.

`POST /capture` now normalizes Gateway capture payload timing before calling `TdaiCore.handleTurnCommitted()`:

- lightweight HTTP turns using `user_content` / `assistant_content` are converted into timestamped user and assistant messages;
- rapid consecutive lightweight captures in the same `session_key` receive strictly increasing synthetic timestamps;
- raw `messages` payloads remain unchanged, while their capture start floor is set before the payload's message timestamps;
- later lightweight captures continue after the latest timestamp already seen for that session.

This prevents first-turn or rapid Gateway captures from being filtered out by the L0 capture cursor when clients do not provide framework-native timestamped messages.

## Related Issue | 关联 Issue

Related to #235

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## What Changed | 修改内容

- Added `src/gateway/capture-request.ts` to normalize Gateway capture timing in one focused helper.
- Updated `TdaiGateway.handleCapture()` to pass normalized `messages` and `startedAt` into `TdaiCore`.
- Added `src/gateway/capture-request.test.ts` covering lightweight turns, rapid same-session captures, raw-message continuity, and raw messages without timestamps.

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
npx vitest run src/gateway/capture-request.test.ts
```

Result:

```text
1 test file passed
5 tests passed
```

```bash
npm test
```

Result:

```text
5 test files passed
72 tests passed
```

```bash
npm run build
```

Result:

```text
passed
```

```bash
git diff --check --cached
```

Result:

```text
passed
```

### Real Gateway Validation | 真实 Gateway 验证

Executed a real local `TdaiGateway` HTTP flow with an isolated temporary data directory, SQLite storage, extraction disabled, and embedding disabled.

Verified:

- Started `TdaiGateway` on `127.0.0.1` with a temporary `data.baseDir`.
- Sent two lightweight `POST /capture` requests using only `user_content`, `assistant_content`, and `session_key`.
- Each capture returned `l0_recorded=2`.
- `POST /search/conversations` found both user marker messages.
- `POST /search/conversations` found both assistant acknowledgement messages.
- The generated `conversations/*.jsonl` file contained 4 records for the session.
- The 4 recorded L0 timestamps were strictly increasing.

Result:

```text
captureRuns=2
userSearchTotal=2
assistantSearchTotal=2
l0Records=4
timestampsIncreasing=true
```
