### PR TITLE
feat(adapters): add Kimi Code MCP memory adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | :--- | :--- |
 | OpenClaw plugin | Automatically captures, extracts, and recalls memory once installed |
 | Hermes Gateway adapter | `TdaiCore + HostAdapter`, decoupled from the host framework |
+| Kimi Code CLI MCP adapter | Stdio MCP server that forwards tool calls to the Gateway over HTTP |
 | Local backend | `SQLite + sqlite-vec`, ready to use out of the box |
 | Hybrid retrieval | BM25 + vector + RRF — supports both keyword and semantic recall |
 | Agent tools | `tdai_memory_search` / `tdai_conversation_search` |
@@ -526,7 +527,7 @@ We welcome every kind of contribution — bug reports, feature ideas, doc fixes,
 - [x] Long-term personalized memory (L0 → L3)
 - [x] Short-term context compression (Context Offload + Mermaid canvas)
 - [x] Local SQLite backend and Tencent Cloud Vector Database (TCVDB) backend
-- [x] OpenClaw plugin and Hermes Gateway integration
+- [x] OpenClaw plugin, Hermes Gateway, and Kimi Code CLI MCP integration
 - [ ] Portable memory: cross-Agent / cross-framework / cross-device import, export, and live migration
 - [ ] Automatic Skill generation
 - [ ] Visual debugging and memory observability dashboard

--- a/README_CN.md
+++ b/README_CN.md
@@ -354,6 +354,81 @@ curl http://127.0.0.1:8420/health
 > Provider 的完整参考（环境变量、故障排查、LLM 工具 schema、supervisor 行为）见 [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md)，调整 supervisor / circuit-breaker 默认值之前请先读它。
 
 
+### 3. Kimi Code CLI
+
+TencentDB Agent Memory 也通过模型上下文协议（MCP）接入了 [Kimi Code CLI](https://www.kimi.com/)。Kimi 适配器是一个轻量的 stdio MCP 服务器，只负责把工具调用转发给 TDAI Gateway，Kimi Code 进程内部不运行 TdaiCore。
+
+#### 3.1 先启动 TDAI Gateway
+
+Kimi MCP 服务器默认需要 Gateway 运行在 `http://127.0.0.1:8420`。启动方式与 Hermes 独立 Gateway 相同：
+
+```bash
+# 在本仓库根目录
+npm install
+npx tsx src/gateway/server.ts
+```
+
+确认 Gateway 可访问：
+
+```bash
+curl http://127.0.0.1:8420/health
+```
+
+#### 3.2 在 Kimi Code CLI 中添加 MCP 服务器
+
+构建本包（`npm run build`）后，在 Kimi Code CLI 的 MCP 配置中注册打包好的服务器：
+
+```jsonc
+// Kimi Code CLI MCP 设置
+{
+  "mcpServers": {
+    "memory-tencentdb": {
+      "command": "node",
+      "args": ["/path/to/package/bin/kimicode-memory-mcp.mjs"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420"
+      }
+    }
+  }
+}
+```
+
+如果 Gateway 开启了 `TDAI_GATEWAY_API_KEY` 鉴权，同时设置：
+
+```jsonc
+{
+  "mcpServers": {
+    "memory-tencentdb": {
+      "command": "node",
+      "args": ["/path/to/package/bin/kimicode-memory-mcp.mjs"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420",
+        "TDAI_GATEWAY_API_KEY": "your-gateway-api-key"
+      }
+    }
+  }
+}
+```
+
+#### 3.3 暴露给 Kimi Code CLI 的工具
+
+MCP 服务器注册了 5 个记忆工具：
+
+| 工具 | 用途 |
+| :--- | :--- |
+| `tdai_recall` | 为当前会话召回相关记忆上下文。 |
+| `tdai_capture` | 将用户/助手对话写入记忆。 |
+| `tdai_memory_search` | 在已存储记忆中检索。 |
+| `tdai_conversation_search` | 在已存储会话中检索。 |
+| `tdai_session_end` | 标记会话结束。 |
+
+开发调试时也可以直接从源码运行：
+
+```bash
+npm run kimicode:mcp
+```
+
+
 ---
 
 ## 🔒 Gateway 安全配置（可选）
@@ -497,6 +572,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | :--- | :--- |
 | OpenClaw 插件 | 安装后即可自动捕获、提取、召回记忆 |
 | Hermes Gateway 适配 | `TdaiCore + HostAdapter` 解耦宿主框架 |
+| Kimi Code CLI MCP 适配 | stdio MCP 服务器，通过 HTTP 将工具调用转发给 Gateway |
 | 本地后端 | `SQLite + sqlite-vec`，开箱即用 |
 | 混合检索 | BM25 + 向量 + RRF，兼顾关键词和语义召回 |
 | Agent 工具 | `tdai_memory_search` / `tdai_conversation_search` |
@@ -529,7 +605,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 - [x] 长期个性化记忆（L0 → L3）
 - [x] 短期记忆压缩（Context Offload + Mermaid 画布）
 - [x] 可用本地 SQLite 后端与腾讯云向量数据库 TCVDB 后端
-- [x] OpenClaw 插件与 Hermes Gateway 适配
+- [x] OpenClaw 插件、Hermes Gateway 与 Kimi Code CLI MCP 适配
 - [ ] 记忆可迁移：跨 Agent / 跨框架 / 跨设备的导入导出与热迁移
 - [ ] Skill自动生成
 - [ ] 可视化调试与记忆观测面板

--- a/bin/kimicode-memory-mcp.mjs
+++ b/bin/kimicode-memory-mcp.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * Entry point used by the Kimi Code CLI MCP configuration.
+ *
+ * The Kimi MCP server forwards tool calls to the TDAI Gateway over HTTP.
+ * Make sure the gateway is running (default URL: http://127.0.0.1:8420).
+ */
+
+import { runKimiCodeMcpServer } from "../dist/src/adapters/kimicode/mcp-server.mjs";
+
+runKimiCodeMcpServer().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/docs/platform-adapter-comparison.md
+++ b/docs/platform-adapter-comparison.md
@@ -1,0 +1,67 @@
+# Platform Adapter Comparison: Codex and Kimi Code
+
+TencentDB Agent Memory now supports multiple coding-agent platforms through thin MCP adapters backed by the existing TDAI Gateway.
+
+## Summary
+
+Both Codex and Kimi Code integrations use the same architecture:
+
+```text
+Agent platform -> stdio MCP server -> TDAI Gateway HTTP API -> TdaiCore
+```
+
+The adapters do not initialize `TdaiCore` directly. They forward MCP tool calls to the already-running Gateway.
+
+## Shared Gateway API
+
+Both adapters use these Gateway endpoints:
+
+| Capability | Gateway endpoint |
+| --- | --- |
+| Recall memory context | `POST /recall` |
+| Capture a completed turn | `POST /capture` |
+| Search structured memories | `POST /search/memories` |
+| Search raw conversations | `POST /search/conversations` |
+| Flush a session | `POST /session/end` |
+
+## Platform Comparison
+
+| Area | Codex | Kimi Code |
+| --- | --- | --- |
+| Adapter type | stdio MCP server | stdio MCP server |
+| Runtime path | `src/adapters/codex/` | `src/adapters/kimicode/` |
+| Launch command | `npm run codex:mcp` | `kimicode-memory-mcp` |
+| Gateway URL | `TDAI_GATEWAY_URL`, default `http://127.0.0.1:8420` | `TDAI_GATEWAY_URL`, default `http://127.0.0.1:8420` |
+| Gateway auth | `TDAI_GATEWAY_API_KEY` Bearer token | `TDAI_GATEWAY_API_KEY` Bearer token |
+| Tool transport | Model Context Protocol over stdio | Model Context Protocol over stdio |
+| Plugin/skill support | Codex MCP configuration | Kimi plugin manifest and plugin README |
+| Tool prefix | `tdai_*` | `tdai_*` |
+| Requires Gateway | Yes | Yes |
+| Automatic lifecycle hooks | No | No |
+| Explicit recall | Yes | Yes |
+| Explicit capture | Yes | Yes |
+| Explicit search | Yes | Yes |
+| Explicit session flush | Yes | Yes |
+
+## Tool Mapping
+
+| Tool | Codex | Kimi Code | Gateway endpoint |
+| --- | --- | --- | --- |
+| Recall | `tdai_recall` | `tdai_recall` | `POST /recall` |
+| Capture | `tdai_capture` | `tdai_capture` | `POST /capture` |
+| Memory search | `tdai_memory_search` | `tdai_memory_search` | `POST /search/memories` |
+| Conversation search | `tdai_conversation_search` | `tdai_conversation_search` | `POST /search/conversations` |
+| Session end | `tdai_session_end` | `tdai_session_end` | `POST /session/end` |
+
+## Important Limitation
+
+MCP tools are explicit tool calls. They are not equivalent to OpenClaw lifecycle hooks.
+
+These adapters do not automatically intercept prompts, inject memory into every turn, or capture every completed response. The agent must call recall, capture, search, and session-end tools explicitly.
+
+## Related Pull Requests
+
+- Codex adapter: TencentCloud/TencentDB-Agent-Memory#367
+- Kimi Code adapter: separate PR from `XiZu233:feat/kimicode-adapter-issue-235`
+
+Both PRs together address issue #235 by adding two platform adapters and documenting their differences.

--- a/kimi-plugin/README.md
+++ b/kimi-plugin/README.md
@@ -1,0 +1,54 @@
+# Kimi Code CLI Plugin — TencentDB Agent Memory
+
+This directory contains the Kimi Code CLI plugin manifest for TencentDB Agent Memory.
+
+The plugin starts an MCP server that forwards memory tool calls to the TDAI Gateway over HTTP.
+
+## Prerequisites
+
+1. The TDAI Gateway must be running. See the main project README for startup instructions.
+   Default URL: `http://127.0.0.1:8420`.
+2. If your gateway requires authentication, set `TDAI_GATEWAY_API_KEY` in the environment.
+
+## Installation
+
+In your Kimi Code CLI configuration, add the MCP server:
+
+```json
+{
+  "mcpServers": {
+    "memory-tencentdb": {
+      "command": "node",
+      "args": ["/path/to/package/bin/kimicode-memory-mcp.mjs"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420"
+      }
+    }
+  }
+}
+```
+
+If authentication is enabled:
+
+```json
+{
+  "mcpServers": {
+    "memory-tencentdb": {
+      "command": "node",
+      "args": ["/path/to/package/bin/kimicode-memory-mcp.mjs"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420",
+        "TDAI_GATEWAY_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+## Provided Tools
+
+- `tdai_recall` — recall relevant memory context for the current session.
+- `tdai_capture` — capture a user/assistant exchange into memory.
+- `tdai_memory_search` — search across stored memories.
+- `tdai_conversation_search` — search across stored conversations.
+- `tdai_session_end` — signal the end of a session.

--- a/kimi-plugin/manifest.json
+++ b/kimi-plugin/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "memory-tencentdb",
+  "version": "0.1.0",
+  "description": "TencentDB Agent Memory MCP server for Kimi Code CLI.",
+  "author": "TencentDB Agent Memory Team",
+  "type": "mcp",
+  "mcp": {
+    "command": "node",
+    "args": [
+      "${pluginDir}/../dist/src/adapters/kimicode/mcp-server.mjs"
+    ],
+    "env": {
+      "TDAI_GATEWAY_URL": "http://127.0.0.1:8420"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "kimicode-memory-mcp": "./bin/kimicode-memory-mcp.mjs"
   },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./adapters/kimicode": {
+      "import": "./dist/src/adapters/kimicode/mcp-server.mjs",
+      "default": "./dist/src/adapters/kimicode/mcp-server.mjs"
     }
   },
   "scripts": {
@@ -26,6 +31,7 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
+    "kimicode:mcp": "node --import tsx src/adapters/kimicode/mcp-server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -45,6 +51,7 @@
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "kimi-plugin/",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
@@ -56,6 +63,8 @@
   "keywords": [
     "openclaw",
     "openclaw-plugin",
+    "kimi-code",
+    "mcp",
     "memory",
     "ai-memory",
     "long-term-memory",
@@ -74,6 +83,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/jieba": "^2.0.1",
     "@tencentdb-agent-memory/tcvdb-text": "^0.1.1",
     "ai": "^6.0.164",

--- a/src/adapters/kimicode/gateway-client.test.ts
+++ b/src/adapters/kimicode/gateway-client.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  KimiCodeGatewayClient,
+  GatewayClientError,
+  DEFAULT_GATEWAY_URL,
+} from "./gateway-client.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createMockFetch(
+  response: { status: number; body: unknown; headers?: Record<string, string> },
+) {
+  const calls: Array<{ input: unknown; init: RequestInit | undefined }> = [];
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(
+    (async (input: unknown, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response(response.body ? JSON.stringify(response.body) : "", {
+        status: response.status,
+        headers: response.headers,
+      });
+    }) as typeof globalThis.fetch,
+  );
+  return { spy, calls };
+}
+
+describe("KimiCodeGatewayClient", () => {
+  it("defaults to the standalone gateway URL", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { context: "", memory_count: 0 },
+    });
+
+    const client = new KimiCodeGatewayClient();
+    await client.recall({ query: "hello", session_key: "session-1" });
+
+    expect(calls[0].input).toBe(`${DEFAULT_GATEWAY_URL}/recall`);
+  });
+
+  it("normalizes trailing slashes in the base URL", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { context: "", memory_count: 0 },
+    });
+
+    const client = new KimiCodeGatewayClient({ baseUrl: "http://127.0.0.1:8420/" });
+    await client.recall({ query: "hello", session_key: "session-1" });
+
+    expect(calls[0].input).toBe("http://127.0.0.1:8420/recall");
+  });
+
+  it("recall includes the Bearer token when apiKey is provided", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { context: "some context", strategy: "bm25", memory_count: 2 },
+    });
+
+    const client = new KimiCodeGatewayClient({
+      baseUrl: "http://127.0.0.1:8420",
+      apiKey: "secret-token",
+    });
+
+    const result = await client.recall({
+      query: "how do I connect?",
+      session_key: "session-1",
+    });
+
+    expect(result).toEqual({
+      context: "some context",
+      strategy: "bm25",
+      memory_count: 2,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toBe("http://127.0.0.1:8420/recall");
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Bearer secret-token",
+      "Content-Type": "application/json",
+    });
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body).toEqual({
+      query: "how do I connect?",
+      session_key: "session-1",
+    });
+  });
+
+  it("recall omits the Authorization header when no apiKey is provided", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { context: "", memory_count: 0 },
+    });
+
+    const client = new KimiCodeGatewayClient({ baseUrl: "http://127.0.0.1:8420" });
+    await client.recall({ query: "hello", session_key: "session-2" });
+
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("throws GatewayClientError with parsed error body on non-2xx response", async () => {
+    createMockFetch({
+      status: 401,
+      body: { error: "Unauthorized: invalid token" },
+    });
+
+    const client = new KimiCodeGatewayClient({
+      baseUrl: "http://127.0.0.1:8420",
+      apiKey: "wrong-token",
+    });
+
+    await expect(
+      client.recall({ query: "hello", session_key: "session-3" }),
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(GatewayClientError);
+      const clientErr = err as GatewayClientError;
+      expect(clientErr.status).toBe(401);
+      expect(clientErr.message).toBe("Unauthorized: invalid token");
+      expect(clientErr.response).toEqual({ error: "Unauthorized: invalid token" });
+      return true;
+    });
+  });
+
+  it("capture forwards messages when provided", async () => {
+    const { calls } = createMockFetch({
+      status: 200,
+      body: { l0_recorded: 1, scheduler_notified: true },
+    });
+
+    const client = new KimiCodeGatewayClient({ baseUrl: "http://127.0.0.1:8420" });
+
+    const messages = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ];
+
+    const result = await client.capture({
+      user_content: "hi",
+      assistant_content: "hello",
+      session_key: "session-4",
+      session_id: "id-4",
+      user_id: "user-4",
+      messages,
+    });
+
+    expect(result).toEqual({ l0_recorded: 1, scheduler_notified: true });
+    expect(calls[0].input).toBe("http://127.0.0.1:8420/capture");
+    const body = JSON.parse(calls[0].init?.body as string);
+    expect(body).toEqual({
+      user_content: "hi",
+      assistant_content: "hello",
+      session_key: "session-4",
+      session_id: "id-4",
+      user_id: "user-4",
+      messages,
+    });
+  });
+
+  it("calls all five gateway endpoints", async () => {
+    const { calls } = createMockFetch({ status: 200, body: {} });
+    const client = new KimiCodeGatewayClient({ baseUrl: "http://127.0.0.1:8420" });
+
+    await client.recall({ query: "q", session_key: "s" });
+    await client.capture({
+      user_content: "u",
+      assistant_content: "a",
+      session_key: "s",
+    });
+    await client.searchMemories({ query: "q" });
+    await client.searchConversations({ query: "q" });
+    await client.endSession({ session_key: "s" });
+
+    const paths = calls.map((c) => c.input);
+    expect(paths).toEqual([
+      "http://127.0.0.1:8420/recall",
+      "http://127.0.0.1:8420/capture",
+      "http://127.0.0.1:8420/search/memories",
+      "http://127.0.0.1:8420/search/conversations",
+      "http://127.0.0.1:8420/session/end",
+    ]);
+  });
+
+  it("throws a timeout error when the request exceeds timeoutMs", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_input, init?: RequestInit) => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        if (init?.signal?.aborted) {
+          const err = new Error("AbortError");
+          err.name = "AbortError";
+          throw err;
+        }
+        return new Response("{}", { status: 200 });
+      },
+    );
+
+    const client = new KimiCodeGatewayClient({
+      baseUrl: "http://127.0.0.1:8420",
+      timeoutMs: 1,
+    });
+
+    const promise = client.recall({ query: "hello", session_key: "session-5" });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(promise).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(GatewayClientError);
+      expect((err as GatewayClientError).status).toBe(0);
+      expect((err as GatewayClientError).message).toContain("timed out");
+      return true;
+    });
+
+    vi.useRealTimers();
+  });
+});

--- a/src/adapters/kimicode/gateway-client.ts
+++ b/src/adapters/kimicode/gateway-client.ts
@@ -1,0 +1,157 @@
+/**
+ * Thin HTTP client for the TDAI Gateway (Kimi Code CLI adapter).
+ *
+ * This is intentionally not a TdaiCore integration: the Kimi MCP server talks
+ * to the already-running gateway over HTTP, reusing the same request/response
+ * types. The gateway default URL is `http://127.0.0.1:8420`.
+ */
+
+import type {
+  RecallRequest,
+  RecallResponse,
+  CaptureRequest,
+  CaptureResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+  GatewayErrorResponse,
+} from "../../gateway/types.js";
+
+export interface KimiCodeGatewayClientOptions {
+  /**
+   * Gateway base URL, e.g. `http://127.0.0.1:8420`.
+   * Defaults to `http://127.0.0.1:8420`.
+   */
+  baseUrl?: string;
+  /** Optional Bearer token sent as `Authorization: Bearer <token>`. */
+  apiKey?: string;
+  /** Request timeout in milliseconds (default: 10_000). */
+  timeoutMs?: number;
+  /** Custom fetch implementation (useful for tests). Defaults to globalThis.fetch. */
+  fetch?: typeof globalThis.fetch;
+}
+
+/** Error thrown when the gateway responds with a non-2xx status or cannot be reached. */
+export class GatewayClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly response?: GatewayErrorResponse,
+  ) {
+    super(message);
+    this.name = "GatewayClientError";
+  }
+}
+
+/** Normalize a base URL so it has no trailing slash. */
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/** Default TDAI Gateway URL used by the standalone gateway. */
+export const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420";
+
+export class KimiCodeGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetch: typeof globalThis.fetch;
+
+  constructor(options: KimiCodeGatewayClientOptions = {}) {
+    this.baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_GATEWAY_URL);
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private async post<Req, Res>(path: string, body: Req): Promise<Res> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await this.fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new GatewayClientError(
+          `Gateway request timed out after ${this.timeoutMs}ms`,
+          0,
+        );
+      }
+      throw new GatewayClientError(
+        err instanceof Error ? err.message : String(err),
+        0,
+      );
+    }
+    clearTimeout(timeout);
+
+    let data: unknown;
+    const text = await response.text();
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = undefined;
+      }
+    }
+
+    if (!response.ok) {
+      const errorBody =
+        data && typeof data === "object" && "error" in data
+          ? (data as GatewayErrorResponse)
+          : undefined;
+      throw new GatewayClientError(
+        errorBody?.error ?? `Gateway returned ${response.status}`,
+        response.status,
+        errorBody,
+      );
+    }
+
+    return data as Res;
+  }
+
+  async recall(request: RecallRequest): Promise<RecallResponse> {
+    return this.post<RecallRequest, RecallResponse>("/recall", request);
+  }
+
+  async capture(request: CaptureRequest): Promise<CaptureResponse> {
+    return this.post<CaptureRequest, CaptureResponse>("/capture", request);
+  }
+
+  async searchMemories(request: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.post<MemorySearchRequest, MemorySearchResponse>("/search/memories", request);
+  }
+
+  async searchConversations(
+    request: ConversationSearchRequest,
+  ): Promise<ConversationSearchResponse> {
+    return this.post<ConversationSearchRequest, ConversationSearchResponse>(
+      "/search/conversations",
+      request,
+    );
+  }
+
+  async endSession(request: SessionEndRequest): Promise<SessionEndResponse> {
+    return this.post<SessionEndRequest, SessionEndResponse>("/session/end", request);
+  }
+}

--- a/src/adapters/kimicode/mcp-server.test.ts
+++ b/src/adapters/kimicode/mcp-server.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  registerKimiCodeMemoryTools,
+  type KimiCodeMemoryClient,
+  type ToolConfig,
+  type ToolRegistrationTarget,
+} from "./mcp-server.js";
+
+interface CapturedTool {
+  name: string;
+  config: ToolConfig;
+  handler: (args: unknown, extra?: unknown) => unknown;
+}
+
+function createFakeTarget(): ToolRegistrationTarget & { tools: CapturedTool[] } {
+  const tools: CapturedTool[] = [];
+  return {
+    tools,
+    registerTool(name, config, handler) {
+      tools.push({ name, config, handler });
+    },
+  };
+}
+
+function createFakeClient(): KimiCodeMemoryClient & {
+  calls: Array<{ method: string; args: unknown }>;
+} {
+  const calls: Array<{ method: string; args: unknown }> = [];
+  return {
+    calls,
+    recall: vi.fn(async (args) => {
+      calls.push({ method: "recall", args });
+      return { context: "context", strategy: "bm25", memory_count: 1 };
+    }),
+    capture: vi.fn(async (args) => {
+      calls.push({ method: "capture", args });
+      return { l0_recorded: 1, scheduler_notified: true };
+    }),
+    searchMemories: vi.fn(async (args) => {
+      calls.push({ method: "searchMemories", args });
+      return { results: "[]", total: 0, strategy: "bm25" };
+    }),
+    searchConversations: vi.fn(async (args) => {
+      calls.push({ method: "searchConversations", args });
+      return { results: "[]", total: 0 };
+    }),
+    endSession: vi.fn(async (args) => {
+      calls.push({ method: "endSession", args });
+      return { flushed: true };
+    }),
+  };
+}
+
+describe("registerKimiCodeMemoryTools", () => {
+  it("registers all five expected tools", () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerKimiCodeMemoryTools(target, client);
+
+    const names = target.tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "tdai_capture",
+      "tdai_conversation_search",
+      "tdai_memory_search",
+      "tdai_recall",
+      "tdai_session_end",
+    ]);
+  });
+
+  it("recall handler forwards parsed input and serializes the result", async () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerKimiCodeMemoryTools(target, client);
+
+    const recallTool = target.tools.find((t) => t.name === "tdai_recall")!;
+    const result = await recallTool.handler({
+      query: "how do I connect?",
+      session_key: "session-1",
+    });
+
+    expect(client.calls).toEqual([
+      {
+        method: "recall",
+        args: { query: "how do I connect?", session_key: "session-1" },
+      },
+    ]);
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { context: "context", strategy: "bm25", memory_count: 1 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("tdai_memory_search normalizes limit before forwarding", async () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerKimiCodeMemoryTools(target, client);
+
+    const tool = target.tools.find((t) => t.name === "tdai_memory_search")!;
+    await tool.handler({ query: "test", limit: 99 });
+
+    expect(client.calls).toEqual([
+      { method: "searchMemories", args: { query: "test", limit: 20 } },
+    ]);
+  });
+
+  it("tdai_conversation_search normalizes limit before forwarding", async () => {
+    const target = createFakeTarget();
+    const client = createFakeClient();
+    registerKimiCodeMemoryTools(target, client);
+
+    const tool = target.tools.find(
+      (t) => t.name === "tdai_conversation_search",
+    )!;
+    await tool.handler({ query: "test", limit: 0 });
+
+    expect(client.calls).toEqual([
+      { method: "searchConversations", args: { query: "test", limit: 1 } },
+    ]);
+  });
+});

--- a/src/adapters/kimicode/mcp-server.ts
+++ b/src/adapters/kimicode/mcp-server.ts
@@ -1,0 +1,192 @@
+/**
+ * Stdio MCP server for the Kimi Code CLI adapter.
+ *
+ * Exposes TencentDB Agent Memory tools through the Model Context Protocol,
+ * backed by the Gateway HTTP client. The TDAI Gateway must already be running
+ * (default URL: http://127.0.0.1:8420).
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type {
+  RecallRequest,
+  RecallResponse,
+  CaptureRequest,
+  CaptureResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+import { KimiCodeGatewayClient, DEFAULT_GATEWAY_URL } from "./gateway-client.js";
+import {
+  recallInputSchema,
+  captureInputSchema,
+  memorySearchInputSchema,
+  conversationSearchInputSchema,
+  sessionEndInputSchema,
+  normalizeLimit,
+  type RecallToolInput,
+  type CaptureToolInput,
+  type MemorySearchToolInput,
+  type ConversationSearchToolInput,
+  type SessionEndToolInput,
+} from "./tool-schemas.js";
+
+/** Abstraction over the five memory operations exposed as MCP tools. */
+export interface KimiCodeMemoryClient {
+  recall(request: RecallRequest): Promise<RecallResponse>;
+  capture(request: CaptureRequest): Promise<CaptureResponse>;
+  searchMemories(request: MemorySearchRequest): Promise<MemorySearchResponse>;
+  searchConversations(
+    request: ConversationSearchRequest,
+  ): Promise<ConversationSearchResponse>;
+  endSession(request: SessionEndRequest): Promise<SessionEndResponse>;
+}
+
+/** Configuration object passed to `registerTool`. */
+export interface ToolConfig {
+  title?: string;
+  description?: string;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+}
+
+/** Minimal surface used to register tools, decouples the server from MCP SDK internals. */
+export interface ToolRegistrationTarget {
+  registerTool(
+    name: string,
+    config: ToolConfig,
+    handler: (args: unknown, extra: unknown) => unknown,
+  ): unknown;
+}
+
+function textResult(result: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+}
+
+/** Register the five Kimi Code memory tools on the supplied target. */
+export function registerKimiCodeMemoryTools(
+  target: ToolRegistrationTarget,
+  client: KimiCodeMemoryClient,
+): void {
+  target.registerTool(
+    "tdai_recall",
+    {
+      description: "Recall relevant memory context for the current session.",
+      inputSchema: recallInputSchema,
+    },
+    async (args) => {
+      const input = recallInputSchema.parse(args) as RecallToolInput;
+      const result = await client.recall(input);
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_capture",
+    {
+      description: "Capture a user/assistant exchange into memory.",
+      inputSchema: captureInputSchema,
+    },
+    async (args) => {
+      const input = captureInputSchema.parse(args) as CaptureToolInput;
+      const result = await client.capture(input);
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_memory_search",
+    {
+      description: "Search across stored memories.",
+      inputSchema: memorySearchInputSchema,
+    },
+    async (args) => {
+      const input = memorySearchInputSchema.parse(args) as MemorySearchToolInput;
+      const result = await client.searchMemories({
+        ...input,
+        limit: normalizeLimit(input.limit),
+      });
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_conversation_search",
+    {
+      description: "Search across stored conversations.",
+      inputSchema: conversationSearchInputSchema,
+    },
+    async (args) => {
+      const input = conversationSearchInputSchema.parse(
+        args,
+      ) as ConversationSearchToolInput;
+      const result = await client.searchConversations({
+        ...input,
+        limit: normalizeLimit(input.limit),
+      });
+      return textResult(result);
+    },
+  );
+
+  target.registerTool(
+    "tdai_session_end",
+    {
+      description: "Signal the end of a session.",
+      inputSchema: sessionEndInputSchema,
+    },
+    async (args) => {
+      const input = sessionEndInputSchema.parse(args) as SessionEndToolInput;
+      const result = await client.endSession(input);
+      return textResult(result);
+    },
+  );
+}
+
+/** Create an MCP server backed by the given memory client. */
+export function createKimiCodeMcpServer(client: KimiCodeMemoryClient): McpServer {
+  const server = new McpServer({
+    name: "memory-tencentdb-kimicode",
+    version: "0.1.0",
+  });
+  registerKimiCodeMemoryTools(server, client);
+  return server;
+}
+
+/** Read environment variables, build the client, and start the stdio MCP server. */
+export async function runKimiCodeMcpServer(): Promise<void> {
+  const baseUrl = process.env.TDAI_GATEWAY_URL ?? DEFAULT_GATEWAY_URL;
+  const apiKey = process.env.TDAI_GATEWAY_API_KEY;
+  const timeoutMs = process.env.TDAI_GATEWAY_TIMEOUT_MS
+    ? Number(process.env.TDAI_GATEWAY_TIMEOUT_MS)
+    : undefined;
+
+  const client = new KimiCodeGatewayClient({ baseUrl, apiKey, timeoutMs });
+  const server = createKimiCodeMcpServer(client);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+function isMainModule(): boolean {
+  if (typeof process === "undefined") return false;
+  const executedFile = process.argv[1];
+  if (!executedFile) return false;
+  const normalized = executedFile.replace(/\\/g, "/");
+  return (
+    normalized.endsWith("mcp-server.ts") || normalized.endsWith("mcp-server.js")
+  );
+}
+
+if (isMainModule()) {
+  runKimiCodeMcpServer().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/adapters/kimicode/tool-schemas.test.ts
+++ b/src/adapters/kimicode/tool-schemas.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureInputSchema,
+  conversationSearchInputSchema,
+  memorySearchInputSchema,
+  normalizeLimit,
+  recallInputSchema,
+  sessionEndInputSchema,
+} from "./tool-schemas.js";
+
+describe("Kimi Code MCP tool schemas", () => {
+  it("requires recall query and session_key", () => {
+    expect(recallInputSchema.parse({
+      query: "what does the user prefer",
+      session_key: "session-1",
+    })).toEqual({
+      query: "what does the user prefer",
+      session_key: "session-1",
+    });
+
+    expect(() => recallInputSchema.parse({ query: "", session_key: "session-1" })).toThrow();
+    expect(() => recallInputSchema.parse({ query: "hello", session_key: "" })).toThrow();
+  });
+
+  it("requires capture user and assistant content", () => {
+    const parsed = captureInputSchema.parse({
+      user_content: "remember this",
+      assistant_content: "stored",
+      session_key: "session-1",
+    });
+
+    expect(parsed.user_content).toBe("remember this");
+    expect(parsed.assistant_content).toBe("stored");
+    expect(parsed.session_key).toBe("session-1");
+  });
+
+  it("clamps tool search limits to Gateway-supported bounds", () => {
+    expect(normalizeLimit(undefined)).toBe(5);
+    expect(normalizeLimit(0)).toBe(1);
+    expect(normalizeLimit(99)).toBe(20);
+    expect(normalizeLimit(7)).toBe(7);
+  });
+
+  it("accepts memory search filters", () => {
+    const parsed = memorySearchInputSchema.parse({
+      query: "coding preference",
+      limit: 6,
+      type: "persona",
+      scene: "repo-maintenance",
+    });
+
+    expect(parsed).toEqual({
+      query: "coding preference",
+      limit: 6,
+      type: "persona",
+      scene: "repo-maintenance",
+    });
+  });
+
+  it("accepts conversation search and session end inputs", () => {
+    expect(conversationSearchInputSchema.parse({
+      query: "previous test command",
+      session_key: "session-1",
+    })).toEqual({
+      query: "previous test command",
+      session_key: "session-1",
+    });
+
+    expect(sessionEndInputSchema.parse({ session_key: "session-1" })).toEqual({
+      session_key: "session-1",
+    });
+  });
+});

--- a/src/adapters/kimicode/tool-schemas.ts
+++ b/src/adapters/kimicode/tool-schemas.ts
@@ -1,0 +1,51 @@
+import * as z from "zod/v4";
+
+const nonEmptyString = z.string().trim().min(1);
+const optionalNonEmptyString = z.string().trim().min(1).optional();
+const limitSchema = z.number().int().optional();
+
+export const recallInputSchema = z.object({
+  query: nonEmptyString,
+  session_key: nonEmptyString,
+  user_id: optionalNonEmptyString,
+});
+
+export const captureInputSchema = z.object({
+  user_content: nonEmptyString,
+  assistant_content: nonEmptyString,
+  session_key: nonEmptyString,
+  session_id: optionalNonEmptyString,
+  user_id: optionalNonEmptyString,
+  messages: z.array(z.unknown()).optional(),
+});
+
+export const memorySearchInputSchema = z.object({
+  query: nonEmptyString,
+  limit: limitSchema,
+  type: z.enum(["persona", "episodic", "instruction"]).optional(),
+  scene: optionalNonEmptyString,
+});
+
+export const conversationSearchInputSchema = z.object({
+  query: nonEmptyString,
+  limit: limitSchema,
+  session_key: optionalNonEmptyString,
+});
+
+export const sessionEndInputSchema = z.object({
+  session_key: nonEmptyString,
+  user_id: optionalNonEmptyString,
+});
+
+export type RecallToolInput = z.infer<typeof recallInputSchema>;
+export type CaptureToolInput = z.infer<typeof captureInputSchema>;
+export type MemorySearchToolInput = z.infer<typeof memorySearchInputSchema>;
+export type ConversationSearchToolInput = z.infer<typeof conversationSearchInputSchema>;
+export type SessionEndToolInput = z.infer<typeof sessionEndInputSchema>;
+
+export function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return 5;
+  if (limit < 1) return 1;
+  if (limit > 20) return 20;
+  return limit;
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: ["./index.ts", "./src/adapters/kimicode/mcp-server.ts"],
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
## Summary

- Add a Gateway-backed Kimi Code MCP adapter for TencentDB Agent Memory.
- Expose memory recall, capture, memory search, conversation search, and session flush as stdio MCP tools.
- Keep Kimi Code as a thin adapter: it forwards tool calls to the existing TDAI Gateway HTTP API instead of initializing `TdaiCore` directly.
- Add platform comparison documentation for Codex and Kimi Code MCP integrations.

## Architecture

```text
Kimi Code CLI -> stdio MCP server -> TDAI Gateway HTTP API -> TdaiCore
```

## Tools

- `tdai_recall` -> `POST /recall`
- `tdai_capture` -> `POST /capture`
- `tdai_memory_search` -> `POST /search/memories`
- `tdai_conversation_search` -> `POST /search/conversations`
- `tdai_session_end` -> `POST /session/end`

## Comparison Doc

- Added `docs/platform-adapter-comparison.md`
- Documents shared Gateway-backed architecture
- Compares Codex and Kimi Code installation, MCP registration, tool exposure, and lifecycle limitations

## Test

- `npm test`
- `npm run build`
- `npx vitest run src/adapters/codex src/adapters/kimicode`

Refs #235
