### PR TITLE
fix(search): sanitize FTS5 query tokens

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("removes FTS5 reserved operators before building a MATCH query", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND NOT beta OR NEAR gamma")).toBe('"alpha" OR "beta" OR "gamma"');
+  });
+
+  it("drops standalone FTS5 operators instead of returning a query", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  });
+
+  it("keeps ordinary keyword search behavior unchanged", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("travel plan API")).toBe('"travel" OR "plan" OR "API"');
+  });
+
+  it("sanitizes FTS5 syntax characters from jieba tokens", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["foo:bar", "C++", "AND", "alpha*", "(beta)", "用户"],
+    });
+
+    expect(buildFtsQuery("unused")).toBe('"foo" OR "bar" OR "C" OR "alpha" OR "beta" OR "用户"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -221,7 +221,7 @@ export function buildFtsQuery(raw: string): string | null {
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
-    tokens = sanitizeFtsTokens(raw.match(/[\p{L}\p{N}_]+/gu) ?? []);
+    tokens = sanitizeFtsTokens([raw]);
   }
 
   if (tokens.length === 0) return null;

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,20 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+function sanitizeFtsTokens(tokens: string[]): string[] {
+  return tokens
+    .flatMap((token) => token.match(/[\p{L}\p{N}_]+/gu) ?? [])
+    .map((token) => token.trim())
+    .filter((token) => {
+      if (!token) return false;
+      if (FTS5_RESERVED_OPERATORS.has(token.toUpperCase())) return false;
+      if (ZH_STOP_WORDS.has(token)) return false;
+      return true;
+    });
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -202,26 +216,12 @@ export function buildFtsQuery(raw: string): string | null {
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+    tokens = sanitizeFtsTokens(jieba.cutForSearch(raw, true));
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    tokens = sanitizeFtsTokens(raw.match(/[\p{L}\p{N}_]+/gu) ?? []);
   }
 
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Summary

Fix #160 by sanitizing tokens before building SQLite FTS5 MATCH expressions in `buildFtsQuery()`.

## Changes

- Remove reserved FTS5 operators (`AND`, `OR`, `NOT`, `NEAR`) from user-provided search tokens.
- Split jieba-produced tokens and fallback tokens through the same Unicode letter/number/underscore whitelist.
- Preserve ordinary keyword search behavior by continuing to quote tokens and join them with `OR`.
- Add regression tests for reserved operators, pure-operator input, ordinary keyword search, and jieba-token syntax sanitization.

## Validation

- `npx vitest run src/core/store/sqlite.test.ts`
- `npm test`
- `npm run build`
