### PR TITLE
fix(data): recalibrate checkpoint counters after cleanup

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -414,6 +414,15 @@ export class TdaiCore {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
       );
+    } finally {
+      try {
+        const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        await checkpoint.recalibrateCounters({ vectorStore: this.vectorStore });
+      } catch (err) {
+        this.logger.warn(
+          `${TAG} Startup checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CheckpointManager } from "./checkpoint.js";
+
+const tmpDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(filePath: string, records: unknown[]): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf-8");
+}
+
+describe("CheckpointManager.recalibrateCounters", () => {
+  afterEach(async () => {
+    await Promise.all(tmpDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recounts L0 and L1 counters from JSONL when no vector store is available", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 99,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 20,
+      total_memories_extracted: 10,
+    });
+    await writeJsonl(path.join(dataDir, "conversations", "2026-07-01.jsonl"), [
+      { id: "l0-1" },
+      { id: "l0-2" },
+      { id: "l0-3" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-07-01.jsonl"), [
+      { id: "l1-1" },
+      { id: "l1-2" },
+    ]);
+
+    await checkpoint.recalibrateCounters();
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(3);
+    expect(cp.total_memories_extracted).toBe(2);
+    expect(cp.memories_since_last_persona).toBe(2);
+  });
+
+  it("prefers vector store counts over JSONL fallbacks when available", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 1,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 100,
+      total_memories_extracted: 100,
+    });
+    await writeJsonl(path.join(dataDir, "conversations", "2026-07-01.jsonl"), [{ id: "jsonl-l0" }]);
+    await writeJsonl(path.join(dataDir, "records", "2026-07-01.jsonl"), [{ id: "jsonl-l1" }]);
+
+    await checkpoint.recalibrateCounters({
+      vectorStore: {
+        countL0: () => 7,
+        countL1: async () => 5,
+      },
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(7);
+    expect(cp.total_memories_extracted).toBe(5);
+    expect(cp.memories_since_last_persona).toBe(1);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -142,6 +143,15 @@ const DEFAULT_CHECKPOINT: Checkpoint = {
 export interface CheckpointLogger {
   info(msg: string): void;
   warn?(msg: string): void;
+}
+
+export interface RecalibrateCountersOptions {
+  vectorStore?: Pick<IMemoryStore, "countL0" | "countL1">;
+}
+
+export interface RecalibrateCountersResult {
+  l0ConversationsCount: number;
+  totalMemoriesExtracted: number;
 }
 
 const noopLogger: CheckpointLogger = { info() {} };
@@ -291,6 +301,77 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Reconcile drift-prone global counters with the actual persisted data.
+   *
+   * The counters are incremented on the hot path, but cleanup/manual JSONL
+   * pruning can remove data later. Prefer the active VectorStore counts when
+   * available, and fall back to local JSONL line counts for degraded/local-only
+   * deployments.
+   */
+  async recalibrateCounters(options: RecalibrateCountersOptions = {}): Promise<RecalibrateCountersResult> {
+    let result: RecalibrateCountersResult = {
+      l0ConversationsCount: 0,
+      totalMemoriesExtracted: 0,
+    };
+
+    const dataDir = path.dirname(path.dirname(this.filePath));
+    await this.mutate(async (cp) => {
+      const l0Count = await this.resolveActualCount({
+        layer: "L0",
+        vectorCount: options.vectorStore?.countL0?.bind(options.vectorStore),
+        fallbackDir: path.join(dataDir, "conversations"),
+      });
+      const l1Count = await this.resolveActualCount({
+        layer: "L1",
+        vectorCount: options.vectorStore?.countL1?.bind(options.vectorStore),
+        fallbackDir: path.join(dataDir, "records"),
+      });
+
+      cp.l0_conversations_count = l0Count;
+      cp.total_memories_extracted = l1Count;
+      cp.memories_since_last_persona = Math.min(cp.memories_since_last_persona, l1Count);
+
+      result = {
+        l0ConversationsCount: l0Count,
+        totalMemoriesExtracted: l1Count,
+      };
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrateCounters: ` +
+      `l0_conversations_count=${result.l0ConversationsCount}, ` +
+      `total_memories_extracted=${result.totalMemoriesExtracted}`,
+    );
+
+    return result;
+  }
+
+  private async resolveActualCount(params: {
+    layer: "L0" | "L1";
+    vectorCount?: () => number | Promise<number>;
+    fallbackDir: string;
+  }): Promise<number> {
+    if (params.vectorCount) {
+      try {
+        const count = await params.vectorCount();
+        if (Number.isFinite(count) && count >= 0) {
+          return count;
+        }
+        this.logger.warn?.(
+          `[checkpoint] ${params.layer} vector count returned invalid value=${count}; falling back to JSONL`,
+        );
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] ${params.layer} vector count failed; falling back to JSONL: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return countJsonlRecords(params.fallbackDir, this.logger);
   }
 
   // ============================
@@ -485,4 +566,44 @@ export class CheckpointManager {
     });
   }
 
+}
+
+async function countJsonlRecords(dirPath: string, logger: CheckpointLogger): Promise<number> {
+  let entries: Array<{ name: string; isFile(): boolean }>;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+
+    const filePath = path.join(dirPath, entry.name);
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      logger.warn?.(
+        `[checkpoint] Failed to read JSONL file while recalibrating ${filePath}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+
+    const lines = raw.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      try {
+        JSON.parse(line);
+        count += 1;
+      } catch {
+        logger.warn?.(`[checkpoint] Skipping malformed JSONL line during recalibration: ${filePath}:${i + 1}`);
+      }
+    }
+  }
+
+  return count;
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -183,6 +184,17 @@ export class LocalMemoryCleaner {
     this.opts.logger?.info(
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
+
+    if (total.changedFiles > 0) {
+      try {
+        const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+        await checkpoint.recalibrateCounters({ vectorStore: this.vectorStore });
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} Checkpoint recalibration failed after cleanup: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
   }
 


### PR DESCRIPTION
## Description | 描述

Recalibrates drift-prone checkpoint counters from actual persisted data so cleanup/manual pruning no longer leaves `recall_checkpoint.json` overstating memory totals.

## Related Issue | 关联 Issue

Closes #157

## Change Type | 修改类型

- [x] Bug fix
- [x] Data consistency improvement
- [x] Tests added

## Self-test Checklist | 自测清单

- [x] Added `CheckpointManager.recalibrateCounters()` with VectorStore counts and JSONL fallback
- [x] Recalibrates counters after local cleanup removes JSONL/VectorStore data
- [x] Recalibrates once during store startup so existing drift self-heals
- [x] Caps `memories_since_last_persona` to the recalibrated L1 total
- [x] Added unit coverage for JSONL fallback and VectorStore-preferred counts

## Verification | 验证

- [x] `npx.cmd vitest run src/utils/checkpoint.test.ts`
- [x] `npm.cmd run build`
- [x] `git diff --check`