### PR TITLE
fix(recall): stabilize prompt-cache memory injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - 环境变量 `TDAI_LLM_DISABLE_THINKING` 支持策略名（如 `deepseek`）和布尔值。
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
+- **Prompt cache 友好的 auto-recall 注入策略** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：新增 `recall.injectionMode`（默认 `prepend`，可选 `append`）与 `recall.showInjected`（默认 `false`）。动态 L1 召回可选择通过宿主 `appendContext` 追加到用户 prompt 后方；生成的 `<relevant-memories>` 默认仅当前轮可见，写入历史前剥离以避免多轮 replay 膨胀。OpenClaw 入口将稳定的 persona / scene / memory-tools 上下文映射到 `prependSystemContext`，让其落在宿主 cache boundary 前方。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps compatibility; `append` uses host `appendContext` to keep the user prompt prefix steadier |
+| `recall.showInjected` | `false` | Persist generated `<relevant-memories>` blocks for debugging; default strips them before history write to prevent replay bloat |
 | `pipeline.everyNConversations` | `5` | Trigger an L1 memory extraction every N turns |
 | `extraction.maxMemoriesPerSession` | `20` | Max memories extracted per L1 pass |
 | `persona.triggerEveryN` | `50` | Generate the user persona every N new memories |

--- a/README_CN.md
+++ b/README_CN.md
@@ -409,6 +409,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回注入位置：`prepend` 保持兼容；`append` 使用宿主 `appendContext`，减少用户 prompt 前缀变化 |
+| `recall.showInjected` | `false` | 是否把生成的 `<relevant-memories>` 保存进历史用于调试；默认写入前剥离，避免多轮 replay 膨胀 |
 | `pipeline.everyNConversations` | `5` | 每 N 轮对话触发一次 L1 记忆提取 |
 | `extraction.maxMemoriesPerSession` | `20` | 单次 L1 最多提取多少条 |
 | `persona.triggerEveryN` | `50` | 每 N 条新记忆触发用户画像生成 |

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,8 @@ import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
 import { ensureL2L3Local } from "./src/core/profile/profile-sync.js";
+import { mapRecallResultToOpenClawPromptBuild } from "./src/adapters/openclaw/prompt-build.js";
+import { stripInjectedRecallFromMessage } from "./src/utils/recall-injection.js";
 
 // Core abstractions (host-neutral)
 import { OpenClawHostAdapter } from "./src/adapters/openclaw/host-adapter.js";
@@ -179,7 +181,7 @@ export default function register(api: OpenClawPluginApi) {
     api.logger.debug?.(
       `${TAG} Config parsed: ` +
       `capture=${cfg.capture.enabled}, ` +
-      `recall=${cfg.recall.enabled}(maxResults=${cfg.recall.maxResults}), ` +
+      `recall=${cfg.recall.enabled}(strategy=${cfg.recall.strategy}, maxResults=${cfg.recall.maxResults}, injectionMode=${cfg.recall.injectionMode}, showInjected=${cfg.recall.showInjected}), ` +
       `extraction=${cfg.extraction.enabled}(dedup=${cfg.extraction.enableDedup}, maxMem=${cfg.extraction.maxMemoriesPerSession}), ` +
       `pipeline=(everyN=${cfg.pipeline.everyNConversations}, warmup=${cfg.pipeline.enableWarmup}, l1Idle=${cfg.pipeline.l1IdleTimeoutSeconds}s, l2DelayAfterL1=${cfg.pipeline.l2DelayAfterL1Seconds}s, l2Min=${cfg.pipeline.l2MinIntervalSeconds}s, l2Max=${cfg.pipeline.l2MaxIntervalSeconds}s, activeWindow=${cfg.pipeline.sessionActiveWindowHours}h), ` +
       `persona(triggerEvery=${cfg.persona.triggerEveryN}, backupCount=${cfg.persona.backupCount}, sceneBackupCount=${cfg.persona.sceneBackupCount}), ` +
@@ -584,17 +586,20 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
-          const appendLen = result.appendSystemContext?.length ?? 0;
+        const hookResult = mapRecallResultToOpenClawPromptBuild(result);
+        if (result?.appendSystemContext || result?.prependContext || result?.appendContext) {
+          const stableLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;
+          const appendLen = result.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `stableSystemContext=${stableLen} chars -> prependSystemContext, ` +
+            `prependContext=${prependLen} chars, appendContext=${appendLen} chars`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -612,43 +617,31 @@ export default function register(api: OpenClawPluginApi) {
     });
   }
 
-  // Strip <relevant-memories> from user messages before they are persisted to
-  // the session JSONL.  The current-turn LLM already saw the full prompt
-  // (effectivePrompt lives in memory), but we don't want recall artifacts
-  // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
-  api.on("before_message_write", (event) => {
-    const msg = event.message as { role?: string; content?: unknown };
-    const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
-    api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
+  if (cfg.recall.enabled) {
+    // Strip generated <relevant-memories> from user messages before they are
+    // persisted to the session JSONL. The current-turn LLM already saw the full
+    // prompt, but persisted recall artifacts would bloat future replay history.
+    api.logger.debug?.(
+      `${TAG} Registering before_message_write hook ` +
+      `(showInjected=${cfg.recall.showInjected}, generated <relevant-memories> cleanup)`,
+    );
+    api.on("before_message_write", (event) => {
+      const msg = event.message as { role?: string; content?: unknown };
+      const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
+      api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
 
-    if (msg.role !== "user") return;
+      const stripped = stripInjectedRecallFromMessage(msg, { showInjected: cfg.recall.showInjected });
+      if (!stripped) return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
-    }
-
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
-  });
+      api.logger.debug?.(
+        `${TAG} [before_message_write] Stripped generated recall block: ` +
+        `removed ${stripped.strippedChars} chars`,
+      );
+      return { message: stripped.message as typeof event.message };
+    });
+  } else {
+    api.logger.debug?.(`${TAG} before_message_write recall cleanup not registered — recall disabled`);
+  }
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule
   if (cfg.capture.enabled) {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -77,6 +77,8 @@
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回注入位置：prepend 保持旧行为；append 使用 OpenClaw appendContext 将召回内容追加到用户 prompt 后方，降低 prompt 前缀变化" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否将自动注入的 <relevant-memories> 保存进历史。默认 false：当前轮仍可见，但写入历史前剥离以避免多轮膨胀；true 仅建议调试使用" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
           "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }

--- a/src/adapters/openclaw/prompt-build.test.ts
+++ b/src/adapters/openclaw/prompt-build.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { mapRecallResultToOpenClawPromptBuild } from "./prompt-build.js";
+
+describe("mapRecallResultToOpenClawPromptBuild", () => {
+  it("places stable recall context before OpenClaw's cache boundary", () => {
+    const mapped = mapRecallResultToOpenClawPromptBuild({
+      appendSystemContext: "stable persona and scene context",
+      prependContext: "dynamic memories before prompt",
+      appendContext: "dynamic memories after prompt",
+    });
+
+    expect(mapped).toEqual({
+      prependSystemContext: "stable persona and scene context",
+      prependContext: "dynamic memories before prompt",
+      appendContext: "dynamic memories after prompt",
+    });
+    expect(mapped).not.toHaveProperty("appendSystemContext");
+  });
+
+  it("returns undefined for empty recall results", () => {
+    expect(mapRecallResultToOpenClawPromptBuild({})).toBeUndefined();
+    expect(mapRecallResultToOpenClawPromptBuild(undefined)).toBeUndefined();
+  });
+});

--- a/src/adapters/openclaw/prompt-build.ts
+++ b/src/adapters/openclaw/prompt-build.ts
@@ -1,0 +1,29 @@
+import type { RecallResult } from "../../core/types.js";
+
+export interface OpenClawPromptBuildResult {
+  prependContext?: string;
+  appendContext?: string;
+  prependSystemContext?: string;
+  appendSystemContext?: string;
+}
+
+/**
+ * Map host-neutral recall output to OpenClaw's prompt mutation fields.
+ *
+ * OpenClaw composes prependSystemContext before its system-prompt cache
+ * boundary. The plugin's stable memory context is therefore returned through
+ * that host-specific field, while dynamic L1 recall remains in the user prompt
+ * via prependContext or appendContext.
+ */
+export function mapRecallResultToOpenClawPromptBuild(
+  result: RecallResult | undefined,
+): OpenClawPromptBuildResult | undefined {
+  if (!result) return undefined;
+
+  const mapped: OpenClawPromptBuildResult = {};
+  if (result.prependContext) mapped.prependContext = result.prependContext;
+  if (result.appendContext) mapped.appendContext = result.appendContext;
+  if (result.appendSystemContext) mapped.prependSystemContext = result.appendSystemContext;
+
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall cache controls", () => {
+  it("defaults to compatibility-safe recall injection behavior", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+    expect(cfg.recall.showInjected).toBe(false);
+  });
+
+  it("accepts append injection and explicit injected-history visibility", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "append",
+        showInjected: true,
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("append");
+    expect(cfg.recall.showInjected).toBe(true);
+  });
+
+  it("falls back to prepend for unknown injection modes", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "middle",
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,10 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /** Dynamic L1 recall placement in the host prompt (default: "prepend" for compatibility). */
+  injectionMode: "prepend" | "append";
+  /** Preserve injected recall blocks in persisted history for debugging (default: false). */
+  showInjected: boolean;
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -529,6 +533,8 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: validateInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
+      showInjected: bool(recallGroup, "showInjected") ?? false,
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
@@ -634,6 +640,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_INJECTION_MODES: RecallConfig["injectionMode"][] = ["prepend", "append"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +650,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateInjectionMode(value: string | undefined): RecallConfig["injectionMode"] | undefined {
+  if (!value) return undefined;
+  return VALID_INJECTION_MODES.includes(value as RecallConfig["injectionMode"])
+    ? (value as RecallConfig["injectionMode"])
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import type { IMemoryStore, L1FtsResult } from "../store/types.js";
+import { performAutoRecall } from "./auto-recall.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("performAutoRecall prompt-cache shape", () => {
+  it("keeps stable persona/scene/tools separate from dynamic L1 recall", async () => {
+    const pluginDataDir = await makePluginDataDir();
+    const cfg = parseConfig({ recall: { strategy: "keyword" } });
+
+    const first = await performAutoRecall({
+      userText: "TypeScript prompt cache",
+      actorId: "default_user",
+      sessionKey: "session-a",
+      cfg,
+      pluginDataDir,
+      vectorStore: makeFtsStore([
+        ftsResult("m1", "用户正在优化 TypeScript prompt cache 方案。"),
+      ]),
+    });
+
+    const second = await performAutoRecall({
+      userText: "TypeScript prompt cache",
+      actorId: "default_user",
+      sessionKey: "session-a",
+      cfg,
+      pluginDataDir,
+      vectorStore: makeFtsStore([
+        ftsResult("m2", "用户本轮关注 showInjected 历史膨胀。"),
+      ]),
+    });
+
+    expect(first?.appendSystemContext).toContain("<user-persona>");
+    expect(first?.appendSystemContext).toContain("<scene-navigation>");
+    expect(first?.appendSystemContext).toContain("<memory-tools-guide>");
+    expect(first?.appendSystemContext).not.toContain("<relevant-memories>");
+    expect(first?.prependContext).toContain("<relevant-memories>");
+    expect(first?.prependContext).toContain("TypeScript prompt cache");
+    expect(first?.appendContext).toBeUndefined();
+
+    expect(second?.appendSystemContext).toBe(first?.appendSystemContext);
+    expect(second?.prependContext).toContain("showInjected 历史膨胀");
+    expect(second?.prependContext).not.toBe(first?.prependContext);
+  });
+
+  it("supports append-mode dynamic recall without moving it into stable system context", async () => {
+    const pluginDataDir = await makePluginDataDir();
+    const cfg = parseConfig({ recall: { strategy: "keyword", injectionMode: "append" } });
+
+    const result = await performAutoRecall({
+      userText: "append context cache",
+      actorId: "default_user",
+      sessionKey: "session-a",
+      cfg,
+      pluginDataDir,
+      vectorStore: makeFtsStore([
+        ftsResult("m1", "appendContext 可以避免改写用户 prompt 前缀。"),
+      ]),
+    });
+
+    expect(result?.prependContext).toBeUndefined();
+    expect(result?.appendContext).toContain("<relevant-memories>");
+    expect(result?.appendContext).toContain("appendContext");
+    expect(result?.appendSystemContext).toContain("<memory-tools-guide>");
+    expect(result?.appendSystemContext).not.toContain("<relevant-memories>");
+  });
+
+  it("applies recall budgets before append-mode injection", async () => {
+    const pluginDataDir = await makePluginDataDir();
+    const cfg = parseConfig({
+      recall: {
+        strategy: "keyword",
+        injectionMode: "append",
+        maxCharsPerMemory: 120,
+        maxTotalRecallChars: 120,
+      },
+    });
+
+    const result = await performAutoRecall({
+      userText: "budgeted recall",
+      actorId: "default_user",
+      sessionKey: "session-a",
+      cfg,
+      pluginDataDir,
+      vectorStore: makeFtsStore([
+        ftsResult("m1", "第一条非常长的召回记忆 ".repeat(20)),
+        ftsResult("m2", "second recall payload should be dropped"),
+      ]),
+    });
+
+    expect(result?.appendContext).toContain("已截断");
+    expect(result?.appendContext).not.toContain("second recall payload");
+    expect(result?.prependContext).toBeUndefined();
+  });
+});
+
+async function makePluginDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-recall-"));
+  tempDirs.push(dir);
+  await fs.mkdir(path.join(dir, ".metadata"), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "persona.md"),
+    "## User Persona\n用户偏好可复核的工程证据。\n",
+    "utf-8",
+  );
+  await fs.writeFile(
+    path.join(dir, ".metadata", "scene_index.json"),
+    JSON.stringify([
+      {
+        filename: "prompt-cache.md",
+        summary: "Prompt cache stability work",
+        heat: 42,
+        created: "2026-07-01T00:00:00+08:00",
+        updated: "2026-07-02T00:00:00+08:00",
+      },
+    ]),
+    "utf-8",
+  );
+  return dir;
+}
+
+function makeFtsStore(results: L1FtsResult[]): IMemoryStore {
+  return {
+    isFtsAvailable: () => true,
+    searchL1Fts: () => results,
+    getCapabilities: () => ({
+      vectorSearch: false,
+      ftsSearch: true,
+      nativeHybridSearch: false,
+      sparseVectors: false,
+    }),
+  } as unknown as IMemoryStore;
+}
+
+function ftsResult(id: string, content: string): L1FtsResult {
+  return {
+    record_id: id,
+    content,
+    type: "persona",
+    priority: 80,
+    scene_name: "prompt-cache",
+    score: 1,
+    timestamp_str: "2026-07-02T10:00:00+08:00",
+    timestamp_start: "2026-07-02T10:00:00+08:00",
+    timestamp_end: "2026-07-02T10:00:00+08:00",
+    session_key: "session-a",
+    session_id: "session-a",
+    metadata_json: "{}",
+  };
+}

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -57,6 +57,8 @@ export interface RecalledMemory {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn) */
   prependContext?: string;
+  /** L1 relevant memories — appended to user prompt text (dynamic, per-turn) */
+  appendContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
   appendSystemContext?: string;
 
@@ -190,9 +192,10 @@ async function performAutoRecallInner(params: {
   //   These change infrequently; when content is identical across turns,
   //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
   //
-  // prependContext (user prompt prefix — dynamic, per-turn):
-  //   L1 relevant memories — different every turn, moved out of system prompt
-  //   so it doesn't bust the system prompt cache.
+  // prependContext / appendContext (user prompt — dynamic, per-turn):
+  //   L1 relevant memories — different every turn, moved out of system prompt.
+  //   The default remains prepend for compatibility; append is an opt-in cache
+  //   optimization for hosts that consume before_prompt_build.appendContext.
   const stableParts: string[] = [];
   if (personaContent) {
     stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
@@ -201,17 +204,24 @@ async function performAutoRecallInner(params: {
     stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
   }
 
-  // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
+  // Dynamic part: L1 relevant memories (changes every turn) → user prompt.
   let prependContext: string | undefined;
+  let appendContext: string | undefined;
   if (memoryLines.length > 0) {
-    prependContext =
+    const relevantMemoriesContext =
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
+    if (cfg.recall.injectionMode === "append") {
+      appendContext = relevantMemoriesContext;
+    } else {
+      prependContext = relevantMemoriesContext;
+    }
   }
 
   // Append memory tools usage guide to the stable part so the agent knows
   // how to actively retrieve deeper context when the injected snippets
   // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
+  const hasDynamicContext = !!prependContext || !!appendContext;
+  if (stableParts.length > 0 || hasDynamicContext) {
     stableParts.push(MEMORY_TOOLS_GUIDE);
   }
 
@@ -227,12 +237,13 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
-  if (!appendSystemContext && !prependContext) {
+  if (!appendSystemContext && !hasDynamicContext) {
     return undefined;
   }
 
   return {
     prependContext,
+    appendContext,
     appendSystemContext,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -199,6 +199,8 @@ export interface CompletedTurn {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
   prependContext?: string;
+  /** L1 relevant memories — appended to user prompt text (dynamic, per-turn). */
+  appendContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
   appendSystemContext?: string;
   /** Recalled L1 memories with scores (for metrics). */

--- a/src/utils/recall-injection.test.ts
+++ b/src/utils/recall-injection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  stripInjectedRecallFromMessage,
+  stripInjectedRecallText,
+} from "./recall-injection.js";
+
+function injected(content: string, prompt = "请继续分析这个问题"): string {
+  return `<relevant-memories>
+以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：
+
+- [persona] ${content}
+</relevant-memories>
+
+${prompt}`;
+}
+
+describe("recall injection stripping", () => {
+  it("strips generated recall blocks from plain user text", () => {
+    const result = stripInjectedRecallText(injected("用户偏好简洁 TypeScript 示例"));
+
+    expect(result?.text).toBe("请继续分析这个问题");
+    expect(result?.strippedChars).toBeGreaterThan(0);
+  });
+
+  it("does not strip user-authored relevant-memory examples without the generated marker", () => {
+    const text = "<relevant-memories>this is documentation, not injected recall</relevant-memories>\n请解释这段 XML";
+
+    expect(stripInjectedRecallText(text)).toBeUndefined();
+  });
+
+  it("strips only user messages unless showInjected is enabled", () => {
+    const user = { role: "user", content: injected("动态召回") };
+    const assistant = { role: "assistant", content: injected("不应处理") };
+
+    expect(stripInjectedRecallFromMessage(user)?.message.content).toBe("请继续分析这个问题");
+    expect(stripInjectedRecallFromMessage(assistant)).toBeUndefined();
+    expect(stripInjectedRecallFromMessage(user, { showInjected: true })).toBeUndefined();
+  });
+
+  it("strips generated recall from text parts and preserves non-text parts", () => {
+    const image = { type: "image", source: "memory://image" };
+    const message = {
+      role: "user",
+      content: [
+        { type: "text", text: injected("多模态场景") },
+        image,
+      ],
+    };
+
+    const result = stripInjectedRecallFromMessage(message);
+
+    expect(result?.message.content).toEqual([
+      { type: "text", text: "请继续分析这个问题" },
+      image,
+    ]);
+  });
+
+  it("prevents generated recall from accumulating across persisted turns by default", () => {
+    const persisted: Array<{ role: "user"; content: string }> = [];
+
+    for (let i = 1; i <= 3; i++) {
+      const result = stripInjectedRecallFromMessage({
+        role: "user" as const,
+        content: injected(`turn ${i}`, `第 ${i} 轮真实用户输入`),
+      });
+      persisted.push(result?.message ?? { role: "user", content: injected(`turn ${i}`) });
+    }
+
+    expect(persisted.map((m) => m.content).join("\n")).not.toContain("<relevant-memories>");
+    expect(persisted.map((m) => m.content)).toEqual([
+      "第 1 轮真实用户输入",
+      "第 2 轮真实用户输入",
+      "第 3 轮真实用户输入",
+    ]);
+  });
+});

--- a/src/utils/recall-injection.ts
+++ b/src/utils/recall-injection.ts
@@ -1,0 +1,69 @@
+const GENERATED_RECALL_MARKER = "以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：";
+const GENERATED_RECALL_RE = new RegExp(
+  `<relevant-memories>\\s*${escapeRegExp(GENERATED_RECALL_MARKER)}[\\s\\S]*?<\\/relevant-memories>\\s*`,
+  "g",
+);
+
+export interface StripInjectedRecallOptions {
+  showInjected?: boolean;
+}
+
+export interface StripInjectedRecallTextResult {
+  text: string;
+  strippedChars: number;
+}
+
+export interface StripInjectedRecallMessageResult<T> {
+  message: T;
+  strippedChars: number;
+}
+
+export function stripInjectedRecallText(text: string): StripInjectedRecallTextResult | undefined {
+  if (!text.includes("<relevant-memories>") || !text.includes(GENERATED_RECALL_MARKER)) {
+    return undefined;
+  }
+
+  const cleaned = text.replace(GENERATED_RECALL_RE, "").trim();
+  if (cleaned === text) return undefined;
+  return { text: cleaned, strippedChars: text.length - cleaned.length };
+}
+
+export function stripInjectedRecallFromMessage<T extends { role?: string; content?: unknown }>(
+  message: T,
+  options: StripInjectedRecallOptions = {},
+): StripInjectedRecallMessageResult<T> | undefined {
+  if (options.showInjected || message.role !== "user") return undefined;
+
+  if (typeof message.content === "string") {
+    const stripped = stripInjectedRecallText(message.content);
+    if (!stripped) return undefined;
+    return {
+      message: { ...message, content: stripped.text } as T,
+      strippedChars: stripped.strippedChars,
+    };
+  }
+
+  if (!Array.isArray(message.content)) return undefined;
+
+  let strippedChars = 0;
+  const cleanedParts = message.content.map((part) => {
+    if (!part || typeof part !== "object") return part;
+    const item = part as Record<string, unknown>;
+    if (item.type !== "text" || typeof item.text !== "string") return part;
+
+    const stripped = stripInjectedRecallText(item.text);
+    if (!stripped) return part;
+    strippedChars += stripped.strippedChars;
+    return { ...item, text: stripped.text };
+  });
+
+  if (strippedChars === 0) return undefined;
+  return {
+    message: { ...message, content: cleanedParts } as T,
+    strippedChars,
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

Fixes #120.

This PR addresses the TencentDB-side prompt-cache risks discussed in #120 without claiming to fix the later-corrected OpenClaw webchat root cause. The issue thread now has two truths that both matter:

- The original 29% webchat regression was traced to OpenClaw webchat session behavior, not TencentDB.
- TencentDB still had cache-hostile memory injection surfaces: dynamic recall could be prepended every turn, injected recall could be persisted into history, and stable persona/scene/tool guidance was not returned through OpenClaw's pre-boundary system-context field.

This PR implements the complete TencentDB-side fix:

- Add `recall.showInjected` with default `false`.
  - Current-turn recall is still visible to the model.
  - Generated `<relevant-memories>` is stripped before history write by default.
  - `true` remains available for explicit debugging.
- Add `recall.injectionMode` with default `prepend` and optional `append`.
  - `prepend` preserves compatibility.
  - `append` emits dynamic L1 recall through OpenClaw `appendContext`, reducing user prompt prefix churn on supported hosts.
- Keep stable persona / scene navigation / memory tools guide in core `appendSystemContext`, then map it at the OpenClaw entrypoint to `prependSystemContext`, so stable memory lands before OpenClaw's cache boundary.
- Extract generated-recall stripping into a tested helper and make it match TencentDB's generated marker, avoiding accidental deletion of user-authored `<relevant-memories>` examples.
- Document the new config in README / README_CN / `openclaw.plugin.json` and add changelog coverage.

## Why This Avoids The Current PR Pitfalls

Compared with the open PRs around #120, this combines the useful parts while closing the gaps:

- Keeps #319's strong default: injected recall is not persisted by default and stable memory is mapped before OpenClaw's cache boundary.
- Adds the missing #346 idea: optional `appendContext` placement for dynamic recall.
- Avoids a broad regex footgun: only strips TencentDB-generated recall blocks with the fixed generated marker.
- Keeps host-specific OpenClaw field mapping out of core recall logic.
- Does not overclaim the corrected OpenClaw webchat regression as a TencentDB bug.

## Validation Evidence

### Deterministic Tests

```bash
npx vitest run src/adapters/openclaw/prompt-build.test.ts src/core/hooks/auto-recall.test.ts src/utils/recall-injection.test.ts src/config.test.ts
```

```text
4 test files passed
13 tests passed
```

```bash
npm test
```

```text
8 test files passed
80 tests passed
```

```bash
npm run build
```

```text
passed
```

```bash
git diff --check
```

```text
passed
```

### Real SQLite Recall Smoke

A real `VectorStore` / SQLite FTS smoke test wrote one L1 record, then called `performAutoRecall()` with `recall.injectionMode="append"`.

Observed result:

```json
{
  "ftsAvailable": true,
  "appendContextHasRecall": true,
  "appendContextHasSqliteMemory": true,
  "prependContextIsEmpty": true,
  "stableHasPersona": true,
  "stableHasScene": true,
  "stableHasToolsGuide": true,
  "stableHasNoDynamicRecall": true
}
```

### OpenClaw Runtime Load

Runtime environment:

- OpenClaw `2026.6.10`
- Isolated profile: `tdai-issue120-codex`
- Plugin loaded from this branch's `dist/index.mjs`

Verified logs include:

```text
[plugins] loading memory-tencentdb from /Users/nianjiu/TencentDB-Agent-Memory/dist/index.mjs
[memory-tdai] Config parsed: ... injectionMode=prepend, showInjected=false ...
[memory-tdai] Registering before_prompt_build hook (auto-recall)
[memory-tdai] Registering before_message_write hook (showInjected=false, generated <relevant-memories> cleanup)
[memory-tdai] Registering agent_end hook (auto-capture)
```

### Real DeepSeek 2-Turn Runtime Proof

For runtime proof, I switched only the isolated profile to:

```json
{
  "recall": {
    "injectionMode": "append",
    "showInjected": false
  }
}
```

Then I seeded a real SQLite L1 record into the profile and ran two real `deepseek/deepseek-chat` turns in the same OpenClaw session.

Both turns showed TencentDB recall through the intended prompt shape:

```text
stableSystemContext=1015 chars -> prependSystemContext, prependContext=0 chars, appendContext=227 chars
```

DeepSeek usage:

| Turn | input | cacheRead | output | total | cacheRead share |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 27401 | 0 | 6 | 27407 | 0.0% |
| 2 | 5937 | 21504 | 7 | 27448 | 78.3% |

Persistence check after both turns:

```bash
rg -n "<relevant-memories>|TypeScript cache proof" \
  ~/.openclaw-tdai-issue120-codex/agents/main/sessions/62e60034-6a7b-4f28-918b-87879ee988be.jsonl || true

rg -n "<relevant-memories>|TypeScript cache proof" \
  ~/.openclaw-tdai-issue120-codex/memory-tdai || true
```

Both commands produced no matches, confirming `showInjected=false` prevented generated recall from being persisted into OpenClaw session history or TencentDB L0 JSONL.

Note: background L1 extraction in the isolated proof profile was not part of this PR's claim and used that profile's default model config. The prompt-cache proof above is from the successful `before_prompt_build` recall path and DeepSeek agent calls.
