### PR TITLE
feat: 新增统一适配 SDK 与 MCP/Dify 平台适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,11 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/adapters/ARCHITECTURE.md`](./docs/adapters/ARCHITECTURE.md) | Core engine + platform adapters, with data-flow diagrams |
+| [`docs/adapters/COMPARISON.md`](./docs/adapters/COMPARISON.md) | OpenClaw vs. Hermes vs. MCP vs. Dify — trade-offs & decision guide |
+| [`docs/adapters/ADDING-A-PLATFORM.md`](./docs/adapters/ADDING-A-PLATFORM.md) | Add a new platform in ~30 lines with the unified adapter SDK |
+| [`src/adapters/mcp/README.md`](./src/adapters/mcp/README.md) | MCP server — Claude Code / Codex / Cursor / Cline setup |
+| [`src/adapters/dify/README.md`](./src/adapters/dify/README.md) | Dify custom-tool (OpenAPI) integration |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -507,6 +507,11 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/adapters/ARCHITECTURE.md`](./docs/adapters/ARCHITECTURE.md) | 核心引擎与各平台适配层架构，含数据流图 |
+| [`docs/adapters/COMPARISON.md`](./docs/adapters/COMPARISON.md) | OpenClaw / Hermes / MCP / Dify 适配方式对比与选型指南 |
+| [`docs/adapters/ADDING-A-PLATFORM.md`](./docs/adapters/ADDING-A-PLATFORM.md) | 用统一适配 SDK 约 30 行接入一个新平台 |
+| [`src/adapters/mcp/README.md`](./src/adapters/mcp/README.md) | MCP 服务器 — Claude Code / Codex / Cursor / Cline 配置 |
+| [`src/adapters/dify/README.md`](./src/adapters/dify/README.md) | Dify 自定义工具（OpenAPI）接入 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/bin/tdai-mcp.mjs
+++ b/bin/tdai-mcp.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+// Thin launcher for the TDAI Memory MCP server.
+//
+// It registers the `tsx` ESM loader in-process, then imports and runs the
+// TypeScript entry point directly. Running in-process (rather than spawning a
+// child) is deliberate: the MCP stdio transport requires an unbroken pipe
+// between the host and THIS process's stdin/stdout.
+//
+// Usage (installed package):   tdai-memory-mcp
+// Usage (repo checkout):       node ./bin/tdai-mcp.mjs
+// Requires: a reachable TDAI Gateway (see src/adapters/mcp/README.md).
+
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const serverEntry = path.resolve(here, "../src/adapters/mcp/server.ts");
+
+async function tryRegisterTsx() {
+  try {
+    const tsx = await import("tsx/esm/api");
+    tsx.register();
+    return true;
+  } catch (err) {
+    process.stderr.write(
+      "[tdai-mcp] could not load the tsx loader — is the package installed?\n" +
+      `[tdai-mcp] ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return false;
+  }
+}
+
+if (!(await tryRegisterTsx())) {
+  process.exit(1);
+}
+
+const mod = await import(pathToFileURL(serverEntry).href);
+await mod.runMain();

--- a/docs/adapters/ADDING-A-PLATFORM.md
+++ b/docs/adapters/ADDING-A-PLATFORM.md
@@ -1,0 +1,133 @@
+# Adding a New Platform in ~30 Lines
+
+> Deliverable for [issue #235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235)
+> (challenge tier: "a unified adapter SDK so a new platform only implements one
+> interface"). This is the recipe the [`src/sdk`](../../src/sdk/README.md) SDK
+> exists to make trivial.
+
+## Mental model: two axes, one interface each
+
+- **Consuming memory on a new platform** → consume a **`MemoryAdapter`** (you
+  usually don't even implement it — a ready `GatewayMemoryAdapter` is provided).
+  You just map `buildMemoryTools(adapter)` onto your host's tool type.
+- **Reaching memory over a new backend/transport** → implement the
+  **`MemoryAdapter`** interface once (e.g. an in-process `TdaiCore`), and every
+  existing platform adapter keeps working unchanged.
+
+Both are single, small interfaces — that is the whole point.
+
+```
+buildMemoryTools(adapter) ──► MemoryTool[] ──► (map to host tool type) ──► your platform
+        ▲
+   MemoryAdapter  ◄── GatewayMemoryAdapter (HTTP)  |  EmbeddedMemoryAdapter (in-process, DIY)
+```
+
+## The recipe (consume memory on a new platform)
+
+### 1. Get an adapter
+
+```ts
+import { GatewayMemoryAdapter } from "../../sdk/index.js";
+
+// Reads TDAI_GATEWAY_URL / TDAI_GATEWAY_API_KEY from the environment.
+const adapter = GatewayMemoryAdapter.fromEnv();
+```
+
+### 2. Build the neutral tools
+
+```ts
+import { buildMemoryTools } from "../../sdk/index.js";
+
+const tools = buildMemoryTools(adapter, { sessionKey: "my-platform-default" });
+// → [{ name, title, description, inputSchema (JSON Schema), invoke(args) }, ...]
+// invoke() never throws: failures come back as { isError: true, text }.
+```
+
+### 3. Map each tool onto your host
+
+That mapping is the *entire* platform-specific surface. Two real examples:
+
+#### Example A — Vercel AI SDK (`ai`, already a repo dependency)
+
+```ts
+import { tool, jsonSchema } from "ai";
+import { GatewayMemoryAdapter, buildMemoryTools } from "../../sdk/index.js";
+
+const adapter = GatewayMemoryAdapter.fromEnv();
+
+export const memoryTools = Object.fromEntries(
+  buildMemoryTools(adapter).map((t) => [
+    t.name,
+    tool({
+      description: t.description,
+      inputSchema: jsonSchema(t.inputSchema),
+      execute: async (args) => (await t.invoke(args as Record<string, unknown>)).text,
+    }),
+  ]),
+);
+// Pass `memoryTools` straight to generateText({ tools: memoryTools, ... }).
+```
+
+#### Example B — any OpenAI-compatible function-calling loop
+
+```ts
+const tools = buildMemoryTools(GatewayMemoryAdapter.fromEnv());
+
+// 1. Advertise them:
+const functions = tools.map((t) => ({
+  type: "function",
+  function: { name: t.name, description: t.description, parameters: t.inputSchema },
+}));
+
+// 2. Dispatch a tool call the model emits:
+async function runToolCall(name: string, argsJson: string): Promise<string> {
+  const t = tools.find((x) => x.name === name);
+  if (!t) return `Unknown tool: ${name}`;
+  const { text } = await t.invoke(JSON.parse(argsJson));
+  return text; // feed back as the tool/function result message
+}
+```
+
+That is the whole integration — the SDK already handled the HTTP contract,
+retries, auth, timeouts, argument coercion, and error shaping.
+
+## The other axis (bring your own transport)
+
+Need memory to come from somewhere other than the Gateway — say the in-process
+`TdaiCore`, or a mock in tests? Implement the one interface and reuse every
+platform adapter as-is:
+
+```ts
+import type { MemoryAdapter } from "../../sdk/index.js";
+
+export class EmbeddedMemoryAdapter implements MemoryAdapter {
+  readonly platform = "embedded";
+  constructor(private core: /* TdaiCore */ any) {}
+
+  async health()   { return { ok: true, status: "ok", degraded: false }; }
+  async recall(i)  { const r = await this.core.handleBeforeRecall(i.query, i.sessionKey);
+                     return { context: r.appendSystemContext ?? "", memoryCount: r.recalledL1Memories?.length ?? 0 }; }
+  async searchMemories(i)       { return this.core.searchMemories(i); }
+  async searchConversations(i)  { return this.core.searchConversations(i); }
+  async capture(i) { const r = await this.core.handleTurnCommitted({ userText: i.userContent, assistantText: i.assistantContent, messages: i.messages ?? [], sessionKey: i.sessionKey });
+                     return { l0Recorded: r.l0RecordedCount, schedulerNotified: r.schedulerNotified }; }
+  async endSession(k) { await this.core.handleSessionEnd(k); }
+}
+```
+
+`buildMemoryTools(new EmbeddedMemoryAdapter(core))` now yields the same tools the
+MCP and Dify adapters use — with no HTTP hop.
+
+## Checklist for a new platform PR
+
+- [ ] Create `src/adapters/<platform>/` (code) or a schema (declarative).
+- [ ] Reuse `GatewayMemoryAdapter` + `buildMemoryTools` — don't hand-roll HTTP.
+- [ ] Map `MemoryTool` → the host's tool type (see examples above).
+- [ ] Add a `README.md` with host config and a running-Gateway note.
+- [ ] Add a test that drives your mapping against a fake adapter (see
+      `src/adapters/mcp/protocol.test.ts` for the pattern).
+- [ ] Link it from [`COMPARISON.md`](./COMPARISON.md) and the root README.
+
+See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for how the pieces fit, and the
+[`MCP`](../../src/adapters/mcp/README.md) / [`Dify`](../../src/adapters/dify/README.md)
+adapters as end-to-end references.

--- a/docs/adapters/ARCHITECTURE.md
+++ b/docs/adapters/ARCHITECTURE.md
@@ -1,0 +1,200 @@
+# TDAI Memory — Core Engine & Adapter Architecture
+
+> Deliverable for [issue #235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235).
+> This document maps the host-neutral memory core and every platform adapter,
+> and annotates the read (recall) and write (capture) data flows.
+
+## 1. The big picture
+
+TDAI separates **memory algorithms** from **the host that consumes them**. One
+engine (`TdaiCore`) is reached two ways: **in-process** (OpenClaw) or across an
+**HTTP boundary** (the Gateway, used by Hermes and — new in this work — the MCP
+and Dify adapters).
+
+```mermaid
+flowchart TB
+    subgraph hosts["Agent platforms"]
+        OC["OpenClaw<br/>(index.ts plugin)"]
+        HM["Hermes<br/>(Python MemoryProvider)"]
+        MCP["Claude Code / Codex / Cursor<br/>(MCP server) — NEW"]
+        DIFY["Dify<br/>(OpenAPI custom tool) — NEW"]
+    end
+
+    subgraph sdk["Unified Adapter SDK (src/sdk) — NEW"]
+        GC["TdaiGatewayClient"]
+        MA["MemoryAdapter + GatewayMemoryAdapter"]
+        BT["buildMemoryTools()"]
+    end
+
+    subgraph gw["TDAI Gateway (src/gateway) — HTTP boundary"]
+        GWS["TdaiGateway HTTP server<br/>/recall /capture /search/* /session/end"]
+    end
+
+    subgraph core["TDAI Core (host-neutral)"]
+        TC["TdaiCore<br/>recall · capture · search · flush"]
+        HA["HostAdapter interface"]
+        subgraph stores["Storage & pipeline"]
+            ST["IMemoryStore<br/>(SQLite-vec / TCVDB)"]
+            EM["EmbeddingService"]
+            PM["MemoryPipelineManager<br/>L0→L1→L2→L3"]
+        end
+    end
+
+    OC -->|"OpenClawHostAdapter (in-process)"| TC
+    HM --> GWS
+    MCP --> MA
+    DIFY -->|"direct HTTP"| GWS
+    MA --> GC --> GWS
+    BT -.builds tools for.-> MCP
+    GWS -->|"StandaloneHostAdapter"| TC
+    TC --> HA
+    TC --> ST & EM & PM
+
+    style sdk fill:#e6f3ff,stroke:#0366d6
+    style MCP fill:#e6ffe6,stroke:#28a745
+    style DIFY fill:#e6ffe6,stroke:#28a745
+```
+
+Everything above the Gateway is a **thin translator**; everything from the
+Gateway down is the shared engine.
+
+## 2. Core engine capabilities (`TdaiCore`)
+
+`src/core/tdai-core.ts` is the single facade both integration styles call. It
+depends only on abstract interfaces (`HostAdapter`, `LLMRunner`), never on a
+concrete host.
+
+| Method | Kind | Purpose | OpenClaw event | Hermes / Gateway |
+| :----- | :--- | :------ | :------------- | :--------------- |
+| `handleBeforeRecall(text, sessionKey)` | read | Retrieve memory context for a turn | `before_prompt_build` hook | `prefetch()` → `POST /recall` |
+| `handleTurnCommitted(turn)` | write | Persist a turn, trigger the pipeline | `agent_end` hook | `sync_turn()` → `POST /capture` |
+| `searchMemories(params)` | read | Search L1 structured memories | `tdai_memory_search` tool | `POST /search/memories` |
+| `searchConversations(params)` | read | Search L0 raw dialogue | `tdai_conversation_search` tool | `POST /search/conversations` |
+| `handleSessionEnd(sessionKey)` | write | Flush one session's buffered work | (process exit → `destroy`) | `on_session_end` → `POST /session/end` |
+| `initialize()` / `destroy()` | lifecycle | Bring up / tear down stores & scheduler | plugin load / `gateway_stop` | Gateway start / stop |
+
+### The host-neutral seam: `HostAdapter`
+
+`TdaiCore` asks the host only three questions (`src/core/types.ts`):
+
+- **Who is the user/session?** → `getRuntimeContext(): RuntimeContext`
+- **How do I call an LLM?** → `getLLMRunnerFactory(): LLMRunnerFactory`
+- **Where do I log?** → `getLogger(): Logger`
+
+Two implementations exist today: `OpenClawHostAdapter` (wraps the OpenClaw
+plugin API, runs the LLM in-process) and `StandaloneHostAdapter` (Gateway;
+OpenAI-compatible HTTP LLM calls). **The new adapters do not add a third** —
+they sit above the Gateway, which already uses `StandaloneHostAdapter`.
+
+### The four memory layers
+
+`handleTurnCommitted` feeds a background pipeline (`MemoryPipelineManager`):
+
+```mermaid
+flowchart LR
+    L0["L0<br/>raw conversation<br/>(l0-recorder)"] -->|extract + dedup| L1["L1<br/>structured memories<br/>(l1-extractor)"]
+    L1 -->|scene clustering| L2["L2<br/>scene blocks<br/>(scene-extractor)"]
+    L2 -->|synthesis| L3["L3<br/>persona<br/>(persona-generator)"]
+    L0 -. vector index .-> ST[("Vector store<br/>+ embeddings")]
+    L1 -. vector index .-> ST
+```
+
+Reads hit L0/L1 (search) and L1+L3 (recall); writes land in L0 and cascade
+upward asynchronously.
+
+## 3. Existing adapter #1 — OpenClaw (in-process)
+
+`index.ts` is the OpenClaw Plugin SDK entry. It constructs an
+`OpenClawHostAdapter` + `TdaiCore` **in the same process** and bridges OpenClaw
+events to core methods.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant OCP as OpenClaw plugin (index.ts)
+    participant Core as TdaiCore (in-process)
+    participant Store as Vector store / pipeline
+
+    Note over OCP: register tools + hooks on load
+    U->>OCP: prompt
+    OCP->>Core: before_prompt_build → handleBeforeRecall()
+    Core->>Store: vector + BM25 search (L1), read L3 persona
+    Store-->>Core: memories + persona
+    Core-->>OCP: RecallResult (prepend / appendSystemContext)
+    OCP-->>U: LLM answer (memory-primed)
+    U->>OCP: (turn ends)
+    OCP->>Core: agent_end → handleTurnCommitted()
+    Core->>Store: record L0, notify scheduler (async L1→L2→L3)
+    Note over OCP,Core: gateway_stop → core.destroy()
+```
+
+- **Coupling:** deep — hooks into `before_prompt_build` / `agent_end`, registers
+  `tdai_memory_search` + `tdai_conversation_search` tools, shares the LLM runner.
+- **Transport:** none (direct method calls).
+- **Language:** TypeScript.
+
+## 4. Existing adapter #2 — Hermes (HTTP provider)
+
+The Gateway (`src/gateway/server.ts`) re-exposes `TdaiCore` over HTTP. Hermes
+runs a **Python** `MemoryProvider` that speaks to it via a small HTTP client.
+
+```mermaid
+sequenceDiagram
+    participant HA as Hermes Agent
+    participant P as MemoryTencentdbProvider (Python)
+    participant C as SdkClient (urllib)
+    participant GW as TdaiGateway (HTTP)
+    participant Core as TdaiCore
+
+    HA->>P: prefetch(query)
+    P->>C: recall()
+    C->>GW: POST /recall
+    GW->>Core: handleBeforeRecall()
+    Core-->>GW: RecallResult
+    GW-->>C: {context, strategy, memory_count}
+    C-->>P: dict
+    P-->>HA: "## Memory\n<context>"
+    HA->>P: sync_turn(user, assistant)  %% background thread
+    P->>C: capture() → POST /capture → handleTurnCommitted()
+```
+
+- **Coupling:** medium — implements Hermes's `MemoryProvider` (prefetch,
+  sync_turn, handle_tool_call, tool schemas, session end).
+- **Transport:** HTTP to a **managed Gateway sidecar** the provider can spawn,
+  health-check, and auto-resurrect (circuit breaker + watchdog).
+- **Language:** Python (client) + TypeScript (Gateway).
+
+## 5. New adapters (this work) — MCP & Dify via the unified SDK
+
+The Gateway boundary is the natural extension point for any non-OpenClaw host.
+This work distills that boundary into a reusable **SDK** (`src/sdk/`) and builds
+two adapters on top:
+
+```mermaid
+flowchart LR
+    subgraph new["src/sdk — one interface to implement / consume"]
+        direction TB
+        MA["MemoryAdapter<br/>(recall · search · capture · flush)"]
+        GMA["GatewayMemoryAdapter (HTTP)"]
+        GC["TdaiGatewayClient<br/>(timeouts · retries · auth · typed errors)"]
+        BT["buildMemoryTools()<br/>neutral tool descriptors"]
+        GMA -->|implements| MA
+        GMA --> GC
+        BT -->|consumes| MA
+    end
+
+    MCP["MCP server<br/>(src/adapters/mcp)"] -->|maps tools→JSON-RPC| BT
+    DIFY["Dify OpenAPI<br/>(src/adapters/dify)"] -.->|calls Gateway directly| GC
+    GC --> GW[("TDAI Gateway")]
+```
+
+- **MCP adapter** (`src/adapters/mcp/`): a pure JSON-RPC 2.0 stdio server that
+  turns `buildMemoryTools()` output into MCP tools. One server → Claude Code,
+  Codex, Cursor, Cline, Windsurf.
+- **Dify adapter** (`src/adapters/dify/`): a declarative OpenAPI schema Dify
+  imports; Dify calls the Gateway directly (the SDK client documents the exact
+  contract).
+
+Both reuse the same Gateway and store as OpenClaw and Hermes — one memory,
+many platforms. See [`COMPARISON.md`](./COMPARISON.md) for the trade-offs and
+[`ADDING-A-PLATFORM.md`](./ADDING-A-PLATFORM.md) for the recipe.

--- a/docs/adapters/COMPARISON.md
+++ b/docs/adapters/COMPARISON.md
@@ -1,0 +1,100 @@
+# Adapter Comparison — Four Ways to Give a Platform TDAI Memory
+
+> Deliverable for [issue #235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235).
+> Compares the two pre-existing adapters (OpenClaw, Hermes) with the two added
+> in this work (MCP, Dify), and gives a decision guide for the next platform.
+
+## At a glance
+
+| Dimension | **OpenClaw** | **Hermes** | **MCP** (new) | **Dify** (new) |
+| :-------- | :----------- | :--------- | :------------ | :------------- |
+| Integration style | In-process plugin | HTTP provider | HTTP via stdio bridge | Declarative HTTP |
+| Reaches core via | `TdaiCore` directly | Gateway | Gateway (SDK) | Gateway (direct) |
+| Transport | none (calls) | HTTP + urllib | JSON-RPC 2.0 / stdio | HTTP (OpenAPI) |
+| Language | TypeScript | Python | TypeScript | YAML (no code) |
+| Process model | shared with host | managed sidecar | child of host | remote call |
+| Coupling to host | **deep** (hooks) | medium (provider) | **shallow** (tools) | **shallow** (tools) |
+| Auto memory capture | ✅ `agent_end` hook | ✅ `sync_turn` | ⚠️ tool-call `tdai_capture` | ⚠️ workflow node |
+| Auto recall injection | ✅ `before_prompt_build` | ✅ `prefetch` | ⚠️ `tdai_recall` tool | ⚠️ workflow node |
+| Hosts unlocked per adapter | 1 | 1 | **many** (any MCP host) | 1 (Dify) |
+| New code to maintain | whole plugin | whole provider | ~1 server on the SDK | **none** (schema) |
+| Lives in | `index.ts` | `hermes-plugin/` | `src/adapters/mcp/` | `src/adapters/dify/` |
+
+Legend: ✅ automatic/implicit · ⚠️ available but model/workflow-driven.
+
+## The two axes
+
+Every integration is a point on two independent axes:
+
+1. **Transport** — how bytes reach the engine: *in-process* (OpenClaw) vs.
+   *HTTP* (everyone else, through the Gateway).
+2. **Coupling** — how tightly the adapter hooks into the host's turn lifecycle:
+   *deep* (lifecycle hooks that auto-recall/auto-capture) vs. *shallow* (the
+   memory surface is just tools the model or a workflow invokes).
+
+```mermaid
+quadrantChart
+    title Transport vs. Coupling
+    x-axis "In-process" --> "HTTP boundary"
+    y-axis "Shallow (tools)" --> "Deep (lifecycle hooks)"
+    quadrant-1 "Remote, auto"
+    quadrant-2 "Embedded, auto"
+    quadrant-3 "Embedded, manual"
+    quadrant-4 "Remote, tool-driven"
+    "OpenClaw": [0.15, 0.9]
+    "Hermes": [0.7, 0.8]
+    "MCP": [0.72, 0.3]
+    "Dify": [0.85, 0.25]
+```
+
+**Why this matters:** deep coupling buys *implicit* memory (every turn is
+recalled and captured with no model effort) at the cost of host-specific hook
+code. Shallow coupling (MCP/Dify) is trivial to add and portable, but recall and
+capture happen only when the agent *decides* to call the tool — or when a
+workflow wires them in explicitly.
+
+## Trade-offs in prose
+
+### OpenClaw — deepest, richest, least portable
+Runs inside the host, so it can hook `before_prompt_build`/`agent_end` and make
+memory invisible and automatic, sharing the host's own LLM. That power is also
+its cost: it is bound to OpenClaw's plugin API and reusable nowhere else.
+
+### Hermes — the template for going remote
+First proof that the Gateway boundary works: a Python provider translating
+Hermes lifecycle calls into HTTP. It still auto-recalls/auto-captures (via
+`prefetch`/`sync_turn`), and it invests heavily in **operational resilience** —
+spawning, health-checking, and resurrecting the Gateway sidecar (circuit
+breaker + watchdog). Great for one platform; that machinery is re-implemented
+per platform.
+
+### MCP — one adapter, many hosts
+The highest-leverage addition. MCP is a shared standard, so a single stdio
+server exposes TDAI to Claude Code, Codex, Cursor, Cline, and Windsurf at once.
+Coupling is shallow (memory shows up as four tools), which keeps the adapter
+tiny — it is ~2 files of protocol glue over the SDK, with **zero** bespoke
+transport code. Trade-off: no lifecycle hooks, so recall/capture are tools the
+model chooses to call rather than automatic steps.
+
+### Dify — zero-code, declarative
+The lightest of all: an OpenAPI schema Dify imports. No process to run, no code
+to maintain — Dify calls the Gateway directly. Ideal for teams already building
+on Dify. Trade-off: bound to Dify, and (like MCP) tool/workflow-driven rather
+than hook-driven.
+
+## Which should the next platform use?
+
+```mermaid
+flowchart TD
+    Q1{Does the platform<br/>speak MCP?} -->|yes| MCP["Use the MCP server<br/>(already done — just add config)"]
+    Q1 -->|no| Q2{Custom tools via<br/>OpenAPI / HTTP?}
+    Q2 -->|yes| DIFY["Point it at the Gateway<br/>(reuse the Dify OpenAPI schema)"]
+    Q2 -->|no| Q3{Runs in Node,<br/>in the host process?}
+    Q3 -->|yes| EMB["Write an in-process adapter<br/>(follow OpenClaw; optionally an<br/>EmbeddedMemoryAdapter over TdaiCore)"]
+    Q3 -->|no| SDK["Build a thin provider on the SDK:<br/>GatewayMemoryAdapter + buildMemoryTools<br/>(follow Hermes / see ADDING-A-PLATFORM.md)"]
+```
+
+**Rule of thumb:** prefer the Gateway boundary and the unified SDK unless you
+specifically need implicit, hook-driven memory — in which case pay for deep
+coupling like OpenClaw. Most modern agent platforms already speak MCP, so for
+them "adding TDAI memory" is now **configuration, not code**.

--- a/docs/adapters/README.md
+++ b/docs/adapters/README.md
@@ -1,0 +1,31 @@
+# Cross-Platform Adapters
+
+How the host-neutral TDAI memory engine reaches each agent platform, and how to
+add the next one. Built for [issue #235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235).
+
+| Doc | Tier | What's inside |
+| :-- | :--- | :------------ |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | 基础 | Core engine (`TdaiCore`) + every adapter, with recall/capture data-flow diagrams |
+| [COMPARISON.md](./COMPARISON.md) | 深入 | OpenClaw vs. Hermes vs. MCP vs. Dify — trade-offs, quadrant, decision tree |
+| [ADDING-A-PLATFORM.md](./ADDING-A-PLATFORM.md) | 拓展 | The ~30-line recipe on the unified adapter SDK |
+
+## What shipped
+
+- **Unified adapter SDK** — [`src/sdk`](../../src/sdk/README.md): `TdaiGatewayClient`
+  (transport), `MemoryAdapter` / `GatewayMemoryAdapter` (the one interface),
+  `buildMemoryTools()` (neutral tool descriptors).
+- **MCP server adapter** — [`src/adapters/mcp`](../../src/adapters/mcp/README.md):
+  one stdio server → Claude Code, Codex, Cursor, Cline, Windsurf.
+- **Dify adapter** — [`src/adapters/dify`](../../src/adapters/dify/README.md):
+  a declarative OpenAPI schema, zero glue code.
+
+## Adapter map
+
+| Platform | Style | Location | Language |
+| :------- | :---- | :------- | :------- |
+| OpenClaw | In-process plugin | `index.ts` | TypeScript |
+| Hermes | HTTP provider | `hermes-plugin/` | Python |
+| Claude Code / Codex / Cursor / Cline | MCP stdio (new) | `src/adapters/mcp/` | TypeScript |
+| Dify | OpenAPI custom tool (new) | `src/adapters/dify/` | YAML |
+
+All four share one Gateway and one memory store — see ARCHITECTURE.md.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "tdai-memory-mcp": "./bin/tdai-mcp.mjs"
   },
   "exports": {
     ".": {

--- a/src/adapters/dify/README.md
+++ b/src/adapters/dify/README.md
@@ -1,0 +1,83 @@
+# TDAI Memory — Dify Adapter
+
+Gives [Dify](https://dify.ai) agents and workflows long-term memory via the
+TDAI four-layer engine. Unlike the MCP adapter, this integration is
+**declarative**: Dify calls the TDAI Gateway's HTTP API directly, so the
+"adapter" is just an OpenAPI schema plus this guide — no glue process to run.
+
+```
+┌─────────────┐   HTTP (OpenAPI custom tool)   ┌───────────┐
+│  Dify app   │ ─────────────────────────────► │  TDAI     │
+│ (agent /    │ ◄───────────────────────────── │  Gateway  │
+│  workflow)  │   tdai_memory_search, …         │  + Core   │
+└─────────────┘                                 └───────────┘
+```
+
+## Tools (from [`openapi.yaml`](./openapi.yaml))
+
+| Operation (tool) | Method / path | Best used as |
+| :--------------- | :------------ | :----------- |
+| `tdai_memory_search`       | `POST /search/memories`      | Agent tool (LLM-called) |
+| `tdai_conversation_search` | `POST /search/conversations` | Agent tool (LLM-called) |
+| `tdai_recall`              | `POST /recall`               | Workflow node (prime the prompt) |
+| `tdai_capture`             | `POST /capture`              | Workflow node (persist the turn) |
+| `tdai_health`              | `GET /health`                | Diagnostics |
+
+## Prerequisites
+
+1. A running TDAI Gateway (see [`../mcp/README.md`](../mcp/README.md#prerequisites-a-running-gateway)).
+2. **The Gateway must be reachable from your Dify instance:**
+   - **Dify self-hosted** on the same host/LAN → use the Gateway's LAN address.
+   - **Dify Cloud** → expose the Gateway over public HTTPS (reverse proxy or a
+     tunnel like `cloudflared`/`ngrok`). Dify Cloud cannot reach `127.0.0.1`.
+   - If you enable a public endpoint, set `TDAI_GATEWAY_API_KEY` on the Gateway
+     and use Bearer auth in Dify (below) — do not expose an open Gateway.
+
+## Import into Dify
+
+1. In Dify, go to **Tools → Custom → Create Custom Tool**.
+2. Set **Schema** by pasting the contents of [`openapi.yaml`](./openapi.yaml)
+   (or a URL to it).
+3. Edit the `servers[0].url` to the address your Dify instance can reach
+   (e.g. `https://memory.example.com` or `http://192.168.1.20:8420`).
+4. **Authorization:**
+   - Open Gateway (default) → **None**.
+   - Auth-enabled Gateway → **API Key**, auth type **Bearer**, header
+     `Authorization`, value = your `TDAI_GATEWAY_API_KEY`.
+5. Save. The five tools now appear under your custom tool.
+
+## Wiring it up
+
+### Agent app (LLM decides when to search)
+
+Add **`tdai_memory_search`** and **`tdai_conversation_search`** to an Agent
+app's tools. The model calls them on its own when it needs to recall something
+about the user — both only require a `query`.
+
+### Workflow (deterministic recall + capture)
+
+`tdai_recall` and `tdai_capture` need a stable `session_key` so memory is scoped
+per conversation. Dify exposes exactly that as `sys.conversation_id`:
+
+```
+[Start] → [Tool: tdai_recall]                     # session_key = {{#sys.conversation_id#}}
+        → [LLM]  (inject recall "context" into the prompt)
+        → [Tool: tdai_capture]                     # session_key = {{#sys.conversation_id#}}
+        → [Answer]
+```
+
+- In the `tdai_recall` node, map `query` = the user input and
+  `session_key` = `{{#sys.conversation_id#}}`. Feed its `context` output into
+  the LLM node's prompt.
+- In the `tdai_capture` node, map `user_content`, `assistant_content`, and the
+  same `session_key`.
+
+## Notes
+
+- The Gateway returns pre-formatted text in `results` / `context`, so no
+  response post-processing is needed — feed it straight to the model.
+- This is the same Gateway the MCP and Hermes adapters use. One Gateway can
+  back Dify, Claude Code, and Hermes at once, sharing a single memory store.
+
+See [`docs/adapters/COMPARISON.md`](../../../docs/adapters/COMPARISON.md) for how
+the declarative Dify approach compares to the code-based adapters.

--- a/src/adapters/dify/openapi.yaml
+++ b/src/adapters/dify/openapi.yaml
@@ -1,0 +1,228 @@
+openapi: 3.0.3
+info:
+  title: TDAI Memory Tools
+  description: >-
+    Long-term memory for Dify agents, backed by the TencentDB-Agent-Memory
+    four-layer engine (L0 conversation → L1 memory → L2 scene → L3 persona).
+    Import this schema as a Dify "Custom Tool"; each operation below becomes a
+    tool your agent (or workflow) can call. It targets the TDAI Gateway HTTP API
+    — the same sidecar the OpenClaw and Hermes integrations use.
+  version: "0.1.0"
+
+servers:
+  # Replace with a URL your Dify instance can actually reach.
+  #   • Dify self-hosted on the same host/network → the Gateway's LAN address.
+  #   • Dify Cloud → a public HTTPS endpoint (reverse proxy / tunnel), since it
+  #     cannot reach 127.0.0.1.
+  - url: http://127.0.0.1:8420
+    description: Local TDAI Gateway
+
+# The Gateway accepts an optional Bearer token (TDAI_GATEWAY_API_KEY). If your
+# Gateway enforces it, choose "API Key / Bearer" auth in Dify and paste the key;
+# if the Gateway is open (default), select "None". The security schemes and
+# response schemas live in the single `components` block at the end of the file.
+security:
+  - bearerAuth: []
+  - {} # allow "no auth" for an open Gateway
+
+paths:
+  /search/memories:
+    post:
+      operationId: tdai_memory_search
+      summary: Search long-term memories
+      description: >-
+        Search the user's structured long-term memories (L1). Use this to recall
+        the user's preferences, past events, instructions, or context from earlier
+        conversations. Returns records ranked by relevance.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [query]
+              properties:
+                query:
+                  type: string
+                  description: What you want to recall about the user.
+                limit:
+                  type: integer
+                  description: Max results (default 5, max 20).
+                  default: 5
+                type:
+                  type: string
+                  description: Optional filter by memory type.
+                  enum: [persona, episodic, instruction]
+      responses:
+        "200":
+          description: Formatted search results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResult"
+
+  /search/conversations:
+    post:
+      operationId: tdai_conversation_search
+      summary: Search conversation history
+      description: >-
+        Search past raw conversation history (L0). Use this when memory search
+        does not have what you need, or when you want the exact words the user
+        said before.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [query]
+              properties:
+                query:
+                  type: string
+                  description: What conversation content to find.
+                limit:
+                  type: integer
+                  description: Max messages (default 5, max 20).
+                  default: 5
+                session_key:
+                  type: string
+                  description: >-
+                    Optional: restrict the search to one session. In a Dify
+                    workflow, wire this to the conversation id.
+      responses:
+        "200":
+          description: Formatted conversation matches.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConversationSearchResult"
+
+  /recall:
+    post:
+      operationId: tdai_recall
+      summary: Recall memory context for a query
+      description: >-
+        Fetch the recall context block (relevant memories + persona) for a query,
+        as the memory engine would inject it before an LLM turn. Best used as a
+        workflow node that primes the model with what is known about the user.
+        Map `session_key` to the Dify conversation id for per-conversation memory.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [query, session_key]
+              properties:
+                query:
+                  type: string
+                  description: The user's current query or intent.
+                session_key:
+                  type: string
+                  description: Stable conversation id (e.g. Dify's sys.conversation_id).
+      responses:
+        "200":
+          description: Recall context.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecallResult"
+
+  /capture:
+    post:
+      operationId: tdai_capture
+      summary: Capture a conversation turn
+      description: >-
+        Persist a completed user/assistant turn into memory (L0 → pipeline). Use
+        as a workflow node after the model replies so the exchange can be
+        structured and recalled in later conversations. Map `session_key` to the
+        Dify conversation id.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_content, assistant_content, session_key]
+              properties:
+                user_content:
+                  type: string
+                  description: The user's message.
+                assistant_content:
+                  type: string
+                  description: The assistant's reply.
+                session_key:
+                  type: string
+                  description: Stable conversation id (e.g. Dify's sys.conversation_id).
+      responses:
+        "200":
+          description: Capture summary.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CaptureResult"
+
+  /health:
+    get:
+      operationId: tdai_health
+      summary: Gateway health check
+      description: Liveness/readiness probe for the TDAI Gateway. No auth required.
+      security: []
+      responses:
+        "200":
+          description: Health status.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResult"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    SearchResult:
+      type: object
+      properties:
+        results:
+          type: string
+          description: Pre-formatted, LLM-readable result text.
+        total:
+          type: integer
+        strategy:
+          type: string
+    ConversationSearchResult:
+      type: object
+      properties:
+        results:
+          type: string
+        total:
+          type: integer
+    RecallResult:
+      type: object
+      properties:
+        context:
+          type: string
+          description: Recall context to inject into the prompt (may be empty).
+        strategy:
+          type: string
+        memory_count:
+          type: integer
+    CaptureResult:
+      type: object
+      properties:
+        l0_recorded:
+          type: integer
+        scheduler_notified:
+          type: boolean
+    HealthResult:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded]
+        version:
+          type: string
+        uptime:
+          type: integer

--- a/src/adapters/mcp/README.md
+++ b/src/adapters/mcp/README.md
@@ -1,0 +1,149 @@
+# TDAI Memory — MCP Server Adapter
+
+Exposes the TDAI four-layer memory engine (L0 → L1 → L2 → L3) to any
+**MCP host** — Claude Code, Codex CLI, Cursor, Cline, Windsurf — over the
+Model Context Protocol's stdio transport.
+
+One small server, many platforms: MCP is the shared integration surface, so a
+single adapter unlocks every MCP-capable agent instead of writing one plugin
+per host.
+
+```
+┌──────────────┐   MCP (JSON-RPC 2.0 / stdio)   ┌───────────────┐   HTTP    ┌───────────┐
+│  MCP host    │ ─────────────────────────────► │ TDAI MCP      │ ────────► │  TDAI     │
+│ (Claude Code,│ ◄───────────────────────────── │ server        │ ◄──────── │  Gateway  │
+│  Codex, …)   │       tools/list, tools/call    │ (this adapter)│           │  + Core   │
+└──────────────┘                                 └───────────────┘           └───────────┘
+```
+
+The adapter is a **thin client**: all memory logic lives in the Gateway/Core.
+It is built entirely on the [unified adapter SDK](../../sdk/README.md)
+(`GatewayMemoryAdapter` + `buildMemoryTools`), so it contains no bespoke
+transport or retry code of its own.
+
+## Tools
+
+| Tool | Layer | Read/Write | Purpose |
+| :--- | :---- | :--------- | :------ |
+| `tdai_memory_search`        | L1 | read  | Search structured long-term memories |
+| `tdai_conversation_search`  | L0 | read  | Search raw past dialogue |
+| `tdai_recall`               | L1+L3 | read | Fetch the recall context block for a query |
+| `tdai_capture`              | L0 | write | Persist a completed user/assistant turn |
+
+## Prerequisites: a running Gateway
+
+The MCP server talks to a TDAI Gateway over HTTP. Start one first (it owns the
+on-disk memory store and the LLM pipeline):
+
+```bash
+# from the repo root — the Gateway listens on 127.0.0.1:8420 by default
+MEMORY_TENCENTDB_LLM_API_KEY=sk-... npx tsx src/gateway/server.ts
+```
+
+Verify it is up:
+
+```bash
+curl -s http://127.0.0.1:8420/health
+# {"status":"ok",...}
+```
+
+> The Gateway is the same sidecar the Hermes provider uses. If you already run
+> it for Hermes, the MCP server can share it — one memory store, many platforms.
+
+## Configuration
+
+The server reads these environment variables:
+
+| Env var | Default | Meaning |
+| :------ | :------ | :------ |
+| `TDAI_GATEWAY_URL`     | `http://127.0.0.1:8420` | Gateway base URL |
+| `TDAI_GATEWAY_API_KEY` | *(unset)* | Bearer token, if the Gateway enforces auth |
+| `TDAI_MCP_SESSION_KEY` | `mcp-default` | Session id used for `recall`/`capture` grouping |
+
+Replace `/ABS/PATH` below with the absolute path to this repo checkout.
+
+### Claude Code
+
+```bash
+claude mcp add tdai-memory \
+  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 \
+  -- npx -y tsx /ABS/PATH/src/adapters/mcp/server.ts
+```
+
+Or add it to `.mcp.json` at your project root:
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "npx",
+      "args": ["-y", "tsx", "/ABS/PATH/src/adapters/mcp/server.ts"],
+      "env": { "TDAI_GATEWAY_URL": "http://127.0.0.1:8420" }
+    }
+  }
+}
+```
+
+If the package is installed (`npm i -g @tencentdb-agent-memory/memory-tencentdb`),
+use the bin instead: `"command": "tdai-memory-mcp"`, `"args": []`.
+
+### Codex CLI
+
+`~/.codex/config.toml`:
+
+```toml
+[mcp_servers.tdai_memory]
+command = "npx"
+args = ["-y", "tsx", "/ABS/PATH/src/adapters/mcp/server.ts"]
+env = { TDAI_GATEWAY_URL = "http://127.0.0.1:8420" }
+```
+
+### Cursor
+
+`.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "npx",
+      "args": ["-y", "tsx", "/ABS/PATH/src/adapters/mcp/server.ts"],
+      "env": { "TDAI_GATEWAY_URL": "http://127.0.0.1:8420" }
+    }
+  }
+}
+```
+
+### Cline / any generic MCP host
+
+Cline and most other hosts accept the same `mcpServers` object as Cursor —
+copy the block above into the host's MCP settings.
+
+## Verifying without a host
+
+Drive the protocol by hand — pipe JSON-RPC lines into the server:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | npx tsx src/adapters/mcp/server.ts
+```
+
+You should see an `initialize` result followed by a `tools/list` result
+carrying the four tools.
+
+## Design notes
+
+- **Pure JSON-RPC 2.0 over stdio** — no MCP framework dependency, matching the
+  Gateway's "native primitives only" approach (`node:http`, no Express).
+- **stdout is sacred** — it is the protocol channel; every diagnostic line goes
+  to stderr. A stray `console.log` would corrupt the stream.
+- **Graceful degradation** — if the Gateway is down, tool calls return an MCP
+  `isError` result with a readable message instead of crashing the host's tool
+  loop (the same contract the Hermes provider follows).
+- **Clean shutdown** — in-flight tool calls are drained before exit, so a
+  response is never truncated when the host closes stdin.
+
+See [`docs/adapters/COMPARISON.md`](../../../docs/adapters/COMPARISON.md) for how
+this adapter compares to the OpenClaw, Hermes, and Dify integrations.

--- a/src/adapters/mcp/protocol.test.ts
+++ b/src/adapters/mcp/protocol.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the MCP JSON-RPC dispatcher — protocol conformance for
+ * initialize / tools/list / tools/call / notifications / error paths.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { McpDispatcher, RpcErr, SUPPORTED_PROTOCOL_VERSIONS } from "./protocol.js";
+import { buildMemoryTools } from "../../sdk/tools.js";
+import type { MemoryAdapter } from "../../sdk/memory-adapter.js";
+
+function fakeAdapter(overrides: Partial<MemoryAdapter> = {}): MemoryAdapter {
+  return {
+    platform: "fake",
+    health: vi.fn(async () => ({ ok: true, status: "ok", degraded: false })),
+    recall: vi.fn(async () => ({ context: "ctx", memoryCount: 1 })),
+    searchMemories: vi.fn(async () => ({ text: "mem-results", total: 2, strategy: "vector" })),
+    searchConversations: vi.fn(async () => ({ text: "conv-results", total: 1 })),
+    capture: vi.fn(async () => ({ l0Recorded: 2, schedulerNotified: true })),
+    endSession: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function makeDispatcher(adapter = fakeAdapter()) {
+  return new McpDispatcher({
+    tools: buildMemoryTools(adapter),
+    serverInfo: { name: "tdai-memory", version: "0.1.0" },
+    instructions: "test instructions",
+  });
+}
+
+describe("McpDispatcher", () => {
+  it("negotiates the requested protocol version on initialize", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26" } });
+    expect(res).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "tdai-memory", version: "0.1.0" },
+        instructions: "test instructions",
+      },
+    });
+  });
+
+  it("falls back to the latest version when the requested one is unknown", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "1999-01-01" } });
+    expect((res!.result as { protocolVersion: string }).protocolVersion).toBe(SUPPORTED_PROTOCOL_VERSIONS[0]);
+  });
+
+  it("lists the memory tools with JSON Schema", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    const tools = (res!.result as { tools: Array<{ name: string; inputSchema: unknown }> }).tools;
+    expect(tools.map((t) => t.name)).toContain("tdai_memory_search");
+    expect(tools.every((t) => typeof t.inputSchema === "object")).toBe(true);
+  });
+
+  it("answers ping with an empty object", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", id: 9, method: "ping" });
+    expect(res).toEqual({ jsonrpc: "2.0", id: 9, result: {} });
+  });
+
+  it("invokes a tool and returns MCP content", async () => {
+    const adapter = fakeAdapter();
+    const d = makeDispatcher(adapter);
+    const res = await d.handle({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "tdai_memory_search", arguments: { query: "cats", limit: 3 } },
+    });
+    expect(res!.result).toEqual({
+      content: [{ type: "text", text: "mem-results" }],
+      isError: false,
+    });
+    expect(adapter.searchMemories).toHaveBeenCalledWith(expect.objectContaining({ query: "cats", limit: 3 }));
+  });
+
+  it("surfaces tool execution failures as isError result (not JSON-RPC error)", async () => {
+    const adapter = fakeAdapter({
+      searchMemories: vi.fn(async () => {
+        throw new Error("gateway unreachable");
+      }),
+    });
+    const d = makeDispatcher(adapter);
+    const res = await d.handle({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "tdai_memory_search", arguments: { query: "x" } },
+    });
+    expect(res!.error).toBeUndefined();
+    expect(res!.result).toMatchObject({ isError: true });
+    expect((res!.result as { content: Array<{ text: string }> }).content[0].text).toContain("gateway unreachable");
+  });
+
+  it("returns InvalidParams for an unknown tool name", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "does_not_exist", arguments: {} },
+    });
+    expect(res!.error).toMatchObject({ code: RpcErr.InvalidParams });
+    expect(res!.error!.message).toContain("Unknown tool");
+  });
+
+  it("returns InvalidParams when tools/call omits a name", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", id: 6, method: "tools/call", params: {} });
+    expect(res!.error).toMatchObject({ code: RpcErr.InvalidParams });
+  });
+
+  it("returns MethodNotFound for unknown methods", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", id: 7, method: "resources/list" });
+    expect(res!.error).toMatchObject({ code: RpcErr.MethodNotFound });
+  });
+
+  it("does not answer notifications (no id)", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "2.0", method: "notifications/initialized" });
+    expect(res).toBeNull();
+  });
+
+  it("rejects a malformed envelope with InvalidRequest", async () => {
+    const d = makeDispatcher();
+    const res = await d.handle({ jsonrpc: "1.0", id: 8, method: "initialize" } as never);
+    expect(res!.error).toMatchObject({ code: RpcErr.InvalidRequest });
+  });
+});

--- a/src/adapters/mcp/protocol.ts
+++ b/src/adapters/mcp/protocol.ts
@@ -1,0 +1,215 @@
+/**
+ * MCP protocol core — a dependency-free JSON-RPC 2.0 dispatcher that maps
+ * Model Context Protocol requests onto the SDK's neutral memory tools.
+ *
+ * This file contains NO I/O: it takes a decoded JSON-RPC request and returns
+ * a JSON-RPC response object (or `null` for notifications). `server.ts` owns
+ * the stdio transport. Keeping the two apart makes the whole protocol layer
+ * unit-testable without spawning a process.
+ *
+ * Implemented MCP methods:
+ *   - `initialize`                 → capabilities + serverInfo (version negotiated)
+ *   - `notifications/initialized`  → no response (notification)
+ *   - `ping`                       → {}
+ *   - `tools/list`                 → the memory tools
+ *   - `tools/call`                 → invoke a tool, return `content` + `isError`
+ *
+ * We deliberately implement only the tools capability — that is all the memory
+ * adapter needs, and it is what Claude Code, Codex, Cursor, and Cline consume.
+ */
+
+import type { MemoryTool } from "../../sdk/tools.js";
+
+// ============================
+// JSON-RPC 2.0 types
+// ============================
+
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+/** Standard JSON-RPC + MCP error codes. */
+export const RpcErr = {
+  ParseError: -32700,
+  InvalidRequest: -32600,
+  MethodNotFound: -32601,
+  InvalidParams: -32602,
+  InternalError: -32603,
+} as const;
+
+// ============================
+// MCP version negotiation
+// ============================
+
+/** Protocol revisions this server understands, newest first. */
+export const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", "2024-11-05"];
+const LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+function negotiateVersion(requested: unknown): string {
+  if (typeof requested === "string" && SUPPORTED_PROTOCOL_VERSIONS.includes(requested)) {
+    return requested;
+  }
+  return LATEST_PROTOCOL_VERSION;
+}
+
+// ============================
+// Dispatcher
+// ============================
+
+export interface McpServerInfo {
+  name: string;
+  version: string;
+}
+
+export interface McpDispatcherOptions {
+  tools: MemoryTool[];
+  serverInfo: McpServerInfo;
+  /** Optional instructions surfaced to the host during `initialize`. */
+  instructions?: string;
+  logger?: (message: string) => void;
+}
+
+export class McpDispatcher {
+  private readonly toolsByName: Map<string, MemoryTool>;
+  private readonly tools: MemoryTool[];
+  private readonly serverInfo: McpServerInfo;
+  private readonly instructions?: string;
+  private readonly log: (message: string) => void;
+
+  constructor(opts: McpDispatcherOptions) {
+    this.tools = opts.tools;
+    this.toolsByName = new Map(opts.tools.map((t) => [t.name, t]));
+    this.serverInfo = opts.serverInfo;
+    this.instructions = opts.instructions;
+    this.log = opts.logger ?? (() => {});
+  }
+
+  /**
+   * Handle one decoded JSON-RPC request.
+   *
+   * Returns a response object, or `null` when the message is a notification
+   * (no `id`) and therefore must not be answered.
+   */
+  async handle(req: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+    const isNotification = req.id === undefined;
+
+    // Validate envelope. Notifications get no error reply per JSON-RPC.
+    if (req.jsonrpc !== "2.0" || typeof req.method !== "string") {
+      if (isNotification) return null;
+      return this.error(req.id ?? null, RpcErr.InvalidRequest, "Invalid JSON-RPC request");
+    }
+
+    // Notifications: process side effects (none needed today) and stay silent.
+    if (isNotification) {
+      this.log(`notification: ${req.method}`);
+      return null;
+    }
+
+    const id = req.id ?? null;
+    try {
+      switch (req.method) {
+        case "initialize":
+          return this.ok(id, this.handleInitialize(req.params));
+        case "ping":
+          return this.ok(id, {});
+        case "tools/list":
+          return this.ok(id, { tools: this.listTools() });
+        case "tools/call":
+          return this.ok(id, await this.callTool(req.params));
+        default:
+          return this.error(id, RpcErr.MethodNotFound, `Method not found: ${req.method}`);
+      }
+    } catch (err) {
+      if (err instanceof RpcInvalidParams) {
+        return this.error(id, RpcErr.InvalidParams, err.message);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      this.log(`internal error handling ${req.method}: ${message}`);
+      return this.error(id, RpcErr.InternalError, message);
+    }
+  }
+
+  // -- Method implementations ----------------------------------------------
+
+  private handleInitialize(params: unknown): unknown {
+    const p = (params ?? {}) as { protocolVersion?: unknown };
+    return {
+      protocolVersion: negotiateVersion(p.protocolVersion),
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: this.serverInfo,
+      ...(this.instructions ? { instructions: this.instructions } : {}),
+    };
+  }
+
+  private listTools(): unknown[] {
+    return this.tools.map((t) => ({
+      name: t.name,
+      title: t.title,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }));
+  }
+
+  private async callTool(params: unknown): Promise<unknown> {
+    const p = (params ?? {}) as { name?: unknown; arguments?: unknown };
+    if (typeof p.name !== "string" || !p.name) {
+      throw new RpcInvalidParams("tools/call requires a string 'name'");
+    }
+    const tool = this.toolsByName.get(p.name);
+    if (!tool) {
+      throw new RpcInvalidParams(`Unknown tool: ${p.name}`);
+    }
+    const args =
+      p.arguments && typeof p.arguments === "object" && !Array.isArray(p.arguments)
+        ? (p.arguments as Record<string, unknown>)
+        : {};
+
+    this.log(`tools/call ${p.name}`);
+    // `invoke` is contractually non-throwing, but guard anyway so a bug in a
+    // tool surfaces as an MCP tool error (visible to the model) rather than a
+    // transport-level JSON-RPC error.
+    let result;
+    try {
+      result = await tool.invoke(args);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      result = { text: message, isError: true as const };
+    }
+
+    return {
+      content: [{ type: "text", text: result.text }],
+      isError: result.isError ?? false,
+    };
+  }
+
+  // -- Response builders ---------------------------------------------------
+
+  private ok(id: JsonRpcId, result: unknown): JsonRpcResponse {
+    return { jsonrpc: "2.0", id, result };
+  }
+
+  private error(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
+    return { jsonrpc: "2.0", id, error: { code, message } };
+  }
+}
+
+/** Thrown by method handlers to produce a JSON-RPC -32602 (Invalid params). */
+class RpcInvalidParams extends Error {}

--- a/src/adapters/mcp/server.test.ts
+++ b/src/adapters/mcp/server.test.ts
@@ -1,0 +1,133 @@
+/**
+ * End-to-end test for the stdio MCP transport: real newline-delimited JSON-RPC
+ * flows through fake streams into a Gateway-backed dispatcher (with a fake
+ * fetch), exercising framing, ordering, and parse-error handling.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PassThrough, Writable } from "node:stream";
+import { createMemoryMcpServer } from "./server.js";
+import { GatewayMemoryAdapter } from "../../sdk/memory-adapter.js";
+
+/** Collect everything written to output and expose parsed JSON-RPC lines. */
+function collector() {
+  const chunks: string[] = [];
+  const output = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return {
+    output,
+    lines: () =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l)),
+  };
+}
+
+/** A fake fetch mapping Gateway routes to canned JSON responses. */
+function gatewayFetch(): typeof fetch {
+  return (async (url: string) => {
+    const path = new URL(String(url)).pathname;
+    const bodies: Record<string, unknown> = {
+      "/health": { status: "ok", version: "test", uptime: 1, stores: { vectorStore: true, embeddingService: true } },
+      "/search/memories": { results: "• user likes tea", total: 1, strategy: "hybrid" },
+    };
+    return new Response(JSON.stringify(bodies[path] ?? {}), { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as unknown as typeof fetch;
+}
+
+async function runSession(inputLines: string[]) {
+  const input = new PassThrough();
+  const { output, lines } = collector();
+  const adapter = new GatewayMemoryAdapter({ fetch: gatewayFetch() });
+
+  const server = createMemoryMcpServer({
+    adapter,
+    streams: { input, output, log: () => {} },
+  });
+  const done = server.start();
+
+  for (const line of inputLines) input.write(line + "\n");
+  input.end();
+  await done;
+  // Allow the serialized write chain to flush.
+  await new Promise((r) => setTimeout(r, 10));
+  return lines();
+}
+
+describe("StdioMcpServer (end-to-end)", () => {
+  it("handles a full initialize → list → call handshake", async () => {
+    const responses = await runSession([
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } }),
+      JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "tdai_memory_search", arguments: { query: "drink" } } }),
+    ]);
+
+    // The notification produces no response → 3 responses for 4 inputs.
+    expect(responses).toHaveLength(3);
+
+    const init = responses.find((r) => r.id === 1);
+    expect(init.result.serverInfo.name).toBe("tdai-memory");
+
+    const list = responses.find((r) => r.id === 2);
+    expect(list.result.tools.length).toBeGreaterThanOrEqual(2);
+
+    const call = responses.find((r) => r.id === 3);
+    expect(call.result.isError).toBe(false);
+    expect(call.result.content[0].text).toContain("tea");
+  });
+
+  it("emits a JSON-RPC parse error for malformed input lines", async () => {
+    const responses = await runSession(["{ this is not json"]);
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({ id: null, error: { code: -32700 } });
+  });
+
+  it("drains an in-flight tool call when stdin closes before it resolves", async () => {
+    // A slow adapter: the response only becomes available well after input.end().
+    // If shutdown did not drain pending work, this response would be lost.
+    const slowAdapter = new GatewayMemoryAdapter({ fetch: gatewayFetch() });
+    const original = slowAdapter.searchMemories.bind(slowAdapter);
+    slowAdapter.searchMemories = async (input) => {
+      await new Promise((r) => setTimeout(r, 40));
+      return original(input);
+    };
+
+    const input = new PassThrough();
+    const { output, lines } = collector();
+    const server = createMemoryMcpServer({ adapter: slowAdapter, streams: { input, output, log: () => {} } });
+    const done = server.start();
+
+    input.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "tdai_memory_search", arguments: { query: "drink" } } }) + "\n");
+    input.end(); // stdin closes immediately — the 40ms handler is still running
+
+    await done; // start() must not resolve until the handler drains
+    expect(lines()).toHaveLength(1);
+    expect(lines()[0]).toMatchObject({ id: 1, result: { isError: false } });
+  });
+
+  it("processes two messages arriving in a single chunk", async () => {    // Both JSON objects are written before any newline flush boundary — the
+    // buffer splitter must still surface both.
+    const input = new PassThrough();
+    const { output, lines } = collector();
+    const server = createMemoryMcpServer({
+      adapter: new GatewayMemoryAdapter({ fetch: gatewayFetch() }),
+      streams: { input, output, log: () => {} },
+    });
+    const done = server.start();
+    input.write(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }) + "\n" +
+      JSON.stringify({ jsonrpc: "2.0", id: 2, method: "ping" }) + "\n",
+    );
+    input.end();
+    await done;
+    await new Promise((r) => setTimeout(r, 10));
+    expect(lines().map((r) => r.id).sort()).toEqual([1, 2]);
+  });
+});

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -1,0 +1,189 @@
+/**
+ * TDAI MCP server — exposes the four-layer memory engine to any MCP host
+ * (Claude Code, Codex, Cursor, Cline, Windsurf, …) over stdio.
+ *
+ * Transport: newline-delimited JSON-RPC 2.0 on stdin/stdout, per the MCP
+ * stdio transport spec. No MCP framework dependency — the same "native
+ * primitives only" philosophy the Gateway uses for HTTP (`node:http`, no
+ * Express). All protocol logic lives in `protocol.ts`; this file is just the
+ * byte plumbing plus a `main()` that builds the adapter from the environment.
+ *
+ * CRITICAL: stdout is the protocol channel. Everything diagnostic goes to
+ * stderr — a single stray `console.log` would corrupt the JSON-RPC stream.
+ *
+ * Run it:
+ *   TDAI_GATEWAY_URL=http://127.0.0.1:8420 npx tsx src/adapters/mcp/server.ts
+ * or wire it into an MCP host — see `src/adapters/mcp/README.md`.
+ */
+
+import { McpDispatcher } from "./protocol.js";
+import type { McpServerInfo } from "./protocol.js";
+import { GatewayMemoryAdapter } from "../../sdk/memory-adapter.js";
+import type { MemoryAdapter } from "../../sdk/memory-adapter.js";
+import { buildMemoryTools } from "../../sdk/tools.js";
+import type { BuildMemoryToolsOptions } from "../../sdk/tools.js";
+
+const SERVER_INFO: McpServerInfo = { name: "tdai-memory", version: "0.1.0" };
+
+const INSTRUCTIONS =
+  "TDAI four-layer memory (L0 conversation → L1 memory → L2 scene → L3 persona). " +
+  "Use tdai_memory_search to recall structured facts about the user, " +
+  "tdai_conversation_search for raw past dialogue, tdai_recall to prime a reply " +
+  "with known context, and tdai_capture to persist an important exchange.";
+
+// ============================
+// Stdio transport
+// ============================
+
+/** Minimal duplex-ish stream surface, so tests can inject fakes. */
+export interface StdioStreams {
+  input: NodeJS.ReadableStream;
+  output: NodeJS.WritableStream;
+  log: (message: string) => void;
+}
+
+export interface StdioMcpServerOptions {
+  dispatcher: McpDispatcher;
+  streams?: Partial<StdioStreams>;
+}
+
+export class StdioMcpServer {
+  private readonly dispatcher: McpDispatcher;
+  private readonly input: NodeJS.ReadableStream;
+  private readonly output: NodeJS.WritableStream;
+  private readonly log: (message: string) => void;
+  private buffer = "";
+  /** Serializes writes so out-of-order async tool calls don't interleave lines. */
+  private writeChain: Promise<void> = Promise.resolve();
+  /** In-flight request handlers, so shutdown can drain them before exiting. */
+  private readonly pending = new Set<Promise<void>>();
+
+  constructor(opts: StdioMcpServerOptions) {
+    this.dispatcher = opts.dispatcher;
+    this.input = opts.streams?.input ?? process.stdin;
+    this.output = opts.streams?.output ?? process.stdout;
+    this.log = opts.streams?.log ?? ((m) => process.stderr.write(`[tdai-mcp] ${m}\n`));
+  }
+
+  /** Attach stream handlers and begin serving. Resolves when input closes. */
+  start(): Promise<void> {
+    this.log(`serving over stdio (server ${SERVER_INFO.name}@${SERVER_INFO.version})`);
+    if (typeof (this.input as NodeJS.ReadStream).setEncoding === "function") {
+      (this.input as NodeJS.ReadStream).setEncoding("utf8");
+    }
+
+    return new Promise<void>((resolve) => {
+      const shutdown = async (reason: string) => {
+        this.log(reason);
+        // Drain in-flight handlers, then all queued writes, so a response is
+        // never truncated when stdin closes mid-request.
+        await Promise.allSettled([...this.pending]);
+        await this.writeChain;
+        resolve();
+      };
+      this.input.on("data", (chunk: string | Buffer) => this.onData(chunk.toString()));
+      this.input.on("end", () => void shutdown("input stream closed; draining and shutting down"));
+      this.input.on("error", (err: Error) => void shutdown(`input stream error: ${err.message}`));
+    });
+  }
+
+  /** Buffer incoming bytes and dispatch each complete newline-terminated line. */
+  private onData(text: string): void {
+    this.buffer += text;
+    let newlineIdx: number;
+    while ((newlineIdx = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, newlineIdx).trim();
+      this.buffer = this.buffer.slice(newlineIdx + 1);
+      if (line) this.dispatchLine(line);
+    }
+  }
+
+  /** Parse one line, hand it to the dispatcher, and enqueue the response. */
+  private dispatchLine(line: string): void {
+    let request: unknown;
+    try {
+      request = JSON.parse(line);
+    } catch {
+      // Parse error → JSON-RPC error with null id (we have no id to echo).
+      this.enqueueWrite({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+      return;
+    }
+
+    // Handle the request asynchronously; responses are serialized by the chain.
+    // Track the handler in `pending` so shutdown can await it before exiting.
+    const task = this.dispatcher
+      .handle(request as never)
+      .then((response) => {
+        if (response) this.enqueueWrite(response);
+      })
+      .catch((err: unknown) => {
+        this.log(`dispatch failure: ${err instanceof Error ? err.message : String(err)}`);
+      })
+      .finally(() => {
+        this.pending.delete(task);
+      });
+    this.pending.add(task);
+  }
+
+  /** Serialize writes; each JSON-RPC message occupies exactly one line. */
+  private enqueueWrite(message: unknown): void {
+    const payload = JSON.stringify(message) + "\n";
+    this.writeChain = this.writeChain.then(
+      () =>
+        new Promise<void>((resolve) => {
+          this.output.write(payload, () => resolve());
+        }),
+    );
+  }
+}
+
+// ============================
+// Factory
+// ============================
+
+export interface CreateMemoryMcpServerOptions {
+  /** Provide a custom adapter (e.g. embedded). Defaults to a Gateway adapter from env. */
+  adapter?: MemoryAdapter;
+  /** Tool-surface options (session key, which tools to expose). */
+  tools?: BuildMemoryToolsOptions;
+  streams?: Partial<StdioStreams>;
+}
+
+/**
+ * Build a fully-wired stdio MCP server: env-configured Gateway adapter →
+ * neutral memory tools → MCP dispatcher → stdio transport.
+ */
+export function createMemoryMcpServer(opts: CreateMemoryMcpServerOptions = {}): StdioMcpServer {
+  const adapter = opts.adapter ?? GatewayMemoryAdapter.fromEnv();
+  const tools = buildMemoryTools(adapter, opts.tools);
+  const dispatcher = new McpDispatcher({
+    tools,
+    serverInfo: SERVER_INFO,
+    instructions: INSTRUCTIONS,
+    logger: opts.streams?.log,
+  });
+  return new StdioMcpServer({ dispatcher, streams: opts.streams });
+}
+
+// ============================
+// CLI entry point
+// ============================
+
+/** Build the env-configured server and serve until stdin closes. */
+export async function runMain(): Promise<void> {
+  const server = createMemoryMcpServer({
+    tools: { sessionKey: process.env.TDAI_MCP_SESSION_KEY || "mcp-default" },
+  });
+  await server.start();
+  process.exit(0);
+}
+
+// Auto-run when executed directly via `tsx src/adapters/mcp/server.ts`.
+// The `bin/tdai-mcp.mjs` launcher instead imports and calls runMain() itself.
+const entry = process.argv[1] ?? "";
+if (entry.endsWith("server.ts") || entry.endsWith("server.js")) {
+  runMain().catch((err) => {
+    process.stderr.write(`[tdai-mcp] fatal: ${err instanceof Error ? err.stack : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -1,0 +1,61 @@
+# TDAI Unified Adapter SDK (`src/sdk`)
+
+A platform-neutral toolkit for wiring the TDAI four-layer memory engine into any
+agent host. It builds on the Gateway HTTP boundary that the OpenClaw and Hermes
+integrations already established and distills the cross-platform surface into
+three small layers.
+
+```
+buildMemoryTools(adapter) ──► MemoryTool[] ─────────────► your platform's tools
+        ▲
+   MemoryAdapter  ◄── GatewayMemoryAdapter ──► TdaiGatewayClient ──► TDAI Gateway
+   (the one interface)     (HTTP transport)     (retries/auth/errors)
+```
+
+| Layer | Export | Responsibility |
+| :---- | :----- | :------------- |
+| Transport  | `TdaiGatewayClient` | Typed client for every Gateway endpoint — timeouts, bounded retries, Bearer auth, typed `TdaiGatewayError`. TS sibling of the Hermes Python client. |
+| Capability | `MemoryAdapter` / `GatewayMemoryAdapter` | The single interface every transport implements and every platform consumes: `recall · searchMemories · searchConversations · capture · endSession · health`. |
+| Tools      | `buildMemoryTools()` | Host-neutral tool descriptors (`name` + `description` + JSON Schema + non-throwing `invoke`). Maps 1:1 onto MCP, Dify, Vercel AI SDK, OpenAI functions, … |
+
+## Quick start
+
+```ts
+import { GatewayMemoryAdapter, buildMemoryTools } from "./sdk/index.js";
+
+const adapter = GatewayMemoryAdapter.fromEnv();      // TDAI_GATEWAY_URL / _API_KEY
+const tools = buildMemoryTools(adapter);             // 4 canonical memory tools
+
+const search = tools.find((t) => t.name === "tdai_memory_search")!;
+const { text } = await search.invoke({ query: "what does the user like?" });
+```
+
+Or use the client directly:
+
+```ts
+import { TdaiGatewayClient } from "./sdk/index.js";
+
+const client = new TdaiGatewayClient({ baseUrl: "http://127.0.0.1:8420" });
+await client.capture({ userContent: "hi", assistantContent: "hello", sessionKey: "s1" });
+const { context } = await client.recall("what's my name?", "s1");
+```
+
+## Design guarantees
+
+- **`invoke` never throws.** Failures (Gateway down, bad args) return
+  `{ isError: true, text }` so a host's tool loop degrades gracefully.
+- **Argument coercion built in.** `limit` accepts `"10"`, `10.9`, etc. and is
+  clamped to `[1, 20]` — LLMs ignore JSON Schema `type` hints.
+- **Retries only where safe.** Network errors, timeouts, and 5xx retry with
+  exponential backoff; 4xx surface immediately.
+- **No runtime dependencies.** Uses the Node global `fetch` (injectable for
+  tests); no HTTP library, no MCP framework.
+
+## Consumers
+
+- [`src/adapters/mcp`](../adapters/mcp/README.md) — MCP stdio server.
+- [`src/adapters/dify`](../adapters/dify/README.md) — Dify OpenAPI tool.
+- Your platform next — see [`docs/adapters/ADDING-A-PLATFORM.md`](../../docs/adapters/ADDING-A-PLATFORM.md).
+
+Tests: `src/sdk/*.test.ts` (client wire-mapping/retries/errors; tool coercion &
+routing). Run `npx vitest run src/sdk`.

--- a/src/sdk/gateway-client.test.ts
+++ b/src/sdk/gateway-client.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for TdaiGatewayClient — verifies wire mapping, auth, retries, timeouts,
+ * and typed error classification using an injected fake fetch.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { TdaiGatewayClient, TdaiGatewayError } from "./gateway-client.js";
+
+type FetchArgs = { url: string; init: RequestInit };
+
+/** Build a fake fetch that returns queued responses and records calls. */
+function fakeFetch(responses: Array<() => Response | Promise<Response>>) {
+  const calls: FetchArgs[] = [];
+  let i = 0;
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    const factory = responses[Math.min(i, responses.length - 1)];
+    i++;
+    return factory();
+  });
+  return { fn: fn as unknown as typeof fetch, calls };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("TdaiGatewayClient", () => {
+  it("posts recall with snake_case body and parses the response", async () => {
+    const { fn, calls } = fakeFetch([() => json({ context: "you like tea", strategy: "hybrid", memory_count: 2 })]);
+    const client = new TdaiGatewayClient({ baseUrl: "http://gw:8420", fetch: fn });
+
+    const res = await client.recall("what do I like?", "s-1", "u-1");
+
+    expect(res).toEqual({ context: "you like tea", strategy: "hybrid", memory_count: 2 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://gw:8420/recall");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      query: "what do I like?",
+      session_key: "s-1",
+      user_id: "u-1",
+    });
+  });
+
+  it("attaches a Bearer header only when an apiKey is set", async () => {
+    const withKey = fakeFetch([() => json({ status: "ok", version: "1", uptime: 1, stores: { vectorStore: true, embeddingService: true } })]);
+    await new TdaiGatewayClient({ fetch: withKey.fn, apiKey: "  secret\n" }).health();
+    expect(headers(withKey.calls[0]).authorization).toBe("Bearer secret"); // trimmed
+
+    const noKey = fakeFetch([() => json({ status: "ok", version: "1", uptime: 1, stores: { vectorStore: true, embeddingService: true } })]);
+    await new TdaiGatewayClient({ fetch: noKey.fn }).health();
+    expect(headers(noKey.calls[0]).authorization).toBeUndefined();
+  });
+
+  it("maps search params and omits absent optionals", async () => {
+    const { fn, calls } = fakeFetch([() => json({ results: "…", total: 3, strategy: "vector" })]);
+    const client = new TdaiGatewayClient({ fetch: fn });
+    await client.searchMemories({ query: "cats", limit: 10 });
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ query: "cats", limit: 10 });
+  });
+
+  it("throws a non-retryable bad_request on HTTP 400", async () => {
+    const { fn, calls } = fakeFetch([() => json({ error: "Missing required field: query" }, 400)]);
+    const client = new TdaiGatewayClient({ fetch: fn, retries: 3 });
+
+    const err = await client.searchMemories({ query: "x" }).catch((e) => e);
+    expect(err).toBeInstanceOf(TdaiGatewayError);
+    expect(err.code).toBe("bad_request");
+    expect(err.status).toBe(400);
+    expect(err.message).toContain("Missing required field");
+    expect(calls).toHaveLength(1); // no retries on 4xx
+  });
+
+  it("classifies HTTP 401 as unauthorized", async () => {
+    const { fn } = fakeFetch([() => json({ error: "Unauthorized" }, 401)]);
+    const err = await new TdaiGatewayClient({ fetch: fn }).recall("q", "s").catch((e) => e);
+    expect(err.code).toBe("unauthorized");
+  });
+
+  it("retries server_error (5xx) up to the configured limit, then throws", async () => {
+    const { fn, calls } = fakeFetch([() => json({ error: "boom" }, 503)]);
+    const client = new TdaiGatewayClient({ fetch: fn, retries: 2, retryBackoffMs: 1 });
+
+    const err = await client.recall("q", "s").catch((e) => e);
+    expect(err.code).toBe("server_error");
+    expect(calls).toHaveLength(3); // initial + 2 retries
+  });
+
+  it("recovers when a retried 5xx eventually succeeds", async () => {
+    const { fn, calls } = fakeFetch([
+      () => json({ error: "boom" }, 500),
+      () => json({ context: "ok", memory_count: 0 }),
+    ]);
+    const client = new TdaiGatewayClient({ fetch: fn, retries: 2, retryBackoffMs: 1 });
+    const res = await client.recall("q", "s");
+    expect(res.context).toBe("ok");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("wraps network failures as code 'network' and retries", async () => {
+    const { fn, calls } = fakeFetch([() => Promise.reject(new Error("ECONNREFUSED"))]);
+    const client = new TdaiGatewayClient({ fetch: fn, retries: 1, retryBackoffMs: 1 });
+    const err = await client.health().catch((e) => e);
+    // health() forces retries: 0, so a single attempt
+    expect(err.code).toBe("network");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("aborts on timeout and reports code 'timeout'", async () => {
+    const hanging: typeof fetch = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+        );
+      })) as unknown as typeof fetch;
+
+    const client = new TdaiGatewayClient({ fetch: hanging, timeoutMs: 15, retries: 0 });
+    const err = await client.recall("q", "s").catch((e) => e);
+    expect(err.code).toBe("timeout");
+    expect(err.message).toContain("timed out");
+  });
+
+  it("fromEnv reads TDAI_GATEWAY_URL / _API_KEY", async () => {
+    vi.stubEnv("TDAI_GATEWAY_URL", "http://example:9000");
+    vi.stubEnv("TDAI_GATEWAY_API_KEY", "k");
+    const { fn, calls } = fakeFetch([() => json({ status: "ok", version: "1", uptime: 0, stores: { vectorStore: false, embeddingService: false } })]);
+    const client = TdaiGatewayClient.fromEnv({ fetch: fn });
+    await client.health();
+    expect(calls[0].url).toBe("http://example:9000/health");
+    expect(headers(calls[0]).authorization).toBe("Bearer k");
+  });
+});
+
+function headers(call: FetchArgs): Record<string, string> {
+  const h = call.init.headers as Record<string, string> | undefined;
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(h ?? {})) lower[k.toLowerCase()] = v;
+  return lower;
+}

--- a/src/sdk/gateway-client.ts
+++ b/src/sdk/gateway-client.ts
@@ -1,0 +1,412 @@
+/**
+ * TdaiGatewayClient — typed, dependency-free HTTP client for the TDAI Gateway.
+ *
+ * This is the transport half of the unified adapter SDK. It wraps every
+ * Gateway endpoint (`src/gateway/server.ts`) with a camelCase TypeScript API,
+ * timeouts, bounded retries, Bearer auth, and typed errors — so a new platform
+ * adapter never has to hand-roll `fetch` calls or reason about the wire format.
+ *
+ * It is the TypeScript sibling of the Hermes provider's Python
+ * `MemoryTencentdbSdkClient` (`hermes-plugin/memory/memory_tencentdb/client.py`)
+ * and speaks the exact same HTTP contract, so both language ecosystems share
+ * one Gateway.
+ *
+ * Usage:
+ *   const client = TdaiGatewayClient.fromEnv();          // reads TDAI_GATEWAY_URL / _API_KEY
+ *   const client = new TdaiGatewayClient({ baseUrl: "http://127.0.0.1:8420" });
+ *   const { context } = await client.recall("what's my name?", "session-1");
+ *   await client.capture({ userContent: "hi", assistantContent: "hello", sessionKey: "session-1" });
+ */
+
+import type {
+  HealthResponse,
+  RecallResponse,
+  CaptureResponse,
+  MemorySearchResponse,
+  ConversationSearchResponse,
+  SessionEndResponse,
+  SeedResponse,
+} from "../gateway/types.js";
+
+// ============================
+// Public options & types
+// ============================
+
+/** Minimal logger — structurally compatible with the core `Logger`. */
+export interface GatewayClientLogger {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+/** Injectable `fetch` implementation (defaults to the Node global). */
+export type FetchLike = typeof fetch;
+
+export interface TdaiGatewayClientOptions {
+  /** Gateway base URL. Default: `http://127.0.0.1:8420`. */
+  baseUrl?: string;
+  /**
+   * Optional Bearer token. When set, every request carries
+   * `Authorization: Bearer <apiKey>`. Leave unset for an open Gateway
+   * (the Gateway's documented legacy default).
+   */
+  apiKey?: string;
+  /** Per-request timeout in milliseconds. Default: 15000. */
+  timeoutMs?: number;
+  /** Retry attempts on transient failures (network / 5xx / timeout). Default: 2. */
+  retries?: number;
+  /** Base backoff between retries in ms (exponential). Default: 250. */
+  retryBackoffMs?: number;
+  /** Override `fetch` (useful for tests). Defaults to `globalThis.fetch`. */
+  fetch?: FetchLike;
+  /** Optional logger for debug/warn traces. */
+  logger?: GatewayClientLogger;
+}
+
+/** Parameters for {@link TdaiGatewayClient.capture}. */
+export interface CaptureParams {
+  userContent: string;
+  assistantContent: string;
+  sessionKey: string;
+  sessionId?: string;
+  userId?: string;
+  /** Full message list; defaults to a [user, assistant] pair on the Gateway. */
+  messages?: unknown[];
+}
+
+/** Parameters for {@link TdaiGatewayClient.searchMemories}. */
+export interface SearchMemoriesParams {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+/** Parameters for {@link TdaiGatewayClient.searchConversations}. */
+export interface SearchConversationsParams {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+/** Parameters for {@link TdaiGatewayClient.seed}. */
+export interface SeedParams {
+  data: unknown;
+  sessionKey?: string;
+  strictRoundRole?: boolean;
+  autoFillTimestamps?: boolean;
+  configOverride?: Record<string, unknown>;
+  /** Seed can be slow — override the default 15s timeout (default here: 300000). */
+  timeoutMs?: number;
+}
+
+// ============================
+// Errors
+// ============================
+
+/**
+ * Thrown for any non-2xx Gateway response or transport failure.
+ *
+ * `status` is the HTTP status (0 for network/timeout errors). `code` is a
+ * stable machine-readable discriminant so adapters can branch on failure
+ * class without string-matching messages.
+ */
+export class TdaiGatewayError extends Error {
+  readonly status: number;
+  readonly code: TdaiGatewayErrorCode;
+  readonly path: string;
+  /** Raw response body text, when available. */
+  readonly body?: string;
+
+  constructor(opts: {
+    message: string;
+    status: number;
+    code: TdaiGatewayErrorCode;
+    path: string;
+    body?: string;
+    cause?: unknown;
+  }) {
+    super(opts.message, { cause: opts.cause });
+    this.name = "TdaiGatewayError";
+    this.status = opts.status;
+    this.code = opts.code;
+    this.path = opts.path;
+    this.body = opts.body;
+  }
+}
+
+export type TdaiGatewayErrorCode =
+  | "timeout"
+  | "network"
+  | "unauthorized"
+  | "bad_request"
+  | "not_found"
+  | "server_error"
+  | "invalid_json"
+  | "unknown";
+
+const DEFAULTS = {
+  baseUrl: "http://127.0.0.1:8420",
+  timeoutMs: 15_000,
+  retries: 2,
+  retryBackoffMs: 250,
+} as const;
+
+// ============================
+// TdaiGatewayClient
+// ============================
+
+export class TdaiGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly retries: number;
+  private readonly retryBackoffMs: number;
+  private readonly fetchImpl: FetchLike;
+  private readonly logger?: GatewayClientLogger;
+
+  constructor(opts: TdaiGatewayClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? DEFAULTS.baseUrl).replace(/\/+$/, "");
+    // Trim defensively — env vars often carry trailing newlines from `echo`
+    // or YAML quoting, which would break an exact-match Bearer comparison.
+    this.apiKey = opts.apiKey?.trim() || undefined;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULTS.timeoutMs;
+    this.retries = Math.max(0, opts.retries ?? DEFAULTS.retries);
+    this.retryBackoffMs = opts.retryBackoffMs ?? DEFAULTS.retryBackoffMs;
+    this.fetchImpl = opts.fetch ?? globalThis.fetch;
+    this.logger = opts.logger;
+
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error(
+        "TdaiGatewayClient: global fetch is unavailable. Use Node >= 18, or pass opts.fetch.",
+      );
+    }
+  }
+
+  /**
+   * Build a client from environment variables:
+   *   TDAI_GATEWAY_URL      (default http://127.0.0.1:8420)
+   *   TDAI_GATEWAY_API_KEY  (optional Bearer token)
+   *   TDAI_GATEWAY_TIMEOUT_MS (optional)
+   * Also accepts the Hermes-namespaced fallbacks used by the Python provider.
+   */
+  static fromEnv(overrides: TdaiGatewayClientOptions = {}): TdaiGatewayClient {
+    const env = globalThis.process?.env ?? {};
+    const host = env.MEMORY_TENCENTDB_GATEWAY_HOST;
+    const port = env.MEMORY_TENCENTDB_GATEWAY_PORT;
+    const hermesUrl = host || port ? `http://${host || "127.0.0.1"}:${port || "8420"}` : undefined;
+    const timeoutRaw = env.TDAI_GATEWAY_TIMEOUT_MS;
+    const timeoutMs = timeoutRaw && /^\d+$/.test(timeoutRaw.trim()) ? Number(timeoutRaw.trim()) : undefined;
+
+    return new TdaiGatewayClient({
+      baseUrl: env.TDAI_GATEWAY_URL || hermesUrl || DEFAULTS.baseUrl,
+      apiKey:
+        env.TDAI_GATEWAY_API_KEY ||
+        env.MEMORY_TENCENTDB_GATEWAY_API_KEY ||
+        undefined,
+      timeoutMs,
+      ...overrides,
+    });
+  }
+
+  // -- API methods ----------------------------------------------------------
+
+  /** `GET /health` — liveness/readiness probe. */
+  health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health", undefined, { timeoutMs: 3_000, retries: 0 });
+  }
+
+  /** `POST /recall` — retrieve memory context for a query (prefetch). */
+  recall(query: string, sessionKey: string, userId?: string): Promise<RecallResponse> {
+    return this.request<RecallResponse>("POST", "/recall", {
+      query,
+      session_key: sessionKey,
+      ...(userId ? { user_id: userId } : {}),
+    });
+  }
+
+  /** `POST /capture` — persist a completed conversation turn (sync_turn). */
+  capture(params: CaptureParams): Promise<CaptureResponse> {
+    return this.request<CaptureResponse>("POST", "/capture", {
+      user_content: params.userContent,
+      assistant_content: params.assistantContent,
+      session_key: params.sessionKey,
+      ...(params.sessionId ? { session_id: params.sessionId } : {}),
+      ...(params.userId ? { user_id: params.userId } : {}),
+      ...(params.messages ? { messages: params.messages } : {}),
+    });
+  }
+
+  /** `POST /search/memories` — search L1 structured memories. */
+  searchMemories(params: SearchMemoriesParams): Promise<MemorySearchResponse> {
+    return this.request<MemorySearchResponse>("POST", "/search/memories", {
+      query: params.query,
+      ...(params.limit != null ? { limit: params.limit } : {}),
+      ...(params.type ? { type: params.type } : {}),
+      ...(params.scene ? { scene: params.scene } : {}),
+    });
+  }
+
+  /** `POST /search/conversations` — search L0 raw conversation history. */
+  searchConversations(params: SearchConversationsParams): Promise<ConversationSearchResponse> {
+    return this.request<ConversationSearchResponse>("POST", "/search/conversations", {
+      query: params.query,
+      ...(params.limit != null ? { limit: params.limit } : {}),
+      ...(params.sessionKey ? { session_key: params.sessionKey } : {}),
+    });
+  }
+
+  /** `POST /session/end` — flush a single session's buffered pipeline work. */
+  endSession(sessionKey: string, userId?: string): Promise<SessionEndResponse> {
+    return this.request<SessionEndResponse>("POST", "/session/end", {
+      session_key: sessionKey,
+      ...(userId ? { user_id: userId } : {}),
+    });
+  }
+
+  /** `POST /seed` — batch-ingest historical conversations (L0 → L1). */
+  seed(params: SeedParams): Promise<SeedResponse> {
+    return this.request<SeedResponse>(
+      "POST",
+      "/seed",
+      {
+        data: params.data,
+        ...(params.sessionKey ? { session_key: params.sessionKey } : {}),
+        ...(params.strictRoundRole ? { strict_round_role: true } : {}),
+        ...(params.autoFillTimestamps === false ? { auto_fill_timestamps: false } : {}),
+        ...(params.configOverride ? { config_override: params.configOverride } : {}),
+      },
+      { timeoutMs: params.timeoutMs ?? 300_000 },
+    );
+  }
+
+  // -- Transport ------------------------------------------------------------
+
+  private async request<T>(
+    method: "GET" | "POST",
+    path: string,
+    body?: unknown,
+    override?: { timeoutMs?: number; retries?: number },
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const timeoutMs = override?.timeoutMs ?? this.timeoutMs;
+    const maxRetries = override?.retries ?? this.retries;
+
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+
+    let lastErr: TdaiGatewayError | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (attempt > 0) {
+        const delay = this.retryBackoffMs * 2 ** (attempt - 1);
+        this.logger?.debug?.(`[tdai-sdk] retry ${attempt}/${maxRetries} ${method} ${path} after ${delay}ms`);
+        await sleep(delay);
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const res = await this.fetchImpl(url, {
+          method,
+          headers,
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        const text = await res.text();
+        if (!res.ok) {
+          const err = toHttpError(res.status, path, text);
+          // Retry only transient server-side failures; surface 4xx immediately.
+          if (err.code === "server_error" && attempt < maxRetries) {
+            lastErr = err;
+            continue;
+          }
+          throw err;
+        }
+
+        return parseJson<T>(text, path);
+      } catch (err) {
+        if (err instanceof TdaiGatewayError) {
+          if (err.code === "invalid_json" || err.code === "bad_request" ||
+              err.code === "unauthorized" || err.code === "not_found") {
+            throw err; // non-retryable
+          }
+          lastErr = err;
+        } else {
+          // fetch rejected: abort (timeout) or network failure.
+          const isAbort = (err as { name?: string })?.name === "AbortError";
+          lastErr = new TdaiGatewayError({
+            message: isAbort
+              ? `Gateway request timed out after ${timeoutMs}ms: ${method} ${path}`
+              : `Gateway request failed: ${method} ${path}: ${errMessage(err)}`,
+            status: 0,
+            code: isAbort ? "timeout" : "network",
+            path,
+            cause: err,
+          });
+        }
+        if (attempt >= maxRetries) throw lastErr;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    // Unreachable in practice — the loop either returns or throws.
+    throw lastErr ?? new TdaiGatewayError({ message: `Gateway request failed: ${method} ${path}`, status: 0, code: "unknown", path });
+  }
+}
+
+// ============================
+// Helpers
+// ============================
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function parseJson<T>(text: string, path: string): T {
+  if (!text) return {} as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch (err) {
+    throw new TdaiGatewayError({
+      message: `Gateway returned non-JSON body for ${path}`,
+      status: 200,
+      code: "invalid_json",
+      path,
+      body: text.slice(0, 500),
+      cause: err,
+    });
+  }
+}
+
+function toHttpError(status: number, path: string, body: string): TdaiGatewayError {
+  let code: TdaiGatewayErrorCode = "unknown";
+  if (status === 401 || status === 403) code = "unauthorized";
+  else if (status === 400 || status === 422) code = "bad_request";
+  else if (status === 404) code = "not_found";
+  else if (status >= 500) code = "server_error";
+
+  // The Gateway encodes errors as `{ error: string }`.
+  let detail = body.slice(0, 500);
+  try {
+    const parsed = JSON.parse(body) as { error?: string };
+    if (parsed?.error) detail = parsed.error;
+  } catch {
+    /* keep raw body slice */
+  }
+
+  return new TdaiGatewayError({
+    message: `Gateway ${status} on ${path}: ${detail}`,
+    status,
+    code,
+    path,
+    body,
+  });
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,61 @@
+/**
+ * TDAI Unified Adapter SDK.
+ *
+ * A platform-neutral toolkit for wiring the TDAI four-layer memory engine
+ * into any agent host. It sits on top of the Gateway HTTP boundary that the
+ * OpenClaw and Hermes adapters already established, and distills the whole
+ * cross-platform surface into three layers:
+ *
+ *   1. Transport   — `TdaiGatewayClient`: typed, retrying HTTP client.
+ *   2. Capability  — `MemoryAdapter`: the one interface every transport
+ *                    implements and every platform consumes.
+ *                    `GatewayMemoryAdapter` is the reference HTTP transport.
+ *   3. Tools       — `buildMemoryTools(adapter)`: host-neutral tool descriptors
+ *                    (name + description + JSON Schema + `invoke`). A new
+ *                    platform adapter just maps these onto its host's tool type.
+ *
+ * See `docs/adapters/ADDING-A-PLATFORM.md` for the end-to-end recipe.
+ */
+
+export {
+  TdaiGatewayClient,
+  TdaiGatewayError,
+} from "./gateway-client.js";
+export type {
+  TdaiGatewayClientOptions,
+  TdaiGatewayErrorCode,
+  FetchLike,
+  GatewayClientLogger,
+  CaptureParams,
+  SearchMemoriesParams,
+  SearchConversationsParams,
+  SeedParams,
+} from "./gateway-client.js";
+
+export {
+  GatewayMemoryAdapter,
+} from "./memory-adapter.js";
+export type {
+  MemoryAdapter,
+  GatewayMemoryAdapterOptions,
+  RecallInput,
+  RecallResult,
+  MemorySearchInput,
+  MemorySearchResult,
+  ConversationSearchInput,
+  ConversationSearchResult,
+  CaptureInput,
+  CaptureResult,
+  MemoryHealth,
+} from "./memory-adapter.js";
+
+export {
+  buildMemoryTools,
+  coerceLimit,
+} from "./tools.js";
+export type {
+  MemoryTool,
+  MemoryToolResult,
+  JsonSchema,
+  BuildMemoryToolsOptions,
+} from "./tools.js";

--- a/src/sdk/memory-adapter.ts
+++ b/src/sdk/memory-adapter.ts
@@ -1,0 +1,198 @@
+/**
+ * MemoryAdapter — the transport-agnostic capability contract of the SDK.
+ *
+ * This is the single interface the "unified adapter SDK" is built around.
+ * It captures *what* TDAI memory can do (recall, search, capture, flush)
+ * without saying *how* the bytes travel. Two axes plug into it:
+ *
+ *   1. Transport (how to reach the engine): `GatewayMemoryAdapter` speaks
+ *      HTTP to the Gateway. A future `EmbeddedMemoryAdapter` could call
+ *      `TdaiCore` in-process — same interface, no platform code changes.
+ *
+ *   2. Platform (which agent host consumes memory): MCP, Dify, LangChain,
+ *      etc. consume a `MemoryAdapter` (usually via {@link buildMemoryTools})
+ *      and translate its capabilities into their own tool/hook surface.
+ *
+ * Every field is normalized to a clean camelCase shape so platform adapters
+ * never touch the snake_case HTTP wire format.
+ */
+
+import { TdaiGatewayClient } from "./gateway-client.js";
+import type { TdaiGatewayClientOptions } from "./gateway-client.js";
+
+// ============================
+// Normalized I/O shapes
+// ============================
+
+export interface RecallInput {
+  query: string;
+  sessionKey: string;
+  userId?: string;
+}
+
+export interface RecallResult {
+  /** Recall context to inject into the prompt (may be empty). */
+  context: string;
+  /** Retrieval strategy the engine used (e.g. "hybrid", "vector"). */
+  strategy?: string;
+  /** Number of L1 memories that contributed to the context. */
+  memoryCount: number;
+}
+
+export interface MemorySearchInput {
+  query: string;
+  limit?: number;
+  /** Optional filter: persona | episodic | instruction. */
+  type?: string;
+  /** Optional scene-block filter. */
+  scene?: string;
+}
+
+export interface MemorySearchResult {
+  /** Human/LLM-readable, pre-formatted result text. */
+  text: string;
+  total: number;
+  strategy: string;
+}
+
+export interface ConversationSearchInput {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export interface ConversationSearchResult {
+  text: string;
+  total: number;
+}
+
+export interface CaptureInput {
+  userContent: string;
+  assistantContent: string;
+  sessionKey: string;
+  sessionId?: string;
+  userId?: string;
+  messages?: unknown[];
+}
+
+export interface CaptureResult {
+  l0Recorded: number;
+  schedulerNotified: boolean;
+}
+
+export interface MemoryHealth {
+  /** True when the engine is reachable (status "ok" or "degraded"). */
+  ok: boolean;
+  /** Raw status string from the engine. */
+  status: string;
+  version?: string;
+  /** True when reachable but running without a vector store. */
+  degraded: boolean;
+}
+
+// ============================
+// The contract
+// ============================
+
+/**
+ * The one interface a new *transport* implements and every *platform*
+ * adapter consumes. Keep it minimal: five verbs cover the full memory
+ * read/write surface the issue asks for.
+ */
+export interface MemoryAdapter {
+  /** Identifies where memory lives / how it is reached (for logs & health). */
+  readonly platform: string;
+
+  /** Liveness + readiness of the underlying engine. */
+  health(): Promise<MemoryHealth>;
+
+  /** Retrieve memory context for the current turn (read). */
+  recall(input: RecallInput): Promise<RecallResult>;
+
+  /** Search L1 structured memories (read). */
+  searchMemories(input: MemorySearchInput): Promise<MemorySearchResult>;
+
+  /** Search L0 raw conversation history (read). */
+  searchConversations(input: ConversationSearchInput): Promise<ConversationSearchResult>;
+
+  /** Persist a completed conversation turn (write). */
+  capture(input: CaptureInput): Promise<CaptureResult>;
+
+  /** Flush a single session's buffered pipeline work (write, best-effort). */
+  endSession(sessionKey: string): Promise<void>;
+}
+
+// ============================
+// Gateway-backed implementation (HTTP transport)
+// ============================
+
+export interface GatewayMemoryAdapterOptions extends TdaiGatewayClientOptions {
+  /** Override the reported platform label (default: "gateway"). */
+  platform?: string;
+  /** Provide a pre-built client instead of constructing one from options. */
+  client?: TdaiGatewayClient;
+}
+
+/**
+ * `MemoryAdapter` over the Gateway HTTP API — the reference transport.
+ *
+ * This is intentionally thin: all resilience (timeouts, retries, auth,
+ * typed errors) lives in {@link TdaiGatewayClient}, so this class only
+ * maps wire responses onto the normalized shapes above.
+ */
+export class GatewayMemoryAdapter implements MemoryAdapter {
+  readonly platform: string;
+  private readonly client: TdaiGatewayClient;
+
+  constructor(opts: GatewayMemoryAdapterOptions = {}) {
+    this.platform = opts.platform ?? "gateway";
+    this.client = opts.client ?? new TdaiGatewayClient(opts);
+  }
+
+  /** Convenience: build from environment variables. */
+  static fromEnv(overrides: GatewayMemoryAdapterOptions = {}): GatewayMemoryAdapter {
+    return new GatewayMemoryAdapter({
+      client: TdaiGatewayClient.fromEnv(overrides),
+      platform: overrides.platform,
+    });
+  }
+
+  async health(): Promise<MemoryHealth> {
+    const res = await this.client.health();
+    return {
+      ok: res.status === "ok" || res.status === "degraded",
+      status: res.status,
+      version: res.version,
+      degraded: res.status === "degraded",
+    };
+  }
+
+  async recall(input: RecallInput): Promise<RecallResult> {
+    const res = await this.client.recall(input.query, input.sessionKey, input.userId);
+    return {
+      context: res.context ?? "",
+      strategy: res.strategy,
+      memoryCount: res.memory_count ?? 0,
+    };
+  }
+
+  async searchMemories(input: MemorySearchInput): Promise<MemorySearchResult> {
+    const res = await this.client.searchMemories(input);
+    return { text: res.results ?? "", total: res.total ?? 0, strategy: res.strategy ?? "" };
+  }
+
+  async searchConversations(input: ConversationSearchInput): Promise<ConversationSearchResult> {
+    const res = await this.client.searchConversations(input);
+    return { text: res.results ?? "", total: res.total ?? 0 };
+  }
+
+  async capture(input: CaptureInput): Promise<CaptureResult> {
+    const res = await this.client.capture(input);
+    return { l0Recorded: res.l0_recorded ?? 0, schedulerNotified: res.scheduler_notified ?? false };
+  }
+
+  async endSession(sessionKey: string): Promise<void> {
+    if (!sessionKey) return;
+    await this.client.endSession(sessionKey);
+  }
+}

--- a/src/sdk/tools.test.ts
+++ b/src/sdk/tools.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for buildMemoryTools + coerceLimit — verifies the neutral tool layer
+ * that every platform adapter consumes.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { buildMemoryTools, coerceLimit } from "./tools.js";
+import type { MemoryAdapter } from "./memory-adapter.js";
+
+/** Minimal in-memory adapter double for exercising the tool layer. */
+function fakeAdapter(overrides: Partial<MemoryAdapter> = {}): MemoryAdapter {
+  return {
+    platform: "fake",
+    health: vi.fn(async () => ({ ok: true, status: "ok", degraded: false })),
+    recall: vi.fn(async () => ({ context: "ctx", strategy: "hybrid", memoryCount: 1 })),
+    searchMemories: vi.fn(async () => ({ text: "mem-results", total: 2, strategy: "vector" })),
+    searchConversations: vi.fn(async () => ({ text: "conv-results", total: 1 })),
+    capture: vi.fn(async () => ({ l0Recorded: 2, schedulerNotified: true })),
+    endSession: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("coerceLimit", () => {
+  it.each([
+    [undefined, 5],
+    [null, 5],
+    ["", 5],
+    ["10", 10],
+    [10.9, 10],
+    ["10.9", 10],
+    [0, 1],
+    [-3, 1],
+    [999, 20],
+    [true, 5],
+    ["abc", 5],
+  ])("coerces %p → %p", (input, expected) => {
+    expect(coerceLimit(input)).toBe(expected);
+  });
+});
+
+describe("buildMemoryTools", () => {
+  it("exposes the four canonical tools by default", () => {
+    const tools = buildMemoryTools(fakeAdapter());
+    expect(tools.map((t) => t.name)).toEqual([
+      "tdai_memory_search",
+      "tdai_conversation_search",
+      "tdai_recall",
+      "tdai_capture",
+    ]);
+    for (const t of tools) {
+      expect(t.inputSchema.type).toBe("object");
+      expect(typeof t.description).toBe("string");
+    }
+  });
+
+  it("can exclude write/recall tools and apply a name prefix", () => {
+    const tools = buildMemoryTools(fakeAdapter(), {
+      includeCapture: false,
+      includeRecall: false,
+      namePrefix: "mem_",
+    });
+    expect(tools.map((t) => t.name)).toEqual(["mem_tdai_memory_search", "mem_tdai_conversation_search"]);
+  });
+
+  it("routes memory_search through the adapter with coerced args", async () => {
+    const adapter = fakeAdapter();
+    const [memSearch] = buildMemoryTools(adapter);
+    const res = await memSearch.invoke({ query: "cats", limit: "9", type: "episodic" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.text).toBe("mem-results");
+    expect(adapter.searchMemories).toHaveBeenCalledWith({
+      query: "cats",
+      limit: 9,
+      type: "episodic",
+      scene: undefined,
+    });
+  });
+
+  it("returns isError (never throws) when a required arg is missing", async () => {
+    const [memSearch] = buildMemoryTools(fakeAdapter());
+    const res = await memSearch.invoke({});
+    expect(res.isError).toBe(true);
+    expect(res.text).toContain("query");
+  });
+
+  it("returns isError (never throws) when the adapter fails", async () => {
+    const adapter = fakeAdapter({
+      searchMemories: vi.fn(async () => {
+        throw new Error("gateway down");
+      }),
+    });
+    const [memSearch] = buildMemoryTools(adapter);
+    const res = await memSearch.invoke({ query: "x" });
+    expect(res.isError).toBe(true);
+    expect(res.text).toContain("gateway down");
+  });
+
+  it("defaults recall/capture session key and honors an override", async () => {
+    const adapter = fakeAdapter();
+    const tools = buildMemoryTools(adapter, { sessionKey: "sess-default" });
+    const recall = tools.find((t) => t.name === "tdai_recall")!;
+    const capture = tools.find((t) => t.name === "tdai_capture")!;
+
+    await recall.invoke({ query: "hi" });
+    expect(adapter.recall).toHaveBeenCalledWith({ query: "hi", sessionKey: "sess-default" });
+
+    await capture.invoke({ user_content: "u", assistant_content: "a", session_key: "sess-override" });
+    expect(adapter.capture).toHaveBeenCalledWith({
+      userContent: "u",
+      assistantContent: "a",
+      sessionKey: "sess-override",
+    });
+  });
+
+  it("capture reports a human-readable summary", async () => {
+    const capture = buildMemoryTools(fakeAdapter()).find((t) => t.name === "tdai_capture")!;
+    const res = await capture.invoke({ user_content: "u", assistant_content: "a" });
+    expect(res.text).toContain("2 message(s) recorded");
+    expect(res.text).toContain("notified");
+  });
+});

--- a/src/sdk/tools.ts
+++ b/src/sdk/tools.ts
@@ -1,0 +1,275 @@
+/**
+ * buildMemoryTools — turn a {@link MemoryAdapter} into platform-neutral tool
+ * descriptors.
+ *
+ * This is what makes "add a new platform in ~30 lines" true. Every agent
+ * host — MCP, Dify, LangChain, an OpenAI function-calling loop — ultimately
+ * needs the same thing: a list of tools with a name, a description, a JSON
+ * Schema for the arguments, and an `invoke(args)` that returns text. This
+ * module produces exactly that, once, from the adapter. A platform adapter
+ * then only has to map `MemoryTool` onto its host's tool type.
+ *
+ * Design choices that keep platform code trivial:
+ *   - `inputSchema` is plain JSON Schema (Draft 2020-12) — MCP, Dify, and
+ *     OpenAI all consume it directly.
+ *   - `invoke` never throws. Failures come back as `{ isError: true, text }`
+ *     so a flaky Gateway degrades to a readable message instead of crashing
+ *     the host's tool loop (mirrors the Hermes provider's behavior).
+ *   - Argument coercion (limit clamping, missing-query guards) lives here so
+ *     no platform has to re-implement it — LLMs routinely send `"10"` or
+ *     `10.5` for an integer field.
+ */
+
+import type {
+  MemoryAdapter,
+  MemorySearchResult,
+  ConversationSearchResult,
+} from "./memory-adapter.js";
+
+// ============================
+// Types
+// ============================
+
+/** Minimal JSON Schema shape (Draft 2020-12) — enough for tool arguments. */
+export interface JsonSchema {
+  type: "object";
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export interface MemoryToolResult {
+  /** Text payload for the model / user. */
+  text: string;
+  /** Structured payload for hosts that support structured tool output. */
+  data?: unknown;
+  /** True when the tool failed; `text` carries a readable error message. */
+  isError?: boolean;
+}
+
+/** A self-contained, host-neutral tool descriptor. */
+export interface MemoryTool {
+  /** Stable tool id (e.g. "tdai_memory_search"). */
+  name: string;
+  /** Short human-facing label. */
+  title: string;
+  /** Model-facing description (when and why to call this tool). */
+  description: string;
+  /** JSON Schema for the tool arguments. */
+  inputSchema: JsonSchema;
+  /** Execute the tool. Never rejects — failures return `{ isError: true }`. */
+  invoke(args: Record<string, unknown>): Promise<MemoryToolResult>;
+}
+
+export interface BuildMemoryToolsOptions {
+  /**
+   * Session key used by recall/capture when the caller doesn't supply one.
+   * Tool platforms are frequently stateless per call, so a stable default
+   * keeps L0/L1 grouping coherent. Default: "default".
+   */
+  sessionKey?: string;
+  /** Include the `tdai_capture` write tool. Default: true. */
+  includeCapture?: boolean;
+  /** Include the `tdai_recall` context tool. Default: true. */
+  includeRecall?: boolean;
+  /** Prefix applied to every tool name (e.g. "memory_"). Default: none. */
+  namePrefix?: string;
+}
+
+// ============================
+// Argument coercion helpers
+// ============================
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+/**
+ * Coerce an LLM-supplied `limit` into an int in [1, max]. LLMs ignore the
+ * `type: integer` hint and send strings ("10"), floats (10.5), null, or
+ * booleans; this mirrors the Python provider's `_coerce_limit`.
+ */
+export function coerceLimit(raw: unknown, def = DEFAULT_LIMIT, max = MAX_LIMIT): number {
+  if (raw === null || raw === undefined || raw === "") return def;
+  if (typeof raw === "boolean") return def;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n)) return def;
+  const truncated = Math.trunc(n);
+  if (truncated < 1) return 1;
+  if (truncated > max) return max;
+  return truncated;
+}
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  if (typeof v !== "string" || v.trim() === "") {
+    throw new ToolArgError(`Missing or empty required parameter: ${key}`);
+  }
+  return v;
+}
+
+function optionalString(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() !== "" ? v : undefined;
+}
+
+class ToolArgError extends Error {}
+
+/** Wrap a handler so it never throws across the host boundary. */
+function guard(
+  handler: (args: Record<string, unknown>) => Promise<MemoryToolResult>,
+): (args: Record<string, unknown>) => Promise<MemoryToolResult> {
+  return async (args) => {
+    try {
+      return await handler(args ?? {});
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { text: message, isError: true };
+    }
+  };
+}
+
+// ============================
+// buildMemoryTools
+// ============================
+
+/**
+ * Produce the canonical TDAI memory tools bound to `adapter`.
+ *
+ * Read tools (always): `tdai_memory_search`, `tdai_conversation_search`.
+ * Context tool (opt-out): `tdai_recall`.
+ * Write tool (opt-out): `tdai_capture`.
+ */
+export function buildMemoryTools(
+  adapter: MemoryAdapter,
+  opts: BuildMemoryToolsOptions = {},
+): MemoryTool[] {
+  const sessionKey = opts.sessionKey ?? "default";
+  const prefix = opts.namePrefix ?? "";
+  const name = (base: string) => `${prefix}${base}`;
+
+  const tools: MemoryTool[] = [];
+
+  // -- memory_search (read) -----------------------------------------------
+  tools.push({
+    name: name("tdai_memory_search"),
+    title: "Search long-term memories",
+    description:
+      "Search the user's long-term structured memories (L1). Use this to recall " +
+      "the user's preferences, past events, instructions, or context from earlier " +
+      "conversations. Returns memory records ranked by relevance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "What you want to recall about the user." },
+        limit: { type: "integer", description: "Max results (default 5, max 20)." },
+        type: {
+          type: "string",
+          enum: ["persona", "episodic", "instruction"],
+          description: "Optional filter by memory type.",
+        },
+        scene: { type: "string", description: "Optional scene-block filter." },
+      },
+      required: ["query"],
+    },
+    invoke: guard(async (args) => {
+      const result: MemorySearchResult = await adapter.searchMemories({
+        query: requireString(args, "query"),
+        limit: coerceLimit(args.limit),
+        type: optionalString(args, "type"),
+        scene: optionalString(args, "scene"),
+      });
+      return { text: result.text, data: result };
+    }),
+  });
+
+  // -- conversation_search (read) -----------------------------------------
+  tools.push({
+    name: name("tdai_conversation_search"),
+    title: "Search conversation history",
+    description:
+      "Search past raw conversation history (L0). Use this when memory search " +
+      "does not have what you need, or when you want the exact words the user " +
+      "said before.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "What conversation content to find." },
+        limit: { type: "integer", description: "Max messages (default 5, max 20)." },
+        session_key: { type: "string", description: "Optional: restrict to one session." },
+      },
+      required: ["query"],
+    },
+    invoke: guard(async (args) => {
+      const result: ConversationSearchResult = await adapter.searchConversations({
+        query: requireString(args, "query"),
+        limit: coerceLimit(args.limit),
+        sessionKey: optionalString(args, "session_key"),
+      });
+      return { text: result.text, data: result };
+    }),
+  });
+
+  // -- recall (read / context) --------------------------------------------
+  if (opts.includeRecall !== false) {
+    tools.push({
+      name: name("tdai_recall"),
+      title: "Recall memory context",
+      description:
+        "Fetch the recall context block (relevant memories + persona) for a query, " +
+        "as the memory engine would inject it before an LLM turn. Useful to prime a " +
+        "response with what is known about the user.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "The user's current query or intent." },
+          session_key: { type: "string", description: "Session id (defaults to the adapter's session)." },
+        },
+        required: ["query"],
+      },
+      invoke: guard(async (args) => {
+        const result = await adapter.recall({
+          query: requireString(args, "query"),
+          sessionKey: optionalString(args, "session_key") ?? sessionKey,
+        });
+        return {
+          text: result.context || "(no relevant memory context)",
+          data: result,
+        };
+      }),
+    });
+  }
+
+  // -- capture (write) -----------------------------------------------------
+  if (opts.includeCapture !== false) {
+    tools.push({
+      name: name("tdai_capture"),
+      title: "Capture a conversation turn",
+      description:
+        "Persist a completed user/assistant turn into memory (L0 → pipeline). " +
+        "Call this after a meaningful exchange so it can be structured and recalled later.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          user_content: { type: "string", description: "The user's message." },
+          assistant_content: { type: "string", description: "The assistant's reply." },
+          session_key: { type: "string", description: "Session id (defaults to the adapter's session)." },
+        },
+        required: ["user_content", "assistant_content"],
+      },
+      invoke: guard(async (args) => {
+        const result = await adapter.capture({
+          userContent: requireString(args, "user_content"),
+          assistantContent: requireString(args, "assistant_content"),
+          sessionKey: optionalString(args, "session_key") ?? sessionKey,
+        });
+        return {
+          text: `Captured turn: ${result.l0Recorded} message(s) recorded, ` +
+            `scheduler ${result.schedulerNotified ? "notified" : "idle"}.`,
+          data: result,
+        };
+      }),
+    });
+  }
+
+  return tools;
+}


### PR DESCRIPTION
## 概述

Resolves #235

本 PR 将现有 Gateway 边界抽象为一套统一适配 SDK，并基于这套 SDK 新增 MCP 与 Dify 两个平台适配，让“为新平台接入 TDAI Memory”变得更简单、更统一，部分平台可以做到主要依赖配置完成接入。

本次实现覆盖 issue 中的四档验收要求：架构说明、单平台读写适配、双平台适配与对比文档、统一适配 SDK。

## 验收标准对照

| 阶段 | 交付物 |
| :--- | :--- |
| 基础：架构图 + 数据流 | [`docs/adapters/ARCHITECTURE.md`](../blob/feat/cross-platform-adapters/docs/adapters/ARCHITECTURE.md)：说明核心 `TdaiCore` 能力、现有适配器关系，以及 recall/capture 数据流图 |
| 进阶：一个平台的读写适配 | [`src/adapters/mcp/`](../blob/feat/cross-platform-adapters/src/adapters/mcp/)：提供 MCP stdio server，暴露 `tdai_memory_search`、`tdai_conversation_search`、`tdai_recall`、`tdai_capture` 等能力 |
| 深入：至少两个平台 + 对比文档 | 新增 [`src/adapters/dify/`](../blob/feat/cross-platform-adapters/src/adapters/dify/) Dify OpenAPI 自定义工具适配，并补充 [`docs/adapters/COMPARISON.md`](../blob/feat/cross-platform-adapters/docs/adapters/COMPARISON.md) |
| 拓展：统一适配 SDK | 新增 [`src/sdk/`](../blob/feat/cross-platform-adapters/src/sdk/) 与 [`docs/adapters/ADDING-A-PLATFORM.md`](../blob/feat/cross-platform-adapters/docs/adapters/ADDING-A-PLATFORM.md)，沉淀统一接口和新增平台接入指南 |

## 主要变更

### `src/sdk`：统一适配 SDK

- 新增 `TdaiGatewayClient`：为 Gateway 各接口提供类型化、无额外依赖的 HTTP client，支持超时、有限重试、Bearer 鉴权和类型化 `TdaiGatewayError`。
- 新增 `MemoryAdapter` 接口与 `GatewayMemoryAdapter`：统一抽象 `recall`、`searchMemories`、`searchConversations`、`capture`、`endSession`、`health` 等能力。
- 新增 `buildMemoryTools()`：生成与宿主无关的工具描述，包括工具名、描述、JSON Schema 和非抛错式 `invoke`，可映射到 MCP、Dify、Vercel AI SDK、OpenAI functions 等平台。

### `src/adapters/mcp`：MCP 平台适配

- 新增基于 stdio 的 JSON-RPC 2.0 MCP server。
- 暴露 TDAI Memory 的检索、会话检索、回忆和写入能力。
- 提供 `tdai-memory-mcp` bin 入口和不同宿主的配置示例。
- 支持关闭时等待进行中的请求完成，避免 stdio 响应被截断。

### `src/adapters/dify`：Dify 平台适配

- 新增 OpenAPI 3.0 schema，可直接作为 Dify 自定义工具导入。
- 补充 agent tools 和 workflow 使用指南，覆盖基于 `sys.conversation_id` 的 recall/capture 流程。

### `docs/adapters`：文档补充

- 新增适配架构说明和数据流图。
- 新增 OpenClaw、Hermes、MCP、Dify 的适配方式对比和选择建议。
- 新增“如何新增一个平台”的接入指南，并提供示例。

## 测试验证

- 新增 43 个测试，覆盖 SDK client 映射、重试、错误处理、工具参数转换、MCP 协议行为、stdio framing 和请求 drain 等流程。
- 完整测试套件通过：110 个测试通过。
- 已进行真实端到端验证：启动 Gateway 后通过 MCP server 写入一轮记忆，并在新的 `tdai_conversation_search` 进程中检索到对应内容，验证 MCP -> SDK -> Gateway -> Core 的完整读写链路。
- TypeScript 在 `strict` + `nodenext` 配置下类型检查通过。
- `npm pack` 已确认包含新增源码并排除测试文件，产物大小约 675 KB，低于 CI 的 2 MB 限制。

## 其他说明

- 现有核心链路保持稳定：未修改 `TdaiCore`、Gateway、OpenClaw/Hermes 适配器。
- 本次新增能力位于现有 HTTP 边界之上，便于后续继续扩展更多平台。
- MCP、Dify、OpenClaw、Hermes 可共享同一个 Gateway 和同一个 memory store。