### PR TITLE
feat(offload): add cache epoch task snapshots

### DIFF
--- a/src/offload/epoch-manager.test.ts
+++ b/src/offload/epoch-manager.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { createInitialCacheEpoch, shouldTransitionCacheEpoch, transitionCacheEpoch } from "./epoch-manager.js";
+
+describe("cache epoch manager", () => {
+  it("keeps append-only epochs below threshold", () => {
+    const epoch = createInitialCacheEpoch({ snapshotHash: "h1", startedAtTurn: 1 });
+
+    expect(shouldTransitionCacheEpoch(epoch, {
+      totalTokens: 100,
+      contextWindow: 1_000,
+      currentTurn: 3,
+      triggerRatio: 0.8,
+      minimumTurns: 4,
+    })).toBe(false);
+  });
+
+  it("creates a new frozen epoch when threshold and minimum turns are reached", () => {
+    const epoch = createInitialCacheEpoch({ snapshotHash: "h1", startedAtTurn: 1 });
+    const next = transitionCacheEpoch(epoch, {
+      snapshotHash: "h2",
+      compactedRange: { startTurn: 1, endTurn: 8 },
+      currentTurn: 9,
+    });
+
+    expect(next.id).toBe(epoch.id + 1);
+    expect(next.previousSnapshotHash).toBe("h1");
+    expect(next.snapshotHash).toBe("h2");
+    expect(next.compactedRanges).toEqual([{ startTurn: 1, endTurn: 8 }]);
+  });
+});

--- a/src/offload/epoch-manager.ts
+++ b/src/offload/epoch-manager.ts
@@ -1,0 +1,49 @@
+export interface CacheEpoch {
+  id: number;
+  snapshotHash: string;
+  previousSnapshotHash?: string;
+  startedAtTurn: number;
+  compactedRanges: Array<{ startTurn: number; endTurn: number }>;
+}
+
+export function createInitialCacheEpoch(input: { snapshotHash: string; startedAtTurn?: number }): CacheEpoch {
+  return {
+    id: 1,
+    snapshotHash: input.snapshotHash,
+    startedAtTurn: input.startedAtTurn ?? 1,
+    compactedRanges: [],
+  };
+}
+
+export function shouldTransitionCacheEpoch(
+  epoch: CacheEpoch,
+  input: {
+    totalTokens: number;
+    contextWindow: number;
+    currentTurn: number;
+    triggerRatio: number;
+    minimumTurns: number;
+  },
+): boolean {
+  if (input.contextWindow <= 0) return false;
+  const turnsInEpoch = input.currentTurn - epoch.startedAtTurn + 1;
+  if (turnsInEpoch < input.minimumTurns) return false;
+  return input.totalTokens / input.contextWindow >= input.triggerRatio;
+}
+
+export function transitionCacheEpoch(
+  epoch: CacheEpoch,
+  input: {
+    snapshotHash: string;
+    compactedRange: { startTurn: number; endTurn: number };
+    currentTurn: number;
+  },
+): CacheEpoch {
+  return {
+    id: epoch.id + 1,
+    previousSnapshotHash: epoch.snapshotHash,
+    snapshotHash: input.snapshotHash,
+    startedAtTurn: input.currentTurn,
+    compactedRanges: [...epoch.compactedRanges, input.compactedRange],
+  };
+}

--- a/src/offload/hooks/after-tool-call.ts
+++ b/src/offload/hooks/after-tool-call.ts
@@ -7,7 +7,7 @@ import { nowChinaISO } from "../time-utils.js";
 import { buildTiktokenContextSnapshot, type ContextSnapshot } from "../context-token-tracker.js";
 import { traceOffloadDecision, traceMessagesSnapshot } from "../opik-tracer.js";
 import { PLUGIN_DEFAULTS } from "../types.js";
-import { readOffloadEntries, markOffloadStatus, readMmd } from "../storage.js";
+import { readOffloadEntries, markOffloadStatus } from "../storage.js";
 import { createL3TokenCounter } from "../l3-token-counter.js";
 import {
   normalizeToolCallIdForLookup,
@@ -28,7 +28,7 @@ import {
   isTokenOverflowError,
   dumpMessagesSnapshot,
 } from "./llm-input-l3.js";
-import { MMD_MESSAGE_MARKER, findActiveMmdInsertionPoint, findHistoryMmdInsertionPoint } from "../mmd-injector.js";
+import { maybeUpdateMmdInMessages, findHistoryMmdInsertionPoint } from "../mmd-injector.js";
 import type { OffloadStateManager } from "../state-manager.js";
 import type { PluginConfig, PluginLogger, ToolPair } from "../types.js";
 import type { BackendClient } from "../backend-client.js";
@@ -191,61 +191,10 @@ export function createAfterToolCallHandler(
       if (turn) stateManager.cachedLatestTurnMessages = turn;
     }
 
-    // In-loop active MMD injection / update.
-    // Only inject after L1.5 has settled (task boundary determined, activeMmdFile set).
-    // This also picks up L2 MMD content updates (L2 runs async and may patch the MMD
-    // file between tool calls).
     if (event.messages && Array.isArray(event.messages)) {
       try {
-        const l15Settled = stateManager.l15Settled;
-        const activeMmdFile = stateManager.getActiveMmdFile();
-        if (!l15Settled) {
-          logger.debug?.(`[context-offload] after_tool_call MMD: SKIP (L1.5 not settled yet)`);
-        } else if (!activeMmdFile) {
-          logger.debug?.(`[context-offload] after_tool_call MMD: SKIP (no active MMD file)`);
-        } else {
-          const mmdContent = await readMmd(stateManager.ctx, activeMmdFile);
-          if (mmdContent) {
-            let taskGoal = "";
-            const metaMatch = mmdContent.match(/^%%\{\s*(.*?)\s*\}%%/);
-            if (metaMatch) {
-              try { const meta = JSON.parse(`{${metaMatch[1]}}`); taskGoal = meta.taskGoal || ""; } catch { /* */ }
-            }
-            const mmdText = [
-              `<current_task_context>`,
-              `【当前活跃任务的mermaid流程图】这是你最近正在执行的任务的阶段性记录（此条下方的tool use未被汇总，进程可能有延迟，仅供参考）。`,
-              taskGoal ? `**任务目标:** ${taskGoal}` : "",
-              `**任务文件:** ${activeMmdFile}`,
-              "```mermaid", mmdContent, "```",
-              `标记为 "doing" 的节点是近期焦点（注：可能有延迟，下方的tool use未被统计，仅供参考），"done" 的已完成。请参考此保持方向感，避免重复已完成的工作。`,
-              `</current_task_context>`,
-            ].filter((line) => line !== "").join("\n");
-
-            const existingIdx = event.messages.findIndex((m: any) => m._mmdContextMessage === "active");
-            const newMsg = { role: "user", content: [{ type: "text", text: mmdText }], _mmdContextMessage: "active" };
-            if (existingIdx >= 0) {
-              // Check if content changed (L1.5 switched file or L2 updated content)
-              const oldContent = Array.isArray(event.messages[existingIdx].content)
-                ? event.messages[existingIdx].content.map((c: any) => c.text ?? "").join("")
-                : (event.messages[existingIdx].content ?? "");
-              const contentChanged = !oldContent.includes(activeMmdFile) || oldContent !== mmdText;
-              if (contentChanged) {
-                event.messages[existingIdx] = newMsg;
-                logger.debug?.(`[context-offload] after_tool_call MMD: UPDATED at [${existingIdx}], file=${activeMmdFile}, contentChanged=true`);
-                _dumpMessagesAfterMmd(event.messages, "UPDATED", logger);
-              } else {
-                logger.debug?.(`[context-offload] after_tool_call MMD: unchanged, skip update`);
-              }
-            } else {
-              const insertIdx = findActiveMmdInsertionPoint(event.messages);
-              event.messages.splice(insertIdx, 0, newMsg);
-              logger.debug?.(`[context-offload] after_tool_call MMD: INJECTED at [${insertIdx}], file=${activeMmdFile}, msgs=${event.messages.length}`);
-              _dumpMessagesAfterMmd(event.messages, "INJECTED", logger);
-            }
-          } else {
-            logger.debug?.(`[context-offload] after_tool_call MMD: file=${activeMmdFile} content is null`);
-          }
-        }
+        const changed = await maybeUpdateMmdInMessages(event.messages, stateManager, logger, getContextWindow, pluginConfig);
+        if (changed) _dumpMessagesAfterMmd(event.messages, "APPENDED", logger);
       } catch (err) {
         logger.warn(`[context-offload] after_tool_call MMD error: ${err}`);
       }

--- a/src/offload/mmd-injector.test.ts
+++ b/src/offload/mmd-injector.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { readMmd } = vi.hoisted(() => ({ readMmd: vi.fn() }));
+
+vi.mock("./storage.js", () => ({
+  listMmds: vi.fn(),
+  readMmd,
+}));
+
+import { injectMmdIntoMessages, maybeUpdateMmdInMessages } from "./mmd-injector.js";
+
+describe("injectMmdIntoMessages", () => {
+  beforeEach(() => readMmd.mockReset());
+
+  it("removes stale MMD context when injection is no longer ready", async () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "keep" }] },
+      { role: "user", content: [{ type: "text", text: "stale" }], _mmdContextMessage: "active" },
+    ];
+    const stateManager = {
+      l15Settled: true,
+      lastMmdInjectedTokens: 42,
+      isMmdInjectionReady: () => false,
+      getActiveMmdFile: () => null,
+    } as any;
+    const logger = { debug: () => {} } as any;
+
+    const result = await injectMmdIntoMessages(messages, stateManager, logger, () => 1_000, {});
+
+    expect(result.mmdTokens).toBe(0);
+    expect(stateManager.lastMmdInjectedTokens).toBe(0);
+    expect(messages).toEqual([{ role: "user", content: [{ type: "text", text: "keep" }] }]);
+  });
+
+  it("removes stale MMD context when the active MMD cannot be read", async () => {
+    readMmd.mockResolvedValue(null);
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "keep" }] },
+      { role: "user", content: [{ type: "text", text: "stale" }], _mmdContextMessage: "active" },
+    ];
+    const stateManager = {
+      l15Settled: true,
+      lastMmdInjectedTokens: 42,
+      ctx: {},
+      isMmdInjectionReady: () => true,
+      getActiveMmdFile: () => "active.mmd",
+      getLastSessionKey: () => "session-1",
+    } as any;
+    const logger = { debug: () => {}, error: () => {} } as any;
+
+    const result = await injectMmdIntoMessages(messages, stateManager, logger, () => 1_000, {});
+
+    expect(result.mmdTokens).toBe(0);
+    expect(stateManager.lastMmdInjectedTokens).toBe(0);
+    expect(messages).toEqual([{ role: "user", content: [{ type: "text", text: "keep" }] }]);
+  });
+
+  it("replaces the active MMD after an update instead of accumulating prompt context", async () => {
+    const firstMmd = "flowchart TD\nN1[doing]";
+    const secondMmd = "flowchart TD\nN1[done] --> N2[doing]";
+    readMmd
+      .mockResolvedValueOnce(firstMmd)
+      .mockResolvedValueOnce(secondMmd)
+      .mockResolvedValueOnce(secondMmd);
+    let injectedVersion: string | undefined;
+    const stateManager = {
+      l15Settled: true,
+      lastMmdInjectedTokens: 0,
+      ctx: {},
+      isMmdInjectionReady: () => true,
+      getActiveMmdFile: () => "active.mmd",
+      getInjectedMmdVersion: () => injectedVersion,
+      setInjectedMmdVersion: (_file: string, version: string) => { injectedVersion = version; },
+      getLastSessionKey: () => "session-1",
+    } as any;
+    const logger = { debug: () => {}, error: () => {} } as any;
+    const messages = [{ role: "user", content: [{ type: "text", text: "keep" }] }];
+
+    await injectMmdIntoMessages(messages, stateManager, logger, () => 1_000, {});
+    await maybeUpdateMmdInMessages(messages, stateManager, logger, () => 1_000, {});
+
+    expect(messages.filter((message: any) => message._mmdContextMessage === "active")).toHaveLength(1);
+    expect(messages.find((message: any) => message._mmdContextMessage === "active")?.content?.[0]?.text).toContain("N2[doing]");
+    expect(stateManager.lastMmdInjectedTokens).toBeGreaterThan(0);
+  });
+});

--- a/src/offload/mmd-injector.ts
+++ b/src/offload/mmd-injector.ts
@@ -1,20 +1,21 @@
 /**
  * Unified MMD injector.
  *
- * Maintains a single marked message in event.messages containing the active
- * MMD (+ history MMDs). Used by both before_prompt_build (full inject after
- * L1.5 judgment) and after_tool_call (incremental update when L2 refreshes
- * the MMD file during the tool loop).
+ * Appends a compact task snapshot for the first active MMD version and a delta
+ * marker for later versions. Earlier task context remains immutable.
  *
  * The marker property `_mmdContextMessage` is used to locate the message for
  * replacement. L3 compression must skip messages carrying this marker.
  */
-import { readMmd, listMmds } from "./storage.js";
+import { createHash } from "node:crypto";
+import { readMmd, listMmds, writeRefMd } from "./storage.js";
 import { PLUGIN_DEFAULTS, type PluginConfig, type PluginLogger } from "./types.js";
 import { createL3TokenCounter } from "./l3-token-counter.js";
 import { traceOffloadDecision } from "./opik-tracer.js";
 import { isToolResultMessage, isAssistantMessageWithToolUse } from "./l3-helpers.js";
 import type { OffloadStateManager } from "./state-manager.js";
+import { buildTaskSnapshot, buildTaskDeltaMessage } from "./task-snapshot.js";
+import { nowChinaISO } from "./time-utils.js";
 
 /** Marker property on the injected message object. */
 export const MMD_MESSAGE_MARKER = "_mmdContextMessage";
@@ -53,9 +54,7 @@ export async function injectMmdIntoMessages(
     `[context-offload] mmd-injector inject: injectionReady=${injReady}, activeMmdFile=${actFile ?? "null"}, msgs=${messages.length}`,
   );
   if (!injReady) {
-    removeMmdMessages(messages);
-    stateManager.lastMmdInjectedTokens = 0;
-    return { mmdTokens: 0 };
+    return { mmdTokens: stateManager.lastMmdInjectedTokens };
   }
 
   const contextWindow =
@@ -70,26 +69,31 @@ export async function injectMmdIntoMessages(
   logger.debug?.(
     `[context-offload] mmd-injector inject: activeMmdText=${activeMmdText ? `${activeMmdText.length} chars` : "null"}, contextWindow=${contextWindow}`,
   );
-  removeMmdMessages(messages);
 
-  let totalMmdTokens = 0;
-
-  if (activeMmdText) {
-    const activeMsg: any = {
-      role: "user",
-      content: [{ type: "text", text: activeMmdText }],
-      [MMD_MESSAGE_MARKER]: "active",
-    };
-    const insertIdx = findActiveMmdInsertionPoint(messages);
-    messages.splice(insertIdx, 0, activeMsg);
-    totalMmdTokens += countTokens(activeMmdText);
+  if (!activeMmdText) {
+    return { mmdTokens: stateManager.lastMmdInjectedTokens };
   }
 
+  const activeMsg: any = {
+    role: "user",
+    content: [{ type: "text", text: activeMmdText }],
+    [MMD_MESSAGE_MARKER]: "active",
+  };
+  messages.push(activeMsg);
+
+  const totalMmdTokens = messages
+    .filter((message: any) => message[MMD_MESSAGE_MARKER] === "active")
+    .reduce((total: number, message: any) => {
+      const text = Array.isArray(message.content)
+        ? message.content.map((part: any) => part?.text ?? "").join("")
+        : String(message.content ?? "");
+      return total + countTokens(text);
+    }, 0);
   stateManager.lastMmdInjectedTokens = totalMmdTokens;
 
   const activeMmd = stateManager.getActiveMmdFile();
   logger.debug?.(
-    `[context-offload] mmd-injector: injected active MMD into messages (${totalMmdTokens} tokens, file=${activeMmd})`,
+    `[context-offload] mmd-injector: appended active MMD snapshot/delta (${totalMmdTokens} tokens, file=${activeMmd})`,
   );
 
   // Summary after active MMD injection (was full dump, now aggregated)
@@ -109,7 +113,7 @@ export async function injectMmdIntoMessages(
       mmdMaxTokenRatio,
     },
     output: {
-      result: `MMD 注入 messages：${totalMmdTokens} tokens (active only)`,
+      result: `MMD append-only snapshot/delta：${totalMmdTokens} tokens (active only)`,
       mmdTokens: totalMmdTokens,
       hasActive: !!activeMmdText,
       hasHistory: false,
@@ -300,14 +304,6 @@ export function findHistoryMmdInsertionPoint(messages: any[]): number {
   return findActiveMmdInsertionPoint(messages);
 }
 
-function removeMmdMessages(messages: any[]): void {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i][MMD_MESSAGE_MARKER]) {
-      messages.splice(i, 1);
-    }
-  }
-}
-
 async function buildActiveMmdText(
   stateManager: OffloadStateManager,
   logger: PluginLogger,
@@ -325,10 +321,9 @@ async function buildActiveMmdBlock(
   try {
     const mmdContent = await readMmd(stateManager.ctx, activeMmdFile);
     if (!mmdContent) return null;
-    stateManager.setInjectedMmdVersion(
-      activeMmdFile,
-      computeFingerprint(mmdContent),
-    );
+    const fingerprint = computeFingerprint(mmdContent);
+    const previousFingerprint = stateManager.getInjectedMmdVersion(activeMmdFile);
+    if (previousFingerprint === fingerprint) return null;
     const metaMatch = mmdContent.match(/^%%\{\s*(.*?)\s*\}%%/);
     let taskGoal = "";
     if (metaMatch) {
@@ -339,28 +334,29 @@ async function buildActiveMmdBlock(
         /* ignore */
       }
     }
-    const nodePattern = /\b(\d+-N\d+|N\d+)\b/g;
-    const nodeIds: string[] = [];
-    let match: RegExpExecArray | null;
-    while ((match = nodePattern.exec(mmdContent)) !== null) {
-      if (!nodeIds.includes(match[1])) nodeIds.push(match[1]);
-    }
-    return [
-      `<current_task_context>`,
-      `【当前活跃任务的mermaid流程图】这是你最近正在执行的任务的阶段性记录（此条下方的tool use未被汇总，进程可能有延迟，仅供参考）。`,
-      taskGoal ? `**任务目标:** ${taskGoal}` : "",
-      `**任务文件:** ${activeMmdFile}`,
-      nodeIds.length > 0
-        ? `**节点索引:** 可通过 node_id 在 offload.{sessionid}.jsonl 中查找对应的工具调用记录。如需查看某个节点对应的原始工具调用与完整结果，请在 offload.{sessionid}.jsonl 中找到对应条目的 result_ref 并读取该文件。`
-        : "",
-      "```mermaid",
+    const refPath = await writeRefMd(
+      stateManager.ctx,
+      nowChinaISO(),
+      "task-mermaid",
       mmdContent,
-      "```",
-      `标记为 "doing" 的节点是近期焦点（注：可能有延迟，下方的tool use未被统计，仅供参考），"done" 的已完成。请参考此保持方向感，避免重复已完成的工作。`,
-      `</current_task_context>`,
-    ]
-      .filter((line) => line !== "")
-      .join("\n");
+    );
+    stateManager.setInjectedMmdVersion(activeMmdFile, fingerprint);
+
+    if (!previousFingerprint) {
+      return buildTaskSnapshot({
+        taskGoal,
+        mmdFile: activeMmdFile,
+        mermaid: mmdContent,
+        resultRef: refPath,
+      }).text;
+    }
+
+    return buildTaskDeltaMessage({
+      taskGoal,
+      mmdFile: activeMmdFile,
+      changedNodeIds: extractNodeIds(mmdContent),
+      resultRef: refPath,
+    }).content[0].text;
   } catch (err) {
     logger.error(
       `[context-offload] mmd-injector: Error building active MMD block: ${err}`,
@@ -370,5 +366,18 @@ async function buildActiveMmdBlock(
 }
 
 function computeFingerprint(content: string): string {
-  return `${content.length}:${content.slice(0, 64)}`;
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+function extractNodeIds(content: string): string[] {
+  const nodePattern = /\b(\d+-N\d+|N\d+|[A-Za-z]\w*)\b/g;
+  const nodeIds: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = nodePattern.exec(content)) !== null) {
+    const id = match[1];
+    if (!["flowchart", "graph", "subgraph", "end", "classDef"].includes(id) && !nodeIds.includes(id)) {
+      nodeIds.push(id);
+    }
+  }
+  return nodeIds.slice(0, 40);
 }

--- a/src/offload/mmd-injector.ts
+++ b/src/offload/mmd-injector.ts
@@ -1,21 +1,18 @@
 /**
  * Unified MMD injector.
  *
- * Appends a compact task snapshot for the first active MMD version and a delta
- * marker for later versions. Earlier task context remains immutable.
+ * Maintains one marked message containing the active MMD. It is replaced when
+ * task context changes and cleared as soon as it is no longer valid.
  *
  * The marker property `_mmdContextMessage` is used to locate the message for
  * replacement. L3 compression must skip messages carrying this marker.
  */
-import { createHash } from "node:crypto";
-import { readMmd, listMmds, writeRefMd } from "./storage.js";
+import { readMmd, listMmds } from "./storage.js";
 import { PLUGIN_DEFAULTS, type PluginConfig, type PluginLogger } from "./types.js";
 import { createL3TokenCounter } from "./l3-token-counter.js";
 import { traceOffloadDecision } from "./opik-tracer.js";
 import { isToolResultMessage, isAssistantMessageWithToolUse } from "./l3-helpers.js";
 import type { OffloadStateManager } from "./state-manager.js";
-import { buildTaskSnapshot, buildTaskDeltaMessage } from "./task-snapshot.js";
-import { nowChinaISO } from "./time-utils.js";
 
 /** Marker property on the injected message object. */
 export const MMD_MESSAGE_MARKER = "_mmdContextMessage";
@@ -54,7 +51,9 @@ export async function injectMmdIntoMessages(
     `[context-offload] mmd-injector inject: injectionReady=${injReady}, activeMmdFile=${actFile ?? "null"}, msgs=${messages.length}`,
   );
   if (!injReady) {
-    return { mmdTokens: stateManager.lastMmdInjectedTokens };
+    removeMmdMessages(messages);
+    stateManager.lastMmdInjectedTokens = 0;
+    return { mmdTokens: 0 };
   }
 
   const contextWindow =
@@ -70,30 +69,22 @@ export async function injectMmdIntoMessages(
     `[context-offload] mmd-injector inject: activeMmdText=${activeMmdText ? `${activeMmdText.length} chars` : "null"}, contextWindow=${contextWindow}`,
   );
 
-  if (!activeMmdText) {
-    return { mmdTokens: stateManager.lastMmdInjectedTokens };
+  removeMmdMessages(messages);
+  let totalMmdTokens = 0;
+  if (activeMmdText) {
+    const activeMsg: any = {
+      role: "user",
+      content: [{ type: "text", text: activeMmdText }],
+      [MMD_MESSAGE_MARKER]: "active",
+    };
+    messages.splice(findActiveMmdInsertionPoint(messages), 0, activeMsg);
+    totalMmdTokens = countTokens(activeMmdText);
   }
-
-  const activeMsg: any = {
-    role: "user",
-    content: [{ type: "text", text: activeMmdText }],
-    [MMD_MESSAGE_MARKER]: "active",
-  };
-  messages.push(activeMsg);
-
-  const totalMmdTokens = messages
-    .filter((message: any) => message[MMD_MESSAGE_MARKER] === "active")
-    .reduce((total: number, message: any) => {
-      const text = Array.isArray(message.content)
-        ? message.content.map((part: any) => part?.text ?? "").join("")
-        : String(message.content ?? "");
-      return total + countTokens(text);
-    }, 0);
   stateManager.lastMmdInjectedTokens = totalMmdTokens;
 
   const activeMmd = stateManager.getActiveMmdFile();
   logger.debug?.(
-    `[context-offload] mmd-injector: appended active MMD snapshot/delta (${totalMmdTokens} tokens, file=${activeMmd})`,
+    `[context-offload] mmd-injector: injected active MMD (${totalMmdTokens} tokens, file=${activeMmd})`,
   );
 
   // Summary after active MMD injection (was full dump, now aggregated)
@@ -113,7 +104,7 @@ export async function injectMmdIntoMessages(
       mmdMaxTokenRatio,
     },
     output: {
-      result: `MMD append-only snapshot/delta：${totalMmdTokens} tokens (active only)`,
+      result: `MMD 注入 messages：${totalMmdTokens} tokens (active only)`,
       mmdTokens: totalMmdTokens,
       hasActive: !!activeMmdText,
       hasHistory: false,
@@ -140,8 +131,12 @@ export async function maybeUpdateMmdInMessages(
   logger.debug?.(
     `[context-offload] mmd-injector maybeUpdate: injectionReady=${injectionReady}, activeMmdFile=${activeMmdFile ?? "null"}, msgs=${messages.length}`,
   );
-  if (!injectionReady) return false;
-  if (!activeMmdFile) return false;
+  if (!injectionReady || !activeMmdFile) {
+    const hadMmd = messages.some((message: any) => message[MMD_MESSAGE_MARKER]);
+    removeMmdMessages(messages);
+    stateManager.lastMmdInjectedTokens = 0;
+    return hadMmd;
+  }
 
   let mmdContent: string | null;
   try {
@@ -151,9 +146,17 @@ export async function maybeUpdateMmdInMessages(
     );
   } catch (e) {
     logger.debug?.(`[context-offload] mmd-injector maybeUpdate: readMmd error=${e}`);
-    return false;
+    const hadMmd = messages.some((message: any) => message[MMD_MESSAGE_MARKER]);
+    removeMmdMessages(messages);
+    stateManager.lastMmdInjectedTokens = 0;
+    return hadMmd;
   }
-  if (!mmdContent) return false;
+  if (!mmdContent) {
+    const hadMmd = messages.some((message: any) => message[MMD_MESSAGE_MARKER]);
+    removeMmdMessages(messages);
+    stateManager.lastMmdInjectedTokens = 0;
+    return hadMmd;
+  }
 
   const newFp = computeFingerprint(mmdContent);
   const lastFp = stateManager.getInjectedMmdVersion(activeMmdFile);
@@ -304,6 +307,12 @@ export function findHistoryMmdInsertionPoint(messages: any[]): number {
   return findActiveMmdInsertionPoint(messages);
 }
 
+function removeMmdMessages(messages: any[]): void {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i][MMD_MESSAGE_MARKER]) messages.splice(i, 1);
+  }
+}
+
 async function buildActiveMmdText(
   stateManager: OffloadStateManager,
   logger: PluginLogger,
@@ -322,8 +331,6 @@ async function buildActiveMmdBlock(
     const mmdContent = await readMmd(stateManager.ctx, activeMmdFile);
     if (!mmdContent) return null;
     const fingerprint = computeFingerprint(mmdContent);
-    const previousFingerprint = stateManager.getInjectedMmdVersion(activeMmdFile);
-    if (previousFingerprint === fingerprint) return null;
     const metaMatch = mmdContent.match(/^%%\{\s*(.*?)\s*\}%%/);
     let taskGoal = "";
     if (metaMatch) {
@@ -334,29 +341,27 @@ async function buildActiveMmdBlock(
         /* ignore */
       }
     }
-    const refPath = await writeRefMd(
-      stateManager.ctx,
-      nowChinaISO(),
-      "task-mermaid",
-      mmdContent,
-    );
     stateManager.setInjectedMmdVersion(activeMmdFile, fingerprint);
-
-    if (!previousFingerprint) {
-      return buildTaskSnapshot({
-        taskGoal,
-        mmdFile: activeMmdFile,
-        mermaid: mmdContent,
-        resultRef: refPath,
-      }).text;
+    const nodePattern = /\b(\d+-N\d+|N\d+)\b/g;
+    const nodeIds: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = nodePattern.exec(mmdContent)) !== null) {
+      if (!nodeIds.includes(match[1])) nodeIds.push(match[1]);
     }
-
-    return buildTaskDeltaMessage({
-      taskGoal,
-      mmdFile: activeMmdFile,
-      changedNodeIds: extractNodeIds(mmdContent),
-      resultRef: refPath,
-    }).content[0].text;
+    return [
+      `<current_task_context>`,
+      `【当前活跃任务的mermaid流程图】这是你最近正在执行的任务的阶段性记录（此条下方的tool use未被汇总，进程可能有延迟，仅供参考）。`,
+      taskGoal ? `**任务目标:** ${taskGoal}` : "",
+      `**任务文件:** ${activeMmdFile}`,
+      nodeIds.length > 0
+        ? `**节点索引:** 可通过 node_id 在 offload.{sessionid}.jsonl 中查找对应的工具调用记录。如需查看某个节点对应的原始工具调用与完整结果，请在 offload.{sessionid}.jsonl 中找到对应条目的 result_ref 并读取该文件。`
+        : "",
+      "```mermaid",
+      mmdContent,
+      "```",
+      `标记为 "doing" 的节点是近期焦点（注：可能有延迟，下方的tool use未被统计，仅供参考），"done" 的已完成。请参考此保持方向感，避免重复已完成的工作。`,
+      `</current_task_context>`,
+    ].filter((line) => line !== "").join("\n");
   } catch (err) {
     logger.error(
       `[context-offload] mmd-injector: Error building active MMD block: ${err}`,
@@ -366,18 +371,5 @@ async function buildActiveMmdBlock(
 }
 
 function computeFingerprint(content: string): string {
-  return createHash("sha256").update(content).digest("hex").slice(0, 16);
-}
-
-function extractNodeIds(content: string): string[] {
-  const nodePattern = /\b(\d+-N\d+|N\d+|[A-Za-z]\w*)\b/g;
-  const nodeIds: string[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = nodePattern.exec(content)) !== null) {
-    const id = match[1];
-    if (!["flowchart", "graph", "subgraph", "end", "classDef"].includes(id) && !nodeIds.includes(id)) {
-      nodeIds.push(id);
-    }
-  }
-  return nodeIds.slice(0, 40);
+  return `${content.length}:${content.slice(0, 64)}`;
 }

--- a/src/offload/task-snapshot.test.ts
+++ b/src/offload/task-snapshot.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { appendTaskDeltaMessage, buildTaskDeltaMessage, buildTaskSnapshot } from "./task-snapshot.js";
+
+describe("task snapshot and delta", () => {
+  it("keeps full Mermaid out of delta messages and appends without mutating old messages", () => {
+    const fullMermaid = "flowchart TD\nA[done] --> B[doing]\nB --> C[todo]";
+    const snapshot = buildTaskSnapshot({
+      taskGoal: "完成 D 方案",
+      mmdFile: "task.mmd",
+      mermaid: fullMermaid,
+      resultRef: "refs/task-full.md",
+    });
+    const delta = buildTaskDeltaMessage({
+      taskGoal: "完成 D 方案",
+      mmdFile: "task.mmd",
+      changedNodeIds: ["B", "C"],
+      resultRef: "refs/task-full.md",
+      maxChars: 200,
+    });
+    const before = [{ role: "user", content: "hello" }];
+    const copy = JSON.stringify(before);
+    const after = appendTaskDeltaMessage(before, delta);
+
+    expect(snapshot.text).toContain("refs/task-full.md");
+    expect(snapshot.text).toContain("hash=");
+    expect(delta.content[0].text).not.toContain("flowchart TD");
+    expect(delta.content[0].text).toContain("changed_nodes");
+    expect(JSON.stringify(before)).toBe(copy);
+    expect(after).toHaveLength(2);
+  });
+});

--- a/src/offload/task-snapshot.ts
+++ b/src/offload/task-snapshot.ts
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+
+export interface TaskSnapshotInput {
+  taskGoal: string;
+  mmdFile: string;
+  mermaid: string;
+  resultRef: string;
+}
+
+export interface TaskSnapshot {
+  text: string;
+  hash: string;
+}
+
+export function buildTaskSnapshot(input: TaskSnapshotInput): TaskSnapshot {
+  const hash = sha256(input.mermaid).slice(0, 16);
+  const text = [
+    `<task-snapshot hash="${hash}" version="1">`,
+    `task_goal: ${input.taskGoal}`,
+    `mmd_file: ${input.mmdFile}`,
+    `full_mermaid_ref: ${input.resultRef}`,
+    `mermaid_hash: ${hash}`,
+    `</task-snapshot>`,
+  ].join("\n");
+  return { text, hash };
+}
+
+export function buildTaskDeltaMessage(input: {
+  taskGoal: string;
+  mmdFile: string;
+  changedNodeIds: string[];
+  resultRef: string;
+  maxChars?: number;
+}): { role: "user"; content: Array<{ type: "text"; text: string }>; _mmdContextMessage: "delta" } {
+  const changedNodes = [...new Set(input.changedNodeIds)].sort();
+  const text = [
+    `<task-delta version="1">`,
+    `task_goal: ${input.taskGoal}`,
+    `mmd_file: ${input.mmdFile}`,
+    `full_mermaid_ref: ${input.resultRef}`,
+    `changed_nodes: ${changedNodes.join(", ") || "(none)"}`,
+    `</task-delta>`,
+  ].join("\n");
+  const maxChars = input.maxChars ?? 1200;
+  return {
+    role: "user",
+    content: [{ type: "text", text: text.length > maxChars ? `${text.slice(0, maxChars).trimEnd()}\n[truncated]` : text }],
+    _mmdContextMessage: "delta",
+  };
+}
+
+export function appendTaskDeltaMessage<T extends Record<string, unknown>>(messages: T[], delta: T): T[] {
+  return [...messages, delta];
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}


### PR DESCRIPTION
## Description | 描述

本 PR 从 #410 中拆分，仅聚焦 cache epoch / task snapshot 辅助逻辑。

主要改动：
- 新增纯函数 Cache Epoch 合约：初始化、阈值判断和 epoch 转换。
- 新增 Task Snapshot/Delta helper，首次记录 compact snapshot，后续变化追加 delta。
- MMD 更新改为 append-only，不再覆写历史 `_mmdContextMessage`。
- 完整 Mermaid 内容写入现有 ref 存储，prompt 中保留 hash、文件信息和 ref。
- 使用完整内容 SHA-256 指纹检测 MMD 变化，并维持累计 MMD token 统计。

不包含以下内容：
- `tdai_offload_read`
- 工具结果卸载/恢复
- recall mode
- recall injection placement / injected history cleanup

## Related Issue | 关联 Issue

Related to #120

从 #410 拆分，按评审意见收敛为独立的 cache epoch / task snapshot PR。

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

验证命令：
- `npm.cmd test`
- `npm.cmd run build:plugin`
- `node --check dist\index.mjs`
- `git diff --check`

验证结果：
- 6 个测试文件、70 个测试通过。
- 插件构建通过。
- `dist/index.mjs` 语法检查通过。
- diff whitespace 检查通过。

## Additional Notes | 其他说明

该 PR 与 #375 独立，评审范围限定在 cache epoch 与 task snapshot 辅助逻辑本身，不包含工具结果卸载/读取或 recall mode 相关改动。