### PR TITLE
fix(profile): sanitize pulled scene filenames

### DIFF
--- a/src/core/profile/profile-sync.test.ts
+++ b/src/core/profile/profile-sync.test.ts
@@ -1,0 +1,64 @@
+import { createHash } from "node:crypto";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { pullProfilesToLocal } from "./profile-sync.js";
+import type { IMemoryStore, ProfileRecord } from "../store/types.js";
+
+const tempDirs: string[] = [];
+
+function md5(text: string): string {
+  return createHash("md5").update(text).digest("hex");
+}
+
+async function makeDataDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "tdai-profile-sync-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeStore(records: ProfileRecord[]): IMemoryStore {
+  return {
+    pullProfiles: async () => records,
+  } as unknown as IMemoryStore;
+}
+
+describe("pullProfilesToLocal", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("keeps remote L2 filenames inside scene_blocks", async () => {
+    const dataDir = await makeDataDir();
+    const content = "remote scene";
+    const store = makeStore([
+      {
+        id: "profile:v1:remote",
+        type: "l2",
+        filename: "../../escaped.md",
+        content,
+        contentMd5: md5(content),
+        version: 1,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+      },
+    ]);
+
+    await pullProfilesToLocal(dataDir, store, {});
+
+    expect(await exists(path.join(dataDir, "escaped.md"))).toBe(false);
+    await expect(readFile(path.join(dataDir, "scene_blocks", "escaped.md"), "utf-8")).resolves.toBe(content);
+  });
+});

--- a/src/core/profile/profile-sync.ts
+++ b/src/core/profile/profile-sync.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { IMemoryStore, ProfileRecord, ProfileSyncRecord } from "../store/types.js";
 import { readSceneIndex, syncSceneIndex } from "../scene/scene-index.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
+import { normalizeSceneFilename } from "../scene/filename-normalizer.js";
 import type { Logger } from "../types.js";
 
 const PROFILE_SCOPE = "global";
@@ -132,11 +133,12 @@ export async function pullProfilesToLocal(
       });
 
       if (record.type === "l2") {
-        const target = path.join(tempBlocksDir, record.filename);
+        const filename = normalizeSceneFilename(record.filename);
+        const target = path.join(tempBlocksDir, filename);
         await fs.writeFile(target, record.content, "utf-8");
         if (md5(record.content) !== record.contentMd5) {
           await fs.rm(target, { force: true });
-          logger.debug?.(`[memory-tdai][profile-sync] MD5 mismatch for ${record.filename} (will re-pull on next sync)`);
+          logger.debug?.(`[memory-tdai][profile-sync] MD5 mismatch for ${filename} (will re-pull on next sync)`);
         }
         continue;
       }


### PR DESCRIPTION
## Summary
- normalize remote L2 profile filenames before writing pulled scene blocks
- keep pulled scene content inside `scene_blocks/` even when remote filenames contain path segments
- add a regression test for `../../escaped.md` profile filenames

## Why
`pullProfilesToLocal()` reads profile records from the remote store and previously joined `record.filename` directly into the temporary `scene_blocks` path. A malformed or stale remote profile filename could escape the scene block directory during pull.

## Tests
- `npm test -- src/core/profile/profile-sync.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`