### PR TITLE
feat(adapters): add Codex MCP memory adapter

### DIFF
--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -1,152 +1,126 @@
 # Codex MCP Adapter
 
-The Codex MCP adapter exposes TencentDB Agent Memory (TDAI) capabilities to
-OpenAI Codex through the Model Context Protocol (MCP). It is a stdio-based MCP
-server that forwards tool calls to the TDAI Gateway over HTTP, keeping Codex as
-a thin orchestration client.
+The Codex MCP adapter connects Codex CLI / IDE to TencentDB Agent Memory through the existing TDAI Gateway.
+
+This adapter is intentionally thin:
+
+- Codex talks to a local stdio MCP server.
+- The MCP server forwards tool calls to the TDAI Gateway.
+- The Gateway owns memory recall, capture, search, session flush, storage, and extraction.
+- `TdaiCore` is unchanged.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    Codex[Codex CLI / Agent]
-    MCP[MCP Adapter<br/>src/adapters/codex]
-    Gateway[TDAI Gateway]
-    Core[TdaiCore]
-    Stores[(Memory Stores)]
+    Codex["Codex CLI / IDE"] --> MCP["Codex MCP Adapter<br/>stdio MCP server"]
+    MCP --> GW["TDAI Gateway<br/>127.0.0.1:8420"]
+    GW --> Core["TdaiCore"]
+    Core --> L0["L0 raw conversation"]
+    Core --> L1["L1 structured memory"]
+    Core --> L2["L2 scene blocks"]
+    Core --> L3["L3 persona"]
+    Core --> Store["SQLite / sqlite-vec<br/>or Tencent VectorDB"]
 
-    Codex -->|stdio MCP| MCP
-    MCP -->|HTTP POST| Gateway
-    Gateway --> Core
-    Core --> Stores
+    OpenClaw["OpenClaw Plugin"] --> Core
+    Hermes["Hermes Provider"] --> GW
 ```
 
-Codex invokes memory tools (`tdai_recall`, `tdai_capture`, etc.) over stdio.
-The MCP adapter translates each tool call into an HTTP request against the
-running TDAI Gateway, which in turn routes to `TdaiCore` and the underlying
-memory stores.
+## Capability Boundary
 
-## Capability boundary
+Codex MCP exposes tools. It does not provide OpenClaw-style lifecycle hooks.
 
-**Supported (explicit MCP tools)**
+Supported:
 
-- `tdai_recall` — retrieve relevant memory context for a session
-- `tdai_capture` — explicitly capture a completed user/assistant turn
-- `tdai_memory_search` — search structured L1 long-term memories
-- `tdai_conversation_search` — search raw L0 conversation history
-- `tdai_session_end` — flush pending pipeline work for a session key
+- explicit recall before a task
+- explicit capture after a meaningful turn
+- structured memory search
+- raw conversation search
+- explicit session flush
 
-**Not supported**
+Not supported in this minimal adapter:
 
-- Automatic capture of every Codex turn. Codex only writes memory when it
-  explicitly calls `tdai_capture`.
-- Automatic recall before every prompt. The model must decide when prior
-  context is useful and call the appropriate tool.
+- automatic prompt interception
+- automatic context injection into every Codex turn
+- automatic capture of every Codex response
 
-## Tool-to-endpoint mapping
+## Tools
 
-| MCP tool                | Gateway endpoint     | Purpose                                           |
-| ----------------------- | -------------------- | ------------------------------------------------- |
-| `tdai_recall`           | `POST /recall`       | Recall memory context for the current session     |
-| `tdai_capture`          | `POST /capture`      | Persist a completed user/assistant turn           |
-| `tdai_memory_search`    | `POST /search/memories`       | Search structured L1 memories by query and filters |
-| `tdai_conversation_search` | `POST /search/conversations` | Search raw L0 conversation history                |
-| `tdai_session_end`      | `POST /session/end`  | Flush pending work for a session key              |
+| Tool | Gateway endpoint | Purpose |
+| --- | --- | --- |
+| `tdai_recall` | `POST /recall` | Recall memory context for a query and session |
+| `tdai_capture` | `POST /capture` | Capture a completed user/assistant turn |
+| `tdai_memory_search` | `POST /search/memories` | Search L1 structured memory |
+| `tdai_conversation_search` | `POST /search/conversations` | Search L0 raw conversation history |
+| `tdai_session_end` | `POST /session/end` | Flush pending work for one session |
 
-## Gateway startup
+## Start the Gateway
 
-The adapter requires an already-running TDAI Gateway. Start it from the project
-root (the default port is `8420`):
+Run the existing Gateway in one terminal:
 
-```bash
-npm run gateway
+```powershell
+cd "E:/00Project/Tencent_summer/TencentDB-Agent-Memory"
+node --import tsx src/gateway/server.ts
 ```
 
-or with a custom base URL and API key:
-
-```bash
-TDAI_GATEWAY_PORT=3000 TDAI_GATEWAY_API_KEY=super-secret npm run gateway
-```
-
-The adapter reads the following environment variables:
-
-| Variable                  | Default                        | Description                        |
-| ------------------------- | ------------------------------ | ---------------------------------- |
-| `TDAI_GATEWAY_URL`        | `http://127.0.0.1:8420`        | Base URL of the TDAI Gateway       |
-| `TDAI_GATEWAY_API_KEY`    | unset                          | Optional Bearer token              |
-| `TDAI_GATEWAY_TIMEOUT_MS` | `10000`                        | Request timeout in milliseconds    |
-
-## Registering with Codex
-
-Use the `codex mcp add` command to register the adapter as an MCP server.
-
-### Without API key
-
-```bash
-codex mcp add memory-tencentdb \
-  node ./dist/adapters/codex/mcp-server.js \
-  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420
-```
-
-### With API key
-
-```bash
-codex mcp add memory-tencentdb \
-  node ./dist/adapters/codex/mcp-server.js \
-  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 \
-  --env TDAI_GATEWAY_API_KEY=your-api-key
-```
-
-> The `codex mcp add` CLI syntax may vary by version; refer to `codex mcp --help`
-> for the exact flags on your installation.
-
-## Example prompts
-
-After registration, Codex can invoke the memory tools automatically or on request.
-
-### Recall
+Default Gateway URL:
 
 ```text
-Before we start, recall what we know about this repo and my preferences.
+http://127.0.0.1:8420
 ```
 
-This should lead Codex to call `tdai_recall` with the current `session_key`.
+If Gateway auth is enabled, set the same token for the MCP adapter:
 
-### Capture
+```powershell
+$env:TDAI_GATEWAY_API_KEY = "your-local-token"
+```
+
+Do not commit API keys or `.env` files.
+
+## Register With Codex
+
+From the repository root:
+
+```powershell
+codex mcp add memory-tencentdb --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 -- npm run codex:mcp
+```
+
+With Gateway auth:
+
+```powershell
+codex mcp add memory-tencentdb --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 --env TDAI_GATEWAY_API_KEY=your-local-token -- npm run codex:mcp
+```
+
+Verify:
+
+```powershell
+codex mcp list
+```
+
+Inside the Codex TUI, run:
 
 ```text
-Capture this: I prefer Jest over Vitest and I want all new tests to use the
-Arrange-Act-Assert pattern.
+/mcp
 ```
 
-Codex should call `tdai_capture` with the user content, its own response, and
-the current `session_key`.
+You should see `memory-tencentdb` and its tools.
 
-### Session end
+## Example Usage
+
+Ask Codex:
 
 ```text
-We're done for now. End the TDAI session for this task.
+Use tdai_recall with query "repository conventions for this project" and session_key "my-codex-session", then summarize any useful context before editing.
 ```
 
-Codex should call `tdai_session_end` to flush any pending memory pipeline work.
+After a useful completed task, ask Codex:
 
-## Programmatic usage
+```text
+Use tdai_capture to store this turn with session_key "my-codex-session": user_content is my original request, assistant_content is the final implementation summary.
+```
 
-You can also embed the adapter in your own MCP host without the stdio entrypoint:
+Flush at the end:
 
-```ts
-import {
-  CodexGatewayClient,
-  createCodexMcpServer,
-  registerCodexMemoryTools,
-} from "@tdai/adapters/codex";
-
-const client = new CodexGatewayClient({
-  baseUrl: "http://127.0.0.1:8420",
-  apiKey: process.env.TDAI_GATEWAY_API_KEY,
-});
-
-const server = createCodexMcpServer(client);
-// or register tools onto an existing MCP-compatible target:
-// registerCodexMemoryTools(target, client);
+```text
+Use tdai_session_end with session_key "my-codex-session".
 ```

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -1,0 +1,152 @@
+# Codex MCP Adapter
+
+The Codex MCP adapter exposes TencentDB Agent Memory (TDAI) capabilities to
+OpenAI Codex through the Model Context Protocol (MCP). It is a stdio-based MCP
+server that forwards tool calls to the TDAI Gateway over HTTP, keeping Codex as
+a thin orchestration client.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Codex[Codex CLI / Agent]
+    MCP[MCP Adapter<br/>src/adapters/codex]
+    Gateway[TDAI Gateway]
+    Core[TdaiCore]
+    Stores[(Memory Stores)]
+
+    Codex -->|stdio MCP| MCP
+    MCP -->|HTTP POST| Gateway
+    Gateway --> Core
+    Core --> Stores
+```
+
+Codex invokes memory tools (`tdai_recall`, `tdai_capture`, etc.) over stdio.
+The MCP adapter translates each tool call into an HTTP request against the
+running TDAI Gateway, which in turn routes to `TdaiCore` and the underlying
+memory stores.
+
+## Capability boundary
+
+**Supported (explicit MCP tools)**
+
+- `tdai_recall` — retrieve relevant memory context for a session
+- `tdai_capture` — explicitly capture a completed user/assistant turn
+- `tdai_memory_search` — search structured L1 long-term memories
+- `tdai_conversation_search` — search raw L0 conversation history
+- `tdai_session_end` — flush pending pipeline work for a session key
+
+**Not supported**
+
+- Automatic capture of every Codex turn. Codex only writes memory when it
+  explicitly calls `tdai_capture`.
+- Automatic recall before every prompt. The model must decide when prior
+  context is useful and call the appropriate tool.
+
+## Tool-to-endpoint mapping
+
+| MCP tool                | Gateway endpoint     | Purpose                                           |
+| ----------------------- | -------------------- | ------------------------------------------------- |
+| `tdai_recall`           | `POST /recall`       | Recall memory context for the current session     |
+| `tdai_capture`          | `POST /capture`      | Persist a completed user/assistant turn           |
+| `tdai_memory_search`    | `POST /search/memories`       | Search structured L1 memories by query and filters |
+| `tdai_conversation_search` | `POST /search/conversations` | Search raw L0 conversation history                |
+| `tdai_session_end`      | `POST /session/end`  | Flush pending work for a session key              |
+
+## Gateway startup
+
+The adapter requires an already-running TDAI Gateway. Start it from the project
+root (the default port is `8420`):
+
+```bash
+npm run gateway
+```
+
+or with a custom base URL and API key:
+
+```bash
+TDAI_GATEWAY_PORT=3000 TDAI_GATEWAY_API_KEY=super-secret npm run gateway
+```
+
+The adapter reads the following environment variables:
+
+| Variable                  | Default                        | Description                        |
+| ------------------------- | ------------------------------ | ---------------------------------- |
+| `TDAI_GATEWAY_URL`        | `http://127.0.0.1:8420`        | Base URL of the TDAI Gateway       |
+| `TDAI_GATEWAY_API_KEY`    | unset                          | Optional Bearer token              |
+| `TDAI_GATEWAY_TIMEOUT_MS` | `10000`                        | Request timeout in milliseconds    |
+
+## Registering with Codex
+
+Use the `codex mcp add` command to register the adapter as an MCP server.
+
+### Without API key
+
+```bash
+codex mcp add memory-tencentdb \
+  node ./dist/adapters/codex/mcp-server.js \
+  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420
+```
+
+### With API key
+
+```bash
+codex mcp add memory-tencentdb \
+  node ./dist/adapters/codex/mcp-server.js \
+  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_GATEWAY_API_KEY=your-api-key
+```
+
+> The `codex mcp add` CLI syntax may vary by version; refer to `codex mcp --help`
+> for the exact flags on your installation.
+
+## Example prompts
+
+After registration, Codex can invoke the memory tools automatically or on request.
+
+### Recall
+
+```text
+Before we start, recall what we know about this repo and my preferences.
+```
+
+This should lead Codex to call `tdai_recall` with the current `session_key`.
+
+### Capture
+
+```text
+Capture this: I prefer Jest over Vitest and I want all new tests to use the
+Arrange-Act-Assert pattern.
+```
+
+Codex should call `tdai_capture` with the user content, its own response, and
+the current `session_key`.
+
+### Session end
+
+```text
+We're done for now. End the TDAI session for this task.
+```
+
+Codex should call `tdai_session_end` to flush any pending memory pipeline work.
+
+## Programmatic usage
+
+You can also embed the adapter in your own MCP host without the stdio entrypoint:
+
+```ts
+import {
+  CodexGatewayClient,
+  createCodexMcpServer,
+  registerCodexMemoryTools,
+} from "@tdai/adapters/codex";
+
+const client = new CodexGatewayClient({
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+const server = createCodexMcpServer(client);
+// or register tools onto an existing MCP-compatible target:
+// registerCodexMemoryTools(target, client);
+```

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
+    "codex:mcp": "node --import tsx src/adapters/codex/mcp-server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -74,6 +75,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/jieba": "^2.0.1",
     "@tencentdb-agent-memory/tcvdb-text": "^0.1.1",
     "ai": "^6.0.164",

--- a/src/adapters/codex/gateway-client.test.ts
+++ b/src/adapters/codex/gateway-client.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  CodexGatewayClient,
+  GatewayClientError,
+  type CodexGatewayClientOptions,
+} from "./gateway-client.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createMockFetch(
+  response: { status: number; body: unknown; headers?: Record<string, string> },
+) {
+  const calls: Array<{ input: unknown; init: RequestInit | undefined }> = [];
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(
+    (async (input: unknown, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response(response.body ? JSON.stringify(response.body) : "", {
+        status: response.status,
+        headers: response.headers,
+      });
+    }) as typeof globalThis.fetch,
+  );
+  return { spy, calls };
+}
+
+describe("CodexGatewayClient", () => {
+  it("recall includes the Bearer token when apiKey is provided", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { context: "some context", strategy: "bm25", memory_count: 2 },
+    });
+
+    const client = new CodexGatewayClient({
+      baseUrl: "http://127.0.0.1:3000/",
+      apiKey: "secret-token",
+    });
+
+    const result = await client.recall({
+      query: "how do I connect?",
+      session_key: "session-1",
+    });
+
+    expect(result).toEqual({
+      context: "some context",
+      strategy: "bm25",
+      memory_count: 2,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toBe("http://127.0.0.1:3000/recall");
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Bearer secret-token",
+      "Content-Type": "application/json",
+    });
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body).toEqual({
+      query: "how do I connect?",
+      session_key: "session-1",
+    });
+  });
+
+  it("recall omits the Authorization header when no apiKey is provided", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { context: "", memory_count: 0 },
+    });
+
+    const client = new CodexGatewayClient({
+      baseUrl: "http://127.0.0.1:3000",
+    });
+
+    await client.recall({ query: "hello", session_key: "session-2" });
+
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("throws GatewayClientError with parsed error body on non-2xx response", async () => {
+    createMockFetch({
+      status: 401,
+      body: { error: "Unauthorized: invalid token" },
+    });
+
+    const client = new CodexGatewayClient({
+      baseUrl: "http://127.0.0.1:3000",
+      apiKey: "wrong-token",
+    });
+
+    await expect(
+      client.recall({ query: "hello", session_key: "session-3" }),
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(GatewayClientError);
+      const clientErr = err as GatewayClientError;
+      expect(clientErr.status).toBe(401);
+      expect(clientErr.message).toBe("Unauthorized: invalid token");
+      expect(clientErr.response).toEqual({ error: "Unauthorized: invalid token" });
+      return true;
+    });
+  });
+
+  it("capture forwards messages when provided", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { l0_recorded: 1, scheduler_notified: true },
+    });
+
+    const client = new CodexGatewayClient({
+      baseUrl: "http://127.0.0.1:3000/",
+    });
+
+    const messages = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ];
+
+    const result = await client.capture({
+      user_content: "hi",
+      assistant_content: "hello",
+      session_key: "session-4",
+      session_id: "id-4",
+      user_id: "user-4",
+      messages,
+    });
+
+    expect(result).toEqual({ l0_recorded: 1, scheduler_notified: true });
+    expect(calls[0].input).toBe("http://127.0.0.1:3000/capture");
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body).toEqual({
+      user_content: "hi",
+      assistant_content: "hello",
+      session_key: "session-4",
+      session_id: "id-4",
+      user_id: "user-4",
+      messages,
+    });
+  });
+});

--- a/src/adapters/codex/gateway-client.ts
+++ b/src/adapters/codex/gateway-client.ts
@@ -1,0 +1,150 @@
+/**
+ * Thin HTTP client for the TDAI Gateway.
+ *
+ * This is intentionally not a TdaiCore integration: Codex talks to the
+ * already-running gateway over HTTP, reusing the same request/response types.
+ */
+
+import type {
+  RecallRequest,
+  RecallResponse,
+  CaptureRequest,
+  CaptureResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+  GatewayErrorResponse,
+} from "../../gateway/types.js";
+
+export interface CodexGatewayClientOptions {
+  /** Gateway base URL, e.g. "http://127.0.0.1:3000". */
+  baseUrl: string;
+  /** Optional Bearer token sent as `Authorization: Bearer <token>`. */
+  apiKey?: string;
+  /** Request timeout in milliseconds (default: 10_000). */
+  timeoutMs?: number;
+  /** Custom fetch implementation (useful for tests). Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+/** Error thrown when the gateway responds with a non-2xx status. */
+export class GatewayClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly response?: GatewayErrorResponse,
+  ) {
+    super(message);
+    this.name = "GatewayClientError";
+  }
+}
+
+/** Normalize a base URL so it has no trailing slash. */
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+export class CodexGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetch: typeof globalThis.fetch;
+
+  constructor(options: CodexGatewayClientOptions) {
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private async post<Req, Res>(path: string, body: Req): Promise<Res> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await this.fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new GatewayClientError(
+          `Gateway request timed out after ${this.timeoutMs}ms`,
+          0,
+        );
+      }
+      throw new GatewayClientError(
+        err instanceof Error ? err.message : String(err),
+        0,
+      );
+    }
+    clearTimeout(timeout);
+
+    let data: unknown;
+    const text = await response.text();
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = undefined;
+      }
+    }
+
+    if (!response.ok) {
+      const errorBody =
+        data && typeof data === "object" && "error" in data
+          ? (data as GatewayErrorResponse)
+          : undefined;
+      throw new GatewayClientError(
+        errorBody?.error ?? `Gateway returned ${response.status}`,
+        response.status,
+        errorBody,
+      );
+    }
+
+    return data as Res;
+  }
+
+  async recall(request: RecallRequest): Promise<RecallResponse> {
+    return this.post<RecallRequest, RecallResponse>("/recall", request);
+  }
+
+  async capture(request: CaptureRequest): Promise<CaptureResponse> {
+    return this.post<CaptureRequest, CaptureResponse>("/capture", request);
+  }
+
+  async searchMemories(request: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.post<MemorySearchRequest, MemorySearchResponse>("/search/memories", request);
+  }
+
+  async searchConversations(
+    request: ConversationSearchRequest,
+  ): Promise<ConversationSearchResponse> {
+    return this.post<ConversationSearchRequest, ConversationSearchResponse>(
+      "/search/conversations",
+      request,
+    );
+  }
+
+  async endSession(request: SessionEndRequest): Promise<SessionEndResponse> {
+    return this.post<SessionEndRequest, SessionEndResponse>("/session/end", request);
+  }
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Codex MCP adapter — barrel re-export.
+ *
+ * Provides a Gateway HTTP client and an MCP server/registration helpers
+ * so Codex can call TencentDB Agent Memory tools through the Model Context Protocol.
+ */
+
+export {
+  CodexGatewayClient,
+  GatewayClientError,
+} from "./gateway-client.js";
+export type { CodexGatewayClientOptions } from "./gateway-client.js";
+
+export {
+  createCodexMcpServer,
+  registerCodexMemoryTools,
+  runCodexMcpServer,
+} from "./mcp-server.js";
+export type { CodexMemoryClient, ToolRegistrationTarget } from "./mcp-server.js";
+
+export {
+  recallInputSchema,
+  captureInputSchema,
+  memorySearchInputSchema,
+  conversationSearchInputSchema,
+  sessionEndInputSchema,
+  normalizeLimit,
+} from "./tool-schemas.js";
+export type {
+  RecallToolInput,
+  CaptureToolInput,
+  MemorySearchToolInput,
+  ConversationSearchToolInput,
+  SessionEndToolInput,
+} from "./tool-schemas.js";

--- a/src/adapters/codex/mcp-server.test.ts
+++ b/src/adapters/codex/mcp-server.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  registerCodexMemoryTools,
+  type CodexMemoryClient,
+  type ToolConfig,
+  type ToolRegistrationTarget,
+} from "./mcp-server.js";
+
+interface CapturedTool {
+  name: string;
+  config: ToolConfig;
+  handler: (args: unknown, extra?: unknown) => unknown;
+}
+
+function createFakeTarget(): ToolRegistrationTarget & { tools: CapturedTool[] } {
+  const tools: CapturedTool[] = [];
+  return {
+    tools,
+    registerTool(name, config, handler) {
+      tools.push({ name, config, handler });
+    },
+  };
+}
+
+function createFakeClient(): CodexMemoryClient & {
+  calls: Array<{ method: string; args: unknown }>;
+} {
+  const calls: Array<{ method: string; args: unknown }> = [];
+  return {
+    calls,
+    recall: vi.fn(async (args) => {
+      calls.push({ method: "recall", args });
+      return { context: "context", strategy: "bm25", memory_count: 1 };
+    }),
+    capture: vi.fn(async (args) => {
+      calls.push({ method: "capture", args });
+      return { l0_recorded: 1, scheduler_notified: true };
+    }),
+    searchMemories: vi.fn(async (args) => {
+      calls.push({ method: "searchMemories", args });
+      return { results: [] };
+    }),
+    searchConversations: vi.fn(async (args) => {
+      calls.push({ method: "searchConversations", args });
+      return { results: [] };
+    }),
+    endSession: vi.fn(async (args) => {
+      calls.push({ method: "endSession", args });
+      return { ok: true };
+    }),
+  };
+}
+
+describe("registerCodexMemoryTools", () => {
+  it("registers all five expected tools", () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerCodexMemoryTools(target, client);
+
+    const names = target.tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "tdai_capture",
+      "tdai_conversation_search",
+      "tdai_memory_search",
+      "tdai_recall",
+      "tdai_session_end",
+    ]);
+  });
+
+  it("recall handler forwards parsed input and serializes the result", async () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerCodexMemoryTools(target, client);
+
+    const recallTool = target.tools.find((t) => t.name === "tdai_recall")!;
+    const result = await recallTool.handler({
+      query: "how do I connect?",
+      session_key: "session-1",
+    });
+
+    expect(client.calls).toEqual([
+      {
+        method: "recall",
+        args: { query: "how do I connect?", session_key: "session-1" },
+      },
+    ]);
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { context: "context", strategy: "bm25", memory_count: 1 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("tdai_memory_search normalizes limit before forwarding", async () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerCodexMemoryTools(target, client);
+
+    const tool = target.tools.find((t) => t.name === "tdai_memory_search")!;
+    await tool.handler({ query: "test", limit: 99 });
+
+    expect(client.calls).toEqual([
+      { method: "searchMemories", args: { query: "test", limit: 20 } },
+    ]);
+  });
+
+  it("tdai_conversation_search normalizes limit before forwarding", async () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerCodexMemoryTools(target, client);
+
+    const tool = target.tools.find(
+      (t) => t.name === "tdai_conversation_search",
+    )!;
+    await tool.handler({ query: "test", limit: 0 });
+
+    expect(client.calls).toEqual([
+      { method: "searchConversations", args: { query: "test", limit: 1 } },
+    ]);
+  });
+});

--- a/src/adapters/codex/mcp-server.ts
+++ b/src/adapters/codex/mcp-server.ts
@@ -78,7 +78,10 @@ export function registerCodexMemoryTools(
   target.registerTool(
     "tdai_recall",
     {
-      description: "Recall relevant memory context for the current session.",
+      title: "TDAI Recall",
+      description:
+        "Recall memory context from TencentDB Agent Memory for the current Codex task. " +
+        "Use before coding when prior preferences, repository conventions, or earlier sessions may matter.",
       inputSchema: recallInputSchema,
     },
     async (args) => {
@@ -91,7 +94,10 @@ export function registerCodexMemoryTools(
   target.registerTool(
     "tdai_capture",
     {
-      description: "Capture a user/assistant exchange into memory.",
+      title: "TDAI Capture",
+      description:
+        "Capture a completed user/assistant turn into TencentDB Agent Memory. " +
+        "This is explicit capture; Codex MCP does not automatically capture every turn.",
       inputSchema: captureInputSchema,
     },
     async (args) => {
@@ -104,7 +110,9 @@ export function registerCodexMemoryTools(
   target.registerTool(
     "tdai_memory_search",
     {
-      description: "Search across stored memories.",
+      title: "TDAI Memory Search",
+      description:
+        "Search structured L1 long-term memories. Use for user preferences, instructions, and episodic memory.",
       inputSchema: memorySearchInputSchema,
     },
     async (args) => {
@@ -120,7 +128,9 @@ export function registerCodexMemoryTools(
   target.registerTool(
     "tdai_conversation_search",
     {
-      description: "Search across stored conversations.",
+      title: "TDAI Conversation Search",
+      description:
+        "Search raw L0 conversation history. Use when exact previous commands, tool outputs, or wording are needed.",
       inputSchema: conversationSearchInputSchema,
     },
     async (args) => {
@@ -138,7 +148,9 @@ export function registerCodexMemoryTools(
   target.registerTool(
     "tdai_session_end",
     {
-      description: "Signal the end of a session.",
+      title: "TDAI Session End",
+      description:
+        "Flush pending memory pipeline work for a session key after a Codex task or session ends.",
       inputSchema: sessionEndInputSchema,
     },
     async (args) => {
@@ -151,21 +163,25 @@ export function registerCodexMemoryTools(
 
 /** Create an MCP server backed by the given memory client. */
 export function createCodexMcpServer(client: CodexMemoryClient): McpServer {
-  const server = new McpServer({
-    name: "memory-tencentdb-codex",
-    version: "0.1.0",
-  });
+  const server = new McpServer(
+    {
+      name: "memory-tencentdb-codex",
+      version: "0.1.0",
+    },
+    {
+      instructions:
+        "TencentDB Agent Memory for Codex. Use tdai_recall or search tools when prior user preferences, " +
+        "repository conventions, or previous sessions may help. Use tdai_capture only for explicit memory writes. " +
+        "This MCP server provides tools; it does not automatically intercept Codex prompts or completed turns.",
+    },
+  );
   registerCodexMemoryTools(server, client);
   return server;
 }
 
 /** Read environment variables, build the client, and start the stdio MCP server. */
 export async function runCodexMcpServer(): Promise<void> {
-  const baseUrl = process.env.TDAI_GATEWAY_URL;
-  if (!baseUrl) {
-    throw new Error("TDAI_GATEWAY_URL is required");
-  }
-
+  const baseUrl = process.env.TDAI_GATEWAY_URL ?? "http://127.0.0.1:8420";
   const apiKey = process.env.TDAI_GATEWAY_API_KEY;
   const timeoutMs = process.env.TDAI_GATEWAY_TIMEOUT_MS
     ? Number(process.env.TDAI_GATEWAY_TIMEOUT_MS)

--- a/src/adapters/codex/mcp-server.ts
+++ b/src/adapters/codex/mcp-server.ts
@@ -1,0 +1,195 @@
+/**
+ * Stdio MCP server for the Codex adapter.
+ *
+ * Exposes TencentDB Agent Memory tools through the Model Context Protocol,
+ * backed by the Gateway HTTP client.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type {
+  RecallRequest,
+  RecallResponse,
+  CaptureRequest,
+  CaptureResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+import { CodexGatewayClient } from "./gateway-client.js";
+import {
+  recallInputSchema,
+  captureInputSchema,
+  memorySearchInputSchema,
+  conversationSearchInputSchema,
+  sessionEndInputSchema,
+  normalizeLimit,
+  type RecallToolInput,
+  type CaptureToolInput,
+  type MemorySearchToolInput,
+  type ConversationSearchToolInput,
+  type SessionEndToolInput,
+} from "./tool-schemas.js";
+
+/** Abstraction over the five memory operations exposed as MCP tools. */
+export interface CodexMemoryClient {
+  recall(request: RecallRequest): Promise<RecallResponse>;
+  capture(request: CaptureRequest): Promise<CaptureResponse>;
+  searchMemories(request: MemorySearchRequest): Promise<MemorySearchResponse>;
+  searchConversations(
+    request: ConversationSearchRequest,
+  ): Promise<ConversationSearchResponse>;
+  endSession(request: SessionEndRequest): Promise<SessionEndResponse>;
+}
+
+/** Configuration object passed to `registerTool`. */
+export interface ToolConfig {
+  title?: string;
+  description?: string;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+}
+
+/** Minimal surface used to register tools, decouples the server from MCP SDK internals. */
+export interface ToolRegistrationTarget {
+  registerTool(
+    name: string,
+    config: ToolConfig,
+    handler: (args: unknown, extra: unknown) => unknown,
+  ): unknown;
+}
+
+function textResult(result: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+}
+
+/** Register the five Codex memory tools on the supplied target. */
+export function registerCodexMemoryTools(
+  target: ToolRegistrationTarget,
+  client: CodexMemoryClient,
+): void {
+  target.registerTool(
+    "tdai_recall",
+    {
+      description: "Recall relevant memory context for the current session.",
+      inputSchema: recallInputSchema,
+    },
+    async (args) => {
+      const input = recallInputSchema.parse(args) as RecallToolInput;
+      const result = await client.recall(input);
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_capture",
+    {
+      description: "Capture a user/assistant exchange into memory.",
+      inputSchema: captureInputSchema,
+    },
+    async (args) => {
+      const input = captureInputSchema.parse(args) as CaptureToolInput;
+      const result = await client.capture(input);
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_memory_search",
+    {
+      description: "Search across stored memories.",
+      inputSchema: memorySearchInputSchema,
+    },
+    async (args) => {
+      const input = memorySearchInputSchema.parse(args) as MemorySearchToolInput;
+      const result = await client.searchMemories({
+        ...input,
+        limit: normalizeLimit(input.limit),
+      });
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_conversation_search",
+    {
+      description: "Search across stored conversations.",
+      inputSchema: conversationSearchInputSchema,
+    },
+    async (args) => {
+      const input = conversationSearchInputSchema.parse(
+        args,
+      ) as ConversationSearchToolInput;
+      const result = await client.searchConversations({
+        ...input,
+        limit: normalizeLimit(input.limit),
+      });
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_session_end",
+    {
+      description: "Signal the end of a session.",
+      inputSchema: sessionEndInputSchema,
+    },
+    async (args) => {
+      const input = sessionEndInputSchema.parse(args) as SessionEndToolInput;
+      const result = await client.endSession(input);
+      return textResult(result);
+    },
+  );
+}
+
+/** Create an MCP server backed by the given memory client. */
+export function createCodexMcpServer(client: CodexMemoryClient): McpServer {
+  const server = new McpServer({
+    name: "memory-tencentdb-codex",
+    version: "0.1.0",
+  });
+  registerCodexMemoryTools(server, client);
+  return server;
+}
+
+/** Read environment variables, build the client, and start the stdio MCP server. */
+export async function runCodexMcpServer(): Promise<void> {
+  const baseUrl = process.env.TDAI_GATEWAY_URL;
+  if (!baseUrl) {
+    throw new Error("TDAI_GATEWAY_URL is required");
+  }
+
+  const apiKey = process.env.TDAI_GATEWAY_API_KEY;
+  const timeoutMs = process.env.TDAI_GATEWAY_TIMEOUT_MS
+    ? Number(process.env.TDAI_GATEWAY_TIMEOUT_MS)
+    : undefined;
+
+  const client = new CodexGatewayClient({ baseUrl, apiKey, timeoutMs });
+  const server = createCodexMcpServer(client);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+function isMainModule(): boolean {
+  if (typeof process === "undefined") return false;
+  const executedFile = process.argv[1];
+  if (!executedFile) return false;
+  const normalized = executedFile.replace(/\\/g, "/");
+  return (
+    normalized.endsWith("mcp-server.ts") || normalized.endsWith("mcp-server.js")
+  );
+}
+
+if (isMainModule()) {
+  runCodexMcpServer().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/adapters/codex/tool-schemas.test.ts
+++ b/src/adapters/codex/tool-schemas.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureInputSchema,
+  conversationSearchInputSchema,
+  memorySearchInputSchema,
+  normalizeLimit,
+  recallInputSchema,
+  sessionEndInputSchema,
+} from "./tool-schemas.js";
+
+describe("Codex MCP tool schemas", () => {
+  it("requires recall query and session_key", () => {
+    expect(recallInputSchema.parse({
+      query: "what does the user prefer",
+      session_key: "session-1",
+    })).toEqual({
+      query: "what does the user prefer",
+      session_key: "session-1",
+    });
+
+    expect(() => recallInputSchema.parse({ query: "", session_key: "session-1" })).toThrow();
+    expect(() => recallInputSchema.parse({ query: "hello", session_key: "" })).toThrow();
+  });
+
+  it("requires capture user and assistant content", () => {
+    const parsed = captureInputSchema.parse({
+      user_content: "remember this",
+      assistant_content: "stored",
+      session_key: "session-1",
+    });
+
+    expect(parsed.user_content).toBe("remember this");
+    expect(parsed.assistant_content).toBe("stored");
+    expect(parsed.session_key).toBe("session-1");
+  });
+
+  it("clamps tool search limits to Gateway-supported bounds", () => {
+    expect(normalizeLimit(undefined)).toBe(5);
+    expect(normalizeLimit(0)).toBe(1);
+    expect(normalizeLimit(99)).toBe(20);
+    expect(normalizeLimit(7)).toBe(7);
+  });
+
+  it("accepts memory search filters", () => {
+    const parsed = memorySearchInputSchema.parse({
+      query: "coding preference",
+      limit: 6,
+      type: "persona",
+      scene: "repo-maintenance",
+    });
+
+    expect(parsed).toEqual({
+      query: "coding preference",
+      limit: 6,
+      type: "persona",
+      scene: "repo-maintenance",
+    });
+  });
+
+  it("accepts conversation search and session end inputs", () => {
+    expect(conversationSearchInputSchema.parse({
+      query: "previous test command",
+      session_key: "session-1",
+    })).toEqual({
+      query: "previous test command",
+      session_key: "session-1",
+    });
+
+    expect(sessionEndInputSchema.parse({ session_key: "session-1" })).toEqual({
+      session_key: "session-1",
+    });
+  });
+});

--- a/src/adapters/codex/tool-schemas.ts
+++ b/src/adapters/codex/tool-schemas.ts
@@ -1,0 +1,51 @@
+import * as z from "zod/v4";
+
+const nonEmptyString = z.string().trim().min(1);
+const optionalNonEmptyString = z.string().trim().min(1).optional();
+const limitSchema = z.number().int().optional();
+
+export const recallInputSchema = z.object({
+  query: nonEmptyString,
+  session_key: nonEmptyString,
+  user_id: optionalNonEmptyString,
+});
+
+export const captureInputSchema = z.object({
+  user_content: nonEmptyString,
+  assistant_content: nonEmptyString,
+  session_key: nonEmptyString,
+  session_id: optionalNonEmptyString,
+  user_id: optionalNonEmptyString,
+  messages: z.array(z.unknown()).optional(),
+});
+
+export const memorySearchInputSchema = z.object({
+  query: nonEmptyString,
+  limit: limitSchema,
+  type: z.enum(["persona", "episodic", "instruction"]).optional(),
+  scene: optionalNonEmptyString,
+});
+
+export const conversationSearchInputSchema = z.object({
+  query: nonEmptyString,
+  limit: limitSchema,
+  session_key: optionalNonEmptyString,
+});
+
+export const sessionEndInputSchema = z.object({
+  session_key: nonEmptyString,
+  user_id: optionalNonEmptyString,
+});
+
+export type RecallToolInput = z.infer<typeof recallInputSchema>;
+export type CaptureToolInput = z.infer<typeof captureInputSchema>;
+export type MemorySearchToolInput = z.infer<typeof memorySearchInputSchema>;
+export type ConversationSearchToolInput = z.infer<typeof conversationSearchInputSchema>;
+export type SessionEndToolInput = z.infer<typeof sessionEndInputSchema>;
+
+export function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return 5;
+  if (limit < 1) return 1;
+  if (limit > 20) return 20;
+  return limit;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,7 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Codex MCP adapter
+export { CodexGatewayClient, GatewayClientError, createCodexMcpServer, registerCodexMemoryTools, runCodexMcpServer } from "./codex/index.js";
+export type { CodexGatewayClientOptions, CodexMemoryClient, ToolRegistrationTarget } from "./codex/index.js";


### PR DESCRIPTION
## Summary
- Add a minimal Codex MCP adapter that exposes TencentDB Agent Memory through stdio MCP tools.
- Reuse the existing TDAI Gateway HTTP API for recall, capture, memory search, conversation search, and session flush.
- Document Codex setup and the current limitation that MCP provides explicit tools, not automatic OpenClaw-style lifecycle hooks.

## Tools
- tdai_recall -> POST /recall
- tdai_capture -> POST /capture
- tdai_memory_search -> POST /search/memories
- tdai_conversation_search -> POST /search/conversations
- tdai_session_end -> POST /session/end

## Test
- npx vitest run src/adapters/codex/gateway-client.test.ts src/adapters/codex/tool-schemas.test.ts src/adapters/codex/mcp-server.test.ts
- npm test
- npm run build

Refs #235