### PR TITLE
fix(runtime): race/timeout hardening — recall abort, profile backup-swap, sandbox fix, SQLITE_BUSY

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,6 +90,9 @@ const pendingRecallEndTimestamps = new Map<string, number>();
 
 // 进程级单例，避免同一进程重复启动清理器导致并发清理竞态
 let sharedMemoryCleaner: LocalMemoryCleaner | undefined;
+/** Config signature (retentionDays|cleanTime) that sharedMemoryCleaner was
+ *  constructed with, so hot-reload config changes trigger recreation. */
+let sharedMemoryCleanerCfg: string | undefined;
 
 /**
  * Sweep both pendingOriginalPrompts and pendingRecallCache for stale entries.
@@ -299,15 +302,22 @@ export default function register(api: OpenClawPluginApi) {
   // Daily local JSONL cleaner (L0/L1), enabled only when retentionDays is configured.
   let memoryCleaner: LocalMemoryCleaner | undefined;
   if (cfg.memoryCleanup.enabled && cfg.memoryCleanup.retentionDays != null) {
-    if (!sharedMemoryCleaner) {
+    const desiredCfg = `${cfg.memoryCleanup.retentionDays}|${cfg.memoryCleanup.cleanTime}`;
+    if (!sharedMemoryCleaner || sharedMemoryCleanerCfg !== desiredCfg) {
+      // Recreate when the retention policy changed since the last register()
+      // (hot-reload) — the singleton previously kept the OLD config silently.
+      if (sharedMemoryCleaner) {
+        try { sharedMemoryCleaner.destroy(); } catch { /* best-effort */ }
+      }
       sharedMemoryCleaner = new LocalMemoryCleaner({
         baseDir: pluginDataDir,
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
       });
+      sharedMemoryCleanerCfg = desiredCfg;
       sharedMemoryCleaner.start();
-      api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);
+      api.logger.debug?.(`${TAG} Memory cleaner started (singleton) retentionDays=${cfg.memoryCleanup.retentionDays}`);
     } else {
       api.logger.debug?.(`${TAG} Memory cleaner already started in this process, reusing existing instance`);
     }
@@ -780,25 +790,28 @@ export default function register(api: OpenClawPluginApi) {
         await core.destroy();
       };
 
-      // Race cleanup against a hard timeout
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      // Await cleanup to completion rather than racing it against a hard
+      // timeout. Abandoning core.destroy() mid-flight previously cleared the
+      // store singleton (resetStores) while the old VectorStore's SQLite handle
+      // was still closing — on hot-reload a new registration reopened the same
+      // vectors.db path and hit SQLITE_BUSY. core.destroy() has its own
+      // internal budget, so the GATEWAY_STOP_TIMEOUT_MS is now a soft warning.
+      const cleanupPromise = doCleanup();
+      const timeoutId = setTimeout(
+        () => api.logger.warn(
+          `${TAG} [gateway_stop] Cleanup still running after ${GATEWAY_STOP_TIMEOUT_MS}ms — waiting it out to avoid hot-reload SQLITE_BUSY`,
+        ),
+        GATEWAY_STOP_TIMEOUT_MS,
+      );
       try {
-        await Promise.race([
-          doCleanup(),
-          new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(
-              () => reject(new Error("timeout")),
-              GATEWAY_STOP_TIMEOUT_MS,
-            );
-          }),
-        ]);
+        await cleanupPromise;
       } catch (err) {
         api.logger.warn(
-          `${TAG} [gateway_stop] Aborted (${Date.now() - hookStartMs}ms): ${err instanceof Error ? err.message : String(err)}. ` +
+          `${TAG} [gateway_stop] Cleanup failed (${Date.now() - hookStartMs}ms): ${err instanceof Error ? err.message : String(err)}. ` +
           `Pending work will recover on next startup.`,
         );
       } finally {
-        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       }
 
       resetStores();

--- a/src/adapters/standalone/llm-runner.ts
+++ b/src/adapters/standalone/llm-runner.ts
@@ -67,8 +67,13 @@ export interface StandaloneLLMConfig {
 // ============================
 
 function resolveSandboxedPath(workspaceDir: string, relativePath: string): string | null {
-  const resolved = path.resolve(workspaceDir, relativePath);
-  if (!resolved.startsWith(path.resolve(workspaceDir))) {
+  const root = path.resolve(workspaceDir);
+  const resolved = path.resolve(root, relativePath);
+  // Use a trailing-separator-aware prefix check so a workspace like `/data/tdai`
+  // does NOT match a sibling such as `/data/tdai-backup/secrets`. Without the
+  // separator, `startsWith` would pass the latter and let the LLM escape the
+  // sandbox via prompt-injected tool calls.
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
     return null;
   }
   return resolved;

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -83,13 +83,18 @@ export async function performAutoRecall(params: {
   const timeoutMs = cfg.recall.timeoutMs ?? 5000;
 
   let timer: ReturnType<typeof setTimeout> | undefined;
+  // Abort the in-flight embedding/VectorStore search when the recall timeout
+  // fires, so the work doesn't keep consuming an embedding API slot / holding
+  // the SQLite connection after we've already given up on the result.
+  const abortController = new AbortController();
 
   return Promise.race([
-    performAutoRecallInner(params).finally(() => {
+    performAutoRecallInner(params, abortController.signal).finally(() => {
       if (timer) clearTimeout(timer);
     }),
     new Promise<undefined>((resolve) => {
       timer = setTimeout(() => {
+        abortController.abort();
         logger?.warn?.(
           `${TAG} ⚠️ Recall timed out after ${timeoutMs}ms — skipping memory injection to avoid blocking the user`,
         );
@@ -99,16 +104,19 @@ export async function performAutoRecall(params: {
   ]);
 }
 
-async function performAutoRecallInner(params: {
-  userText: string;
-  actorId: string;
-  sessionKey: string;
-  cfg: MemoryTdaiConfig;
-  pluginDataDir: string;
-  logger?: Logger;
-  vectorStore?: IMemoryStore;
-  embeddingService?: EmbeddingService;
-}): Promise<RecallResult | undefined> {
+async function performAutoRecallInner(
+  params: {
+    userText: string;
+    actorId: string;
+    sessionKey: string;
+    cfg: MemoryTdaiConfig;
+    pluginDataDir: string;
+    logger?: Logger;
+    vectorStore?: IMemoryStore;
+    embeddingService?: EmbeddingService;
+  },
+  abortSignal?: AbortSignal,
+): Promise<RecallResult | undefined> {
   const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
   const tRecallStart = performance.now();
 
@@ -122,7 +130,7 @@ async function performAutoRecallInner(params: {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
-    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
+    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService, abortSignal);
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
     memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
@@ -140,6 +148,13 @@ async function performAutoRecallInner(params: {
     });
   }
   const tSearchEnd = performance.now();
+
+  // If the recall timeout fired during the search phase, skip the remaining
+  // persona/scene file reads — the result is already going to be discarded.
+  if (abortSignal?.aborted) {
+    logger?.debug?.(`${TAG} Recall aborted after search — skipping persona/scene reads`);
+    return undefined;
+  }
 
   // Read persona (L3 layer)
   const tPersonaStart = performance.now();
@@ -313,6 +328,7 @@ async function searchMemories(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  abortSignal?: AbortSignal,
 ): Promise<SearchResult> {
   const emptyResult: SearchResult = { lines: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
   // Strip gateway-injected inbound metadata (Sender, timestamps, media markers,
@@ -356,7 +372,10 @@ async function searchMemories(
   // Resolve per-call embedding timeout for recall path.
   // Falls back to global embedding.timeoutMs when recallTimeoutMs is not configured.
   const recallEmbeddingTimeoutMs = cfg.embedding?.recallTimeoutMs ?? cfg.embedding?.timeoutMs;
-  const embeddingCallOpts: EmbeddingCallOptions = { timeoutMs: recallEmbeddingTimeoutMs };
+  const embeddingCallOpts: EmbeddingCallOptions = {
+    timeoutMs: recallEmbeddingTimeoutMs,
+    ...(abortSignal ? { abortSignal } : {}),
+  };
 
   try {
     if (effectiveStrategy === "keyword") {

--- a/src/core/profile/profile-sync.ts
+++ b/src/core/profile/profile-sync.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { IMemoryStore, ProfileRecord, ProfileSyncRecord } from "../store/types.js";
@@ -152,18 +152,41 @@ export async function pullProfilesToLocal(
     }
 
     const localBlocksDir = path.join(dataDir, "scene_blocks");
-    await fs.rm(localBlocksDir, { recursive: true, force: true });
     await fs.mkdir(path.dirname(localBlocksDir), { recursive: true });
+
+    // Swap scene_blocks via a backup dir so the original is preserved if the
+    // rename fails (disk full / permissions / EXDEV). Previously we deleted
+    // localBlocksDir first and then renamed — a non-race rename failure left
+    // local scene blocks gone until the next L2 extraction regenerated them.
+    const backupDir = `${localBlocksDir}.old-${randomBytes(4).toString("hex")}`;
+    let movedAside = false;
     try {
-      await fs.rename(tempBlocksDir, localBlocksDir);
-    } catch (err) {
-      if (isRenameRaceError(err)) {
-        // Another concurrent pull already wrote scene_blocks — ours is redundant.
-        // Both pulls fetched the same remote snapshot, so the other result is equivalent.
-        logger.debug?.(`[memory-tdai][profile-sync] scene_blocks rename lost race (${(err as NodeJS.ErrnoException).code}), using existing`);
-        return baseline;
+      try {
+        await fs.rename(localBlocksDir, backupDir);
+        movedAside = true;
+      } catch (err) {
+        // ENOENT just means there was no existing scene_blocks — proceed to
+        // install the new one. Anything else is a real failure.
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
       }
-      throw err;
+      try {
+        await fs.rename(tempBlocksDir, localBlocksDir);
+      } catch (err) {
+        if (isRenameRaceError(err)) {
+          // Another concurrent pull already installed scene_blocks — ours is
+          // redundant. Both pulls fetched the same remote snapshot. Don't
+          // restore our backup (that would clobber the winner's fresh content).
+          logger.debug?.(`[memory-tdai][profile-sync] scene_blocks rename lost race (${(err as NodeJS.ErrnoException).code}), using existing`);
+          return baseline;
+        }
+        // Non-race failure: restore the original so scene_blocks isn't empty.
+        if (movedAside) {
+          await fs.rename(backupDir, localBlocksDir).catch(() => { /* best-effort */ });
+        }
+        throw err;
+      }
+    } finally {
+      if (movedAside) await fs.rm(backupDir, { recursive: true, force: true }).catch(() => { /* best-effort */ });
     }
 
     const tempPersonaPath = path.join(tempDir, "persona.md");


### PR DESCRIPTION
## 拆分自 #391（per YOMXXX review）

独立的安全加固，聚焦 runtime 层：
- `auto-recall.ts`: recall 超时 abort 贯穿到 embedding HTTP（AbortSignal）
- `profile-sync.ts`: scene_blocks 改 backup-swap，rename 失败保留原件
- `llm-runner.ts`: resolveSandboxedPath 前缀穿越修复（`../tdai-backup` 类路径绕过）
- `index.ts`: gateway_stop 始终 await cleanup（防热重载 SQLITE_BUSY）；sharedMemoryCleaner 检测 config 变更并重建

4 files, +100/-40