### PR TITLE
fix(issue-383): Resolve OpenClaw compaction delegate from runtime paths

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -67,6 +67,7 @@ import { SessionRegistry } from "./session-registry.js";
 import { reclaimOffloadData } from "./reclaimer.js";
 import { buildL3TriggerReport, reportL3Trigger } from "./state-reporter.js";
 import { resolveUserId, getUserIdSource } from "./user-id.js";
+import { resolveOpenClawDelegateCompactionToRuntime } from "./openclaw-runtime-delegate.js";
 
 // ─── Module-level state ──────────────────────────────────────────────────────
 // OpenClaw calls registerOffload() multiple times during lifecycle.
@@ -2164,37 +2165,39 @@ class OffloadContextEngine {
     }
     try {
       // Try delegating to runtime's built-in compaction first
-      let delegateFn: any;
-      try {
-        const { createRequire } = await import("node:module");
-        const globalRequire = createRequire("/usr/local/lib/node_modules/openclaw/");
-        const sdk = globalRequire("openclaw/plugin-sdk");
-        delegateFn = sdk.delegateCompactionToRuntime;
-        logger.debug?.(`[context-offload] compact: resolved via createRequire (global path)`);
-      } catch (e1) {
-        logger.debug?.(`[context-offload] compact: createRequire failed: ${e1}`);
+      let delegateFn: any = await resolveOpenClawDelegateCompactionToRuntime(logger);
+      if (!delegateFn) {
         try {
-          const paths = [
-            "/usr/local/lib/node_modules/openclaw/dist/plugin-sdk/index.js",
-            "/usr/lib/node_modules/openclaw/dist/plugin-sdk/index.js",
-          ];
-          for (const p of paths) {
-            try {
-              const sdk = await import(p);
-              delegateFn = sdk.delegateCompactionToRuntime;
-              logger.debug?.(`[context-offload] compact: resolved via absolute path: ${p}`);
-              break;
-            } catch (ep) {
-              logger.debug?.(`[context-offload] compact: absolute path failed: ${p} → ${ep}`);
-            }
-          }
-        } catch { /* ignore */ }
-        if (!delegateFn) {
+          const { createRequire } = await import("node:module");
+          const globalRequire = createRequire("/usr/local/lib/node_modules/openclaw/");
+          const sdk = globalRequire("openclaw/plugin-sdk");
+          delegateFn = sdk.delegateCompactionToRuntime;
+          logger.debug?.(`[context-offload] compact: resolved via createRequire (global path)`);
+        } catch (e1) {
+          logger.debug?.(`[context-offload] compact: createRequire failed: ${e1}`);
           try {
-            const sdk = await import("openclaw/plugin-sdk" as any);
-            delegateFn = sdk.delegateCompactionToRuntime;
-            logger.debug?.(`[context-offload] compact: resolved via direct import`);
+            const paths = [
+              "/usr/local/lib/node_modules/openclaw/dist/plugin-sdk/index.js",
+              "/usr/lib/node_modules/openclaw/dist/plugin-sdk/index.js",
+            ];
+            for (const p of paths) {
+              try {
+                const sdk = await import(p);
+                delegateFn = sdk.delegateCompactionToRuntime;
+                logger.debug?.(`[context-offload] compact: resolved via absolute path: ${p}`);
+                break;
+              } catch (ep) {
+                logger.debug?.(`[context-offload] compact: absolute path failed: ${p} → ${ep}`);
+              }
+            }
           } catch { /* ignore */ }
+          if (!delegateFn) {
+            try {
+              const sdk = await import("openclaw/plugin-sdk" as any);
+              delegateFn = sdk.delegateCompactionToRuntime;
+              logger.debug?.(`[context-offload] compact: resolved via direct import`);
+            } catch { /* ignore */ }
+          }
         }
       }
 

--- a/src/offload/openclaw-runtime-delegate.test.ts
+++ b/src/offload/openclaw-runtime-delegate.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearOpenClawDelegateCacheForTests,
+  resolveOpenClawDelegateCompactionToRuntime,
+} from "./openclaw-runtime-delegate.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  clearOpenClawDelegateCacheForTests();
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveOpenClawDelegateCompactionToRuntime", () => {
+  it("resolves openclaw/plugin-sdk from the plugin require base", async () => {
+    const root = await writeFakeOpenClawSdk();
+
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      baseUrls: [join(root, "plugin-entry.cjs")],
+      includeDefaultRoots: false,
+    });
+
+    await expect(delegate?.({})).resolves.toEqual({ ok: true, compacted: true });
+  });
+
+  it("resolves openclaw/plugin-sdk from an explicit module root", async () => {
+    const root = await writeFakeOpenClawSdk();
+
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      baseUrls: [],
+      moduleRoots: [join(root, "node_modules")],
+      includeDefaultRoots: false,
+    });
+
+    await expect(delegate?.({})).resolves.toEqual({ ok: true, compacted: true });
+  });
+
+  it("returns null when the SDK cannot be found", async () => {
+    const root = await mkdtemp(join(tmpdir(), "tdai-openclaw-sdk-missing-"));
+    tmpDirs.push(root);
+
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      baseUrls: [join(root, "plugin-entry.cjs")],
+      moduleRoots: [],
+      includeDefaultRoots: false,
+    });
+
+    expect(delegate).toBeNull();
+  });
+});
+
+async function writeFakeOpenClawSdk(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "tdai-openclaw-sdk-"));
+  tmpDirs.push(root);
+
+  const packageDir = join(root, "node_modules", "openclaw");
+  const sdkDir = join(packageDir, "dist", "plugin-sdk");
+  await mkdir(sdkDir, { recursive: true });
+  await writeFile(join(root, "plugin-entry.cjs"), "", "utf-8");
+  await writeFakeOpenClawSdkFiles(packageDir, sdkDir);
+
+  return root;
+}
+
+async function writeFakeOpenClawSdkFiles(packageDir: string, sdkDir: string): Promise<void> {
+  await writeFile(
+    join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "openclaw",
+      version: "0.0.0-test",
+      exports: {
+        "./plugin-sdk": "./dist/plugin-sdk/index.cjs",
+      },
+    }),
+    "utf-8",
+  );
+  await writeFile(
+    join(sdkDir, "index.cjs"),
+    "exports.delegateCompactionToRuntime = async () => ({ ok: true, compacted: true });\n",
+    "utf-8",
+  );
+}

--- a/src/offload/openclaw-runtime-delegate.ts
+++ b/src/offload/openclaw-runtime-delegate.ts
@@ -1,0 +1,110 @@
+import { createRequire } from "node:module";
+import { delimiter, dirname, join, resolve } from "node:path";
+
+import type { PluginLogger } from "./types.js";
+
+export type DelegateCompactionToRuntime = (params: any) => Promise<any>;
+
+interface ResolveDelegateOptions {
+  baseUrls?: Array<string | URL>;
+  moduleRoots?: string[];
+  includeDefaultRoots?: boolean;
+}
+
+const SDK_SPECIFIER = "openclaw/plugin-sdk";
+
+let cachedDelegate: DelegateCompactionToRuntime | null | undefined;
+
+/**
+ * Resolve OpenClaw's native compaction bridge from the host installation.
+ *
+ * Plugins can be installed outside the OpenClaw package, and users commonly run
+ * OpenClaw through nvm rather than /usr/local. Probe from the plugin bundle
+ * first, then fall back to the active node prefix and standard global roots.
+ */
+export async function resolveOpenClawDelegateCompactionToRuntime(
+  logger?: PluginLogger,
+  options: ResolveDelegateOptions = {},
+): Promise<DelegateCompactionToRuntime | null> {
+  const useCache = !options.baseUrls && !options.moduleRoots;
+  if (useCache && cachedDelegate !== undefined) return cachedDelegate;
+
+  for (const baseUrl of buildRequireBaseUrls(options)) {
+    try {
+      const sdk = createRequire(baseUrl)(SDK_SPECIFIER);
+      const delegate = sdk?.delegateCompactionToRuntime;
+      if (typeof delegate === "function") {
+        logger?.debug?.(`[context-offload] compact: resolved ${SDK_SPECIFIER} via ${String(baseUrl)}`);
+        if (useCache) cachedDelegate = delegate;
+        return delegate;
+      }
+    } catch (err) {
+      logger?.debug?.(
+        `[context-offload] compact: ${SDK_SPECIFIER} resolve failed from ${String(baseUrl)}: ${formatResolveError(err)}`,
+      );
+    }
+  }
+
+  if (useCache) cachedDelegate = null;
+  return null;
+}
+
+export function clearOpenClawDelegateCacheForTests(): void {
+  cachedDelegate = undefined;
+}
+
+function buildRequireBaseUrls(options: ResolveDelegateOptions): Array<string | URL> {
+  const bases: Array<string | URL> = [];
+  const seen = new Set<string>();
+
+  const addBase = (value: string | URL | null | undefined): void => {
+    if (!value) return;
+    const key = String(value);
+    if (seen.has(key)) return;
+    seen.add(key);
+    bases.push(value);
+  };
+
+  for (const baseUrl of options.baseUrls ?? []) addBase(baseUrl);
+
+  addBase(import.meta.url);
+  addBase(join(process.cwd(), "openclaw-sdk-resolver.cjs"));
+
+  const moduleRoots = [
+    ...(options.includeDefaultRoots === false ? [] : defaultGlobalModuleRoots()),
+    ...(options.moduleRoots ?? []),
+  ];
+  for (const root of moduleRoots) {
+    addBase(join(root, "openclaw", "package.json"));
+    addBase(join(root, "openclaw"));
+    addBase(join(root, "openclaw-sdk-resolver.cjs"));
+  }
+
+  return bases;
+}
+
+function defaultGlobalModuleRoots(): string[] {
+  const roots: string[] = [];
+
+  if (process.env.NODE_PATH) {
+    for (const item of process.env.NODE_PATH.split(delimiter)) {
+      if (item.trim()) roots.push(item.trim());
+    }
+  }
+
+  if (process.execPath) {
+    roots.push(join(resolve(dirname(process.execPath), ".."), "lib", "node_modules"));
+  }
+
+  roots.push("/usr/local/lib/node_modules");
+  roots.push("/usr/lib/node_modules");
+  return roots;
+}
+
+function formatResolveError(err: unknown): string {
+  if (err instanceof Error) {
+    const code = typeof (err as any).code === "string" ? `${(err as any).code}: ` : "";
+    return `${code}${err.message}`;
+  }
+  return String(err);
+}


### PR DESCRIPTION
# PR 标题

Resolve OpenClaw compaction delegate from runtime paths

## 关联 issue

Closes #383

## 背景

当 `memory-tencentdb` 作为 OpenClaw `contextEngine` 使用时，tdai 的 `compact()` 会优先尝试调用 OpenClaw plugin SDK 暴露的 `delegateCompactionToRuntime(params)`，把 transcript compaction 委派回 OpenClaw 原生 runtime。

这条路径对 OpenClaw 集成很重要：OpenClaw runtime 原生知道如何基于 `sessionFile`、`sessionId`、`runtimeContext` 等信息执行 compaction，并返回 OpenClaw 可以采纳的新 session/transcript 元信息。

当前实现主要从固定系统全局路径解析 OpenClaw SDK，例如：

```text
/usr/local/lib/node_modules/openclaw
/usr/local/lib/node_modules/openclaw/dist/plugin-sdk/index.js
/usr/lib/node_modules/openclaw/dist/plugin-sdk/index.js
```

在 nvm 管理 Node.js 的环境中，OpenClaw 可能实际安装在类似路径：

```text
~/.nvm/versions/node/<version>/lib/node_modules/openclaw
```

此时 tdai 无法解析 `openclaw/plugin-sdk`，会落入 self-emergency fallback：

```text
[context-offload] compact: delegateCompactionToRuntime unavailable, self-executing emergency compression
```

## 修改内容

本 PR 新增一个专用 resolver：

```text
src/offload/openclaw-runtime-delegate.ts
```

它会从以下位置尝试解析 `openclaw/plugin-sdk`：

- 插件 bundle 自身的 `import.meta.url`
- 当前工作目录
- `NODE_PATH`
- 当前 Node executable 推导出的 global npm root，例如 nvm prefix 下的 `lib/node_modules`
- 常见系统 global npm root：`/usr/local/lib/node_modules`、`/usr/lib/node_modules`

同时在 `OffloadContextEngine.compact()` 中把该 resolver 放到原有固定路径解析逻辑之前：

```ts
let delegateFn = await resolveOpenClawDelegateCompactionToRuntime(logger);
if (!delegateFn) {
  // Existing /usr/local, /usr/lib and direct import probing remains unchanged.
}
```

当 resolver 成功找到 `delegateCompactionToRuntime` 时，tdai 直接委派给 OpenClaw native compaction。resolver 返回 `null` 时，继续执行原有的 `/usr/local`、`/usr/lib`、direct import 探测逻辑；这些旧逻辑也都失败时，现有 self-emergency fallback 行为保持不变。

## 非本 PR 范围

本 PR 只解决 OpenClaw native compaction delegate 的解析问题。

以下问题刻意不放入本 PR：

- `params.messages` 缺失时 fallback compaction 如何从 `sessionFile` / `sessionManager` 恢复 messages。
- fallback self-emergency / aggressive compression 的压缩结果是否一定低于 OpenClaw token budget。
- OpenClaw native compaction 后仍可能因为 recent-turn 保留策略或 mid-turn precheck 预算不足而继续超限。

这些问题应该作为后续 issue / PR 单独处理，避免把 delegate 解析修复和 fallback 压缩策略调整耦合在一起。

## 测试

### 单元测试与构建

在独立 PR worktree 中安装依赖并验证：

```text
npm install --ignore-scripts --no-package-lock
```

没有生成新的 lockfile。

单元测试：

```text
npm test
```

结果：

```text
Test Files  5 passed (5)
Tests       70 passed (70)
```

构建验证：

```text
npm run build
```

结果：通过。

新增 resolver 的单元测试覆盖了三类路径：

- 能从插件自身的 require base 解析 `openclaw/plugin-sdk`。
- 能从显式 module root 解析 `openclaw/plugin-sdk`，覆盖 nvm/global npm root 这类安装形态。
- 找不到 SDK 时返回 `null`，继续保留现有 fallback 行为。

### OpenClaw 集成验证

为了确认该修复不只是在单元测试中可用，也真实接入了 OpenClaw compaction runtime，本地在 WSL + OpenClaw 中运行了 40k Mid-Turn Precheck 复现实验。

环境：

```text
OS: Windows 11 + WSL2 Ubuntu 22.04
Node.js: v24.17.0 via nvm
OpenClaw: 2026.6.8
OpenClaw install path:
  /home/veteran/.nvm/versions/node/v24.17.0/lib/node_modules/openclaw
contextEngine:
  memory-tencentdb
model:
  bailian/deepseek-v4-flash
```

关键配置：

```text
contextTokens = 40000
reserveTokens = 16384
promptBudgetBeforeReserve = 23616
midTurnPrecheck = true
contextEngine = memory-tencentdb
```

关键计数：

```text
context-overflow-midturn-precheck = 4
auto-compaction succeeded = 3
auto-compaction failed = 0
delegateCompactionToRuntime unavailable = 0
self_emergency = 0
no_messages = 0
Compaction safeguard = 3
tool-result-truncation = 4
post-compaction guard = 3
Already compacted = 0
exhausted provider overflow recovery = 0
```

关键日志片段：

```text
[context-overflow-midturn-precheck] ... route=compact_then_truncate estimatedPromptTokens=25161 promptBudgetBeforeReserve=23616 overflowTokens=1545 ...
context overflow detected (attempt 1/3); attempting auto-compaction for bailian/deepseek-v4-flash
(node:25546) [OPENCLAW_PLUGIN_SDK_COMPAT_DEPRECATED] Warning: openclaw/plugin-sdk/compat is deprecated for new plugins.
[compaction-safeguard] Compaction safeguard: using session branch messages after compaction preparation omitted real conversation content.
[tool-result-truncation] Truncated 3 tool result(s) in session (contextWindow=40000 maxChars=16000 aggregateBudgetChars=16000 oversized=0 aggregate=3) ...
auto-compaction succeeded for bailian/deepseek-v4-flash; retrying prompt
[agents/post-compaction-guard] post-compaction guard armed for 3 attempts
```

后续还出现了多次 OpenClaw native compaction / safeguard 路径：

```text
[context-overflow-midturn-precheck] ... route=compact_then_truncate estimatedPromptTokens=29164 promptBudgetBeforeReserve=23616 overflowTokens=5548 ...
[compaction-safeguard] Compaction safeguard: using session branch messages after compaction preparation omitted real conversation content.
[tool-result-truncation] Truncated 4 tool result(s) in session ...
auto-compaction succeeded for bailian/deepseek-v4-flash; retrying prompt
[agents/post-compaction-guard] post-compaction guard armed for 3 attempts

[context-overflow-midturn-precheck] ... route=compact_then_truncate estimatedPromptTokens=26549 promptBudgetBeforeReserve=23616 overflowTokens=2933 ...
[compaction-safeguard] Compaction safeguard: using session branch messages after compaction preparation omitted real conversation content.
[tool-result-truncation] Truncated 2 tool result(s) in session ...
auto-compaction succeeded for bailian/deepseek-v4-flash; retrying prompt
[agents/post-compaction-guard] post-compaction guard armed for 3 attempts
```

这个结果说明 patched tdai 已经成功接入 OpenClaw native compaction path：

- 没有再出现 `delegateCompactionToRuntime unavailable`。
- 没有落入 tdai `self_emergency` fallback。
- 没有触发 `no_messages`。
- OpenClaw 原生 `compaction-safeguard`、`tool-result-truncation`、`post-compaction-guard` 均被触发。
- OpenClaw 报告 `auto-compaction succeeded` 3 次。

该 run 最终仍以非 0 退出，但原因是模型侧网络超时：

```text
ConnectTimeoutError = 2
LLM request timed out = 4
```

因此该 run 不能证明 SWE-bench 任务完成，但可以证明本 PR 修复的 delegate resolver 已在真实 OpenClaw 集成路径中生效，并且不再触发原先的 `delegateCompactionToRuntime unavailable` / `self_emergency` / `no_messages` 链路。
