### PR TITLE
fix(checkpoint): recalibrate 计数器 + 端到端 before/after 证据 (#157)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "demo:checkpoint-recalibrate": "tsx scripts/demo-checkpoint-recalibration.ts",
     "postinstall": "bash scripts/openclaw-after-tool-call-messages.patch.sh 2>/dev/null || true"
   },
   "files": [

--- a/scripts/demo-checkpoint-recalibration.ts
+++ b/scripts/demo-checkpoint-recalibration.ts
@@ -1,0 +1,106 @@
+/**
+ * Deterministic demo for issue #157: checkpoint counters that never decrease.
+ *
+ * Reproduces the drift and proves the fix end-to-end:
+ *   1. Build a data dir with a KNOWN number of L1 records and L0 conversations.
+ *   2. Write a checkpoint whose aggregate counters are inflated (as happens after
+ *      `memory-cleaner` runs or JSONL files are trimmed — the old code only ever
+ *      increments, so the counters over-report forever).
+ *   3. Run CheckpointManager.recalibrate() and show the counters corrected back
+ *      to the actual on-disk truth (both the store-backed and JSONL-fallback paths).
+ *
+ * Run: npm run demo:checkpoint-recalibrate
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CheckpointManager, type Checkpoint } from "../src/utils/checkpoint.js";
+
+const printingLogger = {
+  info: (msg: string) => console.log(`  ${msg}`),
+  warn: (msg: string) => console.warn(`  ${msg}`),
+};
+
+/** Write `lineCount` non-empty JSONL lines (plus a blank line, which must be ignored). */
+async function writeJsonl(dir: string, name: string, lineCount: number): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  const lines = Array.from({ length: lineCount }, (_, i) => JSON.stringify({ id: `${name}-${i}` }));
+  lines.push(""); // trailing blank line — recalibrate must not count it
+  await fs.writeFile(path.join(dir, name), lines.join("\n"), "utf-8");
+}
+
+async function writeCheckpoint(dataDir: string, patch: Partial<Checkpoint>): Promise<void> {
+  const cp = new CheckpointManager(dataDir);
+  const current = await cp.read();
+  await cp.write({ ...current, ...patch });
+}
+
+async function main(): Promise<void> {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-demo-"));
+
+  try {
+    // 1. Actual on-disk truth: 5 L1 records, 7 L0 conversations.
+    await writeJsonl(path.join(dataDir, "records"), "2026-07-01.jsonl", 3);
+    await writeJsonl(path.join(dataDir, "records"), "2026-07-02.jsonl", 2);
+    await writeJsonl(path.join(dataDir, "conversations"), "s1.jsonl", 4);
+    await writeJsonl(path.join(dataDir, "conversations"), "s2.jsonl", 3);
+    const ACTUAL_L1 = 5;
+    const ACTUAL_L0 = 7;
+
+    // 2. Simulate drift: counters inflated far above reality (e.g. after cleanup).
+    await writeCheckpoint(dataDir, { total_memories_extracted: 999, l0_conversations_count: 512 });
+
+    const cp = new CheckpointManager(dataDir, printingLogger);
+    const before = await cp.read();
+
+    console.log("Checkpoint recalibration demo (issue #157)");
+    console.log("==========================================");
+    console.log(`Actual on-disk truth:  L1 records = ${ACTUAL_L1}, L0 conversations = ${ACTUAL_L0}`);
+    console.log("");
+    console.log("BEFORE (drifted / inflated counters):");
+    console.log(`  total_memories_extracted = ${before.total_memories_extracted}`);
+    console.log(`  l0_conversations_count   = ${before.l0_conversations_count}`);
+    console.log("");
+
+    // 3a. JSONL fallback path (no store configured).
+    console.log("recalibrate() — JSONL fallback path:");
+    await cp.recalibrate();
+    const afterJsonl = await cp.read();
+    console.log("");
+
+    // 3b. Store-backed path (store reports the authoritative L0 count).
+    console.log("recalibrate() — store-backed L0 path:");
+    await writeCheckpoint(dataDir, { total_memories_extracted: 999, l0_conversations_count: 512 });
+    await cp.recalibrate({ vectorStore: { countL0: () => ACTUAL_L0 } });
+    const afterStore = await cp.read();
+    console.log("");
+
+    console.log("AFTER (recalibrated to actual):");
+    console.log(`  total_memories_extracted = ${afterStore.total_memories_extracted}`);
+    console.log(`  l0_conversations_count   = ${afterStore.l0_conversations_count}`);
+    console.log("");
+
+    const pass =
+      afterJsonl.total_memories_extracted === ACTUAL_L1 &&
+      afterJsonl.l0_conversations_count === ACTUAL_L0 &&
+      afterStore.total_memories_extracted === ACTUAL_L1 &&
+      afterStore.l0_conversations_count === ACTUAL_L0;
+
+    console.log(`Result: ${pass ? "PASS ✅ counters corrected downward to on-disk truth" : "FAIL ❌"}`);
+    console.log("");
+    console.log("Interpretation:");
+    console.log("- The old counters only ever increment, so trimming data left them over-reporting forever.");
+    console.log("- recalibrate() rebuilds them from records/*.jsonl (L1) and the store / conversations/*.jsonl (L0).");
+    console.log("- Blank trailing lines are ignored; failures preserve the previous value instead of crashing.");
+
+    if (!pass) process.exitCode = 1;
+  } finally {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(`demo failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+  process.exitCode = 1;
+});

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -415,6 +415,15 @@ export class TdaiCore {
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+
+    try {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.recalibrate({ vectorStore: this.vectorStore });
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private wirePipelineRunners(): void {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager.recalibrate", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-recalibrate-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("replaces drifted counters with JSONL L1 and store L0 counts", async () => {
+    const manager = new CheckpointManager(dataDir);
+    const checkpoint = await manager.read();
+    checkpoint.total_memories_extracted = 50;
+    checkpoint.l0_conversations_count = 45;
+    checkpoint.scenes_processed = 7;
+    await manager.write(checkpoint);
+
+    await writeJsonl("records/2026-07-05.jsonl", [{ id: "m1" }, { id: "m2" }]);
+    await writeJsonl("records/2026-07-06.jsonl", [{ id: "m3" }]);
+
+    const countL0 = vi.fn().mockResolvedValue(4);
+    await manager.recalibrate({ vectorStore: { countL0 } });
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.total_memories_extracted).toBe(3);
+    expect(recalibrated.l0_conversations_count).toBe(4);
+    expect(recalibrated.scenes_processed).toBe(7);
+    expect(countL0).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to L0 JSONL when the store count is unavailable", async () => {
+    const warnings: string[] = [];
+    const manager = new CheckpointManager(dataDir, {
+      info() {},
+      warn: (message) => warnings.push(message),
+    });
+
+    await writeJsonl("records/2026-07-06.jsonl", [{ id: "m1" }]);
+    await writeJsonl("conversations/2026-07-06.jsonl", [
+      { id: "l0-1" },
+      { id: "l0-2" },
+    ]);
+
+    await manager.recalibrate({
+      vectorStore: { countL0: vi.fn().mockRejectedValue(new Error("store offline")) },
+    });
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.total_memories_extracted).toBe(1);
+    expect(recalibrated.l0_conversations_count).toBe(2);
+    expect(warnings.some((message) => message.includes("store offline"))).toBe(true);
+  });
+
+  it("sets both counters to zero when no data exists", async () => {
+    const manager = new CheckpointManager(dataDir);
+    const checkpoint = await manager.read();
+    checkpoint.total_memories_extracted = 12;
+    checkpoint.l0_conversations_count = 8;
+    await manager.write(checkpoint);
+
+    await manager.recalibrate();
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.total_memories_extracted).toBe(0);
+    expect(recalibrated.l0_conversations_count).toBe(0);
+  });
+
+  it("preserves a counter when its source cannot be read", async () => {
+    const warnings: string[] = [];
+    const manager = new CheckpointManager(dataDir, {
+      info() {},
+      warn: (message) => warnings.push(message),
+    });
+    const checkpoint = await manager.read();
+    checkpoint.total_memories_extracted = 12;
+    await manager.write(checkpoint);
+
+    // A file at the expected directory path forces readdir() to fail with ENOTDIR.
+    await fs.writeFile(path.join(dataDir, "records"), "not a directory", "utf-8");
+    await manager.recalibrate();
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.total_memories_extracted).toBe(12);
+    expect(warnings.some((message) => message.includes("preserving checkpoint value"))).toBe(true);
+  });
+
+  async function writeJsonl(relativePath: string, records: unknown[]): Promise<void> {
+    const filePath = path.join(dataDir, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`, "utf-8");
+  }
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -144,6 +144,13 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+export interface RecalibrateSources {
+  /** Store-backed L0 count. When unavailable, L0 JSONL files are used. */
+  vectorStore?: {
+    countL0(): number | Promise<number>;
+  };
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -179,10 +186,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private readonly dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -291,6 +300,81 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Rebuild aggregate counters from their persisted sources of truth.
+   *
+   * L1 memories are counted from records/*.jsonl. L0 records are counted
+   * from the configured store, with conversations/*.jsonl as a degraded-mode
+   * fallback. Source reads happen before the checkpoint lock is acquired so
+   * slow filesystem or remote-store operations do not block other writers.
+   */
+  async recalibrate(sources: RecalibrateSources = {}): Promise<void> {
+    const previous = await this.readRaw();
+    let actualL1: number | undefined;
+    let actualL0: number | undefined;
+    let l0Source = "JSONL";
+
+    try {
+      actualL1 = await this.countJsonlRecords("records");
+    } catch (err) {
+      this.logger.warn?.(
+        `[checkpoint] recalibrate: failed to count L1 JSONL records; preserving checkpoint value: ${formatError(err)}`,
+      );
+    }
+
+    if (sources.vectorStore) {
+      try {
+        actualL0 = normalizeCount(await sources.vectorStore.countL0());
+        l0Source = "store";
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: failed to count L0 store records; falling back to JSONL: ${formatError(err)}`,
+        );
+      }
+    }
+
+    if (actualL0 === undefined) {
+      try {
+        actualL0 = await this.countJsonlRecords("conversations");
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: failed to count L0 JSONL records; preserving checkpoint value: ${formatError(err)}`,
+        );
+      }
+    }
+
+    const updated = await this.mutate((cp) => {
+      if (actualL1 !== undefined) cp.total_memories_extracted = actualL1;
+      if (actualL0 !== undefined) cp.l0_conversations_count = actualL0;
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrate: ` +
+      `L1 ${previous.total_memories_extracted} -> ${updated.total_memories_extracted} (JSONL), ` +
+      `L0 ${previous.l0_conversations_count} -> ${updated.l0_conversations_count} (${l0Source})`,
+    );
+  }
+
+  private async countJsonlRecords(directoryName: string): Promise<number> {
+    const directoryPath = path.join(this.dataDir, directoryName);
+    let entries: import("node:fs").Dirent[];
+
+    try {
+      entries = await fs.readdir(directoryPath, { withFileTypes: true });
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") return 0;
+      throw err;
+    }
+
+    let count = 0;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      const raw = await fs.readFile(path.join(directoryPath, entry.name), "utf-8");
+      count += raw.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+    }
+    return count;
   }
 
   // ============================
@@ -485,4 +569,19 @@ export class CheckpointManager {
     });
   }
 
+}
+
+function normalizeCount(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`invalid record count: ${value}`);
+  }
+  return Math.trunc(value);
+}
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && "code" in value;
+}
+
+function formatError(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
 }


### PR DESCRIPTION
## 概述

针对 issue #157:`total_memories_extracted` 和 `l0_conversations_count` 只增不减。清理测试数据、运行 `memory-cleaner` 或手动裁剪 JSONL 后,checkpoint 仍永久高估现存记录数,导致状态输出错误并影响基于阈值的 pipeline 判断。

本 PR 提供 `CheckpointManager.recalibrate()` 修复,并附**可运行的端到端 demo + before/after 证据**。分支自包含、可独立合并。

## 方案

`recalibrate()` 在启动时根据当前存储重新计算两个计数器:

- L1:统计 `records/*.jsonl` 中的非空行数。
- L0:优先用 vector store 的 `countL0()`;store 不可用时回退统计 `conversations/*.jsonl`。
- 失败时只记录 warning 并保留原 checkpoint 值,不阻止启动。
- 在 store 初始化后接入(`tdai-core.ts`)。

## 证据 / 运行日志

`npm run demo:checkpoint-recalibrate`(构造 5 条 L1 记录 + 7 条 L0 对话,把计数器篡改成虚高后校准):

```text
Checkpoint recalibration demo (issue #157)
==========================================
Actual on-disk truth:  L1 records = 5, L0 conversations = 7

BEFORE (drifted / inflated counters):
  total_memories_extracted = 999
  l0_conversations_count   = 512

recalibrate() — JSONL fallback path:
  [checkpoint] recalibrate: L1 999 -> 5 (JSONL), L0 512 -> 7 (JSONL)
recalibrate() — store-backed L0 path:
  [checkpoint] recalibrate: L1 999 -> 5 (JSONL), L0 512 -> 7 (store)

AFTER (recalibrated to actual):
  total_memories_extracted = 5
  l0_conversations_count   = 7

Result: PASS ✅ counters corrected downward to on-disk truth
```

计数器从虚高的 999/512 **向下校准**回真实的 5/7,两条路径(JSONL fallback、store-backed)均验证通过。

## 具体改动

- `src/utils/checkpoint.ts`:`recalibrate()` + 计数/错误归一化辅助。
- `src/core/tdai-core.ts`:store 初始化后执行重新校准。
- `src/utils/checkpoint.test.ts`:覆盖正常 store count、JSONL fallback、空数据、不可读/损坏路径。
- `scripts/demo-checkpoint-recalibration.ts` + `package.json`:确定性 before/after demo。

## 验证

```bash
npm test        # 5 个测试文件,71 项测试全部通过
npm run build   # 构建通过
npm run demo:checkpoint-recalibrate  # 输出上方 before/after 证据
git diff --check # 干净
```

Refs #157。

Assisted-by: Claude Opus 4.8
