### PR TITLE
fix(store): sanitize FTS5 query operators

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery } from "./sqlite.js";
+
+describe("buildFtsQuery", () => {
+    afterEach(() => {
+        _resetJiebaForTest();
+    });
+
+    it("strips FTS5 operators before fallback tokenization", () => {
+        _setJiebaForTest(null);
+
+        expect(buildFtsQuery("alpha OR beta AND NOT gamma NEAR delta")).toBe(
+            '"alpha" OR "beta" OR "gamma" OR "delta"',
+        );
+    });
+
+    it("returns null when the input contains only FTS5 operators", () => {
+        _setJiebaForTest(null);
+
+        expect(buildFtsQuery("AND or NOT near")).toBeNull();
+    });
+
+    it("keeps operator substrings inside regular words", () => {
+        _setJiebaForTest(null);
+
+        expect(buildFtsQuery("orange candy northeast")).toBe(
+            '"orange" OR "candy" OR "northeast"',
+        );
+    });
+
+    it("strips FTS5 operators before jieba tokenization", () => {
+        let tokenizedText = "";
+
+        _setJiebaForTest({
+            cutForSearch(text: string): string[] {
+                tokenizedText = text;
+                return text.match(/[\p{L}\p{N}_]+/gu) ?? [];
+            },
+        });
+
+        expect(buildFtsQuery("alpha OR beta")).toBe('"alpha" OR "beta"');
+        expect(tokenizedText).not.toMatch(/\bOR\b/i);
+    });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,8 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_QUERY_OPERATORS = /\b(?:AND|OR|NOT|NEAR)\b/gi;
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -196,6 +198,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = raw.replace(FTS5_QUERY_OPERATORS, " ");
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,7 +206,7 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(cleaned, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +221,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
## Description | 描述
Sanitize FTS5 reserved operators before tokenizing natural-language recall queries in buildFtsQuery.

## Related Issue | 关联 Issue
Fixes TencentCloud/TencentDB-Agent-Memory#160

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Ran npm test.