### PR TITLE
fix(gateway): expose safe health diagnostics

### DIFF
--- a/src/gateway/server.health.test.ts
+++ b/src/gateway/server.health.test.ts
@@ -1,0 +1,79 @@
+import http from "node:http";
+import path from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { TdaiGateway } from "./server.js";
+
+describe("TdaiGateway /health", () => {
+  let gateway: TdaiGateway | undefined;
+  let dataDir: string | undefined;
+
+  afterEach(async () => {
+    if (gateway) {
+      await gateway.stop();
+      gateway = undefined;
+    }
+    if (dataDir) {
+      rmSync(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+  });
+
+  it("returns safe diagnostics for the running process and data directory", async () => {
+    dataDir = mkdtempSync(path.join(tmpdir(), "tdai-gateway-health-"));
+    const secretApiKey = "secret-gateway-health-token";
+    const secretLlmKey = "secret-gateway-llm-token";
+
+    gateway = new TdaiGateway({
+      server: {
+        host: "127.0.0.1",
+        port: 0,
+        apiKey: secretApiKey,
+      },
+      data: {
+        baseDir: dataDir,
+      },
+      llm: {
+        baseUrl: "http://127.0.0.1:9/v1",
+        apiKey: secretLlmKey,
+        model: "test-model",
+        maxTokens: 1,
+        timeoutMs: 100,
+      },
+    });
+
+    await gateway.start();
+
+    const server = (gateway as unknown as { server: http.Server | null }).server;
+    const address = server?.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Gateway test server did not bind to a TCP port");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/health`);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.diagnostics).toMatchObject({
+      process: {
+        pid: process.pid,
+        cwd: process.cwd(),
+        home: homedir(),
+      },
+      gateway: {
+        host: "127.0.0.1",
+        port: address.port,
+        dataDir,
+      },
+    });
+    expect(body.diagnostics.process.user).toEqual(expect.any(String));
+
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain(secretApiKey);
+    expect(serialized).not.toContain(secretLlmKey);
+    expect(serialized).not.toContain("apiKey");
+    expect(serialized).not.toContain("TDAI_GATEWAY_API_KEY");
+    expect(serialized).not.toContain("TDAI_LLM_API_KEY");
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -17,6 +17,7 @@
 import http from "node:http";
 import { URL } from "node:url";
 import { timingSafeEqual } from "node:crypto";
+import { homedir, userInfo } from "node:os";
 import { TdaiCore } from "../core/tdai-core.js";
 import { StandaloneHostAdapter } from "../adapters/standalone/host-adapter.js";
 import { loadGatewayConfig } from "./config.js";
@@ -105,6 +106,14 @@ function safeEqual(a: string, b: string): boolean {
   const bb = Buffer.from(b, "utf-8");
   if (ab.length !== bb.length) return false;
   return timingSafeEqual(ab, bb);
+}
+
+function resolveProcessUser(): string | undefined {
+  try {
+    return userInfo().username || undefined;
+  } catch {
+    return process.env.USER || process.env.USERNAME || undefined;
+  }
 }
 
 // ============================
@@ -356,6 +365,12 @@ export class TdaiGateway {
   // ============================
 
   private handleHealth(res: http.ServerResponse): void {
+    const address = this.server?.address();
+    const actualPort =
+      address && typeof address !== "string"
+        ? address.port
+        : this.config.server.port;
+
     const response: HealthResponse = {
       status: this.core.getVectorStore() ? "ok" : "degraded",
       version: VERSION,
@@ -363,6 +378,19 @@ export class TdaiGateway {
       stores: {
         vectorStore: !!this.core.getVectorStore(),
         embeddingService: !!this.core.getEmbeddingService(),
+      },
+      diagnostics: {
+        process: {
+          pid: process.pid,
+          cwd: process.cwd(),
+          user: resolveProcessUser(),
+          home: homedir(),
+        },
+        gateway: {
+          host: this.config.server.host,
+          port: actualPort,
+          dataDir: this.config.data.baseDir,
+        },
       },
     };
     sendJson(res, 200, response);

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -23,6 +23,19 @@ export interface HealthResponse {
     vectorStore: boolean;
     embeddingService: boolean;
   };
+  diagnostics: {
+    process: {
+      pid: number;
+      cwd: string;
+      user?: string;
+      home?: string;
+    };
+    gateway: {
+      host: string;
+      port: number;
+      dataDir: string;
+    };
+  };
 }
 
 // ============================


### PR DESCRIPTION
## Summary
- add safe `/health.diagnostics` fields for the running Gateway process and configured data directory
- report the actual bound port so `port: 0` and process mismatch cases are diagnosable
- cover the response with a Gateway integration test that asserts API/LLM secrets are not exposed

Fixes #62.

## Verification
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run src/gateway/server.health.test.ts`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm build`