### PR TITLE
fix(data): recalibrate checkpoint counters

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -415,6 +415,16 @@ export class TdaiCore {
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+
+    try {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.recalibrate(this.vectorStore);
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint recalibration failed; continuing with existing checkpoint: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private wirePipelineRunners(): void {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+type RecalibratingCheckpointManager = CheckpointManager & {
+  recalibrate(store?: {
+    countL0(): number | Promise<number>;
+    countL1(): number | Promise<number>;
+  }): Promise<void>;
+};
+
+const tempDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(filePath: string, records: unknown[]): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(
+    filePath,
+    records.map((record) => JSON.stringify(record)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+describe("CheckpointManager recalibrate", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recounts L0 and L1 counters from JSONL fallback data", async () => {
+    const dataDir = await makeDataDir();
+    await writeJsonl(path.join(dataDir, "conversations", "2026-07-05.jsonl"), [
+      { sessionKey: "s1", content: "hello" },
+      { sessionKey: "s1", content: "world" },
+      { sessionKey: "s2", content: "again" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-07-05.jsonl"), [
+      { id: "m1", content: "memory 1" },
+      { id: "m2", content: "memory 2" },
+    ]);
+
+    const manager = new CheckpointManager(dataDir) as RecalibratingCheckpointManager;
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      total_processed: 99,
+      memories_since_last_persona: 10,
+      l0_conversations_count: 50,
+      total_memories_extracted: 50,
+      runner_states: {
+        s1: {
+          last_captured_timestamp: 123,
+          last_l1_cursor: 456,
+          last_scene_name: "scene",
+        },
+      },
+    });
+
+    expect(typeof manager.recalibrate).toBe("function");
+    await manager.recalibrate();
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.l0_conversations_count).toBe(3);
+    expect(recalibrated.total_memories_extracted).toBe(2);
+    expect(recalibrated.memories_since_last_persona).toBe(2);
+    expect(recalibrated.total_processed).toBe(99);
+    expect(recalibrated.runner_states.s1?.last_l1_cursor).toBe(456);
+  });
+
+  it("prefers live store counts over JSONL fallback data", async () => {
+    const dataDir = await makeDataDir();
+    await writeJsonl(path.join(dataDir, "conversations", "2026-07-05.jsonl"), [
+      { sessionKey: "s1", content: "jsonl l0" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-07-05.jsonl"), [
+      { id: "m1", content: "jsonl l1" },
+    ]);
+
+    const manager = new CheckpointManager(dataDir) as RecalibratingCheckpointManager;
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      memories_since_last_persona: 4,
+      l0_conversations_count: 99,
+      total_memories_extracted: 99,
+    });
+
+    await manager.recalibrate({
+      countL0: async () => 6,
+      countL1: async () => 7,
+    });
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.l0_conversations_count).toBe(6);
+    expect(recalibrated.total_memories_extracted).toBe(7);
+    expect(recalibrated.memories_since_last_persona).toBe(4);
+  });
+
+  it("recalibrates checkpoint counters after memory cleaner removes JSONL shards", async () => {
+    const dataDir = await makeDataDir();
+    await writeJsonl(path.join(dataDir, "conversations", "2026-07-01.jsonl"), [
+      { sessionKey: "old", content: "old l0 1" },
+      { sessionKey: "old", content: "old l0 2" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-07-01.jsonl"), [
+      { id: "old-m1", content: "old memory 1" },
+      { id: "old-m2", content: "old memory 2" },
+    ]);
+    await writeJsonl(path.join(dataDir, "conversations", "2026-07-05.jsonl"), [
+      { sessionKey: "new", content: "new l0" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-07-05.jsonl"), [
+      { id: "new-m1", content: "new memory" },
+    ]);
+
+    const manager = new CheckpointManager(dataDir) as RecalibratingCheckpointManager;
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      memories_since_last_persona: 9,
+      l0_conversations_count: 99,
+      total_memories_extracted: 99,
+    });
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    });
+
+    await cleaner.runOnce(new Date("2026-07-05T12:00:00Z").getTime());
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.l0_conversations_count).toBe(1);
+    expect(recalibrated.total_memories_extracted).toBe(1);
+    expect(recalibrated.memories_since_last_persona).toBe(1);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -146,6 +146,11 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+export interface CheckpointRecalibrationStore {
+  countL0(): number | Promise<number>;
+  countL1(): number | Promise<number>;
+}
+
 // ============================
 // Per-file async lock
 // ============================
@@ -291,6 +296,68 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Reconcile drift-prone aggregate counters with persisted data.
+   *
+   * Prefer the live store when available because it represents the retrieval
+   * source of truth after dedup updates and cleaner deletions. When no store is
+   * available, fall back to counting JSONL records on disk.
+   */
+  async recalibrate(store?: CheckpointRecalibrationStore): Promise<void> {
+    const [l0Count, l1Count] = await Promise.all([
+      this.countActualRecords("conversations", () => store?.countL0()),
+      this.countActualRecords("records", () => store?.countL1()),
+    ]);
+
+    const cp = await this.mutate((cp) => {
+      cp.l0_conversations_count = l0Count;
+      cp.total_memories_extracted = l1Count;
+      cp.memories_since_last_persona = Math.min(cp.memories_since_last_persona, l1Count);
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrate: l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+  }
+
+  private async countActualRecords(
+    subdir: "conversations" | "records",
+    storeCount: () => number | Promise<number> | undefined,
+  ): Promise<number> {
+    const fromStore = await storeCount();
+    if (typeof fromStore === "number" && Number.isFinite(fromStore) && fromStore >= 0) {
+      return Math.trunc(fromStore);
+    }
+    return this.countJsonlLines(path.join(path.dirname(this.filePath), "..", subdir));
+  }
+
+  private async countJsonlLines(dirPath: string): Promise<number> {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    let total = 0;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      const filePath = path.join(dirPath, entry.name);
+      try {
+        const raw = await fs.readFile(filePath, "utf-8");
+        total += raw.split("\n").filter((line) => line.trim()).length;
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: failed to count ${filePath}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return total;
   }
 
   // ============================

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -184,6 +185,14 @@ export class LocalMemoryCleaner {
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await checkpoint.recalibrate(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint recalibration failed after cleanup: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private scheduleNext(): void {


### PR DESCRIPTION
## Summary
- Add `CheckpointManager.recalibrate()` to sync drift-prone L0/L1 counters with live store counts, falling back to JSONL line counts when no store is available.
- Recalibrate during core startup before scheduler restore and after memory-cleaner cleanup.
- Add regression coverage for JSONL fallback, store-preferred counts, and cleaner-triggered recalibration.

## Test Plan
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --check`

Fixes #157