### PR TITLE
fix(l1): treat content-filtered extraction as failed

### DIFF
--- a/src/core/record/l1-extractor.test.ts
+++ b/src/core/record/l1-extractor.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { LLMRunner, Logger } from "../types.js";
+import { extractL1Memories } from "./l1-extractor.js";
+
+const noopLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+describe("extractL1Memories", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("treats provider content-filter prose as a failed extraction", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "tdai-l1-content-filter-"));
+    tempDirs.push(baseDir);
+
+    const refusingRunner: LLMRunner = {
+      async run() {
+        return "你好，我无法给到相关内容。\nProvider finish_reason: content_filter";
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages: [
+        {
+          id: "msg-1",
+          role: "user",
+          content: "Please remember that project Atlas has a deployment freeze until Friday.",
+          timestamp: Date.parse("2026-06-03T06:21:08Z"),
+        },
+      ],
+      sessionKey: "session-a",
+      baseDir,
+      config: {},
+      options: {
+        enableDedup: false,
+        llmRunner: refusingRunner,
+      },
+      logger: noopLogger,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.extractedCount).toBe(0);
+    expect(result.storedCount).toBe(0);
+    expect(result.failureReason).toBe("content_filter");
+  });
+});

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -43,6 +43,14 @@ interface SceneSegment {
   }>;
 }
 
+type L1ExtractionFailureReason = "empty_response" | "content_filter" | "no_json_array" | "parse_error";
+
+interface ParsedExtractionResult {
+  scenes: SceneSegment[];
+  failureReason?: L1ExtractionFailureReason;
+  failureMessage?: string;
+}
+
 export interface L1ExtractionResult {
   /** Whether extraction succeeded */
   success: boolean;
@@ -56,6 +64,10 @@ export interface L1ExtractionResult {
   sceneNames: string[];
   /** Last scene name (for continuity in next extraction) */
   lastSceneName?: string;
+  /** Why the extraction failed, if success=false */
+  failureReason?: L1ExtractionFailureReason;
+  /** Human-readable failure detail, if success=false */
+  error?: string;
 }
 
 // ============================
@@ -151,7 +163,7 @@ export async function extractL1Memories(params: {
   // Step 1: LLM extraction (scene segmentation + memory extraction)
   let scenes: SceneSegment[];
   try {
-    scenes = await callLlmExtraction({
+    const extraction = await callLlmExtraction({
       newMessages,
       backgroundMessages,
       previousSceneName: options.previousSceneName,
@@ -160,10 +172,35 @@ export async function extractL1Memories(params: {
       model: options.model,
       llmRunner: options.llmRunner,
     });
+    if (extraction.failureReason) {
+      logger?.warn?.(
+        `${TAG} LLM extraction output rejected: reason=${extraction.failureReason}, ` +
+        `message=${extraction.failureMessage ?? "(none)"}`,
+      );
+      return {
+        success: false,
+        extractedCount: 0,
+        storedCount: 0,
+        records: [],
+        sceneNames: [],
+        failureReason: extraction.failureReason,
+        error: extraction.failureMessage,
+      };
+    }
+    scenes = extraction.scenes;
     logger?.debug?.(`${TAG} LLM detected ${scenes.length} scene(s)`);
   } catch (err) {
-    logger?.error(`${TAG} LLM extraction failed: ${err instanceof Error ? err.message : String(err)}`);
-    return { success: false, extractedCount: 0, storedCount: 0, records: [], sceneNames: [] };
+    const message = err instanceof Error ? err.message : String(err);
+    logger?.error(`${TAG} LLM extraction failed: ${message}`);
+    return {
+      success: false,
+      extractedCount: 0,
+      storedCount: 0,
+      records: [],
+      sceneNames: [],
+      failureReason: classifyExtractionFailure(message),
+      error: message,
+    };
   }
 
   // Flatten all memories across scenes
@@ -302,7 +339,7 @@ async function callLlmExtraction(params: {
   model?: string;
   /** Host-neutral LLM runner — when provided, used instead of CleanContextRunner. */
   llmRunner?: LLMRunner;
-}): Promise<SceneSegment[]> {
+}): Promise<ParsedExtractionResult> {
   const { newMessages, backgroundMessages, previousSceneName, config, logger, model, llmRunner } = params;
 
   const userPrompt = formatExtractionPrompt({
@@ -350,10 +387,16 @@ async function callLlmExtraction(params: {
  * Parse the LLM's JSON response into SceneSegment array.
  * Expected format: [{scene_name, message_ids, memories: [...]}]
  */
-function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
+function parseExtractionResult(raw: string, logger?: Logger): ParsedExtractionResult {
   try {
     // Strip markdown code block wrappers if present
     let cleaned = raw.trim();
+    if (!cleaned) {
+      const message = "LLM returned an empty extraction response";
+      logger?.warn?.(`${TAG} ${message}`);
+      return { scenes: [], failureReason: "empty_response", failureMessage: message };
+    }
+
     if (cleaned.startsWith("```")) {
       cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "");
     }
@@ -361,13 +404,15 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
     // Try to extract JSON array
     const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
     if (!arrayMatch) {
-      logger?.warn?.(`${TAG} No JSON array found in extraction response`);
+      const message = "No JSON array found in extraction response";
+      logger?.warn?.(`${TAG} ${message}`);
       // [l1-debug] NO_JSON — dump the full raw so we can see what the LLM actually said
       const rawPreview = raw.slice(0, 2048);
       logger?.warn?.(
         `${TAG} [l1-debug] NO_JSON taskId=l1-extraction, rawLen=${raw.length}, cleanedLen=${cleaned.length}, rawFull=${JSON.stringify(rawPreview)}${raw.length > 2048 ? `…(+${raw.length - 2048})` : ""}`,
       );
-      return [];
+      const failureReason = classifyExtractionFailure(cleaned);
+      return { scenes: [], failureReason: failureReason === "parse_error" ? "no_json_array" : failureReason, failureMessage: message };
     }
 
     // Sanitize control characters inside JSON string literals that LLM may produce
@@ -375,8 +420,9 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
     const parsed = JSON.parse(sanitized) as unknown[];
 
     if (!Array.isArray(parsed)) {
-      logger?.warn?.(`${TAG} Extraction response is not an array`);
-      return [];
+      const message = "Extraction response is not an array";
+      logger?.warn?.(`${TAG} ${message}`);
+      return { scenes: [], failureReason: "parse_error", failureMessage: message };
     }
 
     const scenes: SceneSegment[] = [];
@@ -401,11 +447,21 @@ function parseExtractionResult(raw: string, logger?: Logger): SceneSegment[] {
       });
     }
 
-    return scenes;
+    return { scenes };
   } catch (err) {
-    logger?.warn?.(`${TAG} Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    const message = `Failed to parse extraction result: ${err instanceof Error ? err.message : String(err)}`;
+    logger?.warn?.(`${TAG} ${message}`);
+    return { scenes: [], failureReason: "parse_error", failureMessage: message };
   }
+}
+
+function classifyExtractionFailure(message: string): L1ExtractionFailureReason {
+  const lower = message.toLowerCase();
+  if (lower.includes("content_filter") || lower.includes("finish_reason: content_filter")) {
+    return "content_filter";
+  }
+  if (message.trim().length === 0) return "empty_response";
+  return "parse_error";
 }
 
 // ============================

--- a/src/utils/pipeline-factory.test.ts
+++ b/src/utils/pipeline-factory.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseConfig } from "../config.js";
+import { recordConversation } from "../core/conversation/l0-recorder.js";
+import type { LLMRunner, Logger } from "../core/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { createL1Runner } from "./pipeline-factory.js";
+
+const noopLogger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+describe("createL1Runner", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("does not advance the L1 cursor when extraction output is blocked", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "tdai-l1-runner-content-filter-"));
+    tempDirs.push(baseDir);
+
+    await recordConversation({
+      sessionKey: "session-a",
+      sessionId: "thread-a",
+      baseDir,
+      rawMessages: [
+        {
+          id: "raw-1",
+          role: "user",
+          content: "Please remember that project Atlas has a deployment freeze until Friday.",
+          timestamp: Date.parse("2026-06-03T06:21:08Z"),
+        },
+      ],
+      logger: noopLogger,
+    });
+
+    const refusingRunner: LLMRunner = {
+      async run() {
+        return "你好，我无法给到相关内容。\nProvider finish_reason: content_filter";
+      },
+    };
+
+    const runner = createL1Runner({
+      pluginDataDir: baseDir,
+      cfg: parseConfig({ extraction: { enableDedup: false } }),
+      openclawConfig: {},
+      vectorStore: undefined,
+      embeddingService: undefined,
+      logger: noopLogger,
+      llmRunner: refusingRunner,
+    });
+
+    await expect(runner({ sessionKey: "session-a" })).rejects.toThrow(/L1 extraction failed/i);
+
+    const checkpoint = new CheckpointManager(baseDir, noopLogger);
+    const state = await checkpoint.read();
+
+    expect(state.runner_states["session-a"]?.last_l1_cursor ?? 0).toBe(0);
+    expect(state.total_memories_extracted).toBe(0);
+  });
+});

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -373,6 +373,14 @@ export function createL1Runner(opts: {
 
         totalExtracted += l1Result.extractedCount;
         totalStored += l1Result.storedCount;
+        if (!l1Result.success) {
+          throw new Error(
+            `L1 extraction failed for session ${sessionKey}` +
+            (group.sessionId ? ` (sessionId=${group.sessionId})` : "") +
+            (l1Result.failureReason ? `: ${l1Result.failureReason}` : "") +
+            (l1Result.error ? ` - ${l1Result.error}` : ""),
+          );
+        }
         if (l1Result.lastSceneName) {
           lastSceneName = l1Result.lastSceneName;
         }


### PR DESCRIPTION
## Summary
- classify empty / non-JSON / provider `content_filter` L1 extraction output as failed instead of successful zero-memory extraction
- propagate the failure reason through `L1ExtractionResult`
- make the L1 runner throw on extraction failure so the existing pipeline retry path preserves buffered messages and does not advance `last_l1_cursor`

Fixes #104.

This is intentionally narrower than diagnostics-only approaches: the key behavior change is preventing cursor advancement when the provider blocks or returns unparsable prose, so switching models can retry the same L0 messages instead of silently losing them.

## Verification
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run src/core/record/l1-extractor.test.ts src/utils/pipeline-factory.test.ts src/utils/sanitize.test.ts`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm build`