### PR TITLE
fix(recall): keep stable empty recall wrapper

### DIFF
--- a/src/core/hooks/__tests__/stable-wrapper.test.ts
+++ b/src/core/hooks/__tests__/stable-wrapper.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseConfig } from "../../../config.js";
+import { performAutoRecall } from "../auto-recall.js";
+import type { IMemoryStore, L1FtsResult, StoreCapabilities } from "../../store/types.js";
+import type { Logger } from "../../types.js";
+
+const tempDirs: string[] = [];
+
+const logger: Logger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const capabilities: StoreCapabilities = {
+  vectorSearch: false,
+  ftsSearch: true,
+  nativeHybridSearch: false,
+  sparseVectors: false,
+};
+
+function makeStore(results: L1FtsResult[]): IMemoryStore {
+  return {
+    getCapabilities: () => capabilities,
+    isFtsAvailable: () => true,
+    searchL1Fts: () => results,
+    searchL1Vector: () => [],
+  } as unknown as IMemoryStore;
+}
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-stable-wrapper-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function recall(results: L1FtsResult[], userText = "How is my prompt cache?") {
+  return performAutoRecall({
+    userText,
+    actorId: "agent",
+    sessionKey: "session",
+    cfg: parseConfig({
+      recall: {
+        strategy: "keyword",
+        scoreThreshold: 0,
+      },
+    }),
+    pluginDataDir: await makeDataDir(),
+    logger,
+    vectorStore: makeStore(results),
+  });
+}
+
+function ftsResult(content: string): L1FtsResult {
+  return {
+    record_id: `record-${content}`,
+    content,
+    type: "instruction",
+    priority: 1,
+    scene_name: "",
+    score: 1,
+    timestamp_str: "",
+    timestamp_start: "",
+    timestamp_end: "",
+    session_key: "session",
+    session_id: "session-id",
+    metadata_json: "{}",
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("performAutoRecall stable wrapper", () => {
+  it("keeps a relevant-memories wrapper when L1 search runs with zero hits", async () => {
+    const result = await recall([]);
+
+    expect(result?.prependContext).toContain("<relevant-memories>");
+    expect(result?.prependContext).toContain("未召回相关记忆");
+    expect(result?.prependContext).toContain("</relevant-memories>");
+    expect(result?.appendSystemContext).toContain("<memory-tools-guide>");
+    expect(result?.recalledL1Memories).toEqual([]);
+  });
+
+  it("keeps real recalled memories instead of the empty placeholder", async () => {
+    const result = await recall([ftsResult("User prefers concise answers")]);
+
+    expect(result?.prependContext).toContain("<relevant-memories>");
+    expect(result?.prependContext).toContain("User prefers concise answers");
+    expect(result?.prependContext).not.toContain("未召回相关记忆");
+  });
+
+  it("does not inject the empty wrapper when recall search is skipped", async () => {
+    const result = await recall([], "");
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -27,6 +27,7 @@ const TAG = "[memory-tdai] [recall]";
 const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
 const MIN_TRUNCATED_RECALL_LINE_CHARS = 40;
 const RECALL_LINE_SEPARATOR = "\n";
+const NO_RELEVANT_MEMORIES_PLACEHOLDER = "（本次对话未召回相关记忆）";
 
 /**
  * Memory tools usage guide — injected at the end of memory context so the
@@ -115,12 +116,14 @@ async function performAutoRecallInner(params: {
   // Search relevant memories (L1 layer) — skip only when userText is empty/undefined
   const tSearchStart = performance.now();
   let memoryLines: string[] = [];
+  let memorySearchAttempted = false;
   let effectiveStrategy = "skipped";
   let recalledL1Memories: RecalledMemory[] = [];
   let searchTiming: SearchTiming = { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 };
   if (!userText || userText.length === 0) {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
+    memorySearchAttempted = true;
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
     const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
     memoryLines = searchResult.lines;
@@ -169,7 +172,7 @@ async function performAutoRecallInner(params: {
   }
   const tSceneEnd = performance.now();
 
-  if (memoryLines.length === 0 && !personaContent && !sceneNavigation) {
+  if (!memorySearchAttempted && memoryLines.length === 0 && !personaContent && !sceneNavigation) {
     const totalMs = performance.now() - tRecallStart;
     logger?.info(
       `${TAG} ⏱ Recall timing: total=${totalMs.toFixed(0)}ms, ` +
@@ -202,10 +205,13 @@ async function performAutoRecallInner(params: {
   }
 
   // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
+  // Keep the wrapper even for zero-hit searches so prompt shape stays stable.
   let prependContext: string | undefined;
   if (memoryLines.length > 0) {
     prependContext =
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
+  } else if (memorySearchAttempted) {
+    prependContext = `<relevant-memories>\n${NO_RELEVANT_MEMORIES_PLACEHOLDER}\n</relevant-memories>`;
   }
 
   // Append memory tools usage guide to the stable part so the agent knows


### PR DESCRIPTION
## Summary

Re-scoped per reviewer triage: #375 is now the canonical scoped runtime mitigation for #120, and #195 already owns Gateway/Hermes context splitting.

This PR is no longer trying to be the #120 baseline fix. It is a small follow-up candidate for the one behavior not covered by that baseline: keeping the existing `<relevant-memories>` dynamic recall wrapper stable when an L1 search runs but returns zero hits.

## Review map

The diff is intentionally small. The quickest review path is:

- Core behavior: [`src/core/hooks/auto-recall.ts`](https://github.com/Arreboi06/TencentDB-Agent-Memory/blob/92d962d4f4819753476bf6e7f1a61d4233da194a/src/core/hooks/auto-recall.ts#L116-L214)
  - tracks whether L1 search actually ran
  - keeps the empty `<relevant-memories>` wrapper only for attempted zero-hit recall
  - keeps skipped recall as no injection
- Contract tests: [`src/core/hooks/__tests__/stable-wrapper.test.ts`](https://github.com/Arreboi06/TencentDB-Agent-Memory/blob/92d962d4f4819753476bf6e7f1a61d4233da194a/src/core/hooks/__tests__/stable-wrapper.test.ts#L80-L101)
  - zero-hit search keeps the wrapper
  - real hits do not use the empty placeholder
  - skipped search injects nothing
## What changed

- Keep a `<relevant-memories>...</relevant-memories>` block when recall search is attempted and returns no L1 memories.
- Use a short empty-state placeholder inside that existing wrapper.
- Preserve existing behavior when real L1 memories are recalled.
- Preserve existing behavior when recall search is skipped, such as empty user text.
- Add focused tests around the zero-hit, hit, and skipped-search cases.

## What this deliberately does not change

- No `recall.cacheOptimization` config knobs.
- No Gateway response contract changes.
- No Hermes/OpenClaw adapter contract changes.
- No README / CHANGELOG claims that this replaces #375.

## Why this is a follow-up to #375

#375 addresses the canonical OpenClaw runtime mitigation for #120: dynamic recall placement and history cleanup. This PR only adds the stable-wrapper detail so prefix-matching cache providers do not see the recall prompt layout alternate between "has wrapper" and "no wrapper" on L1 hit vs zero-hit turns.

The implementation stays inside `performAutoRecall` and distinguishes:

- search attempted + zero hits -> stable empty wrapper
- search attempted + hits -> existing real recall wrapper
- search skipped -> no injected wrapper

## Verification

- TDD red check: `npm test -- src/core/hooks/__tests__/stable-wrapper.test.ts` failed before implementation because `prependContext` was `undefined` for zero-hit recall.
- Focused test: `npm test -- src/core/hooks/__tests__/stable-wrapper.test.ts` -> 3 tests passed.
- Full test suite: `npm test` -> 5 test files passed, 70 tests passed.
- Build: `npm run build` -> plugin build and script TypeScript builds passed.
- Whitespace: `git diff --check origin/main...HEAD` -> passed.

Build note: tsdown prints a Node.js v22.17.0 deprecation warning, but the build exits successfully.