### PR TITLE
fix(store): sanitize sqlite fts query tokens

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,341 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { MemoryRecord } from "../record/l1-writer.js";
+import type { L0Record } from "./types.js";
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery, VectorStore } from "./sqlite.js";
+
+const SECURITY_CASES: Array<{ input: string; expected: string | null }> = [
+  { input: 'alpha" OR "beta', expected: '"alpha" OR "beta"' },
+  { input: "alpha' OR 'beta", expected: '"alpha" OR "beta"' },
+  { input: 'alpha "" beta', expected: '"alpha" OR "beta"' },
+  { input: "(alpha) OR (beta)", expected: '"alpha" OR "beta"' },
+  { input: "{alpha beta} AND gamma", expected: '"alpha" OR "beta" OR "gamma"' },
+  { input: "alpha AND beta", expected: '"alpha" OR "beta"' },
+  { input: "alpha or beta", expected: '"alpha" OR "beta"' },
+  { input: "alpha ＯＲ beta", expected: '"alpha" OR "beta"' },
+  { input: "alpha NOT beta", expected: '"alpha" OR "beta"' },
+  { input: "(alpha OR beta) AND NOT gamma", expected: '"alpha" OR "beta" OR "gamma"' },
+  { input: "NEAR(alpha beta, 5)", expected: '"alpha" OR "beta"' },
+  { input: "alpha NEAR/5 beta", expected: '"alpha" OR "beta"' },
+  { input: "ＮＥＡＲ（alpha beta，５）", expected: '"alpha" OR "beta"' },
+  { input: "alpha ＮＥＡＲ／５ beta", expected: '"alpha" OR "beta"' },
+  { input: "alpha*", expected: '"alpha"' },
+  { input: "^alpha", expected: '"alpha"' },
+  { input: "content:alpha", expected: '"content" OR "alpha"' },
+  { input: "-content:alpha", expected: '"content" OR "alpha"' },
+  { input: "{content metadata}:alpha", expected: '"content" OR "metadata" OR "alpha"' },
+  { input: "title:alpha OR body:beta", expected: '"title" OR "alpha" OR "body" OR "beta"' },
+  { input: "AND OR NOT NEAR", expected: null },
+  { input: "near and or not", expected: null },
+  { input: '"" \'\' () {} : * - ^', expected: null },
+  { input: "   *** ((())) :::   ", expected: null },
+  { input: "alpha alpha OR beta", expected: '"alpha" OR "beta"' },
+  { input: "android nearshore notary OR", expected: '"android" OR "nearshore" OR "notary"' },
+  { input: "foo_bar v2", expected: '"foo_bar" OR "v2"' },
+  { input: "ＡＰＩ ＡＮＤ version２", expected: '"API" OR "version2"' },
+  { input: "mañana café 用户 １２３", expected: '"mañana" OR "café" OR "用户" OR "123"' },
+  { input: "C++ OR C#", expected: '"C"' },
+  { input: "alpha\tAND\nbeta", expected: '"alpha" OR "beta"' },
+];
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  describe("advanced FTS5 syntax sanitization", () => {
+    it("builds deterministic OR queries for ordinary fallback tokens", () => {
+      _setJiebaForTest(null);
+
+      expect(buildFtsQuery("travel plan API")).toBe('"travel" OR "plan" OR "API"');
+      expect(buildFtsQuery("用户喜欢编程 TypeScript")).toBe('"用户喜欢编程" OR "TypeScript"');
+    });
+
+    it.each(SECURITY_CASES)("sanitizes fallback input %j", ({ input, expected }) => {
+      _setJiebaForTest(null);
+
+      expect(buildFtsQuery(input)).toBe(expected);
+    });
+
+    it("returns executable MATCH expressions for every non-empty sanitized security case", () => {
+      _setJiebaForTest(null);
+      const db = createExecutionFixtureDb();
+
+      try {
+        for (const { input, expected } of SECURITY_CASES) {
+          const ftsQuery = buildFtsQuery(input);
+          expect(ftsQuery).toBe(expected);
+
+          if (ftsQuery === null) {
+            continue;
+          }
+
+          expect(() => searchDocIds(db, ftsQuery)).not.toThrow();
+        }
+      } finally {
+        db.close();
+      }
+    });
+
+    it.each([
+      {
+        tokens: ["foo:bar", " ", "AND", "C++", "的", "用户", "NEAR", "用户"],
+        expected: '"foo" OR "bar" OR "C" OR "用户"',
+      },
+      {
+        tokens: ["title:alpha", "-body:beta", "{metadata}", "NOT", "gamma*"],
+        expected: '"title" OR "alpha" OR "body" OR "beta" OR "metadata" OR "gamma"',
+      },
+      {
+        tokens: ["ＡＰＩ", "ＯＲ", "version２", "nearshore", "一个"],
+        expected: '"API" OR "version2" OR "nearshore"',
+      },
+    ])("applies the same sanitizer to jieba-produced tokens %#", ({ tokens, expected }) => {
+      _setJiebaForTest({
+        cutForSearch: () => tokens,
+      });
+
+      expect(buildFtsQuery("ignored by fake jieba")).toBe(expected);
+    });
+
+    it("produces an executable FTS5 query whose semantics are not controlled by boolean operators", () => {
+      _setJiebaForTest(null);
+      const db = new DatabaseSync(":memory:");
+
+      try {
+        db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+        const insert = db.prepare("INSERT INTO docs(rowid, content) VALUES (?, ?)");
+        insert.run(1, "alpha beta");
+        insert.run(2, "alpha");
+        insert.run(3, "beta");
+
+        const ftsQuery = buildFtsQuery("alpha AND NOT beta");
+        expect(ftsQuery).toBe('"alpha" OR "beta"');
+
+        const rows = db
+          .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+          .all(ftsQuery) as Array<{ rowid: number }>;
+
+        expect(rows.map((row) => row.rowid)).toEqual([1, 2, 3]);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  describe("deep recall stability", () => {
+    it("keeps ordinary keyword recall stable against the previous token OR strategy", () => {
+      _setJiebaForTest(null);
+      const db = createRecallFixtureDb();
+
+      try {
+        const cases: Array<{ input: string; expectedIds: number[] }> = [
+          { input: "travel plan hotel", expectedIds: [1] },
+          { input: "TypeScript memory", expectedIds: [2, 5] },
+          { input: "coffee beans", expectedIds: [3] },
+          { input: "project roadmap", expectedIds: [4] },
+          { input: "用户 编程 TypeScript", expectedIds: [2, 5] },
+          { input: "release_2026 v2", expectedIds: [6] },
+          { input: "backend compatibility v2", expectedIds: [6] },
+          { input: "android nearshore notary", expectedIds: [8] },
+        ];
+
+        for (const { input, expectedIds } of cases) {
+          const legacyIds = searchDocIds(db, buildLegacyUnsafeFtsQueryForTest(input));
+          const ftsQuery = buildFtsQuery(input);
+          expect(ftsQuery).not.toBeNull();
+          const sanitizedIds = searchDocIds(db, ftsQuery!);
+
+          expect(legacyIds).toEqual(expectedIds);
+          expect(sanitizedIds).toEqual(legacyIds);
+        }
+      } finally {
+        db.close();
+      }
+    });
+
+    it("keeps noisy FTS5 syntax queries recall-equivalent to their clean keyword forms", () => {
+      _setJiebaForTest(null);
+      const db = createRecallFixtureDb();
+
+      try {
+        const cases: Array<{ clean: string; noisy: string; expectedIds: number[] }> = [
+          { clean: "travel API", noisy: "travel AND API", expectedIds: [1, 6] },
+          { clean: "TypeScript memory", noisy: "TypeScript OR memory", expectedIds: [2, 5] },
+          { clean: "coffee beans", noisy: "coffee NOT beans", expectedIds: [3] },
+          { clean: "project roadmap", noisy: "NEAR(project roadmap, 5)", expectedIds: [4] },
+          { clean: "用户 编程", noisy: '"用户" OR "编程"', expectedIds: [5] },
+          { clean: "release_2026 v2", noisy: "release_2026 ＯＲ v2", expectedIds: [6] },
+          { clean: "content metadata alpha", noisy: "{content metadata}:alpha", expectedIds: [7] },
+          { clean: "android nearshore notary", noisy: "android OR nearshore NOT notary", expectedIds: [8] },
+        ];
+
+        for (const { clean, noisy, expectedIds } of cases) {
+          const cleanQuery = buildFtsQuery(clean);
+          const noisyQuery = buildFtsQuery(noisy);
+          expect(cleanQuery).not.toBeNull();
+          expect(noisyQuery).not.toBeNull();
+
+          const cleanIds = searchDocIds(db, cleanQuery!);
+          const noisyIds = searchDocIds(db, noisyQuery!);
+
+          expect(cleanIds).toEqual(expectedIds);
+          expect(noisyIds).toEqual(cleanIds);
+        }
+      } finally {
+        db.close();
+      }
+    });
+  });
+});
+
+describe("VectorStore FTS query sanitization", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("keeps L1 FTS fallback searches executable and recall-equivalent for clean and noisy queries", async () => {
+    _setJiebaForTest(null);
+    const tempDir = await mkdtemp(path.join(tmpdir(), "tdai-fts-l1-"));
+    const store = new VectorStore(path.join(tempDir, "memory.db"), 0);
+
+    try {
+      const init = store.init();
+      expect(init.needsReindex).toBe(false);
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL1(makeMemoryRecord("l1-alpha-beta", "alpha beta memory"), undefined)).toBe(true);
+      expect(store.upsertL1(makeMemoryRecord("l1-alpha", "alpha memory"), undefined)).toBe(true);
+      expect(store.upsertL1(makeMemoryRecord("l1-beta", "beta memory"), undefined)).toBe(true);
+
+      const cleanQuery = buildFtsQuery("alpha beta");
+      const noisyQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(cleanQuery).toBe('"alpha" OR "beta"');
+      expect(noisyQuery).toBe(cleanQuery);
+
+      const cleanIds = store.searchL1Fts(cleanQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+      const noisyIds = store.searchL1Fts(noisyQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+
+      expect(cleanIds).toEqual(["l1-alpha", "l1-alpha-beta", "l1-beta"]);
+      expect(noisyIds).toEqual(cleanIds);
+    } finally {
+      store.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps L0 FTS fallback searches executable and recall-equivalent for clean and noisy queries", async () => {
+    _setJiebaForTest(null);
+    const tempDir = await mkdtemp(path.join(tmpdir(), "tdai-fts-l0-"));
+    const store = new VectorStore(path.join(tempDir, "memory.db"), 0);
+
+    try {
+      const init = store.init();
+      expect(init.needsReindex).toBe(false);
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL0(makeL0Record("l0-alpha-beta", "alpha beta message"), undefined)).toBe(true);
+      expect(store.upsertL0(makeL0Record("l0-alpha", "alpha message"), undefined)).toBe(true);
+      expect(store.upsertL0(makeL0Record("l0-beta", "beta message"), undefined)).toBe(true);
+
+      const cleanQuery = buildFtsQuery("alpha beta");
+      const noisyQuery = buildFtsQuery("alpha AND NOT beta");
+      expect(cleanQuery).toBe('"alpha" OR "beta"');
+      expect(noisyQuery).toBe(cleanQuery);
+
+      const cleanIds = store.searchL0Fts(cleanQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+      const noisyIds = store.searchL0Fts(noisyQuery!, 10)
+        .map((result) => result.record_id)
+        .sort();
+
+      expect(cleanIds).toEqual(["l0-alpha", "l0-alpha-beta", "l0-beta"]);
+      expect(noisyIds).toEqual(cleanIds);
+    } finally {
+      store.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function makeMemoryRecord(id: string, content: string): MemoryRecord {
+  const now = "2026-06-30T00:00:00.000Z";
+  return {
+    id,
+    content,
+    type: "episodic",
+    priority: 50,
+    scene_name: "test",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [now],
+    createdAt: now,
+    updatedAt: now,
+    sessionKey: "test-session-key",
+    sessionId: "test-session-id",
+  };
+}
+
+function makeL0Record(id: string, messageText: string): L0Record {
+  return {
+    id,
+    sessionKey: "test-session-key",
+    sessionId: "test-session-id",
+    role: "user",
+    messageText,
+    recordedAt: "2026-06-30T00:00:00.000Z",
+    timestamp: Date.parse("2026-06-30T00:00:00.000Z"),
+  };
+}
+
+function buildLegacyUnsafeFtsQueryForTest(input: string): string {
+  return input.split(/\s+/).filter(Boolean).join(" OR ");
+}
+
+function createExecutionFixtureDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  db.exec(`
+    INSERT INTO docs(rowid, content) VALUES
+      (1, 'alpha beta gamma content metadata title body foo_bar v2 API version2 manana cafe 用户 123 android nearshore notary C'),
+      (2, 'travel plan hotel TypeScript memory coffee beans project roadmap release_2026 backend');
+  `);
+  return db;
+}
+
+function createRecallFixtureDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  const insert = db.prepare("INSERT INTO docs(rowid, content) VALUES (?, ?)");
+
+  insert.run(1, "travel plan API itinerary hotel booking");
+  insert.run(2, "TypeScript memory search sqlite fts");
+  insert.run(3, "coffee beans espresso grinder");
+  insert.run(4, "project roadmap milestone release");
+  insert.run(5, "用户 编程 TypeScript 记忆 搜索");
+  insert.run(6, "release_2026 v2 API backend compatibility");
+  insert.run(7, "content metadata alpha archive");
+  insert.run(8, "android nearshore notary terms");
+  insert.run(9, "unrelated cooking recipe");
+  insert.run(10, "5 distance marker only");
+
+  return db;
+}
+
+function searchDocIds(db: DatabaseSync, ftsQuery: string): number[] {
+  const rows = db
+    .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+    .all(ftsQuery) as Array<{ rowid: number }>;
+  return rows.map((row) => row.rowid);
+}

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,41 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+// FTS5 parses these words as query operators, so never forward them as
+// user-controlled syntax. Dropping them keeps natural-language recall stable.
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+const FTS5_SAFE_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+const FTS5_NEAR_FUNCTION_DISTANCE_RE = /\bNEAR\s*\(\s*([^)]*?)\s*,\s*\d+\s*\)/gi;
+const FTS5_NEAR_SLASH_DISTANCE_RE = /\bNEAR\s*\/\s*\d+\b/gi;
+
+function normalizeFtsQueryInput(raw: string): string {
+  return raw
+    .normalize("NFKC")
+    .replace(FTS5_NEAR_FUNCTION_DISTANCE_RE, " $1 ")
+    .replace(FTS5_NEAR_SLASH_DISTANCE_RE, " NEAR ");
+}
+
+function sanitizeFtsQueryTokens(rawTokens: string[]): string[] {
+  const tokens: string[] = [];
+
+  for (const rawToken of rawTokens) {
+    const parts = rawToken.normalize("NFKC").match(FTS5_SAFE_TOKEN_RE) ?? [];
+    for (const part of parts) {
+      if (!part) continue;
+      if (ZH_STOP_WORDS.has(part)) continue;
+      if (FTS5_RESERVED_OPERATORS.has(part.toUpperCase())) continue;
+      tokens.push(part);
+    }
+  }
+
+  return [...new Set(tokens)];
+}
+
+function quoteFtsPhraseToken(token: string): string {
+  return `"${token}"`;
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -190,6 +225,10 @@ const ZH_STOP_WORDS = new Set([
  * significantly improved — especially for longer queries and when running
  * in FTS-only fallback mode (no embedding available).
  *
+ * User-provided FTS5 syntax is stripped before phrase quoting. This keeps
+ * operators such as AND / OR / NOT / NEAR, column filters, prefix markers,
+ * and grouping characters from changing the MATCH expression semantics.
+ *
  * Example (with jieba):
  *   "用户喜欢编程和TypeScript" → '"用户" OR "喜欢" OR "编程" OR "TypeScript"'
  * Example (fallback):
@@ -197,35 +236,25 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const normalizedRaw = normalizeFtsQueryInput(raw);
 
-  let tokens: string[];
+  let rawTokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
-    // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
+    rawTokens = jieba.cutForSearch(normalizedRaw, true).map((t) => t.trim());
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
+    rawTokens =
+      normalizedRaw
+        .match(FTS5_SAFE_TOKEN_RE)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];
   }
 
+  const tokens = sanitizeFtsQueryTokens(rawTokens);
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map(quoteFtsPhraseToken);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

This PR fixes the SQLite FTS5 query-syntax injection risk described in #160 by making `buildFtsQuery()` generate `MATCH` expressions only from sanitized keyword tokens.

SQLite already receives the final query through a bound `MATCH ?` parameter, but FTS5 still parses that bound value as an FTS query expression. Therefore, user input such as boolean operators, grouping syntax, column filters, prefix markers, or `NEAR` expressions should not be forwarded as user-controlled FTS5 syntax.

This PR updates the query builder to:

- Normalize input with `NFKC` so full-width forms such as `ＯＲ`, `ＮＥＡＲ`, and `１２３` are handled consistently.
- Extract safe tokens through a whitelist-style matcher: Unicode letters, Unicode numbers, and `_`.
- Remove FTS5 reserved operators including `AND`, `OR`, `NOT`, and `NEAR`.
- Neutralize syntax-like input such as quotes, parentheses, braces, `:`, `*`, `^`, `-`, `NEAR(...)`, and `NEAR/n`.
- Quote every sanitized token before joining them with `OR`.
- Use the same sanitizer for both jieba segmentation results and the fallback regex tokenizer.
- Keep the original keyword-oriented recall behavior while preventing user input from changing FTS5 query semantics.

For example:

```text
(alpha OR beta) AND NOT gamma
```

is now converted into a safe keyword query:

```text
"alpha" OR "beta" OR "gamma"
```

instead of allowing `OR`, `AND`, or `NOT` to act as FTS5 operators.

## Related Issue | 关联 Issue

Fix #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Acceptance Criteria Coverage | 验收标准对应

| Issue #160 验收阶段 | 完成情况 | 本 PR 的对应内容 |
| ---- | ---- | ---- |
| 基础：对 FTS5 特殊字符进行转义，普通用户搜索不受影响 | Completed | 在构造 `MATCH` 表达式前清洗输入，移除 FTS5 操作符和特殊语法；普通输入仍会生成 quoted token `OR` 查询 |
| 进阶：编写完整的安全测试用例，覆盖所有 FTS5 操作符和边界情况 | Completed | 新增表驱动测试，覆盖 `AND` / `OR` / `NOT` / `NEAR`、引号、括号、花括号、列过滤、前缀语法、全角字符、重复 token、纯操作符和纯标点输入 |
| 深入：对比转义前后 recall 效果，确认无明显退化 | Completed | 新增 recall 稳定性测试，对比普通关键词输入和带 FTS5 噪声输入的搜索结果，确认清洗后仍保持预期召回 |
| 拓展：考虑 FTS5 查询白名单或参数化查询方案 | Completed | 保留现有 `MATCH ?` 参数绑定执行方式，并在进入 FTS5 `MATCH` 表达式前增加 token 白名单清洗逻辑 |

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

- [x] Verified normal keyword search behavior
  - Example: `travel plan API` still becomes `"travel" OR "plan" OR "API"`.

- [x] Verified FTS5 operators cannot control query semantics
  - Covered uppercase, lowercase, and full-width variants of `AND`, `OR`, `NOT`, and `NEAR`.
  - Covered `NEAR(alpha beta, 5)` and `alpha NEAR/5 beta`.

- [x] Verified special syntax is sanitized
  - Covered quotes, parentheses, braces, `:`, `*`, `^`, `-`, column-filter-like input, and punctuation-only input.

- [x] Verified fallback tokenizer and jieba token flow share the same sanitizer
  - Forced fallback tokenization in tests.
  - Added fake jieba token cases to ensure segmented tokens are sanitized consistently.

- [x] Verified sanitized queries are executable in SQLite FTS5
  - Used an in-memory FTS5 table to confirm generated `MATCH` expressions do not throw syntax errors.

- [x] Verified `VectorStore` FTS fallback paths
  - Covered L1 search through `upsertL1()` and `searchL1Fts()`.
  - Covered L0 search through `upsertL0()` and `searchL0Fts()`.

- [x] Verified recall stability
  - Compared clean keyword queries and noisy FTS5-syntax-like queries against the same fixture data.
  - Confirmed sanitized queries return the expected record sets.

## Additional Notes | 其他说明

Local test passed:

```bash
npm test -- src/core/store/sqlite.test.ts
```

Result:

```text
1 test file passed
41 tests passed
```
