### PR TITLE
fix(record): retry invalid l1 extraction output and trim pipeline debug logs

### DIFF
--- a/src/core/record/l1-extractor.test.ts
+++ b/src/core/record/l1-extractor.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractL1Memories } from "./l1-extractor.js";
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { LLMRunner, LLMRunParams, Logger } from "../types.js";
+
+class SequenceRunner implements LLMRunner {
+  public calls: LLMRunParams[] = [];
+
+  constructor(private readonly outputs: string[]) {}
+
+  async run(params: LLMRunParams): Promise<string> {
+    this.calls.push(params);
+    return this.outputs.shift() ?? "";
+  }
+}
+
+const logger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-l1-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function sampleMessages(): ConversationMessage[] {
+  const base = Date.now();
+  return [
+    {
+      id: "msg_u1",
+      role: "user",
+      content: "以后回答默认用中文，简洁一点，记住这个长期要求。",
+      timestamp: base,
+    },
+    {
+      id: "msg_a1",
+      role: "assistant",
+      content: "好的，我以后默认用中文并保持简洁。",
+      timestamp: base + 1,
+    },
+  ];
+}
+
+describe("extractL1Memories retry recovery", () => {
+  it("retries once when the first extraction returns natural language instead of JSON", async () => {
+    const runner = new SequenceRunner([
+      "好的，我先分析这段对话，然后再提取记忆。",
+      JSON.stringify([
+        {
+          scene_name: "我在和用户确认长期回答风格偏好",
+          message_ids: ["msg_u1", "msg_a1"],
+          memories: [
+            {
+              content: "用户要求 AI 以后默认用中文并保持简洁。",
+              type: "instruction",
+              priority: 95,
+              source_message_ids: ["msg_u1"],
+              metadata: {},
+            },
+          ],
+        },
+      ]),
+    ]);
+
+    const result = await extractL1Memories({
+      messages: sampleMessages(),
+      sessionKey: "test_session",
+      baseDir: await makeTempDir(),
+      config: {},
+      logger,
+      options: {
+        llmRunner: runner,
+        enableDedup: false,
+      },
+    });
+
+    expect(runner.calls).toHaveLength(2);
+    expect(runner.calls[0]?.taskId).toBe("l1-extraction");
+    expect(runner.calls[1]?.taskId).toBe("l1-extraction-retry");
+    expect(result.success).toBe(true);
+    expect(result.extractedCount).toBe(1);
+    expect(result.storedCount).toBe(1);
+    expect(result.sceneNames).toEqual(["我在和用户确认长期回答风格偏好"]);
+    expect(result.records[0]?.content).toContain("默认用中文");
+  });
+
+  it("retries once when the first extraction returns an empty string", async () => {
+    const runner = new SequenceRunner([
+      "",
+      JSON.stringify([
+        {
+          scene_name: "我在和用户确认长期回答风格偏好",
+          message_ids: ["msg_u1", "msg_a1"],
+          memories: [],
+        },
+      ]),
+    ]);
+
+    const result = await extractL1Memories({
+      messages: sampleMessages(),
+      sessionKey: "test_session_empty",
+      baseDir: await makeTempDir(),
+      config: {},
+      logger,
+      options: {
+        llmRunner: runner,
+        enableDedup: false,
+      },
+    });
+
+    expect(runner.calls).toHaveLength(2);
+    expect(result.success).toBe(true);
+    expect(result.sceneNames).toEqual(["我在和用户确认长期回答风格偏好"]);
+    expect(result.extractedCount).toBe(0);
+    expect(result.storedCount).toBe(0);
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -316,18 +316,16 @@ async function callLlmExtraction(params: {
     `${TAG} [l1-debug] ENTRY taskId=l1-extraction, newMsgs=${newMessages.length}, bgMsgs=${backgroundMessages.length}, userPromptLen=${userPrompt.length}, sysPromptLen=${EXTRACT_MEMORIES_SYSTEM_PROMPT.length}, model=${model ?? "(default)"}, previousSceneName=${previousSceneName ? JSON.stringify(previousSceneName) : "(none)"}, runnerKind=${llmRunner ? "llmRunner" : "CleanContextRunner"}`,
   );
 
-  let result: string;
+  const runTextOnly = async (taskId: string, prompt: string, timeoutMs: number): Promise<string> => {
+    if (llmRunner) {
+      return llmRunner.run({
+        prompt,
+        systemPrompt: EXTRACT_MEMORIES_SYSTEM_PROMPT,
+        taskId,
+        timeoutMs,
+      });
+    }
 
-  if (llmRunner) {
-    // Use the host-neutral LLMRunner interface
-    result = await llmRunner.run({
-      prompt: userPrompt,
-      systemPrompt: EXTRACT_MEMORIES_SYSTEM_PROMPT,
-      taskId: "l1-extraction",
-      timeoutMs: 180_000,
-    });
-  } else {
-    // Fallback: create CleanContextRunner (OpenClaw path)
     const runner = new CleanContextRunner({
       config,
       modelRef: model,
@@ -335,15 +333,28 @@ async function callLlmExtraction(params: {
       logger,
     });
 
-    result = await runner.run({
-      prompt: userPrompt,
+    return runner.run({
+      prompt,
       systemPrompt: EXTRACT_MEMORIES_SYSTEM_PROMPT,
-      taskId: "l1-extraction",
-      timeoutMs: 180_000,
+      taskId,
+      timeoutMs,
     });
-  }
+  };
 
-  return parseExtractionResult(result, logger);
+  const result = await runTextOnly("l1-extraction", userPrompt, 180_000);
+  let scenes = parseExtractionResult(result, logger);
+  if (scenes.length > 0) return scenes;
+
+  const trimmed = result.trim();
+  const retryPrompt = `${userPrompt}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n上一次输出无效：必须返回且仅返回合法 JSON 数组，不能输出解释文本或 Markdown。${trimmed ? `\n上一次无效输出如下（仅供修正参考）：\n${trimmed}` : `\n上一次输出为空。`}\n\n请重新输出且只输出合法 JSON 数组。`;
+
+  logger?.warn?.(`${TAG} Primary extraction output was not parseable; retrying once with stricter JSON-only instruction`);
+  const retried = await runTextOnly("l1-extraction-retry", retryPrompt, 120_000);
+  scenes = parseExtractionResult(retried, logger);
+  if (scenes.length > 0) {
+    logger?.debug?.(`${TAG} Retry recovered ${scenes.length} scene(s) from previously invalid extraction output`);
+  }
+  return scenes;
 }
 
 /**

--- a/src/utils/pipeline-manager.ts
+++ b/src/utils/pipeline-manager.ts
@@ -1047,7 +1047,15 @@ export class MemoryPipelineManager {
       obj[k] = { ...v };
     }
     try {
-      this.logger?.debug?.(`Persisting states: ${JSON.stringify(obj)}`);
+      const sessionKeys = Object.keys(obj);
+      const activeKeys = sessionKeys.filter((key) => {
+        const state = obj[key];
+        return (state?.conversation_count ?? 0) > 0 || (state?.l2_pending_l1_count ?? 0) > 0;
+      });
+      const sampleKeys = sessionKeys.slice(0, 5);
+      this.logger?.debug?.(
+        `${TAG} Persisting states summary: total=${sessionKeys.length}, active=${activeKeys.length}, sample=${sampleKeys.join(",")}`,
+      );
       await this.persister(obj);
     } catch (err) {
       this.logger?.error(


### PR DESCRIPTION
Summary:
- retry L1 extraction once when the first response is empty or non-JSON
- add a regression test covering natural-language and empty-string failures
- replace oversized pipeline state JSON debug logs with a compact summary

Why:
- in real Hermes standalone use with low-cost extraction models, L1 sometimes returns empty text or free-form analysis instead of the required JSON array
- the existing parser then drops the extraction entirely even though a second stricter pass is often enough to recover
- pipeline debug logs can also grow excessively because they dump full persisted state JSON on every write

Validation:
- npm test -- --run src/core/record/l1-extractor.test.ts src/utils/no-think-fetch.test.ts
- npm test
