### PR TITLE
feat: add cross-platform adapter guide and Claude Code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/cross-platform-adapters-cn.md`](./docs/cross-platform-adapters-cn.md) | Cross-platform adapter architecture, data flow, and Claude Code hook example |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -507,6 +507,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/cross-platform-adapters-cn.md`](./docs/cross-platform-adapters-cn.md) | 跨平台适配架构、数据流与 Claude Code Hook 示例 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/docs/cross-platform-adapters-cn.md
+++ b/docs/cross-platform-adapters-cn.md
@@ -1,0 +1,164 @@
+# 跨平台适配指南
+
+本文面向希望把 TencentDB Agent Memory 接入 OpenClaw、Hermes 之外 Agent 平台的开发者。目标是先理解核心边界，再把平台事件翻译成统一的记忆读写 API。
+
+## 核心架构
+
+`TdaiCore` 是宿主无关的记忆引擎入口。各平台不应直接改 L0/L1/L2/L3 记忆流水线，而是通过适配层提供运行时上下文、日志、LLM 调用能力，或通过 HTTP Gateway 调用核心能力。
+
+```mermaid
+flowchart LR
+    subgraph Host["Agent 平台"]
+        OpenClaw["OpenClaw Plugin"]
+        Hermes["Hermes Provider"]
+        Claude["Claude Code Hooks"]
+        Other["Dify / Codex / Other"]
+    end
+
+    OpenClaw -->|"in-process hooks"| OpenClawAdapter["OpenClawHostAdapter"]
+    OpenClawAdapter --> TdaiCore["TdaiCore"]
+
+    Hermes -->|"provider API"| HermesProvider["memory_tencentdb Provider"]
+    Claude -->|"hook stdin/stdout"| ClaudeHook["tdai-memory-hook.mjs"]
+    Other -->|"platform lifecycle"| PlatformAdapter["platform adapter"]
+
+    HermesProvider -->|"HTTP"| Gateway["TDAI Gateway"]
+    ClaudeHook -->|"HTTP"| Gateway
+    PlatformAdapter -->|"HTTP"| Gateway
+    Gateway --> StandaloneAdapter["StandaloneHostAdapter"]
+    StandaloneAdapter --> TdaiCore
+
+    TdaiCore --> Recall["handleBeforeRecall"]
+    TdaiCore --> Capture["handleTurnCommitted"]
+    TdaiCore --> Search["searchMemories / searchConversations"]
+    TdaiCore --> Store[("SQLite / TCVDB / BM25")]
+```
+
+## 数据流
+
+### 召回
+
+```mermaid
+sequenceDiagram
+    participant Host as Agent 平台
+    participant Adapter as 平台适配层
+    participant Gateway as TDAI Gateway
+    participant Core as TdaiCore
+    participant Store as Memory Store
+
+    Host->>Adapter: 用户提交 prompt
+    Adapter->>Gateway: POST /recall { query, session_key }
+    Gateway->>Core: handleBeforeRecall(query, session_key)
+    Core->>Store: 混合检索 L1 / L2 / L3
+    Store-->>Core: relevant memories
+    Core-->>Gateway: RecallResponse
+    Gateway-->>Adapter: context
+    Adapter-->>Host: 注入 <memory-context>
+```
+
+### 捕获
+
+```mermaid
+sequenceDiagram
+    participant Host as Agent 平台
+    participant Adapter as 平台适配层
+    participant Gateway as TDAI Gateway
+    participant Core as TdaiCore
+    participant Pipeline as L0-L3 Pipeline
+
+    Host->>Adapter: 一轮对话结束
+    Adapter->>Gateway: POST /capture { user_content, assistant_content, session_key }
+    Gateway->>Core: handleTurnCommitted(turn)
+    Core->>Pipeline: 写入 L0 并触发 L1/L2/L3 提取
+    Pipeline-->>Core: CaptureResult
+    Core-->>Gateway: l0_recorded / scheduler_notified
+    Gateway-->>Adapter: capture result
+```
+
+## 现有适配方式对比
+
+| 适配方式 | 接入形态 | 核心调用方式 | 适合场景 |
+| :--- | :--- | :--- | :--- |
+| OpenClaw | 插件内进程 | `OpenClawHostAdapter -> TdaiCore` | 宿主允许直接加载 TypeScript 插件，并提供 Agent hook 与 LLM runner |
+| Hermes | Python Provider + Sidecar | `Provider -> HTTP Gateway -> TdaiCore` | 宿主语言不同，或希望把记忆引擎作为独立服务 |
+| Claude Code 示例 | Hook 命令 | `tdai-memory-hook.mjs -> HTTP Gateway -> TdaiCore` | 宿主提供 prompt/stop/session 生命周期事件，但不直接加载本项目代码 |
+| 新平台推荐 | 平台适配层 | `GatewayMemoryClient -> HTTP Gateway -> TdaiCore` | Dify、Codex、其他 Agent 框架 |
+
+## Gateway API 映射
+
+| 平台事件 | 推荐 API | 必填字段 | 作用 |
+| :--- | :--- | :--- | :--- |
+| 用户 prompt 提交前 | `POST /recall` | `query`, `session_key` | 召回长期记忆并注入上下文 |
+| 一轮对话完成后 | `POST /capture` | `user_content`, `assistant_content`, `session_key` | 写入 L0，并触发 L1/L2/L3 提取 |
+| 主动搜索记忆 | `POST /search/memories` | `query` | 查询结构化 L1 记忆 |
+| 主动搜索原始对话 | `POST /search/conversations` | `query` | 查询 L0 对话证据 |
+| 会话结束 | `POST /session/end` | `session_key` | 刷新当前 session 的待处理流水线 |
+
+## 统一 HTTP Client
+
+`GatewayMemoryClient` 封装了 Gateway 的鉴权、超时和错误处理。新平台适配层只需要把宿主事件转成这些方法：
+
+```ts
+import { GatewayMemoryClient } from "./src/adapters/gateway-client.js";
+
+const memory = new GatewayMemoryClient({
+  baseUrl: process.env.TDAI_GATEWAY_URL,
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+const recall = await memory.recall(userPrompt, sessionKey);
+const injected = recall.context;
+
+await memory.capture({
+  user_content: userPrompt,
+  assistant_content: assistantAnswer,
+  session_key: sessionKey,
+});
+```
+
+## Claude Code 示例适配
+
+本仓库提供了一个最小可用的 Claude Code hook 示例：
+
+- [`examples/claude-code/tdai-memory-hook.mjs`](../examples/claude-code/tdai-memory-hook.mjs)
+- [`examples/claude-code/settings.example.json`](../examples/claude-code/settings.example.json)
+
+Hook 事件与 JSON 输出格式参考 Claude Code 官方文档：[Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks)。
+
+接入步骤：
+
+1. 启动 TDAI Gateway。
+
+```bash
+node --import tsx src/gateway/server.ts
+```
+
+2. 在目标 Claude Code 项目中复制 hook。
+
+```bash
+mkdir -p .claude/hooks
+cp /path/to/TencentDB-Agent-Memory/examples/claude-code/tdai-memory-hook.mjs .claude/hooks/
+cp /path/to/TencentDB-Agent-Memory/examples/claude-code/settings.example.json .claude/settings.json
+```
+
+3. 配置环境变量。
+
+```bash
+export TDAI_GATEWAY_URL=http://127.0.0.1:8765
+# 如果 Gateway 配置了 TDAI_GATEWAY_API_KEY，也在 hook 环境中设置同名变量。
+```
+
+Hook 行为：
+
+- `UserPromptSubmit`：保存当前用户 prompt，调用 `/recall`，并把返回的记忆作为 `<memory-context>` 注入。
+- `Stop`：读取上一条用户 prompt 和 assistant 输出，调用 `/capture`。
+- `SessionEnd`：调用 `/session/end`，刷新当前 session 的待处理提取任务。
+
+## 新平台适配检查清单
+
+1. 找到平台的“用户输入前”事件，用它触发 `/recall`。
+2. 找到平台的“一轮回复完成后”事件，用它触发 `/capture`。
+3. 设计稳定的 `session_key`，避免不同项目或用户的记忆混在一起。
+4. 如果平台支持工具或命令，暴露 `/search/memories` 和 `/search/conversations`。
+5. 如果平台有会话结束事件，调用 `/session/end`，不要直接销毁 Gateway。
+6. 适配层失败时应降级为空记忆，避免阻断宿主 Agent 的主流程。

--- a/examples/claude-code/settings.example.json
+++ b/examples/claude-code/settings.example.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/.claude/hooks/tdai-memory-hook.mjs"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/.claude/hooks/tdai-memory-hook.mjs"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/.claude/hooks/tdai-memory-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/claude-code/tdai-memory-hook.mjs
+++ b/examples/claude-code/tdai-memory-hook.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Claude Code hook adapter for TencentDB Agent Memory.
+ *
+ * Hook mapping:
+ * - UserPromptSubmit -> POST /recall, injects recalled context.
+ * - Stop             -> POST /capture, records the last user/assistant turn.
+ * - SessionEnd       -> POST /session/end, flushes pending extraction work.
+ *
+ * This script is intentionally dependency-free so it can be copied into
+ * .claude/hooks/tdai-memory-hook.mjs in any Claude Code project.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const gatewayUrl = (process.env.TDAI_GATEWAY_URL ?? "http://127.0.0.1:8765").replace(/\/+$/, "");
+const apiKey = process.env.TDAI_GATEWAY_API_KEY;
+const timeoutMs = Number(process.env.TDAI_GATEWAY_TIMEOUT_MS ?? "30000");
+const cacheDir = process.env.TDAI_HOOK_CACHE_DIR
+  ?? path.join(os.tmpdir(), "tdai-memory-claude-code");
+
+const input = await readJsonStdin();
+const eventName = input.hook_event_name ?? process.env.TDAI_HOOK_EVENT ?? "";
+const sessionKey = input.session_id ?? input.sessionId ?? stableSessionFromCwd(input.cwd);
+
+try {
+  if (eventName === "UserPromptSubmit") {
+    await handleUserPromptSubmit(input, sessionKey);
+  } else if (eventName === "Stop") {
+    await handleStop(input, sessionKey);
+  } else if (eventName === "SessionEnd") {
+    await handleSessionEnd(sessionKey);
+  }
+} catch (err) {
+  // Hook failures should never break the host Agent. Log to stderr only.
+  console.error(`[tdai-memory-hook] ${err instanceof Error ? err.message : String(err)}`);
+}
+
+async function handleUserPromptSubmit(payload, sessionKey) {
+  const prompt = firstString(payload.prompt, payload.user_prompt, payload.userPrompt);
+  if (!prompt) return;
+
+  await writeCache(sessionKey, {
+    session_key: sessionKey,
+    user_content: prompt,
+    created_at: Date.now(),
+  });
+
+  const recalled = await postJson("/recall", {
+    query: prompt,
+    session_key: sessionKey,
+  });
+
+  const context = typeof recalled.context === "string" ? recalled.context.trim() : "";
+  if (!context) return;
+
+  writeHookOutput({
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: `<memory-context>\n${context}\n</memory-context>`,
+    },
+  });
+}
+
+async function handleStop(payload, sessionKey) {
+  if (payload.stop_hook_active === true) return;
+  if (process.env.TDAI_CAPTURE_ON_STOP === "false") return;
+
+  const cached = await readCache(sessionKey);
+  const userContent = cached?.user_content;
+  const assistantContent = firstString(
+    payload.last_assistant_message,
+    payload.assistant_response,
+    await readLastAssistantMessage(payload.transcript_path),
+  );
+
+  if (!userContent || !assistantContent) return;
+
+  await postJson("/capture", {
+    user_content: userContent,
+    assistant_content: assistantContent,
+    session_key: cached.session_key ?? sessionKey,
+    session_id: sessionKey,
+    messages: [
+      { role: "user", content: userContent },
+      { role: "assistant", content: assistantContent },
+    ],
+  });
+
+  await deleteCache(sessionKey);
+}
+
+async function handleSessionEnd(sessionKey) {
+  if (!sessionKey) return;
+  await postJson("/session/end", { session_key: sessionKey });
+}
+
+async function postJson(route, body) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers = { "Content-Type": "application/json" };
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    const response = await fetch(`${gatewayUrl}${route}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    const parsed = text ? JSON.parse(text) : {};
+    if (!response.ok) {
+      throw new Error(parsed.error ?? `Gateway returned HTTP ${response.status}`);
+    }
+    return parsed;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readJsonStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf-8").trim();
+  return raw ? JSON.parse(raw) : {};
+}
+
+async function writeCache(sessionKey, data) {
+  await fs.mkdir(cacheDir, { recursive: true });
+  await fs.writeFile(cachePath(sessionKey), JSON.stringify(data), "utf-8");
+}
+
+async function readCache(sessionKey) {
+  try {
+    return JSON.parse(await fs.readFile(cachePath(sessionKey), "utf-8"));
+  } catch {
+    return undefined;
+  }
+}
+
+async function deleteCache(sessionKey) {
+  try {
+    await fs.unlink(cachePath(sessionKey));
+  } catch {
+    // no-op
+  }
+}
+
+function cachePath(sessionKey) {
+  return path.join(cacheDir, `${safeFilePart(sessionKey)}.json`);
+}
+
+function safeFilePart(value) {
+  return String(value || "default").replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 160);
+}
+
+function stableSessionFromCwd(cwd) {
+  return cwd ? `claude-code:${cwd}` : "claude-code:default";
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return "";
+}
+
+async function readLastAssistantMessage(transcriptPath) {
+  if (!transcriptPath) return "";
+  try {
+    const content = await fs.readFile(transcriptPath, "utf-8");
+    const lines = content.trim().split(/\r?\n/).reverse();
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      const role = parsed.role ?? parsed.message?.role;
+      if (role !== "assistant") continue;
+      return extractText(parsed.content ?? parsed.message?.content);
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+function extractText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => typeof part === "string" ? part : part?.text)
+    .filter((part) => typeof part === "string" && part.trim())
+    .join("\n");
+}
+
+function writeHookOutput(output) {
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+}

--- a/src/adapters/gateway-client.test.ts
+++ b/src/adapters/gateway-client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { GatewayMemoryClient, GatewayMemoryClientError } from "./gateway-client.js";
+
+describe("GatewayMemoryClient", () => {
+  it("posts recall requests with bearer auth", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new GatewayMemoryClient({
+      baseUrl: "http://127.0.0.1:8765/",
+      apiKey: "secret",
+      fetchFn: async (input, init) => {
+        calls.push({ url: String(input), init });
+        return new Response(JSON.stringify({ context: "memory", strategy: "hybrid", memory_count: 1 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    const result = await client.recall("hello", "session-a", "user-a");
+
+    expect(result.context).toBe("memory");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://127.0.0.1:8765/recall");
+    expect(calls[0].init?.method).toBe("POST");
+    expect((calls[0].init?.headers as Record<string, string>).Authorization).toBe("Bearer secret");
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      query: "hello",
+      session_key: "session-a",
+      user_id: "user-a",
+    });
+  });
+
+  it("surfaces gateway errors with status and parsed body", async () => {
+    const client = new GatewayMemoryClient({
+      fetchFn: async () => new Response(JSON.stringify({ error: "Missing required field: query" }), { status: 400 }),
+    });
+
+    await expect(client.searchMemories({ query: "" })).rejects.toMatchObject({
+      name: "GatewayMemoryClientError",
+      status: 400,
+      message: "Missing required field: query",
+    } satisfies Partial<GatewayMemoryClientError>);
+  });
+});

--- a/src/adapters/gateway-client.ts
+++ b/src/adapters/gateway-client.ts
@@ -1,0 +1,135 @@
+/**
+ * GatewayMemoryClient — small HTTP client for external Agent platform adapters.
+ *
+ * It wraps the TDAI Gateway API exposed by src/gateway/server.ts so adapters
+ * for Claude Code, Dify, Codex, or other hosts can focus on translating host
+ * lifecycle events into recall/capture calls.
+ */
+
+import type {
+  CaptureRequest,
+  CaptureResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../gateway/types.js";
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface GatewayMemoryClientOptions {
+  /** TDAI Gateway base URL, for example "http://127.0.0.1:8765". */
+  baseUrl?: string;
+  /** Optional shared secret configured via TDAI_GATEWAY_API_KEY. */
+  apiKey?: string;
+  /** Request timeout in milliseconds. Defaults to 30 seconds. */
+  timeoutMs?: number;
+  /** Test hook or custom fetch implementation. Defaults to global fetch. */
+  fetchFn?: FetchLike;
+}
+
+export class GatewayMemoryClientError extends Error {
+  readonly status: number;
+  readonly responseBody: unknown;
+
+  constructor(status: number, message: string, responseBody: unknown) {
+    super(message);
+    this.name = "GatewayMemoryClientError";
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
+export class GatewayMemoryClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchFn: FetchLike;
+
+  constructor(opts: GatewayMemoryClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? "http://127.0.0.1:8765").replace(/\/+$/, "");
+    this.apiKey = opts.apiKey;
+    this.timeoutMs = opts.timeoutMs ?? 30_000;
+    this.fetchFn = opts.fetchFn ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  async recall(query: string, sessionKey: string, userId?: string): Promise<RecallResponse> {
+    return this.request<RecallResponse>("POST", "/recall", {
+      query,
+      session_key: sessionKey,
+      ...(userId ? { user_id: userId } : {}),
+    } satisfies RecallRequest);
+  }
+
+  async capture(params: CaptureRequest): Promise<CaptureResponse> {
+    return this.request<CaptureResponse>("POST", "/capture", params);
+  }
+
+  async searchMemories(params: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.request<MemorySearchResponse>("POST", "/search/memories", params);
+  }
+
+  async searchConversations(params: ConversationSearchRequest): Promise<ConversationSearchResponse> {
+    return this.request<ConversationSearchResponse>("POST", "/search/conversations", params);
+  }
+
+  async endSession(sessionKey: string, userId?: string): Promise<SessionEndResponse> {
+    return this.request<SessionEndResponse>("POST", "/session/end", {
+      session_key: sessionKey,
+      ...(userId ? { user_id: userId } : {}),
+    } satisfies SessionEndRequest);
+  }
+
+  private async request<T>(method: "GET" | "POST", path: string, body?: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    const headers: Record<string, string> = {};
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    try {
+      const response = await this.fetchFn(new URL(path, `${this.baseUrl}/`), {
+        method,
+        headers,
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        signal: controller.signal,
+      });
+
+      const raw = await response.text();
+      const parsed = raw ? parseJson(raw) : undefined;
+
+      if (!response.ok) {
+        const message = extractErrorMessage(parsed) ?? `Gateway request failed: ${response.status}`;
+        throw new GatewayMemoryClientError(response.status, message, parsed);
+      }
+
+      return parsed as T;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function extractErrorMessage(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const error = (value as { error?: unknown }).error;
+  return typeof error === "string" ? error : undefined;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -7,7 +7,8 @@
  * Directory structure:
  *   adapters/
  *   ├── openclaw/      — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
- *   └── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   ├── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   └── gateway-client — HTTP client for external platform adapters
  */
 
 // OpenClaw adapter
@@ -17,3 +18,7 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Gateway HTTP client for out-of-process platform adapters
+export { GatewayMemoryClient, GatewayMemoryClientError } from "./gateway-client.js";
+export type { GatewayMemoryClientOptions } from "./gateway-client.js";


### PR DESCRIPTION
## Summary

Refs #235

This PR adds a first cross-platform adapter implementation path for TencentDB Agent Memory:

- Add a cross-platform adapter guide with architecture and recall/capture data-flow diagrams.
- Add a reusable `GatewayMemoryClient` for out-of-process platform adapters.
- Add a Claude Code hook-based adapter example:
  - `UserPromptSubmit -> /recall`
  - `Stop -> /capture`
  - `SessionEnd -> /session/end`
- Link the new adapter guide from README and README_CN.

## Verification

- `npm test`
- `npm run build:plugin`
- `node --check examples/claude-code/tdai-memory-hook.mjs`
- Mocked Gateway recall simulation passed.
