### PR TITLE
feat(utils): add optional cache-shape diagnostics (PrefixShape)

### DIFF
--- a/src/utils/cache-diagnostics.test.ts
+++ b/src/utils/cache-diagnostics.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { captureShape, compareShape, type PrefixShape } from "./cache-diagnostics";
+
+describe("captureShape", () => {
+  it("produces deterministic hashes for identical inputs", () => {
+    const a = captureShape("you are a helpful assistant", [{ name: "read_file" }]);
+    const b = captureShape("you are a helpful assistant", [{ name: "read_file" }]);
+    expect(a.systemHash).toBe(b.systemHash);
+    expect(a.toolsHash).toBe(b.toolsHash);
+    expect(a.prefixHash).toBe(b.prefixHash);
+  });
+
+  it("produces different hashes when system prompt changes", () => {
+    const a = captureShape("you are a helpful assistant");
+    const b = captureShape("you are a coding agent");
+    expect(a.systemHash).not.toBe(b.systemHash);
+    expect(a.prefixHash).not.toBe(b.prefixHash);
+  });
+
+  it("handles empty inputs", () => {
+    const s = captureShape("");
+    expect(s.systemHash).toBeTruthy();
+    expect(typeof s.systemHash).toBe("string");
+  });
+
+  it("estimates tool schema tokens", () => {
+    const s = captureShape("", [{ name: "a".repeat(100) }]);
+    expect(s.toolSchemaTokens).toBeGreaterThan(0);
+  });
+});
+
+describe("compareShape", () => {
+  const stable: PrefixShape = captureShape("you are helpful");
+
+  it("reports no change when shapes are identical", () => {
+    const d = compareShape(stable, stable);
+    expect(d.prefixChanged).toBe(false);
+    expect(d.prefixChangeReasons).toEqual([]);
+  });
+
+  it("reports system change when system hash differs", () => {
+    const changed = captureShape("different system prompt");
+    const d = compareShape(stable, changed);
+    expect(d.prefixChanged).toBe(true);
+    expect(d.prefixChangeReasons).toContain("system");
+  });
+
+  it("reports no change on first turn (prev = null)", () => {
+    const d = compareShape(null, stable);
+    expect(d.prefixChanged).toBe(false);
+  });
+
+  it("prefix hash is deterministic", () => {
+    const d1 = compareShape(null, stable);
+    const d2 = compareShape(null, captureShape("you are helpful"));
+    expect(d1.prefixHash).toBe(d2.prefixHash);
+  });
+});

--- a/src/utils/cache-diagnostics.ts
+++ b/src/utils/cache-diagnostics.ts
@@ -1,0 +1,103 @@
+/**
+ * Cache shape diagnostics — optional utility for reasoning about prompt-cache
+ * hit/miss across turns.
+ *
+ * Inspired by Reasonix `PrefixShape` (`internal/agent/cache_shape.go`, v1.13.1):
+ * capture the system/tool/prefix hashes before each LLM call and compare them
+ * to the previous snapshot to explain *why* a cache miss occurred.
+ *
+ * Usage — platform-side, after building the prompt and before calling the LLM:
+ *
+ *   import { captureShape, compareShape } from "./cache-diagnostics";
+ *   const shape = captureShape(systemPrompt, toolSchemas);
+ *   const diag = compareShape(prevShape, shape);
+ *   if (diag.prefixChanged) {
+ *     logger?.warn("cache miss:", diag.prefixChangeReasons.join(", "));
+ *   }
+ *   prevShape = shape;
+ *
+ * This module has zero runtime dependencies and no side effects.
+ * Import it only where diagnostics are desired; tree-shaking will elide
+ * it from production bundles that don't use it.
+ */
+
+const encoder = new TextEncoder();
+
+function shortHash(data: unknown): string {
+  const json = JSON.stringify(data);
+  const bytes = encoder.encode(json);
+  // Non-cryptographic fast hash for diagnostic comparison only.
+  let hash = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    hash = ((hash << 5) - hash) + bytes[i];
+    hash |= 0; // 32-bit int
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/** Snapshot of the prompt prefix state at one point in time. */
+export interface PrefixShape {
+  /** Hash of the system prompt text. */
+  systemHash: string;
+  /** Hash of the tool schemas / function declarations. */
+  toolsHash: string;
+  /** Combined hash of the full prefix (system + tools). */
+  prefixHash: string;
+  /** Estimated token count for tool schemas (~4 chars/token). */
+  toolSchemaTokens: number;
+}
+
+/** Human-readable cache-hit diagnostic. */
+export interface CacheDiagnostics {
+  /** Whether any prefix component changed. */
+  prefixChanged: boolean;
+  /** Which components changed (e.g. ["system", "tools"]). */
+  prefixChangeReasons: string[];
+  /** Current prefix hash for correlation with provider-side cache metrics. */
+  prefixHash: string;
+  /** Estimation of the prefix token cost. */
+  prefixTokens: number;
+}
+
+/**
+ * Capture a snapshot of the current prefix state.
+ * @param systemPrompt - The full system prompt text.
+ * @param toolSchemas - Array of tool/function schemas.
+ */
+export function captureShape(
+  systemPrompt: string,
+  toolSchemas?: unknown[],
+): PrefixShape {
+  const toolsJSON = toolSchemas ? JSON.stringify(toolSchemas) : "[]";
+  const systemHash = shortHash(systemPrompt);
+  const toolsHash = shortHash(toolsJSON);
+  return {
+    systemHash,
+    toolsHash,
+    prefixHash: shortHash({ system: systemPrompt, tools: toolsJSON }),
+    toolSchemaTokens: Math.ceil(toolsJSON.length / 4),
+  };
+}
+
+/**
+ * Compare two prefix shapes and produce diagnostics.
+ * @param prev - Previous turn's shape (or null on first turn).
+ * @param cur - Current turn's shape.
+ */
+export function compareShape(
+  prev: PrefixShape | null,
+  cur: PrefixShape,
+): CacheDiagnostics {
+  const reasons: string[] = [];
+  if (prev && prev.systemHash !== cur.systemHash) reasons.push("system");
+  if (prev && prev.toolsHash !== cur.toolsHash) reasons.push("tools");
+  if (prev && prev.prefixHash !== cur.prefixHash && reasons.length === 0) {
+    reasons.push("prefix");
+  }
+  return {
+    prefixChanged: reasons.length > 0,
+    prefixChangeReasons: reasons,
+    prefixHash: cur.prefixHash,
+    prefixTokens: cur.toolSchemaTokens,
+  };
+}


### PR DESCRIPTION
## Related Issue
fix #120

## Description

Optional diagnostic utility for reasoning about prompt-cache hit/miss across turns. Inspired by Reasonix `PrefixShape` (internal/agent/cache_shape.go, v1.13.1).

```typescript
const shape = captureShape(systemPrompt, toolSchemas);
const diag = compareShape(prevShape, shape);
if (diag.prefixChanged) {
  logger?.warn("cache miss:", diag.prefixChangeReasons.join(", "));
}
```

**Non-invasive**: zero runtime side effects, no integration required. Platforms import only if they want diagnostics; tree-shaking elides it otherwise.

**Files:**
- `src/utils/cache-diagnostics.ts` PrefixShape + captureShape/compareShape
- `src/utils/cache-diagnostics.test.ts` 8 tests