### PR TITLE
fix: recall injection placement for prompt cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps legacy behavior; `append` places memories after the user prompt to better preserve prefix-matching prompt cache stability |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
-| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps legacy behavior; `append` places memories after the user prompt to better preserve prefix-matching prompt cache stability |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps legacy behavior; `append` returns OpenClaw `appendContext` so supported hosts place memories after the user prompt, which better preserves prefix-matching prompt cache stability. This is an opt-in mitigation for dynamic L1 placement; keep `prepend` on hosts that do not consume `before_prompt_build.appendContext`. |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/README_CN.md
+++ b/README_CN.md
@@ -406,6 +406,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回内容注入位置：`prepend` 保持历史行为；`append` 将记忆追加到用户消息末尾，更利于保持 prefix-matching prompt cache 稳定 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |

--- a/README_CN.md
+++ b/README_CN.md
@@ -406,7 +406,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
-| `recall.injectionMode` | `"prepend"` | 动态 L1 召回内容注入位置：`prepend` 保持历史行为；`append` 将记忆追加到用户消息末尾，更利于保持 prefix-matching prompt cache 稳定 |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回内容注入位置：`prepend` 保持历史行为；`append` 返回 OpenClaw `appendContext`，由支持该字段的宿主将记忆追加到用户消息末尾，更利于保持 prefix-matching prompt cache 稳定。这是动态 L1 位置的可选缓解；若宿主不消费 `before_prompt_build.appendContext`，请保持 `prepend`。 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |

--- a/index.ts
+++ b/index.ts
@@ -584,12 +584,14 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
+        if (result?.appendSystemContext || result?.prependContext || result?.appendContext) {
           const appendLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;
+          const appendContextLen = result.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars, ` +
+            `appendContext=${appendContextLen} chars`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);

--- a/index.ts
+++ b/index.ts
@@ -584,6 +584,8 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
+        // OpenClaw consumes appendContext from the returned hook result; this
+        // plugin only logs its size here for recall observability.
         if (result?.appendSystemContext || result?.prependContext || result?.appendContext) {
           const appendLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,6 +74,7 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回内容注入位置：prepend 保持历史行为，append 将记忆追加到用户消息末尾，减少对 prefix-matching prompt cache 的影响" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,7 +74,7 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
-          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回内容注入位置：prepend 保持历史行为，append 将记忆追加到用户消息末尾，减少对 prefix-matching prompt cache 的影响" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回内容注入位置：prepend 保持历史行为；append 返回 OpenClaw appendContext，由支持该字段的宿主追加到用户消息末尾，减少对 prefix-matching prompt cache 的影响" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall injection mode", () => {
+  it("defaults to prepend for backward-compatible auto-recall injection", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+
+  it("accepts append mode for cache-friendlier dynamic recall injection", () => {
+    const cfg = parseConfig({ recall: { injectionMode: "append" } });
+
+    expect(cfg.recall.injectionMode).toBe("append");
+  });
+
+  it("falls back to prepend for unknown recall injection modes", () => {
+    const cfg = parseConfig({ recall: { injectionMode: "sideways" } });
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,13 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /**
+   * Where dynamic L1 recall context is attached to the user prompt.
+   * - "prepend": legacy behavior, places memories before the user text.
+   * - "append": cache-friendlier for prefix-matching providers because the
+   *   user text remains at the start of the prompt.
+   */
+  injectionMode: "prepend" | "append";
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -529,6 +536,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: validateInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
@@ -634,6 +642,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_INJECTION_MODES: RecallConfig["injectionMode"][] = ["prepend", "append"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +652,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateInjectionMode(value: string | undefined): RecallConfig["injectionMode"] | undefined {
+  if (!value) return undefined;
+  return VALID_INJECTION_MODES.includes(value as RecallConfig["injectionMode"])
+    ? (value as RecallConfig["injectionMode"])
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import type { IMemoryStore, L1FtsResult } from "../store/types.js";
+import { performAutoRecall } from "./auto-recall.js";
+
+const ftsMemory: L1FtsResult = {
+  record_id: "l1-1",
+  content: "User prefers stable prompt prefixes for cache efficiency.",
+  type: "preference",
+  priority: 5,
+  scene_name: "",
+  score: 0.9,
+  timestamp_str: "",
+  timestamp_start: "",
+  timestamp_end: "",
+  session_key: "session-1",
+  session_id: "session-1",
+  metadata_json: "{}",
+};
+
+function createFtsStore(results: L1FtsResult[]): IMemoryStore {
+  return {
+    init: () => ({ needsReindex: false }),
+    isDegraded: () => false,
+    getCapabilities: () => ({
+      vectorSearch: false,
+      ftsSearch: true,
+      nativeHybridSearch: false,
+      sparseVectors: false,
+    }),
+    close: () => {},
+    upsertL1: () => true,
+    deleteL1: () => true,
+    deleteL1Batch: () => true,
+    deleteL1Expired: () => 0,
+    countL1: () => results.length,
+    queryL1Records: () => [],
+    getAllL1Texts: () => [],
+    searchL1Vector: () => [],
+    searchL1Fts: () => results,
+    upsertL0: () => true,
+    deleteL0: () => true,
+    deleteL0Expired: () => 0,
+    countL0: () => 0,
+    queryL0ForL1: () => [],
+    queryL0GroupedBySessionId: () => [],
+    getAllL0Texts: () => [],
+    searchL0Vector: () => [],
+    searchL0Fts: () => [],
+    reindexAll: async () => ({ l1Count: 0, l0Count: 0 }),
+    isFtsAvailable: () => true,
+  };
+}
+
+describe("performAutoRecall injection placement", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tmpDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tmpDirs.length = 0;
+  });
+
+  async function createDataDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), "memory-tdai-recall-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  it("keeps dynamic L1 memories in prependContext by default for compatibility", async () => {
+    const cfg = parseConfig({ recall: { strategy: "keyword" } });
+    const result = await performAutoRecall({
+      userText: "How should we improve prompt cache?",
+      actorId: "default_user",
+      sessionKey: "session-1",
+      cfg,
+      pluginDataDir: await createDataDir(),
+      vectorStore: createFtsStore([ftsMemory]),
+    });
+
+    expect(result?.prependContext).toContain("<relevant-memories>");
+    expect((result as { appendContext?: string } | undefined)?.appendContext).toBeUndefined();
+  });
+
+  it("can append dynamic L1 memories after the user prompt to preserve prefix cache stability", async () => {
+    const cfg = parseConfig({ recall: { strategy: "keyword", injectionMode: "append" } });
+    const result = await performAutoRecall({
+      userText: "How should we improve prompt cache?",
+      actorId: "default_user",
+      sessionKey: "session-1",
+      cfg,
+      pluginDataDir: await createDataDir(),
+      vectorStore: createFtsStore([ftsMemory]),
+    });
+
+    expect(result?.prependContext).toBeUndefined();
+    expect((result as { appendContext?: string } | undefined)?.appendContext).toContain("<relevant-memories>");
+    expect((result as { appendContext?: string } | undefined)?.appendContext).toContain("stable prompt prefixes");
+    expect(result?.appendSystemContext).toContain("<memory-tools-guide>");
+  });
+});

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -82,7 +82,7 @@ describe("performAutoRecall injection placement", () => {
     });
 
     expect(result?.prependContext).toContain("<relevant-memories>");
-    expect((result as { appendContext?: string } | undefined)?.appendContext).toBeUndefined();
+    expect(result?.appendContext).toBeUndefined();
   });
 
   it("can append dynamic L1 memories after the user prompt to preserve prefix cache stability", async () => {
@@ -97,8 +97,8 @@ describe("performAutoRecall injection placement", () => {
     });
 
     expect(result?.prependContext).toBeUndefined();
-    expect((result as { appendContext?: string } | undefined)?.appendContext).toContain("<relevant-memories>");
-    expect((result as { appendContext?: string } | undefined)?.appendContext).toContain("stable prompt prefixes");
+    expect(result?.appendContext).toContain("<relevant-memories>");
+    expect(result?.appendContext).toContain("stable prompt prefixes");
     expect(result?.appendSystemContext).toContain("<memory-tools-guide>");
   });
 });

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -57,6 +57,8 @@ export interface RecalledMemory {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn) */
   prependContext?: string;
+  /** L1 relevant memories — appended to user prompt text (dynamic, per-turn) */
+  appendContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
   appendSystemContext?: string;
 
@@ -190,9 +192,10 @@ async function performAutoRecallInner(params: {
   //   These change infrequently; when content is identical across turns,
   //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
   //
-  // prependContext (user prompt prefix — dynamic, per-turn):
-  //   L1 relevant memories — different every turn, moved out of system prompt
-  //   so it doesn't bust the system prompt cache.
+  // prependContext / appendContext (user prompt — dynamic, per-turn):
+  //   L1 relevant memories — different every turn, moved out of system prompt.
+  //   appendContext is cache-friendlier for prefix-matching providers because
+  //   the original user text stays at the front of the prompt.
   const stableParts: string[] = [];
   if (personaContent) {
     stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
@@ -201,17 +204,23 @@ async function performAutoRecallInner(params: {
     stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
   }
 
-  // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
+  // Dynamic part: L1 relevant memories (changes every turn) → user prompt context.
   let prependContext: string | undefined;
+  let appendContext: string | undefined;
   if (memoryLines.length > 0) {
-    prependContext =
+    const relevantMemoriesContext =
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
+    if (cfg.recall.injectionMode === "append") {
+      appendContext = relevantMemoriesContext;
+    } else {
+      prependContext = relevantMemoriesContext;
+    }
   }
 
   // Append memory tools usage guide to the stable part so the agent knows
   // how to actively retrieve deeper context when the injected snippets
   // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
+  if (stableParts.length > 0 || prependContext || appendContext) {
     stableParts.push(MEMORY_TOOLS_GUIDE);
   }
 
@@ -227,12 +236,13 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
-  if (!appendSystemContext && !prependContext) {
+  if (!appendSystemContext && !prependContext && !appendContext) {
     return undefined;
   }
 
   return {
     prependContext,
+    appendContext,
     appendSystemContext,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -199,6 +199,8 @@ export interface CompletedTurn {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
   prependContext?: string;
+  /** L1 relevant memories — appended to user prompt text (dynamic, per-turn). */
+  appendContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
   appendSystemContext?: string;
   /** Recalled L1 memories with scores (for metrics). */


### PR DESCRIPTION
## Summary

Fixes #120 as an opt-in TencentDB-side mitigation for dynamic L1 recall placement.

This PR adds a configurable `recall.injectionMode` for dynamic L1 auto-recall context:

- `prepend` keeps the current behavior and remains the default for backward compatibility.
- `append` returns dynamic `<relevant-memories>` as OpenClaw `appendContext`, so supported hosts append recalled memories after the user prompt instead of changing the prompt prefix.
- Stable persona / scene / memory-tool guidance remains in `appendSystemContext`; the memory tools guide is still included for both prepend and append dynamic recall modes.

The plugin schema and README/README_CN config tables document the new option and note that `append` depends on hosts consuming `before_prompt_build.appendContext`.

## OpenClaw `appendContext` consumption evidence

The OpenClaw hook contract includes `appendContext` in `PluginHookBeforePromptBuildResult` and in `PLUGIN_PROMPT_MUTATION_RESULT_FIELDS`.

OpenClaw also appends it to the prompt in the known prompt assembly paths:

- CLI runner: `preparedPrompt = `${preparedPrompt}\n\n${hookResult.appendContext}``
- embedded runner: `effectivePrompt = `${effectivePrompt}\n\n${hookResult.appendContext}``

This PR therefore emits the existing host hook field rather than inventing a TencentDB-only field. On hosts that do not support `before_prompt_build.appendContext`, users should keep the default `prepend` mode.

## Scope note

This PR does not claim to fully solve every cache-regression path discussed in #120. It specifically addresses the dynamic L1 recall placement problem by offering an append-mode injection path. It does not change OpenClaw transcript persistence, `showInjected` behavior, or host-side CACHE_BOUNDARY placement.

## Validation

- `npm test` (6 files, 72 tests)
- `npm run build`

I did not run a live DeepSeek/MiMo cache-hit measurement locally; that requires provider traffic and an OpenClaw runtime environment with comparable sessions.
