### PR TITLE
fix(config): support XDG config path fallbacks

### DIFF
--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 import { getEnv } from "../utils/env.js";
+import { optionalConfigFileExists, resolveHomeDir, resolveUserConfigDirs } from "../utils/config-paths.js";
 import { parseConfig as parseMemoryConfig } from "../config.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import { normalizeDisableThinking } from "../utils/no-think-fetch.js";
@@ -78,8 +79,9 @@ export interface GatewayConfig {
  * Resolution order for config file:
  * 1. `TDAI_GATEWAY_CONFIG` env var (explicit path)
  * 2. `./tdai-gateway.yaml` or `./tdai-gateway.json` in CWD
- * 3. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
- * 4. Pure environment-variable config (no file)
+ * 3. `XDG_CONFIG_HOME/tencentdb-agent-memory` or `~/.config/tencentdb-agent-memory`
+ * 4. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
+ * 5. Pure environment-variable config (no file)
  */
 export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
   let fileConfig: Record<string, unknown> = {};
@@ -122,7 +124,7 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   // Data config (expand leading ~ to $HOME so Node.js fs/path can resolve it)
   const dataConfig = obj(fileConfig, "data");
   const rawBaseDir = env("TDAI_DATA_DIR") ?? str(dataConfig, "baseDir") ?? resolveDefaultDataDir();
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+  const home = resolveHomeDir();
   const baseDir = rawBaseDir.startsWith("~/") ? path.join(home, rawBaseDir.slice(2)) : rawBaseDir;
 
   // LLM config
@@ -169,26 +171,35 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
 function resolveConfigPath(): string | null {
   // 1. Explicit env var
   const explicit = getEnv("TDAI_GATEWAY_CONFIG")?.trim();
-  if (explicit && fs.existsSync(explicit)) return explicit;
+  if (explicit && optionalConfigFileExists(explicit)) return explicit;
 
   // 2. CWD
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(process.cwd(), name);
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
-  // 3. Default data dir
+  // 3. Linux/XDG-style user config dir. Also checked on non-Linux hosts when
+  // present so tests and WSL-like environments do not depend on process.platform.
+  for (const dir of resolveUserConfigDirs("tencentdb-agent-memory")) {
+    for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
+      const p = path.join(dir, name);
+      if (optionalConfigFileExists(p)) return p;
+    }
+  }
+
+  // 4. Default data dir
   const dataDir = resolveDefaultDataDir();
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(dataDir, name);
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
   return null;
 }
 
 function resolveDefaultDataDir(): string {
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+  const home = resolveHomeDir();
 
   // New canonical location: everything related to standalone/Hermes-mode TDAI
   // is collected under ~/.memory-tencentdb/ to avoid scattering top-level dirs
@@ -207,9 +218,9 @@ function resolveDefaultDataDir(): string {
   // users don't silently lose their memory store. The install script
   // (install_hermes_memory_tencentdb.sh, Step 0) will migrate it on next run.
   try {
-    if (!fs.existsSync(newDefault)) {
+    if (!optionalConfigFileExists(newDefault)) {
       const legacy = path.join(home, "memory-tdai");
-      if (fs.existsSync(legacy)) {
+      if (optionalConfigFileExists(legacy)) {
         // Stderr-only deprecation hint; doesn't pollute structured logs.
         process.stderr.write(
           `[tdai-gateway] DEPRECATED: using legacy data dir ${legacy}; ` +

--- a/src/utils/config-paths.test.ts
+++ b/src/utils/config-paths.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadGatewayConfig } from "../gateway/config.js";
+import { resolveOpenClawConfigPath } from "./ensure-hook-policy.js";
+import { resolveOpenClawStateDir } from "./openclaw-state-dir.js";
+
+const ORIGINAL_CWD = process.cwd();
+
+let tempDir = "";
+
+function clearGatewayEnv(): void {
+  for (const key of [
+    "TDAI_GATEWAY_CONFIG",
+    "TDAI_GATEWAY_PORT",
+    "TDAI_GATEWAY_HOST",
+    "TDAI_DATA_DIR",
+    "MEMORY_TENCENTDB_ROOT",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_STATE_DIR",
+    "XDG_CONFIG_HOME",
+  ]) {
+    vi.stubEnv(key, "");
+  }
+}
+
+describe("config path resolution", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-config-paths-"));
+    process.chdir(tempDir);
+    clearGatewayEnv();
+  });
+
+  afterEach(() => {
+    process.chdir(ORIGINAL_CWD);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("loads gateway config from XDG_CONFIG_HOME independent of host platform", () => {
+    const home = path.join(tempDir, "home");
+    const xdg = path.join(tempDir, "xdg");
+    const appDir = path.join(xdg, "tencentdb-agent-memory");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "tdai-gateway.yaml"),
+      "server:\n  port: 9511\n  host: 127.0.0.2\n",
+      "utf-8",
+    );
+
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", "");
+    vi.stubEnv("XDG_CONFIG_HOME", xdg);
+
+    const cfg = loadGatewayConfig();
+
+    expect(cfg.server.port).toBe(9511);
+    expect(cfg.server.host).toBe("127.0.0.2");
+  });
+
+  it("loads gateway config from HOME/.config when XDG_CONFIG_HOME is unset", () => {
+    const home = path.join(tempDir, "home");
+    const appDir = path.join(home, ".config", "tencentdb-agent-memory");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "tdai-gateway.json"),
+      JSON.stringify({
+        server: { port: 9461 },
+        data: { baseDir: "~/memory-data" },
+      }),
+      "utf-8",
+    );
+
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", "");
+
+    const cfg = loadGatewayConfig();
+
+    expect(cfg.server.port).toBe(9461);
+    expect(cfg.data.baseDir).toBe(path.join(home, "memory-data"));
+  });
+
+  it("resolves OpenClaw config from USERPROFILE fallback without HOME", () => {
+    const profile = path.join(tempDir, "profile");
+    const openclawDir = path.join(profile, ".openclaw");
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.mkdirSync(openclawDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}", "utf-8");
+
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", profile);
+
+    expect(resolveOpenClawConfigPath()).toBe(configPath);
+    expect(resolveOpenClawStateDir(undefined)).toBe(openclawDir);
+  });
+});

--- a/src/utils/config-paths.ts
+++ b/src/utils/config-paths.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import { homedir, userInfo } from "node:os";
+import path from "node:path";
+import { getEnv } from "./env.js";
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function safeOsHome(): string | undefined {
+  try {
+    return nonEmpty(homedir());
+  } catch {
+    return undefined;
+  }
+}
+
+function safeUserInfoHome(): string | undefined {
+  try {
+    return nonEmpty(userInfo().homedir);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveHomeDir(): string {
+  return (
+    nonEmpty(getEnv("HOME")) ??
+    nonEmpty(getEnv("USERPROFILE")) ??
+    safeOsHome() ??
+    safeUserInfoHome() ??
+    "/tmp"
+  );
+}
+
+export function optionalConfigFileExists(filePath: string): boolean {
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+export function resolveUserConfigDirs(appName: string): string[] {
+  const dirs = [path.join(resolveHomeDir(), ".config", appName)];
+  const xdgConfigHome = nonEmpty(getEnv("XDG_CONFIG_HOME"));
+  if (xdgConfigHome) {
+    dirs.unshift(path.join(xdgConfigHome, appName));
+  }
+  return [...new Set(dirs)];
+}

--- a/src/utils/ensure-hook-policy.ts
+++ b/src/utils/ensure-hook-policy.ts
@@ -8,6 +8,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { optionalConfigFileExists, resolveHomeDir } from "./config-paths.js";
 import { getEnv } from "./env.js";
 import JSON5 from "json5";
 
@@ -139,23 +140,22 @@ function isGatewayStart(): boolean {
   return !skip.includes(cmd);
 }
 
-function resolveConfigPath(): string | null {
+export function resolveOpenClawConfigPath(): string | null {
   // 1. OPENCLAW_CONFIG_PATH env override (same as core uses)
   const envPath = getEnv("OPENCLAW_CONFIG_PATH")?.trim();
-  if (envPath && fs.existsSync(envPath)) return envPath;
+  if (envPath && optionalConfigFileExists(envPath)) return envPath;
 
   // 2. OPENCLAW_STATE_DIR override
   const stateDir = getEnv("OPENCLAW_STATE_DIR")?.trim();
   if (stateDir) {
     const p = path.join(stateDir, "openclaw.json");
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
   // 3. Standard location: ~/.openclaw/openclaw.json
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "";
-  if (!home) return null;
+  const home = resolveHomeDir();
   const p = path.join(home, ".openclaw", "openclaw.json");
-  return fs.existsSync(p) ? p : null;
+  return optionalConfigFileExists(p) ? p : null;
 }
 
 function hasPolicyAlready(root: unknown): boolean {
@@ -213,7 +213,7 @@ export function ensurePluginHookPolicy(params: {
 function manualPatch(logger: Logger): void {
   const TAG = "[memory-tdai] [hook-policy]";
 
-  const configPath = resolveConfigPath();
+  const configPath = resolveOpenClawConfigPath();
   if (!configPath) {
     logger.warn(`${TAG} Cannot locate openclaw.json — please add hooks.allowConversationAccess manually`);
     return;

--- a/src/utils/openclaw-state-dir.ts
+++ b/src/utils/openclaw-state-dir.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os";
 import path from "node:path";
+import { resolveHomeDir } from "./config-paths.js";
 import { getEnv } from "./env.js";
 
 export interface OpenClawRuntimeStateLike {
@@ -30,6 +30,6 @@ export function resolveOpenClawStateDir(
   return (
     runtimeState?.resolveStateDir?.() ||
     getEnv("OPENCLAW_STATE_DIR")?.trim() ||
-    path.join(homedir(), ".openclaw")
+    path.join(resolveHomeDir(), ".openclaw")
   );
 }


### PR DESCRIPTION
## Description 
- Add shared config-path helpers for safe optional file checks and HOME / USERPROFILE / OS home fallback.
- Load Gateway config from `$XDG_CONFIG_HOME/tencentdb-agent-memory` and `~/.config/tencentdb-agent-memory` before the data-dir fallback.
- Reuse the same home/file-exists fallback in OpenClaw hook-policy config lookup and OpenClaw state-dir fallback.

## Related Issue
Fix #103

## Change Type 
- [x] Bug fix | Bug
- [ ] New feature 
- [ ] Documentation update 
- [ ] Code optimization

## Self-test Checklist
- [x] Verified locally
- [x] No existing features affected

## Additional Notes 
Verified locally:
- `./node_modules/.bin/vitest.cmd run src/utils/config-paths.test.ts`
- `./node_modules/.bin/tsdown.cmd`
- `./node_modules/.bin/tsc.cmd -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false`
- `./node_modules/.bin/tsc.cmd --project scripts/export-tencent-vdb/tsconfig.json`
- `./node_modules/.bin/tsc.cmd --project scripts/read-local-memory/tsconfig.json`
- `git diff --cached --check`

Notes from this Windows host:
- `pnpm` is blocked locally by the existing bash postinstall command (`bash ... || true`), so verification used the local package binaries directly.
- Full `vitest run` currently fails only in existing `src/utils/time.test.ts` timezone/Intl assertions on this host; the focused config-path tests pass.
