### PR TITLE
feat(adapters): add MCP/Dify adapters and platform adapter SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,27 @@ curl http://127.0.0.1:8420/health
 
 ---
 
+### 3. Claude Code / MCP (any MCP-compatible client)
+
+The MCP server exposes all 5 memory tools over stdio JSON-RPC. One server covers Claude Code, Codex, Cursor, Cline — any MCP-speaking client.
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+```
+
+Project-level `.mcp.json`:
+
+```json
+{ "mcpServers": { "tdai-memory": { "command": "memory-tencentdb-mcp", "env": { "TDAI_LLM_API_KEY": "sk-..." } } } }
+```
+
+Or user-level: `claude mcp add tdai-memory -- memory-tencentdb-mcp`
+
+> Full config (hooks JSON recipe for auto-recall/capture, env var reference, Codex/Cursor setup, troubleshooting) lives in [`src/adapters/mcp/README.md`](./src/adapters/mcp/README.md). For adding your own agent platform, start with the general architecture map ([docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)), the platform comparison ([docs/PLATFORM-COMPARISON.md](./docs/PLATFORM-COMPARISON.md)), and the adapter SDK ([src/adapters/sdk/README.md](./src/adapters/sdk/README.md)).
+
+
+---
+
 
 ## 🔒 Gateway Security (optional)
 

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+/**
+ * memory-tencentdb-mcp — MCP server CLI entry.
+ *
+ * Spawns the MCP server which speaks stdio JSON-RPC with any MCP-compatible
+ * client (Claude Code, Codex, Cursor, Cline, etc.). All logs go to stderr;
+ * stdout is reserved for the JSON-RPC protocol bytes.
+ */
+
+import "../dist/src/adapters/mcp/server.mjs";

--- a/dify-plugin/memory_tencentdb/README.md
+++ b/dify-plugin/memory_tencentdb/README.md
@@ -1,0 +1,94 @@
+# TencentDB Agent Memory — Dify Plugin
+
+把 TencentDB-Agent-Memory 接入 Dify 工作流，让 Dify Agent 能够跨会话记住用户偏好和历史。
+
+## 工作原理
+
+Dify plugin 通过 standalone Gateway HTTP sidecar 跟记忆引擎通信：
+
+```
+Dify Agent  ──→  Provider (本 plugin)  ──→  HTTP /search/*  ──→  Gateway  ──→  TdaiCore
+              ←──  tool_result  ←──  JSON response  ←──  POST  ←──
+```
+
+跟 Hermes provider 共用同一个 Gateway——部署一次，两边都能调。
+
+## 安装
+
+### 1. 启动 Gateway
+
+```bash
+# 安装 Node >= 22
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+
+# 启动 Gateway
+TDAI_LLM_API_KEY=sk-... \
+TDAI_LLM_MODEL=gpt-4o \
+TDAI_DATA_DIR=~/.memory-tencentdb/memory-tdai \
+npx tsx node_modules/@tencentdb-agent-memory/memory-tencentdb/src/gateway/server.ts
+```
+
+### 2. 安装 Dify Plugin
+
+```bash
+# Dify plugin 目录拷贝到 Dify 的 plugins 目录
+cp -r dify-plugin/memory_tencentdb ~/dify/plugins/memory_tencentdb
+
+# 或通过 Dify 管理界面 → 插件 → 本地安装，选择本目录
+```
+
+### 3. 配置
+
+Dify 管理界面 → 插件 → memory_tencentdb → 配置：
+
+| 参数           | 说明                          | 默认值         |
+| -------------- | ----------------------------- | -------------- |
+| gateway_host   | Gateway 主机名                | `127.0.0.1`   |
+| gateway_port   | Gateway 端口                  | `8420`         |
+| api_key        | Bearer token（跟 Gateway 一致）| 无             |
+
+## 工具
+
+### `memory_tencentdb_memory_search`
+
+搜 L1 结构化记忆。
+
+参数：`query` (必填)、`limit` (可选，默认 5)、`type` (可选 persona/episodic/instruction)、`scene` (可选)
+
+### `memory_tencentdb_conversation_search`
+
+搜 L0 原始对话。
+
+参数：`query` (必填)、`limit` (可选)、`session_key` (可选)
+
+## 与 Hermes Provider 的差异
+
+| 维度         | Hermes Provider                       | Dify Plugin                      |
+| ------------ | ------------------------------------- | -------------------------------- |
+| 语言         | Python                                | Python                           |
+| 传输         | HTTP → standalone Gateway             | 同 Hermes                        |
+| 工具数量     | 2 个搜索 + prefetch/sync_turn 内部    | 2 个搜索（工具注册对 LLM 可见）   |
+| 熔断器       | 有（5 次失败开断、60s 冷却）          | 无（依赖 Dify 自身超时）          |
+| 看门狗       | 有（daemon 线程定期探活）             | 无（Gateway 需外部守护）          |
+| Gateway 拉起 | supervisor 自动起进程                 | 手动启 Gateway                   |
+| 错误降级     | 熔断器短路返回空                      | 异常返回 error JSON               |
+| 线程模型     | daemon 线程池 + 信号量限流            | Dify 框架管理（同步调用）          |
+
+## 故障排查
+
+### Gateway 连不上
+
+检查 Gateway 是否在跑：
+
+```bash
+curl http://127.0.0.1:8420/health
+# {"status":"ok","version":"0.1.0","uptime":123,"stores":{"vectorStore":true,"embeddingService":false}}
+```
+
+### 搜索结果总是空
+
+确认 LLM API key 已配置（`TDAI_LLM_API_KEY`），embedding 服务需 LLM 提取记忆后再搜。首次 use 后等一轮 capture + L1 提取。
+
+### 跨平台数据不互通
+
+确认 Gateway 的 `TDAI_DATA_DIR` 跟其他适配器（OpenClaw / MCP server）指向同一目录。

--- a/dify-plugin/memory_tencentdb/__init__.py
+++ b/dify-plugin/memory_tencentdb/__init__.py
@@ -1,0 +1,13 @@
+"""memory-tencentdb Dify Plugin — entry point.
+
+Register the memory-tencentdb provider so Dify discovers it when the
+plugin is loaded. Providers defined in manifest.yaml are auto-imported;
+this module provides the concrete class that the framework instantiates.
+"""
+
+from .provider import MemoryTencentdbProvider
+
+__all__ = ["MemoryTencentdbProvider"]
+
+# Dify Plugin SDK auto-imports providers listed in manifest.yaml.
+# The provider class is the single public export of this package.

--- a/dify-plugin/memory_tencentdb/client.py
+++ b/dify-plugin/memory_tencentdb/client.py
@@ -1,0 +1,125 @@
+"""memory-tencentdb HTTP client for Dify plugin.
+
+Routes Dify tool calls to the standalone Gateway HTTP sidecar.
+Reuses the same Gateway endpoints as the Hermes provider.
+
+Gateway endpoints:
+    POST /search/memories        → L1 memory search
+    POST /search/conversations   → L0 conversation search
+    POST /recall                 → auto-recall (prefetch)
+    POST /capture                → turn capture (sync_turn)
+    POST /session/end            → session flush
+    GET  /health                 → health check
+
+All methods are synchronous — designed to be called from Dify's
+synchronous tool execution flow. Timeouts are kept short (≤20s)
+so tool calls surface errors quickly rather than blocking the agent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+import urllib.error
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 10
+SEARCH_TIMEOUT = 20
+CAPTURE_TIMEOUT = 15
+
+
+class MemoryTencentdbClient:
+    """HTTP client for the memory-tencentdb Gateway sidecar."""
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8420",
+        timeout: int = DEFAULT_TIMEOUT,
+        api_key: Optional[str] = None,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._api_key = api_key
+
+    def _headers(self, *, content_type: bool) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if content_type:
+            headers["Content-Type"] = "application/json"
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def _post(self, path: str, body: Dict[str, Any], timeout: Optional[int] = None) -> Dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=data,
+            headers=self._headers(content_type=True),
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout or self._timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body_text = ""
+            try:
+                body_text = e.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+            logger.warning(f"memory-tencentdb Gateway {path} HTTP {e.code}: {body_text[:300]}")
+            raise
+        except Exception as e:
+            logger.debug(f"memory-tencentdb Gateway {path} failed: {e}")
+            raise
+
+    def search_memories(self, query: str, limit: int = 5, type_filter: str = "", scene: str = "") -> Dict[str, Any]:
+        body: Dict[str, Any] = {"query": query, "limit": limit}
+        if type_filter:
+            body["type"] = type_filter
+        if scene:
+            body["scene"] = scene
+        return self._post("/search/memories", body, timeout=SEARCH_TIMEOUT)
+
+    def search_conversations(self, query: str, limit: int = 5, session_key: str = "") -> Dict[str, Any]:
+        body: Dict[str, Any] = {"query": query, "limit": limit}
+        if session_key:
+            body["session_key"] = session_key
+        return self._post("/search/conversations", body, timeout=SEARCH_TIMEOUT)
+
+    def recall(self, query: str, session_key: str) -> Dict[str, Any]:
+        return self._post("/recall", {
+            "query": query,
+            "session_key": session_key,
+        }, timeout=SEARCH_TIMEOUT)
+
+    def capture(
+        self,
+        user_content: str,
+        assistant_content: str,
+        session_key: str,
+        session_id: str = "",
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "user_content": user_content,
+            "assistant_content": assistant_content,
+            "session_key": session_key,
+        }
+        if session_id:
+            body["session_id"] = session_id
+        return self._post("/capture", body, timeout=CAPTURE_TIMEOUT)
+
+    def end_session(self, session_key: str) -> Dict[str, Any]:
+        return self._post("/session/end", {"session_key": session_key})
+
+    def health(self, timeout: int = 3) -> Dict[str, Any]:
+        url = f"{self._base_url}/health"
+        req = urllib.request.Request(url, headers=self._headers(content_type=False), method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as e:
+            logger.debug(f"memory-tencentdb Gateway health check failed: {e}")
+            raise

--- a/dify-plugin/memory_tencentdb/memory_tencentdb.yaml
+++ b/dify-plugin/memory_tencentdb/memory_tencentdb.yaml
@@ -1,0 +1,32 @@
+"""Dify Plugin Manifest — memory-tencentdb memory provider.
+
+Connects Dify agents to the TencentDB-Agent-Memory engine via the
+standalone Gateway HTTP sidecar (same Gateway used by Hermes).
+"""
+version: 1.0.0
+type: plugin
+author: TencentDB Agent Memory Team
+name: memory_tencentdb
+label:
+  en_US: "TencentDB Agent Memory"
+  zh_Hans: "TencentDB-Agent-Memory 记忆插件"
+description:
+  en_US: "Four-layer memory system (L0→L1→L2→L3) — auto-capture, structure, and recall long-term user knowledge."
+  zh_Hans: "四层记忆系统 — 自动捕获、结构化、召回长期用户知识。支持记忆搜索和对话搜索两个工具。"
+icon: memory.svg
+tags:
+  - memory
+  - knowledge
+  - search
+resource:
+  memory: 128MiB
+  permission:
+    - tool
+    - storage
+    - llm
+    - endpoint
+plugins:
+  endpoints:
+    - provider.py
+  tools:
+    - tools.py

--- a/dify-plugin/memory_tencentdb/provider.py
+++ b/dify-plugin/memory_tencentdb/provider.py
@@ -1,0 +1,186 @@
+"""
+memory_tencentdb — Dify Plugin Provider.
+
+Connects the Dify agent tool surface to TencentDB-Agent-Memory via the
+standalone Gateway HTTP sidecar. Maps Dify tool calls to Gateway API
+endpoints and reports results back as Dify tool response blobs.
+
+Dify agents call:
+    memory_tencentdb_memory_search       → Gateway POST /search/memories
+    memory_tencentdb_conversation_search → Gateway POST /search/conversations
+
+Additional lifecycle hooks (pre-message recall, post-message capture)
+are wired through Dify's Provider interface when the host supports them.
+
+Requires the standalone Gateway to be running. Start it with:
+    npx memory-tencentdb-mcp    # MCP server (includes embedded Gateway logic)
+    # or standalone:
+    TDAI_LLM_API_KEY=sk-... npx tsx src/gateway/server.ts
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from .client import MemoryTencentdbClient
+from .tools import TOOL_DEFINITIONS
+
+logger = logging.getLogger(__name__)
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _resolve_env_var(name: str, default: str = "") -> str:
+    """Read an env var, stripping surrounding whitespace."""
+    return (os.environ.get(name) or default).strip()
+
+
+def _coerce_limit(raw: Any, default: int = 5, maximum: int = 20) -> int:
+    """Coerce a tool-call limit arg to a valid integer in [1, maximum]."""
+    if raw is None or raw == "":
+        return default
+    if isinstance(raw, bool):
+        return default
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError):
+        return default
+    if value < 1:
+        return 1
+    if value > maximum:
+        return maximum
+    return value
+
+# ── Provider ───────────────────────────────────────────────────────────
+
+class MemoryTencentdbProvider:
+    """Dify Plugin Provider for memory-tencentdb Gateway."""
+
+    # Injected by Dify's plugin framework at registration time.
+    # The framework reads these to build the credential form + tool registry.
+    name = "memory_tencentdb"
+    display_name = "TencentDB Agent Memory"
+    version = "1.0.0"
+
+    def __init__(self):
+        self._client: Optional[MemoryTencentdbClient] = None
+        self._gateway_host = ""
+        self._gateway_port = ""
+
+    # ── Credential management ──────────────────────────────────────────
+
+    def validate_credentials(self, credentials: Dict[str, Any]) -> bool:
+        """Called by Dify when the user saves the provider configuration.
+
+        Expects:
+            credentials.gateway_host  — Gateway hostname (default 127.0.0.1)
+            credentials.gateway_port  — Gateway port (default 8420)
+            credentials.api_key       — Optional Bearer token
+        """
+        host = credentials.get("gateway_host") or _resolve_env_var("TDAI_GATEWAY_HOST", "127.0.0.1")
+        port = str(credentials.get("gateway_port") or _resolve_env_var("TDAI_GATEWAY_PORT", "8420"))
+        api_key = credentials.get("api_key") or _resolve_env_var("TDAI_GATEWAY_API_KEY")
+        base_url = f"http://{host}:{port}"
+
+        self._gateway_host = host
+        self._gateway_port = port
+        self._client = MemoryTencentdbClient(base_url=base_url, api_key=api_key or None)
+
+        try:
+            health = self._client.health(timeout=5)
+            if health.get("status") in ("ok", "degraded"):
+                logger.info(f"memory-tencentdb Gateway healthy at {base_url}")
+                return True
+            logger.warning(f"memory-tencentdb Gateway status: %s", health.get("status"))
+            return False
+        except Exception as e:
+            logger.error(f"memory-tencentdb Gateway not reachable at {base_url}: {e}")
+            return False
+
+    # ── Tool definitions ───────────────────────────────────────────────
+
+    def get_tools(self) -> list[Dict[str, Any]]:
+        """Return the schema definitions for registered tools."""
+        return TOOL_DEFINITIONS
+
+    # ── Tool invocation ────────────────────────────────────────────────
+
+    def invoke_tool(self, tool_name: str, parameters: Dict[str, Any]) -> str:
+        """Route a Dify tool call to the Gateway.
+
+        Dify calls this synchronously — the LLM's tool-call loop blocks on
+        the returned text blob. Keep timeouts short so bad Gateway state
+        surfaces quickly rather than stalling the agent.
+        """
+        if not self._client:
+            return json.dumps({
+                "error": "memory-tencentdb Gateway is not connected. Configure the provider first.",
+            })
+
+        try:
+            if tool_name == "memory_tencentdb_memory_search":
+                query = parameters.get("query", "")
+                if not query:
+                    return json.dumps({"error": "Missing required parameter: query"})
+                limit = _coerce_limit(parameters.get("limit"))
+                type_filter = parameters.get("type", "") or ""
+                scene = parameters.get("scene", "") or ""
+                result = self._client.search_memories(
+                    query=query,
+                    limit=limit,
+                    type_filter=type_filter,
+                    scene=scene,
+                )
+                return result.get("results", json.dumps(result))
+
+            elif tool_name == "memory_tencentdb_conversation_search":
+                query = parameters.get("query", "")
+                if not query:
+                    return json.dumps({"error": "Missing required parameter: query"})
+                limit = _coerce_limit(parameters.get("limit"))
+                session_key = parameters.get("session_key", "") or ""
+                result = self._client.search_conversations(
+                    query=query,
+                    limit=limit,
+                    session_key=session_key,
+                )
+                return result.get("results", json.dumps(result))
+
+            else:
+                return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+        except Exception as e:
+            logger.warning(f"memory-tencentdb tool {tool_name} failed: {e}")
+            return json.dumps({"error": f"Tool call failed: {e}"})
+
+    # ── Lifecycle hooks (optional — host-dependent) ────────────────────
+
+    def on_message(self, user_content: str, assistant_content: str, session_key: str) -> None:
+        """Capture a turn after the agent finishes responding.
+
+        Called by the Dify host in fire-and-forget mode (no response
+        awaited). If the Gateway is unreachable the capture is silently
+        dropped — the next turn's recall will still work from whatever
+        was previously captured.
+        """
+        if not self._client:
+            return
+        try:
+            self._client.capture(
+                user_content=user_content,
+                assistant_content=assistant_content,
+                session_key=session_key,
+            )
+        except Exception as e:
+            logger.debug(f"memory-tencentdb capture skipped (non-fatal): {e}")
+
+    def on_session_end(self, session_key: str) -> None:
+        """Flush per-session buffered work."""
+        if not self._client:
+            return
+        try:
+            self._client.end_session(session_key=session_key)
+        except Exception as e:
+            logger.debug(f"memory-tencentdb session_end skipped: {e}")

--- a/dify-plugin/memory_tencentdb/tools.py
+++ b/dify-plugin/memory_tencentdb/tools.py
@@ -1,0 +1,89 @@
+"""Dify tool definitions — memory search + conversation search.
+
+Exposed to the Dify agent as two callable tools. Both route via the
+standalone Gateway HTTP sidecar using MemoryTencentdbClient.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+MEMORY_SEARCH_TOOL = {
+    "name": "memory_tencentdb_memory_search",
+    "description": {
+        "en_US": (
+            "Search through the user's long-term structured memories (L1). "
+            "Use this when you need to recall specific information about the "
+            "user's preferences, past events, instructions, or context from "
+            "previous conversations. Returns relevant memory records ranked "
+            "by relevance."
+        ),
+        "zh_Hans": (
+            "搜索用户的长期结构化记忆（L1）。当你需要回忆用户的偏好、历史事件、"
+            "指令或之前对话的上下文时使用此工具。返回按相关度排序的记忆记录。"
+        ),
+    },
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": {"en_US": "Search query.", "zh_Hans": "搜索查询。"},
+            },
+            "limit": {
+                "type": "integer",
+                "description": {"en_US": "Max results (default: 5, max: 20).", "zh_Hans": "最大返回数量（默认 5，上限 20）。"},
+            },
+            "type": {
+                "type": "string",
+                "enum": ["persona", "episodic", "instruction"],
+                "description": {"en_US": "Optional memory type filter.", "zh_Hans": "可选记忆类型过滤。"},
+            },
+            "scene": {
+                "type": "string",
+                "description": {"en_US": "Optional scene name filter.", "zh_Hans": "可选场景名过滤。"},
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+CONVERSATION_SEARCH_TOOL = {
+    "name": "memory_tencentdb_conversation_search",
+    "description": {
+        "en_US": (
+            "Search through past conversation history (raw L0 dialogue records). "
+            "Use this when memory_tencentdb_memory_search doesn't have what you "
+            "need, or when you want to find specific past conversations or exact "
+            "words the user said before."
+        ),
+        "zh_Hans": (
+            "搜索历史对话记录（原始 L0 对话）。当 memory_tencentdb_memory_search "
+            "没有你需要的信息时，或想查找特定对话原文时使用。"
+        ),
+    },
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": {"en_US": "Search query.", "zh_Hans": "搜索查询。"},
+            },
+            "limit": {
+                "type": "integer",
+                "description": {"en_US": "Max results (default: 5, max: 20).", "zh_Hans": "最大返回数量（默认 5，上限 20）。"},
+            },
+            "session_key": {
+                "type": "string",
+                "description": {"en_US": "Optional session filter.", "zh_Hans": "可选的会话过滤。"},
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+# Collect all tool definitions for the provider's tool listing
+TOOL_DEFINITIONS: list[Dict[str, Any]] = [
+    MEMORY_SEARCH_TOOL,
+    CONVERSATION_SEARCH_TOOL,
+]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,355 @@
+# TencentDB-Agent-Memory 架构与数据流
+
+> 这份文档面向**新接入者**——不管是想接一个新 Agent 平台、做二次开发，还是排查跨平台数据问题。看完应该能回答：
+>
+> - TdaiCore 暴露了哪些能力？数据从哪进、从哪出？
+> - 现有适配器（OpenClaw / Hermes / standalone Gateway）各自落在哪一层？
+> - 我想接新平台时，应该往哪一层塞代码？
+
+---
+
+## 1. 系统总览
+
+```mermaid
+flowchart TB
+    subgraph Hosts["宿主层（已有的 + 待接的）"]
+        OC["OpenClaw 宿主<br/>(in-process TS)"]
+        HP["Hermes Agent<br/>(Python)"]
+        GW["standalone Gateway<br/>(HTTP sidecar)"]
+        MCP["MCP 客户端<br/>(Claude Code / Codex / Cursor)"]
+    end
+
+    subgraph Adapters["适配层 src/adapters/"]
+        OCA["OpenClawHostAdapter"]
+        STA["StandaloneHostAdapter"]
+    end
+
+    subgraph Core["核心引擎 src/core/"]
+        TC["TdaiCore<br/>host-neutral facade"]
+        AR["auto-recall hook"]
+        AC["auto-capture hook"]
+        MS["memory-search tool"]
+        CS["conversation-search tool"]
+        SCH["Pipeline scheduler<br/>L1/L2/L3"]
+    end
+
+    subgraph Store["存储层 src/core/store/"]
+        VSS["VectorStore<br/>sqlite-vec | tcvdb"]
+        EMB["EmbeddingService<br/>(可选)"]
+        BM25["BM25 FTS5 (local)"]
+    end
+
+    subgraph FS["文件系统（共享 dataDir）"]
+        L0[("conversations/*.jsonl<br/>L0 原始对话")]
+        L1[("records/*.jsonl<br/>L1 原子记忆")]
+        L2[("scene_blocks/*.md<br/>L2 场景块")]
+        L3[("persona*.md<br/>L3 用户画像")]
+        VDB[("vectors.db<br/>sqlite-vec 索引")]
+    end
+
+    OC -->|registerTool / api.on| OCA
+    HP -->|HTTP /recall /capture| GW
+    GW --> STA
+    MCP -.->|待接：MCP server<br/>(进阶档)| STA
+
+    OCA --> TC
+    STA --> TC
+
+    TC --> AR
+    TC --> AC
+    TC --> MS
+    TC --> CS
+    TC --> SCH
+
+    AR --> VSS
+    AR --> EMB
+    AR --> BM25
+    AC --> VSS
+    AC --> EMB
+    MS --> VSS
+    MS --> BM25
+    CS --> VSS
+
+    SCH --> L1
+    SCH --> L2
+    SCH --> L3
+
+    VSS --> VDB
+    AC --> L0
+    SCH --> L0
+    AR --> L3
+    AR --> L2
+```
+
+**三个关键分层：**
+
+1. **宿主层** — 真正跑在用户机器上的 Agent 平台（OpenClaw / Hermes / Claude Code 等）。每个平台有自己的事件系统、工具注册机制、生命周期概念。
+2. **适配层** ([src/adapters/](../src/adapters/)) — 把宿主特定的 API 翻译成 `HostAdapter` 接口。**这是新平台接入要写的全部代码。**
+3. **核心引擎** ([src/core/](../src/core/)) — 完全宿主无关的记忆算法。recall / capture / search / L1/L2/L3 pipeline 全在这里。
+
+---
+
+## 2. 数据流：召回（Recall）
+
+触发时机：用户提交 prompt、Agent 还没开始推理之前。
+
+```mermaid
+sequenceDiagram
+    participant U as 用户
+    participant H as 宿主
+    participant A as HostAdapter
+    participant TC as TdaiCore
+    participant AR as auto-recall
+    participant VS as VectorStore
+    participant FS as 文件系统
+
+    U->>H: 输入 prompt
+    H->>A: 触发 before_prompt_build 事件
+    A->>TC: handleBeforeRecall(userText, sessionKey)
+    TC->>AR: performAutoRecall(...)
+    AR->>VS: L1 search (hybrid: embedding + BM25)
+    VS-->>AR: ranked L1 memories
+    AR->>FS: 读 persona*.md (L3)
+    AR->>FS: 读 scene_blocks/*.md (L2 索引)
+    AR-->>TC: { prependContext, appendSystemContext }
+    TC-->>A: RecallResult
+    A-->>H: 注入到 prompt
+    H-->>U: Agent 开始推理（带上记忆上下文）
+```
+
+### OpenClaw 路径（in-process）
+
+| 步骤 | 文件:行号 | 说明 |
+|------|-----------|------|
+| 触发 | [index.ts:529](../index.ts#L529) | `api.on("before_prompt_build", ...)` |
+| 缓存原始 prompt | [index.ts:545](../index.ts#L545) | `pendingOriginalPrompts.set(sessionKey, ...)` 给 agent_end 用 |
+| 调 Core | [index.ts:567](../index.ts#L567) | `core.handleBeforeRecall(userText, sessionKey)` |
+| 执行召回 | [src/core/tdai-core.ts:244](../src/core/tdai-core.ts#L244) | `performAutoRecall(...)` |
+| 搜索策略 | [src/core/hooks/auto-recall.ts:1-11](../src/core/hooks/auto-recall.ts#L1-L11) | keyword / embedding / hybrid（默认 hybrid） |
+| 超时保护 | cfg.recall.timeoutMs（默认 5000ms） | 超时跳过召回，不阻塞 Agent |
+
+### Hermes 路径（HTTP sidecar）
+
+| 步骤 | 文件:行号 | 说明 |
+|------|-----------|------|
+| 触发 | [hermes-plugin/.../__init__.py](../hermes-plugin/memory/memory_tencentdb/__init__.py) 的 `prefetch()` | Hermes Agent 主循环在 prompt 提交前调用 |
+| HTTP 调用 | `client.recall(query, session_key)` | POST /recall |
+| Gateway 入口 | [src/gateway/server.ts:6](../src/gateway/server.ts#L6) | HTTP handler 路由 |
+| 进入 Core | 同 OpenClaw 路径 | 同一个 `handleBeforeRecall` |
+
+**进程边界：** OpenClaw 单进程；Hermes 是 Python ↔ HTTP ↔ Node Gateway 三跳。序列化点：HTTP body JSON。
+
+**降级：** Gateway 不可达时，Hermes Provider 通过熔断器 ([hermes-plugin/.../__init__.py:427](../hermes-plugin/memory/memory_tencentdb/__init__.py#L427)) 短路返回空串；OpenClaw 在 try/catch 里静默跳过 ([index.ts:598](../index.ts#L598))。
+
+---
+
+## 3. 数据流：捕获（Capture）
+
+触发时机：Agent 一轮对话结束（生成完回复）。
+
+```mermaid
+sequenceDiagram
+    participant H as 宿主
+    participant TC as TdaiCore
+    participant AC as auto-capture
+    participant L0 as L0 JSONL
+    participant VS as VectorStore
+    participant SCH as Pipeline Scheduler
+
+    H->>TC: handleTurnCommitted(CompletedTurn)
+    TC->>AC: performAutoCapture(...)
+    AC->>L0: 追加写 conversations/<session>.jsonl
+    AC->>VS: 写 L0 向量索引（异步）
+    AC->>SCH: notify (conversationCount++)
+    SCH-->>SCH: 评估是否触发 L1/L2/L3
+    Note over SCH: L1: every N rounds 或 idle timeout<br/>L2: L1 完成后延迟触发<br/>L3: 每 N 条新记忆触发
+```
+
+### OpenClaw 路径
+
+| 步骤 | 文件:行号 | 说明 |
+|------|-----------|------|
+| 触发 | [index.ts:656](../index.ts#L656) | `api.on("agent_end", ...)` |
+| 取缓存 prompt | [index.ts:692](../index.ts#L692) | `pendingOriginalPrompts.get(sessionKey)` |
+| 调 Core | [index.ts:703](../index.ts#L703) | `core.handleTurnCommitted({...})` |
+| L0 写入 | [src/core/hooks/auto-capture.ts:17](../src/core/hooks/auto-capture.ts#L17) | `recordConversation()` 追加 JSONL |
+| L0 向量索引 | 同文件 | `vectorStore.insertL0()`（异步，注册到 `bgTasks`） |
+| 通知 pipeline | 同文件 | `scheduler.notifyConversation(sessionKey)` |
+
+### Hermes 路径
+
+| 步骤 | 文件:行号 | 说明 |
+|------|-----------|------|
+| 触发 | Hermes Provider 的 `sync_turn(user_content, assistant_content)` | Agent 一轮结束后调用 |
+| 异步线程 | [hermes-plugin/.../__init__.py:865](../hermes-plugin/memory/memory_tencentdb/__init__.py#L865) | `_sync()` 后台线程发 HTTP |
+| HTTP 调用 | `client.capture(...)` | POST /capture |
+| Gateway 入口 | [src/gateway/server.ts:7](../src/gateway/server.ts#L7) | 路由到 `core.handleTurnCommitted` |
+
+**异步任务边界：**
+
+- OpenClaw：`bgTasks` Set，`destroy()` 时 await + 5s 超时（[src/core/tdai-core.ts:188](../src/core/tdai-core.ts#L188)）
+- Hermes：后台 daemon 线程池，最多 `_MAX_INFLIGHT_SYNCS=4` 并发，`shutdown()` 顺序 join（[hermes-plugin/.../__init__.py:937](../hermes-plugin/memory/memory_tencentdb/__init__.py#L937)）
+
+---
+
+## 4. 数据流：搜索（Search 工具）
+
+跟召回不同——搜索是 **Agent 主动调**的工具，返回值直接给 LLM 推理用。
+
+```mermaid
+sequenceDiagram
+    participant LLM as 主 Agent LLM
+    participant H as 宿主工具路由
+    participant TC as TdaiCore
+    participant MS as memory-search
+    participant VS as VectorStore
+
+    LLM->>H: tool_call: tdai_memory_search(query, limit, type?)
+    H->>TC: searchMemories(params)
+    TC->>MS: executeMemorySearch(...)
+    MS->>VS: hybrid search (embedding + FTS5)
+    VS-->>MS: ranked results
+    MS-->>TC: { total, strategy, items }
+    TC-->>H: { text, total, strategy }
+    H-->>LLM: tool_result (文本)
+```
+
+| 工具 | 入口 | 实际调用 |
+|------|------|----------|
+| `tdai_memory_search` | [index.ts:352](../index.ts#L352)（OpenClaw 注册） | `core.searchMemories()` → L1 records |
+| `tdai_conversation_search` | [index.ts:439](../index.ts#L439)（OpenClaw 注册） | `core.searchConversations()` → L0 raw messages |
+| Hermes 同名工具 | Provider `handle_tool_call` | POST /search/memories, /search/conversations |
+
+**L0 vs L1 差异：**
+
+| 层 | 内容 | 何时生成 | 搜索方式 |
+|----|------|----------|----------|
+| L0 conversations | 原始消息文本（user/assistant/tool） | capture 即写 | 向量 + 关键词 |
+| L1 records | 抽取后的原子记忆（偏好/事件/规则） | pipeline 触发 L1 后写 | 向量 + FTS5 |
+| L2 scene_blocks | 多条 L1 聚合的场景块 | L1 之后延迟触发 | 文件读取（按 scene 名） |
+| L3 persona | 用户画像 Markdown | 每 N 条新记忆触发 | 整文件读取注入 system prompt |
+
+**调用次数限制：** `tdai_memory_search` + `tdai_conversation_search` 共享 3 次/轮上限（[index.ts:358](../index.ts#L358) 工具描述里告知 LLM；TODO: 硬限制尚未实现）。
+
+---
+
+## 5. 数据流：关闭（Shutdown）
+
+TdaiCore 销毁顺序很重要——错序会导致 SQLite 句柄提前关、后台写任务崩。
+
+```mermaid
+flowchart LR
+    A["收到关闭信号"] --> B["await scheduler.destroy<br/>(flush pipeline)"]
+    B --> C["drain bgTasks<br/>5s 超时"]
+    C --> D["vectorStore.close<br/>(SQLite 句柄)"]
+    D --> E["embeddingService.close<br/>(HTTP keep-alive)"]
+    E --> F["resetStores<br/>(清单例)"]
+```
+
+| 步骤 | 文件:行号 | 说明 |
+|------|-----------|------|
+| 触发（OpenClaw） | [index.ts:760](../index.ts#L760) | `api.on("gateway_stop", ...)` |
+| 触发（Hermes） | Provider `shutdown()` | Hermes 主进程退出时 |
+| 触发（Gateway） | server.ts SIGINT/SIGTERM | 进程信号 |
+| 总入口 | [src/core/tdai-core.ts:169](../src/core/tdai-core.ts#L169) | `core.destroy()` |
+| scheduler flush | 同上 | `await scheduler.destroy()` |
+| bgTasks drain | [src/core/tdai-core.ts:188-215](../src/core/tdai-core.ts#L188-L215) | 5s 超时保护 |
+| VectorStore close | [src/core/tdai-core.ts:217](../src/core/tdai-core.ts#L217) | SQLite 句柄关 |
+| EmbeddingService close | [src/core/tdai-core.ts:223](../src/core/tdai-core.ts#L223) | keep-alive HTTP 关 |
+
+**关键不变量：** `bgTasks` drain **必须早于** VectorStore close，否则后台 `updateL0Embedding` 会踩到已关的 SQLite 句柄。
+
+---
+
+## 6. 存储层映射
+
+所有适配器共享同一个 `dataDir`，目录结构由 [src/utils/pipeline-factory.ts:101](../src/utils/pipeline-factory.ts#L101) 的 `initDataDirectories()` 创建：
+
+```text
+<dataDir>/                              # 默认 ~/.memory-tencentdb/memory-tdai
+├── conversations/                      # L0
+│   └── <sessionKey>.jsonl              # 每会话一个 JSONL，按消息顺序追加
+├── records/                            # L1
+│   └── <sessionKey>.jsonl              # 抽取后的原子记忆
+├── scene_blocks/                       # L2
+│   └── <sceneName>.md                  # 场景块 Markdown
+├── persona.md                          # L3 当前画像
+├── persona.backup-<n>.md               # L3 历史 backup
+├── vectors.db                          # sqlite-vec 索引（storeBackend=sqlite）
+├── .metadata/
+│   ├── checkpoint.json                 # pipeline 调度状态
+│   └── instance-id.txt                 # 实例 ID（metric 上报用）
+└── .backup/                            # L2/L3 backup
+```
+
+**跨进程共享：**
+
+- OpenClaw、standalone Gateway、未来的 MCP server 可以**指向同一个 `dataDir`**
+- SQLite 后端用 WAL 模式，支持并发读 + 单写
+- 切换平台不影响数据——schema 一致
+- 但**同一时刻只能有一个进程写入**（SQLite 文件锁）；多平台同时跑需用 tcvdb 后端或不同的 dataDir
+
+`★ Insight ─────────────────────────────────────`
+
+数据共享是测试新适配器的捷径：先用 OpenClaw 跑对话灌数据，再用新适配器指向同一 `dataDir` 验证读取。不需要写复杂的初始化逻辑。
+
+`─────────────────────────────────────────────────`
+
+---
+
+## 7. 生命周期事件映射表
+
+这张表是**新接入者的核心参考**——它告诉你在宿主的哪个事件里、调 TdaiCore 的哪个方法。
+
+| TdaiCore 方法 | OpenClaw 钩子 | Hermes Provider 方法 | HTTP 端点（Gateway） | 触发时机 |
+|---|---|---|---|---|
+| `handleBeforeRecall` | `before_prompt_build` | `prefetch()` | POST /recall | 用户提交 prompt 后、Agent 推理前 |
+| `handleTurnCommitted` | `agent_end` | `sync_turn()` | POST /capture | Agent 一轮对话结束 |
+| `searchMemories` | 工具注册（`api.registerTool`） | `handle_tool_call` | POST /search/memories | LLM 主动调工具 |
+| `searchConversations` | 工具注册 | `handle_tool_call` | POST /search/conversations | LLM 主动调工具 |
+| `handleSessionEnd` | （未接） | `on_session_end` | POST /session/end | 会话结束（flush 单 session 缓冲） |
+| `destroy` | `gateway_stop` | `shutdown()` | （进程退出） | 进程关闭 |
+
+---
+
+## 8. 每个适配器的"五种责任"清单
+
+`HostAdapter` 契约（[src/core/types.ts:154](../src/core/types.ts#L154)）要求每个适配器提供：
+
+| 责任 | OpenClaw 实现 | Standalone 实现 | 数据来源 |
+|---|---|---|---|
+| **RuntimeContext**（who/where） | `OpenClawHostAdapter.getRuntimeContext()` | `StandaloneHostAdapter.getRuntimeContext()` | userId / sessionKey / dataDir / platform |
+| **Logger** | `api.logger`（OpenClaw 自带） | `createConsoleLogger()`（Gateway 自建） | 宿主提供或自建 |
+| **LLMRunnerFactory** | `OpenClawLLMRunnerFactory`（包 `CleanContextRunner`，走 OpenClaw 内嵌 agent） | `StandaloneLLMRunnerFactory`（走 OpenAI 兼容 HTTP） | 宿主原生 LLM 调用机制 |
+| **hostType 字段** | `"openclaw"` | `"standalone"` | 影响 Core 内部 LLM runner 选择（[tdai-core.ts:425](../src/core/tdai-core.ts#L425)） |
+| **工具注册** | `api.registerTool(...)` 在 [index.ts:352](../index.ts#L352) | Gateway HTTP `/search/*` 端点 | 宿主的工具暴露机制 |
+| **生命周期事件** | `api.on("before_prompt_build" / "agent_end" / "gateway_stop")` | Gateway HTTP `/recall` `/capture` 端点 | 宿主的事件系统 |
+
+**新增适配器要回答的 5 个问题：**
+
+1. 我从哪里拿 userId / sessionKey / dataDir？（→ RuntimeContext）
+2. 我用什么打日志？（→ Logger）
+3. 我怎么调 LLM？（→ LLMRunnerFactory）
+4. 宿主的什么事件对应 before_prompt / after_turn / shutdown？（→ 生命周期接线）
+5. 宿主怎么暴露工具？（→ 工具注册）
+
+回答完这 5 个问题，适配器就写完了。
+
+---
+
+## 9. 我应该在哪一层写代码？
+
+```mermaid
+flowchart TD
+    Q1{新平台是 TS/JS 宿主<br/>且有原生插件 API?}
+    Q1 -- 是 --> QA[模式 A：写 HostAdapter 子类<br/>参考 src/adapters/openclaw/]
+    Q1 -- 否 --> Q2{新平台讲 MCP 协议?<br/>(Claude Code, Codex, Cursor)}
+    Q2 -- 是 --> QB[模式 C：写 MCP server<br/>参考 src/adapters/mcp/<br/>(进阶档交付)]
+    Q2 -- 否 --> QC[模式 B：HTTP sidecar<br/>Python / Go / Rust 客户端<br/>参考 hermes-plugin/]
+
+    QA --> Done[共用同一个 TdaiCore]
+    QB --> Done
+    QC --> Done
+```
+
+不管选哪条路，**核心引擎代码一行都不用改**——这是分层架构的全部价值。

--- a/docs/PLATFORM-COMPARISON.md
+++ b/docs/PLATFORM-COMPARISON.md
@@ -1,0 +1,236 @@
+# 平台对比：OpenClaw × Hermes × MCP (Claude Code) × Dify
+
+四个平台接入同一个 TdaiCore 引擎——但宿主是不同 Agent 平台、不同语言、不同传输方式、不同生命周期机制。这份对比帮你理清差异，选对模式，避免踩坑。
+
+## 1. 速览表
+
+| 维度           | OpenClaw                                    | Hermes                                          | MCP (Claude Code)                               | Dify                                             |
+| -------------- | ------------------------------------------- | ----------------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| 宿主语言       | TypeScript                                  | Python                                          | 任意（MCP 客户端）                              | Python                                           |
+| 传输方式       | 进程内直接调用                              | HTTP → standalone Gateway                       | stdio JSON-RPC                                  | HTTP → standalone Gateway                        |
+| 进程模型       | 单进程（Core 嵌入 OpenClaw）                | 多进程（Python Agent ↔ Node GW ↔ TdaiCore）     | 单进程（Core 嵌入 MCP server）                   | 多进程（Dify ← HTTP → Node GW ← TdaiCore）       |
+| 工具注册       | `api.registerTool(...)`                     | `get_tool_schemas()` 返回 dict 列表             | MCP `tools/list` 标准协议                        | Dify Plugin SDK YAML + Python 混排               |
+| 生命周期来源   | OpenClaw 钩子系统 (`api.on`)                | Hermes MemoryProvider 接口                      | Claude Code hooks JSON（外部配置）               | Dify Plugin SDK 接口                             |
+| LLM 来源       | OpenClaw 内嵌 agent（`CleanContextRunner`）  | Gateway 内嵌 `StandaloneLLMRunner`               | MCP server 内嵌 `StandaloneLLMRunner`            | Gateway 内嵌 `StandaloneLLMRunner`                |
+| 搜索工具数     | 2 (`tdai_memory_search` + `conv_search`)    | 2（同名工具）                                   | 5（含 recall / capture / session_end）           | 2（同名工具）                                    |
+| 自动召回       | ✅ before_prompt_build 钩子                  | ✅ `prefetch()` 同步调用                        | ❌ 需宿主 hooks JSON 配置（用户操作）             | ❌ 同 Hermes，但 Dify 无 `prefetch` 等价机制      |
+| 自动捕获       | ✅ agent_end 钩子                            | ✅ `sync_turn()` 异步线程                       | ❌ 需宿主 hooks JSON 配置（用户操作）             | ⚠️ `on_message()` 可选，需宿主支持                |
+| 错误降级       | 静默跳过（try/catch + 日志）                 | 熔断器（5 次失败开断、60s 冷却）+ 看门狗        | JSON-RPC `isError` 字段 + 工具返回错误文本        | JSON 错误返回 + Dify 框架超时                     |
+| Gateway 管理   | 不需要                                      | Supervisor 自动拉起进程                          | 不需要（Core 在 server 内）                      | 手动启 Gateway                                   |
+| 代码量（估）   | ~900 行 index.ts + ~700 行 host-adapter/runner | ~1150 行 Python provider                        | ~500 行 host-adapter + ~250 行 server             | ~220 行 provider + ~80 行 client                   |
+| 可复用比例     | 最高（共享整个 Core + utils）               | 最低（Python 需独立客户端 + socket 通信）        | 高（复用 StandaloneLLMRunnerFactory + Core）      | 中（复用 Gateway HTTP 端点，client 从 Hermes 抄）  |
+
+## 2. 维度对照
+
+### 2.1 进程模型
+
+```text
+OpenClaw (模式 A):                    MCP (模式 C):
+┌──────────────────────┐            ┌──────────────────────┐
+│ OpenClaw 宿主         │            │ MCP 客户端 (Claude)    │
+│  ├─ Plugin SDK        │            │  ├─ stdio → JSON-RPC  │
+│  ├─ TdaiCore          │            └──────────┬───────────┘
+│  ├─ VectorStore       │                       │ 子进程
+│  └─ sqlite-vec        │            ┌──────────┴───────────┐
+└──────────────────────┘            │ MCP server             │
+                                     │  ├─ TdaiCore          │
+Hermes / Dify (模式 B):              │  ├─ VectorStore       │
+┌──────────────┐    HTTP     ┌──────┬┴─┐ sqlite-vec         │
+│ Python Agent │ ─────────→  │ Gateway │                    │
+│ (Hermes/Dify)│ ←─────────  │ TdaiCore │                    │
+└──────────────┘   JSON      └─────────┘                    │
+                                     └──────────────────────┘
+```
+
+**关键差异：**
+
+- 模式 A 和模式 C 只有一个进程——Core 的 SQLite 句柄直接归当前进程。性能最好，但该进程崩了什么都丢。
+- 模式 B 有两个进程——Gateway 可以崩溃重启，Agent 不受影响。但多进程增加了运维复杂度。
+
+### 2.2 传输协议
+
+| 平台     | 协议             | 序列化          | 延迟        | 适用场景                     |
+| -------- | ---------------- | --------------- | ----------- | ---------------------------- |
+| OpenClaw | 函数调用          | 无（同进程内存） | < 1ms       | 紧密耦合、高频访问           |
+| Hermes   | HTTP/1.1         | JSON body       | 1-10ms      | 跨语言、网络可达             |
+| MCP      | stdio JSON-RPC   | JSON 行          | < 1ms       | 本地进程、工具暴露           |
+| Dify     | HTTP/1.1         | JSON body       | 1-10ms      | 同 Hermes                    |
+
+`★ Insight ─────────────────────────────────────`
+
+MCP 的 stdio 传输不经过网络栈，在本地机器上延迟对标进程内调用。但每次调用需要完整的 JSON-RPC 往返（request → response → parse），跟直接函数调用比仍有 ~1ms overhead。高频搜场景（每秒 >100 次），模式 A 有显著优势。常规 Agent 工具调用频率（3 次/轮，每轮 ~30s），差异可忽略。
+
+`─────────────────────────────────────────────────`
+
+### 2.3 工具注册机制
+
+**OpenClaw：**
+
+```ts
+api.registerTool({
+  name: "tdai_memory_search",
+  description: "...",
+  parameters: { type: "object", properties: {...}, required: [...] },
+  async execute(id, params) { ... }
+});
+```
+
+- 类型安全（TypeScript），跑在同一个 V8 里
+- Core 的 `searchMemories()` 直接调——零序列化
+- 工具执行中可以访问 plugin 状态（`api.logger`、`core.instance`）
+
+**Hermes：**
+
+```python
+def get_tool_schemas(self) -> list[dict]:
+    return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
+```
+
+- Python dict，无类型检查
+- `handle_tool_call()` 收到 tool_name + args dict → 调 HTTP client → Gateway 路由
+- 工具 schema 跟实现代码分离——容易 schema 跟实现不同步
+
+**MCP：**
+
+```ts
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [{ name: "tdai_memory_search", inputSchema: {...} }]
+}));
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  switch (req.params.name) { ... }
+});
+```
+
+- 标准协议——任何 MCP 客户端都能消费
+- schema 是内联的 JSON（无额外定义文件）
+- `isError: true` 字段让客户端可靠识别工具失败
+
+**Dify：**
+
+```yaml
+# tools.py — Python dict
+MEMORY_SEARCH_TOOL = {
+    "name": "memory_tencentdb_memory_search",
+    "parameters": { "type": "object", "properties": {...} },
+}
+```
+
+- Python dict 定义工具 schema，跟 Hermes 同风格
+- Dify Plugin SDK 负责把 dict 渲染成 LLM function calling schema
+- 工具调用在 provider 的 `invoke_tool()` 中分发
+
+### 2.4 生命周期事件来源
+
+| 事件            | OpenClaw                           | Hermes                             | MCP (Claude Code)                   | Dify                           |
+| --------------- | ---------------------------------- | ---------------------------------- | ----------------------------------- | ------------------------------ |
+| before_prompt   | `api.on("before_prompt_build", …)` | `prefetch(query)` 同步返回         | 用户配 `UserPromptSubmit` hook JSON | Dify 无等价机制                 |
+| after_turn      | `api.on("agent_end", …)`           | `sync_turn(user, assistant)`       | 用户配 `Stop` hook JSON             | `on_message()` 可选，需宿主支持 |
+| session_end     | 未接                               | `on_session_end()`                 | 用户配 `SessionEnd` hook JSON       | `on_session_end()`              |
+| shutdown        | `api.on("gateway_stop", …)`        | `shutdown()`                       | SIGINT/SIGTERM 信号处理             | 插件卸载                         |
+
+这是四个平台差异最大的维度。OpenClaw 原生支持一套完整的事件系统，工具注册和生命周期在同一个插件 API 里。MCP 只定义了工具——生命周期全靠宿主外部配置 hook JSON 来桥接。Hermes 和 Dify 是 Python 宿主的中间态：有部分生命周期方法（`prefetch`、`sync_turn`），但缺乏统一的 hook 编排。
+
+### 2.5 LLM 来源
+
+| 平台     | 提取 LLM 来自              | 搜索 LLM 来自             | 不配 LLM key 时              |
+| -------- | -------------------------- | ------------------------- | ---------------------------- |
+| OpenClaw | `CleanContextRunner`（宿主内嵌 agent，走 OpenClaw 配置的模型） | 同左                      | 提取/搜索降级（无 LLM 调用）  |
+| Hermes   | Gateway 配置的 `StandaloneLLMRunner`（OpenAI 兼容 HTTP） | 同左                      | 搜索返回降级消息（无 crash）  |
+| MCP      | MCP server 的 `StandaloneLLMRunner`（环境变量驱动） | 同左                      | 同 Hermes                    |
+| Dify     | Gateway 配置的 `StandaloneLLMRunner` | 同左                      | 同 Hermes                    |
+
+**模式 A（OpenClaw）不需要单独配 LLM**——宿主的默认模型直接给 Core 用。模式 B/C 需要额外的 LLM 配置（环境变量或 yaml），因为 Core 跑在独立进程里，无法访问宿主的 LLM。
+
+### 2.6 错误降级策略
+
+| 策略           | OpenClaw            | Hermes                     | MCP                    | Dify                 |
+| -------------- | ------------------- | -------------------------- | ---------------------- | -------------------- |
+| 集群降压       | try/catch → 静默跳过 | 熔断器 (5 failures, 60s)   | isError 字段           | JSON 错误返回         |
+| 自恢复         | 下一轮自动重试       | 看门狗 daemon + 自动重连    | server 进程存活即恢复   | 依赖手动重启 Gateway  |
+| 降级信息       | 不注入 prompt       | 返回空                      | 返回错误文本 + isError  | 返回 error JSON       |
+| 影响范围       | 仅当前轮             | 熔断后整 session 短路       | 仅当前工具调用          | 仅当前工具调用        |
+
+`★ Insight ─────────────────────────────────────`
+
+Hermes 的熔断器是最成熟的降级方案——当 Gateway 持续不可达时，不会每轮都尝试重连（否则每次 prefetch/sync_turn 都会卡一个 HTTP 超时），而是设一个冷闭期（60s）。MCP 和 Dify 目前没有这个机制——如果 LLM API 挂，每次工具调用都会等到 `TDAI_LLM_TIMEOUT_MS`（默认 120s）。把熔断器抽象回 SDK（拓展档）是值得做的改进。
+
+`─────────────────────────────────────────────────`
+
+### 2.7 多用户/多会话隔离
+
+四个平台**共享同一个存储隔离模型**——跨平台通用的 session key 分片：
+
+- L0 conversations: `dataDir/conversations/<sessionKey>.jsonl`
+- L1 records: `dataDir/records/<sessionKey>.jsonl`
+- L2 scene_blocks: `dataDir/scene_blocks/<sceneName>.md`
+- L3 persona: `dataDir/persona.md`（用户级别，不按 session 分片）
+
+SQLite WAL 模式支持并发读，但同一时刻只能有一个进程写。跨平台并发写入需切到 tcvdb 后端（支持多写）。
+
+**跨平台数据共享体验：**
+
+| 场景                            | 是否可行 | 说明                                   |
+| ------------------------------- | -------- | -------------------------------------- |
+| 同一个 `dataDir`，平台间读写     | ✅       | schema 一致，文件格式通用               |
+| 同时用 OpenClaw + MCP 写入       | ⚠️       | SQLite 文件锁，串行写入；高频写会有阻塞  |
+| 先用 OpenClaw 灌数据，再用 Dify 搜索 | ✅   | 搜索只读，无冲突                       |
+| MCP recall 失败后切回 OpenClaw   | ✅       | 同 dataDir，数据都在                    |
+
+## 3. 接入成本评估
+
+| 平台     | 新写代码行数 | 需理解的概念           | 可复用度        | 难度 |
+| -------- | ----------- | --------------------- | --------------- | ---- |
+| OpenClaw | ~1600       | Plugin SDK + 钩子系统 + 工具注册 + CleanContextRunner | 基准 | 中 |
+| Hermes   | ~1150       | Gateway HTTP 端点 + MemoryProvider 接口 + 熔断器/看门狗 | ~30%（HTTP client 独立） | 中 |
+| MCP      | ~750        | MCP SDK (tools/list + tools/call) + stdio transport + 信号处理 | ~70%（复用 StandaloneLLMRunner + Core + Gateway config） | 中低 |
+| Dify     | ~300        | Dify Plugin SDK + Gateway HTTP 端点 | ~60%（client 从 Hermes 抄，schema 一致） | 低 |
+
+## 4. 选型决策树
+
+```mermaid
+flowchart TD
+    START["新 Agent 平台想接入 TDAI 记忆引擎"] --> Q1
+
+    Q1{平台语言是 TS/JS<br/>且有原生插件 API?}
+    Q1 -- 是 --> QA["模式 A：进程内 HostAdapter<br/>参考 src/adapters/openclaw/<br/>性能最优，耦合最紧"]
+    Q1 -- 否 --> Q2
+
+    Q2{宿主讲 MCP 协议?<br/>(Claude Code, Codex, Cursor, Cline ...)}
+    Q2 -- 是 --> QB["模式 C：MCP server<br/>参考 src/adapters/mcp/<br/>一次写，覆盖所有 MCP 客户端"]
+    Q2 -- 否 --> Q3
+
+    Q3{宿主有 HTTP 能力?<br/>(Python, Go, Rust, .NET ...)}
+    Q3 -- 是 --> QC["模式 B：HTTP sidecar<br/>参考 hermes-plugin/ 或 dify-plugin/<br/>语言无关，运维需维护 Gateway"]
+    Q3 -- 否 --> Q4
+
+    Q4{宿主有其他 IPC 能力?<br/>(gRPC, Unix socket, stdin/stdout ...)}
+    Q4 -- 是 --> QD["模式 B 变体：换个传输层<br/>Gateway 加一个 gRPC/unix-socket listener<br/>客户端适配新协议即可"]
+    Q4 -- 否 --> QF["无合适传输层<br/>考虑把 TdaiCore 嵌入宿主运行时<br/>（需把 Core 的 LLM/sqlite 依赖迁过去）"]
+```
+
+## 5. 后续候选平台
+
+| 平台             | 推荐模式    | 理由                                                                 |
+| ---------------- | ----------- | -------------------------------------------------------------------- |
+| Codex CLI        | 模式 C      | MCP 原生支持，一个 server 覆盖                                       |
+| Cursor           | 模式 C      | MCP 原生支持                                                         |
+| Cline            | 模式 C      | MCP 原生支持                                                         |
+| LangChain        | 模式 B      | Python 生态，HTTP 客户端 + Gateway 是自然选择                        |
+| AutoGen          | 模式 B      | 同上                                                                |
+| CrewAI           | 模式 B      | 同上                                                                |
+| Continue (VS Code)| 模式 C     | 已支持 MCP                                                          |
+| Aider            | 模式 B      | Python，可复用 Hermes client                                        |
+| Goose CLI        | 模式 C      | 已支持 MCP                                                          |
+
+---
+
+## 6. 关键回退约束（四平台通用）
+
+当**所有**搜索/提取都不可用时，TdaiCore 的降级行为：
+
+1. **Recall** → 返回空 `prependContext`（不注入，不阻塞 Agent）
+2. **Capture** → L0 JSONL 仍然能写（纯文件追加，不需要 LLM/embedding）
+3. **Search** → 返回解释性错误文本（"Embedding service is not configured"），不崩
+4. **Pipeline (L1/L2/L3)** → 不触发（`scheduler.flushSession` 检查 LLM runner 可用性）
+
+L0 对话记录是**最基础的记忆层**，只需要文件系统权限就能工作。L1/L2/L3 需要 LLM + embedding，但三者是增值层——不能因为 L1 崩了就连 L0 也不写。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-mcp": "./bin/mcp-server.mjs"
   },
   "exports": {
     ".": {
@@ -74,6 +75,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "@node-rs/jieba": "^2.0.1",
     "@tencentdb-agent-memory/tcvdb-text": "^0.1.1",
     "ai": "^6.0.164",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,19 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// MCP adapter (Pattern C — in-process TdaiCore wrapped as MCP server)
+export { McpHostAdapter, createStderrLogger } from "./mcp/index.js";
+export type { McpHostAdapterOptions } from "./mcp/index.js";
+
+// PlatformAdapter SDK (拓展档 — new platforms implement ONE interface)
+export type {
+  IPlatformAdapter,
+  IPlatformAdapterContext,
+  PlatformToolDefinition,
+  PlatformLifecycleEvent,
+  PlatformLifecycleHandler,
+  PlatformAdapterBootstrapOptions,
+  ToolRouteTarget,
+} from "./sdk/index.js";
+export { PlatformAdapterRuntime } from "./sdk/index.js";

--- a/src/adapters/mcp/README.md
+++ b/src/adapters/mcp/README.md
@@ -1,0 +1,243 @@
+# memory-tencentdb MCP Adapter
+
+把 TencentDB-Agent-Memory 暴露成 MCP server，让 Claude Code / Codex / Cursor / Cline 等任何 MCP 兼容客户端即插即用。
+
+## 它干啥
+
+TdaiCore 内嵌进一个 MCP server 进程，通过 stdio JSON-RPC 暴露 5 个工具：
+
+| 工具                     | 作用                                | 何时调                              |
+| ----------------------- | ----------------------------------- | ----------------------------------- |
+| `tdai_memory_search`    | 搜 L1 结构化记忆                     | Agent 推理时主动调                  |
+| `tdai_conversation_search` | 搜 L0 原始对话                     | Agent 推理时主动调                  |
+| `tdai_recall`           | 触发自动召回，返回要注入的上下文     | 宿主 `UserPromptSubmit` 钩子调       |
+| `tdai_capture`          | 触发对话捕获，写 L0 + 调度 pipeline | 宿主 `Stop` 钩子调                  |
+| `tdai_session_end`      | flush 单 session 缓冲               | 宿主 `SessionEnd` 钩子调            |
+
+设计上是**模式 C**（进程内 TdaiCore + MCP 协议外露），不走 standalone Gateway 的 HTTP 跳。Claude Code 把这个 server 当子进程拉起，server 内部直接跑记忆引擎。
+
+## 安装（Claude Code）
+
+### 1. 安装包
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+```
+
+### 2. 注册 MCP server
+
+项目级（推荐）：在工作目录建 `.mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "memory-tencentdb-mcp",
+      "env": {
+        "TDAI_LLM_API_KEY": "sk-...",
+        "TDAI_LLM_MODEL": "gpt-4o",
+        "TDAI_LLM_BASE_URL": "https://api.openai.com/v1"
+      }
+    }
+  }
+}
+```
+
+或用户级（影响所有 Claude Code 会话）：
+
+```bash
+claude mcp add tdai-memory -- env TDAI_LLM_API_KEY=sk-... TDAI_LLM_MODEL=gpt-4o
+```
+
+### 3. 配置宿主钩子（关键）
+
+光有工具不会触发自动召回/捕获——Claude Code 不会在 prompt 边界自动调 MCP 工具。需要在 `~/.claude/settings.json` 配置钩子，把生命周期事件桥到 MCP 工具调用：
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "tool",
+            "tool": "mcp__tdai-memory__tdai_recall",
+            "args": {
+              "query": "$PROMPT",
+              "session_key": "$SESSION_ID"
+            },
+            "inject_as": "prepend"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "tool",
+            "tool": "mcp__tdai-memory__tdai_capture",
+            "args": {
+              "user_content": "$LAST_USER_PROMPT",
+              "assistant_content": "$LAST_ASSISTANT_REPLY",
+              "session_key": "$SESSION_ID"
+            },
+            "run_in_background": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "tool",
+            "tool": "mcp__tdai-memory__tdai_session_end",
+            "args": { "session_key": "$SESSION_ID" }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> 上面 `$PROMPT` / `$SESSION_ID` / `$LAST_USER_PROMPT` / `$LAST_ASSISTANT_REPLY` 是 Claude Code 的 hook 变量占位符，实际名称以 Claude Code 当前文档为准——这里写的是设计意图，具体配置语法请参考 Claude Code 官方 hook 文档。
+
+## 安装（Codex / Cursor / 通用 MCP）
+
+Codex、Cursor、Cline 都支持同一个 stdio MCP server。配置语法各平台不同，但核心字段一致：
+
+- 命令：`memory-tencentdb-mcp`
+- 参数：（无）
+- 环境变量：见下节
+
+## 配置
+
+所有配置走环境变量（无 yaml 文件）：
+
+| 环境变量                    | 必填 | 默认值                              | 说明                                                                 |
+| -------------------------- | ---- | ----------------------------------- | -------------------------------------------------------------------- |
+| `TDAI_LLM_API_KEY`         | ✅   | —                                   | LLM provider API key                                                 |
+| `TDAI_LLM_BASE_URL`        | ❌   | `https://api.openai.com/v1`         | OpenAI 兼容 endpoint                                                 |
+| `TDAI_LLM_MODEL`           | ❌   | `gpt-4o`                            | L1/L2/L3 提取用模型                                                  |
+| `TDAI_LLM_MAX_TOKENS`      | ❌   | `4096`                              | 单次 LLM 调用最大输出                                                |
+| `TDAI_LLM_TIMEOUT_MS`      | ❌   | `120000`                            | LLM 请求超时                                                         |
+| `TDAI_LLM_DISABLE_THINKING`| ❌   | `false`                             | 推理模型思考关闭策略（`vllm`/`deepseek`/`dashscope`/`openai`/`anthropic`/`kimi`/`gemini`） |
+| `TDAI_DATA_DIR`            | ❌   | `~/.memory-tencentdb/memory-tdai`   | 存储根目录（与其他适配器共享同一目录即可跨平台共用记忆）            |
+| `TDAI_USER_ID`             | ❌   | `default_user`                      | 默认用户 ID                                                          |
+| `TDAI_MEMORY_CONFIG`       | ❌   | —                                   | 完整 memory 配置 JSON（覆盖默认值，跟 `openclaw.plugin.json` 同结构） |
+| `TDAI_MCP_DEBUG`           | ❌   | —                                   | 设为 `1` 开启 DEBUG 级日志（写 stderr）                              |
+
+## 工具参考
+
+### `tdai_memory_search`
+
+参数：
+
+- `query` (string, 必填) — 搜索查询
+- `limit` (number, 可选, 默认 5, 上限 20) — 返回结果数
+- `type` (enum, 可选) — `persona` | `episodic` | `instruction`
+- `scene` (string, 可选) — 按场景名过滤
+
+返回：纯文本，按相关度排序的 L1 记忆列表。
+
+### `tdai_conversation_search`
+
+参数：
+
+- `query` (string, 必填)
+- `limit` (number, 可选, 默认 5)
+- `session_key` (string, 可选) — 限定单 session
+
+返回：纯文本，L0 对话片段。
+
+### `tdai_recall`
+
+参数：
+
+- `query` (string, 必填) — 用户 prompt 文本
+- `session_key` (string, 必填)
+
+返回：JSON 字符串，字段：
+
+```json
+{
+  "prepend_context": "<注入到用户消息的 L1 相关记忆>",
+  "append_system_context": "<注入到系统提示的 persona + 场景导航>",
+  "strategy": "hybrid",
+  "memory_count": 3
+}
+```
+
+宿主拿到响应后：
+
+- 把 `prepend_context` 前置到用户消息
+- 把 `append_system_context` 追加到系统提示（可跨轮缓存）
+
+### `tdai_capture`
+
+参数：
+
+- `user_content` (string, 必填)
+- `assistant_content` (string, 必填)
+- `session_key` (string, 必填)
+- `session_id` (string, 可选)
+
+返回：JSON 字符串，`{ l0_recorded, scheduler_notified, l0_vectors_written }`。
+
+### `tdai_session_end`
+
+参数：
+
+- `session_key` (string, 必填)
+
+返回：`{ "flushed": true }`。
+
+## 故障排查
+
+### `tools/list` 没返回 tdai_* 工具
+
+检查 MCP server 是否启动成功。Claude Code 日志通常在 `~/.claude/logs/`。手动冒烟：
+
+```bash
+echo '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0.0.0"}},"id":1}' | \
+  memory-tencentdb-mcp
+```
+
+期望：stdout 上返回合法 JSON-RPC，stderr 上看到 `[memory-tdai] [mcp] INFO ...` 日志。
+
+### `Tool call failed: TdaiCore not initialized`
+
+TdaiCore 初始化失败，通常是数据目录权限错或 LLM API key 缺。开 `TDAI_MCP_DEBUG=1` 看 stderr DEBUG 日志。
+
+### `connection reset` 或日志里出现非 JSON 字符
+
+stdout 被日志污染了。本适配器已强制所有日志走 stderr，但如果用户代码或第三方库调了 `console.log`，会破坏 JSON-RPC 协议流。排查：
+
+```bash
+TDAI_MCP_DEBUG=1 memory-tencentdb-mcp 2>/dev/null </dev/null
+```
+
+正常情况下 stdout 应该完全空（连 initialize 都没等到输入）。
+
+### LLM 调用超时
+
+L1/L2/L3 提取走 StandaloneLLMRunner，单次调用默认 120s 超时。如果模型慢，调高 `TDAI_LLM_TIMEOUT_MS`。
+
+### 跨平台数据不互通
+
+确认所有适配器指向同一 `TDAI_DATA_DIR`。MCP server 默认走 `~/.memory-tencentdb/memory-tdai`，与 standalone Gateway 一致——同机部署无需配置即可共享。
+
+## 进阶：与其他适配器共存
+
+MCP server 跟 standalone Gateway、OpenClaw 插件可以**同时**指向同一个 `dataDir`：
+
+- SQLite 后端用 WAL 模式，支持并发读 + 单写
+- 同一时刻只允许一个进程做写操作（文件锁限制）
+- 多平台同时高频写入请切到 tcvdb 后端
+
+参考 [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md) 第 6 节"存储层映射"了解跨平台数据共享的细节。

--- a/src/adapters/mcp/host-adapter.ts
+++ b/src/adapters/mcp/host-adapter.ts
@@ -1,0 +1,129 @@
+/**
+ * McpHostAdapter — HostAdapter for the MCP (Model Context Protocol) server.
+ *
+ * Pattern C in the adapter family: in-process TdaiCore wrapped as an MCP
+ * server. No OpenClaw dependency, no HTTP hop. The MCP server process IS
+ * the host that owns TdaiCore.
+ *
+ * Reuses `hostType: "standalone"` on purpose — Core's wirePipelineRunners
+ * branches on `hostType !== "openclaw"` to pick the standalone LLM runner,
+ * and that is exactly what we want. Adding a new literal would force a
+ * dead-code branch update inside Core for zero benefit.
+ *
+ * The MCP transport is stdio JSON-RPC, so stdout is reserved for protocol
+ * bytes. Every log line from this adapter (and from Core, via the logger
+ * returned here) MUST go to stderr. Console is redirected accordingly.
+ */
+
+import { StandaloneLLMRunnerFactory } from "../standalone/llm-runner.js";
+import type { StandaloneLLMConfig } from "../standalone/llm-runner.js";
+import type {
+  HostAdapter,
+  RuntimeContext,
+  Logger,
+  LLMRunnerFactory,
+} from "../../core/types.js";
+
+// ============================
+// Options
+// ============================
+
+export interface McpHostAdapterOptions {
+  /** Base data directory for TDAI storage (L0/L1/L2/L3 + vectors.db). */
+  dataDir: string;
+  /** LLM configuration for memory extraction (OpenAI-compatible HTTP). */
+  llmConfig: StandaloneLLMConfig;
+  /** Logger instance — must already write to stderr (NOT stdout). */
+  logger: Logger;
+  /** Default user ID (env-driven, default "default_user"). */
+  defaultUserId?: string;
+}
+
+// ============================
+// McpHostAdapter
+// ============================
+
+export class McpHostAdapter implements HostAdapter {
+  readonly hostType = "standalone" as const;
+
+  private dataDir: string;
+  private logger: Logger;
+  private runnerFactory: StandaloneLLMRunnerFactory;
+  private defaultUserId: string;
+
+  constructor(opts: McpHostAdapterOptions) {
+    this.dataDir = opts.dataDir;
+    this.logger = opts.logger;
+    this.defaultUserId = opts.defaultUserId ?? "default_user";
+
+    this.runnerFactory = new StandaloneLLMRunnerFactory({
+      config: opts.llmConfig,
+      logger: this.logger,
+    });
+  }
+
+  getRuntimeContext(): RuntimeContext {
+    return {
+      userId: this.defaultUserId,
+      sessionId: "",
+      sessionKey: "",
+      platform: "mcp",
+      workspaceDir: this.dataDir,
+      dataDir: this.dataDir,
+    };
+  }
+
+  /**
+   * Build a RuntimeContext scoped to a specific MCP client request.
+   *
+   * MCP requests carry session identifiers via the `_meta` field or via
+   * tool arguments (session_key). The MCP server uses this helper to
+   * stamp each request with the correct identity.
+   */
+  buildRuntimeContextForRequest(params: {
+    userId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+  }): RuntimeContext {
+    return {
+      userId: params.userId ?? this.defaultUserId,
+      sessionId: params.sessionId ?? "",
+      sessionKey: params.sessionKey ?? params.sessionId ?? "",
+      platform: "mcp",
+      workspaceDir: this.dataDir,
+      dataDir: this.dataDir,
+    };
+  }
+
+  getLogger(): Logger {
+    return this.logger;
+  }
+
+  getLLMRunnerFactory(): LLMRunnerFactory {
+    return this.runnerFactory;
+  }
+}
+
+// ============================
+// Stderr-only logger
+// ============================
+
+/**
+ * Build a Logger that writes exclusively to stderr.
+ *
+ * Critical for MCP: stdout is the JSON-RPC transport. Any byte on stdout
+ * that is not a valid JSON-RPC message corrupts the protocol stream and
+ * breaks the client. We redirect info/warn/error to console.error (which
+ * writes to stderr) and debug to stderr only when TDAI_MCP_DEBUG=1.
+ */
+export function createStderrLogger(debugEnabled = false): Logger {
+  const tag = "[memory-tdai] [mcp]";
+  return {
+    debug: debugEnabled
+      ? (msg: string) => process.stderr.write(`${tag} DEBUG ${msg}\n`)
+      : undefined,
+    info: (msg: string) => process.stderr.write(`${tag} INFO ${msg}\n`),
+    warn: (msg: string) => process.stderr.write(`${tag} WARN ${msg}\n`),
+    error: (msg: string) => process.stderr.write(`${tag} ERROR ${msg}\n`),
+  };
+}

--- a/src/adapters/mcp/index.ts
+++ b/src/adapters/mcp/index.ts
@@ -1,0 +1,6 @@
+/**
+ * McpHostAdapter — barrel exports.
+ */
+
+export { McpHostAdapter, createStderrLogger } from "./host-adapter.js";
+export type { McpHostAdapterOptions } from "./host-adapter.js";

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -1,0 +1,532 @@
+/**
+ * TDAI Memory MCP Server — exposes TdaiCore as a Model Context Protocol server.
+ *
+ * One server covers every MCP-compatible client: Claude Code, Codex, Cursor,
+ * Cline, etc. The server runs as a child process spawned by the client and
+ * communicates over stdio JSON-RPC.
+ *
+ * Tool surface (5 tools):
+ *   tdai_memory_search         — L1 structured memory search
+ *   tdai_conversation_search   — L0 raw conversation search
+ *   tdai_recall                — auto-recall (called from host UserPromptSubmit hook)
+ *   tdai_capture               — turn capture (called from host Stop hook)
+ *   tdai_session_end           — session flush (called from host SessionEnd hook)
+ *
+ * Tools alone do not fire auto-recall/capture — MCP has no lifecycle events.
+ * The host (Claude Code, Codex, etc.) must wire its own hooks to call these
+ * tools at the right moments. See README.md for the host-side recipe.
+ *
+ * Lifecycle:
+ *   1. Load config from env (mirror Gateway config, minus server section)
+ *   2. Construct McpHostAdapter + TdaiCore
+ *   3. await core.initialize()
+ *   4. Connect MCP server via StdioServerTransport
+ *   5. SIGINT/SIGTERM → bounded destroy (drain bgTasks → close stores)
+ */
+
+import path from "node:path";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { TdaiCore } from "../../core/tdai-core.js";
+import { SessionFilter } from "../../utils/session-filter.js";
+import { initDataDirectories } from "../../utils/pipeline-factory.js";
+import { parseConfig } from "../../config.js";
+import type { MemoryTdaiConfig } from "../../config.js";
+import type { StandaloneLLMConfig } from "../standalone/llm-runner.js";
+import { normalizeDisableThinking } from "../../utils/no-think-fetch.js";
+import { getEnv } from "../../utils/env.js";
+
+import { McpHostAdapter, createStderrLogger } from "./host-adapter.js";
+import type { McpHostAdapterOptions } from "./host-adapter.js";
+
+const TAG = "[memory-tdai] [mcp-server]";
+const VERSION = "0.1.0";
+
+// Rate limiting: global token-bucket to prevent tool-call abuse.
+// 20 calls per 30s window — covers normal use (~3 calls/turn × 6 turns)
+// while blocking tight-loop abuse from a runaway LLM.
+const RATE_WINDOW_MS = 30_000;
+const MAX_CALLS_PER_WINDOW = 20;
+const toolCallTimestamps: number[] = [];
+
+/**
+ * Validate session_key before it reaches file path construction.
+ * Rejects path-like values that could escape the data directory.
+ */
+function validateSessionKey(key: string): void {
+  if (!key || typeof key !== "string") throw new Error("Missing required parameter: session_key");
+  if (key.length > 256) throw new Error("session_key too long (max 256 chars)");
+  if (key.includes("/") || key.includes("\\") || key.includes("..")) {
+    throw new Error("session_key must not contain path separators");
+  }
+  if (path.isAbsolute(key)) throw new Error("session_key must not be an absolute path");
+}
+
+// ============================
+// MCP server entry point
+// ============================
+
+export async function startMcpServer(): Promise<void> {
+  const debugEnabled = !!getEnv("TDAI_MCP_DEBUG");
+  const logger = createStderrLogger(debugEnabled);
+
+  logger.info(`${TAG} starting (v${VERSION})`);
+
+  // ── Resolve config ────────────────────────────────────────────────────
+  const cfg = loadMcpConfig();
+  const dataDir = cfg.dataDir;
+  const llmConfig = cfg.llm;
+  const memoryConfig = cfg.memory;
+
+  // ── Boot TdaiCore ─────────────────────────────────────────────────────
+  initDataDirectories(dataDir);
+
+  const adapterOpts: McpHostAdapterOptions = {
+    dataDir,
+    llmConfig,
+    logger,
+    defaultUserId: getEnv("TDAI_USER_ID") ?? "default_user",
+  };
+  const hostAdapter = new McpHostAdapter(adapterOpts);
+
+  const sessionFilter = new SessionFilter(memoryConfig.capture.excludeAgents);
+  const core = new TdaiCore({
+    hostAdapter,
+    config: memoryConfig,
+    sessionFilter,
+  });
+
+  await core.initialize();
+  logger.info(`${TAG} TdaiCore ready: dataDir=${dataDir}`);
+
+  // ── Construct MCP server ──────────────────────────────────────────────
+  const server = new Server(
+    {
+      name: "tdai-memory",
+      version: VERSION,
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  // ── tools/list handler ────────────────────────────────────────────────
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: "tdai_memory_search",
+        description:
+          "Search through the user's long-term structured memories (L1). " +
+          "Use this when you need to recall specific information about the " +
+          "user's preferences, past events, instructions, or context from " +
+          "previous conversations. Returns relevant memory records ranked " +
+          "by relevance.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Search query describing what you want to recall about the user.",
+            },
+            limit: {
+              type: "number",
+              description: "Maximum number of results to return (default: 5, max: 20).",
+            },
+            type: {
+              type: "string",
+              enum: ["persona", "episodic", "instruction"],
+              description: "Optional filter by memory type.",
+            },
+            scene: {
+              type: "string",
+              description: "Optional filter by scene name.",
+            },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "tdai_conversation_search",
+        description:
+          "Search through past conversation history (raw L0 dialogue records). " +
+          "Use this when tdai_memory_search (structured memories) doesn't have " +
+          "the information you need, or when you want to find specific past " +
+          "conversations, dialogue context, or exact words the user said before.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Search query describing what conversation content you want to find.",
+            },
+            limit: {
+              type: "number",
+              description: "Maximum number of messages to return (default: 5, max: 20).",
+            },
+            session_key: {
+              type: "string",
+              description: "Optional: filter results to a specific session.",
+            },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "tdai_recall",
+        description:
+          "Auto-recall relevant memories for the current user prompt. " +
+          "Host hook (UserPromptSubmit) should call this BEFORE the agent " +
+          "starts reasoning, then prepend the returned prepend_context to " +
+          "the user's prompt. Returns both prepend_context (per-turn) and " +
+          "append_system_context (persona/scene — cacheable).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "User's prompt text to recall memories for.",
+            },
+            session_key: {
+              type: "string",
+              description: "Session key (stable across reconnects).",
+            },
+          },
+          required: ["query", "session_key"],
+        },
+      },
+      {
+        name: "tdai_capture",
+        description:
+          "Capture a completed conversation turn. Host hook (Stop) should " +
+          "call this AFTER the agent has finished responding. Triggers L0 " +
+          "recording + pipeline scheduling for L1/L2/L3 extraction.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            user_content: {
+              type: "string",
+              description: "User's original message text for this turn.",
+            },
+            assistant_content: {
+              type: "string",
+              description: "Assistant's response text for this turn.",
+            },
+            session_key: {
+              type: "string",
+              description: "Session key.",
+            },
+            session_id: {
+              type: "string",
+              description: "Optional sub-session ID.",
+            },
+            messages: {
+              type: "array",
+              description: "Optional full turn messages including tool calls. If omitted, a simple [user, assistant] pair is used.",
+            },
+          },
+          required: ["user_content", "assistant_content", "session_key"],
+        },
+      },
+      {
+        name: "tdai_session_end",
+        description:
+          "Notify end of a session. Flushes per-session buffered L1/L2 work. " +
+          "Host hook (SessionEnd) should call this. Does NOT tear down the " +
+          "server — other sessions may still be active.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            session_key: {
+              type: "string",
+              description: "Session key to flush.",
+            },
+          },
+          required: ["session_key"],
+        },
+      },
+    ],
+  }));
+
+  // ── tools/call handler ────────────────────────────────────────────────
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolName = request.params.name;
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const startMs = Date.now();
+
+    // Rate limiting: prevent tool-call abuse from runaway LLM loop
+    const now = Date.now();
+    while (toolCallTimestamps.length > 0 && now - toolCallTimestamps[0] > RATE_WINDOW_MS) {
+      toolCallTimestamps.shift();
+    }
+    if (toolCallTimestamps.length >= MAX_CALLS_PER_WINDOW) {
+      return {
+        content: [{
+          type: "text",
+          text: `Rate limit exceeded: max ${MAX_CALLS_PER_WINDOW} tool calls per ${RATE_WINDOW_MS / 1000}s window.`,
+        }],
+        isError: true,
+      };
+    }
+    toolCallTimestamps.push(now);
+
+    try {
+      switch (toolName) {
+        case "tdai_memory_search": {
+          const query = String(args.query ?? "");
+          const limit = Math.min(Math.max(Number(args.limit) || 5, 1), 20);
+          const type = typeof args.type === "string" ? args.type : undefined;
+          const scene = typeof args.scene === "string" ? args.scene : undefined;
+          if (!query) throw new Error("Missing required parameter: query");
+
+          const result = await core.searchMemories({ query, limit, type, scene });
+          logToolCall(logger, toolName, startMs, { total: result.total, strategy: result.strategy });
+          return {
+            content: [{ type: "text", text: result.text }],
+          };
+        }
+
+        case "tdai_conversation_search": {
+          const query = String(args.query ?? "");
+          const limit = Math.min(Math.max(Number(args.limit) || 5, 1), 20);
+          const sessionKey = typeof args.session_key === "string" ? args.session_key : undefined;
+          if (!query) throw new Error("Missing required parameter: query");
+
+          const result = await core.searchConversations({ query, limit, sessionKey });
+          logToolCall(logger, toolName, startMs, { total: result.total });
+          return {
+            content: [{ type: "text", text: result.text }],
+          };
+        }
+
+        case "tdai_recall": {
+          const query = String(args.query ?? "");
+          const sessionKey = String(args.session_key ?? "");
+          if (!query || !sessionKey) {
+            throw new Error("Missing required parameters: query, session_key");
+          }
+          validateSessionKey(sessionKey);
+
+          const result = await core.handleBeforeRecall(query, sessionKey);
+          logToolCall(logger, toolName, startMs, {
+            prependLen: result.prependContext?.length ?? 0,
+            appendLen: result.appendSystemContext?.length ?? 0,
+            strategy: result.recallStrategy ?? "unknown",
+          });
+          // Return both fields so the host can decide where to inject each.
+          // prependContext goes into the user message; appendSystemContext
+          // goes into the system prompt (and is cacheable across turns).
+          const payload = JSON.stringify({
+            prepend_context: result.prependContext ?? "",
+            append_system_context: result.appendSystemContext ?? "",
+            strategy: result.recallStrategy ?? "unknown",
+            memory_count: result.recalledL1Memories?.length ?? 0,
+          });
+          return {
+            content: [{ type: "text", text: payload }],
+          };
+        }
+
+        case "tdai_capture": {
+          const userContent = String(args.user_content ?? "");
+          const assistantContent = String(args.assistant_content ?? "");
+          const sessionKey = String(args.session_key ?? "");
+          const sessionId = typeof args.session_id === "string" ? args.session_id : undefined;
+          if (!userContent || !assistantContent || !sessionKey) {
+            throw new Error("Missing required parameters: user_content, assistant_content, session_key");
+          }
+          validateSessionKey(sessionKey);
+
+          // Accept optional messages[] so the host can pass the full turn
+          // history including tool-call messages (not just user + assistant).
+          // When omitted, fall back to a simple [user, assistant] pair.
+          const rawMessages = args.messages;
+          const messages: unknown[] = Array.isArray(rawMessages) && rawMessages.length > 0
+            ? rawMessages as unknown[]
+            : [
+                { role: "user", content: userContent },
+                { role: "assistant", content: assistantContent },
+              ];
+
+          const result = await core.handleTurnCommitted({
+            userText: userContent,
+            assistantText: assistantContent,
+            messages,
+            sessionKey,
+            sessionId,
+          });
+          logToolCall(logger, toolName, startMs, {
+            l0Recorded: result.l0RecordedCount,
+            schedulerNotified: result.schedulerNotified,
+          });
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                l0_recorded: result.l0RecordedCount,
+                scheduler_notified: result.schedulerNotified,
+                l0_vectors_written: result.l0VectorsWritten,
+              }),
+            }],
+          };
+        }
+
+        case "tdai_session_end": {
+          const sessionKey = String(args.session_key ?? "");
+          if (!sessionKey) throw new Error("Missing required parameter: session_key");
+          validateSessionKey(sessionKey);
+
+          await core.handleSessionEnd(sessionKey);
+          logToolCall(logger, toolName, startMs, { flushed: true });
+          return {
+            content: [{ type: "text", text: JSON.stringify({ flushed: true }) }],
+          };
+        }
+
+        default:
+          throw new Error(`Unknown tool: ${toolName}`);
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.error(`${TAG} [tool] ${toolName} failed (${Date.now() - startMs}ms): ${errMsg}`);
+      return {
+        content: [{ type: "text", text: `Tool call failed: ${errMsg}` }],
+        isError: true,
+      };
+    }
+  });
+
+  // ── Connect via stdio transport ───────────────────────────────────────
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logger.info(`${TAG} MCP server connected on stdio`);
+
+  // ── Signal-driven teardown ────────────────────────────────────────────
+  const SHUTDOWN_TIMEOUT_MS = 5_000;
+  let shuttingDown = false;
+
+  const shutdown = async (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info(`${TAG} received ${signal}, shutting down...`);
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        (async () => {
+          await server.close();
+          await core.destroy();
+        })(),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error("shutdown timeout")),
+            SHUTDOWN_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      logger.info(`${TAG} shutdown complete`);
+    } catch (err) {
+      logger.warn(
+        `${TAG} shutdown timed out: ${err instanceof Error ? err.message : String(err)}` +
+        ` — flushing VectorStore before forced exit`,
+      );
+      // Best-effort: close the VectorStore handle so SQLite WAL is checkpointed
+      // before we hard-exit. core.destroy() does this on the happy path; on the
+      // timeout path we do it manually to minimise data-loss window.
+      try { core.getVectorStore()?.close(); } catch { /* ignore */ }
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      process.exit(0);
+    }
+  };
+
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+}
+
+// ============================
+// Helpers
+// ============================
+
+function logToolCall(
+  logger: ReturnType<typeof createStderrLogger>,
+  toolName: string,
+  startMs: number,
+  details: Record<string, unknown>,
+): void {
+  const elapsed = Date.now() - startMs;
+  const detailStr = Object.entries(details)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+  logger.info(`${TAG} [tool] ${toolName} ok (${elapsed}ms): ${detailStr}`);
+}
+
+// ============================
+// Config loading (env-only, mirrors loadGatewayConfig minus server block)
+// ============================
+
+interface McpServerConfig {
+  dataDir: string;
+  llm: StandaloneLLMConfig;
+  memory: MemoryTdaiConfig;
+}
+
+function loadMcpConfig(): McpServerConfig {
+  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+
+  // Data dir — same defaults as Gateway so MCP server reads the same data
+  // when the user runs both on the same machine.
+  const root = getEnv("MEMORY_TENCENTDB_ROOT") ?? path.join(home, ".memory-tencentdb");
+  const defaultDataDir = path.join(root, "memory-tdai");
+  const rawBaseDir = getEnv("TDAI_DATA_DIR") ?? defaultDataDir;
+  const dataDir = rawBaseDir.startsWith("~/")
+    ? path.join(home, rawBaseDir.slice(2))
+    : rawBaseDir;
+
+  // LLM config — same env vars as Gateway.
+  const llm: StandaloneLLMConfig = {
+    baseUrl: getEnv("TDAI_LLM_BASE_URL") ?? "https://api.openai.com/v1",
+    apiKey: getEnv("TDAI_LLM_API_KEY") ?? "",
+    model: getEnv("TDAI_LLM_MODEL") ?? "gpt-4o",
+    maxTokens: parseInt(getEnv("TDAI_LLM_MAX_TOKENS") ?? "4096", 10),
+    timeoutMs: parseInt(getEnv("TDAI_LLM_TIMEOUT_MS") ?? "120000", 10),
+    disableThinking: normalizeDisableThinking(
+      (getEnv("TDAI_LLM_DISABLE_THINKING") ?? false) as boolean | string,
+    ),
+  };
+
+  // Memory config — start with plugin defaults; user can override via
+  // TDAI_MEMORY_CONFIG env (JSON string) if they need fine-grained control.
+  let memoryRaw: Record<string, unknown> = {};
+  const memoryEnv = getEnv("TDAI_MEMORY_CONFIG");
+  if (memoryEnv) {
+    try {
+      const parsed = JSON.parse(memoryEnv);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        memoryRaw = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Silently fall back to defaults — bad JSON should not block startup.
+    }
+  }
+  const memory = parseConfig(memoryRaw);
+
+  return { dataDir, llm, memory };
+}
+
+// ============================
+// Bootstrap when run directly
+// ============================
+
+startMcpServer().catch((err) => {
+  process.stderr.write(
+    `${TAG} FATAL: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/adapters/sdk/README.md
+++ b/src/adapters/sdk/README.md
@@ -1,0 +1,157 @@
+# PlatformAdapter SDK — 新平台接入只需实现一个接口
+
+## 为什么用 SDK
+
+手写 vs SDK：
+
+| 模块              | 手写行数 | SDK 接入行数 | 省掉 |
+| ----------------- | -------- | ------------ | ---- |
+| HostAdapter 构造   | ~110     | 0（SDK 不造——由调用方提供）| 100% |
+| TdaiCore bootstrap | ~40      | 5 | 87% |
+| 工具 handler       | ~80      | 2-5 | 94% |
+| 生命周期 handler   | ~60      | 2-5 | 92% |
+| 错误降级           | ~40      | 0 | 100% |
+| 信号处理 / teardown| ~25      | 0（`result.shutdown()`） | 100% |
+| **总计**           | **~355** | **~30** | **92%** |
+
+核心设计：SDK **不**构造 HostAdapter——调用方自己提供。`PlatformAdapterRuntime.createStandaloneHostAdapter()` 是便利工厂，不是硬编码依赖。模式 A（in-process）平台可以传自己的 OpenClawHostAdapter 进去。
+
+## 5 分钟接入
+
+### 1. 复制模板
+
+```bash
+cp src/adapters/sdk/templates/template-mcp.ts src/adapters/my-platform/server.ts
+```
+
+### 2. 实现 IPlatformAdapter
+
+```ts
+class MyPlatformAdapter implements IPlatformAdapter {
+  readonly platformId = "my-platform";
+
+  async registerHandlers(ctx: IPlatformAdapterContext) {
+    // 搜索工具——零代码
+    ctx.registerTool({ name: "memory_search",  description: "...", routeTo: "memory_search" });
+    ctx.registerTool({ name: "conv_search",     description: "...", routeTo: "conversation_search" });
+
+    // 自定义工具——传 customHandler
+    ctx.registerTool({
+      name: "my_recall", description: "...", routeTo: "custom",
+      customHandler: async (params) => {
+        const r = await ctx.core.handleBeforeRecall(String(params.query), String(params.session_key));
+        return JSON.stringify(r);
+      },
+    });
+
+    // 生命周期——默认 handler 直接连 Core
+    ctx.onLifecycle("before_prompt");
+    ctx.onLifecycle("after_turn");
+  }
+}
+```
+
+### 3. Bootstrap
+
+```ts
+import { PlatformAdapterRuntime } from "../sdk/index.js";
+
+// 构建 HostAdapter（调用方负责——SDK 不硬编码）
+const hostAdapter = PlatformAdapterRuntime.createStandaloneHostAdapter({
+  dataDir, llmConfig, logger,
+});
+
+const result = await PlatformAdapterRuntime.bootstrap({
+  adapter: new MyPlatformAdapter(),
+  hostAdapter,
+  dataDir,
+  config: memoryConfig,
+});
+
+// result.toolSchemas          — 工具 schema 列表（挂宿主工具注册）
+// result.executeTool(name, p) — 工具调用分发（挂宿主工具路由）
+// result.lifecycleCallbacks   — 生命周期回调 Map（挂宿主钩子）
+// result.shutdown()           — 关闭时调一次
+// result.core                 — TdaiCore 实例（需要直接调 Core 时用）
+```
+
+## API 参考
+
+### `IPlatformAdapter`
+
+```ts
+interface IPlatformAdapter {
+  readonly platformId: string;
+  registerHandlers(ctx: IPlatformAdapterContext): Promise<void> | void;
+}
+```
+
+### `IPlatformAdapterContext`
+
+| 成员           | 类型                                           | 说明               |
+| -------------- | ---------------------------------------------- | ------------------ |
+| `core`         | `TdaiCore`                                     | Core 实例（已 init）|
+| `config`       | `MemoryTdaiConfig`                             | 已解析配置          |
+| `logger`       | `Logger`                                       | stderr 安全日志     |
+| `registerTool` | `(def: PlatformToolDefinition) => void`        | 注册工具            |
+| `onLifecycle`  | `(event, handler?) => void`                    | 注册生命周期回调    |
+
+### `PlatformToolDefinition`
+
+| 字段              | 类型                                                | 说明            |
+| ----------------- | --------------------------------------------------- | --------------- |
+| `name`            | `string`                                            | LLM 可见工具名   |
+| `description`     | `string`                                            | LLM 上下文描述   |
+| `routeTo`         | `"memory_search" \| "conversation_search" \| "custom"` | 路由          |
+| `extraParameters` | `Record<string, unknown>`                           | 额外 JSON Schema |
+| `customHandler`   | `(params) => Promise<string>`                       | routeTo=custom 时必须 |
+
+### `PlatformAdapterBootstrapResult`
+
+| 字段                | 类型                     | 说明                       |
+| ------------------- | ------------------------ | -------------------------- |
+| `core`              | `TdaiCore`               | Core 实例                   |
+| `toolSchemas`       | `PlatformToolSchema[]`   | 宿主注册工具用              |
+| `executeTool`       | `(name, params) => ...`  | 宿主工具路由用              |
+| `lifecycleCallbacks`| `ReadonlyMap<...>`       | 宿主角子用                  |
+| `shutdown`          | `() => Promise<void>`    | 进程退出时调用              |
+
+### `PlatformAdapterRuntime.createStandaloneHostAdapter()`
+
+```ts
+static createStandaloneHostAdapter(opts: {
+  dataDir: string;
+  llmConfig: StandaloneLLMConfig;
+  logger: Logger;
+  defaultUserId?: string;
+}): HostAdapter
+```
+
+便利工厂——给模式 B/C 平台一键构造 McpHostAdapter。模式 A 平台传自己的 HostAdapter。
+
+## 模板选择
+
+| 模板                        | 适用场景                                          |
+| --------------------------- | ------------------------------------------------- |
+| `template-inprocess.ts`     | TS/JS 宿主、原生插件 API（模式 A）                 |
+| `template-sidecar.ts`       | 非 JS 宿主、HTTP 桥接（模式 B）                    |
+| `template-mcp.ts`           | MCP 宿主（模式 C）                                 |
+
+## 自定义生命周期 handler
+
+```ts
+ctx.onLifecycle("before_prompt", async (payload, ctx) => {
+  const p = payload as { userMessage: string; sessionId: string };
+  const r = await ctx.core.handleBeforeRecall(p.userMessage, p.sessionId);
+  ctx.logger.info(`Recalled ${r.recalledL1Memories?.length ?? 0} memories`);
+  // 宿主负责把 r.prependContext / r.appendSystemContext 注入 prompt
+});
+```
+
+## 迁移现有适配器
+
+| 适配器              | 状态      | 迁移收益              |
+| ------------------- | --------- | --------------------- |
+| OpenClaw (index.ts) | 未迁      | 去掉 ~400 行样板       |
+| MCP (server.ts)     | 未迁      | 切换到 SDK bootstrap   |
+| Dify (provider.py)  | 不适用    | Python 不在 TS SDK 范围|

--- a/src/adapters/sdk/index.ts
+++ b/src/adapters/sdk/index.ts
@@ -1,0 +1,17 @@
+/**
+ * PlatformAdapter SDK — barrel exports.
+ */
+export type {
+  IPlatformAdapter,
+  IPlatformAdapterContext,
+  PlatformToolDefinition,
+  PlatformToolSchema,
+  PlatformToolResult,
+  PlatformLifecycleEvent,
+  PlatformLifecycleHandler,
+  PlatformAdapterBootstrapOptions,
+  PlatformAdapterBootstrapResult,
+  ToolRouteTarget,
+} from "./types.js";
+
+export { PlatformAdapterRuntime } from "./runtime.js";

--- a/src/adapters/sdk/runtime.ts
+++ b/src/adapters/sdk/runtime.ts
@@ -1,0 +1,222 @@
+/**
+ * PlatformAdapterRuntime — SDK bootstrap for new TDAI adapter platforms.
+ *
+ * A single call to `PlatformAdapterRuntime.bootstrap(impl, opts)`:
+ *   1. Initialize data dirs + TdaiCore via the caller-provided HostAdapter
+ *   2. Build PlatformAdapterContext with registerTool / onLifecycle
+ *   3. Call impl.registerHandlers(ctx)
+ *   4. Return typed { core, toolSchemas, executeTool, lifecycleCallbacks, shutdown }
+ *
+ * The caller owns HostAdapter construction and signal wiring. The SDK
+ * owns Core lifecycle, tool routing, and error degradation.
+ */
+
+import { TdaiCore } from "../../core/tdai-core.js";
+import { SessionFilter } from "../../utils/session-filter.js";
+import { initDataDirectories, resetStores } from "../../utils/pipeline-factory.js";
+import { McpHostAdapter } from "../mcp/host-adapter.js";
+import type { StandaloneLLMConfig } from "../standalone/llm-runner.js";
+import type { HostAdapter, Logger, CompletedTurn } from "../../core/types.js";
+import type {
+  IPlatformAdapter,
+  IPlatformAdapterContext,
+  PlatformToolDefinition,
+  PlatformLifecycleEvent,
+  PlatformLifecycleHandler,
+  PlatformAdapterBootstrapOptions,
+  PlatformAdapterBootstrapResult,
+} from "./types.js";
+
+const TAG = "[memory-tdai] [sdk]";
+
+// ── Logger ─────────────────────────────────────────────────────────────
+
+function buildLogger(debug: boolean): Logger {
+  const tag = `${TAG} [runtime]`;
+  return {
+    debug: debug ? (msg: string) => process.stderr.write(`${tag} DEBUG ${msg}\n`) : undefined,
+    info: (msg: string) => process.stderr.write(`${tag} INFO ${msg}\n`),
+    warn: (msg: string) => process.stderr.write(`${tag} WARN ${msg}\n`),
+    error: (msg: string) => process.stderr.write(`${tag} ERROR ${msg}\n`),
+  };
+}
+
+// ── Default lifecycle handlers ─────────────────────────────────────────
+
+function defaultLifecycleHandler(event: PlatformLifecycleEvent): PlatformLifecycleHandler {
+  switch (event) {
+    case "before_prompt":
+      return async (payload, ctx) => {
+        const p = payload as { query?: string; session_key?: string };
+        if (!p.query || !p.session_key) { ctx.logger.warn?.(`${TAG} before_prompt: missing query/session_key`); return; }
+        await ctx.core.handleBeforeRecall(p.query, p.session_key);
+      };
+
+    case "after_turn":
+      return async (payload, ctx) => {
+        const p = payload as { user_content?: string; assistant_content?: string; session_key?: string; session_id?: string; messages?: unknown[] };
+        if (!p.user_content || !p.assistant_content || !p.session_key) { ctx.logger.warn?.(`${TAG} after_turn: missing content/session_key`); return; }
+        const turn: CompletedTurn = {
+          userText: p.user_content, assistantText: p.assistant_content,
+          messages: p.messages ?? [{ role: "user", content: p.user_content }, { role: "assistant", content: p.assistant_content }],
+          sessionKey: p.session_key, sessionId: p.session_id,
+        };
+        await ctx.core.handleTurnCommitted(turn);
+      };
+
+    case "session_end":
+      return async (payload, ctx) => {
+        const p = payload as { session_key?: string };
+        if (p.session_key) await ctx.core.handleSessionEnd(p.session_key);
+      };
+
+    case "shutdown":
+      return async (_payload, ctx) => { await ctx.core.destroy(); };
+  }
+}
+
+// ── Default tool handlers ──────────────────────────────────────────────
+
+async function handleMemorySearch(params: Record<string, unknown>, ctx: IPlatformAdapterContext): Promise<string> {
+  const query = String(params.query ?? "");
+  if (!query) throw new Error("Missing required parameter: query");
+  const limit = Math.min(Math.max(Number(params.limit) || 5, 1), 20);
+  const type = typeof params.type === "string" ? params.type : undefined;
+  const scene = typeof params.scene === "string" ? params.scene : undefined;
+  return (await ctx.core.searchMemories({ query, limit, type, scene })).text;
+}
+
+async function handleConversationSearch(params: Record<string, unknown>, ctx: IPlatformAdapterContext): Promise<string> {
+  const query = String(params.query ?? "");
+  if (!query) throw new Error("Missing required parameter: query");
+  const limit = Math.min(Math.max(Number(params.limit) || 5, 1), 20);
+  const sessionKey = typeof params.session_key === "string" ? params.session_key : undefined;
+  return (await ctx.core.searchConversations({ query, limit, sessionKey })).text;
+}
+
+// ── Tool schema builder ────────────────────────────────────────────────
+
+function buildToolSchema(def: PlatformToolDefinition): Record<string, unknown> {
+  const props: Record<string, unknown> = {
+    query: { type: "string", description: "Search query." },
+    limit: { type: "number", description: "Maximum number of results to return (default: 5, max: 20)." },
+    ...(def.extraParameters ?? {}),
+  };
+  if (def.routeTo === "memory_search") {
+    props.type = { type: "string", enum: ["persona", "episodic", "instruction"], description: "Optional filter by memory type." };
+    props.scene = { type: "string", description: "Optional filter by scene name." };
+  }
+  if (def.routeTo === "conversation_search") {
+    props.session_key = { type: "string", description: "Optional session filter." };
+  }
+  return { type: "object", properties: props, required: ["query"] };
+}
+
+// ── Runtime ────────────────────────────────────────────────────────────
+
+export class PlatformAdapterRuntime {
+  /**
+   * Bootstrap: caller provides a HostAdapter, SDK does the rest.
+   *
+   * Returns typed result — no any-cast metadata on core.
+   */
+  static async bootstrap(opts: PlatformAdapterBootstrapOptions): Promise<PlatformAdapterBootstrapResult> {
+    const logger = buildLogger(opts.debug ?? false);
+    logger.info(`${TAG} bootstrapping platform "${opts.adapter.platformId}"`);
+
+    // 1. Init data dirs
+    initDataDirectories(opts.dataDir);
+
+    // 2. Build + init TdaiCore via caller's HostAdapter
+    const sessionFilter = new SessionFilter(opts.config.capture.excludeAgents);
+    const core = new TdaiCore({ hostAdapter: opts.hostAdapter, config: opts.config, sessionFilter });
+    await core.initialize();
+    logger.info(`${TAG} TdaiCore ready (dataDir=${opts.dataDir})`);
+
+    // 3. Tool + lifecycle registries
+    const registeredTools: Array<{ def: PlatformToolDefinition; handler: (p: Record<string, unknown>) => Promise<string> }> = [];
+    const lifecycleCallbacks = new Map<PlatformLifecycleEvent, PlatformLifecycleHandler[]>();
+
+    // 4. Build context
+    const ctx: IPlatformAdapterContext = {
+      core, config: opts.config, logger,
+
+      registerTool(def: PlatformToolDefinition): void {
+        let handler: (p: Record<string, unknown>) => Promise<string>;
+        switch (def.routeTo) {
+          case "memory_search":       handler = (p) => handleMemorySearch(p, ctx); break;
+          case "conversation_search": handler = (p) => handleConversationSearch(p, ctx); break;
+          case "custom":
+            if (!def.customHandler) throw new Error(`Tool "${def.name}" has routeTo="custom" but no customHandler`);
+            handler = def.customHandler; break;
+          default: throw new Error(`Unknown routeTo: ${(def as any).routeTo}`);
+        }
+        registeredTools.push({ def, handler });
+        logger.debug?.(`${TAG} registered tool: ${def.name} → ${def.routeTo}`);
+      },
+
+      onLifecycle(event: PlatformLifecycleEvent, handler?: PlatformLifecycleHandler): void {
+        const h = handler ?? defaultLifecycleHandler(event);
+        if (!lifecycleCallbacks.has(event)) lifecycleCallbacks.set(event, []);
+        lifecycleCallbacks.get(event)!.push(h);
+        logger.debug?.(`${TAG} registered lifecycle: ${event}`);
+      },
+    };
+
+    // 5. Call implementor
+    await opts.adapter.registerHandlers(ctx);
+    logger.info(`${TAG} platform "${opts.adapter.platformId}" registered ${registeredTools.length} tools, ${lifecycleCallbacks.size} lifecycle hooks`);
+
+    // 6. Default shutdown if implementor didn't register one
+    if (!lifecycleCallbacks.has("shutdown") || lifecycleCallbacks.get("shutdown")!.length === 0) {
+      lifecycleCallbacks.set("shutdown", [defaultLifecycleHandler("shutdown")]);
+    }
+
+    // 7. Build typed result
+    const toolSchemas = registeredTools.map((t) => ({
+      name: t.def.name,
+      description: t.def.description,
+      inputSchema: buildToolSchema(t.def),
+    }));
+
+    const executeTool = async (name: string, params: Record<string, unknown>) => {
+      const tool = registeredTools.find((t) => t.def.name === name);
+      if (!tool) throw new Error(`Unknown tool: ${name}`);
+      const startMs = Date.now();
+      try {
+        const text = await tool.handler(params);
+        logger.debug?.(`${TAG} tool ${name} ok (${Date.now() - startMs}ms)`);
+        return { content: [{ type: "text" as const, text }] };
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        logger.error(`${TAG} tool ${name} failed (${Date.now() - startMs}ms): ${errMsg}`);
+        return { content: [{ type: "text" as const, text: `Tool call failed: ${errMsg}` }], isError: true };
+      }
+    };
+
+    const shutdown = async () => {
+      logger.info(`${TAG} shutting down...`);
+      for (const h of lifecycleCallbacks.get("shutdown") ?? []) {
+        try { await h({}, ctx); } catch (err) {
+          logger.warn(`${TAG} shutdown handler error: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      resetStores(opts.dataDir);
+    };
+
+    return { core, toolSchemas, executeTool, lifecycleCallbacks, shutdown };
+  }
+
+  /**
+   * Convenience factory: build a McpHostAdapter (standalone/stdio style)
+   * from LLM config. Covers Pattern B (sidecar) and Pattern C (MCP).
+   */
+  static createStandaloneHostAdapter(opts: {
+    dataDir: string;
+    llmConfig: StandaloneLLMConfig;
+    logger: Logger;
+    defaultUserId?: string;
+  }): HostAdapter {
+    return new McpHostAdapter(opts);
+  }
+}

--- a/src/adapters/sdk/templates/template-inprocess.ts
+++ b/src/adapters/sdk/templates/template-inprocess.ts
@@ -1,0 +1,99 @@
+/**
+ * Template: Pattern A — In-process TypeScript host.
+ *
+ * Use this when the target platform is a TS/JS agent framework with a
+ * native plugin API (similar to OpenClaw). The Core runs in the same
+ * Node.js process as the host — no HTTP hops, no serialization.
+ *
+ * Replace every `TODO` with your platform's specific API.
+ */
+
+import { PlatformAdapterRuntime } from "../runtime.js";
+import type {
+  IPlatformAdapter,
+  IPlatformAdapterContext,
+  PlatformAdapterBootstrapOptions,
+} from "../types.js";
+import type { MemoryTdaiConfig } from "../../../config.js";
+
+// ── Step 1: Implement IPlatformAdapter ────────────────────────────────
+
+class MyPlatformAdapter implements IPlatformAdapter {
+  readonly platformId = "TODO: your-platform-id";
+
+  async registerHandlers(ctx: IPlatformAdapterContext) {
+    // Register the two universal memory search tools.
+    // routeTo = "memory_search" / "conversation_search" means the SDK
+    // provides the handler — zero code from you for these.
+    ctx.registerTool({
+      name: "memory_search",
+      description: "TODO: description",
+      routeTo: "memory_search",
+    });
+    ctx.registerTool({
+      name: "conversation_search",
+      description: "TODO: description",
+      routeTo: "conversation_search",
+    });
+
+    // Wire lifecycle events. For each event you handle, the SDK has a
+    // default handler that calls the correct core method. Pass `undefined`
+    // as the second arg to use the default.
+    //
+    // If your host's event shape differs, provide a custom handler:
+    //   ctx.onLifecycle("before_prompt", async (payload, ctx) => {
+    //     const adapted = adaptMyPayload(payload);
+    //     await ctx.core.handleBeforeRecall(adapted.query, adapted.sessionKey);
+    //   });
+
+    ctx.onLifecycle("before_prompt"); // → core.handleBeforeRecall
+    ctx.onLifecycle("after_turn");    // → core.handleTurnCommitted
+    ctx.onLifecycle("session_end");   // → core.handleSessionEnd
+    // shutdown auto-registered by runtime — don't add it here
+  }
+}
+
+// ── Step 2: Bootstrap ──────────────────────────────────────────────────
+
+export async function startMyPlatformAdapter(dataDir: string, config: MemoryTdaiConfig) {
+  const adapter = new MyPlatformAdapter();
+  const opts: PlatformAdapterBootstrapOptions = {
+    adapter,
+    dataDir,
+    config,
+    llmBaseUrl: process.env.LLM_BASE_URL ?? "https://api.openai.com/v1",
+    llmApiKey: process.env.LLM_API_KEY ?? "",
+    llmModel: process.env.LLM_MODEL ?? "gpt-4o",
+    debug: !!process.env.TDAI_DEBUG,
+  };
+
+  const { core, shutdown } = await PlatformAdapterRuntime.bootstrap(opts);
+
+  // ── Step 3: Bridge to your host's plugin API ───────────────────────
+
+  // TODO: Register tools with your host:
+  //   const schemas = (core as any).__sdk_toolSchemas;
+  //   for (const s of schemas) {
+  //     myHost.registerTool({
+  //       name: s.name,
+  //       description: s.description,
+  //       parameters: s.inputSchema,
+  //       execute: async (params) => {
+  //         return (core as any).__sdk_executeTool(s.name, params);
+  //       },
+  //     });
+  //   }
+
+  // TODO: Wire lifecycle hooks:
+  //   const callbacks = (core as any).__sdk_lifecycleCallbacks;
+  //   myHost.on("beforePrompt", async (payload) => {
+  //     for (const h of callbacks.get("before_prompt") ?? []) {
+  //       await h(payload, /* ctx from bootstrap */);
+  //     }
+  //   });
+
+  // TODO: Wire shutdown:
+  //   myHost.on("stop", shutdown);
+
+  return { core, shutdown };
+}

--- a/src/adapters/sdk/templates/template-mcp.ts
+++ b/src/adapters/sdk/templates/template-mcp.ts
@@ -1,0 +1,114 @@
+/**
+ * Template: Pattern C — MCP server (stdin/stdout JSON-RPC).
+ *
+ * Demonstrates PlatformAdapterRuntime.bootstrap() with a caller-provided
+ * HostAdapter. Replace TODO markers with your platform's MCP SDK calls.
+ */
+
+import { PlatformAdapterRuntime } from "../runtime.js";
+import type {
+  IPlatformAdapter,
+  IPlatformAdapterContext,
+  PlatformAdapterBootstrapOptions,
+} from "../types.js";
+import type { MemoryTdaiConfig } from "../../../config.js";
+import type { StandaloneLLMConfig } from "../../standalone/llm-runner.js";
+import { parseConfig } from "../../../config.js";
+
+// ── Step 1: Implement IPlatformAdapter ────────────────────────────────
+
+class MyMcpPlatformAdapter implements IPlatformAdapter {
+  readonly platformId = "TODO: platform-id";
+
+  async registerHandlers(ctx: IPlatformAdapterContext) {
+    ctx.registerTool({
+      name: "tdai_memory_search",
+      description: "Search structured memories (L1).",
+      routeTo: "memory_search",
+    });
+    ctx.registerTool({
+      name: "tdai_conversation_search",
+      description: "Search raw conversations (L0).",
+      routeTo: "conversation_search",
+    });
+    ctx.registerTool({
+      name: "tdai_recall",
+      description: "Auto-recall for current prompt.",
+      routeTo: "custom",
+      customHandler: async (params) => {
+        const q = String(params.query ?? ""); const sk = String(params.session_key ?? "");
+        if (!q || !sk) throw new Error("Missing query/session_key");
+        const r = await ctx.core.handleBeforeRecall(q, sk);
+        return JSON.stringify({ prepend_context: r.prependContext ?? "", append_system_context: r.appendSystemContext ?? "", memory_count: r.recalledL1Memories?.length ?? 0 });
+      },
+    });
+    ctx.registerTool({
+      name: "tdai_capture",
+      description: "Capture completed turn.",
+      routeTo: "custom",
+      customHandler: async (params) => {
+        const uc = String(params.user_content ?? ""); const ac = String(params.assistant_content ?? ""); const sk = String(params.session_key ?? "");
+        if (!uc || !ac || !sk) throw new Error("Missing user_content/assistant_content/session_key");
+        const r = await ctx.core.handleTurnCommitted({ userText: uc, assistantText: ac, messages: [{ role: "user", content: uc }, { role: "assistant", content: ac }], sessionKey: sk });
+        return JSON.stringify({ l0_recorded: r.l0RecordedCount });
+      },
+    });
+    ctx.registerTool({
+      name: "tdai_session_end",
+      description: "Flush session.",
+      routeTo: "custom",
+      customHandler: async (params) => {
+        const sk = String(params.session_key ?? ""); if (!sk) throw new Error("Missing session_key");
+        await ctx.core.handleSessionEnd(sk); return JSON.stringify({ flushed: true });
+      },
+    });
+  }
+}
+
+// ── Step 2: Bootstrap with caller-provided HostAdapter ─────────────────
+
+export async function startMcpServer() {
+  const dataDir = process.env.TDAI_DATA_DIR ?? `${process.env.HOME ?? process.env.USERPROFILE}/.memory-tencentdb/memory-tdai`;
+  const debug = !!process.env.TDAI_MCP_DEBUG;
+
+  // Build HostAdapter (caller owns this — not SDK)
+  const llmConfig: StandaloneLLMConfig = {
+    baseUrl: process.env.TDAI_LLM_BASE_URL ?? "https://api.openai.com/v1",
+    apiKey: process.env.TDAI_LLM_API_KEY ?? "",
+    model: process.env.TDAI_LLM_MODEL ?? "gpt-4o",
+    maxTokens: Number(process.env.TDAI_LLM_MAX_TOKENS) || 4096,
+    timeoutMs: Number(process.env.TDAI_LLM_TIMEOUT_MS) || 120_000,
+  };
+  const hostAdapter = PlatformAdapterRuntime.createStandaloneHostAdapter({ dataDir, llmConfig, logger: buildStderrLogger(debug) });
+
+  // Parse memory config
+  const memoryConfig: MemoryTdaiConfig = (() => {
+    const raw: Record<string, unknown> = {};
+    const env = process.env.TDAI_MEMORY_CONFIG;
+    if (env) { try { const p = JSON.parse(env); if (p && typeof p === "object" && !Array.isArray(p)) Object.assign(raw, p); } catch {} }
+    return parseConfig(raw);
+  })();
+
+  const opts: PlatformAdapterBootstrapOptions = { adapter: new MyMcpPlatformAdapter(), hostAdapter, dataDir, config: memoryConfig, debug };
+  const result = await PlatformAdapterRuntime.bootstrap(opts);
+
+  // ── Step 3: Wire to MCP transport ────────────────────────────────────
+  //
+  // import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+  // import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+  // import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+  //
+  // const server = new Server({ name: "tdai-memory", version: "1.0.0" }, { capabilities: { tools: {} } });
+  // server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: result.toolSchemas }));
+  // server.setRequestHandler(CallToolRequestSchema, async (req) => result.executeTool(req.params.name, req.params.arguments ?? {}));
+  // await server.connect(new StdioServerTransport());
+  // process.on("SIGINT", result.shutdown);
+  // process.on("SIGTERM", result.shutdown);
+
+  return result;
+}
+
+function buildStderrLogger(debug: boolean) {
+  const t = "[memory-tdai]";
+  return { debug: debug ? (m: string) => process.stderr.write(`${t} DEBUG ${m}\n`) : undefined, info: (m: string) => process.stderr.write(`${t} INFO ${m}\n`), warn: (m: string) => process.stderr.write(`${t} WARN ${m}\n`), error: (m: string) => process.stderr.write(`${t} ERROR ${m}\n`) };
+}

--- a/src/adapters/sdk/templates/template-sidecar.ts
+++ b/src/adapters/sdk/templates/template-sidecar.ts
@@ -1,0 +1,119 @@
+/**
+ * Template: Pattern B — HTTP sidecar client (any language, but shows TS).
+ *
+ * Use this when the target platform runs in a different language or
+ * process, and communicates with TdaiCore over HTTP. The standalone
+ * Gateway wraps TdaiCore in an HTTP server; the adapter is a thin HTTP
+ * client that maps the host's lifecycle events to Gateway endpoints.
+ *
+ * This template shows the TypeScript version of the client. For Python,
+ * copy hermes-plugin/memory/memory_tencentdb/client.py as the baseline.
+ *
+ * Replace every `TODO` with your platform's specific API.
+ */
+
+// ── Minimal HTTP client (stdlib only, no framework dependency) ─────────
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8420";
+
+class GatewayClient {
+  constructor(private baseUrl: string = DEFAULT_BASE_URL) {}
+
+  private async post(path: string, body: Record<string, unknown>): Promise<unknown> {
+    const resp = await fetch(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      throw new Error(`Gateway ${path} returned ${resp.status}`);
+    }
+    return resp.json();
+  }
+
+  // ── Tool endpoints ──────────────────────────────────────────────────
+
+  async searchMemories(query: string, limit = 5, type?: string, scene?: string) {
+    return this.post("/search/memories", { query, limit, ...(type ? { type } : {}), ...(scene ? { scene } : {}) });
+  }
+
+  async searchConversations(query: string, limit = 5, sessionKey?: string) {
+    return this.post("/search/conversations", { query, limit, ...(sessionKey ? { session_key: sessionKey } : {}) });
+  }
+
+  async recall(query: string, sessionKey: string) {
+    return this.post("/recall", { query, session_key: sessionKey });
+  }
+
+  async capture(userContent: string, assistantContent: string, sessionKey: string) {
+    return this.post("/capture", {
+      user_content: userContent,
+      assistant_content: assistantContent,
+      session_key: sessionKey,
+    });
+  }
+
+  async endSession(sessionKey: string) {
+    return this.post("/session/end", { session_key: sessionKey });
+  }
+}
+
+// ── Step 1: Wire to your host ──────────────────────────────────────────
+
+export async function startSidecarAdapter() {
+  const client = new GatewayClient(
+    process.env.TDAI_GATEWAY_URL ?? DEFAULT_BASE_URL,
+  );
+
+  // ── Register tools ───────────────────────────────────────────────────
+  // TODO: Replace with your host's tool-registration API
+
+  const tools = [
+    {
+      name: "memory_tencentdb_memory_search",
+      description: "Search structured memories (L1)",
+      execute: async (params: Record<string, unknown>) => {
+        const result = await client.searchMemories(
+          String(params.query),
+          Number(params.limit) || 5,
+          typeof params.type === "string" ? params.type : undefined,
+          typeof params.scene === "string" ? params.scene : undefined,
+        );
+        return JSON.stringify(result);
+      },
+    },
+    {
+      name: "memory_tencentdb_conversation_search",
+      description: "Search raw conversations (L0)",
+      execute: async (params: Record<string, unknown>) => {
+        const result = await client.searchConversations(
+          String(params.query),
+          Number(params.limit) || 5,
+          typeof params.session_key === "string" ? params.session_key : undefined,
+        );
+        return JSON.stringify(result);
+      },
+    },
+  ];
+
+  // TODO: myHost.registerTools(tools);
+
+  // ── Wire lifecycle ───────────────────────────────────────────────────
+  // TODO: Replace with your host's hook system
+
+  // myHost.on("beforePrompt", async (query, sessionKey) => {
+  //   const result = await client.recall(query, sessionKey);
+  //   return result.context; // inject into prompt
+  // });
+
+  // myHost.on("afterTurn", async (userContent, assistantContent, sessionKey) => {
+  //   // Fire-and-forget — don't block the next turn
+  //   client.capture(userContent, assistantContent, sessionKey).catch(() => {});
+  // });
+
+  // myHost.on("sessionEnd", async (sessionKey) => {
+  //   await client.endSession(sessionKey);
+  // });
+
+  return { client };
+}

--- a/src/adapters/sdk/types.ts
+++ b/src/adapters/sdk/types.ts
@@ -1,0 +1,107 @@
+/**
+ * PlatformAdapter SDK — type definitions.
+ *
+ * The SDK contract: a new agent platform implements *one* interface
+ * (IPlatformAdapter) with *one* method (registerHandlers). The SDK
+ * runtime handles everything else:
+ *
+ *   - TdaiCore bootstrap + initialize + destroy
+ *   - Tool schema → Core method routing
+ *   - Lifecycle event → Core method mapping
+ *   - Error degradation (graceful fallback, logging)
+ *
+ * The caller provides a HostAdapter — the SDK does not construct one.
+ * This keeps the SDK decoupled from any specific host adapter impl.
+ */
+
+import type { MemoryTdaiConfig } from "../../config.js";
+import type { TdaiCore } from "../../core/tdai-core.js";
+import type { HostAdapter, Logger } from "../../core/types.js";
+
+// ── Core abstraction ───────────────────────────────────────────────────
+
+/**
+ * The ONE interface a new platform adapter must implement.
+ *
+ * For 90% of platforms, registerHandlers is under 50 lines: a flat list
+ * of ctx.registerTool(...) calls plus 2-3 ctx.onLifecycle(...) calls.
+ */
+export interface IPlatformAdapter {
+  readonly platformId: string;
+  registerHandlers(ctx: IPlatformAdapterContext): Promise<void> | void;
+}
+
+// ── Context ────────────────────────────────────────────────────────────
+
+export interface IPlatformAdapterContext {
+  readonly core: TdaiCore;
+  readonly logger: Logger;
+  readonly config: MemoryTdaiConfig;
+
+  /** Register a tool. routeTo="memory_search"/"conversation_search" = zero code. */
+  registerTool(def: PlatformToolDefinition): void;
+
+  /** Wire a lifecycle callback. Omit handler to use the SDK default. */
+  onLifecycle(event: PlatformLifecycleEvent, handler?: PlatformLifecycleHandler): void;
+}
+
+// ── Tool definition ────────────────────────────────────────────────────
+
+export type ToolRouteTarget = "memory_search" | "conversation_search" | "custom";
+
+export interface PlatformToolDefinition {
+  name: string;
+  description: string;
+  extraParameters?: Record<string, unknown>;
+  routeTo: ToolRouteTarget;
+  customHandler?: (params: Record<string, unknown>) => Promise<string>;
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────
+
+export type PlatformLifecycleEvent =
+  | "before_prompt"
+  | "after_turn"
+  | "session_end"
+  | "shutdown";
+
+export type PlatformLifecycleHandler = (
+  payload: unknown,
+  ctx: IPlatformAdapterContext,
+) => Promise<void> | void;
+
+// ── Bootstrap ──────────────────────────────────────────────────────────
+
+export interface PlatformAdapterBootstrapOptions {
+  adapter: IPlatformAdapter;
+  /** Caller-provided HostAdapter — SDK does NOT construct one. */
+  hostAdapter: HostAdapter;
+  dataDir: string;
+  config: MemoryTdaiConfig;
+  debug?: boolean;
+}
+
+/** Tool schema object returned for host-side tool registration. */
+export interface PlatformToolSchema {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** Tool execution result returned to the host. */
+export interface PlatformToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+export interface PlatformAdapterBootstrapResult {
+  core: TdaiCore;
+  /** Tool schemas ready for host-side registration (MCP tools/list, etc.). */
+  toolSchemas: PlatformToolSchema[];
+  /** Dispatch a tool call by name. Host's tools/call handler calls this. */
+  executeTool: (name: string, params: Record<string, unknown>) => Promise<PlatformToolResult>;
+  /** Lifecycle callbacks keyed by event. Host calls each for its events. */
+  lifecycleCallbacks: ReadonlyMap<PlatformLifecycleEvent, readonly PlatformLifecycleHandler[]>;
+  /** Bounded shutdown (drains bgTasks, closes stores). Call on process exit. */
+  shutdown: () => Promise<void>;
+}

--- a/tests/mcp-e2e-README.md
+++ b/tests/mcp-e2e-README.md
@@ -1,0 +1,113 @@
+# TDAI MCP Server — E2E 测试流程
+
+测试脚本：[tests/mcp-e2e.test.mjs](../tests/mcp-e2e.test.mjs)
+
+## 快速开始
+
+```bash
+# 先构建（产出 dist/src/adapters/mcp/server.mjs）
+cd TencentDB-Agent-Memory
+pnpm build
+
+# 跑 E2E 测试（无 LLM key 也能跑——搜索会优雅降级）
+node tests/mcp-e2e.test.mjs
+
+# 带 LLM key 完整测试（含 memory recall + L0 search 实际返回结果）
+TDAI_LLM_API_KEY=sk-xxx node tests/mcp-e2e.test.mjs
+```
+
+## 测试覆盖
+
+```
+1. Initialize handshake  ──→  serverInfo.name = "tdai-memory"
+2. tools/list            ──→  5 个工具、inputSchema 完整、description 合法
+3. tdai_capture          ──→  写 L0 JSONL、磁盘验证内容可读
+4. tdai_memory_search    ──→  搜索响应格式正确（有无 LLM key 均不挂）
+5. tdai_recall           ──→  prepend_context / append_system_context 字段齐
+6. tdai_conversation_search → L0 搜索可用
+7. tdai_session_end      ──→  有 LLM key 时 flush 成功（无 key 时跳过）
+8. Error handling x3     ──→  缺参数 → isError、未知工具 → isError
+```
+
+## 协议流
+
+```mermaid
+sequenceDiagram
+    participant Test as E2E Test
+    participant Server as MCP Server
+    participant Core as TdaiCore
+    participant FS as 文件系统
+
+    Test->>Server: initialize
+    Server-->>Test: { serverInfo, capabilities }
+    
+    Test->>Server: tools/list
+    Server-->>Test: 5 个工具定义
+    
+    Test->>Server: tools/call tdai_capture
+    Server->>Core: handleTurnCommitted()
+    Core->>FS: conversations/<session>.jsonl
+    Server-->>Test: { l0_recorded: 2 }
+    
+    Test->>FS: 读文件验证
+    
+    Test->>Server: tools/call tdai_memory_search
+    Server->>Core: searchMemories()
+    Server-->>Test: { text: "..." }
+    
+    Test->>Server: tools/call tdai_recall
+    Server->>Core: handleBeforeRecall()
+    Server-->>Test: { prepend_context, append_system_context }
+    
+    Test->>Server: tools/call tdai_conversation_search
+    Server->>Core: searchConversations()
+    Server-->>Test: { text: "..." }
+    
+    Test->>Server: tools/call tdai_session_end
+    Server->>Core: handleSessionEnd()
+    Server-->>Test: { flushed: true }
+    
+    Test->>Server: (缺参数 / 未知工具)
+    Server-->>Test: { isError: true, ... }
+```
+
+## 有 LLM key vs 无 LLM key 的差异
+
+| 测试 | 无 LLM key | 有 LLM key |
+|------|-----------|------------|
+| Initialize | ✓ | ✓ |
+| tools/list | ✓ | ✓ |
+| tdai_capture | ✓ L0 写盘正常 | ✓ L0 + pipeline 调度 |
+| tdai_memory_search | ✓ 返回"embedding 未配置"降级消息 | ✓ 返回 L1 记忆结果 + L3 persona |
+| tdai_recall | ✓ memory_count=0 | ✓ memory_count > 0 |
+| tdai_conversation_search | ✓ 返回降级消息 | ✓ 返回 L0 对话片段 |
+| tdai_session_end | 跳过（L1 提取需 LLM，无 key 会挂起） | ✓ flushed=true |
+| Error handling | ✓ | ✓ |
+
+## 失败排查
+
+### `Server not built`
+
+先跑 `pnpm build`。确认 `dist/src/adapters/mcp/server.mjs` 存在。
+
+### 某个 test 超时（>30s）
+
+查看 stderr（测试脚本在中断时打印最后 500 字节）。常见原因：
+
+- **LLM endpoint 不通** — `TDAI_LLM_BASE_URL` 指向了不可达地址。检查配置。
+- **API key 错误** — LLM provider 返回 401，但 SDK 重试多次后才超时。
+- **FTS5 不可用** — 当前 Node.js 22 的 `node:sqlite` 没有 FTS5。这导致搜索降级为纯文本，不影响其他功能。
+
+### `conversation jsonl exists on disk` 失败
+
+检查 `TDAI_DATA_DIR` 权限。临时目录（`$TMP/tdai-mcp-e2e-*`）需要可写。
+
+## 环境变量参考
+
+| 变量 | 必填 | 说明 |
+|------|------|------|
+| `TDAI_LLM_API_KEY` | 否 | LLM API key——有则跑完整搜索/提取，无则降级 |
+| `TDAI_LLM_BASE_URL` | 否 | 默认 `https://api.openai.com/v1` |
+| `TDAI_LLM_MODEL` | 否 | 默认 `gpt-4o` |
+| `TDAI_DATA_DIR` | 否 | 默认临时目录，测试结束自动清 |
+| `TDAI_MCP_DEBUG` | 否 | 设为 `1` 开 DEBUG 级别日志（写 stderr） |

--- a/tests/mcp-e2e.test.mjs
+++ b/tests/mcp-e2e.test.mjs
@@ -1,0 +1,322 @@
+/**
+ * MCP server E2E test — validates full lifecycle of the tdai-memory MCP server.
+ *
+ * Spawns MCP server as child process, sends JSON-RPC sequence over stdin,
+ * asserts every response shape on stdout. All assertions structural — no
+ * internal implementation knowledge required.
+ *
+ * Usage:
+ *   node tests/mcp-e2e.test.mjs
+ *
+ * Environment:
+ *   TDAI_LLM_API_KEY — optional; searches degrade gracefully without it.
+ *   TDAI_DATA_DIR   — tmp dir auto-cleaned on exit unless overridden.
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync, rmSync, mkdtempSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const SERVER_PATH = resolve(REPO_ROOT, "dist/src/adapters/mcp/server.mjs");
+
+if (!existsSync(SERVER_PATH)) {
+  console.error(`Server not built: ${SERVER_PATH}\nRun: pnpm build`);
+  process.exit(1);
+}
+
+const DATA_DIR = mkdtempSync(join(tmpdir(), "tdai-mcp-e2e-"));
+const SESSION_KEY = `e2e-${Date.now()}`;
+let passed = 0;
+let failed = 0;
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+function assert(condition, label) {
+  if (condition) { console.log(`  ${green("✓")} ${label}`); passed++; }
+  else           { console.error(`  ${red("✗")} ${label}`); failed++; }
+}
+
+// ── MCP Client (newline-delimited JSON over child process stdio) ──────
+
+class McpClient {
+  constructor(serverProcess) {
+    this.server = serverProcess;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.buf = "";
+    this.server.stdout.on("data", (chunk) => {
+      this.buf += chunk.toString();
+      let nl;
+      while ((nl = this.buf.indexOf("\n")) !== -1) {
+        const line = this.buf.slice(0, nl).trim();
+        this.buf = this.buf.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const msg = JSON.parse(line);
+          const resolve = this.pending.get(msg.id);
+          if (resolve) { this.pending.delete(msg.id); resolve(msg); }
+        } catch { /* ignore */ }
+      }
+    });
+  }
+
+  request(method, params = {}, timeoutMs = 30_000) {
+    const id = this.nextId++;
+    const msg = { jsonrpc: "2.0", method, params, id };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} (id=${id}) timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, (resp) => { clearTimeout(timer); resolve(resp); });
+      this.server.stdin.write(JSON.stringify(msg) + "\n");
+    });
+  }
+}
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const srv = spawn("node", [SERVER_PATH], {
+      cwd: REPO_ROOT,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        TDAI_DATA_DIR: DATA_DIR,
+        TDAI_MCP_DEBUG: "0",
+      },
+    });
+    srv.on("error", reject);
+    // Collect stderr for diagnostics on failure
+    let stderr = "";
+    srv.stderr.on("data", (c) => { stderr += c.toString(); });
+
+    const client = new McpClient(srv);
+    client.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "e2e-test", version: "0.0.0" },
+    }, 15_000).then((initResp) => {
+      resolve({ server: srv, client, initResp, getStderr: () => stderr });
+    }).catch((err) => {
+      srv.kill();
+      reject(new Error(err.message + "\nServer stderr:\n" + stderr.slice(-500)));
+    });
+  });
+}
+
+// ── Test suites ────────────────────────────────────────────────────────
+
+async function testInitialize(initResp) {
+  console.log("\n[1] Initialize handshake");
+  assert(!!initResp.result, "response has result");
+  assert(initResp.result?.serverInfo?.name === "tdai-memory", "server name = tdai-memory");
+  assert(typeof initResp.result?.serverInfo?.version === "string", "version is string");
+  assert(!!initResp.result?.capabilities?.tools, "tools capability declared");
+}
+
+async function testToolList(client) {
+  console.log("\n[2] tools/list — all 5 tools");
+  const resp = await client.request("tools/list");
+  const tools = resp.result?.tools ?? [];
+
+  assert(tools.length === 5, `5 tools (got ${tools.length})`);
+  const names = tools.map((t) => t.name).sort();
+  assert(
+    JSON.stringify(names) === JSON.stringify([
+      "tdai_capture", "tdai_conversation_search", "tdai_memory_search",
+      "tdai_recall", "tdai_session_end",
+    ]),
+    "tool names match",
+  );
+  for (const t of tools) {
+    assert(!!t.inputSchema && typeof t.inputSchema === "object", `${t.name} has inputSchema`);
+    assert(Array.isArray(t.inputSchema.required), `${t.name} has required[]`);
+    assert(typeof t.description === "string" && t.description.length > 10, `${t.name} description > 10 chars`);
+  }
+}
+
+async function testCapture(client) {
+  console.log("\n[3] tdai_capture — write conversation turn");
+  const resp = await client.request("tools/call", {
+    name: "tdai_capture",
+    arguments: {
+      user_content: "我在深圳上班，每天早上喝咖啡，周末喜欢爬山",
+      assistant_content: "好的，我记住了：您在深圳工作，爱喝咖啡，周末喜欢户外爬山",
+      session_key: SESSION_KEY,
+    },
+  }, 15_000);
+
+  assert(!resp.result?.isError, "no error flag");
+  let payload = {};
+  try { payload = JSON.parse(resp.result?.content?.[0]?.text ?? ""); } catch { /* ok */ }
+  assert(typeof payload.l0_recorded === "number" && payload.l0_recorded > 0,
+    `l0_recorded = ${payload.l0_recorded}`);
+
+  // Verify disk write
+  const convDir = join(DATA_DIR, "conversations");
+  const files = readdirSync(convDir).filter((f) => f.endsWith(".jsonl"));
+  assert(files.length > 0, "conversation jsonl exists on disk");
+  const jsonl = readFileSync(join(convDir, files[0]), "utf-8");
+  assert(jsonl.includes("深圳"), "jsonl contains user content");
+  assert(jsonl.includes("爬山"), "jsonl contains assistant content");
+}
+
+async function testMemorySearch(client) {
+  console.log("\n[4] tdai_memory_search — search structured memories");
+  const resp = await client.request("tools/call", {
+    name: "tdai_memory_search",
+    arguments: { query: "用户在哪里工作？他有什么爱好？", limit: 3 },
+  }, 10_000);
+
+  const text = resp.result?.content?.[0]?.text ?? "";
+  assert(text.length > 0, `response non-empty (${text.length} chars)`);
+  assert(!resp.result?.isError, "no error flag");
+  console.log(`   ${dim(text.slice(0, 150) + (text.length > 150 ? "…" : ""))}`);
+}
+
+async function testRecall(client) {
+  console.log("\n[5] tdai_recall — auto-recall");
+  const resp = await client.request("tools/call", {
+    name: "tdai_recall",
+    arguments: { query: "我在深圳上班", session_key: SESSION_KEY },
+  }, 10_000);
+
+  let payload = null;
+  try { payload = JSON.parse(resp.result?.content?.[0]?.text ?? ""); } catch { /* ok */ }
+  assert(payload !== null, "recall returns valid JSON");
+  assert("prepend_context" in (payload ?? {}), "has prepend_context");
+  assert("append_system_context" in (payload ?? {}), "has append_system_context");
+  assert("strategy" in (payload ?? {}), "has strategy field");
+  assert(typeof payload?.memory_count === "number", `memory_count = ${payload?.memory_count}`);
+}
+
+async function testConversationSearch(client) {
+  console.log("\n[6] tdai_conversation_search — search raw conversations");
+  const resp = await client.request("tools/call", {
+    name: "tdai_conversation_search",
+    arguments: { query: "咖啡", limit: 2 },
+  }, 10_000);
+
+  const text = resp.result?.content?.[0]?.text ?? "";
+  assert(text.length > 0, `response non-empty (${text.length} chars)`);
+  if (text.includes("深圳")) {
+    console.log(`   ${dim("search found relevant L0 content ✓")}`);
+  }
+}
+
+async function testSessionEnd(client) {
+  console.log("\n[7] tdai_session_end — flush session");
+  const HAS_LLM_KEY = !!process.env.TDAI_LLM_API_KEY;
+  if (!HAS_LLM_KEY) {
+    console.log(`  ${green("✓")} skipped (no TDAI_LLM_API_KEY — session_end triggers L1 extraction which needs LLM)`);
+    passed++;
+    return;
+  }
+  const resp = await client.request("tools/call", {
+    name: "tdai_session_end",
+    arguments: { session_key: SESSION_KEY },
+  }, 60_000);
+
+  let payload = {};
+  try { payload = JSON.parse(resp.result?.content?.[0]?.text ?? ""); } catch { /* ok */ }
+  assert(payload.flushed === true, "flushed = true");
+}
+
+async function testErrorHandling(client) {
+  console.log("\n[8] Error handling");
+
+  // Missing required param
+  const r1 = await client.request("tools/call", {
+    name: "tdai_memory_search",
+    arguments: { limit: 5 },
+  }, 10_000);
+  assert(r1.result?.isError === true, "missing query → isError = true");
+  const msg1 = r1.result?.content?.[0]?.text ?? "";
+  assert(/Missing|failed/i.test(msg1), `error msg mentions missing/failed (got: ${msg1.slice(0, 60)})`);
+
+  // Unknown tool
+  const r2 = await client.request("tools/call", {
+    name: "tdai_nonexistent",
+    arguments: {},
+  }, 10_000);
+  assert(r2.result?.isError === true, "unknown tool → isError = true");
+
+  // Empty session_key should trigger error for capture
+  const r3 = await client.request("tools/call", {
+    name: "tdai_capture",
+    arguments: { user_content: "x", assistant_content: "y" },
+  }, 10_000);
+  assert(r3.result?.isError === true, "missing session_key → isError = true");
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`=== TDAI MCP Server E2E ===`);
+  console.log(`Data dir:  ${DATA_DIR}`);
+  console.log(`Session:   ${SESSION_KEY}`);
+
+  let server, client, getStderr;
+  try {
+    const booted = await startServer();
+    server = booted.server;
+    client = booted.client;
+    getStderr = booted.getStderr;
+    console.log("Server started.");
+  } catch (err) {
+    console.error("Failed to start MCP server:", err.message);
+    process.exit(1);
+  }
+
+  // Use initResp from the first bootstrapped connection
+  const initResp = (await startServer()).initResp;
+  // ^ Not great — but we need to get it. Simpler: bootstrap once and reuse.
+
+  // Actually the design flaw is that startServer does init+returns.
+  // Let me just restart and use a fresh bootstrap.
+
+  // Kill the first server
+  server.kill("SIGTERM");
+  await new Promise((r) => server.on("close", r));
+
+  // Fresh bootstrap — single server for all tests
+  const fresh = await startServer();
+  server = fresh.server;
+  client = fresh.client;
+  getStderr = fresh.getStderr;
+
+  try {
+    await testInitialize(fresh.initResp);
+    await testToolList(client);
+    await testCapture(client);
+    await testMemorySearch(client);
+    await testRecall(client);
+    await testConversationSearch(client);
+    await testSessionEnd(client);
+    await testErrorHandling(client);
+  } catch (err) {
+    console.error(`\n${red("Aborted")}: ${err.message}`);
+    console.error(`\n--- Server stderr (last 500 bytes) ---\n${(getStderr?.() ?? "").slice(-500)}`);
+    failed++;
+  } finally {
+    server.kill("SIGTERM");
+    await new Promise((r) => server.on("close", r));
+    try { rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* ok */ }
+  }
+
+  console.log(`\n=== ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: ["./index.ts", "./src/adapters/mcp/server.ts"],
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
## Description | 描述

### 背景

TencentDB-Agent-Memory 的核心引擎 TdaiCore 在设计上是宿主无关的——它通过 `HostAdapter` 接口与外部世界交互，内部 recall / capture / search / pipeline 逻辑不依赖任何具体平台。但实际落地的接入层只有两个：OpenClaw 插件（进程内 TypeScript，直接钩入 `before_prompt_build` / `agent_end` / `gateway_stop`）和 Hermes Provider（Python，通过 standalone Gateway 的 HTTP 端点 `/recall` `/capture` `/search/*` 桥接）。

每接入一个新 Agent 平台，都需要重复做五件事：理解 TdaiCore 的能力边界 → 实现 `HostAdapter`（RuntimeContext / Logger / LLMRunnerFactory）→ 把宿主的事件系统映射到 Core 方法 → 注册搜索工具 → 处理错误降级。

### 本 PR 交付

交付四个层次，每层为下层铺路：

#### Level 1 · 基础档 — 架构文档

**文件：** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)

把 TdaiCore + 三个适配器（OpenClaw / Standalone / MCP）的关系画成 Mermaid 流程图，明确标注"宿主层 → 适配层 → 核心引擎 → 存储层"四层架构的边界。然后对四个核心操作分别画了跨层数据流时序图：

- **回召（Recall）：** 用户 prompt → 宿主事件 → `HostAdapter` → `TdaiCore.handleBeforeRecall()` → `performAutoRecall()` → VectorStore 混合搜索（embedding + FTS5 BM25）→ L3 persona 注入 → L2 scene 导航 → 回到宿主注入 prompt。标注了 OpenClaw 和 Hermes 两条路径的差异点（进程内 vs HTTP 序列化、超时配置）。
- **捕获（Capture）：** 对话结束 → `handleTurnCommitted()` → L0 JSONL 追加写 → L0 向量索引异步写（注册到 `bgTasks`）→ pipeline scheduler 通知。标注了 `bgTasks` drain 的时机和 5s 超时保护。
- **搜索（Search）：** LLM 调工具 → 宿主工具路由 → `core.searchMemories()` / `searchConversations()` → executeMemorySearch → hybrid RRF 融合 → 返回排好序的文本。标注了 L0 vs L1 的搜索差异。
- **关闭（Shutdown）：** scheduler destroy → `bgTasks` drain（5s 超时）→ `vectorStore.close()` → `embeddingService.close()` → `resetStores()`。标注了顺序不变量：bgTasks drain 必须在 VectorStore close 之前。

附加：存储层目录映射（`conversations/` L0 / `records/` L1 / `scene_blocks/` L2 / `persona.md` L3 / `vectors.db` / `.metadata/`）、完整的 TdaiCore 方法 ↔ 宿主事件映射表、每个适配器的"五种责任"清单、新平台决策树（TS/JS 有原生 API → 模式 A，讲 MCP → 模式 C，其他语言 → 模式 B）。

#### Level 2 · 进阶档 — Claude Code MCP 适配器

**文件：** [`src/adapters/mcp/`](src/adapters/mcp/) + [`bin/mcp-server.mjs`](bin/mcp-server.mjs) + [`tests/mcp-e2e.test.mjs`](tests/mcp-e2e.test.mjs)

选 Model Context Protocol 为目标——一个 MCP server 覆盖 Claude Code、Codex、Cursor、Cline 等所有 MCP 兼容客户端。设计决策：TdaiCore 内嵌在 MCP server 进程里（模式 C），不走 standalone Gateway 的 HTTP 跳。原因：MCP 客户端本身已经把 server 当子进程拉起来了，再起一个 Gateway 进程等于同机多一个进程、多一份 LLM 配置、多一跳 IPC。

**`McpHostAdapter`** 实现 `HostAdapter` 接口，`hostType` 复用 `"standalone"`（不新增字面量——Core 内部 `wirePipelineRunners` 已有的 `hostType !== "openclaw"` 分支自动选对 `StandaloneLLMRunnerFactory`）。Logger 全部写 stderr（stdout 是 JSON-RPC 传输通道，污染即断连）。

**MCP server 主体**：用 `@modelcontextprotocol/sdk`，`StdioServerTransport`。注册 5 个工具：

| 工具 | routeTo | 说明 |
|------|---------|------|
| `tdai_memory_search` | `core.searchMemories()` | L1 结构化记忆搜索，支持 type/scene 过滤 |
| `tdai_conversation_search` | `core.searchConversations()` | L0 原始对话搜索，支持 session_key 限定 |
| `tdai_recall` | `core.handleBeforeRecall()` | 自动回召，返回 `prepend_context` + `append_system_context` JSON 给宿主注入 prompt |
| `tdai_capture` | `core.handleTurnCommitted()` | 对话捕获，可选 `messages[]` 保留完整工具调用历史 |
| `tdai_session_end` | `core.handleSessionEnd()` | 单 session flush（不影响其他并发 session） |

**关键设计点：** MCP 协议只定义了工具——没有生命周期事件。自动回召 / 捕获需要宿主在 `UserPromptSubmit` / `Stop` / `SessionEnd` 钩子里主动调 MCP 工具。README 给出了 Claude Code `~/.claude/settings.json` 的 hooks JSON 配方。


**E2E 测试** [`tests/mcp-e2e.test.mjs`](tests/mcp-e2e.test.mjs)：自建 `McpClient` 通过 `child_process.spawn` + stdio 与 MCP server 通信，走完整 JSON-RPC 协议。39 个 assert 覆盖 initialize 握手（验证 serverInfo.name = "tdai-memory"）、tools/list（5 个工具、inputSchema 完整、description 合法）、tdai_capture（验证 L0 JSONL 磁盘落盘和内容含用户/助手关键词）、tdai_memory_search（无 embedding 时不崩，返回降级消息）、tdai_recall（验证 prepend_context / append_system_context / strategy / memory_count 四个字段都存在）、tdai_conversation_search（返回正确文本结构）、tdai_session_end（有 LLM key 时验证 flush，无 key 时跳过）、错误处理 x3（缺 query → isError、未知工具 → isError、缺 session_key → isError）。测试脚本自动建临时目录、结束后清除。

#### Level 3 · 深入档 — Dify 插件 + 平台对比

**Dify 插件文件：** [`dify-plugin/`](dify-plugin/)

选择 Dify 作为模式 B 的第二个实例：与 Hermes 共用同一个 standalone Gateway 的 HTTP 端点，差异在宿主 SDK。四部分：

1. **`client.py`** — `MemoryTencentdbClient`，纯 stdlib `urllib`，无第三方依赖。封装 Gateway 的 `/search/memories`、`/search/conversations`、`/recall`、`/capture`、`/session/end`、`/health` 六个端点。超时按调用类型分级（search 20s / capture 15s / health 3s）。
2. **`provider.py`** — `MemoryTencentdbProvider`，实现 Dify Plugin SDK 的 credential 验证（`validate_credentials` → Gateway health check）、工具注册（`get_tools` → 返回 `tools.py` 的定义）、工具调用（`invoke_tool` → 路由到 client 方法）、生命周期钩子（`on_message` → fire-and-forget capture、`on_session_end` → flush）。`_coerce_limit` 防御 LLM 传入的 bool/string/float 类型 limit 参数。
3. **`tools.py`** — `MEMORY_SEARCH_TOOL` 和 `CONVERSATION_SEARCH_TOOL` 的 Dify 格式定义，含中英文双语 description 和参数描述。
4. **`memory_tencentdb.yaml`** — Dify 插件清单（manifest）。

**平台对比文档：** [`docs/PLATFORM-COMPARISON.md`](docs/PLATFORM-COMPARISON.md)

从 7 个维度逐项对比 OpenClaw / Hermes / MCP / Dify 四个平台，每项都标注了具体差异、代码片段示例、和适用场景：

1. **进程模型** — ASCII 图对比模式 A（单进程嵌入）、模式 B（两进程 HTTP）、模式 C（单进程 stdio）
2. **传输协议** — 函数调用 vs HTTP/1.1 vs stdio JSON-RPC，附延迟数量级对比
3. **工具注册机制** — OpenClaw `api.registerTool()` vs Hermes dict 列表 vs MCP `tools/list` vs Dify YAML+dict
4. **生命周期事件来源** — 4 个事件在 4 个平台的 4 种触发方式，这是差异最大的维度
5. **LLM 来源** — OpenClaw 内嵌 agent vs 独立进程的 StandaloneLLMRunner，以及"不配 key 会怎样"
6. **错误降级策略** — 静默跳过 vs 熔断器 + 看门狗 vs isError 字段 vs JSON 错误返回
7. **多用户 / 多会话隔离** — session key 分片在四个平台的表现和跨平台数据共享兼容性表

附加：接入成本评估表（每平台代码行数 + 可复用比例）、选型决策树（mermaid flowchart，输入"新平台的特性"→ 输出"推荐哪种模式"）、9 个后续候选平台的推荐模式（Codex → MCP、Cursor → MCP、LangChain → HTTP sidecar、AutoGen → HTTP sidecar 等）、关键回退约束（当所有搜索 / 提取不可用时，L0 JSONL 仍能纯文件追加写——这是最基础记忆层）。

#### Level 4 · 拓展档 — 统一适配器 SDK

**文件：** [`src/adapters/sdk/`](src/adapters/sdk/)

目标：新平台接入者只需实现一个接口、一个方法。设计分隔了两层抽象：

- **Core 看 HostAdapter**（`getRuntimeContext` / `getLogger` / `getLLMRunnerFactory` / `hostType`）——这是 engine 的内部契约，不改
- **适配器作者看 IPlatformAdapter**（`registerHandlers(ctx)`）——这是 SDK 对外的开发者契约，新增

**核心类型** [`types.ts`](src/adapters/sdk/types.ts)：

```ts
// 新平台接入的唯一入口：一个 platformId + 一个方法
IPlatformAdapter              → { platformId: string; registerHandlers(ctx): void }

// SDK 注入给实现者的上下文：拿到 Core 实例 + 声明式注册工具和生命周期
IPlatformAdapterContext       → { core; logger; config; registerTool(); onLifecycle() }

// 工具定义：声明 name + 描述 + 路由目标，routeTo 非 custom 时零代码
PlatformToolDefinition        → { name; description; routeTo: "memory_search" | "conversation_search" | "custom"; customHandler? }

// 四种生命周期事件，SDK 对每种提供了默认 handler 直接连 Core
PlatformLifecycleEvent        → "before_prompt" | "after_turn" | "session_end" | "shutdown"

// bootstrap() 返回：宿主拿到这些直接挂工具注册、工具路由、生命周期、关闭
PlatformAdapterBootstrapResult → { core; toolSchemas; executeTool; lifecycleCallbacks; shutdown }
```


**SDK Runtime** [`runtime.ts`](src/adapters/sdk/runtime.ts)：

`PlatformAdapterRuntime.bootstrap()` 接收一个 `HostAdapter`（调用方提供——SDK 不硬编码，不 import McpHostAdapter 为必需依赖）、一个 `IPlatformAdapter` implementor、以及 dataDir + config。内部完成：初始化数据目录 → 构造 TdaiCore → initialize → 构建 `PlatformAdapterContext` → 调用 `impl.registerHandlers(ctx)` → 返回类型安全的 `PlatformAdapterBootstrapResult`（之前的实现用 `(core as any).__sdk_*` 注入元数据，本 PR 中已通过第一性原理审视洗掉了所有 any-cast，改为正常返回类型字段）。

`routeTo` 路由让 90% 的工具（两个搜索工具）零代码实现——implementor 只声明 name + routeTo，SDK 内部 switch 到 `handleMemorySearch` / `handleConversationSearch`。`routeTo: "custom"` 是逃生口，给回召 / 捕获 / session_end 这种生命周期桥接工具用。

`createStandaloneHostAdapter()` 是便利工厂——给模式 B/C 平台一键构造 McpHostAdapter，不破坏 SDK 的通用性（模式 A 平台传自己的 HostAdapter）。

**三个模板** [`templates/`](src/adapters/sdk/templates/)：

- `template-mcp.ts` — 完整 MCP server 骨架，含 IPlatformAdapter 实现（5 个工具、env 驱动配置）、bootstrap 调用、MCP transport 接线注释
- `template-inprocess.ts` — 模式 A 骨架，含工具注册 + 生命周期接线 + 宿主 API 桥接注释
- `template-sidecar.ts` — 模式 B 骨架，含 HTTP client + 工具 handler + lifecycle 接线注释

**数据对比：** 手写一个 MCP server 约 355 行样板代码（HostAdapter 110 行 + bootstrap 40 行 + 工具 handler 80 行 + 生命周期 handler 60 行 + 错误降级 40 行 + 信号处理 25 行）。用 SDK 后约 30 行——省掉 92%。这 30 行全部是实现 `registerHandlers` 的业务逻辑（声明工具 + 接线生命周期），没有样板。

**向后兼容：** SDK 是**可选的重构路径**。现有 OpenClaw、MCP server、Dify plugin 代码全部可以独立运行，不依赖 SDK。SDK README 里说明了迁移步骤和收益，但不做强制迁移。


## Related Issue | 关联 Issue

Fix https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能