### PR TITLE
feat(seed): support live target for gateway seed imports

### DIFF
--- a/src/core/seed/seed-runtime.ts
+++ b/src/core/seed/seed-runtime.ts
@@ -51,6 +51,8 @@ export interface SeedRuntimeOptions {
   logger: PipelineLogger;
   /** Progress callback (called after each round). */
   onProgress?: (progress: SeedProgress) => void;
+  /** Whether the seed pipeline owns and should close store resources. */
+  ownsStores?: boolean;
 }
 
 // ============================
@@ -103,6 +105,7 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
     openclawConfig,
     logger,
     l1LlmRunner,
+    ownsStores: opts.ownsStores,
   });
 
   // Wire L2 runner via shared factory (same logic as index.ts live runtime)

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -93,6 +93,15 @@ function sendError(res: http.ServerResponse, status: number, message: string): v
   sendJson(res, status, { error: message } satisfies GatewayErrorResponse);
 }
 
+function createTimestampedSeedDir(baseDir: string): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const ts =
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-` +
+    `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `${baseDir}/seed-${ts}`;
+}
+
 /**
  * Constant-time string equality for secrets.
  *
@@ -486,6 +495,12 @@ export class TdaiGateway {
       return;
     }
 
+    const target = body.target ?? "isolated";
+    if (target !== "isolated" && target !== "live") {
+      sendError(res, 400, 'Invalid seed target. Expected "isolated" or "live".');
+      return;
+    }
+
     // Validate and normalize input (reuses seed CLI's validation layers 2-6)
     let input;
     try {
@@ -506,17 +521,13 @@ export class TdaiGateway {
     }
 
     this.logger.info(
-      `Seed request: ${input.sessions.length} session(s), ` +
+      `Seed request: target=${target}, ${input.sessions.length} session(s), ` +
       `${input.totalRounds} round(s), ${input.totalMessages} message(s)`,
     );
 
-    // Resolve output directory: use gateway's data dir with a timestamped subfolder
-    const now = new Date();
-    const pad = (n: number) => String(n).padStart(2, "0");
-    const ts =
-      `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-` +
-      `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-    const outputDir = `${this.config.data.baseDir}/seed-${ts}`;
+    const outputDir = target === "live"
+      ? this.config.data.baseDir
+      : createTimestampedSeedDir(this.config.data.baseDir);
 
     // Merge config overrides if provided
     // Start with the base memory config + inject llm config from gateway settings
@@ -552,6 +563,7 @@ export class TdaiGateway {
       openclawConfig: {},
       pluginConfig,
       logger: this.logger as import("../utils/pipeline-factory.js").PipelineLogger,
+      ownsStores: target !== "live",
       onProgress: (progress: SeedProgress) => {
         this.logger.debug?.(
           `Seed progress: [${progress.currentRound}/${progress.totalRounds}] ` +

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -129,6 +129,12 @@ export interface SeedRequest {
   strict_round_role?: boolean;
   /** Auto-fill missing timestamps (default: true). */
   auto_fill_timestamps?: boolean;
+  /**
+   * Seed output target.
+   * - isolated: write to a timestamped seed directory (default)
+   * - live: import into the same data directory used by /capture
+   */
+  target?: "isolated" | "live";
   /** Plugin config overrides (deep-merged on top of gateway memory config). */
   config_override?: Record<string, unknown>;
 }

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -70,6 +70,12 @@ export interface PipelineFactoryOptions {
   l1LlmRunner?: import("../core/types.js").LLMRunner;
   /** Host-neutral LLM runner for L2/L3 (tool-call enabled, enableTools=true). */
   l2l3LlmRunner?: import("../core/types.js").LLMRunner;
+  /**
+   * Whether this pipeline owns the cached VectorStore/EmbeddingService and
+   * should close them on destroy. Gateway /seed runs in the same process as
+   * the live core, so it must not close shared stores.
+   */
+  ownsStores?: boolean;
 }
 
 // ============================
@@ -688,6 +694,7 @@ export function createPipelineManager(
  */
 export async function createPipeline(opts: PipelineFactoryOptions): Promise<PipelineInstance> {
   const { pluginDataDir, cfg, openclawConfig, logger, sessionFilter, l1LlmRunner } = opts;
+  const ownsStores = opts.ownsStores ?? true;
 
   // Ensure data directories exist
   initDataDirectories(pluginDataDir);
@@ -717,11 +724,11 @@ export async function createPipeline(opts: PipelineFactoryOptions): Promise<Pipe
   const destroy = async () => {
     logger.info(`${TAG} Destroying pipeline...`);
     await scheduler.destroy();
-    if (vectorStore) {
+    if (ownsStores && vectorStore) {
       logger.info(`${TAG} Closing VectorStore`);
       vectorStore.close();
     }
-    if (embeddingService?.close) {
+    if (ownsStores && embeddingService?.close) {
       try {
         logger.info(`${TAG} Closing EmbeddingService`);
         await embeddingService.close();
@@ -729,7 +736,9 @@ export async function createPipeline(opts: PipelineFactoryOptions): Promise<Pipe
         logger.warn(`${TAG} Error closing EmbeddingService: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    resetStores(pluginDataDir);
+    if (ownsStores) {
+      resetStores(pluginDataDir);
+    }
     logger.info(`${TAG} Pipeline destroyed`);
   };
 


### PR DESCRIPTION
## Description | 描述

Add a `target` option to Gateway `POST /seed`.

- `target: "isolated"` or omitted: keep existing behavior and write to `baseDir/seed-YYYYMMDD-HHmmss`
- `target: "live"`: import seed data into the same live data directory used by `/capture`
- When using `target: "live"`, the temporary seed pipeline does not close shared VectorStore / EmbeddingService resources owned by the Gateway core

## Related Issue | 关联 Issue

Fix #356

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verified with `git diff --check`. Full build/test was not run because this WSL environment does not have Linux Node.js installed; the available `npm` points to a Windows Node installation.