### PR TITLE
ci(encoding): reject invalid UTF-8 and mojibake regressions

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -10,6 +10,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  encoding:
+    name: Encoding Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test encoding detector
+        run: npm run test:encoding
+
+      - name: Reject invalid UTF-8 and mojibake
+        run: npm run check:encoding
+
   # ── 1. Install dependencies ────────────────────────────────
   install:
     name: Install

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "check:encoding": "node scripts/check-text-encoding.mjs",
+    "test:encoding": "node --test scripts/check-text-encoding.test.mjs",
     "postinstall": "bash scripts/openclaw-after-tool-call-messages.patch.sh 2>/dev/null || true"
   },
   "files": [

--- a/scripts/check-text-encoding.mjs
+++ b/scripts/check-text-encoding.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { extname, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const TEXT_EXTENSIONS = new Set([
+  ".cjs", ".css", ".html", ".js", ".json", ".md", ".mjs", ".ps1",
+  ".py", ".sh", ".toml", ".ts", ".tsx", ".txt", ".xml", ".yaml", ".yml",
+]);
+const TEXT_FILENAMES = new Set([".editorconfig", ".gitattributes", ".gitignore", ".npmignore"]);
+
+// Signatures produced when UTF-8 punctuation/emoji is decoded through a
+// Windows legacy code page and written back as UTF-8. Keep this list narrow:
+// ordinary Chinese, accented Latin text, Japanese, and emoji must remain valid.
+const MOJIBAKE_PATTERNS = [
+  { name: "UTF-8 decoded as Windows-1252", regex: /(?:\u00e2\u20ac.|\u00e2\u2020.|\u00e2\u2030.|\u00f0\u0178..|\u00ef\u00bf\u00bd|\u00c3[\u0080-\u00bf])/gu },
+  { name: "UTF-8 decoded as a CJK legacy code page", regex: /(?:\u9225.|\u922b.|\u9983.|\u951f\u65a4\u62f7|\u9251.|\u9252.|\u9239.)/gu },
+];
+
+export function inspectTextBuffer(buffer, file = "<buffer>") {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+  } catch {
+    return [{ file, kind: "invalid-utf8", line: 1, column: 1, message: "file is not valid UTF-8" }];
+  }
+
+  const findings = [];
+  if (requiresUtf8Bom(file) && !hasUtf8Bom(buffer)) {
+    findings.push({
+      file,
+      kind: "missing-utf8-bom",
+      line: 1,
+      column: 1,
+      message: "PowerShell scripts must use UTF-8 with BOM",
+    });
+  }
+
+  for (const pattern of MOJIBAKE_PATTERNS) {
+    pattern.regex.lastIndex = 0;
+    for (const match of text.matchAll(pattern.regex)) {
+      const { line, column } = lineAndColumn(text, match.index ?? 0);
+      findings.push({
+        file,
+        kind: "mojibake",
+        line,
+        column,
+        message: `${pattern.name} signature ${JSON.stringify(match[0])}`,
+      });
+    }
+  }
+
+  let replacementIndex = text.indexOf("\uFFFD");
+  while (replacementIndex !== -1) {
+    const { line, column } = lineAndColumn(text, replacementIndex);
+    findings.push({ file, kind: "replacement-character", line, column, message: "contains U+FFFD replacement character" });
+    replacementIndex = text.indexOf("\uFFFD", replacementIndex + 1);
+  }
+  return findings;
+}
+
+export function isTextPath(file) {
+  const normalized = file.replaceAll("\\", "/");
+  const name = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return TEXT_FILENAMES.has(name) || TEXT_EXTENSIONS.has(extname(name).toLowerCase());
+}
+
+function requiresUtf8Bom(file) {
+  return extname(file.replaceAll("\\", "/")).toLowerCase() === ".ps1";
+}
+
+function hasUtf8Bom(buffer) {
+  return buffer.length >= 3 && buffer[0] === 0xef && buffer[1] === 0xbb && buffer[2] === 0xbf;
+}
+
+async function main() {
+  const root = process.cwd();
+  const requested = process.argv.slice(2);
+  const files = requested.length > 0 ? requested : trackedFiles(root);
+  const findings = [];
+
+  for (const file of files.filter(isTextPath)) {
+    const absolute = resolve(root, file);
+    findings.push(...inspectTextBuffer(await readFile(absolute), relative(root, absolute).replaceAll("\\", "/")));
+  }
+
+  if (findings.length === 0) {
+    console.log(`Encoding check passed (${files.filter(isTextPath).length} tracked text files).`);
+    return;
+  }
+
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line}:${finding.column}: ${finding.message}`);
+    if (process.env.GITHUB_ACTIONS) {
+      console.error(`::error file=${escapeAnnotation(finding.file)},line=${finding.line},col=${finding.column}::${escapeAnnotation(finding.message)}`);
+    }
+  }
+  process.exitCode = 1;
+}
+
+function trackedFiles(root) {
+  const result = spawnSync("git", ["ls-files", "-z"], { cwd: root, encoding: "buffer" });
+  if (result.status !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr.toString("utf8").trim()}`);
+  }
+  return result.stdout.toString("utf8").split("\0").filter(Boolean);
+}
+
+function lineAndColumn(text, index) {
+  const prefix = text.slice(0, index);
+  const line = prefix.split("\n").length;
+  const lastNewline = prefix.lastIndexOf("\n");
+  return { line, column: index - lastNewline };
+}
+
+function escapeAnnotation(value) {
+  return String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/check-text-encoding.test.mjs
+++ b/scripts/check-text-encoding.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { inspectTextBuffer, isTextPath } from "./check-text-encoding.mjs";
+
+const utf8 = (value) => Buffer.from(value, "utf8");
+
+test("accepts intentional multilingual UTF-8", () => {
+  const findings = inspectTextBuffer(utf8("中文，日本語, café — arrows → and emoji 🚀\n"));
+  assert.deepEqual(findings, []);
+});
+
+test("reports Windows-1252 mojibake at its source position", () => {
+  const findings = inspectTextBuffer(utf8("first line\nbroken \u00e2\u20ac\u201d punctuation\n"), "sample.md");
+  assert.equal(findings.length, 1);
+  assert.deepEqual(
+    { kind: findings[0].kind, line: findings[0].line, column: findings[0].column },
+    { kind: "mojibake", line: 2, column: 8 },
+  );
+});
+
+test("reports common Chinese-code-page mojibake", () => {
+  const findings = inspectTextBuffer(utf8("L0\u922b\u62611 and \u9225?quoted"), "sample.ts");
+  assert.equal(findings.length, 2);
+  assert.ok(findings.every((finding) => finding.kind === "mojibake"));
+});
+
+test("rejects malformed UTF-8 bytes", () => {
+  const findings = inspectTextBuffer(Buffer.from([0x66, 0x6f, 0x80]), "bad.py");
+  assert.equal(findings[0].kind, "invalid-utf8");
+});
+
+test("reports replacement characters left by a lossy decode", () => {
+  const findings = inspectTextBuffer(utf8("already replaced: \uFFFD"), "lossy.md");
+  assert.equal(findings[0].kind, "replacement-character");
+});
+
+test("accepts an explicit UTF-8 BOM", () => {
+  const findings = inspectTextBuffer(Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    utf8("PowerShell UTF-8 BOM — 中文\n"),
+  ]), "harden.ps1");
+  assert.deepEqual(findings, []);
+});
+
+test("requires UTF-8 BOM for PowerShell scripts", () => {
+  const findings = inspectTextBuffer(utf8("Write-Host '中文 — ok'\n"), "scripts/harden.ps1");
+  assert.equal(findings[0].kind, "missing-utf8-bom");
+});
+
+test("limits repository scanning to known text formats", () => {
+  assert.equal(isTextPath("src/index.ts"), true);
+  assert.equal(isTextPath(".gitattributes"), true);
+  assert.equal(isTextPath("assets/logo.png"), false);
+});


### PR DESCRIPTION
# ci(encoding): reject invalid UTF-8 and mojibake regressions

## Description | 描述

为受版本控制的文本文件增加可测试的编码守卫，防止 PowerShell/旧代码页链路产生的静默乱码进入仓库。

- 使用 fatal UTF-8 decoder 拒绝非 UTF-8 字节；
- 检测 U+FFFD 替换字符；
- 要求 PowerShell `.ps1` 使用 UTF-8 BOM，覆盖 issue 中的 L1 防线；
- 精确识别 Windows-1252 和中文旧代码页的常见乱码特征；
- 仅扫描 `git ls-files` 返回的已跟踪文本文件，不误扫二进制资产和本地产物；
- GitHub Actions 输出文件、行、列注解，可直接定位问题。

检测器允许正常中文、日文、重音拉丁字符和 emoji，避免“禁止所有非 ASCII”造成的误报。

## Related Issue | 关联 Issue

Closes #387

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

本地验证：

```text
node --test scripts/check-text-encoding.test.mjs
# 8 passed

node scripts/check-text-encoding.mjs
# Encoding check passed (162 tracked text files).

vitest run
# 4 files, 67 tests passed (Node 24.14.0)

npm run build
# passed (Node 24.14.0)
```

该 PR 仅增加编码检测与 CI 接入，不包含适配器、SDK 或其他功能改动。
