### PR TITLE
feat(gateway): add batch capture endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,24 @@ curl http://127.0.0.1:8420/health
 
 ---
 
+### Batch capture through the Gateway
+
+For historical imports that should land in the same live memory directory as
+regular `/capture` calls, use `POST /capture/batch`. Each item uses the existing
+`/capture` payload shape:
+
+```bash
+curl -H "Content-Type: application/json" \
+     -d '{"captures":[{"session_key":"import-1","user_content":"Hello","assistant_content":"Hi"}]}' \
+     http://127.0.0.1:8420/capture/batch
+```
+
+`POST /seed` remains available for isolated seed runs that write to a separate
+timestamped seed output directory.
+
+
+---
+
 
 ## 🔒 Gateway Security (optional)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -356,6 +356,21 @@ curl http://127.0.0.1:8420/health
 
 ---
 
+### 通过 Gateway 批量 capture
+
+如果要导入历史对话，并且希望数据进入普通 `/capture` 使用的同一个实时记忆目录，可以使用 `POST /capture/batch`。数组中的每一项都沿用现有 `/capture` 请求体格式：
+
+```bash
+curl -H "Content-Type: application/json" \
+     -d '{"captures":[{"session_key":"import-1","user_content":"你好","assistant_content":"你好"}]}' \
+     http://127.0.0.1:8420/capture/batch
+```
+
+`POST /seed` 仍然保留，用于写入独立时间戳 seed 输出目录的隔离导入。
+
+
+---
+
 ## 🔒 Gateway 安全配置（可选）
 
 Hermes Gateway 监听 `:8420`，对外提供 capture / search / recall 的 HTTP 接口。新增两个开关，可以把它从“开放的本地 sidecar”切换为“需要鉴权的网络服务”。**两个开关默认都关闭，已有部署的行为不变。**

--- a/src/gateway/capture-batch.test.ts
+++ b/src/gateway/capture-batch.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CAPTURE_BATCH_SIZE,
+  normalizeCaptureBatchRequest,
+  normalizeCapturePayload,
+} from "./capture-batch.js";
+
+describe("capture batch request normalization", () => {
+  it("normalizes multiple /capture payloads and preserves optional messages", () => {
+    const result = normalizeCaptureBatchRequest({
+      captures: [
+        {
+          user_content: "hello",
+          assistant_content: "hi",
+          session_key: "session-a",
+          session_id: "sid-a",
+          messages: [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi" },
+          ],
+        },
+        {
+          user_content: "next",
+          assistant_content: "done",
+          session_key: "session-a",
+        },
+      ],
+      continue_on_error: true,
+    });
+
+    expect(result.continueOnError).toBe(true);
+    expect(result.captures).toHaveLength(2);
+    expect(result.captures[0]).toMatchObject({
+      user_content: "hello",
+      assistant_content: "hi",
+      session_key: "session-a",
+      session_id: "sid-a",
+    });
+    expect(result.captures[0].messages).toHaveLength(2);
+  });
+
+  it("accepts items as a compatibility alias", () => {
+    const result = normalizeCaptureBatchRequest({
+      items: [
+        {
+          user_content: "hello",
+          assistant_content: "hi",
+          session_key: "session-a",
+        },
+      ],
+    });
+
+    expect(result.continueOnError).toBe(false);
+    expect(result.captures).toHaveLength(1);
+  });
+
+  it("rejects an empty batch", () => {
+    expect(() => normalizeCaptureBatchRequest({ captures: [] })).toThrow(
+      "captures must be a non-empty array",
+    );
+  });
+
+  it("rejects batches over the safety limit", () => {
+    const captures = Array.from({ length: MAX_CAPTURE_BATCH_SIZE + 1 }, () => ({
+      user_content: "hello",
+      assistant_content: "hi",
+      session_key: "session-a",
+    }));
+
+    expect(() => normalizeCaptureBatchRequest({ captures })).toThrow(
+      `captures must contain at most ${MAX_CAPTURE_BATCH_SIZE} items`,
+    );
+  });
+
+  it("rejects capture items missing required fields", () => {
+    expect(() =>
+      normalizeCaptureBatchRequest({
+        captures: [
+          {
+            user_content: "hello",
+            assistant_content: "hi",
+          },
+        ],
+      }),
+    ).toThrow("captures[0].session_key must be a non-empty string");
+  });
+
+  it("rejects non-array messages", () => {
+    expect(() =>
+      normalizeCapturePayload({
+        user_content: "hello",
+        assistant_content: "hi",
+        session_key: "session-a",
+        messages: "not an array",
+      }),
+    ).toThrow("capture.messages must be an array when provided");
+  });
+});

--- a/src/gateway/capture-batch.ts
+++ b/src/gateway/capture-batch.ts
@@ -1,0 +1,85 @@
+import type { CaptureBatchRequest, CaptureRequest } from "./types.js";
+
+export const MAX_CAPTURE_BATCH_SIZE = 100;
+
+export class CaptureBatchValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CaptureBatchValidationError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(
+  value: Record<string, unknown>,
+  key: keyof CaptureRequest,
+  label: string,
+): string {
+  const raw = value[key];
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new CaptureBatchValidationError(`${label}.${key} must be a non-empty string`);
+  }
+  return raw;
+}
+
+function readOptionalString(
+  value: Record<string, unknown>,
+  key: keyof CaptureRequest,
+): string | undefined {
+  const raw = value[key];
+  return typeof raw === "string" ? raw : undefined;
+}
+
+export function normalizeCapturePayload(raw: unknown, label = "capture"): CaptureRequest {
+  if (!isRecord(raw)) {
+    throw new CaptureBatchValidationError(`${label} must be an object`);
+  }
+
+  const messages = raw.messages;
+  if (messages !== undefined && !Array.isArray(messages)) {
+    throw new CaptureBatchValidationError(`${label}.messages must be an array when provided`);
+  }
+
+  return {
+    user_content: readRequiredString(raw, "user_content", label),
+    assistant_content: readRequiredString(raw, "assistant_content", label),
+    session_key: readRequiredString(raw, "session_key", label),
+    session_id: readOptionalString(raw, "session_id"),
+    user_id: readOptionalString(raw, "user_id"),
+    messages,
+  };
+}
+
+export function normalizeCaptureBatchRequest(body: CaptureBatchRequest): {
+  captures: CaptureRequest[];
+  continueOnError: boolean;
+} {
+  if (!isRecord(body)) {
+    throw new CaptureBatchValidationError("request body must be an object");
+  }
+
+  const rawCaptures = Array.isArray(body.captures)
+    ? body.captures
+    : Array.isArray(body.items)
+      ? body.items
+      : undefined;
+
+  if (!rawCaptures || rawCaptures.length === 0) {
+    throw new CaptureBatchValidationError("captures must be a non-empty array");
+  }
+  if (rawCaptures.length > MAX_CAPTURE_BATCH_SIZE) {
+    throw new CaptureBatchValidationError(
+      `captures must contain at most ${MAX_CAPTURE_BATCH_SIZE} items`,
+    );
+  }
+
+  return {
+    captures: rawCaptures.map((capture, index) =>
+      normalizeCapturePayload(capture, `captures[${index}]`),
+    ),
+    continueOnError: body.continue_on_error === true,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -5,6 +5,7 @@
  *   GET  /health              — Health check
  *   POST /recall              — Memory recall (prefetch)
  *   POST /capture             — Conversation capture (sync_turn)
+ *   POST /capture/batch       — Batch capture into the live memory directory
  *   POST /search/memories     — L1 memory search
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
@@ -29,6 +30,9 @@ import type {
   RecallResponse,
   CaptureRequest,
   CaptureResponse,
+  CaptureBatchRequest,
+  CaptureBatchResponse,
+  CaptureBatchResultItem,
   MemorySearchRequest,
   MemorySearchResponse,
   ConversationSearchRequest,
@@ -39,6 +43,11 @@ import type {
   SeedResponse,
   GatewayErrorResponse,
 } from "./types.js";
+import {
+  CaptureBatchValidationError,
+  normalizeCaptureBatchRequest,
+  normalizeCapturePayload,
+} from "./capture-batch.js";
 import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
@@ -264,6 +273,8 @@ export class TdaiGateway {
           return await this.handleRecall(req, res);
         case "POST /capture":
           return await this.handleCapture(req, res);
+        case "POST /capture/batch":
+          return await this.handleCaptureBatch(req, res);
         case "POST /search/memories":
           return await this.handleSearchMemories(req, res);
         case "POST /search/conversations":
@@ -393,12 +404,80 @@ export class TdaiGateway {
   private async handleCapture(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     const body = await parseJsonBody<CaptureRequest>(req);
 
-    if (!body.user_content || !body.assistant_content || !body.session_key) {
-      sendError(res, 400, "Missing required fields: user_content, assistant_content, session_key");
-      return;
+    let capture: CaptureRequest;
+    try {
+      capture = normalizeCapturePayload(body);
+    } catch (err) {
+      if (err instanceof CaptureBatchValidationError) {
+        sendError(res, 400, err.message);
+        return;
+      }
+      throw err;
     }
 
     const startMs = Date.now();
+    const response = await this.runCapture(capture);
+    const elapsed = Date.now() - startMs;
+
+    this.logger.info(`Capture completed in ${elapsed}ms: l0=${response.l0_recorded}`);
+
+    sendJson(res, 200, response);
+  }
+
+  private async handleCaptureBatch(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<CaptureBatchRequest>(req);
+
+    let captures: CaptureRequest[];
+    let continueOnError: boolean;
+    try {
+      const normalized = normalizeCaptureBatchRequest(body);
+      captures = normalized.captures;
+      continueOnError = normalized.continueOnError;
+    } catch (err) {
+      if (err instanceof CaptureBatchValidationError) {
+        sendError(res, 400, err.message);
+        return;
+      }
+      throw err;
+    }
+
+    const startMs = Date.now();
+    const results: CaptureBatchResultItem[] = [];
+
+    for (let index = 0; index < captures.length; index++) {
+      try {
+        const item = await this.runCapture(captures[index]);
+        results.push({
+          index,
+          l0_recorded: item.l0_recorded,
+          scheduler_notified: item.scheduler_notified,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({ index, error: message });
+        this.logger.warn(`Capture batch item ${index} failed: ${message}`);
+        if (!continueOnError) break;
+      }
+    }
+
+    const failed = results.filter((item) => item.error).length;
+    const response: CaptureBatchResponse = {
+      total: captures.length,
+      succeeded: results.length - failed,
+      failed,
+      duration_ms: Date.now() - startMs,
+      results,
+    };
+
+    this.logger.info(
+      `Capture batch completed: total=${response.total}, ` +
+      `succeeded=${response.succeeded}, failed=${response.failed}, duration=${response.duration_ms}ms`,
+    );
+
+    sendJson(res, failed === 0 ? 200 : continueOnError ? 207 : 500, response);
+  }
+
+  private async runCapture(body: CaptureRequest): Promise<CaptureResponse> {
     const result = await this.core.handleTurnCommitted({
       userText: body.user_content,
       assistantText: body.assistant_content,
@@ -409,15 +488,11 @@ export class TdaiGateway {
       sessionKey: body.session_key,
       sessionId: body.session_id,
     });
-    const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Capture completed in ${elapsed}ms: l0=${result.l0RecordedCount}`);
-
-    const response: CaptureResponse = {
+    return {
       l0_recorded: result.l0RecordedCount,
       scheduler_notified: result.schedulerNotified,
     };
-    sendJson(res, 200, response);
   }
 
   private async handleSearchMemories(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -60,6 +60,34 @@ export interface CaptureResponse {
 }
 
 // ============================
+// /capture/batch
+// ============================
+
+export interface CaptureBatchRequest {
+  /** Multiple existing /capture payloads to import through the live pipeline. */
+  captures?: unknown[];
+  /** Backward-compatible alias for callers that prefer a generic array name. */
+  items?: unknown[];
+  /** Continue processing remaining items if one capture fails at runtime. */
+  continue_on_error?: boolean;
+}
+
+export interface CaptureBatchResultItem {
+  index: number;
+  l0_recorded?: number;
+  scheduler_notified?: boolean;
+  error?: string;
+}
+
+export interface CaptureBatchResponse {
+  total: number;
+  succeeded: number;
+  failed: number;
+  duration_ms: number;
+  results: CaptureBatchResultItem[];
+}
+
+// ============================
 // /search/memories
 // ============================
 


### PR DESCRIPTION
## Description | 描述

Add a live Gateway batch import endpoint for historical conversations:

- `POST /capture/batch` accepts multiple existing `/capture` payloads.
- Each item is processed through the same `TdaiCore.handleTurnCommitted()` path as `POST /capture`.
- The imported data lands in the live Gateway memory directory, so it can be used together with normal `/capture` traffic.
- `POST /seed` behavior is unchanged and still writes isolated timestamped seed output directories.
- The batch request has a conservative 100-item safety limit and validates every item before processing.
- Runtime item failures are reported per item; callers can opt into `continue_on_error`.
- README and README_CN include a minimal example.

## Related Issue | 关联 Issue

Fix #356

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

Verified with Node v24.15.0:

```bash
npx vitest run src/gateway/capture-batch.test.ts
npm test
npm run build
git diff --check
```

Results:
- `src/gateway/capture-batch.test.ts`: 6 tests passed.
- `npm test`: 5 files / 73 tests passed.
- `npm run build`: plugin and scripts build passed.

## Notes | 说明

This intentionally avoids changing `/seed` output-dir semantics. The new endpoint is for callers that want bulk import into the same live memory store used by `/capture`.
