### PR TITLE
feat(cli): add memory hook adapter

### DIFF
--- a/packages/tdai-memory-cli/.gitignore
+++ b/packages/tdai-memory-cli/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+.pytest_cache/
+.venv/
+*.egg-info/
+*.pyc
+*.log

--- a/packages/tdai-memory-cli/README.md
+++ b/packages/tdai-memory-cli/README.md
@@ -1,0 +1,63 @@
+# TencentDB Agent Memory Hook CLI
+
+This project is the hook-facing CLI adapter for TencentDB Agent Memory Gateway.
+It is intentionally separate from the MCP server project and from Codex
+workspace installation logic.
+It assumes Gateway is already running and does not start, stop, supervise, or
+watch the Gateway process.
+
+Commands:
+
+```bash
+tdai-memory prefetch --query "..." --session-key "..."
+tdai-memory sync-turn --user-content "..." --assistant-content "..." --session-key "..."
+tdai-memory end-session --session-key "..."
+tdai-memory session-start
+```
+
+Hook wrapper commands read hook event JSON from stdin and call the commands above:
+
+```bash
+tdai-memory-hook prefetch
+tdai-memory-hook sync-turn
+tdai-memory-hook end-session
+tdai-memory-hook session-start
+```
+
+See `examples/hooks.json`, `examples/codex/hooks.json`, and
+`examples/claude-code/hooks.json` for command-hook configuration templates.
+Hook failures are non-blocking by default; set `TDAI_HOOK_STRICT=1` to return
+non-zero on Gateway or parsing failures.
+Set `TDAI_HOOK_LOG=/path/to/hooks.jsonl` to append lightweight diagnostics for
+hook invocation tests. The Codex installer defaults this to
+`~/.codex/tdai-memory/logs/hooks.jsonl`.
+
+`session-start` does not write `AGENTS.md` or `CLAUDE.md`. Prompt-file updates
+belong to an explicit installer/plugin step, not to runtime hooks. Other
+commands send requests to the configured Gateway URL and report errors if
+Gateway is unavailable.
+
+Gateway request configuration:
+
+```bash
+TDAI_GATEWAY_URL=http://127.0.0.1:8420
+TDAI_GATEWAY_API_KEY=
+TDAI_SESSION_KEY=
+TDAI_USER_ID=
+TDAI_REQUEST_TIMEOUT_MS=30000
+```
+
+Run from source:
+
+```bash
+cd packages/tdai-memory-cli
+python3 -m tdai_memory_cli prefetch --query "..."
+```
+
+Tests:
+
+```bash
+python3 -m pytest tests/unit -q
+# Requires an already running Gateway at TDAI_GATEWAY_URL.
+TDAI_MEMORY_CLI_E2E=1 python3 -m pytest tests/e2e -q
+```

--- a/packages/tdai-memory-cli/examples/claude-code/hooks.json
+++ b/packages/tdai-memory-cli/examples/claude-code/hooks.json
@@ -1,0 +1,38 @@
+{
+  "description": "TencentDB Agent Memory agent hooks for Claude Code",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_MEMORY_HOOK_MARKER=SessionStart TDAI_GATEWAY_URL=http://127.0.0.1:8421 TDAI_USER_ID=claude-code TDAI_HOOK_LOG=<home>/.claude/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook session-start",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_MEMORY_HOOK_MARKER=UserPromptSubmit TDAI_GATEWAY_URL=http://127.0.0.1:8421 TDAI_USER_ID=claude-code TDAI_HOOK_LOG=<home>/.claude/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook prefetch",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_MEMORY_HOOK_MARKER=Stop TDAI_GATEWAY_URL=http://127.0.0.1:8421 TDAI_USER_ID=claude-code TDAI_HOOK_LOG=<home>/.claude/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook sync-turn",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/tdai-memory-cli/examples/codex/hooks.json
+++ b/packages/tdai-memory-cli/examples/codex/hooks.json
@@ -1,0 +1,42 @@
+{
+  "description": "TencentDB Agent Memory agent hooks for Codex",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_MEMORY_HOOK_MARKER=SessionStart TDAI_GATEWAY_URL=http://127.0.0.1:8420 TDAI_USER_ID=codex TDAI_HOOK_LOG=<home>/.codex/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook session-start",
+            "timeout": 60,
+            "statusMessage": "Checking TDAI memory Gateway"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_MEMORY_HOOK_MARKER=UserPromptSubmit TDAI_GATEWAY_URL=http://127.0.0.1:8420 TDAI_USER_ID=codex TDAI_HOOK_LOG=<home>/.codex/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook prefetch",
+            "timeout": 30,
+            "statusMessage": "Prefetching TDAI memory"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_MEMORY_HOOK_MARKER=Stop TDAI_GATEWAY_URL=http://127.0.0.1:8420 TDAI_USER_ID=codex TDAI_HOOK_LOG=<home>/.codex/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook sync-turn",
+            "timeout": 60,
+            "statusMessage": "Capturing TDAI memory turn"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/tdai-memory-cli/examples/hooks.json
+++ b/packages/tdai-memory-cli/examples/hooks.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_GATEWAY_URL=http://127.0.0.1:8420 TDAI_HOOK_LOG=<home>/.codex/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook session-start",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_GATEWAY_URL=http://127.0.0.1:8420 TDAI_HOOK_LOG=<home>/.codex/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook prefetch",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TDAI_GATEWAY_URL=http://127.0.0.1:8420 TDAI_HOOK_LOG=<home>/.codex/tdai-memory/logs/hooks.jsonl PYTHONPATH=<repo>/packages/tdai-memory-cli python3 -m tdai_memory_cli.hook sync-turn",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/tdai-memory-cli/examples/skills/tdai-memory/SKILL.md
+++ b/packages/tdai-memory-cli/examples/skills/tdai-memory/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: tdai-memory
+description: Use when working with TencentDB Agent Memory, including memory recall, conversation capture, agent hooks, MCP lookup tools, and debugging the TDAI memory CLI.
+version: 0.1.0
+---
+
+# TDAI Memory
+
+TencentDB Agent Memory exposes long-term memory through two reusable surfaces:
+
+- MCP tools for agent-facing memory lookup.
+- Hook CLI commands for health checks, recall prefetch, capture, and flush.
+
+## Choose The Surface
+
+Use MCP tools for answering with memory:
+
+- `tdai_memory_search`: search structured long-term memories.
+- `tdai_conversation_search`: search raw conversation history.
+
+Use CLI commands for hook behavior:
+
+- `session-start`: check Gateway health for the hook runtime.
+- `prefetch`: recall memory context for a user query.
+- `sync-turn`: capture a completed user/assistant turn.
+- `end-session`: flush session pipeline work.
+
+Do not use CLI commands as a substitute for MCP lookup unless debugging the adapter.
+
+## CLI Commands
+
+```bash
+tdai-memory session-start
+tdai-memory prefetch --query "<user prompt>"
+tdai-memory sync-turn \
+  --user-content "<user message>" \
+  --assistant-content "<assistant response>"
+tdai-memory end-session
+```
+
+Use hook wrappers when reading agent hook JSON from stdin:
+
+```bash
+tdai-memory-hook session-start
+tdai-memory-hook prefetch
+tdai-memory-hook sync-turn
+tdai-memory-hook end-session
+```
+
+Hook failures are non-blocking by default. Set `TDAI_HOOK_STRICT=1` only for tests or debugging.
+
+## Rules
+
+- Prefer MCP tools when using memory to answer a user question.
+- Use CLI commands for health checks, capture, and flush.
+- Keep `AGENTS.md` or `CLAUDE.md` updates in an explicit installer/plugin step, not runtime hooks.
+- Do not store dynamic recall results in `AGENTS.md` or `CLAUDE.md`.

--- a/packages/tdai-memory-cli/pyproject.toml
+++ b/packages/tdai-memory-cli/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tdai-memory-cli"
+version = "0.1.0"
+description = "Hook CLI adapter for TencentDB Agent Memory Gateway."
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+tdai-memory = "tdai_memory_cli.__main__:main"
+tdai-memory-hook = "tdai_memory_cli.hook:main"
+
+[tool.setuptools.packages.find]
+include = ["tdai_memory_cli*"]
+exclude = ["tests*", "vibe*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/packages/tdai-memory-cli/tdai_memory_cli/__init__.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/__init__.py
@@ -1,0 +1,3 @@
+"""TencentDB Agent Memory hook CLI adapter."""
+
+__version__ = "0.1.0"

--- a/packages/tdai-memory-cli/tdai_memory_cli/__main__.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/__main__.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .config import load_config
+from .formatters import format_capture, format_error, format_recall, format_session_end
+from .gateway_http import request_json
+from .session import resolve_session_key
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = run_cli(argv)
+    if result.get("stdout"):
+        print(result["stdout"])
+    if result.get("stderr"):
+        print(result["stderr"], file=sys.stderr)
+    return int(result["code"])
+
+
+def run_cli(
+    argv: list[str] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+    request_func: Any | None = None,
+) -> dict[str, Any]:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+        config = load_config(env=env, cwd=cwd)
+        send_request = request_func or request_json
+        if args.command == "prefetch":
+            session_key = resolve_session_key(args.session_key, config.default_session_key)
+            return {
+                "code": 0,
+                "stdout": format_recall(send_request(config, "/recall", body={
+                    "query": args.query,
+                    "session_key": session_key,
+                    "user_id": args.user_id or config.user_id,
+                })),
+            }
+        if args.command == "sync-turn":
+            session_key = resolve_session_key(args.session_key, config.default_session_key)
+            return {
+                "code": 0,
+                "stdout": format_capture(send_request(config, "/capture", body={
+                    "user_content": args.user_content,
+                    "assistant_content": args.assistant_content,
+                    "session_key": session_key,
+                    "session_id": args.session_id or "",
+                    "user_id": args.user_id or config.user_id,
+                    "messages": _read_messages(args),
+                })),
+            }
+        if args.command == "end-session":
+            session_key = resolve_session_key(args.session_key, config.default_session_key)
+            return {
+                "code": 0,
+                "stdout": format_session_end(send_request(config, "/session/end", body={
+                    "session_key": session_key,
+                    "user_id": args.user_id or config.user_id,
+                })),
+            }
+        if args.command == "session-start":
+            gateway_status = _check_gateway_health(config, request_func=send_request)
+            return {
+                "code": 0,
+                "stdout": "\n".join([
+                    "session_start: ok",
+                    f"gateway: {gateway_status}",
+                ]),
+            }
+        return {"code": 2, "stderr": f"Unknown command: {args.command}"}
+    except SystemExit as error:
+        return {"code": int(error.code)}
+    except Exception as error:
+        return {"code": 1, "stderr": format_error(error)}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="tdai-memory")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prefetch = subparsers.add_parser("prefetch", help="Run Gateway /recall for pre-turn context.")
+    prefetch.add_argument("--query", required=True)
+    prefetch.add_argument("--session-key", default="")
+    prefetch.add_argument("--user-id", default="")
+
+    sync_turn = subparsers.add_parser("sync-turn", help="Run Gateway /capture for a completed turn.")
+    sync_turn.add_argument("--user-content", required=True)
+    sync_turn.add_argument("--assistant-content", required=True)
+    sync_turn.add_argument("--session-key", default="")
+    sync_turn.add_argument("--session-id", default="")
+    sync_turn.add_argument("--user-id", default="")
+    sync_turn.add_argument("--messages-json", default="")
+    sync_turn.add_argument("--messages-file", default="")
+
+    end_session = subparsers.add_parser("end-session", help="Run Gateway /session/end.")
+    end_session.add_argument("--session-key", default="")
+    end_session.add_argument("--user-id", default="")
+
+    session_start = subparsers.add_parser("session-start", help="Check Gateway health.")
+    session_start.add_argument("--user-id", default="")
+
+    return parser
+
+
+def _read_messages(args: argparse.Namespace) -> list[Any] | None:
+    if args.messages_json and args.messages_file:
+        raise ValueError("Use only one of --messages-json or --messages-file")
+    if not args.messages_json and not args.messages_file:
+        return None
+    raw = args.messages_json or Path(args.messages_file).read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise ValueError("messages must be a JSON array")
+    return parsed
+
+
+def _check_gateway_health(config: Any, *, request_func: Any) -> str:
+    result = request_func(config, "/health", method="GET", timeout_ms=min(config.timeout_ms, 3000))
+    status = str(result.get("status") or "").strip()
+    if status not in {"ok", "degraded"}:
+        raise RuntimeError(f"TDAI Gateway health check failed: {status or 'unknown'}")
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/tdai-memory-cli/tdai_memory_cli/config.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from .session import generate_default_session_key
+
+DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420"
+DEFAULT_TIMEOUT_MS = 30_000
+
+
+@dataclass(frozen=True)
+class AdapterConfig:
+    gateway_url: str
+    api_key: str
+    default_session_key: str
+    user_id: str
+    timeout_ms: int
+
+
+def load_config(env: dict[str, str] | None = None, cwd: str | None = None) -> AdapterConfig:
+    source = env if env is not None else os.environ
+    current_cwd = cwd or os.getcwd()
+    return AdapterConfig(
+        gateway_url=_normalize_gateway_url(source.get("TDAI_GATEWAY_URL")),
+        api_key=(source.get("TDAI_GATEWAY_API_KEY") or "").strip(),
+        default_session_key=(source.get("TDAI_SESSION_KEY") or "").strip()
+        or generate_default_session_key(current_cwd),
+        user_id=(source.get("TDAI_USER_ID") or "").strip(),
+        timeout_ms=_read_positive_int(source.get("TDAI_REQUEST_TIMEOUT_MS"), DEFAULT_TIMEOUT_MS),
+    )
+
+
+def _normalize_gateway_url(value: str | None) -> str:
+    raw = (value or DEFAULT_GATEWAY_URL).strip() or DEFAULT_GATEWAY_URL
+    return raw.rstrip("/")
+
+
+def _read_positive_int(value: str | None, fallback: int) -> int:
+    try:
+        parsed = int(str(value or "").strip())
+    except ValueError:
+        return fallback
+    return parsed if parsed > 0 else fallback

--- a/packages/tdai-memory-cli/tdai_memory_cli/formatters.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/formatters.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .gateway_http import GatewayHttpError
+
+
+def format_recall(result: dict[str, Any]) -> str:
+    context = str(result.get("context") or "").strip()
+    lines = [
+        "# TDAI Memory Recall",
+        "",
+        f"strategy: {result.get('strategy', 'unknown')}",
+        f"memory_count: {result.get('memory_count', 0)}",
+    ]
+    if context:
+        lines.extend(["", "## Context", "", context])
+    else:
+        lines.extend(["", "No recalled memory context was returned."])
+    return "\n".join(lines)
+
+
+def format_capture(result: dict[str, Any]) -> str:
+    return "\n".join([
+        "# TDAI Memory Capture",
+        "",
+        f"l0_recorded: {result.get('l0_recorded', 0)}",
+        f"scheduler_notified: {_format_bool(bool(result.get('scheduler_notified')))}",
+    ])
+
+
+def format_session_end(result: dict[str, Any]) -> str:
+    return "\n".join([
+        "# TDAI Session End",
+        "",
+        f"flushed: {_format_bool(bool(result.get('flushed')))}",
+    ])
+
+
+def format_error(error: BaseException) -> str:
+    status = "error"
+    path = ""
+    if isinstance(error, GatewayHttpError):
+        status = f"HTTP {error.status}" if error.status > 0 else "error"
+        path = error.path
+    lines = [
+        "# TDAI Memory Adapter Error",
+        "",
+        f"{status}: {error}",
+    ]
+    if path:
+        lines.append(f"path: {path}")
+    return "\n".join(lines)
+
+
+def _format_bool(value: bool) -> str:
+    return "true" if value else "false"

--- a/packages/tdai-memory-cli/tdai_memory_cli/gateway_http.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/gateway_http.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import http.client
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .config import AdapterConfig
+
+
+class GatewayHttpError(RuntimeError):
+    def __init__(self, message: str, *, status: int = 0, path: str = "", body: Any = None):
+        super().__init__(message)
+        self.status = status
+        self.path = path
+        self.body = body
+
+
+def request_json(
+    config: AdapterConfig,
+    path: str,
+    *,
+    method: str = "POST",
+    body: dict[str, Any] | None = None,
+    timeout_ms: int | None = None,
+) -> dict[str, Any]:
+    data = None
+    headers: dict[str, str] = {}
+    if body is not None:
+        data = json.dumps(_omit_empty(body)).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if config.api_key:
+        headers["Authorization"] = f"Bearer {config.api_key}"
+
+    request = urllib.request.Request(
+        f"{config.gateway_url}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+    timeout = (timeout_ms or config.timeout_ms) / 1000
+    last_error: BaseException | None = None
+    for attempt in range(2):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8")
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as error:
+            raw_body = error.read().decode("utf-8", errors="replace")
+            parsed = _parse_json(raw_body)
+            message = parsed.get("error") if isinstance(parsed, dict) else None
+            raise GatewayHttpError(
+                message or f"Gateway returned HTTP {error.code}",
+                status=error.code,
+                path=path,
+                body=parsed,
+            ) from error
+        except (http.client.RemoteDisconnected, ConnectionResetError) as error:
+            last_error = error
+            if attempt == 0:
+                continue
+            raise GatewayHttpError(str(error), path=path) from error
+        except TimeoutError as error:
+            raise GatewayHttpError(
+                f"Gateway request timed out after {timeout}s",
+                path=path,
+            ) from error
+        except urllib.error.URLError as error:
+            raise GatewayHttpError(str(error.reason), path=path) from error
+
+    raise GatewayHttpError(str(last_error), path=path)
+
+
+def _omit_empty(value: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        if item is None:
+            continue
+        if isinstance(item, str) and not item.strip():
+            continue
+        result[key] = item
+    return result
+
+
+def _parse_json(value: str) -> Any:
+    try:
+        return json.loads(value) if value else {}
+    except json.JSONDecodeError:
+        return value[:1000]

--- a/packages/tdai-memory-cli/tdai_memory_cli/hook.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/hook.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from time import time
+from typing import Any, Callable
+
+from .__main__ import run_cli
+
+HookRunner = Callable[[list[str], dict[str, str] | None, str | None], dict[str, Any]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = run_hook(argv)
+    if result.get("stdout"):
+        print(result["stdout"])
+    if result.get("stderr"):
+        print(result["stderr"], file=sys.stderr)
+    return int(result["code"])
+
+
+def run_hook(
+    argv: list[str] | None = None,
+    *,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+    cli_runner: HookRunner | None = None,
+) -> dict[str, Any]:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+        source_env = env if env is not None else os.environ
+        event = _read_event(stdin)
+        cli_args = _build_cli_args(args.command, event)
+        _write_log(source_env, {
+            "phase": "prepared",
+            "command": args.command,
+            "cli_args": cli_args,
+            "event_keys": sorted(event.keys()),
+        })
+        runner = cli_runner or _run_cli
+        result = runner(cli_args, source_env, cwd)
+        _write_log(source_env, {
+            "phase": "completed",
+            "command": args.command,
+            "result_code": result.get("code"),
+        })
+        if result.get("code", 1) == 0:
+            return _adapt_hook_result(args.command, result, event=event, env=source_env)
+        if _strict(source_env):
+            return _adapt_hook_result(args.command, result, event=event, env=source_env)
+        if _requires_json_stdout(args.command):
+            return {
+                "code": 0,
+                "stdout": _continue_json(args.command, event=event, env=source_env),
+                "stderr": result.get("stderr") or result.get("stdout") or "TDAI memory hook failed",
+            }
+        return {
+            "code": 0,
+            "stderr": result.get("stderr") or result.get("stdout") or "TDAI memory hook failed",
+        }
+    except SystemExit as error:
+        return {"code": int(error.code)}
+    except Exception as error:
+        _write_log(env if env is not None else os.environ, {
+            "phase": "error",
+            "error": str(error),
+        })
+        if _strict(env if env is not None else os.environ):
+            return {"code": 1, "stderr": f"TDAI memory hook failed: {error}"}
+        return {"code": 0, "stderr": f"TDAI memory hook skipped: {error}"}
+
+
+def _run_cli(argv: list[str], env: dict[str, str] | None, cwd: str | None) -> dict[str, Any]:
+    return run_cli(argv, env=env, cwd=cwd)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="tdai-memory-hook")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("prefetch", help="Read a user-prompt hook event and call tdai-memory prefetch.")
+    subparsers.add_parser("sync-turn", help="Read a stop hook event and call tdai-memory sync-turn.")
+    subparsers.add_parser("end-session", help="Read a session-end hook event and call tdai-memory end-session.")
+    subparsers.add_parser("session-start", help="Read a session-start hook event and call tdai-memory session-start.")
+    return parser
+
+
+def _adapt_hook_result(
+    command: str,
+    result: dict[str, Any],
+    *,
+    event: dict[str, Any],
+    env: dict[str, str] | None,
+) -> dict[str, Any]:
+    if not _requires_json_stdout(command):
+        return result
+    adapted = {
+        "code": result.get("code", 0),
+        "stdout": _continue_json(command, event=event, env=env),
+    }
+    if result.get("stderr"):
+        adapted["stderr"] = result["stderr"]
+    return adapted
+
+
+def _requires_json_stdout(command: str) -> bool:
+    return command in {"sync-turn", "end-session", "session-start"}
+
+
+def _continue_json(
+    command: str = "",
+    *,
+    event: dict[str, Any] | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
+    payload: dict[str, Any] = {"continue": True}
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _read_event(stdin: str | None) -> dict[str, Any]:
+    raw = sys.stdin.read() if stdin is None else stdin
+    if not raw.strip():
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("hook stdin must be a JSON object")
+    return parsed
+
+
+def _build_cli_args(command: str, event: dict[str, Any]) -> list[str]:
+    if command == "prefetch":
+        return _prefetch_args(event)
+    if command == "sync-turn":
+        return _sync_turn_args(event)
+    if command == "end-session":
+        return _end_session_args(event)
+    if command == "session-start":
+        return _session_start_args(event)
+    raise ValueError(f"Unknown hook command: {command}")
+
+
+def _prefetch_args(event: dict[str, Any]) -> list[str]:
+    query = _first_text(event, [
+        ("prompt",),
+        ("user_prompt",),
+        ("userPrompt",),
+        ("query",),
+        ("input",),
+        ("message",),
+        ("text",),
+    ])
+    if not query:
+        raise ValueError("prefetch hook event does not include a user prompt")
+    args = ["prefetch", "--query", query]
+    _append_common_identity_args(args, event)
+    return args
+
+
+def _sync_turn_args(event: dict[str, Any]) -> list[str]:
+    messages = _messages_from_event(event)
+    user_content = _first_text(event, [
+        ("user_content",),
+        ("userContent",),
+        ("prompt",),
+        ("user_prompt",),
+        ("userPrompt",),
+    ])
+    assistant_content = _first_text(event, [
+        ("assistant_content",),
+        ("assistantContent",),
+        ("assistant_response",),
+        ("assistantResponse",),
+        ("response",),
+        ("completion",),
+        ("output",),
+    ])
+
+    if (not user_content or not assistant_content) and messages:
+        turn = _last_user_assistant_turn(messages)
+        user_content = user_content or turn[0]
+        assistant_content = assistant_content or turn[1]
+
+    if not user_content or not assistant_content:
+        raise ValueError("sync-turn hook event does not include a complete user/assistant turn")
+
+    args = [
+        "sync-turn",
+        "--user-content",
+        user_content,
+        "--assistant-content",
+        assistant_content,
+    ]
+    _append_common_identity_args(args, event)
+    session_id = _session_id(event)
+    if session_id:
+        args.extend(["--session-id", session_id])
+    if messages:
+        args.extend(["--messages-json", json.dumps(messages, ensure_ascii=False, separators=(",", ":"))])
+    return args
+
+
+def _end_session_args(event: dict[str, Any]) -> list[str]:
+    args = ["end-session"]
+    _append_common_identity_args(args, event)
+    return args
+
+
+def _session_start_args(event: dict[str, Any]) -> list[str]:
+    args = ["session-start"]
+    user_id = _first_text(event, [("user_id",), ("userId",), ("user", "id")])
+    if user_id:
+        args.extend(["--user-id", user_id])
+    return args
+
+
+def _append_common_identity_args(args: list[str], event: dict[str, Any]) -> None:
+    session_key = _session_key(event)
+    if session_key:
+        args.extend(["--session-key", session_key])
+    user_id = _first_text(event, [("user_id",), ("userId",), ("user", "id")])
+    if user_id:
+        args.extend(["--user-id", user_id])
+
+
+def _session_key(event: dict[str, Any]) -> str:
+    return _first_text(event, [
+        ("session_key",),
+        ("sessionKey",),
+        ("session_id",),
+        ("sessionId",),
+        ("conversation_id",),
+        ("conversationId",),
+        ("thread_id",),
+        ("threadId",),
+    ])
+
+
+def _session_id(event: dict[str, Any]) -> str:
+    return _first_text(event, [("session_id",), ("sessionId",)])
+
+
+def _messages_from_event(event: dict[str, Any]) -> list[dict[str, str]]:
+    direct = _first_list(event, [("messages",), ("conversation",), ("transcript",)])
+    if direct:
+        return _normalize_messages(direct)
+    transcript_path = _first_text(event, [
+        ("transcript_path",),
+        ("transcriptPath",),
+        ("conversation_path",),
+        ("conversationPath",),
+    ])
+    if not transcript_path:
+        return []
+    return _load_transcript(Path(transcript_path))
+
+
+def _load_transcript(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return []
+    try:
+        parsed = json.loads(raw)
+        return _messages_from_json_value(parsed)
+    except json.JSONDecodeError:
+        messages: list[Any] = []
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                messages.extend(_messages_from_json_value(json.loads(line)))
+            except json.JSONDecodeError:
+                continue
+        return _normalize_messages(messages)
+
+
+def _messages_from_json_value(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if not isinstance(value, dict):
+        return []
+    for key in ("messages", "conversation", "transcript"):
+        item = value.get(key)
+        if isinstance(item, list):
+            return item
+    message = value.get("message")
+    if isinstance(message, dict):
+        return [message]
+    codex_message = _message_from_codex_transcript_entry(value)
+    if codex_message:
+        return [codex_message]
+    return [value]
+
+
+def _message_from_codex_transcript_entry(value: dict[str, Any]) -> dict[str, Any]:
+    entry_type = _string_value(value.get("type"))
+    payload = value.get("payload")
+    if not isinstance(payload, dict):
+        return {}
+
+    if entry_type == "response_item" and payload.get("type") == "message":
+        role = _string_value(payload.get("role"))
+        if role in {"user", "assistant", "system", "tool", "developer"}:
+            return {"role": role, "content": payload.get("content")}
+
+    if entry_type == "event_msg":
+        event_type = _string_value(payload.get("type"))
+        if event_type == "user_message":
+            return {"role": "user", "content": payload.get("message")}
+        if event_type == "agent_message":
+            return {"role": "assistant", "content": payload.get("message")}
+
+    return {}
+
+
+def _normalize_messages(values: list[Any]) -> list[dict[str, str]]:
+    messages: list[dict[str, str]] = []
+    for item in values:
+        if not isinstance(item, dict):
+            continue
+        role = _role_from_item(item)
+        text = _content_from_item(item)
+        if role and text:
+            messages.append({"role": role, "content": text})
+    return messages
+
+
+def _role_from_item(item: dict[str, Any]) -> str:
+    role = _string_value(item.get("role")) or _string_value(item.get("type")) or _string_value(item.get("speaker"))
+    if role in {"human", "user_message"}:
+        return "user"
+    if role in {"ai", "assistant_message"}:
+        return "assistant"
+    return role if role in {"user", "assistant", "system", "tool"} else ""
+
+
+def _content_from_item(item: dict[str, Any]) -> str:
+    for key in ("content", "text", "message"):
+        value = item.get(key)
+        if isinstance(value, dict):
+            nested = _content_from_item(value)
+            if nested:
+                return nested
+        text = _text_from_value(value)
+        if text:
+            return text
+    return ""
+
+
+def _last_user_assistant_turn(messages: list[dict[str, str]]) -> tuple[str, str]:
+    assistant = ""
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if not assistant and message.get("role") == "assistant":
+            assistant = message.get("content", "")
+            continue
+        if assistant and message.get("role") == "user":
+            return message.get("content", ""), assistant
+    return "", assistant
+
+
+def _first_text(data: dict[str, Any], paths: list[tuple[str, ...]]) -> str:
+    for path in paths:
+        value = _value_at_path(data, path)
+        text = _text_from_value(value)
+        if text:
+            return text
+    return ""
+
+
+def _first_list(data: dict[str, Any], paths: list[tuple[str, ...]]) -> list[Any]:
+    for path in paths:
+        value = _value_at_path(data, path)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _value_at_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = data
+    for part in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _text_from_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts = []
+        for item in value:
+            text = _text_from_value(item)
+            if text:
+                parts.append(text)
+        return "\n".join(parts).strip()
+    if isinstance(value, dict):
+        if _string_value(value.get("type")) == "text":
+            return _text_from_value(value.get("text"))
+        for key in ("text", "content", "message"):
+            text = _text_from_value(value.get(key))
+            if text:
+                return text
+    return ""
+
+
+def _string_value(value: Any) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def _strict(env: dict[str, str] | os._Environ[str]) -> bool:
+    return str(env.get("TDAI_HOOK_STRICT", "")).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _write_log(env: dict[str, str] | os._Environ[str], payload: dict[str, Any]) -> None:
+    path = str(env.get("TDAI_HOOK_LOG", "")).strip()
+    if not path:
+        return
+    entry = {"ts": time(), **payload}
+    try:
+        with Path(path).expanduser().open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False, separators=(",", ":")) + "\n")
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/tdai-memory-cli/tdai_memory_cli/session.py
+++ b/packages/tdai-memory-cli/tdai_memory_cli/session.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def sanitize_session_part(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in "._:-" else "-" for ch in value.strip())
+    return cleaned.strip("-") or "default"
+
+
+def generate_default_session_key(cwd: str) -> str:
+    path = Path(cwd).resolve()
+    name = sanitize_session_part(path.name)
+    digest = hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:10]
+    return f"mcp:{name}:{digest}"
+
+
+def resolve_session_key(value: str | None, default: str) -> str:
+    candidate = (value or "").strip()
+    return candidate or default

--- a/packages/tdai-memory-cli/tests/e2e/test_gateway_ollama.py
+++ b/packages/tdai-memory-cli/tests/e2e/test_gateway_ollama.py
@@ -1,0 +1,47 @@
+import os
+import time
+
+import pytest
+
+from tdai_memory_cli.__main__ import run_cli
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TDAI_MEMORY_CLI_E2E") != "1",
+    reason="set TDAI_MEMORY_CLI_E2E=1 to run real Gateway e2e",
+)
+
+
+def test_real_hook_cli_path_with_gateway_ollama():
+    env = {
+        **os.environ,
+        "TDAI_GATEWAY_URL": os.environ.get("TDAI_GATEWAY_URL") or "http://127.0.0.1:8420",
+        "TDAI_REQUEST_TIMEOUT_MS": os.environ.get("TDAI_REQUEST_TIMEOUT_MS") or "120000",
+    }
+    session_key = os.environ.get("TDAI_SESSION_KEY") or f"agent:cli-e2e:{int(time.time() * 1000)}"
+
+    capture = run_cli([
+        "sync-turn",
+        "--user-content",
+        "我正在测试 TencentDB Memory CLI，偏好使用 qwen2.5:7b 和 bge-m3。",
+        "--assistant-content",
+        "已记录：本次 CLI 测试偏好 qwen2.5:7b 和 bge-m3。",
+        "--session-key",
+        session_key,
+    ], env=env)
+    assert capture["code"] == 0, capture.get("stderr")
+    assert "l0_recorded:" in capture["stdout"]
+
+    recall = run_cli([
+        "prefetch",
+        "--query",
+        "我刚才说 CLI 测试偏好什么模型？",
+        "--session-key",
+        session_key,
+    ], env=env)
+    assert recall["code"] == 0, recall.get("stderr")
+    assert "TDAI Memory Recall" in recall["stdout"]
+
+    session_end = run_cli(["end-session", "--session-key", session_key], env=env)
+    assert session_end["code"] == 0, session_end.get("stderr")
+    assert "flushed: true" in session_end["stdout"]

--- a/packages/tdai-memory-cli/tests/unit/test_cli.py
+++ b/packages/tdai-memory-cli/tests/unit/test_cli.py
@@ -1,0 +1,99 @@
+from tdai_memory_cli.__main__ import run_cli
+
+
+class FakeRequester:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, _config, path, *, body=None, method="POST", **_kwargs):
+        self.calls.append((path, method, body))
+        if path == "/health":
+            return {"status": "ok"}
+        if path == "/recall":
+            return {"context": "remembered context", "strategy": "hybrid", "memory_count": 1}
+        if path == "/capture":
+            return {"l0_recorded": 2, "scheduler_notified": True}
+        if path == "/session/end":
+            return {"flushed": True}
+        raise AssertionError(f"unexpected path: {path}")
+
+
+ENV = {
+    "TDAI_GATEWAY_URL": "http://127.0.0.1:8420",
+    "TDAI_SESSION_KEY": "session:default",
+    "TDAI_USER_ID": "user:default",
+}
+
+
+def test_prefetch_maps_to_recall():
+    requester = FakeRequester()
+    result = run_cli(
+        ["prefetch", "--query", "what do I prefer?"],
+        env=ENV,
+        request_func=requester,
+    )
+
+    assert result["code"] == 0
+    assert "remembered context" in result["stdout"]
+    assert requester.calls[0] == ("/recall", "POST", {
+        "query": "what do I prefer?",
+        "session_key": "session:default",
+        "user_id": "user:default",
+    })
+
+
+def test_sync_turn_maps_to_capture():
+    requester = FakeRequester()
+    result = run_cli([
+        "sync-turn",
+        "--user-content",
+        "hello",
+        "--assistant-content",
+        "world",
+        "--session-key",
+        "session:explicit",
+        "--messages-json",
+        '[{"role":"user","content":"hello"}]',
+    ], env=ENV, request_func=requester)
+
+    assert result["code"] == 0
+    assert "l0_recorded: 2" in result["stdout"]
+    assert requester.calls[0] == ("/capture", "POST", {
+        "user_content": "hello",
+        "assistant_content": "world",
+        "session_key": "session:explicit",
+        "session_id": "",
+        "user_id": "user:default",
+        "messages": [{"role": "user", "content": "hello"}],
+    })
+
+
+def test_end_session_maps_to_session_end():
+    requester = FakeRequester()
+    result = run_cli(
+        ["end-session", "--user-id", "user:explicit"],
+        env=ENV,
+        request_func=requester,
+    )
+
+    assert result["code"] == 0
+    assert "flushed: true" in result["stdout"]
+    assert requester.calls[0] == ("/session/end", "POST", {
+        "session_key": "session:default",
+        "user_id": "user:explicit",
+    })
+
+
+def test_session_start_checks_gateway_only():
+    requester = FakeRequester()
+    result = run_cli(
+        ["session-start", "--user-id", "codex"],
+        env=ENV,
+        request_func=requester,
+    )
+
+    assert result["code"] == 0
+    assert "session_start: ok" in result["stdout"]
+    assert "gateway: ok" in result["stdout"]
+    assert "agents_md:" not in result["stdout"]
+    assert requester.calls[0] == ("/health", "GET", None)

--- a/packages/tdai-memory-cli/tests/unit/test_gateway_http.py
+++ b/packages/tdai-memory-cli/tests/unit/test_gateway_http.py
@@ -1,0 +1,36 @@
+import http.client
+import json
+from unittest.mock import patch
+
+from tdai_memory_cli.config import load_config
+from tdai_memory_cli.gateway_http import request_json
+
+
+class FakeResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self.body
+
+
+def test_request_json_retries_remote_disconnect_once():
+    calls = []
+    config = load_config({"TDAI_GATEWAY_URL": "http://gateway.local"}, "/tmp/repo")
+
+    def fake_urlopen(_request, timeout):
+        calls.append(timeout)
+        if len(calls) == 1:
+            raise http.client.RemoteDisconnected("remote closed")
+        return FakeResponse(json.dumps({"context": "ok"}).encode("utf-8"))
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        assert request_json(config, "/recall", body={"query": "q"}) == {"context": "ok"}
+
+    assert len(calls) == 2

--- a/packages/tdai-memory-cli/tests/unit/test_hook.py
+++ b/packages/tdai-memory-cli/tests/unit/test_hook.py
@@ -1,0 +1,202 @@
+import json
+from pathlib import Path
+
+from tdai_memory_cli.hook import run_hook
+
+
+def _runner(calls):
+    def run(argv, env, cwd):
+        calls.append((argv, env, cwd))
+        return {"code": 0, "stdout": "ok"}
+
+    return run
+
+
+def test_prefetch_reads_prompt_from_stdin_json():
+    calls = []
+    result = run_hook(
+        ["prefetch"],
+        stdin=json.dumps({"prompt": "remember me", "session_id": "session:1", "user_id": "user:1"}),
+        env={},
+        cwd="/repo",
+        cli_runner=_runner(calls),
+    )
+
+    assert result == {"code": 0, "stdout": "ok"}
+    assert calls[0][0] == [
+        "prefetch",
+        "--query",
+        "remember me",
+        "--session-key",
+        "session:1",
+        "--user-id",
+        "user:1",
+    ]
+
+
+def test_sync_turn_reads_direct_turn_fields():
+    calls = []
+    result = run_hook(
+        ["sync-turn"],
+        stdin=json.dumps({
+            "user_content": "hello",
+            "assistant_content": "world",
+            "sessionKey": "session:2",
+        }),
+        env={},
+        cli_runner=_runner(calls),
+    )
+
+    assert result["code"] == 0
+    assert calls[0][0] == [
+        "sync-turn",
+        "--user-content",
+        "hello",
+        "--assistant-content",
+        "world",
+        "--session-key",
+        "session:2",
+    ]
+    hook_output = json.loads(result["stdout"])
+    assert hook_output["continue"] is True
+    assert "hookSpecificOutput" not in hook_output
+
+
+def test_sync_turn_reads_last_turn_from_transcript_path(tmp_path: Path):
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        "\n".join([
+            json.dumps({"role": "user", "content": "old"}),
+            json.dumps({"role": "assistant", "content": "old answer"}),
+            json.dumps({"role": "user", "content": "current question"}),
+            json.dumps({"role": "assistant", "content": "current answer"}),
+        ]),
+        encoding="utf-8",
+    )
+    calls = []
+
+    result = run_hook(
+        ["sync-turn"],
+        stdin=json.dumps({"transcript_path": str(transcript), "session_id": "session:3"}),
+        env={},
+        cli_runner=_runner(calls),
+    )
+
+    assert result["code"] == 0
+    argv = calls[0][0]
+    assert argv[:7] == [
+        "sync-turn",
+        "--user-content",
+        "current question",
+        "--assistant-content",
+        "current answer",
+        "--session-key",
+        "session:3",
+    ]
+    assert "--messages-json" in argv
+
+
+def test_sync_turn_reads_codex_transcript_jsonl(tmp_path: Path):
+    transcript = tmp_path / "codex-transcript.jsonl"
+    transcript.write_text(
+        "\n".join([
+            json.dumps({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "codex question"}],
+                },
+            }),
+            json.dumps({
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "message": "codex answer",
+                    "phase": "final_answer",
+                },
+            }),
+        ]),
+        encoding="utf-8",
+    )
+    calls = []
+
+    result = run_hook(
+        ["sync-turn"],
+        stdin=json.dumps({"transcript_path": str(transcript), "session_id": "codex-session"}),
+        env={},
+        cli_runner=_runner(calls),
+    )
+
+    assert result["code"] == 0
+    argv = calls[0][0]
+    assert argv[:7] == [
+        "sync-turn",
+        "--user-content",
+        "codex question",
+        "--assistant-content",
+        "codex answer",
+        "--session-key",
+        "codex-session",
+    ]
+
+
+def test_end_session_uses_session_key():
+    calls = []
+    result = run_hook(
+        ["end-session"],
+        stdin=json.dumps({"session_id": "session:end"}),
+        env={},
+        cli_runner=_runner(calls),
+    )
+
+    assert result["code"] == 0
+    assert calls[0][0] == ["end-session", "--session-key", "session:end"]
+
+
+def test_session_start_reads_user_id():
+    calls = []
+    result = run_hook(
+        ["session-start"],
+        stdin=json.dumps({"agents_path": "/repo/AGENTS.md", "user_id": "codex-user"}),
+        env={},
+        cli_runner=_runner(calls),
+    )
+
+    assert result["code"] == 0
+    hook_output = json.loads(result["stdout"])
+    assert hook_output["continue"] is True
+    assert "hookSpecificOutput" not in hook_output
+    assert calls[0][0] == [
+        "session-start",
+        "--user-id",
+        "codex-user",
+    ]
+
+
+def test_hook_is_non_blocking_by_default_on_cli_failure():
+    def fail(_argv, _env, _cwd):
+        return {"code": 1, "stderr": "gateway down"}
+
+    result = run_hook(
+        ["prefetch"],
+        stdin=json.dumps({"prompt": "q"}),
+        env={},
+        cli_runner=fail,
+    )
+
+    assert result == {"code": 0, "stderr": "gateway down"}
+
+
+def test_hook_can_be_strict():
+    def fail(_argv, _env, _cwd):
+        return {"code": 1, "stderr": "gateway down"}
+
+    result = run_hook(
+        ["prefetch"],
+        stdin=json.dumps({"prompt": "q"}),
+        env={"TDAI_HOOK_STRICT": "1"},
+        cli_runner=fail,
+    )
+
+    assert result == {"code": 1, "stderr": "gateway down"}

--- a/packages/tdai-memory-cli/tests/unit/test_session_config.py
+++ b/packages/tdai-memory-cli/tests/unit/test_session_config.py
@@ -1,0 +1,30 @@
+from tdai_memory_cli.config import load_config
+from tdai_memory_cli.session import generate_default_session_key, resolve_session_key
+
+
+def test_generate_default_session_key_is_stable():
+    first = generate_default_session_key("/tmp/tencentdb-agent-memory")
+    second = generate_default_session_key("/tmp/tencentdb-agent-memory")
+    assert first == second
+    assert first.startswith("mcp:tencentdb-agent-memory:")
+
+
+def test_resolve_session_key_prefers_explicit():
+    assert resolve_session_key(" explicit ", "default") == "explicit"
+    assert resolve_session_key("", "default") == "default"
+
+
+def test_load_config_reads_env():
+    config = load_config({
+        "TDAI_GATEWAY_URL": "http://localhost:9999/",
+        "TDAI_GATEWAY_API_KEY": " secret ",
+        "TDAI_SESSION_KEY": "session:abc",
+        "TDAI_USER_ID": "user-1",
+        "TDAI_REQUEST_TIMEOUT_MS": "1234",
+    }, "/fallback")
+
+    assert config.gateway_url == "http://localhost:9999"
+    assert config.api_key == "secret"
+    assert config.default_session_key == "session:abc"
+    assert config.user_id == "user-1"
+    assert config.timeout_ms == 1234


### PR DESCRIPTION
## 概述

本 PR 新增一个独立的 Python CLI adapter 包：`packages/tdai-memory-cli`。

它提供一组通用命令，让不同 agent runtime 可以通过命令行调用 TencentDB Agent Memory Gateway。CLI 本身不启动、不关闭、不 watch Gateway，只连接一个已经运行中的 TDAI Gateway，并通过 Gateway HTTP API 完成 recall、capture 和 session flush。

## 关联 Issue

Part of #235

## 提供的 CLI 能力

| 命令 | Gateway API | 能力 |
| --- | --- | --- |
| `tdai-memory session-start` | `GET /health` | 检查 Gateway 连通性 |
| `tdai-memory prefetch` | `POST /recall` | 在用户输入进入模型前预取记忆上下文 |
| `tdai-memory sync-turn` | `POST /capture` | 在一轮对话完成后捕获 user/assistant turn |
| `tdai-memory end-session` | `POST /session/end` | 结束 session 并触发 flush |

同时提供一个可选的 stdin 事件适配入口，方便支持 command hook 的 agent runtime 将 hook event 转成 CLI 调用：

| 命令 | 能力 |
| --- | --- |
| `tdai-memory-hook session-start` | 从 stdin 读取 agent hook event，并调用 `tdai-memory session-start` |
| `tdai-memory-hook prefetch` | 从 stdin 读取 agent hook event，并调用 `tdai-memory prefetch` |
| `tdai-memory-hook sync-turn` | 从 stdin 读取 agent hook event，并调用 `tdai-memory sync-turn` |
| `tdai-memory-hook end-session` | 从 stdin 读取 agent hook event，并调用 `tdai-memory end-session` |

## 实现范围

本 PR 包含：

- Python CLI package：`tdai-memory-cli`
- Gateway HTTP client helper
- stdin hook event parser
- Codex / Claude Code hook JSON 示例，展示不同 agent runtime 如何注册命令
- CLI 使用示例 skill 目录：`examples/skills/tdai-memory/`
- session key 生成和配置读取逻辑
- 单元测试和可选 e2e 测试入口

## 设计说明

CLI 默认假设 Gateway 已经由用户或部署环境启动。

整体调用链路是：

```text
Agent runtime
  -> command registration / hook registration
  -> tdai-memory or tdai-memory-hook
  -> tdai-memory
  -> TDAI Gateway HTTP API
  -> TencentDB Agent Memory
```

不同 agent runtime 的 hook 注册方式并不相同，因此本 PR 只提供通用 CLI 命令和可选的 stdin 事件适配入口。Codex / Claude Code 的 hook JSON 放在 `examples/` 下，仅作为注册方式示例。

这样可以让 Codex、Claude Code 或其他支持命令调用的 agent runtime 通过 CLI 接入 TencentDB Agent Memory，同时保持 Gateway 生命周期管理和 CLI adapter 解耦。

`examples/skills/tdai-memory/` 是 CLI 的使用示例 skill 目录，入口文件是 `SKILL.md`，用于说明 agent 在什么场景下应该调用 `tdai-memory` / `tdai-memory-hook`。它不负责安装，也不修改 `AGENTS.md` 或 `CLAUDE.md`。

## Codex / Claude Code hooks 示例

本 PR 在 `examples/` 下提供 Codex 和 Claude Code 的 hook JSON 示例，用于展示不同 agent runtime 如何把自身 hook event 接到通用 CLI 命令上。

| 示例文件 | Runtime | 说明 |
| --- | --- | --- |
| `examples/codex/hooks.json` | Codex | 展示 Codex hook 事件如何调用 `tdai-memory-hook` |
| `examples/claude-code/hooks.json` | Claude Code | 展示 Claude Code hook 事件如何调用 `tdai-memory-hook` |
| `examples/hooks.json` | 通用示例 | 展示最小 command hook 配置形态 |

Codex 示例中的事件映射：

| Codex hook | CLI 调用 | 用途 |
| --- | --- | --- |
| `SessionStart` | `tdai-memory-hook session-start` | 会话开始、恢复或压缩后检查 Gateway 连通性 |
| `UserPromptSubmit` | `tdai-memory-hook prefetch` | 用户输入进入模型前预取记忆上下文 |
| `Stop` | `tdai-memory-hook sync-turn` | assistant 输出完成后捕获本轮对话 |

Claude Code 示例中的事件映射：

| Claude Code hook | CLI 调用 | 用途 |
| --- | --- | --- |
| `SessionStart` | `tdai-memory-hook session-start` | 会话开始时检查 Gateway 连通性 |
| `UserPromptSubmit` | `tdai-memory-hook prefetch` | 用户输入进入模型前预取记忆上下文 |
| `Stop` | `tdai-memory-hook sync-turn` | assistant 输出完成后捕获本轮对话 |

这些 JSON 只作为注册示例存在。不同 agent runtime 可以用自己的 hook 注册方式调用同一组 `tdai-memory` / `tdai-memory-hook` 命令。

## 自测结果

| 检查项 | 命令 | 结果 |
| --- | --- | --- |
| CLI unit tests | `cd packages/tdai-memory-cli && python3 -m pytest tests/unit -q` | `16 passed` |
| Python compile check | `cd packages/tdai-memory-cli && python3 -m py_compile tdai_memory_cli/*.py` | passed |

可选 e2e 测试需要本地已经运行 TDAI Gateway，因此不作为默认自测要求。
