### PR TITLE
fix(data): add recountFromDisk to fix drift in checkpoint counters (#157)

### DIFF
--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CheckpointManager } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("CheckpointManager.recountFromDisk", () => {
+  it("recalibrates L0 and L1 counters using callback-provided values", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    // Seed with stale counters
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 20,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 12,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 20,
+      total_memories_extracted: 15,
+    });
+
+    // Callbacks simulate counting actual on-disk records
+    await checkpoint.recountFromDisk(
+      async () => 5, // L0 conversations actually on disk
+      async () => 8, // L1 memories actually on disk
+    );
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(5);
+    expect(cp.total_memories_extracted).toBe(8);
+    // Other fields should be preserved
+    expect(cp.total_processed).toBe(20);
+    expect(cp.memories_since_last_persona).toBe(12);
+  });
+
+  it("leaves counters unchanged when the count callback throws", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir, {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    });
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 10,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 0,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 10,
+      total_memories_extracted: 10,
+    });
+
+    // Callback that always fails (e.g., DB connection lost)
+    await checkpoint.recountFromDisk(
+      async () => { throw new Error("DB unavailable"); },
+      async () => 0,
+    );
+
+    // Counters should be unchanged after error
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(10);
+    expect(cp.total_memories_extracted).toBe(10);
+  });
+
+  it("handles zero-count recalibration (all data pruned)", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 100,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 5,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 100,
+      total_memories_extracted: 50,
+    });
+
+    // Everything was cleaned up
+    await checkpoint.recountFromDisk(
+      async () => 0,
+      async () => 0,
+    );
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+  });
+
+  it("supports callback-based counting for flexibility", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    // Demonstrate that callbacks can use any data source —
+    // they don't need to know about vector stores internally
+    let callCount = 0;
+    const trackedValues: number[] = [];
+
+    await checkpoint.recountFromDisk(
+      async () => {
+        callCount++;
+        // In real code this could read from a file, DB, or API
+        const files = await fs.readdir(dataDir);
+        trackedValues.push(files.length);
+        return files.length;
+      },
+      async () => {
+        callCount++;
+        return 42; // Could be any async computation
+      },
+    );
+
+    expect(callCount).toBe(2);
+    const cp = await checkpoint.read();
+    expect(cp.total_memories_extracted).toBe(42);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -485,4 +485,59 @@ export class CheckpointManager {
     });
   }
 
+  /**
+   * Recalculate global counters from on-disk data files.
+   *
+   * `total_memories_extracted` and `l0_conversations_count` are only ever
+   * incremented in the normal capture path — no code path decrements them
+   * after cleanup, test-pipeline teardown, or manual JSONL pruning.
+   *
+   * Call this after any data-deletion operation to bring the checkpoint
+   * counters back in line with reality.
+   *
+   * @param getL0ConversationCount  Callback that returns the current count of
+   *   L0 conversations actually present on disk.
+   * @param getL1MemoryCount  Callback that returns the current count of L1
+   *   memories actually present on disk.
+   */
+  async recountFromDisk(
+    getL0ConversationCount: () => Promise<number>,
+    getL1MemoryCount: () => Promise<number>,
+  ): Promise<void> {
+    await this.mutate((cp) => {
+      // Counters are derived from actual data, not accumulated deltas.
+      // Set a sentinel that tells callers the counters were recalculated.
+      const flag = "__recount_pending__";
+      (cp as Record<string, unknown>)[flag] = true;
+    });
+
+    // Perform the actual count outside the lock to avoid holding it
+    // during I/O.
+    let l0Count: number;
+    let l1Count: number;
+    try {
+      [l0Count, l1Count] = await Promise.all([
+        getL0ConversationCount(),
+        getL1MemoryCount(),
+      ]);
+    } catch (err) {
+      this.logger.warn(
+        `[checkpoint] recountFromDisk failed to count data: ${err}`,
+      );
+      return;
+    }
+
+    await this.mutate((cp) => {
+      cp.l0_conversations_count = l0Count;
+      cp.total_memories_extracted = l1Count;
+      delete (cp as Record<string, unknown>).__recount_pending__;
+    });
+
+    this.logger.info(
+      `[checkpoint] recountFromDisk: ` +
+      `l0_conversations_count=${l0Count}, ` +
+      `total_memories_extracted=${l1Count}`,
+    );
+  }
+
 }


### PR DESCRIPTION
## Summary
Add `recountFromDisk()` method to `CheckpointManager` to fix permanently-drifting counters after data cleanup.

## Root Cause
`total_memories_extracted` and `l0_conversations_count` are only ever incremented — never decremented. After cleanup operations (test pipeline teardown, memory-cleaner runs, manual JSONL pruning), the counters permanently overstate reality.

## Fix
Added `recountFromDisk(getL0ConversationCount, getL1MemoryCount)` that:
1. Accepts callbacks to count actual on-disk data
2. Performs I/O outside the file lock
3. Atomically updates checkpoint counters to match ground truth
4. Logs the recount for observability

Callers should invoke this after any data-deletion operation.

Fixes #157

Assisted-by: claude-code:deepseek-v4-pro