### PR TITLE
fix(scene): normalize indexed filenames on read

### DIFF
--- a/src/core/scene/scene-index.test.ts
+++ b/src/core/scene/scene-index.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readSceneIndex } from "./scene-index.js";
+
+const tempDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "tdai-scene-index-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("readSceneIndex", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("normalizes filenames loaded from metadata", async () => {
+    const dataDir = await makeDataDir();
+    const metadataDir = path.join(dataDir, ".metadata");
+    await mkdir(metadataDir, { recursive: true });
+    await writeFile(
+      path.join(metadataDir, "scene_index.json"),
+      JSON.stringify([
+        {
+          filename: "../../secret.md",
+          summary: "unsafe",
+          heat: 1,
+          created: "2026-07-02T00:00:00.000Z",
+          updated: "2026-07-02T00:00:00.000Z",
+        },
+      ]),
+      "utf-8",
+    );
+
+    const entries = await readSceneIndex(dataDir);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].filename).toBe("secret.md");
+  });
+});

--- a/src/core/scene/scene-index.ts
+++ b/src/core/scene/scene-index.ts
@@ -5,6 +5,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { parseSceneBlock } from "./scene-format.js";
+import { normalizeSceneFilename } from "./filename-normalizer.js";
 
 export interface SceneIndexEntry {
   filename: string;
@@ -31,7 +32,7 @@ export async function readSceneIndex(dataDir: string): Promise<SceneIndexEntry[]
     for (const item of parsed) {
       if (!item || typeof item !== "object") continue;
 
-      const filename = typeof item.filename === "string" ? item.filename : "";
+      const filename = typeof item.filename === "string" ? normalizeSceneFilename(item.filename) : "";
       if (!filename) continue;
 
       entries.push({


### PR DESCRIPTION
## Summary
- normalize filenames loaded from `.metadata/scene_index.json`
- prevent stale or malformed scene metadata from feeding path segments to downstream readers/navigation
- add a regression test for `../../secret.md` metadata filenames

## Why
`scene_index.json` is normally generated by `syncSceneIndex()`, but stale/corrupt metadata can be consumed by persona generation and recall navigation. Normalizing on read keeps downstream code operating on safe single-segment scene filenames.

## Tests
- `npm test -- src/core/scene/scene-index.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`