### PR TITLE
fix(hermes): install durable memory provider link

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,15 @@ npm install tsx
 **3. Link to the Hermes plugin directory**:
 
 ```bash
-rm -rf ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
-ln -sf ~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb \
-       ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+PLUGIN_SRC=~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb
+
+mkdir -p ~/.hermes/hermes-agent/plugins/memory ~/.hermes/plugins
+ln -sfn "$PLUGIN_SRC" ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+ln -sfn "$PLUGIN_SRC" ~/.hermes/plugins/memory_tencentdb
 ```
 
 > The directory **must** be named `memory_tencentdb` (with an underscore) — Hermes uses this as the provider key. `memory-tencentdb` (with a hyphen) is only an alias at the config level and **cannot** be used as the directory name.
+> The installer creates both links: the checkout-tree link keeps compatibility with bundled Hermes installs, while the user-scope link under `~/.hermes/plugins/` survives Hermes checkout updates.
 
 **4. Declare the provider in `~/.hermes/config.yaml`**:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -291,12 +291,15 @@ npm install tsx
 **3. 链接到 Hermes 插件目录**：
 
 ```bash
-rm -rf ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
-ln -sf ~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb \
-       ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+PLUGIN_SRC=~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb
+
+mkdir -p ~/.hermes/hermes-agent/plugins/memory ~/.hermes/plugins
+ln -sfn "$PLUGIN_SRC" ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+ln -sfn "$PLUGIN_SRC" ~/.hermes/plugins/memory_tencentdb
 ```
 
 > 此处目录名必须是 **`memory_tencentdb`**（下划线）—— Hermes 用它作为 provider key。`memory-tencentdb`（连字符）只是配置层面的别名，**不**能作为目录名。
+> 安装脚本会创建两个链接：checkout-tree 链接兼容内置 Hermes 安装，`~/.hermes/plugins/` 下的 user-scope 链接可在 Hermes checkout 更新后继续保留。
 
 **4. 在 `~/.hermes/config.yaml` 中声明 provider**：
 

--- a/scripts/install_hermes_memory_tencentdb.sh
+++ b/scripts/install_hermes_memory_tencentdb.sh
@@ -50,7 +50,7 @@ USER_HOME=$(eval echo ~$USERNAME)
 NPM_PACKAGE="@tencentdb-agent-memory/memory-tencentdb@latest"
 
 # Hermes 路径
-HERMES_HOME="$USER_HOME/.hermes"
+HERMES_HOME="${HERMES_HOME:-$USER_HOME/.hermes}"
 # HERMES_AGENT_DIR（fix: issue #18）
 # 用户通过环境变量传什么就用什么；未设置时 fallback 到传统路径。
 # 如果目录不存在，后续前置检查会统一报错。
@@ -209,16 +209,48 @@ echo "[memory-tencentdb] Gateway dependencies installed"
 
 echo "[memory-tencentdb] Step 2.5: Linking plugin into hermes plugins directory..."
 
-HERMES_PLUGIN_DIR="$HERMES_AGENT_DIR/plugins/memory/memory_tencentdb"
 PLUGIN_SRC_DIR="$TDAI_INSTALL_DIR/hermes-plugin/memory/memory_tencentdb"
+HERMES_CHECKOUT_PLUGIN_DIR="$HERMES_AGENT_DIR/plugins/memory/memory_tencentdb"
+HERMES_USER_PLUGIN_DIR="$HERMES_HOME/plugins/memory_tencentdb"
 
-# 移除旧链接/目录
-rm -rf "$HERMES_PLUGIN_DIR"
+MISSING_SRC=0
+for f in __init__.py plugin.yaml client.py supervisor.py; do
+    if [ ! -f "$PLUGIN_SRC_DIR/$f" ]; then
+        echo "[ERROR] Missing hermes plugin source file: $PLUGIN_SRC_DIR/$f" >&2
+        MISSING_SRC=1
+    fi
+done
+if [ "$MISSING_SRC" -ne 0 ]; then
+    exit 1
+fi
 
-# 创建 symlink 使 hermes 能发现插件
-ln -sf "$PLUGIN_SRC_DIR" "$HERMES_PLUGIN_DIR"
+link_hermes_plugin() {
+    local target="$1"
+    local source="$2"
+    local label="$3"
 
-echo "[memory-tencentdb] Plugin linked: $HERMES_PLUGIN_DIR -> $PLUGIN_SRC_DIR"
+    mkdir -p "$(dirname "$target")"
+
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        echo "[ERROR] $label plugin target exists and is not a symlink: $target" >&2
+        echo "[ERROR] Refusing to overwrite it. Move it aside and re-run the installer." >&2
+        exit 1
+    fi
+
+    ln -sfn "$source" "$target"
+
+    if [ ! -f "$target/plugin.yaml" ] || [ ! -f "$target/__init__.py" ]; then
+        echo "[ERROR] $label plugin link verification failed: $target" >&2
+        exit 1
+    fi
+
+    echo "[memory-tencentdb] $label plugin linked: $target -> $(readlink "$target")"
+}
+
+# Keep the checkout-tree link for bundled Hermes installs, and also create the
+# durable user-scope provider link so Hermes updates do not detach memory.
+link_hermes_plugin "$HERMES_CHECKOUT_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes checkout"
+link_hermes_plugin "$HERMES_USER_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes user"
 
 # ---------- Step 3: 提示用户手动开启 memory_tencentdb（不自动修改 config） ----------
 
@@ -325,6 +357,29 @@ echo "  Env file:       $ENVFILE"
 echo ""
 echo "  Installed files in tdai dir:"
 ls -la "$TDAI_INSTALL_DIR"/ 2>/dev/null | head -20 || echo "  (none)"
+echo ""
+
+print_plugin_link_summary() {
+    local target="$1"
+    local expected="$2"
+    local label="$3"
+
+    if [ ! -L "$target" ]; then
+        echo "  [WARN] $label plugin link missing: $target"
+        return
+    fi
+
+    local actual
+    actual="$(readlink "$target")"
+    if [ "$actual" = "$expected" ]; then
+        echo "  [OK] $label plugin link: $target -> $actual"
+    else
+        echo "  [WARN] $label plugin link points to unexpected target: $actual (expected: $expected)"
+    fi
+}
+
+print_plugin_link_summary "$HERMES_CHECKOUT_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes checkout"
+print_plugin_link_summary "$HERMES_USER_PLUGIN_DIR" "$PLUGIN_SRC_DIR" "Hermes user"
 echo ""
 
 # 验证 hermes 插件文件存在（在解压目录中）

--- a/scripts/install_hermes_memory_tencentdb.sh
+++ b/scripts/install_hermes_memory_tencentdb.sh
@@ -323,12 +323,14 @@ _append_or_update_env() {
     local key="$1"
     local value="$2"
     local file="$3"
+    local tmp
     if [ ! -f "$file" ]; then
         touch "$file"
     fi
     # 移除已有的同名变量行（含注释掉的和带引号的），再追加
-    sed -i "/^${key}=/d" "$file"
-    sed -i "/^# *${key}=/d" "$file"
+    tmp="$(mktemp "${file}.XXXXXX")"
+    grep -Ev "^${key}=|^# *${key}=" "$file" > "$tmp" || true
+    mv "$tmp" "$file"
     # python-dotenv 要求含空格/引号/特殊字符的值用双引号包裹
     echo "${key}=\"${value}\"" >> "$file"
 }

--- a/src/install-hermes.test.ts
+++ b/src/install-hermes.test.ts
@@ -1,0 +1,96 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+describe("install_hermes_memory_tencentdb.sh", () => {
+  it("links memory_tencentdb into checkout and durable user plugin directories", () => {
+    const root = mkdtempSync(join(tmpdir(), "memory-tencentdb-install-"));
+
+    try {
+      const fakeBin = join(root, "bin");
+      const installDir = join(root, "tdai-memory-openclaw-plugin");
+      const dataDir = join(root, "memory-tdai");
+      const hermesHome = join(root, ".hermes");
+      const hermesAgentDir = join(hermesHome, "hermes-agent");
+      const sudoSink = join(root, "sudo-tee-output");
+
+      mkdirSync(fakeBin, { recursive: true });
+      mkdirSync(hermesAgentDir, { recursive: true });
+
+      writeExecutable(
+        join(fakeBin, "npm"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"@tencentdb-agent-memory/memory-tencentdb@latest"* ]]; then
+  pkg="node_modules/@tencentdb-agent-memory/memory-tencentdb"
+  mkdir -p "$pkg/hermes-plugin/memory/memory_tencentdb" "$pkg/src/gateway"
+  touch "$pkg/hermes-plugin/memory/memory_tencentdb/__init__.py"
+  touch "$pkg/hermes-plugin/memory/memory_tencentdb/client.py"
+  touch "$pkg/hermes-plugin/memory/memory_tencentdb/supervisor.py"
+  printf 'name: memory_tencentdb\\n' > "$pkg/hermes-plugin/memory/memory_tencentdb/plugin.yaml"
+  touch "$pkg/src/gateway/server.ts"
+fi
+exit 0
+`,
+      );
+      writeExecutable(join(fakeBin, "npx"), "#!/usr/bin/env bash\nexit 0\n");
+      writeExecutable(
+        join(fakeBin, "sudo"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "tee" ]]; then
+  cat > "${sudoSink}"
+  exit 0
+fi
+exit 1
+`,
+      );
+
+      const script = resolve("scripts/install_hermes_memory_tencentdb.sh");
+      const result = spawnSync("bash", [script], {
+        cwd: root,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          INSTALL_AS_USER: "memory_tencentdb_test_user",
+          MEMORY_TENCENTDB_ROOT: root,
+          TDAI_INSTALL_DIR: installDir,
+          TDAI_DATA_DIR: dataDir,
+          HERMES_HOME: hermesHome,
+          HERMES_AGENT_DIR: hermesAgentDir,
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+
+      const pluginSource = join(installDir, "hermes-plugin/memory/memory_tencentdb");
+      const checkoutLink = join(hermesAgentDir, "plugins/memory/memory_tencentdb");
+      const userLink = join(hermesHome, "plugins/memory_tencentdb");
+
+      expect(lstatSync(checkoutLink).isSymbolicLink()).toBe(true);
+      expect(lstatSync(userLink).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(checkoutLink)).toBe(pluginSource);
+      expect(readlinkSync(userLink)).toBe(pluginSource);
+      expect(statSync(join(hermesHome, ".env")).isFile()).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/install-hermes.test.ts
+++ b/src/install-hermes.test.ts
@@ -51,6 +51,17 @@ exit 0
       );
       writeExecutable(join(fakeBin, "npx"), "#!/usr/bin/env bash\nexit 0\n");
       writeExecutable(
+        join(fakeBin, "sed"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "-i" ]]; then
+  echo "sed -i is not portable in this installer test" >&2
+  exit 64
+fi
+exec /usr/bin/sed "$@"
+`,
+      );
+      writeExecutable(
         join(fakeBin, "sudo"),
         `#!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Description | 描述
Fix the Hermes installer path that can silently detach `memory_tencentdb` after a Hermes checkout update.

This PR keeps the existing checkout-tree link for bundled Hermes installs and adds the durable user-scope provider link under `$HERMES_HOME/plugins/memory_tencentdb`:
- checkout compatibility: `$HERMES_AGENT_DIR/plugins/memory/memory_tencentdb`
- durable provider link: `$HERMES_HOME/plugins/memory_tencentdb`

It also makes the installer safer and easier to audit:
- honors `HERMES_HOME` overrides, matching the Hermes provider docs
- validates required provider files before linking
- refuses to overwrite non-symlink plugin targets
- prints both link targets in the install summary
- updates the README and README_CN manual install snippets so the documented recovery path matches the installer behavior

## Related Issue | 关联 Issue
Fix #167

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with:
- `npx vitest run src/install-hermes.test.ts`
- `bash -n scripts/install_hermes_memory_tencentdb.sh`
- `git diff --check`
- `npm run build`

The new Vitest smoke test runs the installer with fake `npm`, `npx`, and `sudo tee` commands in a temporary Hermes home and asserts that both plugin links point to the installed provider source.
