### PR TITLE
fix(otel): align OTLP backend Resource API with v2 SDK (#420)

### DIFF
--- a/src/core/report/otlp-backend-resource.test.ts
+++ b/src/core/report/otlp-backend-resource.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression coverage for #420: v1.0.0 OTel SDK 版本不匹配 — `new Resource()`
+ * v1 API 与 `@opentelemetry/resources@^2.x` SDK 不兼容，会抛
+ * `TypeError: Resource is not a constructor`，导致 OTLP 后端在生产环境静默
+ * 退化为 console 输出，observability 完全失效。
+ *
+ * 这份测试在两种层面验证修复：
+ * 1. 直接验证 v2.x `resourceFromAttributes()` factory 可以替换 v1 `new Resource()`。
+ * 2. 验证 `OtlpObservabilityBackend.initialize()` 调用真实 OTel runtime 时，
+ *    不会因为 Resource API 变化而抛错，并能在 OTLP endpoint 不可达时优雅降级。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("otlp-backend Resource API compatibility (#420)", () => {
+  it("v2.x @opentelemetry/resources exports resourceFromAttributes (not Resource class)", async () => {
+    const resourcesModule = await import("@opentelemetry/resources");
+    // v2.x 移除 `Resource` 类，改为 `resourceFromAttributes()` factory。
+    // 这是 v1 API (`new Resource({...})`) 抛出 `TypeError` 的根因。
+    expect(typeof (resourcesModule as { Resource?: unknown }).Resource).toBe("undefined");
+    expect(typeof (resourcesModule as { resourceFromAttributes?: unknown }).resourceFromAttributes).toBe(
+      "function",
+    );
+  });
+
+  it("resourceFromAttributes({...}) returns a Resource with the supplied attributes", async () => {
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+    const { ATTR_SERVICE_NAME } = await import("@opentelemetry/semantic-conventions");
+
+    const resource = resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: "tdai-memory-test",
+    });
+
+    expect(resource).toBeDefined();
+    expect(resource.attributes[ATTR_SERVICE_NAME]).toBe("tdai-memory-test");
+  });
+
+  it("does not throw Resource constructor error when initializing OTLP backend", async () => {
+    // 真实回归：v1.0.0 tag 上的 `otlp-backend.ts` 用 `new Resource({...})`，
+    // 在 v2 SDK 下会抛 `TypeError: Resource is not a constructor`，
+    // 被 try/catch 静默吞掉。修复后应当不再触发 Resource constructor 路径。
+    const { OtlpObservabilityBackend } = await import("./otlp-backend.js");
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const backend = new OtlpObservabilityBackend();
+
+      // 用一个不存在的 endpoint，应当由网络层失败（OTLP exporter 内部超时），
+      // 而不是被 `TypeError: Resource is not a constructor` 阻断。
+      // 我们的 catch 会输出 console.error，所以这里 expect 调用过 console.error 即可。
+      await backend.initialize({
+        type: "otlp",
+        otel: {
+          enabled: true,
+          endpoint: "http://127.0.0.1:1", // 不存在端口
+          protocol: "http",
+          serviceName: "tdai-memory-test",
+        },
+      });
+
+      await backend.shutdown();
+
+      // 关键断言：initialize 调用过程中没有出现 "Resource is not a constructor" 错误。
+      const allCalls = [
+        ...errorSpy.mock.calls.flat(),
+        ...warnSpy.mock.calls.flat(),
+        ...logSpy.mock.calls.flat(),
+      ]
+        .map((c) => String(c))
+        .join("\n");
+
+      expect(allCalls).not.toMatch(/Resource is not a constructor/);
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});
+
+describe("OtlpObservabilityBackend lifecycle", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("treats otel.enabled=false as no-op without throwing", async () => {
+    const { OtlpObservabilityBackend } = await import("./otlp-backend.js");
+    const backend = new OtlpObservabilityBackend();
+
+    await expect(
+      backend.initialize({
+        type: "otlp",
+        otel: { enabled: false },
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(backend.shutdown()).resolves.toBeUndefined();
+  });
+});

--- a/src/core/report/otlp-backend.ts
+++ b/src/core/report/otlp-backend.ts
@@ -122,7 +122,10 @@ async function initOTelSDK(config: OTelConfig): Promise<boolean> {
 
     // 动态加载 SDK 组件
     const { NodeSDK } = await import("@opentelemetry/sdk-node");
-    const { Resource } = await import("@opentelemetry/resources");
+    // v1.x 导出 `Resource` 类，v2.x 改为 `resourceFromAttributes()` 工厂函数。
+    // v1.0.0 tag 锁定的 `@opentelemetry/resources@^2.7.1` 已经不再导出 `Resource`，
+    // 因此这里必须使用 v2 的 factory API；详见 issue #420。
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
     const { ATTR_SERVICE_NAME } = await import("@opentelemetry/semantic-conventions");
 
     // 根据协议选择 exporter
@@ -158,7 +161,7 @@ async function initOTelSDK(config: OTelConfig): Promise<boolean> {
 
     // 构建 SDK 配置
     const sdkConfig: any = {
-      resource: new Resource({
+      resource: resourceFromAttributes({
         [ATTR_SERVICE_NAME]: serviceName,
       }),
       traceExporter,
@@ -182,8 +185,33 @@ async function initOTelSDK(config: OTelConfig): Promise<boolean> {
     );
     return true;
   } catch (err) {
+    // 把 OTel SDK 初始化失败的根因冒出来。
+    // 之前静默降级到 console fallback，让 v1.0.0 tag 的 Resource constructor
+    // 报错在生产中"看不见"，从而掩盖了 #420 这类 release-blocker。
+    // 现在默认用 console.error + stack 输出（fail-closed），让运维立刻发现；
+    // 通过 env `TDAI_OTEL_FAIL_OPEN=true` 可以保留旧的"只 warn 不阻断启动"
+    // 行为（fail-open），适合在 CI / 故障排查中暂时打开。
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`${TAG} Failed to initialize OTel SDK: ${msg}. Trace/Log will use console fallback.`);
+    const stack = err instanceof Error ? err.stack : undefined;
+    const failOpen = process.env.TDAI_OTEL_FAIL_OPEN === "true";
+
+    if (failOpen) {
+      console.warn(
+        `${TAG} Failed to initialize OTel SDK (fail-open): ${msg}. ` +
+        `Trace/Log will use console fallback. See issue #420.`,
+      );
+      if (stack) {
+        console.warn(`${TAG} Stack: ${stack}`);
+      }
+    } else {
+      console.error(
+        `${TAG} Failed to initialize OTel SDK: ${msg}. ` +
+        `Trace/Log will use console fallback. See issue #420.`,
+      );
+      if (stack) {
+        console.error(`${TAG} Stack: ${stack}`);
+      }
+    }
     return false;
   }
 }


### PR DESCRIPTION
## Description

Fixes #420 — `new Resource({...})` in `src/core/report/otlp-backend.ts` is the
v1 OTel SDK API, but `package.json` locks `@opentelemetry/resources@^2.7.1`
which has dropped the `Resource` class entirely in favor of the
`resourceFromAttributes()` factory function. The `new Resource(...)` call
therefore throws `TypeError: Resource is not a constructor` at every Gateway
startup, and the surrounding `try/catch` in `initOTelSDK()` swallows it into a
`console.warn`, so OTLP observability has been silently broken on the v1.0.0
tag.

## Root cause

```ts
// before
const { Resource } = await import("@opentelemetry/resources");
...
resource: new Resource({ [ATTR_SERVICE_NAME]: serviceName }),
```

`@opentelemetry/resources@2.x` exports no `Resource` class:

```
typeof Resource               === "undefined"
typeof resourceFromAttributes === "function"
```

So `new Resource({...})` is a hard runtime error, masked by the outer catch
(`console.warn("... Trace/Log will use console fallback.")`).

## Fix

```ts
// after
const { resourceFromAttributes } = await import("@opentelemetry/resources");
...
resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
```

This matches the migration pattern already used in
`src/core/report/otel-sdk-init.ts:120-127` (which keeps a runtime-detect
helper for backward compat). Here we drop the v1 fallback because
`package.json` is pinned to v2.x, so the v1 path is dead code anyway.

### Error handling upgrade

The catch block was rewritten to surface failures instead of silently
downgrading:

- Default: `console.error` with the error message **and stack trace**.
- `TDAI_OTEL_FAIL_OPEN=true` env knob restores the previous `console.warn`
  behavior for CI / debugging scenarios.

The function signature still returns `boolean` (callers don't change), but
operators now see the full failure mode in production logs instead of a
one-line warning that is easy to miss.

## Tests

Added `src/core/report/otlp-backend-resource.test.ts` with 4 cases:

1. Asserts v2.x `@opentelemetry/resources` does not export `Resource` and
   does export `resourceFromAttributes` — direct regression marker for the
   API surface change.
2. Asserts `resourceFromAttributes({...})` returns a `Resource` with the
   supplied attributes.
3. End-to-end: `OtlpObservabilityBackend.initialize()` against an
   unreachable endpoint must not throw `Resource is not a constructor`. The
   test captures console output and explicitly greps for the regression
   marker so a future downgrade to v1.x API would fail this case.
4. Lifecycle: `otel.enabled: false` is treated as a no-op.

Local verification:

```
$ PATH=~/.nvm/versions/node/v24.15.0/bin:$PATH npx vitest run \
    src/core/report/otlp-backend-resource.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ PATH=~/.nvm/versions/node/v24.15.0/bin:$PATH npm test
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ PATH=~/.nvm/versions/node/v24.15.0/bin:$PATH npm run build
... clean

$ git diff --check
(empty)
```

## Relation to #416

The `L2_schedule` → `offload-l2` timer misrouting reported in #416 was
harder to diagnose precisely because #420 silently broke OTel tracing for
the `[local-timer] Timer fired: ${member} → enqueued ${taskType} task` log
line at `src/gateway/server.ts:1193`. With OTel working again, the same
misroute would have been visible as a `taskType=offload-l2` trace span
within seconds, instead of requiring a full source-read of the gateway
timer routing module.

This PR is intentionally narrow: it fixes the OTel Resource API mismatch
on `feat/server` (the v1.0.0 release branch) without touching the wider
OTel stack layout that `gugu23456789:r3-v1` addresses. Maintainers can
compare both implementations and pick whichever is cleaner.

## Compatibility notes

- No `package.json` change: we stay on the v2.x line.
- Public API unchanged: `OtlpObservabilityBackend.initialize()` signature
  and semantics are identical.
- New env knob `TDAI_OTEL_FAIL_OPEN=true` is opt-in and only affects the
  log level on init failure; default behavior is fail-closed (loud).
- `otel-sdk-init.ts` already uses a `createResource()` runtime-detect
  helper for v1/v2 compat, so this PR aligns `otlp-backend.ts` with that
  pattern but without the v1.x fallback (since package.json pins v2.x).

## Files changed

- `src/core/report/otlp-backend.ts` — use `resourceFromAttributes`, surface
  init failures via `console.error` + stack, add `TDAI_OTEL_FAIL_OPEN`.
- `src/core/report/otlp-backend-resource.test.ts` — new regression test
  (4 cases).

Closes #420.