### PR TITLE
fix(hermes): inject stable system context

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -375,6 +375,7 @@ class MemoryTencentdbProvider(MemoryProvider):
         self._user_id = ""
         self._gateway_available = False
         self._initialized = False  # Track if initialize() has been called
+        self._latest_system_context = ""
 
         # Background sync threads.
         # We allow at most _MAX_INFLIGHT_SYNCS in-flight sync threads at any
@@ -816,7 +817,7 @@ class MemoryTencentdbProvider(MemoryProvider):
     def system_prompt_block(self) -> str:
         if not self._gateway_available:
             return ""
-        return (
+        block = (
             "# memory-tencentdb Memory\n"
             f"Active. User: {self._user_id}.\n"
             "Four-layer memory system (L0→L1→L2→L3) with automatic conversation "
@@ -824,6 +825,9 @@ class MemoryTencentdbProvider(MemoryProvider):
             "Use memory_tencentdb_memory_search to find specific memories, "
             "memory_tencentdb_conversation_search to search raw conversation history."
         )
+        if self._latest_system_context:
+            block = f"{block}\n\n{self._latest_system_context}"
+        return block
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Synchronous recall — fetch memories in real-time for the current turn."""
@@ -844,7 +848,11 @@ class MemoryTencentdbProvider(MemoryProvider):
                 session_key=effective_session,
                 user_id=self._user_id,
             )
-            context = result.get("context", "")
+            system_context = result.get("system_context", "")
+            if system_context:
+                self._latest_system_context = system_context
+
+            context = result.get("prepend_context") or result.get("context", "")
             self._record_success()
             if context:
                 return f"## memory-tencentdb Memory\n{context}"

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -45,6 +45,13 @@ logger = logging.getLogger(__name__)
 _BREAKER_THRESHOLD = 5
 _BREAKER_COOLDOWN_SECS = 60
 
+# ``system_prompt_block()`` has no user query, but the Gateway's /recall
+# contract requires a non-empty one. This reserved probe is intentionally
+# unlikely to match L1 records; only the stable ``system_context`` field from
+# the split recall contract is consumed from its response.
+_SYSTEM_CONTEXT_PROBE_QUERY = "[memory-tencentdb system context]"
+_SYSTEM_CONTEXT_TTL_SECS = 60.0
+
 # Gateway resurrect throttle: minimum seconds between two consecutive
 # ensure_running() attempts triggered by in-flight request failures.
 # Chosen smaller than _BREAKER_COOLDOWN_SECS so we can try to revive the
@@ -376,6 +383,7 @@ class MemoryTencentdbProvider(MemoryProvider):
         self._gateway_available = False
         self._initialized = False  # Track if initialize() has been called
         self._latest_system_context = ""
+        self._system_context_refreshed_at = 0.0
 
         # Background sync threads.
         # We allow at most _MAX_INFLIGHT_SYNCS in-flight sync threads at any
@@ -737,6 +745,8 @@ class MemoryTencentdbProvider(MemoryProvider):
         """
         self._session_id = session_id
         self._user_id = kwargs.get("user_id", "default")
+        self._latest_system_context = ""
+        self._system_context_refreshed_at = 0.0
 
         host = _resolve_gateway_host()
         port = _resolve_gateway_port()
@@ -817,6 +827,7 @@ class MemoryTencentdbProvider(MemoryProvider):
     def system_prompt_block(self) -> str:
         if not self._gateway_available:
             return ""
+        system_context = self._refresh_system_context()
         block = (
             "# memory-tencentdb Memory\n"
             f"Active. User: {self._user_id}.\n"
@@ -825,9 +836,45 @@ class MemoryTencentdbProvider(MemoryProvider):
             "Use memory_tencentdb_memory_search to find specific memories, "
             "memory_tencentdb_conversation_search to search raw conversation history."
         )
-        if self._latest_system_context:
-            block = f"{block}\n\n{self._latest_system_context}"
+        if system_context:
+            block = f"{block}\n\n{system_context}"
         return block
+
+    def _refresh_system_context(self) -> str:
+        """Refresh stable system context without injecting dynamic L1 recall.
+
+        A successful response, including an explicitly empty context, is
+        cached for a short TTL. Failures leave the timestamp and last-known
+        value untouched so prompt construction remains fail-open.
+        """
+        now = time.monotonic()
+        if (
+            self._system_context_refreshed_at > 0.0
+            and now - self._system_context_refreshed_at < _SYSTEM_CONTEXT_TTL_SECS
+        ):
+            return self._latest_system_context
+        if not self._ensure_alive_for_request() or not self._client:
+            return self._latest_system_context
+
+        try:
+            result = self._client.recall(
+                query=_SYSTEM_CONTEXT_PROBE_QUERY,
+                session_key=self._session_id,
+                user_id=self._user_id,
+            )
+            # Never fall back to ``context`` here: that backward-compatible
+            # field may contain dynamic L1 memories and does not belong in a
+            # stable system prompt.
+            value = result.get("system_context", "")
+            self._latest_system_context = value.strip() if isinstance(value, str) else ""
+            self._system_context_refreshed_at = now
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            logger.debug("memory-tencentdb system context refresh failed: %s", e)
+            self._try_recover_gateway()
+
+        return self._latest_system_context
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Synchronous recall — fetch memories in real-time for the current turn."""
@@ -848,9 +895,12 @@ class MemoryTencentdbProvider(MemoryProvider):
                 session_key=effective_session,
                 user_id=self._user_id,
             )
-            system_context = result.get("system_context", "")
-            if system_context:
-                self._latest_system_context = system_context
+            if effective_session == self._session_id and "system_context" in result:
+                system_context = result.get("system_context", "")
+                self._latest_system_context = (
+                    system_context.strip() if isinstance(system_context, str) else ""
+                )
+                self._system_context_refreshed_at = time.monotonic()
 
             context = result.get("prepend_context") or result.get("context", "")
             self._record_success()

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -357,6 +357,36 @@ def test_prefetch_recovers_when_stuck_false_and_breaker_closed(
     assert fake.ensure_running_calls >= 1
 
 
+def test_prefetch_uses_dynamic_recall_and_caches_system_context(
+    provider_with_fake_supervisor,
+):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+    fake.client.recall.return_value = {
+        "context": "legacy combined context",
+        "system_context": "<user-persona>stable persona</user-persona>",
+        "prepend_context": "<relevant-memories>L1 fact</relevant-memories>",
+    }
+
+    result = provider.prefetch(query="hello", session_id="test-session")
+
+    assert "<relevant-memories>L1 fact</relevant-memories>" in result
+    assert "legacy combined context" not in result
+    assert "<user-persona>stable persona</user-persona>" in provider.system_prompt_block()
+
+
+def test_prefetch_falls_back_to_legacy_context(
+    provider_with_fake_supervisor,
+):
+    provider = provider_with_fake_supervisor
+    fake = provider._fake
+    fake.client.recall.return_value = {"context": "legacy context only"}
+
+    result = provider.prefetch(query="hello", session_id="test-session")
+
+    assert "legacy context only" in result
+
+
 def test_prefetch_respects_open_breaker(provider_with_fake_supervisor):
     """Breaker should still take precedence — the lazy probe must not
     turn every request into a respawn attempt during a confirmed outage."""

--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1,0 +1,71 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { TdaiGateway } from "./server.js";
+
+function jsonRequest(body: unknown): Readable {
+  const req = new Readable({
+    read() {
+      this.push(JSON.stringify(body));
+      this.push(null);
+    },
+  });
+  return req;
+}
+
+function jsonResponse() {
+  let status = 0;
+  let payload = "";
+
+  return {
+    response: {
+      writeHead(nextStatus: number) {
+        status = nextStatus;
+      },
+      end(chunk: string) {
+        payload = chunk;
+      },
+    },
+    get status() {
+      return status;
+    },
+    get body() {
+      return JSON.parse(payload) as Record<string, unknown>;
+    },
+  };
+}
+
+describe("TdaiGateway recall", () => {
+  it("returns split system and prepend contexts with a backward-compatible context", async () => {
+    const gateway = new TdaiGateway();
+    (gateway as unknown as { core: unknown }).core = {
+      handleBeforeRecall: async () => ({
+        appendSystemContext: "<user-persona>stable persona</user-persona>",
+        prependContext: "<relevant-memories>L1 fact</relevant-memories>",
+        recallStrategy: "hybrid",
+        recalledL1Memories: [{ id: "m1" }, { id: "m2" }],
+      }),
+    };
+
+    const res = jsonResponse();
+
+    await (
+      gateway as unknown as {
+        handleRecall(req: Readable, res: typeof res.response): Promise<void>;
+      }
+    ).handleRecall(
+      jsonRequest({ query: "hello", session_key: "test-session" }),
+      res.response,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      context:
+        "<user-persona>stable persona</user-persona>\n\n" +
+        "<relevant-memories>L1 fact</relevant-memories>",
+      system_context: "<user-persona>stable persona</user-persona>",
+      prepend_context: "<relevant-memories>L1 fact</relevant-memories>",
+      strategy: "hybrid",
+      memory_count: 2,
+    });
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -380,10 +380,19 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    const systemContext = result.appendSystemContext ?? "";
+    const prependContext = result.prependContext ?? "";
+    const context = [systemContext, prependContext].filter(Boolean).join("\n\n");
+
+    this.logger.info(
+      `Recall completed in ${elapsed}ms: ` +
+      `system_context=${systemContext.length} chars, prepend_context=${prependContext.length} chars`,
+    );
 
     const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
+      context,
+      system_context: systemContext,
+      prepend_context: prependContext,
       strategy: result.recallStrategy,
       memory_count: result.recalledL1Memories?.length ?? 0,
     };

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -36,7 +36,12 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Backward-compatible combined context for older clients. */
   context: string;
+  /** Stable persona / scene / tool guidance context for system prompt injection. */
+  system_context?: string;
+  /** Dynamic L1 recall context for per-turn prefetch injection. */
+  prepend_context?: string;
   strategy?: string;
   memory_count?: number;
 }

--- a/tests/hermes/test_memory_tencentdb_system_context.py
+++ b/tests/hermes/test_memory_tencentdb_system_context.py
@@ -1,0 +1,158 @@
+"""Repo-only regression tests for Hermes stable system-context injection."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import time
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+# The production plugin imports Hermes' base class at module import time. Keep
+# this test runnable from a standalone repository checkout by installing the
+# smallest structural stub before importing the provider package.
+agent_module = types.ModuleType("agent")
+memory_provider_module = types.ModuleType("agent.memory_provider")
+
+
+class MemoryProvider:
+    pass
+
+
+memory_provider_module.MemoryProvider = MemoryProvider
+agent_module.memory_provider = memory_provider_module
+sys.modules.setdefault("agent", agent_module)
+sys.modules.setdefault("agent.memory_provider", memory_provider_module)
+
+repo_root = pathlib.Path(__file__).resolve().parents[2]
+hermes_plugin_root = repo_root / "hermes-plugin"
+sys.path.insert(0, str(hermes_plugin_root))
+
+from memory.memory_tencentdb import (  # noqa: E402
+    MemoryTencentdbProvider,
+    _SYSTEM_CONTEXT_PROBE_QUERY,
+)
+
+
+def make_provider() -> MemoryTencentdbProvider:
+    provider = MemoryTencentdbProvider()
+    provider._gateway_available = True
+    provider._client = MagicMock()
+    provider._session_id = "session-205"
+    provider._user_id = "user-205"
+    provider._ensure_alive_for_request = MagicMock(return_value=True)
+    provider._record_success = MagicMock()
+    provider._record_failure = MagicMock()
+    provider._try_recover_gateway = MagicMock()
+    return provider
+
+
+class SystemContextInjectionTest(unittest.TestCase):
+    def test_injects_only_stable_context_with_non_empty_probe(self) -> None:
+        provider = make_provider()
+        provider._client.recall.return_value = {
+            "system_context": "## L3 Persona\nPrefers concise technical answers.",
+            "prepend_context": "DYNAMIC_L1_MUST_NOT_BE_IN_SYSTEM_PROMPT",
+            "context": "BACKWARD_COMPATIBLE_COMBINED_CONTEXT",
+        }
+
+        block = provider.system_prompt_block()
+
+        self.assertIn("Prefers concise technical answers", block)
+        self.assertNotIn("DYNAMIC_L1", block)
+        self.assertNotIn("BACKWARD_COMPATIBLE", block)
+        provider._client.recall.assert_called_once_with(
+            query=_SYSTEM_CONTEXT_PROBE_QUERY,
+            session_key="session-205",
+            user_id="user-205",
+        )
+        self.assertTrue(_SYSTEM_CONTEXT_PROBE_QUERY)
+
+    def test_ttl_avoids_recalling_on_each_prompt_build(self) -> None:
+        provider = make_provider()
+        provider._client.recall.return_value = {"system_context": "stable persona"}
+
+        self.assertIn("stable persona", provider.system_prompt_block())
+        self.assertIn("stable persona", provider.system_prompt_block())
+
+        provider._client.recall.assert_called_once()
+
+    def test_prefetch_primes_system_context_cache(self) -> None:
+        provider = make_provider()
+        provider._client.recall.return_value = {
+            "system_context": "persona from actual user query",
+            "prepend_context": "dynamic memory for this turn",
+            "context": "combined fallback",
+        }
+
+        recalled = provider.prefetch("What do I prefer?")
+        block = provider.system_prompt_block()
+
+        self.assertEqual(recalled, "## memory-tencentdb Memory\ndynamic memory for this turn")
+        self.assertIn("persona from actual user query", block)
+        provider._client.recall.assert_called_once_with(
+            query="What do I prefer?",
+            session_key="session-205",
+            user_id="user-205",
+        )
+
+    def test_prefetch_for_another_session_does_not_prime_prompt_cache(self) -> None:
+        provider = make_provider()
+        provider._client.recall.side_effect = [
+            {
+                "system_context": "persona from another session",
+                "prepend_context": "other session recall",
+            },
+            {"system_context": "persona for session-205"},
+        ]
+
+        provider.prefetch("foreign query", session_id="session-other")
+        block = provider.system_prompt_block()
+
+        self.assertNotIn("persona from another session", block)
+        self.assertIn("persona for session-205", block)
+        self.assertEqual(provider._client.recall.call_count, 2)
+        self.assertEqual(
+            provider._client.recall.call_args_list[1].kwargs["session_key"],
+            "session-205",
+        )
+
+    def test_failure_keeps_last_known_system_context(self) -> None:
+        provider = make_provider()
+        provider._latest_system_context = "last known persona"
+        provider._system_context_refreshed_at = time.monotonic() - 120.0
+        provider._client.recall.side_effect = ConnectionError("Gateway unavailable")
+
+        block = provider.system_prompt_block()
+
+        self.assertIn("last known persona", block)
+        provider._record_failure.assert_called_once()
+        provider._try_recover_gateway.assert_called_once()
+        self.assertLess(provider._system_context_refreshed_at, time.monotonic() - 60.0)
+
+    def test_successful_empty_response_clears_stale_context(self) -> None:
+        provider = make_provider()
+        provider._latest_system_context = "stale persona"
+        provider._client.recall.return_value = {"system_context": ""}
+
+        block = provider.system_prompt_block()
+
+        self.assertNotIn("stale persona", block)
+        self.assertGreater(provider._system_context_refreshed_at, 0.0)
+
+    def test_older_gateway_context_is_not_injected_as_system_context(self) -> None:
+        provider = make_provider()
+        provider._client.recall.return_value = {
+            "context": "legacy response may contain dynamic L1",
+        }
+
+        block = provider.system_prompt_block()
+
+        self.assertNotIn("legacy response may contain dynamic L1", block)
+        provider._record_success.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description | 描述

Fixes the main Hermes persona/system-prompt bug in #205. The two additional write/tool bullets in that issue remain out of scope.

This is a focused follow-up to the approved split-context contract in #195. `system_prompt_block()` now obtains and caches only the stable `system_context` returned by that contract, so generated L3 persona/system guidance is visible to Hermes without moving dynamic L1 recall into the stable system prompt.

## Why this shape | 方案依据

This also addresses the verification/runtime gaps noted on the current #206 candidate:

- the Gateway rejects `query=""`; this implementation uses a reserved non-empty probe;
- no second `recalledL3_persona` wire field is added because #195 already exposes the correct stable `system_context` boundary;
- the backward-compatible combined `context` and dynamic `prepend_context` fields are explicitly ignored by the system-prompt refresh path;
- regression tests live outside the provider package and stub `agent.memory_provider` before import, so both unittest and pytest run from a repo-only checkout;
- the root test path is excluded from the npm package.

## Behavior | 行为

- Refresh stable system context on the first prompt build and after a 60-second TTL.
- Let a normal user-query `prefetch()` prime the same cache, avoiding a second Gateway call.
- Prime the prompt cache only when prefetch belongs to the provider's own session, preventing cross-session context leakage.
- Cache successful empty responses so a Gateway without generated persona is not polled on every prompt.
- On recall failure, keep the last-known stable context, record the failure, and trigger the existing recovery path without breaking prompt construction.
- Reset cached context when the provider is initialized for a session/user.

## Dependency | 依赖

This PR depends on #195 and starts from its approved head commit `e644d0b`.

Until #195 lands, the diff against `main` also includes that PR's split-context commit. The unique change here is the signed commit `1c85c31`; relative to #195 it changes only the Hermes provider and one focused repo-only test file. I will rebase onto `main` after #195 merges.

## Verification | 验证

```text
$ python3 -m pytest tests/hermes/test_memory_tencentdb_system_context.py
7 passed

$ python3 tests/hermes/test_memory_tencentdb_system_context.py
Ran 7 tests - OK

$ npm test
Test Files  5 passed (5)
Tests       68 passed (68)

$ npm run build
Build complete

$ npm pack --dry-run --json
Passed; 148 package entries and tests/hermes is excluded

$ python3 -m py_compile hermes-plugin/memory/memory_tencentdb/__init__.py tests/hermes/test_memory_tencentdb_system_context.py
Passed

$ git diff --check
Passed
```

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Commit includes the required DCO sign-off
