### PR TITLE
fix(manifest): declare memory capability

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { registerMemoryCapabilityIfAvailable } from "./src/utils/memory-capability.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -163,6 +164,7 @@ export default function register(api: OpenClawPluginApi) {
     `${TAG} Registering plugin ... ` +
     `startTimestamp=${pluginStartTimestamp} (${new Date(pluginStartTimestamp).toISOString()})`,
   );
+  registerMemoryCapabilityIfAvailable(api as any, api.logger);
 
   let cfg: MemoryTdaiConfig;
   try {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,7 @@
 {
   "id": "memory-tencentdb",
   "name": "Memory (TencentDB)",
+  "kind": "memory",
   "description": "Four-layer memory system — auto-captures, structures, and profiles conversational knowledge",
   "commandAliases": ["memory-tdai"],
   "activation": {

--- a/src/utils/memory-capability.test.ts
+++ b/src/utils/memory-capability.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerMemoryCapabilityIfAvailable } from "./memory-capability.js";
+
+describe("registerMemoryCapabilityIfAvailable", () => {
+  it("registers an empty memory capability when the host supports it", () => {
+    const registerMemoryCapability = vi.fn();
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+
+    const registered = registerMemoryCapabilityIfAvailable(
+      { registerMemoryCapability },
+      logger,
+    );
+
+    expect(registered).toBe(true);
+    expect(registerMemoryCapability).toHaveBeenCalledWith({});
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("skips older hosts without failing plugin registration", () => {
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+
+    const registered = registerMemoryCapabilityIfAvailable({}, logger);
+
+    expect(registered).toBe(false);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("registerMemoryCapability unavailable"),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("treats host registration failures as non-fatal", () => {
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+    const registerMemoryCapability = vi.fn(() => {
+      throw new Error("slot loader rejected plugin");
+    });
+
+    const registered = registerMemoryCapabilityIfAvailable(
+      { registerMemoryCapability },
+      logger,
+    );
+
+    expect(registered).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("slot loader rejected plugin"),
+    );
+  });
+});

--- a/src/utils/memory-capability.ts
+++ b/src/utils/memory-capability.ts
@@ -1,0 +1,32 @@
+type MemoryCapabilityApi = {
+  registerMemoryCapability?: (capability: Record<string, never>) => void;
+};
+
+type CapabilityLogger = {
+  debug?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+const TAG = "[memory-tdai]";
+
+export function registerMemoryCapabilityIfAvailable(
+  api: MemoryCapabilityApi,
+  logger?: CapabilityLogger,
+): boolean {
+  if (typeof api.registerMemoryCapability !== "function") {
+    logger?.debug?.(`${TAG} registerMemoryCapability unavailable; skipping memory slot declaration`);
+    return false;
+  }
+
+  try {
+    api.registerMemoryCapability({});
+    logger?.debug?.(`${TAG} Memory capability registered for host doctor checks`);
+    return true;
+  } catch (err) {
+    logger?.warn?.(
+      `${TAG} registerMemoryCapability failed; continuing without host memory slot declaration: ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Description | 描述

Declare the plugin as a host memory provider so OpenClaw doctor / slot checks do
not report `memory slot plugin not found` when memory-tencentdb is loaded.

This keeps the runtime behavior defensive:
- `openclaw.plugin.json` declares `kind: "memory"` so the host slot loader can
  classify this plugin as a memory provider.
- `register()` feature-detects `api.registerMemoryCapability` and registers an
  empty capability when the host supports it.
- Older hosts without `registerMemoryCapability` continue loading normally.
- Host registration failures are logged as warnings and do not block plugin
  startup.
- The new helper is covered by unit tests for supported hosts, older hosts, and
  failure paths.

## Related Issue | 关联 Issue

Fix #119

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-119 npx vitest run src/utils/memory-capability.test.ts
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-119 npm test
PATH=$HOME/.nvm/versions/node/v24.15.0/bin:$PATH npm_config_cache=/tmp/npm-cache-tam-119 npm run build
git diff --check
```

Results:
- `src/utils/memory-capability.test.ts`: 3 tests passed.
- `npm test`: 5 files / 70 tests passed.
- `npm run build`: plugin and scripts build passed.

## Notes | 说明

There is another open implementation (#132). This PR keeps the same
compatibility shape but adds focused unit coverage around the host API
feature-detection and non-fatal failure behavior.
