### PR TITLE
feat(adapters): add platform adapter SDK

### DIFF
--- a/docs/platform-adapters.md
+++ b/docs/platform-adapters.md
@@ -60,6 +60,7 @@ const memory = new GatewayMemoryAdapter({
   platform: "my-agent",
   sessionKey: process.env.MY_AGENT_SESSION_ID ?? process.cwd(),
   userId: process.env.USER,
+  sessionEndTimeoutMs: 180_000,
 });
 
 const recall = await memory.recall({ query: "How does this repo prefer tests?" });
@@ -74,6 +75,13 @@ The SDK prefixes session keys with the platform name, so `workspace:/repo`
 becomes `codex:workspace:/repo`, `codebuddy:workspace:/repo`, or
 `claude-code:workspace:/repo`. This keeps memories separated by runtime while
 allowing all platforms to share the same Gateway.
+
+`recall()` returns `context`, which combines dynamic L1 memories with stable
+persona/scene context. The raw Gateway response also exposes
+`prepend_context` for the per-turn L1 memory block and `append_context` for the
+stable persona/scene block. `endSession()` may wait for a real LLM-backed L1
+flush, so the SDK gives that operation a longer timeout by default and lets
+callers override it with `sessionEndTimeoutMs`.
 
 For a reusable platform package, implement one interface:
 
@@ -114,6 +122,7 @@ const memory = createMemoryAdapter({
     apiKey: process.env.MEMORY_TENCENTDB_GATEWAY_API_KEY,
     sessionKey: process.cwd(),
     userId: process.env.USER,
+    sessionEndTimeoutMs: 180_000,
   },
 });
 ```

--- a/docs/platform-adapters.md
+++ b/docs/platform-adapters.md
@@ -1,0 +1,182 @@
+# Platform Adapters
+
+TencentDB Agent Memory keeps the memory engine host-neutral. Platform adapters
+translate each agent runtime into the same Gateway operations:
+
+- `recall`: fetch memory context before an LLM turn
+- `capture`: persist the completed user/assistant turn
+- `searchMemories`: query L1 structured memories
+- `searchConversations`: query L0 raw conversations
+- `endSession`: flush pending pipeline work for one session
+
+```mermaid
+flowchart LR
+  OpenClaw["OpenClaw plugin hooks"] --> Core["TdaiCore"]
+  Hermes["Hermes MemoryProvider"] --> Gateway["HTTP Gateway"]
+  Codex["Codex hooks/scripts"] --> SDK["GatewayMemoryAdapter SDK"]
+  CodeBuddy["CodeBuddy hooks/scripts"] --> SDK
+  Claude["Claude Code hooks/scripts"] --> SDK
+  SDK --> Gateway
+  Gateway --> Core
+  Core --> Store["SQLite / TCVDB store"]
+  Core --> Layers["L0 conversations\nL1 memories\nL2 scenes\nL3 persona"]
+```
+
+## Implemented Platforms
+
+| Platform | Entry point | Transport | Lifecycle mapping |
+| --- | --- | --- | --- |
+| OpenClaw | `index.ts`, `src/adapters/openclaw/` | In-process plugin hooks | `before_prompt_build` -> recall, `agent_end` -> capture, `gateway_stop` -> shutdown |
+| Hermes | `hermes-plugin/memory/memory_tencentdb/` | HTTP Gateway sidecar | `prefetch` -> `/recall`, `sync_turn` -> `/capture`, `shutdown` -> `/session/end` |
+| Codex | `src/adapters/codex/` | SDK over HTTP Gateway | Local hooks or wrappers call recall/capture/search around Codex turns |
+| CodeBuddy | `src/adapters/codebuddy/` | SDK over HTTP Gateway | CodeBuddy hooks or wrappers call the same SDK operations |
+| Claude Code | `src/adapters/claude-code/` | SDK over HTTP Gateway | Claude Code hooks or wrappers call the same SDK operations |
+
+## Core Boundary
+
+`TdaiCore` owns memory storage, retrieval, extraction, and lifecycle decisions.
+Adapters translate host events into core operations; they do not duplicate memory
+logic.
+
+| Core capability | Core method or Gateway route | Adapter responsibility |
+| --- | --- | --- |
+| Recall memory before a turn | `handleBeforeRecall()` / `POST /recall` | Provide query text and stable session key; place returned context in the host prompt |
+| Capture a completed turn | `handleTurnCommitted()` / `POST /capture` | Send clean user and assistant content after success |
+| Search structured memories | `searchMemories()` / `POST /search/memories` | Expose optional user-facing lookup tools |
+| Search raw conversations | `searchConversations()` / `POST /search/conversations` | Expose debugging or audit lookup tools |
+| Flush session work | `flushSession()` / `POST /session/end` | Call when the host session finishes |
+
+## Unified Adapter SDK
+
+`GatewayMemoryAdapter` is the shared SDK for platforms that live outside the
+OpenClaw process. A new platform can either instantiate it directly or implement
+one `MemoryPlatformAdapterDefinition` interface and pass it to
+`createPlatformMemoryAdapter()`.
+
+```ts
+import { GatewayMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb/adapters";
+
+const memory = new GatewayMemoryAdapter({
+  platform: "my-agent",
+  sessionKey: process.env.MY_AGENT_SESSION_ID ?? process.cwd(),
+  userId: process.env.USER,
+});
+
+const recall = await memory.recall({ query: "How does this repo prefer tests?" });
+
+await memory.capture({
+  userContent: "How does this repo prefer tests?",
+  assistantContent: "Use Vitest and keep tests close to the adapter code.",
+});
+```
+
+The SDK prefixes session keys with the platform name, so `workspace:/repo`
+becomes `codex:workspace:/repo`, `codebuddy:workspace:/repo`, or
+`claude-code:workspace:/repo`. This keeps memories separated by runtime while
+allowing all platforms to share the same Gateway.
+
+For a reusable platform package, implement one interface:
+
+```ts
+import {
+  createPlatformMemoryAdapter,
+  type MemoryPlatformAdapterDefinition,
+} from "@tencentdb-agent-memory/memory-tencentdb/adapters";
+
+const MyAgentMemoryPlatformAdapter: MemoryPlatformAdapterDefinition = {
+  platform: "my-agent",
+  fromEnv(env) {
+    return {
+      baseUrl: env.MY_AGENT_GATEWAY_URL,
+      apiKey: env.MY_AGENT_API_KEY,
+      sessionKey: env.MY_AGENT_SESSION_ID ?? env.MY_AGENT_WORKSPACE,
+      userId: env.MY_AGENT_USER_ID,
+    };
+  },
+};
+
+const memory = createPlatformMemoryAdapter(MyAgentMemoryPlatformAdapter, process.env);
+```
+
+## Provider Registry
+
+The SDK also supports a provider registry: callers choose a provider name and
+pass a small config object. Built-in providers register themselves when their
+modules are imported.
+
+```ts
+import { createMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb/adapters";
+
+const memory = createMemoryAdapter({
+  provider: "codebuddy",
+  config: {
+    baseUrl: "http://127.0.0.1:8420",
+    apiKey: process.env.MEMORY_TENCENTDB_GATEWAY_API_KEY,
+    sessionKey: process.cwd(),
+    userId: process.env.USER,
+  },
+});
+```
+
+Third-party platforms can register one definition and then use the same
+`provider + config` shape:
+
+```ts
+import {
+  createMemoryAdapter,
+  registerMemoryPlatformAdapter,
+  type MemoryPlatformAdapterDefinition,
+} from "@tencentdb-agent-memory/memory-tencentdb/adapters";
+
+const MyAgentProvider: MemoryPlatformAdapterDefinition = {
+  platform: "my-agent",
+  fromEnv(env) {
+    return {
+      baseUrl: env.MY_AGENT_GATEWAY_URL,
+      apiKey: env.MY_AGENT_API_KEY,
+      sessionKey: env.MY_AGENT_SESSION_ID ?? env.MY_AGENT_WORKSPACE,
+      userId: env.MY_AGENT_USER_ID,
+    };
+  },
+  fromConfig(config) {
+    return {
+      baseUrl: config.baseUrl as string | undefined,
+      apiKey: config.apiKey as string | undefined,
+      sessionKey: config.sessionKey as string | undefined,
+      userId: config.userId as string | undefined,
+    };
+  },
+};
+
+registerMemoryPlatformAdapter(MyAgentProvider);
+
+const memory = createMemoryAdapter({
+  provider: "my-agent",
+  config: { sessionKey: "workspace:/repo" },
+});
+```
+
+## Platform Differences
+
+| Concern | Codex | CodeBuddy | Claude Code |
+| --- | --- | --- | --- |
+| Adapter class | `CodexMemoryGatewayClient` | `CodeBuddyMemoryAdapter` | `ClaudeCodeMemoryAdapter` |
+| Default Gateway URL env | `MEMORY_TENCENTDB_GATEWAY_URL` | `CODEBUDDY_MEMORY_GATEWAY_URL` then common env | `CLAUDE_CODE_MEMORY_GATEWAY_URL` then common env |
+| Default API key env | `MEMORY_TENCENTDB_GATEWAY_API_KEY` then `TDAI_GATEWAY_API_KEY` | `CODEBUDDY_MEMORY_API_KEY` then common env | `CLAUDE_CODE_MEMORY_API_KEY` then common env |
+| Session identity env | `CODEX_SESSION_ID` or `CODEX_WORKSPACE` | `CODEBUDDY_SESSION_ID` or `CODEBUDDY_WORKSPACE` | `CLAUDE_CODE_SESSION_ID` or `CLAUDE_CODE_WORKSPACE` |
+| User identity env | `CODEX_USER_ID` | `CODEBUDDY_USER_ID` | `CLAUDE_CODE_USER_ID` |
+| Best integration point | Wrapper around Codex turns | CodeBuddy hook or command wrapper | Claude Code hook or command wrapper |
+
+## Adapter Checklist
+
+Use this checklist when adding another platform:
+
+1. Add a small wrapper class that extends `GatewayMemoryAdapter`.
+2. Or, for the minimal SDK path, implement one `MemoryPlatformAdapterDefinition`.
+3. Define platform-specific env names for Gateway URL, API key, session, and user.
+4. Use `createGatewayAdapterOptions()` or `createPlatformMemoryAdapter()` so defaults and caller overrides behave consistently.
+5. Register reusable providers with `registerMemoryPlatformAdapter()` so callers can use `createMemoryAdapter({ provider, config })`.
+6. Call `recall()` before model execution and inject returned context after the user's original prompt when possible.
+7. Call `capture()` after a successful turn with clean user and assistant text.
+8. Call `endSession()` when the host session ends.
+9. Add tests for env mapping, provider config mapping, session key prefixing, Gateway endpoint mapping, and error propagation.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     ".": {
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./adapters": {
+      "import": "./dist/src/adapters/index.mjs",
+      "default": "./dist/src/adapters/index.mjs"
     }
   },
   "scripts": {

--- a/src/adapters/claude-code/gateway-client.ts
+++ b/src/adapters/claude-code/gateway-client.ts
@@ -1,0 +1,61 @@
+import {
+  GatewayMemoryAdapter,
+  createGatewayAdapterOptions,
+  registerMemoryPlatformAdapter,
+  type GatewayMemoryAdapterOptions,
+  type MemoryAdapterProviderConfig,
+  type MemoryPlatformAdapterDefinition,
+  type PlatformEnv,
+} from "../sdk/index.js";
+
+export interface ClaudeCodeMemoryAdapterEnv extends PlatformEnv {
+  CLAUDE_CODE_MEMORY_GATEWAY_URL?: string;
+  CLAUDE_CODE_MEMORY_API_KEY?: string;
+  CLAUDE_CODE_WORKSPACE?: string;
+  CLAUDE_CODE_SESSION_ID?: string;
+  CLAUDE_CODE_USER_ID?: string;
+}
+
+export type ClaudeCodeMemoryAdapterOptions = Partial<Omit<GatewayMemoryAdapterOptions, "platform">> & {
+  platform?: "claude-code";
+};
+
+export const ClaudeCodeMemoryPlatformAdapter: MemoryPlatformAdapterDefinition<ClaudeCodeMemoryAdapterEnv> = {
+  platform: "claude-code",
+  fromEnv(env) {
+    return {
+      baseUrl: env.CLAUDE_CODE_MEMORY_GATEWAY_URL ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
+      apiKey: env.CLAUDE_CODE_MEMORY_API_KEY ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+      sessionKey: env.CLAUDE_CODE_SESSION_ID ?? env.CLAUDE_CODE_WORKSPACE ?? process.cwd(),
+      userId: env.CLAUDE_CODE_USER_ID,
+    };
+  },
+  fromConfig(config: MemoryAdapterProviderConfig, env = process.env) {
+    return {
+      baseUrl: config.baseUrl as string | undefined ?? env.CLAUDE_CODE_MEMORY_GATEWAY_URL ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
+      apiKey: config.apiKey as string | undefined ?? env.CLAUDE_CODE_MEMORY_API_KEY ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+      timeoutMs: config.timeoutMs as number | undefined,
+      fetchImpl: config.fetchImpl as typeof fetch | undefined,
+      sessionKey: config.sessionKey as string | undefined ?? env.CLAUDE_CODE_SESSION_ID ?? env.CLAUDE_CODE_WORKSPACE ?? process.cwd(),
+      userId: config.userId as string | undefined ?? env.CLAUDE_CODE_USER_ID,
+    };
+  },
+};
+
+registerMemoryPlatformAdapter(ClaudeCodeMemoryPlatformAdapter);
+
+export class ClaudeCodeMemoryAdapter extends GatewayMemoryAdapter {
+  static fromEnv(env: ClaudeCodeMemoryAdapterEnv = process.env): ClaudeCodeMemoryAdapter {
+    const defaults = ClaudeCodeMemoryPlatformAdapter.fromEnv(env);
+    return new ClaudeCodeMemoryAdapter({
+      baseUrl: defaults.baseUrl,
+      apiKey: defaults.apiKey,
+      sessionKey: defaults.sessionKey,
+      userId: defaults.userId,
+    });
+  }
+
+  constructor(opts: ClaudeCodeMemoryAdapterOptions = {}) {
+    super(createGatewayAdapterOptions({ platform: "claude-code" }, opts));
+  }
+}

--- a/src/adapters/claude-code/gateway-client.ts
+++ b/src/adapters/claude-code/gateway-client.ts
@@ -35,6 +35,7 @@ export const ClaudeCodeMemoryPlatformAdapter: MemoryPlatformAdapterDefinition<Cl
       baseUrl: config.baseUrl as string | undefined ?? env.CLAUDE_CODE_MEMORY_GATEWAY_URL ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
       apiKey: config.apiKey as string | undefined ?? env.CLAUDE_CODE_MEMORY_API_KEY ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
       timeoutMs: config.timeoutMs as number | undefined,
+      sessionEndTimeoutMs: config.sessionEndTimeoutMs as number | undefined,
       fetchImpl: config.fetchImpl as typeof fetch | undefined,
       sessionKey: config.sessionKey as string | undefined ?? env.CLAUDE_CODE_SESSION_ID ?? env.CLAUDE_CODE_WORKSPACE ?? process.cwd(),
       userId: config.userId as string | undefined ?? env.CLAUDE_CODE_USER_ID,

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Claude Code adapter — Gateway client for Claude Code hooks and wrappers.
+ */
+export { ClaudeCodeMemoryAdapter } from "./gateway-client.js";
+export { ClaudeCodeMemoryPlatformAdapter } from "./gateway-client.js";
+export type {
+  ClaudeCodeMemoryAdapterEnv,
+  ClaudeCodeMemoryAdapterOptions,
+} from "./gateway-client.js";

--- a/src/adapters/codebuddy/gateway-client.ts
+++ b/src/adapters/codebuddy/gateway-client.ts
@@ -35,6 +35,7 @@ export const CodeBuddyMemoryPlatformAdapter: MemoryPlatformAdapterDefinition<Cod
       baseUrl: config.baseUrl as string | undefined ?? env.CODEBUDDY_MEMORY_GATEWAY_URL ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
       apiKey: config.apiKey as string | undefined ?? env.CODEBUDDY_MEMORY_API_KEY ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
       timeoutMs: config.timeoutMs as number | undefined,
+      sessionEndTimeoutMs: config.sessionEndTimeoutMs as number | undefined,
       fetchImpl: config.fetchImpl as typeof fetch | undefined,
       sessionKey: config.sessionKey as string | undefined ?? env.CODEBUDDY_SESSION_ID ?? env.CODEBUDDY_WORKSPACE ?? process.cwd(),
       userId: config.userId as string | undefined ?? env.CODEBUDDY_USER_ID,

--- a/src/adapters/codebuddy/gateway-client.ts
+++ b/src/adapters/codebuddy/gateway-client.ts
@@ -1,0 +1,61 @@
+import {
+  GatewayMemoryAdapter,
+  createGatewayAdapterOptions,
+  registerMemoryPlatformAdapter,
+  type GatewayMemoryAdapterOptions,
+  type MemoryAdapterProviderConfig,
+  type MemoryPlatformAdapterDefinition,
+  type PlatformEnv,
+} from "../sdk/index.js";
+
+export interface CodeBuddyMemoryAdapterEnv extends PlatformEnv {
+  CODEBUDDY_MEMORY_GATEWAY_URL?: string;
+  CODEBUDDY_MEMORY_API_KEY?: string;
+  CODEBUDDY_WORKSPACE?: string;
+  CODEBUDDY_SESSION_ID?: string;
+  CODEBUDDY_USER_ID?: string;
+}
+
+export type CodeBuddyMemoryAdapterOptions = Partial<Omit<GatewayMemoryAdapterOptions, "platform">> & {
+  platform?: "codebuddy";
+};
+
+export const CodeBuddyMemoryPlatformAdapter: MemoryPlatformAdapterDefinition<CodeBuddyMemoryAdapterEnv> = {
+  platform: "codebuddy",
+  fromEnv(env) {
+    return {
+      baseUrl: env.CODEBUDDY_MEMORY_GATEWAY_URL ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
+      apiKey: env.CODEBUDDY_MEMORY_API_KEY ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+      sessionKey: env.CODEBUDDY_SESSION_ID ?? env.CODEBUDDY_WORKSPACE ?? process.cwd(),
+      userId: env.CODEBUDDY_USER_ID,
+    };
+  },
+  fromConfig(config: MemoryAdapterProviderConfig, env = process.env) {
+    return {
+      baseUrl: config.baseUrl as string | undefined ?? env.CODEBUDDY_MEMORY_GATEWAY_URL ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
+      apiKey: config.apiKey as string | undefined ?? env.CODEBUDDY_MEMORY_API_KEY ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+      timeoutMs: config.timeoutMs as number | undefined,
+      fetchImpl: config.fetchImpl as typeof fetch | undefined,
+      sessionKey: config.sessionKey as string | undefined ?? env.CODEBUDDY_SESSION_ID ?? env.CODEBUDDY_WORKSPACE ?? process.cwd(),
+      userId: config.userId as string | undefined ?? env.CODEBUDDY_USER_ID,
+    };
+  },
+};
+
+registerMemoryPlatformAdapter(CodeBuddyMemoryPlatformAdapter);
+
+export class CodeBuddyMemoryAdapter extends GatewayMemoryAdapter {
+  static fromEnv(env: CodeBuddyMemoryAdapterEnv = process.env): CodeBuddyMemoryAdapter {
+    const defaults = CodeBuddyMemoryPlatformAdapter.fromEnv(env);
+    return new CodeBuddyMemoryAdapter({
+      baseUrl: defaults.baseUrl,
+      apiKey: defaults.apiKey,
+      sessionKey: defaults.sessionKey,
+      userId: defaults.userId,
+    });
+  }
+
+  constructor(opts: CodeBuddyMemoryAdapterOptions = {}) {
+    super(createGatewayAdapterOptions({ platform: "codebuddy" }, opts));
+  }
+}

--- a/src/adapters/codebuddy/index.ts
+++ b/src/adapters/codebuddy/index.ts
@@ -1,0 +1,9 @@
+/**
+ * CodeBuddy adapter — Gateway client for CodeBuddy hooks and wrappers.
+ */
+export { CodeBuddyMemoryAdapter } from "./gateway-client.js";
+export { CodeBuddyMemoryPlatformAdapter } from "./gateway-client.js";
+export type {
+  CodeBuddyMemoryAdapterEnv,
+  CodeBuddyMemoryAdapterOptions,
+} from "./gateway-client.js";

--- a/src/adapters/codex/gateway-client.ts
+++ b/src/adapters/codex/gateway-client.ts
@@ -41,6 +41,7 @@ export const CodexMemoryPlatformAdapter: MemoryPlatformAdapterDefinition<CodexMe
       baseUrl: config.baseUrl as string | undefined ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
       apiKey: config.apiKey as string | undefined ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
       timeoutMs: config.timeoutMs as number | undefined,
+      sessionEndTimeoutMs: config.sessionEndTimeoutMs as number | undefined,
       fetchImpl: config.fetchImpl as typeof fetch | undefined,
       sessionKey: config.sessionKey as string | undefined ?? env.CODEX_SESSION_ID ?? env.CODEX_WORKSPACE ?? process.cwd(),
       userId: config.userId as string | undefined ?? env.CODEX_USER_ID,

--- a/src/adapters/codex/gateway-client.ts
+++ b/src/adapters/codex/gateway-client.ts
@@ -1,0 +1,67 @@
+import {
+  GatewayMemoryAdapter,
+  createGatewayAdapterOptions,
+  registerMemoryPlatformAdapter,
+  type GatewayCaptureParams,
+  type GatewayConversationSearchParams,
+  type MemoryAdapterProviderConfig,
+  type GatewayMemoryAdapterOptions,
+  type GatewayMemorySearchParams,
+  type GatewayRecallParams,
+  type MemoryPlatformAdapterDefinition,
+  type PlatformEnv,
+} from "../sdk/index.js";
+
+export interface CodexMemoryGatewayClientEnv extends PlatformEnv {
+  CODEX_WORKSPACE?: string;
+  CODEX_SESSION_ID?: string;
+  CODEX_USER_ID?: string;
+}
+
+export type CodexMemoryGatewayClientOptions = Partial<Omit<GatewayMemoryAdapterOptions, "platform">> & {
+  platform?: "codex";
+};
+export type CodexRecallParams = GatewayRecallParams;
+export type CodexCaptureParams = GatewayCaptureParams;
+export type CodexMemorySearchParams = GatewayMemorySearchParams;
+export type CodexConversationSearchParams = GatewayConversationSearchParams;
+
+export const CodexMemoryPlatformAdapter: MemoryPlatformAdapterDefinition<CodexMemoryGatewayClientEnv> = {
+  platform: "codex",
+  fromEnv(env) {
+    return {
+      baseUrl: env.MEMORY_TENCENTDB_GATEWAY_URL,
+      apiKey: env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+      sessionKey: env.CODEX_SESSION_ID ?? env.CODEX_WORKSPACE ?? process.cwd(),
+      userId: env.CODEX_USER_ID,
+    };
+  },
+  fromConfig(config: MemoryAdapterProviderConfig, env = process.env) {
+    return {
+      baseUrl: config.baseUrl as string | undefined ?? env.MEMORY_TENCENTDB_GATEWAY_URL,
+      apiKey: config.apiKey as string | undefined ?? env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY,
+      timeoutMs: config.timeoutMs as number | undefined,
+      fetchImpl: config.fetchImpl as typeof fetch | undefined,
+      sessionKey: config.sessionKey as string | undefined ?? env.CODEX_SESSION_ID ?? env.CODEX_WORKSPACE ?? process.cwd(),
+      userId: config.userId as string | undefined ?? env.CODEX_USER_ID,
+    };
+  },
+};
+
+registerMemoryPlatformAdapter(CodexMemoryPlatformAdapter);
+
+export class CodexMemoryGatewayClient extends GatewayMemoryAdapter {
+  static fromEnv(env: CodexMemoryGatewayClientEnv = process.env): CodexMemoryGatewayClient {
+    const defaults = CodexMemoryPlatformAdapter.fromEnv(env);
+    return new CodexMemoryGatewayClient({
+      baseUrl: defaults.baseUrl,
+      apiKey: defaults.apiKey,
+      sessionKey: defaults.sessionKey,
+      userId: defaults.userId,
+    });
+  }
+
+  constructor(opts: CodexMemoryGatewayClientOptions = {}) {
+    super(createGatewayAdapterOptions({ platform: "codex" }, opts));
+  }
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Codex adapter — Gateway client for Codex hooks, scripts, and local agents.
+ */
+export { CodexMemoryGatewayClient } from "./gateway-client.js";
+export { CodexMemoryPlatformAdapter } from "./gateway-client.js";
+export type {
+  CodexCaptureParams,
+  CodexConversationSearchParams,
+  CodexMemoryGatewayClientEnv,
+  CodexMemoryGatewayClientOptions,
+  CodexMemorySearchParams,
+  CodexRecallParams,
+} from "./gateway-client.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -7,7 +7,11 @@
  * Directory structure:
  *   adapters/
  *   ├── openclaw/      — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
- *   └── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   ├── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   ├── sdk/           — Shared Gateway adapter SDK for platform wrappers
+ *   ├── codex/         — Codex-facing Gateway client
+ *   ├── codebuddy/     — CodeBuddy-facing Gateway client
+ *   └── claude-code/   — Claude Code-facing Gateway client
  */
 
 // OpenClaw adapter
@@ -17,3 +21,52 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Shared Gateway SDK
+export {
+  GatewayMemoryAdapter,
+  createGatewayAdapterOptions,
+  createMemoryAdapter,
+  createPlatformMemoryAdapter,
+  getMemoryPlatformAdapter,
+  listMemoryAdapterProviders,
+  registerMemoryPlatformAdapter,
+} from "./sdk/index.js";
+export type {
+  GatewayCaptureParams,
+  GatewayConversationSearchParams,
+  GatewayMemoryAdapterOptions,
+  GatewayMemorySearchParams,
+  GatewayRecallParams,
+  MemoryAdapterConfig,
+  MemoryAdapterProviderConfig,
+  MemoryPlatformAdapterDefinition,
+  MemoryAdapterPlatform,
+  PlatformAdapterDefaults,
+  PlatformEnv,
+} from "./sdk/index.js";
+
+// Codex adapter
+export { CodexMemoryGatewayClient, CodexMemoryPlatformAdapter } from "./codex/index.js";
+export type {
+  CodexCaptureParams,
+  CodexConversationSearchParams,
+  CodexMemoryGatewayClientEnv,
+  CodexMemoryGatewayClientOptions,
+  CodexMemorySearchParams,
+  CodexRecallParams,
+} from "./codex/index.js";
+
+// CodeBuddy adapter
+export { CodeBuddyMemoryAdapter, CodeBuddyMemoryPlatformAdapter } from "./codebuddy/index.js";
+export type {
+  CodeBuddyMemoryAdapterEnv,
+  CodeBuddyMemoryAdapterOptions,
+} from "./codebuddy/index.js";
+
+// Claude Code adapter
+export { ClaudeCodeMemoryAdapter, ClaudeCodeMemoryPlatformAdapter } from "./claude-code/index.js";
+export type {
+  ClaudeCodeMemoryAdapterEnv,
+  ClaudeCodeMemoryAdapterOptions,
+} from "./claude-code/index.js";

--- a/src/adapters/platform-adapters.test.ts
+++ b/src/adapters/platform-adapters.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ClaudeCodeMemoryAdapter } from "./claude-code/index.js";
+import { CodeBuddyMemoryAdapter } from "./codebuddy/index.js";
+import { CodexMemoryGatewayClient } from "./codex/index.js";
+import { createMemoryAdapter } from "./sdk/index.js";
+
+function mockFetch(responseBody: unknown) {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch);
+  return calls;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("platform adapters", () => {
+  it("uses registered built-in providers through provider config", async () => {
+    const calls = mockFetch({ context: "configured memory" });
+
+    const adapter = createMemoryAdapter({
+      provider: "codebuddy",
+      config: {
+        baseUrl: "http://configured-gateway/",
+        apiKey: "configured-secret",
+        sessionKey: "/repo",
+        userId: "leo",
+      },
+    });
+
+    await adapter.recall({ query: "q" });
+
+    expect(String(calls[0].input)).toBe("http://configured-gateway/recall");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer configured-secret" });
+    expect(JSON.parse(calls[0].init?.body as string)).toMatchObject({
+      session_key: "codebuddy:/repo",
+      user_id: "leo",
+    });
+  });
+
+  it("creates Codex adapters from Codex-friendly environment variables", async () => {
+    const calls = mockFetch({ context: "codex memory" });
+    const adapter = CodexMemoryGatewayClient.fromEnv({
+      MEMORY_TENCENTDB_GATEWAY_URL: "http://gateway.local/",
+      MEMORY_TENCENTDB_GATEWAY_API_KEY: "codex-secret",
+      CODEX_WORKSPACE: "/repo",
+      CODEX_USER_ID: "leo",
+    });
+
+    await adapter.recall({ query: "q" });
+
+    expect(String(calls[0].input)).toBe("http://gateway.local/recall");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer codex-secret" });
+    expect(JSON.parse(calls[0].init?.body as string)).toMatchObject({
+      session_key: "codex:/repo",
+      user_id: "leo",
+    });
+  });
+
+  it("creates CodeBuddy adapters with CodeBuddy env fallbacks", async () => {
+    const calls = mockFetch({ context: "codebuddy memory" });
+    const adapter = CodeBuddyMemoryAdapter.fromEnv({
+      CODEBUDDY_MEMORY_GATEWAY_URL: "http://codebuddy-gateway/",
+      CODEBUDDY_MEMORY_API_KEY: "codebuddy-secret",
+      CODEBUDDY_WORKSPACE: "/repo",
+      CODEBUDDY_USER_ID: "drive888",
+    });
+
+    await adapter.recall({ query: "q" });
+
+    expect(String(calls[0].input)).toBe("http://codebuddy-gateway/recall");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer codebuddy-secret" });
+    expect(JSON.parse(calls[0].init?.body as string)).toMatchObject({
+      session_key: "codebuddy:/repo",
+      user_id: "drive888",
+    });
+  });
+
+  it("creates Claude Code adapters with Claude env fallbacks", async () => {
+    const calls = mockFetch({ context: "claude memory" });
+    const adapter = ClaudeCodeMemoryAdapter.fromEnv({
+      CLAUDE_CODE_MEMORY_GATEWAY_URL: "http://claude-gateway/",
+      CLAUDE_CODE_MEMORY_API_KEY: "claude-secret",
+      CLAUDE_CODE_SESSION_ID: "thread-1",
+      CLAUDE_CODE_USER_ID: "leo",
+    });
+
+    await adapter.capture({ userContent: "u", assistantContent: "a" });
+
+    expect(String(calls[0].input)).toBe("http://claude-gateway/capture");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer claude-secret" });
+    expect(JSON.parse(calls[0].init?.body as string)).toMatchObject({
+      session_key: "claude-code:thread-1",
+      user_content: "u",
+      assistant_content: "a",
+      user_id: "leo",
+    });
+  });
+});

--- a/src/adapters/sdk/gateway-adapter.test.ts
+++ b/src/adapters/sdk/gateway-adapter.test.ts
@@ -20,6 +20,7 @@ function mockFetch(responseBody: unknown, status = 200) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -166,6 +167,36 @@ describe("GatewayMemoryAdapter", () => {
     expect(JSON.parse(calls[2].init?.body as string)).toEqual({
       session_key: "claude-code:thread:abc",
     });
+  });
+
+  it("uses a longer timeout for session flushes than ordinary requests", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("This operation was aborted", "AbortError"));
+        });
+        setTimeout(() => {
+          resolve(new Response(JSON.stringify({ flushed: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }));
+        }, 25);
+      });
+    }) as typeof fetch);
+    const adapter = new GatewayMemoryAdapter({
+      platform: "codex",
+      sessionKey: "s",
+      timeoutMs: 10,
+      sessionEndTimeoutMs: 50,
+      fetchImpl,
+    });
+
+    const result = adapter.endSession();
+    await vi.advanceTimersByTimeAsync(30);
+
+    await expect(result).resolves.toEqual({ flushed: true });
   });
 
   it("raises Gateway errors with response body details", async () => {

--- a/src/adapters/sdk/gateway-adapter.test.ts
+++ b/src/adapters/sdk/gateway-adapter.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GatewayMemoryAdapter,
+  createMemoryAdapter,
+  createPlatformMemoryAdapter,
+  registerMemoryPlatformAdapter,
+} from "./gateway-adapter.js";
+
+function mockFetch(responseBody: unknown, status = 200) {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    return new Response(JSON.stringify(responseBody), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof globalThis.fetch);
+  return calls;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GatewayMemoryAdapter", () => {
+  it("creates adapters from a provider config registry", async () => {
+    registerMemoryPlatformAdapter({
+      platform: "registry-agent",
+      fromConfig(config) {
+        return {
+          baseUrl: config.baseUrl,
+          apiKey: config.apiKey,
+          sessionKey: config.sessionKey,
+          userId: config.userId,
+        };
+      },
+    });
+    const calls = mockFetch({ context: "registry memory" });
+
+    const adapter = createMemoryAdapter({
+      provider: "registry-agent",
+      config: {
+        baseUrl: "http://registry-gateway/",
+        apiKey: "registry-secret",
+        sessionKey: "workspace:/repo",
+        userId: "leo",
+      },
+    });
+
+    await adapter.recall({ query: "q" });
+
+    expect(String(calls[0].input)).toBe("http://registry-gateway/recall");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer registry-secret" });
+    expect(JSON.parse(calls[0].init?.body as string)).toMatchObject({
+      session_key: "registry-agent:workspace:/repo",
+      user_id: "leo",
+    });
+  });
+
+  it("raises a clear error for unknown adapter providers", () => {
+    expect(() => createMemoryAdapter({ provider: "missing-agent" })).toThrow(
+      "Unknown memory adapter provider: missing-agent",
+    );
+  });
+
+  it("creates a full adapter from a single platform definition interface", async () => {
+    const calls = mockFetch({ context: "new platform memory" });
+    const adapter = createPlatformMemoryAdapter(
+      {
+        platform: "my-agent",
+        fromEnv(env) {
+          return {
+            baseUrl: env.MY_AGENT_GATEWAY_URL,
+            apiKey: env.MY_AGENT_API_KEY,
+            sessionKey: env.MY_AGENT_SESSION_ID ?? env.MY_AGENT_WORKSPACE,
+            userId: env.MY_AGENT_USER_ID,
+          };
+        },
+      },
+      {
+        MY_AGENT_GATEWAY_URL: "http://my-agent-gateway/",
+        MY_AGENT_API_KEY: "agent-secret",
+        MY_AGENT_WORKSPACE: "/repo",
+        MY_AGENT_USER_ID: "leo",
+      },
+    );
+
+    await adapter.recall({ query: "q" });
+
+    expect(String(calls[0].input)).toBe("http://my-agent-gateway/recall");
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer agent-secret" });
+    expect(JSON.parse(calls[0].init?.body as string)).toMatchObject({
+      session_key: "my-agent:/repo",
+      user_id: "leo",
+    });
+  });
+
+  it("maps recall and capture to the Gateway contract with platform session keys", async () => {
+    const calls = mockFetch({ context: "<memory>repo prefers vitest</memory>", strategy: "hybrid", memory_count: 1 });
+    const adapter = new GatewayMemoryAdapter({
+      platform: "codebuddy",
+      baseUrl: "http://127.0.0.1:8420/",
+      apiKey: "secret",
+      sessionKey: "workspace:/repo",
+      userId: "drive888",
+    });
+
+    const recall = await adapter.recall({ query: "test style?" });
+    await adapter.capture({
+      userContent: "test style?",
+      assistantContent: "Use Vitest.",
+      sessionId: "turn-1",
+    });
+
+    expect(recall.context).toBe("<memory>repo prefers vitest</memory>");
+    expect(calls.map((call) => String(call.input))).toEqual([
+      "http://127.0.0.1:8420/recall",
+      "http://127.0.0.1:8420/capture",
+    ]);
+    expect(calls[0].init?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer secret",
+    });
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "test style?",
+      session_key: "codebuddy:workspace:/repo",
+      user_id: "drive888",
+    });
+    expect(JSON.parse(calls[1].init?.body as string)).toEqual({
+      user_content: "test style?",
+      assistant_content: "Use Vitest.",
+      session_key: "codebuddy:workspace:/repo",
+      session_id: "turn-1",
+      user_id: "drive888",
+    });
+  });
+
+  it("supports search and session lifecycle through the same SDK surface", async () => {
+    const calls = mockFetch({ results: "[]", total: 0, strategy: "hybrid", flushed: true });
+    const adapter = new GatewayMemoryAdapter({
+      platform: "claude-code",
+      sessionKey: "thread:abc",
+    });
+
+    await adapter.searchMemories({ query: "preference", limit: 3, type: "preference", scene: "repo" });
+    await adapter.searchConversations({ query: "previous", limit: 2 });
+    await adapter.endSession();
+
+    expect(calls.map((call) => String(call.input))).toEqual([
+      "http://127.0.0.1:8420/search/memories",
+      "http://127.0.0.1:8420/search/conversations",
+      "http://127.0.0.1:8420/session/end",
+    ]);
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "preference",
+      limit: 3,
+      type: "preference",
+      scene: "repo",
+    });
+    expect(JSON.parse(calls[1].init?.body as string)).toEqual({
+      query: "previous",
+      limit: 2,
+      session_key: "claude-code:thread:abc",
+    });
+    expect(JSON.parse(calls[2].init?.body as string)).toEqual({
+      session_key: "claude-code:thread:abc",
+    });
+  });
+
+  it("raises Gateway errors with response body details", async () => {
+    mockFetch({ error: "no auth" }, 401);
+    const adapter = new GatewayMemoryAdapter({ platform: "codex", sessionKey: "s" });
+
+    await expect(adapter.recall({ query: "q" })).rejects.toThrow(
+      "Gateway /recall failed: HTTP 401",
+    );
+  });
+});

--- a/src/adapters/sdk/gateway-adapter.ts
+++ b/src/adapters/sdk/gateway-adapter.ts
@@ -14,6 +14,7 @@ export interface GatewayMemoryAdapterOptions {
   baseUrl?: string;
   apiKey?: string;
   timeoutMs?: number;
+  sessionEndTimeoutMs?: number;
   fetchImpl?: typeof fetch;
   sessionKey: string;
   userId?: string;
@@ -58,6 +59,7 @@ export interface PlatformAdapterDefaults {
   baseUrl?: string;
   apiKey?: string;
   timeoutMs?: number;
+  sessionEndTimeoutMs?: number;
   fetchImpl?: typeof fetch;
   sessionKey?: string;
   userId?: string;
@@ -67,6 +69,7 @@ export interface MemoryAdapterProviderConfig {
   baseUrl?: string;
   apiKey?: string;
   timeoutMs?: number;
+  sessionEndTimeoutMs?: number;
   fetchImpl?: typeof fetch;
   sessionKey?: string;
   userId?: string;
@@ -86,6 +89,8 @@ export interface MemoryAdapterConfig<TConfig extends MemoryAdapterProviderConfig
   provider: MemoryAdapterPlatform;
   config?: TConfig;
 }
+
+const DEFAULT_SESSION_END_TIMEOUT_MS = 180_000;
 
 const platformRegistry = new Map<MemoryAdapterPlatform, MemoryPlatformAdapterDefinition>();
 
@@ -110,6 +115,7 @@ export function createGatewayAdapterOptions(
     baseUrl: overrides.baseUrl ?? defaults.baseUrl,
     apiKey: overrides.apiKey ?? defaults.apiKey,
     timeoutMs: overrides.timeoutMs ?? defaults.timeoutMs,
+    sessionEndTimeoutMs: overrides.sessionEndTimeoutMs ?? defaults.sessionEndTimeoutMs,
     fetchImpl: overrides.fetchImpl ?? defaults.fetchImpl,
     sessionKey: overrides.sessionKey ?? defaults.sessionKey ?? process.cwd(),
     userId: overrides.userId ?? defaults.userId,
@@ -151,6 +157,7 @@ export class GatewayMemoryAdapter {
   protected readonly baseUrl: string;
   protected readonly apiKey?: string;
   protected readonly timeoutMs: number;
+  protected readonly sessionEndTimeoutMs: number;
   protected readonly fetchImpl: typeof fetch;
   protected readonly defaultSessionKey: string;
   protected readonly defaultUserId?: string;
@@ -160,6 +167,7 @@ export class GatewayMemoryAdapter {
     this.baseUrl = (opts.baseUrl ?? "http://127.0.0.1:8420").replace(/\/+$/, "");
     this.apiKey = opts.apiKey?.trim() || undefined;
     this.timeoutMs = opts.timeoutMs ?? 10_000;
+    this.sessionEndTimeoutMs = opts.sessionEndTimeoutMs ?? Math.max(this.timeoutMs, DEFAULT_SESSION_END_TIMEOUT_MS);
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.defaultSessionKey = opts.sessionKey;
     this.defaultUserId = opts.userId;
@@ -206,10 +214,18 @@ export class GatewayMemoryAdapter {
   }
 
   endSession(sessionKey?: string, userId?: string): Promise<SessionEndResponse> {
-    return this.post<SessionEndResponse>("/session/end", {
-      session_key: this.resolveSessionKey(sessionKey),
-      ...this.userField(userId),
-    });
+    return this.request<SessionEndResponse>(
+      "/session/end",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_key: this.resolveSessionKey(sessionKey),
+          ...this.userField(userId),
+        }),
+      },
+      this.sessionEndTimeoutMs,
+    );
   }
 
   protected resolveSessionKey(sessionKey = this.defaultSessionKey): string {
@@ -233,9 +249,9 @@ export class GatewayMemoryAdapter {
     });
   }
 
-  private async request<T>(pathname: string, init: RequestInit): Promise<T> {
+  private async request<T>(pathname: string, init: RequestInit, timeoutMs = this.timeoutMs): Promise<T> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const headers = {
         ...(init.headers as Record<string, string> | undefined),

--- a/src/adapters/sdk/gateway-adapter.ts
+++ b/src/adapters/sdk/gateway-adapter.ts
@@ -1,0 +1,258 @@
+import type {
+  CaptureResponse,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchResponse,
+  RecallResponse,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export type MemoryAdapterPlatform = "codex" | "codebuddy" | "claude-code" | (string & {});
+
+export interface GatewayMemoryAdapterOptions {
+  platform: MemoryAdapterPlatform;
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  sessionKey: string;
+  userId?: string;
+}
+
+export interface GatewayRecallParams {
+  query: string;
+  sessionKey?: string;
+  userId?: string;
+}
+
+export interface GatewayCaptureParams {
+  userContent: string;
+  assistantContent: string;
+  sessionKey?: string;
+  sessionId?: string;
+  userId?: string;
+  messages?: unknown[];
+}
+
+export interface GatewayMemorySearchParams {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface GatewayConversationSearchParams {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export interface PlatformEnv {
+  MEMORY_TENCENTDB_GATEWAY_URL?: string;
+  MEMORY_TENCENTDB_GATEWAY_API_KEY?: string;
+  TDAI_GATEWAY_API_KEY?: string;
+}
+
+export interface PlatformAdapterDefaults {
+  platform: MemoryAdapterPlatform;
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  sessionKey?: string;
+  userId?: string;
+}
+
+export interface MemoryAdapterProviderConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  sessionKey?: string;
+  userId?: string;
+  [key: string]: unknown;
+}
+
+export interface MemoryPlatformAdapterDefinition<
+  TEnv extends Record<string, string | undefined> = Record<string, string | undefined>,
+  TConfig extends MemoryAdapterProviderConfig = MemoryAdapterProviderConfig,
+> {
+  platform: MemoryAdapterPlatform;
+  fromEnv(env: TEnv & PlatformEnv): Omit<PlatformAdapterDefaults, "platform">;
+  fromConfig?(config: TConfig, env?: TEnv & PlatformEnv): Omit<PlatformAdapterDefaults, "platform">;
+}
+
+export interface MemoryAdapterConfig<TConfig extends MemoryAdapterProviderConfig = MemoryAdapterProviderConfig> {
+  provider: MemoryAdapterPlatform;
+  config?: TConfig;
+}
+
+const platformRegistry = new Map<MemoryAdapterPlatform, MemoryPlatformAdapterDefinition>();
+
+export function registerMemoryPlatformAdapter(definition: MemoryPlatformAdapterDefinition): void {
+  platformRegistry.set(definition.platform, definition);
+}
+
+export function getMemoryPlatformAdapter(provider: MemoryAdapterPlatform): MemoryPlatformAdapterDefinition | undefined {
+  return platformRegistry.get(provider);
+}
+
+export function listMemoryAdapterProviders(): MemoryAdapterPlatform[] {
+  return [...platformRegistry.keys()];
+}
+
+export function createGatewayAdapterOptions(
+  defaults: PlatformAdapterDefaults,
+  overrides: Partial<GatewayMemoryAdapterOptions> = {},
+): GatewayMemoryAdapterOptions {
+  return {
+    platform: overrides.platform ?? defaults.platform,
+    baseUrl: overrides.baseUrl ?? defaults.baseUrl,
+    apiKey: overrides.apiKey ?? defaults.apiKey,
+    timeoutMs: overrides.timeoutMs ?? defaults.timeoutMs,
+    fetchImpl: overrides.fetchImpl ?? defaults.fetchImpl,
+    sessionKey: overrides.sessionKey ?? defaults.sessionKey ?? process.cwd(),
+    userId: overrides.userId ?? defaults.userId,
+  };
+}
+
+export function createMemoryAdapter<TConfig extends MemoryAdapterProviderConfig>(
+  options: MemoryAdapterConfig<TConfig>,
+  env: PlatformEnv = process.env,
+  overrides: Partial<GatewayMemoryAdapterOptions> = {},
+): GatewayMemoryAdapter {
+  const definition = platformRegistry.get(options.provider);
+  if (!definition) {
+    throw new Error(`Unknown memory adapter provider: ${options.provider}`);
+  }
+  const config = options.config ?? {} as TConfig;
+  const defaults = definition.fromConfig
+    ? definition.fromConfig(config, env)
+    : definition.fromEnv(env);
+  return new GatewayMemoryAdapter(createGatewayAdapterOptions({
+    platform: definition.platform,
+    ...defaults,
+  }, overrides));
+}
+
+export function createPlatformMemoryAdapter<TEnv extends Record<string, string | undefined>>(
+  definition: MemoryPlatformAdapterDefinition<TEnv>,
+  env: TEnv & PlatformEnv = process.env as TEnv & PlatformEnv,
+  overrides: Partial<GatewayMemoryAdapterOptions> = {},
+): GatewayMemoryAdapter {
+  return new GatewayMemoryAdapter(createGatewayAdapterOptions({
+    platform: definition.platform,
+    ...definition.fromEnv(env),
+  }, overrides));
+}
+
+export class GatewayMemoryAdapter {
+  protected readonly platform: MemoryAdapterPlatform;
+  protected readonly baseUrl: string;
+  protected readonly apiKey?: string;
+  protected readonly timeoutMs: number;
+  protected readonly fetchImpl: typeof fetch;
+  protected readonly defaultSessionKey: string;
+  protected readonly defaultUserId?: string;
+
+  constructor(opts: GatewayMemoryAdapterOptions) {
+    this.platform = opts.platform;
+    this.baseUrl = (opts.baseUrl ?? "http://127.0.0.1:8420").replace(/\/+$/, "");
+    this.apiKey = opts.apiKey?.trim() || undefined;
+    this.timeoutMs = opts.timeoutMs ?? 10_000;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.defaultSessionKey = opts.sessionKey;
+    this.defaultUserId = opts.userId;
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.get<HealthResponse>("/health");
+  }
+
+  recall(params: GatewayRecallParams): Promise<RecallResponse> {
+    return this.post<RecallResponse>("/recall", {
+      query: params.query,
+      session_key: this.resolveSessionKey(params.sessionKey),
+      ...this.userField(params.userId),
+    });
+  }
+
+  capture(params: GatewayCaptureParams): Promise<CaptureResponse> {
+    return this.post<CaptureResponse>("/capture", {
+      user_content: params.userContent,
+      assistant_content: params.assistantContent,
+      session_key: this.resolveSessionKey(params.sessionKey),
+      ...(params.sessionId ? { session_id: params.sessionId } : {}),
+      ...this.userField(params.userId),
+      ...(params.messages ? { messages: params.messages } : {}),
+    });
+  }
+
+  searchMemories(params: GatewayMemorySearchParams): Promise<MemorySearchResponse> {
+    return this.post<MemorySearchResponse>("/search/memories", {
+      query: params.query,
+      ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      ...(params.type ? { type: params.type } : {}),
+      ...(params.scene ? { scene: params.scene } : {}),
+    });
+  }
+
+  searchConversations(params: GatewayConversationSearchParams): Promise<ConversationSearchResponse> {
+    return this.post<ConversationSearchResponse>("/search/conversations", {
+      query: params.query,
+      ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      session_key: this.resolveSessionKey(params.sessionKey),
+    });
+  }
+
+  endSession(sessionKey?: string, userId?: string): Promise<SessionEndResponse> {
+    return this.post<SessionEndResponse>("/session/end", {
+      session_key: this.resolveSessionKey(sessionKey),
+      ...this.userField(userId),
+    });
+  }
+
+  protected resolveSessionKey(sessionKey = this.defaultSessionKey): string {
+    return sessionKey.startsWith(`${this.platform}:`) ? sessionKey : `${this.platform}:${sessionKey}`;
+  }
+
+  private userField(userId?: string): { user_id?: string } {
+    const resolved = userId ?? this.defaultUserId;
+    return resolved ? { user_id: resolved } : {};
+  }
+
+  private async get<T>(pathname: string): Promise<T> {
+    return this.request<T>(pathname, { method: "GET" });
+  }
+
+  private async post<T>(pathname: string, body: Record<string, unknown>): Promise<T> {
+    return this.request<T>(pathname, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  private async request<T>(pathname: string, init: RequestInit): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const headers = {
+        ...(init.headers as Record<string, string> | undefined),
+        ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
+      };
+      const response = await this.fetchImpl(`${this.baseUrl}${pathname}`, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Gateway ${pathname} failed: HTTP ${response.status}${text ? ` ${text}` : ""}`);
+      }
+      return await response.json() as T;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/adapters/sdk/index.ts
+++ b/src/adapters/sdk/index.ts
@@ -1,0 +1,22 @@
+export {
+  GatewayMemoryAdapter,
+  createMemoryAdapter,
+  createGatewayAdapterOptions,
+  createPlatformMemoryAdapter,
+  getMemoryPlatformAdapter,
+  listMemoryAdapterProviders,
+  registerMemoryPlatformAdapter,
+} from "./gateway-adapter.js";
+export type {
+  GatewayCaptureParams,
+  GatewayConversationSearchParams,
+  MemoryAdapterConfig,
+  MemoryAdapterProviderConfig,
+  GatewayMemoryAdapterOptions,
+  GatewayMemorySearchParams,
+  GatewayRecallParams,
+  MemoryPlatformAdapterDefinition,
+  MemoryAdapterPlatform,
+  PlatformAdapterDefaults,
+  PlatformEnv,
+} from "./gateway-adapter.js";

--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRecallResponse } from "./server.js";
+
+describe("buildRecallResponse", () => {
+  it("exposes both dynamic L1 memories and stable recall context", () => {
+    const response = buildRecallResponse({
+      prependContext: "<relevant-memories>\n- [instruction] codex marker\n</relevant-memories>",
+      appendSystemContext: "<user-persona>\nproject persona\n</user-persona>",
+      recallStrategy: "hybrid",
+      recalledL1Memories: [{ content: "codex marker", score: 0, type: "instruction" }],
+    });
+
+    expect(response.context).toContain("codex marker");
+    expect(response.context).toContain("project persona");
+    expect(response.prepend_context).toContain("codex marker");
+    expect(response.append_context).toContain("project persona");
+    expect(response.memory_count).toBe(1);
+    expect(response.strategy).toBe("hybrid");
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -40,6 +40,7 @@ import type {
   GatewayErrorResponse,
 } from "./types.js";
 import type { Logger } from "../core/types.js";
+import type { RecallResult } from "../core/hooks/auto-recall.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
@@ -91,6 +92,17 @@ function sendJson(res: http.ServerResponse, status: number, body: unknown): void
 
 function sendError(res: http.ServerResponse, status: number, message: string): void {
   sendJson(res, status, { error: message } satisfies GatewayErrorResponse);
+}
+
+export function buildRecallResponse(result: RecallResult): RecallResponse {
+  const context = [result.prependContext, result.appendSystemContext].filter(Boolean).join("\n\n");
+  return {
+    context,
+    ...(result.prependContext ? { prepend_context: result.prependContext } : {}),
+    ...(result.appendSystemContext ? { append_context: result.appendSystemContext } : {}),
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+  };
 }
 
 /**
@@ -380,13 +392,9 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    const response = buildRecallResponse(result);
 
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
+    this.logger.info(`Recall completed in ${elapsed}ms: context=${response.context.length} chars`);
     sendJson(res, 200, response);
   }
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -37,6 +37,8 @@ export interface RecallRequest {
 
 export interface RecallResponse {
   context: string;
+  prepend_context?: string;
+  append_context?: string;
   strategy?: string;
   memory_count?: number;
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: ["./index.ts", "./src/adapters/index.ts"],
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
> [!NOTE]
> This PR is being re-scoped and is not currently intended for merge.
>
> The shared Gateway client and adapter-kit work will rely on #316, and the recall response compatibility work will remain with #372.

## 变更说明

实现 #235 的跨平台记忆适配层：在现有 `TdaiCore` / Gateway 能力之上，新增统一 adapter SDK，让 Codex、CodeBuddy、Claude Code 等外部平台可以通过同一套接口接入 TencentDB Agent Memory。

## 架构图与数据流

```mermaid
flowchart LR
  subgraph Platform["平台接入层"]
    OpenClaw["OpenClaw 插件"]
    Hermes["Hermes Provider"]
  end

  subgraph Adapter["适配层"]
    A1["OpenClawHostAdapter - 进程内调用"]
    A2["Gateway + StandaloneHostAdapter - HTTP 调用"]
  end

  subgraph Core["核心记忆引擎"]
    TdaiCore["TdaiCore"]
    Memory["Recall / Capture / Search / L1-L3 Pipeline"]
  end

  subgraph Store["存储层"]
    DB["SQLite / FTS5 / sqlite-vec / VectorDB"]
    Files["Markdown / JSONL 文件"]
  end

  OpenClaw --> A1
  Hermes --> A2

  A1 --> TdaiCore
  A2 --> TdaiCore

  TdaiCore --> Memory
  Memory --> DB
  Memory --> Files
```

核心数据流：

1. 平台通过 adapter SDK 创建平台 adapter。
2. adapter 调用 Gateway 的 `/recall`、`/capture`、`/search/*`、`/session/end`。
3. Gateway 转发到 `TdaiCore`。
4. `TdaiCore` 继续负责 L0/L1/L2/L3 记忆写入、召回和持久化。

## 主要修改

- 新增统一 adapter SDK，封装 Gateway 的 `recall`、`capture`、`search`、`endSession` 调用。
- 新增 Codex、CodeBuddy、Claude Code 三个平台适配器。
- 新增统一导出入口：`@tencentdb-agent-memory/memory-tencentdb/adapters`。
- 新增平台适配文档：`docs/platform-adapters.md`。
- 补充真实场景支持：`/recall` 返回完整上下文，`endSession` 支持较长 L1 flush 超时。

## 平台差异

**Codex**

提供 `CodexMemoryGatewayClient` 和 `provider: "codex"` 两种 SDK 使用方式。默认从 `CODEX_SESSION_ID`、`CODEX_WORKSPACE` 或当前项目路径生成 session key。当前实现的是 Codex 侧可调用的记忆 SDK，不自动接管 Codex UI / CLI 的原生对话流程。

**CodeBuddy**

提供 `CodeBuddyMemoryAdapter` 和 `provider: "codebuddy"` 两种 SDK 使用方式。默认优先读取 `CODEBUDDY_MEMORY_GATEWAY_URL`、`CODEBUDDY_MEMORY_API_KEY`、`CODEBUDDY_SESSION_ID`、`CODEBUDDY_WORKSPACE` 等平台变量。当前实现的是 CodeBuddy 适配入口，具体调用时机由 CodeBuddy 插件、hook 或 wrapper 接入。

**Claude Code**

提供 `ClaudeCodeMemoryAdapter` 和 `provider: "claude-code"` 两种 SDK 使用方式。默认优先读取 `CLAUDE_CODE_MEMORY_GATEWAY_URL`、`CLAUDE_CODE_MEMORY_API_KEY`、`CLAUDE_CODE_SESSION_ID`、`CLAUDE_CODE_WORKSPACE` 等平台变量。当前实现的是 Claude Code 适配入口，不拦截或替换 Claude Code 原生命令。

## 统一 Adapter SDK 设计

新平台只需要实现 `MemoryPlatformAdapterDefinition`，把平台自己的环境变量映射成 Gateway 所需配置。

```ts
export interface MemoryPlatformAdapterDefinition {
  platform: MemoryAdapterPlatform;
  fromEnv(env: PlatformEnv): Omit<PlatformAdapterDefaults, "platform">;
  fromConfig?(config: MemoryAdapterProviderConfig, env?: PlatformEnv): Omit<PlatformAdapterDefaults, "platform">;
}
```

新平台接入示例：

```js
const ThirdPartyIdeMemoryAdapter = {
  platform: "third-party-ide",
  fromEnv(env) {
    return {
      baseUrl: env.THIRD_PARTY_IDE_MEMORY_GATEWAY_URL,
      apiKey: env.THIRD_PARTY_IDE_MEMORY_API_KEY,
      sessionKey: env.THIRD_PARTY_IDE_SESSION_KEY,
      userId: env.THIRD_PARTY_IDE_USER_ID,
    };
  },
};

const memory = createPlatformMemoryAdapter(ThirdPartyIdeMemoryAdapter);
```

SDK 统一负责 Gateway 调用、Bearer token、平台前缀 session key、HTTP 错误处理和 session flush。

## 进阶验证：Codex adapter 基本记忆读写

验证内容：

- 使用 Codex adapter SDK 接入 Gateway。
- 使用真实 LLM 完成 L1 自动抽取。
- 使用 `bge-m3:latest` 完成 1024 维 embedding。
- 验证 `capture -> L0 -> L1 extraction -> L1 search -> recall.context`。
- Gateway 日志确认 L0/L1 向量写入成功，并通过 hybrid/vector search 召回。

测试截图：

<img width="841" height="410" alt="image" src="https://github.com/user-attachments/assets/4422586d-7543-4c1e-b616-2be597ad6f36" />

<img width="609" height="169" alt="image" src="https://github.com/user-attachments/assets/2ff359fa-158e-49a6-b49c-ce3fd1838e34" />

Gist：

- [验证脚本](https://gist.github.com/drive888/7f8e77b0f68c4f9454f7c1e3177c0f7e)
- [验证结果](https://gist.github.com/drive888/26635eb7469a66c2bce18522d5e835bb)


## 拓展验证：新平台只实现一个接口接入

验证内容：

- 使用模拟平台 `third-party-ide`。
- 该平台只实现 `MemoryPlatformAdapterDefinition`。
- 通过 `createPlatformMemoryAdapter()` 复用统一 SDK。
- 验证新平台完成 `capture -> endSession -> searchConversations -> searchMemories -> recall`。
- 同时用 Codex SDK 路径对照，证明真实平台和新平台复用同一套接入模式。

测试截图：

<img width="414" height="171" alt="image" src="https://github.com/user-attachments/assets/876c3415-a8f2-4c7a-9469-47a9caa5f0db" />

<img width="595" height="156" alt="image" src="https://github.com/user-attachments/assets/7bddd882-de64-46f9-891a-e79719bb147d" />

Gist：

- [验证脚本组](https://gist.github.com/drive888/76ee519592cc865e1c111834efd5faac)
- [验证结果](https://gist.github.com/drive888/d5e109ae46276ec679cf063f232edbda)


## 测试

本地验证：

```bash
npm test -- src/adapters src/gateway/server.test.ts
npm run build:plugin
```

## 关联 Issue

Closes #235