### PR TITLE
fix(checkpoint): recalibrate counters after cleanup (#157)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { CheckpointManager } from "./src/utils/checkpoint.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -274,6 +275,10 @@ export default function register(api: OpenClawPluginApi) {
   const coreReady = core.initialize().then(() => {
     // Keep cleaner's SQLite handle updated after store init
     memoryCleaner?.setVectorStore(core.getVectorStore());
+
+    // Set checkpoint manager for cleaner to adjust counters after cleanup
+    const checkpointManager = new CheckpointManager(pluginDataDir, api.logger);
+    memoryCleaner?.setCheckpointManager(checkpointManager);
 
     // Pull L2/L3 profiles if remote store supports it
     const vs = core.getVectorStore();

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager counter adjustment", () => {
+  let tempDir: string;
+  let checkpointManager: CheckpointManager;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(process.cwd(), "checkpoint-test-"));
+    checkpointManager = new CheckpointManager(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("adjustGlobalCounters decrements counters correctly", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 100,
+      total_memories_extracted: 50,
+      total_processed: 200,
+      scenes_processed: 10,
+    });
+
+    await checkpointManager.adjustGlobalCounters({
+      l0_conversations_count: -20,
+      total_memories_extracted: -10,
+      total_processed: -30,
+      scenes_processed: -2,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(80);
+    expect(cp.total_memories_extracted).toBe(40);
+    expect(cp.total_processed).toBe(170);
+    expect(cp.scenes_processed).toBe(8);
+  });
+
+  it("adjustGlobalCounters increments counters correctly", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 10,
+      total_memories_extracted: 5,
+    });
+
+    await checkpointManager.adjustGlobalCounters({
+      l0_conversations_count: 5,
+      total_memories_extracted: 3,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(15);
+    expect(cp.total_memories_extracted).toBe(8);
+  });
+
+  it("adjustGlobalCounters protects counters from going below zero", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 5,
+      total_memories_extracted: 3,
+    });
+
+    await checkpointManager.adjustGlobalCounters({
+      l0_conversations_count: -10,
+      total_memories_extracted: -5,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+  });
+
+  it("adjustGlobalCounters handles partial delta updates", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 100,
+      total_memories_extracted: 50,
+    });
+
+    await checkpointManager.adjustGlobalCounters({
+      l0_conversations_count: -10,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(90);
+    expect(cp.total_memories_extracted).toBe(50);
+  });
+
+  it("recalibrate replaces counters with actual values", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 1000,
+      total_memories_extracted: 500,
+      total_processed: 2000,
+      scenes_processed: 100,
+    });
+
+    await checkpointManager.adjustGlobalCounters({
+      memories_since_last_persona: 50,
+    });
+
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 50,
+      total_memories_extracted: 25,
+      total_processed: 100,
+      scenes_processed: 5,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(50);
+    expect(cp.total_memories_extracted).toBe(25);
+    expect(cp.total_processed).toBe(100);
+    expect(cp.scenes_processed).toBe(5);
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+
+  it("recalibrate handles partial actual count updates", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 1000,
+      total_memories_extracted: 500,
+    });
+
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 50,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(50);
+    expect(cp.total_memories_extracted).toBe(500);
+  });
+
+  it("recalibrate protects counters from going below zero", async () => {
+    await checkpointManager.recalibrate({
+      l0_conversations_count: 100,
+    });
+
+    await checkpointManager.recalibrate({
+      l0_conversations_count: -50,
+    });
+
+    const cp = await checkpointManager.read();
+    expect(cp.l0_conversations_count).toBe(0);
+  });
+
+  it("adjustGlobalCounters logs the adjustment", async () => {
+    const logger = {
+      info: vi.fn(),
+    };
+    const manager = new CheckpointManager(tempDir, logger);
+
+    await manager.recalibrate({
+      l0_conversations_count: 100,
+      total_memories_extracted: 50,
+    });
+
+    await manager.adjustGlobalCounters({
+      l0_conversations_count: -20,
+      total_memories_extracted: -10,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("adjustGlobalCounters"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("l0_conversations_count=80"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("total_memories_extracted=40"));
+  });
+
+  it("recalibrate logs the recalibration", async () => {
+    const logger = {
+      info: vi.fn(),
+    };
+    const manager = new CheckpointManager(tempDir, logger);
+
+    await manager.recalibrate({
+      l0_conversations_count: 100,
+    });
+
+    await manager.recalibrate({
+      l0_conversations_count: 50,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("recalibrate"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("l0_conversations_count=50"));
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -485,4 +485,89 @@ export class CheckpointManager {
     });
   }
 
+  // ============================
+  // Global counter adjustment (for cleanup / migration)
+  // ============================
+
+  /**
+   * Adjust global counters by delta values.
+   * Used when data is deleted (memory-cleaner) or migrated.
+   * All counters are protected from going below zero (floor-at-zero).
+   *
+   * @param deltas - Object containing delta values for each counter.
+   *   Positive values increment, negative values decrement.
+   */
+  async adjustGlobalCounters(deltas: {
+    total_processed?: number;
+    l0_conversations_count?: number;
+    total_memories_extracted?: number;
+    scenes_processed?: number;
+    memories_since_last_persona?: number;
+  }): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      if (deltas.total_processed !== undefined) {
+        cp.total_processed = Math.max(0, cp.total_processed + deltas.total_processed);
+      }
+      if (deltas.l0_conversations_count !== undefined) {
+        cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count + deltas.l0_conversations_count);
+      }
+      if (deltas.total_memories_extracted !== undefined) {
+        cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted + deltas.total_memories_extracted);
+      }
+      if (deltas.scenes_processed !== undefined) {
+        cp.scenes_processed = Math.max(0, cp.scenes_processed + deltas.scenes_processed);
+      }
+      if (deltas.memories_since_last_persona !== undefined) {
+        cp.memories_since_last_persona = Math.max(0, cp.memories_since_last_persona + deltas.memories_since_last_persona);
+      }
+    });
+
+    this.logger.info(
+      `[checkpoint] adjustGlobalCounters: ` +
+      `total_processed=${cp.total_processed}, ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `scenes_processed=${cp.scenes_processed}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+  }
+
+  /**
+   * Recalibrate global counters by replacing them with actual counts.
+   * Used when counters are out of sync with actual data (e.g., after manual cleanup,
+   * data rollback, or migration).
+   *
+   * @param actualCounts - Object containing actual counts from the storage layer.
+   */
+  async recalibrate(actualCounts: {
+    total_processed?: number;
+    l0_conversations_count?: number;
+    total_memories_extracted?: number;
+    scenes_processed?: number;
+  }): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      if (actualCounts.total_processed !== undefined) {
+        cp.total_processed = Math.max(0, actualCounts.total_processed);
+      }
+      if (actualCounts.l0_conversations_count !== undefined) {
+        cp.l0_conversations_count = Math.max(0, actualCounts.l0_conversations_count);
+      }
+      if (actualCounts.total_memories_extracted !== undefined) {
+        cp.total_memories_extracted = Math.max(0, actualCounts.total_memories_extracted);
+      }
+      if (actualCounts.scenes_processed !== undefined) {
+        cp.scenes_processed = Math.max(0, actualCounts.scenes_processed);
+      }
+      cp.memories_since_last_persona = 0;
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrate: ` +
+      `total_processed=${cp.total_processed}, ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `scenes_processed=${cp.scenes_processed}`,
+    );
+  }
+
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
@@ -12,6 +13,7 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  checkpointManager?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -33,14 +35,20 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpointManager?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpointManager = opts.checkpointManager;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  setCheckpointManager(checkpointManager: CheckpointManager | undefined): void {
+    this.checkpointManager = checkpointManager;
   }
 
   start(): void {
@@ -163,6 +171,28 @@ export class LocalMemoryCleaner {
 
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
+      }
+
+      // ── Recalibrate checkpoint counters after cleanup ──
+      if (this.checkpointManager && (removedL0 > 0 || removedL1 > 0)) {
+        try {
+          let currentL0 = 0;
+          let currentL1 = 0;
+          try { currentL0 = await vectorStore.countL0(); } catch { /* non-fatal */ }
+          try { currentL1 = await vectorStore.countL1(); } catch { /* non-fatal */ }
+          await this.checkpointManager.recalibrate({
+            total_processed: currentL0,
+            l0_conversations_count: currentL0,
+            total_memories_extracted: currentL1,
+          });
+          this.opts.logger?.info(
+            `${TAG} [Checkpoint] Recalibrated counters: total_processed=${currentL0}, l0_conversations_count=${currentL0}, total_memories_extracted=${currentL1}`,
+          );
+        } catch (err) {
+          this.opts.logger?.warn(
+            `${TAG} [Checkpoint] Failed to recalibrate counters: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
 
       // ── Post-delete: audit summary ──


### PR DESCRIPTION
## Description | 描述

修复 Checkpoint 计数器只增不减导致数据清理后计数器高估的问题。

问题背景 ： CheckpointManager 中的全局计数器（ total_memories_extracted 、 l0_conversations_count 、 total_processed 、 scenes_processed ）只有递增方法，没有递减或重新计算逻辑。当发生以下操作时，计数器会永久高估实际情况：
- 删除测试 pipeline 状态
- 运行 memory-cleaner 清理旧数据
- 手动 JSONL 文件修剪
- 重置某个 session 的数据
- 历史数据回滚

解决方案 ：
1. 新增 adjustGlobalCounters() 方法 ( checkpoint.ts )
   - 通过 delta 值调整全局计数器
   - 支持正向增量和负向减量
   - 所有计数器都有 floor-at-zero 保护，防止变为负数
2. 新增 recalibrate() 方法 ( checkpoint.ts )
   - 用实际存储中的计数直接替换计数器值
   - 在数据清理、回滚或迁移后使用
   - 自动重置 memories_since_last_persona 为 0
3. 集成 memory-cleaner ( memory-cleaner.ts )
   - 在清理完成后调用 recalibrate() 重新计算计数器
   - 通过 vectorStore.countL0() 和 vectorStore.countL1() 获取实际计数
   - 处理异常情况，不会影响清理流程
4. 依赖注入 ( index.ts )
   - 在核心初始化完成后创建 CheckpointManager 实例
   - 将其注入到 LocalMemoryCleaner 中
5. 测试覆盖 ( checkpoint.test.ts )
   - 9 个测试用例覆盖计数器调整、校准、floor-at-zero 保护等场景

## Related Issue | 关联 Issue
Fix#157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
核心设计思路 ：
采用 recalibrate 策略 而非直接 decrement 的原因：
1. 语义匹配 ： deleteL0Expired() 返回的是删除的消息记录数，而 l0_conversations_count 追踪的是 conversation rounds，两者不是 1:1 关系
2. 准确性 ：清理后重新读取数据库中的实际计数，确保计数器与实际数据完全一致
3. 容错性 ：即使清理过程中出现异常，下次清理时仍能重新校准
覆盖场景 ：
- memory-cleaner 自动清理旧数据 → 计数器自动校准
- 手动 JSONL 文件修剪 → 通过 recalibrate() 手动校准
- 重置 session 数据 → 通过 adjustGlobalCounters() 调整
- 历史数据回滚 → 通过 recalibrate() 重新计算
安全性 ：
- 所有计数器调整都有 floor-at-zero 保护，防止变为负数
- 使用 mutate() 方法保证线程安全
- memory-cleaner 中的异常处理确保计数器校准失败不会影响清理流程