### PR TITLE
fix(offload): invalidate token cache after stripping deleted tool_use blocks (#234)

### DIFF
--- a/src/offload/hooks/before-prompt-build.ts
+++ b/src/offload/hooks/before-prompt-build.ts
@@ -8,7 +8,7 @@
  */
 import { PLUGIN_DEFAULTS } from "../types.js";
 import { readOffloadEntries, markOffloadStatus } from "../storage.js";
-import { buildTiktokenContextSnapshot } from "../context-token-tracker.js";
+import { buildTiktokenContextSnapshot, invalidateTokenCache } from "../context-token-tracker.js";
 import { traceOffloadDecision } from "../opik-tracer.js";
 import { injectMmdIntoMessages, findHistoryMmdInsertionPoint } from "../mmd-injector.js";
 import { createL3TokenCounter } from "../l3-token-counter.js";
@@ -109,6 +109,9 @@ export function createBeforePromptBuildHandler(
                   content.splice(j, 1);
                 }
               }
+              // Invalidate token cache after mutation so the next
+              // buildTiktokenContextSnapshot sees the post-strip count.
+              invalidateTokenCache(msg);
             }
           }
         }

--- a/src/offload/hooks/llm-input-l3.ts
+++ b/src/offload/hooks/llm-input-l3.ts
@@ -1378,6 +1378,9 @@ async function fastPathReApply(messages: any[], stateManager: OffloadStateManage
             }
           }
         }
+        // Invalidate token cache after mutation so the next
+        // buildTiktokenContextSnapshot sees the post-strip count.
+        invalidateTokenCache(msg);
       }
     }
     if (msg._offloaded) continue;


### PR DESCRIPTION
## Summary
Add `invalidateTokenCache(msg)` calls after `content.splice()` operations that strip deleted `tool_use` blocks from mixed assistant messages.

## Root Cause
`context-token-tracker.ts` caches per-message token counts in a WeakMap. Two offload hooks strip deleted tool_use blocks with `content.splice(...)` but never invalidated the cache, so the next `buildTiktokenContextSnapshot` returned stale pre-strip counts.

## Fix
Added `invalidateTokenCache(msg)` calls after splice operations in:
- `src/offload/hooks/before-prompt-build.ts` (line 109)
- `src/offload/hooks/llm-input-l3.ts` (line 1377)

Fixes #234

Assisted-by: claude-code:deepseek-v4-pro