### PR TITLE
fix(search): escape FTS5 phrase tokens in buildFtsQuery

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildFtsQuery, quoteFts5Phrase } from "./sqlite.js";
+
+describe("quoteFts5Phrase", () => {
+  it("wraps a token as an FTS5 phrase", () => {
+    expect(quoteFts5Phrase("hello")).toBe('"hello"');
+  });
+
+  it("escapes embedded double quotes by doubling them", () => {
+    expect(quoteFts5Phrase('foo"bar')).toBe('"foo""bar"');
+  });
+
+  it("keeps FTS5 operators as phrase text", () => {
+    expect(quoteFts5Phrase("AND")).toBe('"AND"');
+    expect(quoteFts5Phrase("NOT")).toBe('"NOT"');
+    expect(quoteFts5Phrase("NEAR")).toBe('"NEAR"');
+  });
+});
+
+describe("buildFtsQuery", () => {
+  it("returns null for empty or punctuation-only input", () => {
+    expect(buildFtsQuery("   ")).toBeNull();
+    expect(buildFtsQuery("!!! ((( )))")).toBeNull();
+  });
+
+  it("quotes normal tokens and joins them with controlled OR", () => {
+    expect(buildFtsQuery("hello world")).toBe('"hello" OR "world"');
+  });
+
+  it("treats FTS5 boolean operators as quoted user text tokens", () => {
+    expect(buildFtsQuery("foo OR bar NOT baz AND qux")).toBe(
+      '"foo" OR "OR" OR "bar" OR "NOT" OR "baz" OR "AND" OR "qux"',
+    );
+  });
+
+  it("does not preserve punctuation as executable FTS5 syntax", () => {
+    expect(buildFtsQuery("NEAR(foo bar) title:baz qux*")).toBe(
+      '"NEAR" OR "foo" OR "bar" OR "title" OR "baz" OR "qux"',
+    );
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -139,6 +139,10 @@ function requireNodeSqlite(): typeof import("node:sqlite") {
 // FTS5 helpers (adapted from openclaw core hybrid.ts)
 // ============================
 
+export function quoteFts5Phrase(token: string): string {
+  return `"${token.replaceAll('"', '""')}"`;
+}
+
 // ── Chinese word segmentation (jieba) ──
 // Lazy-loaded singleton: initialised on first call to `buildFtsQuery`.
 // If @node-rs/jieba is unavailable, falls back to Unicode-regex splitting.
@@ -225,7 +229,7 @@ export function buildFtsQuery(raw: string): string | null {
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map(quoteFts5Phrase);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

Fixes FTS5 MATCH query construction in `buildFtsQuery()` by escaping user-provided tokens as quoted FTS5 phrases.

Previously, embedded double quotes were removed from tokens before building the OR-joined FTS5 query. This could silently alter user input and did not explicitly protect the FTS5 query expression boundary. Although SQL parameters are used, the value passed to `MATCH ?` is still parsed by SQLite FTS5 as a query expression, so user input must not be able to change FTS5 query semantics.

This PR adds `quoteFts5Phrase()` and escapes embedded double quotes by doubling them. `buildFtsQuery()` now emits only application-controlled `OR` operators between quoted phrase terms, while user-provided FTS5 operators such as `AND`, `OR`, `NOT`, `NEAR`, `*`, and parentheses are treated as text after tokenization.

## Related Issue | 关联 Issue

Fix #160 

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Added unit tests for FTS5 phrase quoting and `buildFtsQuery()` behavior, covering normal token queries, punctuation-only input, boolean operator tokens, and embedded double quote escaping.

Tested with:

```bash
npm test -- src/core/store/sqlite.test.ts
npm test
npm run build
``` {data-source-line="550"}