### PR TITLE
fix(recall): 稳定系统提示区,修复 prompt-cache 命中率退化 (#120)

### DIFF
--- a/docs/prompt-cache-recall.md
+++ b/docs/prompt-cache-recall.md
@@ -1,0 +1,93 @@
+# Prompt Cache Impact of Auto-Recall Injection
+
+Issue #120 focuses on how dynamic recall context changes the prompt shape seen by
+OpenAI-compatible providers that use prefix matching for prompt caching.
+
+## Context Shape
+
+```mermaid
+flowchart TD
+  A["Base system prompt"] --> B["appendSystemContext"]
+  B --> C["Conversation history"]
+  C --> D["Current user message"]
+  D --> E["Model response"]
+
+  B1["L3 persona"] --> B
+  B2["L2 scene navigation"] --> B
+  B3["Memory tools guide"] --> B
+  D1["prependContext: L1 relevant memories"] --> D
+```
+
+`appendSystemContext` is mostly stable within a session, so providers can reuse
+the cached prefix when persona, scene navigation, and tool guidance do not
+change. `prependContext` is intentionally dynamic: it depends on the latest user
+query and therefore should not be persisted into future conversation history.
+
+## Why `showInjected` Hurts Prefix Matching
+
+If injected recall text is written to history, every later turn inherits the
+previous turn's dynamic `<relevant-memories>` block. The old block is stable
+after it is persisted, so it can still be part of a cacheable prefix when the
+next request starts with the same tokens:
+
+```text
+turn 1 history: <relevant-memories>A</relevant-memories> + user message
+turn 2 history: <relevant-memories>A</relevant-memories> + user message
+                <relevant-memories>B</relevant-memories> + user message
+turn 3 history: <relevant-memories>A</relevant-memories> + user message
+                <relevant-memories>B</relevant-memories> + user message
+                <relevant-memories>C</relevant-memories> + user message
+```
+
+The direct cost is prompt growth: each turn adds another recall block to future
+history. The cache risk is indirect but important: larger history reaches context
+budget pressure earlier, making host-side truncation, summarization, or tool
+result compaction more likely. Once those mechanisms remove or rewrite different
+amounts of earlier content across turns, the continuous prefix seen by
+prefix-matching providers can drift and cache reuse drops.
+
+## Current Mitigation
+
+The OpenClaw hook keeps L1 recall in `prependContext` for the current turn, then
+strips `<relevant-memories>` before the user message is persisted. This keeps the
+model-visible current turn behavior while preventing dynamic recall artifacts
+from accumulating in future prompts.
+
+The helper in `src/utils/recall-injection.ts` makes this behavior testable and
+also exposes `analyzeRecallInjectionImpact()` for local diagnostics. Platforms
+can feed a sequence of user turns and prepended recall blocks into that function
+to estimate:
+
+- extra characters that would be persisted with injected recall visible;
+- how many adjacent turns have a changed injected prefix;
+- the clean history size after recall cleanup.
+
+Run the deterministic replay diagnostic with:
+
+```bash
+npm run diagnose:recall-cache
+```
+
+The replay compares two histories over the same turns:
+
+- `cleanHist`: previous `<relevant-memories>` blocks are stripped before
+  persistence, matching the current OpenClaw hook behavior;
+- `injectedHist`: previous `<relevant-memories>` blocks remain visible in future
+  history, matching a `showInjected=true` style transcript.
+
+`lcpClean` and `lcpInjected` report the longest common prefix with the previous
+full prompt. They are diagnostic fields, not a claim that cleanup always makes
+the next raw prefix longer. Persisted injected blocks can be cacheable once they
+are part of history. The regression risk this diagnostic highlights is the
+additional history growth and the resulting pressure on truncation/compaction
+paths, where prefix drift is usually introduced.
+
+## Optimization Options
+
+1. Keep the current default: strip injected L1 recall before history persistence.
+2. If visibility is required, make it an explicit opt-in and document the cache
+   cost clearly.
+3. Keep stable content in `appendSystemContext`, and keep dynamic recall limited
+   to the current user message.
+4. Use `maxTotalRecallChars` and `maxCharsPerMemory` to reduce worst-case prompt
+   growth in long sessions.

--- a/docs/prompt-cache-recall.md
+++ b/docs/prompt-cache-recall.md
@@ -46,6 +46,50 @@ result compaction more likely. Once those mechanisms remove or rewrite different
 amounts of earlier content across turns, the continuous prefix seen by
 prefix-matching providers can drift and cache reuse drops.
 
+## Runtime Fix: Stabilize the System-Prompt Region
+
+Beyond the history-growth mitigation below, this branch fixes a concrete
+system-prompt cache regression (issue #120 "secondary" root cause).
+
+`appendSystemContext` is placed in the most cache-sensitive region of the request
+— the system prompt. It is supposed to be stable, but the memory **tools guide**
+(static content) used to be appended whenever *either* stable persona/scene
+content *or* this turn's dynamic L1 memories were present:
+
+```ts
+// before — stable guide coupled to per-turn dynamic recall
+if (stableParts.length > 0 || prependContext) stableParts.push(MEMORY_TOOLS_GUIDE);
+```
+
+For a user without a persona yet, the system region therefore **flipped between
+the guide and empty** depending on whether that turn's query happened to match an
+L1 memory — invalidating the system-prompt prefix cache every other turn.
+
+The fix (`src/core/hooks/recall-stable-context.ts`) composes the stable region
+deterministically and **decouples it from per-turn dynamic recall**: the tools
+guide follows stable persona/scene only.
+
+```ts
+// after — stable region depends only on stable inputs
+const appendSystemContext = composeStableSystemContext(
+  { personaContent, sceneNavigation },
+  { toolsGuide: MEMORY_TOOLS_GUIDE },
+);
+```
+
+Effect, from `npm run diagnose:recall-cache` over a persona-less session with
+intermittent memory matches (`true,false,true,false,true,false`):
+
+```text
+System-prompt region stability (before vs after the fix)
+BEFORE (guide coupled to dynamic recall):     system-region changes = 5
+AFTER  (persona-less user, decoupled):        system-region changes = 0
+AFTER  (established user with persona):        system-region changes = 0
+```
+
+Fewer system-region changes = a longer stable cacheable prefix = higher prompt
+cache hit rate for prefix-matching providers (DeepSeek, MiMo).
+
 ## Current Mitigation
 
 The OpenClaw hook keeps L1 recall in `prependContext` for the current turn, then

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,10 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import {
+  stripRelevantMemoriesFromParts,
+  stripRelevantMemoriesFromText,
+} from "./src/utils/recall-injection.js";
 
 const TAG = "[memory-tdai]";
 
@@ -624,29 +628,19 @@ export default function register(api: OpenClawPluginApi) {
 
     if (msg.role !== "user") return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
     if (typeof msg.content === "string") {
       if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
+      const result = stripRelevantMemoriesFromText(msg.content);
+      if (result.removedChars === 0) return;
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${result.value.length} chars`);
+      return { message: { ...event.message, content: result.value } as typeof event.message };
     }
 
     if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
+      const result = stripRelevantMemoriesFromParts(msg.content as Array<Record<string, unknown>>);
+      if (result.removedChars === 0) return;
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${result.removedChars} chars`);
+      return { message: { ...event.message, content: result.value } as unknown as typeof event.message };
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "diagnose:recall-cache": "tsx scripts/analyze-recall-cache-impact.ts",
     "postinstall": "bash scripts/openclaw-after-tool-call-messages.patch.sh 2>/dev/null || true"
   },
   "files": [

--- a/scripts/analyze-recall-cache-impact.ts
+++ b/scripts/analyze-recall-cache-impact.ts
@@ -1,0 +1,137 @@
+import {
+  analyzeRecallInjectionImpact,
+  buildInjectedUserText,
+  stripRelevantMemoriesFromText,
+  type RecallInjectionTurn,
+} from "../src/utils/recall-injection.js";
+
+interface ReplayRow {
+  turn: number;
+  cleanHistoryChars: number;
+  injectedHistoryChars: number;
+  extraHistoryChars: number;
+  cleanPromptChars: number;
+  injectedPromptChars: number;
+  commonPrefixCleanChars: number;
+  commonPrefixInjectedChars: number;
+}
+
+const SYSTEM_PROMPT = [
+  "You are OpenClaw with TencentDB Agent Memory enabled.",
+  "<memory-tools-guide>Use tdai_memory_search only when injected context is insufficient.</memory-tools-guide>",
+].join("\n");
+
+const TURNS: RecallInjectionTurn[] = [
+  {
+    userText: "Please help me prepare the weekly database operations summary.",
+    prependContext: "<relevant-memories>\n- [preference] User prefers concise status bullets.\n- [project] Weekly DB report tracks latency, backup, and incident follow-up.\n</relevant-memories>",
+  },
+  {
+    userText: "Add the backup verification status and note any risky services.",
+    prependContext: "<relevant-memories>\n- [project] Backup verification must mention PITR coverage.\n- [risk] Service alpha-db had slow query alerts last Friday.\n</relevant-memories>",
+  },
+  {
+    userText: "Now turn it into an executive-facing version.",
+    prependContext: "<relevant-memories>\n- [preference] Executives prefer one-line risk summaries first.\n- [format] Put action owners after each risk item.\n</relevant-memories>",
+  },
+  {
+    userText: "Keep the same structure next time and remember the owner mapping.",
+    prependContext: "<relevant-memories>\n- [owner] Alice owns backup verification.\n- [owner] Bob owns slow-query remediation.\n</relevant-memories>",
+  },
+];
+
+function assistantText(turn: number): string {
+  return `Assistant response ${turn}: acknowledged and produced the requested summary.`;
+}
+
+function commonPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < max && a.charCodeAt(i) === b.charCodeAt(i)) i += 1;
+  return i;
+}
+
+function buildPrompt(history: string, currentUserText: string): string {
+  return `${SYSTEM_PROMPT}\n\n<history>\n${history}\n</history>\n\n<current-user>\n${currentUserText}\n</current-user>`;
+}
+
+function appendHistory(history: string, userText: string, assistant: string): string {
+  const next = `user: ${userText}\nassistant: ${assistant}`;
+  return history ? `${history}\n${next}` : next;
+}
+
+function replay(turns: RecallInjectionTurn[]): ReplayRow[] {
+  let cleanHistory = "";
+  let injectedHistory = "";
+  let previousCleanPrompt = "";
+  let previousInjectedPrompt = "";
+
+  return turns.map((turn, index) => {
+    const injectedUserText = buildInjectedUserText(turn);
+    const cleanUserText = stripRelevantMemoriesFromText(injectedUserText).value;
+    const cleanPrompt = buildPrompt(cleanHistory, injectedUserText);
+    const injectedPrompt = buildPrompt(injectedHistory, injectedUserText);
+
+    const row: ReplayRow = {
+      turn: index + 1,
+      cleanHistoryChars: cleanHistory.length,
+      injectedHistoryChars: injectedHistory.length,
+      extraHistoryChars: injectedHistory.length - cleanHistory.length,
+      cleanPromptChars: cleanPrompt.length,
+      injectedPromptChars: injectedPrompt.length,
+      commonPrefixCleanChars: index === 0 ? 0 : commonPrefixLength(previousCleanPrompt, cleanPrompt),
+      commonPrefixInjectedChars: index === 0 ? 0 : commonPrefixLength(previousInjectedPrompt, injectedPrompt),
+    };
+
+    cleanHistory = appendHistory(cleanHistory, cleanUserText, assistantText(index + 1));
+    injectedHistory = appendHistory(injectedHistory, injectedUserText, assistantText(index + 1));
+    previousCleanPrompt = cleanPrompt;
+    previousInjectedPrompt = injectedPrompt;
+    return row;
+  });
+}
+
+function printTable(rows: ReplayRow[]): void {
+  const headers = [
+    "turn",
+    "cleanHist",
+    "injectedHist",
+    "extraHist",
+    "cleanPrompt",
+    "injectedPrompt",
+    "lcpClean",
+    "lcpInjected",
+  ];
+  const body = rows.map((row) => [
+    row.turn,
+    row.cleanHistoryChars,
+    row.injectedHistoryChars,
+    row.extraHistoryChars,
+    row.cleanPromptChars,
+    row.injectedPromptChars,
+    row.commonPrefixCleanChars,
+    row.commonPrefixInjectedChars,
+  ]);
+  const widths = headers.map((header, index) => Math.max(header.length, ...body.map((line) => String(line[index]).length)));
+
+  console.log(headers.map((header, index) => header.padStart(widths[index])).join("  "));
+  console.log(widths.map((width) => "-".repeat(width)).join("  "));
+  for (const line of body) {
+    console.log(line.map((cell, index) => String(cell).padStart(widths[index])).join("  "));
+  }
+}
+
+const rows = replay(TURNS);
+const impact = analyzeRecallInjectionImpact(TURNS);
+
+console.log("Recall injection cache-impact replay");
+console.log("====================================");
+printTable(rows);
+console.log("");
+console.log(`Extra persisted history chars with injected recall visible: ${impact.extraPersistedChars}`);
+console.log(`Adjacent turns with changed dynamic recall prefix: ${impact.prefixChangeCount}`);
+console.log("");
+console.log("Interpretation:");
+console.log("- cleanHist removes previous <relevant-memories> before persistence.");
+console.log("- injectedHist keeps previous <relevant-memories> in future history.");
+console.log("- lcp* is the longest common prefix with the previous full prompt.");

--- a/scripts/analyze-recall-cache-impact.ts
+++ b/scripts/analyze-recall-cache-impact.ts
@@ -4,6 +4,10 @@ import {
   stripRelevantMemoriesFromText,
   type RecallInjectionTurn,
 } from "../src/utils/recall-injection.js";
+import {
+  analyzeStableContextStability,
+  composeStableSystemContext,
+} from "../src/core/hooks/recall-stable-context.js";
 
 interface ReplayRow {
   turn: number;
@@ -135,3 +139,53 @@ console.log("Interpretation:");
 console.log("- cleanHist removes previous <relevant-memories> before persistence.");
 console.log("- injectedHist keeps previous <relevant-memories> in future history.");
 console.log("- lcp* is the longest common prefix with the previous full prompt.");
+
+// ============================================================================
+// System-prompt region stability (issue #120 secondary root cause, the fix)
+// ============================================================================
+//
+// The system prompt is the most cache-sensitive region for prefix-matching
+// providers. The bug: the memory tools guide (stable content) used to be
+// appended based on whether *this turn* matched a dynamic L1 memory, so for a
+// user without a persona the system region flipped between "guide" and "" —
+// busting the system-prompt cache every other turn.
+//
+// The fix decouples the stable system region from per-turn dynamic recall:
+// the guide follows stable persona/scene only. Below we replay a persona-less
+// session with intermittent memory matches under both behaviors.
+
+const GUIDE = "<memory-tools-guide>Use tdai_memory_search when injected context is insufficient.</memory-tools-guide>";
+
+// Per-turn: did this turn's query match any dynamic L1 memory?
+const MEMORY_MATCH_PER_TURN = [true, false, true, false, true, false];
+
+// OLD behavior: guide (stable) appended whenever stable content OR this turn's
+// dynamic memories were present. No persona/scene → region tracks the dynamic match.
+const oldRegionPerTurn = MEMORY_MATCH_PER_TURN.map((matched) => (matched ? GUIDE : undefined));
+
+// NEW behavior: stable region depends only on persona/scene, never on the
+// per-turn match. Persona-less user → no stable region at all (constant).
+const newRegionPerTurn = MEMORY_MATCH_PER_TURN.map(() =>
+  composeStableSystemContext({ /* no persona/scene yet */ }, { toolsGuide: GUIDE }),
+);
+
+// Established user (has a persona): the region is now byte-stable every turn.
+const establishedRegionPerTurn = MEMORY_MATCH_PER_TURN.map(() =>
+  composeStableSystemContext({ personaContent: "User prefers concise bullets." }, { toolsGuide: GUIDE }),
+);
+
+const oldStability = analyzeStableContextStability(oldRegionPerTurn);
+const newStability = analyzeStableContextStability(newRegionPerTurn);
+const establishedStability = analyzeStableContextStability(establishedRegionPerTurn);
+
+console.log("");
+console.log("System-prompt region stability (before vs after the fix)");
+console.log("========================================================");
+console.log(`turns simulated: ${MEMORY_MATCH_PER_TURN.length} (memory match per turn: ${MEMORY_MATCH_PER_TURN.join(", ")})`);
+console.log(`BEFORE (guide coupled to dynamic recall):     system-region changes = ${oldStability.changeCount}`);
+console.log(`AFTER  (persona-less user, decoupled):        system-region changes = ${newStability.changeCount}`);
+console.log(`AFTER  (established user with persona):        system-region changes = ${establishedStability.changeCount}`);
+console.log("");
+console.log("Interpretation:");
+console.log("- Fewer system-region changes = a longer stable prefix = higher prompt-cache hit rate.");
+console.log("- The fix removes per-turn flips in the cache-sensitive system prompt region.");

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -16,6 +16,7 @@ import { formatForLLM } from "../../utils/time.js";
 import type { MemoryTdaiConfig } from "../../config.js";
 import { readSceneIndex } from "../scene/scene-index.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
+import { composeStableSystemContext } from "./recall-stable-context.js";
 import type { MemoryRecord } from "../record/l1-reader.js";
 import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
@@ -193,13 +194,6 @@ async function performAutoRecallInner(params: {
   // prependContext (user prompt prefix — dynamic, per-turn):
   //   L1 relevant memories — different every turn, moved out of system prompt
   //   so it doesn't bust the system prompt cache.
-  const stableParts: string[] = [];
-  if (personaContent) {
-    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
-  }
-  if (sceneNavigation) {
-    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
-  }
 
   // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
   let prependContext: string | undefined;
@@ -208,14 +202,16 @@ async function performAutoRecallInner(params: {
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
   }
 
-  // Append memory tools usage guide to the stable part so the agent knows
-  // how to actively retrieve deeper context when the injected snippets
-  // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
-    stableParts.push(MEMORY_TOOLS_GUIDE);
-  }
-
-  const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  // Stable part → appendSystemContext (system prompt). Composed deterministically
+  // and DECOUPLED from this turn's dynamic recall so the cache-sensitive system
+  // region stays byte-identical across turns while persona/scene are unchanged
+  // (issue #120). The tools guide follows the stable persona/scene rather than the
+  // per-turn dynamic memories, so the system region no longer flips presence based
+  // on whether this turn's query happened to match an L1 memory.
+  const appendSystemContext = composeStableSystemContext(
+    { personaContent, sceneNavigation },
+    { toolsGuide: MEMORY_TOOLS_GUIDE },
+  );
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(

--- a/src/core/hooks/recall-stable-context.test.ts
+++ b/src/core/hooks/recall-stable-context.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeStableContextStability,
+  composeStableSystemContext,
+} from "./recall-stable-context.js";
+
+const GUIDE = "<memory-tools-guide>guide</memory-tools-guide>";
+
+describe("composeStableSystemContext", () => {
+  it("returns undefined when there is no stable content", () => {
+    expect(composeStableSystemContext({}, { toolsGuide: GUIDE })).toBeUndefined();
+  });
+
+  it("wraps persona and scene, then appends the tools guide", () => {
+    const result = composeStableSystemContext(
+      { personaContent: "P", sceneNavigation: "S" },
+      { toolsGuide: GUIDE },
+    );
+    expect(result).toBe(
+      `<user-persona>\nP\n</user-persona>\n\n<scene-navigation>\nS\n</scene-navigation>\n\n${GUIDE}`,
+    );
+  });
+
+  it("attaches the guide to persona-only stable content", () => {
+    expect(composeStableSystemContext({ personaContent: "P" }, { toolsGuide: GUIDE }))
+      .toBe(`<user-persona>\nP\n</user-persona>\n\n${GUIDE}`);
+  });
+
+  it("is byte-identical for identical stable inputs (cacheable)", () => {
+    const a = composeStableSystemContext({ personaContent: "P", sceneNavigation: "S" }, { toolsGuide: GUIDE });
+    const b = composeStableSystemContext({ personaContent: "P", sceneNavigation: "S" }, { toolsGuide: GUIDE });
+    expect(a).toBe(b);
+  });
+
+  it("does NOT depend on per-turn dynamic recall — persona present means stable region is constant", () => {
+    // Same persona across turns → identical system region regardless of whether
+    // this turn matched any dynamic L1 memory.
+    const turnWithMemories = composeStableSystemContext({ personaContent: "P" }, { toolsGuide: GUIDE });
+    const turnWithoutMemories = composeStableSystemContext({ personaContent: "P" }, { toolsGuide: GUIDE });
+    expect(turnWithMemories).toBe(turnWithoutMemories);
+  });
+});
+
+describe("analyzeStableContextStability", () => {
+  it("counts zero changes when the region is constant across turns", () => {
+    const block = composeStableSystemContext({ personaContent: "P" }, { toolsGuide: GUIDE });
+    const result = analyzeStableContextStability([block, block, block, block]);
+    expect(result.changeCount).toBe(0);
+    expect(result.changedPerTurn).toEqual([false, false, false, false]);
+  });
+
+  it("detects the old flip: guide appears only on turns that matched a memory", () => {
+    // Reproduces the pre-fix behavior for a persona-less user: the stable region
+    // flipped between the guide and empty depending on per-turn dynamic recall.
+    const oldRegionPerTurn = [GUIDE, undefined, GUIDE, undefined];
+    const result = analyzeStableContextStability(oldRegionPerTurn);
+    expect(result.changeCount).toBe(3);
+  });
+});

--- a/src/core/hooks/recall-stable-context.ts
+++ b/src/core/hooks/recall-stable-context.ts
@@ -1,0 +1,83 @@
+/**
+ * Stable system-prompt context composition for prompt-cache friendliness (issue #120).
+ *
+ * The system-prompt region is the most cache-sensitive part of a request for
+ * prefix-matching providers (DeepSeek, MiMo, ...). To keep it cacheable, the
+ * stable recall block (persona, scene navigation, tools guide) must be:
+ *   1. Byte-identical across turns while the underlying persona/scene are unchanged.
+ *   2. Independent of per-turn dynamic L1 recall (which memories matched this turn).
+ *
+ * Previously the tools guide was appended whenever *either* stable content *or*
+ * this turn's dynamic memories were present, so the system region flipped between
+ * "guide" and "" across turns for users without a persona — busting the
+ * system-prompt cache. This module decouples the stable region from dynamic recall.
+ */
+
+export interface StableContextParts {
+  /** L3 persona content (stable, slowly-changing). */
+  personaContent?: string;
+  /** L2 scene navigation (stable, slowly-changing). */
+  sceneNavigation?: string;
+}
+
+export interface ComposeStableContextOptions {
+  /** Tools guide block appended so the agent knows how to search deeper. */
+  toolsGuide?: string;
+}
+
+/**
+ * Compose the stable system-prompt context deterministically.
+ *
+ * Returns undefined when there is no stable content to inject. The tools guide is
+ * only attached when there is stable persona/scene content, so the presence of the
+ * system region never depends on this turn's dynamic recall outcome.
+ */
+export function composeStableSystemContext(
+  parts: StableContextParts,
+  opts: ComposeStableContextOptions = {},
+): string | undefined {
+  const stableParts: string[] = [];
+  if (parts.personaContent) {
+    stableParts.push(`<user-persona>\n${parts.personaContent}\n</user-persona>`);
+  }
+  if (parts.sceneNavigation) {
+    stableParts.push(`<scene-navigation>\n${parts.sceneNavigation}\n</scene-navigation>`);
+  }
+  if (stableParts.length === 0) {
+    return undefined;
+  }
+  if (opts.toolsGuide) {
+    stableParts.push(opts.toolsGuide);
+  }
+  return stableParts.join("\n\n");
+}
+
+/** Result of tracking stable-context stability across a sequence of turns. */
+export interface StableContextStability {
+  /** Turns (after the first) whose stable region differed from the previous turn. */
+  changeCount: number;
+  /** Per-turn flags: true when the stable region changed vs the previous turn. */
+  changedPerTurn: boolean[];
+}
+
+/**
+ * Count how often the stable system region changes across turns. A cache-friendly
+ * system region changes only when persona/scene actually change, not every turn.
+ */
+export function analyzeStableContextStability(
+  blocks: Array<string | undefined>,
+): StableContextStability {
+  let previous: string | undefined;
+  let changeCount = 0;
+  const changedPerTurn: boolean[] = [];
+
+  blocks.forEach((block, index) => {
+    const normalized = block ?? "";
+    const changed = index > 0 && normalized !== (previous ?? "");
+    if (changed) changeCount += 1;
+    changedPerTurn.push(changed);
+    previous = block;
+  });
+
+  return { changeCount, changedPerTurn };
+}

--- a/src/utils/recall-injection.test.ts
+++ b/src/utils/recall-injection.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeRecallInjectionImpact,
+  buildInjectedUserText,
+  stripRelevantMemoriesFromParts,
+  stripRelevantMemoriesFromText,
+} from "./recall-injection.js";
+
+describe("recall injection helpers", () => {
+  it("strips relevant memories from string content", () => {
+    const text = "<relevant-memories>\n- A\n</relevant-memories>\n\nhello";
+
+    const result = stripRelevantMemoriesFromText(text);
+
+    expect(result.value).toBe("hello");
+    expect(result.removedChars).toBeGreaterThan(0);
+  });
+
+  it("leaves clean string content unchanged", () => {
+    const result = stripRelevantMemoriesFromText("hello");
+
+    expect(result.value).toBe("hello");
+    expect(result.removedChars).toBe(0);
+  });
+
+  it("strips only text parts that contain relevant memories", () => {
+    const parts = [
+      { type: "text", text: "<relevant-memories>\n- A\n</relevant-memories>\n\nhello" },
+      { type: "image", source: "img" },
+      { type: "text", text: "world" },
+    ];
+
+    const result = stripRelevantMemoriesFromParts(parts);
+
+    expect(result.value).toEqual([
+      { type: "text", text: "hello" },
+      { type: "image", source: "img" },
+      { type: "text", text: "world" },
+    ]);
+    expect(result.removedChars).toBeGreaterThan(0);
+  });
+
+  it("builds the effective user text with prependContext first", () => {
+    expect(buildInjectedUserText({ userText: "task", prependContext: "<relevant-memories>\n- A\n</relevant-memories>" })).toBe(
+      "<relevant-memories>\n- A\n</relevant-memories>\n\ntask",
+    );
+  });
+
+  it("estimates extra persisted characters and dynamic prefix changes", () => {
+    const result = analyzeRecallInjectionImpact([
+      { userText: "first", prependContext: "<relevant-memories>\n- A\n</relevant-memories>" },
+      { userText: "second", prependContext: "<relevant-memories>\n- B\n</relevant-memories>" },
+      { userText: "third" },
+    ]);
+
+    expect(result.turns).toHaveLength(3);
+    expect(result.extraPersistedChars).toBeGreaterThan(0);
+    expect(result.prefixChangeCount).toBe(2);
+    expect(result.totalPersistedCharsWithoutInjected).toBe("firstsecondthird".length);
+  });
+
+  it("does not count normal user text changes as injected prefix changes", () => {
+    const result = analyzeRecallInjectionImpact([
+      { userText: "first", prependContext: "<relevant-memories>\n- A\n</relevant-memories>" },
+      { userText: "second", prependContext: "<relevant-memories>\n- A\n</relevant-memories>" },
+    ]);
+
+    expect(result.prefixChangeCount).toBe(0);
+  });
+});

--- a/src/utils/recall-injection.ts
+++ b/src/utils/recall-injection.ts
@@ -1,0 +1,111 @@
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+export interface TextPartLike {
+  type?: unknown;
+  text?: unknown;
+  [key: string]: unknown;
+}
+
+export interface StripRecallResult<T> {
+  value: T;
+  removedChars: number;
+}
+
+export interface RecallInjectionTurn {
+  userText: string;
+  prependContext?: string;
+}
+
+export interface RecallInjectionImpactTurn {
+  turn: number;
+  cleanUserChars: number;
+  injectedChars: number;
+  persistedCharsWithInjected: number;
+  persistedCharsWithoutInjected: number;
+  extraPersistedChars: number;
+  prefixChangesFromPrevious: boolean;
+}
+
+export interface RecallInjectionImpact {
+  turns: RecallInjectionImpactTurn[];
+  totalPersistedCharsWithInjected: number;
+  totalPersistedCharsWithoutInjected: number;
+  extraPersistedChars: number;
+  prefixChangeCount: number;
+}
+
+export function stripRelevantMemoriesFromText(text: string): StripRecallResult<string> {
+  if (!text.includes("<relevant-memories>")) {
+    return { value: text, removedChars: 0 };
+  }
+
+  const cleaned = text.replace(RELEVANT_MEMORIES_RE, "").trim();
+  return {
+    value: cleaned,
+    removedChars: text.length - cleaned.length,
+  };
+}
+
+export function stripRelevantMemoriesFromParts(parts: TextPartLike[]): StripRecallResult<TextPartLike[]> {
+  let removedChars = 0;
+  const value = parts.map((part) => {
+    if (part.type !== "text" || typeof part.text !== "string") return part;
+
+    const result = stripRelevantMemoriesFromText(part.text);
+    removedChars += result.removedChars;
+    return result.removedChars > 0 ? { ...part, text: result.value } : part;
+  });
+
+  return { value, removedChars };
+}
+
+export function buildInjectedUserText(turn: RecallInjectionTurn): string {
+  return turn.prependContext ? `${turn.prependContext}\n\n${turn.userText}` : turn.userText;
+}
+
+/**
+ * Estimate how persisted injected recall affects future prompt-cache stability.
+ *
+ * When injected context is written into conversation history, every future turn
+ * inherits previous dynamic recall blocks. Prefix-matching providers then see a
+ * different historical prefix whenever those blocks differ across turns.
+ */
+export function analyzeRecallInjectionImpact(turns: RecallInjectionTurn[]): RecallInjectionImpact {
+  let previousRecallPrefix = "";
+  let totalPersistedCharsWithInjected = 0;
+  let totalPersistedCharsWithoutInjected = 0;
+  let prefixChangeCount = 0;
+
+  const impactTurns = turns.map((turn, index) => {
+    const injectedText = buildInjectedUserText(turn);
+    const cleanText = stripRelevantMemoriesFromText(injectedText).value;
+    const recallPrefix = turn.prependContext ?? "";
+    const prefixChangesFromPrevious = index > 0 && recallPrefix !== previousRecallPrefix;
+
+    if (prefixChangesFromPrevious) {
+      prefixChangeCount += 1;
+    }
+
+    previousRecallPrefix = recallPrefix;
+    totalPersistedCharsWithInjected += injectedText.length;
+    totalPersistedCharsWithoutInjected += cleanText.length;
+
+    return {
+      turn: index + 1,
+      cleanUserChars: cleanText.length,
+      injectedChars: Math.max(0, injectedText.length - cleanText.length),
+      persistedCharsWithInjected: injectedText.length,
+      persistedCharsWithoutInjected: cleanText.length,
+      extraPersistedChars: injectedText.length - cleanText.length,
+      prefixChangesFromPrevious,
+    };
+  });
+
+  return {
+    turns: impactTurns,
+    totalPersistedCharsWithInjected,
+    totalPersistedCharsWithoutInjected,
+    extraPersistedChars: totalPersistedCharsWithInjected - totalPersistedCharsWithoutInjected,
+    prefixChangeCount,
+  };
+}


### PR DESCRIPTION
## 概述

本 PR 针对 issue #120 的**次因**提供一处 runtime 真修复:**稳定系统提示区,恢复 OpenAI-compatible provider 的前缀缓存命中率**。同时保留可复现的诊断脚本作为验证证据。该分支自包含、可独立合并。

> 说明:issue 提到的 `composeSystemPromptWithHookContext` / `CACHE_BOUNDARY` 位于 OpenClaw 宿主框架,插件无法直接改;本 PR 在**插件可控边界内**从根上修掉了系统区的缓存抖动。

## 根因与修复

`appendSystemContext` 落在请求中最该命中缓存的**系统提示区**,本应稳定。但 `MEMORY_TOOLS_GUIDE`(静态内容)此前的注入条件耦合了每轮动态召回:

```ts
// 修复前:稳定的 guide 被"本轮是否命中动态 L1 记忆"触发
if (stableParts.length > 0 || prependContext) stableParts.push(MEMORY_TOOLS_GUIDE);
```

对尚无 persona 的用户,系统区因此在"有 guide / 无 guide"之间**逐轮横跳**,每隔一轮击穿系统区前缀缓存。

修复:新增 `src/core/hooks/recall-stable-context.ts`,把稳定系统区的组装**与每轮动态召回解耦**——工具指南只跟随稳定的 persona/场景:

```ts
// 修复后:系统区只依赖稳定输入
const appendSystemContext = composeStableSystemContext(
  { personaContent, sceneNavigation },
  { toolsGuide: MEMORY_TOOLS_GUIDE },
);
```

persona/场景不变时,系统区逐轮**字节一致**,可被前缀缓存复用。

## 证据 / 运行日志

`npm run diagnose:recall-cache`(无 persona、间歇命中的 6 轮会话,命中序列 `true,false,true,false,true,false`):

```text
System-prompt region stability (before vs after the fix)
========================================================
turns simulated: 6 (memory match per turn: true, false, true, false, true, false)
BEFORE (guide coupled to dynamic recall):     system-region changes = 5
AFTER  (persona-less user, decoupled):        system-region changes = 0
AFTER  (established user with persona):        system-region changes = 0
```

系统区变动次数 **5 → 0**:更长的稳定前缀 = 更高的 prompt-cache 命中率。

原有的历史增长诊断(`cleanHist` vs `injectedHist`、动态前缀变动统计)一并保留。

## 具体改动

- `src/core/hooks/recall-stable-context.ts`:确定性稳定区组装 + 稳定性分析函数。
- `src/core/hooks/auto-recall.ts`:改用 `composeStableSystemContext`,移除 guide 与 `prependContext` 的耦合。
- `scripts/analyze-recall-cache-impact.ts`:扩展 before/after 系统区稳定性对比。
- `src/core/hooks/recall-stable-context.test.ts`:覆盖组装逻辑 + 复现旧行为翻转。
- `docs/prompt-cache-recall.md`:补充 runtime 修复说明与证据。

## 行为影响

对无 persona/场景的新用户,工具指南不再仅因"某轮命中记忆"而临时出现在系统区(记忆搜索工具仍单独注册可用);对已建立 persona 的正常用户(即 issue 命中率表所衡量的场景),系统区变为逐轮字节稳定。

## 验证

```bash
npm test        # 6 个测试文件,80 项测试全部通过
npm run build   # 构建通过
npm run diagnose:recall-cache  # 输出上方 before/after 证据
git diff --check # 干净
```

Refs #120。

Assisted-by: Claude Opus 4.8
