### PR TITLE
fix(checkpoint): recalculate memory counters from storage

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -409,11 +409,29 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      try {
+        await new CheckpointManager(this.dataDir, this.logger).recalculateCounters(this.vectorStore);
+      } catch (checkpointErr) {
+        this.logger.warn(
+          `${TAG} Checkpoint counter recalculation failed: ${
+            checkpointErr instanceof Error ? checkpointErr.message : String(checkpointErr)
+          }`,
+        );
+      }
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
       );
+      try {
+        await new CheckpointManager(this.dataDir, this.logger).recalculateCounters();
+      } catch (checkpointErr) {
+        this.logger.warn(
+          `${TAG} Checkpoint counter recalculation failed: ${
+            checkpointErr instanceof Error ? checkpointErr.message : String(checkpointErr)
+          }`,
+        );
+      }
     }
   }
 

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import type { Checkpoint } from "./checkpoint.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(filePath: string, rows: unknown[]): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(
+    filePath,
+    rows.map((row) => JSON.stringify(row)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    last_captured_timestamp: 0,
+    total_processed: 0,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 0,
+    runner_states: {},
+    pipeline_states: {},
+    l0_conversations_count: 999,
+    total_memories_extracted: 888,
+    ...overrides,
+  };
+}
+
+function makeStore(params: {
+  l0: number;
+  l1: number;
+  degraded?: boolean;
+}): IMemoryStore {
+  return {
+    isDegraded: () => params.degraded ?? false,
+    countL0: () => params.l0,
+    countL1: () => params.l1,
+  } as unknown as IMemoryStore;
+}
+
+describe("CheckpointManager counter recalculation", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recalculates counters from JSONL files when no vector store is available", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-1", content: "first" },
+      { id: "l0-2", content: "second" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-1", content: "memory" },
+    ]);
+
+    await checkpoint.recalculateCounters();
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(2);
+    expect(actual.total_memories_extracted).toBe(1);
+  });
+
+  it("prefers vector store counts over JSONL counts", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-jsonl" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-jsonl" },
+    ]);
+
+    await checkpoint.recalculateCounters(makeStore({ l0: 7, l1: 3 }));
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(7);
+    expect(actual.total_memories_extracted).toBe(3);
+  });
+
+  it("falls back to JSONL counts when vector store is degraded", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-1" },
+      { id: "l0-2" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-1" },
+    ]);
+
+    await checkpoint.recalculateCounters(makeStore({ l0: 100, l1: 50, degraded: true }));
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(2);
+    expect(actual.total_memories_extracted).toBe(1);
+  });
+
+  it("reflects manual JSONL deletion after recalculation", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const l0Path = path.join(dataDir, "conversations", "2026-01-01.jsonl");
+    const l1Path = path.join(dataDir, "records", "2026-01-01.jsonl");
+
+    await checkpoint.write(makeCheckpoint({ l0_conversations_count: 5, total_memories_extracted: 4 }));
+    await writeJsonl(l0Path, [{ id: "l0-1" }, { id: "l0-2" }]);
+    await writeJsonl(l1Path, [{ id: "l1-1" }]);
+    await fs.rm(l0Path);
+
+    await checkpoint.recalculateCounters();
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(0);
+    expect(actual.total_memories_extracted).toBe(1);
+  });
+});

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -135,4 +135,25 @@ describe("CheckpointManager counter recalculation", () => {
     expect(actual.l0_conversations_count).toBe(0);
     expect(actual.total_memories_extracted).toBe(1);
   });
+
+  it("resets counters to zero when storage is cleared but checkpoint remains", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write(makeCheckpoint({ l0_conversations_count: 12, total_memories_extracted: 6 }));
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-before-reset" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-before-reset" },
+    ]);
+    await fs.rm(path.join(dataDir, "conversations"), { recursive: true, force: true });
+    await fs.rm(path.join(dataDir, "records"), { recursive: true, force: true });
+
+    await checkpoint.recalculateCounters();
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(0);
+    expect(actual.total_memories_extracted).toBe(0);
+  });
 });

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -179,10 +180,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -291,6 +294,28 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Recalculate storage-derived counters from the current source of truth.
+   *
+   * The two counters below are derived state: capture/extraction paths increment
+   * them, while cleanup/manual deletion/reset paths can remove the underlying
+   * records. Recalculation restores them from VectorStore when available, or
+   * from local JSONL shards as a fallback.
+   */
+  async recalculateCounters(vectorStore?: IMemoryStore): Promise<void> {
+    const counts = await this.readStorageCounts(vectorStore);
+    const cp = await this.mutate((cp) => {
+      cp.l0_conversations_count = counts.l0;
+      cp.total_memories_extracted = counts.l1;
+    });
+    this.logger.info(
+      `[checkpoint] recalculateCounters: ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `source=${counts.source}`,
+    );
   }
 
   // ============================
@@ -485,4 +510,62 @@ export class CheckpointManager {
     });
   }
 
+  private async readStorageCounts(
+    vectorStore?: IMemoryStore,
+  ): Promise<{ l0: number; l1: number; source: "vectorStore" | "jsonl" }> {
+    if (vectorStore && !vectorStore.isDegraded()) {
+      try {
+        const [l0, l1] = await Promise.all([
+          vectorStore.countL0(),
+          vectorStore.countL1(),
+        ]);
+        return { l0, l1, source: "vectorStore" };
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] vectorStore count failed, falling back to JSONL: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const [l0, l1] = await Promise.all([
+      countJsonLines(path.join(this.dataDir, "conversations")),
+      countJsonLines(path.join(this.dataDir, "records")),
+    ]);
+    return { l0, l1, source: "jsonl" };
+  }
+
+}
+
+async function countJsonLines(dirPath: string): Promise<number> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".jsonl") && !entry.name.endsWith(".json")) continue;
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+    } catch {
+      continue;
+    }
+
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        JSON.parse(line);
+        count += 1;
+      } catch {
+        // Keep recalculation tolerant of partially corrupt local shards.
+      }
+    }
+  }
+  return count;
 }

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import type { Checkpoint } from "./checkpoint.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    last_captured_timestamp: 0,
+    total_processed: 0,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 0,
+    runner_states: {},
+    pipeline_states: {},
+    l0_conversations_count: 100,
+    total_memories_extracted: 40,
+    ...overrides,
+  };
+}
+
+function makeCleaningStore(): IMemoryStore {
+  let l0CountCalls = 0;
+  let l1CountCalls = 0;
+
+  return {
+    isDegraded: () => false,
+    countL0: () => {
+      l0CountCalls += 1;
+      return l0CountCalls === 1 ? 100 : 4;
+    },
+    countL1: () => {
+      l1CountCalls += 1;
+      return l1CountCalls === 1 ? 40 : 2;
+    },
+    deleteL0Expired: () => 96,
+    deleteL1Expired: () => 38,
+  } as unknown as IMemoryStore;
+}
+
+describe("LocalMemoryCleaner checkpoint counter refresh", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recalculates checkpoint counters after automatic cleanup", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: makeCleaningStore(),
+      logger: {
+        info() {},
+        warn() {},
+        error() {},
+      },
+    });
+
+    await cleaner.runOnce(new Date("2026-01-03T12:00:00Z").getTime());
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(4);
+    expect(actual.total_memories_extracted).toBe(2);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -178,6 +179,14 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    try {
+      await new CheckpointManager(this.opts.baseDir, this.opts.logger).recalculateCounters(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint counter recalculation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(


### PR DESCRIPTION
## Description | 描述

本 PR 修复 memory 清理或存储 reset 后 checkpoint 计数器漂移的问题。

`l0_conversations_count` 和 `total_memories_extracted` 属于派生计数器。正常写入路径会递增它们，但自动清理、手动删除或存储 reset 可能删除真实的 L0/L1 数据，却不会同步减少 checkpoint 中的旧计数，导致状态展示与实际数据不一致。

本次修复增加了一个保守的 `CheckpointManager.recalculateCounters()` 路径：

- `vectorStore` 可用且健康时，优先使用 `countL0()` / `countL1()` 作为真实计数。
- `vectorStore` 不可用、degraded 或计数失败时，fallback 到 `conversations/*.jsonl` 和 `records/*.jsonl` 的有效 JSON 行数。
- 在 store 初始化后和本地 cleaner 清理完成后触发重算。
- 保持现有 checkpoint schema 和 cursor 语义不变，避免扩大变更范围。

## Related Issue | 关联 Issue

Fix #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

本地验证命令：

```bash
npm.cmd test -- src/utils/checkpoint.test.ts src/utils/memory-cleaner.test.ts
npm.cmd test
npm.cmd run build
```

## Additional Notes | 其他说明

已覆盖的清理 / reset 场景：

- 手动删除 JSONL 后重新计算 checkpoint 计数。
- 自动 cleaner 清理后刷新 checkpoint 计数。
- `conversations/` 和 `records/` 被清空但旧 checkpoint 仍存在时，计数归零。


Checkpoint 设计补充：

这个问题暴露出 checkpoint 中有两类状态需要区分：

- 处理进度状态：例如 `last_captured_timestamp`、`last_l1_cursor`。这类字段描述增量处理应该从哪里继续，更适合用时间戳 / cursor 表达。
- 派生统计状态：例如 `l0_conversations_count`、`total_memories_extracted`。这类字段描述当前存储里有多少数据，更适合从真实存储重新计算。

长期来看，更好的 Checkpoint 设计可以采用 hybrid 模式：

- checkpoint 只保存恢复处理流程所必需的 cursor / timestamp。
- L0/L1 数量从 `countL0()`、`countL1()` 或 JSONL fallback 中获取。
- 如果需要缓存统计值，应把它们作为带来源和刷新时间的 snapshot，而不是作为不可回退的累加计数器。
