### PR TITLE
feat: issue-235

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | Document | Contents |
 | :--- | :--- |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
+| [`docs/cross-platform-adapters.md`](./docs/cross-platform-adapters.md) | OpenClaw, Hermes, and Codex adapter architecture and integration guide |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |
 
@@ -526,7 +527,7 @@ We welcome every kind of contribution — bug reports, feature ideas, doc fixes,
 - [x] Long-term personalized memory (L0 → L3)
 - [x] Short-term context compression (Context Offload + Mermaid canvas)
 - [x] Local SQLite backend and Tencent Cloud Vector Database (TCVDB) backend
-- [x] OpenClaw plugin and Hermes Gateway integration
+- [x] OpenClaw plugin, Hermes Gateway integration, and Codex Gateway adapter
 - [ ] Portable memory: cross-Agent / cross-framework / cross-device import, export, and live migration
 - [ ] Automatic Skill generation
 - [ ] Visual debugging and memory observability dashboard

--- a/README_CN.md
+++ b/README_CN.md
@@ -508,6 +508,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | 文档 | 内容 |
 | :--- | :--- |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
+| [`docs/cross-platform-adapters.md`](./docs/cross-platform-adapters.md) | OpenClaw、Hermes、Codex 适配架构与接入指南 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |
 
@@ -529,7 +530,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 - [x] 长期个性化记忆（L0 → L3）
 - [x] 短期记忆压缩（Context Offload + Mermaid 画布）
 - [x] 可用本地 SQLite 后端与腾讯云向量数据库 TCVDB 后端
-- [x] OpenClaw 插件与 Hermes Gateway 适配
+- [x] OpenClaw 插件、Hermes Gateway 适配与 Codex Gateway 适配
 - [ ] 记忆可迁移：跨 Agent / 跨框架 / 跨设备的导入导出与热迁移
 - [ ] Skill自动生成
 - [ ] 可视化调试与记忆观测面板

--- a/docs/cross-platform-adapters.md
+++ b/docs/cross-platform-adapters.md
@@ -126,6 +126,9 @@ the adapter sends `session_key`.
    only adds `Authorization`; the Gateway must still be configured to enforce it.
 5. Fail fast on missing session identity. Silent fallback keys make unrelated
    conversations contaminate each other.
+   `defaultSessionKey` / `CODEX_SESSION_ID` are only for single-thread Codex
+   integrations; multi-session clients must pass `sessionKey` on each scoped
+   operation.
 6. Prefer the Gateway for new platforms unless the platform runs inside the
    same process and can implement `HostAdapter` directly.
 

--- a/docs/cross-platform-adapters.md
+++ b/docs/cross-platform-adapters.md
@@ -1,0 +1,140 @@
+# Cross-Platform Adapters
+
+TencentDB Agent Memory keeps memory logic in `TdaiCore` and exposes it through
+host adapters or the HTTP Gateway. A platform adapter should only translate the
+platform lifecycle into the core memory operations:
+
+- `recall`: fetch memory before the next model turn.
+- `capture`: persist a completed user/assistant turn.
+- `searchMemories`: search L1 structured memories.
+- `searchConversations`: search L0 raw conversation evidence.
+- `endSession`: flush buffered session work.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph Core["TDAI Core"]
+        TdaiCore["TdaiCore"]
+        L0["L0 Conversation"]
+        L1["L1 Atom"]
+        L2["L2 Scenario"]
+        L3["L3 Persona"]
+        TdaiCore --> L0 --> L1 --> L2 --> L3
+    end
+
+    OpenClaw["OpenClaw Plugin<br/>in-process hooks"] --> OpenClawAdapter["OpenClawHostAdapter"]
+    OpenClawAdapter --> TdaiCore
+
+    Hermes["Hermes Provider<br/>prefetch / sync_turn"] --> HermesClient["Python Gateway Client"]
+    Codex["Codex Agent<br/>prompt / turn bridge"] --> CodexClient["CodexMemoryAdapter"]
+
+    HermesClient --> Gateway["TDAI Gateway<br/>HTTP sidecar"]
+    CodexClient --> Gateway
+    Gateway --> StandaloneAdapter["StandaloneHostAdapter"]
+    StandaloneAdapter --> TdaiCore
+```
+
+## Existing Adapters
+
+| Platform | Integration point | Boundary | Recall path | Capture path |
+| :--- | :--- | :--- | :--- | :--- |
+| OpenClaw | Plugin hooks in `index.ts` | In-process `HostAdapter` | `before_prompt_build` calls `TdaiCore.handleBeforeRecall()` | `agent_end` calls `TdaiCore.handleTurnCommitted()` |
+| Hermes | `memory_tencentdb` provider | HTTP Gateway sidecar | `prefetch(query)` calls `POST /recall` | `sync_turn(user, assistant)` calls `POST /capture` |
+| Codex | TypeScript client adapter | HTTP Gateway sidecar | `CodexMemoryAdapter.recall()` calls `POST /recall` | `CodexMemoryAdapter.captureTurn()` calls `POST /capture` |
+
+OpenClaw can call `TdaiCore` directly because it owns the plugin process and
+provides a host API for logging, state, and LLM execution. Hermes and Codex are
+out-of-process integrations, so they use the Gateway as the stable contract.
+
+## Codex Adapter
+
+The Codex adapter lives in `src/adapters/codex/` and is exported from
+`src/adapters/index.ts`.
+
+```ts
+import { CodexMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb/adapters";
+
+const memory = new CodexMemoryAdapter({
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+  defaultSessionKey: process.env.CODEX_SESSION_ID,
+});
+
+const recall = await memory.recall({
+  query: userPrompt,
+  sessionKey: "codex-thread-235",
+});
+
+const promptWithMemory = [
+  recall.context,
+  userPrompt,
+].filter(Boolean).join("\n\n");
+
+await memory.captureTurn({
+  userContent: userPrompt,
+  assistantContent: assistantReply,
+  sessionKey: "codex-thread-235",
+});
+```
+
+For environment-based setup:
+
+```ts
+import { createCodexMemoryAdapterFromEnv } from "@tencentdb-agent-memory/memory-tencentdb/adapters";
+
+const memory = createCodexMemoryAdapterFromEnv();
+```
+
+The helper reads:
+
+| Environment variable | Purpose |
+| :--- | :--- |
+| `MEMORY_TENCENTDB_GATEWAY_URL` or `TDAI_GATEWAY_URL` | Gateway base URL |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` or `TDAI_GATEWAY_API_KEY` | Bearer token for protected Gateway routes |
+| `CODEX_SESSION_ID` or `CODEX_THREAD_ID` | Default session key |
+
+## Gateway Contract
+
+All out-of-process adapters should use the Gateway contract instead of reaching
+into core files:
+
+| Method | Endpoint | Required fields | Response |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/health` | none | Gateway status and store availability |
+| `POST` | `/recall` | `query`, `session_key` | prompt context, strategy, memory count |
+| `POST` | `/capture` | `user_content`, `assistant_content`, `session_key` | L0 count and scheduler notification |
+| `POST` | `/search/memories` | `query` | formatted L1 results |
+| `POST` | `/search/conversations` | `query` | formatted L0 results |
+| `POST` | `/session/end` | `session_key` | flush status |
+
+Adapters should keep platform naming at their edge and translate to Gateway
+snake_case at the HTTP boundary. For example, Codex callers pass `sessionKey`;
+the adapter sends `session_key`.
+
+## Best Practices
+
+1. Use one stable `sessionKey` per agent thread. This keeps L0 capture cursors,
+   L1 extraction, and session flushes scoped correctly.
+2. Call recall before constructing the final model prompt. Inject returned
+   context as platform-owned presentation text; TDAI owns retrieval, not prompt
+   layout.
+3. Call capture after a completed user/assistant turn. Do not capture partial
+   tool output unless the platform intentionally treats it as conversation
+   evidence.
+4. Keep authentication client-side and Gateway-side explicit. A client API key
+   only adds `Authorization`; the Gateway must still be configured to enforce it.
+5. Fail fast on missing session identity. Silent fallback keys make unrelated
+   conversations contaminate each other.
+6. Prefer the Gateway for new platforms unless the platform runs inside the
+   same process and can implement `HostAdapter` directly.
+
+## Adding Another Platform
+
+1. Identify the platform lifecycle hooks that correspond to recall, capture,
+   search, and session end.
+2. Decide whether the platform is in-process (`HostAdapter`) or out-of-process
+   (Gateway client). Most external agents should use the Gateway.
+3. Implement a narrow adapter that maps platform-native names to TDAI names.
+4. Add contract tests for route, method, request body, auth, and error handling.
+5. Document session identity, startup requirements, and failure behavior.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     ".": {
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./adapters": {
+      "import": "./dist/src/adapters/index.mjs",
+      "default": "./dist/src/adapters/index.mjs"
     }
   },
   "scripts": {
@@ -41,6 +45,7 @@
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",
     "scripts/README.memory-tencentdb-ctl.md",
+    "docs/",
     "src",
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Four-layer local memory system plugin for OpenClaw — auto-captures, structures, and profiles conversational knowledge using local LLM + SQLite vector search (L0→L1→L2→L3 pipeline)",
   "type": "module",
   "main": "./dist/index.mjs",
+  "types": "./index.ts",
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
@@ -11,10 +12,12 @@
   },
   "exports": {
     ".": {
+      "types": "./index.ts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
     "./adapters": {
+      "types": "./src/adapters/index.ts",
       "import": "./dist/src/adapters/index.mjs",
       "default": "./dist/src/adapters/index.mjs"
     }

--- a/src/adapters/codex/client.test.ts
+++ b/src/adapters/codex/client.test.ts
@@ -96,6 +96,103 @@ describe("CodexMemoryAdapter", () => {
     });
   });
 
+  it("checks Gateway health without a request body", async () => {
+    const { calls, fetchMock } = createFetchMock([
+      jsonResponse({
+        status: "ok",
+        version: "0.3.6",
+        uptime: 42,
+        stores: { vectorStore: true, embeddingService: true },
+      }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await adapter.health();
+
+    expect(result.status).toBe("ok");
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].input)).toBe("http://localhost:8420/health");
+    expect(calls[0].init?.method).toBe("GET");
+    expect(calls[0].init?.body).toBeUndefined();
+    expect(calls[0].init?.headers).toEqual({});
+  });
+
+  it("posts memory search requests with optional filters", async () => {
+    const { calls, fetchMock } = createFetchMock([
+      jsonResponse({ results: "memory result", total: 1, strategy: "hybrid" }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await adapter.searchMemories({
+      query: "repo rules",
+      limit: 5,
+      type: "fact",
+      scene: "coding",
+    });
+
+    expect(result).toEqual({ results: "memory result", total: 1, strategy: "hybrid" });
+    expect(String(calls[0].input)).toBe("http://localhost:8420/search/memories");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "repo rules",
+      limit: 5,
+      type: "fact",
+      scene: "coding",
+    });
+  });
+
+  it("posts conversation search requests with snake_case session filters", async () => {
+    const { calls, fetchMock } = createFetchMock([
+      jsonResponse({ results: "conversation result", total: 2 }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await adapter.searchConversations({
+      query: "issue 235",
+      limit: 3,
+      sessionKey: "codex-thread-235",
+    });
+
+    expect(result).toEqual({ results: "conversation result", total: 2 });
+    expect(String(calls[0].input)).toBe("http://localhost:8420/search/conversations");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "issue 235",
+      limit: 3,
+      session_key: "codex-thread-235",
+    });
+  });
+
+  it("flushes a Codex session through the Gateway session end endpoint", async () => {
+    const { calls, fetchMock } = createFetchMock([
+      jsonResponse({ flushed: true }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      defaultSessionKey: "codex-thread-235",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await adapter.endSession({ userId: "ceilf6" });
+
+    expect(result).toEqual({ flushed: true });
+    expect(String(calls[0].input)).toBe("http://localhost:8420/session/end");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      session_key: "codex-thread-235",
+      user_id: "ceilf6",
+    });
+  });
+
   it("fails fast when a session-scoped operation has no session key", async () => {
     const { fetchMock } = createFetchMock([]);
     const adapter = new CodexMemoryAdapter({
@@ -118,6 +215,34 @@ describe("CodexMemoryAdapter", () => {
 
     await expect(adapter.recall({ query: "hello", sessionKey: "s1" })).rejects.toThrow(
       "TDAI Gateway POST /recall failed with 401: Unauthorized: invalid token",
+    );
+  });
+
+  it("surfaces nested Gateway error messages", async () => {
+    const { fetchMock } = createFetchMock([
+      jsonResponse({ error: { message: "adapter route unavailable", code: "not_found" } }, { status: 404 }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(adapter.recall({ query: "hello", sessionKey: "s1" })).rejects.toThrow(
+      "TDAI Gateway POST /recall failed with 404: adapter route unavailable",
+    );
+  });
+
+  it("stringifies nested Gateway error objects without a message field", async () => {
+    const { fetchMock } = createFetchMock([
+      jsonResponse({ error: { code: "invalid_body", fields: ["session_key"] } }, { status: 400 }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(adapter.recall({ query: "hello", sessionKey: "s1" })).rejects.toThrow(
+      'TDAI Gateway POST /recall failed with 400: {"code":"invalid_body","fields":["session_key"]}',
     );
   });
 

--- a/src/adapters/codex/client.test.ts
+++ b/src/adapters/codex/client.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CodexMemoryAdapter,
+  createCodexMemoryAdapterFromEnv,
+} from "./client";
+
+type FetchCall = {
+  input: string | URL | Request;
+  init?: RequestInit;
+};
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+function createFetchMock(responses: Response[]) {
+  const calls: FetchCall[] = [];
+  const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ input, init });
+    const next = responses.shift();
+    if (!next) throw new Error("unexpected fetch call");
+    return next;
+  });
+  return { calls, fetchMock };
+}
+
+describe("CodexMemoryAdapter", () => {
+  it("posts recall requests to the Gateway with auth and snake_case fields", async () => {
+    const { calls, fetchMock } = createFetchMock([
+      jsonResponse({ context: "<memory-context>remember repo rules</memory-context>", strategy: "hybrid", memory_count: 1 }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://127.0.0.1:8420/",
+      apiKey: "secret",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await adapter.recall({
+      query: "How should I run tests?",
+      sessionKey: "codex-thread-235",
+      userId: "ceilf6",
+    });
+
+    expect(result.context).toContain("remember repo rules");
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].input)).toBe("http://127.0.0.1:8420/recall");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(calls[0].init?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer secret",
+    });
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "How should I run tests?",
+      session_key: "codex-thread-235",
+      user_id: "ceilf6",
+    });
+  });
+
+  it("captures a completed Codex turn through the Gateway capture endpoint", async () => {
+    const { calls, fetchMock } = createFetchMock([
+      jsonResponse({ l0_recorded: 2, scheduler_notified: true }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await adapter.captureTurn({
+      userContent: "implement issue 235",
+      assistantContent: "implemented the adapter",
+      sessionKey: "codex-thread-235",
+      sessionId: "turn-1",
+      messages: [
+        { role: "user", content: "implement issue 235" },
+        { role: "assistant", content: "implemented the adapter" },
+      ],
+    });
+
+    expect(result).toEqual({ l0_recorded: 2, scheduler_notified: true });
+    expect(String(calls[0].input)).toBe("http://localhost:8420/capture");
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      user_content: "implement issue 235",
+      assistant_content: "implemented the adapter",
+      session_key: "codex-thread-235",
+      session_id: "turn-1",
+      messages: [
+        { role: "user", content: "implement issue 235" },
+        { role: "assistant", content: "implemented the adapter" },
+      ],
+    });
+  });
+
+  it("fails fast when a session-scoped operation has no session key", async () => {
+    const { fetchMock } = createFetchMock([]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(adapter.recall({ query: "missing session" })).rejects.toThrow("sessionKey is required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces Gateway HTTP errors with route and status", async () => {
+    const { fetchMock } = createFetchMock([
+      jsonResponse({ error: "Unauthorized: invalid token" }, { status: 401 }),
+    ]);
+    const adapter = new CodexMemoryAdapter({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(adapter.recall({ query: "hello", sessionKey: "s1" })).rejects.toThrow(
+      "TDAI Gateway POST /recall failed with 401: Unauthorized: invalid token",
+    );
+  });
+
+  it("creates an adapter from Codex-oriented environment variables", () => {
+    const adapter = createCodexMemoryAdapterFromEnv({
+      MEMORY_TENCENTDB_GATEWAY_URL: "http://gateway:8420",
+      MEMORY_TENCENTDB_GATEWAY_API_KEY: "adapter-secret",
+      CODEX_SESSION_ID: "thread-abc",
+    });
+
+    expect(adapter.baseUrl).toBe("http://gateway:8420");
+    expect(adapter.defaultSessionKey).toBe("thread-abc");
+  });
+
+  it("falls back to the default Gateway URL when env base URL is blank", () => {
+    const adapter = createCodexMemoryAdapterFromEnv({
+      MEMORY_TENCENTDB_GATEWAY_URL: "",
+      TDAI_GATEWAY_URL: "",
+    });
+
+    expect(adapter.baseUrl).toBe("http://127.0.0.1:8420");
+  });
+});

--- a/src/adapters/codex/client.ts
+++ b/src/adapters/codex/client.ts
@@ -21,6 +21,11 @@ export interface CodexMemoryAdapterOptions {
   baseUrl?: string;
   apiKey?: string;
   timeoutMs?: number;
+  /**
+   * Default session identity for single-thread Codex integrations.
+   * Multi-session callers should pass sessionKey per operation so unrelated
+   * conversations cannot share the same memory scope.
+   */
   defaultSessionKey?: string;
   fetch?: FetchLike;
 }
@@ -135,6 +140,8 @@ export class CodexMemoryAdapter {
   }
 
   private resolveSessionKey(sessionKey?: string): string {
+    // defaultSessionKey is only a single-session convenience; multi-thread
+    // integrations must pass sessionKey explicitly for every scoped operation.
     const resolved = sessionKey?.trim() || this.defaultSessionKey;
     if (!resolved) {
       throw new Error("sessionKey is required for Codex memory operations");
@@ -197,7 +204,34 @@ async function readJsonResponse(response: Response): Promise<unknown> {
 function getGatewayErrorMessage(payload: unknown): string {
   if (payload && typeof payload === "object" && "error" in payload) {
     const error = (payload as { error?: unknown }).error;
-    if (typeof error === "string" && error.length > 0) return error;
+    const message = stringifyGatewayError(error);
+    if (message) return message;
   }
   return "unknown error";
+}
+
+function stringifyGatewayError(error: unknown): string | undefined {
+  if (typeof error === "string") {
+    const trimmed = error.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (error && typeof error === "object") {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message.trim();
+    }
+
+    try {
+      const serialized = JSON.stringify(error);
+      return serialized && serialized.length > 0 ? serialized : undefined;
+    } catch {
+      return String(error);
+    }
+  }
+
+  if (error !== undefined && error !== null) {
+    return String(error);
+  }
+  return undefined;
 }

--- a/src/adapters/codex/client.ts
+++ b/src/adapters/codex/client.ts
@@ -1,0 +1,203 @@
+/**
+ * CodexMemoryAdapter — TypeScript client adapter for Codex-style agents.
+ *
+ * Codex does not run inside the OpenClaw plugin host. This adapter treats the
+ * TDAI Gateway as the stable boundary and maps Codex turn/session data to the
+ * same HTTP contract used by other out-of-process platforms.
+ */
+
+import type {
+  CaptureResponse,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchResponse,
+  RecallResponse,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+type FetchLike = typeof fetch;
+
+export interface CodexMemoryAdapterOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  defaultSessionKey?: string;
+  fetch?: FetchLike;
+}
+
+export interface CodexRecallInput {
+  query: string;
+  sessionKey?: string;
+  userId?: string;
+}
+
+export interface CodexCaptureTurnInput {
+  userContent: string;
+  assistantContent: string;
+  sessionKey?: string;
+  sessionId?: string;
+  userId?: string;
+  messages?: unknown[];
+}
+
+export interface CodexMemorySearchInput {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface CodexConversationSearchInput {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export interface CodexSessionEndInput {
+  sessionKey?: string;
+  userId?: string;
+}
+
+export class CodexMemoryAdapter {
+  readonly baseUrl: string;
+  readonly defaultSessionKey?: string;
+
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(opts: CodexMemoryAdapterOptions = {}) {
+    const baseUrl = opts.baseUrl?.trim() || "http://127.0.0.1:8420";
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.apiKey = opts.apiKey?.trim() || undefined;
+    this.timeoutMs = opts.timeoutMs ?? 10_000;
+    this.defaultSessionKey = opts.defaultSessionKey?.trim() || undefined;
+    this.fetchImpl = opts.fetch ?? globalThis.fetch;
+
+    if (!this.fetchImpl) {
+      throw new Error("CodexMemoryAdapter requires a fetch implementation");
+    }
+  }
+
+  async health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  async recall(input: CodexRecallInput): Promise<RecallResponse> {
+    const sessionKey = this.resolveSessionKey(input.sessionKey);
+    return this.request<RecallResponse>("POST", "/recall", {
+      query: input.query,
+      session_key: sessionKey,
+      ...(input.userId ? { user_id: input.userId } : {}),
+    });
+  }
+
+  async buildPromptContext(input: CodexRecallInput): Promise<string> {
+    const response = await this.recall(input);
+    return response.context ?? "";
+  }
+
+  async captureTurn(input: CodexCaptureTurnInput): Promise<CaptureResponse> {
+    const sessionKey = this.resolveSessionKey(input.sessionKey);
+    return this.request<CaptureResponse>("POST", "/capture", {
+      user_content: input.userContent,
+      assistant_content: input.assistantContent,
+      session_key: sessionKey,
+      ...(input.sessionId ? { session_id: input.sessionId } : {}),
+      ...(input.userId ? { user_id: input.userId } : {}),
+      ...(input.messages ? { messages: input.messages } : {}),
+    });
+  }
+
+  async searchMemories(input: CodexMemorySearchInput): Promise<MemorySearchResponse> {
+    return this.request<MemorySearchResponse>("POST", "/search/memories", {
+      query: input.query,
+      ...(input.limit !== undefined ? { limit: input.limit } : {}),
+      ...(input.type ? { type: input.type } : {}),
+      ...(input.scene ? { scene: input.scene } : {}),
+    });
+  }
+
+  async searchConversations(input: CodexConversationSearchInput): Promise<ConversationSearchResponse> {
+    return this.request<ConversationSearchResponse>("POST", "/search/conversations", {
+      query: input.query,
+      ...(input.limit !== undefined ? { limit: input.limit } : {}),
+      ...(input.sessionKey ? { session_key: input.sessionKey } : {}),
+    });
+  }
+
+  async endSession(input: CodexSessionEndInput = {}): Promise<SessionEndResponse> {
+    const sessionKey = this.resolveSessionKey(input.sessionKey);
+    return this.request<SessionEndResponse>("POST", "/session/end", {
+      session_key: sessionKey,
+      ...(input.userId ? { user_id: input.userId } : {}),
+    });
+  }
+
+  private resolveSessionKey(sessionKey?: string): string {
+    const resolved = sessionKey?.trim() || this.defaultSessionKey;
+    if (!resolved) {
+      throw new Error("sessionKey is required for Codex memory operations");
+    }
+    return resolved;
+  }
+
+  private async request<T>(
+    method: "GET" | "POST",
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {};
+      if (body !== undefined) headers["Content-Type"] = "application/json";
+      if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      const payload = await readJsonResponse(response);
+      if (!response.ok) {
+        const message = getGatewayErrorMessage(payload);
+        throw new Error(`TDAI Gateway ${method} ${path} failed with ${response.status}: ${message}`);
+      }
+      return payload as T;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function createCodexMemoryAdapterFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): CodexMemoryAdapter {
+  return new CodexMemoryAdapter({
+    baseUrl: env.MEMORY_TENCENTDB_GATEWAY_URL ?? env.TDAI_GATEWAY_URL,
+    apiKey: env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+    defaultSessionKey: env.CODEX_SESSION_ID ?? env.CODEX_THREAD_ID,
+  });
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+function getGatewayErrorMessage(payload: unknown): string {
+  if (payload && typeof payload === "object" && "error" in payload) {
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string" && error.length > 0) return error;
+  }
+  return "unknown error";
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Codex adapter — barrel exports.
+ */
+export {
+  CodexMemoryAdapter,
+  createCodexMemoryAdapterFromEnv,
+} from "./client.js";
+export type {
+  CodexCaptureTurnInput,
+  CodexConversationSearchInput,
+  CodexMemoryAdapterOptions,
+  CodexMemorySearchInput,
+  CodexRecallInput,
+  CodexSessionEndInput,
+} from "./client.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -7,7 +7,8 @@
  * Directory structure:
  *   adapters/
  *   ├── openclaw/      — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
- *   └── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   ├── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   └── codex/         — Codex-style Gateway client adapter
  */
 
 // OpenClaw adapter
@@ -17,3 +18,14 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Codex adapter
+export { CodexMemoryAdapter, createCodexMemoryAdapterFromEnv } from "./codex/index.js";
+export type {
+  CodexCaptureTurnInput,
+  CodexConversationSearchInput,
+  CodexMemoryAdapterOptions,
+  CodexMemorySearchInput,
+  CodexRecallInput,
+  CodexSessionEndInput,
+} from "./codex/index.js";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: ["./index.ts", "./src/adapters/index.ts"],
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
## Summary
- add a Codex Gateway client adapter for recall, capture, search, and session flush flows
- expose the adapter through the package `./adapters` subpath and build entry
- document OpenClaw, Hermes, and Codex cross-platform adapter architecture and best practices

## Verification
- `npm test`
- `npm run build`
- `node -e "import('@tencentdb-agent-memory/memory-tencentdb/adapters').then(m=>{ if (!m.CodexMemoryAdapter) throw new Error('missing CodexMemoryAdapter'); console.log(Object.keys(m).filter(k=>k.includes('Codex')).sort().join(',')); })"`
- `npm pack --dry-run`

Closes #235