### PR TITLE
fix(store): sanitize FTS5 operators in buildFtsQuery (fixes #160)

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { buildFtsQuery, _resetJiebaForTest, _setJiebaForTest } from "./sqlite.js";
+
+/** Extract the per-token quoted terms that buildFtsQuery() emits. */
+function quotedTerms(out: string): string[] {
+  return out.match(/"[^"]*"/g) ?? [];
+}
+
+describe("buildFtsQuery() — FTS5 operator sanitization (issue #160)", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  // ── Behavior 1: FTS5 boolean/positional operators stripped ──
+
+  it("strips AND/OR/NOT/NEAR operators so they cannot alter query semantics", () => {
+    _setJiebaForTest(null); // force fallback (regex) tokenizer
+
+    const out = buildFtsQuery("foo AND bar OR baz NOT qux NEAR hello");
+    expect(out).not.toBeNull();
+
+    const tokens = quotedTerms(out!);
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"AND"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"OR"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"NOT"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"NEAR"');
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+    expect(out).toContain('"qux"');
+    expect(out).toContain('"hello"');
+  });
+
+  // ── Behavior 2: Case-insensitive operator stripping ──
+
+  it("strips operators case-insensitively", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery("foo and bar Or baz not qux");
+    expect(out).not.toBeNull();
+
+    const tokens = quotedTerms(out!);
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"AND"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"OR"');
+    expect(tokens.map((t) => t.toUpperCase())).not.toContain('"NOT"');
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+    expect(out).toContain('"qux"');
+  });
+
+  // ── Behavior 3: FTS5 special characters stripped ──
+
+  it("strips FTS5 special characters (parens, stars, colons, carets, dashes, single-quotes)", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery("foo\"bar' baz(qux) run* far: test^ end");
+    expect(out).not.toBeNull();
+    // Note: single `"` chars in output are the legitimate per-token quoting
+    // format used by buildFtsQuery — not injection. Check injection chars:
+    expect(out).not.toContain("'");
+    expect(out).not.toContain("*");
+    expect(out).not.toContain(":");
+    expect(out).not.toContain("^");
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+    expect(out).toContain('"qux"');
+    expect(out).toContain('"run"');
+    expect(out).toContain('"far"');
+    expect(out).toContain('"test"');
+    expect(out).toContain('"end"');
+  });
+
+  it("strips the exclude operator (minus sign)", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery("foo -bar -baz");
+    expect(out).not.toBeNull();
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+  });
+
+  // ── Behavior 4: Column filter syntax blocked ──
+
+  it("strips column filter syntax (content:foo)", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery("content:foo title:bar baz");
+    expect(out).not.toBeNull();
+    expect(out).toContain('"content"');
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"title"');
+    expect(out).toContain('"bar"');
+    expect(out).toContain('"baz"');
+  });
+
+  // ── Behavior 5: Word-boundary protection ──
+
+  it("does not treat operator substrings as operators (word-boundary)", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery("ANDROID scanner ORDER_NOTES nothing");
+    expect(out).not.toBeNull();
+    expect(out).toContain('"ANDROID"');
+    expect(out).toContain('"scanner"');
+    expect(out).toContain('"ORDER_NOTES"');
+    expect(out).toContain('"nothing"');
+  });
+
+  // ── Behavior 6: Pure-operator input returns null ──
+
+  it("returns null when input contains only FTS5 syntax and operators", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+    expect(buildFtsQuery("' \" : ( ) * ^ -")).toBeNull();
+    expect(buildFtsQuery("   *** ((())) :::   ")).toBeNull();
+  });
+
+  // ── Behavior 7: Empty-token filtering in quoting ──
+
+  it("filters empty tokens after quote-stripping to avoid bare \"\" in output", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery('foo "" "" bar');
+    expect(out).not.toBeNull();
+    expect(out).toContain('"foo"');
+    expect(out).toContain('"bar"');
+    expect(out).not.toContain('""');
+  });
+
+  // ── Behavior 8: Jieba path also sanitized ──
+
+  it("applies the same sanitizer to jieba-produced tokens", () => {
+    // Mock jieba returning operator-laced tokens
+    _setJiebaForTest({
+      cutForSearch: () => ["foo:bar", " ", "AND", "C++", "的", "用户", "NEAR"],
+    } as ReturnType<typeof _setJiebaForTest>);
+
+    const out = buildFtsQuery("ignored by fake jieba");
+    expect(out).not.toBeNull();
+    // "foo:bar" → "foo" + "bar" (colon stripped before jieba; jieba keeps it as one token,
+    // then the final quote-stripping won't split it — this is expected: colon was already
+    // removed from raw input, so the token is "foobar" post-strip.)
+    // Actually: sanitizeFtsRaw removes : from raw input *before* jieba sees it,
+    // so jieba receives "ignored by fake jieba" with no colons, but our mock jieba
+    // returns tokens that include "foo:bar" (simulating jieba preserving colons).
+    // In real usage, jieba would never receive colons since sanitizeFtsRaw runs first.
+    // But the final `replaceAll('"', "")` filtering still protects against leak-through.
+    // The key test is: "AND" and "NEAR" operator tokens from jieba must be filtered out.
+    expect(out).not.toContain('"AND"');
+    expect(out).not.toContain('"NEAR"');
+    expect(out).toContain('"用户"');
+  });
+
+  // ── Behavior 9: Normal recall unaffected ──
+
+  it("preserves normal Chinese text without operators", () => {
+    _setJiebaForTest(null);
+
+    const out = buildFtsQuery("用户 喜欢 TypeScript 编程");
+    expect(out).not.toBeNull();
+    expect(out).toContain('"用户"');
+    expect(out).toContain('"喜欢"');
+    expect(out).toContain('"TypeScript"');
+    expect(out).toContain('"编程"');
+  });
+
+  it("returns null for empty and whitespace-only input", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("")).toBeNull();
+    expect(buildFtsQuery("   ")).toBeNull();
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,6 +175,30 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * Strip FTS5 special operators and syntax from raw search input before
+ * tokenization (defense-in-depth for issue #160).
+ *
+ * The double-quoting in `buildFtsQuery()` already neutralizes most
+ * injection vectors — FTS5 operators like `AND`/`OR`/`NOT`/`NEAR` end up
+ * wrapped as literal string terms, which is harmless but means a user
+ * can still alter query semantics (e.g. by typing `NOT foo` to exclude
+ * results). Stripping them here ensures the resulting query is always a
+ * plain OR-of-terms, matching the documented behavior.
+ *
+ * Also strips FTS5 syntax characters (`"` `'` `(` `)` `*` `:` `^` `-`)
+ * so they cannot leak through the jieba tokenizer (the regex fallback
+ * already drops most of them, but jieba may preserve them in edge cases).
+ *
+ * Uses `\b` word boundaries so common words containing operator substrings
+ * (e.g. ANDROID, SCANNER, ORDER, NOTION) are NOT affected.
+ */
+function sanitizeFtsRaw(raw: string): string {
+  return raw
+    .replace(/["'()*:\^-]/g, " ")                // strip FTS5 syntax characters
+    .replace(/\b(?:AND|OR|NOT|NEAR)\b/gi, " ");  // strip FTS5 boolean/positional operators
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -196,6 +220,10 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  // Issue #160: strip FTS5 operators / special chars from raw input before
+  // tokenization. Defense-in-depth on top of the per-token double-quoting
+  // already applied below.
+  const cleaned = sanitizeFtsRaw(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +231,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,14 +246,24 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  // FTS5 operator keywords that must never appear as standalone query terms.
+  // Both sanitizeFtsRaw (input-level) and this token-level filter apply so
+  // that even if an operator leaks through jieba, it is caught here.
+  const FTS5_OPERATORS = new Set(["and", "or", "not", "near"]);
+  // Quote each token: strip embedded double-quotes first, filter empty
+  // results and FTS5 operator tokens, then wrap with FTS5 quotes.
+  const quoted = tokens
+    .map((t) => t.replaceAll('"', ""))
+    .filter((t) => t.length > 0 && !FTS5_OPERATORS.has(t.toLowerCase()))
+    .map((t) => `"${t}"`);
+  if (quoted.length === 0) return null;
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Summary

Closes #160

Adds FTS5 operator injection protection to `buildFtsQuery()` in `src/core/store/sqlite.ts` using a defense-in-depth approach:

### Changes

**`src/core/store/sqlite.ts`** — New `sanitizeFtsRaw()` + token-level filter:

| Layer | Purpose |
|---|---|
| **Input-level** (`sanitizeFtsRaw`) | Strip FTS5 syntax chars (`"'()*:\^-`) and boolean operators (`AND`/`OR`/`NOT`/`NEAR`) before tokenization. Uses `\b` word-boundary to protect words like `ANDROID`. |
| **Token-level** (`FTS5_OPERATORS` Set) | Secondary defense — filters operator tokens that may leak through jieba tokenizer. |
| **Quoting** | Filter empty tokens after `replaceAll('"', "")` to avoid bare `""` in output. |

All 4 existing call sites (`auto-recall`, `l1-dedup`, `conversation-search`, `memory-search`) benefit automatically with no changes needed.

**`src/core/store/sqlite.test.ts`** — 11 new security test cases covering:
- FTS5 boolean operators stripped (AND/OR/NOT/NEAR)
- Case-insensitive operator stripping
- FTS5 special characters (`"'()*:\^-`)
- Exclude operator (`-`) stripped
- Column filter syntax (`content:foo`) blocked
- Word-boundary protection (`ANDROID` preserved)
- Pure-operator input returns `null`
- Empty token filtering
- Jieba mock path sanitization
- Normal Chinese/English recall unaffected
- Empty/whitespace input

### Testing

```
npx vitest run --reporter=verbose
# 5 files passed · 78 tests passed (67 existing + 11 new, zero regressions)
```