### PR TITLE
fix:checkpoint,issue #157

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -514,6 +514,7 @@ export class TdaiCore {
     this.schedulerStartPromise = (async () => {
       try {
         const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        await checkpoint.recalibrate({ vectorStore: this.vectorStore });
         const cp = await checkpoint.read();
         scheduler.start(checkpoint.getAllPipelineStates(cp));
         this.logger.debug?.(`${TAG} Scheduler started`);

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CheckpointManager, type Checkpoint } from "./checkpoint.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    last_captured_timestamp: 0,
+    total_processed: 0,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 0,
+    runner_states: {},
+    pipeline_states: {},
+    l0_conversations_count: 0,
+    total_memories_extracted: 0,
+    ...overrides,
+  };
+}
+
+async function makeTempDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonlLines(dir: string, fileName: string, count: number): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  const lines = Array.from({ length: count }, (_, i) => JSON.stringify({ id: i }));
+  await fs.writeFile(path.join(dir, fileName), `${lines.join("\n")}\n`, "utf-8");
+}
+
+function makeVectorStore(params: {
+  countL0: () => number | Promise<number>;
+  degraded?: boolean;
+}): IMemoryStore {
+  return {
+    isDegraded: () => params.degraded ?? false,
+    countL0: params.countL0,
+  } as unknown as IMemoryStore;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager.recalibrate", () => {
+  it("overwrites drifted counters from real storage without touching split session states", async () => {
+    const dataDir = await makeTempDataDir();
+    const manager = new CheckpointManager(dataDir);
+    const runnerStates = {
+      "session-a": {
+        last_captured_timestamp: 123,
+        last_l1_cursor: 456,
+        last_scene_name: "planning",
+      },
+    };
+    const pipelineStates = {
+      "session-a": {
+        conversation_count: 3,
+        last_extraction_time: "2026-01-01T00:00:00.000Z",
+        last_extraction_updated_time: "2026-01-01T00:01:00.000Z",
+        last_active_time: 789,
+        l2_pending_l1_count: 2,
+        warmup_threshold: 4,
+        l2_last_extraction_time: "2026-01-01T00:02:00.000Z",
+      },
+    };
+
+    await manager.write(makeCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 50,
+      runner_states: runnerStates,
+      pipeline_states: pipelineStates,
+    }));
+    await writeJsonlLines(path.join(dataDir, "records"), "2026-01-01.jsonl", 42);
+    await writeJsonlLines(path.join(dataDir, "conversations"), "2026-01-01.jsonl", 9);
+
+    await manager.recalibrate({ vectorStore: makeVectorStore({ countL0: () => 17 }) });
+
+    const cp = await manager.read();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(17);
+    expect(cp.runner_states).toEqual(runnerStates);
+    expect(cp.pipeline_states).toEqual(pipelineStates);
+  });
+
+  it("falls back to conversations JSONL when vectorStore countL0 fails", async () => {
+    const dataDir = await makeTempDataDir();
+    const manager = new CheckpointManager(dataDir);
+
+    await manager.write(makeCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 50,
+    }));
+    await writeJsonlLines(path.join(dataDir, "records"), "2026-01-01.jsonl", 2);
+    await fs.mkdir(path.join(dataDir, "conversations"), { recursive: true });
+    await fs.writeFile(
+      path.join(dataDir, "conversations", "2026-01-01.jsonl"),
+      '{"id":1}\n\n{"id":2}\r\n   \n{"id":3}\n',
+      "utf-8",
+    );
+
+    await manager.recalibrate({
+      vectorStore: makeVectorStore({
+        countL0: () => {
+          throw new Error("db unavailable");
+        },
+      }),
+    });
+
+    const cp = await manager.read();
+    expect(cp.total_memories_extracted).toBe(2);
+    expect(cp.l0_conversations_count).toBe(3);
+  });
+
+  it("falls back to zero when records and conversations directories do not exist", async () => {
+    const dataDir = await makeTempDataDir();
+    const manager = new CheckpointManager(dataDir);
+
+    await manager.write(makeCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 50,
+    }));
+
+    await manager.recalibrate();
+
+    const cp = await manager.read();
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.l0_conversations_count).toBe(0);
+  });
+});
+
+describe("CheckpointManager.captureAtomically", () => {
+  it("increments l0_conversations_count by captured message rows", async () => {
+    const dataDir = await makeTempDataDir();
+    const manager = new CheckpointManager(dataDir);
+
+    await manager.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 123,
+      messageCount: 3,
+    }));
+
+    const cp = await manager.read();
+    expect(cp.total_processed).toBe(3);
+    expect(cp.l0_conversations_count).toBe(3);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -144,6 +145,10 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+export interface RecalibrateOptions {
+  vectorStore?: IMemoryStore;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -154,6 +159,7 @@ const noopLogger: CheckpointLogger = { info() {} };
 // coordinate instance creation.
 
 const fileLocks = new Map<string, Promise<void>>();
+const JSONL_FILE_PATTERN = /\.jsonl$/;
 
 /**
  * Serialize async critical sections per file path.
@@ -178,11 +184,40 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
   }
 }
 
+async function countJsonlNonEmptyLines(dirPath: string, logger: CheckpointLogger): Promise<number> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let total = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !JSONL_FILE_PATTERN.test(entry.name)) continue;
+
+    const filePath = path.join(dirPath, entry.name);
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      total += raw.split(/\r?\n/).filter((line) => line.trim()).length;
+    } catch (err) {
+      logger.warn?.(
+        `[checkpoint] Failed to count JSONL lines in ${filePath}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return total;
+}
+
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -291,6 +326,47 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Reconcile drift-prone aggregate counters with the real backing data.
+   *
+   * L1 count is derived from records/*.jsonl because those files are the local
+   * append-only source for persisted memories. L0 prefers VectorStore when
+   * available, then falls back to conversations/*.jsonl.
+   */
+  async recalibrate(opts: RecalibrateOptions = {}): Promise<void> {
+    const totalMemoriesExtracted = await countJsonlNonEmptyLines(
+      path.join(this.dataDir, "records"),
+      this.logger,
+    );
+    const l0ConversationsCount = await this.resolveL0Count(opts.vectorStore);
+
+    const cp = await this.mutate((cp) => {
+      cp.total_memories_extracted = totalMemoriesExtracted;
+      cp.l0_conversations_count = l0ConversationsCount;
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrated counters: ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `l0_conversations_count=${cp.l0_conversations_count}`,
+    );
+  }
+
+  private async resolveL0Count(vectorStore?: IMemoryStore): Promise<number> {
+    if (vectorStore && !vectorStore.isDegraded()) {
+      try {
+        return await vectorStore.countL0();
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] Failed to count L0 via VectorStore; falling back to JSONL: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return countJsonlNonEmptyLines(path.join(this.dataDir, "conversations"), this.logger);
   }
 
   // ============================
@@ -479,8 +555,8 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        // Increment by message rows to match VectorStore/JSONL recalibration.
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }


### PR DESCRIPTION
## 关联 Issue

Fix #157

## 背景

当前 `recall_checkpoint.json` 中的 `total_memories_extracted` 和 `l0_conversations_count` 是增量累加字段。
当 `memory-cleaner` 清理历史数据，或者用户手动删除 `records/*.jsonl` / SQLite 中的记录后，checkpoint 中的计数不会同步下降，导致 checkpoint 计数高于真实数据。
这会让后续依赖 checkpoint 的 pipeline / scheduler 使用过期的聚合计数。

## 本 PR 做了什么

1. 在 `CheckpointManager` 中新增 `recalibrate()` 方法：
   - 用真实存储数据重新校准 checkpoint 中容易漂移的计数字段。
   - 只更新：
     - `total_memories_extracted`
     - `l0_conversations_count`
   - 不修改 `runner_states` 和 `pipeline_states`，避免破坏已有 session 状态恢复。
   - 
2. 新增安全的 JSONL 统计逻辑：
   - 统计 `records/*.jsonl` 中的非空行数，作为真实 L1 memory 数量。
   - 统计 `conversations/*.jsonl` 中的非空行数，作为 L0 fallback 数量。
   - 目录不存在时返回 `0`。
   - 单个文件读取失败时只记录 warning，不中断启动流程。
   - 不解析 JSON 内容，只按非空行计数，降低历史脏数据导致校准失败的风险。
   
3. L0 计数优先使用 VectorStore：
   - 如果 `vectorStore` 可用，优先调用 `vectorStore.countL0()`。
   - 如果 `vectorStore` 不可用、处于 degraded 状态，或 `countL0()` 抛错，则 fallback 到 `conversations/*.jsonl` 非空行数。

4. 在 scheduler 启动恢复 checkpoint 前执行校准：
   - 在 `TdaiCore.ensureSchedulerStarted()` 中，读取 checkpoint 并恢复 pipeline state 之前，先调用：

   ```ts
   await checkpoint.recalibrate({ vectorStore: this.vectorStore });
   ```

   - 确保后续 `scheduler.start(...)` 使用的是校准后的 checkpoint。

5. 调整 `captureAtomically()` 的 L0 计数语义：
   - 原来每次 capture 成功只执行 `l0_conversations_count += 1`。
   - 现在改为按实际捕获的消息行数累加：

   ```ts
   cp.l0_conversations_count += result.messageCount;
   ```
   - 这样可以和 `vectorStore.countL0()` / `conversations/*.jsonl` 的真实行数语义保持一致。

6. 新增单元测试：

   - 覆盖 checkpoint 原计数为 `50`，但 `records/*.jsonl` 真实只有 `42` 行时，校准后变为 `42`。
   - 覆盖 `runner_states` / `pipeline_states` 在校准后保持不变。
   - 覆盖 `vectorStore.countL0()` 优先路径。
   - 覆盖 `vectorStore.countL0()` 失败后 fallback 到 `conversations/*.jsonl`。
   - 覆盖目录不存在时计数归零。
   - 覆盖 `captureAtomically()` 按消息行数累加 L0 计数。

## 验证

已执行：

```bash
npm run test -- src/utils/checkpoint.test.ts
npm run test
```

## 验证结果

- 定向测试通过：`1 passed (1), 4 tests passed`
<img width="957" height="444" alt="image" src="https://github.com/user-attachments/assets/a9d40032-9689-4062-9dd5-4cdd5fac8915" />
- 全量测试通过：`5 passed (5), 71 tests passed`
<img width="951" height="357" alt="image" src="https://github.com/user-attachments/assets/a4540cd2-d6d9-4fa7-9703-69a0d47e4fb7" />


## Change Type | 修改类型

- [x] Bug fix | Bug 修复


## Additional Notes | 其他说明

本 PR 没有直接修改 `dist/index.mjs`，只修改 `src` 源码并新增单元测试。
```