### PR TITLE
fix(search): sanitize FTS5 query input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 ### 🐛 修复
 
+#### 搜索 / 召回
+- **FTS5 查询输入安全清洗**：`buildFtsQuery()` 在分词前移除 `AND` / `OR` / `NOT` / `NEAR`、`NEAR/n` 距离语法和 FTS5 控制字符，避免用户搜索文本改变 MATCH 查询语义；查询仍通过 SQLite prepared statement 参数传入，并用字母/数字 token 白名单保留普通搜索词和包含操作符子串的正常单词。
+
 #### 数据安全 / 数据隔离
 - **L2 LLM 提取失败导致 `scene_blocks/` 被清空 / 半写入** ([#88](https://github.com/Tencent/TencentDB-Agent-Memory/issues/88))：Phase 1 已对 `scene_blocks/` 做完整快照，但 LLM 抛错时 `catch` 直接 `return`，沙箱里的部分写入 / 删除不会回滚，后续 recall 因此看不到场景导航，降级为碎片召回。新增 `BackupManager.findLatestBackup` + `restoreLatestDirectory`，在 LLM 失败时自动从最新备份恢复；采用 fail-soft 设计：无备份时不动目标目录，恢复过程自身的错误也不会替换原始 LLM 错误。
 - **Cleaner 安全加固**：`computeCutoffMsByLocalDay` 拒绝无效 cutoff（未来时间 / 距今不足 24h）；SQLite 与 TCVDB 在 `expired/total > 80%` 时阻止删除；`runOnce` 增加最小保留护栏（L0:50 / L1:20）并产出 `cleaner_summary` JSON 审计日志；新增 `__tests__/cleaner/verify-cleaner-safety.ts` E2E 校验。

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery, VectorStore } from "./sqlite.js";
+import type { MemoryRecord } from "../record/l1-writer.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-sqlite-fts-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeMemory(id: string, content: string): MemoryRecord {
+  const now = "2026-07-05T00:00:00+08:00";
+  return {
+    id,
+    content,
+    type: "episodic",
+    priority: 50,
+    scene_name: "search",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [now],
+    createdAt: now,
+    updatedAt: now,
+    sessionKey: "session",
+    sessionId: "session-id",
+  };
+}
+
+function buildLegacyFtsQuery(raw: string): string | null {
+  const tokens =
+    raw
+      .match(/[\p{L}\p{N}_]+/gu)
+      ?.map((t) => t.trim())
+      .filter(Boolean) ?? [];
+
+  if (tokens.length === 0) return null;
+  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`).filter((t) => t !== '""');
+  if (quoted.length === 0) return null;
+  return quoted.join(" OR ");
+}
+
+afterEach(async () => {
+  _resetJiebaForTest();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("buildFtsQuery", () => {
+  it("keeps ordinary recall queries unchanged after sanitization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("memory sqlite user preference")).toBe(
+      '"memory" OR "sqlite" OR "user" OR "preference"',
+    );
+    expect(buildFtsQuery("旅行计划 API TypeScript")).toBe(
+      '"旅行计划" OR "API" OR "TypeScript"',
+    );
+  });
+
+  it("removes FTS5 boolean operators before tokenizing user text", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("apple OR banana AND NOT cherry NEAR date")).toBe(
+      '"apple" OR "banana" OR "cherry" OR "date"',
+    );
+  });
+
+  it("removes FTS5 operator distance syntax and control characters", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('alpha NEAR/5 beta title:gamma -delta "quoted" (group)*')).toBe(
+      '"alpha" OR "beta" OR "title" OR "gamma" OR "delta" OR "quoted" OR "group"',
+    );
+  });
+
+  it("sanitizes input before jieba tokenization", () => {
+    const seenInputs: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string) {
+        seenInputs.push(text);
+        return text.match(/[\p{L}\p{N}_]+/gu) ?? [];
+      },
+    });
+
+    expect(buildFtsQuery('memory AND sqlite NEAR/3 "injection"*')).toBe(
+      '"memory" OR "sqlite" OR "injection"',
+    );
+    expect(seenInputs).toHaveLength(1);
+    expect(seenInputs[0]).not.toMatch(/\b(?:AND|OR|NOT|NEAR)\b/i);
+    expect(seenInputs[0]).not.toMatch(/["'()*:^{}\[\]-]/);
+  });
+
+  it("preserves words that only contain operator substrings", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("ANDROID scanner ordinary nearby")).toBe(
+      '"ANDROID" OR "scanner" OR "ordinary" OR "nearby"',
+    );
+  });
+
+  it("returns null when input contains only FTS5 syntax", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('AND OR NOT NEAR/10 "()" * -')).toBeNull();
+  });
+
+  it("recalls expected FTS memories after sanitizing operator-heavy input", async () => {
+    _setJiebaForTest(null);
+    const dataDir = await makeTempDir();
+    const store = new VectorStore(path.join(dataDir, "memory.sqlite"), 0);
+    store.init({ provider: "none", model: "none", dimensions: 0 });
+    try {
+      store.upsertL1(makeMemory("mem-1", "memory sqlite user preference"), undefined);
+      store.upsertL1(makeMemory("mem-2", "旅行计划 API TypeScript"), undefined);
+      store.upsertL1(makeMemory("mem-3", "ANDROID scanner ordinary nearby"), undefined);
+
+      const normalQuery = buildFtsQuery("memory sqlite user preference");
+      const noisyQuery = buildFtsQuery('memory AND sqlite NEAR/3 user "preference"*');
+      const mixedLanguageQuery = buildFtsQuery("旅行计划 API TypeScript");
+      const operatorSubstringQuery = buildFtsQuery("ANDROID scanner ordinary nearby");
+
+      expect(normalQuery).toBe('"memory" OR "sqlite" OR "user" OR "preference"');
+      expect(noisyQuery).toBe('"memory" OR "sqlite" OR "user" OR "preference"');
+      expect(mixedLanguageQuery).toBe('"旅行计划" OR "API" OR "TypeScript"');
+      expect(operatorSubstringQuery).toBe('"ANDROID" OR "scanner" OR "ordinary" OR "nearby"');
+
+      expect(store.searchL1Fts(normalQuery!, 5).map((r) => r.record_id)).toEqual(["mem-1"]);
+      expect(store.searchL1Fts(noisyQuery!, 5).map((r) => r.record_id)).toEqual(["mem-1"]);
+      expect(store.searchL1Fts(mixedLanguageQuery!, 5).map((r) => r.record_id)).toEqual(["mem-2"]);
+      expect(store.searchL1Fts(operatorSubstringQuery!, 5).map((r) => r.record_id)).toEqual(["mem-3"]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("prints real recall output parity between legacy and sanitized FTS query builders", async () => {
+    _setJiebaForTest(null);
+    const dataDir = await makeTempDir();
+    const store = new VectorStore(path.join(dataDir, "memory.sqlite"), 0);
+    store.init({ provider: "none", model: "none", dimensions: 0 });
+    try {
+      const memories = [
+        makeMemory("mem-1", "memory sqlite user preference"),
+        makeMemory("mem-2", "旅行计划 API TypeScript"),
+        makeMemory("mem-3", "ANDROID scanner ordinary nearby"),
+        makeMemory("mem-4", "project issue recall screenshot comparison"),
+      ];
+      for (const memory of memories) {
+        store.upsertL1(memory, undefined);
+      }
+
+      const cases = [
+        "memory sqlite user preference",
+        "旅行计划 API TypeScript",
+        "ANDROID scanner ordinary nearby",
+        "project recall screenshot comparison",
+        'memory AND sqlite NEAR/3 user "preference"*',
+      ];
+
+      const comparison = cases.map((rawQuery) => {
+        const legacyQuery = buildLegacyFtsQuery(rawQuery);
+        const sanitizedQuery = buildFtsQuery(rawQuery);
+        const legacyRows = legacyQuery ? store.searchL1Fts(legacyQuery, 10) : [];
+        const sanitizedRows = sanitizedQuery ? store.searchL1Fts(sanitizedQuery, 10) : [];
+        return {
+          rawQuery,
+          legacyQuery,
+          sanitizedQuery,
+          legacyRecall: legacyRows.map((r) => ({ id: r.record_id, content: r.content })),
+          sanitizedRecall: sanitizedRows.map((r) => ({ id: r.record_id, content: r.content })),
+        };
+      });
+
+      console.log("\nFTS recall parity: legacy vs sanitized");
+      console.log(JSON.stringify(comparison, null, 2));
+
+      for (const item of comparison) {
+        expect(item.sanitizedRecall.map((r) => r.id)).toEqual(item.legacyRecall.map((r) => r.id));
+        expect(item.sanitizedRecall.map((r) => r.content)).toEqual(item.legacyRecall.map((r) => r.content));
+      }
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,25 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATOR_WORDS = /\b(?:AND|OR|NOT|NEAR)(?:\s*\/\s*\d+)?\b/gi;
+const FTS5_CONTROL_CHARS = /["'()*:^{}\[\]-]+/g;
+const FTS5_OPERATOR_TOKENS = new Set(["and", "or", "not", "near"]);
+
+/**
+ * Query-side allow-list sanitizer.
+ *
+ * SQLite's FTS5 `MATCH` query is passed as a prepared-statement parameter in
+ * `searchL1Fts()` / `searchL0Fts()`, but FTS5 still parses the parameter as a
+ * query grammar. Remove grammar operators and control characters before
+ * tokenization, then only keep letter/number tokens below. Normal search words
+ * are still quoted as phrases by `buildFtsQuery()`.
+ */
+function sanitizeFtsQueryInput(raw: string): string {
+  return raw
+    .replace(FTS5_OPERATOR_WORDS, " ")
+    .replace(FTS5_CONTROL_CHARS, " ");
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -197,13 +216,14 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const cleaned = sanitizeFtsQueryInput(raw);
 
   let tokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -211,6 +231,8 @@ export function buildFtsQuery(raw: string): string | null {
         if (!/[\p{L}\p{N}]/u.test(t)) return false;
         // Remove common Chinese stop-words to reduce noise
         if (ZH_STOP_WORDS.has(t)) return false;
+        // Defense in depth in case a tokenizer emits FTS5 operators.
+        if (FTS5_OPERATOR_TOKENS.has(t.toLowerCase())) return false;
         return true;
       });
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
@@ -218,14 +240,15 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        .filter((t) => t && !FTS5_OPERATOR_TOKENS.has(t.toLowerCase())) ?? [];
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`).filter((t) => t !== '""');
+  if (quoted.length === 0) return null;
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## 变更说明

修复 `buildFtsQuery()` 未在分词前清理 FTS5 查询语法的问题，避免用户输入中的 `AND` / `OR` / `NOT` / `NEAR` 等操作符影响 MATCH 查询语义。

## 问题原因

`buildFtsQuery()` 会把用户输入分词后用 `OR` 拼成 FTS5 查询。虽然每个 token 会被双引号包裹，但原始输入在进入 jieba 或 fallback regex 分词前没有显式清理 FTS5 操作符，存在 defense-in-depth 缺口。

## 主要修改

- 在 `buildFtsQuery()` 分词前清理 `AND` / `OR` / `NOT` / `NEAR` / `NEAR/n`
- 清理 FTS5 控制字符，避免用户输入改变查询结构
- 在 jieba 路径和 fallback regex 路径中都使用清理后的输入
- 增加 token 级过滤，防止 tokenizer 输出 FTS5 操作符
- 保留普通搜索词，例如 `ANDROID`、`ordinary`、中文查询和 API 关键词
- 保留 SQLite prepared statement 参数传入方式，并在查询构造前增加 token 白名单式清洗
- 补充 `CHANGELOG.md`

## Recall 一致性验证

为确认清洗逻辑不会影响正常召回效果，新增真实 SQLite FTS 召回对比测试。

测试方式：

1. 创建临时 SQLite `VectorStore`
2. 写入多条 L1 memory：
   - `mem-1`: `memory sqlite user preference`
   - `mem-2`: `旅行计划 API TypeScript`
   - `mem-3`: `ANDROID scanner ordinary nearby`
   - `mem-4`: `project issue recall screenshot comparison`
3. 对同一批 raw query，分别使用：
   - 旧逻辑 `legacyQuery`
   - 新逻辑 `sanitizedQuery`
4. 分别调用真实 `searchL1Fts()` 查询 SQLite FTS
5. 对比两边返回的 `record_id` 和 `content`

覆盖 query：

- `memory sqlite user preference`
- `旅行计划 API TypeScript`
- `ANDROID scanner ordinary nearby`
- `project recall screenshot comparison`
- `memory AND sqlite NEAR/3 user "preference"*`

验证结果：

- 普通英文 query：旧逻辑和新逻辑召回一致
- 中文 + API 混合 query：旧逻辑和新逻辑召回一致
- 包含 operator 子串的普通词，例如 `ANDROID` / `ordinary`：未被误删，召回一致
- 带 FTS5 语法噪声的 query：新逻辑会清理 `AND` / `NEAR/3` / 引号 / `*`，但真实召回结果仍与旧逻辑一致

真实输出中可以看到每组 query 都打印了：

- `legacyQuery`
- `sanitizedQuery`
- `legacyRecall`
- `sanitizedRecall`

其中 `legacyRecall` 和 `sanitizedRecall` 的 `id/content` 完全一致，确认清洗后没有造成正常召回退化。

部分测试截图：
<img width="630" height="546" alt="image" src="https://github.com/user-attachments/assets/6bf8f459-6457-4435-8145-30dac0444d4c" />
<img width="660" height="511" alt="image" src="https://github.com/user-attachments/assets/8484fd9b-819b-4a94-892c-0a2b2bb72c3d" />


## 测试

- `npm test -- src/core/store/sqlite.test.ts --reporter=verbose`
  - `1 test file passed`
  - `8 tests passed`
  - 输出包含 `FTS recall parity: legacy vs sanitized` 的真实召回对比
- `npm test`
  - `5 test files passed`
  - `75 tests passed`
- `npm run build:plugin`
  - build passed

## 关联 Issue

Closes #160