### PR TITLE
fix(data): recalculate checkpoint after cleanup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { CheckpointManager } from "./src/utils/checkpoint.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -274,6 +275,7 @@ export default function register(api: OpenClawPluginApi) {
   const coreReady = core.initialize().then(() => {
     // Keep cleaner's SQLite handle updated after store init
     memoryCleaner?.setVectorStore(core.getVectorStore());
+    memoryCleaner?.setCheckpointManager(new CheckpointManager(pluginDataDir, api.logger));
 
     // Pull L2/L3 profiles if remote store supports it
     const vs = core.getVectorStore();
@@ -305,6 +307,7 @@ export default function register(api: OpenClawPluginApi) {
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
+        checkpoint: new CheckpointManager(pluginDataDir, api.logger),
       });
       sharedMemoryCleaner.start();
       api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -514,6 +514,7 @@ export class TdaiCore {
     this.schedulerStartPromise = (async () => {
       try {
         const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        await this.recalculateCheckpoint(checkpoint);
         const cp = await checkpoint.read();
         scheduler.start(checkpoint.getAllPipelineStates(cp));
         this.logger.debug?.(`${TAG} Scheduler started`);
@@ -531,5 +532,23 @@ export class TdaiCore {
     });
 
     return this.schedulerStartPromise;
+  }
+
+  private async recalculateCheckpoint(checkpoint: CheckpointManager): Promise<void> {
+    try {
+      let l0ConversationsCount: number | undefined;
+      let totalMemoriesExtracted: number | undefined;
+
+      if (this.vectorStore && !this.vectorStore.isDegraded()) {
+        try { l0ConversationsCount = await this.vectorStore.countL0(); } catch { /* fall back to JSONL */ }
+        try { totalMemoriesExtracted = await this.vectorStore.countL1(); } catch { /* fall back to JSONL */ }
+      }
+
+      await checkpoint.recalculate({ l0ConversationsCount, totalMemoriesExtracted });
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint recalculation failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,284 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { readConversationMessagesGroupedBySessionId } from "../core/conversation/l0-recorder.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+describe("CheckpointManager recalculation", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recalculates counters after manual JSONL pruning", async () => {
+    const dataDir = await makeTempDataDir();
+    await writeL0Records(dataDir, [
+      l0Record("session-a", "l0-1", "2026-06-29T00:00:00.000Z", 101),
+      l0Record("session-a", "l0-2", "2026-06-29T00:00:01.000Z", 102),
+    ]);
+    await writeL1Records(dataDir, [
+      l1Record("session-a", "l1-1", "2026-06-29T00:00:00.000Z"),
+      l1Record("session-a", "l1-2", "2026-06-29T00:00:01.000Z"),
+      l1Record("session-a", "l1-3", "2026-06-29T00:00:02.000Z"),
+    ]);
+
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write({
+      ...(await checkpoint.read()),
+      l0_conversations_count: 9,
+      total_processed: 9,
+      total_memories_extracted: 8,
+      memories_since_last_persona: 7,
+    });
+
+    await checkpoint.recalculate();
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(2);
+    expect(cp.total_processed).toBe(2);
+    expect(cp.total_memories_extracted).toBe(3);
+    expect(cp.memories_since_last_persona).toBe(2);
+  });
+
+  it("clamps stale L1 and L2 cursors to retained local data", async () => {
+    const dataDir = await makeTempDataDir();
+    await writeL0Records(dataDir, [
+      l0Record("session-a", "l0-1", "2026-06-29T00:00:00.000Z", 101),
+    ]);
+    await writeL1Records(dataDir, [
+      l1Record("session-a", "l1-1", "2026-06-29T00:00:01.000Z"),
+    ]);
+
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write({
+      ...(await checkpoint.read()),
+      runner_states: {
+        "session-a": {
+          last_captured_timestamp: 999,
+          last_l1_cursor: Date.parse("2026-06-30T00:00:00.000Z"),
+          last_scene_name: "old",
+        },
+      },
+      pipeline_states: {
+        "session-a": {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: "2026-06-30T00:00:00.000Z",
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+    });
+
+    await checkpoint.recalculate();
+
+    const cp = await checkpoint.read();
+    expect(cp.runner_states["session-a"].last_captured_timestamp).toBe(101);
+    expect(cp.runner_states["session-a"].last_l1_cursor).toBe(Date.parse("2026-06-29T00:00:00.000Z"));
+    expect(cp.pipeline_states["session-a"].last_extraction_updated_time).toBe("2026-06-29T00:00:01.000Z");
+
+    await writeL0Records(dataDir, [
+      l0Record("session-a", "l0-1", "2026-06-29T00:00:00.000Z", 101),
+      l0Record("session-a", "l0-new-after-cleanup", "2026-06-29T00:00:02.000Z", 103),
+    ]);
+    const groups = await readConversationMessagesGroupedBySessionId(
+      "session-a",
+      dataDir,
+      cp.runner_states["session-a"].last_l1_cursor,
+    );
+    expect(groups.flatMap((group) => group.messages.map((message) => message.id))).toEqual(["l0-new-after-cleanup"]);
+  });
+
+  it("resets stale session cursors when a session has no retained data", async () => {
+    const dataDir = await makeTempDataDir();
+    await writeL0Records(dataDir, [
+      l0Record("session-a", "l0-1", "2026-06-29T00:00:00.000Z", 101),
+    ]);
+    await writeL1Records(dataDir, [
+      l1Record("session-a", "l1-1", "2026-06-29T00:00:01.000Z"),
+    ]);
+
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write({
+      ...(await checkpoint.read()),
+      runner_states: {
+        "session-a": {
+          last_captured_timestamp: 101,
+          last_l1_cursor: Date.parse("2026-06-29T00:00:00.000Z"),
+          last_scene_name: "kept",
+        },
+        "session-b": {
+          last_captured_timestamp: 999,
+          last_l1_cursor: Date.parse("2026-06-30T00:00:00.000Z"),
+          last_scene_name: "deleted",
+        },
+      },
+      pipeline_states: {
+        "session-a": {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: "2026-06-29T00:00:01.000Z",
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+        "session-b": {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: "2026-06-30T00:00:00.000Z",
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+    });
+
+    const result = await checkpoint.recalculate();
+
+    const cp = await checkpoint.read();
+    expect(cp.runner_states["session-a"].last_captured_timestamp).toBe(101);
+    expect(cp.runner_states["session-a"].last_l1_cursor).toBe(Date.parse("2026-06-29T00:00:00.000Z"));
+    expect(cp.pipeline_states["session-a"].last_extraction_updated_time).toBe("2026-06-29T00:00:01.000Z");
+    expect(cp.runner_states["session-b"].last_captured_timestamp).toBe(0);
+    expect(cp.runner_states["session-b"].last_l1_cursor).toBe(0);
+    expect(cp.pipeline_states["session-b"].last_extraction_updated_time).toBe("");
+    expect(result.adjustedRunnerSessions).toBe(1);
+    expect(result.adjustedPipelineSessions).toBe(1);
+  });
+
+  it("uses post-cleanup store counts when provided by memory cleaner", async () => {
+    const dataDir = await makeTempDataDir();
+    await writeL0Records(dataDir, [
+      l0Record("session-a", "old-l0", "2026-06-28T00:00:00.000Z", 101),
+      l0Record("session-a", "new-l0", "2026-06-30T00:00:00.000Z", 201),
+    ]);
+    await writeL1Records(dataDir, [
+      l1Record("session-a", "old-l1", "2026-06-28T00:00:00.000Z"),
+      l1Record("session-a", "new-l1", "2026-06-30T00:00:00.000Z"),
+    ]);
+
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write({
+      ...(await checkpoint.read()),
+      l0_conversations_count: 10,
+      total_processed: 10,
+      total_memories_extracted: 10,
+      memories_since_last_persona: 10,
+    });
+
+    const store = new FakeMemoryStore({ l0: 1, l1: 1 });
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: store,
+      checkpoint,
+    });
+
+    await cleaner.runOnce(Date.parse("2026-06-30T12:00:00.000Z"));
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(1);
+    expect(cp.total_processed).toBe(1);
+    expect(cp.total_memories_extracted).toBe(1);
+    expect(cp.memories_since_last_persona).toBe(1);
+
+    const conversations = await readFile(path.join(dataDir, "conversations", "2026-06-30.jsonl"), "utf-8");
+    expect(conversations).toContain("new-l0");
+  });
+});
+
+async function makeTempDataDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeL0Records(dataDir: string, records: Array<Record<string, unknown>>): Promise<void> {
+  const dir = path.join(dataDir, "conversations");
+  await writeRecordsByShardDate(dir, records, "recordedAt");
+}
+
+async function writeL1Records(dataDir: string, records: Array<Record<string, unknown>>): Promise<void> {
+  const dir = path.join(dataDir, "records");
+  await writeRecordsByShardDate(dir, records, "updatedAt");
+}
+
+async function writeRecordsByShardDate(
+  dir: string,
+  records: Array<Record<string, unknown>>,
+  dateField: string,
+): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  const byDate = new Map<string, Record<string, unknown>[]>();
+  for (const record of records) {
+    const value = typeof record[dateField] === "string" ? record[dateField] as string : "2026-06-29T00:00:00.000Z";
+    const shard = value.slice(0, 10);
+    byDate.set(shard, [...(byDate.get(shard) ?? []), record]);
+  }
+  for (const [shard, shardRecords] of byDate) {
+    await writeFile(path.join(dir, `${shard}.jsonl`), shardRecords.map((record) => JSON.stringify(record)).join("\n") + "\n");
+  }
+}
+
+function l0Record(sessionKey: string, id: string, recordedAt: string, timestamp: number): Record<string, unknown> {
+  return {
+    sessionKey,
+    sessionId: "sid",
+    recordedAt,
+    id,
+    role: "user",
+    content: id,
+    timestamp,
+  };
+}
+
+function l1Record(sessionKey: string, id: string, updatedAt: string): Record<string, unknown> {
+  return {
+    id,
+    content: id,
+    type: "episodic",
+    priority: 50,
+    scene_name: "test",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [updatedAt],
+    createdAt: updatedAt,
+    updatedAt,
+    sessionKey,
+    sessionId: "sid",
+  };
+}
+
+class FakeMemoryStore implements Partial<IMemoryStore> {
+  constructor(private readonly counts: { l0: number; l1: number }) {}
+
+  isDegraded(): boolean {
+    return false;
+  }
+
+  async countL0(): Promise<number> {
+    return this.counts.l0;
+  }
+
+  async countL1(): Promise<number> {
+    return this.counts.l1;
+  }
+
+  async deleteL0Expired(): Promise<number> {
+    return 1;
+  }
+
+  async deleteL1Expired(): Promise<number> {
+    return 1;
+  }
+}

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -146,6 +146,28 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+export interface CheckpointRecalculateOptions {
+  /** Actual retained L0 row count from the active store. Falls back to local JSONL count when omitted. */
+  l0ConversationsCount?: number;
+  /** Actual retained L1 record count from the active store. Falls back to local JSONL count when omitted. */
+  totalMemoriesExtracted?: number;
+}
+
+export interface CheckpointRecalculateResult {
+  before: Pick<Checkpoint, "l0_conversations_count" | "total_memories_extracted" | "total_processed" | "memories_since_last_persona">;
+  after: Pick<Checkpoint, "l0_conversations_count" | "total_memories_extracted" | "total_processed" | "memories_since_last_persona">;
+  adjustedRunnerSessions: number;
+  adjustedPipelineSessions: number;
+}
+
+interface LocalDataSnapshot {
+  l0Count: number;
+  l1Count: number;
+  maxL0TimestampBySession: Map<string, number>;
+  maxL0RecordedAtMsBySession: Map<string, number>;
+  maxL1UpdatedAtBySession: Map<string, string>;
+}
+
 // ============================
 // Per-file async lock
 // ============================
@@ -296,6 +318,95 @@ export class CheckpointManager {
   // ============================
   // Public API — mutating (all serialized via file lock)
   // ============================
+
+  /**
+   * Recalculate checkpoint counters from retained data.
+   *
+   * Local JSONL files are scanned as the fallback source of truth. Callers that
+   * have an initialized VectorStore should pass post-cleanup store counts via
+   * `options`, because SQLite/TCVDB contain exactly the rows used by recall.
+   *
+   * This intentionally corrects counters downward as well as upward. It also
+   * clamps per-session cursors when local retained data proves a cursor points
+   * beyond the newest available row, preventing stale checkpoint state from
+   * skipping retained records after manual pruning or cleanup.
+   */
+  async recalculate(options: CheckpointRecalculateOptions = {}): Promise<CheckpointRecalculateResult> {
+    const snapshot = await this.scanLocalData();
+
+    let result!: CheckpointRecalculateResult;
+    const cp = await this.mutate((cp) => {
+      const before = pickCounterSnapshot(cp);
+      const actualL0 = options.l0ConversationsCount ?? snapshot.l0Count;
+      const actualL1 = options.totalMemoriesExtracted ?? snapshot.l1Count;
+      const memoryDelta = actualL1 - cp.total_memories_extracted;
+
+      cp.l0_conversations_count = Math.max(0, actualL0);
+      cp.total_processed = Math.max(0, actualL0);
+      cp.total_memories_extracted = Math.max(0, actualL1);
+      cp.memories_since_last_persona = clampNonNegative(
+        cp.memories_since_last_persona + memoryDelta,
+        cp.total_memories_extracted,
+      );
+      cp.last_persona_at = Math.min(cp.last_persona_at, cp.total_processed);
+
+      let adjustedRunnerSessions = 0;
+      for (const [sessionKey, state] of Object.entries(cp.runner_states ?? {})) {
+        let adjusted = false;
+        const maxCaptured = snapshot.maxL0TimestampBySession.get(sessionKey);
+        if (maxCaptured !== undefined && state.last_captured_timestamp > maxCaptured) {
+          state.last_captured_timestamp = maxCaptured;
+          adjusted = true;
+        } else if (maxCaptured === undefined && state.last_captured_timestamp > 0) {
+          state.last_captured_timestamp = 0;
+          adjusted = true;
+        }
+
+        const maxL1Cursor = snapshot.maxL0RecordedAtMsBySession.get(sessionKey);
+        if (maxL1Cursor !== undefined && state.last_l1_cursor > maxL1Cursor) {
+          state.last_l1_cursor = maxL1Cursor;
+          adjusted = true;
+        } else if (maxL1Cursor === undefined && state.last_l1_cursor > 0) {
+          state.last_l1_cursor = 0;
+          adjusted = true;
+        }
+
+        if (adjusted) {
+          adjustedRunnerSessions++;
+        }
+      }
+
+      let adjustedPipelineSessions = 0;
+      for (const [sessionKey, state] of Object.entries(cp.pipeline_states ?? {})) {
+        const maxUpdatedAt = snapshot.maxL1UpdatedAtBySession.get(sessionKey);
+        if (maxUpdatedAt !== undefined && state.last_extraction_updated_time > maxUpdatedAt) {
+          state.last_extraction_updated_time = maxUpdatedAt;
+          adjustedPipelineSessions++;
+        } else if (maxUpdatedAt === undefined && state.last_extraction_updated_time) {
+          state.last_extraction_updated_time = "";
+          adjustedPipelineSessions++;
+        }
+      }
+
+      result = {
+        before,
+        after: pickCounterSnapshot(cp),
+        adjustedRunnerSessions,
+        adjustedPipelineSessions,
+      };
+    });
+
+    this.logger.info(
+      `[checkpoint] recalculate: ` +
+      `L0 ${result.before.l0_conversations_count}→${result.after.l0_conversations_count}, ` +
+      `L1 ${result.before.total_memories_extracted}→${result.after.total_memories_extracted}, ` +
+      `total_processed ${result.before.total_processed}→${result.after.total_processed}, ` +
+      `memories_since ${result.before.memories_since_last_persona}→${result.after.memories_since_last_persona}, ` +
+      `runnerAdjusted=${result.adjustedRunnerSessions}, pipelineAdjusted=${result.adjustedPipelineSessions}`,
+    );
+
+    return result;
+  }
 
   // ============================
   // Persona methods (L3)
@@ -485,4 +596,126 @@ export class CheckpointManager {
     });
   }
 
+  private async scanLocalData(): Promise<LocalDataSnapshot> {
+    const dataDir = path.dirname(path.dirname(this.filePath));
+    const snapshot: LocalDataSnapshot = {
+      l0Count: 0,
+      l1Count: 0,
+      maxL0TimestampBySession: new Map(),
+      maxL0RecordedAtMsBySession: new Map(),
+      maxL1UpdatedAtBySession: new Map(),
+    };
+
+    await scanJsonlDir(path.join(dataDir, "conversations"), (record) => {
+      const sessionKey = asNonEmptyString(record.sessionKey);
+      if (!sessionKey) return;
+
+      snapshot.l0Count += 1;
+
+      const timestamp = asFiniteNumber(record.timestamp);
+      if (timestamp !== undefined) {
+        setMaxNumber(snapshot.maxL0TimestampBySession, sessionKey, timestamp);
+      }
+
+      const recordedAtMs = asEpochMs(record.recordedAt);
+      if (recordedAtMs !== undefined) {
+        setMaxNumber(snapshot.maxL0RecordedAtMsBySession, sessionKey, recordedAtMs);
+      }
+    });
+
+    await scanJsonlDir(path.join(dataDir, "records"), (record) => {
+      const sessionKey = asNonEmptyString(record.sessionKey);
+      if (!sessionKey) return;
+
+      snapshot.l1Count += 1;
+
+      const updatedAt = asNonEmptyString(record.updatedAt) ?? asNonEmptyString(record.createdAt);
+      if (updatedAt) {
+        setMaxString(snapshot.maxL1UpdatedAtBySession, sessionKey, updatedAt);
+      }
+    });
+
+    return snapshot;
+  }
+
+}
+
+async function scanJsonlDir(dirPath: string, onRecord: (record: Record<string, unknown>) => void): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const files = entries
+    .filter((entry) => entry.isFile() && /^\d{4}-\d{2}-\d{2}\.(?:jsonl|json)$/.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const fileName of files) {
+    let raw: string;
+    try {
+      raw = await fs.readFile(path.join(dirPath, fileName), "utf-8");
+    } catch {
+      continue;
+    }
+
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          onRecord(parsed as Record<string, unknown>);
+        }
+      } catch {
+        // Ignore malformed JSONL lines, matching readers' fault-tolerant behavior.
+      }
+    }
+  }
+}
+
+function pickCounterSnapshot(
+  cp: Checkpoint,
+): CheckpointRecalculateResult["before"] {
+  return {
+    l0_conversations_count: cp.l0_conversations_count,
+    total_memories_extracted: cp.total_memories_extracted,
+    total_processed: cp.total_processed,
+    memories_since_last_persona: cp.memories_since_last_persona,
+  };
+}
+
+function clampNonNegative(value: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(value, Math.max(0, max)));
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asEpochMs(value: unknown): number | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function setMaxNumber(map: Map<string, number>, key: string, value: number): void {
+  const prev = map.get(key);
+  if (prev === undefined || value > prev) {
+    map.set(key, value);
+  }
+}
+
+function setMaxString(map: Map<string, string>, key: string, value: string): void {
+  const prev = map.get(key);
+  if (prev === undefined || value > prev) {
+    map.set(key, value);
+  }
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -12,6 +13,7 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  checkpoint?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -33,14 +35,20 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpoint?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpoint = opts.checkpoint;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  setCheckpointManager(checkpoint: CheckpointManager | undefined): void {
+    this.checkpoint = checkpoint;
   }
 
   start(): void {
@@ -180,6 +188,10 @@ export class LocalMemoryCleaner {
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
     }
 
+    if (this.checkpoint && total.changedFiles > 0) {
+      await this.recalculateCheckpoint();
+    }
+
     this.opts.logger?.info(
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
@@ -275,6 +287,29 @@ export class LocalMemoryCleaner {
     }
 
     return stats;
+  }
+
+  private async recalculateCheckpoint(): Promise<void> {
+    let l0ConversationsCount: number | undefined;
+    let totalMemoriesExtracted: number | undefined;
+
+    if (this.vectorStore && !this.vectorStore.isDegraded()) {
+      try { l0ConversationsCount = await this.vectorStore.countL0(); } catch { /* fall back to JSONL */ }
+      try { totalMemoriesExtracted = await this.vectorStore.countL1(); } catch { /* fall back to JSONL */ }
+    }
+
+    try {
+      const result = await this.checkpoint!.recalculate({ l0ConversationsCount, totalMemoriesExtracted });
+      this.opts.logger?.info(
+        `${TAG} [checkpoint] recalculated after cleanup: ` +
+        `L0 ${result.before.l0_conversations_count}→${result.after.l0_conversations_count}, ` +
+        `L1 ${result.before.total_memories_extracted}→${result.after.total_memories_extracted}`,
+      );
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `${TAG} [checkpoint] recalculation failed after cleanup: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION

## Description | 描述

This PR fixes checkpoint drift after local memory data is cleaned or pruned.

Issue #157 points out that checkpoint counters such as `l0_conversations_count`, `total_processed`, and `total_memories_extracted` only ever increase. When retained L0/L1 data is removed by memory cleanup, manual JSONL pruning, or a session reset, the checkpoint can remain ahead of the actual data. That drift can also leave per-session cursors ahead of retained records, causing later incremental L1/L2 processing to skip records that should still be processed.

This PR adds `CheckpointManager.recalculate()` and wires it into cleanup/startup paths:

- Rebuild checkpoint counters from the active VectorStore counts when available.
- Fall back to scanning retained local JSONL shards:
  - `conversations/YYYY-MM-DD.jsonl`
  - `records/YYYY-MM-DD.jsonl`
- Clamp stale per-session runner cursors:
  - `runner_states[session].last_captured_timestamp`
  - `runner_states[session].last_l1_cursor`
- Clamp stale per-session pipeline cursors:
  - `pipeline_states[session].last_extraction_updated_time`
- Reset session cursors to `0` or `""` when checkpoint state still exists but retained data for that session no longer exists.
- Recalculate checkpoint state before scheduler startup so restored pipeline states start from corrected checkpoint data.
- Recalculate checkpoint state after `LocalMemoryCleaner` removes JSONL shards or VectorStore rows.

Example:

```text
checkpoint.last_l1_cursor = 2026-06-30T00:00:00.000Z
retained newest L0 recordedAt = 2026-06-29T00:00:00.000Z
new retained row after cleanup = 2026-06-29T00:00:02.000Z
```

is now corrected so the L1 cursor is rolled back to:

```text
2026-06-29T00:00:00.000Z
```

instead of leaving the stale 2026-06-30 cursor and skipping the new retained row.

## Related Issue | 关联 Issue

Fix #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Acceptance Criteria Coverage | 验收标准对应

### 基础：阅读源码，画出 checkpoint 数据流图，确认漂移问题和影响范围

Completed.

Checkpoint data flow:

<img width="1115" height="2018" alt="issue-157-checkpoint-flow" src="https://github.com/user-attachments/assets/827bbfed-9913-4e9a-abd8-5e23c7b670c4" />

Confirmed checkpoint update and read paths:

- L0 capture path:
  - `captureAtomically()` advances `runner_states[session].last_captured_timestamp`.
  - It increments `total_processed`.
  - It increments `l0_conversations_count`.
- L1 extraction path:
  - `markL1ExtractionComplete()` advances `runner_states[session].last_l1_cursor`.
  - It increments `total_memories_extracted`.
  - It increments `memories_since_last_persona`.
- L2 pipeline path:
  - `PipelineManager.runL2()` reads `pipeline_states[session].last_extraction_updated_time` as the L1 incremental cursor.
  - It advances that cursor to the latest processed L1 `updatedAt`.
- Cleanup paths:
  - `LocalMemoryCleaner` removes expired `conversations/` and `records/` JSONL shards.
  - It can also delete expired L0/L1 rows from the active VectorStore.
  - Before this PR, cleanup did not reduce checkpoint counters or rollback stale cursors.

Impact:

- Global counters could permanently overstate retained data.
- L1 could skip retained L0 rows because `last_l1_cursor` was newer than the remaining `recordedAt` values.
- L2 could skip retained L1 rows because `last_extraction_updated_time` was newer than the remaining `updatedAt` values.
- Resetting a session's data could leave old session cursors in checkpoint state, causing newly retained records for that session to be skipped.

### 进阶：实现至少一种修复方案并提交 PR（增加 `decrement` 或引入 `recalculate` 逻辑）

Completed.

Added `CheckpointManager.recalculate(options)` in `src/utils/checkpoint.ts`.

The recalculation updates:

- `l0_conversations_count`
- `total_processed`
- `total_memories_extracted`
- `memories_since_last_persona`
- `last_persona_at`
- `runner_states[session].last_captured_timestamp`
- `runner_states[session].last_l1_cursor`
- `pipeline_states[session].last_extraction_updated_time`

The method accepts optional store-derived counts:

```ts
{
  l0ConversationsCount?: number;
  totalMemoriesExtracted?: number;
}
```

When store counts are not available, it scans local JSONL as the source of truth. This handles manual pruning and JSONL-only fallback mode.

This PR uses recalculation instead of a narrow decrement API because cleanup can remove arbitrary shards, DB rows, or whole sessions. In those cases, the exact decrement amount may not be available at the checkpoint layer.

### 深入：覆盖多种清理场景（手动 / 自动 / 重置）的测试用例

Completed.

Added `src/utils/checkpoint.test.ts` with coverage for:

- Manual JSONL pruning:
  - Starts checkpoint counters above retained L0/L1 data.
  - Verifies `recalculate()` lowers counters to the retained rows.
- Stale cursor rollback:
  - Starts L1 and L2 cursors ahead of retained local data.
  - Verifies L1 cursor is clamped to retained L0 `recordedAt`.
  - Verifies L2 cursor is clamped to retained L1 `updatedAt`.
- Incremental skip prevention:
  - Writes a new L0 row after recalculation.
  - Verifies `readConversationMessagesGroupedBySessionId()` reads that row using the corrected L1 cursor.
- Session reset:
  - Keeps retained data for `session-a`.
  - Leaves stale checkpoint state for deleted/reset `session-b`.
  - Verifies `session-b` runner cursors reset to `0`.
  - Verifies `session-b` pipeline cursor resets to `""`.
  - Verifies `session-a` state remains unchanged.
- Automatic cleaner cleanup:
  - Runs `LocalMemoryCleaner.runOnce()`.
  - Verifies checkpoint recalculation uses post-cleanup store counts when provided.
  - Verifies retained JSONL data remains available after cleanup.

### 拓展：分析是否有更好的 Checkpoint 设计模式（如基于时间戳而非计数器）

Addressed through a compatibility-preserving cursor-first repair.

This PR keeps the existing checkpoint schema to avoid a broad migration, but treats timestamp cursors as the correctness-critical state:

- `last_l1_cursor` is based on retained L0 `recordedAt`, which is the actual L1 incremental source cursor.
- `last_extraction_updated_time` is based on retained L1 `updatedAt`, which is the actual L2 incremental source cursor.
- Counters are recalculated as derived status/trigger values instead of being trusted as append-only truth after cleanup.

A larger redesign could make counters fully derived from retained storage and use timestamp cursors as the primary checkpoint contract. This PR keeps that redesign out of scope and implements the minimal compatible fix for issue #157.

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

- [x] Checkpoint counters recalculate after manual JSONL pruning
  - Created retained L0/L1 JSONL records.
  - Started checkpoint counters above actual retained rows.
  - Verified `l0_conversations_count`, `total_processed`, `total_memories_extracted`, and `memories_since_last_persona` are recalculated downward.

- [x] Stale L1 and L2 cursors are clamped to retained local data
  - Started `last_l1_cursor` ahead of retained L0 `recordedAt`.
  - Started `last_extraction_updated_time` ahead of retained L1 `updatedAt`.
  - Verified both cursors are rolled back to the newest retained local data.

- [x] Incremental L1 processing does not skip rows after checkpoint drift repair
  - Wrote a new L0 row whose `recordedAt` is below the old stale cursor but above the corrected cursor.
  - Verified `readConversationMessagesGroupedBySessionId()` returns that row with the corrected cursor.

- [x] Session reset/no-data cleanup resets stale per-session cursors
  - Kept retained data for one session.
  - Removed retained data for another session while leaving checkpoint state behind.
  - Verified the deleted/reset session's runner cursors reset to `0`.
  - Verified the deleted/reset session's pipeline cursor resets to `""`.
  - Verified the retained session remains unchanged.

- [x] Automatic cleaner recalculates checkpoint after cleanup
  - Ran `LocalMemoryCleaner.runOnce()` with expired and retained L0/L1 JSONL rows.
  - Provided post-cleanup store counts through a fake VectorStore.
  - Verified checkpoint counters match post-cleanup store counts.
  - Verified retained non-expired JSONL data remains present.

- [x] Real SQLite + JSONL cleanup flow works end to end
  - Verified a real local cleanup flow with actual `VectorStore` SQLite storage, JSONL shards, `LocalMemoryCleaner`, `CheckpointManager`, and both SQLite/JSONL incremental L0 readers.
  - Inserted 60 L0 rows and 25 L1 rows into both SQLite and JSONL so cleanup exceeds the cleaner minimum-retention thresholds (`MIN_RETAIN_L0=50`, `MIN_RETAIN_L1=20`).
  - Marked 10 L0 rows and 5 L1 rows as expired, then ran the real `LocalMemoryCleaner.runOnce()`.
  - Verified checkpoint counters recalculate to 50 retained L0 rows and 20 retained L1 rows after cleanup:
    - `l0_conversations_count=50`
    - `total_processed=50`
    - `total_memories_extracted=20`
    - `memories_since_last_persona=20`
  - Verified retained `session-a` stale cursors roll back to the newest retained data:
    - `last_captured_timestamp=249`
    - `last_l1_cursor=2026-06-30T00:00:49.000Z`
    - `last_extraction_updated_time=2026-06-30T00:00:19.000Z`
  - Verified reset/deleted `session-b` stale cursors are cleared:
    - `last_captured_timestamp=0`
    - `last_l1_cursor=0`
    - `last_extraction_updated_time=""`
  - Inserted a new post-cleanup L0 row, `new-l0-after-cleanup`, and verified it is not skipped by either incremental read path:
    - real SQLite `queryL0GroupedBySessionId()`
    - JSONL fallback `readConversationMessagesGroupedBySessionId()`

- [x] Startup path recalculates checkpoint before scheduler state restore
  - Wired `TdaiCore.ensureSchedulerStarted()` to call checkpoint recalculation before reading pipeline states.
  - Store count failures fall back to JSONL scan instead of making startup fail.

- [x] Full test suite passes

```bash
npx vitest run src/utils/checkpoint.test.ts
```

```text
1 test file passed
4 tests passed
```

```bash
npx tsx /Users/lyra/Documents/Codex/2026-06-30/zi-x/work/verify-issue157-real.ts
```

```text
passed
counters: L0=50, totalProcessed=50, L1=20, memoriesSince=20
retained session cursor: last_l1_cursor=2026-06-30T00:00:49.000Z
reset session cursor: last_l1_cursor=0
SQLite incremental read IDs: ["new-l0-after-cleanup"]
JSONL incremental read IDs: ["new-l0-after-cleanup"]
```

```bash
npm test
```

```text
5 test files passed
71 tests passed
```

```bash
npm run build
```

```text
passed
```

```bash
git diff --check
```

```text
passed
```
