### PR TITLE
fix(openclaw): map stable recall context before cache boundary

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,7 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import { mapRecallResultToOpenClawPromptBuild } from "./src/adapters/openclaw/prompt-build.js";
 
 const TAG = "[memory-tdai]";
 
@@ -589,12 +590,13 @@ export default function register(api: OpenClawPluginApi) {
           const prependLen = result.prependContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendLen} chars -> prependSystemContext, ` +
+            `prependContext=${prependLen} chars`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return mapRecallResultToOpenClawPromptBuild(result);
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);

--- a/src/adapters/openclaw/prompt-build.test.ts
+++ b/src/adapters/openclaw/prompt-build.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { mapRecallResultToOpenClawPromptBuild } from "./prompt-build.js";
+
+describe("mapRecallResultToOpenClawPromptBuild", () => {
+  it("returns stable recall through prependSystemContext", () => {
+    const result = mapRecallResultToOpenClawPromptBuild({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<relevant-memories>dynamic</relevant-memories>",
+    });
+
+    expect(result).toEqual({
+      prependSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<relevant-memories>dynamic</relevant-memories>",
+    });
+    expect(result).not.toHaveProperty("appendSystemContext");
+  });
+
+  it("returns undefined when there is no prompt context", () => {
+    expect(mapRecallResultToOpenClawPromptBuild(undefined)).toBeUndefined();
+    expect(mapRecallResultToOpenClawPromptBuild({})).toBeUndefined();
+  });
+});

--- a/src/adapters/openclaw/prompt-build.ts
+++ b/src/adapters/openclaw/prompt-build.ts
@@ -1,0 +1,34 @@
+import type { RecallResult } from "../../core/types.js";
+
+export interface OpenClawPromptBuildResult {
+  prependContext?: string;
+  appendContext?: string;
+  prependSystemContext?: string;
+  appendSystemContext?: string;
+}
+
+/**
+ * Convert host-neutral recall output to OpenClaw's prompt-build hook shape.
+ *
+ * Core uses appendSystemContext for stable persona / scene / tool guidance.
+ * OpenClaw composes prependSystemContext before its cache boundary, so the
+ * plugin returns stable recall through that host field while dynamic L1 recall
+ * stays in prependContext.
+ */
+export function mapRecallResultToOpenClawPromptBuild(
+  result: RecallResult | undefined,
+): OpenClawPromptBuildResult | undefined {
+  if (!result) return undefined;
+
+  const hookResult: OpenClawPromptBuildResult = {};
+
+  if (result.prependContext) {
+    hookResult.prependContext = result.prependContext;
+  }
+
+  if (result.appendSystemContext) {
+    hookResult.prependSystemContext = result.appendSystemContext;
+  }
+
+  return Object.keys(hookResult).length > 0 ? hookResult : undefined;
+}


### PR DESCRIPTION
## Description | 描述

This PR narrows #319 to the cache-boundary follow-up for issue #120.

OpenClaw composes `prependSystemContext` before its cache boundary. TencentDB core still returns stable persona / scene / tool guidance as `appendSystemContext`, so the OpenClaw plugin entrypoint now maps that stable field to `prependSystemContext` when returning the `before_prompt_build` hook result.

Changes:

- Adds `mapRecallResultToOpenClawPromptBuild()` for the OpenClaw prompt-build hook shape.
- Returns stable `appendSystemContext` as OpenClaw `prependSystemContext`.
- Keeps dynamic L1 recall in `prependContext`.
- Leaves core `RecallResult` unchanged.
- Adds focused unit coverage for the hook mapping.

## Related Issue | 关联 Issue

Refs #120

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [x] Code optimization | 代码优化
- [x] Test coverage | 测试覆盖

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verified with:

```bash
npx vitest run src/adapters/openclaw/prompt-build.test.ts
```

```text
1 test file passed
2 tests passed
```

```bash
npm test
```

```text
5 test files passed
69 tests passed
```

```bash
npm run build
```

```text
passed
```

```bash
git diff --check
```

```text
passed
```