### PR TITLE
fix(l1): filter trivial extraction inputs

### DIFF
--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -19,4 +19,22 @@ describe("prompt injection filtering", () => {
   it("allows normal user content through L1 extraction", () => {
     expect(shouldExtractL1("Please remember that I prefer concise TypeScript examples.")).toBe(true);
   });
+
+  it("keeps L0 archival permissive while filtering trivial L1 extraction input", () => {
+    expect(shouldCaptureL0("OK")).toBe(true);
+    expect(shouldCaptureL0("好的")).toBe(true);
+    expect(shouldExtractL1("OK")).toBe(false);
+    expect(shouldExtractL1("hi")).toBe(false);
+    expect(shouldExtractL1("好的")).toBe(false);
+  });
+
+  it("keeps short but meaningful identity and preference statements for L1", () => {
+    expect(shouldExtractL1("I am Bob")).toBe(true);
+    expect(shouldExtractL1("我叫小王")).toBe(true);
+    expect(shouldExtractL1("记住我喜欢茶")).toBe(true);
+  });
+
+  it("rejects oversized L1 extraction input", () => {
+    expect(shouldExtractL1("a".repeat(5001))).toBe(false);
+  });
 });

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -135,17 +135,20 @@ export function shouldCaptureL0(text: string): boolean {
 export function shouldExtractL1(text: string): boolean {
   // First apply the same structural filters as L0
   if (!shouldCaptureL0(text)) return false;
+  const trimmed = text.trim();
 
   // ── Length filters ──
-  // const isCJK = /[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/.test(text);
-  // if (isCJK && text.length < 2) return false;
-  // if (!isCJK && text.length < 2) return false;
-  // if (text.length > 5000) return false;
+  const cjkChars = trimmed.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g)?.length ?? 0;
+  const asciiWordChars = trimmed.match(/[A-Za-z0-9]/g)?.length ?? 0;
+  if (cjkChars > 0 && cjkChars < 4) return false;
+  if (cjkChars === 0 && asciiWordChars > 0 && asciiWordChars < 4) return false;
+  if (trimmed.length > 5000) return false;
 
   // ── Content-quality filters ──
+  if (isConversationalFiller(trimmed)) return false;
   // Match strings composed entirely of non-word, non-space, non-CJK characters (1–5 chars).
-  if (/^[^\w\s\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]{1,5}$/.test(text)) return false;
-  if (/^[?？]+$/.test(text)) return false;
+  if (/^[^\w\s\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]{1,5}$/.test(trimmed)) return false;
+  if (/^[?？]+$/.test(trimmed)) return false;
 
   // ── Security filters ──
   // Reject prompt-injection payloads — prevent malicious content from being
@@ -153,6 +156,11 @@ export function shouldExtractL1(text: string): boolean {
   if (looksLikePromptInjection(text)) return false;
 
   return true;
+}
+
+function isConversationalFiller(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/[.!?。！？～~\s]+/g, "");
+  return /^(ok|okay|hi|hello|hey|thanks|thankyou|thx|好的|好|嗯|嗯嗯|哦|噢|行|可以|谢谢|收到|明白)$/.test(normalized);
 }
 
 /**


### PR DESCRIPTION
## Description | 描述
Restore a conservative L1 quality gate for trivial extraction inputs.

This addresses the Problem 1 path in #82 without taking on the broader pre-extraction, retry, or post-validation scope:
- keep L0 capture permissive so raw conversation archival still records short user turns
- filter trivial L1 extraction inputs such as `OK`, `hi`, and `好的`
- reject very short non-CJK/CJK fragments before they spend LLM extraction tokens
- reject oversized L1 extraction inputs above 5000 characters
- preserve short but meaningful identity/preference statements such as `I am Bob`, `我叫小王`, and `记住我喜欢茶`

## Related Issue | 关联 Issue
Related to #82

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with:
- `npx vitest run src/utils/sanitize.test.ts`
- `git diff --check`
- `npm run build`

This PR intentionally keeps the scope small so it can be reviewed independently from larger L1 pipeline redesigns.
