### PR TITLE
fix(recall): stabilize prompt-cache memory injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps legacy behavior; `append` uses OpenClaw `appendContext` to avoid changing the user prompt prefix on compatible hosts |
+| `recall.showInjected` | `false` | Preserve injected `<relevant-memories>` in persisted history. Keep `false` to avoid replaying stale dynamic recall and growing the prompt prefix |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/README_CN.md
+++ b/README_CN.md
@@ -406,6 +406,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回注入位置：`prepend` 保持旧行为；`append` 在兼容 OpenClaw 中使用 `appendContext`，减少对用户消息前缀缓存的影响 |
+| `recall.showInjected` | `false` | 是否把注入的 `<relevant-memories>` 保留到持久化历史；建议保持 `false`，避免重复回放动态召回内容导致历史膨胀 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,10 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import {
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./src/adapters/openclaw/recall-injection.js";
 
 const TAG = "[memory-tdai]";
 
@@ -584,17 +588,21 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
+        const hookResult = shapeOpenClawRecallResult(result, cfg.recall.injectionMode);
+
+        if (hookResult?.appendSystemContext || hookResult?.prependContext || hookResult?.appendContext) {
           const appendLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;
+          const appendContextLen = hookResult.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars, ` +
+            `appendContext=${appendContextLen} chars, injectionMode=${cfg.recall.injectionMode}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -624,30 +632,20 @@ export default function register(api: OpenClawPluginApi) {
 
     if (msg.role !== "user") return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
+    const stripped = stripInjectedRecallFromMessage(msg, cfg.recall.showInjected);
+    if (!stripped) {
+      if (cfg.recall.showInjected && msg.role === "user") {
+        api.logger.debug?.(`${TAG} [before_message_write] Preserving injected recall because recall.showInjected=true`);
+      }
+      return;
     }
 
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
+    if (stripped.contentType === "string") {
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped injected recall: removed ${stripped.strippedChars} chars`);
+    } else {
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped injected recall from parts: removed ${stripped.strippedChars} chars`);
     }
+    return { message: stripped.message as typeof event.message };
   });
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,6 +74,8 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回注入位置：prepend 保持旧行为；append 使用 appendContext 降低对用户消息前缀缓存的影响" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否将 <relevant-memories> 保留到持久化对话历史中；默认 false 以避免历史膨胀" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./recall-injection.js";
+
+describe("shapeOpenClawRecallResult", () => {
+  it("keeps legacy prependContext in prepend mode", () => {
+    const result = shapeOpenClawRecallResult(
+      {
+        appendSystemContext: "<user-persona>stable</user-persona>",
+        prependContext: "<relevant-memories>dynamic</relevant-memories>",
+      },
+      "prepend",
+    );
+
+    expect(result).toEqual({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<relevant-memories>dynamic</relevant-memories>",
+    });
+  });
+
+  it("moves dynamic recall to appendContext in append mode", () => {
+    const result = shapeOpenClawRecallResult(
+      {
+        appendSystemContext: "<user-persona>stable</user-persona>",
+        prependContext: "<relevant-memories>dynamic</relevant-memories>",
+        recallStrategy: "hybrid",
+      },
+      "append",
+    );
+
+    expect(result).toEqual({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      appendContext: "<relevant-memories>dynamic</relevant-memories>",
+      recallStrategy: "hybrid",
+    });
+  });
+});
+
+describe("stripInjectedRecallFromMessage", () => {
+  it("strips relevant memories from persisted user strings by default", () => {
+    const result = stripInjectedRecallFromMessage(
+      {
+        role: "user",
+        content: "<relevant-memories>\nold dynamic recall\n</relevant-memories>\n\nWhat changed?",
+      },
+      false,
+    );
+
+    expect(result?.message.content).toBe("What changed?");
+    expect(result?.strippedChars).toBeGreaterThan(0);
+  });
+
+  it("preserves injected recall when showInjected is enabled", () => {
+    const message = {
+      role: "user",
+      content: "<relevant-memories>debug me</relevant-memories>\nQuestion",
+    };
+
+    expect(stripInjectedRecallFromMessage(message, true)).toBeUndefined();
+  });
+
+  it("strips only text parts in multipart user content", () => {
+    const result = stripInjectedRecallFromMessage(
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<relevant-memories>dynamic</relevant-memories>\nLook at this image",
+          },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/a.png" },
+          },
+        ],
+      },
+      false,
+    );
+
+    expect(result?.message.content).toEqual([
+      {
+        type: "text",
+        text: "Look at this image",
+      },
+      {
+        type: "image_url",
+        image_url: { url: "https://example.com/a.png" },
+      },
+    ]);
+  });
+});

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,83 @@
+import type { RecallResult } from "../../core/types.js";
+import type { RecallInjectionMode } from "../../config.js";
+
+export interface OpenClawRecallHookResult extends RecallResult {
+  /** Dynamic recall appended after the user prompt when the host supports it. */
+  appendContext?: string;
+}
+
+export type MessageContentPart = Record<string, unknown>;
+
+export interface StripInjectedRecallResult<TMessage extends { role?: string; content?: unknown }> {
+  message: TMessage;
+  strippedChars: number;
+  contentType: "string" | "parts";
+}
+
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+/**
+ * Shape core recall output for OpenClaw's prompt-build hook.
+ *
+ * Core keeps dynamic L1 recall in `prependContext` because not every host has
+ * an append hook field. OpenClaw does, so `append` mode lets users keep
+ * dynamic recall out of the prompt prefix for prefix-matching cache providers.
+ */
+export function shapeOpenClawRecallResult(
+  result: RecallResult | undefined,
+  injectionMode: RecallInjectionMode,
+): OpenClawRecallHookResult | undefined {
+  if (!result) return undefined;
+  if (injectionMode !== "append" || !result.prependContext) {
+    return result;
+  }
+
+  const { prependContext, ...rest } = result;
+  return {
+    ...rest,
+    appendContext: prependContext,
+  };
+}
+
+/**
+ * Remove dynamic recall artifacts before user messages are persisted.
+ *
+ * The current model call has already seen the injected context by the time
+ * `before_message_write` runs. Keeping the block in history makes future
+ * turns replay stale dynamic recall and grows the prompt prefix over time.
+ */
+export function stripInjectedRecallFromMessage<TMessage extends { role?: string; content?: unknown }>(
+  message: TMessage,
+  showInjected: boolean,
+): StripInjectedRecallResult<TMessage> | undefined {
+  if (showInjected || message.role !== "user") return undefined;
+
+  if (typeof message.content === "string") {
+    if (!message.content.includes("<relevant-memories>")) return undefined;
+    const cleaned = message.content.replace(RELEVANT_MEMORIES_RE, "").trim();
+    if (cleaned === message.content) return undefined;
+    return {
+      message: { ...message, content: cleaned },
+      strippedChars: message.content.length - cleaned.length,
+      contentType: "string",
+    };
+  }
+
+  if (!Array.isArray(message.content)) return undefined;
+
+  let strippedChars = 0;
+  const cleanedParts = (message.content as MessageContentPart[]).map((part) => {
+    if (part.type !== "text" || typeof part.text !== "string") return part;
+    if (!part.text.includes("<relevant-memories>")) return part;
+    const cleaned = part.text.replace(RELEVANT_MEMORIES_RE, "").trim();
+    strippedChars += part.text.length - cleaned.length;
+    return { ...part, text: cleaned };
+  });
+
+  if (strippedChars === 0) return undefined;
+  return {
+    message: { ...message, content: cleanedParts },
+    strippedChars,
+    contentType: "parts",
+  };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall prompt-cache options", () => {
+  it("keeps legacy prepend mode while stripping injected recall by default", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+    expect(cfg.recall.showInjected).toBe(false);
+  });
+
+  it("accepts append injection mode and explicit showInjected opt-in", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "append",
+        showInjected: true,
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("append");
+    expect(cfg.recall.showInjected).toBe(true);
+  });
+
+  it("falls back to prepend for unknown injection modes", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "prefix-cache-magic",
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,14 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /**
+   * Where to place dynamic L1 recall in OpenClaw prompt mutation.
+   * - "prepend": legacy behavior, before the user prompt
+   * - "append": after the user prompt when the host supports appendContext
+   */
+  injectionMode: RecallInjectionMode;
+  /** Preserve injected <relevant-memories> blocks in persisted history (default: false). */
+  showInjected: boolean;
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -94,6 +102,8 @@ export interface RecallConfig {
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
 }
+
+export type RecallInjectionMode = "prepend" | "append";
 
 /** Embedding service configuration for vector search. */
 export interface EmbeddingConfig {
@@ -529,6 +539,8 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: validateRecallInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
+      showInjected: bool(recallGroup, "showInjected") ?? false,
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
@@ -634,6 +646,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_RECALL_INJECTION_MODES: RecallInjectionMode[] = ["prepend", "append"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +656,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateRecallInjectionMode(value: string | undefined): RecallInjectionMode | undefined {
+  if (!value) return undefined;
+  return VALID_RECALL_INJECTION_MODES.includes(value as RecallInjectionMode)
+    ? (value as RecallInjectionMode)
     : undefined;
 }
 


### PR DESCRIPTION
## Description | 描述

Fixes #120.

Add explicit prompt-cache controls for TencentDB recall injection while keeping the default behavior backward compatible.

This PR keeps the TencentDB-side mitigation scoped:
- [x] Add `recall.injectionMode` with `prepend` as the backward-compatible default
- [x] Add opt-in `append` mode that emits dynamic L1 recall as OpenClaw `appendContext`
- [x] Add `recall.showInjected` so preserving `<relevant-memories>` in persisted history is explicit opt-in
- [x] Keep persisted history clean by default to avoid replaying stale dynamic recall blocks
- [x] Move OpenClaw recall shaping and injected-history stripping into a tested adapter helper
- [x] Document both options in the plugin manifest and README files

## Cache impact | 缓存影响
- [x] Stable memory context remains in `appendSystemContext`
- [x] Dynamic L1 recall can stay out of the user prompt prefix with `recall.injectionMode="append"` on compatible OpenClaw hosts
- [x] Persisted history avoids dynamic recall growth by default with `recall.showInjected=false`

## Related Issue | 关联 Issue

Fix #120

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
npx.cmd vitest run src/config.test.ts src/adapters/openclaw/recall-injection.test.ts
npx.cmd vitest run
npm.cmd run build
git diff --check
```

Results:
- [x] Targeted tests: 2 files / 8 tests passed
- [x] Full test suite: 6 files / 75 tests passed
- [x] Build passed
- [x] Whitespace check passed