### PR TITLE
feat(adapters): add Codex Gateway adapter

### DIFF
--- a/docs/platform-adapters.md
+++ b/docs/platform-adapters.md
@@ -1,0 +1,79 @@
+# Platform Adapter Guide
+
+TencentDB-Agent-Memory keeps memory logic in `TdaiCore` and connects host
+platforms through thin adapters. This guide summarizes the current patterns and
+adds a Codex/CLI HTTP adapter path for new Agent hosts.
+
+## Core Boundary
+
+`TdaiCore` exposes four host-neutral operations:
+
+- `handleBeforeRecall(query, sessionKey)` maps to a before-prompt recall hook.
+- `handleTurnCommitted(turn)` maps to an after-turn capture hook.
+- `searchMemories(params)` maps to an L1 structured-memory search tool.
+- `searchConversations(params)` maps to an L0 raw-conversation search tool.
+
+Each platform adapter is responsible for identity, lifecycle, and transport. It
+should not reimplement L0/L1/L2/L3 memory logic.
+
+## Existing Adapter Patterns
+
+OpenClaw is an in-process adapter:
+
+- `OpenClawHostAdapter` wraps `OpenClawPluginApi`.
+- Hooks in `index.ts` call `TdaiCore` directly.
+- LLM calls can use the OpenClaw embedded agent runtime.
+
+Hermes is a sidecar adapter:
+
+- The Python provider starts or discovers the Node Gateway.
+- The provider calls `/recall`, `/capture`, `/search/*`, and `/session/end`.
+- Gateway handlers call `TdaiCore` inside the Node process.
+
+## Codex/CLI Adapter
+
+`CodexMemoryAdapter` is a lightweight TypeScript client for Codex-like CLI
+agents that can call the Gateway over HTTP. It provides:
+
+- `recall(query)` for prompt-context injection.
+- `captureTurn({ userText, assistantText, messages })` for after-turn writes.
+- `searchMemories(...)` and `searchConversations(...)` for tool-style lookup.
+- `endSession()` for shutdown or conversation flush.
+
+Minimal usage:
+
+```ts
+import { CodexMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb/src/adapters";
+
+const memory = new CodexMemoryAdapter({
+  gatewayUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+  sessionKey: "codex:workspace:/repo/path",
+  sessionId: "thread-123",
+});
+
+const context = await memory.buildPromptContext(userPrompt);
+
+await memory.captureTurn({
+  userText: userPrompt,
+  assistantText,
+  messages: [
+    { role: "user", content: userPrompt },
+    { role: "assistant", content: assistantText },
+  ],
+});
+```
+
+## Best Practices
+
+- Use a stable `sessionKey` per workspace/thread family so recall can find past
+  context after reconnects.
+- Use a narrower `sessionId` for a single conversation stream when the host can
+  distinguish it.
+- Keep adapters thin: translate host events to Gateway or `TdaiCore` calls.
+- Pass raw message arrays when the host has them; otherwise the adapter can
+  still capture the user/assistant texts.
+- Configure Gateway auth before exposing the port beyond loopback and pass the
+  same bearer token through the adapter.
+- Treat `/capture` as non-blocking from the host's perspective when possible;
+  memory extraction may continue asynchronously after L0 capture.

--- a/src/adapters/codex/gateway-client.test.ts
+++ b/src/adapters/codex/gateway-client.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { CodexMemoryAdapter, GatewayHttpError } from "./gateway-client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("CodexMemoryAdapter", () => {
+  it("sends recall requests with session key and bearer auth", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ context: "remembered", memory_count: 1 }));
+    const adapter = new CodexMemoryAdapter({
+      gatewayUrl: "http://localhost:8420/",
+      apiKey: " secret ",
+      sessionKey: "codex-session",
+      userId: "user-1",
+      fetchImpl: fetchImpl as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await adapter.recall("what should I know?");
+
+    expect(result.context).toBe("remembered");
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:8420/recall", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({
+        Authorization: "Bearer secret",
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({
+        query: "what should I know?",
+        session_key: "codex-session",
+        user_id: "user-1",
+      }),
+    }));
+  });
+
+  it("captures a completed turn with optional raw messages", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ l0_recorded: 2, scheduler_notified: true }));
+    const adapter = new CodexMemoryAdapter({
+      sessionKey: "codex-session",
+      sessionId: "turn-stream",
+      fetchImpl: fetchImpl as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await adapter.captureTurn({
+      userText: "hello",
+      assistantText: "hi",
+      messages: [{ role: "user", content: "hello" }, { role: "assistant", content: "hi" }],
+    });
+
+    expect(result.l0_recorded).toBe(2);
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      user_content: "hello",
+      assistant_content: "hi",
+      session_key: "codex-session",
+      session_id: "turn-stream",
+      messages: [{ role: "user", content: "hello" }, { role: "assistant", content: "hi" }],
+    });
+  });
+
+  it("throws GatewayHttpError with status and body on non-2xx responses", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: "Unauthorized" }, 401));
+    const adapter = new CodexMemoryAdapter({
+      sessionKey: "codex-session",
+      fetchImpl: fetchImpl as unknown as typeof globalThis.fetch,
+    });
+
+    await expect(adapter.searchMemories({ query: "x" })).rejects.toMatchObject({
+      name: "GatewayHttpError",
+      status: 401,
+      responseBody: JSON.stringify({ error: "Unauthorized" }),
+    } satisfies Partial<GatewayHttpError>);
+  });
+});

--- a/src/adapters/codex/gateway-client.ts
+++ b/src/adapters/codex/gateway-client.ts
@@ -1,0 +1,191 @@
+import type {
+  CaptureRequest,
+  CaptureResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  GatewayErrorResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export interface CodexMemoryAdapterOptions {
+  gatewayUrl?: string;
+  apiKey?: string;
+  sessionKey: string;
+  sessionId?: string;
+  userId?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export interface CaptureTurnParams {
+  userText: string;
+  assistantText: string;
+  messages?: unknown[];
+  sessionKey?: string;
+  sessionId?: string;
+}
+
+export interface SearchMemoriesParams {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface SearchConversationsParams {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export class GatewayHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly responseBody: string,
+  ) {
+    super(message);
+    this.name = "GatewayHttpError";
+  }
+}
+
+/**
+ * Thin adapter for Codex/CLI-style agents that talk to the TDAI Gateway.
+ *
+ * It maps a host's turn lifecycle onto the Gateway endpoints:
+ * - before prompt: `recall(query)`
+ * - after turn: `captureTurn(...)`
+ * - tools: `searchMemories(...)` / `searchConversations(...)`
+ * - shutdown: `endSession()`
+ */
+export class CodexMemoryAdapter {
+  private readonly gatewayUrl: string;
+  private readonly apiKey?: string;
+  private readonly sessionKey: string;
+  private readonly sessionId?: string;
+  private readonly userId?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: CodexMemoryAdapterOptions) {
+    if (!options.sessionKey) {
+      throw new Error("CodexMemoryAdapter requires a non-empty sessionKey");
+    }
+
+    this.gatewayUrl = (options.gatewayUrl ?? "http://127.0.0.1:8420").replace(/\/+$/, "");
+    this.apiKey = options.apiKey?.trim() || undefined;
+    this.sessionKey = options.sessionKey;
+    this.sessionId = options.sessionId;
+    this.userId = options.userId;
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request<undefined, HealthResponse>("GET", "/health");
+  }
+
+  recall(query: string, sessionKey = this.sessionKey): Promise<RecallResponse> {
+    const body: RecallRequest = {
+      query,
+      session_key: sessionKey,
+    };
+    if (this.userId) body.user_id = this.userId;
+    return this.request<RecallRequest, RecallResponse>("POST", "/recall", body);
+  }
+
+  async buildPromptContext(query: string, sessionKey = this.sessionKey): Promise<string> {
+    const result = await this.recall(query, sessionKey);
+    return result.context;
+  }
+
+  captureTurn(params: CaptureTurnParams): Promise<CaptureResponse> {
+    const body: CaptureRequest = {
+      user_content: params.userText,
+      assistant_content: params.assistantText,
+      session_key: params.sessionKey ?? this.sessionKey,
+    };
+    const sessionId = params.sessionId ?? this.sessionId;
+    if (sessionId) body.session_id = sessionId;
+    if (this.userId) body.user_id = this.userId;
+    if (params.messages) body.messages = params.messages;
+    return this.request<CaptureRequest, CaptureResponse>("POST", "/capture", body);
+  }
+
+  searchMemories(params: SearchMemoriesParams): Promise<MemorySearchResponse> {
+    const body: MemorySearchRequest = {
+      query: params.query,
+      limit: params.limit,
+      type: params.type,
+      scene: params.scene,
+    };
+    return this.request<MemorySearchRequest, MemorySearchResponse>("POST", "/search/memories", body);
+  }
+
+  searchConversations(params: SearchConversationsParams): Promise<ConversationSearchResponse> {
+    const body: ConversationSearchRequest = {
+      query: params.query,
+      limit: params.limit,
+      session_key: params.sessionKey,
+    };
+    return this.request<ConversationSearchRequest, ConversationSearchResponse>("POST", "/search/conversations", body);
+  }
+
+  endSession(sessionKey = this.sessionKey): Promise<SessionEndResponse> {
+    const body: SessionEndRequest = {
+      session_key: sessionKey,
+    };
+    if (this.userId) body.user_id = this.userId;
+    return this.request<SessionEndRequest, SessionEndResponse>("POST", "/session/end", body);
+  }
+
+  private async request<TRequest, TResponse>(
+    method: "GET" | "POST",
+    path: string,
+    body?: TRequest,
+  ): Promise<TResponse> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {};
+      if (method === "POST") headers["Content-Type"] = "application/json";
+      if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+      const response = await this.fetchImpl(`${this.gatewayUrl}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+
+      if (!response.ok) {
+        const parsed = parseJson<GatewayErrorResponse>(text);
+        throw new GatewayHttpError(
+          parsed?.error ?? `Gateway request failed: ${method} ${path}`,
+          response.status,
+          text,
+        );
+      }
+
+      return (text ? JSON.parse(text) : {}) as TResponse;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseJson<T>(text: string): T | undefined {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Codex/CLI adapter barrel exports.
+ */
+export { CodexMemoryAdapter, GatewayHttpError } from "./gateway-client.js";
+export type {
+  CaptureTurnParams,
+  CodexMemoryAdapterOptions,
+  SearchConversationsParams,
+  SearchMemoriesParams,
+} from "./gateway-client.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,12 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Codex/CLI adapter
+export { CodexMemoryAdapter, GatewayHttpError } from "./codex/index.js";
+export type {
+  CaptureTurnParams,
+  CodexMemoryAdapterOptions,
+  SearchConversationsParams,
+  SearchMemoriesParams,
+} from "./codex/index.js";


### PR DESCRIPTION
## Description | 描述

Adds a lightweight Codex/CLI Gateway adapter and a platform adapter guide. The adapter maps Codex-like agent lifecycle events to the existing TDAI Gateway endpoints while keeping memory logic inside `TdaiCore`.

## Related Issue | 关联 Issue

Closes #235

## Change Type | 修改类型

- [x] New platform adapter
- [x] Documentation
- [x] Tests added

## Self-test Checklist | 自测清单

- [x] Reviewed `TdaiCore` recall/capture/search boundaries
- [x] Compared in-process OpenClaw adapter with Hermes/Gateway sidecar flow
- [x] Added `CodexMemoryAdapter` for Gateway-backed recall, capture, search, and session flush
- [x] Exported the adapter from `src/adapters`
- [x] Added platform adapter guide and best practices
- [x] Added unit coverage for auth headers, capture payloads, and Gateway errors

## Verification | 验证

- [x] `npx.cmd vitest run src/adapters/codex/gateway-client.test.ts`
- [x] `npm.cmd run build`
- [x] `git diff --check`