### PR TITLE
fix(search): sanitize FTS5 reserved operators in query building

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+  it("strips FTS5 operators before building an FTS query", () => {
+    const query = buildFtsQuery(
+      "alpha OR beta AND gamma NOT delta NEAR epsilon",
+    );
+
+    expect(query).toBe('"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -168,11 +168,56 @@ function getJieba(): JiebaInstance | null {
  * Kept small on purpose — only high-frequency function words.
  */
 const ZH_STOP_WORDS = new Set([
-  "的", "了", "在", "是", "我", "有", "和", "就", "不", "人", "都", "一",
-  "一个", "上", "也", "很", "到", "说", "要", "去", "你", "会", "着",
-  "没有", "看", "好", "自己", "这", "他", "她", "它", "们", "那",
-  "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
+  "的",
+  "了",
+  "在",
+  "是",
+  "我",
+  "有",
+  "和",
+  "就",
+  "不",
+  "人",
+  "都",
+  "一",
+  "一个",
+  "上",
+  "也",
+  "很",
+  "到",
+  "说",
+  "要",
+  "去",
+  "你",
+  "会",
+  "着",
+  "没有",
+  "看",
+  "好",
+  "自己",
+  "这",
+  "他",
+  "她",
+  "它",
+  "们",
+  "那",
+  "吗",
+  "吧",
+  "呢",
+  "啊",
+  "呀",
+  "哦",
+  "嗯",
 ]);
+
+function sanitizeFtsInput(raw: string): string {
+  return raw
+    .replace(/["'()]/g, " ")
+    .replace(/[*-]/g, " ")
+    .replace(/\b(?:AND|OR|NOT|NEAR)\b/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 /**
  * Build an FTS5 MATCH query from raw text.
@@ -196,6 +241,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = sanitizeFtsInput(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +249,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +264,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];
@@ -357,11 +403,11 @@ export class VectorStore implements IMemoryStore {
 
   // Prepared statements — L1 (initialized in init())
   private stmtUpsertMeta!: StatementSync;
-  private stmtDeleteVec?: StatementSync;   // optional — only set when vecTablesReady
-  private stmtInsertVec?: StatementSync;   // optional — only set when vecTablesReady
+  private stmtDeleteVec?: StatementSync; // optional — only set when vecTablesReady
+  private stmtInsertVec?: StatementSync; // optional — only set when vecTablesReady
   private stmtDeleteMeta!: StatementSync;
   private stmtGetMeta!: StatementSync;
-  private stmtSearchVec?: StatementSync;   // optional — only set when vecTablesReady
+  private stmtSearchVec?: StatementSync; // optional — only set when vecTablesReady
   private stmtQueryBySessionId!: StatementSync;
   private stmtQueryBySessionIdSince!: StatementSync;
   private stmtQueryBySessionKey!: StatementSync;
@@ -371,11 +417,11 @@ export class VectorStore implements IMemoryStore {
 
   // Prepared statements — L0 (initialized in init())
   private stmtL0UpsertMeta!: StatementSync;
-  private stmtL0DeleteVec?: StatementSync;   // optional — only set when vecTablesReady
-  private stmtL0InsertVec?: StatementSync;   // optional — only set when vecTablesReady
+  private stmtL0DeleteVec?: StatementSync; // optional — only set when vecTablesReady
+  private stmtL0InsertVec?: StatementSync; // optional — only set when vecTablesReady
   private stmtL0DeleteMeta!: StatementSync;
   private stmtL0GetMeta!: StatementSync;
-  private stmtL0SearchVec?: StatementSync;   // optional — only set when vecTablesReady
+  private stmtL0SearchVec?: StatementSync; // optional — only set when vecTablesReady
   /** L0 query for L1 runner: all messages for a session key */
   private stmtL0QueryAll!: StatementSync;
   /** L0 query for L1 runner: messages after a timestamp cursor */
@@ -436,7 +482,6 @@ export class VectorStore implements IMemoryStore {
     return this.degraded;
   }
 
-
   /**
    * Load sqlite-vec extension and initialize database schema.
    * Must be called once after construction.
@@ -458,10 +503,13 @@ export class VectorStore implements IMemoryStore {
       const message = err instanceof Error ? err.message : String(err);
       this.logger?.error(
         `${TAG} Failed to load sqlite-vec extension: ${message}. ` +
-        `VectorStore entering degraded mode — all operations will be no-ops.`,
+          `VectorStore entering degraded mode — all operations will be no-ops.`,
       );
       this.degraded = true;
-      return { needsReindex: false, reason: `sqlite-vec load failed: ${message}` };
+      return {
+        needsReindex: false,
+        reason: `sqlite-vec load failed: ${message}`,
+      };
     }
 
     // ── Schema creation & prepared statements ──────────────────────────────
@@ -473,7 +521,7 @@ export class VectorStore implements IMemoryStore {
       const message = err instanceof Error ? err.message : String(err);
       this.logger?.error(
         `${TAG} Schema initialization failed: ${message}. ` +
-        `VectorStore entering degraded mode.`,
+          `VectorStore entering degraded mode.`,
       );
       this.degraded = true;
       return { needsReindex: false, reason: `schema init failed: ${message}` };
@@ -484,7 +532,9 @@ export class VectorStore implements IMemoryStore {
    * Internal schema initialization — separated from init() so we can
    * catch errors at the top level and degrade gracefully.
    */
-  private initSchema(providerInfo?: EmbeddingProviderInfo): VectorStoreInitResult {
+  private initSchema(
+    providerInfo?: EmbeddingProviderInfo,
+  ): VectorStoreInitResult {
     // Tracks which provider/model/dimensions were used to generate vectors.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS embedding_meta (
@@ -507,14 +557,21 @@ export class VectorStore implements IMemoryStore {
 
         if (providerChanged || modelChanged || dimsChanged) {
           const reasons: string[] = [];
-          if (providerChanged) reasons.push(`provider: ${savedMeta.provider} → ${providerInfo.provider}`);
-          if (modelChanged) reasons.push(`model: ${savedMeta.model} → ${providerInfo.model}`);
-          if (dimsChanged) reasons.push(`dimensions: ${savedMeta.dimensions} → ${this.dimensions}`);
+          if (providerChanged)
+            reasons.push(
+              `provider: ${savedMeta.provider} → ${providerInfo.provider}`,
+            );
+          if (modelChanged)
+            reasons.push(`model: ${savedMeta.model} → ${providerInfo.model}`);
+          if (dimsChanged)
+            reasons.push(
+              `dimensions: ${savedMeta.dimensions} → ${this.dimensions}`,
+            );
           reindexReason = reasons.join(", ");
 
           this.logger?.info(
             `${TAG} Embedding config changed (${reindexReason}). ` +
-            `Dropping vector tables for rebuild...`,
+              `Dropping vector tables for rebuild...`,
           );
 
           // Drop and re-create vector tables with new dimensions
@@ -535,18 +592,22 @@ export class VectorStore implements IMemoryStore {
         if (l1Count > 0 || l0Count > 0) {
           this.logger?.info(
             `${TAG} No embedding_meta found but existing data exists ` +
-            `(L1=${l1Count}, L0=${l0Count}). Dropping vector tables for safety...`,
+              `(L1=${l1Count}, L0=${l0Count}). Dropping vector tables for safety...`,
           );
           this.dropVectorTables();
           needsReindex = true;
-          reindexReason = "legacy DB without embedding_meta — cannot verify vector compatibility";
-        } else if (existingVecDims !== null && existingVecDims !== this.dimensions) {
+          reindexReason =
+            "legacy DB without embedding_meta — cannot verify vector compatibility";
+        } else if (
+          existingVecDims !== null &&
+          existingVecDims !== this.dimensions
+        ) {
           // vec0 tables exist (from a previous provider="none" placeholder or
           // different config) but with mismatched dimensions.  Drop them so they
           // get re-created with the correct dimensions below.
           this.logger?.info(
             `${TAG} vec0 table dimension mismatch (existing=${existingVecDims}, ` +
-            `required=${this.dimensions}). Dropping vector tables for rebuild...`,
+              `required=${this.dimensions}). Dropping vector tables for rebuild...`,
           );
           this.dropVectorTables();
           // No needsReindex — there's no data to re-embed
@@ -577,15 +638,29 @@ export class VectorStore implements IMemoryStore {
 
     // Indexes for common queries
     this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_type ON l1_records(type)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_session_key ON l1_records(session_key)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_session_id ON l1_records(session_id)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_scene ON l1_records(scene_name)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_ts_start ON l1_records(timestamp_start)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_ts_end ON l1_records(timestamp_end)");
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_session_key ON l1_records(session_key)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_session_id ON l1_records(session_id)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_scene ON l1_records(scene_name)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_ts_start ON l1_records(timestamp_start)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_ts_end ON l1_records(timestamp_end)",
+    );
     // Composite index: session_id exact match + updated_time range scan (for incremental L2 queries)
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_session_updated ON l1_records(session_id, updated_time)");
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_session_updated ON l1_records(session_id, updated_time)",
+    );
     // Composite index: session_key exact match + updated_time range scan (for pipeline cursor queries)
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l1_sessionkey_updated ON l1_records(session_key, updated_time)");
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l1_sessionkey_updated ON l1_records(session_key, updated_time)",
+    );
 
     // Vector virtual table (cosine distance) — only created when dimensions > 0.
     // When provider="none", dimensions=0 and vec0 tables are deferred until a
@@ -620,10 +695,16 @@ export class VectorStore implements IMemoryStore {
     `);
 
     if (this.dimensions > 0) {
-      this.stmtDeleteVec = this.db.prepare("DELETE FROM l1_vec WHERE record_id = ?");
-      this.stmtInsertVec = this.db.prepare("INSERT INTO l1_vec (record_id, embedding, updated_time) VALUES (?, ?, ?)");
+      this.stmtDeleteVec = this.db.prepare(
+        "DELETE FROM l1_vec WHERE record_id = ?",
+      );
+      this.stmtInsertVec = this.db.prepare(
+        "INSERT INTO l1_vec (record_id, embedding, updated_time) VALUES (?, ?, ?)",
+      );
     }
-    this.stmtDeleteMeta = this.db.prepare("DELETE FROM l1_records WHERE record_id = ?");
+    this.stmtDeleteMeta = this.db.prepare(
+      "DELETE FROM l1_records WHERE record_id = ?",
+    );
 
     this.stmtGetMeta = this.db.prepare(`
       SELECT content, type, priority, scene_name, session_key, session_id,
@@ -658,17 +739,29 @@ export class VectorStore implements IMemoryStore {
 
     // Migration: add timestamp column if missing (existing DBs pre-v3.x)
     try {
-      this.db.exec("ALTER TABLE l0_conversations ADD COLUMN timestamp INTEGER DEFAULT 0");
-      this.logger?.debug?.(`${TAG} Migrated l0_conversations: added timestamp column`);
+      this.db.exec(
+        "ALTER TABLE l0_conversations ADD COLUMN timestamp INTEGER DEFAULT 0",
+      );
+      this.logger?.debug?.(
+        `${TAG} Migrated l0_conversations: added timestamp column`,
+      );
     } catch {
       // Column already exists — expected on non-first run
     }
 
     // Indexes for L0 queries
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_session ON l0_conversations(session_key)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_session_id ON l0_conversations(session_id)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_recorded ON l0_conversations(recorded_at)");
-    this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_timestamp ON l0_conversations(timestamp)");
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l0_session ON l0_conversations(session_key)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l0_session_id ON l0_conversations(session_id)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l0_recorded ON l0_conversations(recorded_at)",
+    );
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_l0_timestamp ON l0_conversations(timestamp)",
+    );
 
     // L0 vector virtual table (cosine distance, same dimensions as L1) — deferred when dimensions=0
     if (this.dimensions > 0) {
@@ -693,10 +786,16 @@ export class VectorStore implements IMemoryStore {
     `);
 
     if (this.dimensions > 0) {
-      this.stmtL0DeleteVec = this.db.prepare("DELETE FROM l0_vec WHERE record_id = ?");
-      this.stmtL0InsertVec = this.db.prepare("INSERT INTO l0_vec (record_id, embedding, recorded_at) VALUES (?, ?, ?)");
+      this.stmtL0DeleteVec = this.db.prepare(
+        "DELETE FROM l0_vec WHERE record_id = ?",
+      );
+      this.stmtL0InsertVec = this.db.prepare(
+        "INSERT INTO l0_vec (record_id, embedding, recorded_at) VALUES (?, ?, ?)",
+      );
     }
-    this.stmtL0DeleteMeta = this.db.prepare("DELETE FROM l0_conversations WHERE record_id = ?");
+    this.stmtL0DeleteMeta = this.db.prepare(
+      "DELETE FROM l0_conversations WHERE record_id = ?",
+    );
 
     this.stmtL0GetMeta = this.db.prepare(`
       SELECT session_key, session_id, role, message_text, recorded_at, timestamp
@@ -791,7 +890,9 @@ export class VectorStore implements IMemoryStore {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      this.stmtL1FtsDelete = this.db.prepare("DELETE FROM l1_fts WHERE record_id = ?");
+      this.stmtL1FtsDelete = this.db.prepare(
+        "DELETE FROM l1_fts WHERE record_id = ?",
+      );
 
       this.stmtL1FtsSearch = this.db.prepare(`
         SELECT record_id, content_original AS content, type, priority, scene_name,
@@ -810,7 +911,9 @@ export class VectorStore implements IMemoryStore {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      this.stmtL0FtsDelete = this.db.prepare("DELETE FROM l0_fts WHERE record_id = ?");
+      this.stmtL0FtsDelete = this.db.prepare(
+        "DELETE FROM l0_fts WHERE record_id = ?",
+      );
 
       this.stmtL0FtsSearch = this.db.prepare(`
         SELECT record_id, message_text_original AS message_text, session_key, session_id, role, recorded_at, timestamp,
@@ -822,7 +925,9 @@ export class VectorStore implements IMemoryStore {
       `);
 
       this.ftsAvailable = true;
-      this.logger?.debug?.(`${TAG} FTS5 tables initialized (l1_fts, l0_fts) [schema v2 — jieba segmented]`);
+      this.logger?.debug?.(
+        `${TAG} FTS5 tables initialized (l1_fts, l0_fts) [schema v2 — jieba segmented]`,
+      );
 
       // Rebuild FTS index if migrated from v1 or tables were freshly created
       if (needsFtsRebuild) {
@@ -833,7 +938,7 @@ export class VectorStore implements IMemoryStore {
       this.ftsAvailable = false;
       this.logger?.warn(
         `${TAG} FTS5 tables NOT available (fts5 may not be compiled in): ${message}. ` +
-        `FTS-based keyword search will be unavailable; recall will use in-memory scoring if needed.`,
+          `FTS-based keyword search will be unavailable; recall will use in-memory scoring if needed.`,
       );
     }
 
@@ -915,13 +1020,18 @@ export class VectorStore implements IMemoryStore {
   }
 
   private writeEmbeddingMeta(meta: EmbeddingMeta): void {
-    this.db.prepare(
-      "INSERT INTO embedding_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-    ).run("embedding_provider_info", JSON.stringify(meta));
+    this.db
+      .prepare(
+        "INSERT INTO embedding_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+      )
+      .run("embedding_provider_info", JSON.stringify(meta));
   }
 
   /** Allowed table names for row counting (whitelist to prevent SQL injection). */
-  private static readonly COUNTABLE_TABLES = new Set(["l1_records", "l0_conversations"]);
+  private static readonly COUNTABLE_TABLES = new Set([
+    "l1_records",
+    "l0_conversations",
+  ]);
 
   /**
    * Extra rows to retrieve from vec0 KNN search to compensate for legacy
@@ -934,7 +1044,9 @@ export class VectorStore implements IMemoryStore {
 
   private tableRowCount(table: string): number {
     if (!VectorStore.COUNTABLE_TABLES.has(table)) {
-      this.logger?.warn(`${TAG} tableRowCount: rejected unknown table name "${table}"`);
+      this.logger?.warn(
+        `${TAG} tableRowCount: rejected unknown table name "${table}"`,
+      );
       return 0;
     }
     try {
@@ -997,7 +1109,9 @@ export class VectorStore implements IMemoryStore {
    */
   upsertL1(record: MemoryRecord, embedding: Float32Array | undefined): boolean {
     if (this.degraded) {
-      this.logger?.warn(`${TAG} [L1-upsert] SKIPPED (degraded mode) id=${record.id}`);
+      this.logger?.warn(
+        `${TAG} [L1-upsert] SKIPPED (degraded mode) id=${record.id}`,
+      );
       return false;
     }
     try {
@@ -1012,16 +1126,17 @@ export class VectorStore implements IMemoryStore {
           ? timestamps.reduce((a, b) => (a > b ? a : b))
           : tsStr;
 
-      const skipVec = !embedding || embedding.every(v => v === 0) || !this.vecTablesReady;
+      const skipVec =
+        !embedding || embedding.every((v) => v === 0) || !this.vecTablesReady;
 
       this.logger?.debug?.(
         `${TAG} [L1-upsert] START id=${recordId}, type=${record.type}, ` +
-        `content="${record.content.slice(0, 60)}..."` +
-        (embedding
-          ? `, embeddingDims=${embedding.length}, ` +
-            `embeddingNorm=${Math.sqrt(Array.from(embedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}` +
-            `${skipVec ? " (ZERO VECTOR or vec tables not ready — vec write will be skipped)" : ""}`
-          : " (no embedding — metadata-only write)"),
+          `content="${record.content.slice(0, 60)}..."` +
+          (embedding
+            ? `, embeddingDims=${embedding.length}, ` +
+              `embeddingNorm=${Math.sqrt(Array.from(embedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}` +
+              `${skipVec ? " (ZERO VECTOR or vec tables not ready — vec write will be skipped)" : ""}`
+            : " (no embedding — metadata-only write)"),
       );
 
       this.db.exec("BEGIN");
@@ -1046,7 +1161,11 @@ export class VectorStore implements IMemoryStore {
         if (!skipVec) {
           // vec0 does not support ON CONFLICT → delete then insert
           this.stmtDeleteVec!.run(recordId);
-          this.stmtInsertVec!.run(recordId, Buffer.from(embedding!.buffer), record.updatedAt);
+          this.stmtInsertVec!.run(
+            recordId,
+            Buffer.from(embedding!.buffer),
+            record.updatedAt,
+          );
         } else {
           this.logger?.debug?.(
             `${TAG} [L1-upsert] Skipping vec write (${embedding ? "zero vector" : "no embedding"}) id=${recordId}`,
@@ -1059,7 +1178,7 @@ export class VectorStore implements IMemoryStore {
             this.stmtL1FtsDelete.run(recordId);
             this.stmtL1FtsInsert.run(
               tokenizeForFts(record.content), // content — segmented for indexing
-              record.content,                 // content_original — raw for display
+              record.content, // content_original — raw for display
               recordId,
               record.type,
               record.priority,
@@ -1083,10 +1202,14 @@ export class VectorStore implements IMemoryStore {
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
-      this.logger?.debug?.(`${TAG} [L1-upsert] OK id=${recordId}${skipVec ? " (meta-only)" : ""}`);
+      this.logger?.debug?.(
+        `${TAG} [L1-upsert] OK id=${recordId}${skipVec ? " (meta-only)" : ""}`,
+      );
       return true;
     } catch (err) {
       this.logger?.warn(
@@ -1105,7 +1228,8 @@ export class VectorStore implements IMemoryStore {
    */
   searchL1Vector(queryEmbedding: Float32Array, topK = 5): VectorSearchResult[] {
     if (this.degraded || !this.vecTablesReady) {
-      if (this.degraded) this.logger?.warn(`${TAG} [L1-search] SKIPPED (degraded mode)`);
+      if (this.degraded)
+        this.logger?.warn(`${TAG} [L1-search] SKIPPED (degraded mode)`);
       return [];
     }
     try {
@@ -1121,8 +1245,8 @@ export class VectorStore implements IMemoryStore {
 
       this.logger?.debug?.(
         `${TAG} [L1-search] START topK=${topK}, retrieveCount=${retrieveCount}, ` +
-        `queryEmbeddingDims=${queryEmbedding.length}, ` +
-        `queryNorm=${Math.sqrt(Array.from(queryEmbedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}`,
+          `queryEmbeddingDims=${queryEmbedding.length}, ` +
+          `queryNorm=${Math.sqrt(Array.from(queryEmbedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}`,
       );
 
       const rows = this.stmtSearchVec!.all(
@@ -1130,7 +1254,9 @@ export class VectorStore implements IMemoryStore {
         retrieveCount,
       ) as Array<{ record_id: string; distance: number }>;
 
-      this.logger?.debug?.(`${TAG} [L1-search] vec0 returned ${rows.length} candidate(s)`);
+      this.logger?.debug?.(
+        `${TAG} [L1-search] vec0 returned ${rows.length} candidate(s)`,
+      );
 
       if (rows.length === 0) return [];
 
@@ -1162,14 +1288,16 @@ export class VectorStore implements IMemoryStore {
           | undefined;
 
         if (!meta) {
-          this.logger?.warn(`${TAG} [L1-search] record_id=${record_id} has vector but NO metadata (orphan)`);
+          this.logger?.warn(
+            `${TAG} [L1-search] record_id=${record_id} has vector but NO metadata (orphan)`,
+          );
           continue;
         }
 
         const score = 1.0 - distance;
         this.logger?.debug?.(
           `${TAG} [L1-search] HIT id=${record_id}, distance=${distance.toFixed(4)}, score=${score.toFixed(4)}, ` +
-          `type=${meta.type}, content="${meta.content.slice(0, 60)}..."`,
+            `type=${meta.type}, content="${meta.content.slice(0, 60)}..."`,
         );
 
         results.push({
@@ -1215,13 +1343,19 @@ export class VectorStore implements IMemoryStore {
         this.stmtDeleteMeta.run(recordId);
         if (this.vecTablesReady) this.stmtDeleteVec!.run(recordId);
         if (this.ftsAvailable) {
-          try { this.stmtL1FtsDelete.run(recordId); } catch { /* non-fatal */ }
+          try {
+            this.stmtL1FtsDelete.run(recordId);
+          } catch {
+            /* non-fatal */
+          }
         }
         this.db.exec("COMMIT");
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
       return true;
@@ -1249,14 +1383,20 @@ export class VectorStore implements IMemoryStore {
           this.stmtDeleteMeta.run(id);
           if (this.vecTablesReady) this.stmtDeleteVec!.run(id);
           if (this.ftsAvailable) {
-            try { this.stmtL1FtsDelete.run(id); } catch { /* non-fatal */ }
+            try {
+              this.stmtL1FtsDelete.run(id);
+            } catch {
+              /* non-fatal */
+            }
           }
         }
         this.db.exec("COMMIT");
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
       return true;
@@ -1283,22 +1423,24 @@ export class VectorStore implements IMemoryStore {
       return 0;
     }
     try {
-      const row = this.db.prepare(
-        "SELECT COUNT(*) AS cnt FROM l1_records WHERE updated_time != '' AND updated_time < ?",
-      ).get(cutoffIso) as { cnt: number } | undefined;
+      const row = this.db
+        .prepare(
+          "SELECT COUNT(*) AS cnt FROM l1_records WHERE updated_time != '' AND updated_time < ?",
+        )
+        .get(cutoffIso) as { cnt: number } | undefined;
       const expiredCount = row?.cnt ?? 0;
       if (expiredCount <= 0) return 0;
 
       // Ratio protection: refuse to delete > 80% in one pass
-      const totalRow = this.db.prepare(
-        "SELECT COUNT(*) AS cnt FROM l1_records",
-      ).get() as { cnt: number };
+      const totalRow = this.db
+        .prepare("SELECT COUNT(*) AS cnt FROM l1_records")
+        .get() as { cnt: number };
       const total = totalRow.cnt;
       const ratio = total > 0 ? expiredCount / total : 0;
       if (ratio > 0.8) {
         this.logger?.warn(
           `${TAG} [L1-deleteExpired] BLOCKED: would delete ${expiredCount}/${total} ` +
-          `(${(ratio * 100).toFixed(1)}%) — exceeds 80% safety threshold, cutoff=${cutoffIso}`,
+            `(${(ratio * 100).toFixed(1)}%) — exceeds 80% safety threshold, cutoff=${cutoffIso}`,
         );
         return 0;
       }
@@ -1306,13 +1448,17 @@ export class VectorStore implements IMemoryStore {
       this.db.exec("BEGIN");
       try {
         if (this.vecTablesReady) {
-          this.db.prepare(
-            "DELETE FROM l1_vec WHERE updated_time != '' AND updated_time < ?",
-          ).run(cutoffIso);
+          this.db
+            .prepare(
+              "DELETE FROM l1_vec WHERE updated_time != '' AND updated_time < ?",
+            )
+            .run(cutoffIso);
         }
-        this.db.prepare(
-          "DELETE FROM l1_records WHERE updated_time != '' AND updated_time < ?",
-        ).run(cutoffIso);
+        this.db
+          .prepare(
+            "DELETE FROM l1_records WHERE updated_time != '' AND updated_time < ?",
+          )
+          .run(cutoffIso);
         this.db.exec("COMMIT");
         this.logger?.info?.(
           `${TAG} [L1-deleteExpired] Deleted ${expiredCount}/${total} records (cutoff=${cutoffIso})`,
@@ -1321,7 +1467,9 @@ export class VectorStore implements IMemoryStore {
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
     } catch (err) {
@@ -1371,15 +1519,30 @@ export class VectorStore implements IMemoryStore {
 
       // Priority: sessionId > sessionKey (sessionId is more specific)
       if (sessionId && updatedAfter) {
-        raw = this.stmtQueryBySessionIdSince.all(sessionId, updatedAfter) as Record<string, unknown>[];
+        raw = this.stmtQueryBySessionIdSince.all(
+          sessionId,
+          updatedAfter,
+        ) as Record<string, unknown>[];
       } else if (sessionId) {
-        raw = this.stmtQueryBySessionId.all(sessionId) as Record<string, unknown>[];
+        raw = this.stmtQueryBySessionId.all(sessionId) as Record<
+          string,
+          unknown
+        >[];
       } else if (sessionKey && updatedAfter) {
-        raw = this.stmtQueryBySessionKeySince.all(sessionKey, updatedAfter) as Record<string, unknown>[];
+        raw = this.stmtQueryBySessionKeySince.all(
+          sessionKey,
+          updatedAfter,
+        ) as Record<string, unknown>[];
       } else if (sessionKey) {
-        raw = this.stmtQueryBySessionKey.all(sessionKey) as Record<string, unknown>[];
+        raw = this.stmtQueryBySessionKey.all(sessionKey) as Record<
+          string,
+          unknown
+        >[];
       } else if (updatedAfter) {
-        raw = this.stmtQueryAllSince.all(updatedAfter) as Record<string, unknown>[];
+        raw = this.stmtQueryAllSince.all(updatedAfter) as Record<
+          string,
+          unknown
+        >[];
       } else {
         raw = this.stmtQueryAll.all() as Record<string, unknown>[];
       }
@@ -1388,7 +1551,7 @@ export class VectorStore implements IMemoryStore {
       if (raw.length > 0 && !("record_id" in raw[0] && "content" in raw[0])) {
         this.logger?.warn(
           `${TAG} [L1-query] Schema mismatch: first row missing expected columns. ` +
-          `Got keys: [${Object.keys(raw[0]).join(", ")}]`,
+            `Got keys: [${Object.keys(raw[0]).join(", ")}]`,
         );
         return [];
       }
@@ -1397,12 +1560,12 @@ export class VectorStore implements IMemoryStore {
 
       this.logger?.info(
         `${TAG} [L1-query] filter={sessionKey=${sessionKey ?? "(all)"}, sessionId=${sessionId ?? "(all)"}, updatedAfter=${updatedAfter ?? "(none)"}}, ` +
-        `returned ${rows.length} record(s)`,
+          `returned ${rows.length} record(s)`,
       );
       return rows;
     } catch (err) {
       this.logger?.warn(
-        `${TAG} [L1-query] FAILED (non-fatal, returning empty): ${err instanceof Error ? err.message : String(err)}`
+        `${TAG} [L1-query] FAILED (non-fatal, returning empty): ${err instanceof Error ? err.message : String(err)}`,
       );
       return [];
     }
@@ -1426,20 +1589,23 @@ export class VectorStore implements IMemoryStore {
    */
   upsertL0(record: L0Record, embedding: Float32Array | undefined): boolean {
     if (this.degraded) {
-      this.logger?.warn(`${TAG} [L0-upsert] SKIPPED (degraded mode) id=${record.id}`);
+      this.logger?.warn(
+        `${TAG} [L0-upsert] SKIPPED (degraded mode) id=${record.id}`,
+      );
       return false;
     }
     try {
-      const skipVec = !embedding || embedding.every(v => v === 0) || !this.vecTablesReady;
+      const skipVec =
+        !embedding || embedding.every((v) => v === 0) || !this.vecTablesReady;
 
       this.logger?.debug?.(
         `${TAG} [L0-upsert] START id=${record.id}, session=${record.sessionKey}, role=${record.role}, ` +
-        `text="${record.messageText.slice(0, 60)}..."` +
-        (embedding
-          ? `, embeddingDims=${embedding.length}, ` +
-            `embeddingNorm=${Math.sqrt(Array.from(embedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}` +
-            `${skipVec ? " (ZERO VECTOR or vec tables not ready — vec write will be skipped)" : ""}`
-          : " (no embedding — metadata-only write)"),
+          `text="${record.messageText.slice(0, 60)}..."` +
+          (embedding
+            ? `, embeddingDims=${embedding.length}, ` +
+              `embeddingNorm=${Math.sqrt(Array.from(embedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}` +
+              `${skipVec ? " (ZERO VECTOR or vec tables not ready — vec write will be skipped)" : ""}`
+            : " (no embedding — metadata-only write)"),
       );
 
       this.db.exec("BEGIN");
@@ -1457,7 +1623,11 @@ export class VectorStore implements IMemoryStore {
         if (!skipVec) {
           // vec0 does not support ON CONFLICT → delete then insert
           this.stmtL0DeleteVec!.run(record.id);
-          this.stmtL0InsertVec!.run(record.id, Buffer.from(embedding!.buffer), record.recordedAt);
+          this.stmtL0InsertVec!.run(
+            record.id,
+            Buffer.from(embedding!.buffer),
+            record.recordedAt,
+          );
         } else {
           this.logger?.debug?.(
             `${TAG} [L0-upsert] Skipping vec write (${embedding ? "zero vector" : "no embedding"}) id=${record.id}`,
@@ -1470,7 +1640,7 @@ export class VectorStore implements IMemoryStore {
             this.stmtL0FtsDelete.run(record.id);
             this.stmtL0FtsInsert.run(
               tokenizeForFts(record.messageText), // message_text — segmented for indexing
-              record.messageText,                 // message_text_original — raw for display
+              record.messageText, // message_text_original — raw for display
               record.id,
               record.sessionKey,
               record.sessionId,
@@ -1490,10 +1660,14 @@ export class VectorStore implements IMemoryStore {
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
-      this.logger?.debug?.(`${TAG} [L0-upsert] OK id=${record.id}${skipVec ? " (meta-only)" : ""}`);
+      this.logger?.debug?.(
+        `${TAG} [L0-upsert] OK id=${record.id}${skipVec ? " (meta-only)" : ""}`,
+      );
       return true;
     } catch (err) {
       this.logger?.warn(
@@ -1518,25 +1692,39 @@ export class VectorStore implements IMemoryStore {
     if (this.degraded || !this.vecTablesReady) {
       return false;
     }
-    if (!embedding || embedding.every(v => v === 0)) {
-      this.logger?.debug?.(`${TAG} [L0-update-embedding] Skipping zero vector for ${recordId}`);
+    if (!embedding || embedding.every((v) => v === 0)) {
+      this.logger?.debug?.(
+        `${TAG} [L0-update-embedding] Skipping zero vector for ${recordId}`,
+      );
       return false;
     }
     try {
       // Look up recorded_at from metadata for the vec0 row
-      const meta = this.stmtL0GetMeta.get(recordId) as { recorded_at: string } | undefined;
+      const meta = this.stmtL0GetMeta.get(recordId) as
+        | { recorded_at: string }
+        | undefined;
       if (!meta) {
-        this.logger?.warn(`${TAG} [L0-update-embedding] No metadata found for ${recordId}, skipping`);
+        this.logger?.warn(
+          `${TAG} [L0-update-embedding] No metadata found for ${recordId}, skipping`,
+        );
         return false;
       }
 
       this.db.exec("BEGIN");
       try {
         this.stmtL0DeleteVec!.run(recordId);
-        this.stmtL0InsertVec!.run(recordId, Buffer.from(embedding.buffer), meta.recorded_at);
+        this.stmtL0InsertVec!.run(
+          recordId,
+          Buffer.from(embedding.buffer),
+          meta.recorded_at,
+        );
         this.db.exec("COMMIT");
       } catch (err) {
-        try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
+        try {
+          this.db.exec("ROLLBACK");
+        } catch {
+          /* ignore */
+        }
         throw err;
       }
       return true;
@@ -1554,9 +1742,13 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL0Vector(queryEmbedding: Float32Array, topK = 5): L0VectorSearchResult[] {
+  searchL0Vector(
+    queryEmbedding: Float32Array,
+    topK = 5,
+  ): L0VectorSearchResult[] {
     if (this.degraded || !this.vecTablesReady) {
-      if (this.degraded) this.logger?.warn(`${TAG} [L0-search] SKIPPED (degraded mode)`);
+      if (this.degraded)
+        this.logger?.warn(`${TAG} [L0-search] SKIPPED (degraded mode)`);
       return [];
     }
     try {
@@ -1571,8 +1763,8 @@ export class VectorStore implements IMemoryStore {
 
       this.logger?.debug?.(
         `${TAG} [L0-search] START topK=${topK}, retrieveCount=${retrieveCount}, ` +
-        `queryEmbeddingDims=${queryEmbedding.length}, ` +
-        `queryNorm=${Math.sqrt(Array.from(queryEmbedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}`,
+          `queryEmbeddingDims=${queryEmbedding.length}, ` +
+          `queryNorm=${Math.sqrt(Array.from(queryEmbedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}`,
       );
 
       const rows = this.stmtL0SearchVec!.all(
@@ -1580,7 +1772,9 @@ export class VectorStore implements IMemoryStore {
         retrieveCount,
       ) as Array<{ record_id: string; distance: number }>;
 
-      this.logger?.debug?.(`${TAG} [L0-search] vec0 returned ${rows.length} candidate(s)`);
+      this.logger?.debug?.(
+        `${TAG} [L0-search] vec0 returned ${rows.length} candidate(s)`,
+      );
 
       if (rows.length === 0) return [];
 
@@ -1608,14 +1802,16 @@ export class VectorStore implements IMemoryStore {
           | undefined;
 
         if (!meta) {
-          this.logger?.warn(`${TAG} [L0-search] record_id=${record_id} has vector but NO metadata (orphan)`);
+          this.logger?.warn(
+            `${TAG} [L0-search] record_id=${record_id} has vector but NO metadata (orphan)`,
+          );
           continue;
         }
 
         const score = 1.0 - distance;
         this.logger?.debug?.(
           `${TAG} [L0-search] HIT id=${record_id}, distance=${distance.toFixed(4)}, score=${score.toFixed(4)}, ` +
-          `role=${meta.role}, session=${meta.session_key}, text="${meta.message_text.slice(0, 60)}..."`,
+            `role=${meta.role}, session=${meta.session_key}, text="${meta.message_text.slice(0, 60)}..."`,
         );
 
         results.push({
@@ -1657,13 +1853,19 @@ export class VectorStore implements IMemoryStore {
         this.stmtL0DeleteMeta.run(recordId);
         if (this.vecTablesReady) this.stmtL0DeleteVec!.run(recordId);
         if (this.ftsAvailable) {
-          try { this.stmtL0FtsDelete.run(recordId); } catch { /* non-fatal */ }
+          try {
+            this.stmtL0FtsDelete.run(recordId);
+          } catch {
+            /* non-fatal */
+          }
         }
         this.db.exec("COMMIT");
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
       return true;
@@ -1688,22 +1890,24 @@ export class VectorStore implements IMemoryStore {
     }
 
     try {
-      const row = this.db.prepare(
-        "SELECT COUNT(*) AS cnt FROM l0_conversations WHERE recorded_at != '' AND recorded_at < ?",
-      ).get(cutoffIso) as { cnt: number } | undefined;
+      const row = this.db
+        .prepare(
+          "SELECT COUNT(*) AS cnt FROM l0_conversations WHERE recorded_at != '' AND recorded_at < ?",
+        )
+        .get(cutoffIso) as { cnt: number } | undefined;
       const expiredCount = row?.cnt ?? 0;
       if (expiredCount <= 0) return 0;
 
       // Ratio protection: refuse to delete > 80% in one pass
-      const totalRow = this.db.prepare(
-        "SELECT COUNT(*) AS cnt FROM l0_conversations",
-      ).get() as { cnt: number };
+      const totalRow = this.db
+        .prepare("SELECT COUNT(*) AS cnt FROM l0_conversations")
+        .get() as { cnt: number };
       const total = totalRow.cnt;
       const ratio = total > 0 ? expiredCount / total : 0;
       if (ratio > 0.8) {
         this.logger?.warn(
           `${TAG} [L0-deleteExpired] BLOCKED: would delete ${expiredCount}/${total} ` +
-          `(${(ratio * 100).toFixed(1)}%) — exceeds 80% safety threshold, cutoff=${cutoffIso}`,
+            `(${(ratio * 100).toFixed(1)}%) — exceeds 80% safety threshold, cutoff=${cutoffIso}`,
         );
         return 0;
       }
@@ -1711,13 +1915,17 @@ export class VectorStore implements IMemoryStore {
       this.db.exec("BEGIN");
       try {
         if (this.vecTablesReady) {
-          this.db.prepare(
-            "DELETE FROM l0_vec WHERE recorded_at != '' AND recorded_at < ?",
-          ).run(cutoffIso);
+          this.db
+            .prepare(
+              "DELETE FROM l0_vec WHERE recorded_at != '' AND recorded_at < ?",
+            )
+            .run(cutoffIso);
         }
-        this.db.prepare(
-          "DELETE FROM l0_conversations WHERE recorded_at != '' AND recorded_at < ?",
-        ).run(cutoffIso);
+        this.db
+          .prepare(
+            "DELETE FROM l0_conversations WHERE recorded_at != '' AND recorded_at < ?",
+          )
+          .run(cutoffIso);
         this.db.exec("COMMIT");
         this.logger?.info?.(
           `${TAG} [L0-deleteExpired] Deleted ${expiredCount}/${total} records (cutoff=${cutoffIso})`,
@@ -1726,7 +1934,9 @@ export class VectorStore implements IMemoryStore {
       } catch (err) {
         try {
           this.db.exec("ROLLBACK");
-        } catch { /* ignore rollback errors */ }
+        } catch {
+          /* ignore rollback errors */
+        }
         throw err;
       }
     } catch (err) {
@@ -1764,12 +1974,20 @@ export class VectorStore implements IMemoryStore {
    * Get all L1 record texts for re-embedding.
    * Returns record_id → content pairs.
    */
-  getAllL1Texts(): Array<{ record_id: string; content: string; updated_time: string }> {
+  getAllL1Texts(): Array<{
+    record_id: string;
+    content: string;
+    updated_time: string;
+  }> {
     if (this.degraded) return [];
     try {
       return this.db
         .prepare("SELECT record_id, content, updated_time FROM l1_records")
-        .all() as Array<{ record_id: string; content: string; updated_time: string }>;
+        .all() as Array<{
+        record_id: string;
+        content: string;
+        updated_time: string;
+      }>;
     } catch (err) {
       this.logger?.warn(
         `${TAG} getAllL1Texts failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
@@ -1782,12 +2000,22 @@ export class VectorStore implements IMemoryStore {
    * Get all L0 message texts for re-embedding.
    * Returns record_id → message_text/recorded_at tuples.
    */
-  getAllL0Texts(): Array<{ record_id: string; message_text: string; recorded_at: string }> {
+  getAllL0Texts(): Array<{
+    record_id: string;
+    message_text: string;
+    recorded_at: string;
+  }> {
     if (this.degraded) return [];
     try {
       return this.db
-        .prepare("SELECT record_id, message_text, recorded_at FROM l0_conversations")
-        .all() as Array<{ record_id: string; message_text: string; recorded_at: string }>;
+        .prepare(
+          "SELECT record_id, message_text, recorded_at FROM l0_conversations",
+        )
+        .all() as Array<{
+        record_id: string;
+        message_text: string;
+        recorded_at: string;
+      }>;
     } catch (err) {
       this.logger?.warn(
         `${TAG} getAllL0Texts failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
@@ -1812,7 +2040,10 @@ export class VectorStore implements IMemoryStore {
     onProgress?: (done: number, total: number, layer: "L1" | "L0") => void,
   ): Promise<{ l1Count: number; l0Count: number }> {
     if (this.degraded || !this.vecTablesReady) {
-      if (this.degraded) this.logger?.warn(`${TAG} reindexAll skipped: VectorStore is in degraded mode`);
+      if (this.degraded)
+        this.logger?.warn(
+          `${TAG} reindexAll skipped: VectorStore is in degraded mode`,
+        );
       return { l1Count: 0, l0Count: 0 };
     }
 
@@ -1827,10 +2058,18 @@ export class VectorStore implements IMemoryStore {
           this.db.exec("BEGIN");
           try {
             this.stmtDeleteVec!.run(record_id);
-            this.stmtInsertVec!.run(record_id, Buffer.from(embedding.buffer), updated_time);
+            this.stmtInsertVec!.run(
+              record_id,
+              Buffer.from(embedding.buffer),
+              updated_time,
+            );
             this.db.exec("COMMIT");
           } catch (txErr) {
-            try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
+            try {
+              this.db.exec("ROLLBACK");
+            } catch {
+              /* ignore */
+            }
             throw txErr;
           }
         } catch (err) {
@@ -1852,10 +2091,18 @@ export class VectorStore implements IMemoryStore {
           this.db.exec("BEGIN");
           try {
             this.stmtL0DeleteVec!.run(record_id);
-            this.stmtL0InsertVec!.run(record_id, Buffer.from(embedding.buffer), recorded_at);
+            this.stmtL0InsertVec!.run(
+              record_id,
+              Buffer.from(embedding.buffer),
+              recorded_at,
+            );
             this.db.exec("COMMIT");
           } catch (txErr) {
-            try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
+            try {
+              this.db.exec("ROLLBACK");
+            } catch {
+              /* ignore */
+            }
             throw txErr;
           }
         } catch (err) {
@@ -1911,26 +2158,34 @@ export class VectorStore implements IMemoryStore {
       if (afterRecordedAtMs && afterRecordedAtMs > 0) {
         // Convert epoch ms to ISO string for recorded_at comparison
         const afterRecordedAtIso = new Date(afterRecordedAtMs).toISOString();
-        rows = this.stmtL0QueryAfter.all(sessionKey, afterRecordedAtIso, limit) as Array<Record<string, unknown>>;
+        rows = this.stmtL0QueryAfter.all(
+          sessionKey,
+          afterRecordedAtIso,
+          limit,
+        ) as Array<Record<string, unknown>>;
       } else {
-        rows = this.stmtL0QueryAll.all(sessionKey, limit) as Array<Record<string, unknown>>;
+        rows = this.stmtL0QueryAll.all(sessionKey, limit) as Array<
+          Record<string, unknown>
+        >;
       }
 
       this.logger?.info(
         `${TAG} [L0-query] session=${sessionKey}, afterRecordedAtMs=${afterRecordedAtMs ?? "(all)"}, ` +
-        `limit=${limit}, returned ${rows.length} row(s)`,
+          `limit=${limit}, returned ${rows.length} row(s)`,
       );
 
       // Reverse: SQL returns newest-first (DESC), callers expect chronological order
-      return rows.map((r) => ({
-        record_id: r.record_id as string,
-        session_key: r.session_key as string,
-        session_id: (r.session_id as string) || "",
-        role: r.role as string,
-        message_text: r.message_text as string,
-        recorded_at: (r.recorded_at as string) || "",
-        timestamp: (r.timestamp as number) || 0,
-      })).reverse();
+      return rows
+        .map((r) => ({
+          record_id: r.record_id as string,
+          session_key: r.session_key as string,
+          session_id: (r.session_id as string) || "",
+          role: r.role as string,
+          message_text: r.message_text as string,
+          recorded_at: (r.recorded_at as string) || "",
+          timestamp: (r.timestamp as number) || 0,
+        }))
+        .reverse();
     } catch (err) {
       this.logger?.warn(
         `${TAG} [L0-query] FAILED (non-fatal, returning empty): ${err instanceof Error ? err.message : String(err)}`,
@@ -1950,7 +2205,16 @@ export class VectorStore implements IMemoryStore {
     sessionKey: string,
     afterRecordedAtMs?: number,
     limit = 50,
-  ): Array<{ sessionId: string; messages: Array<{ id: string; role: string; content: string; timestamp: number; recordedAtMs: number }> }> {
+  ): Array<{
+    sessionId: string;
+    messages: Array<{
+      id: string;
+      role: string;
+      content: string;
+      timestamp: number;
+      recordedAtMs: number;
+    }>;
+  }> {
     if (this.degraded) {
       this.logger?.warn(`${TAG} [L0-query-grouped] SKIPPED (degraded mode)`);
       return [];
@@ -1959,7 +2223,16 @@ export class VectorStore implements IMemoryStore {
       const rows = this.queryL0ForL1(sessionKey, afterRecordedAtMs, limit);
 
       // Group by session_id
-      const groupMap = new Map<string, Array<{ id: string; role: string; content: string; timestamp: number; recordedAtMs: number }>>();
+      const groupMap = new Map<
+        string,
+        Array<{
+          id: string;
+          role: string;
+          content: string;
+          timestamp: number;
+          recordedAtMs: number;
+        }>
+      >();
       for (const row of rows) {
         const sid = row.session_id || "";
         let group = groupMap.get(sid);
@@ -1977,7 +2250,16 @@ export class VectorStore implements IMemoryStore {
       }
 
       // Convert to array, sorted by earliest message timestamp
-      const groups: Array<{ sessionId: string; messages: Array<{ id: string; role: string; content: string; timestamp: number; recordedAtMs: number }> }> = [];
+      const groups: Array<{
+        sessionId: string;
+        messages: Array<{
+          id: string;
+          role: string;
+          content: string;
+          timestamp: number;
+          recordedAtMs: number;
+        }>;
+      }> = [];
       for (const [sessionId, messages] of groupMap) {
         if (messages.length > 0) {
           groups.push({ sessionId, messages });
@@ -1987,7 +2269,7 @@ export class VectorStore implements IMemoryStore {
 
       this.logger?.info(
         `${TAG} [L0-query-grouped] session=${sessionKey}, afterRecordedAtMs=${afterRecordedAtMs ?? "(all)"}, ` +
-        `${rows.length} messages across ${groups.length} group(s)`,
+          `${rows.length} messages across ${groups.length} group(s)`,
       );
 
       return groups;
@@ -2009,7 +2291,10 @@ export class VectorStore implements IMemoryStore {
   queryL1RecordsCursor(afterId: string, pageSize: number): L1RecordRow[] {
     if (this.degraded) return [];
     try {
-      return this.stmtL1QueryMigrationCursor.all(afterId, pageSize) as unknown as L1RecordRow[];
+      return this.stmtL1QueryMigrationCursor.all(
+        afterId,
+        pageSize,
+      ) as unknown as L1RecordRow[];
     } catch (err) {
       this.logger?.warn(
         `${TAG} [L1-query-cursor] FAILED (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
@@ -2026,7 +2311,10 @@ export class VectorStore implements IMemoryStore {
   queryL0RecordsCursor(afterId: string, pageSize: number): L0RecordRow[] {
     if (this.degraded) return [];
     try {
-      return this.stmtL0QueryMigrationCursor.all(afterId, pageSize) as unknown as L0RecordRow[];
+      return this.stmtL0QueryMigrationCursor.all(
+        afterId,
+        pageSize,
+      ) as unknown as L0RecordRow[];
     } catch (err) {
       this.logger?.warn(
         `${TAG} [L0-query-cursor] FAILED (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
@@ -2103,7 +2391,10 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL0Fts(ftsQuery: string, limit = VectorStore.FTS_DEFAULT_LIMIT): L0FtsSearchResult[] {
+  searchL0Fts(
+    ftsQuery: string,
+    limit = VectorStore.FTS_DEFAULT_LIMIT,
+  ): L0FtsSearchResult[] {
     if (this.degraded || !this.ftsAvailable) return [];
     try {
       const rows = this.stmtL0FtsSearch.all(ftsQuery, limit) as Array<{
@@ -2151,12 +2442,16 @@ export class VectorStore implements IMemoryStore {
     try {
       // Check if l1_fts exists at all
       const l1Exists = this.db
-        .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='l1_fts'")
+        .prepare(
+          "SELECT 1 FROM sqlite_master WHERE type='table' AND name='l1_fts'",
+        )
         .get();
       if (!l1Exists) {
         // Fresh install — tables will be created with v2 schema.
         // Still need rebuild if there's existing data in l1_records.
-        const hasData = this.db.prepare("SELECT 1 FROM l1_records LIMIT 1").get();
+        const hasData = this.db
+          .prepare("SELECT 1 FROM l1_records LIMIT 1")
+          .get();
         return !!hasData;
       }
 
@@ -2172,7 +2467,9 @@ export class VectorStore implements IMemoryStore {
       }
 
       // v1 → v2: drop both FTS tables (data will be repopulated by rebuildFtsIndex)
-      this.logger?.info(`${TAG} Migrating FTS5 tables from v1 to v2 (jieba segmented)`);
+      this.logger?.info(
+        `${TAG} Migrating FTS5 tables from v1 to v2 (jieba segmented)`,
+      );
       this.db.exec("DROP TABLE IF EXISTS l1_fts");
       this.db.exec("DROP TABLE IF EXISTS l0_fts");
       return true;
@@ -2198,7 +2495,9 @@ export class VectorStore implements IMemoryStore {
     if (!this.ftsAvailable) return;
 
     try {
-      this.logger?.info(`${TAG} Rebuilding FTS5 index with jieba segmentation…`);
+      this.logger?.info(
+        `${TAG} Rebuilding FTS5 index with jieba segmentation…`,
+      );
 
       // ── Rebuild L1 FTS ──
       // Clear existing FTS data
@@ -2206,31 +2505,33 @@ export class VectorStore implements IMemoryStore {
 
       // Read all L1 records from metadata table
       const l1Rows = this.db
-        .prepare(`
+        .prepare(
+          `
           SELECT record_id, content, type, priority, scene_name,
                  session_key, session_id, timestamp_str, timestamp_start, timestamp_end, metadata_json
           FROM l1_records
-        `)
+        `,
+        )
         .all() as Array<{
-          record_id: string;
-          content: string;
-          type: string;
-          priority: number;
-          scene_name: string;
-          session_key: string;
-          session_id: string;
-          timestamp_str: string;
-          timestamp_start: string;
-          timestamp_end: string;
-          metadata_json: string;
-        }>;
+        record_id: string;
+        content: string;
+        type: string;
+        priority: number;
+        scene_name: string;
+        session_key: string;
+        session_id: string;
+        timestamp_str: string;
+        timestamp_start: string;
+        timestamp_end: string;
+        metadata_json: string;
+      }>;
 
       let l1Count = 0;
       for (const r of l1Rows) {
         try {
           this.stmtL1FtsInsert.run(
-            tokenizeForFts(r.content),  // content — segmented
-            r.content,                   // content_original — raw
+            tokenizeForFts(r.content), // content — segmented
+            r.content, // content_original — raw
             r.record_id,
             r.type,
             r.priority,
@@ -2254,26 +2555,28 @@ export class VectorStore implements IMemoryStore {
       this.db.exec("DELETE FROM l0_fts");
 
       const l0Rows = this.db
-        .prepare(`
+        .prepare(
+          `
           SELECT record_id, message_text, session_key, session_id, role, recorded_at, timestamp
           FROM l0_conversations
-        `)
+        `,
+        )
         .all() as Array<{
-          record_id: string;
-          message_text: string;
-          session_key: string;
-          session_id: string;
-          role: string;
-          recorded_at: string;
-          timestamp: number;
-        }>;
+        record_id: string;
+        message_text: string;
+        session_key: string;
+        session_id: string;
+        role: string;
+        recorded_at: string;
+        timestamp: number;
+      }>;
 
       let l0Count = 0;
       for (const r of l0Rows) {
         try {
           this.stmtL0FtsInsert.run(
-            tokenizeForFts(r.message_text),  // message_text — segmented
-            r.message_text,                   // message_text_original — raw
+            tokenizeForFts(r.message_text), // message_text — segmented
+            r.message_text, // message_text_original — raw
             r.record_id,
             r.session_key,
             r.session_id,


### PR DESCRIPTION
## Description | 描述
This PR fixes a security gap in FTS5 query construction by sanitizing user input before it is tokenized and converted into an FTS query. The previous implementation allowed reserved FTS5 operators such as AND, OR, NOT, NEAR, quotes, and parentheses to flow into query generation, which could change the semantics of the search expression.

This change introduces a lightweight sanitization step before jieba/regex token extraction, so normal keyword searches still work while reserved syntax is neutralized. A regression test was also added to cover common operator-like inputs and ensure the generated query remains predictable.

## Related Issue | 关联 Issue
Fix #160

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Validated locally with:
- `npx vitest run src/core/store/sqlite.test.ts`
- `npm run build:plugin`