### PR TITLE
[codex] fix(store): sanitize FTS5 operators

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("removes a standalone AND operator before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("foo AND bar")).toBe('"foo" OR "bar"');
+  });
+
+  it("removes a standalone OR operator before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("foo OR bar")).toBe('"foo" OR "bar"');
+  });
+
+  it("removes a standalone NOT operator before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("foo NOT bar")).toBe('"foo" OR "bar"');
+  });
+
+  it("removes a standalone NEAR operator before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("foo NEAR bar")).toBe('"foo" OR "bar"');
+  });
+
+  it("removes standalone operators case-insensitively", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("foo and bar Or baz nOt qux near end")).toBe(
+      '"foo" OR "bar" OR "baz" OR "qux" OR "end"',
+    );
+  });
+
+  it("returns null when the input contains only standalone operators", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  });
+
+  it("preserves normal words containing operator substrings", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("ANDROID ordinary notable nearby OR中文")).toBe(
+      '"ANDROID" OR "ordinary" OR "notable" OR "nearby" OR "OR中文"',
+    );
+  });
+
+  it("uses the cleaned input for jieba search tokenization", () => {
+    const calls: Array<{ text: string; hmm: boolean }> = [];
+    _setJiebaForTest({
+      cutForSearch(text, hmm) {
+        calls.push({ text, hmm });
+        return text.split(/\s+/).filter(Boolean);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe(
+      '"用户" OR "TypeScript" OR "记忆"',
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].hmm).toBe(true);
+    expect(calls[0].text.split(/\s+/).filter(Boolean)).toEqual(["用户", "TypeScript", "记忆"]);
+  });
+
+  it("preserves existing jieba filtering, deduplication, and quoting behavior", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["用户", "用户", "的", ",", "TypeScript", '"quoted"'],
+    });
+
+    expect(buildFtsQuery("normal input")).toBe('"用户" OR "TypeScript" OR "quoted"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,9 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+// Unicode-aware boundaries preserve words that merely contain operator text.
+const FTS5_OPERATOR_RE = /(?<![\p{L}\p{N}_])(?:AND|OR|NOT|NEAR)(?![\p{L}\p{N}_])/giu;
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -196,6 +199,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = raw.replace(FTS5_OPERATOR_RE, " ");
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +207,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +222,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
## Summary

Fixes #160.

`buildFtsQuery()` previously passed raw user input directly to both tokenization paths, allowing standalone SQLite FTS5 operators to become searchable tokens. This PR removes `AND`, `OR`, `NOT`, and `NEAR` before tokenization while preserving the existing OR-query construction behavior.

## Changes

- Sanitize standalone FTS5 operators before jieba and fallback tokenization
- Use Unicode-aware boundaries so words containing operator substrings remain unchanged
- Add Vitest coverage for all four operators, case-insensitive input, word boundaries, both tokenization paths, and existing filtering/deduplication behavior

## Test

- `npm test` — 76 tests passed
- `npm run build` — passed
