### PR TITLE
fix(core/store): strip FTS5 boolean operators before tokenisation.

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, it, expect } from "vitest";
+
+import { buildFtsQuery, _resetJiebaForTest, _setJiebaForTest } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  // ─── FTS5 operator sanitization ──────────────────────────────────────────
+
+  it("strips AND so the word itself is not a token", () => {
+    const result = buildFtsQuery("hello AND world");
+    expect(result).not.toBeNull();
+    // The phrase terms must only be "hello" and "world", not "AND"
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1)); // strip outer quotes
+    expect(phrases).toContain("hello");
+    expect(phrases).toContain("world");
+    expect(phrases).not.toContain("AND");
+  });
+
+  it("strips OR so the word itself is not a token", () => {
+    const result = buildFtsQuery("cat OR dog");
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).toContain("cat");
+    expect(phrases).toContain("dog");
+    expect(phrases).not.toContain("OR");
+  });
+
+  it("strips NOT so the word itself is not a token", () => {
+    const result = buildFtsQuery("food NOT fish");
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).toContain("food");
+    expect(phrases).toContain("fish");
+    expect(phrases).not.toContain("NOT");
+  });
+
+  it("strips NEAR so the word itself is not a token", () => {
+    const result = buildFtsQuery("apple NEAR orange");
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).toContain("apple");
+    expect(phrases).toContain("orange");
+    expect(phrases).not.toContain("NEAR");
+  });
+
+  // A standalone operator with no other tokens → null (no tokens survive sanitization)
+  it("returns null when input is only an operator", () => {
+    for (const op of ["AND", "and", "And", "OR", "or", "NOT", "not", "NEAR", "near"]) {
+      expect(buildFtsQuery(op), `"${op}" alone should produce null`).toBeNull();
+    }
+  });
+
+  it("strips operators case-insensitively in mixed input", () => {
+    const mixedCase = ["and", "And", "or", "Or", "not", "Not", "near", "Near"];
+    for (const form of mixedCase) {
+      const result = buildFtsQuery(`hello ${form} world`);
+      expect(result, `input with "${form}": result should not be null`).not.toBeNull();
+      const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+      expect(phrases).toContain("hello");
+      expect(phrases).toContain("world");
+      expect(phrases).not.toContain(form);
+      expect(phrases).not.toContain(form.toUpperCase());
+    }
+  });
+
+  it("does not strip operator string when it appears as a substring", () => {
+    // "android" contains "and" but is not a standalone keyword
+    const result = buildFtsQuery("android");
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).toContain("android");
+  });
+
+  it("does not strip operator-like substrings inside longer words", () => {
+    // "notation" contains "not"; "border" contains "or"
+    const result = buildFtsQuery("notation border");
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).toContain("notation");
+    expect(phrases).toContain("border");
+  });
+
+  // ─── Normal query behaviour ───────────────────────────────────────────────
+
+  it("returns null for an empty string", () => {
+    expect(buildFtsQuery("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only input", () => {
+    expect(buildFtsQuery("   ")).toBeNull();
+  });
+
+  it("returns null for punctuation-only input", () => {
+    expect(buildFtsQuery("!@#$%^&*()")).toBeNull();
+  });
+
+  it("wraps each token in double quotes", () => {
+    const result = buildFtsQuery("hello world");
+    expect(result).not.toBeNull();
+    for (const part of result!.split(" OR ")) {
+      expect(part.trim()).toMatch(/^".*"$/);
+    }
+  });
+
+  it("joins tokens with OR", () => {
+    const result = buildFtsQuery("foo bar baz");
+    expect(result).not.toBeNull();
+    expect(result).toContain(" OR ");
+  });
+
+  it("handles a single token", () => {
+    const result = buildFtsQuery("typescript");
+    expect(result).toBe('"typescript"');
+  });
+
+  it("strips double-quotes inside token values to prevent FTS5 phrase injection", () => {
+    // Quotes in user input must not appear as unescaped chars inside the phrase terms
+    const result = buildFtsQuery('say "hello"');
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    for (const phrase of phrases) {
+      expect(phrase).not.toContain('"');
+    }
+  });
+
+  it("strips operators when mixed with other chars", () => {
+    const result = buildFtsQuery("foo AND bar OR baz");
+    expect(result).not.toBeNull();
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).not.toContain("AND");
+    expect(phrases).not.toContain("OR");
+    expect(phrases).toContain("foo");
+    expect(phrases).toContain("bar");
+    expect(phrases).toContain("baz");
+  });
+
+  // ─── jieba tokenization path ──────────────────────────────────────────────
+
+  it("strips FTS5 operators before jieba tokenization", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        seen.push(text);
+        return text.split(/\s+/).filter(Boolean);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe(
+      '"用户" OR "TypeScript" OR "记忆"',
+    );
+    // jieba must receive the sanitized text — operators replaced by spaces, not the original
+    expect(seen).toEqual(["用户   TypeScript   记忆"]);
+  });
+
+  it("does not strip operator substrings embedded inside tokens via jieba", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        seen.push(text);
+        return text.split(/\s+/).filter(Boolean);
+      },
+    });
+
+    const result = buildFtsQuery("android notable nearby");
+    expect(result).not.toBeNull();
+    // android/notable/nearby must survive — they only contain operator substrings, not whole-word operators
+    const phrases = result!.split(" OR ").map((p) => p.slice(1, -1));
+    expect(phrases).toContain("android");
+    expect(phrases).toContain("notable");
+    expect(phrases).toContain("nearby");
+    // jieba received the text unchanged (no whole-word operators present)
+    expect(seen).toEqual(["android notable nearby"]);
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,9 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+/** FTS5 boolean operators — must be stripped before tokenisation to avoid altering query semantics. */
+const FTS5_OPS_RE = /\b(?:AND|OR|NOT|NEAR)\b/gi;
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -196,6 +199,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const sanitized = raw.replace(FTS5_OPS_RE, " ");
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +207,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(sanitized, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +222,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      sanitized
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
Fixes #160

User input containing FTS5 boolean operators (`AND`, `OR`, `NOT`, `NEAR`) is passed raw into `buildFtsQuery`, which emits them as bare tokens in the generated MATCH expression. SQLite interprets them as query syntax, causing unexpected query-logic injection instead of literal search.

## Root cause

`buildFtsQuery` passes `raw` directly to both tokenization paths without sanitizing FTS5 reserved words first.

## Fix

Strips whole-word FTS5 operators with `/\b(?:AND|OR|NOT|NEAR)\b/gi` before either tokenization path runs:

```ts
const FTS5_OPS_RE = /\b(?:AND|OR|NOT|NEAR)\b/gi;

export function buildFtsQuery(raw: string): string | null {
  const sanitized = raw.replace(FTS5_OPS_RE, " ");
  // ... jieba path uses sanitized, fallback path uses sanitized
}
```

The `\b` word-boundary anchors ensure that substrings embedded in normal words (`android`, `notable`, `nearby`) are preserved.

## Tests (18 cases)

**Operator sanitization**
- AND / OR / NOT / NEAR each stripped in isolation (per-operator granularity)
- Operator-only input returns `null` (no surviving tokens)
- Case-insensitive stripping (`and`, `And`, `AND` etc.)
- Boundary-word safety: `notation`, `border` (contain operator substrings) survive
- Mixed operators in one query stripped correctly

**jieba tokenization path**
- Operators stripped before `jieba.cutForSearch` — verified via `_setJiebaForTest` spy
- Boundary-word safety also tested through jieba path

**Fallback tokenization path + edge cases**
- Empty string → `null`
- Whitespace-only → `null`
- Punctuation-only → `null`
- Tokens wrapped in double quotes
- Tokens joined with `OR`
- Single token
- Double-quote injection guard (user quotes stripped from phrase terms)