### PR TITLE
fix(search): sanitize FTS5 query tokens

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("strips FTS5 operators and control syntax in regex fallback mode", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('alpha AND beta OR gamma NOT delta NEAR/5 "quoted" (group)*')).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta" OR "quoted" OR "group"',
+    );
+  });
+
+  it("sanitizes input before jieba tokenization", () => {
+    const seenInputs: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string) {
+        seenInputs.push(text);
+        return text.match(/[\p{L}\p{N}_]+/gu) ?? [];
+      },
+    });
+
+    expect(buildFtsQuery("memory AND sqlite NEAR/3 injection")).toBe(
+      '"memory" OR "sqlite" OR "injection"',
+    );
+    expect(seenInputs).toEqual(["memory   sqlite   injection"]);
+  });
+
+  it("returns null when input contains only FTS5 syntax", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('AND OR NOT NEAR/10 "()" * -')).toBeNull();
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,15 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATOR_WORDS = /\b(?:AND|OR|NOT|NEAR)(?:\s*\/\s*\d+)?\b/gi;
+const FTS5_CONTROL_CHARS = /["'()*:^{}\[\]-]+/g;
+
+function sanitizeFtsQueryInput(raw: string): string {
+  return raw
+    .replace(FTS5_OPERATOR_WORDS, " ")
+    .replace(FTS5_CONTROL_CHARS, " ");
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -196,6 +205,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = sanitizeFtsQueryInput(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +213,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +228,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
## Description | 描述

Fixes #160.

Sanitize FTS5 MATCH query construction so user input cannot alter query semantics through FTS5 operators or control syntax.

This PR keeps the change intentionally scoped:
- [x] Strip FTS5 operator words such as `AND`, `OR`, `NOT`, and `NEAR/5` before tokenization
- [x] Strip FTS5 control syntax such as quotes, parentheses, wildcard, column markers, and unary minus
- [x] Keep normal keyword search behavior by preserving sanitized text tokens
- [x] Apply the same sanitization before both jieba tokenization and regex fallback tokenization
- [x] Add focused regression tests for injection-like input and empty syntax-only input

## Related Issue | 关联 Issue

Fix #160

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
npx.cmd vitest run src/core/store/sqlite.test.ts
npx.cmd vitest run
```

Results:
- [x] `src/core/store/sqlite.test.ts`: 3 tests passed
- [x] Full test suite: 5 files / 70 tests passed