### PR TITLE
fix(checkpoint): recalibrate counters from storage

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -409,6 +409,8 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.recalibrate(this.vectorStore);
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("recalibrates derived counters from persisted L0 and L1 JSONL data", async () => {
+    await fs.mkdir(path.join(tempDir, "conversations"), { recursive: true });
+    await fs.mkdir(path.join(tempDir, "records"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(tempDir, "conversations", "2026-07-09.jsonl"),
+      [
+        JSON.stringify({ sessionKey: "s1", role: "user", content: "hello" }),
+        JSON.stringify({ sessionKey: "s1", role: "assistant", content: "hi" }),
+        "not-json",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await fs.writeFile(
+      path.join(tempDir, "records", "2026-07-09.jsonl"),
+      [
+        JSON.stringify({
+          id: "m1",
+          content: "old memory",
+          createdAt: "2026-07-08T00:00:00.000Z",
+          updatedAt: "2026-07-08T00:00:00.000Z",
+        }),
+        JSON.stringify({
+          id: "m2",
+          content: "new memory",
+          createdAt: "2026-07-09T10:00:00.000Z",
+          updatedAt: "2026-07-09T10:00:00.000Z",
+        }),
+        JSON.stringify({
+          id: "m3",
+          content: "newer memory",
+          createdAt: "2026-07-09T11:00:00.000Z",
+          updatedAt: "2026-07-09T11:00:00.000Z",
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const checkpoint = new CheckpointManager(tempDir);
+    const stale = await checkpoint.read();
+    await checkpoint.write({
+      ...stale,
+      total_processed: 0,
+      l0_conversations_count: 0,
+      total_memories_extracted: 1,
+      memories_since_last_persona: 0,
+      last_persona_time: "2026-07-09T09:00:00.000Z",
+      request_persona_update: true,
+      persona_update_reason: "manual",
+      runner_states: {
+        s1: {
+          last_captured_timestamp: 100,
+          last_l1_cursor: 200,
+          last_scene_name: "Existing Scene",
+        },
+      },
+    });
+
+    const result = await checkpoint.recalibrate();
+    const repaired = await checkpoint.read();
+
+    expect(result).toEqual({
+      total_processed: 2,
+      l0_conversations_count: 2,
+      total_memories_extracted: 3,
+      memories_since_last_persona: 2,
+    });
+    expect(repaired.total_processed).toBe(2);
+    expect(repaired.l0_conversations_count).toBe(2);
+    expect(repaired.total_memories_extracted).toBe(3);
+    expect(repaired.memories_since_last_persona).toBe(2);
+    expect(repaired.request_persona_update).toBe(true);
+    expect(repaired.persona_update_reason).toBe("manual");
+    expect(repaired.runner_states.s1?.last_scene_name).toBe("Existing Scene");
+  });
+
+  it("counts all L1 records as since-persona when no persona cursor exists", async () => {
+    await fs.mkdir(path.join(tempDir, "records"), { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, "records", "2026-07-09.jsonl"),
+      [
+        JSON.stringify({ id: "m1", content: "first" }),
+        JSON.stringify({ id: "m2", content: "second" }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const checkpoint = new CheckpointManager(tempDir);
+
+    await expect(checkpoint.recalibrate()).resolves.toMatchObject({
+      total_memories_extracted: 2,
+      memories_since_last_persona: 2,
+    });
+  });
+
+  it("uses current vector store counts when a store is available", async () => {
+    const vectorStore = {
+      isDegraded: () => false,
+      countL0: () => 4,
+      countL1: () => 3,
+      queryL1Records: () => [
+        {
+          record_id: "m3",
+          content: "after persona",
+          type: "persona",
+          priority: 10,
+          scene_name: "Scene",
+          session_key: "s1",
+          session_id: "",
+          timestamp_str: "",
+          timestamp_start: "",
+          timestamp_end: "",
+          created_time: "2026-07-09T10:00:00.000Z",
+          updated_time: "2026-07-09T10:00:00.000Z",
+          metadata_json: "{}",
+        },
+      ],
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const checkpoint = new CheckpointManager(tempDir);
+    const overReported = await checkpoint.read();
+    await checkpoint.write({
+      ...overReported,
+      total_processed: 10,
+      l0_conversations_count: 10,
+      total_memories_extracted: 8,
+      memories_since_last_persona: 8,
+      last_persona_time: "2026-07-09T09:00:00.000Z",
+    });
+
+    const result = await checkpoint.recalibrate(vectorStore);
+    const repaired = await checkpoint.read();
+
+    expect(result).toEqual({
+      total_processed: 4,
+      l0_conversations_count: 4,
+      total_memories_extracted: 3,
+      memories_since_last_persona: 1,
+    });
+    expect(repaired.total_processed).toBe(4);
+    expect(repaired.total_memories_extracted).toBe(3);
+    expect(repaired.memories_since_last_persona).toBe(1);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -144,6 +145,13 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+export interface CheckpointRecalibrationResult {
+  total_processed: number;
+  l0_conversations_count: number;
+  total_memories_extracted: number;
+  memories_since_last_persona: number;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -180,9 +188,11 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 
 export class CheckpointManager {
   private filePath: string;
+  private dataDir: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -293,6 +303,164 @@ export class CheckpointManager {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
   }
 
+  /**
+   * Recalculate derived counters from persisted L0/L1 data.
+   *
+   * This repairs checkpoint drift after memory cleanup or manual pruning.
+   * When a store is available, its current row counts are authoritative;
+   * otherwise JSONL shards are used as the local fallback.
+   */
+  async recalibrate(vectorStore?: IMemoryStore): Promise<CheckpointRecalibrationResult> {
+    const result = await this.mutate(async (cp) => {
+      const l0Stats = await this.countL0Stats(vectorStore);
+      const l1Stats = await this.countL1Stats(cp.last_persona_time, vectorStore);
+
+      cp.total_processed = l0Stats.totalProcessed;
+      cp.l0_conversations_count = l0Stats.recordCount;
+      cp.total_memories_extracted = l1Stats.totalRecords;
+      cp.memories_since_last_persona = l1Stats.recordsSinceLastPersona;
+    });
+
+    const summary: CheckpointRecalibrationResult = {
+      total_processed: result.total_processed,
+      l0_conversations_count: result.l0_conversations_count,
+      total_memories_extracted: result.total_memories_extracted,
+      memories_since_last_persona: result.memories_since_last_persona,
+    };
+
+    this.logger.info(
+      `[checkpoint] recalibrate: ` +
+      `total_processed=${summary.total_processed}, ` +
+      `l0_conversations_count=${summary.l0_conversations_count}, ` +
+      `total_memories_extracted=${summary.total_memories_extracted}, ` +
+      `memories_since_last_persona=${summary.memories_since_last_persona}`,
+    );
+
+    return summary;
+  }
+
+  async recalibrateCounters(vectorStore?: IMemoryStore): Promise<CheckpointRecalibrationResult> {
+    return this.recalibrate(vectorStore);
+  }
+
+  private async countL0Stats(vectorStore?: IMemoryStore): Promise<{ totalProcessed: number; recordCount: number }> {
+    if (vectorStore && !vectorStore.isDegraded()) {
+      try {
+        const count = await vectorStore.countL0();
+        return { totalProcessed: count, recordCount: count };
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: countL0 failed, falling back to JSONL: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const conversationsDir = path.join(this.dataDir, "conversations");
+    let recordCount = 0;
+
+    await this.scanJsonlLines(conversationsDir, (parsed) => {
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof (parsed as Record<string, unknown>).role === "string" &&
+        typeof (parsed as Record<string, unknown>).content === "string"
+      ) {
+        recordCount += 1;
+      }
+    });
+
+    return { totalProcessed: recordCount, recordCount };
+  }
+
+  private async countL1Stats(
+    lastPersonaTime: string,
+    vectorStore?: IMemoryStore,
+  ): Promise<{
+    totalRecords: number;
+    recordsSinceLastPersona: number;
+  }> {
+    const lastPersonaMs = lastPersonaTime ? Date.parse(lastPersonaTime) : Number.NaN;
+    const hasPersonaCursor = Number.isFinite(lastPersonaMs);
+
+    if (vectorStore && !vectorStore.isDegraded()) {
+      try {
+        const totalRecords = await vectorStore.countL1();
+        const recordsSinceLastPersona = hasPersonaCursor
+          ? (await vectorStore.queryL1Records({ updatedAfter: lastPersonaTime })).length
+          : totalRecords;
+        return { totalRecords, recordsSinceLastPersona };
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: countL1 failed, falling back to JSONL: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const recordsDir = path.join(this.dataDir, "records");
+    let totalRecords = 0;
+    let recordsSinceLastPersona = 0;
+
+    await this.scanJsonlLines(recordsDir, (parsed) => {
+      if (!parsed || typeof parsed !== "object") return;
+      const record = parsed as Record<string, unknown>;
+      if (typeof record.content !== "string" || typeof record.id !== "string") return;
+
+      totalRecords += 1;
+
+      if (!hasPersonaCursor) {
+        recordsSinceLastPersona += 1;
+        return;
+      }
+
+      const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : "";
+      const createdAt = typeof record.createdAt === "string" ? record.createdAt : "";
+      const recordMs = Date.parse(updatedAt || createdAt);
+      if (Number.isFinite(recordMs) && recordMs > lastPersonaMs) {
+        recordsSinceLastPersona += 1;
+      }
+    });
+
+    return { totalRecords, recordsSinceLastPersona };
+  }
+
+  private async scanJsonlLines(
+    dir: string,
+    visit: (parsed: unknown) => void,
+  ): Promise<void> {
+    const dateFilePattern = /^\d{4}-\d{2}-\d{2}\.jsonl$/;
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const files = entries
+      .filter((entry) => entry.isFile() && dateFilePattern.test(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const file of files) {
+      const filePath = path.join(dir, file);
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, "utf-8");
+      } catch {
+        this.logger.warn?.(`[checkpoint] recalibrate: failed to read ${filePath}`);
+        continue;
+      }
+
+      for (const line of raw.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          visit(JSON.parse(line));
+        } catch {
+          this.logger.warn?.(`[checkpoint] recalibrate: skipped malformed JSONL line in ${filePath}`);
+        }
+      }
+    }
+  }
+
   // ============================
   // Public API — mutating (all serialized via file lock)
   // ============================
@@ -330,6 +498,12 @@ export class CheckpointManager {
       cp.scenes_processed += 1;
     });
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
+  }
+
+  async ensureScenesProcessedAtLeast(minScenesProcessed: number): Promise<void> {
+    await this.mutate((cp) => {
+      cp.scenes_processed = Math.max(cp.scenes_processed, minScenesProcessed);
+    });
   }
 
   // ============================

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
+import { CheckpointManager } from "./checkpoint.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
 
@@ -178,6 +179,15 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await checkpoint.recalibrate(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint recalibration failed after cleanup: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -541,15 +541,15 @@ export function createL2Runner(opts: {
           `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
           `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
           `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
-          `Repairing...`,
+          `Recalibrating counters from local storage...`,
         );
-        await checkpoint.write({
-          ...postState,
-          scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
-          total_processed: Math.max(postState.total_processed, preTotalProcessed),
-          memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
-        });
-        logger.info(`${TAG} [L2] Checkpoint repaired`);
+        const recalibrated = await checkpoint.recalibrate(vectorStore);
+        await checkpoint.ensureScenesProcessedAtLeast(preScenesProcessed);
+        logger.info(
+          `${TAG} [L2] Checkpoint counters recalibrated: ` +
+          `total_processed=${recalibrated.total_processed}, ` +
+          `memories_since=${recalibrated.memories_since_last_persona}`,
+        );
       }
 
       if (vectorStore && supportsProfileSyncWrite(vectorStore)) {
@@ -695,6 +695,13 @@ export async function createPipeline(opts: PipelineFactoryOptions): Promise<Pipe
   // Initialize stores (once-async: reuses cached result if already initialized)
   const stores = await initStores(cfg, pluginDataDir, logger);
   const { vectorStore, embeddingService } = stores;
+
+  try {
+    const checkpoint = new CheckpointManager(pluginDataDir, logger);
+    await checkpoint.recalibrate(vectorStore);
+  } catch (err) {
+    logger.warn(`${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   // Create pipeline manager
   const scheduler = createPipelineManager(cfg, logger, sessionFilter);


### PR DESCRIPTION
## Description | 描述
Fixes checkpoint counter drift after cleanup or manual pruning by recalculating derived counters from actual persisted data.

- Add `CheckpointManager.recalibrate()` to refresh `total_processed`, `l0_conversations_count`, `total_memories_extracted`, and `memories_since_last_persona`.
- Prefer current store counts via `countL0()`, `countL1()`, and `queryL1Records({ updatedAfter })`, with JSONL shard counting as the fallback when the store is unavailable.
- Run recalibration during pipeline/core startup, after the memory cleaner completes, and in the existing L2 checkpoint repair path.
- Preserve non-derived checkpoint fields and keep the existing `scenes_processed` regression guard.
- Add regression tests for JSONL fallback counting, persona cursor handling, and vector-store-backed recalibration.

## Related Issue | 关联 Issue
Fix #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Verification run locally:

- `npx vitest run src/utils/checkpoint.test.ts`
- `npm test`
- `npm run build`