### PR TITLE
fix(checkpoint): recalibrate counters after cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### 🐛 修复
 
 #### 数据安全 / 数据隔离
+- **Checkpoint 聚合计数清理后漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：新增 `CheckpointManager.recalibrate()`，启动时根据实际 L0/L1 数据校准 `total_processed`、`l0_conversations_count`、`total_memories_extracted`、`memories_since_last_persona`；`memory-cleaner` 删除过期分片或存储记录后会立即触发同一校准，避免状态页和 persona 触发阈值长期高估。校准只改聚合计数，不改 per-session runner/pipeline cursor，避免影响增量处理边界。
 - **L2 LLM 提取失败导致 `scene_blocks/` 被清空 / 半写入** ([#88](https://github.com/Tencent/TencentDB-Agent-Memory/issues/88))：Phase 1 已对 `scene_blocks/` 做完整快照，但 LLM 抛错时 `catch` 直接 `return`，沙箱里的部分写入 / 删除不会回滚，后续 recall 因此看不到场景导航，降级为碎片召回。新增 `BackupManager.findLatestBackup` + `restoreLatestDirectory`，在 LLM 失败时自动从最新备份恢复；采用 fail-soft 设计：无备份时不动目标目录，恢复过程自身的错误也不会替换原始 LLM 错误。
 - **Cleaner 安全加固**：`computeCutoffMsByLocalDay` 拒绝无效 cutoff（未来时间 / 距今不足 24h）；SQLite 与 TCVDB 在 `expired/total > 80%` 时阻止删除；`runOnce` 增加最小保留护栏（L0:50 / L1:20）并产出 `cleaner_summary` JSON 审计日志；新增 `__tests__/cleaner/verify-cleaner-safety.ts` E2E 校验。
 - **场景文件名含空格导致 Persona Scene Navigation 引用失效**：LLM 在 L2 偶发用 `Daily Rhythm in Shanghai.md` 这类含空格的名字创建 scene block，导致 `persona.md` 中 `### Path: scene_blocks/<name>.md` 引用无法被下游 `\S+\.md` 风格解析器（health-checker 等）识别，soak 后健康检查必报 `Scene Navigation 存在但无场景引用`。修复：(1) `scene-extraction` prompt 增加"📛 文件命名规范（强制）"段，禁止空格 / 括号 / 引号等标点；(2) 新增 `core/scene/filename-normalizer.ts`，在 `SceneExtractor.extract` Phase 5b（cleanup 后、`syncSceneIndex` 前）自动归一化文件名（空格 → `-`、剥离危险标点、冲突时追加 `-2` 后缀），下游 PersonaGenerator / recall / profile-sync 自动使用干净名，无需改动。

--- a/index.ts
+++ b/index.ts
@@ -305,6 +305,9 @@ export default function register(api: OpenClawPluginApi) {
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
+        onAfterCleanup: async () => {
+          await core.recalibrateCheckpoint("memory-cleaner");
+        },
       });
       sharedMemoryCleaner.start();
       api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);
@@ -312,6 +315,9 @@ export default function register(api: OpenClawPluginApi) {
       api.logger.debug?.(`${TAG} Memory cleaner already started in this process, reusing existing instance`);
     }
     memoryCleaner = sharedMemoryCleaner;
+    memoryCleaner.setAfterCleanup(async () => {
+      await core.recalibrateCheckpoint("memory-cleaner");
+    });
   } else {
     api.logger.debug?.(`${TAG} Memory cleaner disabled (retentionDays not configured)`);
   }

--- a/src/core/conversation/l0-recorder.test.ts
+++ b/src/core/conversation/l0-recorder.test.ts
@@ -1,0 +1,50 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { countL0JsonlStats } from "./l0-recorder.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-l0-stats-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("countL0JsonlStats", () => {
+  it("counts parseable message rows and distinct capture batches", async () => {
+    const dir = await makeTempDir();
+    const conversationsDir = path.join(dir, "conversations");
+    await mkdir(conversationsDir, { recursive: true });
+    await writeFile(
+      path.join(conversationsDir, "2026-06-01.jsonl"),
+      [
+        JSON.stringify({ id: "a", recordedAt: "2026-06-01T10:00:00.000Z" }),
+        JSON.stringify({ id: "b", recordedAt: "2026-06-01T10:00:00.000Z" }),
+        JSON.stringify({ id: "c", recordedAt: "2026-06-01T11:00:00.000Z" }),
+        JSON.stringify({ id: "d" }),
+        "{not-json",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await writeFile(
+      path.join(conversationsDir, "notes.jsonl"),
+      JSON.stringify({ id: "ignored", recordedAt: "2026-06-01T12:00:00.000Z" }),
+      "utf-8",
+    );
+
+    await expect(countL0JsonlStats(dir)).resolves.toEqual({ messages: 4, captures: 2 });
+  });
+
+  it("returns zeros when the conversations directory is missing", async () => {
+    const dir = await makeTempDir();
+    await expect(countL0JsonlStats(dir)).resolves.toEqual({ messages: 0, captures: 0 });
+  });
+});

--- a/src/core/conversation/l0-recorder.ts
+++ b/src/core/conversation/l0-recorder.ts
@@ -65,6 +65,13 @@ export interface L0ConversationRecord {
   messages: ConversationMessage[];
 }
 
+export interface L0JsonlStats {
+  /** Parseable L0 JSONL message rows. */
+  messages: number;
+  /** Distinct capture batches, keyed by recordedAt. */
+  captures: number;
+}
+
 const TAG = "[memory-tdai][l0]";
 
 // ============================
@@ -391,6 +398,61 @@ export async function readConversationRecords(
 }
 
 /**
+ * Count persisted L0 JSONL rows for checkpoint recalibration.
+ *
+ * `messages` mirrors `total_processed` fallback semantics: one parseable
+ * JSONL row is one captured message. `captures` mirrors
+ * `l0_conversations_count`: one successful capture batch writes all rows with
+ * the same `recordedAt`, so distinct `recordedAt` values approximate the
+ * historical capture count without needing a separate batch table.
+ */
+export async function countL0JsonlStats(
+  baseDir: string,
+  logger?: Logger,
+): Promise<L0JsonlStats> {
+  const conversationsDir = path.join(baseDir, "conversations");
+  const dateFilePattern = /^\d{4}-\d{2}-\d{2}\.jsonl$/;
+
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(conversationsDir, { withFileTypes: true });
+  } catch {
+    return { messages: 0, captures: 0 };
+  }
+
+  const captureKeys = new Set<string>();
+  let messages = 0;
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !dateFilePattern.test(entry.name)) continue;
+    const filePath = path.join(conversationsDir, entry.name);
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch {
+      logger?.warn?.(`${TAG} Failed to read L0 file for stats: ${filePath}`);
+      continue;
+    }
+
+    const lines = raw.split("\n").filter((line) => line.trim());
+    for (let i = 0; i < lines.length; i++) {
+      try {
+        const parsed = JSON.parse(lines[i]) as Partial<L0MessageRecord>;
+        messages++;
+        if (typeof parsed.recordedAt === "string" && parsed.recordedAt.length > 0) {
+          captureKeys.add(parsed.recordedAt);
+        }
+      } catch {
+        logger?.warn?.(`${TAG} Skipping malformed JSONL line while counting ${filePath}:${i + 1}`);
+      }
+    }
+  }
+
+  return { messages, captures: captureKeys.size };
+}
+
+/**
  * Read L0 messages across all conversation records for a session,
  * optionally filtered by a cursor timestamp (messages after the cursor).
  *
@@ -565,5 +627,4 @@ function extractUserAssistantMessages(messages: unknown[]): ConversationMessage[
 
   return result;
 }
-
 

--- a/src/core/record/l1-reader.test.ts
+++ b/src/core/record/l1-reader.test.ts
@@ -1,0 +1,64 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { countL1JsonlLines, countL1JsonlLinesSince } from "./l1-reader.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-l1-stats-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("L1 JSONL checkpoint counters", () => {
+  it("counts parseable records across dated shard files", async () => {
+    const dir = await makeTempDir();
+    const recordsDir = path.join(dir, "records");
+    await mkdir(recordsDir, { recursive: true });
+    await writeFile(
+      path.join(recordsDir, "2026-06-01.jsonl"),
+      [
+        JSON.stringify({ id: "old", updatedAt: "2026-06-01T10:00:00.000Z" }),
+        JSON.stringify({ id: "boundary", updatedAt: "2026-06-01T12:00:00.000Z" }),
+        "{bad-json",
+      ].join("\n"),
+      "utf-8",
+    );
+    await writeFile(
+      path.join(recordsDir, "2026-06-02.jsonl"),
+      `${JSON.stringify({ id: "new", updatedAt: "2026-06-02T10:00:00.000Z" })}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      path.join(recordsDir, "scratch.jsonl"),
+      `${JSON.stringify({ id: "ignored", updatedAt: "2026-06-03T10:00:00.000Z" })}\n`,
+      "utf-8",
+    );
+
+    await expect(countL1JsonlLines(dir)).resolves.toBe(3);
+    await expect(countL1JsonlLinesSince(dir, "2026-06-01T12:00:00.000Z")).resolves.toBe(1);
+  });
+
+  it("treats an empty persona timestamp as all surviving records", async () => {
+    const dir = await makeTempDir();
+    const recordsDir = path.join(dir, "records");
+    await mkdir(recordsDir, { recursive: true });
+    await writeFile(
+      path.join(recordsDir, "2026-06-01.jsonl"),
+      [
+        JSON.stringify({ id: "a", updatedAt: "2026-06-01T10:00:00.000Z" }),
+        JSON.stringify({ id: "b", updatedAt: "2026-06-01T11:00:00.000Z" }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await expect(countL1JsonlLinesSince(dir, "")).resolves.toBe(2);
+  });
+});

--- a/src/core/record/l1-reader.ts
+++ b/src/core/record/l1-reader.ts
@@ -203,9 +203,87 @@ export async function readAllMemoryRecords(
   }
 }
 
+/**
+ * Count parseable L1 JSONL rows for checkpoint recalibration.
+ *
+ * L1 writes are append-only at the file layer. Recalibrating from the
+ * surviving JSONL rows keeps `total_memories_extracted` aligned after
+ * memory-cleaner deletes old shards or an operator manually prunes records.
+ */
+export async function countL1JsonlLines(
+  baseDir: string,
+  logger?: Logger,
+): Promise<number> {
+  return countL1JsonlLinesInternal(baseDir, undefined, logger);
+}
+
+/**
+ * Count surviving L1 JSONL rows newer than the last persona timestamp.
+ *
+ * The comparison is strict (`updatedAt > sinceIso`), matching the L1 store
+ * query filters and avoiding double-counting the record at the persona
+ * boundary.
+ */
+export async function countL1JsonlLinesSince(
+  baseDir: string,
+  sinceIso: string,
+  logger?: Logger,
+): Promise<number> {
+  if (!sinceIso) {
+    return countL1JsonlLines(baseDir, logger);
+  }
+  return countL1JsonlLinesInternal(baseDir, sinceIso, logger);
+}
+
 // ============================
 // Helpers
 // ============================
+
+async function countL1JsonlLinesInternal(
+  baseDir: string,
+  sinceIso: string | undefined,
+  logger?: Logger,
+): Promise<number> {
+  const recordsDir = path.join(baseDir, "records");
+  const dateFilePattern = /^\d{4}-\d{2}-\d{2}\.jsonl$/;
+
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(recordsDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !dateFilePattern.test(entry.name)) continue;
+    const filePath = path.join(recordsDir, entry.name);
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch {
+      logger?.warn?.(`${TAG} Failed to read L1 file for stats: ${filePath}`);
+      continue;
+    }
+
+    const lines = raw.split("\n").filter((line) => line.trim());
+    for (let i = 0; i < lines.length; i++) {
+      try {
+        const parsed = JSON.parse(lines[i]) as Partial<MemoryRecord>;
+        if (sinceIso) {
+          const updatedAt = typeof parsed.updatedAt === "string" ? parsed.updatedAt : "";
+          if (updatedAt <= sinceIso) continue;
+        }
+        count++;
+      } catch {
+        logger?.warn?.(`${TAG} Skipping malformed JSONL line while counting ${filePath}:${i + 1}`);
+      }
+    }
+  }
+
+  return count;
+}
 
 function sanitizeFilename(name: string): string {
   return name.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_");

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -36,6 +36,8 @@ import { performAutoRecall } from "./hooks/auto-recall.js";
 import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
+import { countL0JsonlStats } from "./conversation/l0-recorder.js";
+import { countL1JsonlLines, countL1JsonlLinesSince } from "./record/l1-reader.js";
 import {
   initDataDirectories,
   initStores,
@@ -48,6 +50,7 @@ import {
 } from "../utils/pipeline-factory.js";
 import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
 import { CheckpointManager } from "../utils/checkpoint.js";
+import type { CheckpointRecalibrationResult } from "../utils/checkpoint.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
 
@@ -144,7 +147,8 @@ export class TdaiCore {
     this.logger.debug?.(`${TAG} Initializing TDAI Core: dataDir=${this.dataDir}`);
     initDataDirectories(this.dataDir);
 
-    // Initialize stores (async)
+    // Initialize stores. Recalibration below waits for this promise so startup
+    // counters are synced before the first capture can start the scheduler.
     this.storeReady = this.initStores();
 
     // Create pipeline manager (sync — does not need store)
@@ -160,6 +164,11 @@ export class TdaiCore {
         });
     }
 
+    try {
+      await this.recalibrateCheckpoint("startup");
+    } catch (err) {
+      this.logger.warn(`${TAG} Startup checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
     this.logger.debug?.(`${TAG} TDAI Core initialized`);
   }
 
@@ -390,6 +399,59 @@ export class TdaiCore {
   /** Whether the scheduler has been started (or is currently starting). */
   isSchedulerStarted(): boolean {
     return this.schedulerStartPromise !== undefined;
+  }
+
+  /**
+   * Recount durable L0/L1 data and overwrite checkpoint aggregate counters.
+   *
+   * Per-session runner cursors and pipeline states are deliberately left
+   * untouched. Those cursors drive incremental extraction correctness; the
+   * recalibrated fields are aggregate status and persona-threshold inputs.
+   */
+  async recalibrateCheckpoint(reason = "manual"): Promise<CheckpointRecalibrationResult> {
+    await this.storeReady?.catch(() => {});
+
+    const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+    const cp = await checkpoint.read();
+
+    const [l0Stats, totalMemoriesExtracted, memoriesSinceLastPersona] = await Promise.all([
+      countL0JsonlStats(this.dataDir, this.logger),
+      countL1JsonlLines(this.dataDir, this.logger),
+      countL1JsonlLinesSince(this.dataDir, cp.last_persona_time, this.logger),
+    ]);
+
+    let totalProcessed = l0Stats.messages;
+    const vectorStore = this.vectorStore;
+    if (vectorStore && !vectorStore.isDegraded()) {
+      const storeL0Count = await vectorStore.countL0();
+      // Store count is authoritative when available. If it reports empty while
+      // JSONL still has rows, keep the file count to avoid wiping counters
+      // during partial migrations or degraded bootstrap.
+      if (storeL0Count > 0 || l0Stats.messages === 0) {
+        totalProcessed = storeL0Count;
+      }
+    }
+
+    const result = await checkpoint.recalibrate({
+      total_processed: totalProcessed,
+      l0_conversations_count: l0Stats.captures,
+      total_memories_extracted: totalMemoriesExtracted,
+      memories_since_last_persona: memoriesSinceLastPersona,
+    });
+
+    if (result.changed) {
+      this.logger.info(
+        `${TAG} Checkpoint recalibrated (${reason}): ` +
+        `total_processed ${result.before.total_processed}->${result.after.total_processed}, ` +
+        `l0_conversations_count ${result.before.l0_conversations_count}->${result.after.l0_conversations_count}, ` +
+        `total_memories_extracted ${result.before.total_memories_extracted}->${result.after.total_memories_extracted}, ` +
+        `memories_since_last_persona ${result.before.memories_since_last_persona}->${result.after.memories_since_last_persona}`,
+      );
+    } else {
+      this.logger.debug?.(`${TAG} Checkpoint recalibration (${reason}) found no drift`);
+    }
+
+    return result;
   }
 
   /** Set the instance ID for metrics (may be resolved asynchronously). */

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager.recalibrate", () => {
+  it("overwrites aggregate counters and preserves per-session state", async () => {
+    const dir = await makeTempDir();
+    const manager = new CheckpointManager(dir);
+    const checkpoint = await manager.read();
+    checkpoint.total_processed = 120;
+    checkpoint.memories_since_last_persona = 30;
+    checkpoint.l0_conversations_count = 40;
+    checkpoint.total_memories_extracted = 50;
+    checkpoint.last_persona_time = "2026-06-01T00:00:00.000Z";
+    checkpoint.runner_states.sessionA = {
+      last_captured_timestamp: 123,
+      last_l1_cursor: 456,
+      last_scene_name: "scene-a",
+    };
+    checkpoint.pipeline_states.sessionA = {
+      conversation_count: 7,
+      last_extraction_time: "2026-06-02T00:00:00.000Z",
+      last_extraction_updated_time: "2026-06-02T00:00:00.000Z",
+      last_active_time: 789,
+      l2_pending_l1_count: 3,
+      warmup_threshold: 4,
+      l2_last_extraction_time: "2026-06-03T00:00:00.000Z",
+    };
+    await manager.write(checkpoint);
+
+    const result = await manager.recalibrate({
+      total_processed: 12,
+      memories_since_last_persona: 3,
+      l0_conversations_count: 4,
+      total_memories_extracted: 5,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.before).toEqual({
+      total_processed: 120,
+      memories_since_last_persona: 30,
+      l0_conversations_count: 40,
+      total_memories_extracted: 50,
+    });
+    expect(result.after).toEqual({
+      total_processed: 12,
+      memories_since_last_persona: 3,
+      l0_conversations_count: 4,
+      total_memories_extracted: 5,
+    });
+
+    const after = await manager.read();
+    expect(after.runner_states.sessionA).toEqual(checkpoint.runner_states.sessionA);
+    expect(after.pipeline_states.sessionA).toEqual(checkpoint.pipeline_states.sessionA);
+    expect(after.last_persona_time).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("supports partial no-op recalibration reports", async () => {
+    const dir = await makeTempDir();
+    const manager = new CheckpointManager(dir);
+
+    await manager.recalibrate({ total_processed: 2 });
+    const result = await manager.recalibrate({ total_processed: 2 });
+
+    expect(result.changed).toBe(false);
+    expect(result.before.total_processed).toBe(2);
+    expect(result.after.total_processed).toBe(2);
+  });
+
+  it("rejects negative and fractional counts", async () => {
+    const dir = await makeTempDir();
+    const manager = new CheckpointManager(dir);
+
+    await expect(manager.recalibrate({ total_processed: -1 })).rejects.toThrow(RangeError);
+    await expect(manager.recalibrate({ total_memories_extracted: 1.5 })).rejects.toThrow(RangeError);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -146,6 +146,43 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+export interface CheckpointCounterSnapshot {
+  total_processed: number;
+  memories_since_last_persona: number;
+  l0_conversations_count: number;
+  total_memories_extracted: number;
+}
+
+export interface CheckpointRecalibrationCounts {
+  total_processed?: number;
+  memories_since_last_persona?: number;
+  l0_conversations_count?: number;
+  total_memories_extracted?: number;
+}
+
+export interface CheckpointRecalibrationResult {
+  changed: boolean;
+  before: CheckpointCounterSnapshot;
+  after: CheckpointCounterSnapshot;
+}
+
+function snapshotCounters(cp: Checkpoint): CheckpointCounterSnapshot {
+  return {
+    total_processed: cp.total_processed,
+    memories_since_last_persona: cp.memories_since_last_persona,
+    l0_conversations_count: cp.l0_conversations_count,
+    total_memories_extracted: cp.total_memories_extracted,
+  };
+}
+
+function validateRecalibrationCount(name: keyof CheckpointRecalibrationCounts, value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`checkpoint recalibration count "${name}" must be a non-negative integer`);
+  }
+  return value;
+}
+
 // ============================
 // Per-file async lock
 // ============================
@@ -330,6 +367,59 @@ export class CheckpointManager {
       cp.scenes_processed += 1;
     });
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
+  }
+
+  /**
+   * Re-synchronize aggregate counters with authoritative storage counts.
+   *
+   * Only derived global counters are touched. Per-session runner cursors,
+   * pipeline state, persona timestamps, and scene counters are intentionally
+   * preserved so recalibration cannot cause incremental L0/L1 processing to
+   * rewind or skip work.
+   */
+  async recalibrate(actual: CheckpointRecalibrationCounts): Promise<CheckpointRecalibrationResult> {
+    const next = {
+      total_processed: validateRecalibrationCount("total_processed", actual.total_processed),
+      memories_since_last_persona: validateRecalibrationCount(
+        "memories_since_last_persona",
+        actual.memories_since_last_persona,
+      ),
+      l0_conversations_count: validateRecalibrationCount(
+        "l0_conversations_count",
+        actual.l0_conversations_count,
+      ),
+      total_memories_extracted: validateRecalibrationCount(
+        "total_memories_extracted",
+        actual.total_memories_extracted,
+      ),
+    };
+
+    let before!: CheckpointCounterSnapshot;
+    let after!: CheckpointCounterSnapshot;
+
+    await this.mutate((cp) => {
+      before = snapshotCounters(cp);
+      if (next.total_processed !== undefined) {
+        cp.total_processed = next.total_processed;
+      }
+      if (next.memories_since_last_persona !== undefined) {
+        cp.memories_since_last_persona = next.memories_since_last_persona;
+      }
+      if (next.l0_conversations_count !== undefined) {
+        cp.l0_conversations_count = next.l0_conversations_count;
+      }
+      if (next.total_memories_extracted !== undefined) {
+        cp.total_memories_extracted = next.total_memories_extracted;
+      }
+      after = snapshotCounters(cp);
+    });
+
+    const changed = Object.keys(before).some((key) => {
+      const field = key as keyof CheckpointCounterSnapshot;
+      return before[field] !== after[field];
+    });
+
+    return { changed, before, after };
   }
 
   // ============================

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import type { CleanupStats } from "./memory-cleaner.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalMemoryCleaner post-cleanup hook", () => {
+  it("calls onAfterCleanup when expired shards are removed", async () => {
+    const dir = await makeTempDir();
+    await mkdir(path.join(dir, "conversations"), { recursive: true });
+    await mkdir(path.join(dir, "records"), { recursive: true });
+    await writeFile(path.join(dir, "conversations", "2026-01-01.jsonl"), "{}\n", "utf-8");
+    await writeFile(path.join(dir, "records", "2026-01-01.jsonl"), "{}\n", "utf-8");
+
+    const calls: CleanupStats[] = [];
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dir,
+      retentionDays: 3,
+      cleanTime: "03:00",
+      onAfterCleanup: (stats) => {
+        calls.push({ ...stats });
+      },
+    });
+
+    await cleaner.runOnce(Date.parse("2026-01-10T12:00:00.000Z"));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].changedFiles).toBe(2);
+    expect(calls[0].deleteFailedFiles).toBe(0);
+  });
+
+  it("does not call onAfterCleanup when nothing changed", async () => {
+    const dir = await makeTempDir();
+    const calls: CleanupStats[] = [];
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dir,
+      retentionDays: 3,
+      cleanTime: "03:00",
+      onAfterCleanup: (stats) => {
+        calls.push({ ...stats });
+      },
+    });
+
+    await cleaner.runOnce(Date.parse("2026-01-10T12:00:00.000Z"));
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -6,19 +6,20 @@ import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
 
+export interface CleanupStats {
+  scannedFiles: number;
+  changedFiles: number;
+  skippedNonShardFiles: number;
+  deleteFailedFiles: number;
+}
+
 export interface MemoryCleanerOptions {
   baseDir: string;
   retentionDays: number;
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
-}
-
-interface CleanupStats {
-  scannedFiles: number;
-  changedFiles: number;
-  skippedNonShardFiles: number;
-  deleteFailedFiles: number;
+  onAfterCleanup?: (stats: CleanupStats) => void | Promise<void>;
 }
 
 const TAG = "[memory-tdai][cleaner]";
@@ -33,14 +34,20 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private afterCleanup?: (stats: CleanupStats) => void | Promise<void>;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.afterCleanup = opts.onAfterCleanup;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  setAfterCleanup(callback: ((stats: CleanupStats) => void | Promise<void>) | undefined): void {
+    this.afterCleanup = callback;
   }
 
   start(): void {
@@ -184,6 +191,15 @@ export class LocalMemoryCleaner {
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+    if (total.changedFiles > 0 && this.afterCleanup) {
+      try {
+        await this.afterCleanup(total);
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} post-cleanup checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   private scheduleNext(): void {


### PR DESCRIPTION
## Description | 描述

Fixes #157.

This PR fixes checkpoint aggregate-counter drift after cleanup or manual JSONL pruning. Before this change, `recall_checkpoint.json` only ever incremented several global counters:

- `total_processed`
- `l0_conversations_count`
- `total_memories_extracted`
- `memories_since_last_persona`

When `memory-cleaner` removed old L0/L1 shards or an operator manually pruned JSONL data, those counters stayed inflated. That made status reporting inaccurate and could keep persona-trigger thresholds artificially high. The per-session cursors still remain the source of truth for incremental processing; this PR intentionally does not rewrite them.

## Root Cause | 根因

`CheckpointManager` had atomic increment paths for capture and L1 extraction, but no inverse or recount path. Cleanup deletes durable data from JSONL and/or store layers, while checkpoint counters were not reconciled afterward.

This means the checkpoint could permanently report more processed conversations or extracted memories than the surviving data actually contains.

## Changes | 修改内容

- Add `CheckpointManager.recalibrate()` with before/after reporting and validation for non-negative integer counts.
- Add L0 JSONL counting helper:
  - `messages`: parseable L0 JSONL rows, used as fallback for `total_processed`
  - `captures`: distinct `recordedAt` batches, used for `l0_conversations_count`
- Add L1 JSONL counting helpers:
  - total surviving L1 JSONL records for `total_memories_extracted`
  - surviving records with `updatedAt > last_persona_time` for `memories_since_last_persona`
- Run checkpoint recalibration during `TdaiCore.initialize()` before the first scheduler start.
- Add a `LocalMemoryCleaner` post-cleanup hook and wire it to `core.recalibrateCheckpoint("memory-cleaner")`, so cleanup fixes drift immediately instead of waiting for the next restart.
- Keep cleaner singleton reuse safe by refreshing the post-cleanup callback on each plugin registration.
- Update `CHANGELOG.md` under `[Unreleased]`.

## Safety Notes | 安全性说明

- Recalibration only updates the four aggregate counters listed above.
- It does not change `runner_states`, `pipeline_states`, L1 cursor fields, scene counters, or persona timestamps.
- Incremental L1 processing remains cursor-driven, so recalibration cannot cause skipped records or cursor rewind.
- Startup recalibration is non-fatal: if recounting fails, the core still starts and logs a warning.

## Testing | 验证

Focused tests added:

- `src/utils/checkpoint.test.ts`
  - overwrites drifted aggregate counters
  - preserves per-session runner/pipeline state
  - reports no-op recalibration correctly
  - rejects negative/fractional counts
- `src/core/conversation/l0-recorder.test.ts`
  - counts L0 message rows and distinct capture batches
  - ignores malformed JSON and non-date files
- `src/core/record/l1-reader.test.ts`
  - counts surviving L1 JSONL records
  - handles strict `updatedAt > last_persona_time` persona boundary
- `src/utils/memory-cleaner.test.ts`
  - verifies cleanup triggers the post-cleanup recalibration hook only when files were removed

Commands run:

```bash
npx vitest run src/utils/checkpoint.test.ts src/core/conversation/l0-recorder.test.ts src/core/record/l1-reader.test.ts src/utils/memory-cleaner.test.ts
npm test
npm run build
npm pack --dry-run --json
git diff --check
```

Results:

- focused tests: 4 files / 9 tests passed
- full test suite: 8 files / 76 tests passed
- build: passed
- pack dry-run: passed
- diff whitespace check: passed
