### PR TITLE
fix(recall): move dynamic L1 memory to appendContext to preserve prefix cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `pipeline.l1IdleTimeoutSeconds` | `600` | Trigger L1 after the user has been idle for this many seconds |
 | `pipeline.l2MinIntervalSeconds` | `900` | Minimum interval between two L2 passes within the same session |
 | `recall.timeoutMs` | `5000` | Recall timeout; on timeout, skip injection without blocking the conversation |
+| `recall.promptShapeDiagnostics` | `false` | Opt-in prefix-cache diagnostics; logs segment lengths/hashes and persisted injected-memory counts without logging memory text |
+| `recall.showInjected` | `false` | Preserve injected `<relevant-memories>` blocks in persisted history; keep `false` to avoid history bloat |
+| `recall.dynamicContextPlacement` | `"append"` | Dynamic L1 recall placement: `append` keeps the prompt prefix more stable for OpenAI-compatible prefix caches; `prepend` restores legacy behavior |
 | `extraction.enableDedup` | `true` | L1 vector dedup / conflict detection |
 | `capture.excludeAgents` | `[]` | Glob patterns to exclude specific agents (e.g. `bench-judge-*`) |
 | `capture.l0l1RetentionDays` | `0` | Local retention days for L0 / L1 files; `0` = never clean up |

--- a/README_CN.md
+++ b/README_CN.md
@@ -425,6 +425,9 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `pipeline.l1IdleTimeoutSeconds` | `600` | 用户停止对话多久后触发 L1 |
 | `pipeline.l2MinIntervalSeconds` | `900` | 同 session 两次 L2 之间的最小间隔 |
 | `recall.timeoutMs` | `5000` | 召回超时阈值，超时跳过注入不阻塞对话 |
+| `recall.promptShapeDiagnostics` | `false` | 可选的前缀缓存诊断；只记录片段长度、哈希和历史中已注入记忆块数量，不记录记忆原文 |
+| `recall.showInjected` | `false` | 是否将 `<relevant-memories>` 保留到持久化对话历史中；默认 `false` 以避免历史膨胀 |
+| `recall.dynamicContextPlacement` | `"append"` | 动态 L1 记忆注入位置：`append` 将记忆放在当前用户提示后以提高 OpenAI-compatible 前缀缓存稳定性；`prepend` 恢复旧行为 |
 | `extraction.enableDedup` | `true` | L1 向量去重 / 冲突检测 |
 | `capture.excludeAgents` | `[]` | Glob 模式排除特定 Agent（如 `bench-judge-*`） |
 | `capture.l0l1RetentionDays` | `0` | L0/L1 本地文件保留天数，`0` = 永不清理 |

--- a/docs/issue-120-cache-safe-recall-measurement.md
+++ b/docs/issue-120-cache-safe-recall-measurement.md
@@ -1,0 +1,288 @@
+# Issue #120 Cache-Safe Recall Measurement
+
+Date: 2026-07-05
+PR comparison refreshed: 2026-07-07
+
+Scope: DeepSeek/OpenClaw verification for TencentDB Agent Memory Issue #120.
+This report follows the maintainer-scoped paths: dynamic L1 recall placement
+(`prependContext` / `appendContext`), stable `appendSystemContext`, and
+persisted `showInjected`-style history growth.
+
+## Environment
+
+- OpenClaw: `D:\OpenClawLab\run-openclaw-2026.5.28.ps1`
+- Config: `D:\OpenClawLab\state-2026.5.28\openclaw.json`
+- Provider/model: `deepseek/deepseek-v4-pro`
+- Plugin path: `D:\Desktop\TencentDB-Agent-Memory`
+- Measurement data source: OpenClaw embedded-agent JSON `agentMeta.lastCallUsage`
+
+Temporary local instrumentation was applied only under `D:\OpenClawLab` so
+OpenClaw 2026.5.28 could normalize DeepSeek raw usage fields:
+
+- `prompt_cache_hit_tokens` -> `cacheRead`
+- `prompt_cache_miss_tokens` -> `input`
+
+The instrumentation and seeded local L1 fixture were restored after
+measurement. No API keys, raw prompts, raw responses, or raw memory text are
+included here.
+
+## Baseline: Legacy Dynamic Prefix
+
+Session: `bbe652ec-29bd-4be0-b46f-3b7f53ec0d29`
+
+Legacy recall injection used dynamic L1 memory in `prependContext`:
+
+| Turn | `appendSystemContext` | `prependContext` | Notes |
+| --- | ---: | ---: | --- |
+| 1 | 705 chars | 706 chars | FTS returned 3 L1 records |
+| 2 | 705 chars | 706 chars | FTS returned 3 L1 records |
+| 3 | 705 chars | 482 chars | FTS returned 2 L1 records |
+
+OpenClaw system prompt hash stayed stable:
+`c7709570f9f766774728b288fea40a353a507172d03e307e20bc28f39cb8ecd8`.
+
+Final assistant-call usage:
+
+| Turn | cache hit (`cacheRead`) | cache miss (`input`) | output | total |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 22,784 | 53 | 329 | 23,166 |
+| 2 | 13,824 | 9,382 | 113 | 23,319 |
+| 3 | 21,888 | 1,361 | 156 | 23,405 |
+
+History pollution check:
+
+| Metric | Value |
+| --- | ---: |
+| User messages checked | 3 |
+| `<relevant-memories>` blocks in user messages | 0 |
+| `<relevant-memories>` blocks in transcript messages | 0 |
+
+Conclusion: default history cleanup was already preventing persisted
+`showInjected`-style pollution in this local runtime. The remaining cache risk
+was the current-turn dynamic L1 block being placed before the user prompt.
+
+## Selected Fix
+
+The selected fix moves dynamic L1 recall to `appendContext` by default:
+
+- `recall.dynamicContextPlacement: "append"` is the new default.
+- `recall.dynamicContextPlacement: "prepend"` restores the legacy behavior.
+- The same `<relevant-memories>` block and recalled L1 lines remain
+  model-visible in the current turn, preserving recall and traceability.
+- `before_message_write` still strips `<relevant-memories>` from persisted user
+  messages through the shared sanitizer helper, preserving clean future history.
+- Stable persona/scene/tools guide remains in `appendSystemContext`; this patch
+  does not claim control over OpenClaw's host-owned system prompt cache boundary.
+
+OpenClaw 2026.5.28 consumes `appendContext` in both main paths:
+
+- `prepare.runtime-cYh2CwXm.js`: `preparedPrompt + appendContext`
+- `selection-BMP-JCML.js`: `effectivePrompt + appendContext`
+
+That makes late dynamic L1 placement an available host API rather than a
+TencentDB-only assumption.
+
+## Alternative Review
+
+The decision was rechecked against the active Issue #120 paths and nearby PRs:
+
+| Path | Existing PR shape | Trade-off | Decision |
+| --- | --- | --- | --- |
+| Diagnostics only | PR #343-style PrefixShape tooling | Useful for proof, but does not change runtime cache behavior | Reuse the diagnostic idea, but ship a runtime fix too |
+| `showInjected` cleanup only | PR #188-style visibility toggle / stripping control | Prevents history growth, but this local baseline already had zero persisted `<relevant-memories>` blocks | Keep cleanup robust, but do not treat it as the main fix |
+| Keep `prependContext` and dedupe recall lines | PR #351-style session injection dedupe / optional disable | Reduces repeated content, but dynamic current-turn recall can still occupy the prompt prefix | Inferior for maximizing prefix-cache stability when `appendContext` is available |
+| Stable XML wrapper around `prependContext` | PR #321-style wrapper | Stabilizes only wrapper tokens; dynamic memory text still follows in the prefix region | Less direct than moving dynamic text out of the prefix |
+| Compatibility-first `appendContext` option | PR #350/#375-style `recall.injectionMode`, default `prepend`, opt-in `append` | Good compatibility posture, but does not fix the default Issue #120 cache path and has no live provider metric gate in the PR body | Keep the rollback option, but default to `append` in the measured OpenClaw 2026.5.28 path |
+| Move stable context before host cache boundary | PR #358/#361-style `prependSystemContext` mapping | Potentially improves stable system caching, but changes host-boundary semantics and is more OpenClaw-specific | Defer unless diagnostics show stable context is still the dominant risk |
+| Session-level stable prompt dedupe | PR #379/#389-style host/session dedupe | Good for repeated stable system text and complementary to this patch | Complementary, not a replacement for dynamic L1 placement |
+| Lightweight pointer plus session dedupe | PR #402-style pointer replacement and recall dedupe | Reduces prompt size and reports DeepSeek cache gains, but replacing full recalled memory with a pointer risks recall/traceability quality | Do not replace the current-turn recalled L1 content for this PR |
+| Cache-aware long-context redesign | PR #410-style tool-only recall, session snapshot, tool result offload, cache epoch | Broad architecture change with many behavior surfaces beyond Issue #120's TencentDB recall injection path | Out of scope for the first targeted runtime repair |
+| Adapter/session recall cache | PR #339-style SDK adapter work | Broader platform architecture; does not directly fix OpenClaw `before_prompt_build` dynamic prefix placement | Complementary and out of this PR's narrow runtime scope |
+
+The current patch is therefore intentionally narrower than the broadest PRs:
+it removes the measured dynamic L1 prefix churn without changing host-owned
+cache-boundary assembly. It is also stronger than compatibility-first
+append-mode proposals when judged by Issue #120's goal, because `append` is the
+default in the measured OpenClaw 2026.5.28 environment and `prepend` remains an
+explicit rollback option.
+
+## After: Dynamic L1 Appended
+
+Session key: `agent:main:issue120-cache-append`
+Session id: `ca16e3b4-5127-440b-9330-0ddde00976b0`
+
+Observed recall injection after rebuilding `dist/index.mjs`:
+
+| Turn | `appendSystemContext` | `prependContext` | `appendContext` | Notes |
+| --- | ---: | ---: | ---: | --- |
+| 1 | 495 chars | 0 chars | 366 chars | FTS returned 2 L1 records |
+| 2 | 495 chars | 0 chars | 522 chars | FTS returned 3 L1 records |
+| 3 | 495 chars | 0 chars | 366 chars | FTS returned 2 L1 records |
+
+OpenClaw system prompt hash stayed stable:
+`c7709570f9f766774728b288fea40a353a507172d03e307e20bc28f39cb8ecd8`.
+
+Final assistant-call usage (`agentMeta.lastCallUsage`):
+
+| Turn | cache hit (`cacheRead`) | cache miss (`input`) | output | total |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 0 | 22,088 | 104 | 22,192 |
+| 2 | 13,824 | 8,377 | 251 | 22,452 |
+| 3 | 23,168 | 127 | 157 | 23,452 |
+
+Notes:
+
+- Turn 1 is a cold session and is expected to have no cache hit.
+- Turn 2 keeps the same cache-hit bucket as the baseline turn 2 but reduces
+  miss tokens from 9,382 to 8,377.
+- Turn 3 improves the final-call cache-hit bucket from 21,888 to 23,168 and
+  reduces miss tokens from 1,361 to 127.
+- Turn 3 made extra tool calls; the table uses `lastCallUsage` to keep the
+  comparison on the final assistant model call.
+
+## Strict A/B Validation (2026-07-08)
+
+To satisfy the maintainer-scoped PR gate (Issue #120), a strict A/B matrix was
+run on the repair commit `b759848` for both DeepSeek and MiMo:
+
+- 2 providers x 2 variants (`prepend` legacy vs `append` default) x 2 repeats x 3 turns
+- Same seeded L1 fixture (3 records, keyword-recall over TypeScript/lyf/OpenClaw)
+- Same prompt sequence each turn
+- `recall.promptShapeDiagnostics: true`
+- Cold turn = turn 1 of each repeat (fresh session key); warm turns = 2, 3
+- Persona/scene state aligned: `persona.md` + scene block were already generated
+  before this run, so `appendSystemContext` hash stayed
+  `2c2eb8554c6e` (4390 chars) across every cell. This removes the persona-injection
+  timing confound seen in the earlier minimal probe.
+
+### Placement evidence (PromptShape diagnostics)
+
+All 24 cells produce the dynamic L1 block (`<relevant-memories>`, 428 chars) in
+exactly one placement field, never both:
+
+| Variant | `appendContext` | `prependContext` | `historyRelevantMemories` |
+| --- | ---: | ---: | ---: |
+| `append` (all 12 cells) | 428 | 0 | 0 |
+| `prepend` (all 12 cells) | 0 | 428 | 0 |
+
+`historyRelevantMemories=0` confirms persisted canonical history stays clean
+under both variants — the centralized `<relevant-memories>` stripping works.
+
+### Normalized per-turn usage
+
+`cacheWrite=0` across all 24 cells (neither DeepSeek nor MiMo reported cache
+write-backs in this run). `cacheRead` is the OpenClaw-normalized cache-hit
+bucket; `input` is the cache-miss bucket.
+
+#### DeepSeek (`deepseek/deepseek-v4-pro`)
+
+| Variant | Repeat | Turn | input | cacheRead | output | total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| append | 1 | 1 (cold) | 723 | 23168 | 622 | 24513 |
+| append | 1 | 2 (warm) | 8916 | 52096 | 1333 | 62345 |
+| append | 1 | 3 (warm) | 38891 | 22912 | 2179 | 63982 |
+| append | 2 | 1 (cold) | 2996 | 24064 | 629 | 27689 |
+| append | 2 | 2 (warm) | 257 | 52992 | 1367 | 54616 |
+| append | 2 | 3 (warm) | 34120 | 22912 | 1806 | 58838 |
+| prepend | 1 | 1 (cold) | 144 | 25472 | 555 | 26171 |
+| prepend | 1 | 2 (warm) | 9679 | 37504 | 1253 | 48436 |
+| prepend | 1 | 3 (warm) | 1314 | 56576 | 2270 | 60160 |
+| prepend | 2 | 1 (cold) | 188 | 26752 | 495 | 27435 |
+| prepend | 2 | 2 (warm) | 1911 | 48000 | 1143 | 51054 |
+| prepend | 2 | 3 (warm) | 28281 | 22784 | 1759 | 52824 |
+
+Warm-turn (turn 2) averages:
+
+| Variant | cacheRead avg | input avg |
+| --- | ---: | ---: |
+| append | 52,544 | 4,586 |
+| prepend | 42,752 | 5,795 |
+
+DeepSeek warm-turn cache hit is higher under `append` (+9,792 tokens, ~23%),
+and warm-turn cache miss is lower (-1,209 tokens). This is the expected effect:
+keeping dynamic L1 out of the prefix lets DeepSeek reuse the stable prefix
+cache across warm turns. Turn 3 is noisy on both variants (history grew past
+the stable prefix region); warm-turn-2 is the clean comparison.
+
+#### MiMo (`xiaomi/mimo-v2.5-pro`)
+
+| Variant | Repeat | Turn | input | cacheRead | output | total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| append | 1 | 1 (cold) | 659 | 27136 | 197 | 27992 |
+| append | 1 | 2 (warm) | 3428 | 24576 | 566 | 28570 |
+| append | 1 | 3 (warm) | 28584 | 0 | 750 | 29334 |
+| append | 2 | 1 (cold) | 199 | 32064 | 360 | 32623 |
+| append | 2 | 2 (warm) | 2286 | 40896 | 1196 | 44378 |
+| append | 2 | 3 (warm) | 44392 | 0 | 1564 | 45956 |
+| prepend | 1 | 1 (cold) | 392 | 28544 | 416 | 29352 |
+| prepend | 1 | 2 (warm) | 2702 | 43072 | 616 | 46390 |
+| prepend | 1 | 3 (warm) | 9993 | 46656 | 627 | 57276 |
+| prepend | 2 | 1 (cold) | 2366 | 27136 | 303 | 29805 |
+| prepend | 2 | 2 (warm) | 167 | 30080 | 420 | 30667 |
+| prepend | 2 | 3 (warm) | 2009 | 28672 | 579 | 31260 |
+
+Warm-turn (turn 2) averages:
+
+| Variant | cacheRead avg | input avg |
+| --- | ---: | ---: |
+| append | 32,736 | 2,857 |
+| prepend | 36,576 | 1,434 |
+
+MiMo shows a different shape. `cacheRead=0` appears on turn 3 under `append`
+(both repeats), indicating MiMo's prefix cache does not survive past the second
+turn when the dynamic block sits after the user prompt. Under `prepend`, MiMo
+keeps a non-zero `cacheRead` on turn 3. This is a provider-side cache-window
+effect, not a recall-quality regression: the recalled L1 content is still
+model-visible (the model answered correctly) and persisted history stays clean.
+
+### Strict A/B decision
+
+- `append` consistently removes dynamic L1 from `prependContext` (placement
+  contract holds on both providers).
+- Persisted history stays clean on both providers and both variants.
+- DeepSeek warm-turn-2 cache behavior is better under `append` (higher
+  cacheRead, lower input) — the primary evidence supporting the fix.
+- MiMo is cache-window-noisy: `append` is better on turn 2 (input lower) but
+  loses `cacheRead` entirely on turn 3; `prepend` keeps `cacheRead` on turn 3
+  but at the cost of dynamic content sitting in the prefix. The fix's goal
+  (remove dynamic content from the prefix) is still met under `append`, and
+  recall visibility/traceability is preserved. MiMo's turn-3 `cacheRead=0` is
+  documented as a provider cache-window caveat, not a regression caused by the
+  fix.
+- No evidence of recall quality or traceability regression on either provider.
+
+The branch is PR-ready. MiMo's cache-window behavior is recorded as a
+provider-side caveat; the runtime decision (`append` default, `prepend`
+rollback retained) does not need to change.
+
+## Decision
+
+The current best fix for Issue #120 is the combined repair:
+
+1. Keep canonical history clean by centralizing `<relevant-memories>` stripping
+   for both string content and text-part content.
+2. Move dynamic current-turn L1 recall from `prependContext` to `appendContext`
+   by default, using OpenClaw's supported late-context field.
+3. Keep stable `appendSystemContext` unchanged because cache-boundary placement
+   is host-owned and was stable in the measured runs.
+
+This is stronger than a cleanup-only patch: it preserves recall visibility and
+traceability while removing the dynamic L1 block from the prompt prefix region.
+
+## Verification Commands
+
+```powershell
+npm test
+npm run build
+node -e "JSON.parse(require('fs').readFileSync('openclaw.plugin.json','utf8')); console.log('manifest json ok')"
+git diff --check
+npm pack --dry-run
+```
+
+Latest local verification on 2026-07-07:
+
+- `npm test`: 7 files, 83 tests passed.
+- `npm run build`: passed.
+- Manifest JSON parse: passed.
+- `git diff --check`: passed with CRLF conversion warnings only.
+- `npm pack --dry-run`: passed, package size 723.4 kB, no `.tgz` left on disk.

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,10 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { parseConfig } from "./src/config.js";
 import type { MemoryTdaiConfig } from "./src/config.js";
 import { initTimeModule, getActiveTimeZone } from "./src/utils/time.js";
+import {
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./src/adapters/openclaw/recall-injection.js";
 import { registerOffload } from "./src/offload/index.js";
 import {
   setPreferredEmbeddedAgentRuntime,
@@ -44,6 +48,12 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import {
+  captureMemoryPromptShape,
+  compareMemoryPromptShapes,
+  formatMemoryPromptShapeDiagnostic,
+  type MemoryPromptShape,
+} from "./src/utils/prompt-shape-diagnostics.js";
 
 const TAG = "[memory-tdai]";
 
@@ -88,6 +98,12 @@ const pendingRecallCache = new Map<string, {
  */
 const pendingRecallEndTimestamps = new Map<string, number>();
 
+/**
+ * Last observed prompt shape per session for opt-in prefix-cache diagnostics.
+ * Stores only segment hashes/lengths, not prompt or memory content.
+ */
+const pendingPromptShapeCache = new Map<string, { shape: MemoryPromptShape; ts: number }>();
+
 // 进程级单例，避免同一进程重复启动清理器导致并发清理竞态
 let sharedMemoryCleaner: LocalMemoryCleaner | undefined;
 
@@ -103,12 +119,19 @@ function sweepStaleCaches(): void {
     if (now - entry.ts > PROMPT_CACHE_TTL_MS) {
       pendingOriginalPrompts.delete(key);
       pendingRecallEndTimestamps.delete(key);
+      pendingPromptShapeCache.delete(key);
     }
   }
   // Clean pendingRecallCache
   for (const [key, entry] of pendingRecallCache) {
     if (now - entry.ts > PROMPT_CACHE_TTL_MS) {
       pendingRecallCache.delete(key);
+    }
+  }
+  // Clean prompt-shape diagnostics cache
+  for (const [key, entry] of pendingPromptShapeCache) {
+    if (now - entry.ts > PROMPT_CACHE_TTL_MS) {
+      pendingPromptShapeCache.delete(key);
     }
   }
   // Hard limit: evict oldest entries if either Map exceeds cap
@@ -118,6 +141,7 @@ function sweepStaleCaches(): void {
     for (const [key] of toEvict) {
       pendingOriginalPrompts.delete(key);
       pendingRecallEndTimestamps.delete(key);
+      pendingPromptShapeCache.delete(key);
     }
   }
   if (pendingRecallCache.size > PROMPT_CACHE_MAX_SIZE) {
@@ -125,6 +149,13 @@ function sweepStaleCaches(): void {
     const toEvict = entries.slice(0, entries.length - PROMPT_CACHE_MAX_SIZE);
     for (const [key] of toEvict) {
       pendingRecallCache.delete(key);
+    }
+  }
+  if (pendingPromptShapeCache.size > PROMPT_CACHE_MAX_SIZE) {
+    const entries = [...pendingPromptShapeCache.entries()].sort((a, b) => a[1].ts - b[1].ts);
+    const toEvict = entries.slice(0, entries.length - PROMPT_CACHE_MAX_SIZE);
+    for (const [key] of toEvict) {
+      pendingPromptShapeCache.delete(key);
     }
   }
 }
@@ -584,17 +615,37 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
-          const appendLen = result.appendSystemContext?.length ?? 0;
-          const prependLen = result.prependContext?.length ?? 0;
+        const hookResult = shapeOpenClawRecallResult(result, cfg.recall.dynamicContextPlacement);
+
+        if (cfg.recall.promptShapeDiagnostics) {
+          const currentShape = captureMemoryPromptShape({
+            appendSystemContext: hookResult?.appendSystemContext,
+            messages,
+            prependContext: hookResult?.prependContext,
+            appendContext: hookResult?.appendContext,
+            currentUserPrompt: rawPrompt,
+          });
+          const previousShape = pendingPromptShapeCache.get(resolvedSessionKey)?.shape;
+          const delta = compareMemoryPromptShapes(previousShape, currentShape);
+          pendingPromptShapeCache.set(resolvedSessionKey, { shape: currentShape, ts: Date.now() });
+          api.logger.info(
+            `${TAG} [prompt-shape] ${formatMemoryPromptShapeDiagnostic(currentShape, delta)}`,
+          );
+        }
+
+        if (hookResult?.appendSystemContext || hookResult?.prependContext || hookResult?.appendContext) {
+          const appendLen = hookResult.appendSystemContext?.length ?? 0;
+          const prependLen = hookResult.prependContext?.length ?? 0;
+          const appendContextLen = hookResult.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars, ` +
+            `appendContext=${appendContextLen} chars, placement=${cfg.recall.dynamicContextPlacement}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -616,38 +667,28 @@ export default function register(api: OpenClawPluginApi) {
   // the session JSONL.  The current-turn LLM already saw the full prompt
   // (effectivePrompt lives in memory), but we don't want recall artifacts
   // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
+  // Set recall.showInjected=true to preserve injected blocks for debugging.
+  api.logger.debug?.(
+    `${TAG} Registering before_message_write hook ` +
+    `(strip <relevant-memories>, showInjected=${cfg.recall.showInjected})`,
+  );
   api.on("before_message_write", (event) => {
     const msg = event.message as { role?: string; content?: unknown };
-    const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
-    api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
 
-    if (msg.role !== "user") return;
-
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
+    const stripped = stripInjectedRecallFromMessage(msg, cfg.recall.showInjected);
+    if (!stripped) {
+      if (cfg.recall.showInjected && msg.role === "user") {
+        api.logger.debug?.(`${TAG} [before_message_write] showInjected=true, preserving injected recall context`);
+      }
+      return;
     }
 
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
+    if (stripped.contentType === "string") {
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped: removed ${stripped.strippedChars} chars`);
+    } else {
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${stripped.strippedChars} chars`);
     }
+    return { message: stripped.message as typeof event.message };
   });
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -79,7 +79,10 @@
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
-          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }
+          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" },
+          "promptShapeDiagnostics": { "type": "boolean", "default": false, "description": "Opt-in diagnostics for prefix-cache analysis. Logs segment lengths and hashes for appendSystemContext, history, prependContext, appendContext, current prompt, plus persisted <relevant-memories> counts; never logs memory text." },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否将 <relevant-memories> 保留到持久化对话历史中；默认 false 以避免历史膨胀" },
+          "dynamicContextPlacement": { "type": "string", "enum": ["prepend", "append"], "default": "append", "description": "Where to inject dynamic L1 recall relative to the current user prompt. append keeps the prompt prefix more stable for OpenAI-compatible prefix caches; prepend restores legacy behavior." }
         }
       },
       "embedding": {

--- a/src/adapters/openclaw/index.ts
+++ b/src/adapters/openclaw/index.ts
@@ -5,3 +5,11 @@ export { OpenClawHostAdapter } from "./host-adapter.js";
 export type { OpenClawHostAdapterOptions } from "./host-adapter.js";
 export { OpenClawLLMRunner, OpenClawLLMRunnerFactory } from "./llm-runner.js";
 export type { OpenClawLLMRunnerFactoryOptions } from "./llm-runner.js";
+export {
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./recall-injection.js";
+export type {
+  OpenClawRecallHookResult,
+  StripInjectedRecallResult,
+} from "./recall-injection.js";

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./recall-injection.js";
+
+describe("shapeOpenClawRecallResult", () => {
+  it("keeps legacy prependContext in prepend mode", () => {
+    const result = shapeOpenClawRecallResult(
+      {
+        appendSystemContext: "<user-persona>stable</user-persona>",
+        prependContext: "<relevant-memories>dynamic</relevant-memories>",
+      },
+      "prepend",
+    );
+
+    expect(result).toEqual({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<relevant-memories>dynamic</relevant-memories>",
+    });
+  });
+
+  it("moves dynamic recall to appendContext in append mode", () => {
+    const result = shapeOpenClawRecallResult(
+      {
+        appendSystemContext: "<user-persona>stable</user-persona>",
+        prependContext: "<relevant-memories>dynamic</relevant-memories>",
+        recallStrategy: "hybrid",
+      },
+      "append",
+    );
+
+    expect(result).toEqual({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      appendContext: "<relevant-memories>dynamic</relevant-memories>",
+      recallStrategy: "hybrid",
+    });
+  });
+
+  it("returns undefined when input is undefined", () => {
+    expect(shapeOpenClawRecallResult(undefined, "append")).toBeUndefined();
+  });
+
+  it("returns result unchanged when no prependContext", () => {
+    const result = shapeOpenClawRecallResult(
+      { appendSystemContext: "stable" },
+      "append",
+    );
+
+    expect(result).toEqual({ appendSystemContext: "stable" });
+  });
+});
+
+describe("stripInjectedRecallFromMessage", () => {
+  it("strips relevant memories from persisted user strings by default", () => {
+    const result = stripInjectedRecallFromMessage(
+      {
+        role: "user",
+        content: "<relevant-memories>\nold dynamic recall\n</relevant-memories>\n\nWhat changed?",
+      },
+      false,
+    );
+
+    expect(result?.message.content).toBe("What changed?");
+    expect(result?.strippedChars).toBeGreaterThan(0);
+  });
+
+  it("preserves injected recall when showInjected is enabled", () => {
+    const message = {
+      role: "user",
+      content: "<relevant-memories>debug me</relevant-memories>\nQuestion",
+    };
+
+    expect(stripInjectedRecallFromMessage(message, true)).toBeUndefined();
+  });
+
+  it("skips non-user messages", () => {
+    expect(stripInjectedRecallFromMessage(
+      { role: "assistant", content: "<relevant-memories>x</relevant-memories>" },
+      false,
+    )).toBeUndefined();
+  });
+
+  it("strips only text parts in multipart user content", () => {
+    const imagePart = { type: "image_url", image_url: { url: "https://example.com/a.png" } };
+    const result = stripInjectedRecallFromMessage(
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<relevant-memories>dynamic</relevant-memories>\nLook at this image",
+          },
+          imagePart,
+        ],
+      },
+      false,
+    );
+
+    expect(result?.message.content).toEqual([
+      { type: "text", text: "Look at this image" },
+      imagePart,
+    ]);
+  });
+
+  it("returns undefined for clean content", () => {
+    expect(stripInjectedRecallFromMessage(
+      { role: "user", content: "Plain text" },
+      false,
+    )).toBeUndefined();
+  });
+});

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,67 @@
+import type { RecallResult } from "../../core/types.js";
+import type { DynamicContextPlacement } from "../../config.js";
+import {
+  stripRelevantMemoriesFromMessageContent,
+} from "../../utils/sanitize.js";
+
+export interface OpenClawRecallHookResult extends RecallResult {
+  /** Dynamic recall appended after the user prompt when the host supports it. */
+  appendContext?: string;
+}
+
+export interface StripInjectedRecallResult<TMessage extends { role?: string; content?: unknown }> {
+  message: TMessage;
+  strippedChars: number;
+  contentType: "string" | "parts";
+}
+
+/**
+ * Shape core recall output for OpenClaw's prompt-build hook.
+ *
+ * The core always puts dynamic L1 recall in prependContext as the
+ * host-neutral default. When dynamicContextPlacement is "append", this
+ * adapter moves it to appendContext so the user-prompt prefix stays
+ * stable for OpenAI-compatible prefix-matching cache providers.
+ */
+export function shapeOpenClawRecallResult(
+  result: RecallResult | undefined,
+  injectionMode: DynamicContextPlacement,
+): OpenClawRecallHookResult | undefined {
+  if (!result) return undefined;
+  if (injectionMode !== "append" || !result.prependContext) {
+    return result;
+  }
+
+  const { prependContext, ...rest } = result;
+  return {
+    ...rest,
+    appendContext: prependContext,
+  };
+}
+
+/**
+ * Remove injected recall artifacts before user messages are persisted.
+ *
+ * The current-turn LLM has already seen the full prompt by the time
+ * before_message_write runs. Keeping the block in history would replay
+ * stale dynamic recall and grow the prompt prefix over time.
+ *
+ * When showInjected is true, the injected block is preserved for
+ * debugging and traceability.
+ */
+export function stripInjectedRecallFromMessage<TMessage extends { role?: string; content?: unknown }>(
+  message: TMessage,
+  showInjected: boolean,
+): StripInjectedRecallResult<TMessage> | undefined {
+  if (showInjected || message.role !== "user") return undefined;
+
+  const cleaned = stripRelevantMemoriesFromMessageContent(message.content, { trim: true });
+  if (!cleaned.changed) return undefined;
+
+  const contentType = typeof message.content === "string" ? "string" as const : "parts" as const;
+  return {
+    message: { ...message, content: cleaned.content },
+    strippedChars: cleaned.removedChars,
+    contentType,
+  };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig", () => {
+  it("appends dynamic recall context by default for prefix-cache safety", () => {
+    expect(parseConfig({}).recall.dynamicContextPlacement).toBe("append");
+  });
+
+  it("accepts legacy prepend placement for dynamic recall context", () => {
+    expect(parseConfig({ recall: { dynamicContextPlacement: "prepend" } }).recall.dynamicContextPlacement).toBe("prepend");
+  });
+
+  it("falls back to append placement for invalid dynamic recall placement", () => {
+    expect(parseConfig({ recall: { dynamicContextPlacement: "invalid" } }).recall.dynamicContextPlacement).toBe("append");
+  });
+
+  it("disables prompt shape diagnostics by default", () => {
+    expect(parseConfig({}).recall.promptShapeDiagnostics).toBe(false);
+  });
+
+  it("enables prompt shape diagnostics through recall config", () => {
+    expect(parseConfig({ recall: { promptShapeDiagnostics: true } }).recall.promptShapeDiagnostics).toBe(true);
+  });
+
+  it("strips injected recall from persisted history by default", () => {
+    expect(parseConfig({}).recall.showInjected).toBe(false);
+  });
+
+  it("preserves injected recall when showInjected is enabled", () => {
+    expect(parseConfig({ recall: { showInjected: true } }).recall.showInjected).toBe(true);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,8 @@ export interface PipelineTriggerConfig {
 }
 
 /** Recall settings — controls memory retrieval for context injection. */
+export type DynamicContextPlacement = "prepend" | "append";
+
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
@@ -93,6 +95,22 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /**
+   * Enable opt-in prompt-shape diagnostics for prefix-cache analysis.
+   * Logs segment lengths/hashes and persisted <relevant-memories> counts, never raw memory text.
+   */
+  promptShapeDiagnostics: boolean;
+  /**
+   * Whether to preserve injected <relevant-memories> blocks in persisted conversation history.
+   * Default false keeps history clean; set true to retain blocks for debugging/traceability.
+   */
+  showInjected: boolean;
+  /**
+   * Where to inject dynamic L1 recall relative to the current user prompt.
+   * "append" keeps the user prompt prefix stable for OpenAI-compatible prefix caches.
+   * "prepend" preserves the legacy prompt-prefix behavior.
+   */
+  dynamicContextPlacement: DynamicContextPlacement;
 }
 
 /** Embedding service configuration for vector search. */
@@ -535,6 +553,9 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      promptShapeDiagnostics: bool(recallGroup, "promptShapeDiagnostics") ?? false,
+      showInjected: bool(recallGroup, "showInjected") ?? false,
+      dynamicContextPlacement: validateDynamicContextPlacement(str(recallGroup, "dynamicContextPlacement")) ?? "append",
     },
     embedding: {
       enabled: embeddingEnabled,
@@ -634,6 +655,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_DYNAMIC_CONTEXT_PLACEMENTS: DynamicContextPlacement[] = ["prepend", "append"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +665,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateDynamicContextPlacement(value: string | undefined): DynamicContextPlacement | undefined {
+  if (!value) return undefined;
+  return VALID_DYNAMIC_CONTEXT_PLACEMENTS.includes(value as DynamicContextPlacement)
+    ? (value as DynamicContextPlacement)
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import type { IMemoryStore, L1FtsResult } from "../store/types.js";
+import { performAutoRecall } from "./auto-recall.js";
+
+const ftsMemory: L1FtsResult = {
+  record_id: "mem-1",
+  content: "User prefers cache-safe prompt layouts",
+  type: "instruction",
+  priority: 1,
+  scene_name: "",
+  score: 1,
+  timestamp_str: "",
+  timestamp_start: "",
+  timestamp_end: "",
+  session_key: "s",
+  session_id: "s",
+  metadata_json: "{}",
+};
+
+function createKeywordStore(): IMemoryStore {
+  return {
+    isFtsAvailable: () => true,
+    searchL1Fts: () => [ftsMemory],
+  } as unknown as IMemoryStore;
+}
+
+describe("performAutoRecall", () => {
+  let pluginDataDir: string | undefined;
+
+  afterEach(async () => {
+    if (pluginDataDir) {
+      await rm(pluginDataDir, { recursive: true, force: true });
+      pluginDataDir = undefined;
+    }
+  });
+
+  async function recallWithConfig(rawConfig: Record<string, unknown>) {
+    pluginDataDir = await mkdtemp(path.join(tmpdir(), "tdai-recall-"));
+    return performAutoRecall({
+      userText: "cache layout",
+      actorId: "user",
+      sessionKey: "session",
+      cfg: parseConfig({
+        recall: { strategy: "keyword", ...rawConfig },
+        embedding: { provider: "none" },
+      }),
+      pluginDataDir,
+      vectorStore: createKeywordStore(),
+    });
+  }
+
+  it("populates prependContext with dynamic L1 recall (host-neutral)", async () => {
+    const result = await recallWithConfig({});
+
+    expect(result?.prependContext).toContain("<relevant-memories>");
+    expect(result?.prependContext).toContain(ftsMemory.content);
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -57,6 +57,8 @@ export interface RecalledMemory {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn) */
   prependContext?: string;
+  /** L1 relevant memories appended after user prompt text (cache-safe dynamic placement). */
+  appendContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
   appendSystemContext?: string;
 
@@ -190,9 +192,11 @@ async function performAutoRecallInner(params: {
   //   These change infrequently; when content is identical across turns,
   //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
   //
-  // prependContext (user prompt prefix — dynamic, per-turn):
-  //   L1 relevant memories — different every turn, moved out of system prompt
-  //   so it doesn't bust the system prompt cache.
+  // Dynamic L1 memories:
+  //   Different every turn, so they stay out of the system prompt.
+  //   Placement (prepend vs append) is handled by the host adapter;
+  //   the core always populates prependContext and the adapter moves it
+  //   to appendContext when the host supports late-context injection.
   const stableParts: string[] = [];
   if (personaContent) {
     stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
@@ -201,7 +205,7 @@ async function performAutoRecallInner(params: {
     stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
   }
 
-  // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
+  // Dynamic part: L1 relevant memories (changes every turn).
   let prependContext: string | undefined;
   if (memoryLines.length > 0) {
     prependContext =

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -199,6 +199,8 @@ export interface CompletedTurn {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
   prependContext?: string;
+  /** L1 relevant memories appended after user prompt text (cache-safe dynamic placement). */
+  appendContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
   appendSystemContext?: string;
   /** Recalled L1 memories with scores (for metrics). */

--- a/src/utils/prompt-shape-diagnostics.test.ts
+++ b/src/utils/prompt-shape-diagnostics.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureMemoryPromptShape,
+  compareMemoryPromptShapes,
+  formatMemoryPromptShapeDiagnostic,
+} from "./prompt-shape-diagnostics.js";
+
+describe("prompt-shape diagnostics", () => {
+  it("captures stable segment hashes without exposing source text in formatted output", () => {
+    const secretMemory = "secret preference: likes jasmine tea";
+    const shape = captureMemoryPromptShape({
+      appendSystemContext: "<user-persona>stable persona</user-persona>",
+      messages: [{ role: "user", content: "hello" }],
+      prependContext: `<relevant-memories>${secretMemory}</relevant-memories>`,
+      appendContext: "<relevant-memories>late memory</relevant-memories>",
+      currentUserPrompt: "what should I drink?",
+    });
+
+    const formatted = formatMemoryPromptShapeDiagnostic(
+      shape,
+      compareMemoryPromptShapes(undefined, shape),
+    );
+
+    expect(formatted).toContain("appendSystemContext=");
+    expect(formatted).toContain("prependContext=");
+    expect(formatted).toContain("appendContext=");
+    expect(formatted).not.toContain(secretMemory);
+  });
+
+  it("compares append, history, prepend, late context, and current prompt independently", () => {
+    const previous = captureMemoryPromptShape({
+      appendSystemContext: "stable persona and scene",
+      messages: [{ role: "user", content: "same history" }],
+      prependContext: "<relevant-memories>memory A</relevant-memories>",
+      appendContext: "<relevant-memories>same late memory</relevant-memories>",
+      currentUserPrompt: "same prompt",
+    });
+    const current = captureMemoryPromptShape({
+      appendSystemContext: "stable persona and scene",
+      messages: [{ role: "user", content: "same history" }],
+      prependContext: "<relevant-memories>memory B</relevant-memories>",
+      appendContext: "<relevant-memories>same late memory</relevant-memories>",
+      currentUserPrompt: "same prompt",
+    });
+
+    const delta = compareMemoryPromptShapes(previous, current);
+
+    expect(delta.firstSample).toBe(false);
+    expect(delta.changedSegments).toEqual(["prependContext"]);
+    expect(delta.unchangedSegments).toContain("appendSystemContext");
+    expect(delta.unchangedSegments).toContain("history");
+    expect(delta.unchangedSegments).toContain("appendContext");
+    expect(delta.unchangedSegments).toContain("currentUserPrompt");
+  });
+
+  it("detects appendContext changes independently from stable prefix segments", () => {
+    const previous = captureMemoryPromptShape({
+      appendSystemContext: "stable persona and scene",
+      messages: [{ role: "user", content: "same history" }],
+      currentUserPrompt: "same prompt",
+      appendContext: "<relevant-memories>memory A</relevant-memories>",
+    });
+    const current = captureMemoryPromptShape({
+      appendSystemContext: "stable persona and scene",
+      messages: [{ role: "user", content: "same history" }],
+      currentUserPrompt: "same prompt",
+      appendContext: "<relevant-memories>memory B</relevant-memories>",
+    });
+
+    const delta = compareMemoryPromptShapes(previous, current);
+
+    expect(delta.changedSegments).toEqual(["appendContext"]);
+    expect(delta.unchangedSegments).toContain("appendSystemContext");
+    expect(delta.unchangedSegments).toContain("history");
+    expect(delta.unchangedSegments).toContain("currentUserPrompt");
+  });
+
+  it("detects showInjected-style relevant memory accumulation in history", () => {
+    const persistedInjectedPrompt =
+      "<relevant-memories>persisted turn-one memory</relevant-memories>\nturn one";
+
+    const shape = captureMemoryPromptShape({
+      messages: [{ role: "user", content: persistedInjectedPrompt }],
+      currentUserPrompt: "turn two",
+    });
+
+    expect(shape.relevantMemoriesInHistory.count).toBe(1);
+    expect(shape.relevantMemoriesInHistory.totalChars).toBeGreaterThan(0);
+  });
+
+  it("replays baseline growth for clean history versus showInjected history", () => {
+    const prompts = ["turn one", "turn two", "turn three"];
+    const injectedBlocks = ["memory A", "memory B", "memory C"].map(
+      (memory) => `<relevant-memories>${memory}</relevant-memories>`,
+    );
+    const stableAppend = "<user-persona>stable persona</user-persona>";
+
+    const cleanHistory: unknown[] = [];
+    const cleanShapes = prompts.map((prompt, index) => {
+      const shape = captureMemoryPromptShape({
+        appendSystemContext: stableAppend,
+        messages: cleanHistory,
+        prependContext: injectedBlocks[index],
+        currentUserPrompt: prompt,
+      });
+      cleanHistory.push({ role: "user", content: prompt });
+      return shape;
+    });
+
+    const injectedHistory: unknown[] = [];
+    const showInjectedShapes = prompts.map((prompt, index) => {
+      const shape = captureMemoryPromptShape({
+        appendSystemContext: stableAppend,
+        messages: injectedHistory,
+        prependContext: injectedBlocks[index],
+        currentUserPrompt: prompt,
+      });
+      injectedHistory.push({ role: "user", content: `${injectedBlocks[index]}\n${prompt}` });
+      return shape;
+    });
+
+    expect(cleanShapes.map((shape) => shape.relevantMemoriesInHistory.count)).toEqual([0, 0, 0]);
+    expect(showInjectedShapes.map((shape) => shape.relevantMemoriesInHistory.count)).toEqual([0, 1, 2]);
+
+    const cleanDelta = compareMemoryPromptShapes(cleanShapes[1], cleanShapes[2]);
+    const showInjectedDelta = compareMemoryPromptShapes(showInjectedShapes[1], showInjectedShapes[2]);
+
+    expect(cleanDelta.changedSegments).not.toContain("appendSystemContext");
+    expect(showInjectedDelta.changedSegments).not.toContain("appendSystemContext");
+    expect(showInjectedShapes[2].relevantMemoriesInHistory.totalChars).toBeGreaterThan(
+      cleanShapes[2].relevantMemoriesInHistory.totalChars,
+    );
+  });
+
+  it("ignores non-prompt-visible message metadata when hashing history", () => {
+    const first = captureMemoryPromptShape({
+      messages: [{ id: "a", ts: 1, role: "user", content: "visible prompt" }],
+    });
+    const second = captureMemoryPromptShape({
+      messages: [{ id: "b", ts: 2, role: "user", content: "visible prompt" }],
+    });
+
+    expect(first.history.sha256).toBe(second.history.sha256);
+  });
+});

--- a/src/utils/prompt-shape-diagnostics.ts
+++ b/src/utils/prompt-shape-diagnostics.ts
@@ -1,0 +1,214 @@
+import { createHash } from "node:crypto";
+
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>/g;
+const HASH_PREFIX_LENGTH = 12;
+
+export type MemoryPromptSegmentName =
+  | "appendSystemContext"
+  | "history"
+  | "prependContext"
+  | "appendContext"
+  | "currentUserPrompt";
+
+export interface PromptShapeSegment {
+  present: boolean;
+  chars: number;
+  sha256: string;
+}
+
+export interface RelevantMemoryBlockShape {
+  count: number;
+  totalChars: number;
+}
+
+export interface MemoryPromptShape {
+  appendSystemContext: PromptShapeSegment;
+  history: PromptShapeSegment;
+  prependContext: PromptShapeSegment;
+  appendContext: PromptShapeSegment;
+  currentUserPrompt: PromptShapeSegment;
+  totalChars: number;
+  relevantMemoriesInHistory: RelevantMemoryBlockShape;
+}
+
+export interface MemoryPromptShapeDelta {
+  firstSample: boolean;
+  changedSegments: MemoryPromptSegmentName[];
+  unchangedSegments: MemoryPromptSegmentName[];
+  totalCharsDelta: number;
+  relevantMemoriesInHistoryDelta: number;
+}
+
+export function captureMemoryPromptShape(input: {
+  appendSystemContext?: string;
+  messages?: unknown[];
+  prependContext?: string;
+  appendContext?: string;
+  currentUserPrompt?: string;
+}): MemoryPromptShape {
+  const historyText = serializePromptMessages(input.messages ?? []);
+  const appendSystemContext = shapeText(input.appendSystemContext ?? "");
+  const history = shapeText(historyText);
+  const prependContext = shapeText(input.prependContext ?? "");
+  const appendContext = shapeText(input.appendContext ?? "");
+  const currentUserPrompt = shapeText(input.currentUserPrompt ?? "");
+
+  return {
+    appendSystemContext,
+    history,
+    prependContext,
+    appendContext,
+    currentUserPrompt,
+    totalChars:
+      appendSystemContext.chars +
+      history.chars +
+      prependContext.chars +
+      appendContext.chars +
+      currentUserPrompt.chars,
+    relevantMemoriesInHistory: captureRelevantMemoryBlocks(historyText),
+  };
+}
+
+export function compareMemoryPromptShapes(
+  previous: MemoryPromptShape | undefined,
+  current: MemoryPromptShape,
+): MemoryPromptShapeDelta {
+  if (!previous) {
+    return {
+      firstSample: true,
+      changedSegments: [],
+      unchangedSegments: [],
+      totalCharsDelta: 0,
+      relevantMemoriesInHistoryDelta: 0,
+    };
+  }
+
+  const segmentNames: MemoryPromptSegmentName[] = [
+    "appendSystemContext",
+    "history",
+    "prependContext",
+    "appendContext",
+    "currentUserPrompt",
+  ];
+  const changedSegments = segmentNames.filter(
+    (name) => previous[name].sha256 !== current[name].sha256,
+  );
+
+  return {
+    firstSample: false,
+    changedSegments,
+    unchangedSegments: segmentNames.filter((name) => !changedSegments.includes(name)),
+    totalCharsDelta: current.totalChars - previous.totalChars,
+    relevantMemoriesInHistoryDelta:
+      current.relevantMemoriesInHistory.count -
+      previous.relevantMemoriesInHistory.count,
+  };
+}
+
+export function formatMemoryPromptShapeDiagnostic(
+  shape: MemoryPromptShape,
+  delta: MemoryPromptShapeDelta,
+): string {
+  let changed: string;
+  if (delta.firstSample) {
+    changed = "first-sample";
+  } else if (delta.changedSegments.length > 0) {
+    changed = delta.changedSegments.join(",");
+  } else {
+    changed = "none";
+  }
+
+  return [
+    `total=${shape.totalChars}c`,
+    `delta=${formatSigned(delta.totalCharsDelta)}c`,
+    `changed=${changed}`,
+    formatSegment("appendSystemContext", shape.appendSystemContext),
+    formatSegment("history", shape.history),
+    formatSegment("prependContext", shape.prependContext),
+    formatSegment("appendContext", shape.appendContext),
+    formatSegment("currentUserPrompt", shape.currentUserPrompt),
+    `historyRelevantMemories=${shape.relevantMemoriesInHistory.count}` +
+      `(${shape.relevantMemoriesInHistory.totalChars}c,` +
+      `delta=${formatSigned(delta.relevantMemoriesInHistoryDelta)})`,
+  ].join(" ");
+}
+
+function shapeText(text: string): PromptShapeSegment {
+  return {
+    present: text.length > 0,
+    chars: text.length,
+    sha256: hashText(text),
+  };
+}
+
+function captureRelevantMemoryBlocks(text: string): RelevantMemoryBlockShape {
+  const matches = [...text.matchAll(RELEVANT_MEMORIES_RE)].map((match) => match[0]);
+  return {
+    count: matches.length,
+    totalChars: matches.reduce((sum, block) => sum + block.length, 0),
+  };
+}
+
+function serializePromptMessages(messages: unknown[]): string {
+  if (messages.length === 0) return "";
+  return stableStringify(messages.map(toPromptVisibleMessage));
+}
+
+function toPromptVisibleMessage(message: unknown): unknown {
+  if (!message || typeof message !== "object") return message;
+  const record = message as Record<string, unknown>;
+  return {
+    role: record.role,
+    content: toPromptVisibleContent(record.content),
+  };
+}
+
+function toPromptVisibleContent(content: unknown): unknown {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return content;
+
+  return content.map((part) => {
+    if (!part || typeof part !== "object") return part;
+    const record = part as Record<string, unknown>;
+    if (record.type === "text" && typeof record.text === "string") {
+      return { type: "text", text: record.text };
+    }
+    return normalizeForStableJson(record);
+  });
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeForStableJson(value));
+}
+
+function normalizeForStableJson(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const normalized = value.map((item) => normalizeForStableJson(item, seen));
+    seen.delete(value);
+    return normalized;
+  }
+
+  const record = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    normalized[key] = normalizeForStableJson(record[key], seen);
+  }
+  seen.delete(value);
+  return normalized;
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function formatSegment(name: MemoryPromptSegmentName, segment: PromptShapeSegment): string {
+  return `${name}=${segment.chars}c/${segment.sha256.slice(0, HASH_PREFIX_LENGTH)}`;
+}
+
+function formatSigned(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
+}

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { looksLikePromptInjection, shouldCaptureL0, shouldExtractL1 } from "./sanitize.js";
+import {
+  looksLikePromptInjection,
+  shouldCaptureL0,
+  shouldExtractL1,
+  stripRelevantMemoriesFromMessageContent,
+  stripRelevantMemoriesFromText,
+} from "./sanitize.js";
 
 describe("prompt injection filtering", () => {
   it("detects common prompt-injection payloads", () => {
@@ -18,5 +24,48 @@ describe("prompt injection filtering", () => {
 
   it("allows normal user content through L1 extraction", () => {
     expect(shouldExtractL1("Please remember that I prefer concise TypeScript examples.")).toBe(true);
+  });
+});
+
+describe("relevant memory stripping", () => {
+  it("strips injected memories from string content while preserving user text", () => {
+    const input = "<relevant-memories>dynamic memory</relevant-memories>\nWhat should we measure?";
+
+    const cleaned = stripRelevantMemoriesFromText(input, { trim: true });
+
+    expect(cleaned.changed).toBe(true);
+    expect(cleaned.text).toBe("What should we measure?");
+    expect(cleaned.text).not.toContain("<relevant-memories>");
+    expect(cleaned.removedChars).toBeGreaterThan(0);
+  });
+
+  it("strips injected memories from text parts and preserves non-text parts", () => {
+    const imagePart = { type: "image", imageUrl: "memory-safe://example" };
+    const content = [
+      {
+        type: "text",
+        text: "<relevant-memories>dynamic memory</relevant-memories>\nContinue the task.",
+      },
+      imagePart,
+    ];
+
+    const cleaned = stripRelevantMemoriesFromMessageContent(content, { trim: true });
+
+    expect(cleaned.changed).toBe(true);
+    expect(cleaned.removedChars).toBeGreaterThan(0);
+    expect(cleaned.content).toEqual([
+      { type: "text", text: "Continue the task." },
+      imagePart,
+    ]);
+  });
+
+  it("leaves content unchanged when no injected memory block is present", () => {
+    const content = [{ type: "text", text: "Plain user text" }];
+
+    const cleaned = stripRelevantMemoriesFromMessageContent(content, { trim: true });
+
+    expect(cleaned.changed).toBe(false);
+    expect(cleaned.removedChars).toBe(0);
+    expect(cleaned.content).toBe(content);
   });
 });

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -3,6 +3,98 @@
  * Removes injected tags, gateway metadata, media noise, etc.
  */
 
+// Trailing \s* is intentional: it removes whitespace after </relevant-memories>
+// so that sanitized output does not accumulate blank lines. The old inline regex
+// in sanitizeText did not strip trailing whitespace; this module-level regex
+// supersedes it with the improved behavior.
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+// Fallback for truncated/malformed injection where the closing </relevant-memories>
+// is missing (e.g., from streaming or partial content). The main regex won't match
+// these, so we additionally strip any orphaned opening tag through end-of-string.
+const ORPHANED_RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*$/g;
+
+export interface StripRelevantMemoriesResult {
+  text: string;
+  removedChars: number;
+  changed: boolean;
+}
+
+export interface StripRelevantMemoriesContentResult {
+  content: unknown;
+  removedChars: number;
+  changed: boolean;
+}
+
+/**
+ * Remove current-turn injected L1 recall blocks without touching ordinary user
+ * text. Used by both persistence cleanup and memory-pipeline sanitization.
+ */
+export function stripRelevantMemoriesFromText(
+  text: string,
+  options: { trim?: boolean } = {},
+): StripRelevantMemoriesResult {
+  if (!text.includes("<relevant-memories>")) {
+    return { text, removedChars: 0, changed: false };
+  }
+
+  // Remove complete blocks; then clean up orphaned opening tags only when
+  // the block regex missed something (truncated/malformed injection).
+  const stripped = text.replace(RELEVANT_MEMORIES_RE, "");
+  const tagCleaned = stripped.includes("<relevant-memories>")
+    ? stripped.replace(ORPHANED_RELEVANT_MEMORIES_RE, "")
+    : stripped;
+  const tagRemovedChars = text.length - tagCleaned.length;
+  const cleaned = options.trim ? tagCleaned.trim() : tagCleaned;
+  return {
+    text: cleaned,
+    removedChars: tagRemovedChars,
+    changed: cleaned !== text,
+  };
+}
+
+/**
+ * Remove injected recall blocks from OpenClaw user-message content while
+ * preserving non-text parts such as images.
+ */
+export function stripRelevantMemoriesFromMessageContent(
+  content: unknown,
+  options: { trim?: boolean } = {},
+): StripRelevantMemoriesContentResult {
+  if (typeof content === "string") {
+    const cleaned = stripRelevantMemoriesFromText(content, options);
+    return {
+      content: cleaned.text,
+      removedChars: cleaned.removedChars,
+      changed: cleaned.changed,
+    };
+  }
+
+  if (!Array.isArray(content)) {
+    return { content, removedChars: 0, changed: false };
+  }
+
+  let removedChars = 0;
+  let changed = false;
+  const cleanedParts = (content as Array<unknown>).map((part) => {
+    if (!part || typeof part !== "object") return part;
+    const record = part as Record<string, unknown>;
+    if (record.type !== "text" || typeof record.text !== "string") return part;
+
+    const cleaned = stripRelevantMemoriesFromText(record.text, options);
+    if (!cleaned.changed) return part;
+    removedChars += cleaned.removedChars;
+    changed = true;
+    return { ...record, text: cleaned.text };
+  });
+
+  return {
+    content: changed ? cleanedParts : content,
+    removedChars,
+    changed,
+  };
+}
+
 /**
  * Clean text for the memory pipeline: remove injected tags, metadata,
  * timestamps, media markers and base64 image data.
@@ -13,7 +105,7 @@ export function sanitizeText(text: string): string {
   let cleaned = text;
 
   // Remove injected memory context tags (prevent feedback loops)
-  cleaned = cleaned.replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>/g, "");
+  cleaned = stripRelevantMemoriesFromText(cleaned).text;
   cleaned = cleaned.replace(/<user-persona>[\s\S]*?<\/user-persona>/g, "");
   cleaned = cleaned.replace(/<relevant-scenes>[\s\S]*?<\/relevant-scenes>/g, "");
   cleaned = cleaned.replace(/<scene-navigation>[\s\S]*?<\/scene-navigation>/g, "");


### PR DESCRIPTION
## Summary | 描述

Fix #120 — 修复 OpenAI-compatible provider（DeepSeek、MiMo）的 prompt prefix-matching 缓存命中率退化。

### 根因

动态 L1 记忆召回（~500-1700 tokens）每轮注入到 `prependContext`（用户消息开头），导致每轮的 prompt 前缀哈希都不同 → prefix-matching 缓存无法复用。

### 方案

将动态 L1 召回从 `prependContext` 移动到 `appendContext`（用户消息之后），保持 prompt prefix 稳定，同时模型在当前轮仍看到完整的记忆内容。

## 关键改动

| 文件 | 说明 |
|------|------|
| `src/config.ts` | 新增 `recall.dynamicContextPlacement`（"append" 默认、"prepend" 回退）和 `recall.showInjected` 开关 |
| `src/core/hooks/auto-recall.ts` | 将动态 L1 从 placement 决策中抽取出来；core 始终输出 prependContext，适配器决定最终位置 |
| `src/adapters/openclaw/recall-injection.ts` | OpenClaw 适配器：placement 路由（prepend ↔ appendContext）+ showInjected 清理控制 |
| `src/utils/sanitize.ts` | 集中化 `<relevant-memories>` 清理（string + parts），处理不完整标签边界 |
| `src/utils/prompt-shape-diagnostics.ts` | 四段上下文观察：appendSystemContext / history / prependContext / appendContext |
| `index.ts` | 集成适配器路由 + 统一清理 + 诊断日志 |
| `docs/issue-120-cache-safe-recall-measurement.md` | 完整 A/B 测量报告 |

## A/B 验证结果

**2 provider × 2 variant × 2 repeat × 3 turn = 24 cells**

| Provider | Warm-turn cacheRead (prepend → append) | cache miss |
|----------|---------------------------------------|------------|
| DeepSeek | 42,752 → **52,544** (+23%) | 5,795 → 4,586 (-21%) |
| MiMo | 36,576 → 32,736 | 1,434 → 2,857 |

- `append` 在所有 12 cells 中 prependContext=0、动态 L1 仅在 appendContext
- 持久化 history 在所有 24 cells 中 historyRelevantMemories=0
- MiMo turn-3 cacheRead=0 是 provider 端 cache-window 特性，非回归

## 配置

```json
{
  "recall": {
    "dynamicContextPlacement": "append",
    "showInjected": false
  }
}
```

回退到旧行为：`"dynamicContextPlacement": "prepend"`

## 验证

| 命令 | 状态 |
|------|:--:|
| `pnpm test` | ✅ 8 passed, 93 tests |
| `npm run build` | ✅ |
| manifest JSON parse | ✅ |
| `git diff --check` | ✅ |
| `npm pack --dry-run` | ✅ |
