### PR TITLE
fix(search): buildFtsQuery does not sanitize FTS5 operators — user input alters query semantics

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,50 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  beforeEach(() => {
+    _setJiebaForTest(null);
+  });
+
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("quotes normal tokens and joins them with OR", () => {
+    expect(buildFtsQuery("TypeScript SQLite memory")).toBe('"TypeScript" OR "SQLite" OR "memory"');
+  });
+
+  it("removes FTS5 operators supplied by user input", () => {
+    expect(buildFtsQuery("alpha OR beta AND NOT NEAR gamma")).toBe('"alpha" OR "beta" OR "gamma"');
+  });
+
+  it("drops FTS5 punctuation while keeping searchable words", () => {
+    expect(buildFtsQuery('"project") OR content:* NOT secret')).toBe('"project" OR "content" OR "secret"');
+  });
+
+  it("normalizes full-width text and filters common Chinese stop words", () => {
+    expect(buildFtsQuery("我 在 上海 写 ＴｙｐｅＳｃｒｉｐｔ")).toBe('"上海" OR "写" OR "TypeScript"');
+  });
+
+  it("returns null when no searchable terms remain", () => {
+    expect(buildFtsQuery('OR AND NOT NEAR "()" *')).toBeNull();
+  });
+
+  it("produces MATCH expressions that SQLite FTS5 can execute safely", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+    db.prepare("INSERT INTO docs(content) VALUES (?)").run("project secret memory");
+
+    try {
+      const query = buildFtsQuery('"project") OR content:* NOT secret');
+      expect(query).toBe('"project" OR "content" OR "secret"');
+
+      const rows = db.prepare("SELECT content FROM docs WHERE docs MATCH ?").all(query);
+      expect(rows).toEqual([{ content: "project secret memory" }]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -200,33 +200,36 @@ export function buildFtsQuery(raw: string): string | null {
 
   let tokens: string[];
   if (jieba) {
-    // jieba cutForSearch: splits long words further for better recall
-    // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
+    // jieba cutForSearch splits long words further for better recall.
     tokens = jieba
       .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .flatMap(sanitizeFtsWords);
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    tokens = sanitizeFtsWords(raw);
   }
 
   if (tokens.length === 0) return null;
   const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
   return quoted.join(" OR ");
+}
+
+const FTS_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+const FTS_RESERVED_WORDS = new Set(["OR", "AND", "NEAR", "NOT"]);
+
+function sanitizeFtsWords(rawToken: string): string[] {
+  const parts = rawToken.normalize("NFKC").match(FTS_TOKEN_RE) ?? [];
+
+  return parts
+    .map((t) => t.trim())
+    .filter((t) => {
+      if (t.length === 0) return false;
+      if (FTS_RESERVED_WORDS.has(t.toUpperCase())) return false;
+      if (ZH_STOP_WORDS.has(t)) return false;
+      return true;
+    });
 }
 
 /**


### PR DESCRIPTION
## Description | 描述
修复了buildFtsQuery未过滤FTS操作符的问题

## Related Issue | 关联 Issue
Fix #160 

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
<!-- Optional | 可选 -->