### PR TITLE
fix(offload): invalidate token cache after tool use stripping

### DIFF
--- a/src/offload/hooks/before-prompt-build.ts
+++ b/src/offload/hooks/before-prompt-build.ts
@@ -24,6 +24,7 @@ import {
   replaceWithSummary,
   replaceAssistantToolUseWithSummary,
   compressNonCurrentToolUseBlocks,
+  stripDeletedToolUseBlocks,
   getCurrentTaskNodeIds,
 } from "../l3-helpers.js";
 import {
@@ -99,18 +100,7 @@ export function createBeforePromptBuildHandler(
         // FIX: For mixed assistant messages (text + tool_use), strip deleted tool_use
         // blocks to prevent orphaned tool_use without matching tool_result (Anthropic 400).
         if (hasDeleted && isAssistantMessageWithToolUse(msg) && !isOnlyToolUseAssistant(msg)) {
-          const content = msg.type === "message" ? msg.message?.content : msg.content;
-          if (Array.isArray(content)) {
-            for (let j = content.length - 1; j >= 0; j--) {
-              const block = content[j] as any;
-              if ((block.type === "tool_use" || block.type === "toolCall") && block.id) {
-                const blockIdNorm = normalizeToolCallIdForLookup(block.id);
-                if (stateManager.deletedOffloadIds.has(block.id) || stateManager.deletedOffloadIds.has(blockIdNorm)) {
-                  content.splice(j, 1);
-                }
-              }
-            }
-          }
+          stripDeletedToolUseBlocks(msg, stateManager.deletedOffloadIds);
         }
         if (msg._offloaded) continue;
         if (tid && hasConfirmed && (stateManager.confirmedOffloadIds.has(tid) || (tidNorm && stateManager.confirmedOffloadIds.has(tidNorm)))) {

--- a/src/offload/hooks/llm-input-l3.ts
+++ b/src/offload/hooks/llm-input-l3.ts
@@ -23,6 +23,7 @@ import {
   replaceWithSummary,
   replaceAssistantToolUseWithSummary,
   compressNonCurrentToolUseBlocks,
+  stripDeletedToolUseBlocks,
   getCurrentTaskNodeIds,
 } from "../l3-helpers.js";
 import type { OffloadStateManager } from "../state-manager.js";
@@ -1367,18 +1368,7 @@ async function fastPathReApply(messages: any[], stateManager: OffloadStateManage
     // FIX: For mixed assistant messages (text + tool_use), strip deleted tool_use
     // blocks to prevent orphaned tool_use without matching tool_result (Anthropic 400).
     if (hasDeleted && isAssistantMessageWithToolUse(msg) && !isOnlyToolUseAssistant(msg)) {
-      const content = msg.type === "message" ? msg.message?.content : msg.content;
-      if (Array.isArray(content)) {
-        for (let j = content.length - 1; j >= 0; j--) {
-          const block = content[j] as any;
-          if ((block.type === "tool_use" || block.type === "toolCall") && block.id) {
-            const blockIdNorm = normalizeToolCallIdForLookup(block.id);
-            if (stateManager.deletedOffloadIds.has(block.id) || stateManager.deletedOffloadIds.has(blockIdNorm)) {
-              content.splice(j, 1);
-            }
-          }
-        }
-      }
+      stripDeletedToolUseBlocks(msg, stateManager.deletedOffloadIds);
     }
     if (msg._offloaded) continue;
     if (tid && hasConfirmed && (stateManager.confirmedOffloadIds.has(tid) || (tidNorm && stateManager.confirmedOffloadIds.has(tidNorm)))) {

--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -35,6 +35,7 @@ import {
   replaceWithSummary,
   replaceAssistantToolUseWithSummary,
   compressNonCurrentToolUseBlocks,
+  stripDeletedToolUseBlocks,
   getCurrentTaskNodeIds,
 } from "./l3-helpers.js";
 import { createL3TokenCounter } from "./l3-token-counter.js";
@@ -1545,18 +1546,7 @@ class OffloadContextEngine {
           // FIX: For mixed assistant messages (text + tool_use), strip deleted tool_use
           // blocks to prevent orphaned tool_use without matching tool_result (Anthropic 400).
           if (hasDeleted && isAssistantMessageWithToolUse(msg) && !isOnlyToolUseAssistant(msg)) {
-            const content = msg.type === "message" ? msg.message?.content : msg.content;
-            if (Array.isArray(content)) {
-              for (let j = content.length - 1; j >= 0; j--) {
-                const block = content[j] as any;
-                if ((block.type === "tool_use" || block.type === "toolCall") && block.id) {
-                  const blockIdNorm = normalizeToolCallIdForLookup(block.id);
-                  if (stateManager.deletedOffloadIds.has(block.id) || stateManager.deletedOffloadIds.has(blockIdNorm)) {
-                    content.splice(j, 1);
-                  }
-                }
-              }
-            }
+            stripDeletedToolUseBlocks(msg, stateManager.deletedOffloadIds);
           }
           if (msg._offloaded) continue;
           if (tid && hasConfirmed && (stateManager.confirmedOffloadIds.has(tid) || (tidNorm && stateManager.confirmedOffloadIds.has(tidNorm)))) {

--- a/src/offload/l3-helpers.test.ts
+++ b/src/offload/l3-helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTiktokenContextSnapshot,
+  invalidateTokenCache,
+} from "./context-token-tracker.js";
+import { stripDeletedToolUseBlocks } from "./l3-helpers.js";
+
+function makeMixedAssistantMessage() {
+  return {
+    role: "assistant",
+    content: [
+      { type: "text", text: "I will inspect the repository." },
+      {
+        type: "tool_use",
+        id: "toolu_deleted_01",
+        name: "read_file",
+        input: {
+          path: "/tmp/large.log",
+          reason: "x".repeat(2000),
+        },
+      },
+      { type: "text", text: "The useful text should stay." },
+    ],
+  };
+}
+
+describe("stripDeletedToolUseBlocks", () => {
+  it("invalidates cached token counts after removing deleted tool_use blocks", () => {
+    const msg = makeMixedAssistantMessage();
+    const before = buildTiktokenContextSnapshot("before", [msg], null, null);
+
+    const removed = stripDeletedToolUseBlocks(msg, new Set(["toolu_deleted_01"]));
+    const after = buildTiktokenContextSnapshot("after", [msg], null, null);
+
+    expect(removed).toBe(1);
+    expect(msg.content).toEqual([
+      { type: "text", text: "I will inspect the repository." },
+      { type: "text", text: "The useful text should stay." },
+    ]);
+    expect(after.totalTokens).toBeLessThan(before.totalTokens);
+  });
+
+  it("leaves cached counts untouched when no deleted block matches", () => {
+    const msg = makeMixedAssistantMessage();
+    const before = buildTiktokenContextSnapshot("before", [msg], null, null);
+
+    const removed = stripDeletedToolUseBlocks(msg, new Set(["other_id"]));
+    const after = buildTiktokenContextSnapshot("after", [msg], null, null);
+
+    expect(removed).toBe(0);
+    expect(after.totalTokens).toBe(before.totalTokens);
+
+    invalidateTokenCache(msg);
+  });
+});

--- a/src/offload/l3-helpers.ts
+++ b/src/offload/l3-helpers.ts
@@ -302,6 +302,34 @@ export function compressNonCurrentToolUseBlocks(
   invalidateTokenCache(msg);
 }
 
+/**
+ * Remove deleted tool_use blocks from a mixed assistant message.
+ *
+ * The message object is mutated in place, so invalidate the per-message token
+ * cache whenever a block is actually removed.
+ */
+export function stripDeletedToolUseBlocks(
+  msg: any,
+  deletedIds: Set<string>,
+): number {
+  const content = getMessageContent(msg);
+  if (!Array.isArray(content)) return 0;
+
+  let removed = 0;
+  for (let j = content.length - 1; j >= 0; j--) {
+    const block = content[j] as any;
+    if (!isToolUseBlock(block) || !block.id) continue;
+    const blockIdNorm = normalizeToolCallIdForLookup(block.id);
+    if (deletedIds.has(block.id) || deletedIds.has(blockIdNorm)) {
+      content.splice(j, 1);
+      removed++;
+    }
+  }
+
+  if (removed > 0) invalidateTokenCache(msg);
+  return removed;
+}
+
 /** Get the set of node_ids belonging to the current active task */
 export async function getCurrentTaskNodeIds(
   stateManager: OffloadStateManager,


### PR DESCRIPTION
## Description | 描述

Fix the stale token-cache path after deleted `tool_use` blocks are stripped out
of mixed assistant messages.

`buildTiktokenContextSnapshot()` caches token counts by message object identity
and `_offloaded` state. The offload fast paths mutate mixed assistant messages
in place with `content.splice(...)`, but the old code did not invalidate that
per-message cache. A later token snapshot could therefore keep counting the
removed `tool_use` payload and trigger unnecessary guard/emergency compression.

This PR keeps the runtime change narrow:
- adds `stripDeletedToolUseBlocks()` as the shared helper for deleted
  `tool_use` removal,
- invalidates the token cache only when a block is actually removed,
- reuses the helper in the before-prompt-build fast path, the llm-input L3 fast
  path, and the context-engine assemble fast path,
- adds a Vitest regression that seeds the cache, strips a deleted block, and
  verifies the next snapshot reflects the smaller message.

## Related Issue | 关联 Issue

Fix #233

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-233 npx vitest run src/offload/l3-helpers.test.ts
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-233 npm test
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-233 npm run build
git diff --check
```

Results:
- `src/offload/l3-helpers.test.ts`: 2 tests passed.
- `npm test`: 5 files / 69 tests passed.
- `npm run build`: plugin and scripts build passed.
