### PR TITLE
Fix 157 checkpoint recalibrate

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -47,7 +47,7 @@ import {
   createL3Runner,
 } from "../utils/pipeline-factory.js";
 import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
-import { CheckpointManager } from "../utils/checkpoint.js";
+import { CheckpointManager, recalibrateCheckpointFromStore } from "../utils/checkpoint.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
 
@@ -409,6 +409,15 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      if (this.vectorStore) {
+        try {
+          await recalibrateCheckpointFromStore(this.dataDir, this.vectorStore, this.logger);
+        } catch (err) {
+          this.logger.warn(
+            `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -148,6 +148,8 @@ describe("CheckpointManager", () => {
     const checkpoint = new CheckpointManager(dataDir);
     const conversationsDir = path.join(dataDir, "conversations");
     const recordsDir = path.join(dataDir, "records");
+    const existingL1Cursor = Date.parse("2026-07-05T00:00:09.000Z");
+    const remainingRecordedAt = Date.parse("2026-07-05T00:00:02.000Z");
 
     await fs.mkdir(conversationsDir, { recursive: true });
     await fs.mkdir(recordsDir, { recursive: true });
@@ -160,7 +162,7 @@ describe("CheckpointManager", () => {
     );
     await fs.writeFile(path.join(recordsDir, "2026-07-05.jsonl"), "{\"id\":\"m1\"}\n");
 
-    await checkpoint.markL1ExtractionComplete("session-a", 5, 9000);
+    await checkpoint.markL1ExtractionComplete("session-a", 5, existingL1Cursor);
     await checkpoint.captureAtomically("session-a", undefined, async () => ({
       maxTimestamp: 9000,
       messageCount: 5,
@@ -175,7 +177,57 @@ describe("CheckpointManager", () => {
     expect(cp.total_processed).toBe(2);
     expect(cp.last_captured_timestamp).toBe(2000);
     expect(cp.runner_states["session-a"]?.last_captured_timestamp).toBe(2000);
-    expect(cp.runner_states["session-a"]?.last_l1_cursor).toBe(2000);
+    expect(cp.runner_states["session-a"]?.last_l1_cursor).toBe(remainingRecordedAt);
+  });
+
+  it("uses recordedAt, not message timestamp, when bounding L1 cursors", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const conversationsDir = path.join(dataDir, "conversations");
+    const existingL1Cursor = Date.parse("2026-07-05T00:00:09.000Z");
+    const remainingRecordedAt = Date.parse("2026-07-05T00:00:05.000Z");
+
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(conversationsDir, "2026-07-05.jsonl"),
+      JSON.stringify({
+        id: "c1",
+        sessionKey: "session-a",
+        timestamp: 1000,
+        recordedAt: "2026-07-05T00:00:05.000Z",
+      }) + "\n",
+    );
+
+    await checkpoint.write({
+      last_captured_timestamp: 9000,
+      total_processed: 9,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 0,
+      scenes_processed: 0,
+      runner_states: {
+        "session-a": {
+          last_captured_timestamp: 9000,
+          last_l1_cursor: existingL1Cursor,
+          last_scene_name: "",
+        },
+      },
+      pipeline_states: {},
+      l0_conversations_count: 9,
+      total_memories_extracted: 0,
+    });
+
+    await recalibrateCheckpointFromStore(dataDir, {
+      countL0: () => 99,
+      countL1: () => 0,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.last_captured_timestamp).toBe(1000);
+    expect(cp.runner_states["session-a"]?.last_captured_timestamp).toBe(1000);
+    expect(cp.runner_states["session-a"]?.last_l1_cursor).toBe(remainingRecordedAt);
   });
 
   it("bounds L2 cursors after local memory records roll back", async () => {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager, recalibrateCheckpointFromStore } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager", () => {
+  it("recalibrates drifted aggregate counters from actual store counts", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.markL1ExtractionComplete("session-a", 9, 123);
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 456,
+      messageCount: 3,
+    }));
+
+    await checkpoint.recalibrate({
+      totalMemoriesExtracted: 4,
+      l0ConversationsCount: 2,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.total_memories_extracted).toBe(4);
+    expect(cp.l0_conversations_count).toBe(2);
+    expect(cp.memories_since_last_persona).toBe(4);
+    expect(cp.total_processed).toBe(3);
+  });
+
+  it("recalibrates aggregate counters from store count methods", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.markL1ExtractionComplete("session-a", 12, 123);
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 456,
+      messageCount: 3,
+    }));
+
+    await recalibrateCheckpointFromStore(dataDir, {
+      countL0: () => 5,
+      countL1: () => 7,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(5);
+    expect(cp.total_memories_extracted).toBe(7);
+    expect(cp.memories_since_last_persona).toBe(7);
+  });
+
+  it("prefers local JSONL counts so manual pruning is reflected", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const recordsDir = path.join(dataDir, "records");
+    const conversationsDir = path.join(dataDir, "conversations");
+
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-05.jsonl"),
+      "{\"id\":\"m1\"}\n{\"id\":\"m2\"}\n{\"id\":\"m3\"}\n{\"id\":\"m4\"}\n",
+    );
+    await fs.writeFile(
+      path.join(conversationsDir, "2026-07-05.jsonl"),
+      "{\"id\":\"c1\"}\n{\"id\":\"c2\"}\n",
+    );
+
+    await checkpoint.markL1ExtractionComplete("session-a", 12, 123);
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 456,
+      messageCount: 3,
+    }));
+
+    const store = {
+      countL0: () => 99,
+      countL1: () => 99,
+    };
+
+    await recalibrateCheckpointFromStore(dataDir, store);
+    let cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(2);
+    expect(cp.total_memories_extracted).toBe(4);
+    expect(cp.memories_since_last_persona).toBe(4);
+
+    await fs.writeFile(path.join(recordsDir, "2026-07-05.jsonl"), "{\"id\":\"m1\"}\n");
+    await fs.writeFile(path.join(conversationsDir, "2026-07-05.jsonl"), "{\"id\":\"c1\"}\n");
+
+    await recalibrateCheckpointFromStore(dataDir, store);
+    cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(1);
+    expect(cp.total_memories_extracted).toBe(1);
+    expect(cp.memories_since_last_persona).toBe(1);
+    expect(cp.total_processed).toBe(1);
+  });
+
+  it("bounds L1 cursors after a local history rollback", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const conversationsDir = path.join(dataDir, "conversations");
+    const recordsDir = path.join(dataDir, "records");
+
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(conversationsDir, "2026-07-05.jsonl"),
+      [
+        JSON.stringify({ id: "c1", sessionKey: "session-a", timestamp: 1000, recordedAt: "2026-07-05T00:00:01.000Z" }),
+        JSON.stringify({ id: "c2", sessionKey: "session-a", timestamp: 2000, recordedAt: "2026-07-05T00:00:02.000Z" }),
+      ].join("\n") + "\n",
+    );
+    await fs.writeFile(path.join(recordsDir, "2026-07-05.jsonl"), "{\"id\":\"m1\"}\n");
+
+    await checkpoint.markL1ExtractionComplete("session-a", 5, 9000);
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 9000,
+      messageCount: 5,
+    }));
+
+    await recalibrateCheckpointFromStore(dataDir, {
+      countL0: () => 99,
+      countL1: () => 99,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.total_processed).toBe(2);
+    expect(cp.last_captured_timestamp).toBe(2000);
+    expect(cp.runner_states["session-a"]?.last_captured_timestamp).toBe(2000);
+    expect(cp.runner_states["session-a"]?.last_l1_cursor).toBe(2000);
+  });
+
+  it("bounds L2 cursors after local memory records roll back", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const recordsDir = path.join(dataDir, "records");
+
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-05.jsonl"),
+      [
+        JSON.stringify({ id: "m1", sessionKey: "session-a", updatedAt: "2026-07-05T00:00:01.000Z" }),
+        JSON.stringify({ id: "m2", sessionKey: "session-a", updatedAt: "2026-07-05T00:00:02.000Z" }),
+      ].join("\n") + "\n",
+    );
+
+    await checkpoint.mergePipelineStates({
+      "session-a": {
+        conversation_count: 0,
+        last_extraction_time: "",
+        last_extraction_updated_time: "2026-07-05T00:00:09.000Z",
+        last_active_time: 0,
+        l2_pending_l1_count: 0,
+        warmup_threshold: 0,
+        l2_last_extraction_time: "",
+      },
+    });
+
+    await recalibrateCheckpointFromStore(dataDir, {
+      countL0: () => 0,
+      countL1: () => 99,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.total_memories_extracted).toBe(2);
+    expect(cp.pipeline_states["session-a"]?.last_extraction_updated_time).toBe("2026-07-05T00:00:02.000Z");
+  });
+
+  it("clears cursors when local shards are fully pruned", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const conversationsDir = path.join(dataDir, "conversations");
+    const recordsDir = path.join(dataDir, "records");
+
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(path.join(conversationsDir, "2026-07-05.jsonl"), "");
+    await fs.writeFile(path.join(recordsDir, "2026-07-05.jsonl"), "");
+
+    await checkpoint.markL1ExtractionComplete("session-a", 5, 9000);
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 9000,
+      messageCount: 5,
+    }));
+    await checkpoint.mergePipelineStates({
+      "session-a": {
+        conversation_count: 0,
+        last_extraction_time: "",
+        last_extraction_updated_time: "2026-07-05T00:00:09.000Z",
+        last_active_time: 0,
+        l2_pending_l1_count: 0,
+        warmup_threshold: 0,
+        l2_last_extraction_time: "",
+      },
+    });
+
+    await recalibrateCheckpointFromStore(dataDir, {
+      countL0: () => 99,
+      countL1: () => 99,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.total_processed).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.last_captured_timestamp).toBe(0);
+    expect(cp.runner_states["session-a"]?.last_captured_timestamp).toBe(0);
+    expect(cp.runner_states["session-a"]?.last_l1_cursor).toBe(0);
+    expect(cp.pipeline_states["session-a"]?.last_extraction_updated_time).toBe("");
+  });
+});

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -18,6 +18,43 @@ afterEach(async () => {
 });
 
 describe("CheckpointManager", () => {
+  it("decrements drift-prone counters when a cleanup path knows removed counts", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.markL1ExtractionComplete("session-a", 7, 123);
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 456,
+      messageCount: 4,
+    }));
+
+    await checkpoint.decrementCounters({
+      l0ConversationsCount: 1,
+      totalProcessed: 2,
+      totalMemoriesExtracted: 3,
+      memoriesSinceLastPersona: 3,
+    });
+
+    let cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.total_processed).toBe(2);
+    expect(cp.total_memories_extracted).toBe(4);
+    expect(cp.memories_since_last_persona).toBe(4);
+
+    await checkpoint.decrementCounters({
+      l0ConversationsCount: 99,
+      totalProcessed: 99,
+      totalMemoriesExtracted: 99,
+      memoriesSinceLastPersona: 99,
+    });
+
+    cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.total_processed).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+
   it("recalibrates drifted aggregate counters from actual store counts", async () => {
     const dataDir = await makeTempDir();
     const checkpoint = new CheckpointManager(dataDir);
@@ -175,6 +212,84 @@ describe("CheckpointManager", () => {
     const cp = await checkpoint.read();
     expect(cp.total_memories_extracted).toBe(2);
     expect(cp.pipeline_states["session-a"]?.last_extraction_updated_time).toBe("2026-07-05T00:00:02.000Z");
+  });
+
+  it("resets cursors for sessions removed by a session reset", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const conversationsDir = path.join(dataDir, "conversations");
+    const recordsDir = path.join(dataDir, "records");
+
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(conversationsDir, "2026-07-05.jsonl"),
+      JSON.stringify({ id: "c-b", sessionKey: "session-b", timestamp: 3000 }) + "\n",
+    );
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-05.jsonl"),
+      JSON.stringify({ id: "m-b", sessionKey: "session-b", updatedAt: "2026-07-05T00:00:03.000Z" }) + "\n",
+    );
+
+    await checkpoint.write({
+      last_captured_timestamp: 9000,
+      total_processed: 9,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 9,
+      scenes_processed: 0,
+      runner_states: {
+        "session-a": {
+          last_captured_timestamp: 9000,
+          last_l1_cursor: 9000,
+          last_scene_name: "",
+        },
+        "session-b": {
+          last_captured_timestamp: 9000,
+          last_l1_cursor: 9000,
+          last_scene_name: "",
+        },
+      },
+      pipeline_states: {
+        "session-a": {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: "2026-07-05T00:00:09.000Z",
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+        "session-b": {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: "2026-07-05T00:00:09.000Z",
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+      l0_conversations_count: 9,
+      total_memories_extracted: 9,
+    });
+
+    await recalibrateCheckpointFromStore(dataDir, {
+      countL0: () => 99,
+      countL1: () => 99,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.total_processed).toBe(1);
+    expect(cp.total_memories_extracted).toBe(1);
+    expect(cp.runner_states["session-a"]?.last_captured_timestamp).toBe(0);
+    expect(cp.runner_states["session-a"]?.last_l1_cursor).toBe(0);
+    expect(cp.runner_states["session-b"]?.last_captured_timestamp).toBe(3000);
+    expect(cp.runner_states["session-b"]?.last_l1_cursor).toBe(3000);
+    expect(cp.pipeline_states["session-a"]?.last_extraction_updated_time).toBe("");
+    expect(cp.pipeline_states["session-b"]?.last_extraction_updated_time).toBe("2026-07-05T00:00:03.000Z");
   });
 
   it("clears cursors when local shards are fully pruned", async () => {

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -172,6 +172,17 @@ export interface CheckpointRecalibrationCounts {
   maxL1UpdatedAtBySession?: Record<string, string>;
 }
 
+export interface CheckpointDecrementCounts {
+  /** Known decrease for l0_conversations_count. */
+  l0ConversationsCount?: number;
+  /** Known number of removed L0 messages. */
+  totalProcessed?: number;
+  /** Known number of removed L1 records. */
+  totalMemoriesExtracted?: number;
+  /** Known number of removed memories from the persona threshold window. */
+  memoriesSinceLastPersona?: number;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 /**
@@ -202,6 +213,20 @@ export async function recalibrateCheckpointFromStore(
     maxL1UpdatedAt: jsonlL1Stats?.maxUpdatedAt,
     maxL1UpdatedAtBySession: jsonlL1Stats?.maxUpdatedAtBySession,
   });
+}
+
+export async function recalibrateCheckpointFromLocalData(
+  dataDir: string,
+  logger?: CheckpointLogger,
+): Promise<void> {
+  await recalibrateCheckpointFromStore(
+    dataDir,
+    {
+      countL0: () => 0,
+      countL1: () => 0,
+    },
+    logger,
+  );
 }
 
 // ============================
@@ -554,6 +579,44 @@ export class CheckpointManager {
   }
 
   /**
+   * Decrement aggregate checkpoint counters when a cleanup path knows exactly
+   * how many rows it removed. Use recalibrate() when removals may have happened
+   * outside the current process or cursor bounds need repair.
+   */
+  async decrementCounters(counts: CheckpointDecrementCounts): Promise<void> {
+    const l0ConversationsCount = normalizeOptionalCount(counts.l0ConversationsCount);
+    const totalProcessed = normalizeOptionalCount(counts.totalProcessed);
+    const totalMemoriesExtracted = normalizeOptionalCount(counts.totalMemoriesExtracted);
+    const memoriesSinceLastPersona = normalizeOptionalCount(counts.memoriesSinceLastPersona);
+
+    const cp = await this.mutate((cp) => {
+      if (l0ConversationsCount !== undefined) {
+        cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count - l0ConversationsCount);
+      }
+      if (totalProcessed !== undefined) {
+        cp.total_processed = Math.max(0, cp.total_processed - totalProcessed);
+      }
+      if (totalMemoriesExtracted !== undefined) {
+        cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted - totalMemoriesExtracted);
+      }
+      if (memoriesSinceLastPersona !== undefined) {
+        cp.memories_since_last_persona = Math.max(0, cp.memories_since_last_persona - memoriesSinceLastPersona);
+      }
+      cp.memories_since_last_persona = Math.min(
+        cp.memories_since_last_persona,
+        cp.total_memories_extracted,
+      );
+    });
+
+    this.logger.info(
+      `[checkpoint] decrementCounters: l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_processed=${cp.total_processed}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+  }
+
+  /**
    * Reconcile aggregate checkpoint counters with counts from the actual store.
    *
    * These counters are incremented on capture/extraction, but cleanup paths can
@@ -578,7 +641,9 @@ export class CheckpointManager {
         const cursorMax = maxL0Timestamp ?? 0;
         cp.last_captured_timestamp = Math.min(cp.last_captured_timestamp, cursorMax);
         for (const [sessionKey, state] of Object.entries(cp.runner_states ?? {})) {
-          const sessionMax = counts.maxL0TimestampBySession?.[sessionKey] ?? cursorMax;
+          const sessionMax = counts.hasLocalL0Stats
+            ? counts.maxL0TimestampBySession?.[sessionKey] ?? 0
+            : counts.maxL0TimestampBySession?.[sessionKey] ?? cursorMax;
           state.last_captured_timestamp = Math.min(state.last_captured_timestamp, sessionMax);
           state.last_l1_cursor = Math.min(state.last_l1_cursor, sessionMax);
         }
@@ -592,7 +657,9 @@ export class CheckpointManager {
       }
       if (counts.hasLocalL1Stats || maxL1UpdatedAt) {
         for (const [sessionKey, state] of Object.entries(cp.pipeline_states ?? {})) {
-          const sessionMax = counts.maxL1UpdatedAtBySession?.[sessionKey] ?? maxL1UpdatedAt ?? "";
+          const sessionMax = counts.hasLocalL1Stats
+            ? counts.maxL1UpdatedAtBySession?.[sessionKey] ?? ""
+            : counts.maxL1UpdatedAtBySession?.[sessionKey] ?? maxL1UpdatedAt ?? "";
           if (state.last_extraction_updated_time && state.last_extraction_updated_time > sessionMax) {
             state.last_extraction_updated_time = sessionMax;
           }

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -162,6 +162,10 @@ export interface CheckpointRecalibrationCounts {
   maxL0Timestamp?: number;
   /** Newest L0 message timestamp currently present per session key. */
   maxL0TimestampBySession?: Record<string, number>;
+  /** Newest L0 recordedAt timestamp currently present. Used by the L1 cursor. */
+  maxL0RecordedAtMs?: number;
+  /** Newest L0 recordedAt timestamp currently present per session key. */
+  maxL0RecordedAtMsBySession?: Record<string, number>;
   /** Actual L1 records currently present in the store. */
   totalMemoriesExtracted?: number;
   /** True when local L1 JSONL shards were read, including empty shards. */
@@ -208,6 +212,8 @@ export async function recalibrateCheckpointFromStore(
     hasLocalL0Stats: jsonlL0Stats !== undefined,
     maxL0Timestamp: jsonlL0Stats?.maxTimestamp,
     maxL0TimestampBySession: jsonlL0Stats?.maxTimestampBySession,
+    maxL0RecordedAtMs: jsonlL0Stats?.maxRecordedAtMs,
+    maxL0RecordedAtMsBySession: jsonlL0Stats?.maxRecordedAtMsBySession,
     totalMemoriesExtracted: jsonlL1Stats?.count ?? storeL1Count,
     hasLocalL1Stats: jsonlL1Stats !== undefined,
     maxL1UpdatedAt: jsonlL1Stats?.maxUpdatedAt,
@@ -265,6 +271,8 @@ interface LocalJsonlStats {
   count: number;
   maxTimestamp?: number;
   maxTimestampBySession: Record<string, number>;
+  maxRecordedAtMs?: number;
+  maxRecordedAtMsBySession: Record<string, number>;
   maxUpdatedAt?: string;
   maxUpdatedAtBySession: Record<string, string>;
 }
@@ -281,9 +289,13 @@ function getStringField(record: Record<string, unknown>, ...keys: string[]): str
   return undefined;
 }
 
-function getTimestampMs(record: Record<string, unknown>): number | undefined {
+function getMessageTimestampMs(record: Record<string, unknown>): number | undefined {
   const timestamp = record.timestamp;
   if (typeof timestamp === "number" && Number.isFinite(timestamp)) return timestamp;
+  return undefined;
+}
+
+function getRecordedAtMs(record: Record<string, unknown>): number | undefined {
   const recordedAt = getStringField(record, "recordedAt", "recorded_at");
   if (!recordedAt) return undefined;
   const ms = Date.parse(recordedAt);
@@ -312,6 +324,7 @@ async function readLocalJsonlStats(dataDir: string, subdir: "conversations" | "r
   const stats: LocalJsonlStats = {
     count: 0,
     maxTimestampBySession: {},
+    maxRecordedAtMsBySession: {},
     maxUpdatedAtBySession: {},
   };
   let sawShard = false;
@@ -332,13 +345,23 @@ async function readLocalJsonlStats(dataDir: string, subdir: "conversations" | "r
         }
         if (!parsed) continue;
         const sessionKey = getStringField(parsed, "sessionKey", "session_key");
-        const timestamp = getTimestampMs(parsed);
+        const timestamp = getMessageTimestampMs(parsed);
         if (timestamp !== undefined) {
           stats.maxTimestamp = Math.max(stats.maxTimestamp ?? 0, timestamp);
           if (sessionKey) {
             stats.maxTimestampBySession[sessionKey] = Math.max(
               stats.maxTimestampBySession[sessionKey] ?? 0,
               timestamp,
+            );
+          }
+        }
+        const recordedAtMs = getRecordedAtMs(parsed);
+        if (recordedAtMs !== undefined) {
+          stats.maxRecordedAtMs = Math.max(stats.maxRecordedAtMs ?? 0, recordedAtMs);
+          if (sessionKey) {
+            stats.maxRecordedAtMsBySession[sessionKey] = Math.max(
+              stats.maxRecordedAtMsBySession[sessionKey] ?? 0,
+              recordedAtMs,
             );
           }
         }
@@ -627,6 +650,7 @@ export class CheckpointManager {
     const l0ConversationsCount = normalizeOptionalCount(counts.l0ConversationsCount);
     const totalProcessed = normalizeOptionalCount(counts.totalProcessed);
     const maxL0Timestamp = normalizeOptionalCount(counts.maxL0Timestamp);
+    const maxL0RecordedAtMs = normalizeOptionalCount(counts.maxL0RecordedAtMs);
     const totalMemoriesExtracted = normalizeOptionalCount(counts.totalMemoriesExtracted);
     const maxL1UpdatedAt = counts.maxL1UpdatedAt;
 
@@ -638,14 +662,18 @@ export class CheckpointManager {
         cp.total_processed = totalProcessed;
       }
       if (counts.hasLocalL0Stats || maxL0Timestamp !== undefined) {
-        const cursorMax = maxL0Timestamp ?? 0;
-        cp.last_captured_timestamp = Math.min(cp.last_captured_timestamp, cursorMax);
+        const captureCursorMax = maxL0Timestamp ?? 0;
+        const l1CursorMax = maxL0RecordedAtMs ?? captureCursorMax;
+        cp.last_captured_timestamp = Math.min(cp.last_captured_timestamp, captureCursorMax);
         for (const [sessionKey, state] of Object.entries(cp.runner_states ?? {})) {
-          const sessionMax = counts.hasLocalL0Stats
+          const captureSessionMax = counts.hasLocalL0Stats
             ? counts.maxL0TimestampBySession?.[sessionKey] ?? 0
-            : counts.maxL0TimestampBySession?.[sessionKey] ?? cursorMax;
-          state.last_captured_timestamp = Math.min(state.last_captured_timestamp, sessionMax);
-          state.last_l1_cursor = Math.min(state.last_l1_cursor, sessionMax);
+            : counts.maxL0TimestampBySession?.[sessionKey] ?? captureCursorMax;
+          const l1SessionMax = counts.hasLocalL0Stats
+            ? counts.maxL0RecordedAtMsBySession?.[sessionKey] ?? captureSessionMax
+            : counts.maxL0RecordedAtMsBySession?.[sessionKey] ?? l1CursorMax;
+          state.last_captured_timestamp = Math.min(state.last_captured_timestamp, captureSessionMax);
+          state.last_l1_cursor = Math.min(state.last_l1_cursor, l1SessionMax);
         }
       }
       if (totalMemoriesExtracted !== undefined) {

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -139,12 +140,69 @@ const DEFAULT_CHECKPOINT: Checkpoint = {
   total_memories_extracted: 0,
 };
 
+function normalizeOptionalCount(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+}
+
 export interface CheckpointLogger {
   info(msg: string): void;
   warn?(msg: string): void;
 }
 
+export interface CheckpointRecalibrationCounts {
+  /** Actual L0 rows currently present in the store. */
+  l0ConversationsCount?: number;
+  /** Actual L0 rows currently present; used by status/persona counters. */
+  totalProcessed?: number;
+  /** True when local L0 JSONL shards were read, including empty shards. */
+  hasLocalL0Stats?: boolean;
+  /** Newest L0 message timestamp currently present. */
+  maxL0Timestamp?: number;
+  /** Newest L0 message timestamp currently present per session key. */
+  maxL0TimestampBySession?: Record<string, number>;
+  /** Actual L1 records currently present in the store. */
+  totalMemoriesExtracted?: number;
+  /** True when local L1 JSONL shards were read, including empty shards. */
+  hasLocalL1Stats?: boolean;
+  /** Newest L1 updatedAt timestamp currently present. */
+  maxL1UpdatedAt?: string;
+  /** Newest L1 updatedAt timestamp currently present per session key. */
+  maxL1UpdatedAtBySession?: Record<string, string>;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
+
+/**
+ * Reconcile checkpoint counters from actual persisted row counts.
+ * Local JSONL shards are the durable source when present; store counts are
+ * retained as the fallback for remote/degraded deployments without local files.
+ */
+export async function recalibrateCheckpointFromStore(
+  dataDir: string,
+  store: Pick<IMemoryStore, "countL0" | "countL1">,
+  logger?: CheckpointLogger,
+): Promise<void> {
+  const [storeL0Count, storeL1Count, jsonlL0Stats, jsonlL1Stats] = await Promise.all([
+    store.countL0(),
+    store.countL1(),
+    readLocalJsonlStats(dataDir, "conversations"),
+    readLocalJsonlStats(dataDir, "records"),
+  ]);
+  const checkpoint = new CheckpointManager(dataDir, logger);
+  await checkpoint.recalibrate({
+    l0ConversationsCount: jsonlL0Stats?.count ?? storeL0Count,
+    totalProcessed: jsonlL0Stats?.count ?? storeL0Count,
+    hasLocalL0Stats: jsonlL0Stats !== undefined,
+    maxL0Timestamp: jsonlL0Stats?.maxTimestamp,
+    maxL0TimestampBySession: jsonlL0Stats?.maxTimestampBySession,
+    totalMemoriesExtracted: jsonlL1Stats?.count ?? storeL1Count,
+    hasLocalL1Stats: jsonlL1Stats !== undefined,
+    maxL1UpdatedAt: jsonlL1Stats?.maxUpdatedAt,
+    maxL1UpdatedAtBySession: jsonlL1Stats?.maxUpdatedAtBySession,
+  });
+}
 
 // ============================
 // Per-file async lock
@@ -176,6 +234,105 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
       fileLocks.delete(filePath);
     }
   }
+}
+
+interface LocalJsonlStats {
+  count: number;
+  maxTimestamp?: number;
+  maxTimestampBySession: Record<string, number>;
+  maxUpdatedAt?: string;
+  maxUpdatedAtBySession: Record<string, string>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? value as Record<string, unknown> : undefined;
+}
+
+function getStringField(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}
+
+function getTimestampMs(record: Record<string, unknown>): number | undefined {
+  const timestamp = record.timestamp;
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) return timestamp;
+  const recordedAt = getStringField(record, "recordedAt", "recorded_at");
+  if (!recordedAt) return undefined;
+  const ms = Date.parse(recordedAt);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function getUpdatedAt(record: Record<string, unknown>): string | undefined {
+  return getStringField(record, "updatedAt", "updated_at", "updated_time");
+}
+
+function maxIso(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return b > a ? b : a;
+}
+
+async function readLocalJsonlStats(dataDir: string, subdir: "conversations" | "records"): Promise<LocalJsonlStats | undefined> {
+  const dir = path.join(dataDir, subdir);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const stats: LocalJsonlStats = {
+    count: 0,
+    maxTimestampBySession: {},
+    maxUpdatedAtBySession: {},
+  };
+  let sawShard = false;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    sawShard = true;
+    try {
+      const raw = await fs.readFile(path.join(dir, entry.name), "utf-8");
+      for (const line of raw.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        stats.count += 1;
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = asRecord(JSON.parse(trimmed));
+        } catch {
+          continue;
+        }
+        if (!parsed) continue;
+        const sessionKey = getStringField(parsed, "sessionKey", "session_key");
+        const timestamp = getTimestampMs(parsed);
+        if (timestamp !== undefined) {
+          stats.maxTimestamp = Math.max(stats.maxTimestamp ?? 0, timestamp);
+          if (sessionKey) {
+            stats.maxTimestampBySession[sessionKey] = Math.max(
+              stats.maxTimestampBySession[sessionKey] ?? 0,
+              timestamp,
+            );
+          }
+        }
+        const updatedAt = getUpdatedAt(parsed);
+        if (updatedAt) {
+          stats.maxUpdatedAt = maxIso(stats.maxUpdatedAt, updatedAt);
+          if (sessionKey) {
+            stats.maxUpdatedAtBySession[sessionKey] = maxIso(
+              stats.maxUpdatedAtBySession[sessionKey],
+              updatedAt,
+            )!;
+          }
+        }
+      }
+    } catch {
+      // Recalibration is best-effort; unreadable shards should not block startup.
+    }
+  }
+  return sawShard ? stats : undefined;
 }
 
 export class CheckpointManager {
@@ -394,6 +551,61 @@ export class CheckpointManager {
         };
       }
     });
+  }
+
+  /**
+   * Reconcile aggregate checkpoint counters with counts from the actual store.
+   *
+   * These counters are incremented on capture/extraction, but cleanup paths can
+   * remove rows from JSONL/SQLite later. Recalibration keeps status reporting
+   * and persona thresholds from drifting upward forever.
+   */
+  async recalibrate(counts: CheckpointRecalibrationCounts): Promise<void> {
+    const l0ConversationsCount = normalizeOptionalCount(counts.l0ConversationsCount);
+    const totalProcessed = normalizeOptionalCount(counts.totalProcessed);
+    const maxL0Timestamp = normalizeOptionalCount(counts.maxL0Timestamp);
+    const totalMemoriesExtracted = normalizeOptionalCount(counts.totalMemoriesExtracted);
+    const maxL1UpdatedAt = counts.maxL1UpdatedAt;
+
+    const cp = await this.mutate((cp) => {
+      if (l0ConversationsCount !== undefined) {
+        cp.l0_conversations_count = l0ConversationsCount;
+      }
+      if (totalProcessed !== undefined) {
+        cp.total_processed = totalProcessed;
+      }
+      if (counts.hasLocalL0Stats || maxL0Timestamp !== undefined) {
+        const cursorMax = maxL0Timestamp ?? 0;
+        cp.last_captured_timestamp = Math.min(cp.last_captured_timestamp, cursorMax);
+        for (const [sessionKey, state] of Object.entries(cp.runner_states ?? {})) {
+          const sessionMax = counts.maxL0TimestampBySession?.[sessionKey] ?? cursorMax;
+          state.last_captured_timestamp = Math.min(state.last_captured_timestamp, sessionMax);
+          state.last_l1_cursor = Math.min(state.last_l1_cursor, sessionMax);
+        }
+      }
+      if (totalMemoriesExtracted !== undefined) {
+        cp.total_memories_extracted = totalMemoriesExtracted;
+        cp.memories_since_last_persona = Math.min(
+          cp.memories_since_last_persona,
+          totalMemoriesExtracted,
+        );
+      }
+      if (counts.hasLocalL1Stats || maxL1UpdatedAt) {
+        for (const [sessionKey, state] of Object.entries(cp.pipeline_states ?? {})) {
+          const sessionMax = counts.maxL1UpdatedAtBySession?.[sessionKey] ?? maxL1UpdatedAt ?? "";
+          if (state.last_extraction_updated_time && state.last_extraction_updated_time > sessionMax) {
+            state.last_extraction_updated_time = sessionMax;
+          }
+        }
+      }
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrate: l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_processed=${cp.total_processed}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
   }
 
   // ============================

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalMemoryCleaner", () => {
+  it("recalibrates from remaining JSONL shards when no vector store is available", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const conversationsDir = path.join(dataDir, "conversations");
+    const recordsDir = path.join(dataDir, "records");
+
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(conversationsDir, "2026-07-04.jsonl"),
+      "{\"id\":\"old-c1\"}\n{\"id\":\"old-c2\"}\n",
+    );
+    await fs.writeFile(path.join(conversationsDir, "2026-07-05.jsonl"), "{\"id\":\"new-c1\"}\n");
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-04.jsonl"),
+      "{\"id\":\"old-m1\"}\n{\"id\":\"old-m2\"}\n",
+    );
+    await fs.writeFile(path.join(recordsDir, "2026-07-05.jsonl"), "{\"id\":\"new-m1\"}\n");
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 3,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 3,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 3,
+      total_memories_extracted: 3,
+    });
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "00:00",
+    });
+
+    await cleaner.runOnce(new Date("2026-07-06T12:00:00+08:00").getTime());
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(1);
+    expect(cp.total_processed).toBe(1);
+    expect(cp.total_memories_extracted).toBe(1);
+    expect(cp.memories_since_last_persona).toBe(1);
+    await expect(fs.stat(path.join(conversationsDir, "2026-07-04.jsonl"))).rejects.toThrow();
+    await expect(fs.stat(path.join(recordsDir, "2026-07-04.jsonl"))).rejects.toThrow();
+  });
+
+  it("decrements checkpoint counters from known cleanup counts before recalibration", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 60,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 30,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 60,
+      total_memories_extracted: 30,
+    });
+
+    let l0CountCalls = 0;
+    let l1CountCalls = 0;
+    let l0 = 60;
+    let l1 = 30;
+    const vectorStore = {
+      countL0: () => {
+        l0CountCalls += 1;
+        if (l0CountCalls > 1) throw new Error("count unavailable");
+        return l0;
+      },
+      countL1: () => {
+        l1CountCalls += 1;
+        if (l1CountCalls > 1) throw new Error("count unavailable");
+        return l1;
+      },
+      deleteL0Expired: () => {
+        l0 -= 5;
+        return 5;
+      },
+      deleteL1Expired: () => {
+        l1 -= 4;
+        return 4;
+      },
+    } as unknown as IMemoryStore;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "00:00",
+      vectorStore,
+    });
+
+    await cleaner.runOnce(new Date("2026-07-06T12:00:00+08:00").getTime());
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(55);
+    expect(cp.total_processed).toBe(55);
+    expect(cp.total_memories_extracted).toBe(26);
+    expect(cp.memories_since_last_persona).toBe(26);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,7 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
-import { recalibrateCheckpointFromStore } from "./checkpoint.js";
+import { CheckpointManager, recalibrateCheckpointFromLocalData, recalibrateCheckpointFromStore } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -180,11 +180,35 @@ export class LocalMemoryCleaner {
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
 
+      if (removedL0 > 0 || removedL1 > 0) {
+        try {
+          const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+          await checkpoint.decrementCounters({
+            l0ConversationsCount: removedL0,
+            totalProcessed: removedL0,
+            totalMemoriesExtracted: removedL1,
+            memoriesSinceLastPersona: removedL1,
+          });
+        } catch (err) {
+          this.opts.logger?.warn(
+            `${TAG} Checkpoint decrement failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
       try {
         await recalibrateCheckpointFromStore(this.opts.baseDir, vectorStore, this.opts.logger);
       } catch (err) {
         this.opts.logger?.warn(
           `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      try {
+        await recalibrateCheckpointFromLocalData(this.opts.baseDir, this.opts.logger);
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} Checkpoint local recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { recalibrateCheckpointFromStore } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -178,6 +179,14 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+
+      try {
+        await recalibrateCheckpointFromStore(this.opts.baseDir, vectorStore, this.opts.logger);
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     this.opts.logger?.info(


### PR DESCRIPTION
## 变更说明

修复 #157 中 `recall_checkpoint.json` 计数器只增不减导致的 checkpoint 漂移问题。

此前 `total_memories_extracted`、`l0_conversations_count`、`total_processed`、`memories_since_last_persona` 等字段只会在写入路径递增；当 memory-cleaner、手动 JSONL 修剪、session reset、历史数据回滚等操作删除实际数据后，checkpoint 仍会保留过大的计数和过旧的 cursor，导致状态展示不准，甚至让增量处理跳过仍应处理的数据。

本 PR 增加两种修复路径：

1. `decrementCounters()`：用于清理路径已知删除数量的场景。
2. `recalibrate()`：用于启动、手动修剪、reset、rollback 等需要从实际数据重算的场景。

## 架构图与数据流

```mermaid
flowchart TD
  Cleaner["memory-cleaner"]
  Startup["TdaiCore startup"]
  Manual["手动 JSONL 修剪 / reset / rollback"]

  JSONL_L0["实际数据源: conversations/*.jsonl"]
  JSONL_L1["实际数据源: records/*.jsonl"]
  Store["实际数据源: SQLite / VectorDB"]

  Decrement["修复路径: decrementCounters()<br/>已知删除量时扣减"]
  Recalibrate["修复路径: recalibrate()<br/>从实际数据重算"]

  Counters["recall_checkpoint.json<br/>聚合计数器<br/>l0_conversations_count<br/>total_processed<br/>total_memories_extracted<br/>memories_since_last_persona"]
  RunnerCursor["recall_checkpoint.json<br/>Runner Cursor<br/>last_captured_timestamp<br/>last_l1_cursor"]
  PipelineCursor["recall_checkpoint.json<br/>Pipeline Cursor<br/>last_extraction_updated_time"]

  Cleaner --> Decrement
  Decrement --> Counters

  Startup --> Recalibrate
  Manual --> Recalibrate

  JSONL_L0 --> Recalibrate
  JSONL_L1 --> Recalibrate
  Store --> Recalibrate

  Recalibrate --> Counters
  Recalibrate --> RunnerCursor
  Recalibrate --> PipelineCursor
```
## 核心数据流

1. 正常写入时，checkpoint 仍按原逻辑递增计数和推进 cursor。
2. `memory-cleaner` 删除数据后，先用已知删除量调用 `decrementCounters()` 快速扣减。
3. 随后调用 `recalibrate()`，从 JSONL 或 store 实际数据重新校准。
4. 插件启动时也会执行 recalibration，修复进程外发生的手动删除、reset、rollback。
5. 本地 JSONL shard 存在时优先使用 JSONL 作为真实数据源；否则回退到 store count。
6. cursor 会被收紧到实际数据最大时间戳，避免增量处理跳过仍存在的数据。

## 主要修改

包括：
- checkpoint 支持按删除量扣减计数。
- checkpoint 支持从 JSONL / store 重新计算计数和 cursor。
- `TdaiCore` 启动后自动校准 checkpoint。
- `memory-cleaner` 删除数据后自动修正 checkpoint。
- session reset 后清空缺失 session 的 cursor。
- history rollback 后收紧 L0/L1/L2 cursor，避免跳过后续增量处理。
- 补充手动清理、自动清理、重置/边界场景测试。

## 两种修复方式

### 1. decrementCounters

适用于当前进程明确知道删除数量的场景，例如 memory-cleaner 删除过期 L0/L1 记录。

该方法会扣减：

- `l0_conversations_count`
- `total_processed`
- `total_memories_extracted`
- `memories_since_last_persona`

并保证计数不会低于 0。

### 2. recalibrate

适用于无法可靠知道删除数量的场景，例如：

- 插件重启后发现数据已被手动修剪
- 用户删除部分 JSONL 文件
- session reset
- 历史数据回滚
- store 和 JSONL 之间发生漂移

该方法会从实际数据重新计算：

- L0 实际记录数
- L1 实际记录数
- L0 最大 timestamp
- L1 最大 updatedAt
- 每个 session 的最大 L0/L1 cursor

并修正 checkpoint 中对应字段。

## 深入测试覆盖

本 PR 补充了手动清理、自动清理、重置/边界三类测试场景：

- 手动清理：覆盖 JSONL 修剪、history rollback、records rollback、空 shard 清理后，checkpoint 计数和 cursor 能按现存数据重新校准。
- 自动清理：覆盖 memory-cleaner 有 vectorStore 时的 decrement + recalibrate，以及无 vectorStore 时基于本地 JSONL 的 recalibrate。
- 重置/边界：覆盖 session reset 后 cursor 清零、从 store count 重新校准，以及 decrement 过量时计数 clamp 到 0。

## 关于更好的Checkpoint 设计模式分析

更彻底的方案是让 checkpoint 不再保存聚合计数，而是完全从实际数据按需派生状态，例如基于 JSONL / store 的记录数和 timestamp cursor 计算进度。

但当前项目中 checkpoint 计数仍被多个路径读取：

- 状态展示
- persona 触发阈值
- backup offset
- L1/L2/L3 pipeline 调度

如果本 PR 直接移除计数器，会扩大改动范围并提高回归风险。

因此本 PR 采用折中设计：

1. 保留计数器作为缓存字段，兼容现有调用方。
2. 增加 `decrementCounters()`，让已知删除量的 cleanup 路径能即时修正。
3. 增加 `recalibrate()`，让启动、手动修剪、reset、rollback 等场景能从真实数据恢复。
4. 将 JSONL / store 视为 source of truth，checkpoint 视为可修复缓存。
5. cursor 使用实际数据 timestamp / updatedAt 做边界，避免增量处理跳过数据。

长期方向可以继续减少业务逻辑对单调递增计数器的依赖，将 checkpoint 聚合字段逐步降级为派生缓存。

## 测试

本地验证：

```bash
npm test
npm run build
git diff --check
```

验证结果：

- `npm test`：6 files / 77 tests passed
- `npm run build`：passed
- `git diff --check`：passed

## 关联 Issue

Closes #157