### PR TITLE
fix(checkpoint): add recalibrate() to fix counter drift after cleanup

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -159,7 +159,8 @@ export class TdaiCore {
           this.wirePipelineRunners();
         });
     }
-
+    const cp = new CheckpointManager(this.dataDir, this.logger);
+    await cp.recalibrate();
     this.logger.debug?.(`${TAG} TDAI Core initialized`);
   }
 

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
 
 // ============================
 // Types
@@ -181,10 +183,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 export class CheckpointManager {
   private filePath: string;
   private logger: CheckpointLogger;
+  private dataDir:string;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
+    this.dataDir = dataDir;
   }
 
   // ============================
@@ -270,6 +274,7 @@ export class CheckpointManager {
   }
 
   // ============================
+  
   // Public API — read-only
   // ============================
 
@@ -292,6 +297,30 @@ export class CheckpointManager {
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
   }
+  
+ async getTotalLines(folderPath: string): Promise<number> {
+    const files = await readdir(folderPath);
+    const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+    
+    let total = 0;
+    for (const file of jsonlFiles) {
+        const content = await readFile(join(folderPath, file), 'utf-8');
+        const lines = content.split(/\r?\n/);
+        // 过滤空行（比如末尾的空行）
+        const nonEmpty = lines.filter(line => line.trim() !== '');
+        total += nonEmpty.length;
+    }
+    return total;
+ }
+ async recalibrate(): Promise<void>{
+    await this.mutate(async(cp)=>{
+      const recordsPath=path.join(this.dataDir,"records");
+      const conversationPath=path.join(this.dataDir,"conversations");
+      cp.total_memories_extracted=await this.getTotalLines(recordsPath);
+      cp.l0_conversations_count=await this.getTotalLines(conversationPath);
+    })
+  }
+
 
   // ============================
   // Public API — mutating (all serialized via file lock)


### PR DESCRIPTION
fix(checkpoint): add recalibrate() to fix counter drift after cleanup


## Description | 描述

添加 `recalibrate()` 方法到 `CheckpointManager`，在网关启动时根据磁盘实际数据重新校准计数器，解决清理数据后计数器只增不减导致的漂移问题。

### 根因

- `captureAtomically()` (checkpoint.ts L483): `l0_conversations_count += 1`
- `markL1ExtractionComplete()` (checkpoint.ts L424): `total_memories_extracted += n`
- `memory-cleaner` 删除过期数据后，从不更新 checkpoint 计数器

### 修复

| 文件 | 改动 |
|------|------|
| `src/utils/checkpoint.ts` | 新增 `getTotalLines()` + `recalibrate()` 方法 |
| `src/core/tdai-core.ts` | `initialize()` 末尾调用 `recalibrate()` |

### 数据流图

```mermaid
flowchart TD
    subgraph 启动修复["启动时修复（新增）"]
        START["程序启动"] --> INIT["initialize()"]
        INIT --> RECAL["recalibrate()"]
        RECAL -->|"fs.readdir() 数 records/*.jsonl"| SET1["total_memories_extracted = 实际行数"]
        RECAL -->|"fs.readdir() 数 conversations/*.jsonl"| SET2["l0_conversations_count = 实际行数"]
    end
    subgraph 正常流程["正常运行时（只增不减）"]
        L0["L0 对话捕获 captureAtomically()"] -->|"+1"| L0CTR["l0_conversations_count"]
        L1["L1 记忆提取 markL1ExtractionComplete()"] -->|"+n"| L1CTR["total_memories_extracted"]
    end
    subgraph 清理流程["清理流程（删文件不更新计数器）"]
        CLEANER["memory-cleaner 定时清理"] -->|"删除过期 .jsonl"| DISK["records/ + conversations/"]
        DISK -.->|"❌ 不更新计数器"| DRIFT["计数器漂移"]
    end
    L0CTR --> CP["recall_checkpoint.json"]
    L1CTR --> CP
    DRIFT --> CP
    RECAL -.->|"✅ 重新对齐"| CP
    style DRIFT fill:#ff6b6b,color:#fff
    style RECAL fill:#51cf66,color:#fff
    style CP fill:#ffd43b
```

## Related Issue | 关联 Issue

Fix #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过（`npm test` 67 passed, `tsdown` build OK）
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Signed-off-by: Deng-Gulou
