### PR TITLE
fix(search): sanitize FTS5 operators before tokenization

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("keeps ordinary fallback tokens OR-joined as quoted phrases", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("travel plan API")).toBe('"travel" OR "plan" OR "API"');
+  });
+
+  it("strips FTS5 operators before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta OR NOT gamma NEAR delta")).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta"',
+    );
+  });
+
+  it("strips operators case-insensitively without deleting containing words", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("android ordinary notable nearby Or NOT")).toBe(
+      '"android" OR "ordinary" OR "notable" OR "nearby"',
+    );
+  });
+
+  it("returns null when input contains only FTS5 operators", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  });
+
+  it("applies the same operator stripping before jieba tokenization", () => {
+    const cutInputs: string[] = [];
+
+    _setJiebaForTest({
+      cutForSearch(text, hmm) {
+        cutInputs.push(text);
+        expect(hmm).toBe(true);
+        return text.split(/\s+/).filter(Boolean);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe('"用户" OR "TypeScript" OR "记忆"');
+    expect(cutInputs).toEqual(["用户   TypeScript   记忆"]);
+  });
+
+  it("filters FTS5 operators returned by jieba while keeping normal tokens", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["用户", "AND", "TypeScript", "OR", "用户", "的", "nearby"],
+    });
+
+    expect(buildFtsQuery("ignored raw text")).toBe('"用户" OR "TypeScript" OR "nearby"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,23 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATOR_RE = /(?<![\p{L}\p{N}_])(?:AND|OR|NOT|NEAR)(?![\p{L}\p{N}_])/giu;
+const FTS5_OPERATOR_TOKENS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function stripFts5Operators(raw: string): string {
+  return raw.replace(FTS5_OPERATOR_RE, " ");
+}
+
+function isSearchableFtsToken(token: string): boolean {
+  if (!token) return false;
+  // Remove pure whitespace / punctuation tokens
+  if (!/[\p{L}\p{N}]/u.test(token)) return false;
+  if (FTS5_OPERATOR_TOKENS.has(token.toUpperCase())) return false;
+  // Remove common Chinese stop-words to reduce noise
+  if (ZH_STOP_WORDS.has(token)) return false;
+  return true;
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -197,31 +214,25 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const cleaned = stripFts5Operators(raw);
 
   let tokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .filter(isSearchableFtsToken);
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        .filter(isSearchableFtsToken) ?? [];
   }
 
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Description | 描述

Fixes #160.

This PR hardens `buildFtsQuery()` against SQLite FTS5 operator injection by filtering reserved FTS5 operators before query tokenization and again at token level.

The change keeps FTS5-specific validation at the query-construction boundary:
- `sanitizeText()` remains responsible for memory-pipeline text cleanup.
- `buildFtsQuery()` owns conversion from user text to SQLite FTS5 `MATCH` syntax.

What changed:
- Strip standalone `AND` / `OR` / `NOT` / `NEAR` before both jieba and fallback tokenization.
- Filter the same reserved operators again after tokenization as defense-in-depth.
- Keep the existing quoted-token `OR` recall strategy unchanged.
- Preserve normal words containing operator substrings, such as `android`, `ordinary`, `notable`, and `nearby`.
- Add focused tests for fallback and mocked jieba paths.

## Related Issue | 关联 Issue

Fixes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Validation:
- `npm test -- src/core/store/sqlite.test.ts`
  - 1 file passed, 6 tests passed
- `npm test`
  - 5 files passed, 73 tests passed
- `npm run build`
  - build passed
  - dist total: 784.38 kB
- `npm pack --dry-run`
  - package size: 710.5 kB, below the 2048 kB limit


<summary>Evidence screenshots | 验证截图</summary>

### Targeted test | 定向测试

<img width="912" height="378" alt="01-targeted-test" src="https://github.com/user-attachments/assets/090effce-b51e-4d59-8f1f-5bc82a956c02" />

### Full test suite | 全量测试

<img width="931" height="378" alt="02-full-test" src="https://github.com/user-attachments/assets/8abb9d07-9cca-437d-962d-686ae0ef3fbf" />

### Build | 构建

<img width="1096" height="840" alt="03-build" src="https://github.com/user-attachments/assets/efff6457-9778-4961-9ebf-9f6a7774249a" />

### Package size | 打包体积

<img width="1096" height="1038" alt="04-pack-size" src="https://github.com/user-attachments/assets/996a44ef-8309-401b-8e75-d54fb6cb0c9b" />

### Smoke output | 烟雾测试输出

<img width="900" height="220" alt="05-smoke-output" src="https://github.com/user-attachments/assets/1afae2d9-64c4-4af2-99a7-ddb37416be89" />



## Additional Notes | 其他说明

Environment:
- OS: macOS 15.7.1 (24G231), arm64
- CPU: Apple M1
- Memory: 8 GB
- Node.js: v25.9.0
- npm: 11.12.1
- Package: @tencentdb-agent-memory/memory-tencentdb v0.3.6

No runtime dependency, public API, schema, or indexing behavior changes.