### PR TITLE
feat: add cross-platform memory adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,111 @@ curl http://127.0.0.1:8420/health
 > For the complete provider reference (environment variables, troubleshooting, LLM tool schemas, supervisor behavior), see [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md). Please read it before adjusting the supervisor / circuit-breaker defaults.
 
 
+### 3. Codex
+
+In addition to OpenClaw and Hermes, this plugin also supports Codex. The Codex integration lives in `codex-plugin/memory/memory_tencentdb/` and uses the shared `src/adapters/adapter-sdk` to talk to the Gateway.
+
+Codex data flow:
+
+```text
+Codex Hooks / MCP
+  -> codex-plugin/memory/memory_tencentdb/adapter.ts
+  -> src/adapters/adapter-sdk
+  -> Gateway HTTP API
+  -> TdaiCore
+```
+
+The Codex plugin provides:
+
+- `UserPromptSubmit` hook: calls `/recall` before each turn and injects recalled memory into Codex context.
+- `Stop` hook: calls `/capture` after each assistant response and stores the completed turn.
+- MCP tools: `tdai_memory_search` and `tdai_conversation_search` for explicit structured-memory and raw-conversation search.
+
+#### 3.1 Install the Codex plugin
+
+From the repository root:
+
+```bat
+npm install
+node scripts\install-codex-plugin.js
+```
+
+The installer will:
+
+- link `codex-plugin/memory/memory_tencentdb` to `%USERPROFILE%\.agents\plugins\tencentdb-memory`;
+- write the local Codex marketplace;
+- enable the `tdai-memory` MCP server in `%USERPROFILE%\.codex\config.toml`;
+- try to run `codex plugin add tencentdb-memory@local-codex-plugins`.
+
+After installation, restart Codex and trust the `UserPromptSubmit` and `Stop` hooks with `/hooks` or Settings -> Hooks.
+
+#### 3.2 Configure the Gateway
+
+The Codex plugin does not auto-start the Gateway. Start it manually from the repository root:
+
+```bat
+set TDAI_GATEWAY_URL=http://127.0.0.1:8420
+set TDAI_GATEWAY_API_KEY=your-api-key
+node --import tsx src/gateway/server.ts
+```
+
+Also write the Gateway URL and API key to the user environment so the Codex process can read them:
+
+```bat
+setx TDAI_GATEWAY_URL "http://127.0.0.1:8420"
+setx TDAI_GATEWAY_API_KEY "your-api-key"
+```
+
+`setx` only affects newly started processes, so restart Codex afterwards.
+
+
+### 4. Claude Code
+
+Claude Code integration lives in `claudecode-plugin/memory/memory_tencentdb/` and also reuses the shared `src/adapters/adapter-sdk`.
+
+Claude Code data flow:
+
+```text
+Claude Code Hooks / MCP
+  -> claudecode-plugin/memory/memory_tencentdb/adapter.ts
+  -> src/adapters/adapter-sdk
+  -> Gateway HTTP API
+  -> TdaiCore
+```
+
+The Claude Code plugin provides:
+
+- `UserPromptSubmit` hook: calls `/recall` before each turn and injects recalled memory into Claude Code context.
+- `Stop` hook: calls `/capture` after each assistant response and stores the completed turn.
+- MCP tools: `tdai_memory_search` and `tdai_conversation_search`.
+- `transcript_path` fallback: when the Stop event lacks the user prompt, the adapter can read the latest user/assistant turn from Claude Code's JSONL transcript.
+
+#### 4.1 Start the Gateway
+
+The Claude Code plugin does not auto-start the Gateway. Start it manually from the repository root:
+
+```bat
+set TDAI_GATEWAY_URL=http://127.0.0.1:8420
+set TDAI_GATEWAY_API_KEY=your-api-key
+node --import tsx src/gateway/server.ts
+```
+
+Write the environment variables to the user environment so the Claude Code process can read them:
+
+```bat
+setx TDAI_GATEWAY_URL "http://127.0.0.1:8420"
+setx TDAI_GATEWAY_API_KEY "your-api-key"
+```
+
+#### 4.2 Start Claude Code with the plugin
+
+Use `--plugin-dir` to start Claude Code with the plugin loaded:
+
+```bat
+claude --plugin-dir D:\xiniuniao\TencentDB-Agent-Memory\claudecode-plugin\memory\memory_tencentdb
+```
+
+
 ---
 
 
@@ -494,6 +599,8 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | :--- | :--- |
 | OpenClaw plugin | Automatically captures, extracts, and recalls memory once installed |
 | Hermes Gateway adapter | `TdaiCore + HostAdapter`, decoupled from the host framework |
+| Codex / Claude Code adapters | Hook and MCP integration via the shared `adapter-sdk` |
+| Unified adapter SDK | New platforms only need to implement `MemoryPlatformAdapter` |
 | Local backend | `SQLite + sqlite-vec`, ready to use out of the box |
 | Hybrid retrieval | BM25 + vector + RRF — supports both keyword and semantic recall |
 | Agent tools | `tdai_memory_search` / `tdai_conversation_search` |
@@ -527,6 +634,8 @@ We welcome every kind of contribution — bug reports, feature ideas, doc fixes,
 - [x] Short-term context compression (Context Offload + Mermaid canvas)
 - [x] Local SQLite backend and Tencent Cloud Vector Database (TCVDB) backend
 - [x] OpenClaw plugin and Hermes Gateway integration
+- [x] Codex and Claude Code adapters
+- [x] Unified adapter SDK; new platforms only need to implement `MemoryPlatformAdapter`
 - [ ] Portable memory: cross-Agent / cross-framework / cross-device import, export, and live migration
 - [ ] Automatic Skill generation
 - [ ] Visual debugging and memory observability dashboard

--- a/README_CN.md
+++ b/README_CN.md
@@ -354,6 +354,111 @@ curl http://127.0.0.1:8420/health
 > Provider 的完整参考（环境变量、故障排查、LLM 工具 schema、supervisor 行为）见 [`hermes-plugin/memory/memory_tencentdb/README.md`](./hermes-plugin/memory/memory_tencentdb/README.md)，调整 supervisor / circuit-breaker 默认值之前请先读它。
 
 
+### 3. Codex
+
+除 OpenClaw 和 Hermes 外，本插件也支持 Codex。Codex 接入通过本仓库内置的 `codex-plugin/memory/memory_tencentdb/` 插件完成，插件基于统一的 `src/adapters/adapter-sdk` 访问 Gateway。
+
+Codex 适配的数据流如下：
+
+```text
+Codex Hooks / MCP
+  -> codex-plugin/memory/memory_tencentdb/adapter.ts
+  -> src/adapters/adapter-sdk
+  -> Gateway HTTP API
+  -> TdaiCore
+```
+
+当前 Codex 插件提供：
+
+- `UserPromptSubmit` hook：对话前调用 `/recall`，把召回记忆注入 Codex 上下文。
+- `Stop` hook：回答后调用 `/capture`，写入本轮用户问题和助手回答。
+- MCP 工具：`tdai_memory_search`、`tdai_conversation_search`，用于主动搜索结构化记忆和原始对话。
+
+#### 3.1 安装 Codex 插件
+
+在仓库根目录执行：
+
+```bat
+npm install
+node scripts\install-codex-plugin.js
+```
+
+安装脚本会：
+
+- 将 `codex-plugin/memory/memory_tencentdb` 软连接到 `%USERPROFILE%\.agents\plugins\tencentdb-memory`。
+- 写入本地 Codex marketplace。
+- 在 `%USERPROFILE%\.codex\config.toml` 中启用 `tdai-memory` MCP。
+- 尝试执行 `codex plugin add tencentdb-memory@local-codex-plugins`。
+
+安装后重启 Codex，并在 Codex 中执行 `/hooks` 或进入 Settings -> Hooks，信任 `UserPromptSubmit` 和 `Stop` 两个 hook。
+
+#### 3.2 配置 Gateway
+
+Codex 插件不会自动启动 Gateway。请先在仓库根目录手动启动：
+
+```bat
+set TDAI_GATEWAY_URL=http://127.0.0.1:8420
+set TDAI_GATEWAY_API_KEY=your-api-key
+node --import tsx src/gateway/server.ts
+```
+
+同时建议把 Gateway 地址和 API Key 写入用户环境变量，供 Codex 进程读取：
+
+```bat
+setx TDAI_GATEWAY_URL "http://127.0.0.1:8420"
+setx TDAI_GATEWAY_API_KEY "your-api-key"
+```
+
+`setx` 只对新进程生效，设置后需要重启 Codex。
+
+
+### 4. Claude Code
+
+Claude Code 接入通过 `claudecode-plugin/memory/memory_tencentdb/` 插件完成，同样复用统一的 `src/adapters/adapter-sdk`。
+
+Claude Code 适配的数据流如下：
+
+```text
+Claude Code Hooks / MCP
+  -> claudecode-plugin/memory/memory_tencentdb/adapter.ts
+  -> src/adapters/adapter-sdk
+  -> Gateway HTTP API
+  -> TdaiCore
+```
+
+当前 Claude Code 插件提供：
+
+- `UserPromptSubmit` hook：对话前调用 `/recall`，把召回记忆注入 Claude Code 上下文。
+- `Stop` hook：回答后调用 `/capture`，写入本轮对话。
+- MCP 工具：`tdai_memory_search`、`tdai_conversation_search`。
+- `transcript_path` 兜底读取：当 Stop 事件缺少用户问题时，可从 Claude Code transcript 中提取最后一轮 user/assistant。
+
+#### 4.1 启动 Gateway
+
+Claude Code 插件不会自动启动 Gateway。请先在仓库根目录手动启动：
+
+```bat
+set TDAI_GATEWAY_URL=http://127.0.0.1:8420
+set TDAI_GATEWAY_API_KEY=your-api-key
+node --import tsx src/gateway/server.ts
+```
+
+并将环境变量写入用户环境，供 Claude Code 进程读取：
+
+```bat
+setx TDAI_GATEWAY_URL "http://127.0.0.1:8420"
+setx TDAI_GATEWAY_API_KEY "your-api-key"
+```
+
+#### 4.2 启动 Claude Code 并加载插件
+
+使用 `--plugin-dir` 启动 Claude Code 并加载插件：
+
+```bat
+claude --plugin-dir D:\xiniuniao\TencentDB-Agent-Memory\claudecode-plugin\memory\memory_tencentdb
+```
+
+
 ---
 
 ## 🔒 Gateway 安全配置（可选）
@@ -497,6 +602,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | :--- | :--- |
 | OpenClaw 插件 | 安装后即可自动捕获、提取、召回记忆 |
 | Hermes Gateway 适配 | `TdaiCore + HostAdapter` 解耦宿主框架 |
+| Codex / Claude Code 适配 | 基于统一 `adapter-sdk` 接入 Hook 与 MCP |
+| 统一适配器 SDK | 新平台只需实现 `MemoryPlatformAdapter` |
 | 本地后端 | `SQLite + sqlite-vec`，开箱即用 |
 | 混合检索 | BM25 + 向量 + RRF，兼顾关键词和语义召回 |
 | Agent 工具 | `tdai_memory_search` / `tdai_conversation_search` |
@@ -530,6 +637,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 - [x] 短期记忆压缩（Context Offload + Mermaid 画布）
 - [x] 可用本地 SQLite 后端与腾讯云向量数据库 TCVDB 后端
 - [x] OpenClaw 插件与 Hermes Gateway 适配
+- [x] Codex 与 Claude Code 适配
+- [x] 统一 adapter-sdk，新增平台只需实现 `MemoryPlatformAdapter`
 - [ ] 记忆可迁移：跨 Agent / 跨框架 / 跨设备的导入导出与热迁移
 - [ ] Skill自动生成
 - [ ] 可视化调试与记忆观测面板

--- a/claudecode-plugin/memory/memory_tencentdb/.claude-plugin/plugin.json
+++ b/claudecode-plugin/memory/memory_tencentdb/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "tencentdb-memory",
+  "version": "1.0.0",
+  "description": "TencentDB Agent Memory four-layer memory system via Gateway sidecar",
+  "author": {
+    "name": "TencentDB Agent Memory Team"
+  }
+}

--- a/claudecode-plugin/memory/memory_tencentdb/.mcp.json
+++ b/claudecode-plugin/memory/memory_tencentdb/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "node",
+      "args": ["--import", "tsx", "${CLAUDE_PLUGIN_ROOT}/mcp-server.ts"]
+    }
+  }
+}

--- a/claudecode-plugin/memory/memory_tencentdb/__tests__/test_gateway_shutdown_leak.test.ts
+++ b/claudecode-plugin/memory/memory_tencentdb/__tests__/test_gateway_shutdown_leak.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the adapter SDK Gateway ownership contract.
+ *
+ * Mirrors the Hermes test_gateway_shutdown_leak.py scope for Claude Code:
+ * Claude Code does not own the Gateway process, so it must never auto-spawn
+ * or terminate Gateway. The plugin may only check health and tell the user to
+ * start Gateway manually.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ensureGateway } from "../../../../src/adapters/adapter-sdk/gateway-supervisor.js";
+
+const PLUGIN_DIR = join(__dirname, "..");
+const REPO_ROOT = join(PLUGIN_DIR, "..", "..", "..");
+const SDK_DIR = join(REPO_ROOT, "src", "adapters", "adapter-sdk");
+
+describe("GatewayShutdownLeakTest", () => {
+  it("does not spawn Gateway when health check fails", async () => {
+    const gateway = {
+      baseUrl: "http://127.0.0.1:18420",
+      isHealthy: vi.fn().mockResolvedValue(false),
+    };
+    const logger = { warn: vi.fn() };
+
+    const ok = await ensureGateway({ gateway: gateway as never, logger });
+
+    expect(ok).toBe(false);
+    expect(gateway.isHealthy).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Start it manually with: node --import tsx src/gateway/server.ts"),
+    );
+  });
+
+  it("does not warn or change process ownership when Gateway is healthy", async () => {
+    const gateway = {
+      baseUrl: "http://127.0.0.1:8420",
+      isHealthy: vi.fn().mockResolvedValue(true),
+    };
+    const logger = { warn: vi.fn() };
+
+    const ok = await ensureGateway({ gateway: gateway as never, logger });
+
+    expect(ok).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("SDK supervisor contains no child-process spawn path", () => {
+    const source = readFileSync(join(SDK_DIR, "gateway-supervisor.ts"), "utf-8");
+
+    expect(source).toContain("ensureGateway");
+    expect(source).toContain("isHealthy");
+    expect(source).not.toContain("child_process");
+    expect(source).not.toContain("spawn(");
+    expect(source).not.toContain("MEMORY_TENCENTDB_GATEWAY_CMD");
+  });
+
+  it("Claude Code entrypoints delegate lifecycle behavior to the adapter SDK", () => {
+    const mcpSource = readFileSync(join(PLUGIN_DIR, "mcp-server.ts"), "utf-8");
+    const recallSource = readFileSync(join(PLUGIN_DIR, "hooks", "recall.ts"), "utf-8");
+    const captureSource = readFileSync(join(PLUGIN_DIR, "hooks", "capture.ts"), "utf-8");
+
+    expect(mcpSource).toContain("runMemoryMcpServer");
+    expect(recallSource).toContain("runRecallHook");
+    expect(captureSource).toContain("runCaptureHook");
+    expect(mcpSource).not.toContain("spawn");
+    expect(recallSource).not.toContain("spawn");
+    expect(captureSource).not.toContain("spawn");
+  });
+});

--- a/claudecode-plugin/memory/memory_tencentdb/__tests__/test_memory_tencentdb_recovery.test.ts
+++ b/claudecode-plugin/memory/memory_tencentdb/__tests__/test_memory_tencentdb_recovery.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for memory-tencentdb adapter self-healing and degraded behavior.
+ *
+ * Mirrors the Hermes test_memory_tencentdb_recovery.py scope for Claude Code:
+ * request-path failures must not break the host agent. Hooks degrade to
+ * empty recall context or skipped capture output, and successful capture
+ * clears the prompt cache.
+ */
+
+import { Readable, Writable } from "node:stream";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { claudeCodeMemoryAdapter } from "../adapter.js";
+import { runCaptureHook, runRecallHook } from "../../../../src/adapters/adapter-sdk/hook-runner.js";
+import type { PromptCache } from "../../../../src/adapters/adapter-sdk/index.js";
+
+class MemoryPromptCache implements PromptCache {
+  readonly values = new Map<string, string>();
+  cleanupCalls = 0;
+  deleteCalls: string[] = [];
+
+  get(sessionKey: string): string | null {
+    return this.values.get(sessionKey) ?? null;
+  }
+
+  set(sessionKey: string, prompt: string): void {
+    this.values.set(sessionKey, prompt);
+  }
+
+  delete(sessionKey: string): void {
+    this.deleteCalls.push(sessionKey);
+    this.values.delete(sessionKey);
+  }
+
+  cleanup(): void {
+    this.cleanupCalls += 1;
+  }
+}
+
+function stdinFrom(value: unknown) {
+  return Readable.from([JSON.stringify(value)]);
+}
+
+function captureStdout() {
+  let output = "";
+  const stdout = new Writable({
+    write(chunk, _encoding, callback) {
+      output += Buffer.from(chunk).toString("utf-8");
+      callback();
+    },
+  });
+  return { stdout, read: () => JSON.parse(output) };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("MemoryTencentdbRecoveryTest", () => {
+  it("recall hook returns empty context when Gateway is unavailable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+    const cache = new MemoryPromptCache();
+    const io = captureStdout();
+
+    await runRecallHook(claudeCodeMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "cc-session", prompt: "remember my name" }),
+      stdout: io.stdout,
+      cache,
+      logger: { warn: vi.fn() },
+    });
+
+    expect(io.read()).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: "",
+      },
+    });
+    expect(cache.cleanupCalls).toBe(1);
+    expect(cache.get("cc-session")).toBe("remember my name");
+  });
+
+  it("recall hook recovers on the request path when Gateway responds again", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ context: "User prefers TypeScript", memory_count: 1 }),
+    }));
+    const cache = new MemoryPromptCache();
+    const io = captureStdout();
+
+    await runRecallHook(claudeCodeMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "cc-session", prompt: "what do I prefer?" }),
+      stdout: io.stdout,
+      cache,
+    });
+
+    expect(io.read().hookSpecificOutput.additionalContext).toBe("User prefers TypeScript");
+    expect(cache.get("cc-session")).toBe("what do I prefer?");
+  });
+
+  it("capture hook degrades without blocking Claude Code when Gateway capture fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Gateway unavailable" }),
+    }));
+    const cache = new MemoryPromptCache();
+    cache.set("cc-session", "My name is Alex");
+    const io = captureStdout();
+
+    await runCaptureHook(claudeCodeMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "cc-session", last_assistant_message: "Got it" }),
+      stdout: io.stdout,
+      cache,
+      logger: { warn: vi.fn() },
+    });
+
+    expect(io.read()).toEqual({ continue: true });
+    expect(cache.get("cc-session")).toBe("My name is Alex");
+    expect(cache.deleteCalls).toEqual([]);
+  });
+
+  it("capture hook deletes prompt cache after successful capture", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ l0_recorded: 1, scheduler_notified: true }),
+    }));
+    const cache = new MemoryPromptCache();
+    cache.set("cc-session", "My name is Alex");
+    const io = captureStdout();
+
+    await runCaptureHook(claudeCodeMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "cc-session", last_assistant_message: "Got it" }),
+      stdout: io.stdout,
+      cache,
+    });
+
+    expect(io.read()).toEqual({ continue: true });
+    expect(cache.get("cc-session")).toBeNull();
+    expect(cache.deleteCalls).toEqual(["cc-session"]);
+  });
+
+  it("capture hook can recover user and assistant text from Claude transcript", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ l0_recorded: 1, scheduler_notified: true }),
+    }));
+    const tmp = mkdtempSync(join(tmpdir(), "tdai-cc-transcript-"));
+    const transcriptPath = join(tmp, "transcript.jsonl");
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ message: { role: "user", content: "My name is Alex" } }),
+        JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "Got it" }] } }),
+      ].join("\n"),
+    );
+    const cache = new MemoryPromptCache();
+    const io = captureStdout();
+
+    try {
+      await runCaptureHook(claudeCodeMemoryAdapter, {
+        stdin: stdinFrom({ session_id: "cc-session", transcript_path: transcriptPath }),
+        stdout: io.stdout,
+        cache,
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+
+    expect(io.read()).toEqual({ continue: true });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/capture"),
+      expect.objectContaining({
+        body: JSON.stringify({
+          user_content: "My name is Alex",
+          assistant_content: "Got it",
+          session_key: "cc-session",
+        }),
+      }),
+    );
+  });
+});

--- a/claudecode-plugin/memory/memory_tencentdb/adapter.ts
+++ b/claudecode-plugin/memory/memory_tencentdb/adapter.ts
@@ -1,0 +1,147 @@
+import * as fs from "node:fs";
+import type {
+  CaptureResult,
+  MemoryPlatformAdapter,
+  PromptCache,
+  RecallResult,
+} from "../../../src/adapters/adapter-sdk/index.js";
+
+interface ClaudeCodeBaseEvent {
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  hook_event_name?: string;
+}
+
+interface ClaudeCodeRecallEvent extends ClaudeCodeBaseEvent {
+  prompt?: string;
+}
+
+interface ClaudeCodeCaptureEvent extends ClaudeCodeBaseEvent {
+  last_assistant_message?: string | null;
+  assistant_response?: string | null;
+}
+
+interface ClaudeCodeRecallOutput {
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit";
+    additionalContext: string;
+  };
+}
+
+interface ClaudeCodeCaptureOutput {
+  continue: boolean;
+}
+
+interface TranscriptTurn {
+  userText?: string;
+  assistantText?: string;
+}
+
+export const claudeCodeMemoryAdapter: MemoryPlatformAdapter<
+  ClaudeCodeRecallEvent,
+  ClaudeCodeCaptureEvent,
+  ClaudeCodeRecallOutput,
+  ClaudeCodeCaptureOutput
+> = {
+  platform: "claudecode",
+
+  parseRecall(event: ClaudeCodeRecallEvent, cache: PromptCache) {
+    const sessionKey = event.session_id;
+    const prompt = event.prompt;
+    if (!sessionKey || !prompt) return null;
+
+    cache.set(sessionKey, prompt);
+    return {
+      query: prompt,
+      session_key: sessionKey,
+    };
+  },
+
+  formatRecall(result: RecallResult): ClaudeCodeRecallOutput {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: result.context ?? "",
+      },
+    };
+  },
+
+  parseCapture(event: ClaudeCodeCaptureEvent, cache: PromptCache) {
+    const sessionKey = event.session_id;
+    if (!sessionKey) return null;
+
+    const transcriptTurn = readLatestTranscriptTurn(event.transcript_path);
+    const userContent = cache.get(sessionKey) ?? transcriptTurn.userText;
+    const assistantContent =
+      event.last_assistant_message ??
+      event.assistant_response ??
+      transcriptTurn.assistantText;
+
+    if (!userContent || !assistantContent) return null;
+
+    return {
+      user_content: userContent,
+      assistant_content: assistantContent,
+      session_key: sessionKey,
+    };
+  },
+
+  formatCapture(_result: CaptureResult): ClaudeCodeCaptureOutput {
+    return { continue: true };
+  },
+};
+
+function readLatestTranscriptTurn(transcriptPath: string | undefined): TranscriptTurn {
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return {};
+
+  let userText: string | undefined;
+  let assistantText: string | undefined;
+
+  try {
+    const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      const entry = JSON.parse(line) as Record<string, unknown>;
+      const message = readRecord(entry.message);
+      const role = readString(message?.role) ?? readString(entry.role);
+      const content = normalizeContent(message?.content ?? entry.content);
+
+      if (!content) continue;
+      if (role === "user") userText = content;
+      if (role === "assistant") assistantText = content;
+    }
+  } catch {
+    return {};
+  }
+
+  return { userText, assistantText };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function normalizeContent(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return undefined;
+
+  const text = value
+    .map((part) => {
+      if (typeof part === "string") return part;
+      const record = readRecord(part);
+      return readString(record?.text);
+    })
+    .filter((part): part is string => Boolean(part))
+    .join("\n")
+    .trim();
+
+  return text || undefined;
+}

--- a/claudecode-plugin/memory/memory_tencentdb/hooks.json
+++ b/claudecode-plugin/memory/memory_tencentdb/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node --import tsx ${CLAUDE_PLUGIN_ROOT}/hooks/recall.ts",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node --import tsx ${CLAUDE_PLUGIN_ROOT}/hooks/capture.ts",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claudecode-plugin/memory/memory_tencentdb/hooks/capture.ts
+++ b/claudecode-plugin/memory/memory_tencentdb/hooks/capture.ts
@@ -1,0 +1,4 @@
+import { runCaptureHook } from "../../../../src/adapters/adapter-sdk/index.js";
+import { claudeCodeMemoryAdapter } from "../adapter.js";
+
+await runCaptureHook(claudeCodeMemoryAdapter);

--- a/claudecode-plugin/memory/memory_tencentdb/hooks/hooks.json
+++ b/claudecode-plugin/memory/memory_tencentdb/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node --import tsx ${CLAUDE_PLUGIN_ROOT}/hooks/recall.ts",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node --import tsx ${CLAUDE_PLUGIN_ROOT}/hooks/capture.ts",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claudecode-plugin/memory/memory_tencentdb/hooks/recall.ts
+++ b/claudecode-plugin/memory/memory_tencentdb/hooks/recall.ts
@@ -1,0 +1,4 @@
+import { runRecallHook } from "../../../../src/adapters/adapter-sdk/index.js";
+import { claudeCodeMemoryAdapter } from "../adapter.js";
+
+await runRecallHook(claudeCodeMemoryAdapter);

--- a/claudecode-plugin/memory/memory_tencentdb/mcp-server.ts
+++ b/claudecode-plugin/memory/memory_tencentdb/mcp-server.ts
@@ -1,0 +1,6 @@
+import { runMemoryMcpServer } from "../../../src/adapters/adapter-sdk/index.js";
+
+await runMemoryMcpServer({
+  name: "tencentdb-memory",
+  version: "1.0.0",
+});

--- a/claudecode-plugin/memory/memory_tencentdb/plugin.json
+++ b/claudecode-plugin/memory/memory_tencentdb/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "tencentdb-memory",
+  "description": "TencentDB Agent Memory — four-layer memory system (L0 conversation / L1 extraction / L2 scene / L3 persona) via Gateway sidecar",
+  "version": "1.0.0",
+  "author": { "name": "TencentDB Agent Memory Team" }
+}

--- a/codex-plugin/memory/memory_tencentdb/.codex-plugin/plugin.json
+++ b/codex-plugin/memory/memory_tencentdb/.codex-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "tencentdb-memory",
+  "version": "1.0.0",
+  "description": "TencentDB Agent Memory — four-layer memory system (L0 conversation / L1 extraction / L2 scene / L3 persona) via Gateway sidecar",
+  "author": {
+    "name": "TencentDB Agent Memory Team"
+  },
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/hooks.json"
+}

--- a/codex-plugin/memory/memory_tencentdb/.mcp.json
+++ b/codex-plugin/memory/memory_tencentdb/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcp_servers": {
+    "tdai-memory": {
+      "command": "npx",
+      "args": ["tsx", "${PLUGIN_ROOT}/mcp-server.ts"]
+    }
+  }
+}

--- a/codex-plugin/memory/memory_tencentdb/__tests__/test_gateway_shutdown_leak.test.ts
+++ b/codex-plugin/memory/memory_tencentdb/__tests__/test_gateway_shutdown_leak.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the adapter SDK Gateway ownership contract.
+ *
+ * Mirrors the Hermes test_gateway_shutdown_leak.py scope for Codex:
+ * Codex does not own the Gateway process, so it must never auto-spawn or
+ * terminate Gateway. The plugin may only check health and tell the user to
+ * start Gateway manually.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ensureGateway } from "../../../../src/adapters/adapter-sdk/gateway-supervisor.js";
+
+const PLUGIN_DIR = join(__dirname, "..");
+const REPO_ROOT = join(PLUGIN_DIR, "..", "..", "..");
+const SDK_DIR = join(REPO_ROOT, "src", "adapters", "adapter-sdk");
+
+describe("GatewayShutdownLeakTest", () => {
+  it("does not spawn Gateway when health check fails", async () => {
+    const gateway = {
+      baseUrl: "http://127.0.0.1:18420",
+      isHealthy: vi.fn().mockResolvedValue(false),
+    };
+    const logger = { warn: vi.fn() };
+
+    const ok = await ensureGateway({ gateway: gateway as never, logger });
+
+    expect(ok).toBe(false);
+    expect(gateway.isHealthy).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Start it manually with: node --import tsx src/gateway/server.ts"),
+    );
+  });
+
+  it("does not warn or change process ownership when Gateway is healthy", async () => {
+    const gateway = {
+      baseUrl: "http://127.0.0.1:8420",
+      isHealthy: vi.fn().mockResolvedValue(true),
+    };
+    const logger = { warn: vi.fn() };
+
+    const ok = await ensureGateway({ gateway: gateway as never, logger });
+
+    expect(ok).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("SDK supervisor contains no child-process spawn path", () => {
+    const source = readFileSync(join(SDK_DIR, "gateway-supervisor.ts"), "utf-8");
+
+    expect(source).toContain("ensureGateway");
+    expect(source).toContain("isHealthy");
+    expect(source).not.toContain("child_process");
+    expect(source).not.toContain("spawn(");
+    expect(source).not.toContain("MEMORY_TENCENTDB_GATEWAY_CMD");
+  });
+
+  it("Codex entrypoints delegate lifecycle behavior to the adapter SDK", () => {
+    const mcpSource = readFileSync(join(PLUGIN_DIR, "mcp-server.ts"), "utf-8");
+    const recallSource = readFileSync(join(PLUGIN_DIR, "hooks", "recall.ts"), "utf-8");
+    const captureSource = readFileSync(join(PLUGIN_DIR, "hooks", "capture.ts"), "utf-8");
+
+    expect(mcpSource).toContain("runMemoryMcpServer");
+    expect(recallSource).toContain("runRecallHook");
+    expect(captureSource).toContain("runCaptureHook");
+    expect(mcpSource).not.toContain("spawn");
+    expect(recallSource).not.toContain("spawn");
+    expect(captureSource).not.toContain("spawn");
+  });
+});

--- a/codex-plugin/memory/memory_tencentdb/__tests__/test_memory_tencentdb_recovery.test.ts
+++ b/codex-plugin/memory/memory_tencentdb/__tests__/test_memory_tencentdb_recovery.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for memory-tencentdb adapter self-healing and degraded behavior.
+ *
+ * Mirrors the Hermes test_memory_tencentdb_recovery.py scope for Codex:
+ * request-path failures must not break the host agent. Hooks degrade to
+ * empty recall context or skipped capture output, and successful capture
+ * clears the prompt cache.
+ */
+
+import { Readable, Writable } from "node:stream";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { codexMemoryAdapter } from "../adapter.js";
+import { runCaptureHook, runRecallHook } from "../../../../src/adapters/adapter-sdk/hook-runner.js";
+import type { PromptCache } from "../../../../src/adapters/adapter-sdk/index.js";
+
+class MemoryPromptCache implements PromptCache {
+  readonly values = new Map<string, string>();
+  cleanupCalls = 0;
+  deleteCalls: string[] = [];
+
+  get(sessionKey: string): string | null {
+    return this.values.get(sessionKey) ?? null;
+  }
+
+  set(sessionKey: string, prompt: string): void {
+    this.values.set(sessionKey, prompt);
+  }
+
+  delete(sessionKey: string): void {
+    this.deleteCalls.push(sessionKey);
+    this.values.delete(sessionKey);
+  }
+
+  cleanup(): void {
+    this.cleanupCalls += 1;
+  }
+}
+
+function stdinFrom(value: unknown) {
+  return Readable.from([JSON.stringify(value)]);
+}
+
+function captureStdout() {
+  let output = "";
+  const stdout = new Writable({
+    write(chunk, _encoding, callback) {
+      output += Buffer.from(chunk).toString("utf-8");
+      callback();
+    },
+  });
+  return { stdout, read: () => JSON.parse(output) };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("MemoryTencentdbRecoveryTest", () => {
+  it("recall hook returns empty context when Gateway is unavailable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+    const cache = new MemoryPromptCache();
+    const io = captureStdout();
+
+    await runRecallHook(codexMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "codex-session", prompt: "remember my name" }),
+      stdout: io.stdout,
+      cache,
+      logger: { warn: vi.fn() },
+    });
+
+    expect(io.read()).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: "",
+      },
+    });
+    expect(cache.cleanupCalls).toBe(1);
+    expect(cache.get("codex-session")).toBe("remember my name");
+  });
+
+  it("recall hook recovers on the request path when Gateway responds again", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ context: "User prefers TypeScript", memory_count: 1 }),
+    }));
+    const cache = new MemoryPromptCache();
+    const io = captureStdout();
+
+    await runRecallHook(codexMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "codex-session", prompt: "what do I prefer?" }),
+      stdout: io.stdout,
+      cache,
+    });
+
+    expect(io.read().hookSpecificOutput.additionalContext).toBe("User prefers TypeScript");
+    expect(cache.get("codex-session")).toBe("what do I prefer?");
+  });
+
+  it("capture hook degrades without blocking Codex when Gateway capture fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Gateway unavailable" }),
+    }));
+    const cache = new MemoryPromptCache();
+    cache.set("codex-session", "My name is Alex");
+    const io = captureStdout();
+
+    await runCaptureHook(codexMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "codex-session", last_assistant_message: "Got it" }),
+      stdout: io.stdout,
+      cache,
+      logger: { warn: vi.fn() },
+    });
+
+    expect(io.read()).toEqual({ continue: true });
+    expect(cache.get("codex-session")).toBe("My name is Alex");
+    expect(cache.deleteCalls).toEqual([]);
+  });
+
+  it("capture hook deletes prompt cache after successful capture", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ l0_recorded: 1, scheduler_notified: true }),
+    }));
+    const cache = new MemoryPromptCache();
+    cache.set("codex-session", "My name is Alex");
+    const io = captureStdout();
+
+    await runCaptureHook(codexMemoryAdapter, {
+      stdin: stdinFrom({ session_id: "codex-session", last_assistant_message: "Got it" }),
+      stdout: io.stdout,
+      cache,
+    });
+
+    expect(io.read()).toEqual({ continue: true });
+    expect(cache.get("codex-session")).toBeNull();
+    expect(cache.deleteCalls).toEqual(["codex-session"]);
+  });
+});

--- a/codex-plugin/memory/memory_tencentdb/adapter.ts
+++ b/codex-plugin/memory/memory_tencentdb/adapter.ts
@@ -1,0 +1,80 @@
+import type {
+  CaptureResult,
+  MemoryPlatformAdapter,
+  PromptCache,
+  RecallResult,
+} from "../../../src/adapters/adapter-sdk/index.js";
+
+interface CodexBaseEvent {
+  session_id?: string;
+  hook_event_name?: string;
+  cwd?: string;
+}
+
+interface CodexRecallEvent extends CodexBaseEvent {
+  prompt?: string;
+}
+
+interface CodexCaptureEvent extends CodexBaseEvent {
+  last_assistant_message?: string | null;
+}
+
+interface CodexRecallOutput {
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit";
+    additionalContext: string;
+  };
+}
+
+interface CodexCaptureOutput {
+  continue: boolean;
+}
+
+export const codexMemoryAdapter: MemoryPlatformAdapter<
+  CodexRecallEvent,
+  CodexCaptureEvent,
+  CodexRecallOutput,
+  CodexCaptureOutput
+> = {
+  platform: "codex",
+
+  parseRecall(event: CodexRecallEvent, cache: PromptCache) {
+    const sessionKey = event.session_id;
+    const prompt = event.prompt;
+    if (!sessionKey || !prompt) return null;
+
+    cache.set(sessionKey, prompt);
+    return {
+      query: prompt,
+      session_key: sessionKey,
+    };
+  },
+
+  formatRecall(result: RecallResult): CodexRecallOutput {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: result.context ?? "",
+      },
+    };
+  },
+
+  parseCapture(event: CodexCaptureEvent, cache: PromptCache) {
+    const sessionKey = event.session_id;
+    const assistantContent = event.last_assistant_message;
+    if (!sessionKey || !assistantContent) return null;
+
+    const userContent = cache.get(sessionKey);
+    if (!userContent) return null;
+
+    return {
+      user_content: userContent,
+      assistant_content: assistantContent,
+      session_key: sessionKey,
+    };
+  },
+
+  formatCapture(_result: CaptureResult): CodexCaptureOutput {
+    return { continue: true };
+  },
+};

--- a/codex-plugin/memory/memory_tencentdb/hooks/capture.ts
+++ b/codex-plugin/memory/memory_tencentdb/hooks/capture.ts
@@ -1,0 +1,4 @@
+import { runCaptureHook } from "../../../../src/adapters/adapter-sdk/index.js";
+import { codexMemoryAdapter } from "../adapter.js";
+
+await runCaptureHook(codexMemoryAdapter);

--- a/codex-plugin/memory/memory_tencentdb/hooks/hooks.json
+++ b/codex-plugin/memory/memory_tencentdb/hooks/hooks.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${PLUGIN_ROOT}/hooks/recall.ts",
+            "commandWindows": "cmd.exe /c npx tsx %PLUGIN_ROOT%\\hooks\\recall.ts",
+            "timeout": 10,
+            "statusMessage": "Recalling memory context…"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${PLUGIN_ROOT}/hooks/capture.ts",
+            "commandWindows": "cmd.exe /c npx tsx %PLUGIN_ROOT%\\hooks\\capture.ts",
+            "timeout": 30,
+            "statusMessage": "Capturing conversation turn…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/codex-plugin/memory/memory_tencentdb/hooks/recall.ts
+++ b/codex-plugin/memory/memory_tencentdb/hooks/recall.ts
@@ -1,0 +1,4 @@
+import { runRecallHook } from "../../../../src/adapters/adapter-sdk/index.js";
+import { codexMemoryAdapter } from "../adapter.js";
+
+await runRecallHook(codexMemoryAdapter);

--- a/codex-plugin/memory/memory_tencentdb/mcp-server.ts
+++ b/codex-plugin/memory/memory_tencentdb/mcp-server.ts
@@ -1,0 +1,6 @@
+import { runMemoryMcpServer } from "../../../src/adapters/adapter-sdk/index.js";
+
+await runMemoryMcpServer({
+  name: "tencentdb-memory",
+  version: "1.0.0",
+});

--- a/codex-plugin/memory/memory_tencentdb/skills/tencentdb-memory/SKILL.md
+++ b/codex-plugin/memory/memory_tencentdb/skills/tencentdb-memory/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: tencentdb-memory
+description: Search the user's persistent memory across four tiers — conversation archive (L0), extracted facts (L1), scene clusters (L2), and persona profile (L3). Use when the user references past context, asks "what did we decide about…", or needs to recall preferences, instructions, or previous conversations.
+---
+
+## TencentDB Agent Memory
+
+This project integrates a four-layer local memory system (L0→L1→L2→L3) that automatically captures and organizes conversational knowledge.
+
+### Memory Tiers
+
+| Tier | Name | Description |
+|------|------|-------------|
+| **L0** | Conversation Archive | Raw conversation turns stored as they happened |
+| **L1** | Extracted Facts | Structured memories: user preferences, decisions, instructions, episodic events |
+| **L2** | Scenes | Topic clusters grouping related conversations |
+| **L3** | Persona | Persistent user profile derived from long-term patterns |
+
+### Automatic Recall and Capture
+
+- **Memory recall happens automatically** before each user prompt via the `UserPromptSubmit` hook. You do NOT need to call memory tools before every response — recalled context is already injected.
+- **Memory capture happens automatically** after each turn via the `Stop` hook. You do NOT need to manually save or record conversations.
+
+### When to Use Memory Tools
+
+Only call memory tools when you need to go beyond the automatically-recalled context:
+
+- **Use `tdai_memory_search`** when the user asks about past facts, preferences, decisions, or instructions they have shared. Example queries:
+  - "What programming languages does the user prefer?"
+  - "What did we decide about the database migration?"
+  - "What code style instructions has the user given?"
+
+- **Use `tdai_conversation_search`** when you need to find a specific past conversation or discussion. Example queries:
+  - "What did we discuss about the auth system last week?"
+  - "Find conversations about the API refactoring"
+
+### Search Result Format
+
+Both tools return results as text. Memory search results include the memory content and type label. Conversation search results include relevant conversation snippets. If no matching results are found, the tools return an empty response — this is normal and means no relevant memories exist yet.
+
+### Guidance
+
+1. Do NOT call memory tools before every response. Recall is automatic.
+2. Only search when the user explicitly asks about their past or when the task clearly requires historical context.
+3. When in doubt, prefer `tdai_memory_search` over `tdai_conversation_search` — it returns structured, higher-quality results.
+4. If both searches return empty, tell the user honestly that no relevant memories were found.

--- a/scripts/install-codex-plugin.js
+++ b/scripts/install-codex-plugin.js
@@ -1,0 +1,302 @@
+/**
+ * Install the tencentdb-memory plugin into Codex's local marketplace.
+ *
+ * This development install links the repository plugin directory into
+ * ~/.agents/plugins/tencentdb-memory instead of copying it. The marketplace
+ * entry is still written normally, so Codex can discover and install the
+ * plugin while local edits remain visible after Codex refreshes/restarts.
+ *
+ * Usage: node scripts/install-codex-plugin.js
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+// ============================
+// Configuration
+// ============================
+
+const PLUGIN_NAME = "tencentdb-memory";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const PLUGIN_SRC_DIR = path.join(
+  PROJECT_ROOT,
+  "codex-plugin",
+  "memory",
+  "memory_tencentdb",
+);
+const MARKETPLACE_DIR = path.join(os.homedir(), ".agents", "plugins");
+const MARKETPLACE_FILE = path.join(MARKETPLACE_DIR, "marketplace.json");
+const PLUGIN_INSTALL_DIR = path.join(MARKETPLACE_DIR, PLUGIN_NAME);
+const CODEX_CONFIG_FILE = path.join(os.homedir(), ".codex", "config.toml");
+const PLUGIN_CONFIG_ID = `${PLUGIN_NAME}@local-codex-plugins`;
+const MCP_SERVER_NAME = "tdai-memory";
+
+// ============================
+// Helpers
+// ============================
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function loadMarketplace() {
+  if (!fs.existsSync(MARKETPLACE_FILE)) {
+    return { name: "local-codex-plugins", plugins: [] };
+  }
+  try {
+    const raw = fs.readFileSync(MARKETPLACE_FILE, "utf-8");
+    const marketplace = JSON.parse(raw);
+    if (!marketplace.plugins) marketplace.plugins = [];
+    if (!marketplace.name) marketplace.name = "local-codex-plugins";
+    return marketplace;
+  } catch (err) {
+    fail(`Failed to parse existing marketplace.json: ${err}`);
+  }
+}
+
+function saveMarketplace(marketplace) {
+  ensureDir(MARKETPLACE_DIR);
+  fs.writeFileSync(
+    MARKETPLACE_FILE,
+    JSON.stringify(marketplace, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+function removeExistingLink(target) {
+  if (!fs.existsSync(target)) return;
+
+  const stat = fs.lstatSync(target);
+  if (!stat.isSymbolicLink()) {
+    fail(
+      `Refusing to remove non-symlink install directory: ${target}\n` +
+        "Delete it manually if you want to replace the copied install with a link.",
+    );
+  }
+
+  fs.rmSync(target, { recursive: true, force: true });
+}
+
+function linkDir(src, dest) {
+  removeExistingLink(dest);
+  fs.symlinkSync(src, dest, process.platform === "win32" ? "junction" : "dir");
+}
+
+function createPluginEntry() {
+  // Codex local marketplace paths must be ./-prefixed and relative to the
+  // marketplace root. On Windows, the personal marketplace is resolved from
+  // the home directory in current Codex builds, so keep the .agents/plugins
+  // prefix used by the previous installer.
+  const relPath = path.relative(os.homedir(), PLUGIN_INSTALL_DIR).split(path.sep).join("/");
+  return {
+    name: PLUGIN_NAME,
+    source: {
+      source: "local",
+      path: `./${relPath}`,
+    },
+    policy: {
+      installation: "AVAILABLE",
+      authentication: "ON_INSTALL",
+    },
+    category: "Productivity",
+  };
+}
+
+function upsertTomlKey(lines, start, end, key, value) {
+  const keyPattern = new RegExp(`^\\s*${key}\\s*=`);
+  for (let i = start; i < end; i++) {
+    if (keyPattern.test(lines[i])) {
+      lines[i] = `${key} = ${value}`;
+      return;
+    }
+  }
+  lines.splice(end, 0, `${key} = ${value}`);
+}
+
+function enablePluginMcpServer() {
+  const section = `[plugins."${PLUGIN_CONFIG_ID}".mcp_servers."${MCP_SERVER_NAME}"]`;
+  ensureDir(path.dirname(CODEX_CONFIG_FILE));
+
+  const raw = fs.existsSync(CODEX_CONFIG_FILE)
+    ? fs.readFileSync(CODEX_CONFIG_FILE, "utf-8")
+    : "";
+  const lines = raw ? raw.replace(/\r\n/g, "\n").split("\n") : [];
+  let start = lines.findIndex((line) => line.trim() === section);
+
+  if (start < 0) {
+    if (lines.length > 0 && lines[lines.length - 1] !== "") {
+      lines.push("");
+    }
+    lines.push(section);
+    lines.push("enabled = true");
+    lines.push('default_tools_approval_mode = "prompt"');
+  } else {
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (/^\s*\[.*\]\s*$/.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    upsertTomlKey(lines, start + 1, end, "enabled", "true");
+    end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (/^\s*\[.*\]\s*$/.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    upsertTomlKey(lines, start + 1, end, "default_tools_approval_mode", '"prompt"');
+  }
+
+  fs.writeFileSync(CODEX_CONFIG_FILE, lines.join("\n").replace(/\n*$/, "\n"), "utf-8");
+}
+
+function quotedToml(value) {
+  return JSON.stringify(value);
+}
+
+function tomlArray(values) {
+  return `[${values.map((value) => quotedToml(value)).join(", ")}]`;
+}
+
+function upsertTomlSection(section, entries) {
+  ensureDir(path.dirname(CODEX_CONFIG_FILE));
+
+  const raw = fs.existsSync(CODEX_CONFIG_FILE)
+    ? fs.readFileSync(CODEX_CONFIG_FILE, "utf-8")
+    : "";
+  const lines = raw ? raw.replace(/\r\n/g, "\n").split("\n") : [];
+  let start = lines.findIndex((line) => line.trim() === section);
+
+  if (start < 0) {
+    if (lines.length > 0 && lines[lines.length - 1] !== "") {
+      lines.push("");
+    }
+    lines.push(section);
+    for (const [key, value] of Object.entries(entries)) {
+      lines.push(`${key} = ${value}`);
+    }
+  } else {
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (/^\s*\[.*\]\s*$/.test(lines[i])) {
+        end = i;
+        break;
+      }
+    }
+    for (const [key, value] of Object.entries(entries)) {
+      upsertTomlKey(lines, start + 1, end, key, value);
+      end = lines.length;
+      for (let i = start + 1; i < lines.length; i++) {
+        if (/^\s*\[.*\]\s*$/.test(lines[i])) {
+          end = i;
+          break;
+        }
+      }
+    }
+  }
+
+  fs.writeFileSync(CODEX_CONFIG_FILE, lines.join("\n").replace(/\n*$/, "\n"), "utf-8");
+}
+
+function enableGlobalMcpServer() {
+  const mcpServerPath = path
+    .join(PLUGIN_SRC_DIR, "mcp-server.ts")
+    .split(path.sep)
+    .join("/");
+  const projectRoot = PROJECT_ROOT.split(path.sep).join("/");
+  upsertTomlSection(`[mcp_servers."${MCP_SERVER_NAME}"]`, {
+    command: quotedToml("cmd.exe"),
+    args: tomlArray(["/c", "npx", "tsx", mcpServerPath]),
+    cwd: quotedToml(projectRoot),
+    startup_timeout_sec: "30",
+    env_vars: tomlArray([
+      "TDAI_GATEWAY_URL",
+      "TDAI_GATEWAY_API_KEY",
+    ]),
+  });
+}
+
+// ============================
+// Run
+// ============================
+
+console.log(`Installing ${PLUGIN_NAME} plugin via directory link...`);
+console.log(`  Plugin source:  ${PLUGIN_SRC_DIR}`);
+console.log(`  Plugin link:    ${PLUGIN_INSTALL_DIR}`);
+console.log(`  Marketplace:    ${MARKETPLACE_FILE}`);
+
+const manifestPath = path.join(PLUGIN_SRC_DIR, ".codex-plugin", "plugin.json");
+if (!fs.existsSync(manifestPath)) {
+  fail(`Plugin manifest not found at ${manifestPath}`);
+}
+
+ensureDir(MARKETPLACE_DIR);
+linkDir(PLUGIN_SRC_DIR, PLUGIN_INSTALL_DIR);
+console.log("Plugin link created.");
+
+const marketplace = loadMarketplace();
+
+const legacyIdx = marketplace.plugins.findIndex((p) => p.name === "memory-tencentdb");
+if (legacyIdx >= 0) {
+  marketplace.plugins.splice(legacyIdx, 1);
+  console.log("Removed legacy 'memory-tencentdb' entry.");
+}
+
+const entry = createPluginEntry();
+const existingIdx = marketplace.plugins.findIndex((p) => p.name === PLUGIN_NAME);
+if (existingIdx >= 0) {
+  marketplace.plugins[existingIdx] = entry;
+  console.log(`Updated existing ${PLUGIN_NAME} entry.`);
+} else {
+  marketplace.plugins.push(entry);
+  console.log(`Added ${PLUGIN_NAME} entry.`);
+}
+
+saveMarketplace(marketplace);
+console.log(`Marketplace saved to ${MARKETPLACE_FILE}`);
+enablePluginMcpServer();
+console.log(`Enabled plugin MCP server in ${CODEX_CONFIG_FILE}`);
+enableGlobalMcpServer();
+console.log(`Enabled global MCP server '${MCP_SERVER_NAME}' in ${CODEX_CONFIG_FILE}`);
+console.log("");
+
+let cliInstalled = false;
+try {
+  execSync(`codex plugin add ${PLUGIN_NAME}@${marketplace.name}`, {
+    stdio: "pipe",
+    timeout: 30_000,
+  });
+  console.log(`Installed ${PLUGIN_NAME} via Codex CLI.`);
+  cliInstalled = true;
+} catch {
+  // Codex CLI may be unavailable or may not know the marketplace yet.
+}
+
+console.log("");
+console.log("Next steps:");
+console.log("  1. Restart Codex");
+if (cliInstalled) {
+  console.log("  2. Review and trust the plugin hooks with /hooks or Settings -> Hooks");
+} else {
+  console.log(`  2. Install or enable \"${PLUGIN_NAME}\" from the ${marketplace.name} marketplace`);
+  console.log("  3. Review and trust the plugin hooks with /hooks or Settings -> Hooks");
+}
+console.log("");
+console.log("Notes:");
+console.log("  - This script does not bundle .ts files; it links to repository source.");
+console.log("  - Plugin MCP, hooks, and skills are discovered from .codex-plugin/plugin.json.");
+console.log("  - Installing/enabling a plugin does not automatically trust its hooks.");

--- a/scripts/uninstall-codex-plugin.js
+++ b/scripts/uninstall-codex-plugin.js
@@ -1,0 +1,195 @@
+/**
+ * Uninstall the tencentdb-memory plugin from Codex's local marketplace.
+ *
+ * Removes the plugin entry from ~/.agents/plugins/marketplace.json,
+ * deletes the copied plugin directory, and prints guidance for remaining
+ * manual cleanup steps.
+ *
+ * Usage: node scripts/uninstall-codex-plugin.js
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync } from "node:child_process";
+
+// ============================
+// Configuration
+// ============================
+
+const PLUGIN_NAME = "tencentdb-memory";
+const MARKETPLACE_DIR = path.join(os.homedir(), ".agents", "plugins");
+const MARKETPLACE_FILE = path.join(MARKETPLACE_DIR, "marketplace.json");
+const PLUGIN_INSTALL_DIR = path.join(MARKETPLACE_DIR, PLUGIN_NAME);
+const CODEX_CONFIG_FILE = path.join(os.homedir(), ".codex", "config.toml");
+const PLUGIN_CONFIG_ID = `${PLUGIN_NAME}@local-codex-plugins`;
+const MCP_SERVER_NAME = "tdai-memory";
+
+// ============================
+// Main
+// ============================
+
+function loadMarketplace() {
+  if (!fs.existsSync(MARKETPLACE_FILE)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(MARKETPLACE_FILE, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function printCleanupGuidance() {
+  const isWindows = process.platform === "win32";
+  process.stderr.write("\nManual cleanup steps:\n\n");
+
+  if (isWindows) {
+    process.stderr.write(
+      "  1. Stop the Gateway process: close the terminal running the Gateway,\n",
+    );
+    process.stderr.write(
+      "     or run: taskkill /F /IM node.exe  (caution: kills all Node.js processes)\n\n",
+    );
+    process.stderr.write(
+      "  2. (Optional) Delete stored memory data:\n",
+    );
+    process.stderr.write(
+      "     rmdir /s %USERPROFILE%\\.memory-tencentdb\n",
+    );
+    process.stderr.write(
+      "     WARNING: This permanently deletes all stored memories and cannot be undone.\n",
+    );
+  } else {
+    process.stderr.write(
+      '  1. Stop the Gateway process: pkill -f "gateway/server.ts"\n\n',
+    );
+    process.stderr.write(
+      "  2. (Optional) Delete stored memory data:\n",
+    );
+    process.stderr.write(
+      "     rm -rf ~/.memory-tencentdb\n",
+    );
+    process.stderr.write(
+      "     WARNING: This permanently deletes all stored memories and cannot be undone.\n",
+    );
+  }
+}
+
+function removeTomlSections(sectionPred) {
+  if (!fs.existsSync(CODEX_CONFIG_FILE)) return 0;
+
+  const lines = fs.readFileSync(CODEX_CONFIG_FILE, "utf-8").replace(/\r\n/g, "\n").split("\n");
+  const out = [];
+  let removed = 0;
+  let skipping = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const isSection = /^\[.*\]$/.test(trimmed);
+    if (isSection) {
+      skipping = sectionPred(trimmed);
+      if (skipping) {
+        removed++;
+        continue;
+      }
+    }
+    if (!skipping) out.push(line);
+  }
+
+  fs.writeFileSync(CODEX_CONFIG_FILE, out.join("\n").replace(/\n*$/, "\n"), "utf-8");
+  return removed;
+}
+
+function removeCodexConfig() {
+  const removed = removeTomlSections((section) =>
+    section === `[plugins."${PLUGIN_CONFIG_ID}"]` ||
+    section.startsWith(`[plugins."${PLUGIN_CONFIG_ID}".`) ||
+    section === `[mcp_servers."${MCP_SERVER_NAME}"]` ||
+    section.startsWith(`[mcp_servers."${MCP_SERVER_NAME}".`) ||
+    section.startsWith(`[hooks.state."${PLUGIN_CONFIG_ID}:`),
+  );
+  if (removed > 0) {
+    console.log(`Removed ${removed} Codex config section(s) from ${CODEX_CONFIG_FILE}`);
+  }
+}
+
+// --- Run ---
+
+console.log(`Uninstalling ${PLUGIN_NAME} plugin…`);
+
+const marketplace = loadMarketplace();
+
+if (!marketplace || !marketplace.plugins) {
+  console.log("No marketplace file found. Plugin was not installed.");
+  printCleanupGuidance();
+  process.exit(0);
+}
+
+const idx = marketplace.plugins.findIndex((p) => p.name === PLUGIN_NAME);
+
+if (idx < 0) {
+  console.log(
+    `Plugin "${PLUGIN_NAME}" not found in marketplace. Nothing to remove.`,
+  );
+  printCleanupGuidance();
+  process.exit(0);
+}
+
+// Remove the entry
+marketplace.plugins.splice(idx, 1);
+console.log(`Removed "${PLUGIN_NAME}" from marketplace.`);
+
+if (marketplace.plugins.length === 0) {
+  // Delete the marketplace file if empty
+  fs.unlinkSync(MARKETPLACE_FILE);
+  console.log(
+    `Marketplace file deleted (no remaining plugins): ${MARKETPLACE_FILE}`,
+  );
+} else {
+  // Preserve other plugins
+  fs.writeFileSync(
+    MARKETPLACE_FILE,
+    JSON.stringify(marketplace, null, 2) + "\n",
+    "utf-8",
+  );
+  console.log(
+    `Marketplace preserved with ${marketplace.plugins.length} remaining plugin(s).`,
+  );
+}
+
+// Try to remove via Codex CLI first (handles cache cleanup)
+try {
+  execSync(`codex plugin remove ${PLUGIN_NAME}@local-codex-plugins`, {
+    stdio: "pipe",
+    timeout: 15_000,
+  });
+  console.log(`Removed ${PLUGIN_NAME} via Codex CLI.`);
+} catch {
+  // CLI not available — manual cleanup
+}
+
+// Remove the copied plugin directory from marketplace root
+if (fs.existsSync(PLUGIN_INSTALL_DIR)) {
+  fs.rmSync(PLUGIN_INSTALL_DIR, { recursive: true, force: true });
+  console.log(`Removed plugin directory: ${PLUGIN_INSTALL_DIR}`);
+}
+
+// Also remove from Codex cache if CLI didn't handle it
+const cacheDir = path.join(
+  os.homedir(),
+  ".codex",
+  "plugins",
+  "cache",
+  "local-codex-plugins",
+  PLUGIN_NAME,
+);
+if (fs.existsSync(cacheDir)) {
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  console.log(`Removed plugin cache: ${cacheDir}`);
+}
+
+removeCodexConfig();
+printCleanupGuidance();
+console.log("Uninstall complete.");

--- a/src/adapters/adapter-sdk/gateway-client.ts
+++ b/src/adapters/adapter-sdk/gateway-client.ts
@@ -1,0 +1,82 @@
+import type {
+  CaptureInput,
+  CaptureResult,
+  ConversationSearchInput,
+  ConversationSearchResult,
+  GatewayClientOptions,
+  GatewayHealth,
+  MemorySearchInput,
+  MemorySearchResult,
+  RecallInput,
+  RecallResult,
+} from "./types.js";
+
+const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export class GatewayClient {
+  readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: GatewayClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? process.env.TDAI_GATEWAY_URL ?? DEFAULT_GATEWAY_URL).replace(/\/+$/, "");
+    this.apiKey = opts.apiKey ?? process.env.TDAI_GATEWAY_API_KEY;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async health(timeoutMs = 2_000): Promise<GatewayHealth | null> {
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}/health`, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as GatewayHealth;
+    } catch {
+      return null;
+    }
+  }
+
+  async isHealthy(timeoutMs = 2_000): Promise<boolean> {
+    const health = await this.health(timeoutMs);
+    return health?.status === "ok" || health?.status === "degraded";
+  }
+
+  async recall(input: RecallInput): Promise<RecallResult> {
+    return this.post<RecallResult>("/recall", input);
+  }
+
+  async capture(input: CaptureInput, timeoutMs = this.timeoutMs): Promise<CaptureResult> {
+    const response = await this.post<Omit<CaptureResult, "ok">>("/capture", input, timeoutMs);
+    return { ...response, ok: true };
+  }
+
+  async searchMemories(input: MemorySearchInput): Promise<MemorySearchResult> {
+    return this.post<MemorySearchResult>("/search/memories", input);
+  }
+
+  async searchConversations(input: ConversationSearchInput): Promise<ConversationSearchResult> {
+    return this.post<ConversationSearchResult>("/search/conversations", input);
+  }
+
+  private async post<T>(path: string, body: unknown, timeoutMs = this.timeoutMs): Promise<T> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const message = typeof payload?.error === "string" ? payload.error : `Gateway request failed: ${response.status}`;
+      throw new Error(message);
+    }
+    return payload as T;
+  }
+}

--- a/src/adapters/adapter-sdk/gateway-supervisor.ts
+++ b/src/adapters/adapter-sdk/gateway-supervisor.ts
@@ -1,0 +1,21 @@
+import { GatewayClient } from "./gateway-client.js";
+import type { Logger } from "./types.js";
+
+export interface EnsureGatewayOptions {
+  gateway?: GatewayClient;
+  gatewayUrl?: string;
+  logger?: Logger;
+  timeoutMs?: number;
+}
+
+export async function ensureGateway(opts: EnsureGatewayOptions = {}): Promise<boolean> {
+  const gateway = opts.gateway ?? new GatewayClient({ baseUrl: opts.gatewayUrl });
+  const logger = opts.logger;
+  if (await gateway.isHealthy(opts.timeoutMs ?? 3_000)) return true;
+
+  logger?.warn?.(
+    `Gateway not running at ${gateway.baseUrl}. ` +
+      "Start it manually with: node --import tsx src/gateway/server.ts",
+  );
+  return false;
+}

--- a/src/adapters/adapter-sdk/hook-runner.ts
+++ b/src/adapters/adapter-sdk/hook-runner.ts
@@ -1,0 +1,97 @@
+import { GatewayClient } from "./gateway-client.js";
+import { FilePromptCache } from "./prompt-cache.js";
+import type {
+  CaptureResult,
+  HookRunnerOptions,
+  MemoryPlatformAdapter,
+  RecallResult,
+} from "./types.js";
+
+async function readJson<T>(stdin: NodeJS.ReadableStream): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf-8")) as T;
+}
+
+function writeJson(stdout: NodeJS.WritableStream, value: unknown): void {
+  stdout.write(JSON.stringify(value));
+}
+
+export async function runRecallHook<RecallEvent, RecallOutput>(
+  adapter: MemoryPlatformAdapter<RecallEvent, unknown, RecallOutput, unknown>,
+  opts: HookRunnerOptions = {},
+): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const logger = opts.logger;
+  const cache = opts.cache ?? new FilePromptCache();
+
+  try {
+    const event = await readJson<RecallEvent>(opts.stdin ?? process.stdin);
+    cache.cleanup?.();
+
+    const input = adapter.parseRecall(event, cache);
+    if (!input) {
+      writeJson(stdout, adapter.formatRecall(emptyRecall()));
+      return;
+    }
+
+    const gateway = new GatewayClient({
+      baseUrl: opts.gatewayUrl,
+      apiKey: opts.apiKey,
+      timeoutMs: opts.timeoutMs ?? 10_000,
+      logger,
+    });
+    const result = await gateway.recall(input);
+    writeJson(stdout, adapter.formatRecall(result));
+  } catch (err) {
+    logger?.warn?.(`Recall hook degraded: ${err instanceof Error ? err.message : String(err)}`);
+    writeJson(stdout, adapter.formatRecall(emptyRecall()));
+  }
+}
+
+export async function runCaptureHook<CaptureEvent, CaptureOutput>(
+  adapter: MemoryPlatformAdapter<unknown, CaptureEvent, unknown, CaptureOutput>,
+  opts: HookRunnerOptions = {},
+): Promise<void> {
+  const stdout = opts.stdout ?? process.stdout;
+  const logger = opts.logger;
+  const cache = opts.cache ?? new FilePromptCache();
+
+  try {
+    const event = await readJson<CaptureEvent>(opts.stdin ?? process.stdin);
+    const input = adapter.parseCapture(event, cache);
+    if (!input) {
+      writeJson(stdout, adapter.formatCapture(skippedCapture("adapter returned null")));
+      return;
+    }
+
+    const gateway = new GatewayClient({
+      baseUrl: opts.gatewayUrl,
+      apiKey: opts.apiKey,
+      timeoutMs: opts.timeoutMs ?? 30_000,
+      logger,
+    });
+    const result = await gateway.capture(input);
+    cache.delete(input.session_key);
+    writeJson(stdout, adapter.formatCapture(result));
+  } catch (err) {
+    logger?.warn?.(`Capture hook degraded: ${err instanceof Error ? err.message : String(err)}`);
+    writeJson(stdout, adapter.formatCapture(skippedCapture("gateway unavailable")));
+  }
+}
+
+function emptyRecall(): RecallResult {
+  return { context: "", memory_count: 0 };
+}
+
+function skippedCapture(reason: string): CaptureResult {
+  return {
+    ok: false,
+    skipped: true,
+    reason,
+    l0_recorded: 0,
+    scheduler_notified: false,
+  };
+}

--- a/src/adapters/adapter-sdk/index.ts
+++ b/src/adapters/adapter-sdk/index.ts
@@ -1,0 +1,23 @@
+export { GatewayClient } from "./gateway-client.js";
+export { ensureGateway } from "./gateway-supervisor.js";
+export type { EnsureGatewayOptions } from "./gateway-supervisor.js";
+export { FilePromptCache } from "./prompt-cache.js";
+export { runCaptureHook, runRecallHook } from "./hook-runner.js";
+export { runMemoryMcpServer } from "./mcp-server.js";
+export type { MemoryMcpServerOptions } from "./mcp-server.js";
+export type {
+  CaptureInput,
+  CaptureResult,
+  ConversationSearchInput,
+  ConversationSearchResult,
+  GatewayClientOptions,
+  GatewayHealth,
+  HookRunnerOptions,
+  Logger,
+  MemoryPlatformAdapter,
+  MemorySearchInput,
+  MemorySearchResult,
+  PromptCache,
+  RecallInput,
+  RecallResult,
+} from "./types.js";

--- a/src/adapters/adapter-sdk/mcp-server.ts
+++ b/src/adapters/adapter-sdk/mcp-server.ts
@@ -1,0 +1,87 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { GatewayClient } from "./gateway-client.js";
+import { ensureGateway } from "./gateway-supervisor.js";
+import type { Logger } from "./types.js";
+
+export interface MemoryMcpServerOptions {
+  name?: string;
+  version?: string;
+  gatewayUrl?: string;
+  apiKey?: string;
+  checkGateway?: boolean;
+  logger?: Logger;
+}
+
+export async function runMemoryMcpServer(opts: MemoryMcpServerOptions = {}): Promise<void> {
+  const logger = opts.logger ?? stderrLogger("[tdai-mcp]");
+  const gateway = new GatewayClient({
+    baseUrl: opts.gatewayUrl,
+    apiKey: opts.apiKey,
+    logger,
+  });
+
+  if (opts.checkGateway ?? true) {
+    await ensureGateway({ gateway, logger });
+  }
+
+  const server = new McpServer({
+    name: opts.name ?? "tencentdb-memory",
+    version: opts.version ?? "1.0.0",
+  });
+
+  server.tool(
+    "tdai_memory_search",
+    {
+      query: z.string(),
+      limit: z.number().optional(),
+      type: z.string().optional(),
+      scene: z.string().optional(),
+    },
+    async (params) => {
+      try {
+        const result = await gateway.searchMemories(params);
+        return { content: [{ type: "text" as const, text: result.results ?? "" }] };
+      } catch {
+        return unavailable("Memory search unavailable. Please try again later.");
+      }
+    },
+  );
+
+  server.tool(
+    "tdai_conversation_search",
+    {
+      query: z.string(),
+      limit: z.number().optional(),
+      session_key: z.string().optional(),
+    },
+    async (params) => {
+      try {
+        const result = await gateway.searchConversations(params);
+        return { content: [{ type: "text" as const, text: result.results ?? "" }] };
+      } catch {
+        return unavailable("Conversation search unavailable. Please try again later.");
+      }
+    },
+  );
+
+  await server.connect(new StdioServerTransport());
+}
+
+function unavailable(text: string) {
+  return {
+    content: [{ type: "text" as const, text }],
+    isError: true as const,
+  };
+}
+
+function stderrLogger(tag: string): Logger {
+  const write = (message: string) => process.stderr.write(`${tag} ${message}\n`);
+  return {
+    debug: write,
+    info: write,
+    warn: write,
+    error: write,
+  };
+}

--- a/src/adapters/adapter-sdk/prompt-cache.ts
+++ b/src/adapters/adapter-sdk/prompt-cache.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { PromptCache } from "./types.js";
+
+const DEFAULT_STALE_MS = 24 * 60 * 60 * 1000;
+
+interface PromptRecord {
+  prompt: string;
+  timestamp: string;
+}
+
+export class FilePromptCache implements PromptCache {
+  private readonly dir: string;
+  private readonly staleMs: number;
+
+  constructor(opts: { dir?: string; staleMs?: number } = {}) {
+    this.dir = opts.dir ?? path.join(os.homedir(), ".memory-tencentdb", "prompts");
+    this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+  }
+
+  get(sessionKey: string): string | null {
+    const filePath = this.filePath(sessionKey);
+    if (!fs.existsSync(filePath)) return null;
+    try {
+      const record = JSON.parse(fs.readFileSync(filePath, "utf-8")) as PromptRecord;
+      return record.prompt || null;
+    } catch {
+      return null;
+    }
+  }
+
+  set(sessionKey: string, prompt: string): void {
+    fs.mkdirSync(this.dir, { recursive: true });
+    const record: PromptRecord = {
+      prompt,
+      timestamp: new Date().toISOString(),
+    };
+    fs.writeFileSync(this.filePath(sessionKey), JSON.stringify(record), "utf-8");
+  }
+
+  delete(sessionKey: string): void {
+    try {
+      const filePath = this.filePath(sessionKey);
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    } catch {
+      // Best-effort cache cleanup.
+    }
+  }
+
+  cleanup(): void {
+    if (!fs.existsSync(this.dir)) return;
+    const now = Date.now();
+    for (const entry of fs.readdirSync(this.dir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      const filePath = path.join(this.dir, entry.name);
+      try {
+        const record = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<PromptRecord>;
+        const timestamp = record.timestamp ? Date.parse(record.timestamp) : 0;
+        if (!timestamp || now - timestamp > this.staleMs) fs.unlinkSync(filePath);
+      } catch {
+        try {
+          fs.unlinkSync(filePath);
+        } catch {
+          // Ignore corrupt file cleanup failures.
+        }
+      }
+    }
+  }
+
+  private filePath(sessionKey: string): string {
+    return path.join(this.dir, `${encodeURIComponent(sessionKey)}.json`);
+  }
+}

--- a/src/adapters/adapter-sdk/types.ts
+++ b/src/adapters/adapter-sdk/types.ts
@@ -1,0 +1,71 @@
+import type {
+  CaptureRequest,
+  CaptureResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+} from "../../gateway/types.js";
+
+export type Logger = {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type RecallInput = RecallRequest;
+export type CaptureInput = CaptureRequest;
+export type RecallResult = RecallResponse;
+export type CaptureResult = CaptureResponse & {
+  ok: boolean;
+  skipped?: boolean;
+  reason?: string;
+};
+
+export type MemorySearchInput = MemorySearchRequest;
+export type MemorySearchResult = MemorySearchResponse;
+export type ConversationSearchInput = ConversationSearchRequest;
+export type ConversationSearchResult = ConversationSearchResponse;
+export type GatewayHealth = HealthResponse;
+
+export interface PromptCache {
+  get(sessionKey: string): string | null;
+  set(sessionKey: string, prompt: string): void;
+  delete(sessionKey: string): void;
+  cleanup?(): void;
+}
+
+export interface MemoryPlatformAdapter<
+  RecallEvent = unknown,
+  CaptureEvent = unknown,
+  RecallOutput = unknown,
+  CaptureOutput = unknown,
+> {
+  readonly platform: string;
+  parseRecall(event: RecallEvent, cache: PromptCache): RecallInput | null;
+  formatRecall(result: RecallResult): RecallOutput;
+  parseCapture(event: CaptureEvent, cache: PromptCache): CaptureInput | null;
+  formatCapture(result: CaptureResult): CaptureOutput;
+}
+
+export interface GatewayClientOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+}
+
+export interface HookRunnerOptions {
+  gatewayUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  cache?: PromptCache;
+  logger?: Logger;
+  stdin?: NodeJS.ReadableStream;
+  stdout?: NodeJS.WritableStream;
+}

--- a/多平台适配方式对比.md
+++ b/多平台适配方式对比.md
@@ -1,0 +1,202 @@
+# 多平台适配方式对比说明
+
+本文对比 OpenClaw、Hermes、Codex、Claude Code 四种接入方式，说明它们与核心引擎、Gateway、统一 Adapter SDK 的关系。
+
+## 1. 总览对比
+
+| 平台 | 接入位置 | 记忆读取 | 记忆写入 | 搜索工具 | 是否使用 Gateway | 是否使用 Adapter SDK | Gateway 生命周期 |
+|---|---|---|---|---|---|---|---|
+| OpenClaw | `index.ts` 插件入口 | OpenClaw hook | OpenClaw hook | OpenClaw tool | 不一定，原生插件可直接进入核心能力 | 否 | 由 OpenClaw 插件体系和项目部署方式决定 |
+| Hermes | `hermes-plugin/memory/memory_tencentdb` Provider | `prefetch()` -> Gateway `/recall` | `sync_turn()` -> Gateway `/capture` | Provider tool call -> Gateway search | 是 | 否，使用 Python Provider + Client | Hermes Provider 可通过 supervisor 管理 Gateway |
+| Codex | `codex-plugin/memory/memory_tencentdb` | `UserPromptSubmit` -> SDK -> Gateway `/recall` | `Stop` -> SDK -> Gateway `/capture` | MCP -> SDK -> Gateway search | 是 | 是 | 不自动启动，用户手动启动 Gateway |
+| Claude Code | `claudecode-plugin/memory/memory_tencentdb` | `UserPromptSubmit` -> SDK -> Gateway `/recall` | `Stop` -> SDK -> Gateway `/capture` | MCP -> SDK -> Gateway search | 是 | 是 | 不自动启动，用户手动启动 Gateway |
+| 新平台 | 平台自己的 hooks / tools / provider | 实现 `parseRecall()` 后由 SDK 调用 Gateway | 实现 `parseCapture()` 后由 SDK 调用 Gateway | 复用 SDK MCP 或平台工具封装 | 推荐是 | 推荐是 | 默认不自动启动 Gateway |
+
+## 2. OpenClaw 插件方式
+
+OpenClaw 是项目最早适配的平台之一，特点是平台原生插件能力较完整。
+
+### 接入特点
+
+- 入口是根目录插件入口 `index.ts`。
+- 按 OpenClaw Plugin SDK 注册工具、钩子和配置。
+- 平台上下文、工具调用和 hook 由 OpenClaw 插件系统调度。
+- 更适合深度集成 OpenClaw 自身的上下文压缩、工具调用和记忆能力。
+
+### 数据流特点
+
+```mermaid
+flowchart LR
+  OpenClaw["OpenClaw Runtime"] --> Plugin["memory-tencentdb OpenClaw Plugin<br/>index.ts"]
+  Plugin --> Hooks["Hooks / Tools"]
+  Hooks --> Core["TdaiCore / Memory Pipeline"]
+  Core --> Store["SQLite / BM25 / Vector Store"]
+```
+
+### 优点
+
+- 与 OpenClaw 平台能力耦合更紧，用户安装体验简单。
+- 可以充分利用 OpenClaw Plugin SDK 的工具注册和 hook 机制。
+- 适合 OpenClaw 用户作为主入口使用。
+
+### 代价
+
+- 适配逻辑与 OpenClaw 平台模型绑定。
+- 其他平台不能直接复用 OpenClaw 插件入口。
+
+## 3. Hermes Provider 方式
+
+Hermes 通过 Provider 接入，Provider 自身是 Python 侧实现，通过 HTTP Gateway 与核心引擎通信。
+
+### 接入特点
+
+- 目录是 `hermes-plugin/memory/memory_tencentdb`。
+- Provider 实现 Hermes 需要的记忆生命周期方法。
+- 通过 `client.py` 请求 Gateway。
+- 通过 `supervisor.py` 管理 Gateway 进程和恢复逻辑。
+
+### 数据流特点
+
+```mermaid
+flowchart LR
+  Hermes["Hermes Agent"] --> Provider["memory_tencentdb Provider"]
+  Provider --> Client["Python Gateway Client"]
+  Client --> Gateway["TDAI Gateway"]
+  Gateway --> Core["TdaiCore"]
+  Core --> Store["Memory Stores"]
+```
+
+### 优点
+
+- 与 Hermes Provider 模型匹配。
+- Python 侧可实现 watchdog、supervisor、恢复机制。
+- Gateway 把 TypeScript 核心引擎与 Python 平台隔离开。
+
+### 代价
+
+- Provider、Client、Supervisor 是 Hermes 专属实现。
+- 其他平台复用时仍要重新写平台层逻辑。
+- Gateway 生命周期策略比 Codex/Claude Code 更复杂，需要测试防止进程泄漏和 stale Gateway 复用。
+
+## 4. Codex 插件方式
+
+Codex 插件使用统一 Adapter SDK。平台插件只负责把 Codex hook payload 转成 SDK 输入，并把 SDK 输出转回 Codex 需要的格式。
+
+### 接入特点
+
+- 目录是 `codex-plugin/memory/memory_tencentdb`。
+- `adapter.ts` 实现 `MemoryPlatformAdapter`。
+- `hooks/recall.ts` 调用 `runRecallHook(codexMemoryAdapter)`。
+- `hooks/capture.ts` 调用 `runCaptureHook(codexMemoryAdapter)`。
+- `mcp-server.ts` 调用 `runMemoryMcpServer()`。
+
+### 数据流特点
+
+```mermaid
+flowchart LR
+  Codex["Codex Runtime"] --> Hooks["Codex Hooks<br/>UserPromptSubmit / Stop"]
+  Codex --> MCP["Codex MCP Tools"]
+  Hooks --> Adapter["codexMemoryAdapter"]
+  Adapter --> SDK["Adapter SDK"]
+  MCP --> SDK
+  SDK --> Gateway["TDAI Gateway"]
+  Gateway --> Core["TdaiCore"]
+```
+
+### 优点
+
+- 平台代码很薄，主要是 hook payload 解析和输出格式化。
+- 记忆读写、Gateway 请求、MCP 搜索工具可复用 SDK。
+- SDK 不自动启动 Gateway，行为边界清晰。
+
+### 代价
+
+- 用户需要先启动 Gateway。
+- Codex 插件安装还需要平台自己的插件目录、MCP、hooks 配置。
+- Codex hook payload 的字段变化需要更新 `adapter.ts`。
+
+## 5. Claude Code 插件方式
+
+Claude Code 与 Codex 类似，也使用统一 Adapter SDK，但 capture 阶段额外支持从 transcript 中恢复最近一轮 user / assistant 内容。
+
+### 接入特点
+
+- 目录是 `claudecode-plugin/memory/memory_tencentdb`。
+- `adapter.ts` 实现 `MemoryPlatformAdapter`。
+- `hooks/recall.ts` 调用 `runRecallHook(claudeCodeMemoryAdapter)`。
+- `hooks/capture.ts` 调用 `runCaptureHook(claudeCodeMemoryAdapter)`。
+- `mcp-server.ts` 调用 `runMemoryMcpServer()`。
+- `.claude-plugin/plugin.json` 描述 Claude Code 插件结构。
+
+### 数据流特点
+
+```mermaid
+flowchart LR
+  Claude["Claude Code Runtime"] --> Hooks["Claude Code Hooks<br/>UserPromptSubmit / Stop"]
+  Claude --> MCP["Claude Code MCP Tools"]
+  Hooks --> Adapter["claudeCodeMemoryAdapter"]
+  Adapter --> Transcript["Transcript fallback<br/>optional"]
+  Adapter --> SDK["Adapter SDK"]
+  MCP --> SDK
+  SDK --> Gateway["TDAI Gateway"]
+  Gateway --> Core["TdaiCore"]
+```
+
+### 优点
+
+- 与 Codex 共用 SDK，平台差异集中在 `adapter.ts`。
+- capture 阶段可从 prompt cache 或 transcript 恢复完整对话。
+- Gateway 不可用时 hook 降级，不阻断 Claude Code 对话。
+
+### 代价
+
+- 用户需要先启动 Gateway。
+- Claude Code 插件目录和 hook manifest 需要符合 Claude Code 规范。
+- transcript 格式如果变化，需要同步更新 `adapter.ts`。
+
+## 6. Adapter SDK 与各平台职责边界
+
+| 职责 | OpenClaw | Hermes | Codex | Claude Code | Adapter SDK |
+|---|---|---|---|---|---|
+| 平台插件声明 | 是 | 是 | 是 | 是 | 否 |
+| 平台 hook payload 解析 | 是 | 是 | `adapter.ts` | `adapter.ts` | 否 |
+| Gateway HTTP 请求封装 | 可选 | Python client | 复用 SDK | 复用 SDK | 是 |
+| MCP 搜索工具注册 | 平台工具 | Provider tool | 复用 SDK | 复用 SDK | 是 |
+| prompt cache | 平台/插件逻辑 | Provider 状态 | 复用 SDK | 复用 SDK | 是 |
+| Gateway 健康检查 | 平台/部署决定 | Supervisor | 复用 SDK | 复用 SDK | 是 |
+| Gateway 自动启动 | 平台/部署决定 | Hermes supervisor 可管理 | 否 | 否 | 否 |
+| TdaiCore 初始化 | 插件/核心路径 | Gateway | Gateway | Gateway | 否 |
+
+## 7. 为什么 Codex 和 Claude Code 使用统一 SDK
+
+Codex 和 Claude Code 的平台差异主要在三处：
+
+- hook 输入字段不同。
+- hook 输出格式不同。
+- 插件声明、安装路径和启动方式不同。
+
+但它们访问记忆能力的方式是一致的：
+
+- 读取记忆：`POST /recall`
+- 写入记忆：`POST /capture`
+- 搜索记忆：`POST /search/memories`
+- 搜索对话：`POST /search/conversations`
+
+因此，把 Gateway 请求、错误降级、prompt cache、MCP 工具注册放进 Adapter SDK，可以避免每个平台重复实现同一套逻辑。新平台只需要把自己的事件结构映射到统一接口即可。
+
+## 8. 推荐适配策略
+
+新增平台时优先选择 Adapter SDK，除非平台有非常强的平台原生需求。
+
+推荐路径：
+
+1. 平台支持 hooks + tools / MCP：使用 Adapter SDK。
+2. 平台语言不是 TypeScript，但可以访问 HTTP：参考 Hermes，写平台语言 Provider + Gateway client。
+3. 平台需要深度嵌入核心引擎：参考 OpenClaw，但需要理解 TdaiCore 生命周期和平台插件能力。
+
+默认建议：
+
+- 新平台不要直接初始化 TdaiCore。
+- 新平台不要重复实现 Gateway HTTP 请求细节。
+- 新平台不要自动启动 Gateway，除非平台明确有 supervisor 生命周期模型。
+- 新平台先实现 recall / capture，再补 search / session end。

--- a/新平台适配指南.md
+++ b/新平台适配指南.md
@@ -1,0 +1,397 @@
+# 新平台适配指南
+
+本文说明如何基于统一 Adapter SDK 为新的 Agent 平台接入 TencentDB-Agent-Memory。目标是让新平台只实现一个平台适配接口，其余记忆读写、Gateway 请求、MCP 搜索工具和错误降级逻辑复用 `src/adapters/adapter-sdk`。
+
+## 1. 适配目标
+
+新平台接入后至少应该支持：
+
+- 记忆读取：用户输入后，调用 Gateway `/recall`，把相关记忆注入 Agent 上下文。
+- 记忆写入：一轮对话完成后，调用 Gateway `/capture`，写入 L0 对话并触发后续记忆提取。
+- 记忆搜索：通过 MCP 或平台工具调用 `/search/memories` 和 `/search/conversations`。
+- 降级策略：Gateway 不可用时不阻断宿主 Agent。
+
+推荐接入路径：
+
+```text
+Platform Hooks / Tools
+        |
+        v
+MemoryPlatformAdapter
+        |
+        v
+Adapter SDK
+        |
+        v
+TDAI Gateway
+        |
+        v
+TdaiCore
+```
+
+## 2. Adapter SDK 提供了什么
+
+SDK 位于：
+
+```text
+src/adapters/adapter-sdk
+```
+
+核心模块：
+
+| 文件 | 职责 |
+|---|---|
+| `types.ts` | 定义 `MemoryPlatformAdapter`、`PromptCache`、Gateway 输入输出类型 |
+| `gateway-client.ts` | HTTP client，封装 `/health`、`/recall`、`/capture`、search 接口 |
+| `gateway-supervisor.ts` | 只做 Gateway 健康检查，不自动启动 Gateway |
+| `hook-runner.ts` | 读取 hook stdin，调用 adapter，访问 Gateway，输出平台格式 |
+| `mcp-server.ts` | 注册通用 MCP 搜索工具 |
+| `prompt-cache.ts` | 在 recall hook 与 capture hook 之间缓存用户输入 |
+| `index.ts` | SDK 统一导出 |
+
+SDK 不做的事：
+
+- 不自动启动 Gateway。
+- 不直接初始化 TdaiCore。
+- 不理解具体平台 hook payload。
+- 不修改具体平台的配置文件。
+
+## 3. 新平台只需要实现的接口
+
+新平台核心只需要实现 `MemoryPlatformAdapter`：
+
+```ts
+import type {
+  CaptureResult,
+  MemoryPlatformAdapter,
+  PromptCache,
+  RecallResult,
+} from "../src/adapters/adapter-sdk/index.js";
+
+export const myPlatformMemoryAdapter: MemoryPlatformAdapter<
+  MyRecallEvent,
+  MyCaptureEvent,
+  MyRecallOutput,
+  MyCaptureOutput
+> = {
+  platform: "my-platform",
+
+  parseRecall(event: MyRecallEvent, cache: PromptCache) {
+    // 1. 从平台 hook payload 中取出 sessionKey 和用户输入
+    // 2. 把用户输入写入 cache，供 capture hook 使用
+    // 3. 返回 Gateway /recall 所需结构
+    return {
+      query: event.prompt,
+      session_key: event.sessionId,
+    };
+  },
+
+  formatRecall(result: RecallResult): MyRecallOutput {
+    // 把 Gateway recall 结果转换成平台需要的 hook 输出
+    return {
+      additionalContext: result.context ?? "",
+    };
+  },
+
+  parseCapture(event: MyCaptureEvent, cache: PromptCache) {
+    // 1. 从平台事件中取 assistant 输出
+    // 2. 从 cache 或 transcript 中取 user 输入
+    // 3. 返回 Gateway /capture 所需结构
+    const userContent = cache.get(event.sessionId);
+    if (!userContent || !event.assistantText) return null;
+
+    return {
+      user_content: userContent,
+      assistant_content: event.assistantText,
+      session_key: event.sessionId,
+    };
+  },
+
+  formatCapture(_result: CaptureResult): MyCaptureOutput {
+    // 通常应继续平台执行，不要因为记忆写入影响 Agent 对话
+    return { continue: true };
+  },
+};
+```
+
+四个方法的职责：
+
+| 方法 | 输入 | 输出 | 作用 |
+|---|---|---|---|
+| `parseRecall()` | 平台 recall hook event + cache | `RecallInput \| null` | 把平台用户输入转成 `/recall` 请求 |
+| `formatRecall()` | Gateway recall result | 平台 recall hook output | 把记忆上下文注入平台 |
+| `parseCapture()` | 平台 capture hook event + cache | `CaptureInput \| null` | 把一轮 user/assistant 对话转成 `/capture` 请求 |
+| `formatCapture()` | Gateway capture result | 平台 capture hook output | 告诉平台继续执行或返回平台要求的格式 |
+
+返回 `null` 的场景：
+
+- 平台事件缺少 session id。
+- 用户输入为空。
+- assistant 输出为空。
+- capture 阶段找不到对应用户输入。
+
+SDK 会把 `null` 视为可降级跳过，不会阻断宿主 Agent。
+
+## 4. 推荐目录结构
+
+假设新平台叫 `myagent`，推荐目录：
+
+```text
+myagent-plugin/
+  memory/
+    memory_tencentdb/
+      adapter.ts
+      mcp-server.ts
+      hooks/
+        recall.ts
+        capture.ts
+        hooks.json
+      README.md
+      README_CN.md
+      __tests__/
+        test_gateway_shutdown_leak.test.ts
+        test_memory_tencentdb_recovery.test.ts
+```
+
+最小文件：
+
+- `adapter.ts`：实现 `MemoryPlatformAdapter`。
+- `hooks/recall.ts`：调用 `runRecallHook(adapter)`。
+- `hooks/capture.ts`：调用 `runCaptureHook(adapter)`。
+- `mcp-server.ts`：调用 `runMemoryMcpServer()`。
+- 平台自己的 manifest / config 文件。
+
+## 5. Hook 入口写法
+
+### recall hook
+
+```ts
+#!/usr/bin/env node
+
+import { runRecallHook } from "../../../src/adapters/adapter-sdk/index.js";
+import { myPlatformMemoryAdapter } from "../adapter.js";
+
+await runRecallHook(myPlatformMemoryAdapter);
+```
+
+### capture hook
+
+```ts
+#!/usr/bin/env node
+
+import { runCaptureHook } from "../../../src/adapters/adapter-sdk/index.js";
+import { myPlatformMemoryAdapter } from "../adapter.js";
+
+await runCaptureHook(myPlatformMemoryAdapter);
+```
+
+### MCP server
+
+```ts
+#!/usr/bin/env node
+
+import { runMemoryMcpServer } from "../../../src/adapters/adapter-sdk/index.js";
+
+await runMemoryMcpServer({
+  name: "tencentdb-memory",
+  version: "1.0.0",
+});
+```
+
+## 6. Gateway 启动与环境变量
+
+Adapter SDK 默认访问：
+
+```text
+http://127.0.0.1:8420
+```
+
+启动 Gateway：
+
+```bash
+node --import tsx src/gateway/server.ts
+```
+
+常用环境变量：
+
+| 变量 | 作用 |
+|---|---|
+| `TDAI_GATEWAY_URL` | Gateway 地址，默认 `http://127.0.0.1:8420` |
+| `TDAI_GATEWAY_API_KEY` | Gateway Bearer 鉴权 key |
+| `TDAI_DATA_DIR` | 记忆数据目录 |
+| `TDAI_LLM_API_KEY` | LLM API Key |
+| `TDAI_LLM_BASE_URL` | LLM API Base URL |
+| `TDAI_LLM_MODEL` | LLM 模型名 |
+
+注意：
+
+- SDK 不会自动启动 Gateway。
+- 如果 Gateway 开启鉴权，平台插件和 Gateway 必须使用同一个 `TDAI_GATEWAY_API_KEY`。
+- 平台 hook 进程需要继承这些环境变量。
+
+## 7. 适配步骤
+
+### 步骤 1：确认平台 hook 能力
+
+先确认平台是否提供：
+
+- 用户输入前/后 hook，适合 recall。
+- assistant 回复完成 hook，适合 capture。
+- 工具注册或 MCP 能力，适合 search。
+- 稳定 session id，适合把多轮对话关联到同一会话。
+
+如果平台没有稳定 session id，需要自己生成一个稳定 key，例如：
+
+```text
+workspace path + user id + conversation id
+```
+
+### 步骤 2：实现 `adapter.ts`
+
+重点处理：
+
+- session id 字段。
+- user prompt 字段。
+- assistant response 字段。
+- transcript fallback，若平台 capture event 不直接给出完整内容。
+- 输出格式，必须符合平台 hook 规范。
+
+### 步骤 3：实现 hook runner 入口
+
+hook 文件通常非常薄，只负责调用 SDK：
+
+```ts
+await runRecallHook(myPlatformMemoryAdapter);
+await runCaptureHook(myPlatformMemoryAdapter);
+```
+
+### 步骤 4：实现 MCP 或平台工具
+
+如果平台支持 MCP，直接复用：
+
+```ts
+await runMemoryMcpServer();
+```
+
+如果平台不支持 MCP，就在平台工具层调用 `GatewayClient`：
+
+```ts
+const gateway = new GatewayClient();
+const result = await gateway.searchMemories({ query: "typescript", limit: 5 });
+```
+
+### 步骤 5：编写平台安装文档
+
+至少说明：
+
+- 如何启动 Gateway。
+- 如何配置 `TDAI_GATEWAY_API_KEY`。
+- 如何让平台加载插件。
+- 如何验证 recall / capture 是否生效。
+- 如何卸载或停用。
+
+### 步骤 6：补测试
+
+推荐测试命名与 Hermes 保持一致：
+
+```text
+__tests__/test_gateway_shutdown_leak.test.ts
+__tests__/test_memory_tencentdb_recovery.test.ts
+```
+
+测试范围：
+
+- `test_gateway_shutdown_leak`：
+  - SDK 不自动 spawn Gateway。
+  - Gateway down 时只提示手动启动。
+  - 平台入口不包含进程管理逻辑。
+
+- `test_memory_tencentdb_recovery`：
+  - recall 请求失败时返回空 context。
+  - capture 请求失败时不阻断平台。
+  - capture 成功后清理 prompt cache。
+  - 平台 transcript fallback，如果平台需要。
+
+SDK 本身测试位于：
+
+```text
+src/adapters/adapter-sdk/__tests__
+```
+
+新增平台不应重复测试 SDK 的全部内部逻辑，只需要测试平台 adapter 映射和降级行为。
+
+## 8. 最小适配检查清单
+
+提交新平台适配前，检查：
+
+- [ ] 已实现 `MemoryPlatformAdapter`。
+- [ ] recall hook 能拿到稳定 session id 和用户输入。
+- [ ] capture hook 能拿到 user content、assistant content、session id。
+- [ ] capture 失败不会阻断宿主 Agent。
+- [ ] Gateway 不可用时有明确降级行为。
+- [ ] 如果平台支持 MCP，已注册 `tdai_memory_search` 和 `tdai_conversation_search`。
+- [ ] README 写明 Gateway 启动、插件启用、验证和卸载方式。
+- [ ] 已添加平台级测试。
+- [ ] 已运行 SDK + 平台测试。
+
+## 9. 常见问题
+
+### 9.1 为什么不在每个平台里直接初始化 TdaiCore？
+
+直接初始化 TdaiCore 会让每个平台都处理配置、存储、pipeline、模型和生命周期，适配成本高，也容易出现行为不一致。通过 Gateway 访问核心引擎，可以让平台适配层保持轻量。
+
+### 9.2 为什么 SDK 不自动启动 Gateway？
+
+不同平台对进程生命周期的管理方式不同。自动启动 Gateway 容易造成 orphan process、stale config 复用和权限问题。当前 SDK 只做 health check，并提示用户手动启动 Gateway。
+
+### 9.3 没有 MCP 的平台怎么办？
+
+可以直接使用 `GatewayClient` 包装成平台自己的 tool：
+
+```ts
+import { GatewayClient } from "../src/adapters/adapter-sdk/index.js";
+
+const gateway = new GatewayClient();
+const result = await gateway.searchConversations({
+  query: "previous discussion",
+  limit: 5,
+});
+```
+
+### 9.4 capture 时拿不到用户输入怎么办？
+
+优先在 recall hook 中用 `PromptCache` 保存用户输入，capture hook 中通过 `session_key` 取回。如果平台提供 transcript，可以像 Claude Code adapter 一样实现 transcript fallback。
+
+### 9.5 Gateway 开启鉴权后插件请求 401 怎么办？
+
+确认 Gateway 启动终端和 Agent 平台进程都设置了相同的：
+
+```bash
+TDAI_GATEWAY_API_KEY=your-key
+```
+
+Windows `cmd.exe`：
+
+```bat
+set TDAI_GATEWAY_API_KEY=your-key
+```
+
+PowerShell：
+
+```powershell
+$env:TDAI_GATEWAY_API_KEY="your-key"
+```
+
+持久设置：
+
+```bat
+setx TDAI_GATEWAY_API_KEY "your-key"
+```
+
+## 10. 参考实现
+
+- Codex：`codex-plugin/memory/memory_tencentdb/adapter.ts`
+- Claude Code：`claudecode-plugin/memory/memory_tencentdb/adapter.ts`
+- Hermes Provider：`hermes-plugin/memory/memory_tencentdb`
+- Adapter SDK：`src/adapters/adapter-sdk`
+- SDK tests：`src/adapters/adapter-sdk/__tests__`

--- a/适配架构图.md
+++ b/适配架构图.md
@@ -1,0 +1,172 @@
+# TencentDB-Agent-Memory 多平台适配架构图
+
+本文说明核心记忆引擎、Gateway、统一 Adapter SDK 与各 Agent 平台适配层之间的关系，并标注记忆读取、记忆写入和搜索工具的数据流。
+
+## 1. 总体架构
+
+```mermaid
+flowchart LR
+  subgraph Platforms["Agent 平台层"]
+    OpenClaw["OpenClaw Plugin<br/>index.ts"]
+    Hermes["Hermes Provider<br/>hermes-plugin/memory/memory_tencentdb"]
+    Codex["Codex Plugin<br/>codex-plugin/memory/memory_tencentdb"]
+    ClaudeCode["Claude Code Plugin<br/>claudecode-plugin/memory/memory_tencentdb"]
+    Future["未来平台<br/>Dify / LangGraph / Custom Agent"]
+  end
+
+  subgraph AdapterLayer["平台适配层"]
+    OpenClawAdapter["OpenClaw 适配逻辑<br/>工具注册 / Hooks"]
+    HermesAdapter["Hermes Provider + Client<br/>prefetch / sync_turn / tools"]
+    AdapterSDK["统一 Adapter SDK<br/>src/adapters/adapter-sdk"]
+    FutureAdapter["实现 MemoryPlatformAdapter<br/>parse + format"]
+  end
+
+  subgraph GatewayLayer["Gateway 层"]
+    Gateway["TDAI HTTP Gateway<br/>src/gateway/server.ts<br/>:8420"]
+  end
+
+  subgraph CoreLayer["核心记忆引擎"]
+    TdaiCore["TdaiCore<br/>recall / capture / search"]
+    Pipeline["Memory Pipeline<br/>L0 -> L1 -> L2 -> L3"]
+    Store["Stores<br/>SQLite / BM25 / Vector Store"]
+  end
+
+  OpenClaw --> OpenClawAdapter
+  Hermes --> HermesAdapter
+  Codex --> AdapterSDK
+  ClaudeCode --> AdapterSDK
+  Future --> FutureAdapter --> AdapterSDK
+
+  OpenClawAdapter --> TdaiCore
+  HermesAdapter --> Gateway
+  AdapterSDK --> Gateway
+
+  Gateway --> TdaiCore
+  TdaiCore --> Pipeline
+  Pipeline --> Store
+```
+
+说明：
+
+- OpenClaw 是原生插件接入，入口是 `index.ts`，负责注册工具和钩子。
+- Hermes 通过 `hermes-plugin/memory/memory_tencentdb` 里的 Provider 接入，经 HTTP Gateway 调用核心引擎。
+- Codex 与 Claude Code 通过统一 Adapter SDK 接入，平台插件只负责解析平台事件和格式化平台输出。
+- 未来平台不需要重新理解 Gateway 请求细节，只需要实现 `MemoryPlatformAdapter` 接口。
+
+## 2. 记忆读取数据流
+
+记忆读取发生在用户输入后、模型生成前，用于把相关历史记忆注入平台上下文。
+
+```mermaid
+sequenceDiagram
+  participant User as User
+  participant Agent as Agent Platform
+  participant Hook as Platform Recall Hook
+  participant SDK as Adapter SDK
+  participant Gateway as TDAI Gateway
+  participant Core as TdaiCore
+  participant Store as Memory Stores
+
+  User->>Agent: 输入新问题
+  Agent->>Hook: 触发 prompt / pre-turn hook
+  Hook->>SDK: parseRecall(event, cache)
+  SDK->>Gateway: POST /recall { query, session_key }
+  Gateway->>Core: core.recall()
+  Core->>Store: 检索 L1 / L2 / L3 与会话上下文
+  Store-->>Core: 返回相关记忆
+  Core-->>Gateway: RecallResponse
+  Gateway-->>SDK: { context, memory_count, strategy }
+  SDK->>Hook: formatRecall(result)
+  Hook-->>Agent: 注入 additionalContext / prompt context
+  Agent-->>User: 基于记忆生成回答
+```
+
+平台差异：
+
+- Codex：`UserPromptSubmit` hook 调用 `runRecallHook()`，输出 `additionalContext`。
+- Claude Code：`UserPromptSubmit` hook 调用 `runRecallHook()`，输出 `additionalContext`。
+- Hermes：Provider 的 `prefetch()` 通过 Gateway client 调用 `/recall`。
+- OpenClaw：插件钩子在平台内注册，按 OpenClaw Plugin SDK 的上下文注入方式工作。
+
+## 3. 记忆写入数据流
+
+记忆写入发生在一轮对话完成后，用于记录 L0 原始对话并驱动后续分层提取。
+
+```mermaid
+sequenceDiagram
+  participant Agent as Agent Platform
+  participant Hook as Platform Capture Hook
+  participant SDK as Adapter SDK
+  participant Gateway as TDAI Gateway
+  participant Core as TdaiCore
+  participant Pipeline as Memory Pipeline
+  participant Store as Memory Stores
+
+  Agent->>Hook: 一轮回复完成
+  Hook->>SDK: parseCapture(event, cache)
+  SDK->>Gateway: POST /capture { user_content, assistant_content, session_key }
+  Gateway->>Core: core.capture()
+  Core->>Store: 写入 L0 Conversation
+  Core->>Pipeline: 通知 L1/L2/L3 异步提取
+  Pipeline->>Store: 写入 Atom / Scenario / Persona
+  Gateway-->>SDK: CaptureResponse
+  SDK->>SDK: capture 成功后删除 prompt cache
+  SDK-->>Hook: formatCapture(result)
+  Hook-->>Agent: continue=true，不阻断宿主 Agent
+```
+
+关键约束：
+
+- Adapter SDK 不自动启动 Gateway，只做健康检查和 HTTP 请求封装。
+- Gateway 需要用户或部署脚本手动启动：`node --import tsx src/gateway/server.ts`。
+- capture 失败时，Codex / Claude Code hook 降级为继续执行，不阻断 Agent 正常对话。
+
+## 4. 搜索工具数据流
+
+搜索工具用于 Agent 主动检索长期记忆或原始对话。
+
+```mermaid
+sequenceDiagram
+  participant Agent as Agent Platform
+  participant MCP as MCP Server / Tool Provider
+  participant SDK as Adapter SDK MCP Server
+  participant Gateway as TDAI Gateway
+  participant Core as TdaiCore
+  participant Store as Memory Stores
+
+  Agent->>MCP: 调用 tdai_memory_search 或 tdai_conversation_search
+  MCP->>SDK: runMemoryMcpServer 注册工具
+  SDK->>Gateway: POST /search/memories 或 /search/conversations
+  Gateway->>Core: search memories / conversations
+  Core->>Store: 查询 L1 或 L0
+  Store-->>Core: 返回搜索结果
+  Core-->>Gateway: SearchResponse
+  Gateway-->>SDK: { results, total }
+  SDK-->>MCP: MCP tool result
+  MCP-->>Agent: 返回可读搜索结果
+```
+
+当前工具：
+
+- `tdai_memory_search`：检索结构化长期记忆，主要对应 L1/L2/L3。
+- `tdai_conversation_search`：检索原始对话记录，主要对应 L0 Conversation。
+
+## 5. SDK 在架构中的职责边界
+
+`src/adapters/adapter-sdk` 只处理跨平台通用能力：
+
+- `GatewayClient`：封装 `/health`、`/recall`、`/capture`、`/search/memories`、`/search/conversations`。
+- `ensureGateway`：检查 Gateway 是否可用，并提示手动启动。
+- `runRecallHook`：读取平台 hook stdin，调用 adapter 解析事件，向 Gateway 请求 recall，输出平台格式结果。
+- `runCaptureHook`：读取平台 hook stdin，调用 adapter 解析事件，向 Gateway 请求 capture，成功后清理 prompt cache。
+- `runMemoryMcpServer`：注册通用 MCP 搜索工具。
+- `FilePromptCache`：在 recall 与 capture hook 之间保存用户输入，便于写入完整一轮对话。
+
+SDK 不负责：
+
+- 启动或停止 Gateway。
+- 直接初始化 TdaiCore。
+- 理解具体平台的 hook payload。
+- 修改平台自身配置文件格式。
+
+这些职责由各平台插件或部署脚本完成。


### PR DESCRIPTION
## Description | 描述

本 PR 引入统一的跨平台 Adapter SDK，并基于该 SDK 新增 Codex 与 Claude Code 两个平台适配，目标是新平台能通过现有 TDAI Gateway API 接入 TencentDB-Agent-Memory 的核心记忆能力，而不需要为每个平台重复理解和实现 TdaiCore 的调用细节。

**统一 Adapter SDK**
本 PR 在 src/adapters/adapter-sdk 下封装了一套轻量级适配 SDK，将多平台接入中重复出现的能力统一收敛到一层：

- Gateway 健康检查
- /recall 记忆召回
- /capture 对话写入
- /search/memories 长期记忆搜索
- /search/conversations 原始对话搜索
- recall / capture hook runner
- prompt cache
- MCP search server 注册

这样新平台不再需要直接关心 Gateway HTTP 请求格式、鉴权 header、错误降级、MCP 工具注册等通用逻辑，只需要实现一个 MemoryPlatformAdapter 接口，把平台自己的 hook payload 映射成统一的 recall / capture 输入即可。

**Codex / Claude Code 示例接入**
本 PR 以 Codex 和 Claude Code 为例，基于统一 Adapter SDK 完成了两个 Agent 平台的记忆能力接入，验证新平台只需要实现平台事件映射逻辑，即可复用 Gateway 记忆读写、MCP 搜索工具和错误降级能力。

- Codex 接入位于 codex-plugin/memory/memory_tencentdb。它通过 adapter.ts 实现 MemoryPlatformAdapter，将 Codex 的 UserPromptSubmit 与 Stop hook payload 分别映射为 SDK 的 recall / capture 输入。运行时，UserPromptSubmit 阶段调用 runRecallHook() 获取记忆上下文并写入 Codex 的 additionalContext；Stop 阶段调用 runCaptureHook()，结合 prompt cache 中保存的用户输入与 assistant 输出写入对话记忆。同时，Codex 通过 runMemoryMcpServer() 注册 tdai_memory_search 和 tdai_conversation_search 两个 MCP 工具。
- Claude Code 接入位于 claudecode-plugin/memory/memory_tencentdb，整体接入方式与 Codex 保持一致，同样通过 MemoryPlatformAdapter 对接 UserPromptSubmit、Stop hook 和 MCP server。区别在于 Claude Code adapter 额外支持 transcript fallback：当 capture 阶段无法从 prompt cache 中取到用户输入或 assistant 内容时，会尝试从 Claude Code transcript 中恢复最近一轮 user / assistant 对话，从而提升记忆写入的稳定性。

通过这两个示例可以看到，新平台适配层本身保持很薄，只负责解析平台 hook payload、生成 SDK 所需的 recall / capture 请求，以及格式化平台要求的 hook 输出；真正的 Gateway 通信、prompt cache、MCP 工具注册和失败降级逻辑都由统一 Adapter SDK 复用。

新增文档：
适配架构图.md：说明核心记忆引擎、Gateway、OpenClaw、Hermes、Codex、Claude Code 的整体架构和数据流
多平台适配方式对比.md：对比 OpenClaw Plugin、Hermes Provider、Codex Plugin、Claude Code Plugin 的接入方式差异
新平台适配指南.md：说明后续新 Agent 平台如何通过实现 MemoryPlatformAdapter 接入记忆读写能力

最后，同步更新了Readme中配置codex和claude code的内容

## Related Issue | 关联 Issue

Related to #235

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

```text
$ cmd.exe /c npx.cmd vitest run src\adapters\adapter-sdk\__tests__
结果：Test Files 3 passed, Tests 15 passed
覆盖：GatewayClient、ensureGateway、hook-runner 的成功路径、错误降级、鉴权和 prompt cache 清理

$ cmd.exe /c npx.cmd vitest run codex-plugin\memory\memory_tencentdb\__tests__
结果：Test Files 2 passed, Tests 8 passed
覆盖：Codex Gateway 生命周期边界、recall/capture 降级、prompt cache 清理、SDK 委托

$ cmd.exe /c npx.cmd vitest run claudecode-plugin\memory\memory_tencentdb\__tests__
结果：Test Files 2 passed, Tests 9 passed
覆盖：Claude Code Gateway 生命周期边界、recall/capture 降级、prompt cache 清理、transcript fallback、SDK 委托

$ cmd.exe /c npx.cmd vitest run src\adapters\adapter-sdk\__tests__ codex-plugin\memory\memory_tencentdb\__tests__ claudecode-plugin\memory\memory_tencentdb\__tests__
结果：Test Files 7 passed, Tests 32 passed
覆盖：SDK、Codex adapter、Claude Code adapter 三组测试合并运行，确认测试之间无冲突

$ cmd.exe /c npx.cmd tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --types node claudecode-plugin\memory\memory_tencentdb\adapter.ts claudecode-plugin\memory\memory_tencentdb\hooks\recall.ts claudecode-plugin\memory\memory_tencentdb\hooks\capture.ts claudecode-plugin\memory\memory_tencentdb\mcp-server.ts
结果：Passed
覆盖：Claude Code adapter、recall hook、capture hook、MCP server 的 TypeScript 类型检查
```