### PR TITLE
fix(offload): resolve OpenClaw compaction delegate from runtime paths

### DIFF
--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -67,6 +67,7 @@ import { SessionRegistry } from "./session-registry.js";
 import { reclaimOffloadData } from "./reclaimer.js";
 import { buildL3TriggerReport, reportL3Trigger } from "./state-reporter.js";
 import { resolveUserId, getUserIdSource } from "./user-id.js";
+import { resolveOpenClawDelegateCompactionToRuntime } from "./openclaw-runtime-delegate.js";
 
 // ─── Module-level state ──────────────────────────────────────────────────────
 // OpenClaw calls registerOffload() multiple times during lifecycle.
@@ -2164,39 +2165,7 @@ class OffloadContextEngine {
     }
     try {
       // Try delegating to runtime's built-in compaction first
-      let delegateFn: any;
-      try {
-        const { createRequire } = await import("node:module");
-        const globalRequire = createRequire("/usr/local/lib/node_modules/openclaw/");
-        const sdk = globalRequire("openclaw/plugin-sdk");
-        delegateFn = sdk.delegateCompactionToRuntime;
-        logger.debug?.(`[context-offload] compact: resolved via createRequire (global path)`);
-      } catch (e1) {
-        logger.debug?.(`[context-offload] compact: createRequire failed: ${e1}`);
-        try {
-          const paths = [
-            "/usr/local/lib/node_modules/openclaw/dist/plugin-sdk/index.js",
-            "/usr/lib/node_modules/openclaw/dist/plugin-sdk/index.js",
-          ];
-          for (const p of paths) {
-            try {
-              const sdk = await import(p);
-              delegateFn = sdk.delegateCompactionToRuntime;
-              logger.debug?.(`[context-offload] compact: resolved via absolute path: ${p}`);
-              break;
-            } catch (ep) {
-              logger.debug?.(`[context-offload] compact: absolute path failed: ${p} → ${ep}`);
-            }
-          }
-        } catch { /* ignore */ }
-        if (!delegateFn) {
-          try {
-            const sdk = await import("openclaw/plugin-sdk" as any);
-            delegateFn = sdk.delegateCompactionToRuntime;
-            logger.debug?.(`[context-offload] compact: resolved via direct import`);
-          } catch { /* ignore */ }
-        }
-      }
+      const delegateFn = await resolveOpenClawDelegateCompactionToRuntime(logger);
 
       if (typeof delegateFn === "function") {
         logger.debug?.(`[context-offload] compact: >>> delegateCompactionToRuntime START`);

--- a/src/offload/openclaw-runtime-delegate.test.ts
+++ b/src/offload/openclaw-runtime-delegate.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearOpenClawDelegateCacheForTests,
+  resolveOpenClawDelegateCompactionToRuntime,
+} from "./openclaw-runtime-delegate.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  clearOpenClawDelegateCacheForTests();
+  await Promise.all(tmpDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("resolveOpenClawDelegateCompactionToRuntime", () => {
+  it("resolves a CommonJS SDK from an explicit global module root", async () => {
+    const root = await writeFakeSdk("commonjs");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      moduleRoots: [join(root, "node_modules")],
+      includeDefaults: false,
+    });
+
+    await expect(delegate?.({ source: "test" })).resolves.toEqual({ compacted: true });
+  });
+
+  it("loads an ESM-only SDK through dynamic import", async () => {
+    const root = await writeFakeSdk("module");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      moduleRoots: [join(root, "node_modules")],
+      includeDefaults: false,
+    });
+
+    await expect(delegate?.({})).resolves.toEqual({ compacted: true });
+  });
+
+  it("derives the nvm global root from process.execPath", async () => {
+    const root = await writeFakeSdk("commonjs", "prefix/lib");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      execPath: join(root, "prefix", "bin", "node"),
+      env: {},
+      platform: "linux",
+    });
+
+    expect(delegate).toBeTypeOf("function");
+  });
+
+  it("resolves SDKs exposed through NODE_PATH", async () => {
+    const root = await writeFakeSdk("commonjs");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      env: { NODE_PATH: join(root, "node_modules") },
+      execPath: "",
+      platform: "linux",
+    });
+
+    expect(delegate).toBeTypeOf("function");
+  });
+
+  it("resolves the Windows npm global root under APPDATA", async () => {
+    const root = await writeFakeSdk("commonjs", "AppData/npm");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      env: { APPDATA: join(root, "AppData") },
+      execPath: "",
+      platform: "win32",
+    });
+
+    expect(delegate).toBeTypeOf("function");
+  });
+
+  it("continues after an invalid require base", async () => {
+    const root = await writeFakeSdk("commonjs");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      baseUrls: ["relative-path.cjs"],
+      moduleRoots: [join(root, "node_modules")],
+      includeDefaults: false,
+    });
+
+    expect(delegate).toBeTypeOf("function");
+  });
+
+  it("returns null when the SDK has no delegate export", async () => {
+    const root = await writeFakeSdk("missing");
+    const delegate = await resolveOpenClawDelegateCompactionToRuntime(undefined, {
+      moduleRoots: [join(root, "node_modules")],
+      includeDefaults: false,
+    });
+
+    expect(delegate).toBeNull();
+  });
+});
+
+async function writeFakeSdk(kind: "commonjs" | "module" | "missing", moduleParent = ""): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "tdai-openclaw-sdk-"));
+  tmpDirs.push(root);
+  const packageDir = join(root, moduleParent, "node_modules", "openclaw");
+  const entry = join(packageDir, "dist", "plugin-sdk", kind === "commonjs" ? "index.cjs" : "index.js");
+  await mkdir(dirname(entry), { recursive: true });
+  await writeFile(join(packageDir, "package.json"), JSON.stringify({
+    name: "openclaw",
+    type: kind === "commonjs" ? "commonjs" : "module",
+    exports: { "./plugin-sdk": `./dist/plugin-sdk/${kind === "commonjs" ? "index.cjs" : "index.js"}` },
+  }));
+  const source = kind === "commonjs"
+    ? "exports.delegateCompactionToRuntime = async () => ({ compacted: true });\n"
+    : kind === "module"
+      ? "export async function delegateCompactionToRuntime() { return { compacted: true }; }\n"
+      : "export const unrelated = true;\n";
+  await writeFile(entry, source);
+  return root;
+}

--- a/src/offload/openclaw-runtime-delegate.ts
+++ b/src/offload/openclaw-runtime-delegate.ts
@@ -1,0 +1,154 @@
+import { createRequire } from "node:module";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { PluginLogger } from "./types.js";
+
+export type DelegateCompactionToRuntime = (params: any) => Promise<any>;
+
+interface ResolveDelegateOptions {
+  baseUrls?: Array<string | URL>;
+  moduleRoots?: string[];
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  cwd?: string;
+  platform?: NodeJS.Platform;
+  includeDefaults?: boolean;
+}
+
+const SDK_SPECIFIER = "openclaw/plugin-sdk";
+let cachedDelegate: DelegateCompactionToRuntime | undefined;
+
+/** Resolve OpenClaw's native compaction bridge without assuming /usr/local. */
+export async function resolveOpenClawDelegateCompactionToRuntime(
+  logger?: PluginLogger,
+  options: ResolveDelegateOptions = {},
+): Promise<DelegateCompactionToRuntime | null> {
+  const useCache = Object.keys(options).length === 0;
+  if (useCache && cachedDelegate) return cachedDelegate;
+
+  const failures: string[] = [];
+  for (const baseUrl of buildRequireBases(options)) {
+    let requireFromBase: ReturnType<typeof createRequire>;
+    try {
+      requireFromBase = createRequire(baseUrl);
+    } catch (error) {
+      failures.push(`${String(baseUrl)}: ${formatResolveError(error)}`);
+      continue;
+    }
+    try {
+      const delegate = getDelegate(requireFromBase(SDK_SPECIFIER));
+      if (delegate) {
+        logger?.debug?.(`[context-offload] compact: resolved ${SDK_SPECIFIER} from ${String(baseUrl)}`);
+        if (useCache) cachedDelegate = delegate;
+        return delegate;
+      }
+      failures.push(`${String(baseUrl)}: export missing`);
+      continue;
+    } catch (error) {
+      try {
+        // ESM-only plugin SDKs cannot be loaded with require(). Resolve the
+        // exported entry with the same base, then load it through import().
+        const resolvedPath = requireFromBase.resolve(SDK_SPECIFIER);
+        const delegate = getDelegate(await import(pathToFileURL(resolvedPath).href));
+        if (delegate) {
+          logger?.debug?.(`[context-offload] compact: resolved ESM ${SDK_SPECIFIER} from ${resolvedPath}`);
+          if (useCache) cachedDelegate = delegate;
+          return delegate;
+        }
+        failures.push(`${String(baseUrl)}: ESM export missing`);
+      } catch (importError) {
+        failures.push(`${String(baseUrl)}: ${formatResolveError(importError ?? error)}`);
+      }
+    }
+  }
+
+  logger?.debug?.(
+    `[context-offload] compact: ${SDK_SPECIFIER} unavailable after ${failures.length} probe(s): ${failures.join("; ")}`,
+  );
+  // Do not cache misses: OpenClaw may finish loading its SDK after plugin init.
+  return null;
+}
+
+export function clearOpenClawDelegateCacheForTests(): void {
+  cachedDelegate = undefined;
+}
+
+function getDelegate(moduleValue: any): DelegateCompactionToRuntime | null {
+  const candidate = moduleValue?.delegateCompactionToRuntime
+    ?? moduleValue?.default?.delegateCompactionToRuntime;
+  return typeof candidate === "function" ? candidate : null;
+}
+
+function buildRequireBases(options: ResolveDelegateOptions): Array<string | URL> {
+  const values: Array<string | URL> = [...(options.baseUrls ?? [])];
+  if (options.includeDefaults !== false) {
+    values.push(import.meta.url, join(options.cwd ?? process.cwd(), "tdai-openclaw-resolver.cjs"));
+  }
+
+  for (const root of buildModuleRoots(options)) {
+    // A require created beside node_modules searches that module root. The
+    // package-local base also supports Node package self-reference exports.
+    values.push(
+      join(dirname(root), "tdai-openclaw-resolver.cjs"),
+      join(root, "openclaw", "package.json"),
+    );
+  }
+
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = String(value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildModuleRoots(options: ResolveDelegateOptions): string[] {
+  const roots = [...(options.moduleRoots ?? [])];
+  if (options.includeDefaults === false) return dedupePaths(roots);
+
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const execPath = options.execPath ?? process.execPath;
+
+  for (const entry of (env.NODE_PATH ?? "").split(delimiter)) {
+    if (entry.trim()) roots.push(entry.trim());
+  }
+
+  const prefixes = [env.npm_config_prefix, env.PREFIX].filter((value): value is string => !!value);
+  if (execPath) {
+    const execDir = dirname(resolve(execPath));
+    prefixes.push(platform === "win32" ? execDir : resolve(execDir, ".."));
+  }
+
+  for (const prefix of prefixes) {
+    roots.push(platform === "win32" ? join(prefix, "node_modules") : join(prefix, "lib", "node_modules"));
+  }
+
+  if (platform === "win32" && env.APPDATA) {
+    roots.push(join(env.APPDATA, "npm", "node_modules"));
+  } else if (platform !== "win32") {
+    roots.push("/usr/local/lib/node_modules", "/usr/lib/node_modules");
+  }
+
+  return dedupePaths(roots);
+}
+
+function dedupePaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  return paths.filter((value) => {
+    const key = resolve(value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function formatResolveError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const code = typeof (error as NodeJS.ErrnoException).code === "string"
+    ? `${(error as NodeJS.ErrnoException).code}: `
+    : "";
+  return `${code}${error.message}`;
+}


### PR DESCRIPTION
# fix(offload): resolve OpenClaw compaction delegate from runtime paths

## Description | 描述

修复 OpenClaw 通过 nvm、非系统 npm prefix 或 Windows global npm 路径安装时，`compact()` 无法解析 `delegateCompactionToRuntime` 而误降级到 self-emergency 压缩的问题。

新增独立 resolver，按以下来源解析 `openclaw/plugin-sdk`：

- 插件 bundle 和当前工作目录；
- `NODE_PATH`；
- `npm_config_prefix` / `PREFIX`；
- 从 `process.execPath` 推导的 nvm/global npm root；
- Windows `%APPDATA%/npm/node_modules`；
- Unix 常见 global npm root。

resolver 同时支持 CommonJS 和 ESM-only SDK，仅缓存成功结果；失败不缓存，避免插件初始化时序导致永久降级。所有探测均失败时，保留现有 self-emergency fallback。

## Related Issue | 关联 Issue

Closes #383

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

新增 7 个回归测试：CommonJS SDK、ESM-only SDK、nvm `process.execPath`、`NODE_PATH`、Windows `%APPDATA%` npm root、非法 require base 恢复，以及缺少 delegate 导出时保留 fallback。

```text
vitest run src/offload/openclaw-runtime-delegate.test.ts
# 7 passed

vitest run
# 5 files, 74 tests passed (Node 24.14.0)

npm run build
# passed (Node 24.14.0)
```

本 PR 不改动 fallback 压缩策略，不处理 `params.messages` 缺失等下游问题。
