### PR TITLE
fix(core): storage hardening — Buffer safety, embedding abort, atomic instanceId

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# fix(core): Storage Hardening
+
+拆分自 #391，per [YOMXXX review](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/391#issuecomment-4923202779)。
+
+## 修复范围
+
+聚焦 `src/core/store/` + `src/core/report/`，不涉及 Gateway、Offload、Runtime 层。
+
+## 具体修复
+
+### `src/core/store/sqlite.ts` — Buffer 安全 + Extension 锁定
+
+| 问题 | 修复 |
+|:---|:---|
+| `Buffer.from(emb.buffer)` 缺少 byteOffset/byteLength，Float32Array subarray 视图会写出整个底层 buffer | 6 处补全 `byteOffset, byteLength` 参数 |
+| `enableLoadExtension(true)` 加载 sqlite-vec 后未重置，未来 SQL 路径可能加载任意 extension | 加载后立即 `enableLoadExtension(false)` |
+
+### `src/core/store/embedding.ts` — Abort 信号贯穿
+
+| 问题 | 修复 |
+|:---|:---|
+| recall 超时后 embedding HTTP 请求继续占用 API slot / 连接 | `EmbeddingCallOptions` 新增 `abortSignal`，`AbortSignal.any` 合并超时与外部信号 |
+
+### `src/core/report/reporter.ts` — InstanceId 并发安全
+
+| 问题 | 修复 |
+|:---|:---|
+| 并发冷启动时两个调用同时 miss cache → 生成两个 UUID → last-writer 覆盖 | 加 `_instanceIdInFlight` Promise 锁 |
+| `writeFile` 非原子，崩溃可留下截断文件导致 instanceId 漂移 | 改为 `tmp + rename` 原子写 |
+
+## 验证
+
+- 3 files, +63/-31
+- 无 API 变更，无新增依赖
+- 与 #39 / #232 / #242 / #287 / #288 / #289 / #347 均不重叠

--- a/src/core/report/reporter.ts
+++ b/src/core/report/reporter.ts
@@ -83,21 +83,37 @@ class LocalReporter implements IReporter {
 
 let _instanceIdCache: string | undefined;
 
+// Serializes concurrent cold-start instance-id creation so two parallel calls
+// don't both miss the cache, both generate a UUID, and both write (last-writer
+// wins producing a transient duplicate id in early metrics).
+let _instanceIdInFlight: Promise<string> | null = null;
+
 export async function getOrCreateInstanceId(pluginDataDir: string): Promise<string> {
   if (_instanceIdCache) return _instanceIdCache;
+  if (_instanceIdInFlight) return _instanceIdInFlight;
 
-  const idFile = path.join(pluginDataDir, ".metadata", "instance_id");
-  try {
-    const existing = (await fs.readFile(idFile, "utf-8")).trim();
-    if (existing) {
-      _instanceIdCache = existing;
-      return existing;
-    }
-  } catch { /* file doesn't exist */ }
+  _instanceIdInFlight = (async () => {
+    const idFile = path.join(pluginDataDir, ".metadata", "instance_id");
+    try {
+      const existing = (await fs.readFile(idFile, "utf-8")).trim();
+      if (existing) {
+        _instanceIdCache = existing;
+        return existing;
+      }
+    } catch { /* file doesn't exist */ }
 
-  const newId = randomUUID();
-  await fs.mkdir(path.dirname(idFile), { recursive: true });
-  await fs.writeFile(idFile, newId, "utf-8");
-  _instanceIdCache = newId;
-  return newId;
+    const newId = randomUUID();
+    await fs.mkdir(path.dirname(idFile), { recursive: true });
+    // Atomic write (tmp + rename) so a crash mid-write can't leave a truncated
+    // instance_id file that would silently change the instance id on next boot.
+    const tmp = `${idFile}.${randomUUID()}.tmp`;
+    await fs.writeFile(tmp, newId, "utf-8");
+    await fs.rename(tmp, idFile);
+    _instanceIdCache = newId;
+    return newId;
+  })().finally(() => {
+    _instanceIdInFlight = null;
+  });
+
+  return _instanceIdInFlight;
 }

--- a/src/core/store/embedding.ts
+++ b/src/core/store/embedding.ts
@@ -66,6 +66,10 @@ export interface EmbeddingProviderInfo {
 export interface EmbeddingCallOptions {
   /** Override the default timeout for this call (milliseconds). */
   timeoutMs?: number;
+  /** Optional abort signal — when aborted, the in-flight HTTP request is
+   *  cancelled. Used by the recall hot path so a recall timeout actually
+   *  stops the embedding call instead of letting it run to its own timeout. */
+  abortSignal?: AbortSignal;
 }
 
 export interface EmbeddingService {
@@ -449,19 +453,25 @@ async function postEmbeddingRequest(params: {
   headers: Record<string, string>;
   body: Record<string, unknown>;
   timeoutMs: number;
+  abortSignal?: AbortSignal;
 }): Promise<unknown> {
-  const { fetchUrl, headers, body, timeoutMs } = params;
+  const { fetchUrl, headers, body, timeoutMs, abortSignal } = params;
   let lastError: Error | undefined;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+      // Combine the per-call timeout signal with the caller's abort signal so
+      // either one cancels the fetch. AbortSignal.any is available on Node 20+.
+      const signals: AbortSignal[] = [controller.signal];
+      if (abortSignal) signals.push(abortSignal);
+      const combined = signals.length === 1 ? signals[0]! : AbortSignal.any(signals);
       try {
         const resp = await fetch(fetchUrl, {
           method: "POST",
           headers,
           body: JSON.stringify(body),
-          signal: controller.signal,
+          signal: combined,
         });
         if (!resp.ok) {
           const errBody = await resp.text().catch(() => "(unable to read body)");
@@ -570,13 +580,13 @@ export class OpenAIEmbeddingService implements EmbeddingService {
       const results: Float32Array[] = [];
       for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
         const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
-        const chunkResults = await this._callApi(chunk, options?.timeoutMs);
+        const chunkResults = await this._callApi(chunk, options);
         results.push(...chunkResults);
       }
       return results;
     }
 
-    return this._callApi(processedTexts, options?.timeoutMs);
+    return this._callApi(processedTexts, options);
   }
 
   /**
@@ -591,7 +601,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
     return text.slice(0, this.maxInputChars);
   }
 
-  private async _callApi(texts: string[], timeoutOverride?: number): Promise<Float32Array[]> {
+  private async _callApi(texts: string[], options?: EmbeddingCallOptions): Promise<Float32Array[]> {
     const body: Record<string, unknown> = {
       input: texts,
       model: this.model,
@@ -618,7 +628,8 @@ export class OpenAIEmbeddingService implements EmbeddingService {
       fetchUrl,
       headers,
       body,
-      timeoutMs: timeoutOverride ?? this.timeoutMs,
+      timeoutMs: options?.timeoutMs ?? this.timeoutMs,
+      abortSignal: options?.abortSignal,
     })) as OpenAIEmbeddingResponse;
 
     if (!json.data || !Array.isArray(json.data)) {
@@ -722,16 +733,16 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
       const results: Float32Array[] = [];
       for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
         const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
-        const chunkResults = await this._callApi(chunk, options?.timeoutMs);
+        const chunkResults = await this._callApi(chunk, options);
         results.push(...chunkResults);
       }
       return results;
     }
 
-    return this._callApi(processedTexts, options?.timeoutMs);
+    return this._callApi(processedTexts, options);
   }
 
-  private async _callApi(texts: string[], timeoutOverride?: number): Promise<Float32Array[]> {
+  private async _callApi(texts: string[], options?: EmbeddingCallOptions): Promise<Float32Array[]> {
     // ZeroEntropy rejects requests without `input_type`. We default to
     // "query" because the recall hot path is the only caller of embed()
     // that returns a Float32Array; capture-side batches eventually feed
@@ -761,7 +772,8 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
       fetchUrl,
       headers,
       body,
-      timeoutMs: timeoutOverride ?? this.timeoutMs,
+      timeoutMs: options?.timeoutMs ?? this.timeoutMs,
+      abortSignal: options?.abortSignal,
     })) as ZeroEntropyEmbeddingResponse;
 
     if (!json.results || !Array.isArray(json.results)) {

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -454,6 +454,10 @@ export class VectorStore implements IMemoryStore {
       const sqliteVec = require("sqlite-vec");
       this.db.enableLoadExtension(true);
       sqliteVec.load(this.db);
+      // Re-disable extension loading for the lifetime of the connection — only
+      // sqlite-vec should ever be loaded. Defense-in-depth against any future
+      // SQL path that could otherwise load an arbitrary extension.
+      this.db.enableLoadExtension(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger?.error(
@@ -1046,7 +1050,7 @@ export class VectorStore implements IMemoryStore {
         if (!skipVec) {
           // vec0 does not support ON CONFLICT → delete then insert
           this.stmtDeleteVec!.run(recordId);
-          this.stmtInsertVec!.run(recordId, Buffer.from(embedding!.buffer), record.updatedAt);
+          this.stmtInsertVec!.run(recordId, Buffer.from(embedding!.buffer, embedding!.byteOffset, embedding!.byteLength), record.updatedAt);
         } else {
           this.logger?.debug?.(
             `${TAG} [L1-upsert] Skipping vec write (${embedding ? "zero vector" : "no embedding"}) id=${recordId}`,
@@ -1126,7 +1130,7 @@ export class VectorStore implements IMemoryStore {
       );
 
       const rows = this.stmtSearchVec!.all(
-        Buffer.from(queryEmbedding.buffer),
+        Buffer.from(queryEmbedding.buffer, queryEmbedding.byteOffset, queryEmbedding.byteLength),
         retrieveCount,
       ) as Array<{ record_id: string; distance: number }>;
 
@@ -1457,7 +1461,7 @@ export class VectorStore implements IMemoryStore {
         if (!skipVec) {
           // vec0 does not support ON CONFLICT → delete then insert
           this.stmtL0DeleteVec!.run(record.id);
-          this.stmtL0InsertVec!.run(record.id, Buffer.from(embedding!.buffer), record.recordedAt);
+          this.stmtL0InsertVec!.run(record.id, Buffer.from(embedding!.buffer, embedding!.byteOffset, embedding!.byteLength), record.recordedAt);
         } else {
           this.logger?.debug?.(
             `${TAG} [L0-upsert] Skipping vec write (${embedding ? "zero vector" : "no embedding"}) id=${record.id}`,
@@ -1533,7 +1537,7 @@ export class VectorStore implements IMemoryStore {
       this.db.exec("BEGIN");
       try {
         this.stmtL0DeleteVec!.run(recordId);
-        this.stmtL0InsertVec!.run(recordId, Buffer.from(embedding.buffer), meta.recorded_at);
+        this.stmtL0InsertVec!.run(recordId, Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength), meta.recorded_at);
         this.db.exec("COMMIT");
       } catch (err) {
         try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
@@ -1576,7 +1580,7 @@ export class VectorStore implements IMemoryStore {
       );
 
       const rows = this.stmtL0SearchVec!.all(
-        Buffer.from(queryEmbedding.buffer),
+        Buffer.from(queryEmbedding.buffer, queryEmbedding.byteOffset, queryEmbedding.byteLength),
         retrieveCount,
       ) as Array<{ record_id: string; distance: number }>;
 
@@ -1827,7 +1831,7 @@ export class VectorStore implements IMemoryStore {
           this.db.exec("BEGIN");
           try {
             this.stmtDeleteVec!.run(record_id);
-            this.stmtInsertVec!.run(record_id, Buffer.from(embedding.buffer), updated_time);
+            this.stmtInsertVec!.run(record_id, Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength), updated_time);
             this.db.exec("COMMIT");
           } catch (txErr) {
             try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
@@ -1852,7 +1856,7 @@ export class VectorStore implements IMemoryStore {
           this.db.exec("BEGIN");
           try {
             this.stmtL0DeleteVec!.run(record_id);
-            this.stmtL0InsertVec!.run(record_id, Buffer.from(embedding.buffer), recorded_at);
+            this.stmtL0InsertVec!.run(record_id, Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength), recorded_at);
             this.db.exec("COMMIT");
           } catch (txErr) {
             try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }


### PR DESCRIPTION
# fix(offload): Tracing & Token Hardening

拆分自 #391，per [YOMXXX review](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/391#issuecomment-4923202779)。

## 修复范围

聚焦 `src/offload/` 层：token estimate、local LLM、Opik tracing。不涉及 store、runtime、gateway 层。

## 具体修复

### `src/offload/fast-token-estimate.ts` — Astral-平面 Token 修正

| 问题 | 修复 |
|:---|:---|
| astral-plane 字符（emoji / CJK extension B，U+10000+）编码为 surrogate pair，原实现把 high surrogate 和 low surrogate 各计为一个 token | high surrogate 检测后跳过低代理（`i += 2`），修正 ~2× token 高估 |

### `src/offload/local-llm/index.ts` — L1.5 Fallback 修正

| 问题 | 修复 |
|:---|:---|
| 解析失败返回 `{taskCompleted: false, ...}` — normalizeJudgment 把 `false` 当有效判断，永远不触发 "LLM 不可用" 重试 | 改为 `{taskCompleted: null, ...}`，`== null` 检查触发重试路径 |

### `src/offload/opik-tracer.ts` — ESM 兼容 + Trace 截断

| 问题 | 修复 |
|:---|:---|
| ESM 下 `require("opik")` 为 `undefined`，tracer 永久静默关闭 | 改为 `createRequire(import.meta.url)` |
| 未脱敏 tool 输出（文件内容、环境变量）完整写入 trace，泄露到 Opik backend | 统一截断到 2000 字符 |

## 验证

- 3 files, +41/-15
- 无 API 变更，无新增依赖
- 与 #39 / #232 / #242 / #287 / #288 / #289 / #347 均不重叠