### PR TITLE
docs(readme): explain mermaid symbol conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,59 @@ graph LR
     style Agent fill:#fffbeb,stroke:#f59e0b,stroke-width:2px,color:#92400e
 ```
 
+#### How Tool Logs Become Mermaid Symbols
+
+The short-term offload path is intentionally white-box. A verbose tool result is
+not replaced by an opaque summary; it is split into three linked artifacts:
+
+1. **Raw evidence in `refs/`.** The full tool output is written to a Markdown
+   file so no detail is lost.
+2. **A JSONL index row.** `offload-<sessionId>.jsonl` records the tool call,
+   a compact summary, the `result_ref`, and the original `tool_call_id`.
+3. **A Mermaid node.** L2 groups related JSONL rows into a task canvas and
+   backfills each row with the generated `node_id`.
+
+For example, a raw tool result like this:
+
+```text
+tool_call_id: call_check_1
+tool: npm test -- src/core/store/sqlite.fts.test.ts
+result:
+  FAIL src/core/store/sqlite.fts.test.ts
+  SQLite FTS5 syntax error near "OR"
+  query: alpha OR beta*
+```
+
+is persisted as full evidence under `refs/` and indexed as one JSONL row:
+
+```json
+{
+  "timestamp": "2026-07-01T01:20:00.000Z",
+  "node_id": "003-N2",
+  "tool_call": "npm test -- src/core/store/sqlite.fts.test.ts",
+  "summary": "FTS5 test failed because the generated MATCH query treated OR and * as operators.",
+  "result_ref": "refs/2026-07-01T01-20-00-000Z-call_check_1.md",
+  "tool_call_id": "call_check_1",
+  "score": 8
+}
+```
+
+L2 then keeps only the task-level structure in the active canvas:
+
+```mermaid
+flowchart TD
+    003-N1["Reproduce FTS5 query failure"]
+    003-N2["Sanitize reserved FTS5 operators"]
+    003-N3["Verify normal keyword recall still works"]
+    003-N1 --> 003-N2 --> 003-N3
+```
+
+The conversion rule is simple: Mermaid carries **state and topology**, JSONL
+carries the **node-to-evidence index**, and `refs/*.md` carries the **raw
+payload**. When an Agent needs details behind `003-N2`, it looks up the row with
+`node_id = "003-N2"` in `offload-<sessionId>.jsonl`, reads `result_ref`, and
+opens the corresponding file in `refs/`.
+
 ---
 
 ## Quick Start

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,6 +109,52 @@ graph LR
     style MMD fill:#eff6ff,stroke:#3b82f6,stroke-width:2px
     style Agent fill:#fffbeb,stroke:#f59e0b,stroke-width:2px
 ```
+
+#### 工具日志如何转换成 Mermaid 符号
+
+短期卸载链路是白盒的。系统不会把冗长工具结果替换成不可追溯的摘要，而是拆成三类互相链接的产物：
+
+1. **`refs/` 中的原始证据**：完整工具输出写入 Markdown 文件，保证细节不丢失。
+2. **JSONL 索引行**：`offload-<sessionId>.jsonl` 记录工具调用、压缩摘要、`result_ref` 和原始 `tool_call_id`。
+3. **Mermaid 节点**：L2 将相关 JSONL 行组织成任务画布，并把生成的 `node_id` 回填到对应 JSONL 行。
+
+例如，一段原始工具结果：
+
+```text
+tool_call_id: call_check_1
+tool: npm test -- src/core/store/sqlite.fts.test.ts
+result:
+  FAIL src/core/store/sqlite.fts.test.ts
+  SQLite FTS5 syntax error near "OR"
+  query: alpha OR beta*
+```
+
+会先作为完整证据保存到 `refs/`，再被索引成一条 JSONL：
+
+```json
+{
+  "timestamp": "2026-07-01T01:20:00.000Z",
+  "node_id": "003-N2",
+  "tool_call": "npm test -- src/core/store/sqlite.fts.test.ts",
+  "summary": "FTS5 测试失败，因为生成的 MATCH 查询把 OR 和 * 当成了操作符。",
+  "result_ref": "refs/2026-07-01T01-20-00-000Z-call_check_1.md",
+  "tool_call_id": "call_check_1",
+  "score": 8
+}
+```
+
+L2 在活跃任务画布中只保留任务级结构：
+
+```mermaid
+flowchart TD
+    003-N1["复现 FTS5 查询失败"]
+    003-N2["清理 FTS5 保留操作符"]
+    003-N3["验证普通关键词召回仍然可用"]
+    003-N1 --> 003-N2 --> 003-N3
+```
+
+转换规则可以概括为：Mermaid 保存**状态和拓扑关系**，JSONL 保存**节点到证据的索引**，`refs/*.md` 保存**原始载荷**。当 Agent 需要核对 `003-N2` 背后的细节时，只需在 `offload-<sessionId>.jsonl` 中查找 `node_id = "003-N2"` 的行，读取其中的 `result_ref`，再打开对应的 `refs/` 文件。
+
 ---
 
 ## 快速开始


### PR DESCRIPTION
## Description | 描述
Add a concrete README example that explains how short-term tool logs are converted into Mermaid task symbols.

This fills the documentation gap from #282 by showing the full traceable chain:
- raw tool call/result input
- persisted `refs/*.md` evidence and `offload-<sessionId>.jsonl` index row
- generated Mermaid canvas node structure
- `node_id -> result_ref -> refs/*.md` drill-down rule

The same section is added to both `README.md` and `README_CN.md` so English and Chinese users see the same behavior model.

## Related Issue | 关联 Issue
Fix #282

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Docs-only change. Verified with `git diff --check`.
