### PR TITLE
fix(offload): tracing/token hardening — astral token, L1.5 null fallback, createRequire

### DIFF
--- a/src/offload/fast-token-estimate.ts
+++ b/src/offload/fast-token-estimate.ts
@@ -283,7 +283,14 @@ export function fastEstimateTokens(text: string): number {
     if (cp >= 0x21 && cp <= 0x7E) { tokens += 0.6; i++; continue; }
 
     // ── Other Unicode (emoji etc.) ──
-    if (cp > 0x7F) { tokens += 2.5; i++; continue; }
+    if (cp > 0x7F) {
+      tokens += 2.5;
+      // Astral-plane characters (U+10000+) are encoded as a surrogate pair;
+      // skip the low surrogate so it isn't counted again as a second token
+      // (previously emoji / CJK extension-B were ~2× over-estimated).
+      i += cp >= 0xD800 && cp <= 0xDBFF && i + 1 < n ? 2 : 1;
+      continue;
+    }
 
     i++;
   }

--- a/src/offload/local-llm/index.ts
+++ b/src/offload/local-llm/index.ts
@@ -115,11 +115,13 @@ export class LocalLlmClient {
     if (!result) {
       this.logger?.warn?.(`${TAG} L1.5: failed to parse judgment from LLM response (${raw.length} chars)`);
       // Return all-null to trigger normalizeJudgment's "LLM unavailable" path
+      // (which checks `== null` on each field). Returning `false` here would be
+      // treated as a real no-op judgment and never trigger the retry path.
       return {
-        taskCompleted: false,
-        isContinuation: false,
-        isLongTask: false,
-      } as L15Response;
+        taskCompleted: null,
+        isContinuation: null,
+        isLongTask: null,
+      } as unknown as L15Response;
     }
 
     return result as L15Response;

--- a/src/offload/opik-tracer.ts
+++ b/src/offload/opik-tracer.ts
@@ -4,6 +4,7 @@
  */
 import type { PluginLogger } from "./types.js";
 import { getEnv } from "../utils/env.js";
+import { createRequire } from "node:module";
 
 // Opik client types (minimal shape to avoid hard dependency)
 interface OpikClient {
@@ -23,6 +24,18 @@ interface OpikSpan {
 let client: OpikClient | null = null;
 let tracerEnabled = false;
 let tracerInitTried = false;
+
+/**
+ * Max characters of any single string field emitted to Opik. Tool I/O (file
+ * contents, env vars, command output) routinely contains secrets; truncating
+ * limits (though does not eliminate) leakage to the Opik backend.
+ */
+const MAX_TRACE_FIELD_CHARS = 2000;
+
+function truncateForTrace(s: string): string {
+  if (typeof s !== "string" || s.length <= MAX_TRACE_FIELD_CHARS) return s;
+  return s.slice(0, MAX_TRACE_FIELD_CHARS) + `…[truncated ${s.length - MAX_TRACE_FIELD_CHARS} chars]`;
+}
 
 function extractLayerTag(stage: string): string {
   const match = stage.match(/^(L\d+(?:\.\d+)?)/i);
@@ -96,8 +109,11 @@ export function initOffloadOpikTracer(
     // Dynamic import — graceful when opik is not installed
     let OpikConstructor: new (params: Record<string, unknown>) => OpikClient;
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const opikModule = require("opik") as { Opik: new (params: Record<string, unknown>) => OpikClient };
+      // createRequire lets an ESM module load a CommonJS dependency. A bare
+      // require() is undefined under Node ESM and silently disabled the tracer
+      // even when opik was installed.
+      const moduleRequire = createRequire(import.meta.url);
+      const opikModule = moduleRequire("opik") as { Opik: new (params: Record<string, unknown>) => OpikClient };
       OpikConstructor = opikModule.Opik;
     } catch {
       logger.debug?.("[context-offload] opik package not available, tracer disabled");
@@ -173,7 +189,8 @@ export function traceOffloadDecision(params: {
 
 /**
  * Serialize a single message into a diagnostic object for tracing.
- * Outputs full content text (no truncation) for debugging purposes.
+ * Content is truncated per MAX_TRACE_FIELD_CHARS so tool I/O (which may carry
+ * secrets) is not shipped verbatim to the Opik backend.
  */
 function serializeMessageForTrace(msg: any, index: number): Record<string, unknown> {
   const role = msg.role ?? msg.message?.role ?? msg.type ?? "unknown";
@@ -187,18 +204,18 @@ function serializeMessageForTrace(msg: any, index: number): Record<string, unkno
   let contentLength: number;
   if (typeof content === "string") {
     contentLength = content.length;
-    contentText = content;
+    contentText = truncateForTrace(content);
   } else if (Array.isArray(content)) {
     const parts: string[] = [];
     for (const c of content) {
       if (typeof c !== "object" || c === null) continue;
       if (c.type === "text" && typeof c.text === "string") {
-        parts.push(c.text);
+        parts.push(truncateForTrace(c.text));
       } else if (c.type === "tool_use") {
-        const inputStr = c.input != null ? JSON.stringify(c.input) : "";
+        const inputStr = c.input != null ? truncateForTrace(JSON.stringify(c.input)) : "";
         parts.push(`[tool_use: ${c.name ?? "?"} id=${c.id ?? "?"} input=${inputStr}]`);
       } else if (c.type === "tool_result") {
-        const resultStr = typeof c.content === "string" ? c.content : JSON.stringify(c.content ?? "");
+        const resultStr = typeof c.content === "string" ? truncateForTrace(c.content) : truncateForTrace(JSON.stringify(c.content ?? ""));
         parts.push(`[tool_result: id=${c.tool_use_id ?? "?"} content=${resultStr}]`);
       } else {
         parts.push(`[${c.type ?? "unknown_block"}]`);
@@ -339,8 +356,8 @@ export function traceOffloadModelIo(params: {
       provider: params.provider,
       input: {
         url: params.url,
-        systemPrompt: params.systemPrompt,
-        userPrompt: params.userPrompt,
+        systemPrompt: truncateForTrace(params.systemPrompt),
+        userPrompt: truncateForTrace(params.userPrompt),
       },
       metadata: {
         stage: params.stage,
@@ -352,7 +369,7 @@ export function traceOffloadModelIo(params: {
     });
     span.update({
       output: {
-        responseContent: params.responseContent,
+        responseContent: truncateForTrace(params.responseContent),
         usage: params.usage,
         durationMs: dur,
         duration: durStr,


### PR DESCRIPTION
## 拆分自 #391（per YOMXXX review）

独立的安全加固，聚焦 offload 层：
- `fast-token-estimate.ts`: astral-plane 字符（emoji/CJK ext B）跳过低代理，修正 ~2x token 高估
- `local-llm/index.ts`: L1.5 解析失败 fallback 改 all-null，真正触发 normalizeJudgment 重试
- `opik-tracer.ts`: createRequire 加载 opik（ESM 下 require 失效）；trace 内容截断 2000 字符防脱敏泄露

3 files, +41/-15