### PR TITLE
fix(offload): preserve namespaced model ids

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -52,6 +52,7 @@ import type { OffloadConfig } from "../config.js";
 import type { PluginConfig, PluginLogger } from "./types.js";
 import { BackendClient } from "./backend-client.js";
 import { LocalLlmClient } from "./local-llm/index.js";
+import { getContextWindowForModelRef, parseOffloadModelRef } from "./model-ref.js";
 import { resolveApiKeyFromAuthProfile } from "./auth-profile-key.js";
 import type { L1Request, L15Request, L2Request } from "./backend-client.js";
 import { parseMmdMeta } from "./mmd-meta.js";
@@ -363,9 +364,9 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
     }
 
     if (resolvedModelRef) {
-      const modelParts = resolvedModelRef.split("/", 2);
-      const providerKey = modelParts[0];
-      const modelId = modelParts[1] ?? resolvedModelRef;
+      const modelRef = parseOffloadModelRef(resolvedModelRef);
+      const providerKey = modelRef?.providerKey ?? resolvedModelRef;
+      const modelId = modelRef?.modelId ?? resolvedModelRef;
       const models = (api.config as any)?.models;
       const providerCfg = models?.providers?.[providerKey];
       const baseUrl = providerCfg?.baseUrl ?? providerCfg?.baseURL;
@@ -852,14 +853,8 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
       const models = config?.models;
       // 1. If we know the model, find its exact contextWindow from providers
       if (defaultModel && models) {
-        const [providerKey, modelId] = defaultModel.split("/", 2);
-        const provider = models.providers?.[providerKey];
-        if (provider?.models) {
-          const modelList = Array.isArray(provider.models) ? provider.models : [];
-          for (const m of modelList) {
-            if (m.id === modelId && typeof m.contextWindow === "number") return m.contextWindow;
-          }
-        }
+        const contextWindow = getContextWindowForModelRef(models, defaultModel);
+        if (contextWindow) return contextWindow;
       }
       // 2. Fallback: top-level models.contextWindow
       if (models?.contextWindow && typeof models.contextWindow === "number") return models.contextWindow;

--- a/src/offload/model-ref.test.ts
+++ b/src/offload/model-ref.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getContextWindowForModelRef,
+  parseOffloadModelRef,
+} from "./model-ref.js";
+
+describe("parseOffloadModelRef", () => {
+  it("preserves namespaced model ids after the provider separator", () => {
+    expect(parseOffloadModelRef("siliconflow/deepseek-ai/DeepSeek-V4-Flash")).toEqual({
+      providerKey: "siliconflow",
+      modelId: "deepseek-ai/DeepSeek-V4-Flash",
+    });
+  });
+
+  it("returns null for aliases or malformed refs", () => {
+    expect(parseOffloadModelRef("claude-code")).toBeNull();
+    expect(parseOffloadModelRef("/missing-provider")).toBeNull();
+    expect(parseOffloadModelRef("provider/")).toBeNull();
+    expect(parseOffloadModelRef("   ")).toBeNull();
+  });
+});
+
+describe("getContextWindowForModelRef", () => {
+  it("matches provider model entries with slash-containing model ids", () => {
+    const models = {
+      providers: {
+        siliconflow: {
+          models: [
+            { id: "deepseek-ai/DeepSeek-V4-Flash", contextWindow: 128000 },
+            { id: "deepseek-ai", contextWindow: 4096 },
+          ],
+        },
+      },
+    };
+
+    expect(
+      getContextWindowForModelRef(models, "siliconflow/deepseek-ai/DeepSeek-V4-Flash"),
+    ).toBe(128000);
+  });
+});

--- a/src/offload/model-ref.ts
+++ b/src/offload/model-ref.ts
@@ -1,0 +1,36 @@
+export interface OffloadModelRef {
+  providerKey: string;
+  modelId: string;
+}
+
+export function parseOffloadModelRef(raw: string | null | undefined): OffloadModelRef | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const slashIdx = trimmed.indexOf("/");
+  if (slashIdx <= 0 || slashIdx === trimmed.length - 1) return null;
+
+  return {
+    providerKey: trimmed.slice(0, slashIdx),
+    modelId: trimmed.slice(slashIdx + 1),
+  };
+}
+
+export function getContextWindowForModelRef(
+  models: any,
+  rawModelRef: string | null | undefined,
+): number | undefined {
+  const modelRef = parseOffloadModelRef(rawModelRef);
+  if (!modelRef || !models) return undefined;
+
+  const provider = models.providers?.[modelRef.providerKey];
+  const modelList = Array.isArray(provider?.models) ? provider.models : [];
+  for (const model of modelList) {
+    if (model?.id === modelRef.modelId && typeof model.contextWindow === "number") {
+      return model.contextWindow;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Description | 描述

Fix `offload.model` parsing for provider/model refs whose model id itself
contains slashes, for example:

```text
siliconflow/deepseek-ai/DeepSeek-V4-Flash
```

The previous `split("/", 2)` path truncated that model id to `deepseek-ai`,
which can make the local offload LLM request fail with a bad model id. The same
split also prevented exact `contextWindow` lookup for slash-containing model
ids.

This PR keeps the change intentionally small:
- adds an offload-local `parseOffloadModelRef()` helper that splits only at the
  first `/`,
- uses it when initializing the local offload LLM client,
- uses it for exact provider model `contextWindow` lookup,
- adds focused tests for namespaced model ids and malformed / alias refs.

## Related Issue | 关联 Issue

Fix #24

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-24 npx vitest run src/offload/model-ref.test.ts
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-24 npm test
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-24 npm run build
git diff --check
```

Results:
- `src/offload/model-ref.test.ts`: 3 tests passed.
- `npm test`: 5 files / 70 tests passed.
- `npm run build`: plugin and scripts build passed.

## Notes | 说明

There is another open implementation (#240). This PR takes a narrower route by
keeping the parser local to the offload module instead of moving the
clean-context runner parser, while still covering both the local LLM model id
and context-window lookup paths.
