### PR TITLE
fix(embedding): cap and configure remote request batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 For all fields, types, and constraints see [`openclaw.plugin.json`](./openclaw.plugin.json)。
 
 - `embedding.*` — remote embedding service (OpenAI-compatible API)
+  - `embedding.batchSize` (default `10`): maximum texts per remote request. The safe default matches the DashScope limit; increase it only when the target provider documents a larger batch limit.
   - `embedding.sendDimensions` (default `true`): whether to include the `dimensions` field in the request body. OpenAI `text-embedding-3-*` models rely on it for Matryoshka truncation, but some self-hosted / OSS models (e.g. **BGE-M3**) do not support custom dimensions and will reject the request with HTTP 400 `does not support matryoshka representation`. Set it to `false` for those backends, e.g.:
     ```json
     {

--- a/README_CN.md
+++ b/README_CN.md
@@ -441,6 +441,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 完整字段、类型、约束见 [`openclaw.plugin.json`](./openclaw.plugin.json) 。
 
 - `embedding.*` — 远程 embedding 服务（OpenAI 兼容 API）
+  - `embedding.batchSize`（默认 `10`）：单次远程请求的最大文本数。默认值兼容 DashScope 上限；仅在目标 provider 明确支持更大批次时调高。
   - `embedding.sendDimensions`（默认 `true`）：是否在请求体中携带 `dimensions` 字段。OpenAI `text-embedding-3-*` 系列依赖该字段做 Matryoshka 维度截断；但部分自托管 / 开源模型（如 **BGE-M3**）不支持自定义维度，会以 HTTP 400 报 `does not support matryoshka representation` 拒绝请求。此时请显式设为 `false`，例如：
     ```json
     {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -97,6 +97,7 @@
           "conflictRecallTopK": { "type": "number", "default": 5, "description": "冲突检测时召回 Top-K 数" },
           "maxInputChars": { "type": "number", "default": 5000, "description": "Embedding 输入文本最大字符数，超出时截断并打印警告日志（默认 5000，适合大多数模型的 token 上限）" },
           "timeoutMs": { "type": "number", "default": 10000, "description": "单次 embedding API 调用超时（毫秒），超时后会自动重试（最多 3 次）" },
+          "batchSize": { "type": "integer", "minimum": 1, "maximum": 2048, "default": 10, "description": "单次 embedding API 请求的最大文本数。默认 10，兼容 DashScope 上限；确认服务端支持时可调大。" },
           "recallTimeoutMs": { "type": "number", "description": "recall 路径 embedding 超时（毫秒），覆盖 timeoutMs。用户等待中，建议设短一些（如 3000）" },
           "captureTimeoutMs": { "type": "number", "description": "capture 路径 embedding 超时（毫秒），覆盖 timeoutMs。后台运行，可设长一些（如 15000）" }
         }

--- a/src/config.embedding.test.ts
+++ b/src/config.embedding.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+const validRemoteEmbedding = {
+  enabled: true,
+  provider: "dashscope",
+  baseUrl: "https://dashscope.example/v1",
+  apiKey: "test-key",
+  model: "text-embedding-v4",
+  dimensions: 1024,
+};
+
+describe("embedding.batchSize config", () => {
+  it("defaults remote providers to the DashScope-safe limit", () => {
+    const config = parseConfig({ embedding: validRemoteEmbedding });
+
+    expect(config.embedding.enabled).toBe(true);
+    expect(config.embedding.batchSize).toBe(10);
+    expect(config.embedding.configError).toBeUndefined();
+  });
+
+  it("preserves a valid provider-specific override", () => {
+    const config = parseConfig({
+      embedding: { ...validRemoteEmbedding, batchSize: 256 },
+    });
+
+    expect(config.embedding.enabled).toBe(true);
+    expect(config.embedding.batchSize).toBe(256);
+  });
+
+  it.each([0, 1.5, 2049])("disables embedding for invalid batchSize %s", (batchSize) => {
+    const config = parseConfig({
+      embedding: { ...validRemoteEmbedding, batchSize },
+    });
+
+    expect(config.embedding.enabled).toBe(false);
+    expect(config.embedding.batchSize).toBe(10);
+    expect(config.embedding.configError).toContain("batchSize must be an integer between 1 and 2048");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,8 @@ export interface EmbeddingConfig {
   maxInputChars: number;
   /** Timeout per embedding API call in milliseconds (default: 10000). */
   timeoutMs: number;
+  /** Maximum texts per remote embedding request (default: 10). */
+  batchSize: number;
   /** Override timeoutMs for recall-path embedding calls (user-facing, should be shorter). Falls back to timeoutMs. */
   recallTimeoutMs?: number;
   /** Override timeoutMs for capture-path embedding calls (background L1 dedup, can be longer). Falls back to timeoutMs. */
@@ -375,6 +377,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
   const embeddingProviderRaw = str(embeddingGroup, "provider") ?? "none";
   const embeddingModelRaw = str(embeddingGroup, "model") ?? "";
   const embeddingDimensionsRaw = num(embeddingGroup, "dimensions");
+  const embeddingBatchSizeRaw = num(embeddingGroup, "batchSize");
   const embeddingProxyUrl = str(embeddingGroup, "proxyUrl");
 
   // provider="none" → embedding disabled (default for zero-config users)
@@ -436,6 +439,18 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     } else {
       embeddingProvider = embeddingProviderRaw;
     }
+  }
+
+  const embeddingBatchSize = embeddingBatchSizeRaw ?? 10;
+  if (
+    embeddingProvider !== "none"
+    && (!Number.isInteger(embeddingBatchSize) || embeddingBatchSize < 1 || embeddingBatchSize > 2048)
+  ) {
+    const errorMsg =
+      `Embedding batchSize must be an integer between 1 and 2048; received ${embeddingBatchSize}. `
+      + "Embedding has been disabled.";
+    embeddingConfigError = embeddingConfigError ? `${embeddingConfigError} ${errorMsg}` : errorMsg;
+    embeddingEnabled = false;
   }
 
   // When provider="none", dimensions=0 signals VectorStore to skip vec0 table
@@ -548,6 +563,9 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       proxyUrl: embeddingProxyUrl,
       maxInputChars: num(embeddingGroup, "maxInputChars") ?? 5000,
       timeoutMs: num(embeddingGroup, "timeoutMs") ?? 10_000,
+      batchSize: Number.isInteger(embeddingBatchSize) && embeddingBatchSize >= 1 && embeddingBatchSize <= 2048
+        ? embeddingBatchSize
+        : 10,
       recallTimeoutMs: num(embeddingGroup, "recallTimeoutMs") ?? undefined,
       captureTimeoutMs: num(embeddingGroup, "captureTimeoutMs") ?? undefined,
       modelCacheDir: optStr(embeddingGroup, "modelCacheDir"),

--- a/src/core/store/embedding.test.ts
+++ b/src/core/store/embedding.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OpenAIEmbeddingService } from "./embedding.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createService(batchSize?: number): OpenAIEmbeddingService {
+  return new OpenAIEmbeddingService({
+    provider: "dashscope",
+    baseUrl: "https://dashscope.example/v1",
+    apiKey: "test-key",
+    model: "text-embedding-v4",
+    dimensions: 2,
+    sendDimensions: false,
+    batchSize,
+  });
+}
+
+function stubEmbeddingApi(batchSizes: number[]): void {
+  vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as { input: string[] };
+    batchSizes.push(body.input.length);
+    if (body.input.length > 10) {
+      return new Response("batch size is invalid", { status: 400, statusText: "Bad Request" });
+    }
+    return Response.json({
+      data: body.input.map((_text, index) => ({ index, embedding: [index + 1, 1] })),
+    });
+  }));
+}
+
+describe("OpenAIEmbeddingService remote batching", () => {
+  it("keeps every default request within the DashScope limit", async () => {
+    const batchSizes: number[] = [];
+    stubEmbeddingApi(batchSizes);
+
+    const embeddings = await createService().embedBatch(
+      Array.from({ length: 21 }, (_value, index) => `text-${index}`),
+    );
+
+    expect(batchSizes).toEqual([10, 10, 1]);
+    expect(embeddings).toHaveLength(21);
+  });
+
+  it("allows an explicit larger limit for providers that support it", async () => {
+    const batchSizes: number[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { input: string[] };
+      batchSizes.push(body.input.length);
+      return Response.json({
+        data: body.input.map((_text, index) => ({ index, embedding: [index + 1, 1] })),
+      });
+    }));
+
+    await createService(256).embedBatch(Array.from({ length: 11 }, (_, index) => `text-${index}`));
+
+    expect(batchSizes).toEqual([11]);
+  });
+
+  it.each([0, 1.5, 2049])("rejects invalid batchSize %s", (batchSize) => {
+    expect(() => createService(batchSize)).toThrow(/batchSize must be an integer between 1 and 2048/);
+  });
+});

--- a/src/core/store/embedding.ts
+++ b/src/core/store/embedding.ts
@@ -43,6 +43,8 @@ export interface OpenAIEmbeddingConfig {
   maxInputChars?: number;
   /** Timeout per API call in milliseconds (default: 10000). */
   timeoutMs?: number;
+  /** Maximum texts sent in one remote request (default: 10, maximum: 2048). */
+  batchSize?: number;
 }
 
 export interface LocalEmbeddingConfig {
@@ -362,8 +364,20 @@ export class LocalEmbeddingService implements EmbeddingService {
 // OpenAI-compatible implementation
 // ============================
 
-/** Max texts per batch (OpenAI limit is 2048, we use a safe value) */
-const MAX_BATCH_SIZE = 256;
+/** DashScope-compatible endpoints reject more than 10 texts per request. */
+const DEFAULT_REMOTE_BATCH_SIZE = 10;
+/** OpenAI's documented upper bound; prevents accidental unbounded requests. */
+const MAX_REMOTE_BATCH_SIZE = 2048;
+
+function normalizeRemoteBatchSize(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_REMOTE_BATCH_SIZE;
+  if (!Number.isInteger(value) || value < 1 || value > MAX_REMOTE_BATCH_SIZE) {
+    throw new Error(
+      `EmbeddingService: batchSize must be an integer between 1 and ${MAX_REMOTE_BATCH_SIZE}`,
+    );
+  }
+  return value;
+}
 
 /**
  * Max retries for embedding API calls (transient errors: network, 429, DNS).
@@ -507,6 +521,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
   private readonly proxyUrl?: string;
   private readonly maxInputChars?: number;
   private readonly timeoutMs: number;
+  private readonly batchSize: number;
   private readonly logger?: Logger;
 
   constructor(config: OpenAIEmbeddingConfig, logger?: Logger) {
@@ -531,6 +546,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
     this.proxyUrl = config.proxyUrl?.trim() || undefined;
     this.maxInputChars = config.maxInputChars && config.maxInputChars > 0 ? config.maxInputChars : undefined;
     this.timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_API_TIMEOUT_MS;
+    this.batchSize = normalizeRemoteBatchSize(config.batchSize);
     this.logger = logger;
   }
 
@@ -566,10 +582,10 @@ export class OpenAIEmbeddingService implements EmbeddingService {
       : texts;
 
     // Split into sub-batches if needed
-    if (processedTexts.length > MAX_BATCH_SIZE) {
+    if (processedTexts.length > this.batchSize) {
       const results: Float32Array[] = [];
-      for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
-        const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
+      for (let i = 0; i < processedTexts.length; i += this.batchSize) {
+        const chunk = processedTexts.slice(i, i + this.batchSize);
         const chunkResults = await this._callApi(chunk, options?.timeoutMs);
         results.push(...chunkResults);
       }
@@ -665,6 +681,7 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
   private readonly sendDimensions: boolean;
   private readonly maxInputChars?: number;
   private readonly timeoutMs: number;
+  private readonly batchSize: number;
   private readonly logger?: Logger;
 
   constructor(config: OpenAIEmbeddingConfig, logger?: Logger) {
@@ -687,6 +704,7 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
     this.sendDimensions = config.sendDimensions ?? true;
     this.maxInputChars = config.maxInputChars && config.maxInputChars > 0 ? config.maxInputChars : undefined;
     this.timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_API_TIMEOUT_MS;
+    this.batchSize = normalizeRemoteBatchSize(config.batchSize);
     this.logger = logger;
   }
 
@@ -718,10 +736,10 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
 
     const processedTexts = truncateEmbeddingInputs(texts, this.maxInputChars, this.logger);
 
-    if (processedTexts.length > MAX_BATCH_SIZE) {
+    if (processedTexts.length > this.batchSize) {
       const results: Float32Array[] = [];
-      for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
-        const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
+      for (let i = 0; i < processedTexts.length; i += this.batchSize) {
+        const chunk = processedTexts.slice(i, i + this.batchSize);
         const chunkResults = await this._callApi(chunk, options?.timeoutMs);
         results.push(...chunkResults);
       }

--- a/src/core/store/factory.ts
+++ b/src/core/store/factory.ts
@@ -100,6 +100,7 @@ export function createStoreBundle(
           dimensions: config.embedding.dimensions,
           sendDimensions: config.embedding.sendDimensions,
           maxInputChars: config.embedding.maxInputChars,
+          batchSize: config.embedding.batchSize,
         }, logger);
       }
 


### PR DESCRIPTION
# fix(embedding): cap and configure remote request batches

## Description | 描述

修复 L0 后台 embedding 在 11–256 条文本时将过大批次直接发送到 DashScope/Tencent-compatible API，导致 HTTP 400 并丢失向量索引的问题。

- 远程 embedding 默认最大批次从 256 改为 10；
- 输入 21 条时稳定拆分为 `[10, 10, 1]`，并保留结果顺序；
- 新增 `embedding.batchSize` 配置（1–2048），确认服务端支持时可调大，避免对 OpenAI-compatible 服务造成不必要的吞吐损失；
- OpenAI-compatible 与 ZeroEntropy 路径使用同一配置约束；
- manifest、解析后配置和 store factory 完整透传。

## Related Issue | 关联 Issue

Closes #236

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

```text
vitest run src/core/store/embedding.test.ts
# 5 passed

vitest run src/config.embedding.test.ts
# 5 passed

vitest run
# 6 files, 77 tests passed (Node 24.14.0)

npm run build
# passed (Node 24.14.0)
```

客户端 4xx（除 429）仍不重试；该 PR 通过请求前分片消除已知的批次参数错误，不用无效重试掩盖配置错误。
