### PR TITLE
docs(adapters): clarify adapter PR boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/adapters/contribution-guide.md`](./docs/adapters/contribution-guide.md) | Adapter PR boundaries, review checklist, and cross-platform contribution lanes |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -507,6 +507,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/adapters/contribution-guide.md`](./docs/adapters/contribution-guide.md) | Adapter PR 边界、Review 清单与跨平台贡献分工 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/docs/adapters/contribution-guide.md
+++ b/docs/adapters/contribution-guide.md
@@ -1,0 +1,40 @@
+# Adapter Contribution Guide
+
+This guide helps contributors keep cross-platform adapter pull requests focused and easy to review. It is especially
+useful for issue #235, where several adapter efforts may run in parallel.
+
+## Adapter Lanes
+
+| Lane | Owns | Should avoid |
+| :--- | :--- | :--- |
+| Shared Gateway client | Typed HTTP client for `/recall`, `/capture`, `/search/*`, `/session/end`, retry/error handling, lifecycle helpers | Platform-specific hooks, CLI processes, MCP protocol details |
+| Coding-agent adapter | Codex-style or Claude Code-style lifecycle mapping, session key strategy, prompt injection/capture examples | Reimplementing the shared Gateway HTTP client |
+| MCP bridge | MCP server/stdio transport, tool schemas, protocol-level validation, process lifecycle | Duplicating coding-agent lifecycle docs unless needed for MCP examples |
+| Dify/workflow adapter | Dify extension points, conversation identity mapping, workflow-specific setup | Generic Gateway SDK code that belongs in the shared client lane |
+| Documentation-only PR | Architecture diagrams, comparison tables, verification playbooks, migration notes | Shipping unverified adapter code snippets as if they were production APIs |
+
+## Review Checklist
+
+Before opening or updating an adapter PR:
+
+1. Identify the lane in the PR description.
+2. Link the issue or PR that owns any dependency lane.
+3. Keep duplicated Gateway request/response types out of platform-specific adapters when a shared client already exists.
+4. Include the hook mapping: before-turn recall, after-turn capture, explicit search, and session end/flush.
+5. Show how the adapter builds stable `session_key` values from platform identity.
+6. Document auth behavior for `TDAI_GATEWAY_API_KEY` when the Gateway is exposed beyond localhost.
+7. Add focused tests for request shape, auth headers, error handling, and session identity.
+8. Run the project checks that match the changed files, and list them in the PR body.
+
+## Suggested PR Body Note
+
+```md
+Adapter lane: <shared Gateway client | coding-agent adapter | MCP bridge | Dify adapter | docs>
+Depends on / complements: <PR or issue link>
+
+This PR intentionally does not implement <other lane>, because that scope is covered by <PR or issue link>.
+```
+
+Using these lanes keeps adapter work additive: a platform-specific adapter can depend on the shared Gateway client, an
+MCP bridge can expose the same capabilities through protocol tooling, and documentation can clarify integration without
+creating another competing implementation.


### PR DESCRIPTION
## Description | 描述

This PR narrows #441 into a documentation-only supplement for the ongoing #235 adapter work.

It adds `docs/adapters/contribution-guide.md`, which documents review lanes for parallel adapter PRs:
- shared Gateway client
- coding-agent adapters
- MCP bridge
- Dify/workflow adapters
- documentation-only PRs

The guide also adds a short review checklist covering session identity, lifecycle hook mapping, Gateway auth, focused tests, and PR body scope notes.

This intentionally does **not** ship another Gateway SDK implementation, because the reusable Gateway client lane is already covered by #316, while coding-agent and MCP-specific lanes are covered separately by #405 and #372.

## Related Issue | 关联 Issue

Related to #235
Complements #316, #405, and #372

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verification performed:
- `git diff --check`

No runtime code changed.