### PR TITLE
fix(store): sanitize FTS5 search input

### DIFF
--- a/src/core/store/sqlite-fts-query.test.ts
+++ b/src/core/store/sqlite-fts-query.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+  sanitizeFts5Input,
+} from "./sqlite.js";
+
+afterEach(() => {
+  _resetJiebaForTest();
+});
+
+describe("sanitizeFts5Input", () => {
+  it.each(["AND", "OR", "NOT", "NEAR", "and", "or", "not", "near"])(
+    "removes the standalone %s operator case-insensitively",
+    (operator) => {
+      expect(sanitizeFts5Input(`alpha ${operator} beta`)).toBe("alpha   beta");
+    },
+  );
+
+  it("does not remove operator text embedded in normal keywords", () => {
+    expect(sanitizeFts5Input("android origin notable nearby"))
+      .toBe("android origin notable nearby");
+  });
+
+  it.each(["\"", "'", "(", ")", "*", ":", "^", "{", "}", "+", "-"])(
+    "neutralizes the %s structural character without joining adjacent tokens",
+    (character) => {
+      expect(sanitizeFts5Input(`alpha${character}beta`)).toBe("alpha beta");
+    },
+  );
+
+  it("preserves ordinary Latin, CJK, numeric, underscore, and whitespace input", () => {
+    expect(sanitizeFts5Input("TypeScript API_2 用户偏好 2026\n旅行"))
+      .toBe("TypeScript API_2 用户偏好 2026\n旅行");
+  });
+});
+
+describe("buildFtsQuery FTS5 sanitization", () => {
+  it("neutralizes a combined injection payload in the regex fallback", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('\"alpha\" OR NEAR(beta gamma) NOT title:admin*'))
+      .toBe('\"alpha\" OR \"beta\" OR \"gamma\" OR \"title\" OR \"admin\"');
+  });
+
+  it("sanitizes input before passing it to jieba", () => {
+    const cutForSearch = vi.fn(() => ["alpha", "beta"]);
+    _setJiebaForTest({ cutForSearch });
+
+    expect(buildFtsQuery("alpha OR NEAR(beta)"))
+      .toBe('\"alpha\" OR \"beta\"');
+    expect(cutForSearch).toHaveBeenCalledWith("alpha     beta ", true);
+  });
+
+  it("returns null when input contains only FTS5 syntax", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('AND OR NOT NEAR \"\'()*:^{}+-')).toBeNull();
+  });
+
+  it("keeps normal keyword-search behavior", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("TypeScript API_2 用户偏好 2026"))
+      .toBe('\"TypeScript\" OR \"API_2\" OR \"用户偏好\" OR \"2026\"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,19 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+// FTS5 query syntax must be removed before tokenization so neither jieba nor
+// the regex fallback can turn user-controlled syntax into a MATCH expression.
+const FTS5_BOOLEAN_OPERATORS = /\b(?:AND|OR|NOT|NEAR)\b/gi;
+const FTS5_SPECIAL_CHARACTERS = /["'()*:^{}+\-]/g;
+
+/**
+ * Remove FTS5 operators and structural characters from user-provided text.
+ * Replacing them with spaces preserves token boundaries and normal keywords.
+ */
+export function sanitizeFts5Input(raw: string): string {
+  return raw.replace(FTS5_BOOLEAN_OPERATORS, " ").replace(FTS5_SPECIAL_CHARACTERS, " ");
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -197,13 +210,14 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const sanitized = sanitizeFts5Input(raw);
 
   let tokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(sanitized, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +232,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      sanitized
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];


### PR DESCRIPTION
## Description | 描述

Sanitize user-controlled SQLite FTS5 input before tokenization.

- Add `sanitizeFts5Input()` to remove FTS5 boolean operators and structural characters.
- Apply the same sanitization to both jieba and Unicode-regex fallback paths.
- Replace syntax with whitespace to preserve token boundaries and normal keyword recall.
- Add regression tests covering operators, structural characters, combined payloads, edge cases, and ordinary CJK/Latin searches.

## Related Issue | 关联 Issue

Closes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Test results:

- `npm.cmd exec vitest run src/core/store/sqlite-fts-query.test.ts`: 25 passed
- `npm.cmd test`: 92 passed
- `npm.cmd run build:plugin`: passed

## Additional Notes | 其他说明

Existing token quoting already mitigates many practical injection paths. This change adds an explicit defense-in-depth boundary before both tokenization implementations and guards it with security regression tests.