### PR TITLE
feat(recall): add optional remote rerank

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `pipeline.l1IdleTimeoutSeconds` | `600` | Trigger L1 after the user has been idle for this many seconds |
 | `pipeline.l2MinIntervalSeconds` | `900` | Minimum interval between two L2 passes within the same session |
 | `recall.timeoutMs` | `5000` | Recall timeout; on timeout, skip injection without blocking the conversation |
+| `recall.rerank.enabled` | `false` | Optional remote rerank for recalled L1 candidates before recall budget trimming |
+| `recall.rerank.baseUrl` | `""` | OpenAI-compatible rerank base URL; the plugin calls `${baseUrl}/rerank` |
+| `recall.rerank.model` | `""` | Remote rerank model name |
+| `recall.rerank.timeoutMs` | `1000` | Remote rerank timeout; failures keep the original recall order |
 | `extraction.enableDedup` | `true` | L1 vector dedup / conflict detection |
 | `capture.excludeAgents` | `[]` | Glob patterns to exclude specific agents (e.g. `bench-judge-*`) |
 | `capture.l0l1RetentionDays` | `0` | Local retention days for L0 / L1 files; `0` = never clean up |

--- a/README_CN.md
+++ b/README_CN.md
@@ -425,6 +425,10 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `pipeline.l1IdleTimeoutSeconds` | `600` | 用户停止对话多久后触发 L1 |
 | `pipeline.l2MinIntervalSeconds` | `900` | 同 session 两次 L2 之间的最小间隔 |
 | `recall.timeoutMs` | `5000` | 召回超时阈值，超时跳过注入不阻塞对话 |
+| `recall.rerank.enabled` | `false` | 可选远程 rerank，在召回预算截断前重排 L1 候选 |
+| `recall.rerank.baseUrl` | `""` | OpenAI-compatible rerank base URL；插件调用 `${baseUrl}/rerank` |
+| `recall.rerank.model` | `""` | 远程 rerank 模型名 |
+| `recall.rerank.timeoutMs` | `1000` | 远程 rerank 超时；失败时保留原召回顺序 |
 | `extraction.enableDedup` | `true` | L1 向量去重 / 冲突检测 |
 | `capture.excludeAgents` | `[]` | Glob 模式排除特定 Agent（如 `bench-judge-*`） |
 | `capture.l0l1RetentionDays` | `0` | L0/L1 本地文件保留天数，`0` = 永不清理 |

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,22 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /** Optional remote reranker applied after initial recall and before budget trimming. */
+  rerank: RemoteRerankConfig;
+}
+
+/** Remote rerank configuration for recall candidates. */
+export interface RemoteRerankConfig {
+  /** Enable remote reranking (default: false). */
+  enabled: boolean;
+  /** OpenAI-compatible rerank base URL. The plugin calls `${baseUrl}/rerank`. */
+  baseUrl: string;
+  /** API key for the rerank service. */
+  apiKey: string;
+  /** Rerank model name. */
+  model: string;
+  /** Request timeout in milliseconds (default: 1000). */
+  timeoutMs: number;
 }
 
 /** Embedding service configuration for vector search. */
@@ -535,6 +551,16 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      rerank: (() => {
+        const rerankGroup = obj(recallGroup, "rerank");
+        return {
+          enabled: bool(rerankGroup, "enabled") ?? false,
+          baseUrl: str(rerankGroup, "baseUrl") ?? "",
+          apiKey: str(rerankGroup, "apiKey") ?? "",
+          model: str(rerankGroup, "model") ?? "",
+          timeoutMs: num(rerankGroup, "timeoutMs") ?? 1000,
+        };
+      })(),
     },
     embedding: {
       enabled: embeddingEnabled,

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -22,6 +22,7 @@ import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
 import type { Logger } from "../types.js";
+import { rerankRecallLines } from "../recall/rerank.js";
 
 const TAG = "[memory-tdai] [recall]";
 const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
@@ -125,6 +126,7 @@ async function performAutoRecallInner(params: {
     const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
+    memoryLines = await rerankRecallLines({ query: userText, lines: memoryLines, cfg, logger });
     memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
 
     // Extract structured RecalledMemory from formatted lines for metric reporting

--- a/src/core/recall/rerank.test.ts
+++ b/src/core/recall/rerank.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../../config";
+import { applyRerankResponse, rerankRecallLines } from "./rerank";
+
+const lines = [
+  "- [episodic] old candidate",
+  "- [instruction] best candidate",
+  "- [persona] fallback candidate",
+];
+
+describe("applyRerankResponse", () => {
+  it("reorders recall lines by remote scores and keeps unranked lines", () => {
+    const reordered = applyRerankResponse(lines, {
+      results: [
+        { index: 1, relevance_score: 0.91 },
+        { index: 0, relevance_score: 0.12 },
+      ],
+    });
+
+    expect(reordered).toEqual([
+      "- [instruction] best candidate",
+      "- [episodic] old candidate",
+      "- [persona] fallback candidate",
+    ]);
+  });
+
+  it("rejects unsupported response shapes", () => {
+    expect(applyRerankResponse(lines, {})).toBeUndefined();
+    expect(applyRerankResponse(lines, { results: [{ index: 9, relevance_score: 1 }] })).toBeUndefined();
+  });
+});
+
+describe("rerankRecallLines", () => {
+  it("is a no-op when remote rerank is disabled", async () => {
+    const fetchImpl = vi.fn();
+    const cfg = parseConfig({});
+
+    await expect(rerankRecallLines({ query: "q", lines, cfg, fetchImpl: fetchImpl as unknown as typeof fetch }))
+      .resolves.toBe(lines);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("calls a remote rerank endpoint and applies the returned order", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      results: [
+        { index: 2, relevance_score: 0.8 },
+        { index: 1, relevance_score: 0.7 },
+        { index: 0, relevance_score: 0.1 },
+      ],
+    }), { status: 200 }));
+    const cfg = parseConfig({
+      recall: {
+        rerank: {
+          enabled: true,
+          baseUrl: "https://rerank.example/v1/",
+          apiKey: "secret",
+          model: "bge-reranker",
+        },
+      },
+    });
+
+    await expect(rerankRecallLines({ query: "memory query", lines, cfg, fetchImpl: fetchImpl as unknown as typeof fetch }))
+      .resolves.toEqual([
+        "- [persona] fallback candidate",
+        "- [instruction] best candidate",
+        "- [episodic] old candidate",
+      ]);
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://rerank.example/v1/rerank", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({ Authorization: "Bearer secret" }),
+      body: JSON.stringify({
+        model: "bge-reranker",
+        query: "memory query",
+        documents: lines,
+        top_n: lines.length,
+      }),
+    }));
+  });
+
+  it("keeps original order when the remote call fails", async () => {
+    const fetchImpl = vi.fn(async () => new Response("{}", { status: 500 }));
+    const cfg = parseConfig({
+      recall: {
+        rerank: {
+          enabled: true,
+          baseUrl: "https://rerank.example/v1",
+          apiKey: "secret",
+          model: "bge-reranker",
+        },
+      },
+    });
+
+    await expect(rerankRecallLines({ query: "q", lines, cfg, fetchImpl: fetchImpl as unknown as typeof fetch }))
+      .resolves.toBe(lines);
+  });
+});

--- a/src/core/recall/rerank.ts
+++ b/src/core/recall/rerank.ts
@@ -1,0 +1,106 @@
+import type { MemoryTdaiConfig } from "../../config.js";
+import type { Logger } from "../types.js";
+
+const TAG = "[memory-tdai] [recall-rerank]";
+
+interface RerankResultItem {
+  index?: unknown;
+  relevance_score?: unknown;
+  score?: unknown;
+}
+
+interface RerankResponse {
+  results?: RerankResultItem[];
+}
+
+export async function rerankRecallLines(params: {
+  query: string;
+  lines: string[];
+  cfg: MemoryTdaiConfig;
+  logger?: Logger;
+  fetchImpl?: typeof fetch;
+}): Promise<string[]> {
+  const { query, lines, cfg, logger, fetchImpl = fetch } = params;
+  const rerank = cfg.recall.rerank;
+
+  if (!rerank?.enabled || lines.length < 2) return lines;
+  if (!rerank.baseUrl || !rerank.apiKey || !rerank.model) {
+    logger?.warn?.(`${TAG} enabled but baseUrl/apiKey/model is incomplete; keeping original recall order`);
+    return lines;
+  }
+
+  const timeoutMs = rerank.timeoutMs > 0 ? rerank.timeoutMs : 1000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const baseUrl = rerank.baseUrl.replace(/\/+$/, "");
+    const response = await fetchImpl(`${baseUrl}/rerank`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${rerank.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: rerank.model,
+        query,
+        documents: lines,
+        top_n: lines.length,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger?.warn?.(`${TAG} remote rerank failed with HTTP ${response.status}; keeping original recall order`);
+      return lines;
+    }
+
+    const json = await response.json() as RerankResponse;
+    const reordered = applyRerankResponse(lines, json);
+    if (!reordered) {
+      logger?.warn?.(`${TAG} remote rerank returned an unsupported response shape; keeping original recall order`);
+      return lines;
+    }
+
+    logger?.debug?.(`${TAG} reordered ${lines.length} recall candidate(s)`);
+    return reordered;
+  } catch (err) {
+    logger?.warn?.(`${TAG} remote rerank failed: ${err instanceof Error ? err.message : String(err)}; keeping original recall order`);
+    return lines;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function applyRerankResponse(lines: string[], response: RerankResponse): string[] | undefined {
+  if (!Array.isArray(response.results)) return undefined;
+
+  const ranked: Array<{ index: number; score: number }> = [];
+  for (const item of response.results) {
+    const index = typeof item.index === "number" ? item.index : undefined;
+    const score =
+      typeof item.relevance_score === "number" ? item.relevance_score :
+      typeof item.score === "number" ? item.score :
+      undefined;
+    if (index == null || score == null) continue;
+    if (!Number.isInteger(index) || index < 0 || index >= lines.length) continue;
+    ranked.push({ index, score });
+  }
+
+  if (ranked.length === 0) return undefined;
+
+  ranked.sort((a, b) => b.score - a.score);
+  const used = new Set<number>();
+  const reordered: string[] = [];
+  for (const item of ranked) {
+    if (used.has(item.index)) continue;
+    used.add(item.index);
+    reordered.push(lines[item.index]);
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!used.has(i)) reordered.push(lines[i]);
+  }
+
+  return reordered;
+}


### PR DESCRIPTION
## Description | 描述
Add a narrow, default-off remote rerank step for auto-recalled L1 memories.

The recall pipeline still runs the existing keyword / embedding / hybrid search first. When `recall.rerank.enabled` is configured with a `baseUrl`, `apiKey`, and `model`, the plugin calls `${baseUrl}/rerank` with the initial recalled candidates and reorders them by the returned `index` / `relevance_score` values before applying recall character budgets.

This keeps the feature conservative:
- Existing deployments are unchanged because rerank is disabled by default.
- Search still works when rerank is unavailable.
- HTTP errors, malformed responses, incomplete config, and timeout failures keep the original recall order.
- The request has a short independent timeout (`recall.rerank.timeoutMs`, default `1000ms`) so rerank cannot block the broader recall path for long.

## Related Issue | 关联 Issue
Fix #3

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证
- `npx vitest run src/core/recall/rerank.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`

## Additional Notes | 其他说明
The implementation intentionally targets auto-recall only as a first step, because that is where irrelevant top-K memories directly enter prompt context. Agent-initiated `tdai_memory_search` can remain deterministic and inspectable unless maintainers want rerank applied there as a follow-up.
