### PR TITLE
fix(runtime): race/timeout hardening — recall abort, profile backup-swap, sandbox, SQLITE_BUSY

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# fix(runtime): Race & Timeout Hardening
+
+拆分自 #391，per [YOMXXX review](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/391#issuecomment-4923202779)。
+
+## 修复范围
+
+聚焦 runtime 层：hooks、profile、sandbox、gateway lifecycle。不涉及 store、offload 层。
+
+## 具体修复
+
+### `src/core/hooks/auto-recall.ts` — Recall 超时 Abort 贯穿
+
+| 问题 | 修复 |
+|:---|:---|
+| recall 超时后 Promise.race 返回 undefined，但 embedding/VectorStore 仍在运行 | 新增 `AbortController`，超时时 abort，信号贯穿到 embedding |
+
+### `src/core/profile/profile-sync.ts` — Scene Blocks Backup-Swap
+
+| 问题 | 修复 |
+|:---|:---|
+| 原实现先 `rm -rf scene_blocks` 再 rename，rename 失败则本地 blocks 永久丢失 | 改为 backup-swap：先 rename 旧目录为 `.old-*`，rename 失败则恢复 |
+| 并发 pull 时 rename race 检测保留 | 保留 `isRenameRaceError` 判断 |
+
+### `src/adapters/standalone/llm-runner.ts` — Sandbox 路径穿越
+
+| 问题 | 修复 |
+|:---|:---|
+| `startsWith(workspaceDir)` 无尾部分隔符，`/data/tdai-backup` 能绕过 `/data/tdai` 沙箱 | 改为 `resolved === root \|\| resolved.startsWith(root + path.sep)` |
+
+### `index.ts` — Gateway Stop SQLITE_BUSY + Cleaner Hot-Reload
+
+| 问题 | 修复 |
+|:---|:---|
+| gateway_stop 用 `Promise.race` 竞速，超时后 resetStores 清理 singleton，旧 VectorStore 还在关闭 → 热重载 SQLITE_BUSY | 改为始终 `await cleanupPromise`，超时仅 warn |
+| `sharedMemoryCleaner` 是进程单例，热重载 config 变更 retentionDays 后仍用旧值 | 新增 `sharedMemoryCleanerCfg` 签名，变更时销毁重建 |
+
+## 验证
+
+- 4 files, +100/-40
+- 无 API 变更，无新增依赖
+- 与 #39 / #232 / #242 / #287 / #288 / #289 / #347 均不重叠

--- a/index.ts
+++ b/index.ts
@@ -90,6 +90,9 @@ const pendingRecallEndTimestamps = new Map<string, number>();
 
 // 进程级单例，避免同一进程重复启动清理器导致并发清理竞态
 let sharedMemoryCleaner: LocalMemoryCleaner | undefined;
+/** Config signature (retentionDays|cleanTime) that sharedMemoryCleaner was
+ *  constructed with, so hot-reload config changes trigger recreation. */
+let sharedMemoryCleanerCfg: string | undefined;
 
 /**
  * Sweep both pendingOriginalPrompts and pendingRecallCache for stale entries.
@@ -299,15 +302,22 @@ export default function register(api: OpenClawPluginApi) {
   // Daily local JSONL cleaner (L0/L1), enabled only when retentionDays is configured.
   let memoryCleaner: LocalMemoryCleaner | undefined;
   if (cfg.memoryCleanup.enabled && cfg.memoryCleanup.retentionDays != null) {
-    if (!sharedMemoryCleaner) {
+    const desiredCfg = `${cfg.memoryCleanup.retentionDays}|${cfg.memoryCleanup.cleanTime}`;
+    if (!sharedMemoryCleaner || sharedMemoryCleanerCfg !== desiredCfg) {
+      // Recreate when the retention policy changed since the last register()
+      // (hot-reload) — the singleton previously kept the OLD config silently.
+      if (sharedMemoryCleaner) {
+        try { sharedMemoryCleaner.destroy(); } catch { /* best-effort */ }
+      }
       sharedMemoryCleaner = new LocalMemoryCleaner({
         baseDir: pluginDataDir,
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
       });
+      sharedMemoryCleanerCfg = desiredCfg;
       sharedMemoryCleaner.start();
-      api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);
+      api.logger.debug?.(`${TAG} Memory cleaner started (singleton) retentionDays=${cfg.memoryCleanup.retentionDays}`);
     } else {
       api.logger.debug?.(`${TAG} Memory cleaner already started in this process, reusing existing instance`);
     }
@@ -780,25 +790,28 @@ export default function register(api: OpenClawPluginApi) {
         await core.destroy();
       };
 
-      // Race cleanup against a hard timeout
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      // Await cleanup to completion rather than racing it against a hard
+      // timeout. Abandoning core.destroy() mid-flight previously cleared the
+      // store singleton (resetStores) while the old VectorStore's SQLite handle
+      // was still closing — on hot-reload a new registration reopened the same
+      // vectors.db path and hit SQLITE_BUSY. core.destroy() has its own
+      // internal budget, so the GATEWAY_STOP_TIMEOUT_MS is now a soft warning.
+      const cleanupPromise = doCleanup();
+      const timeoutId = setTimeout(
+        () => api.logger.warn(
+          `${TAG} [gateway_stop] Cleanup still running after ${GATEWAY_STOP_TIMEOUT_MS}ms — waiting it out to avoid hot-reload SQLITE_BUSY`,
+        ),
+        GATEWAY_STOP_TIMEOUT_MS,
+      );
       try {
-        await Promise.race([
-          doCleanup(),
-          new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(
-              () => reject(new Error("timeout")),
-              GATEWAY_STOP_TIMEOUT_MS,
-            );
-          }),
-        ]);
+        await cleanupPromise;
       } catch (err) {
         api.logger.warn(
-          `${TAG} [gateway_stop] Aborted (${Date.now() - hookStartMs}ms): ${err instanceof Error ? err.message : String(err)}. ` +
+          `${TAG} [gateway_stop] Cleanup failed (${Date.now() - hookStartMs}ms): ${err instanceof Error ? err.message : String(err)}. ` +
           `Pending work will recover on next startup.`,
         );
       } finally {
-        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       }
 
       resetStores();

--- a/src/adapters/standalone/llm-runner.ts
+++ b/src/adapters/standalone/llm-runner.ts
@@ -67,8 +67,13 @@ export interface StandaloneLLMConfig {
 // ============================
 
 function resolveSandboxedPath(workspaceDir: string, relativePath: string): string | null {
-  const resolved = path.resolve(workspaceDir, relativePath);
-  if (!resolved.startsWith(path.resolve(workspaceDir))) {
+  const root = path.resolve(workspaceDir);
+  const resolved = path.resolve(root, relativePath);
+  // Use a trailing-separator-aware prefix check so a workspace like `/data/tdai`
+  // does NOT match a sibling such as `/data/tdai-backup/secrets`. Without the
+  // separator, `startsWith` would pass the latter and let the LLM escape the
+  // sandbox via prompt-injected tool calls.
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
     return null;
   }
   return resolved;

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -83,13 +83,18 @@ export async function performAutoRecall(params: {
   const timeoutMs = cfg.recall.timeoutMs ?? 5000;
 
   let timer: ReturnType<typeof setTimeout> | undefined;
+  // Abort the in-flight embedding/VectorStore search when the recall timeout
+  // fires, so the work doesn't keep consuming an embedding API slot / holding
+  // the SQLite connection after we've already given up on the result.
+  const abortController = new AbortController();
 
   return Promise.race([
-    performAutoRecallInner(params).finally(() => {
+    performAutoRecallInner(params, abortController.signal).finally(() => {
       if (timer) clearTimeout(timer);
     }),
     new Promise<undefined>((resolve) => {
       timer = setTimeout(() => {
+        abortController.abort();
         logger?.warn?.(
           `${TAG} ⚠️ Recall timed out after ${timeoutMs}ms — skipping memory injection to avoid blocking the user`,
         );
@@ -99,16 +104,19 @@ export async function performAutoRecall(params: {
   ]);
 }
 
-async function performAutoRecallInner(params: {
-  userText: string;
-  actorId: string;
-  sessionKey: string;
-  cfg: MemoryTdaiConfig;
-  pluginDataDir: string;
-  logger?: Logger;
-  vectorStore?: IMemoryStore;
-  embeddingService?: EmbeddingService;
-}): Promise<RecallResult | undefined> {
+async function performAutoRecallInner(
+  params: {
+    userText: string;
+    actorId: string;
+    sessionKey: string;
+    cfg: MemoryTdaiConfig;
+    pluginDataDir: string;
+    logger?: Logger;
+    vectorStore?: IMemoryStore;
+    embeddingService?: EmbeddingService;
+  },
+  abortSignal?: AbortSignal,
+): Promise<RecallResult | undefined> {
   const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
   const tRecallStart = performance.now();
 
@@ -122,7 +130,7 @@ async function performAutoRecallInner(params: {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
-    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
+    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService, abortSignal);
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
     memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
@@ -140,6 +148,13 @@ async function performAutoRecallInner(params: {
     });
   }
   const tSearchEnd = performance.now();
+
+  // If the recall timeout fired during the search phase, skip the remaining
+  // persona/scene file reads — the result is already going to be discarded.
+  if (abortSignal?.aborted) {
+    logger?.debug?.(`${TAG} Recall aborted after search — skipping persona/scene reads`);
+    return undefined;
+  }
 
   // Read persona (L3 layer)
   const tPersonaStart = performance.now();
@@ -313,6 +328,7 @@ async function searchMemories(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  abortSignal?: AbortSignal,
 ): Promise<SearchResult> {
   const emptyResult: SearchResult = { lines: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
   // Strip gateway-injected inbound metadata (Sender, timestamps, media markers,
@@ -356,7 +372,10 @@ async function searchMemories(
   // Resolve per-call embedding timeout for recall path.
   // Falls back to global embedding.timeoutMs when recallTimeoutMs is not configured.
   const recallEmbeddingTimeoutMs = cfg.embedding?.recallTimeoutMs ?? cfg.embedding?.timeoutMs;
-  const embeddingCallOpts: EmbeddingCallOptions = { timeoutMs: recallEmbeddingTimeoutMs };
+  const embeddingCallOpts: EmbeddingCallOptions = {
+    timeoutMs: recallEmbeddingTimeoutMs,
+    ...(abortSignal ? { abortSignal } : {}),
+  };
 
   try {
     if (effectiveStrategy === "keyword") {

--- a/src/core/profile/profile-sync.ts
+++ b/src/core/profile/profile-sync.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { IMemoryStore, ProfileRecord, ProfileSyncRecord } from "../store/types.js";
@@ -152,18 +152,41 @@ export async function pullProfilesToLocal(
     }
 
     const localBlocksDir = path.join(dataDir, "scene_blocks");
-    await fs.rm(localBlocksDir, { recursive: true, force: true });
     await fs.mkdir(path.dirname(localBlocksDir), { recursive: true });
+
+    // Swap scene_blocks via a backup dir so the original is preserved if the
+    // rename fails (disk full / permissions / EXDEV). Previously we deleted
+    // localBlocksDir first and then renamed — a non-race rename failure left
+    // local scene blocks gone until the next L2 extraction regenerated them.
+    const backupDir = `${localBlocksDir}.old-${randomBytes(4).toString("hex")}`;
+    let movedAside = false;
     try {
-      await fs.rename(tempBlocksDir, localBlocksDir);
-    } catch (err) {
-      if (isRenameRaceError(err)) {
-        // Another concurrent pull already wrote scene_blocks — ours is redundant.
-        // Both pulls fetched the same remote snapshot, so the other result is equivalent.
-        logger.debug?.(`[memory-tdai][profile-sync] scene_blocks rename lost race (${(err as NodeJS.ErrnoException).code}), using existing`);
-        return baseline;
+      try {
+        await fs.rename(localBlocksDir, backupDir);
+        movedAside = true;
+      } catch (err) {
+        // ENOENT just means there was no existing scene_blocks — proceed to
+        // install the new one. Anything else is a real failure.
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
       }
-      throw err;
+      try {
+        await fs.rename(tempBlocksDir, localBlocksDir);
+      } catch (err) {
+        if (isRenameRaceError(err)) {
+          // Another concurrent pull already installed scene_blocks — ours is
+          // redundant. Both pulls fetched the same remote snapshot. Don't
+          // restore our backup (that would clobber the winner's fresh content).
+          logger.debug?.(`[memory-tdai][profile-sync] scene_blocks rename lost race (${(err as NodeJS.ErrnoException).code}), using existing`);
+          return baseline;
+        }
+        // Non-race failure: restore the original so scene_blocks isn't empty.
+        if (movedAside) {
+          await fs.rename(backupDir, localBlocksDir).catch(() => { /* best-effort */ });
+        }
+        throw err;
+      }
+    } finally {
+      if (movedAside) await fs.rm(backupDir, { recursive: true, force: true }).catch(() => { /* best-effort */ });
     }
 
     const tempPersonaPath = path.join(tempDir, "persona.md");

--- a/src/core/store/embedding.ts
+++ b/src/core/store/embedding.ts
@@ -66,6 +66,13 @@ export interface EmbeddingProviderInfo {
 export interface EmbeddingCallOptions {
   /** Override the default timeout for this call (milliseconds). */
   timeoutMs?: number;
+  /**
+   * External signal to abort the in-flight embedding request.
+   * When set, the embedding call will be aborted if this signal fires
+   * (in addition to the built-in timeout). Used by auto-recall to cancel
+   * embedding work when the recall timeout expires.
+   */
+  abortSignal?: AbortSignal;
 }
 
 export interface EmbeddingService {
@@ -443,19 +450,35 @@ function truncateEmbeddingInputs(
  * services own body construction and response shape — this helper handles
  * fetch, abort-on-timeout, exponential backoff, and the `EmbeddingApiError`
  * non-retry rule for 4xx responses (except 429).
+ *
+ * When `callerSignal` is provided, the request is also aborted if the
+ * caller's signal fires (on top of the built-in timeout). This lets
+ * auto-recall cancel in-flight embedding work when the recall deadline
+ * expires, freeing the embedding API slot and HTTP connection.
  */
 async function postEmbeddingRequest(params: {
   fetchUrl: string;
   headers: Record<string, string>;
   body: Record<string, unknown>;
   timeoutMs: number;
+  callerSignal?: AbortSignal;
 }): Promise<unknown> {
-  const { fetchUrl, headers, body, timeoutMs } = params;
+  const { fetchUrl, headers, body, timeoutMs, callerSignal } = params;
   let lastError: Error | undefined;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // If the caller already aborted (e.g. recall deadline passed during a
+    // previous retry), don't waste attempts — throw immediately.
+    if (callerSignal?.aborted) {
+      throw new DOMException("Embedding request aborted by caller", "AbortError");
+    }
     try {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+      // Combine the caller's signal with our internal timeout: if the
+      // caller aborts (e.g. recall deadline), cancel this request. The
+      // internal timeout signal is passed to fetch() directly below.
+      const onCallerAbort = () => controller.abort();
+      callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
       try {
         const resp = await fetch(fetchUrl, {
           method: "POST",
@@ -479,6 +502,7 @@ async function postEmbeddingRequest(params: {
         return await resp.json();
       } finally {
         clearTimeout(timeoutId);
+        callerSignal?.removeEventListener("abort", onCallerAbort);
       }
     } catch (err) {
       // Non-retryable errors (4xx client errors) — rethrow immediately
@@ -569,14 +593,18 @@ export class OpenAIEmbeddingService implements EmbeddingService {
     if (processedTexts.length > MAX_BATCH_SIZE) {
       const results: Float32Array[] = [];
       for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
+        // Check for external abort between sub-batches to avoid wasted API calls
+        if (options?.abortSignal?.aborted) {
+          throw new DOMException("Embedding request aborted by caller", "AbortError");
+        }
         const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
-        const chunkResults = await this._callApi(chunk, options?.timeoutMs);
+        const chunkResults = await this._callApi(chunk, options?.timeoutMs, options?.abortSignal);
         results.push(...chunkResults);
       }
       return results;
     }
 
-    return this._callApi(processedTexts, options?.timeoutMs);
+    return this._callApi(processedTexts, options?.timeoutMs, options?.abortSignal);
   }
 
   /**
@@ -591,7 +619,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
     return text.slice(0, this.maxInputChars);
   }
 
-  private async _callApi(texts: string[], timeoutOverride?: number): Promise<Float32Array[]> {
+  private async _callApi(texts: string[], timeoutOverride?: number, abortSignal?: AbortSignal): Promise<Float32Array[]> {
     const body: Record<string, unknown> = {
       input: texts,
       model: this.model,
@@ -619,6 +647,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
       headers,
       body,
       timeoutMs: timeoutOverride ?? this.timeoutMs,
+      callerSignal: abortSignal,
     })) as OpenAIEmbeddingResponse;
 
     if (!json.data || !Array.isArray(json.data)) {
@@ -721,17 +750,20 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
     if (processedTexts.length > MAX_BATCH_SIZE) {
       const results: Float32Array[] = [];
       for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
+        if (options?.abortSignal?.aborted) {
+          throw new DOMException("Embedding request aborted by caller", "AbortError");
+        }
         const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
-        const chunkResults = await this._callApi(chunk, options?.timeoutMs);
+        const chunkResults = await this._callApi(chunk, options?.timeoutMs, options?.abortSignal);
         results.push(...chunkResults);
       }
       return results;
     }
 
-    return this._callApi(processedTexts, options?.timeoutMs);
+    return this._callApi(processedTexts, options?.timeoutMs, options?.abortSignal);
   }
 
-  private async _callApi(texts: string[], timeoutOverride?: number): Promise<Float32Array[]> {
+  private async _callApi(texts: string[], timeoutOverride?: number, abortSignal?: AbortSignal): Promise<Float32Array[]> {
     // ZeroEntropy rejects requests without `input_type`. We default to
     // "query" because the recall hot path is the only caller of embed()
     // that returns a Float32Array; capture-side batches eventually feed
@@ -762,6 +794,7 @@ export class ZeroEntropyEmbeddingService implements EmbeddingService {
       headers,
       body,
       timeoutMs: timeoutOverride ?? this.timeoutMs,
+      callerSignal: abortSignal,
     })) as ZeroEntropyEmbeddingResponse;
 
     if (!json.results || !Array.isArray(json.results)) {


### PR DESCRIPTION
# fix(offload): Tracing & Token Hardening

拆分自 #391，per [YOMXXX review](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/391#issuecomment-4923202779)。

## 修复范围

聚焦 `src/offload/` 层：token estimate、local LLM、Opik tracing。不涉及 store、runtime、gateway 层。

## 具体修复

### `src/offload/fast-token-estimate.ts` — Astral-平面 Token 修正

| 问题 | 修复 |
|:---|:---|
| astral-plane 字符（emoji / CJK extension B，U+10000+）编码为 surrogate pair，原实现把 high surrogate 和 low surrogate 各计为一个 token | high surrogate 检测后跳过低代理（`i += 2`），修正 ~2× token 高估 |

### `src/offload/local-llm/index.ts` — L1.5 Fallback 修正

| 问题 | 修复 |
|:---|:---|
| 解析失败返回 `{taskCompleted: false, ...}` — normalizeJudgment 把 `false` 当有效判断，永远不触发 "LLM 不可用" 重试 | 改为 `{taskCompleted: null, ...}`，`== null` 检查触发重试路径 |

### `src/offload/opik-tracer.ts` — ESM 兼容 + Trace 截断

| 问题 | 修复 |
|:---|:---|
| ESM 下 `require("opik")` 为 `undefined`，tracer 永久静默关闭 | 改为 `createRequire(import.meta.url)` |
| 未脱敏 tool 输出（文件内容、环境变量）完整写入 trace，泄露到 Opik backend | 统一截断到 2000 字符 |

## 验证

- 3 files, +41/-15
- 无 API 变更，无新增依赖
- 与 #39 / #232 / #242 / #287 / #288 / #289 / #347 均不重叠