### PR TITLE
feat(recall): add opt-in tool-only cache mode

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,12 +74,17 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "mode": { "type": "string", "enum": ["auto", "tool-only"], "default": "auto", "description": "召回模式：auto 保持自动 L1 召回；tool-only 停止每轮自动搜索，由 Agent 按需调用记忆工具" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
-          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }
+          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" },
+          "sessionSnapshotMaxTokens": { "type": "number", "default": 1600, "description": "稳定 session snapshot 的 token 预算" },
+          "sceneSummaryMaxItems": { "type": "number", "default": 6, "description": "稳定快照中最多纳入的场景摘要条数" },
+          "dynamicRecallMaxTokens": { "type": "number", "default": 900, "description": "auto 模式下动态召回片段预算" },
+          "maxSearchCallsPerTurn": { "type": "number", "default": 3, "description": "tdai_memory_search 与 tdai_conversation_search 每轮合计调用预算" }
         }
       },
       "embedding": {

--- a/src/config.cache-aware.test.ts
+++ b/src/config.cache-aware.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("cache-aware context defaults", () => {
+  it("keeps automatic recall as the backward-compatible default", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.mode).toBe("auto");
+    expect(cfg.recall.maxSearchCallsPerTurn).toBe(3);
+  });
+
+  it("parses opt-in tool-only mode and bounded recall controls", () => {
+    const cfg = parseConfig({
+      recall: {
+        mode: "tool-only",
+        sessionSnapshotMaxTokens: 800,
+        sceneSummaryMaxItems: 4,
+        dynamicRecallMaxTokens: 500,
+        maxSearchCallsPerTurn: 2,
+      },
+    });
+
+    expect(cfg.recall.mode).toBe("tool-only");
+    expect(cfg.recall.sessionSnapshotMaxTokens).toBe(800);
+    expect(cfg.recall.sceneSummaryMaxItems).toBe(4);
+    expect(cfg.recall.dynamicRecallMaxTokens).toBe(500);
+    expect(cfg.recall.maxSearchCallsPerTurn).toBe(2);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,8 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /** Recall mode. "tool-only" disables automatic L1 search (default: "auto"). */
+  mode: "auto" | "tool-only";
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -93,6 +95,14 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /** Stable session snapshot token budget (default: 1600) */
+  sessionSnapshotMaxTokens: number;
+  /** Max scene summary items in the stable snapshot (default: 6) */
+  sceneSummaryMaxItems: number;
+  /** Dynamic recall token budget in auto mode (default: 900) */
+  dynamicRecallMaxTokens: number;
+  /** Combined active-search call budget per user turn (default: 3) */
+  maxSearchCallsPerTurn: number;
 }
 
 /** Embedding service configuration for vector search. */
@@ -529,12 +539,17 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      mode: validateRecallMode(str(recallGroup, "mode")) ?? "auto",
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      sessionSnapshotMaxTokens: num(recallGroup, "sessionSnapshotMaxTokens") ?? 1600,
+      sceneSummaryMaxItems: num(recallGroup, "sceneSummaryMaxItems") ?? 6,
+      dynamicRecallMaxTokens: num(recallGroup, "dynamicRecallMaxTokens") ?? 900,
+      maxSearchCallsPerTurn: num(recallGroup, "maxSearchCallsPerTurn") ?? 3,
     },
     embedding: {
       enabled: embeddingEnabled,
@@ -634,6 +649,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_RECALL_MODES: RecallConfig["mode"][] = ["auto", "tool-only"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +659,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateRecallMode(value: string | undefined): RecallConfig["mode"] | undefined {
+  if (!value) return undefined;
+  return VALID_RECALL_MODES.includes(value as RecallConfig["mode"])
+    ? (value as RecallConfig["mode"])
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.tool-only.test.ts
+++ b/src/core/hooks/auto-recall.tool-only.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../../config.js";
+import { performAutoRecall } from "./auto-recall.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("performAutoRecall tool-only mode", () => {
+  it("does not search or prepend dynamic memories when explicitly enabled", async () => {
+    const pluginDataDir = await mkdtemp(join(tmpdir(), "tdai-recall-"));
+    tempDirs.push(pluginDataDir);
+    const cfg = parseConfig({ recall: { mode: "tool-only" } });
+    const searchL1Fts = vi.fn(async () => []);
+    const vectorStore = {
+      isFtsAvailable: () => true,
+      searchL1Fts,
+      getCapabilities: () => ({ nativeHybridSearch: false }),
+    } as any;
+
+    const result = await performAutoRecall({
+      userText: "帮我回忆项目规划",
+      actorId: "user",
+      sessionKey: "agent:test:session",
+      cfg,
+      pluginDataDir,
+      vectorStore,
+    });
+
+    expect(searchL1Fts).not.toHaveBeenCalled();
+    expect(result?.prependContext).toBeUndefined();
+    expect(result?.appendSystemContext).toContain("<session-context");
+    expect(result?.appendSystemContext).toContain("tdai_memory_search");
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -16,6 +16,7 @@ import { formatForLLM } from "../../utils/time.js";
 import type { MemoryTdaiConfig } from "../../config.js";
 import { readSceneIndex } from "../scene/scene-index.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
+import { buildSessionSnapshot } from "../session/session-snapshot.js";
 import type { MemoryRecord } from "../record/l1-reader.js";
 import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.js";
 import { buildFtsQuery } from "../store/sqlite.js";
@@ -32,7 +33,11 @@ const RECALL_LINE_SEPARATOR = "\n";
  * Memory tools usage guide — injected at the end of memory context so the
  * main agent knows how to actively retrieve deeper information.
  */
-const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
+function buildMemoryToolsGuide(maxSearchCallsPerTurn: number): string {
+  const maxCalls = Number.isFinite(maxSearchCallsPerTurn) && maxSearchCallsPerTurn > 0
+    ? Math.floor(maxSearchCallsPerTurn)
+    : 3;
+  return `<memory-tools-guide>
 ## 记忆工具调用指南
 
 当上方注入的记忆片段不足以回答用户问题时，可主动调用以下工具获取更多信息：
@@ -42,10 +47,11 @@ const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
 - **read_file**（Scene Navigation 中的路径）：当已定位到相关情境，且需要该场景的完整画像、事件经过或阶段结论时使用。
 
 ### ⚠️ 调用次数限制
-每轮对话中，tdai_memory_search 和 tdai_conversation_search **合计最多调用 3 次**。
-- 首次搜索无结果时，可换关键词或换工具重试，但总调用次数不要超过 3 次。
-- 若 3 次搜索后仍无结果，说明该信息不在记忆中，请直接根据已有信息回复用户，不要继续搜索。
-</memory-tools-guide>`
+每轮对话中，tdai_memory_search 和 tdai_conversation_search **合计最多调用 ${maxCalls} 次**。
+- 首次搜索无结果时，可换关键词或换工具重试，但总调用次数不要超过 ${maxCalls} 次。
+- 若 ${maxCalls} 次搜索后仍无结果，说明该信息不在记忆中，请直接根据已有信息回复用户，不要继续搜索。
+</memory-tools-guide>`;
+}
 
 /** A single recalled L1 memory with its search score and type. */
 export interface RecalledMemory {
@@ -112,7 +118,8 @@ async function performAutoRecallInner(params: {
   const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
   const tRecallStart = performance.now();
 
-  // Search relevant memories (L1 layer) — skip only when userText is empty/undefined
+  // Search relevant memories (L1 layer) unless the operator explicitly selects
+  // tool-only mode. This preserves the existing automatic recall default.
   const tSearchStart = performance.now();
   let memoryLines: string[] = [];
   let effectiveStrategy = "skipped";
@@ -120,12 +127,17 @@ async function performAutoRecallInner(params: {
   let searchTiming: SearchTiming = { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 };
   if (!userText || userText.length === 0) {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
+  } else if (cfg.recall.mode !== "auto") {
+    logger?.debug?.(`${TAG} recall.mode=${cfg.recall.mode}, skipping automatic L1 search; use memory tools on demand`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
     const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
-    memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
+    memoryLines = applyRecallBudget(memoryLines, {
+      ...cfg.recall,
+      maxTotalRecallChars: cfg.recall.maxTotalRecallChars || cfg.recall.dynamicRecallMaxTokens * 4,
+    }, logger);
 
     // Extract structured RecalledMemory from formatted lines for metric reporting
     recalledL1Memories = memoryLines.map((line) => {
@@ -161,27 +173,15 @@ async function performAutoRecallInner(params: {
   try {
     const sceneIndex = await readSceneIndex(pluginDataDir);
     if (sceneIndex.length > 0) {
-      sceneNavigation = generateSceneNavigation(sceneIndex, pluginDataDir);
-      logger?.debug?.(`${TAG} Scene navigation generated: ${sceneIndex.length} scenes`);
+      const sceneLimit = cfg.recall.sceneSummaryMaxItems > 0 ? cfg.recall.sceneSummaryMaxItems : sceneIndex.length;
+      const boundedSceneIndex = sceneIndex.slice(0, sceneLimit);
+      sceneNavigation = generateSceneNavigation(boundedSceneIndex, pluginDataDir);
+      logger?.debug?.(`${TAG} Scene navigation generated: ${boundedSceneIndex.length}/${sceneIndex.length} scenes`);
     }
   } catch {
     logger?.debug?.(`${TAG} No scene index found`);
   }
   const tSceneEnd = performance.now();
-
-  if (memoryLines.length === 0 && !personaContent && !sceneNavigation) {
-    const totalMs = performance.now() - tRecallStart;
-    logger?.info(
-      `${TAG} ⏱ Recall timing: total=${totalMs.toFixed(0)}ms, ` +
-      `search=${(tSearchEnd - tSearchStart).toFixed(0)}ms(strategy=${effectiveStrategy},hits=${memoryLines.length},` +
-      `fts=${searchTiming.ftsMs.toFixed(0)}ms/${searchTiming.ftsHits}hits,` +
-      `vec=${searchTiming.embeddingMs.toFixed(0)}ms/${searchTiming.embeddingHits}hits), ` +
-      `persona=${(tPersonaEnd - tPersonaStart).toFixed(0)}ms, ` +
-      `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms — no context to inject`,
-    );
-    logger?.debug?.(`${TAG} No memories/persona/scenes to inject`);
-    return undefined;
-  }
 
   // Split recall context into stable and dynamic parts to optimize prompt caching.
   //
@@ -194,16 +194,16 @@ async function performAutoRecallInner(params: {
   //   L1 relevant memories — different every turn, moved out of system prompt
   //   so it doesn't bust the system prompt cache.
   const stableParts: string[] = [];
-  if (personaContent) {
-    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
-  }
-  if (sceneNavigation) {
-    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
-  }
+  const sessionSnapshot = buildSessionSnapshot({
+    persona: personaContent,
+    sceneNavigation,
+    maxTokens: cfg.recall.sessionSnapshotMaxTokens,
+  });
+  stableParts.push(sessionSnapshot.text);
 
   // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
   let prependContext: string | undefined;
-  if (memoryLines.length > 0) {
+  if (cfg.recall.mode === "auto" && memoryLines.length > 0) {
     prependContext =
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
   }
@@ -211,9 +211,7 @@ async function performAutoRecallInner(params: {
   // Append memory tools usage guide to the stable part so the agent knows
   // how to actively retrieve deeper context when the injected snippets
   // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
-    stableParts.push(MEMORY_TOOLS_GUIDE);
-  }
+  stableParts.push(buildMemoryToolsGuide(cfg.recall.maxSearchCallsPerTurn));
 
   const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
 
@@ -630,7 +628,10 @@ async function searchHybrid(
 
   // Sort by combined RRF score and take top results
   const sorted = [...mergedMap.entries()]
-    .sort((a, b) => b[1].rrfScore - a[1].rrfScore)
+    .sort((a, b) => {
+      const scoreDiff = b[1].rrfScore - a[1].rrfScore;
+      return scoreDiff !== 0 ? scoreDiff : a[0].localeCompare(b[0]);
+    })
     .slice(0, maxResults);
 
   if (sorted.length > 0) {

--- a/src/core/session/session-snapshot.test.ts
+++ b/src/core/session/session-snapshot.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionSnapshot } from "./session-snapshot.js";
+
+describe("buildSessionSnapshot", () => {
+  it("is deterministic and excludes dynamic or volatile fields", () => {
+    const input = {
+      persona: "  用户偏好中文回答。\n",
+      sceneNavigation: "- 项目A\n- 项目B",
+      stableMemories: [
+        { id: "m2", content: "第二条", type: "instruction" },
+        { id: "m1", content: "第一条", type: "persona", score: 0.98, createdAt: "2026-01-01T00:00:00Z" },
+      ],
+      maxTokens: 200,
+    };
+
+    const first = buildSessionSnapshot(input);
+    const second = buildSessionSnapshot({ ...input, now: "2026-07-06T00:00:00Z" });
+
+    expect(second).toEqual(first);
+    expect(first.text).toContain("<session-context");
+    expect(first.text).toContain("hash=");
+    expect(first.text).toContain("m1");
+    expect(first.text.indexOf("m1")).toBeLessThan(first.text.indexOf("m2"));
+    expect(first.text).not.toContain("score");
+    expect(first.text).not.toContain("createdAt");
+    expect(first.text).not.toContain("2026-07-06");
+  });
+});

--- a/src/core/session/session-snapshot.ts
+++ b/src/core/session/session-snapshot.ts
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+
+export interface StableSnapshotMemory {
+  id: string;
+  type?: string;
+  content: string;
+  sceneName?: string;
+}
+
+export interface SessionSnapshotInput {
+  persona?: string;
+  sceneNavigation?: string;
+  stableMemories?: StableSnapshotMemory[];
+  maxTokens?: number;
+  now?: string;
+}
+
+export interface SessionSnapshot {
+  text: string;
+  hash: string;
+  estimatedTokens: number;
+}
+
+export function buildSessionSnapshot(input: SessionSnapshotInput): SessionSnapshot {
+  const maxTokens = normalizePositive(input.maxTokens) ?? 1600;
+  const stable = normalizeSnapshotInput(input);
+  const body = renderSnapshotBody(stable);
+  const boundedBody = truncateToEstimatedTokens(body, maxTokens);
+  const hash = sha256(boundedBody).slice(0, 16);
+  const text = `<session-context hash="${hash}" version="1">\n${boundedBody}\n</session-context>`;
+  return { text, hash, estimatedTokens: estimateTokens(text) };
+}
+
+function normalizeSnapshotInput(input: SessionSnapshotInput): Required<Pick<SessionSnapshotInput, "persona" | "sceneNavigation" | "stableMemories">> {
+  const stableMemories = [...(input.stableMemories ?? [])]
+    .filter((m) => m.id && m.content)
+    .map((m) => ({
+      id: String(m.id),
+      type: m.type ? String(m.type) : "memory",
+      content: normalizeText(m.content),
+      sceneName: m.sceneName ? normalizeText(m.sceneName) : undefined,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    persona: normalizeText(input.persona ?? ""),
+    sceneNavigation: normalizeText(input.sceneNavigation ?? ""),
+    stableMemories,
+  };
+}
+
+function renderSnapshotBody(input: Required<Pick<SessionSnapshotInput, "persona" | "sceneNavigation" | "stableMemories">>): string {
+  const parts: string[] = [];
+  if (input.persona) {
+    parts.push(["## persona", input.persona].join("\n"));
+  }
+  if (input.sceneNavigation) {
+    parts.push(["## scene_navigation", input.sceneNavigation].join("\n"));
+  }
+  if (input.stableMemories.length > 0) {
+    parts.push([
+      "## stable_memories",
+      ...input.stableMemories.map((m) => {
+        const scene = m.sceneName ? ` scene="${escapeAttr(m.sceneName)}"` : "";
+        return `- id="${escapeAttr(m.id)}" type="${escapeAttr(m.type ?? "memory")}"${scene}: ${m.content}`;
+      }),
+    ].join("\n"));
+  }
+  if (parts.length === 0) {
+    parts.push("## stable_context\n(empty)");
+  }
+  return parts.join("\n\n");
+}
+
+export function estimateTokens(text: string): number {
+  let cjk = 0;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if ((code >= 0x4e00 && code <= 0x9fff) || (code >= 0x3400 && code <= 0x4dbf) || (code >= 0xf900 && code <= 0xfaff)) cjk++;
+  }
+  return Math.ceil(cjk * 1.5 + (text.length - cjk) / 4);
+}
+
+function truncateToEstimatedTokens(text: string, maxTokens: number): string {
+  if (estimateTokens(text) <= maxTokens) return text;
+  const chars = Array.from(text);
+  let lo = 0;
+  let hi = chars.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (estimateTokens(chars.slice(0, mid).join("")) <= maxTokens) lo = mid;
+    else hi = mid - 1;
+  }
+  return `${chars.slice(0, Math.max(0, lo - 20)).join("").trimEnd()}\n[truncated]`;
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/[ \t]+$/gm, "").trim();
+}
+
+function escapeAttr(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function normalizePositive(value: number | undefined): number | undefined {
+  return value != null && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}


### PR DESCRIPTION
## Description | 描述

本 Draft PR 从 #410 中拆分，仅聚焦 #375 尚未覆盖的剩余召回缓存行为。

主要改动：
- 新增可选配置 `recall.mode="tool-only"`，启用后停止每轮自动 L1 搜索，由 Agent 按需调用记忆工具。
- 默认仍为 `recall.mode="auto"`，保持现有自动召回行为兼容。
- 将 persona 与 scene navigation 规范化为确定性、带 hash 且带 token 上限的 session snapshot。
- 增加 scene 数量、动态召回预算和每轮主动搜索次数配置。
- 为 hybrid recall 的同分结果增加确定性排序。

不包含以下内容：
- `recall.injectionMode`
- `recall.showInjected`
- `appendContext` 注入位置调整
- injected history cleanup

以上行为已由 #375 覆盖，或属于 #375 的处理范围。

## Related Issue | 关联 Issue

Related to #120

从 #410 拆分，作为与 #375 并行收敛的后续 PR。

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

验证命令：
- `npm.cmd test`
- `npm.cmd run build:plugin`
- `node --check dist\index.mjs`
- `git diff --check`

验证结果：
- 7 个测试文件、71 个测试通过。
- 插件构建通过。
- `dist/index.mjs` 语法检查通过。
- diff whitespace 检查通过。

## Additional Notes | 其他说明

当前以 Draft 形式提交，以便在 #375 仍处于评审阶段时保持评审范围收敛。待 #375 合入后，将基于最新 `main` 进行 rebase 并重新验证。