### PR TITLE
fix(checkpoint): recalibrate counters on startup to fix drift after cleanup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { CheckpointManager } from "./src/utils/checkpoint.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -305,6 +306,7 @@ export default function register(api: OpenClawPluginApi) {
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
+        checkpoint: new CheckpointManager(pluginDataDir, api.logger),
       });
       sharedMemoryCleaner.start();
       api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { CheckpointManager } from "./checkpoint.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+function makeDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "cp-test-"));
+}
+
+function mockStore(l1: number, l0: number): Pick<IMemoryStore, "countL1" | "countL0"> & IMemoryStore {
+  return {
+    countL1: async () => l1,
+    countL0: async () => l0,
+  } as unknown as IMemoryStore;
+}
+
+describe("CheckpointManager.recalibrate", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeDir();
+    await fs.mkdir(path.join(dir, ".metadata"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("is a no-op when store is not provided", async () => {
+    const cm = new CheckpointManager(dir);
+    await cm.recalibrate();
+    // No checkpoint file should be created
+    const filePath = path.join(dir, ".metadata", "recall_checkpoint.json");
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it("writes store counts into the checkpoint", async () => {
+    const cm = new CheckpointManager(dir);
+    const store = mockStore(42, 7);
+    const result = await cm.recalibrate(store);
+
+    expect(result).toEqual({ total_memories_extracted: 42, l0_conversations_count: 7 });
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(7);
+  });
+
+  it("returns undefined when store is not provided", async () => {
+    const cm = new CheckpointManager(dir);
+    const result = await cm.recalibrate();
+    expect(result).toBeUndefined();
+  });
+
+  it("corrects inflated counters left by memory-cleaner", async () => {
+    const cm = new CheckpointManager(dir);
+    // Simulate drift: counters say 1000/500 but actual store holds far fewer
+    const store = mockStore(1000, 500);
+    await cm.recalibrate(store);
+
+    const store2 = mockStore(8, 3);
+    await cm.recalibrate(store2);
+
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(8);
+    expect(cp.l0_conversations_count).toBe(3);
+  });
+
+  it("handles zero counts (empty store)", async () => {
+    const cm = new CheckpointManager(dir);
+    await cm.recalibrate(mockStore(0, 0));
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.l0_conversations_count).toBe(0);
+  });
+
+  it("returns undefined and skips write when store throws", async () => {
+    const cm = new CheckpointManager(dir);
+    // Seed a known counter value
+    await cm.recalibrate(mockStore(10, 5));
+
+    const throwingStore = {
+      countL1: async () => { throw new Error("SQLite connection lost"); },
+      countL0: async () => 0,
+    } as unknown as IMemoryStore;
+
+    const result = await cm.recalibrate(throwingStore);
+    expect(result).toBeUndefined();
+
+    // Counters must remain unchanged — no partial write
+    const cp = await cm.read();
+    expect(cp.total_memories_extracted).toBe(10);
+    expect(cp.l0_conversations_count).toBe(5);
+  });
+
+  it("preserves unrelated checkpoint fields after recalibration", async () => {
+    const cm = new CheckpointManager(dir);
+    // Set a sentinel value on an unrelated field
+    await cm.markPersonaGenerated(99);
+    const before = await cm.read();
+    expect(before.last_persona_at).toBe(99);
+
+    await cm.recalibrate(mockStore(5, 2));
+
+    const after = await cm.read();
+    expect(after.total_memories_extracted).toBe(5);
+    expect(after.l0_conversations_count).toBe(2);
+    expect(after.last_persona_at).toBe(99);
+  });
+
+  // ─── memories_since_last_persona adjustment ───────────────────────────────
+
+  it("decrements memories_since_last_persona by the number of removed L1 records", async () => {
+    const cm = new CheckpointManager(dir);
+    // Seed: 10 total L1, 8 since last persona update
+    await cm.recalibrate(mockStore(10, 5));
+    const seeded = await cm.read();
+    // manually bump memories_since_last_persona to a known value
+    await (cm as any).mutate((cp: any) => { cp.memories_since_last_persona = 8; });
+
+    // Recalibrate down to 4 L1 records (6 removed)
+    await cm.recalibrate(mockStore(4, 5));
+
+    const after = await cm.read();
+    expect(after.total_memories_extracted).toBe(4);
+    // 8 - 6 = 2
+    expect(after.memories_since_last_persona).toBe(2);
+  });
+
+  it("does not let memories_since_last_persona go below zero", async () => {
+    const cm = new CheckpointManager(dir);
+    await cm.recalibrate(mockStore(10, 5));
+    await (cm as any).mutate((cp: any) => { cp.memories_since_last_persona = 2; });
+
+    // Remove 10 L1 records — more than memories_since_last_persona
+    await cm.recalibrate(mockStore(0, 5));
+
+    const after = await cm.read();
+    expect(after.memories_since_last_persona).toBe(0);
+  });
+
+  it("does not change memories_since_last_persona when L1 count increases", async () => {
+    const cm = new CheckpointManager(dir);
+    await cm.recalibrate(mockStore(5, 3));
+    await (cm as any).mutate((cp: any) => { cp.memories_since_last_persona = 4; });
+
+    // Store grew — no records removed, so counter must stay unchanged
+    await cm.recalibrate(mockStore(9, 3));
+
+    const after = await cm.read();
+    expect(after.memories_since_last_persona).toBe(4);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -483,6 +484,45 @@ export class CheckpointManager {
         cp.l0_conversations_count += 1;
       }
     });
+  }
+
+  // ============================
+  // Recalibration
+  // ============================
+
+  /**
+   * Recalibrate global counters against actual data held in the store.
+   *
+   * Call once on gateway startup to fix counter drift that accumulates when
+   * memory-cleaner deletes records from JSONL/SQLite but never decrements the
+   * checkpoint counters (`total_memories_extracted`, `l0_conversations_count`).
+   * Returns the corrected values, or undefined when store is unavailable.
+   */
+  async recalibrate(store?: IMemoryStore): Promise<{ total_memories_extracted: number; l0_conversations_count: number } | undefined> {
+    if (!store) return undefined;
+    let actualL1: number, actualL0: number;
+    try {
+      [actualL1, actualL0] = await Promise.all([store.countL1(), store.countL0()]);
+    } catch (err) {
+      this.logger.info(
+        `[checkpoint] recalibrate skipped: ${err instanceof Error ? err.message : err}`,
+      );
+      return undefined;
+    }
+    const cp = await this.mutate((cp) => {
+      const removedL1 = Math.max(0, cp.total_memories_extracted - actualL1);
+      cp.total_memories_extracted = actualL1;
+      cp.l0_conversations_count = actualL0;
+      if (removedL1 > 0) {
+        cp.memories_since_last_persona = Math.max(0, cp.memories_since_last_persona - removedL1);
+      }
+    });
+    this.logger.info(
+      `[checkpoint] recalibrate: total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+    return { total_memories_extracted: cp.total_memories_extracted, l0_conversations_count: cp.l0_conversations_count };
   }
 
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -12,6 +13,7 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  checkpoint?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -33,14 +35,20 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpoint?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpoint = opts.checkpoint;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  setCheckpoint(checkpoint: CheckpointManager | undefined): void {
+    this.checkpoint = checkpoint;
   }
 
   start(): void {
@@ -163,6 +171,16 @@ export class LocalMemoryCleaner {
 
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
+        if (this.checkpoint) {
+          try {
+            await this.checkpoint.recalibrate(vectorStore);
+          } catch (err) {
+            this.opts.logger?.info(
+              `${TAG} Checkpoint recalibration failed after cleanup (non-fatal): ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
       }
 
       // ── Post-delete: audit summary ──

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -696,6 +696,9 @@ export async function createPipeline(opts: PipelineFactoryOptions): Promise<Pipe
   const stores = await initStores(cfg, pluginDataDir, logger);
   const { vectorStore, embeddingService } = stores;
 
+  // Recalibrate counters against actual store data to fix drift after cleanup
+  await new CheckpointManager(pluginDataDir, logger).recalibrate(vectorStore);
+
   // Create pipeline manager
   const scheduler = createPipelineManager(cfg, logger, sessionFilter);
 


### PR DESCRIPTION
Closes #157

Memory-cleaner deletes records from JSONL/SQLite but never decrements the checkpoint counters (`total_memories_extracted`, `l0_conversations_count`, `memories_since_last_persona`), causing counter drift over time that accumulates silently after every cleanup pass.

## Root cause

`CheckpointManager` has no way to reconcile its counters against actual store state. The `LocalMemoryCleaner` deletes L0/L1 records but leaves counters inflated, and the scheduler startup reads these stale counters without correction.

## Fix

Adds `CheckpointManager.recalibrate(store?)` that:
- Reads actual L1/L0 counts concurrently via `Promise.all([store.countL1(), store.countL0()])`
- Adjusts `total_memories_extracted` and `l0_conversations_count` to match actual store state
- Decrements `memories_since_last_persona` by the L1 delta (so persona-update decisions stay accurate)
- Clamps all values to `>= 0` — no counter goes negative
- Is a no-op when `store` is unavailable; skips silently on transient store errors (non-fatal)

Wired in two places:
1. **`pipeline-factory.ts`** — called at gateway startup before reading checkpoint state
2. **`memory-cleaner.ts`** — called after each cleanup pass when records were actually removed

## Tests (10 cases)

- No-op without store, no file created
- Writes correct L1/L0 counts into checkpoint
- Corrects inflated counters (drift simulation)
- Handles zero counts (empty store)
- Returns `undefined` and skips write on store error (no partial write)
- Preserves unrelated checkpoint fields
- Decrements `memories_since_last_persona` by removed-L1 delta
- Floors `memories_since_last_persona` at 0 when removal exceeds current value
- Does not change `memories_since_last_persona` when L1 count increases