### PR TITLE
fix(hermes): require explicit memory indexing

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -1056,7 +1056,7 @@ class MemoryTencentdbProvider(MemoryProvider):
             return
 
         try:
-            self._client.write_explicit_memory(
+            result = self._client.write_explicit_memory(
                 action=action,
                 target=target,
                 content=content,
@@ -1064,6 +1064,8 @@ class MemoryTencentdbProvider(MemoryProvider):
                 session_id=self._session_id,
                 user_id=self._user_id,
             )
+            if result.get("stored") is False:
+                raise RuntimeError("Gateway did not index explicit memory")
             self._record_success()
         except Exception as e:
             self._record_failure()

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -1048,9 +1048,27 @@ class MemoryTencentdbProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes to memory-tencentdb for indexing."""
-        # TODO: Implement mirroring of Hermes builtin MEMORY.md/USER.md writes
-        # to memory-tencentdb's recall index for conflict suppression and dedup.
-        pass
+        if action.strip().lower() != "add":
+            return
+        if not content.strip():
+            return
+        if not self._ensure_alive_for_request() or not self._client:
+            return
+
+        try:
+            self._client.write_explicit_memory(
+                action=action,
+                target=target,
+                content=content,
+                session_key=self._session_id,
+                session_id=self._session_id,
+                user_id=self._user_id,
+            )
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            logger.warning("memory-tencentdb explicit memory sync failed: %s", e)
+            self._try_recover_gateway()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Trigger session-level flush on the Gateway."""

--- a/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/hermes-plugin/memory/memory_tencentdb/client.py
@@ -139,6 +139,28 @@ class MemoryTencentdbSdkClient:
             body["user_id"] = user_id
         return self._post("/capture", body)
 
+    def write_explicit_memory(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        session_key: str,
+        session_id: str = "",
+        user_id: str = "",
+    ) -> Dict[str, Any]:
+        """Mirror a host-native durable-memory write directly into L1."""
+        body: Dict[str, Any] = {
+            "action": action,
+            "target": target,
+            "content": content,
+            "session_key": session_key,
+        }
+        if session_id:
+            body["session_id"] = session_id
+        if user_id:
+            body["user_id"] = user_id
+        return self._post("/memories/explicit", body)
+
     def search_memories(self, query: str, limit: int = 5, type_filter: str = "", scene: str = "") -> Dict[str, Any]:
         """Search L1 structured memories."""
         body: Dict[str, Any] = {"query": query, "limit": limit}

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -433,3 +433,32 @@ def test_shutdown_is_idempotent(provider_with_fake_supervisor):
     provider = provider_with_fake_supervisor
     provider.shutdown()
     provider.shutdown()  # must not raise
+
+
+def test_on_memory_write_mirrors_explicit_adds(provider_with_fake_supervisor):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+
+    provider.on_memory_write(
+        action="add",
+        target="memory",
+        content="TencentDB retry probe memory: durable memory round-trip verification marker.",
+    )
+
+    fake.client.write_explicit_memory.assert_called_once_with(
+        action="add",
+        target="memory",
+        content="TencentDB retry probe memory: durable memory round-trip verification marker.",
+        session_key="test-session",
+        session_id="test-session",
+        user_id="test-user",
+    )
+
+
+def test_on_memory_write_ignores_non_add_actions(provider_with_fake_supervisor):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+
+    provider.on_memory_write(action="remove", target="memory", content="obsolete")
+
+    fake.client.write_explicit_memory.assert_not_called()

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -438,6 +438,7 @@ def test_shutdown_is_idempotent(provider_with_fake_supervisor):
 def test_on_memory_write_mirrors_explicit_adds(provider_with_fake_supervisor):
     provider = provider_with_fake_supervisor
     fake = provider._fake
+    fake.client.write_explicit_memory.return_value = {"stored": True}
 
     provider.on_memory_write(
         action="add",
@@ -453,6 +454,22 @@ def test_on_memory_write_mirrors_explicit_adds(provider_with_fake_supervisor):
         session_id="test-session",
         user_id="test-user",
     )
+
+
+def test_on_memory_write_recovers_when_gateway_does_not_index(provider_with_fake_supervisor):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+    fake.client.write_explicit_memory.return_value = {"stored": False}
+    fake.ensure_running_calls = 0
+
+    provider.on_memory_write(
+        action="add",
+        target="memory",
+        content="TencentDB retry probe memory: durable memory round-trip verification marker.",
+    )
+
+    fake.client.write_explicit_memory.assert_called_once()
+    assert fake.ensure_running_calls == 1
 
 
 def test_on_memory_write_ignores_non_add_actions(provider_with_fake_supervisor):

--- a/src/core/record/explicit-memory.test.ts
+++ b/src/core/record/explicit-memory.test.ts
@@ -44,15 +44,52 @@ describe("ingestExplicitMemory", () => {
     const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-user-"));
     tempDirs.push(baseDir);
 
+    const upsertL1 = vi.fn(async () => true);
+
     const record = await ingestExplicitMemory({
       action: "add",
       target: "user",
       content: "The user prefers concise answers.",
       baseDir,
       sessionKey: "session-key",
+      vectorStore: { upsertL1 } as any,
     });
 
     expect(record?.type).toBe("persona");
     expect(record?.scene_name).toBe("hermes_user_profile");
+  });
+
+  it("rejects explicit memory writes when no search index is available", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-no-index-"));
+    tempDirs.push(baseDir);
+
+    const record = await ingestExplicitMemory({
+      action: "add",
+      target: "memory",
+      content: "This marker must not be reported as stored without an index.",
+      baseDir,
+      sessionKey: "session-key",
+    });
+
+    expect(record).toBeNull();
+  });
+
+  it("rejects explicit memory writes when vector indexing fails", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-index-fail-"));
+    tempDirs.push(baseDir);
+
+    const upsertL1 = vi.fn(async () => false);
+
+    const record = await ingestExplicitMemory({
+      action: "add",
+      target: "memory",
+      content: "This marker must not be reported as stored after upsert failure.",
+      baseDir,
+      sessionKey: "session-key",
+      vectorStore: { upsertL1 } as any,
+    });
+
+    expect(upsertL1).toHaveBeenCalledOnce();
+    expect(record).toBeNull();
   });
 });

--- a/src/core/record/explicit-memory.test.ts
+++ b/src/core/record/explicit-memory.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ingestExplicitMemory } from "./explicit-memory.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("ingestExplicitMemory", () => {
+  it("stores Hermes memory target as an instruction L1 record", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-memory-"));
+    tempDirs.push(baseDir);
+
+    const embed = vi.fn(async () => new Float32Array([0.5, 0.25]));
+    const upsertL1 = vi.fn(async () => true);
+
+    const record = await ingestExplicitMemory({
+      action: "add",
+      target: "memory",
+      content: "Remember that the user wants retry probe summaries.",
+      baseDir,
+      sessionKey: "session-key",
+      sessionId: "session-id",
+      vectorStore: { upsertL1 } as any,
+      embeddingService: { embed } as any,
+    });
+
+    expect(record?.type).toBe("instruction");
+    expect(record?.scene_name).toBe("hermes_explicit_memory");
+    expect(upsertL1).toHaveBeenCalledOnce();
+    expect(embed).toHaveBeenCalledWith("Remember that the user wants retry probe summaries.");
+
+    const [shardName] = await readdir(path.join(baseDir, "records"));
+    const shard = path.join(baseDir, "records", shardName);
+    const saved = await readFile(shard, "utf-8");
+    expect(saved).toContain("Remember that the user wants retry probe summaries.");
+  });
+
+  it("maps Hermes user target to a persona record", async () => {
+    const baseDir = await mkdtemp(path.join(os.tmpdir(), "tdai-explicit-user-"));
+    tempDirs.push(baseDir);
+
+    const record = await ingestExplicitMemory({
+      action: "add",
+      target: "user",
+      content: "The user prefers concise answers.",
+      baseDir,
+      sessionKey: "session-key",
+    });
+
+    expect(record?.type).toBe("persona");
+    expect(record?.scene_name).toBe("hermes_user_profile");
+  });
+});

--- a/src/core/record/explicit-memory.ts
+++ b/src/core/record/explicit-memory.ts
@@ -1,0 +1,63 @@
+/**
+ * Explicit memory ingest: mirrors host-native durable-memory writes directly
+ * into L1 without pretending they were conversation turns.
+ */
+
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore } from "../store/types.js";
+import type { Logger } from "../types.js";
+import { generateMemoryId, writeMemory, type MemoryRecord, type MemoryType } from "./l1-writer.js";
+
+export interface ExplicitMemoryIngestParams {
+  action: string;
+  target: string;
+  content: string;
+  baseDir: string;
+  sessionKey: string;
+  sessionId?: string;
+  logger?: Logger;
+  vectorStore?: IMemoryStore;
+  embeddingService?: EmbeddingService;
+}
+
+function classifyTarget(target: string): { type: MemoryType; sceneName: string } {
+  const normalized = target.trim().toLowerCase();
+
+  if (normalized === "user" || normalized === "user.md" || normalized === "profile") {
+    return { type: "persona", sceneName: "hermes_user_profile" };
+  }
+
+  return { type: "instruction", sceneName: "hermes_explicit_memory" };
+}
+
+export async function ingestExplicitMemory(params: ExplicitMemoryIngestParams): Promise<MemoryRecord | null> {
+  const action = params.action.trim().toLowerCase();
+  if (action !== "add") return null;
+
+  const content = params.content.trim();
+  if (!content) return null;
+
+  const { type, sceneName } = classifyTarget(params.target);
+
+  return writeMemory({
+    memory: {
+      content,
+      type,
+      priority: 90,
+      source_message_ids: [],
+      metadata: {},
+      scene_name: sceneName,
+    },
+    decision: {
+      record_id: generateMemoryId(),
+      action: "store",
+      target_ids: [],
+    },
+    baseDir: params.baseDir,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    logger: params.logger,
+    vectorStore: params.vectorStore,
+    embeddingService: params.embeddingService,
+  });
+}

--- a/src/core/record/explicit-memory.ts
+++ b/src/core/record/explicit-memory.ts
@@ -59,5 +59,6 @@ export async function ingestExplicitMemory(params: ExplicitMemoryIngestParams): 
     logger: params.logger,
     vectorStore: params.vectorStore,
     embeddingService: params.embeddingService,
+    requireVectorStoreWrite: true,
   });
 }

--- a/src/core/record/l1-writer.ts
+++ b/src/core/record/l1-writer.ts
@@ -147,11 +147,28 @@ export async function writeMemory(params: {
   vectorStore?: IMemoryStore;
   /** Optional embedding service (required when vectorStore is provided) */
   embeddingService?: EmbeddingService;
+  /** Return null unless the VectorStore write succeeds. */
+  requireVectorStoreWrite?: boolean;
 }): Promise<MemoryRecord | null> {
-  const { memory, decision, baseDir, sessionKey, sessionId, logger, vectorStore, embeddingService } = params;
+  const {
+    memory,
+    decision,
+    baseDir,
+    sessionKey,
+    sessionId,
+    logger,
+    vectorStore,
+    embeddingService,
+    requireVectorStoreWrite = false,
+  } = params;
 
   if (decision.action === "skip") {
     logger?.debug?.(`${TAG} Skipping memory: ${memory.content.slice(0, 50)}...`);
+    return null;
+  }
+
+  if (requireVectorStoreWrite && !vectorStore) {
+    logger?.warn?.(`${TAG} VectorStore write required but VectorStore is unavailable; rejecting memory write`);
     return null;
   }
 
@@ -220,6 +237,7 @@ export async function writeMemory(params: {
   }
 
   // === Vector Store dual-write ===
+  let vectorWriteOk = false;
   if (vectorStore) {
     try {
       logger?.debug?.(
@@ -247,17 +265,26 @@ export async function writeMemory(params: {
       }
 
       const upsertOk = await vectorStore.upsertL1(record, embedding);
+      vectorWriteOk = upsertOk === true;
       logger?.debug?.(`${TAG} [vec-dual-write] upsert result=${upsertOk} id=${record.id}`);
     } catch (err) {
       // Vector write failure should NOT block the main JSONL write
       logger?.warn?.(
         `${TAG} [vec-dual-write] FAILED (JSONL already written) id=${record.id}: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (requireVectorStoreWrite) {
+        return null;
+      }
     }
   } else {
     logger?.debug?.(
       `${TAG} [vec-dual-write] SKIPPED id=${record.id}: vectorStore=${!!vectorStore}`,
     );
+  }
+
+  if (requireVectorStoreWrite && !vectorWriteOk) {
+    logger?.warn?.(`${TAG} [vec-dual-write] REQUIRED write failed id=${record.id}`);
+    return null;
   }
 
   return record;

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -28,6 +28,7 @@ import type {
   CompletedTurn,
   MemorySearchParams,
   ConversationSearchParams,
+  ExplicitMemoryWriteParams,
 } from "./types.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import type { IMemoryStore } from "./store/types.js";
@@ -36,6 +37,7 @@ import { performAutoRecall } from "./hooks/auto-recall.js";
 import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
+import { ingestExplicitMemory } from "./record/explicit-memory.js";
 import {
   initDataDirectories,
   initStores,
@@ -361,6 +363,35 @@ export class TdaiCore {
     await this.storeReady?.catch(() => {});
     if (!this.scheduler) return;
     await this.scheduler.flushSession(sessionKey);
+  }
+
+  /**
+   * Mirror explicit host durable-memory writes directly into L1.
+   */
+  async ingestExplicitMemory(params: ExplicitMemoryWriteParams): Promise<{ stored: boolean; memoryId?: string; type?: string }> {
+    await this.storeReady?.catch(() => {});
+
+    const record = await ingestExplicitMemory({
+      action: params.action,
+      target: params.target,
+      content: params.content,
+      baseDir: this.dataDir,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      logger: this.logger,
+      vectorStore: this.vectorStore,
+      embeddingService: this.embeddingService,
+    });
+
+    if (!record) {
+      return { stored: false };
+    }
+
+    return {
+      stored: true,
+      memoryId: record.id,
+      type: record.type,
+    };
   }
 
   // ============================

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -239,3 +239,12 @@ export interface ConversationSearchParams {
   limit?: number;
   sessionKey?: string;
 }
+
+/** Parameters for explicit host-native durable-memory ingestion. */
+export interface ExplicitMemoryWriteParams {
+  action: string;
+  target: string;
+  content: string;
+  sessionKey: string;
+  sessionId?: string;
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -5,6 +5,7 @@
  *   GET  /health              — Health check
  *   POST /recall              — Memory recall (prefetch)
  *   POST /capture             — Conversation capture (sync_turn)
+ *   POST /memories/explicit   — Explicit durable-memory ingest
  *   POST /search/memories     — L1 memory search
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
@@ -29,6 +30,8 @@ import type {
   RecallResponse,
   CaptureRequest,
   CaptureResponse,
+  ExplicitMemoryWriteRequest,
+  ExplicitMemoryWriteResponse,
   MemorySearchRequest,
   MemorySearchResponse,
   ConversationSearchRequest,
@@ -198,7 +201,7 @@ export class TdaiGateway {
     if (!loopback && !authOn) {
       this.logger.warn(
         `Gateway is bound to ${host} (non-loopback) WITHOUT an API key. ` +
-        "Every /capture, /search/conversations, /recall, /seed call from the " +
+        "Every /capture, /memories/explicit, /search/conversations, /recall, /seed call from the " +
         "network is currently unauthenticated. Bind to 127.0.0.1, or set " +
         "TDAI_GATEWAY_API_KEY, before continuing."
       );
@@ -264,6 +267,8 @@ export class TdaiGateway {
           return await this.handleRecall(req, res);
         case "POST /capture":
           return await this.handleCapture(req, res);
+        case "POST /memories/explicit":
+          return await this.handleExplicitMemoryWrite(req, res);
         case "POST /search/memories":
           return await this.handleSearchMemories(req, res);
         case "POST /search/conversations":
@@ -416,6 +421,30 @@ export class TdaiGateway {
     const response: CaptureResponse = {
       l0_recorded: result.l0RecordedCount,
       scheduler_notified: result.schedulerNotified,
+    };
+    sendJson(res, 200, response);
+  }
+
+  private async handleExplicitMemoryWrite(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<ExplicitMemoryWriteRequest>(req);
+
+    if (!body.action || !body.target || !body.content || !body.session_key) {
+      sendError(res, 400, "Missing required fields: action, target, content, session_key");
+      return;
+    }
+
+    const result = await this.core.ingestExplicitMemory({
+      action: body.action,
+      target: body.target,
+      content: body.content,
+      sessionKey: body.session_key,
+      sessionId: body.session_id,
+    });
+
+    const response: ExplicitMemoryWriteResponse = {
+      stored: result.stored,
+      memory_id: result.memoryId,
+      type: result.type,
     };
     sendJson(res, 200, response);
   }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -60,6 +60,25 @@ export interface CaptureResponse {
 }
 
 // ============================
+// /memories/explicit
+// ============================
+
+export interface ExplicitMemoryWriteRequest {
+  action: string;
+  target: string;
+  content: string;
+  session_key: string;
+  session_id?: string;
+  user_id?: string;
+}
+
+export interface ExplicitMemoryWriteResponse {
+  stored: boolean;
+  memory_id?: string;
+  type?: string;
+}
+
+// ============================
 // /search/memories
 // ============================
 


### PR DESCRIPTION
## Summary
- build on #418 and require explicit Hermes memory writes to reach the searchable L1 index before reporting `stored: true`
- keep normal L1 extraction writes fault-tolerant by making the strict VectorStore requirement opt-in
- treat Gateway `stored:false` as a Hermes provider sync failure so it is logged and routed through the existing recovery path

## Verification
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run src/core/record/explicit-memory.test.ts`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm test`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm build`
- `python3 -m py_compile hermes-plugin/memory/memory_tencentdb/__init__.py hermes-plugin/memory/memory_tencentdb/client.py hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py`

## Notes
- `python3 -m pytest hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py -q` could not run locally because this Python environment does not have `pytest` installed.

Fixes #417
Supersedes #418