### PR TITLE
feat(adapter): 新增 Claude Code 记忆适配

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@
 __tests__/
 
 # 开发文档与辅助
-docs/
 benchmark-runs/
 workspace/
 
@@ -19,4 +18,6 @@ workspace/
 
 # 运行时产物
 node_modules/
+**/__pycache__/
+*.py[cod]
 *.tgz

--- a/README.md
+++ b/README.md
@@ -504,6 +504,10 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/coding-agent-adapter-quickstart.md`](./docs/coding-agent-adapter-quickstart.md) | Generic Gateway client and coding-agent lifecycle mapping |
+| [`docs/claude-code-adapter-setup.md`](./docs/claude-code-adapter-setup.md) | Install and configure the Claude Code hook adapter |
+| [`docs/hermes-adapter-setup.md`](./docs/hermes-adapter-setup.md) | Hermes Provider and Gateway setup |
+| [`docs/platform-adapter-comparison.md`](./docs/platform-adapter-comparison.md) | Cross-platform adapter architecture and trade-offs |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README.md
+++ b/README.md
@@ -504,7 +504,8 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
-| [`docs/coding-agent-adapter-quickstart.md`](./docs/coding-agent-adapter-quickstart.md) | Generic Gateway client and coding-agent lifecycle mapping |
+| [`docs/platform-adapter-architecture.md`](./docs/platform-adapter-architecture.md) | Layered adapter architecture, unified SDK interface, and data-flow diagrams |
+| [`docs/coding-agent-adapter-quickstart.md`](./docs/coding-agent-adapter-quickstart.md) | Onboard a new platform by implementing one interface; generic Gateway client |
 | [`docs/claude-code-adapter-setup.md`](./docs/claude-code-adapter-setup.md) | Install and configure the Claude Code hook adapter |
 | [`docs/hermes-adapter-setup.md`](./docs/hermes-adapter-setup.md) | Hermes Provider and Gateway setup |
 | [`docs/platform-adapter-comparison.md`](./docs/platform-adapter-comparison.md) | Cross-platform adapter architecture and trade-offs |

--- a/README_CN.md
+++ b/README_CN.md
@@ -507,6 +507,10 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/coding-agent-adapter-quickstart.md`](./docs/coding-agent-adapter-quickstart.md) | 通用 Gateway 客户端与 Coding Agent 生命周期映射 |
+| [`docs/claude-code-adapter-setup.md`](./docs/claude-code-adapter-setup.md) | Claude Code Hook 适配器安装与配置 |
+| [`docs/hermes-adapter-setup.md`](./docs/hermes-adapter-setup.md) | Hermes Provider 与 Gateway 配置 |
+| [`docs/platform-adapter-comparison.md`](./docs/platform-adapter-comparison.md) | 跨平台适配架构与差异对比 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -507,7 +507,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
-| [`docs/coding-agent-adapter-quickstart.md`](./docs/coding-agent-adapter-quickstart.md) | 通用 Gateway 客户端与 Coding Agent 生命周期映射 |
+| [`docs/platform-adapter-architecture.md`](./docs/platform-adapter-architecture.md) | 分层适配架构、统一 SDK 接口与数据流图 |
+| [`docs/coding-agent-adapter-quickstart.md`](./docs/coding-agent-adapter-quickstart.md) | 实现一个接口即可接入新平台;通用 Gateway 客户端 |
 | [`docs/claude-code-adapter-setup.md`](./docs/claude-code-adapter-setup.md) | Claude Code Hook 适配器安装与配置 |
 | [`docs/hermes-adapter-setup.md`](./docs/hermes-adapter-setup.md) | Hermes Provider 与 Gateway 配置 |
 | [`docs/platform-adapter-comparison.md`](./docs/platform-adapter-comparison.md) | 跨平台适配架构与差异对比 |

--- a/docs/claude-code-adapter-setup.md
+++ b/docs/claude-code-adapter-setup.md
@@ -1,0 +1,161 @@
+# Claude Code Adapter Setup
+
+This guide shows how to connect Claude Code to TencentDB Agent Memory through
+Claude Code hooks and the existing TDAI Gateway.
+
+## Data Flow
+
+```mermaid
+flowchart LR
+  Claude["Claude Code"]
+  Hook["Claude Code hook"]
+  Adapter["handleClaudeCodeHook"]
+  Gateway["TDAI Gateway"]
+  Core["TdaiCore"]
+  Store["L0/L1/L2/L3 storage"]
+
+  Claude --> Hook
+  Hook --> Adapter
+  Adapter --> Gateway
+  Gateway --> Core
+  Core --> Store
+```
+
+## Hook Mapping
+
+| Claude Code hook | Adapter action | Gateway endpoint |
+| --- | --- | --- |
+| `UserPromptSubmit` | Recall memory and inject additional prompt context | `POST /recall` |
+| `Stop` | Pair the transcript's latest user prompt with `last_assistant_message` | `POST /capture` |
+| `SessionStart` | Health-check the Gateway | `GET /health` |
+| `SessionEnd` | Flush pending work without capturing the last turn again | `POST /session/end` |
+
+## Gateway Configuration
+
+Start the Gateway before launching Claude Code:
+
+```bash
+cd /path/to/TencentDB-Agent-Memory
+TDAI_GATEWAY_HOST="127.0.0.1" \
+TDAI_GATEWAY_PORT="8420" \
+TDAI_LLM_API_KEY="sk-your-api-key" \
+TDAI_LLM_BASE_URL="https://api.deepseek.com/v1" \
+TDAI_LLM_MODEL="deepseek-v4-pro" \
+TDAI_LLM_DISABLE_THINKING="deepseek" \
+npx tsx src/gateway/server.ts
+```
+
+For DeepSeek, use the OpenAI-compatible `/v1` endpoint for the Gateway. Claude
+Code may use DeepSeek's Anthropic-compatible `/anthropic` endpoint, but the
+Gateway's standalone runner calls OpenAI-compatible chat completions.
+
+## Install the Hook Command
+
+Install the package globally so Claude Code can resolve the hook command:
+
+```bash
+npm install --global @tencentdb-agent-memory/memory-tencentdb
+```
+
+For a source checkout, build the standalone entry and use its absolute path in
+the settings below:
+
+```bash
+npm install
+npm run build:plugin
+node /absolute/path/to/TencentDB-Agent-Memory/dist/memory-tencentdb-claude-hook.mjs
+```
+
+## Claude Code Settings
+
+Add hooks to `~/.claude/settings.json` or a project-level Claude Code settings
+file. Hook commands inherit the environment of the `claude` process, so export
+`TDAI_GATEWAY_URL` and, when enabled, `TDAI_GATEWAY_API_KEY` before starting
+Claude Code.
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memory-tencentdb-claude-hook",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memory-tencentdb-claude-hook",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memory-tencentdb-claude-hook",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memory-tencentdb-claude-hook",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Claude Code normally gives `SessionEnd` hooks only a short shutdown budget.
+The explicit timeout above gives the Gateway's session flush enough time while
+the adapter's HTTP timeout remains bounded by `TDAI_GATEWAY_TIMEOUT_MS`
+(default: 10000).
+
+The adapter keys memory by Claude's stable `session_id`, so changing directories
+inside one Claude session does not split recall, capture, and flush across
+different Gateway sessions.
+
+## Smoke Test
+
+Simulate a `UserPromptSubmit` hook:
+
+```bash
+printf '%s\n' '{"hook_event_name":"UserPromptSubmit","session_id":"demo","cwd":"'$PWD'","prompt":"What should I remember?"}' \
+  | TDAI_GATEWAY_URL=http://127.0.0.1:8420 memory-tencentdb-claude-hook
+```
+
+The hook prints JSON with `hookSpecificOutput.additionalContext` when recall
+returns non-empty context. Empty recall exits successfully with no output.
+
+At `Stop`, Claude Code supplies the final response in
+`last_assistant_message`. The adapter uses that field because the JSONL
+transcript is written asynchronously, and reads the transcript only to find the
+corresponding human prompt. Tool-result rows and meta/sidechain rows are not
+captured as user messages. Transcript timestamps are forwarded to the Gateway,
+allowing its atomic checkpoint to ignore exact hook retries. Gateway errors are
+written to stderr for diagnostics but always return exit code 0 so memory cannot
+block Claude Code.
+
+The hook provides automatic recall and capture only. It removes the core's
+`memory-tools-guide` block because this adapter does not register
+`tdai_memory_search` or `tdai_conversation_search` as Claude Code tools. Hosts
+that expose those searches separately can use `CodingAgentGatewayClient`'s
+`searchMemories()` and `searchConversations()` methods.

--- a/docs/coding-agent-adapter-quickstart.md
+++ b/docs/coding-agent-adapter-quickstart.md
@@ -1,0 +1,81 @@
+# Coding Agent Adapter Quickstart
+
+This guide shows the smallest useful adapter shape for coding-agent hosts such
+as Codex, Claude Code, Cursor, Continue, or other tools that can call a local
+HTTP sidecar.
+
+The adapter talks to the existing TDAI Gateway. It does not embed `TdaiCore`
+inside the host process, so each platform only needs to map its own session and
+message events into Gateway requests.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Host["Coding-agent host"] --> Adapter["CodingAgentGatewayClient"]
+  Adapter --> Gateway["TDAI Gateway HTTP API"]
+  Gateway --> Core["TdaiCore"]
+  Core --> Store["L0/L1/L2/L3 storage"]
+```
+
+## Minimal usage
+
+```ts
+import { CodingAgentGatewayClient } from "@tencentdb-agent-memory/memory-tencentdb";
+
+const memory = new CodingAgentGatewayClient({
+  baseUrl: process.env.TDAI_GATEWAY_URL ?? "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+const sessionKey = `${workspacePath}:${threadId}`;
+
+const recall = await memory.recall({
+  query: userPrompt,
+  sessionKey,
+  userId,
+});
+
+const promptWithMemory = recall.context
+  ? `${recall.context}\n\n${userPrompt}`
+  : userPrompt;
+
+await memory.capture({
+  userContent: userPrompt,
+  assistantContent: assistantReply,
+  sessionKey,
+  sessionId: threadId,
+  userId,
+});
+```
+
+## Event mapping
+
+| Host event | Gateway call | Required fields |
+| --- | --- | --- |
+| Before prompt/model call | `recall()` | `query`, `sessionKey` |
+| After assistant response | `capture()` | `userContent`, `assistantContent`, `sessionKey` |
+| User searches memory | `searchMemories()` | `query` |
+| User searches raw turns | `searchConversations()` | `query` |
+| Thread/workspace closes | `endSession()` | `sessionKey` |
+
+## Session key guidance
+
+Use a stable key that isolates unrelated work while still allowing continuity
+inside one project. Good candidates:
+
+- `workspace:<absolute path>`
+- `repo:<remote url>#<branch>`
+- `thread:<host thread id>`
+- `workspace:<path>:thread:<id>` when the host supports multiple concurrent
+  conversations per workspace
+
+## Validation checklist
+
+- `health()` returns `status: "ok"` or `status: "degraded"`.
+- A `capture()` call records at least one L0 turn.
+- A later `recall()` call with the same `sessionKey` returns non-empty context
+  after the pipeline has processed the turn.
+- If `TDAI_GATEWAY_API_KEY` is enabled on the Gateway, the adapter passes the
+  same key as a Bearer token.
+

--- a/docs/coding-agent-adapter-quickstart.md
+++ b/docs/coding-agent-adapter-quickstart.md
@@ -36,8 +36,13 @@ const recall = await memory.recall({
   userId,
 });
 
-const promptWithMemory = recall.context
-  ? `${recall.context}\n\n${userPrompt}`
+const recalledContext = [
+  recall.prepend_context,
+  recall.append_system_context ?? recall.context,
+].filter(Boolean).join("\n\n");
+
+const promptWithMemory = recalledContext
+  ? `${recalledContext}\n\n${userPrompt}`
   : userPrompt;
 
 await memory.capture({
@@ -46,6 +51,9 @@ await memory.capture({
   sessionKey,
   sessionId: threadId,
   userId,
+  // Preserve host timestamps when available so retries are checkpoint-idempotent.
+  messages: hostMessages,
+  startedAt: turnStartedAt,
 });
 ```
 
@@ -74,8 +82,8 @@ inside one project. Good candidates:
 
 - `health()` returns `status: "ok"` or `status: "degraded"`.
 - A `capture()` call records at least one L0 turn.
-- A later `recall()` call with the same `sessionKey` returns non-empty context
-  after the pipeline has processed the turn.
+- A later `recall()` call returns dynamic L1 content in `prepend_context` and
+  stable persona/scene content in `append_system_context` after the pipeline
+  has processed the turn. `context` remains the legacy stable-context field.
 - If `TDAI_GATEWAY_API_KEY` is enabled on the Gateway, the adapter passes the
   same key as a Bearer token.
-

--- a/docs/coding-agent-adapter-quickstart.md
+++ b/docs/coding-agent-adapter-quickstart.md
@@ -8,6 +8,61 @@ The adapter talks to the existing TDAI Gateway. It does not embed `TdaiCore`
 inside the host process, so each platform only needs to map its own session and
 message events into Gateway requests.
 
+For the full layered architecture and annotated recall/capture data-flow
+diagrams, see [`platform-adapter-architecture.md`](./platform-adapter-architecture.md).
+
+## Onboard a new platform: implement one interface
+
+The unified SDK lets a new coding-agent platform integrate by implementing a
+single `CodingAgentPlatformAdapter` interface. Transport, timeouts, Bearer auth,
+recall-context flattening, and fail-open handling are all provided by
+`runCodingAgentAdapter` — you never re-write them per platform.
+
+```ts
+import {
+  runCodingAgentAdapter,
+  type CodingAgentPlatformAdapter,
+} from "@tencentdb-agent-memory/memory-tencentdb";
+
+// 1. Map your platform's native payload → neutral lifecycle event,
+//    and recalled memory → your platform's native response shape.
+const myAdapter: CodingAgentPlatformAdapter<MyHostPayload> = {
+  platform: "my-agent",
+  toEvent(input) {
+    switch (input.stage) {
+      case "before-prompt":
+        return { kind: "recall", recall: { query: input.prompt, sessionKey: input.threadId } };
+      case "after-reply":
+        return {
+          kind: "capture",
+          turn: { userContent: input.prompt, assistantContent: input.reply, sessionKey: input.threadId },
+        };
+      case "close":
+        return { kind: "session-end", sessionKey: input.threadId };
+      default:
+        return { kind: "noop" };
+    }
+  },
+  renderRecall(context) {
+    // Return whatever shape your host expects to inject context.
+    return { systemPrompt: context };
+  },
+};
+
+// 2. Drive it — the SDK handles the Gateway call, timeout, auth, and fail-open.
+const result = await runCodingAgentAdapter(myAdapter, hostPayload, {
+  gateway: { baseUrl: process.env.TDAI_GATEWAY_URL, apiKey: process.env.TDAI_GATEWAY_API_KEY },
+});
+```
+
+The Claude Code adapter (`src/adapters/claude-code/`) is the reference
+implementation of exactly this interface.
+
+## Low-level client (optional)
+
+If you need direct control instead of the lifecycle runner, the same transport
+is available as `CodingAgentGatewayClient`.
+
 ## Architecture
 
 ```mermaid

--- a/docs/hermes-adapter-setup.md
+++ b/docs/hermes-adapter-setup.md
@@ -1,0 +1,144 @@
+# Hermes Adapter Setup
+
+This guide is the Hermes-specific path for the platform-adapter work in issue
+#235. Hermes uses the existing Python `memory_tencentdb` provider and the Node
+TDAI Gateway sidecar.
+
+## Data Flow
+
+```mermaid
+flowchart LR
+  Hermes["Hermes Agent"]
+  Provider["memory_tencentdb provider"]
+  Supervisor["GatewaySupervisor"]
+  Client["MemoryTencentdbSdkClient"]
+  Gateway["TDAI Gateway"]
+  Core["TdaiCore"]
+  Store["L0/L1/L2/L3 storage"]
+
+  Hermes --> Provider
+  Provider --> Supervisor
+  Provider --> Client
+  Supervisor --> Gateway
+  Client --> Gateway
+  Gateway --> Core
+  Core --> Store
+```
+
+## Enable the Provider
+
+The provider directory must be named `memory_tencentdb`.
+
+```bash
+rm -rf ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+ln -sf ~/.memory-tencentdb/tdai-memory-openclaw-plugin/hermes-plugin/memory/memory_tencentdb \
+       ~/.hermes/hermes-agent/plugins/memory/memory_tencentdb
+```
+
+Then enable it in `~/.hermes/config.yaml`:
+
+```yaml
+memory:
+  provider: memory_tencentdb
+```
+
+## Configure the Gateway
+
+For a developer checkout, the explicit command is the most predictable option:
+
+```bash
+export MEMORY_TENCENTDB_GATEWAY_CMD="sh -c 'cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin && exec npx tsx src/gateway/server.ts'"
+export MEMORY_TENCENTDB_GATEWAY_HOST="127.0.0.1"
+export MEMORY_TENCENTDB_GATEWAY_PORT="8420"
+```
+
+The provider also supports zero-config auto-discovery when the checkout lives
+under one of the documented default locations.
+
+## Configure LLM Credentials
+
+Hermes-facing config can use the provider names:
+
+```bash
+export MEMORY_TENCENTDB_LLM_API_KEY="sk-your-api-key"
+export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"
+export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"
+```
+
+When the Hermes provider starts the Gateway, `GatewaySupervisor` bridges these
+variables into the Gateway names:
+
+```bash
+TDAI_LLM_API_KEY
+TDAI_LLM_BASE_URL
+TDAI_LLM_MODEL
+```
+
+If both names are set, the explicit `TDAI_LLM_*` value wins.
+
+For a Gateway started by the provider, the supervisor also mirrors its resolved
+host and port into `TDAI_GATEWAY_HOST` and `TDAI_GATEWAY_PORT`. The Node Gateway
+therefore listens on the same endpoint that the Hermes client probes, including
+when `MEMORY_TENCENTDB_GATEWAY_HOST` or
+`MEMORY_TENCENTDB_GATEWAY_PORT` uses a non-default value.
+
+### DeepSeek Example
+
+Claude Code may be configured with DeepSeek's Anthropic-compatible endpoint:
+
+```bash
+ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+ANTHROPIC_MODEL="deepseek-v4-pro[1M]"
+```
+
+The TDAI Gateway uses OpenAI-compatible chat completions, so configure Hermes
+memory with the DeepSeek `/v1` endpoint and a Gateway-supported model name:
+
+```bash
+export MEMORY_TENCENTDB_LLM_API_KEY="$ANTHROPIC_AUTH_TOKEN"
+export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.deepseek.com/v1"
+export MEMORY_TENCENTDB_LLM_MODEL="deepseek-v4-pro"
+export TDAI_LLM_DISABLE_THINKING="deepseek"
+```
+
+When using `TDAI_LLM_*` directly, use the same values:
+
+```bash
+export TDAI_LLM_API_KEY="$ANTHROPIC_AUTH_TOKEN"
+export TDAI_LLM_BASE_URL="https://api.deepseek.com/v1"
+export TDAI_LLM_MODEL="deepseek-v4-pro"
+export TDAI_LLM_DISABLE_THINKING="deepseek"
+```
+
+## Lifecycle Mapping
+
+| Hermes call | Gateway endpoint | Result |
+| --- | --- | --- |
+| `prefetch(query)` | `POST /recall` | Combines dynamic L1 and stable persona/scene context for prompt injection |
+| `sync_turn(user, assistant)` | `POST /capture` | Records the turn and notifies the pipeline |
+| `handle_tool_call(memory_tencentdb_memory_search)` | `POST /search/memories` | Searches L1 structured memories |
+| `handle_tool_call(memory_tencentdb_conversation_search)` | `POST /search/conversations` | Searches L0 conversation history |
+| `shutdown()` / session end | `POST /session/end` | Flushes pending session work |
+
+## Smoke Test
+
+Start the Gateway manually:
+
+```bash
+cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin
+TDAI_LLM_API_KEY="sk-your-api-key" \
+TDAI_LLM_BASE_URL="https://api.deepseek.com/v1" \
+TDAI_LLM_MODEL="deepseek-v4-pro" \
+TDAI_LLM_DISABLE_THINKING="deepseek" \
+npx tsx src/gateway/server.ts
+```
+
+Verify health:
+
+```bash
+curl http://127.0.0.1:8420/health
+```
+
+Then launch Hermes with the provider enabled. A successful first conversation
+should call `prefetch()` before the model turn and `sync_turn()` after the
+assistant response.

--- a/docs/platform-adapter-architecture.md
+++ b/docs/platform-adapter-architecture.md
@@ -1,0 +1,129 @@
+# Platform Adapter Architecture
+
+This document answers the **基础 (foundational)** acceptance goal of issue #235:
+draw the architecture that connects the core memory engine (`TdaiCore`) to each
+platform adapter, and annotate the data flow. It also describes the **拓展
+(challenge)** goal: a unified adapter SDK where a new platform is integrated by
+implementing a single interface.
+
+## 1. Layered architecture
+
+```mermaid
+flowchart TB
+  subgraph Hosts["Agent platforms (hosts)"]
+    OC["OpenClaw plugin"]
+    HM["Hermes provider (Python)"]
+    CC["Claude Code hooks"]
+    NX["Any new coding agent<br/>(Codex / Cursor / Continue ...)"]
+  end
+
+  subgraph SDK["Unified coding-agent adapter SDK<br/>(src/adapters/coding-agent)"]
+    IFACE["CodingAgentPlatformAdapter&lt;TInput&gt;<br/>toEvent() + renderRecall()"]
+    RUN["runCodingAgentAdapter()<br/>lifecycle · timeouts · auth · fail-open"]
+    GC["CodingAgentGatewayClient<br/>HTTP transport"]
+  end
+
+  GW["TDAI Gateway (HTTP API)<br/>/recall /capture /search /session/end /health"]
+  CORE["TdaiCore<br/>recall · capture · search"]
+  STORE["L0 → L1 → L2 → L3 storage<br/>(local, no external API)"]
+
+  OC -->|in-process| CORE
+  HM -->|HTTP| GW
+  CC -->|implements| IFACE
+  NX -.->|implements| IFACE
+  IFACE --> RUN --> GC -->|HTTP| GW
+  GW --> CORE --> STORE
+```
+
+- **OpenClaw** embeds `TdaiCore` in-process (no HTTP hop).
+- **Hermes** and every **coding-agent** host reach the core through the
+  Gateway sidecar over HTTP, so the core never has to know the host.
+- **Claude Code** is the reference implementation of the SDK interface. A new
+  platform only implements the same interface (dotted arrow) and reuses the
+  entire SDK runner + transport unchanged.
+
+## 2. Unified adapter interface (拓展 goal)
+
+A new platform is integrated by implementing one interface — no new transport,
+timeout, auth, or error-handling code:
+
+```ts
+export interface CodingAgentPlatformAdapter<TInput> {
+  readonly platform: string;
+  // Map a platform-native payload into a neutral lifecycle event.
+  toEvent(input: TInput): CodingAgentEvent | Promise<CodingAgentEvent>;
+  // Render recalled memory back into the platform's native response shape.
+  renderRecall(context: string, input: TInput): unknown;
+}
+```
+
+`runCodingAgentAdapter(adapter, input, options)` then drives the lifecycle:
+it resolves the event, calls the Gateway, flattens recall context, renders the
+platform response, and **always fails open** (exit code 0, error to stderr) so
+memory being unavailable never blocks the host agent.
+
+```mermaid
+flowchart LR
+  IN["platform payload"] --> TE["adapter.toEvent()"]
+  TE --> EV{"event.kind"}
+  EV -->|recall| R["client.recall()"] --> CB["combineRecallContext()"] --> RR["adapter.renderRecall()"] --> OUT["native response"]
+  EV -->|capture| C["client.capture()"]
+  EV -->|session-end| S["client.endSession()"]
+  EV -->|health| H["client.health()"]
+  EV -->|noop| N["exit 0"]
+```
+
+## 3. Recall data flow (before the model call)
+
+```mermaid
+sequenceDiagram
+  participant Host as Host (e.g. Claude Code)
+  participant SDK as runCodingAgentAdapter
+  participant GW as TDAI Gateway
+  participant Core as TdaiCore
+
+  Host->>SDK: toEvent(payload) → {kind: recall, query, sessionKey}
+  SDK->>GW: POST /recall {query, session_key}
+  GW->>Core: recall(query, sessionKey)
+  Core-->>GW: {prepend_context (L1), append_system_context (persona/scene)}
+  GW-->>SDK: RecallResponse
+  SDK->>SDK: combineRecallContext() → strip tool-guide, dedup
+  SDK-->>Host: renderRecall(context) → native injection (additionalContext)
+```
+
+## 4. Capture + session flush data flow (after the turn)
+
+```mermaid
+sequenceDiagram
+  participant Host as Host
+  participant SDK as runCodingAgentAdapter
+  participant GW as TDAI Gateway
+  participant Core as TdaiCore
+
+  Host->>SDK: toEvent(payload) → {kind: capture, turn}
+  SDK->>GW: POST /capture {user_content, assistant_content, session_key, started_at}
+  GW->>Core: capture(turn) → L0 record + schedule L1/L2/L3
+  Core-->>GW: {l0_recorded}
+  Note over Host,SDK: on session close
+  Host->>SDK: toEvent(payload) → {kind: session-end, sessionKey}
+  SDK->>GW: POST /session/end {session_key}
+  GW->>Core: flush pending pipeline for session
+```
+
+## 5. Capability boundary (`TdaiCore`)
+
+Every adapter maps onto the same core capabilities, nothing more:
+
+| Capability | Gateway route | Purpose |
+| --- | --- | --- |
+| recall | `POST /recall` | Fetch dynamic L1 + stable persona/scene context for a turn |
+| capture | `POST /capture` | Record an L0 turn and schedule L1→L3 extraction |
+| search memories | `POST /search/memories` | Query distilled L1+ memories |
+| search conversations | `POST /search/conversations` | Query raw L0 turns |
+| session flush | `POST /session/end` | Flush the pipeline for a session |
+| health | `GET /health` | Liveness / store readiness |
+
+See [`platform-adapter-comparison.md`](./platform-adapter-comparison.md) for how
+OpenClaw, Hermes, Claude Code, and Dify differ across these routes, and
+[`coding-agent-adapter-quickstart.md`](./coding-agent-adapter-quickstart.md) for
+the minimal code to onboard a new platform.

--- a/docs/platform-adapter-comparison.md
+++ b/docs/platform-adapter-comparison.md
@@ -1,0 +1,65 @@
+# Platform Adapter Comparison
+
+This document compares the platform adapter shapes relevant to issue #235.
+All paths reuse the same `TdaiCore` capability boundary: recall, capture,
+memory search, conversation search, and session flush.
+
+## Summary
+
+| Platform | Adapter shape | Runtime boundary | Recall timing | Capture timing | Status |
+| --- | --- | --- | --- | --- | --- |
+| OpenClaw | In-process plugin | `index.ts` calls `TdaiCore` directly | `before_prompt_build` | `agent_end` / committed turn | Existing |
+| Hermes | Python provider + Node Gateway | HTTP sidecar | `prefetch(query)` -> `/recall` | `sync_turn()` -> `/capture` | Existing, documented |
+| Claude Code | Hook adapter + Node Gateway | Hook command over stdio, then HTTP | `UserPromptSubmit` -> `/recall` | `Stop` -> `/capture`; `SessionEnd` -> `/session/end` | Added as lightweight adapter |
+| Dify | Tool plugin + Node Gateway | Dify tool runtime, then HTTP | `tdai_recall` tool | `tdai_capture` tool | Covered by upstream PR #394 |
+
+## Core Data Flow
+
+```mermaid
+flowchart LR
+  Core["TdaiCore"]
+  Store["L0/L1/L2/L3 storage"]
+  OpenClaw["OpenClaw plugin"]
+  Gateway["TDAI Gateway"]
+  Hermes["Hermes provider"]
+  Claude["Claude Code hooks"]
+  Dify["Dify tool plugin"]
+
+  OpenClaw --> Core
+  Hermes --> Gateway
+  Claude --> Gateway
+  Dify --> Gateway
+  Gateway --> Core
+  Core --> Store
+```
+
+## Adapter Differences
+
+| Dimension | OpenClaw | Hermes | Claude Code | Dify |
+| --- | --- | --- | --- | --- |
+| Host integration | Plugin SDK hooks | `MemoryProvider` implementation | Claude Code hook commands | Dify tool plugin |
+| Transport | In-process TypeScript | HTTP Gateway | Hook stdin/stdout + HTTP Gateway | Tool invocation + HTTP Gateway |
+| Session key | OpenClaw session/runtime state | Hermes session id | Stable Claude `session_id` | Workflow/session variables |
+| Prompt injection | Direct `prependContext` mutation | `prefetch()` return string | `hookSpecificOutput.additionalContext` | Tool result consumed by workflow |
+| Turn capture | Direct committed-turn object | Background `sync_turn()` thread | Latest transcript user/assistant turn | Tool call payload |
+| Gateway auth | Not applicable in-process | Optional Bearer token | Optional Bearer token | Optional Bearer token |
+| Best fit | Native OpenClaw users | Hermes users who want memory provider semantics | Claude Code users who can configure hooks | Dify workflows and tool nodes |
+
+## Claude Code Notes
+
+The Claude Code adapter intentionally stays thin:
+
+- `UserPromptSubmit` calls recall and returns dynamic L1 plus stable
+  persona/scene context as `additionalContext`.
+- `Stop` pairs the latest human prompt from the transcript with Claude Code's
+  authoritative `last_assistant_message`, then captures it through the Gateway.
+- `SessionEnd` flushes the session without capturing the final turn twice.
+
+This keeps platform-specific behavior in `src/adapters/claude-code/` while
+reusing the generic `CodingAgentGatewayClient` HTTP wrapper.
+
+## Dify Notes
+
+Dify is a good target platform for this issue, but a full implementation is
+already covered by PR #394. For this branch, Dify is treated as a comparison
+point rather than reimplemented from scratch.

--- a/docs/platform-adapter-comparison.md
+++ b/docs/platform-adapter-comparison.md
@@ -4,6 +4,11 @@ This document compares the platform adapter shapes relevant to issue #235.
 All paths reuse the same `TdaiCore` capability boundary: recall, capture,
 memory search, conversation search, and session flush.
 
+For the layered architecture and annotated data-flow diagrams, see
+[`platform-adapter-architecture.md`](./platform-adapter-architecture.md). The
+coding-agent hosts below (Claude Code, and any new agent) share one
+`CodingAgentPlatformAdapter` interface driven by `runCodingAgentAdapter`.
+
 ## Summary
 
 | Platform | Adapter shape | Runtime boundary | Recall timing | Capture timing | Status |
@@ -55,8 +60,10 @@ The Claude Code adapter intentionally stays thin:
   authoritative `last_assistant_message`, then captures it through the Gateway.
 - `SessionEnd` flushes the session without capturing the final turn twice.
 
-This keeps platform-specific behavior in `src/adapters/claude-code/` while
-reusing the generic `CodingAgentGatewayClient` HTTP wrapper.
+This keeps platform-specific behavior in `src/adapters/claude-code/` — which
+implements the shared `CodingAgentPlatformAdapter` interface — while the generic
+`runCodingAgentAdapter` runner and `CodingAgentGatewayClient` handle transport,
+auth, recall flattening, and fail-open for every coding-agent platform.
 
 ## Dify Notes
 

--- a/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/hermes-plugin/memory/memory_tencentdb/README.md
@@ -148,6 +148,24 @@ export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.openai.com/v1"   # optional
 export MEMORY_TENCENTDB_LLM_MODEL="gpt-4o"                         # optional
 ```
 
+When this provider starts the Gateway subprocess, the supervisor bridges
+these Hermes-facing names to the Gateway-facing `TDAI_LLM_*` names unless
+the operator already set explicit `TDAI_LLM_*` values. This keeps existing
+Hermes config schemas working while matching the Node Gateway's actual config
+reader (`src/gateway/config.ts`). It also sets `TDAI_GATEWAY_HOST` and
+`TDAI_GATEWAY_PORT` from the provider's resolved endpoint so the child Gateway
+and the Hermes client cannot silently use different ports.
+
+For DeepSeek, use the OpenAI-compatible endpoint, not the Anthropic-compatible
+Claude Code endpoint:
+
+```bash
+export MEMORY_TENCENTDB_LLM_API_KEY="$ANTHROPIC_AUTH_TOKEN"
+export MEMORY_TENCENTDB_LLM_BASE_URL="https://api.deepseek.com/v1"
+export MEMORY_TENCENTDB_LLM_MODEL="deepseek-v4-pro"
+export TDAI_LLM_DISABLE_THINKING="deepseek"
+```
+
 ### 3. Start the Gateway
 
 You have three options; pick whichever fits your deployment.
@@ -237,10 +255,12 @@ eliminates a silent no-op.
 | `MEMORY_TENCENTDB_LLM_BASE_URL`   | `https://api.openai.com/v1`  | OpenAI-compatible API base URL      |
 | `MEMORY_TENCENTDB_LLM_MODEL`      | `gpt-4o`                     | Model name                          |
 
-> ⚠️ Only `MEMORY_TENCENTDB_*` env vars are honored by this provider for the
-> Gateway location and LLM credentials. Data-directory resolution is
-> deliberately delegated to the Gateway via `TDAI_DATA_DIR` (see above) so
-> the provider and the Gateway can never disagree about where L0~L3 live.
+> ⚠️ `MEMORY_TENCENTDB_*` env vars are honored by this provider for Gateway
+> location and provider-facing LLM credentials. The spawned Node Gateway reads
+> `TDAI_LLM_*`; the supervisor bridges the LLM aliases for subprocess mode.
+> Data-directory resolution is deliberately delegated to the Gateway via
+> `TDAI_DATA_DIR` (see above) so the provider and the Gateway can never
+> disagree about where L0~L3 live.
 
 ## LLM Tools
 

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -844,7 +844,15 @@ class MemoryTencentdbProvider(MemoryProvider):
                 session_key=effective_session,
                 user_id=self._user_id,
             )
-            context = result.get("context", "")
+            dynamic_context = result.get("prepend_context", "")
+            stable_context = result.get("append_system_context") or result.get("context", "")
+            context_parts = []
+            for value in (dynamic_context, stable_context):
+                if isinstance(value, str):
+                    value = value.strip()
+                    if value and value not in context_parts:
+                        context_parts.append(value)
+            context = "\n\n".join(context_parts)
             self._record_success()
             if context:
                 return f"## memory-tencentdb Memory\n{context}"

--- a/hermes-plugin/memory/memory_tencentdb/supervisor.py
+++ b/hermes-plugin/memory/memory_tencentdb/supervisor.py
@@ -166,8 +166,7 @@ class GatewaySupervisor:
 
         try:
             env = os.environ.copy()
-            env["MEMORY_TENCENTDB_GATEWAY_PORT"] = str(self._port)
-            env["MEMORY_TENCENTDB_GATEWAY_HOST"] = self._host
+            self._bridge_gateway_env(env)
             # Note: we deliberately do NOT inject TDAI_GATEWAY_API_KEY into
             # the child's env from here. Whether the Gateway enforces auth is
             # the operator's call — they configure it on the Gateway side
@@ -217,6 +216,36 @@ class GatewaySupervisor:
 
         # Wait for health check
         return self._wait_for_health()
+
+    def _bridge_gateway_env(self, env: dict) -> None:
+        """Prepare endpoint and LLM variables for the Node Gateway child."""
+        port = str(self._port)
+        env["MEMORY_TENCENTDB_GATEWAY_HOST"] = self._host
+        env["MEMORY_TENCENTDB_GATEWAY_PORT"] = port
+        env["TDAI_GATEWAY_HOST"] = self._host
+        env["TDAI_GATEWAY_PORT"] = port
+        self._bridge_hermes_llm_env(env)
+
+    @staticmethod
+    def _bridge_hermes_llm_env(env: dict) -> None:
+        """Bridge Hermes-facing LLM env names to Gateway-facing names.
+
+        Hermes provider configuration exposes ``MEMORY_TENCENTDB_LLM_*`` keys,
+        while the Node Gateway reads ``TDAI_LLM_*``.  When the supervisor owns
+        the Gateway child process, copy the Hermes names into their Gateway
+        counterparts unless the operator already set an explicit ``TDAI_*``
+        value. This keeps existing Hermes configs runnable without hiding an
+        intentional Gateway-side override.
+        """
+        for hermes_key, gateway_key in (
+            ("MEMORY_TENCENTDB_LLM_API_KEY", "TDAI_LLM_API_KEY"),
+            ("MEMORY_TENCENTDB_LLM_BASE_URL", "TDAI_LLM_BASE_URL"),
+            ("MEMORY_TENCENTDB_LLM_MODEL", "TDAI_LLM_MODEL"),
+        ):
+            hermes_value = (env.get(hermes_key) or "").strip()
+            gateway_value = (env.get(gateway_key) or "").strip()
+            if hermes_value and not gateway_value:
+                env[gateway_key] = hermes_value
 
     def _resolve_log_dir(self) -> str:
         """Pick a directory to store Gateway stdout/stderr logs.

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -223,6 +223,56 @@ def test_reap_dead_process_drops_handle():
     assert sup._process is None
 
 
+def test_supervisor_bridges_hermes_llm_env_to_gateway_env():
+    env = {
+        "MEMORY_TENCENTDB_LLM_API_KEY": " sk-hermes ",
+        "MEMORY_TENCENTDB_LLM_BASE_URL": " https://example.test/v1 ",
+        "MEMORY_TENCENTDB_LLM_MODEL": " hermes-model ",
+    }
+
+    supervisor_module.GatewaySupervisor._bridge_hermes_llm_env(env)
+
+    assert env["TDAI_LLM_API_KEY"] == "sk-hermes"
+    assert env["TDAI_LLM_BASE_URL"] == "https://example.test/v1"
+    assert env["TDAI_LLM_MODEL"] == "hermes-model"
+
+
+def test_supervisor_aligns_child_gateway_endpoint_env():
+    supervisor = supervisor_module.GatewaySupervisor(
+        host="127.0.0.2",
+        port=18420,
+        gateway_cmd="fake-cmd",
+    )
+    env = {
+        "TDAI_GATEWAY_HOST": "stale-host",
+        "TDAI_GATEWAY_PORT": "9999",
+    }
+
+    supervisor._bridge_gateway_env(env)
+
+    assert env["MEMORY_TENCENTDB_GATEWAY_HOST"] == "127.0.0.2"
+    assert env["MEMORY_TENCENTDB_GATEWAY_PORT"] == "18420"
+    assert env["TDAI_GATEWAY_HOST"] == "127.0.0.2"
+    assert env["TDAI_GATEWAY_PORT"] == "18420"
+
+
+def test_supervisor_does_not_clobber_explicit_gateway_llm_env():
+    env = {
+        "MEMORY_TENCENTDB_LLM_API_KEY": "sk-hermes",
+        "MEMORY_TENCENTDB_LLM_BASE_URL": "https://hermes.example/v1",
+        "MEMORY_TENCENTDB_LLM_MODEL": "hermes-model",
+        "TDAI_LLM_API_KEY": "sk-tdai",
+        "TDAI_LLM_BASE_URL": "https://tdai.example/v1",
+        "TDAI_LLM_MODEL": "tdai-model",
+    }
+
+    supervisor_module.GatewaySupervisor._bridge_hermes_llm_env(env)
+
+    assert env["TDAI_LLM_API_KEY"] == "sk-tdai"
+    assert env["TDAI_LLM_BASE_URL"] == "https://tdai.example/v1"
+    assert env["TDAI_LLM_MODEL"] == "tdai-model"
+
+
 def test_reap_dead_process_keeps_alive_handle():
     sup = supervisor_module.GatewaySupervisor(gateway_cmd="")
     alive = _FakePopen(returncode=None)
@@ -355,6 +405,24 @@ def test_prefetch_recovers_when_stuck_false_and_breaker_closed(
     )
     assert provider._gateway_available
     assert fake.ensure_running_calls >= 1
+
+
+def test_prefetch_combines_dynamic_and_stable_gateway_context(
+    provider_with_fake_supervisor,
+):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+    provider._stop_watchdog()
+    fake.client.recall.return_value = {
+        "context": "stable persona",
+        "prepend_context": "dynamic L1",
+        "append_system_context": "stable persona",
+    }
+
+    result = provider.prefetch(query="what did we decide?")
+
+    assert "dynamic L1\n\nstable persona" in result
+    assert result.count("stable persona") == 1
 
 
 def test_prefetch_respects_open_breaker(provider_with_fake_supervisor):

--- a/index.ts
+++ b/index.ts
@@ -53,6 +53,14 @@ export type {
   CodingAgentRecallRequest,
   CodingAgentTurn,
 } from "./src/adapters/coding-agent/index.js";
+export { buildSessionKey, extractLatestTurn, handleClaudeCodeHook } from "./src/adapters/claude-code/index.js";
+export type {
+  ClaudeCodeHookClient,
+  ClaudeCodeHookInput,
+  ClaudeCodeHookOptions,
+  ClaudeCodeHookResult,
+  TranscriptTurn,
+} from "./src/adapters/claude-code/index.js";
 
 const TAG = "[memory-tdai]";
 

--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,15 @@ import {
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
 
+export { CodingAgentGatewayClient, CodingAgentGatewayError } from "./src/adapters/coding-agent/index.js";
+export type {
+  CodingAgentConversationSearchRequest,
+  CodingAgentGatewayClientOptions,
+  CodingAgentMemorySearchRequest,
+  CodingAgentRecallRequest,
+  CodingAgentTurn,
+} from "./src/adapters/coding-agent/index.js";
+
 const TAG = "[memory-tdai]";
 
 /**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-claude-hook": "./dist/memory-tencentdb-claude-hook.mjs"
   },
   "exports": {
     ".": {
@@ -47,8 +48,15 @@
     "hermes-plugin/",
     "openclaw.plugin.json",
     "README.md",
+    "docs/coding-agent-adapter-quickstart.md",
+    "docs/claude-code-adapter-setup.md",
+    "docs/hermes-adapter-setup.md",
+    "docs/platform-adapter-comparison.md",
     "CHANGELOG.md",
     "LICENSE",
+    "!**/__pycache__/",
+    "!**/*.pyc",
+    "!**/*.pyo",
     "!src/**/*.test.ts",
     "!src/**/*.spec.ts",
     "!src/**/__tests__/"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "hermes-plugin/",
     "openclaw.plugin.json",
     "README.md",
+    "docs/platform-adapter-architecture.md",
     "docs/coding-agent-adapter-quickstart.md",
     "docs/claude-code-adapter-setup.md",
     "docs/hermes-adapter-setup.md",

--- a/src/adapters/claude-code/hook-handler.test.ts
+++ b/src/adapters/claude-code/hook-handler.test.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSessionKey,
+  extractLatestTurn,
+  handleClaudeCodeHook,
+  type ClaudeCodeHookClient,
+} from "./hook-handler.js";
+
+function createClient(): ClaudeCodeHookClient {
+  return {
+    health: vi.fn(async () => ({ status: "ok" })),
+    recall: vi.fn(async () => ({ context: "<memory>use pnpm</memory>" })),
+    capture: vi.fn(async () => ({ l0_recorded: 2 })),
+    endSession: vi.fn(async () => ({ flushed: true })),
+  };
+}
+
+function writeTranscript(rows?: unknown[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-claude-hook-"));
+  const file = path.join(dir, "session.jsonl");
+  fs.writeFileSync(file, (rows ?? [
+    JSON.stringify({
+      cwd: "/tmp/project",
+      sessionId: "s1",
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "remember pnpm" }] },
+    }),
+    JSON.stringify({
+      cwd: "/tmp/project",
+      sessionId: "s1",
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "noted" }] },
+    }),
+  ]).map((row) => typeof row === "string" ? row : JSON.stringify(row)).join("\n"));
+  return file;
+}
+
+describe("Claude Code hook adapter", () => {
+  it("returns additional context for UserPromptSubmit", async () => {
+    const client = createClient();
+    const result = await handleClaudeCodeHook({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "s1",
+      cwd: "/tmp/project",
+      prompt: "what package manager?",
+    }, { client });
+
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "what package manager?",
+      sessionKey: "claude-code:s1",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout ?? "{}")).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: "<memory>use pnpm</memory>",
+      },
+    });
+  });
+
+  it("captures the latest transcript turn on Stop", async () => {
+    const client = createClient();
+    const transcriptPath = writeTranscript();
+
+    const result = await handleClaudeCodeHook({
+      hook_event_name: "Stop",
+      session_id: "s1",
+      transcript_path: transcriptPath,
+    }, { client });
+
+    expect(result.exitCode).toBe(0);
+    expect(client.capture).toHaveBeenCalledWith({
+      userContent: "remember pnpm",
+      assistantContent: "noted",
+      sessionKey: "claude-code:s1",
+      sessionId: "s1",
+    });
+  });
+
+  it("extracts the latest turn from a Claude transcript", () => {
+    const transcriptPath = writeTranscript();
+
+    expect(extractLatestTurn({ transcript_path: transcriptPath })).toEqual({
+      userContent: "remember pnpm",
+      assistantContent: "noted",
+    });
+  });
+
+  it("uses the stable Claude session id even when cwd changes", () => {
+    expect(buildSessionKey({
+      cwd: "/tmp/project",
+      session_id: "abc",
+    })).toBe("claude-code:abc");
+    expect(buildSessionKey({
+      cwd: "/tmp/project/packages/api",
+      session_id: "abc",
+    })).toBe("claude-code:abc");
+  });
+
+  it("combines dynamic L1 and stable recall context", async () => {
+    const client = createClient();
+    vi.mocked(client.recall).mockResolvedValue({
+      context: "stable persona",
+      prepend_context: "dynamic L1",
+      append_system_context: [
+        "stable persona",
+        "<memory-tools-guide>unavailable tdai tools</memory-tools-guide>",
+      ].join("\n\n"),
+    });
+
+    const result = await handleClaudeCodeHook({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "s1",
+      prompt: "what package manager?",
+    }, { client });
+
+    expect(JSON.parse(result.stdout ?? "{}").hookSpecificOutput.additionalContext)
+      .toBe("dynamic L1\n\nstable persona");
+  });
+
+  it("uses last_assistant_message when the transcript lags behind Stop", async () => {
+    const client = createClient();
+    const transcriptPath = writeTranscript([
+      {
+        type: "user",
+        promptId: "old-prompt",
+        message: { role: "user", content: [{ type: "text", text: "old prompt" }] },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+      },
+      {
+        type: "user",
+        promptId: "current-prompt",
+        timestamp: "2026-07-12T06:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "current prompt" }] },
+      },
+    ]);
+
+    await handleClaudeCodeHook({
+      hook_event_name: "Stop",
+      session_id: "s1",
+      prompt_id: "current-prompt",
+      transcript_path: transcriptPath,
+      last_assistant_message: "current reply",
+    }, { client });
+
+    expect(client.capture).toHaveBeenCalledWith({
+      userContent: "current prompt",
+      assistantContent: "current reply",
+      sessionKey: "claude-code:s1",
+      sessionId: "s1",
+      messages: [
+        { role: "user", content: "current prompt", timestamp: 1_783_836_000_000 },
+        { role: "assistant", content: "current reply", timestamp: 1_783_836_000_001 },
+      ],
+      startedAt: 1_783_835_999_999,
+    });
+  });
+
+  it("skips capture instead of pairing a current reply with an old prompt", async () => {
+    const client = createClient();
+    const transcriptPath = writeTranscript([
+      {
+        type: "user",
+        promptId: "old-prompt",
+        message: { role: "user", content: "old prompt" },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+      },
+    ]);
+
+    await handleClaudeCodeHook({
+      hook_event_name: "Stop",
+      session_id: "s1",
+      prompt_id: "current-prompt",
+      transcript_path: transcriptPath,
+      last_assistant_message: "current reply",
+    }, { client });
+
+    expect(client.capture).not.toHaveBeenCalled();
+  });
+
+  it("does not treat tool results as user prompts", () => {
+    const transcriptPath = writeTranscript([
+      {
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "inspect the build" }] },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash" }] },
+      },
+      {
+        type: "user",
+        sourceToolAssistantUUID: "assistant-tool-row",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "large command output" }],
+        },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "the build passes" }] },
+      },
+    ]);
+
+    expect(extractLatestTurn({ transcript_path: transcriptPath })).toEqual({
+      userContent: "inspect the build",
+      assistantContent: "the build passes",
+    });
+  });
+
+  it("flushes on SessionEnd without capturing the last turn again", async () => {
+    const client = createClient();
+
+    const result = await handleClaudeCodeHook({
+      hook_event_name: "SessionEnd",
+      session_id: "s1",
+      cwd: "/tmp/project",
+    }, { client });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(client.capture).not.toHaveBeenCalled();
+    expect(client.endSession).toHaveBeenCalledWith("claude-code:s1");
+  });
+
+  it("fails open when the Gateway is unavailable", async () => {
+    const client = createClient();
+    vi.mocked(client.recall).mockRejectedValue(new Error("connection refused"));
+
+    const result = await handleClaudeCodeHook({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "s1",
+      prompt: "continue",
+    }, { client });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("connection refused");
+  });
+});

--- a/src/adapters/claude-code/hook-handler.ts
+++ b/src/adapters/claude-code/hook-handler.ts
@@ -1,0 +1,294 @@
+import fs from "node:fs";
+import { CodingAgentGatewayClient } from "../coding-agent/index.js";
+import type {
+  CodingAgentGatewayClientOptions,
+  CodingAgentRecallRequest,
+  CodingAgentTurn,
+} from "../coding-agent/index.js";
+
+export interface ClaudeCodeHookInput {
+  hook_event_name?: string;
+  hookEventName?: string;
+  session_id?: string;
+  sessionId?: string;
+  prompt_id?: string;
+  promptId?: string;
+  transcript_path?: string;
+  transcriptPath?: string;
+  cwd?: string;
+  prompt?: string;
+  message?: unknown;
+  last_assistant_message?: string;
+  lastAssistantMessage?: string;
+  stop_hook_active?: boolean;
+  stopHookActive?: boolean;
+  reason?: string;
+}
+
+export interface ClaudeCodeHookClient {
+  health(): Promise<unknown>;
+  recall(request: CodingAgentRecallRequest): Promise<{
+    context?: string;
+    prepend_context?: string;
+    append_system_context?: string;
+  }>;
+  capture(turn: CodingAgentTurn): Promise<unknown>;
+  endSession(sessionKey: string): Promise<unknown>;
+}
+
+export interface ClaudeCodeHookOptions {
+  client?: ClaudeCodeHookClient;
+  gateway?: CodingAgentGatewayClientOptions;
+}
+
+export interface ClaudeCodeHookResult {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface TranscriptTurn {
+  userContent: string;
+  assistantContent: string;
+  userTimestamp?: number;
+  assistantTimestamp?: number;
+}
+
+export async function handleClaudeCodeHook(
+  input: ClaudeCodeHookInput,
+  options: ClaudeCodeHookOptions = {},
+): Promise<ClaudeCodeHookResult> {
+  const client = options.client ?? new CodingAgentGatewayClient(options.gateway);
+  const eventName = getEventName(input);
+
+  try {
+    if (eventName === "UserPromptSubmit") {
+      return await handleUserPromptSubmit(input, client);
+    }
+    if (eventName === "Stop") {
+      return await handleStop(input, client);
+    }
+    if (eventName === "SessionEnd") {
+      const sessionKey = buildSessionKey(input);
+      if (sessionKey) await client.endSession(sessionKey);
+      return { exitCode: 0 };
+    }
+    if (eventName === "SessionStart") {
+      await client.health();
+      return { exitCode: 0 };
+    }
+    return { exitCode: 0 };
+  } catch (err) {
+    return {
+      exitCode: 0,
+      stderr: `tdai claude-code hook skipped: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+async function handleUserPromptSubmit(
+  input: ClaudeCodeHookInput,
+  client: ClaudeCodeHookClient,
+): Promise<ClaudeCodeHookResult> {
+  const query = extractPrompt(input);
+  const sessionKey = buildSessionKey(input);
+  if (!query || !sessionKey) return { exitCode: 0 };
+
+  const result = await client.recall({
+    query,
+    sessionKey,
+  });
+
+  const context = combineRecallContext(result);
+  if (!context) return { exitCode: 0 };
+
+  return {
+    exitCode: 0,
+    stdout: JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: context,
+      },
+    }),
+  };
+}
+
+async function handleStop(
+  input: ClaudeCodeHookInput,
+  client: ClaudeCodeHookClient,
+): Promise<ClaudeCodeHookResult> {
+  const turn = extractLatestTurn(input);
+  const sessionKey = buildSessionKey(input);
+  if (turn && sessionKey) {
+    const hasTimestamps = turn.userTimestamp !== undefined && turn.assistantTimestamp !== undefined;
+    await client.capture({
+      userContent: turn.userContent,
+      assistantContent: turn.assistantContent,
+      sessionKey,
+      sessionId: getSessionId(input),
+      ...(hasTimestamps ? {
+        messages: [
+          { role: "user", content: turn.userContent, timestamp: turn.userTimestamp },
+          { role: "assistant", content: turn.assistantContent, timestamp: turn.assistantTimestamp },
+        ],
+        startedAt: Math.max(0, turn.userTimestamp! - 1),
+      } : {}),
+    });
+  }
+
+  return { exitCode: 0 };
+}
+
+export function buildSessionKey(input: ClaudeCodeHookInput): string | null {
+  const sessionId = getSessionId(input);
+  return sessionId ? `claude-code:${sessionId}` : null;
+}
+
+export function extractLatestTurn(input: ClaudeCodeHookInput): TranscriptTurn | null {
+  const transcriptPath = input.transcript_path ?? input.transcriptPath;
+  if (!transcriptPath || !fs.existsSync(transcriptPath)) return null;
+
+  let latestUser = "";
+  let latestCompletedTurn: TranscriptTurn | null = null;
+  let latestUserTimestamp: number | undefined;
+  let lastAssistantRow = -1;
+  let lastToolResultRow = -1;
+  const targetPromptId = getPromptId(input);
+
+  const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/);
+  for (const [rowIndex, line] of lines.entries()) {
+    if (!line.trim()) continue;
+    let row: unknown;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const record = typeof row === "object" && row !== null
+      ? row as Record<string, unknown>
+      : undefined;
+    if (!record || record.isMeta === true || record.isSidechain === true) continue;
+    const message = record.message;
+    if (!message || typeof message !== "object") continue;
+    const role = (message as Record<string, unknown>).role;
+    const rawContent = (message as Record<string, unknown>).content;
+    if (
+      role === "user" &&
+      (containsToolResult(rawContent) || record.sourceToolAssistantUUID !== undefined)
+    ) {
+      lastToolResultRow = rowIndex;
+      continue;
+    }
+    const content = contentToText(rawContent);
+    if (!content) continue;
+    if (role === "user") {
+      if (targetPromptId && getTranscriptPromptId(record) !== targetPromptId) continue;
+      latestUser = content;
+      latestUserTimestamp = parseTranscriptTimestamp(record.timestamp);
+    } else if (role === "assistant" && latestUser) {
+      const assistantTimestamp = parseTranscriptTimestamp(record.timestamp);
+      latestCompletedTurn = {
+        userContent: latestUser,
+        assistantContent: content,
+        ...(latestUserTimestamp !== undefined ? { userTimestamp: latestUserTimestamp } : {}),
+        ...(assistantTimestamp !== undefined ? { assistantTimestamp } : {}),
+      };
+      lastAssistantRow = rowIndex;
+    }
+  }
+
+  const currentAssistant = getLastAssistantMessage(input);
+  if (latestUser && currentAssistant) {
+    const completedTimestamp = latestCompletedTurn?.userContent === latestUser
+      ? latestCompletedTurn.assistantTimestamp
+      : undefined;
+    const assistantTimestamp = completedTimestamp ?? (
+      latestUserTimestamp !== undefined ? latestUserTimestamp + 1 : undefined
+    );
+    return {
+      userContent: latestUser,
+      assistantContent: currentAssistant,
+      ...(latestUserTimestamp !== undefined ? { userTimestamp: latestUserTimestamp } : {}),
+      ...(assistantTimestamp !== undefined ? { assistantTimestamp } : {}),
+    };
+  }
+  if (
+    !latestCompletedTurn ||
+    latestCompletedTurn.userContent !== latestUser ||
+    lastToolResultRow > lastAssistantRow
+  ) {
+    return null;
+  }
+  return latestCompletedTurn;
+}
+
+function getEventName(input: ClaudeCodeHookInput): string {
+  return input.hook_event_name ?? input.hookEventName ?? "";
+}
+
+function getSessionId(input: ClaudeCodeHookInput): string {
+  return input.session_id ?? input.sessionId ?? "";
+}
+
+function getPromptId(input: ClaudeCodeHookInput): string {
+  return input.prompt_id ?? input.promptId ?? "";
+}
+
+function getTranscriptPromptId(record: Record<string, unknown>): string {
+  const value = record.promptId ?? record.prompt_id;
+  return typeof value === "string" ? value : "";
+}
+
+function parseTranscriptTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string") return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function extractPrompt(input: ClaudeCodeHookInput): string {
+  if (typeof input.prompt === "string") return input.prompt;
+  return contentToText(input.message);
+}
+
+function getLastAssistantMessage(input: ClaudeCodeHookInput): string {
+  const value = input.last_assistant_message ?? input.lastAssistantMessage;
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function combineRecallContext(result: {
+  context?: string;
+  prepend_context?: string;
+  append_system_context?: string;
+}): string {
+  const dynamicContext = result.prepend_context?.trim();
+  const stableContext = (result.append_system_context ?? result.context)
+    ?.replace(/<memory-tools-guide>[\s\S]*?<\/memory-tools-guide>/gi, "")
+    .trim();
+  return [...new Set([dynamicContext, stableContext].filter((value): value is string => !!value))]
+    .join("\n\n");
+}
+
+function contentToText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (!Array.isArray(value)) return "";
+
+  return value
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!part || typeof part !== "object") return "";
+      const record = part as Record<string, unknown>;
+      if (record.type !== undefined && record.type !== "text") return "";
+      if (typeof record.text === "string") return record.text;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function containsToolResult(value: unknown): boolean {
+  return Array.isArray(value) && value.some((part) => (
+    !!part && typeof part === "object" && (part as Record<string, unknown>).type === "tool_result"
+  ));
+}

--- a/src/adapters/claude-code/hook-handler.ts
+++ b/src/adapters/claude-code/hook-handler.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
-import { CodingAgentGatewayClient } from "../coding-agent/index.js";
+import { runCodingAgentAdapter } from "../coding-agent/index.js";
 import type {
   CodingAgentGatewayClientOptions,
+  CodingAgentPlatformAdapter,
   CodingAgentRecallRequest,
   CodingAgentTurn,
 } from "../coding-agent/index.js";
@@ -54,89 +55,76 @@ export interface TranscriptTurn {
   assistantTimestamp?: number;
 }
 
-export async function handleClaudeCodeHook(
-  input: ClaudeCodeHookInput,
-  options: ClaudeCodeHookOptions = {},
-): Promise<ClaudeCodeHookResult> {
-  const client = options.client ?? new CodingAgentGatewayClient(options.gateway);
-  const eventName = getEventName(input);
+/**
+ * Claude Code reference implementation of the unified {@link CodingAgentPlatformAdapter}.
+ *
+ * It only maps Claude Code hook payloads onto neutral lifecycle events and
+ * renders recalled memory back into `hookSpecificOutput`. Transport, timeouts,
+ * auth, recall flattening, and fail-open handling live in the shared SDK.
+ */
+export const claudeCodeAdapter: CodingAgentPlatformAdapter<ClaudeCodeHookInput> = {
+  platform: "claude-code",
 
-  try {
+  toEvent(input) {
+    const eventName = getEventName(input);
+
     if (eventName === "UserPromptSubmit") {
-      return await handleUserPromptSubmit(input, client);
+      const query = extractPrompt(input);
+      const sessionKey = buildSessionKey(input);
+      if (!query || !sessionKey) return { kind: "noop" };
+      return { kind: "recall", recall: { query, sessionKey } };
     }
+
     if (eventName === "Stop") {
-      return await handleStop(input, client);
+      const turn = extractLatestTurn(input);
+      const sessionKey = buildSessionKey(input);
+      if (!turn || !sessionKey) return { kind: "noop" };
+      const hasTimestamps = turn.userTimestamp !== undefined && turn.assistantTimestamp !== undefined;
+      return {
+        kind: "capture",
+        turn: {
+          userContent: turn.userContent,
+          assistantContent: turn.assistantContent,
+          sessionKey,
+          sessionId: getSessionId(input),
+          ...(hasTimestamps ? {
+            messages: [
+              { role: "user", content: turn.userContent, timestamp: turn.userTimestamp },
+              { role: "assistant", content: turn.assistantContent, timestamp: turn.assistantTimestamp },
+            ],
+            startedAt: Math.max(0, turn.userTimestamp! - 1),
+          } : {}),
+        },
+      };
     }
+
     if (eventName === "SessionEnd") {
       const sessionKey = buildSessionKey(input);
-      if (sessionKey) await client.endSession(sessionKey);
-      return { exitCode: 0 };
+      return sessionKey ? { kind: "session-end", sessionKey } : { kind: "noop" };
     }
+
     if (eventName === "SessionStart") {
-      await client.health();
-      return { exitCode: 0 };
+      return { kind: "health" };
     }
-    return { exitCode: 0 };
-  } catch (err) {
+
+    return { kind: "noop" };
+  },
+
+  renderRecall(context) {
     return {
-      exitCode: 0,
-      stderr: `tdai claude-code hook skipped: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-}
-
-async function handleUserPromptSubmit(
-  input: ClaudeCodeHookInput,
-  client: ClaudeCodeHookClient,
-): Promise<ClaudeCodeHookResult> {
-  const query = extractPrompt(input);
-  const sessionKey = buildSessionKey(input);
-  if (!query || !sessionKey) return { exitCode: 0 };
-
-  const result = await client.recall({
-    query,
-    sessionKey,
-  });
-
-  const context = combineRecallContext(result);
-  if (!context) return { exitCode: 0 };
-
-  return {
-    exitCode: 0,
-    stdout: JSON.stringify({
       hookSpecificOutput: {
         hookEventName: "UserPromptSubmit",
         additionalContext: context,
       },
-    }),
-  };
-}
+    };
+  },
+};
 
-async function handleStop(
+export async function handleClaudeCodeHook(
   input: ClaudeCodeHookInput,
-  client: ClaudeCodeHookClient,
+  options: ClaudeCodeHookOptions = {},
 ): Promise<ClaudeCodeHookResult> {
-  const turn = extractLatestTurn(input);
-  const sessionKey = buildSessionKey(input);
-  if (turn && sessionKey) {
-    const hasTimestamps = turn.userTimestamp !== undefined && turn.assistantTimestamp !== undefined;
-    await client.capture({
-      userContent: turn.userContent,
-      assistantContent: turn.assistantContent,
-      sessionKey,
-      sessionId: getSessionId(input),
-      ...(hasTimestamps ? {
-        messages: [
-          { role: "user", content: turn.userContent, timestamp: turn.userTimestamp },
-          { role: "assistant", content: turn.assistantContent, timestamp: turn.assistantTimestamp },
-        ],
-        startedAt: Math.max(0, turn.userTimestamp! - 1),
-      } : {}),
-    });
-  }
-
-  return { exitCode: 0 };
+  return runCodingAgentAdapter(claudeCodeAdapter, input, options);
 }
 
 export function buildSessionKey(input: ClaudeCodeHookInput): string | null {
@@ -254,19 +242,6 @@ function extractPrompt(input: ClaudeCodeHookInput): string {
 function getLastAssistantMessage(input: ClaudeCodeHookInput): string {
   const value = input.last_assistant_message ?? input.lastAssistantMessage;
   return typeof value === "string" ? value.trim() : "";
-}
-
-function combineRecallContext(result: {
-  context?: string;
-  prepend_context?: string;
-  append_system_context?: string;
-}): string {
-  const dynamicContext = result.prepend_context?.trim();
-  const stableContext = (result.append_system_context ?? result.context)
-    ?.replace(/<memory-tools-guide>[\s\S]*?<\/memory-tools-guide>/gi, "")
-    .trim();
-  return [...new Set([dynamicContext, stableContext].filter((value): value is string => !!value))]
-    .join("\n\n");
 }
 
 function contentToText(value: unknown): string {

--- a/src/adapters/claude-code/hook.ts
+++ b/src/adapters/claude-code/hook.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { handleClaudeCodeHook } from "./hook-handler.js";
+
+async function main(): Promise<void> {
+  const raw = readFileSync(0, "utf-8");
+  const input = raw.trim() ? JSON.parse(raw) : {};
+  const timeoutMs = Number.parseInt(process.env.TDAI_GATEWAY_TIMEOUT_MS ?? "", 10);
+  const result = await handleClaudeCodeHook(input, {
+    gateway: {
+      baseUrl: process.env.TDAI_GATEWAY_URL,
+      apiKey: process.env.TDAI_GATEWAY_API_KEY,
+      ...(Number.isFinite(timeoutMs) && timeoutMs > 0 ? { timeoutMs } : {}),
+    },
+  });
+
+  if (result.stdout) process.stdout.write(`${result.stdout}\n`);
+  if (result.stderr) process.stderr.write(`${result.stderr}\n`);
+  process.exitCode = result.exitCode;
+}
+
+main().catch((err) => {
+  process.stderr.write(`tdai claude-code hook failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exitCode = 0;
+});

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -1,0 +1,12 @@
+export {
+  buildSessionKey,
+  extractLatestTurn,
+  handleClaudeCodeHook,
+} from "./hook-handler.js";
+export type {
+  ClaudeCodeHookClient,
+  ClaudeCodeHookInput,
+  ClaudeCodeHookOptions,
+  ClaudeCodeHookResult,
+  TranscriptTurn,
+} from "./hook-handler.js";

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -1,5 +1,6 @@
 export {
   buildSessionKey,
+  claudeCodeAdapter,
   extractLatestTurn,
   handleClaudeCodeHook,
 } from "./hook-handler.js";

--- a/src/adapters/coding-agent/gateway-client.test.ts
+++ b/src/adapters/coding-agent/gateway-client.test.ts
@@ -54,6 +54,7 @@ describe("CodingAgentGatewayClient", () => {
       sessionKey: "workspace:/tmp/project",
       sessionId: "thread-42",
       messages: [{ role: "user", content: "fix the failing test" }],
+      startedAt: 1_720_000_000_000,
     });
 
     expect(calls[0].input).toBe("http://127.0.0.1:8420/capture");
@@ -63,6 +64,7 @@ describe("CodingAgentGatewayClient", () => {
       session_key: "workspace:/tmp/project",
       session_id: "thread-42",
       messages: [{ role: "user", content: "fix the failing test" }],
+      started_at: 1_720_000_000_000,
     });
   });
 
@@ -93,5 +95,61 @@ describe("CodingAgentGatewayClient", () => {
       responseBody: "unauthorized",
     } satisfies Partial<CodingAgentGatewayError>);
   });
-});
 
+  it("maps search and session lifecycle requests to Gateway fields", async () => {
+    const { fetchImpl, calls } = mockFetch({ results: "ok", total: 1 });
+    const client = new CodingAgentGatewayClient({ fetch: fetchImpl });
+
+    await client.searchMemories({
+      query: "package manager",
+      limit: 3,
+      type: "preference",
+      scene: "workspace",
+    });
+    await client.searchConversations({
+      query: "pnpm",
+      limit: 2,
+      sessionKey: "repo:thread-1",
+    });
+    await client.endSession("repo:thread-1", "alice");
+
+    expect(calls.map((call) => call.input)).toEqual([
+      "http://127.0.0.1:8420/search/memories",
+      "http://127.0.0.1:8420/search/conversations",
+      "http://127.0.0.1:8420/session/end",
+    ]);
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "package manager",
+      limit: 3,
+      type: "preference",
+      scene: "workspace",
+    });
+    expect(JSON.parse(calls[1].init?.body as string)).toEqual({
+      query: "pnpm",
+      limit: 2,
+      session_key: "repo:thread-1",
+    });
+    expect(JSON.parse(calls[2].init?.body as string)).toEqual({
+      session_key: "repo:thread-1",
+      user_id: "alice",
+    });
+  });
+
+  it("aborts requests after the configured timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn((_input: string | URL | Request, init?: RequestInit) => (
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        })
+      )) as unknown as typeof globalThis.fetch;
+      const client = new CodingAgentGatewayClient({ timeoutMs: 25, fetch: fetchImpl });
+
+      const assertion = expect(client.health()).rejects.toMatchObject({ name: "AbortError" });
+      await vi.advanceTimersByTimeAsync(25);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/adapters/coding-agent/gateway-client.test.ts
+++ b/src/adapters/coding-agent/gateway-client.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { CodingAgentGatewayClient, CodingAgentGatewayError } from "./gateway-client.js";
+
+function mockFetch(responseBody: unknown, init: ResponseInit = {}) {
+  const calls: Array<{ input: string | URL | Request; init?: RequestInit }> = [];
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ input, init });
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      ...init,
+      headers: { "Content-Type": "application/json", ...init.headers },
+    });
+  }) as unknown as typeof globalThis.fetch;
+
+  return { fetchImpl, calls };
+}
+
+describe("CodingAgentGatewayClient", () => {
+  it("sends recall requests using Gateway field names", async () => {
+    const { fetchImpl, calls } = mockFetch({ context: "memory", memory_count: 1 });
+    const client = new CodingAgentGatewayClient({
+      baseUrl: "http://127.0.0.1:8420/",
+      apiKey: " secret ",
+      fetch: fetchImpl,
+    });
+
+    const response = await client.recall({
+      query: "what did we decide?",
+      sessionKey: "repo:thread-1",
+      userId: "alice",
+    });
+
+    expect(response.context).toBe("memory");
+    expect(calls[0].input).toBe("http://127.0.0.1:8420/recall");
+    expect(calls[0].init?.method).toBe("POST");
+    expect(calls[0].init?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer secret",
+    });
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      query: "what did we decide?",
+      session_key: "repo:thread-1",
+      user_id: "alice",
+    });
+  });
+
+  it("captures a coding-agent turn with optional raw messages", async () => {
+    const { fetchImpl, calls } = mockFetch({ l0_recorded: 2, scheduler_notified: true });
+    const client = new CodingAgentGatewayClient({ fetch: fetchImpl });
+
+    await client.capture({
+      userContent: "fix the failing test",
+      assistantContent: "patched the assertion",
+      sessionKey: "workspace:/tmp/project",
+      sessionId: "thread-42",
+      messages: [{ role: "user", content: "fix the failing test" }],
+    });
+
+    expect(calls[0].input).toBe("http://127.0.0.1:8420/capture");
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      user_content: "fix the failing test",
+      assistant_content: "patched the assertion",
+      session_key: "workspace:/tmp/project",
+      session_id: "thread-42",
+      messages: [{ role: "user", content: "fix the failing test" }],
+    });
+  });
+
+  it("uses GET for health and omits auth when no api key is configured", async () => {
+    const { fetchImpl, calls } = mockFetch({
+      status: "ok",
+      version: "0.1.0",
+      uptime: 1,
+      stores: { vectorStore: true, embeddingService: true },
+    });
+    const client = new CodingAgentGatewayClient({ fetch: fetchImpl });
+
+    await client.health();
+
+    expect(calls[0].input).toBe("http://127.0.0.1:8420/health");
+    expect(calls[0].init?.method).toBe("GET");
+    expect(calls[0].init?.headers).toEqual({});
+    expect(calls[0].init?.body).toBeUndefined();
+  });
+
+  it("throws a typed error for non-2xx responses", async () => {
+    const fetchImpl = vi.fn(async () => new Response("unauthorized", { status: 401 })) as unknown as typeof globalThis.fetch;
+    const client = new CodingAgentGatewayClient({ fetch: fetchImpl });
+
+    await expect(client.searchMemories({ query: "secret" })).rejects.toMatchObject({
+      name: "CodingAgentGatewayError",
+      status: 401,
+      responseBody: "unauthorized",
+    } satisfies Partial<CodingAgentGatewayError>);
+  });
+});
+

--- a/src/adapters/coding-agent/gateway-client.ts
+++ b/src/adapters/coding-agent/gateway-client.ts
@@ -1,0 +1,147 @@
+import type {
+  CaptureResponse,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchResponse,
+  RecallResponse,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export interface CodingAgentGatewayClientOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface CodingAgentTurn {
+  userContent: string;
+  assistantContent: string;
+  sessionKey: string;
+  sessionId?: string;
+  userId?: string;
+  messages?: unknown[];
+}
+
+export interface CodingAgentRecallRequest {
+  query: string;
+  sessionKey: string;
+  userId?: string;
+}
+
+export interface CodingAgentMemorySearchRequest {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface CodingAgentConversationSearchRequest {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export class CodingAgentGatewayError extends Error {
+  readonly status: number;
+  readonly responseBody: string;
+
+  constructor(status: number, responseBody: string) {
+    super(`TDAI Gateway request failed with HTTP ${status}: ${responseBody}`);
+    this.name = "CodingAgentGatewayError";
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
+/**
+ * Thin HTTP client for coding-agent platforms that connect to TDAI through
+ * the Gateway sidecar instead of embedding TdaiCore in-process.
+ */
+export class CodingAgentGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: CodingAgentGatewayClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? "http://127.0.0.1:8420").replace(/\/+$/, "");
+    this.apiKey = options.apiKey?.trim() || undefined;
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  recall(request: CodingAgentRecallRequest): Promise<RecallResponse> {
+    return this.request<RecallResponse>("POST", "/recall", {
+      query: request.query,
+      session_key: request.sessionKey,
+      ...(request.userId ? { user_id: request.userId } : {}),
+    });
+  }
+
+  capture(turn: CodingAgentTurn): Promise<CaptureResponse> {
+    return this.request<CaptureResponse>("POST", "/capture", {
+      user_content: turn.userContent,
+      assistant_content: turn.assistantContent,
+      session_key: turn.sessionKey,
+      ...(turn.sessionId ? { session_id: turn.sessionId } : {}),
+      ...(turn.userId ? { user_id: turn.userId } : {}),
+      ...(turn.messages ? { messages: turn.messages } : {}),
+    });
+  }
+
+  searchMemories(request: CodingAgentMemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.request<MemorySearchResponse>("POST", "/search/memories", {
+      query: request.query,
+      ...(request.limit !== undefined ? { limit: request.limit } : {}),
+      ...(request.type ? { type: request.type } : {}),
+      ...(request.scene ? { scene: request.scene } : {}),
+    });
+  }
+
+  searchConversations(request: CodingAgentConversationSearchRequest): Promise<ConversationSearchResponse> {
+    return this.request<ConversationSearchResponse>("POST", "/search/conversations", {
+      query: request.query,
+      ...(request.limit !== undefined ? { limit: request.limit } : {}),
+      ...(request.sessionKey ? { session_key: request.sessionKey } : {}),
+    });
+  }
+
+  endSession(sessionKey: string, userId?: string): Promise<SessionEndResponse> {
+    return this.request<SessionEndResponse>("POST", "/session/end", {
+      session_key: sessionKey,
+      ...(userId ? { user_id: userId } : {}),
+    });
+  }
+
+  private async request<T>(method: "GET" | "POST", path: string, body?: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {};
+      if (body !== undefined) headers["Content-Type"] = "application/json";
+      if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      const text = await response.text();
+      if (!response.ok) {
+        throw new CodingAgentGatewayError(response.status, text);
+      }
+      return (text ? JSON.parse(text) : {}) as T;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+

--- a/src/adapters/coding-agent/gateway-client.ts
+++ b/src/adapters/coding-agent/gateway-client.ts
@@ -21,6 +21,7 @@ export interface CodingAgentTurn {
   sessionId?: string;
   userId?: string;
   messages?: unknown[];
+  startedAt?: number;
 }
 
 export interface CodingAgentRecallRequest {
@@ -91,6 +92,7 @@ export class CodingAgentGatewayClient {
       ...(turn.sessionId ? { session_id: turn.sessionId } : {}),
       ...(turn.userId ? { user_id: turn.userId } : {}),
       ...(turn.messages ? { messages: turn.messages } : {}),
+      ...(turn.startedAt !== undefined ? { started_at: turn.startedAt } : {}),
     });
   }
 
@@ -144,4 +146,3 @@ export class CodingAgentGatewayClient {
     }
   }
 }
-

--- a/src/adapters/coding-agent/index.ts
+++ b/src/adapters/coding-agent/index.ts
@@ -1,0 +1,12 @@
+export {
+  CodingAgentGatewayClient,
+  CodingAgentGatewayError,
+} from "./gateway-client.js";
+export type {
+  CodingAgentConversationSearchRequest,
+  CodingAgentGatewayClientOptions,
+  CodingAgentMemorySearchRequest,
+  CodingAgentRecallRequest,
+  CodingAgentTurn,
+} from "./gateway-client.js";
+

--- a/src/adapters/coding-agent/index.ts
+++ b/src/adapters/coding-agent/index.ts
@@ -10,3 +10,16 @@ export type {
   CodingAgentTurn,
 } from "./gateway-client.js";
 
+export {
+  combineRecallContext,
+  runCodingAgentAdapter,
+} from "./platform-adapter.js";
+export type {
+  CodingAgentAdapterOptions,
+  CodingAgentAdapterResult,
+  CodingAgentClient,
+  CodingAgentEvent,
+  CodingAgentPlatformAdapter,
+  CodingAgentRecallLike,
+} from "./platform-adapter.js";
+

--- a/src/adapters/coding-agent/platform-adapter.test.ts
+++ b/src/adapters/coding-agent/platform-adapter.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  combineRecallContext,
+  runCodingAgentAdapter,
+  type CodingAgentClient,
+  type CodingAgentPlatformAdapter,
+} from "./platform-adapter.js";
+
+function createClient(): CodingAgentClient {
+  return {
+    health: vi.fn(async () => ({ status: "ok" })),
+    recall: vi.fn(async () => ({ prepend_context: "dynamic", append_system_context: "stable" })),
+    capture: vi.fn(async () => ({ l0_recorded: 1 })),
+    endSession: vi.fn(async () => ({ flushed: true })),
+  };
+}
+
+/**
+ * A fictional platform integrated purely by implementing the single
+ * CodingAgentPlatformAdapter interface — the "new platform = one interface"
+ * acceptance goal of issue #235.
+ */
+const demoAdapter: CodingAgentPlatformAdapter<{ event: string; text?: string; id?: string }> = {
+  platform: "demo",
+  toEvent(input) {
+    if (input.event === "prompt" && input.text && input.id) {
+      return { kind: "recall", recall: { query: input.text, sessionKey: `demo:${input.id}` } };
+    }
+    if (input.event === "reply" && input.text && input.id) {
+      return {
+        kind: "capture",
+        turn: { userContent: "q", assistantContent: input.text, sessionKey: `demo:${input.id}` },
+      };
+    }
+    if (input.event === "close" && input.id) {
+      return { kind: "session-end", sessionKey: `demo:${input.id}` };
+    }
+    return { kind: "noop" };
+  },
+  renderRecall(context) {
+    return { inject: context };
+  },
+};
+
+describe("unified coding-agent adapter SDK", () => {
+  it("recalls and renders context via the platform interface", async () => {
+    const client = createClient();
+    const result = await runCodingAgentAdapter(demoAdapter, { event: "prompt", text: "hi", id: "1" }, { client });
+
+    expect(client.recall).toHaveBeenCalledWith({ query: "hi", sessionKey: "demo:1" });
+    expect(JSON.parse(result.stdout ?? "{}")).toEqual({ inject: "dynamic\n\nstable" });
+  });
+
+  it("captures a completed turn", async () => {
+    const client = createClient();
+    await runCodingAgentAdapter(demoAdapter, { event: "reply", text: "done", id: "1" }, { client });
+
+    expect(client.capture).toHaveBeenCalledWith({
+      userContent: "q",
+      assistantContent: "done",
+      sessionKey: "demo:1",
+    });
+  });
+
+  it("flushes the session on close", async () => {
+    const client = createClient();
+    await runCodingAgentAdapter(demoAdapter, { event: "close", id: "1" }, { client });
+
+    expect(client.endSession).toHaveBeenCalledWith("demo:1");
+  });
+
+  it("does nothing for unmapped events", async () => {
+    const client = createClient();
+    const result = await runCodingAgentAdapter(demoAdapter, { event: "unknown" }, { client });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(client.recall).not.toHaveBeenCalled();
+    expect(client.capture).not.toHaveBeenCalled();
+  });
+
+  it("fails open when the Gateway throws", async () => {
+    const client = createClient();
+    vi.mocked(client.recall).mockRejectedValue(new Error("connection refused"));
+
+    const result = await runCodingAgentAdapter(demoAdapter, { event: "prompt", text: "hi", id: "1" }, { client });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("connection refused");
+    expect(result.stderr).toContain("demo");
+  });
+
+  it("combines dynamic and stable context and strips the tool guide", () => {
+    expect(combineRecallContext({
+      prepend_context: "dynamic L1",
+      append_system_context: "stable persona\n\n<memory-tools-guide>tools</memory-tools-guide>",
+      context: "stable persona",
+    })).toBe("dynamic L1\n\nstable persona");
+  });
+});

--- a/src/adapters/coding-agent/platform-adapter.ts
+++ b/src/adapters/coding-agent/platform-adapter.ts
@@ -1,0 +1,127 @@
+import { CodingAgentGatewayClient } from "./gateway-client.js";
+import type {
+  CodingAgentGatewayClientOptions,
+  CodingAgentRecallRequest,
+  CodingAgentTurn,
+} from "./gateway-client.js";
+
+/**
+ * Unified coding-agent adapter SDK.
+ *
+ * A new coding-agent platform (Claude Code, Codex, Cursor, Continue, ...) is
+ * integrated by implementing a single {@link CodingAgentPlatformAdapter}
+ * interface. Everything else — HTTP transport, timeouts, Bearer auth, recall
+ * context flattening, and fail-open error handling — is provided once by
+ * {@link runCodingAgentAdapter}, so platform bindings stay thin.
+ */
+
+/** Gateway recall payload shape, tolerant of the legacy `context` field. */
+export interface CodingAgentRecallLike {
+  context?: string;
+  prepend_context?: string;
+  append_system_context?: string;
+}
+
+/**
+ * Minimal Gateway client contract the SDK depends on.
+ * {@link CodingAgentGatewayClient} satisfies it structurally.
+ */
+export interface CodingAgentClient {
+  health(): Promise<unknown>;
+  recall(request: CodingAgentRecallRequest): Promise<CodingAgentRecallLike>;
+  capture(turn: CodingAgentTurn): Promise<unknown>;
+  endSession(sessionKey: string, userId?: string): Promise<unknown>;
+}
+
+/** Host-neutral memory lifecycle event produced by a platform binding. */
+export type CodingAgentEvent =
+  | { kind: "recall"; recall: CodingAgentRecallRequest }
+  | { kind: "capture"; turn: CodingAgentTurn }
+  | { kind: "session-end"; sessionKey: string; userId?: string }
+  | { kind: "health" }
+  | { kind: "noop" };
+
+/**
+ * The one interface a platform must implement.
+ *
+ * - `toEvent` maps a platform-native payload into a neutral lifecycle event.
+ * - `renderRecall` maps recalled memory back into the platform's native
+ *   response shape (only called when there is non-empty context to inject).
+ */
+export interface CodingAgentPlatformAdapter<TInput> {
+  /** Stable platform id, surfaced in diagnostics (e.g. "claude-code"). */
+  readonly platform: string;
+  toEvent(input: TInput): CodingAgentEvent | Promise<CodingAgentEvent>;
+  renderRecall(context: string, input: TInput): unknown;
+}
+
+export interface CodingAgentAdapterOptions {
+  client?: CodingAgentClient;
+  gateway?: CodingAgentGatewayClientOptions;
+}
+
+export interface CodingAgentAdapterResult {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Drive one platform adapter through the memory lifecycle against the Gateway.
+ *
+ * Always fails open: any Gateway or parsing error is reported on stderr with
+ * exit code 0, so the host agent is never blocked when memory is unavailable.
+ */
+export async function runCodingAgentAdapter<TInput>(
+  adapter: CodingAgentPlatformAdapter<TInput>,
+  input: TInput,
+  options: CodingAgentAdapterOptions = {},
+): Promise<CodingAgentAdapterResult> {
+  const client = options.client ?? new CodingAgentGatewayClient(options.gateway);
+
+  try {
+    const event = await adapter.toEvent(input);
+    switch (event.kind) {
+      case "recall": {
+        const response = await client.recall(event.recall);
+        const context = combineRecallContext(response);
+        if (!context) return { exitCode: 0 };
+        return { exitCode: 0, stdout: JSON.stringify(adapter.renderRecall(context, input)) };
+      }
+      case "capture":
+        await client.capture(event.turn);
+        return { exitCode: 0 };
+      case "session-end":
+        if (event.userId !== undefined) await client.endSession(event.sessionKey, event.userId);
+        else await client.endSession(event.sessionKey);
+        return { exitCode: 0 };
+      case "health":
+        await client.health();
+        return { exitCode: 0 };
+      default:
+        return { exitCode: 0 };
+    }
+  } catch (err) {
+    return {
+      exitCode: 0,
+      stderr: `tdai ${adapter.platform} adapter skipped: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Flatten a Gateway recall response into a single injectable string.
+ *
+ * Combines dynamic L1 (`prepend_context`) with stable persona/scene context
+ * (`append_system_context`, falling back to the legacy `context` field),
+ * de-duplicates, and strips the tool-guide block that is only relevant to MCP
+ * tool hosts rather than context-injection hooks.
+ */
+export function combineRecallContext(response: CodingAgentRecallLike): string {
+  const dynamicContext = response.prepend_context?.trim();
+  const stableContext = (response.append_system_context ?? response.context)
+    ?.replace(/<memory-tools-guide>[\s\S]*?<\/memory-tools-guide>/gi, "")
+    .trim();
+  return [...new Set([dynamicContext, stableContext].filter((value): value is string => !!value))]
+    .join("\n\n");
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -9,6 +9,7 @@
  *   ├── openclaw/       — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
  *   ├── standalone/     — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
  *   └── coding-agent/   — Gateway client for coding-agent hosts (Codex, Claude Code, Cursor)
+ *   └── claude-code/    — Claude Code hook adapter (UserPromptSubmit / Stop)
  */
 
 // OpenClaw adapter
@@ -28,3 +29,13 @@ export type {
   CodingAgentRecallRequest,
   CodingAgentTurn,
 } from "./coding-agent/index.js";
+
+// Claude Code hook adapter
+export { buildSessionKey, extractLatestTurn, handleClaudeCodeHook } from "./claude-code/index.js";
+export type {
+  ClaudeCodeHookClient,
+  ClaudeCodeHookInput,
+  ClaudeCodeHookOptions,
+  ClaudeCodeHookResult,
+  TranscriptTurn,
+} from "./claude-code/index.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -6,8 +6,9 @@
  *
  * Directory structure:
  *   adapters/
- *   ├── openclaw/      — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
- *   └── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   ├── openclaw/       — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
+ *   ├── standalone/     — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   └── coding-agent/   — Gateway client for coding-agent hosts (Codex, Claude Code, Cursor)
  */
 
 // OpenClaw adapter
@@ -17,3 +18,13 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Coding-agent Gateway client
+export { CodingAgentGatewayClient, CodingAgentGatewayError } from "./coding-agent/index.js";
+export type {
+  CodingAgentConversationSearchRequest,
+  CodingAgentGatewayClientOptions,
+  CodingAgentMemorySearchRequest,
+  CodingAgentRecallRequest,
+  CodingAgentTurn,
+} from "./coding-agent/index.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -8,8 +8,9 @@
  *   adapters/
  *   ├── openclaw/       — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
  *   ├── standalone/     — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
- *   └── coding-agent/   — Gateway client for coding-agent hosts (Codex, Claude Code, Cursor)
- *   └── claude-code/    — Claude Code hook adapter (UserPromptSubmit / Stop)
+ *   ├── coding-agent/   — Unified coding-agent adapter SDK: Gateway client +
+ *   │                     CodingAgentPlatformAdapter interface + runCodingAgentAdapter
+ *   └── claude-code/    — Claude Code binding (reference CodingAgentPlatformAdapter impl)
  */
 
 // OpenClaw adapter
@@ -20,18 +21,29 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
 
-// Coding-agent Gateway client
-export { CodingAgentGatewayClient, CodingAgentGatewayError } from "./coding-agent/index.js";
+// Coding-agent Gateway client + unified platform adapter SDK
+export {
+  CodingAgentGatewayClient,
+  CodingAgentGatewayError,
+  combineRecallContext,
+  runCodingAgentAdapter,
+} from "./coding-agent/index.js";
 export type {
+  CodingAgentAdapterOptions,
+  CodingAgentAdapterResult,
+  CodingAgentClient,
   CodingAgentConversationSearchRequest,
+  CodingAgentEvent,
   CodingAgentGatewayClientOptions,
   CodingAgentMemorySearchRequest,
+  CodingAgentPlatformAdapter,
+  CodingAgentRecallLike,
   CodingAgentRecallRequest,
   CodingAgentTurn,
 } from "./coding-agent/index.js";
 
-// Claude Code hook adapter
-export { buildSessionKey, extractLatestTurn, handleClaudeCodeHook } from "./claude-code/index.js";
+// Claude Code hook adapter (reference implementation of CodingAgentPlatformAdapter)
+export { buildSessionKey, claudeCodeAdapter, extractLatestTurn, handleClaudeCodeHook } from "./claude-code/index.js";
 export type {
   ClaudeCodeHookClient,
   ClaudeCodeHookInput,

--- a/src/gateway/recall-response.test.ts
+++ b/src/gateway/recall-response.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildGatewayRecallResponse } from "./recall-response.js";
+
+describe("buildGatewayRecallResponse", () => {
+  it("preserves dynamic and stable context as separate fields", () => {
+    expect(buildGatewayRecallResponse({
+      prependContext: "dynamic L1",
+      appendSystemContext: "stable persona",
+      recallStrategy: "hybrid",
+      recalledL1Memories: [{ content: "x", score: 1, type: "fact" }],
+    })).toEqual({
+      context: "stable persona",
+      prepend_context: "dynamic L1",
+      append_system_context: "stable persona",
+      strategy: "hybrid",
+      memory_count: 1,
+    });
+  });
+
+  it("keeps the legacy context field backward compatible", () => {
+    expect(buildGatewayRecallResponse({ prependContext: "dynamic only" })).toEqual({
+      context: "",
+      prepend_context: "dynamic only",
+      strategy: undefined,
+      memory_count: 0,
+    });
+  });
+});

--- a/src/gateway/recall-response.ts
+++ b/src/gateway/recall-response.ts
@@ -1,0 +1,16 @@
+import type { RecallResult } from "../core/types.js";
+import type { RecallResponse } from "./types.js";
+
+/** Preserve the core's stable/dynamic context boundary across HTTP. */
+export function buildGatewayRecallResponse(result: RecallResult): RecallResponse {
+  return {
+    // Keep the legacy field unchanged for existing Gateway clients.
+    context: result.appendSystemContext ?? "",
+    ...(result.prependContext ? { prepend_context: result.prependContext } : {}),
+    ...(result.appendSystemContext
+      ? { append_system_context: result.appendSystemContext }
+      : {}),
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -39,6 +39,7 @@ import type {
   SeedResponse,
   GatewayErrorResponse,
 } from "./types.js";
+import { buildGatewayRecallResponse } from "./recall-response.js";
 import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
@@ -380,13 +381,12 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    this.logger.info(
+      `Recall completed in ${elapsed}ms: stable=${result.appendSystemContext?.length ?? 0} chars, ` +
+      `dynamic=${result.prependContext?.length ?? 0} chars`,
+    );
 
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
+    const response: RecallResponse = buildGatewayRecallResponse(result);
     sendJson(res, 200, response);
   }
 
@@ -408,6 +408,7 @@ export class TdaiGateway {
       ],
       sessionKey: body.session_key,
       sessionId: body.session_id,
+      startedAt: body.started_at,
     });
     const elapsed = Date.now() - startMs;
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -36,7 +36,12 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Legacy stable-context field kept for backward compatibility. */
   context: string;
+  /** Dynamic L1 context associated with the current user turn. */
+  prepend_context?: string;
+  /** Stable persona, scene, and tool guidance context. */
+  append_system_context?: string;
   strategy?: string;
   memory_count?: number;
 }
@@ -52,6 +57,7 @@ export interface CaptureRequest {
   session_id?: string;
   user_id?: string;
   messages?: unknown[];
+  started_at?: number;
 }
 
 export interface CaptureResponse {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,10 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: {
+    index: "./index.ts",
+    "memory-tencentdb-claude-hook": "./src/adapters/claude-code/hook.ts",
+  },
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
## 概述

本 PR 为 issue #235 提供 Claude Code 平台适配,并进一步把 coding-agent 层抽象为**统一适配器 SDK**。该分支**自包含、可独立合并**,不依赖任何尚未合并的 PR。

## 对照 issue #235 的渐进式验收标准

| 阶段 | 标准 | 本 PR |
| :-- | :-- | :-- |
| 基础 | 核心引擎与各平台适配层架构图 + 数据流标注 | ✅ `docs/platform-adapter-architecture.md`:分层架构图 + recall/capture/session 数据流时序图 |
| 进阶 | 为一个平台实现基本记忆读写 | ✅ Claude Code Hook 适配(`UserPromptSubmit`→recall,`Stop`→capture,`SessionEnd`→flush) |
| 深入 | 适配 ≥2 平台 + 对比文档 | ✅ Claude Code + Hermes,`docs/platform-adapter-comparison.md` |
| 拓展 | 封装统一适配器 SDK,新平台只需实现一个接口 | ✅ `CodingAgentPlatformAdapter`(`toEvent` + `renderRecall`)+ `runCodingAgentAdapter` 编排器 |

## 统一 SDK 设计

新平台接入只需实现一个接口:

- `toEvent(input)`:把平台原生载荷映射为中立生命周期事件(recall / capture / session-end / health / noop)。
- `renderRecall(context, input)`:把召回记忆渲染回平台原生响应结构。

传输、超时、Bearer 鉴权、recall 上下文扁平化、fail-open 全部由 `runCodingAgentAdapter` 统一提供,平台绑定层保持极薄。Claude Code 适配器即该接口的参考实现;`platform-adapter.test.ts` 用一个 demo 平台证明"实现一个接口即可接入新平台"。

## 主要改动

- `src/adapters/coding-agent/platform-adapter.ts`:统一接口 + 运行器 + `combineRecallContext`。
- `src/adapters/claude-code/`:重构为该接口的参考实现,公开 API(`handleClaudeCodeHook` / `extractLatestTurn` / `buildSessionKey`)完全不变。
- transcript 安全解析:过滤 `tool_result`、meta、sidechain,按 `prompt_id` 精确配对当前回合,并用 `last_assistant_message` 补齐 transcript 落后的情况。
- `src/gateway/recall-response.ts`:分别暴露 `prepend_context` 与 `append_system_context`,保留 legacy `context`。
- `package.json` / `tsdown.config.ts`:发布 `memory-tencentdb-claude-hook` 可执行命令,并把 4 份适配文档纳入 npm 包。
- Hermes 插件:对齐 Gateway host/port 与 LLM 环境变量,消费完整 recall 上下文。

## 与其它 #235 相关 PR 的关系

之前有同学建议把本 PR 拆散、依赖 #316/#372 等基线。考虑到这些基线目前仍未合并,本 PR 选择保持**自包含**以便独立合并、独立验证;其中的通用 SDK 层与那些基线在概念上可互补,若基线先合并,可在其上做去重 rebase。

## 验证

```bash
npm test        # 8 个测试文件,91 项测试全部通过
npm run build   # 构建通过
git diff --check # 干净
npm pack --dry-run # 含可执行 Hook 与 5 份适配文档
```

Refs #235。

Assisted-by: Claude Opus 4.8
