### PR TITLE
fix(hermes): mirror explicit memory writes (#417)

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -1048,9 +1048,27 @@ class MemoryTencentdbProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes to memory-tencentdb for indexing."""
-        # TODO: Implement mirroring of Hermes builtin MEMORY.md/USER.md writes
-        # to memory-tencentdb's recall index for conflict suppression and dedup.
-        pass
+        if action.strip().lower() != "add":
+            return
+        if not content.strip():
+            return
+        if not self._ensure_alive_for_request() or not self._client:
+            return
+
+        try:
+            self._client.write_explicit_memory(
+                action=action,
+                target=target,
+                content=content,
+                session_key=self._session_id,
+                session_id=self._session_id,
+                user_id=self._user_id,
+            )
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            logger.warning("memory-tencentdb explicit memory sync failed: %s", e)
+            self._try_recover_gateway()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Trigger session-level flush on the Gateway."""

--- a/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/hermes-plugin/memory/memory_tencentdb/client.py
@@ -139,6 +139,28 @@ class MemoryTencentdbSdkClient:
             body["user_id"] = user_id
         return self._post("/capture", body)
 
+    def write_explicit_memory(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        session_key: str,
+        session_id: str = "",
+        user_id: str = "",
+    ) -> Dict[str, Any]:
+        """Mirror a host-native durable-memory write directly into L1."""
+        body: Dict[str, Any] = {
+            "action": action,
+            "target": target,
+            "content": content,
+            "session_key": session_key,
+        }
+        if session_id:
+            body["session_id"] = session_id
+        if user_id:
+            body["user_id"] = user_id
+        return self._post("/memories/explicit", body)
+
     def search_memories(self, query: str, limit: int = 5, type_filter: str = "", scene: str = "") -> Dict[str, Any]:
         """Search L1 structured memories."""
         body: Dict[str, Any] = {"query": query, "limit": limit}

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -433,3 +433,32 @@ def test_shutdown_is_idempotent(provider_with_fake_supervisor):
     provider = provider_with_fake_supervisor
     provider.shutdown()
     provider.shutdown()  # must not raise
+
+
+def test_on_memory_write_mirrors_explicit_adds(provider_with_fake_supervisor):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+
+    provider.on_memory_write(
+        action="add",
+        target="memory",
+        content="TencentDB retry probe memory: durable memory round-trip verification marker.",
+    )
+
+    fake.client.write_explicit_memory.assert_called_once_with(
+        action="add",
+        target="memory",
+        content="TencentDB retry probe memory: durable memory round-trip verification marker.",
+        session_key="test-session",
+        session_id="test-session",
+        user_id="test-user",
+    )
+
+
+def test_on_memory_write_ignores_non_add_actions(provider_with_fake_supervisor):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+
+    provider.on_memory_write(action="remove", target="memory", content="obsolete")
+
+    fake.client.write_explicit_memory.assert_not_called()

--- a/src/core/record/explicit-memory.test.ts
+++ b/src/core/record/explicit-memory.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ingestExplicitMemory } from "./explicit-memory.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("ingestExplicitMemory", () => {
+  it("stores Hermes memory target as an instruction L1 record", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-memory-"));
+    tempDirs.push(baseDir);
+
+    const embed = vi.fn(async () => new Float32Array([0.5, 0.25]));
+    const upsertL1 = vi.fn(async () => true);
+
+    const record = await ingestExplicitMemory({
+      action: "add",
+      target: "memory",
+      content: "Remember that the user wants retry probe summaries.",
+      baseDir,
+      sessionKey: "session-key",
+      sessionId: "session-id",
+      vectorStore: { upsertL1 } as any,
+      embeddingService: { embed } as any,
+    });
+
+    expect(record?.type).toBe("instruction");
+    expect(record?.scene_name).toBe("hermes_explicit_memory");
+    expect(upsertL1).toHaveBeenCalledOnce();
+    expect(embed).toHaveBeenCalledWith("Remember that the user wants retry probe summaries.");
+
+    const [shardName] = await readdir(path.join(baseDir, "records"));
+    const shard = path.join(baseDir, "records", shardName);
+    const saved = await readFile(shard, "utf-8");
+    expect(saved).toContain("Remember that the user wants retry probe summaries.");
+  });
+
+  it("maps Hermes user target to a persona record", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-user-"));
+    tempDirs.push(baseDir);
+
+    const record = await ingestExplicitMemory({
+      action: "add",
+      target: "user",
+      content: "The user prefers concise answers.",
+      baseDir,
+      sessionKey: "session-key",
+    });
+
+    expect(record?.type).toBe("persona");
+    expect(record?.scene_name).toBe("hermes_user_profile");
+  });
+});

--- a/src/core/record/explicit-memory.ts
+++ b/src/core/record/explicit-memory.ts
@@ -1,0 +1,63 @@
+/**
+ * Explicit memory ingest: mirrors host-native durable-memory writes directly
+ * into L1 without pretending they were conversation turns.
+ */
+
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore } from "../store/types.js";
+import type { Logger } from "../types.js";
+import { generateMemoryId, writeMemory, type MemoryRecord, type MemoryType } from "./l1-writer.js";
+
+export interface ExplicitMemoryIngestParams {
+  action: string;
+  target: string;
+  content: string;
+  baseDir: string;
+  sessionKey: string;
+  sessionId?: string;
+  logger?: Logger;
+  vectorStore?: IMemoryStore;
+  embeddingService?: EmbeddingService;
+}
+
+function classifyTarget(target: string): { type: MemoryType; sceneName: string } {
+  const normalized = target.trim().toLowerCase();
+
+  if (normalized === "user" || normalized === "user.md" || normalized === "profile") {
+    return { type: "persona", sceneName: "hermes_user_profile" };
+  }
+
+  return { type: "instruction", sceneName: "hermes_explicit_memory" };
+}
+
+export async function ingestExplicitMemory(params: ExplicitMemoryIngestParams): Promise<MemoryRecord | null> {
+  const action = params.action.trim().toLowerCase();
+  if (action !== "add") return null;
+
+  const content = params.content.trim();
+  if (!content) return null;
+
+  const { type, sceneName } = classifyTarget(params.target);
+
+  return writeMemory({
+    memory: {
+      content,
+      type,
+      priority: 90,
+      source_message_ids: [],
+      metadata: {},
+      scene_name: sceneName,
+    },
+    decision: {
+      record_id: generateMemoryId(),
+      action: "store",
+      target_ids: [],
+    },
+    baseDir: params.baseDir,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    logger: params.logger,
+    vectorStore: params.vectorStore,
+    embeddingService: params.embeddingService,
+  });
+}

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -28,6 +28,7 @@ import type {
   CompletedTurn,
   MemorySearchParams,
   ConversationSearchParams,
+  ExplicitMemoryWriteParams,
 } from "./types.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import type { IMemoryStore } from "./store/types.js";
@@ -36,6 +37,7 @@ import { performAutoRecall } from "./hooks/auto-recall.js";
 import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
+import { ingestExplicitMemory } from "./record/explicit-memory.js";
 import {
   initDataDirectories,
   initStores,
@@ -361,6 +363,35 @@ export class TdaiCore {
     await this.storeReady?.catch(() => {});
     if (!this.scheduler) return;
     await this.scheduler.flushSession(sessionKey);
+  }
+
+  /**
+   * Mirror explicit host durable-memory writes directly into L1.
+   */
+  async ingestExplicitMemory(params: ExplicitMemoryWriteParams): Promise<{ stored: boolean; memoryId?: string; type?: string }> {
+    await this.storeReady?.catch(() => {});
+
+    const record = await ingestExplicitMemory({
+      action: params.action,
+      target: params.target,
+      content: params.content,
+      baseDir: this.dataDir,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      logger: this.logger,
+      vectorStore: this.vectorStore,
+      embeddingService: this.embeddingService,
+    });
+
+    if (!record) {
+      return { stored: false };
+    }
+
+    return {
+      stored: true,
+      memoryId: record.id,
+      type: record.type,
+    };
   }
 
   // ============================

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -239,3 +239,12 @@ export interface ConversationSearchParams {
   limit?: number;
   sessionKey?: string;
 }
+
+/** Parameters for explicit host-native durable-memory ingestion. */
+export interface ExplicitMemoryWriteParams {
+  action: string;
+  target: string;
+  content: string;
+  sessionKey: string;
+  sessionId?: string;
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -5,6 +5,7 @@
  *   GET  /health              — Health check
  *   POST /recall              — Memory recall (prefetch)
  *   POST /capture             — Conversation capture (sync_turn)
+ *   POST /memories/explicit   — Explicit durable-memory ingest
  *   POST /search/memories     — L1 memory search
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
@@ -29,6 +30,8 @@ import type {
   RecallResponse,
   CaptureRequest,
   CaptureResponse,
+  ExplicitMemoryWriteRequest,
+  ExplicitMemoryWriteResponse,
   MemorySearchRequest,
   MemorySearchResponse,
   ConversationSearchRequest,
@@ -198,7 +201,7 @@ export class TdaiGateway {
     if (!loopback && !authOn) {
       this.logger.warn(
         `Gateway is bound to ${host} (non-loopback) WITHOUT an API key. ` +
-        "Every /capture, /search/conversations, /recall, /seed call from the " +
+        "Every /capture, /memories/explicit, /search/conversations, /recall, /seed call from the " +
         "network is currently unauthenticated. Bind to 127.0.0.1, or set " +
         "TDAI_GATEWAY_API_KEY, before continuing."
       );
@@ -264,6 +267,8 @@ export class TdaiGateway {
           return await this.handleRecall(req, res);
         case "POST /capture":
           return await this.handleCapture(req, res);
+        case "POST /memories/explicit":
+          return await this.handleExplicitMemoryWrite(req, res);
         case "POST /search/memories":
           return await this.handleSearchMemories(req, res);
         case "POST /search/conversations":
@@ -416,6 +421,30 @@ export class TdaiGateway {
     const response: CaptureResponse = {
       l0_recorded: result.l0RecordedCount,
       scheduler_notified: result.schedulerNotified,
+    };
+    sendJson(res, 200, response);
+  }
+
+  private async handleExplicitMemoryWrite(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<ExplicitMemoryWriteRequest>(req);
+
+    if (!body.action || !body.target || !body.content || !body.session_key) {
+      sendError(res, 400, "Missing required fields: action, target, content, session_key");
+      return;
+    }
+
+    const result = await this.core.ingestExplicitMemory({
+      action: body.action,
+      target: body.target,
+      content: body.content,
+      sessionKey: body.session_key,
+      sessionId: body.session_id,
+    });
+
+    const response: ExplicitMemoryWriteResponse = {
+      stored: result.stored,
+      memory_id: result.memoryId,
+      type: result.type,
     };
     sendJson(res, 200, response);
   }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -60,6 +60,25 @@ export interface CaptureResponse {
 }
 
 // ============================
+// /memories/explicit
+// ============================
+
+export interface ExplicitMemoryWriteRequest {
+  action: string;
+  target: string;
+  content: string;
+  session_key: string;
+  session_id?: string;
+  user_id?: string;
+}
+
+export interface ExplicitMemoryWriteResponse {
+  stored: boolean;
+  memory_id?: string;
+  type?: string;
+}
+
+// ============================
 // /search/memories
 // ============================
 


### PR DESCRIPTION
*Description | 描述*
This PR fixes Hermes explicit memory writes not being mirrored into TencentDB memory search.

Before this change:
- Hermes `memory(action="add", ...)` writes were stored in Hermes built-in memory
- the `memory_tencentdb` provider received the callback
- but `on_memory_write(...)` in the Hermes plugin was effectively a no-op
- result: explicit memories could not be retrieved through TencentDB memory search, even though conversation search still worked

This PR adds a dedicated explicit-memory ingest path instead of faking conversation capture:
- implements `on_memory_write(...)` in the Hermes TencentDB plugin
- adds client support for forwarding explicit memory writes to the gateway
- adds a new explicit-memory endpoint in the gateway/core path
- writes explicit Hermes memories directly into TencentDB L1 memory
- maps Hermes targets explicitly:
  - `target="memory"` -> `instruction`
  - `target="user"` -> `persona`

This makes Hermes explicit memory round-trip work correctly with TencentDB memory search.

*Related Issue | 关联 Issue*
Fix #417

*Change Type | 修改类型*
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

*Self-test Checklist | 自测清单*
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

*Additional Notes | 其他说明*
Local verification completed with:
- `npm test -- src/core/record/explicit-memory.test.ts`
- `npm run build:plugin`
- provider Python tests passed
- real Hermes round-trip verified in a fresh process:
  explicit `memory add` -> `memory_tencentdb_memory_search` returned the inserted marker

