### PR TITLE
fix(search): sanitize FTS5 query tokens

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,209 @@
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+const require = createRequire(import.meta.url);
+
+function expectFallbackQuery(raw: string, expected: string | null): void {
+  _setJiebaForTest(null);
+  expect(buildFtsQuery(raw)).toBe(expected);
+}
+
+function legacyFallbackFtsQuery(raw: string): string | null {
+  const tokens =
+    raw
+      .match(/[\p{L}\p{N}_]+/gu)
+      ?.map((t) => t.trim())
+      .filter(Boolean) ?? [];
+
+  if (tokens.length === 0) return null;
+  return tokens.map((t) => `"${t.replaceAll('"', "")}"`).join(" OR ");
+}
+
+function queryFtsMatches(query: string): string[] {
+  const { DatabaseSync } = require("node:sqlite") as typeof import("node:sqlite");
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec(`
+      CREATE VIRTUAL TABLE docs USING fts5(id UNINDEXED, content);
+      INSERT INTO docs (id, content) VALUES
+        ('travel', 'travel plan api_v2 itinerary budget'),
+        ('typescript', 'typescript sqlite fts5 search builder'),
+        ('memory', 'agent memory recall ranking alpha123'),
+        ('recipe', 'sourdough starter bread recipe'),
+        ('mixed', 'travel sqlite memory alpha123 api_v2');
+    `);
+
+    return (
+      db
+        .prepare("SELECT id FROM docs WHERE docs MATCH ? ORDER BY id")
+        .all(query) as Array<{ id: string }>
+    ).map((row) => row.id);
+  } finally {
+    db.close();
+  }
+}
+
+function expectWhitelistedMatchExpression(query: string): void {
+  expect(query).toMatch(/^"[\p{L}\p{N}_]+"(?: OR "[\p{L}\p{N}_]+")*$/u);
+}
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("removes FTS5 operators before fallback tokenization", () => {
+    expectFallbackQuery(
+      "alpha AND beta or gamma NOT delta NEAR epsilon",
+      '"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon"',
+    );
+  });
+
+  it.each([
+    ["AND"],
+    ["and"],
+    ["And"],
+    ["OR"],
+    ["or"],
+    ["Or"],
+    ["NOT"],
+    ["not"],
+    ["Not"],
+    ["NEAR"],
+    ["near"],
+    ["Near"],
+  ])("removes the %s FTS5 operator as a standalone token", (operator) => {
+    expectFallbackQuery(`alpha ${operator} beta`, '"alpha" OR "beta"');
+  });
+
+  it("does not strip operator substrings inside normal words", () => {
+    expectFallbackQuery(
+      "candy origin notepad nearest ordinary android",
+      '"candy" OR "origin" OR "notepad" OR "nearest" OR "ordinary" OR "android"',
+    );
+  });
+
+  it("removes FTS5 syntax characters without dropping normal fallback terms", () => {
+    expectFallbackQuery(
+      'title:alpha (beta) "gamma" delta*',
+      '"title" OR "alpha" OR "beta" OR "gamma" OR "delta"',
+    );
+  });
+
+  it("neutralizes common FTS5 query grammar constructs", () => {
+    expectFallbackQuery(
+      '^title:alpha {body}:beta -{archived}:gamma NEAR(delta epsilon, 5) "exact phrase" tag*',
+      '"title" OR "alpha" OR "body" OR "beta" OR "archived" OR "gamma" OR "delta" OR "epsilon" OR "5" OR "exact" OR "phrase" OR "tag"',
+    );
+  });
+
+  it("builds a whitelist-only MATCH expression from hostile fallback input", () => {
+    _setJiebaForTest(null);
+
+    const query = buildFtsQuery(
+      '^title:alpha {body}:beta OR "quoted phrase" NOT gamma NEAR(delta epsilon, 5) tag*',
+    );
+
+    expect(query).not.toBeNull();
+    expectWhitelistedMatchExpression(query!);
+  });
+
+  it.each([
+    [""],
+    ["   \t\n"],
+    ['AND OR NOT NEAR "()" *'],
+    ['"\'()[]{}^*:*-+,.!?'],
+  ])("returns null when fallback input has no searchable terms: %j", (raw) => {
+    expectFallbackQuery(raw, null);
+  });
+
+  it("preserves normal mixed-language fallback search terms", () => {
+    expectFallbackQuery(
+      "旅行 plan API_v2 alpha123",
+      '"旅行" OR "plan" OR "API_v2" OR "alpha123"',
+    );
+  });
+
+  it("keeps fallback query output unchanged for normal user searches", () => {
+    _setJiebaForTest(null);
+
+    const normalQueries = [
+      "travel plan API_v2",
+      "TypeScript sqlite fts5",
+      "agent memory recall alpha123",
+      "sourdough starter recipe",
+      "multi word search 2026",
+    ];
+
+    for (const query of normalQueries) {
+      expect(buildFtsQuery(query)).toBe(legacyFallbackFtsQuery(query));
+    }
+  });
+
+  it("keeps fallback FTS5 recall unchanged for normal user searches", () => {
+    _setJiebaForTest(null);
+
+    const normalQueries = [
+      "travel plan API_v2",
+      "TypeScript sqlite",
+      "agent memory alpha123",
+      "sourdough recipe",
+      "travel memory api_v2",
+    ];
+
+    for (const raw of normalQueries) {
+      const legacyQuery = legacyFallbackFtsQuery(raw);
+      const sanitizedQuery = buildFtsQuery(raw);
+      expect(sanitizedQuery).toBe(legacyQuery);
+      expect(sanitizedQuery).not.toBeNull();
+      expect(queryFtsMatches(sanitizedQuery!)).toEqual(queryFtsMatches(legacyQuery!));
+    }
+  });
+
+  it("sanitizes raw text before jieba tokenization", () => {
+    _setJiebaForTest({
+      cutForSearch(text: string) {
+        expect(text).toBe("alpha   beta   gamma ");
+        return text.match(/[\p{L}\p{N}_]+/gu) ?? [];
+      },
+    });
+
+    expect(buildFtsQuery("alpha AND beta NEAR(gamma)")).toBe('"alpha" OR "beta" OR "gamma"');
+  });
+
+  it("removes FTS5 operators and syntax before jieba tokenization", () => {
+    _setJiebaForTest({
+      cutForSearch(text: string) {
+        expect(text).not.toMatch(/\b(?:AND|OR|NOT|NEAR)\b/iu);
+        expect(text).not.toMatch(/["'()[\]{}^*:]/u);
+        return text.match(/[\p{L}\p{N}_]+/gu) ?? [];
+      },
+    });
+
+    expect(buildFtsQuery('^alpha AND "beta" OR (gamma) NOT {delta}:epsilon NEAR(zeta) eta*')).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon" OR "zeta" OR "eta"',
+    );
+  });
+
+  it("filters FTS5 operator tokens returned by jieba", () => {
+    _setJiebaForTest({
+      cutForSearch() {
+        return ["alpha", "AND", "or", "beta", "NEAR"];
+      },
+    });
+
+    expect(buildFtsQuery("alpha AND beta")).toBe('"alpha" OR "beta"');
+  });
+
+  it("deduplicates jieba tokens after sanitization", () => {
+    _setJiebaForTest({
+      cutForSearch() {
+        return ["alpha", "alpha", "AND", "beta", "beta"];
+      },
+    });
+
+    expect(buildFtsQuery("alpha AND beta")).toBe('"alpha" OR "beta"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,18 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATOR_RE = /\b(?:AND|OR|NOT|NEAR)\b/giu;
+const FTS5_SPECIAL_SYNTAX_RE = /["'()[\]{}^*:]/gu;
+const FTS5_OPERATOR_TOKENS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function stripFtsSyntax(raw: string): string {
+  return raw.replace(FTS5_OPERATOR_RE, " ").replace(FTS5_SPECIAL_SYNTAX_RE, " ");
+}
+
+function isFtsOperatorToken(token: string): boolean {
+  return FTS5_OPERATOR_TOKENS.has(token.toUpperCase());
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -183,6 +195,11 @@ const ZH_STOP_WORDS = new Set([
  *
  * Falls back to Unicode-regex splitting (`/[\p{L}\p{N}_]+/gu`) if
  * jieba is not installed.
+ *
+ * Security model: this is a whitelist-based MATCH expression builder. User
+ * text is reduced to word/number tokens, FTS5 syntax is stripped, and the only
+ * operator we emit is this function's fixed `OR`. Callers execute the result
+ * through prepared `MATCH ?` statements, so user text never becomes SQL text.
  *
  * Tokens are OR-joined as quoted FTS5 phrase terms so that a document
  * matching *any* token is returned.  BM25 naturally ranks documents that
@@ -196,6 +213,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = stripFtsSyntax(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,12 +221,14 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
         // Remove pure whitespace / punctuation tokens
         if (!/[\p{L}\p{N}]/u.test(t)) return false;
+        // Remove FTS5 reserved operators before building a MATCH expression
+        if (isFtsOperatorToken(t)) return false;
         // Remove common Chinese stop-words to reduce noise
         if (ZH_STOP_WORDS.has(t)) return false;
         return true;
@@ -218,10 +238,10 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        .filter((t) => t && !isFtsOperatorToken(t)) ?? [];
   }
 
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Description
 修复 `buildFtsQuery()` 未显式清理 SQLite FTS5 查询操作符和特殊语法的问题。
 本 PR 在分词前移除 `AND`、`OR`、`NOT`、`NEAR` 等 FTS5 保留操作符，并剥离常见 FTS5 查询语法字符，确保最终生成的 `MATCH`表达式只包含白名单 token 和代码固定插入的 `OR`。同时补充安全、边界、白名单和 recall 回归测试，确认普通用户搜索结果无明显退化。

  ## Related Issue
  Fix #160

  ## Change Type
  - [x] Bug fix | Bug 修复
  - [ ] New feature | 新功能
  - [ ] Documentation update | 文档更新
  - [ ] Code optimization | 代码优化

  ## Self-test Checklist
  - [x] Verified locally | 本地验证通过
  - [x] No existing features affected | 无影响现有功能

  ## Additional Notes
  本地已验证：
  - `npx.cmd vitest run src/core/store/sqlite.test.ts`
  - `npm.cmd run build:plugin`