### PR TITLE
feat(adapter): add Codex MCP gateway bridge

### DIFF
--- a/docs/codex-mcp-adapter.md
+++ b/docs/codex-mcp-adapter.md
@@ -28,7 +28,7 @@ Codex supports STDIO MCP servers through `config.toml`. Add the following to
 ```toml
 [mcp_servers.tencentdb_memory]
 command = "memory-tencentdb-mcp"
-env = { TDAI_GATEWAY_URL = "http://127.0.0.1:8787", TDAI_GATEWAY_API_KEY = "replace-me" }
+env = { TDAI_GATEWAY_URL = "http://127.0.0.1:8420", TDAI_GATEWAY_API_KEY = "replace-me" }
 startup_timeout_sec = 10
 tool_timeout_sec = 30
 ```

--- a/docs/codex-mcp-adapter.md
+++ b/docs/codex-mcp-adapter.md
@@ -33,9 +33,20 @@ startup_timeout_sec = 10
 tool_timeout_sec = 30
 ```
 
+These fields follow the official Codex
+[`mcp_servers.<id>` configuration reference](https://developers.openai.com/codex/config-reference#configtoml):
+`command` launches a STDIO server, `env` forwards its environment, and the two
+timeout fields bound startup and tool execution.
+
 The command also accepts `TDAI_GATEWAY_TIMEOUT_MS`; its default is 10000.
 STDOUT is reserved for MCP JSON-RPC frames, while fatal startup errors are
 written to STDERR.
+
+The server implements the current published MCP revision (`2025-11-25`) and
+negotiates the older `2025-06-18`, `2025-03-26`, and `2024-11-05` revisions.
+It enforces the MCP initialization handshake before exposing tools and rejects
+invalid/null JSON-RPC request IDs. This keeps the adapter compatible with
+current Codex clients while preserving older MCP clients through negotiation.
 
 ## Tools
 
@@ -51,3 +62,27 @@ written to STDERR.
 per-turn L1 data, while `append_system_context` is stable persona, scene, and
 tool guidance. A host should not flatten those fields into the same prompt
 position.
+
+## Adapter boundary
+
+The MCP process is intentionally a thin transport adapter rather than a second
+memory implementation:
+
+| Concern | OpenClaw plugin | Hermes integration | Codex MCP adapter |
+|---|---|---|---|
+| Host protocol | Plugin hooks | Hermes lifecycle | MCP over STDIO |
+| Memory API | `TdaiCore` in process | Gateway/client integration | Authenticated Gateway HTTP |
+| Storage and ranking | Shared TDAI implementation | Shared TDAI implementation | Shared TDAI implementation |
+| Session isolation | OpenClaw session key | Hermes session key | Explicit `session_key` argument |
+
+This boundary keeps ranking, capture semantics, and storage migrations in one
+place. The adapter validates MCP inputs, preserves dynamic versus stable recall
+contexts, and converts Gateway failures into tool errors; it does not fork
+memory behavior for Codex.
+
+For production use, bind the Gateway to localhost unless remote access is
+required, configure `TDAI_GATEWAY_API_KEY`, and pass secrets through the MCP
+environment rather than command-line arguments. STDOUT must remain reserved for
+JSON-RPC frames. Gateway URLs containing inline credentials, query strings, or
+fragments are rejected so configuration cannot silently change request routing
+or expose credentials in URL diagnostics.

--- a/docs/codex-mcp-adapter.md
+++ b/docs/codex-mcp-adapter.md
@@ -1,0 +1,53 @@
+# Codex MCP adapter
+
+The `memory-tencentdb-mcp` command exposes the existing TDAI Gateway as a
+STDIO Model Context Protocol server. The memory engine remains in the Gateway;
+the adapter owns protocol validation, tool schemas, authentication, and error
+translation.
+
+```mermaid
+flowchart LR
+  C["Codex"] -->|"MCP over STDIO"| M["memory-tencentdb-mcp"]
+  M -->|"Authenticated HTTP"| G["TDAI Gateway"]
+  G --> T["TdaiCore"]
+  T --> S["SQLite or TCVDB"]
+```
+
+## Prerequisites
+
+1. Start the TDAI Gateway and set its API key when it is reachable beyond
+   localhost.
+2. Build or install this package so `memory-tencentdb-mcp` is on `PATH`.
+3. Use a stable `session_key`; it is the memory scope used by recall/capture.
+
+## Codex configuration
+
+Codex supports STDIO MCP servers through `config.toml`. Add the following to
+`~/.codex/config.toml`, or to `.codex/config.toml` in a trusted project:
+
+```toml
+[mcp_servers.tencentdb_memory]
+command = "memory-tencentdb-mcp"
+env = { TDAI_GATEWAY_URL = "http://127.0.0.1:8787", TDAI_GATEWAY_API_KEY = "replace-me" }
+startup_timeout_sec = 10
+tool_timeout_sec = 30
+```
+
+The command also accepts `TDAI_GATEWAY_TIMEOUT_MS`; its default is 10000.
+STDOUT is reserved for MCP JSON-RPC frames, while fatal startup errors are
+written to STDERR.
+
+## Tools
+
+| Tool | Purpose | Mutates memory |
+|---|---|---:|
+| `tdai_recall` | Return dynamic L1 and stable persona/scene context separately | No |
+| `tdai_memory_search` | Search structured L1 memory | No |
+| `tdai_conversation_search` | Search raw L0 conversation history | No |
+| `tdai_capture` | Persist a completed user/assistant turn | Yes |
+| `tdai_session_end` | Flush pending work for a session | Yes |
+
+`tdai_recall` preserves the core context boundary: `prepend_context` is
+per-turn L1 data, while `append_system_context` is stable persona, scene, and
+tool guidance. A host should not flatten those fields into the same prompt
+position.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-mcp": "./dist/memory-tencentdb-mcp.mjs"
   },
   "exports": {
     ".": {
@@ -47,6 +48,7 @@
     "hermes-plugin/",
     "openclaw.plugin.json",
     "README.md",
+    "docs/codex-mcp-adapter.md",
     "CHANGELOG.md",
     "LICENSE",
     "!src/**/*.test.ts",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,7 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// STDIO MCP bridge for Codex and other MCP-capable hosts.
+export { TdaiGatewayClient, TdaiMcpServer } from "./mcp/index.js";
+export type { GatewayClientOptions } from "./mcp/index.js";

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import {
+  createMcpServerFromEnvironment,
+  runStdioMcpServer,
+} from "./server.js";
+
+try {
+  await runStdioMcpServer(createMcpServerFromEnvironment());
+} catch (error) {
+  // STDOUT is reserved for MCP JSON-RPC frames.
+  process.stderr.write(
+    `[memory-tencentdb-mcp] ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/src/adapters/mcp/gateway-client.test.ts
+++ b/src/adapters/mcp/gateway-client.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { GatewayRequestError, TdaiGatewayClient } from "./gateway-client.js";
+
+describe("TdaiGatewayClient", () => {
+  it("sends authenticated JSON requests to the configured base path", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ total: 1, results: "match", strategy: "hybrid" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = new TdaiGatewayClient({
+      baseUrl: "https://memory.example.test/api/",
+      apiKey: "secret",
+      fetchImpl,
+    });
+
+    await expect(client.searchMemories({ query: "project", limit: 3 })).resolves.toMatchObject({
+      total: 1,
+      results: "match",
+    });
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).toBe("https://memory.example.test/api/search/memories");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({ authorization: "Bearer secret" }),
+      body: JSON.stringify({ query: "project", limit: 3 }),
+    });
+  });
+
+  it("surfaces structured HTTP errors without exposing credentials", async () => {
+    const client = new TdaiGatewayClient({
+      baseUrl: "http://127.0.0.1:8787",
+      apiKey: "do-not-leak",
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ error: "invalid session", code: "BAD_SESSION" }), {
+          status: 400,
+        }),
+      ),
+    });
+
+    const error = await client.recall({ query: "q", session_key: "s" }).catch((value) => value);
+    expect(error).toBeInstanceOf(GatewayRequestError);
+    expect(error).toMatchObject({ status: 400, code: "BAD_SESSION", message: "invalid session" });
+    expect(String(error)).not.toContain("do-not-leak");
+  });
+
+  it("rejects unsupported gateway URL schemes", () => {
+    expect(() => new TdaiGatewayClient({ baseUrl: "file:///tmp/gateway" })).toThrow(
+      "must use http or https",
+    );
+  });
+
+  it("rejects malformed gateway URLs", () => {
+    expect(() => new TdaiGatewayClient({ baseUrl: "not a URL" })).toThrow(
+      "Invalid TDAI Gateway URL",
+    );
+  });
+
+  it("reports invalid JSON responses as gateway errors", async () => {
+    const client = new TdaiGatewayClient({
+      baseUrl: "http://127.0.0.1:8787",
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(new Response("not-json", { status: 502 })),
+    });
+    await expect(client.endSession({ session_key: "s" })).rejects.toThrow(
+      "Gateway returned invalid JSON",
+    );
+  });
+
+  it("uses every Gateway route without requiring an API key", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(
+      async () => new Response("{}", { status: 200 }),
+    );
+    const client = new TdaiGatewayClient({ baseUrl: "http://localhost:8787", fetchImpl });
+
+    await client.recall({ query: "q", session_key: "s" });
+    await client.capture({ user_content: "u", assistant_content: "a", session_key: "s" });
+    await client.searchConversations({ query: "q" });
+    await client.endSession({ session_key: "s" });
+
+    expect(fetchImpl.mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual([
+      "/recall",
+      "/capture",
+      "/search/conversations",
+      "/session/end",
+    ]);
+    const headers = fetchImpl.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers.authorization).toBeUndefined();
+  });
+
+  it("maps network and timeout failures to stable client errors", async () => {
+    const networkClient = new TdaiGatewayClient({
+      baseUrl: "http://localhost:8787",
+      fetchImpl: vi.fn<typeof fetch>().mockRejectedValue(new Error("connection refused")),
+    });
+    await expect(networkClient.recall({ query: "q", session_key: "s" })).rejects.toThrow(
+      "Gateway request failed: connection refused",
+    );
+
+    const timeoutClient = new TdaiGatewayClient({
+      baseUrl: "http://localhost:8787",
+      timeoutMs: 1,
+      fetchImpl: vi.fn<typeof fetch>().mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      })),
+    });
+    await expect(timeoutClient.recall({ query: "q", session_key: "s" })).rejects.toThrow(
+      "timed out after 1ms",
+    );
+  });
+});

--- a/src/adapters/mcp/gateway-client.test.ts
+++ b/src/adapters/mcp/gateway-client.test.ts
@@ -1,8 +1,53 @@
+import { createServer } from "node:http";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { GatewayRequestError, TdaiGatewayClient } from "./gateway-client.js";
 
 describe("TdaiGatewayClient", () => {
+  it("honors the HTTP route, authorization, and JSON contract end to end", async () => {
+    const requests: Array<{ url?: string; authorization?: string; body: unknown }> = [];
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        requests.push({
+          url: request.url,
+          authorization: request.headers.authorization,
+          body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
+        });
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ total: 1, results: [{ content: "matched" }] }));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+      const client = new TdaiGatewayClient({
+        baseUrl: `http://127.0.0.1:${address.port}/v1/`,
+        apiKey: "integration-secret",
+      });
+
+      await expect(client.searchMemories({ query: "project", limit: 2 })).resolves.toMatchObject({
+        total: 1,
+      });
+      expect(requests).toEqual([{
+        url: "/v1/search/memories",
+        authorization: "Bearer integration-secret",
+        body: { query: "project", limit: 2 },
+      }]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    }
+  });
+
   it("sends authenticated JSON requests to the configured base path", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(JSON.stringify({ total: 1, results: "match", strategy: "hybrid" }), {
@@ -52,6 +97,15 @@ describe("TdaiGatewayClient", () => {
     );
   });
 
+  it("rejects ambiguous or credential-bearing gateway URLs", () => {
+    expect(() => new TdaiGatewayClient({ baseUrl: "https://user:secret@memory.test" })).toThrow(
+      "must not contain credentials",
+    );
+    expect(() => new TdaiGatewayClient({ baseUrl: "https://memory.test/api?tenant=a" })).toThrow(
+      "must not contain a query or fragment",
+    );
+  });
+
   it("rejects malformed gateway URLs", () => {
     expect(() => new TdaiGatewayClient({ baseUrl: "not a URL" })).toThrow(
       "Invalid TDAI Gateway URL",
@@ -65,6 +119,18 @@ describe("TdaiGatewayClient", () => {
     });
     await expect(client.endSession({ session_key: "s" })).rejects.toThrow(
       "Gateway returned invalid JSON",
+    );
+  });
+
+  it("rejects JSON responses that violate the Gateway object contract", async () => {
+    const client = new TdaiGatewayClient({
+      baseUrl: "http://127.0.0.1:8787",
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify(["unexpected"]), { status: 200 }),
+      ),
+    });
+    await expect(client.recall({ query: "q", session_key: "s" })).rejects.toThrow(
+      "non-object JSON response",
     );
   });
 

--- a/src/adapters/mcp/gateway-client.ts
+++ b/src/adapters/mcp/gateway-client.ts
@@ -1,0 +1,142 @@
+import type {
+  CaptureRequest,
+  CaptureResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export interface GatewayClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export class GatewayRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "GatewayRequestError";
+  }
+}
+
+export class TdaiGatewayClient {
+  private readonly baseUrl: URL;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: GatewayClientOptions) {
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.apiKey = options.apiKey?.trim() || undefined;
+    this.timeoutMs = normalizeTimeout(options.timeoutMs);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  recall(request: RecallRequest): Promise<RecallResponse> {
+    return this.post("recall", request);
+  }
+
+  capture(request: CaptureRequest): Promise<CaptureResponse> {
+    return this.post("capture", request);
+  }
+
+  searchMemories(request: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.post("search/memories", request);
+  }
+
+  searchConversations(
+    request: ConversationSearchRequest,
+  ): Promise<ConversationSearchResponse> {
+    return this.post("search/conversations", request);
+  }
+
+  endSession(request: SessionEndRequest): Promise<SessionEndResponse> {
+    return this.post("session/end", request);
+  }
+
+  private async post<T>(route: string, body: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(new URL(route, this.baseUrl), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          ...(this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {}),
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      const payload = await readJsonResponse(response);
+      if (!response.ok) {
+        const error = asRecord(payload);
+        throw new GatewayRequestError(
+          typeof error?.error === "string"
+            ? error.error
+            : `Gateway request failed with HTTP ${response.status}`,
+          response.status,
+          typeof error?.code === "string" ? error.code : undefined,
+        );
+      }
+      return payload as T;
+    } catch (error) {
+      if (error instanceof GatewayRequestError) throw error;
+      if (controller.signal.aborted) {
+        throw new GatewayRequestError(`Gateway request timed out after ${this.timeoutMs}ms`);
+      }
+      throw new GatewayRequestError(
+        `Gateway request failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function normalizeBaseUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Invalid TDAI Gateway URL: ${value}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("TDAI Gateway URL must use http or https");
+  }
+  if (!url.pathname.endsWith("/")) url.pathname += "/";
+  return url;
+}
+
+function normalizeTimeout(value: number | undefined): number {
+  return Number.isSafeInteger(value) && value! > 0 ? value! : 10_000;
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new GatewayRequestError(
+      `Gateway returned invalid JSON with HTTP ${response.status}`,
+      response.status,
+    );
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/src/adapters/mcp/gateway-client.ts
+++ b/src/adapters/mcp/gateway-client.ts
@@ -89,6 +89,12 @@ export class TdaiGatewayClient {
           typeof error?.code === "string" ? error.code : undefined,
         );
       }
+      if (!asRecord(payload)) {
+        throw new GatewayRequestError(
+          `Gateway returned a non-object JSON response with HTTP ${response.status}`,
+          response.status,
+        );
+      }
       return payload as T;
     } catch (error) {
       if (error instanceof GatewayRequestError) throw error;
@@ -113,6 +119,12 @@ function normalizeBaseUrl(value: string): URL {
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error("TDAI Gateway URL must use http or https");
+  }
+  if (url.username || url.password) {
+    throw new Error("TDAI Gateway URL must not contain credentials");
+  }
+  if (url.search || url.hash) {
+    throw new Error("TDAI Gateway URL must not contain a query or fragment");
   }
   if (!url.pathname.endsWith("/")) url.pathname += "/";
   return url;

--- a/src/adapters/mcp/index.ts
+++ b/src/adapters/mcp/index.ts
@@ -1,0 +1,10 @@
+export {
+  GatewayRequestError,
+  TdaiGatewayClient,
+} from "./gateway-client.js";
+export type { GatewayClientOptions } from "./gateway-client.js";
+export {
+  createMcpServerFromEnvironment,
+  runStdioMcpServer,
+  TdaiMcpServer,
+} from "./server.js";

--- a/src/adapters/mcp/server.test.ts
+++ b/src/adapters/mcp/server.test.ts
@@ -1,0 +1,216 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+import { GatewayRequestError } from "./gateway-client.js";
+import {
+  createMcpServerFromEnvironment,
+  runStdioMcpServer,
+  TdaiMcpServer,
+} from "./server.js";
+
+function gateway() {
+  return {
+    recall: vi.fn().mockResolvedValue({ prepend_context: "dynamic", append_system_context: "stable" }),
+    capture: vi.fn().mockResolvedValue({ l0_recorded: 2, scheduler_notified: true }),
+    searchMemories: vi.fn().mockResolvedValue({ results: "memory", total: 1, strategy: "hybrid" }),
+    searchConversations: vi.fn().mockResolvedValue({ results: "conversation", total: 1 }),
+    endSession: vi.fn().mockResolvedValue({ flushed: true }),
+  };
+}
+
+describe("TdaiMcpServer", () => {
+  it("negotiates initialize and advertises tool capabilities", async () => {
+    const server = new TdaiMcpServer(gateway());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-03-26" },
+    });
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: "memory-tencentdb" },
+      },
+    });
+  });
+
+  it("falls back to the current protocol for unsupported client versions", async () => {
+    const server = new TdaiMcpServer(gateway());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "1900-01-01" },
+    });
+    expect(response?.result).toMatchObject({ protocolVersion: "2025-06-18" });
+  });
+
+  it("publishes five tools with closed JSON schemas", async () => {
+    const server = new TdaiMcpServer(gateway());
+    const response = await server.handle({ jsonrpc: "2.0", id: "tools", method: "tools/list" });
+    const tools = (response?.result as { tools: Array<{ inputSchema: { additionalProperties: boolean } }> }).tools;
+    expect(tools).toHaveLength(5);
+    expect(tools.every((tool) => tool.inputSchema.additionalProperties === false)).toBe(true);
+  });
+
+  it("validates and dispatches recall calls", async () => {
+    const mock = gateway();
+    const server = new TdaiMcpServer(mock);
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "tdai_recall",
+        arguments: { query: "current task", session_key: "project-a" },
+      },
+    });
+    expect(mock.recall).toHaveBeenCalledWith({ query: "current task", session_key: "project-a" });
+    expect(response?.result).toMatchObject({
+      structuredContent: { prepend_context: "dynamic", append_system_context: "stable" },
+    });
+  });
+
+  it("returns JSON-RPC invalid params errors before calling the gateway", async () => {
+    const mock = gateway();
+    const server = new TdaiMcpServer(mock);
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "tdai_memory_search", arguments: { query: "q", limit: 500 } },
+    });
+    expect(response).toMatchObject({ error: { code: -32602 } });
+    expect(mock.searchMemories).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "tdai_capture",
+      { user_content: "question", assistant_content: "answer", session_key: "s", session_id: "run" },
+      "capture",
+      { user_content: "question", assistant_content: "answer", session_key: "s", session_id: "run" },
+    ],
+    [
+      "tdai_memory_search",
+      { query: "memory", limit: 10, type: "fact", scene: "work" },
+      "searchMemories",
+      { query: "memory", limit: 10, type: "fact", scene: "work" },
+    ],
+    [
+      "tdai_conversation_search",
+      { query: "source", session_key: "s" },
+      "searchConversations",
+      { query: "source", session_key: "s" },
+    ],
+    [
+      "tdai_session_end",
+      { session_key: "s" },
+      "endSession",
+      { session_key: "s" },
+    ],
+  ])("dispatches %s with validated arguments", async (name, args, method, expected) => {
+    const mock = gateway();
+    const server = new TdaiMcpServer(mock);
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: name,
+      method: "tools/call",
+      params: { name, arguments: args },
+    });
+    expect(mock[method as keyof typeof mock]).toHaveBeenCalledWith(expected);
+    expect(response?.result).not.toMatchObject({ isError: true });
+  });
+
+  it("converts gateway failures into MCP tool errors", async () => {
+    const mock = gateway();
+    mock.capture.mockRejectedValue(new GatewayRequestError("gateway unavailable"));
+    const server = new TdaiMcpServer(mock);
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: {
+        name: "tdai_capture",
+        arguments: {
+          user_content: "question",
+          assistant_content: "answer",
+          session_key: "s",
+        },
+      },
+    });
+    expect(response?.result).toMatchObject({ isError: true });
+  });
+
+  it("does not respond to notifications", async () => {
+    const server = new TdaiMcpServer(gateway());
+    await expect(server.handle({ jsonrpc: "2.0", method: "notifications/initialized" }))
+      .resolves.toBeUndefined();
+  });
+
+  it("returns protocol errors for invalid requests, methods, and tools", async () => {
+    const server = new TdaiMcpServer(gateway());
+    await expect(server.handle(null)).resolves.toMatchObject({ error: { code: -32600 } });
+    await expect(server.handle({ jsonrpc: "2.0", id: 1, method: "missing" }))
+      .resolves.toMatchObject({ error: { code: -32601 } });
+    await expect(server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "missing", arguments: {} },
+    })).resolves.toMatchObject({ error: { code: -32602 } });
+    await expect(server.handle({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "tdai_recall", arguments: { query: "q" } },
+    })).resolves.toMatchObject({ error: { code: -32602 } });
+  });
+
+  it("constructs a Gateway client from environment configuration", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ results: "ok", total: 1, strategy: "hybrid" }), { status: 200 }),
+    );
+    const server = createMcpServerFromEnvironment({
+      TDAI_GATEWAY_URL: "http://memory.test:9000/base",
+      TDAI_GATEWAY_API_KEY: "key",
+      TDAI_GATEWAY_TIMEOUT_MS: "2500",
+    }, { fetchImpl });
+    await server.handle({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: { name: "tdai_memory_search", arguments: { query: "q" } },
+    });
+    expect(String(fetchImpl.mock.calls[0][0])).toBe("http://memory.test:9000/base/search/memories");
+  });
+
+  it("rejects invalid environment timeout configuration", () => {
+    expect(() => createMcpServerFromEnvironment({ TDAI_GATEWAY_TIMEOUT_MS: "zero" })).toThrow(
+      "must be a positive integer",
+    );
+  });
+});
+
+describe("runStdioMcpServer", () => {
+  it("emits one JSON-RPC frame per input line and recovers from parse errors", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    let text = "";
+    output.on("data", (chunk) => { text += chunk.toString(); });
+
+    const running = runStdioMcpServer(new TdaiMcpServer(gateway()), input, output);
+    input.end('not-json\n{"jsonrpc":"2.0","id":1,"method":"ping"}\n');
+    await running;
+
+    const frames = text.trim().split("\n").map((line) => JSON.parse(line));
+    expect(frames).toEqual([
+      { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+      { jsonrpc: "2.0", id: 1, result: {} },
+    ]);
+  });
+});

--- a/src/adapters/mcp/server.test.ts
+++ b/src/adapters/mcp/server.test.ts
@@ -230,6 +230,22 @@ describe("TdaiMcpServer", () => {
     expect(String(fetchImpl.mock.calls[0][0])).toBe("http://memory.test:9000/base/search/memories");
   });
 
+  it("uses the project Gateway default port when no URL is configured", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ results: "ok", total: 1, strategy: "hybrid" }), { status: 200 }),
+    );
+    const server = createMcpServerFromEnvironment({}, { fetchImpl });
+    await initialize(server);
+    await server.handle({
+      jsonrpc: "2.0",
+      id: 9,
+      method: "tools/call",
+      params: { name: "tdai_memory_search", arguments: { query: "q" } },
+    });
+
+    expect(String(fetchImpl.mock.calls[0][0])).toBe("http://127.0.0.1:8420/search/memories");
+  });
+
   it("rejects invalid environment timeout configuration", () => {
     expect(() => createMcpServerFromEnvironment({ TDAI_GATEWAY_TIMEOUT_MS: "zero" })).toThrow(
       "must be a positive integer",

--- a/src/adapters/mcp/server.test.ts
+++ b/src/adapters/mcp/server.test.ts
@@ -18,18 +18,28 @@ function gateway() {
   };
 }
 
+async function initialize(server: TdaiMcpServer, protocolVersion = "2025-11-25") {
+  const response = await server.handle({
+    jsonrpc: "2.0",
+    id: "initialize",
+    method: "initialize",
+    params: {
+      protocolVersion,
+      capabilities: {},
+      clientInfo: { name: "vitest", version: "1.0.0" },
+    },
+  });
+  await server.handle({ jsonrpc: "2.0", method: "notifications/initialized" });
+  return response;
+}
+
 describe("TdaiMcpServer", () => {
   it("negotiates initialize and advertises tool capabilities", async () => {
     const server = new TdaiMcpServer(gateway());
-    const response = await server.handle({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: { protocolVersion: "2025-03-26" },
-    });
+    const response = await initialize(server, "2025-03-26");
     expect(response).toMatchObject({
       jsonrpc: "2.0",
-      id: 1,
+      id: "initialize",
       result: {
         protocolVersion: "2025-03-26",
         capabilities: { tools: { listChanged: false } },
@@ -40,17 +50,13 @@ describe("TdaiMcpServer", () => {
 
   it("falls back to the current protocol for unsupported client versions", async () => {
     const server = new TdaiMcpServer(gateway());
-    const response = await server.handle({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: { protocolVersion: "1900-01-01" },
-    });
-    expect(response?.result).toMatchObject({ protocolVersion: "2025-06-18" });
+    const response = await initialize(server, "1900-01-01");
+    expect(response?.result).toMatchObject({ protocolVersion: "2025-11-25" });
   });
 
   it("publishes five tools with closed JSON schemas", async () => {
     const server = new TdaiMcpServer(gateway());
+    await initialize(server);
     const response = await server.handle({ jsonrpc: "2.0", id: "tools", method: "tools/list" });
     const tools = (response?.result as { tools: Array<{ inputSchema: { additionalProperties: boolean } }> }).tools;
     expect(tools).toHaveLength(5);
@@ -60,6 +66,7 @@ describe("TdaiMcpServer", () => {
   it("validates and dispatches recall calls", async () => {
     const mock = gateway();
     const server = new TdaiMcpServer(mock);
+    await initialize(server);
     const response = await server.handle({
       jsonrpc: "2.0",
       id: 2,
@@ -78,6 +85,7 @@ describe("TdaiMcpServer", () => {
   it("returns JSON-RPC invalid params errors before calling the gateway", async () => {
     const mock = gateway();
     const server = new TdaiMcpServer(mock);
+    await initialize(server);
     const response = await server.handle({
       jsonrpc: "2.0",
       id: 3,
@@ -86,6 +94,15 @@ describe("TdaiMcpServer", () => {
     });
     expect(response).toMatchObject({ error: { code: -32602 } });
     expect(mock.searchMemories).not.toHaveBeenCalled();
+
+    const extraArgument = await server.handle({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "tdai_recall", arguments: { query: "q", session_key: "s", hidden: true } },
+    });
+    expect(extraArgument).toMatchObject({ error: { code: -32602 } });
+    expect(mock.recall).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -116,6 +133,7 @@ describe("TdaiMcpServer", () => {
   ])("dispatches %s with validated arguments", async (name, args, method, expected) => {
     const mock = gateway();
     const server = new TdaiMcpServer(mock);
+    await initialize(server);
     const response = await server.handle({
       jsonrpc: "2.0",
       id: name,
@@ -130,6 +148,7 @@ describe("TdaiMcpServer", () => {
     const mock = gateway();
     mock.capture.mockRejectedValue(new GatewayRequestError("gateway unavailable"));
     const server = new TdaiMcpServer(mock);
+    await initialize(server);
     const response = await server.handle({
       jsonrpc: "2.0",
       id: 4,
@@ -146,15 +165,36 @@ describe("TdaiMcpServer", () => {
     expect(response?.result).toMatchObject({ isError: true });
   });
 
-  it("does not respond to notifications", async () => {
+  it("does not respond to notifications and enters the operation phase", async () => {
     const server = new TdaiMcpServer(gateway());
-    await expect(server.handle({ jsonrpc: "2.0", method: "notifications/initialized" }))
+    const response = await initialize(server);
+    expect(response?.result).toMatchObject({ protocolVersion: "2025-11-25" });
+    await expect(server.handle({ jsonrpc: "2.0", method: "notifications/unknown" }))
       .resolves.toBeUndefined();
+    await expect(server.handle({ jsonrpc: "2.0", id: "tools", method: "tools/list" }))
+      .resolves.toMatchObject({ result: { tools: expect.any(Array) } });
+  });
+
+  it("enforces initialization and rejects null request IDs", async () => {
+    const server = new TdaiMcpServer(gateway());
+    await expect(server.handle({ jsonrpc: "2.0", id: 1, method: "tools/list" }))
+      .resolves.toMatchObject({ error: { code: -32002 } });
+    await expect(server.handle({ jsonrpc: "2.0", id: null, method: "ping" }))
+      .resolves.toMatchObject({ error: { code: -32600 } });
+    await expect(server.handle({ jsonrpc: "2.0", id: 1.5, method: "ping" }))
+      .resolves.toMatchObject({ error: { code: -32600 } });
+    await expect(server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "initialize",
+      params: { protocolVersion: "2025-11-25" },
+    })).resolves.toMatchObject({ error: { code: -32602 } });
   });
 
   it("returns protocol errors for invalid requests, methods, and tools", async () => {
     const server = new TdaiMcpServer(gateway());
     await expect(server.handle(null)).resolves.toMatchObject({ error: { code: -32600 } });
+    await initialize(server);
     await expect(server.handle({ jsonrpc: "2.0", id: 1, method: "missing" }))
       .resolves.toMatchObject({ error: { code: -32601 } });
     await expect(server.handle({
@@ -180,6 +220,7 @@ describe("TdaiMcpServer", () => {
       TDAI_GATEWAY_API_KEY: "key",
       TDAI_GATEWAY_TIMEOUT_MS: "2500",
     }, { fetchImpl });
+    await initialize(server);
     await server.handle({
       jsonrpc: "2.0",
       id: 8,

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -244,7 +244,7 @@ export function createMcpServerFromEnvironment(
   options: { fetchImpl?: typeof fetch } = {},
 ): TdaiMcpServer {
   const gatewayOptions: GatewayClientOptions = {
-    baseUrl: env.TDAI_GATEWAY_URL?.trim() || "http://127.0.0.1:8787",
+    baseUrl: env.TDAI_GATEWAY_URL?.trim() || "http://127.0.0.1:8420",
     apiKey: env.TDAI_GATEWAY_API_KEY,
     timeoutMs: parsePositiveInteger(env.TDAI_GATEWAY_TIMEOUT_MS),
     fetchImpl: options.fetchImpl,

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -1,0 +1,348 @@
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+
+import {
+  GatewayRequestError,
+  TdaiGatewayClient,
+  type GatewayClientOptions,
+} from "./gateway-client.js";
+
+const SERVER_NAME = "memory-tencentdb";
+const SERVER_VERSION = "0.3.6";
+const SUPPORTED_PROTOCOL_VERSIONS = new Set([
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+]);
+const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
+
+type JsonRpcId = string | number | null;
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+interface GatewayOperations {
+  recall(request: { query: string; session_key: string }): Promise<unknown>;
+  capture(request: {
+    user_content: string;
+    assistant_content: string;
+    session_key: string;
+    session_id?: string;
+  }): Promise<unknown>;
+  searchMemories(request: {
+    query: string;
+    limit?: number;
+    type?: string;
+    scene?: string;
+  }): Promise<unknown>;
+  searchConversations(request: {
+    query: string;
+    limit?: number;
+    session_key?: string;
+  }): Promise<unknown>;
+  endSession(request: { session_key: string }): Promise<unknown>;
+}
+
+const TOOLS = [
+  {
+    name: "tdai_recall",
+    description:
+      "Recall memory context for the current task. Returns dynamic L1 context separately from stable persona/scene context so the client can place each correctly.",
+    inputSchema: objectSchema({
+      query: stringProperty("Current user request or a concise recall query"),
+      session_key: stringProperty("Stable session key used to scope memory"),
+    }, ["query", "session_key"]),
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: "tdai_capture",
+    description:
+      "Capture one completed user/assistant turn into TencentDB Agent Memory.",
+    inputSchema: objectSchema({
+      user_content: stringProperty("User message to persist"),
+      assistant_content: stringProperty("Assistant response to persist"),
+      session_key: stringProperty("Stable session key used to scope memory"),
+      session_id: stringProperty("Optional concrete conversation instance ID"),
+    }, ["user_content", "assistant_content", "session_key"]),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+  },
+  {
+    name: "tdai_memory_search",
+    description: "Search structured long-term memories (L1) by keyword or meaning.",
+    inputSchema: objectSchema({
+      query: stringProperty("Search query"),
+      limit: integerProperty("Maximum results", 1, 50),
+      type: stringProperty("Optional memory type filter"),
+      scene: stringProperty("Optional scene filter"),
+    }, ["query"]),
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: "tdai_conversation_search",
+    description: "Search raw conversation history (L0) for exact details and source context.",
+    inputSchema: objectSchema({
+      query: stringProperty("Search query"),
+      limit: integerProperty("Maximum results", 1, 50),
+      session_key: stringProperty("Optional session scope"),
+    }, ["query"]),
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: "tdai_session_end",
+    description: "Flush pending memory pipeline work for a completed session.",
+    inputSchema: objectSchema({
+      session_key: stringProperty("Session key to flush"),
+    }, ["session_key"]),
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
+] as const;
+
+export class TdaiMcpServer {
+  constructor(private readonly gateway: GatewayOperations) {}
+
+  async handle(request: unknown): Promise<Record<string, unknown> | undefined> {
+    const parsed = parseRequest(request);
+    if (!parsed.ok) return errorResponse(null, -32600, parsed.message);
+    const rpc = parsed.value;
+
+    // Notifications deliberately have no response.
+    if (rpc.id === undefined) return undefined;
+
+    try {
+      switch (rpc.method) {
+        case "initialize":
+          return successResponse(rpc.id, initializeResult(rpc.params));
+        case "ping":
+          return successResponse(rpc.id, {});
+        case "tools/list":
+          return successResponse(rpc.id, { tools: TOOLS });
+        case "tools/call":
+          return successResponse(rpc.id, await this.callTool(rpc.params));
+        default:
+          return errorResponse(rpc.id, -32601, `Method not found: ${rpc.method}`);
+      }
+    } catch (error) {
+      if (error instanceof InvalidParamsError) {
+        return errorResponse(rpc.id, -32602, error.message);
+      }
+      return errorResponse(
+        rpc.id,
+        -32603,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private async callTool(params: unknown): Promise<Record<string, unknown>> {
+    const value = requireRecord(params, "tools/call params");
+    const name = requireString(value.name, "name");
+    const args = value.arguments === undefined
+      ? {}
+      : requireRecord(value.arguments, "arguments");
+
+    try {
+      let result: unknown;
+      switch (name) {
+        case "tdai_recall":
+          result = await this.gateway.recall({
+            query: requireString(args.query, "query"),
+            session_key: requireString(args.session_key, "session_key"),
+          });
+          break;
+        case "tdai_capture":
+          result = await this.gateway.capture({
+            user_content: requireString(args.user_content, "user_content"),
+            assistant_content: requireString(args.assistant_content, "assistant_content"),
+            session_key: requireString(args.session_key, "session_key"),
+            ...optionalString(args, "session_id"),
+          });
+          break;
+        case "tdai_memory_search":
+          result = await this.gateway.searchMemories({
+            query: requireString(args.query, "query"),
+            ...optionalLimit(args.limit),
+            ...optionalString(args, "type"),
+            ...optionalString(args, "scene"),
+          });
+          break;
+        case "tdai_conversation_search":
+          result = await this.gateway.searchConversations({
+            query: requireString(args.query, "query"),
+            ...optionalLimit(args.limit),
+            ...optionalString(args, "session_key"),
+          });
+          break;
+        case "tdai_session_end":
+          result = await this.gateway.endSession({
+            session_key: requireString(args.session_key, "session_key"),
+          });
+          break;
+        default:
+          throw new InvalidParamsError(`Unknown tool: ${name}`);
+      }
+      return toolResult(result, false);
+    } catch (error) {
+      if (error instanceof InvalidParamsError) throw error;
+      const message = error instanceof GatewayRequestError
+        ? error.message
+        : `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`;
+      return toolResult({ error: message }, true);
+    }
+  }
+}
+
+export async function runStdioMcpServer(
+  server: TdaiMcpServer,
+  input: Readable = process.stdin,
+  output: Writable = process.stdout,
+): Promise<void> {
+  const lines = createInterface({ input, crlfDelay: Infinity, terminal: false });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    let request: unknown;
+    try {
+      request = JSON.parse(line) as unknown;
+    } catch {
+      output.write(`${JSON.stringify(errorResponse(null, -32700, "Parse error"))}\n`);
+      continue;
+    }
+    const response = await server.handle(request);
+    if (response) output.write(`${JSON.stringify(response)}\n`);
+  }
+}
+
+export function createMcpServerFromEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+  options: { fetchImpl?: typeof fetch } = {},
+): TdaiMcpServer {
+  const gatewayOptions: GatewayClientOptions = {
+    baseUrl: env.TDAI_GATEWAY_URL?.trim() || "http://127.0.0.1:8787",
+    apiKey: env.TDAI_GATEWAY_API_KEY,
+    timeoutMs: parsePositiveInteger(env.TDAI_GATEWAY_TIMEOUT_MS),
+    fetchImpl: options.fetchImpl,
+  };
+  return new TdaiMcpServer(new TdaiGatewayClient(gatewayOptions));
+}
+
+function initializeResult(params: unknown): Record<string, unknown> {
+  const value = params && typeof params === "object" && !Array.isArray(params)
+    ? params as Record<string, unknown>
+    : {};
+  const requested = typeof value.protocolVersion === "string"
+    ? value.protocolVersion
+    : DEFAULT_PROTOCOL_VERSION;
+  return {
+    protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.has(requested)
+      ? requested
+      : DEFAULT_PROTOCOL_VERSION,
+    capabilities: { tools: { listChanged: false } },
+    serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+    instructions:
+      "Use tdai_recall before work that benefits from prior context. Use search tools for deeper lookup. Capture a completed turn only when durable memory is appropriate.",
+  };
+}
+
+function parseRequest(value: unknown):
+  | { ok: true; value: JsonRpcRequest }
+  | { ok: false; message: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, message: "Invalid Request" };
+  }
+  const request = value as Record<string, unknown>;
+  if (request.jsonrpc !== "2.0" || typeof request.method !== "string") {
+    return { ok: false, message: "Invalid Request" };
+  }
+  if (
+    request.id !== undefined &&
+    request.id !== null &&
+    typeof request.id !== "string" &&
+    typeof request.id !== "number"
+  ) {
+    return { ok: false, message: "Invalid Request" };
+  }
+  return { ok: true, value: request as unknown as JsonRpcRequest };
+}
+
+function successResponse(id: JsonRpcId, result: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function errorResponse(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function toolResult(value: unknown, isError: boolean): Record<string, unknown> {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+class InvalidParamsError extends Error {}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidParamsError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new InvalidParamsError(`${label} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalString(
+  args: Record<string, unknown>,
+  key: string,
+): Record<string, string> {
+  if (args[key] === undefined) return {};
+  return { [key]: requireString(args[key], key) };
+}
+
+function optionalLimit(value: unknown): { limit?: number } {
+  if (value === undefined) return {};
+  if (!Number.isSafeInteger(value) || (value as number) < 1 || (value as number) > 50) {
+    throw new InvalidParamsError("limit must be an integer between 1 and 50");
+  }
+  return { limit: value as number };
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error("TDAI_GATEWAY_TIMEOUT_MS must be a positive integer");
+  }
+  return parsed;
+}
+
+function objectSchema(
+  properties: Record<string, unknown>,
+  required: string[],
+): Record<string, unknown> {
+  return { type: "object", properties, required, additionalProperties: false };
+}
+
+function stringProperty(description: string): Record<string, unknown> {
+  return { type: "string", minLength: 1, description };
+}
+
+function integerProperty(
+  description: string,
+  minimum: number,
+  maximum: number,
+): Record<string, unknown> {
+  return { type: "integer", minimum, maximum, description };
+}

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -10,13 +10,15 @@ import {
 const SERVER_NAME = "memory-tencentdb";
 const SERVER_VERSION = "0.3.6";
 const SUPPORTED_PROTOCOL_VERSIONS = new Set([
+  "2025-11-25",
   "2025-06-18",
   "2025-03-26",
   "2024-11-05",
 ]);
-const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
+const DEFAULT_PROTOCOL_VERSION = "2025-11-25";
 
-type JsonRpcId = string | number | null;
+type JsonRpcId = string | number;
+type JsonRpcResponseId = JsonRpcId | null;
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -102,6 +104,8 @@ const TOOLS = [
 ] as const;
 
 export class TdaiMcpServer {
+  private lifecycle: "uninitialized" | "initializing" | "ready" = "uninitialized";
+
   constructor(private readonly gateway: GatewayOperations) {}
 
   async handle(request: unknown): Promise<Record<string, unknown> | undefined> {
@@ -109,15 +113,30 @@ export class TdaiMcpServer {
     if (!parsed.ok) return errorResponse(null, -32600, parsed.message);
     const rpc = parsed.value;
 
-    // Notifications deliberately have no response.
-    if (rpc.id === undefined) return undefined;
+    if (rpc.id === undefined) {
+      if (rpc.method === "notifications/initialized" && this.lifecycle === "initializing") {
+        this.lifecycle = "ready";
+      }
+      // JSON-RPC notifications deliberately have no response, including
+      // malformed or out-of-order lifecycle notifications.
+      return undefined;
+    }
 
     try {
+      if (rpc.method === "ping") return successResponse(rpc.id, {});
+      if (rpc.method === "initialize") {
+        if (this.lifecycle !== "uninitialized") {
+          return errorResponse(rpc.id, -32600, "Server is already initialized");
+        }
+        const result = initializeResult(rpc.params);
+        this.lifecycle = "initializing";
+        return successResponse(rpc.id, result);
+      }
+      if (this.lifecycle !== "ready") {
+        return errorResponse(rpc.id, -32002, "Server is not initialized");
+      }
+
       switch (rpc.method) {
-        case "initialize":
-          return successResponse(rpc.id, initializeResult(rpc.params));
-        case "ping":
-          return successResponse(rpc.id, {});
         case "tools/list":
           return successResponse(rpc.id, { tools: TOOLS });
         case "tools/call":
@@ -148,12 +167,14 @@ export class TdaiMcpServer {
       let result: unknown;
       switch (name) {
         case "tdai_recall":
+          assertAllowedKeys(args, ["query", "session_key"]);
           result = await this.gateway.recall({
             query: requireString(args.query, "query"),
             session_key: requireString(args.session_key, "session_key"),
           });
           break;
         case "tdai_capture":
+          assertAllowedKeys(args, ["user_content", "assistant_content", "session_key", "session_id"]);
           result = await this.gateway.capture({
             user_content: requireString(args.user_content, "user_content"),
             assistant_content: requireString(args.assistant_content, "assistant_content"),
@@ -162,6 +183,7 @@ export class TdaiMcpServer {
           });
           break;
         case "tdai_memory_search":
+          assertAllowedKeys(args, ["query", "limit", "type", "scene"]);
           result = await this.gateway.searchMemories({
             query: requireString(args.query, "query"),
             ...optionalLimit(args.limit),
@@ -170,6 +192,7 @@ export class TdaiMcpServer {
           });
           break;
         case "tdai_conversation_search":
+          assertAllowedKeys(args, ["query", "limit", "session_key"]);
           result = await this.gateway.searchConversations({
             query: requireString(args.query, "query"),
             ...optionalLimit(args.limit),
@@ -177,6 +200,7 @@ export class TdaiMcpServer {
           });
           break;
         case "tdai_session_end":
+          assertAllowedKeys(args, ["session_key"]);
           result = await this.gateway.endSession({
             session_key: requireString(args.session_key, "session_key"),
           });
@@ -229,18 +253,22 @@ export function createMcpServerFromEnvironment(
 }
 
 function initializeResult(params: unknown): Record<string, unknown> {
-  const value = params && typeof params === "object" && !Array.isArray(params)
-    ? params as Record<string, unknown>
-    : {};
-  const requested = typeof value.protocolVersion === "string"
-    ? value.protocolVersion
-    : DEFAULT_PROTOCOL_VERSION;
+  const value = requireRecord(params, "initialize params");
+  const requested = requireString(value.protocolVersion, "protocolVersion");
+  requireRecord(value.capabilities, "capabilities");
+  const clientInfo = requireRecord(value.clientInfo, "clientInfo");
+  requireString(clientInfo.name, "clientInfo.name");
+  requireString(clientInfo.version, "clientInfo.version");
   return {
     protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.has(requested)
       ? requested
       : DEFAULT_PROTOCOL_VERSION,
     capabilities: { tools: { listChanged: false } },
-    serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+    serverInfo: {
+      name: SERVER_NAME,
+      title: "TencentDB Agent Memory",
+      version: SERVER_VERSION,
+    },
     instructions:
       "Use tdai_recall before work that benefits from prior context. Use search tools for deeper lookup. Capture a completed turn only when durable memory is appropriate.",
   };
@@ -258,10 +286,12 @@ function parseRequest(value: unknown):
   }
   if (
     request.id !== undefined &&
-    request.id !== null &&
     typeof request.id !== "string" &&
     typeof request.id !== "number"
   ) {
+    return { ok: false, message: "Invalid Request" };
+  }
+  if (typeof request.id === "number" && !Number.isSafeInteger(request.id)) {
     return { ok: false, message: "Invalid Request" };
   }
   return { ok: true, value: request as unknown as JsonRpcRequest };
@@ -272,7 +302,7 @@ function successResponse(id: JsonRpcId, result: unknown): Record<string, unknown
 }
 
 function errorResponse(
-  id: JsonRpcId,
+  id: JsonRpcResponseId,
   code: number,
   message: string,
 ): Record<string, unknown> {
@@ -280,9 +310,10 @@ function errorResponse(
 }
 
 function toolResult(value: unknown, isError: boolean): Record<string, unknown> {
+  const structuredContent = asRecord(value) ?? { value };
   return {
     content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
-    structuredContent: value,
+    structuredContent,
     ...(isError ? { isError: true } : {}),
   };
 }
@@ -317,6 +348,23 @@ function optionalLimit(value: unknown): { limit?: number } {
     throw new InvalidParamsError("limit must be an integer between 1 and 50");
   }
   return { limit: value as number };
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): void {
+  const allowedSet = new Set(allowed);
+  const unexpected = Object.keys(value).filter((key) => !allowedSet.has(key));
+  if (unexpected.length > 0) {
+    throw new InvalidParamsError(`Unexpected argument(s): ${unexpected.join(", ")}`);
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {

--- a/src/gateway/recall-response.test.ts
+++ b/src/gateway/recall-response.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGatewayRecallResponse } from "./recall-response.js";
+
+describe("buildGatewayRecallResponse", () => {
+  it("preserves stable and dynamic context as separate transport fields", () => {
+    expect(buildGatewayRecallResponse({
+      prependContext: "dynamic L1",
+      appendSystemContext: "stable persona",
+      recallStrategy: "hybrid",
+      recalledL1Memories: [{ content: "x", score: 1, type: "fact" }],
+    })).toEqual({
+      context: "stable persona",
+      prepend_context: "dynamic L1",
+      append_system_context: "stable persona",
+      strategy: "hybrid",
+      memory_count: 1,
+    });
+  });
+
+  it("keeps the legacy context field backward compatible", () => {
+    expect(buildGatewayRecallResponse({ prependContext: "dynamic only" })).toEqual({
+      context: "",
+      prepend_context: "dynamic only",
+      strategy: undefined,
+      memory_count: 0,
+    });
+  });
+});

--- a/src/gateway/recall-response.ts
+++ b/src/gateway/recall-response.ts
@@ -1,0 +1,16 @@
+import type { RecallResult } from "../core/types.js";
+import type { RecallResponse } from "./types.js";
+
+/** Preserve the core's stable/dynamic context boundary across HTTP. */
+export function buildGatewayRecallResponse(result: RecallResult): RecallResponse {
+  return {
+    // Do not change the legacy field's semantics for Hermes/existing clients.
+    context: result.appendSystemContext ?? "",
+    ...(result.prependContext ? { prepend_context: result.prependContext } : {}),
+    ...(result.appendSystemContext
+      ? { append_system_context: result.appendSystemContext }
+      : {}),
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -39,6 +39,7 @@ import type {
   SeedResponse,
   GatewayErrorResponse,
 } from "./types.js";
+import { buildGatewayRecallResponse } from "./recall-response.js";
 import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
@@ -380,13 +381,12 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    this.logger.info(
+      `Recall completed in ${elapsed}ms: stable=${result.appendSystemContext?.length ?? 0} chars, ` +
+      `dynamic=${result.prependContext?.length ?? 0} chars`,
+    );
 
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
+    const response: RecallResponse = buildGatewayRecallResponse(result);
     sendJson(res, 200, response);
   }
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -36,7 +36,12 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Legacy stable-context field. Kept for backward compatibility. */
   context: string;
+  /** Dynamic L1 context that belongs next to the current user turn. */
+  prepend_context?: string;
+  /** Stable persona/scene/tool guidance for the host system prompt. */
+  append_system_context?: string;
   strategy?: string;
   memory_count?: number;
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,10 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: {
+    index: "./index.ts",
+    "memory-tencentdb-mcp": "./src/adapters/mcp/cli.ts",
+  },
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
<!-- PR Title: feat(adapter): add a Codex MCP gateway bridge -->

## Description | 描述

Add a focused STDIO MCP adapter that exposes the existing TDAI Gateway to
Codex and other MCP clients. The adapter remains a transport boundary; storage,
ranking, capture, and pipeline behavior stay in the existing memory engine.

### Adapter capabilities

- Publish an executable `memory-tencentdb-mcp` npm command.
- Implement the latest published MCP revision (`2025-11-25`) and negotiate
  `2025-06-18`, `2025-03-26`, and `2024-11-05` clients.
- Enforce the MCP initialization lifecycle, integer/string request IDs, closed
  tool schemas, runtime rejection of extra arguments, notifications, parse
  errors, and MCP tool-error semantics.
- Expose five tools: recall, capture, L1 memory search, L0 conversation search,
  and session flush.
- Call the Gateway through an authenticated, timeout-bounded HTTP client that
  preserves base paths, validates object responses, and rejects ambiguous or
  credential-bearing URLs.
- Reserve STDOUT for newline-delimited MCP JSON-RPC frames and send fatal
  startup diagnostics to STDERR.

### Recall compatibility

The Gateway now returns `prepend_context` and `append_system_context`
separately so MCP hosts do not flatten dynamic and stable prompt content. The
legacy `context` field keeps its original meaning for existing clients.

### Documentation

The adapter guide includes architecture, security boundaries, all five tools,
environment variables, and a Codex `config.toml` example verified against the
official `mcp_servers.<id>` configuration reference.

## Related Issue | 关联 Issue

Closes #235

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

### Validation

- Node.js 24: 7 test files, 95 tests passed.
- MCP/Gateway coverage includes lifecycle negotiation, all tools, strict input
  validation, parse errors, tool errors, timeout/network failures, real local
  HTTP routing, Bearer authentication, and response-shape validation.
- `npm run build`: passed; generated executable MCP bundle is about 14.4 KB.
- `npm pack --dry-run --json`: passed and includes the MCP binary and guide.
- `git diff --check`: passed.

The current Gateway scopes memory by `session_key`. This adapter does not claim
`user_id` as a tenant-isolation boundary because the core storage path does not
yet enforce that scope.
