### PR TITLE
[codex] fix checkpoint counter recalibration

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -415,6 +415,14 @@ export class TdaiCore {
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+
+    try {
+      await new CheckpointManager(this.dataDir, this.logger).recalibrate();
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint recalibration failed; counters may be stale: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private wirePipelineRunners(): void {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -32,14 +32,23 @@ describe("CheckpointManager recalibration", () => {
       last_persona_time: "",
       request_persona_update: false,
       persona_update_reason: "",
-      memories_since_last_persona: 4,
+      memories_since_last_persona: 40,
       scenes_processed: 0,
       runner_states: {},
       pipeline_states: {},
       l0_conversations_count: 50,
       total_memories_extracted: 45,
     });
-    await fs.writeFile(path.join(dataDir, "conversations", "2026-07-01.jsonl"), "{}\n{}\n\n", "utf-8");
+    await fs.writeFile(
+      path.join(dataDir, "conversations", "2026-07-01.jsonl"),
+      [
+        JSON.stringify({ sessionKey: "s1", sessionId: "a", recordedAt: "2026-07-01T10:00:00.000Z" }),
+        JSON.stringify({ sessionKey: "s1", sessionId: "a", recordedAt: "2026-07-01T10:00:00.000Z" }),
+        JSON.stringify({ sessionKey: "s1", sessionId: "a", recordedAt: "2026-07-01T10:05:00.000Z" }),
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
     await fs.writeFile(path.join(dataDir, "records", "2026-07-01.jsonl"), "{}\n{}\n{}\n", "utf-8");
 
     const recalibrated = await checkpoint.recalibrate();
@@ -47,20 +56,62 @@ describe("CheckpointManager recalibration", () => {
     expect(recalibrated.l0_conversations_count).toBe(2);
     expect(recalibrated.total_memories_extracted).toBe(3);
     expect(recalibrated.total_processed).toBe(9);
-    expect(recalibrated.memories_since_last_persona).toBe(4);
+    expect(recalibrated.memories_since_last_persona).toBe(3);
   });
 
   it("counts captured L0 message records so incremental updates match recalibration", async () => {
     const dataDir = await makeTempDataDir();
     const checkpoint = new CheckpointManager(dataDir);
 
-    await checkpoint.captureAtomically("session-a", undefined, async () => ({
-      maxTimestamp: 200,
-      messageCount: 2,
-    }));
+    await checkpoint.captureAtomically("session-a", undefined, async () => {
+      await fs.writeFile(
+        path.join(dataDir, "conversations", "2026-07-01.jsonl"),
+        [
+          JSON.stringify({ sessionKey: "session-a", sessionId: "turn-1", recordedAt: "2026-07-01T10:00:00.000Z" }),
+          JSON.stringify({ sessionKey: "session-a", sessionId: "turn-1", recordedAt: "2026-07-01T10:00:00.000Z" }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+      return {
+        maxTimestamp: 200,
+        messageCount: 2,
+      };
+    });
 
     const cp = await checkpoint.read();
-    expect(cp.l0_conversations_count).toBe(2);
+    expect(cp.l0_conversations_count).toBe(1);
     expect(cp.total_processed).toBe(2);
+
+    const recalibrated = await checkpoint.recalibrate();
+    expect(recalibrated.l0_conversations_count).toBe(1);
+    expect(recalibrated.total_processed).toBe(2);
+  });
+
+  it("rejects malformed JSONL without overwriting existing counters", async () => {
+    const dataDir = await makeTempDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 4,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 7,
+      total_memories_extracted: 9,
+    });
+    await fs.writeFile(path.join(dataDir, "records", "2026-07-01.jsonl"), "{not json}\n", "utf-8");
+
+    await expect(checkpoint.recalibrate()).rejects.toThrow("Malformed JSONL");
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(7);
+    expect(cp.total_memories_extracted).toBe(9);
+    expect(cp.memories_since_last_persona).toBe(4);
   });
 });

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  await fs.mkdir(path.join(dir, "conversations"), { recursive: true });
+  await fs.mkdir(path.join(dir, "records"), { recursive: true });
+  await fs.mkdir(path.join(dir, ".metadata"), { recursive: true });
+  return dir;
+}
+
+describe("CheckpointManager recalibration", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recounts persisted JSONL records and decreases drifted counters", async () => {
+    const dataDir = await makeTempDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 123,
+      total_processed: 9,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 4,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 50,
+      total_memories_extracted: 45,
+    });
+    await fs.writeFile(path.join(dataDir, "conversations", "2026-07-01.jsonl"), "{}\n{}\n\n", "utf-8");
+    await fs.writeFile(path.join(dataDir, "records", "2026-07-01.jsonl"), "{}\n{}\n{}\n", "utf-8");
+
+    const recalibrated = await checkpoint.recalibrate();
+
+    expect(recalibrated.l0_conversations_count).toBe(2);
+    expect(recalibrated.total_memories_extracted).toBe(3);
+    expect(recalibrated.total_processed).toBe(9);
+    expect(recalibrated.memories_since_last_persona).toBe(4);
+  });
+
+  it("counts captured L0 message records so incremental updates match recalibration", async () => {
+    const dataDir = await makeTempDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 200,
+      messageCount: 2,
+    }));
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(2);
+    expect(cp.total_processed).toBe(2);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -145,6 +145,10 @@ export interface CheckpointLogger {
 }
 
 const noopLogger: CheckpointLogger = { info() {} };
+const COUNTER_JSONL_DIRS = {
+  l0: "conversations",
+  l1: "records",
+} as const;
 
 // ============================
 // Per-file async lock
@@ -179,10 +183,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -396,6 +402,37 @@ export class CheckpointManager {
     });
   }
 
+  /**
+   * Recount persisted L0/L1 JSONL records and align aggregate counters.
+   *
+   * These counters are maintained incrementally during normal capture/extraction,
+   * but cleanup jobs or manual JSONL pruning can remove records outside that path.
+   * Recalibration makes the checkpoint reflect the current persisted data again.
+   */
+  async recalibrate(): Promise<Checkpoint> {
+    const actualL0 = await countJsonlRecords(path.join(this.dataDir, COUNTER_JSONL_DIRS.l0));
+    const actualL1 = await countJsonlRecords(path.join(this.dataDir, COUNTER_JSONL_DIRS.l1));
+    let previousL0 = 0;
+    let previousL1 = 0;
+
+    const cp = await this.mutate((cp) => {
+      previousL0 = cp.l0_conversations_count;
+      previousL1 = cp.total_memories_extracted;
+      cp.l0_conversations_count = actualL0;
+      cp.total_memories_extracted = actualL1;
+    });
+
+    if (previousL0 !== actualL0 || previousL1 !== actualL1) {
+      this.logger.info(
+        `[checkpoint] recalibrated counters: ` +
+        `l0_conversations_count ${previousL0}->${actualL0}, ` +
+        `total_memories_extracted ${previousL1}->${actualL1}`,
+      );
+    }
+
+    return cp;
+  }
+
   // ============================
   // L1-specific methods
   // ============================
@@ -479,10 +516,32 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }
 
+}
+
+async function countJsonlRecords(dirPath: string): Promise<number> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let total = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const filePath = path.join(dirPath, entry.name);
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+    total += raw.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+  }
+  return total;
 }

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -25,8 +25,10 @@
  */
 
 import fs from "node:fs/promises";
+import { createReadStream } from "node:fs";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import { createInterface } from "node:readline/promises";
 
 // ============================
 // Types
@@ -100,7 +102,7 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /** Total L0 capture batches recorded. Each batch may contain multiple JSONL message records. */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
@@ -403,30 +405,45 @@ export class CheckpointManager {
   }
 
   /**
-   * Recount persisted L0/L1 JSONL records and align aggregate counters.
+   * Recount persisted L0/L1 JSONL data and align aggregate counters.
    *
    * These counters are maintained incrementally during normal capture/extraction,
    * but cleanup jobs or manual JSONL pruning can remove records outside that path.
    * Recalibration makes the checkpoint reflect the current persisted data again.
    */
   async recalibrate(): Promise<Checkpoint> {
-    const actualL0 = await countJsonlRecords(path.join(this.dataDir, COUNTER_JSONL_DIRS.l0));
-    const actualL1 = await countJsonlRecords(path.join(this.dataDir, COUNTER_JSONL_DIRS.l1));
     let previousL0 = 0;
     let previousL1 = 0;
+    let previousMemoriesSincePersona = 0;
+    let actualL0 = 0;
+    let actualL1 = 0;
+    let actualMemoriesSincePersona = 0;
 
-    const cp = await this.mutate((cp) => {
+    const cp = await this.mutate(async (cp) => {
+      actualL0 = await countL0CaptureBatches(path.join(this.dataDir, COUNTER_JSONL_DIRS.l0));
+      actualL1 = await countJsonlRecords(path.join(this.dataDir, COUNTER_JSONL_DIRS.l1));
       previousL0 = cp.l0_conversations_count;
       previousL1 = cp.total_memories_extracted;
+      previousMemoriesSincePersona = cp.memories_since_last_persona;
+      // total_processed/last_persona_at are monotonic capture offsets used by
+      // persona backup labels. Recalibration only clamps the L1 threshold counter
+      // so deleted memories cannot keep triggering persona generation.
+      actualMemoriesSincePersona = Math.min(cp.memories_since_last_persona, actualL1);
       cp.l0_conversations_count = actualL0;
       cp.total_memories_extracted = actualL1;
+      cp.memories_since_last_persona = actualMemoriesSincePersona;
     });
 
-    if (previousL0 !== actualL0 || previousL1 !== actualL1) {
+    if (
+      previousL0 !== actualL0 ||
+      previousL1 !== actualL1 ||
+      previousMemoriesSincePersona !== actualMemoriesSincePersona
+    ) {
       this.logger.info(
         `[checkpoint] recalibrated counters: ` +
         `l0_conversations_count ${previousL0}->${actualL0}, ` +
-        `total_memories_extracted ${previousL1}->${actualL1}`,
+        `total_memories_extracted ${previousL1}->${actualL1}, ` +
+        `memories_since_last_persona ${previousMemoriesSincePersona}->${actualMemoriesSincePersona}`,
       );
     }
 
@@ -516,7 +533,7 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        cp.l0_conversations_count += result.messageCount;
+        cp.l0_conversations_count += 1;
       }
     });
   }
@@ -524,24 +541,64 @@ export class CheckpointManager {
 }
 
 async function countJsonlRecords(dirPath: string): Promise<number> {
+  let count = 0;
+  await readJsonlRecords(dirPath, () => {
+    count += 1;
+  });
+  return count;
+}
+
+async function countL0CaptureBatches(dirPath: string): Promise<number> {
+  const batches = new Set<string>();
+  await readJsonlRecords(dirPath, (record, location) => {
+    const sessionKey = typeof record.sessionKey === "string" ? record.sessionKey : "";
+    const sessionId = typeof record.sessionId === "string" ? record.sessionId : "";
+    const recordedAt = typeof record.recordedAt === "string" ? record.recordedAt : "";
+    batches.add(recordedAt ? `${sessionKey}\0${sessionId}\0${recordedAt}` : location);
+  });
+  return batches.size;
+}
+
+async function readJsonlRecords(
+  dirPath: string,
+  onRecord: (record: Record<string, unknown>, location: string) => void,
+): Promise<void> {
   let entries;
   try {
     entries = await fs.readdir(dirPath, { withFileTypes: true });
-  } catch {
-    return 0;
+  } catch (err) {
+    if (isNodeErrorWithCode(err, "ENOENT")) return;
+    throw err;
   }
 
-  let total = 0;
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
     const filePath = path.join(dirPath, entry.name);
-    let raw: string;
-    try {
-      raw = await fs.readFile(filePath, "utf-8");
-    } catch {
-      continue;
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: "utf-8" }),
+      crlfDelay: Infinity,
+    });
+
+    let lineNumber = 0;
+    for await (const line of rl) {
+      lineNumber += 1;
+      if (!line.trim()) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (err) {
+        throw new Error(
+          `Malformed JSONL in ${filePath}:${lineNumber}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error(`Invalid JSONL record in ${filePath}:${lineNumber}: expected object`);
+      }
+      onRecord(parsed as Record<string, unknown>, `${filePath}:${lineNumber}`);
     }
-    total += raw.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
   }
-  return total;
+}
+
+function isNodeErrorWithCode(err: unknown, code: string): boolean {
+  return typeof err === "object" && err !== null && "code" in err && (err as { code?: unknown }).code === code;
 }


### PR DESCRIPTION
## Summary

- Add `CheckpointManager.recalibrate()` to recount persisted L0/L1 JSONL records and reset drifted aggregate counters.
- Run checkpoint recalibration once during core startup, even if store initialization falls back to degraded mode.
- Align L0 incremental counting with persisted message records and add regression coverage for counter drift after pruning.

Fixes #157.

## Verification

- `npm test`
- `npm run build`
