### PR TITLE
fix(store): sanitize FTS5 queries to prevent syntax errors and injection

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  it("handles basic keyword searches", () => {
+    const query = buildFtsQuery("测试 项目");
+    expect(query).toBe('"测试" OR "项目"');
+  });
+
+  it("filters out FTS5 special punctuation syntax", () => {
+    // These characters should be stripped/replaced before FTS tokenization
+    const query = buildFtsQuery("测试 \" ' ( ) * - 崩溃");
+    // jieba will segment it, but the quotes and special chars shouldn't be passed verbatim
+    // It should end up like "测试" OR "崩溃"
+    expect(query).toBe('"测试" OR "崩溃"');
+  });
+
+  it("downcases FTS5 boolean operators so they are treated as literal search terms", () => {
+    // "AND", "OR", "NOT", "NEAR" are FTS5 keywords and should be downcased to "and", "or", "not", "near"
+    const query = buildFtsQuery("数据库 AND 崩溃 OR 测试 NOT 正常 NEAR 1");
+    // Because jieba tokenizer splits these and we downcase them, they become regular words.
+    // NOTE: '1' is kept because it's a number.
+    expect(query).toBe('"数据" OR "据库" OR "数据库" OR "and" OR "崩溃" OR "or" OR "测试" OR "not" OR "正常" OR "near" OR "1"');
+  });
+
+  it("handles empty or purely special character inputs", () => {
+    expect(buildFtsQuery("")).toBeNull();
+    expect(buildFtsQuery("\" ' ( ) * -")).toBeNull();
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -34,6 +34,7 @@ import type {
   L0FtsResult,
 } from "./types.js";
 import type { Logger } from "../types.js";
+import { sanitizeFtsQuery } from "../../utils/sanitize.js";
 
 // ============================
 // Types
@@ -196,6 +197,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const safeRaw = sanitizeFtsQuery(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +205,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(safeRaw, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +220,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      safeRaw
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -403,3 +403,32 @@ function escapeControlCharsInJsonStrings(text: string): string {
 
   return out.join("");
 }
+
+// ============================
+// FTS5 Input Sanitization
+// ============================
+
+/**
+ * Sanitize raw user input before feeding it into FTS5 MATCH queries.
+ * 
+ * FTS5 has special operators (AND, OR, NOT, NEAR) and syntax characters (", ', (, ), *, -)
+ * that can cause syntax errors or unintended logic if exposed to unescaped user input.
+ * 
+ * This function:
+ * 1. Strips out FTS5 syntax characters to prevent syntax breakage.
+ * 2. Downcases FTS5 uppercase keywords (AND, OR, NOT, NEAR) so they are treated 
+ *    as regular search terms instead of boolean operators.
+ */
+export function sanitizeFtsQuery(text: string): string {
+  if (!text) return "";
+
+  // 1. Strip FTS5 punctuation/special syntax characters: " ' ( ) * -
+  // We replace them with space to avoid merging words unintentionally.
+  let safeText = text.replace(/["'()*\\-]/g, " ");
+
+  // 2. Downcase FTS5 boolean operators to strip their special semantics
+  safeText = safeText.replace(/\b(AND|OR|NOT|NEAR)\b/g, (match) => match.toLowerCase());
+
+  // 3. Clean up extra spaces
+  return safeText.replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## Description | 描述
为 buildFtsQuery 增加了 FTS5 专属的输入净化（Sanitize）逻辑：

1、新增 sanitizeFtsQuery 函数，过滤了会引发底层 FTS5 解析异常的特殊标点（"、'、(、)、*、-）。
2、将用户输入中的 AND、OR、NOT、NEAR 等高危 FTS5 大写关键字降级为小写，防止其充当逻辑操作符篡改查询语义。
3、补充了涵盖各类注入边界的安全测试用例。

## Related Issue | 关联 Issue
Fix #160 

## Change Type | 修改类型
 Bug fix | Bug 修复

## Self-test Checklist | 自测清单
 Verified locally | 本地验证通过 (已通过 Vitest 所有测试)
 No existing features affected | 无影响现有功能 (不影响普通的分词和搜索召回率)

## Additional Notes | 其他说明
本次修改主要更新了 src/utils/sanitize.ts 及 src/core/store/sqlite.ts，并新增了对应的 src/core/store/sqlite.test.ts 文件以确保安全迭代。