### PR TITLE
fix(recall): scope memory search by session

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -376,6 +376,10 @@ export default function register(api: OpenClawPluginApi) {
             type: "string",
             description: "Optional filter by scene name",
           },
+          session_key: {
+            type: "string",
+            description: "Optional filter by session key. Use the current session key to keep results scoped to this conversation.",
+          },
         },
         required: ["query"],
       },
@@ -385,15 +389,23 @@ export default function register(api: OpenClawPluginApi) {
         const limit = Math.min(Math.max(Number(params.limit) || 5, 1), 20);
         const typeFilter = typeof params.type === "string" ? params.type : undefined;
         const sceneFilter = typeof params.scene === "string" ? params.scene : undefined;
+        const sessionKeyFilter = typeof params.session_key === "string" ? params.session_key : undefined;
 
         api.logger.debug?.(
           `${TAG} [tool] tdai_memory_search called: ` +
           `query="${query.length > 80 ? query.slice(0, 80) + "…" : query}", ` +
-          `limit=${limit}, type=${typeFilter ?? "(all)"}, scene=${sceneFilter ?? "(all)"}`,
+          `limit=${limit}, type=${typeFilter ?? "(all)"}, scene=${sceneFilter ?? "(all)"}, ` +
+          `session_key=${sessionKeyFilter ?? "(all)"}`,
         );
 
         try {
-          const result = await core.searchMemories({ query, limit, type: typeFilter, scene: sceneFilter });
+          const result = await core.searchMemories({
+            query,
+            limit,
+            type: typeFilter,
+            scene: sceneFilter,
+            sessionKey: sessionKeyFilter,
+          });
 
           const elapsedMs = Date.now() - startMs;
           api.logger.debug?.(
@@ -403,7 +415,7 @@ export default function register(api: OpenClawPluginApi) {
           );
           report("tool_call", {
             tool: "tdai_memory_search",
-            query, limit, typeFilter, sceneFilter,
+            query, limit, typeFilter, sceneFilter, sessionKeyFilter,
             resultCount: result.total,
             strategy: result.strategy,
             durationMs: elapsedMs,
@@ -419,7 +431,7 @@ export default function register(api: OpenClawPluginApi) {
           api.logger.error(`${TAG} [tool] tdai_memory_search failed (${elapsedMs}ms): ${errMsg}`);
           report("tool_call", {
             tool: "tdai_memory_search",
-            query, limit, typeFilter, sceneFilter,
+            query, limit, typeFilter, sceneFilter, sessionKeyFilter,
             durationMs: elapsedMs,
             success: false,
             error: errMsg,

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -109,7 +109,7 @@ async function performAutoRecallInner(params: {
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
 }): Promise<RecallResult | undefined> {
-  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
+  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService, sessionKey } = params;
   const tRecallStart = performance.now();
 
   // Search relevant memories (L1 layer) — skip only when userText is empty/undefined
@@ -122,7 +122,7 @@ async function performAutoRecallInner(params: {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
-    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
+    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService, sessionKey);
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
     memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
@@ -262,6 +262,22 @@ interface SearchResult {
   timing: SearchTiming;
 }
 
+function filterBySessionKey<T extends { session_key: string }>(
+  results: T[],
+  sessionKey: string | undefined,
+  logger: Logger | undefined,
+  stage: string,
+): T[] {
+  if (!sessionKey) return results;
+  const filtered = results.filter((r) => r.session_key === sessionKey);
+  if (filtered.length !== results.length) {
+    logger?.debug?.(
+      `${TAG} [${stage}] session filter kept ${filtered.length}/${results.length} for session=${sessionKey}`,
+    );
+  }
+  return filtered;
+}
+
 /**
  * Search memories and return both formatted lines and structured details.
  *
@@ -277,8 +293,9 @@ async function searchMemoriesWithDetails(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  sessionKey?: string,
 ): Promise<{ lines: string[]; memories: RecalledMemory[]; timing: SearchTiming }> {
-  const result = await searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService);
+  const result = await searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService, sessionKey);
 
   // Extract structured data from formatted memory lines.
   // Format: "- [type|scene] content (活动时间: ...)" or "- [type] content"
@@ -313,6 +330,7 @@ async function searchMemories(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  sessionKey?: string,
 ): Promise<SearchResult> {
   const emptyResult: SearchResult = { lines: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
   // Strip gateway-injected inbound metadata (Sender, timestamps, media markers,
@@ -339,7 +357,7 @@ async function searchMemories(
     `${TAG} [searchMemories] strategy=${strategy}, embeddingAvailable=${embeddingAvailable}, ` +
     `vectorStore=${vectorStore ? "available" : "UNAVAILABLE"}, ` +
     `embeddingService=${embeddingService ? "available" : "UNAVAILABLE"}, ` +
-    `maxResults=${maxResults}, threshold=${threshold}`,
+    `maxResults=${maxResults}, threshold=${threshold}, session=${sessionKey ?? "(none)"}`,
   );
 
   // Determine effective strategy (fall back to keyword if embedding not available)
@@ -361,13 +379,13 @@ async function searchMemories(
   try {
     if (effectiveStrategy === "keyword") {
       const tFts = performance.now();
-      const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore);
+      const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore, sessionKey);
       return { lines, timing: { ftsMs: performance.now() - tFts, embeddingMs: 0, ftsHits: lines.length, embeddingHits: 0 } };
     }
 
     if (effectiveStrategy === "embedding") {
       const tEmb = performance.now();
-      const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts);
+      const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts, sessionKey);
       return { lines, timing: { ftsMs: 0, embeddingMs: performance.now() - tEmb, ftsHits: 0, embeddingHits: lines.length } };
     }
 
@@ -376,15 +394,17 @@ async function searchMemories(
     // to avoid a redundant second HTTP request and a wasted local embed().
     if (vectorStore?.getCapabilities().nativeHybridSearch) {
       const tNative = performance.now();
-      const results = await vectorStore.searchL1Hybrid({ query: cleanText, topK: maxResults });
+      const candidateK = sessionKey ? maxResults * 4 : maxResults;
+      const rawResults = await vectorStore.searchL1Hybrid({ query: cleanText, topK: candidateK });
+      const results = filterBySessionKey(rawResults, sessionKey, logger, "hybrid-native");
       const nativeMs = performance.now() - tNative;
-      logger?.debug?.(`${TAG} [hybrid-native] Single-call hybrid: ${results.length} results in ${nativeMs.toFixed(0)}ms`);
-      const lines = results.map((r) => formatMemoryLine(vectorResultToFormatable(r)));
+      logger?.debug?.(`${TAG} [hybrid-native] Single-call hybrid: ${results.length}/${rawResults.length} results in ${nativeMs.toFixed(0)}ms`);
+      const lines = results.slice(0, maxResults).map((r) => formatMemoryLine(vectorResultToFormatable(r)));
       return { lines, timing: { ftsMs: 0, embeddingMs: nativeMs, ftsHits: 0, embeddingHits: results.length } };
     }
 
     // Fallback: run keyword + embedding in parallel, merge with client-side RRF (SQLite path)
-    return await searchHybrid(cleanText, pluginDataDir, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts);
+    return await searchHybrid(cleanText, pluginDataDir, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts, sessionKey);
   } catch (err) {
     logger?.warn?.(`${TAG} Memory search failed (strategy=${effectiveStrategy}): ${err instanceof Error ? err.message : String(err)}`);
     return emptyResult;
@@ -402,13 +422,16 @@ async function searchByKeyword(
   threshold: number,
   logger?: Logger,
   vectorStore?: IMemoryStore,
+  sessionKey?: string,
 ): Promise<string[]> {
   // Prefer FTS5 if available
   if (vectorStore?.isFtsAvailable()) {
     const ftsQuery = buildFtsQuery(userText);
     if (ftsQuery) {
       logger?.debug?.(`${TAG} [keyword-fts] Using FTS5 BM25 search: query="${ftsQuery}"`);
-      const ftsResults = await vectorStore.searchL1Fts(ftsQuery, maxResults * 2);
+      const candidateK = sessionKey ? maxResults * 4 : maxResults * 2;
+      const rawFtsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+      const ftsResults = filterBySessionKey(rawFtsResults, sessionKey, logger, "keyword-fts");
       if (ftsResults.length > 0) {
         logger?.debug?.(
           `${TAG} [keyword-fts] FTS5 raw results (${ftsResults.length}): ` +
@@ -455,6 +478,7 @@ async function searchByEmbedding(
   embeddingService: EmbeddingService,
   logger?: Logger,
   embeddingCallOpts?: EmbeddingCallOptions,
+  sessionKey?: string,
 ): Promise<string[]> {
   logger?.debug?.(
     `${TAG} [embedding-search] START query="${userText.slice(0, 80)}...", maxResults=${maxResults}, threshold=${threshold}`,
@@ -463,10 +487,12 @@ async function searchByEmbedding(
   logger?.debug?.(
     `${TAG} [embedding-search] Query embedding OK: dims=${queryEmbedding.length}, ` +
     `norm=${Math.sqrt(Array.from(queryEmbedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}, ` +
-    `searching top-${maxResults * 2}...`,
+    `searching top-${sessionKey ? maxResults * 4 : maxResults * 2}...`,
   );
   // Retrieve more candidates for subsequent filtering
-  const vecResults: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, maxResults * 2);
+  const candidateK = sessionKey ? maxResults * 4 : maxResults * 2;
+  const rawVecResults: L1SearchResult[] = await vectorStore.searchL1Vector(queryEmbedding, candidateK);
+  const vecResults = filterBySessionKey(rawVecResults, sessionKey, logger, "embedding-search");
 
   if (vecResults.length === 0) {
     logger?.debug?.(`${TAG} [embedding-search] Returned 0 results`);
@@ -517,9 +543,10 @@ async function searchHybrid(
   embeddingService: EmbeddingService,
   logger?: Logger,
   embeddingCallOpts?: EmbeddingCallOptions,
+  sessionKey?: string,
 ): Promise<SearchResult> {
   // Run keyword and embedding searches in parallel
-  const candidateK = maxResults * 3; // retrieve more for merging
+  const candidateK = sessionKey ? maxResults * 5 : maxResults * 3; // retrieve more for filtering/merging
 
   const [keywordResult, embeddingResult] = await Promise.all([
     // Keyword search: FTS5 only (no in-memory fallback)
@@ -530,7 +557,8 @@ async function searchHybrid(
         if (vectorStore.isFtsAvailable()) {
           const ftsQuery = buildFtsQuery(userText);
           if (ftsQuery) {
-            const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+            const rawFtsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+            const ftsResults = filterBySessionKey(rawFtsResults, sessionKey, logger, "hybrid-keyword-fts");
             if (ftsResults.length > 0) {
               logger?.debug?.(`${TAG} [hybrid-keyword-fts] FTS5 found ${ftsResults.length} candidates`);
               // Convert FtsSearchResult to ScoredRecord for RRF merge
@@ -572,7 +600,8 @@ async function searchHybrid(
         logger?.debug?.(
           `${TAG} [hybrid-embedding] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const results = await vectorStore.searchL1Vector(queryEmbedding, candidateK, userText);
+        const rawResults = await vectorStore.searchL1Vector(queryEmbedding, candidateK, userText);
+        const results = filterBySessionKey(rawResults, sessionKey, logger, "hybrid-embedding");
         logger?.debug?.(`${TAG} [hybrid-embedding] Got ${results.length} candidates`);
         return { results, ms: performance.now() - tStart };
       } catch (err) {

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -293,6 +293,7 @@ export class TdaiCore {
       limit: params.limit ?? 5,
       type: params.type,
       scene: params.scene,
+      sessionKey: params.sessionKey,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
       logger: this.logger,

--- a/src/core/tools/memory-search.test.ts
+++ b/src/core/tools/memory-search.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { executeMemorySearch } from "./memory-search.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore, L1FtsResult, L1SearchResult } from "../store/types.js";
+import type { Logger } from "../types.js";
+
+const logger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function l1Result(overrides: Partial<L1SearchResult> = {}): L1SearchResult {
+  return {
+    record_id: "record-1",
+    content: "prefers safe database migrations",
+    type: "instruction",
+    priority: 1,
+    scene_name: "work",
+    score: 0.9,
+    timestamp_str: "2026-07-01T00:00:00.000Z",
+    timestamp_start: "2026-07-01T00:00:00.000Z",
+    timestamp_end: "2026-07-01T00:00:00.000Z",
+    session_key: "session-a",
+    session_id: "session-a-id",
+    metadata_json: "{}",
+    ...overrides,
+  };
+}
+
+function createStore(opts: {
+  fts?: L1FtsResult[];
+  vector?: L1SearchResult[];
+  ftsAvailable?: boolean;
+}): { store: IMemoryStore; ftsLimits: number[]; vectorLimits: number[] } {
+  const ftsLimits: number[] = [];
+  const vectorLimits: number[] = [];
+  const store = {
+    isFtsAvailable: () => opts.ftsAvailable ?? true,
+    getCapabilities: () => ({
+      vectorSearch: true,
+      ftsSearch: opts.ftsAvailable ?? true,
+      nativeHybridSearch: false,
+      sparseVectors: false,
+    }),
+    searchL1Fts: (_query: string, limit = 10) => {
+      ftsLimits.push(limit);
+      return opts.fts ?? [];
+    },
+    searchL1Vector: (_embedding: Float32Array, limit = 10) => {
+      vectorLimits.push(limit);
+      return opts.vector ?? [];
+    },
+  } as unknown as IMemoryStore;
+  return { store, ftsLimits, vectorLimits };
+}
+
+const embeddingService: EmbeddingService = {
+  embed: async () => new Float32Array([0.1, 0.2, 0.3]),
+  embedBatch: async (texts) => texts.map(() => new Float32Array([0.1, 0.2, 0.3])),
+  getDimensions: () => 3,
+  getProviderInfo: () => ({ provider: "test", model: "fake" }),
+  isReady: () => true,
+  startWarmup: () => {},
+};
+
+describe("executeMemorySearch session filtering", () => {
+  it("filters L1 FTS results to the requested session after over-retrieval", async () => {
+    const { store, ftsLimits } = createStore({
+      fts: [
+        l1Result({ record_id: "other-high-score", session_key: "session-b", score: 0.99 }),
+        l1Result({ record_id: "match-1", session_key: "session-a", score: 0.8 }),
+        l1Result({ record_id: "match-2", session_key: "session-a", score: 0.7 }),
+      ],
+    });
+
+    const result = await executeMemorySearch({
+      query: "safe database migrations",
+      limit: 2,
+      sessionKey: "session-a",
+      vectorStore: store,
+      logger,
+    });
+
+    expect(ftsLimits).toEqual([10]);
+    expect(result.strategy).toBe("fts");
+    expect(result.results.map((r) => r.id)).toEqual(["match-1", "match-2"]);
+    expect(result.results.every((r) => r.session_key === "session-a")).toBe(true);
+  });
+
+  it("keeps unscoped memory search global when no session key is provided", async () => {
+    const { store, ftsLimits } = createStore({
+      fts: [
+        l1Result({ record_id: "session-b-memory", session_key: "session-b", score: 0.99 }),
+        l1Result({ record_id: "session-a-memory", session_key: "session-a", score: 0.8 }),
+      ],
+    });
+
+    const result = await executeMemorySearch({
+      query: "safe database migrations",
+      limit: 2,
+      vectorStore: store,
+      logger,
+    });
+
+    expect(ftsLimits).toEqual([6]);
+    expect(result.results.map((r) => r.id)).toEqual(["session-b-memory", "session-a-memory"]);
+  });
+
+  it("filters merged hybrid results so vector-only cross-session hits do not leak", async () => {
+    const { store, ftsLimits, vectorLimits } = createStore({
+      fts: [
+        l1Result({ record_id: "shared-match", session_key: "session-a", score: 0.7 }),
+        l1Result({ record_id: "other-fts", session_key: "session-b", score: 0.6 }),
+      ],
+      vector: [
+        l1Result({ record_id: "other-vector", session_key: "session-b", score: 0.98 }),
+        l1Result({ record_id: "shared-match", session_key: "session-a", score: 0.9 }),
+        l1Result({ record_id: "vector-match", session_key: "session-a", score: 0.85 }),
+      ],
+    });
+
+    const result = await executeMemorySearch({
+      query: "safe database migrations",
+      limit: 3,
+      sessionKey: "session-a",
+      vectorStore: store,
+      embeddingService,
+      logger,
+    });
+
+    expect(ftsLimits).toEqual([15]);
+    expect(vectorLimits).toEqual([15]);
+    expect(result.strategy).toBe("hybrid");
+    expect(result.results.map((r) => r.id)).toEqual(["shared-match", "vector-match"]);
+    expect(result.results.every((r) => r.session_key === "session-a")).toBe(true);
+  });
+});

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -25,6 +25,7 @@ export interface MemorySearchResultItem {
   type: string;
   priority: number;
   scene_name: string;
+  session_key: string;
   score: number;
   created_at: string;
   updated_at: string;
@@ -75,6 +76,22 @@ function rrfMergeL1(...lists: MemorySearchResultItem[][]): MemorySearchResultIte
     .map(({ item, rrfScore }) => ({ ...item, score: rrfScore }));
 }
 
+function filterBySessionKey(
+  results: MemorySearchResultItem[],
+  sessionKey: string | undefined,
+  logger: Logger | undefined,
+  stage: string,
+): MemorySearchResultItem[] {
+  if (!sessionKey) return results;
+  const filtered = results.filter((r) => r.session_key === sessionKey);
+  if (filtered.length !== results.length) {
+    logger?.debug?.(
+      `${TAG} [${stage}] session filter kept ${filtered.length}/${results.length} for session=${sessionKey}`,
+    );
+  }
+  return filtered;
+}
+
 // ============================
 // Search implementation
 // ============================
@@ -84,6 +101,7 @@ export async function executeMemorySearch(params: {
   limit: number;
   type?: string;
   scene?: string;
+  sessionKey?: string;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
   logger?: Logger;
@@ -93,6 +111,7 @@ export async function executeMemorySearch(params: {
     limit,
     type: typeFilter,
     scene: sceneFilter,
+    sessionKey,
     vectorStore,
     embeddingService,
     logger,
@@ -101,6 +120,7 @@ export async function executeMemorySearch(params: {
   logger?.debug?.(
     `${TAG} CALLED: query="${query.slice(0, 100)}", limit=${limit}, ` +
     `typeFilter=${typeFilter ?? "(none)"}, sceneFilter=${sceneFilter ?? "(none)"}, ` +
+    `sessionKey=${sessionKey ?? "(all)"}, ` +
     `vectorStore=${vectorStore ? "available" : "UNAVAILABLE"}, ` +
     `embeddingService=${embeddingService ? "available" : "UNAVAILABLE"}`,
   );
@@ -133,7 +153,7 @@ export async function executeMemorySearch(params: {
   }
 
   // ── Over-retrieve for later filtering and RRF merging ──
-  const candidateK = limit * 3;
+  const candidateK = sessionKey ? limit * 5 : limit * 3;
 
   // ── Run available search strategies in parallel ──
   const [ftsItems, vecItems] = await Promise.all([
@@ -155,6 +175,7 @@ export async function executeMemorySearch(params: {
           type: r.type,
           priority: r.priority,
           scene_name: r.scene_name,
+          session_key: r.session_key,
           score: r.score,
           created_at: r.timestamp_start,
           updated_at: r.timestamp_end,
@@ -184,6 +205,7 @@ export async function executeMemorySearch(params: {
           type: r.type,
           priority: r.priority,
           scene_name: r.scene_name,
+          session_key: r.session_key,
           score: r.score,
           created_at: r.timestamp_start,
           updated_at: r.timestamp_end,
@@ -224,6 +246,8 @@ export async function executeMemorySearch(params: {
     // Single-source: use whichever list has results (already sorted by score)
     results = ftsOk ? ftsItems : vecItems;
   }
+
+  results = filterBySessionKey(results, sessionKey, logger, "post-merge");
 
   // ── Apply secondary filters (type, scene) ──
   const preFilterCount = results.length;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -231,6 +231,7 @@ export interface MemorySearchParams {
   limit?: number;
   type?: string;
   scene?: string;
+  sessionKey?: string;
 }
 
 /** Search parameters for L0 conversation search. */


### PR DESCRIPTION
## Description | 描述
Fix L1 memory search leakage across sessions by threading the active session key through both automatic recall and the `tdai_memory_search` tool path.

This PR keeps the change intentionally scoped:
- Auto-recall now passes the current `sessionKey` into L1 search.
- Keyword, embedding, client-side hybrid, and native hybrid recall searches filter L1 candidates by `session_key`.
- `tdai_memory_search` accepts an optional `session_key` parameter and applies the same filter after RRF merge.
- Session-scoped searches over-retrieve candidates before filtering, so high-ranking memories from other sessions do not starve valid results from the current session.
- Added fake-store regression tests covering FTS-only, unscoped global search, and hybrid FTS/vector merging.

## Related Issue | 关联 Issue
Fix #111

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verified with Node v24.15.0:

```bash
npx vitest run src/core/tools/memory-search.test.ts
npm test
npm run build
git diff --check
```
