### PR TITLE
feat(gateway): add live batch capture import

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,40 @@ curl http://127.0.0.1:8420/health
 
 ---
 
+## Batch Capture Into The Live Store
+
+Use `POST /capture/batch` when you want to import historical conversations into
+the same live memory directory used by normal `/capture` traffic. This keeps the
+imported data searchable together with ongoing Gateway captures.
+
+The endpoint accepts either multiple existing `/capture` payloads:
+
+```bash
+curl -H "Content-Type: application/json" \
+     -d '{"captures":[{"session_key":"import-1","user_content":"Hello","assistant_content":"Hi"}]}' \
+     http://127.0.0.1:8420/capture/batch
+```
+
+or the same seed-style `sessions/conversations` input shape used by `POST /seed`:
+
+```bash
+curl -H "Content-Type: application/json" \
+     -d '{"data":{"sessions":[{"sessionKey":"import-1","conversations":[[{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi"}]]}]}}' \
+     http://127.0.0.1:8420/capture/batch
+```
+
+`POST /capture/batch` runs through the live `TdaiCore` capture path and disables
+the live cold-start timestamp floor for imported history. `POST /seed` is still
+available for isolated seed runs that write to a separate timestamped output
+directory.
+
+For safety, one request can import at most 100 rounds/items. Set
+`continue_on_error: true` to receive per-item failures while continuing the rest
+of the batch.
+
+
+---
+
 
 ## 🔒 Gateway Security (optional)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -356,6 +356,33 @@ curl http://127.0.0.1:8420/health
 
 ---
 
+## 批量 Capture 到实时记忆目录
+
+如果要导入历史对话，并且希望数据进入普通 `/capture` 使用的同一个实时记忆目录，可以使用 `POST /capture/batch`。这样导入的数据会和后续 Gateway capture 数据一起检索和召回。
+
+接口可以接收多个现有 `/capture` 请求体：
+
+```bash
+curl -H "Content-Type: application/json" \
+     -d '{"captures":[{"session_key":"import-1","user_content":"你好","assistant_content":"你好"}]}' \
+     http://127.0.0.1:8420/capture/batch
+```
+
+也可以接收和 `POST /seed` 相同的 `sessions/conversations` 输入格式：
+
+```bash
+curl -H "Content-Type: application/json" \
+     -d '{"data":{"sessions":[{"sessionKey":"import-1","conversations":[[{"role":"user","content":"你好"},{"role":"assistant","content":"你好"}]]}]}}' \
+     http://127.0.0.1:8420/capture/batch
+```
+
+`POST /capture/batch` 复用实时 `TdaiCore` capture 路径，并会为历史导入关闭实时 capture 的冷启动时间戳下限，避免旧时间戳被误过滤。`POST /seed` 仍然保留，用于写入独立时间戳目录的隔离导入。
+
+出于安全考虑，单次请求最多导入 100 个 round/item。需要单项失败后继续处理剩余数据时，可以设置 `continue_on_error: true`。
+
+
+---
+
 ## 🔒 Gateway 安全配置（可选）
 
 Hermes Gateway 监听 `:8420`，对外提供 capture / search / recall 的 HTTP 接口。新增两个开关，可以把它从“开放的本地 sidecar”切换为“需要鉴权的网络服务”。**两个开关默认都关闭，已有部署的行为不变。**

--- a/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/hermes-plugin/memory/memory_tencentdb/README.md
@@ -16,7 +16,7 @@ Hermes Agent (Python)
   └─ MemoryManager
        └─ MemoryTencentdbProvider        (this directory)
             ├─ GatewaySupervisor          — starts / health-checks the sidecar
-            └─ MemoryTencentdbSdkClient   — POST /recall, /capture, /search/*, /session/end
+            └─ MemoryTencentdbSdkClient   — POST /recall, /capture, /capture/batch, /search/*, /session/end
                     │
                     ▼  HTTP (127.0.0.1:8420 by default)
             memory-tencentdb Gateway (Node.js)
@@ -34,6 +34,7 @@ Hermes lifecycle → Gateway mapping:
 |-----------------------------|------------------|------------------------------------------------------------|
 | `prefetch(query)`           | `POST /recall`   | Synchronous. Returns `<memory-context>` text for injection |
 | `sync_turn(user, assistant)`| `POST /capture`  | Fire-and-forget on a background daemon thread (max 4 in-flight) |
+| `capture_batch(...)`        | `POST /capture/batch` | Batch import into the live Gateway memory directory |
 | `shutdown()` / `on_session_end` | `POST /session/end` | Flush pending pipeline work                             |
 | `get_tool_schemas()`        | —                | Advertises two LLM tools (see below)                       |
 

--- a/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/hermes-plugin/memory/memory_tencentdb/client.py
@@ -10,7 +10,7 @@ import json
 import logging
 import urllib.request
 import urllib.error
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +138,45 @@ class MemoryTencentdbSdkClient:
         if user_id:
             body["user_id"] = user_id
         return self._post("/capture", body)
+
+    def capture_batch(
+        self,
+        captures: Optional[List[Dict[str, Any]]] = None,
+        data: Any = None,
+        session_key: str = "",
+        strict_round_role: bool = False,
+        auto_fill_timestamps: bool = True,
+        continue_on_error: bool = False,
+        timeout: int = 300,
+    ) -> Dict[str, Any]:
+        """Batch import conversations into the live Gateway memory store.
+
+        Args:
+            captures: List of existing ``/capture`` payload dictionaries.
+            data: Seed-style input — Format A ``{"sessions": [...]}`` or Format B ``[...]``.
+            session_key: Fallback session key for seed-style input.
+            strict_round_role: Require each seed round to have both user and assistant.
+            auto_fill_timestamps: Auto-fill missing seed timestamps (default True).
+            continue_on_error: Continue processing if one item fails at runtime.
+            timeout: Request timeout in seconds (batch import can be slow, default 300s).
+
+        Returns:
+            Summary dict with total, succeeded, failed, source, and per-item results.
+        """
+        body: Dict[str, Any] = {}
+        if captures is not None:
+            body["captures"] = captures
+        if data is not None:
+            body["data"] = data
+        if session_key:
+            body["session_key"] = session_key
+        if strict_round_role:
+            body["strict_round_role"] = True
+        if not auto_fill_timestamps:
+            body["auto_fill_timestamps"] = False
+        if continue_on_error:
+            body["continue_on_error"] = True
+        return self._post("/capture/batch", body, timeout=timeout)
 
     def search_memories(self, query: str, limit: int = 5, type_filter: str = "", scene: str = "") -> Dict[str, Any]:
         """Search L1 structured memories."""

--- a/src/gateway/capture-batch.test.ts
+++ b/src/gateway/capture-batch.test.ts
@@ -1,0 +1,285 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { MemoryTdaiConfig } from "../config.js";
+import { performAutoCapture } from "../core/hooks/auto-capture.js";
+import type { Logger } from "../core/types.js";
+import {
+  buildCaptureTurn,
+  HISTORICAL_CAPTURE_STARTED_AT,
+  MAX_CAPTURE_BATCH_SIZE,
+  normalizeCaptureBatchRequest,
+  normalizeCapturePayload,
+} from "./capture-batch.js";
+
+const testLogger: Logger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+describe("capture batch request normalization", () => {
+  it("keeps single /capture payloads timestamp-free when callers omit timestamps", () => {
+    const capture = normalizeCapturePayload({
+      user_content: "live question",
+      assistant_content: "live answer",
+      session_key: "live-session",
+    });
+
+    expect(capture.messages).toEqual([
+      { role: "user", content: "live question" },
+      { role: "assistant", content: "live answer" },
+    ]);
+  });
+
+  it("normalizes multiple /capture payloads for historical live import", () => {
+    const result = normalizeCaptureBatchRequest({
+      captures: [
+        {
+          user_content: "hello",
+          assistant_content: "hi",
+          session_key: "session-a",
+          session_id: "sid-a",
+        },
+        {
+          user_content: "next",
+          assistant_content: "done",
+          session_key: "session-a",
+          messages: [
+            { role: "user", content: "next", timestamp: "2026-07-02T00:00:00.000Z" },
+            { role: "assistant", content: "done" },
+          ],
+        },
+      ],
+      continue_on_error: true,
+    }, 1_000);
+
+    expect(result.source).toBe("captures");
+    expect(result.continueOnError).toBe(true);
+    expect(result.captures).toHaveLength(2);
+    expect(result.captures[0]).toMatchObject({
+      index: 0,
+      startedAt: HISTORICAL_CAPTURE_STARTED_AT,
+      capture: {
+        user_content: "hello",
+        assistant_content: "hi",
+        session_key: "session-a",
+        session_id: "sid-a",
+      },
+    });
+
+    const firstMessages = result.captures[0]!.capture.messages as Array<{ timestamp: number }>;
+    expect(firstMessages.map((message) => message.timestamp)).toEqual([1_000, 1_100]);
+
+    const secondMessages = result.captures[1]!.capture.messages as Array<{ timestamp: number }>;
+    expect(secondMessages[0]!.timestamp).toBe(Date.parse("2026-07-02T00:00:00.000Z"));
+    expect(secondMessages[1]!.timestamp).toBe(1_200);
+  });
+
+  it("accepts seed-format data and converts each round to a live capture item", () => {
+    const result = normalizeCaptureBatchRequest({
+      data: {
+        sessions: [
+          {
+            sessionKey: "historical-session",
+            sessionId: "import-run-1",
+            conversations: [
+              [
+                { role: "user", content: "What did we decide?", timestamp: "2024-01-01T00:00:00.000Z" },
+                { role: "assistant", content: "Use the live gateway store.", timestamp: "2024-01-01T00:00:01.000Z" },
+              ],
+            ],
+          },
+        ],
+      },
+      strict_round_role: true,
+    });
+
+    expect(result.source).toBe("seed");
+    expect(result.captures).toHaveLength(1);
+    expect(result.captures[0]).toMatchObject({
+      index: 0,
+      startedAt: HISTORICAL_CAPTURE_STARTED_AT,
+      sourceSessionIndex: 0,
+      sourceRoundIndex: 0,
+      capture: {
+        user_content: "What did we decide?",
+        assistant_content: "Use the live gateway store.",
+        session_key: "historical-session",
+        session_id: "import-run-1",
+      },
+    });
+
+    const messages = result.captures[0]!.capture.messages as Array<{ timestamp: number }>;
+    expect(messages.map((message) => message.timestamp)).toEqual([
+      Date.parse("2024-01-01T00:00:00.000Z"),
+      Date.parse("2024-01-01T00:00:01.000Z"),
+    ]);
+  });
+
+  it("auto-fills missing timestamps for seed-format HTTP imports by default", () => {
+    const result = normalizeCaptureBatchRequest({
+      data: [
+        {
+          sessionKey: "seed-without-timestamps",
+          conversations: [
+            [
+              { role: "user", content: "missing ts" },
+              { role: "assistant", content: "filled" },
+            ],
+          ],
+        },
+      ],
+    });
+
+    const messages = result.captures[0]!.capture.messages as Array<{ timestamp: number }>;
+    expect(messages).toHaveLength(2);
+    expect(messages.every((message) => Number.isInteger(message.timestamp) && message.timestamp > 0)).toBe(true);
+    expect(messages[1]!.timestamp).toBeGreaterThan(messages[0]!.timestamp);
+  });
+
+  it("builds historical CompletedTurn objects with the cold-start floor disabled", () => {
+    const normalized = normalizeCaptureBatchRequest({
+      captures: [
+        {
+          user_content: "old question",
+          assistant_content: "old answer",
+          session_key: "history",
+          messages: [
+            { role: "user", content: "old question", timestamp: 10 },
+            { role: "assistant", content: "old answer", timestamp: 20 },
+          ],
+        },
+      ],
+    });
+
+    const item = normalized.captures[0]!;
+    const turn = buildCaptureTurn(item.capture, { startedAt: item.startedAt });
+    expect(turn.startedAt).toBe(0);
+    expect(turn.messages).toEqual(item.capture.messages);
+  });
+
+  it("lets historical timestamps pass through the real capture path", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "tdai-capture-batch-"));
+    const messages = [
+      { role: "user", content: "old question", timestamp: 10 },
+      { role: "assistant", content: "old answer", timestamp: 20 },
+    ];
+
+    try {
+      const liveColdStart = await performAutoCapture({
+        messages,
+        sessionKey: "cold-start",
+        cfg: {} as MemoryTdaiConfig,
+        pluginDataDir: path.join(tempDir, "live"),
+        pluginStartTimestamp: Date.now(),
+        logger: testLogger,
+      });
+      expect(liveColdStart.l0RecordedCount).toBe(0);
+
+      const historicalImport = await performAutoCapture({
+        messages,
+        sessionKey: "historical-import",
+        cfg: {} as MemoryTdaiConfig,
+        pluginDataDir: path.join(tempDir, "import"),
+        pluginStartTimestamp: HISTORICAL_CAPTURE_STARTED_AT,
+        logger: testLogger,
+      });
+      expect(historicalImport.l0RecordedCount).toBe(2);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects seed-format data when timestamp filling is disabled and all timestamps are missing", () => {
+    expect(() =>
+      normalizeCaptureBatchRequest({
+        data: [
+          {
+            sessionKey: "seed-without-timestamps",
+            conversations: [
+              [
+                { role: "user", content: "missing ts" },
+                { role: "assistant", content: "not fillable" },
+              ],
+            ],
+          },
+        ],
+        auto_fill_timestamps: false,
+      }),
+    ).toThrow("requires timestamps unless auto_fill_timestamps is true");
+  });
+
+  it("rejects ambiguous requests that provide both seed data and capture items", () => {
+    expect(() =>
+      normalizeCaptureBatchRequest({
+        data: { sessions: [] },
+        captures: [
+          {
+            user_content: "hello",
+            assistant_content: "hi",
+            session_key: "session-a",
+          },
+        ],
+      }),
+    ).toThrow("provide either data or captures, not both");
+  });
+
+  it("rejects batches over the safety limit", () => {
+    const captures = Array.from({ length: MAX_CAPTURE_BATCH_SIZE + 1 }, () => ({
+      user_content: "hello",
+      assistant_content: "hi",
+      session_key: "session-a",
+    }));
+
+    expect(() => normalizeCaptureBatchRequest({ captures })).toThrow(
+      `captures must contain at most ${MAX_CAPTURE_BATCH_SIZE} items`,
+    );
+  });
+
+  it("rejects capture items missing required fields", () => {
+    expect(() =>
+      normalizeCaptureBatchRequest({
+        captures: [
+          {
+            user_content: "hello",
+            assistant_content: "hi",
+          },
+        ],
+      }),
+    ).toThrow("captures[0].session_key must be a non-empty string");
+  });
+
+  it("rejects malformed message timestamps instead of silently falling back to now", () => {
+    expect(() =>
+      normalizeCapturePayload({
+        user_content: "hello",
+        assistant_content: "hi",
+        session_key: "session-a",
+        messages: [
+          { role: "user", content: "hello", timestamp: "yesterday-ish" },
+          { role: "assistant", content: "hi" },
+        ],
+      }),
+    ).toThrow("valid ISO 8601 string");
+  });
+
+  it("rejects seed rounds that cannot become completed capture turns", () => {
+    expect(() =>
+      normalizeCaptureBatchRequest({
+        data: [
+          {
+            sessionKey: "partial",
+            conversations: [
+              [
+                { role: "user", content: "only user", timestamp: 1 },
+              ],
+            ],
+          },
+        ],
+      }),
+    ).toThrow("must contain at least one user and one assistant message");
+  });
+});

--- a/src/gateway/capture-batch.ts
+++ b/src/gateway/capture-batch.ts
@@ -1,0 +1,266 @@
+import type { CompletedTurn } from "../core/types.js";
+import { validateAndNormalizeRaw, SeedValidationError } from "../core/seed/input.js";
+import type { NormalizedInput } from "../core/seed/types.js";
+import type { CaptureBatchRequest, CaptureRequest } from "./types.js";
+
+export const MAX_CAPTURE_BATCH_SIZE = 100;
+export const HISTORICAL_CAPTURE_STARTED_AT = 0;
+const TIMESTAMP_STEP_MS = 100;
+
+export class CaptureBatchValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CaptureBatchValidationError";
+  }
+}
+
+export interface NormalizedCaptureBatchItem {
+  index: number;
+  capture: CaptureRequest;
+  startedAt: number;
+  sourceSessionIndex?: number;
+  sourceRoundIndex?: number;
+}
+
+export interface NormalizedCaptureBatch {
+  captures: NormalizedCaptureBatchItem[];
+  continueOnError: boolean;
+  source: "captures" | "seed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(
+  value: Record<string, unknown>,
+  key: keyof CaptureRequest,
+  label: string,
+): string {
+  const raw = value[key];
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new CaptureBatchValidationError(`${label}.${key} must be a non-empty string`);
+  }
+  return raw;
+}
+
+function readOptionalString(
+  value: Record<string, unknown>,
+  key: keyof CaptureRequest,
+): string | undefined {
+  const raw = value[key];
+  return typeof raw === "string" && raw.trim().length > 0 ? raw : undefined;
+}
+
+function parseTimestamp(value: unknown, label: string): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number") {
+    if (!Number.isInteger(value)) {
+      throw new CaptureBatchValidationError(`${label} must be an integer epoch millisecond timestamp`);
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value).getTime();
+    if (Number.isNaN(parsed)) {
+      throw new CaptureBatchValidationError(`${label} must be an epoch millisecond number or valid ISO 8601 string`);
+    }
+    return parsed;
+  }
+  throw new CaptureBatchValidationError(`${label} must be an epoch millisecond number or valid ISO 8601 string`);
+}
+
+function makeTimestampAllocator(startMs: number): () => number {
+  let next = startMs;
+  return () => {
+    const value = next;
+    next += TIMESTAMP_STEP_MS;
+    return value;
+  };
+}
+
+function normalizeMessages(
+  rawMessages: unknown[] | undefined,
+  userContent: string,
+  assistantContent: string,
+  nextTimestamp: (() => number) | undefined,
+  label: string,
+): unknown[] {
+  if (!rawMessages) {
+    if (!nextTimestamp) {
+      return [
+        { role: "user", content: userContent },
+        { role: "assistant", content: assistantContent },
+      ];
+    }
+    return [
+      { role: "user", content: userContent, timestamp: nextTimestamp() },
+      { role: "assistant", content: assistantContent, timestamp: nextTimestamp() },
+    ];
+  }
+
+  return rawMessages.map((message, index) => {
+    if (!isRecord(message)) return message;
+    const parsed = parseTimestamp(message.timestamp, `${label}.messages[${index}].timestamp`);
+    if (parsed !== undefined) return { ...message, timestamp: parsed };
+    if (nextTimestamp) return { ...message, timestamp: nextTimestamp() };
+    return message;
+  });
+}
+
+export function normalizeCapturePayload(
+  raw: unknown,
+  label = "capture",
+  nextTimestamp?: () => number,
+): CaptureRequest {
+  if (!isRecord(raw)) {
+    throw new CaptureBatchValidationError(`${label} must be an object`);
+  }
+
+  const rawMessages = raw.messages;
+  if (rawMessages !== undefined && !Array.isArray(rawMessages)) {
+    throw new CaptureBatchValidationError(`${label}.messages must be an array when provided`);
+  }
+
+  const userContent = readRequiredString(raw, "user_content", label);
+  const assistantContent = readRequiredString(raw, "assistant_content", label);
+  const sessionKey = readRequiredString(raw, "session_key", label);
+
+  return {
+    user_content: userContent,
+    assistant_content: assistantContent,
+    session_key: sessionKey,
+    session_id: readOptionalString(raw, "session_id"),
+    user_id: readOptionalString(raw, "user_id"),
+    messages: normalizeMessages(rawMessages, userContent, assistantContent, nextTimestamp, label),
+  };
+}
+
+function normalizeSeedInput(body: CaptureBatchRequest): NormalizedInput {
+  try {
+    const input = validateAndNormalizeRaw(body.data, {
+      sessionKey: body.session_key,
+      strictRoundRole: body.strict_round_role,
+      autoFillTimestamps: body.auto_fill_timestamps ?? true,
+    });
+    if (!input.hasTimestamps) {
+      throw new CaptureBatchValidationError(
+        "seed-format batch import requires timestamps unless auto_fill_timestamps is true",
+      );
+    }
+    return input;
+  } catch (err) {
+    if (err instanceof CaptureBatchValidationError) throw err;
+    if (err instanceof SeedValidationError) {
+      throw new CaptureBatchValidationError(err.message);
+    }
+    throw err;
+  }
+}
+
+function capturesFromSeedInput(input: NormalizedInput): NormalizedCaptureBatchItem[] {
+  const captures: NormalizedCaptureBatchItem[] = [];
+
+  for (const session of input.sessions) {
+    for (let roundIndex = 0; roundIndex < session.rounds.length; roundIndex++) {
+      const round = session.rounds[roundIndex]!;
+      const userMessage = round.messages.find((message) => message.role === "user");
+      const assistantMessage = [...round.messages].reverse().find((message) => message.role === "assistant");
+
+      if (!userMessage || !assistantMessage) {
+        throw new CaptureBatchValidationError(
+          `data.sessions[${session.sourceIndex}].conversations[${roundIndex}] must contain at least one user and one assistant message`,
+        );
+      }
+
+      captures.push({
+        index: captures.length,
+        capture: {
+          user_content: userMessage.content,
+          assistant_content: assistantMessage.content,
+          session_key: session.sessionKey,
+          session_id: session.sessionId,
+          messages: round.messages.map((message) => ({
+            role: message.role,
+            content: message.content,
+            timestamp: message.timestamp,
+          })),
+        },
+        startedAt: HISTORICAL_CAPTURE_STARTED_AT,
+        sourceSessionIndex: session.sourceIndex,
+        sourceRoundIndex: roundIndex,
+      });
+    }
+  }
+
+  return captures;
+}
+
+function enforceBatchLimit(captures: NormalizedCaptureBatchItem[]): void {
+  if (captures.length === 0) {
+    throw new CaptureBatchValidationError("captures must be a non-empty array");
+  }
+  if (captures.length > MAX_CAPTURE_BATCH_SIZE) {
+    throw new CaptureBatchValidationError(
+      `captures must contain at most ${MAX_CAPTURE_BATCH_SIZE} items`,
+    );
+  }
+}
+
+export function normalizeCaptureBatchRequest(
+  body: CaptureBatchRequest,
+  nowMs = Date.now(),
+): NormalizedCaptureBatch {
+  if (!isRecord(body)) {
+    throw new CaptureBatchValidationError("request body must be an object");
+  }
+
+  const hasSeedData = body.data !== undefined;
+  const rawCaptures = Array.isArray(body.captures)
+    ? body.captures
+    : Array.isArray(body.items)
+      ? body.items
+      : undefined;
+
+  if (hasSeedData && rawCaptures) {
+    throw new CaptureBatchValidationError("provide either data or captures, not both");
+  }
+
+  const continueOnError = body.continue_on_error === true;
+
+  if (hasSeedData) {
+    const captures = capturesFromSeedInput(normalizeSeedInput(body));
+    enforceBatchLimit(captures);
+    return { captures, continueOnError, source: "seed" };
+  }
+
+  if (!rawCaptures) {
+    throw new CaptureBatchValidationError("captures must be a non-empty array");
+  }
+
+  const nextTimestamp = makeTimestampAllocator(nowMs);
+  const captures = rawCaptures.map((capture, index) => ({
+    index,
+    capture: normalizeCapturePayload(capture, `captures[${index}]`, nextTimestamp),
+    startedAt: HISTORICAL_CAPTURE_STARTED_AT,
+  }));
+  enforceBatchLimit(captures);
+  return { captures, continueOnError, source: "captures" };
+}
+
+export function buildCaptureTurn(
+  capture: CaptureRequest,
+  opts?: { startedAt?: number },
+): CompletedTurn {
+  return {
+    userText: capture.user_content,
+    assistantText: capture.assistant_content,
+    messages: capture.messages ?? [
+      { role: "user", content: capture.user_content },
+      { role: "assistant", content: capture.assistant_content },
+    ],
+    sessionKey: capture.session_key,
+    sessionId: capture.session_id,
+    startedAt: opts?.startedAt,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -5,6 +5,7 @@
  *   GET  /health              — Health check
  *   POST /recall              — Memory recall (prefetch)
  *   POST /capture             — Conversation capture (sync_turn)
+ *   POST /capture/batch       — Batch capture into the live memory directory
  *   POST /search/memories     — L1 memory search
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
@@ -29,6 +30,9 @@ import type {
   RecallResponse,
   CaptureRequest,
   CaptureResponse,
+  CaptureBatchRequest,
+  CaptureBatchResponse,
+  CaptureBatchResultItem,
   MemorySearchRequest,
   MemorySearchResponse,
   ConversationSearchRequest,
@@ -40,9 +44,15 @@ import type {
   GatewayErrorResponse,
 } from "./types.js";
 import type { Logger } from "../core/types.js";
-import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
+import { validateAndNormalizeRaw, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
+import {
+  buildCaptureTurn,
+  CaptureBatchValidationError,
+  normalizeCaptureBatchRequest,
+  normalizeCapturePayload,
+} from "./capture-batch.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
@@ -198,7 +208,7 @@ export class TdaiGateway {
     if (!loopback && !authOn) {
       this.logger.warn(
         `Gateway is bound to ${host} (non-loopback) WITHOUT an API key. ` +
-        "Every /capture, /search/conversations, /recall, /seed call from the " +
+        "Every /capture, /capture/batch, /search/conversations, /recall, /seed call from the " +
         "network is currently unauthenticated. Bind to 127.0.0.1, or set " +
         "TDAI_GATEWAY_API_KEY, before continuing."
       );
@@ -264,6 +274,8 @@ export class TdaiGateway {
           return await this.handleRecall(req, res);
         case "POST /capture":
           return await this.handleCapture(req, res);
+        case "POST /capture/batch":
+          return await this.handleCaptureBatch(req, res);
         case "POST /search/memories":
           return await this.handleSearchMemories(req, res);
         case "POST /search/conversations":
@@ -393,31 +405,98 @@ export class TdaiGateway {
   private async handleCapture(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     const body = await parseJsonBody<CaptureRequest>(req);
 
-    if (!body.user_content || !body.assistant_content || !body.session_key) {
-      sendError(res, 400, "Missing required fields: user_content, assistant_content, session_key");
-      return;
+    let capture: CaptureRequest;
+    try {
+      capture = normalizeCapturePayload(body);
+    } catch (err) {
+      if (err instanceof CaptureBatchValidationError) {
+        sendError(res, 400, err.message);
+        return;
+      }
+      throw err;
     }
 
     const startMs = Date.now();
-    const result = await this.core.handleTurnCommitted({
-      userText: body.user_content,
-      assistantText: body.assistant_content,
-      messages: body.messages ?? [
-        { role: "user", content: body.user_content },
-        { role: "assistant", content: body.assistant_content },
-      ],
-      sessionKey: body.session_key,
-      sessionId: body.session_id,
-    });
+    const response = await this.runCapture(capture);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Capture completed in ${elapsed}ms: l0=${result.l0RecordedCount}`);
+    this.logger.info(`Capture completed in ${elapsed}ms: l0=${response.l0_recorded}`);
 
-    const response: CaptureResponse = {
+    sendJson(res, 200, response);
+  }
+
+  private async handleCaptureBatch(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<CaptureBatchRequest>(req);
+
+    let normalized;
+    try {
+      normalized = normalizeCaptureBatchRequest(body);
+    } catch (err) {
+      if (err instanceof CaptureBatchValidationError) {
+        sendError(res, 400, err.message);
+        return;
+      }
+      throw err;
+    }
+
+    const startMs = Date.now();
+    const results: CaptureBatchResultItem[] = [];
+
+    for (const item of normalized.captures) {
+      try {
+        const captureResult = await this.runCapture(item.capture, { startedAt: item.startedAt });
+        results.push({
+          index: item.index,
+          session_key: item.capture.session_key,
+          session_id: item.capture.session_id,
+          source_session_index: item.sourceSessionIndex,
+          source_round_index: item.sourceRoundIndex,
+          l0_recorded: captureResult.l0_recorded,
+          scheduler_notified: captureResult.scheduler_notified,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          index: item.index,
+          session_key: item.capture.session_key,
+          session_id: item.capture.session_id,
+          source_session_index: item.sourceSessionIndex,
+          source_round_index: item.sourceRoundIndex,
+          error: message,
+        });
+        this.logger.warn(`Capture batch item ${item.index} failed: ${message}`);
+        if (!normalized.continueOnError) break;
+      }
+    }
+
+    const failed = results.filter((item) => item.error).length;
+    const response: CaptureBatchResponse = {
+      total: normalized.captures.length,
+      succeeded: results.length - failed,
+      failed,
+      source: normalized.source,
+      duration_ms: Date.now() - startMs,
+      results,
+    };
+
+    this.logger.info(
+      `Capture batch completed: total=${response.total}, source=${response.source}, ` +
+      `succeeded=${response.succeeded}, failed=${response.failed}, duration=${response.duration_ms}ms`,
+    );
+
+    sendJson(res, failed === 0 ? 200 : normalized.continueOnError ? 207 : 500, response);
+  }
+
+  private async runCapture(
+    body: CaptureRequest,
+    opts?: { startedAt?: number },
+  ): Promise<CaptureResponse> {
+    const result = await this.core.handleTurnCommitted(buildCaptureTurn(body, opts));
+
+    return {
       l0_recorded: result.l0RecordedCount,
       scheduler_notified: result.schedulerNotified,
     };
-    sendJson(res, 200, response);
   }
 
   private async handleSearchMemories(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -60,6 +60,47 @@ export interface CaptureResponse {
 }
 
 // ============================
+// /capture/batch
+// ============================
+
+export interface CaptureBatchRequest {
+  /** Multiple existing /capture payloads to import through the live pipeline. */
+  captures?: unknown[];
+  /** Compatibility alias for callers that prefer a generic array name. */
+  items?: unknown[];
+  /** Seed-style input: Format A `{ sessions: [...] }` or Format B `[...]`. */
+  data?: unknown;
+  /** Fallback session key for seed-style input. */
+  session_key?: string;
+  /** Require each seed round to have both user and assistant messages. */
+  strict_round_role?: boolean;
+  /** Auto-fill missing seed timestamps (default: true). */
+  auto_fill_timestamps?: boolean;
+  /** Continue processing remaining items if one capture fails at runtime. */
+  continue_on_error?: boolean;
+}
+
+export interface CaptureBatchResultItem {
+  index: number;
+  session_key?: string;
+  session_id?: string;
+  source_session_index?: number;
+  source_round_index?: number;
+  l0_recorded?: number;
+  scheduler_notified?: boolean;
+  error?: string;
+}
+
+export interface CaptureBatchResponse {
+  total: number;
+  succeeded: number;
+  failed: number;
+  source: "captures" | "seed";
+  duration_ms: number;
+  results: CaptureBatchResultItem[];
+}
+
+// ============================
 // /search/memories
 // ============================
 


### PR DESCRIPTION
## Summary

- Add `POST /capture/batch` as a live Gateway import endpoint that writes into the same memory directory used by normal `/capture`.
- Accept both multiple existing `/capture` payloads and seed-style `sessions/conversations` data, so users can bulk import historical conversations without switching to an isolated seed output directory.
- Run batch imports through `TdaiCore.handleTurnCommitted()` with `startedAt: 0`, which disables the live cold-start timestamp floor for historical data.
- Preserve normal single `/capture` timestamp behavior so first live captures are not accidentally filtered.
- Add a Hermes Python client method plus English/Chinese docs for the new endpoint.

## Why this approach

`POST /seed` creates and destroys its own pipeline/store in a timestamped output directory. Pointing that path at the live Gateway directory would risk shared store lifecycle problems. This PR keeps `/seed` isolated and adds a dedicated live import path instead.

Compared with #357, this covers the missing seed-compatible input path and the old-timestamp import case. A plain loop over `/capture` payloads can still lose historical messages because `handleTurnCommitted()` normally uses the current time as the cold-start floor when no session cursor exists.

## Validation

```bash
npx vitest run src/gateway/capture-batch.test.ts
npm test
npm run build
git diff --check
```

Results:

- `src/gateway/capture-batch.test.ts`: 12 tests passed.
- `npm test`: 5 files / 79 tests passed.
- `npm run build`: plugin and scripts build passed.
- `git diff --check`: passed.

Fixes #356.
