### PR TITLE
fix: stabilize cache-aware recall for issue 120

### DIFF
--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyRecallBudgetToItems,
+  buildStableRecallContext,
+  canonicalSortRecallItems,
+  formatRecallDisplayItem,
+  type RecallDisplayItem,
+} from "./auto-recall.js";
+
+function item(overrides: Partial<RecallDisplayItem> = {}): RecallDisplayItem {
+  return {
+    recordId: "record-a",
+    type: "episodic",
+    priority: 50,
+    sceneName: "scene-a",
+    content: "content",
+    score: 0.5,
+    ...overrides,
+  };
+}
+
+describe("canonical recall ordering", () => {
+  it("returns the same order for the same item set in different input orders", () => {
+    const a = item({ recordId: "a", type: "episodic", sceneName: "s2" });
+    const b = item({ recordId: "b", type: "instruction", sceneName: "s1" });
+    const c = item({ recordId: "c", type: "persona", sceneName: "s3" });
+
+    expect(canonicalSortRecallItems([c, a, b]).map((entry) => entry.recordId))
+      .toEqual(canonicalSortRecallItems([b, c, a]).map((entry) => entry.recordId));
+  });
+
+  it("sorts by type rank before other keys", () => {
+    const sorted = canonicalSortRecallItems([
+      item({ recordId: "e", type: "episodic" }),
+      item({ recordId: "p", type: "persona" }),
+      item({ recordId: "i", type: "instruction" }),
+    ]);
+
+    expect(sorted.map((entry) => entry.recordId)).toEqual(["i", "p", "e"]);
+  });
+
+  it("uses priority, scene name, and record id as stable tie breakers", () => {
+    const sorted = canonicalSortRecallItems([
+      item({ recordId: "b", type: "episodic", priority: 50, sceneName: "same" }),
+      item({ recordId: "c", type: "episodic", priority: 90, sceneName: "same" }),
+      item({ recordId: "a", type: "episodic", priority: 50, sceneName: "same" }),
+      item({ recordId: "d", type: "episodic", priority: 50, sceneName: "aaa" }),
+    ]);
+
+    expect(sorted.map((entry) => entry.recordId)).toEqual(["c", "d", "a", "b"]);
+  });
+
+  it("falls back to content hash when record id is missing", () => {
+    const first = canonicalSortRecallItems([
+      item({ recordId: "", content: "beta" }),
+      item({ recordId: "", content: "alpha" }),
+    ]).map(formatRecallDisplayItem);
+    const second = canonicalSortRecallItems([
+      item({ recordId: "", content: "alpha" }),
+      item({ recordId: "", content: "beta" }),
+    ]).map(formatRecallDisplayItem);
+
+    expect(first).toEqual(second);
+  });
+
+  it("keeps budgeted output deterministic for the same item set", () => {
+    const recall = {
+      maxResults: 5,
+      maxCharsPerMemory: 80,
+      maxTotalRecallChars: 140,
+      scoreThreshold: 0,
+      strategy: "hybrid" as const,
+      enabled: true,
+      timeoutMs: 5000,
+    };
+    const a = item({ recordId: "a", type: "instruction", content: "a".repeat(120) });
+    const b = item({ recordId: "b", type: "episodic", content: "b".repeat(120) });
+    const c = item({ recordId: "c", type: "persona", content: "c".repeat(120) });
+
+    const first = applyRecallBudgetToItems([c, a, b], recall).map(formatRecallDisplayItem);
+    const second = applyRecallBudgetToItems([b, c, a], recall).map(formatRecallDisplayItem);
+
+    expect(first).toEqual(second);
+  });
+});
+
+describe("stable recall context ordering", () => {
+  it("places tools guide before persona and scene navigation", () => {
+    const context = buildStableRecallContext({
+      personaContent: "persona",
+      sceneNavigation: "scene navigation",
+      hasDynamicRecall: true,
+    });
+
+    expect(context).toBeTruthy();
+    expect(context).not.toContain("<relevant-memories>");
+    expect(context!.indexOf("<memory-tools-guide>")).toBeLessThan(context!.indexOf("<user-persona>"));
+    expect(context!.indexOf("<user-persona>")).toBeLessThan(context!.indexOf("<scene-navigation>"));
+  });
+
+  it("does not create stable context when nothing is available", () => {
+    expect(buildStableRecallContext({ hasDynamicRecall: false })).toBeUndefined();
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -12,6 +12,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { formatForLLM } from "../../utils/time.js";
 import type { MemoryTdaiConfig } from "../../config.js";
 import { readSceneIndex } from "../scene/scene-index.js";
@@ -54,10 +55,31 @@ export interface RecalledMemory {
   type: string;
 }
 
+export interface RecallDisplayItem {
+  recordId: string;
+  type: string;
+  priority: number;
+  sceneName: string;
+  content: string;
+  score: number;
+  activityStartTime?: string;
+  activityEndTime?: string;
+  timestamp?: string;
+}
+
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn) */
   prependContext?: string;
-  /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
+  /**
+   * Stable recall context prepended to the system prompt (persona, scene nav, tools guide).
+   * Placed BEFORE CACHE_BOUNDARY so providers can cache it across turns.
+   * Infrequently-changing content — ideal for prefix-matching prompt caching.
+   */
+  prependSystemContext?: string;
+  /**
+   * Dynamic recall context appended to the system prompt (after CACHE_BOUNDARY).
+   * Currently used by L4 offload for per-turn skill generation results.
+   */
   appendSystemContext?: string;
 
   // ── Metric payload (for pendingRecallCache in index.ts) ──
@@ -123,21 +145,14 @@ async function performAutoRecallInner(params: {
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
     const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
-    memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
-    memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
-
-    // Extract structured RecalledMemory from formatted lines for metric reporting
-    recalledL1Memories = memoryLines.map((line) => {
-      const match = line.match(/^-\s+\[([^\]]+)\]\s+(.+?)(?:\s*\(活动时间:.*\))?$/);
-      if (match) {
-        const tag = match[1];
-        const content = match[2].trim();
-        const typePart = tag.includes("|") ? tag.split("|")[0] : tag;
-        return { content, score: 0, type: typePart };
-      }
-      return { content: line, score: 0, type: "unknown" };
-    });
+    const displayItems = canonicalSortRecallItems(applyRecallBudgetToItems(searchResult.items, cfg.recall, logger));
+    memoryLines = displayItems.map(formatRecallDisplayItem);
+    recalledL1Memories = displayItems.map((item) => ({
+      content: item.content,
+      score: item.score,
+      type: item.type,
+    }));
   }
   const tSearchEnd = performance.now();
 
@@ -185,22 +200,19 @@ async function performAutoRecallInner(params: {
 
   // Split recall context into stable and dynamic parts to optimize prompt caching.
   //
-  // appendSystemContext (system prompt end — stable, cacheable):
-  //   persona, scene navigation, memory tools guide
-  //   These change infrequently; when content is identical across turns,
-  //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
+  // prependSystemContext (system prompt prefix — before CACHE_BOUNDARY, cacheable):
+  //   memory tools guide, persona, scene navigation
+  //   These change infrequently (persona/scene pipeline updates); when content is
+  //   identical across turns, providers with prefix-matching caches (OpenAI,
+  //   DeepSeek, Anthropic) can reuse the cached prefix — saving ~4000 chars/turn.
+  //
+  //   Critical: prependSystemContext is placed BEFORE CACHE_BOUNDARY so the stable
+  //   workspace prefix remains consistent for caching. Previously this content was
+  //   in appendSystemContext (AFTER CACHE_BOUNDARY), which busted the cache every turn.
   //
   // prependContext (user prompt prefix — dynamic, per-turn):
   //   L1 relevant memories — different every turn, moved out of system prompt
   //   so it doesn't bust the system prompt cache.
-  const stableParts: string[] = [];
-  if (personaContent) {
-    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
-  }
-  if (sceneNavigation) {
-    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
-  }
-
   // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
   let prependContext: string | undefined;
   if (memoryLines.length > 0) {
@@ -208,14 +220,11 @@ async function performAutoRecallInner(params: {
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
   }
 
-  // Append memory tools usage guide to the stable part so the agent knows
-  // how to actively retrieve deeper context when the injected snippets
-  // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
-    stableParts.push(MEMORY_TOOLS_GUIDE);
-  }
-
-  const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  const prependSystemContext = buildStableRecallContext({
+    personaContent,
+    sceneNavigation,
+    hasDynamicRecall: memoryLines.length > 0,
+  });
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(
@@ -227,13 +236,13 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
-  if (!appendSystemContext && !prependContext) {
+  if (!prependSystemContext && !prependContext) {
     return undefined;
   }
 
   return {
     prependContext,
-    appendSystemContext,
+    prependSystemContext,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,
     recallStrategy: effectiveStrategy,
@@ -258,16 +267,15 @@ interface SearchTiming {
 }
 
 interface SearchResult {
-  lines: string[];
+  items: RecallDisplayItem[];
   timing: SearchTiming;
 }
 
 /**
  * Search memories and return both formatted lines and structured details.
  *
- * This is a thin wrapper around `searchMemories` that also captures
- * the recalled memory metadata for metric reporting (agent_turn event).
- * It parses the returned formatted lines to extract type/content info.
+ * This is a thin wrapper around `searchMemories` that keeps structured
+ * recall items for metric reporting instead of parsing formatted prompt text.
  */
 async function searchMemoriesWithDetails(
   userText: string,
@@ -279,21 +287,16 @@ async function searchMemoriesWithDetails(
   embeddingService?: EmbeddingService,
 ): Promise<{ lines: string[]; memories: RecalledMemory[]; timing: SearchTiming }> {
   const result = await searchMemories(userText, pluginDataDir, cfg, logger, strategy, vectorStore, embeddingService);
+  const items = canonicalSortRecallItems(result.items);
+  const lines = items.map(formatRecallDisplayItem);
 
-  // Extract structured data from formatted memory lines.
-  // Format: "- [type|scene] content (活动时间: ...)" or "- [type] content"
-  const memories: RecalledMemory[] = result.lines.map((line) => {
-    const match = line.match(/^-\s+\[([^\]]+)\]\s+(.+?)(?:\s*\(活动时间:.*\))?$/);
-    if (match) {
-      const tag = match[1];
-      const content = match[2].trim();
-      const typePart = tag.includes("|") ? tag.split("|")[0] : tag;
-      return { content, score: 0, type: typePart };
-    }
-    return { content: line, score: 0, type: "unknown" };
-  });
+  const memories: RecalledMemory[] = items.map((item) => ({
+    content: item.content,
+    score: item.score,
+    type: item.type,
+  }));
 
-  return { lines: result.lines, memories, timing: result.timing };
+  return { lines, memories, timing: result.timing };
 }
 
 /**
@@ -314,7 +317,7 @@ async function searchMemories(
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
 ): Promise<SearchResult> {
-  const emptyResult: SearchResult = { lines: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
+  const emptyResult: SearchResult = { items: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
   // Strip gateway-injected inbound metadata (Sender, timestamps, media markers,
   // base64 image data, etc.) so FTS / embedding queries are based on pure user intent.
   const cleanText = sanitizeText(userText);
@@ -361,14 +364,14 @@ async function searchMemories(
   try {
     if (effectiveStrategy === "keyword") {
       const tFts = performance.now();
-      const lines = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore);
-      return { lines, timing: { ftsMs: performance.now() - tFts, embeddingMs: 0, ftsHits: lines.length, embeddingHits: 0 } };
+      const items = await searchByKeyword(cleanText, pluginDataDir, maxResults, threshold, logger, vectorStore);
+      return { items, timing: { ftsMs: performance.now() - tFts, embeddingMs: 0, ftsHits: items.length, embeddingHits: 0 } };
     }
 
     if (effectiveStrategy === "embedding") {
       const tEmb = performance.now();
-      const lines = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts);
-      return { lines, timing: { ftsMs: 0, embeddingMs: performance.now() - tEmb, ftsHits: 0, embeddingHits: lines.length } };
+      const items = await searchByEmbedding(cleanText, maxResults, threshold, vectorStore!, embeddingService!, logger, embeddingCallOpts);
+      return { items, timing: { ftsMs: 0, embeddingMs: performance.now() - tEmb, ftsHits: 0, embeddingHits: items.length } };
     }
 
     // Hybrid: if the store natively supports hybrid search (e.g. TCVDB does
@@ -379,8 +382,8 @@ async function searchMemories(
       const results = await vectorStore.searchL1Hybrid({ query: cleanText, topK: maxResults });
       const nativeMs = performance.now() - tNative;
       logger?.debug?.(`${TAG} [hybrid-native] Single-call hybrid: ${results.length} results in ${nativeMs.toFixed(0)}ms`);
-      const lines = results.map((r) => formatMemoryLine(vectorResultToFormatable(r)));
-      return { lines, timing: { ftsMs: 0, embeddingMs: nativeMs, ftsHits: 0, embeddingHits: results.length } };
+      const items = results.map(vectorResultToRecallDisplayItem);
+      return { items, timing: { ftsMs: 0, embeddingMs: nativeMs, ftsHits: 0, embeddingHits: results.length } };
     }
 
     // Fallback: run keyword + embedding in parallel, merge with client-side RRF (SQLite path)
@@ -402,7 +405,7 @@ async function searchByKeyword(
   threshold: number,
   logger?: Logger,
   vectorStore?: IMemoryStore,
-): Promise<string[]> {
+): Promise<RecallDisplayItem[]> {
   // Prefer FTS5 if available
   if (vectorStore?.isFtsAvailable()) {
     const ftsQuery = buildFtsQuery(userText);
@@ -420,7 +423,7 @@ async function searchByKeyword(
 
         if (filtered.length > 0) {
           logger?.debug?.(`${TAG} [keyword-fts] FTS5 found ${filtered.length} results (from ${ftsResults.length} raw, threshold=${threshold})`);
-          return filtered.map((r) => formatMemoryLine(ftsResultToFormatable(r)));
+          return filtered.map(ftsResultToRecallDisplayItem);
         }
 
         // BM25 absolute scores are unreliable when the document set is very
@@ -431,7 +434,7 @@ async function searchByKeyword(
             `${TAG} [keyword-fts] All ${ftsResults.length} results below threshold=${threshold} ` +
             `but document set is small — returning all matched results`,
           );
-          return ftsResults.slice(0, maxResults).map((r) => formatMemoryLine(ftsResultToFormatable(r)));
+          return ftsResults.slice(0, maxResults).map(ftsResultToRecallDisplayItem);
         }
         logger?.debug?.(`${TAG} [keyword-fts] FTS5 returned 0 results above threshold (from ${ftsResults.length} raw)`);
       }
@@ -455,7 +458,7 @@ async function searchByEmbedding(
   embeddingService: EmbeddingService,
   logger?: Logger,
   embeddingCallOpts?: EmbeddingCallOptions,
-): Promise<string[]> {
+): Promise<RecallDisplayItem[]> {
   logger?.debug?.(
     `${TAG} [embedding-search] START query="${userText.slice(0, 80)}...", maxResults=${maxResults}, threshold=${threshold}`,
   );
@@ -487,7 +490,7 @@ async function searchByEmbedding(
 
   if (filtered.length > 0) {
     logger?.debug?.(`${TAG} [embedding-search] Found ${filtered.length} relevant memories above threshold (from ${vecResults.length} candidates)`);
-    return filtered.map((r) => formatMemoryLine(vectorResultToFormatable(r)));
+    return filtered.map(vectorResultToRecallDisplayItem);
   }
 
   logger?.debug?.(`${TAG} [embedding-search] No results above threshold ${threshold}`);
@@ -593,14 +596,14 @@ async function searchHybrid(
 
   if (keywordResults.length === 0 && embeddingResults.length === 0) {
     logger?.debug?.(`${TAG} Hybrid search: both strategies returned 0 results`);
-    return { lines: [], timing };
+    return { items: [], timing };
   }
 
   // RRF merge: k=60 is a standard constant from the RRF paper
   const RRF_K = 60;
 
-  // Map: record_id → { rrfScore, formatable }
-  const mergedMap = new Map<string, { rrfScore: number; formatable: FormatableMemory }>();
+  // Map: record_id → { rrfScore, item }
+  const mergedMap = new Map<string, { rrfScore: number; item: RecallDisplayItem }>();
 
   // Process keyword results
   for (let rank = 0; rank < keywordResults.length; rank++) {
@@ -611,7 +614,7 @@ async function searchHybrid(
     if (existing) {
       existing.rrfScore += rrfScore;
     } else {
-      mergedMap.set(id, { rrfScore, formatable: recordToFormatable(r.record) });
+      mergedMap.set(id, { rrfScore, item: recordToRecallDisplayItem(r.record, r.score) });
     }
   }
 
@@ -624,7 +627,7 @@ async function searchHybrid(
     if (existing) {
       existing.rrfScore += rrfScore;
     } else {
-      mergedMap.set(id, { rrfScore, formatable: vectorResultToFormatable(r) });
+      mergedMap.set(id, { rrfScore, item: vectorResultToRecallDisplayItem(r) });
     }
   }
 
@@ -638,11 +641,11 @@ async function searchHybrid(
       `${TAG} Hybrid search found ${sorted.length} results ` +
       `(keyword=${keywordResults.length}, embedding=${embeddingResults.length})`,
     );
-    return { lines: sorted.map(([, { formatable }]) => formatMemoryLine(formatable)), timing };
+    return { items: sorted.map(([, { item, rrfScore }]) => ({ ...item, score: rrfScore })), timing };
   }
 
   logger?.debug?.(`${TAG} Hybrid search: no results after merge`);
-  return { lines: [], timing };
+  return { items: [], timing };
 }
 
 // ============================
@@ -664,15 +667,73 @@ async function searchHybrid(
  *   - [instruction] 用户要求回答时使用中文，保持简洁。
  */
 interface FormatableMemory {
+  recordId?: string;
   type: string;
   content: string;
+  priority?: number;
   scene_name?: string;
+  score?: number;
   /** Activity time range start (段时间 start), may be empty */
   activity_start_time?: string;
   /** Activity time range end (段时间 end), may be empty */
   activity_end_time?: string;
   /** Activity point-in-time (点时间: when it happened), may be empty */
   timestamp?: string;
+}
+
+export function canonicalSortRecallItems(items: RecallDisplayItem[]): RecallDisplayItem[] {
+  return [...items].sort((a, b) => {
+    const typeDiff = getRecallTypeRank(a.type) - getRecallTypeRank(b.type);
+    if (typeDiff !== 0) return typeDiff;
+
+    const priorityDiff = b.priority - a.priority;
+    if (priorityDiff !== 0) return priorityDiff;
+
+    const sceneDiff = a.sceneName.localeCompare(b.sceneName);
+    if (sceneDiff !== 0) return sceneDiff;
+
+    const recordIdDiff = a.recordId.localeCompare(b.recordId);
+    if (recordIdDiff !== 0) return recordIdDiff;
+
+    return hashRecallContent(a.content).localeCompare(hashRecallContent(b.content));
+  });
+}
+
+export function formatRecallDisplayItem(item: RecallDisplayItem): string {
+  return formatMemoryLine({
+    recordId: item.recordId,
+    type: item.type,
+    priority: item.priority,
+    content: item.content,
+    scene_name: item.sceneName,
+    score: item.score,
+    activity_start_time: item.activityStartTime,
+    activity_end_time: item.activityEndTime,
+    timestamp: item.timestamp,
+  });
+}
+
+export function buildStableRecallContext(params: {
+  personaContent?: string;
+  sceneNavigation?: string;
+  hasDynamicRecall: boolean;
+}): string | undefined {
+  const { personaContent, sceneNavigation, hasDynamicRecall } = params;
+  const stableParts: string[] = [];
+
+  // The tools guide is static, so keep it first. If persona or scene navigation
+  // changes later, the static prefix can still participate in prefix matching.
+  if (personaContent || sceneNavigation || hasDynamicRecall) {
+    stableParts.push(MEMORY_TOOLS_GUIDE);
+  }
+  if (personaContent) {
+    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
+  }
+  if (sceneNavigation) {
+    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
+  }
+
+  return stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
 }
 
 function formatMemoryLine(m: FormatableMemory): string {
@@ -705,29 +766,32 @@ function formatMemoryLine(m: FormatableMemory): string {
   return line;
 }
 
-function applyRecallBudget(
-  lines: string[],
+export function applyRecallBudgetToItems(
+  items: RecallDisplayItem[],
   recall: MemoryTdaiConfig["recall"],
   logger?: Logger,
-): string[] {
+): RecallDisplayItem[] {
   const maxCharsPerMemory = normalizeBudgetLimit(recall.maxCharsPerMemory);
   const maxTotalRecallChars = normalizeBudgetLimit(recall.maxTotalRecallChars);
 
   if (!maxCharsPerMemory && !maxTotalRecallChars) {
-    return lines;
+    return canonicalSortRecallItems(items);
   }
 
-  const budgeted: string[] = [];
+  const sortedItems = canonicalSortRecallItems(items);
+  const budgeted: RecallDisplayItem[] = [];
   let usedChars = 0;
   let truncatedCount = 0;
   let droppedCount = 0;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (let i = 0; i < sortedItems.length; i++) {
+    const item = sortedItems[i];
+    const line = formatRecallDisplayItem(item);
     const perMemoryBounded = maxCharsPerMemory
-      ? truncateRecallLine(line, maxCharsPerMemory)
-      : line;
-    let wasTruncated = perMemoryBounded !== line;
+      ? fitRecallItemToFormattedLine(item, maxCharsPerMemory)
+      : item;
+    let boundedLine = formatRecallDisplayItem(perMemoryBounded);
+    let wasTruncated = boundedLine !== line;
 
     if (!maxTotalRecallChars) {
       budgeted.push(perMemoryBounded);
@@ -738,31 +802,32 @@ function applyRecallBudget(
     const separatorChars = budgeted.length > 0 ? RECALL_LINE_SEPARATOR.length : 0;
     const remainingChars = maxTotalRecallChars - usedChars - separatorChars;
     if (remainingChars <= 0) {
-      droppedCount += lines.length - i;
+      droppedCount += sortedItems.length - i;
       break;
     }
 
-    if (perMemoryBounded.length > remainingChars) {
+    if (boundedLine.length > remainingChars) {
       const canFit = remainingChars >= MIN_TRUNCATED_RECALL_LINE_CHARS;
       if (canFit) {
-        const totalBounded = truncateRecallLine(perMemoryBounded, remainingChars);
+        const totalBounded = fitRecallItemToFormattedLine(perMemoryBounded, remainingChars);
+        boundedLine = formatRecallDisplayItem(totalBounded);
         budgeted.push(totalBounded);
-        usedChars += separatorChars + totalBounded.length;
-        wasTruncated ||= totalBounded !== perMemoryBounded;
+        usedChars += separatorChars + boundedLine.length;
+        wasTruncated ||= boundedLine !== formatRecallDisplayItem(perMemoryBounded);
         if (wasTruncated) truncatedCount++;
       }
-      droppedCount += lines.length - i - (canFit ? 1 : 0);
+      droppedCount += sortedItems.length - i - (canFit ? 1 : 0);
       break;
     }
 
     budgeted.push(perMemoryBounded);
-    usedChars += separatorChars + perMemoryBounded.length;
+    usedChars += separatorChars + boundedLine.length;
     if (wasTruncated) truncatedCount++;
   }
 
   if (truncatedCount > 0 || droppedCount > 0) {
     logger?.debug?.(
-      `${TAG} Recall budget applied: input=${lines.length}, output=${budgeted.length}, ` +
+      `${TAG} Recall budget applied: input=${items.length}, output=${budgeted.length}, ` +
       `truncated=${truncatedCount}, dropped=${droppedCount}, ` +
       `maxCharsPerMemory=${recall.maxCharsPerMemory}, maxTotalRecallChars=${recall.maxTotalRecallChars}`,
     );
@@ -771,21 +836,56 @@ function applyRecallBudget(
   return budgeted;
 }
 
+function getRecallTypeRank(type: string): number {
+  switch (type) {
+    case "instruction":
+      return 0;
+    case "persona":
+      return 1;
+    case "episodic":
+      return 2;
+    default:
+      return 9;
+  }
+}
+
+function hashRecallContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function fitRecallItemToFormattedLine(item: RecallDisplayItem, maxChars: number): RecallDisplayItem {
+  const line = formatRecallDisplayItem(item);
+  if (Array.from(line).length <= maxChars) return item;
+
+  const contentCodePoints = Array.from(item.content);
+  let low = 0;
+  let high = contentCodePoints.length;
+  let best = "";
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidateContent = buildTruncatedRecallContent(contentCodePoints, mid);
+    const candidate = { ...item, content: candidateContent };
+    if (Array.from(formatRecallDisplayItem(candidate)).length <= maxChars) {
+      best = candidateContent;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return { ...item, content: best };
+}
+
+function buildTruncatedRecallContent(contentCodePoints: string[], contentLength: number): string {
+  const raw = contentCodePoints.slice(0, contentLength).join("").trimEnd();
+  if (!raw) return "";
+  return `${raw}${RECALL_TRUNCATION_SUFFIX}`;
+}
+
 function normalizeBudgetLimit(value: number | undefined): number | undefined {
   if (value == null || !Number.isFinite(value) || value <= 0) return undefined;
   return Math.floor(value);
-}
-
-function truncateRecallLine(line: string, maxChars: number): string {
-  // Count and slice by code point, not UTF-16 code unit, so a cut never lands
-  // between the halves of a surrogate pair (which would corrupt a non-BMP
-  // character to U+FFFD when the line is UTF-8 encoded for the request).
-  const cps = Array.from(line);
-  if (cps.length <= maxChars) return line;
-  if (maxChars <= RECALL_TRUNCATION_SUFFIX.length) {
-    return cps.slice(0, maxChars).join("");
-  }
-  return `${cps.slice(0, maxChars - RECALL_TRUNCATION_SUFFIX.length).join("").trimEnd()}${RECALL_TRUNCATION_SUFFIX}`;
 }
 
 /**
@@ -812,27 +912,22 @@ function formatTimestamp(ts: string | undefined): string | undefined {
   return formatForLLM(ts);
 }
 
-/**
- * Build a FormatableMemory from a full MemoryRecord (keyword search path).
- * Handles empty metadata, empty timestamps array gracefully.
- */
-function recordToFormatable(record: MemoryRecord): FormatableMemory {
+function recordToRecallDisplayItem(record: MemoryRecord, score = 0): RecallDisplayItem {
   const meta = record.metadata as { activity_start_time?: string; activity_end_time?: string } | undefined;
   return {
+    recordId: record.id || hashRecallContent(record.content),
     type: record.type,
+    priority: record.priority ?? 0,
+    sceneName: record.scene_name || "",
     content: record.content,
-    scene_name: record.scene_name || undefined,
-    activity_start_time: meta?.activity_start_time || undefined,
-    activity_end_time: meta?.activity_end_time || undefined,
+    score,
+    activityStartTime: meta?.activity_start_time || undefined,
+    activityEndTime: meta?.activity_end_time || undefined,
     timestamp: (record.timestamps && record.timestamps.length > 0) ? record.timestamps[0] : undefined,
   };
 }
 
-/**
- * Build a FormatableMemory from a VectorSearchResult (embedding search path).
- * Handles empty/invalid metadata_json, empty timestamp_str gracefully.
- */
-function vectorResultToFormatable(r: L1SearchResult): FormatableMemory {
+function vectorResultToRecallDisplayItem(r: L1SearchResult): RecallDisplayItem {
   let activityStart: string | undefined;
   let activityEnd: string | undefined;
   if (r.metadata_json && r.metadata_json !== "{}") {
@@ -843,20 +938,19 @@ function vectorResultToFormatable(r: L1SearchResult): FormatableMemory {
     } catch { /* ignore parse errors — treat as no metadata */ }
   }
   return {
-    type: r.type,
+    recordId: r.record_id || hashRecallContent(r.content),
+    type: r.type || "unknown",
+    priority: r.priority ?? 0,
+    sceneName: r.scene_name || "",
     content: r.content,
-    scene_name: r.scene_name || undefined,
-    activity_start_time: activityStart,
-    activity_end_time: activityEnd,
+    score: r.score ?? 0,
+    activityStartTime: activityStart,
+    activityEndTime: activityEnd,
     timestamp: r.timestamp_str || undefined,
   };
 }
 
-/**
- * Build a FormatableMemory from an FtsSearchResult (FTS5 keyword search path).
- * Handles empty/invalid metadata_json, empty timestamp_str gracefully.
- */
-function ftsResultToFormatable(r: L1FtsResult): FormatableMemory {
+function ftsResultToRecallDisplayItem(r: L1FtsResult): RecallDisplayItem {
   let activityStart: string | undefined;
   let activityEnd: string | undefined;
   if (r.metadata_json && r.metadata_json !== "{}") {
@@ -867,11 +961,14 @@ function ftsResultToFormatable(r: L1FtsResult): FormatableMemory {
     } catch { /* ignore parse errors — treat as no metadata */ }
   }
   return {
-    type: r.type,
+    recordId: r.record_id || hashRecallContent(r.content),
+    type: r.type || "unknown",
+    priority: r.priority ?? 0,
+    sceneName: r.scene_name || "",
     content: r.content,
-    scene_name: r.scene_name || undefined,
-    activity_start_time: activityStart,
-    activity_end_time: activityEnd,
+    score: r.score ?? 0,
+    activityStartTime: activityStart,
+    activityEndTime: activityEnd,
     timestamp: r.timestamp_str || undefined,
   };
 }

--- a/src/core/scene/scene-navigation.test.ts
+++ b/src/core/scene/scene-navigation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import type { SceneIndexEntry } from "./scene-index.js";
+import {
+  generateSceneNavigation,
+  getSceneNavigationHeatBucket,
+  getSceneNavigationRecencyBucket,
+  scoreSceneForNavigation,
+  selectTopScenesForNavigation,
+} from "./scene-navigation.js";
+
+function scene(filename: string, overrides: Partial<SceneIndexEntry> = {}): SceneIndexEntry {
+  return {
+    filename,
+    summary: `summary for ${filename}`,
+    heat: 1,
+    created: "2026-07-01T00:00:00.000Z",
+    updated: "2026-07-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("scene navigation", () => {
+  it("limits output to top N scenes by default", () => {
+    const entries = Array.from({ length: 8 }, (_, i) => scene(`scene-${i}.md`, { heat: 80 - i }));
+
+    const output = generateSceneNavigation(entries, "D:\\memory");
+
+    expect(output).toContain("Showing top 5 scenes out of 8.");
+    expect((output.match(/### Path:/g) ?? []).length).toBe(5);
+    expect(output).toContain("Additional scenes omitted");
+  });
+
+  it("calculates heat buckets", () => {
+    expect(getSceneNavigationHeatBucket(0)).toBe(0);
+    expect(getSceneNavigationHeatBucket(1)).toBe(1);
+    expect(getSceneNavigationHeatBucket(9)).toBe(1);
+    expect(getSceneNavigationHeatBucket(10)).toBe(2);
+    expect(getSceneNavigationHeatBucket(29)).toBe(3);
+    expect(getSceneNavigationHeatBucket(30)).toBe(4);
+  });
+
+  it("calculates recency buckets", () => {
+    const now = new Date("2026-07-11T12:00:00+08:00");
+
+    expect(getSceneNavigationRecencyBucket("2026-07-11T01:00:00+08:00", now)).toBe(3);
+    expect(getSceneNavigationRecencyBucket("2026-07-10T23:00:00+08:00", now)).toBe(2);
+    expect(getSceneNavigationRecencyBucket("2026-07-10T11:00:00+08:00", now)).toBe(1);
+    expect(getSceneNavigationRecencyBucket("2026-07-03T12:00:00+08:00", now)).toBe(0);
+    expect(getSceneNavigationRecencyBucket("not-a-date", now)).toBe(0);
+    expect(getSceneNavigationRecencyBucket("", now)).toBe(0);
+  });
+
+  it("uses filename as a stable tie breaker", () => {
+    const now = new Date("2026-07-11T12:00:00+08:00");
+    const selected = selectTopScenesForNavigation([
+      scene("b.md", { heat: 10, updated: "2026-07-11T01:00:00+08:00" }),
+      scene("a.md", { heat: 10, updated: "2026-07-11T01:00:00+08:00" }),
+    ], { now, topN: 2 });
+
+    expect(selected.map((entry) => entry.filename)).toEqual(["a.md", "b.md"]);
+  });
+
+  it("keeps order stable for small changes that do not cross buckets", () => {
+    const beforeNow = new Date("2026-07-11T12:00:00+08:00");
+    const afterNow = new Date("2026-07-11T13:00:00+08:00");
+    const before = [
+      scene("a.md", { heat: 21, updated: "2026-07-11T02:00:00+08:00" }),
+      scene("b.md", { heat: 21, updated: "2026-07-11T02:00:00+08:00" }),
+    ];
+    const after = [
+      scene("a.md", { heat: 29, updated: "2026-07-11T02:00:00+08:00" }),
+      scene("b.md", { heat: 29, updated: "2026-07-11T02:00:00+08:00" }),
+    ];
+
+    expect(selectTopScenesForNavigation(before, { now: beforeNow, topN: 2 }).map((entry) => entry.filename))
+      .toEqual(selectTopScenesForNavigation(after, { now: afterNow, topN: 2 }).map((entry) => entry.filename));
+  });
+
+  it("changes score when heat crosses a bucket", () => {
+    const now = new Date("2026-07-11T12:00:00+08:00");
+    const before = scoreSceneForNavigation(scene("a.md", { heat: 29 }), now);
+    const after = scoreSceneForNavigation(scene("a.md", { heat: 30 }), now);
+
+    expect(after - before).toBe(10);
+  });
+
+  it("truncates at scene block boundaries", () => {
+    const output = generateSceneNavigation([
+      scene("a.md", { heat: 100, summary: "a".repeat(120) }),
+      scene("b.md", { heat: 90, summary: "b".repeat(120) }),
+      scene("c.md", { heat: 80, summary: "c".repeat(120) }),
+    ], undefined, { maxChars: 650 });
+
+    expect(output.length).toBeLessThanOrEqual(650);
+    expect(output).toContain("Additional scenes omitted");
+  });
+});

--- a/src/core/scene/scene-navigation.ts
+++ b/src/core/scene/scene-navigation.ts
@@ -9,22 +9,64 @@ import path from "node:path";
 import type { SceneIndexEntry } from "./scene-index.js";
 
 const NAV_HEADER = "---\n## 🗺️ Scene Navigation (Scene Index)";
+export const DEFAULT_SCENE_NAV_TOP_N = 5;
+export const DEFAULT_SCENE_NAV_MAX_CHARS = 2000;
 
 const NAV_FOOTER = `📌 使用说明：
 - Path 是 scene block 的绝对路径，可直接使用 read_file 读取完整内容
 - 热度：该场景被记忆命中的累计次数，越高越重要
 - Summary：场景的核心要点摘要`;
 
-/**
- * Build a fire-emoji string based on heat value (visual priority cue for the agent).
- */
-function heatEmoji(heat: number): string {
-  if (heat >= 1000) return " 🔥🔥🔥🔥🔥";
-  if (heat >= 500) return " 🔥🔥🔥🔥";
-  if (heat >= 200) return " 🔥🔥🔥";
-  if (heat >= 100) return " 🔥🔥";
-  if (heat >= 50) return " 🔥";
-  return "";
+const NAV_OMITTED_NOTICE = "Additional scenes omitted to keep the system prompt cache-friendly.";
+
+export interface SceneNavigationOptions {
+  topN?: number;
+  maxChars?: number;
+  now?: Date;
+}
+
+export function getSceneNavigationHeatBucket(heat: number): number {
+  if (!Number.isFinite(heat) || heat <= 0) return 0;
+  return Math.floor(heat / 10) + 1;
+}
+
+export function getSceneNavigationRecencyBucket(updated: string, now: Date): number {
+  if (!updated) return 0;
+  const updatedAt = new Date(updated);
+  if (Number.isNaN(updatedAt.getTime())) return 0;
+
+  const ageMs = now.getTime() - updatedAt.getTime();
+  if (ageMs < 0) return 3;
+
+  const hourMs = 60 * 60 * 1000;
+  const dayMs = 24 * hourMs;
+  if (ageMs <= 12 * hourMs) return 3;
+  if (ageMs <= dayMs) return 2;
+  if (ageMs <= 7 * dayMs) return 1;
+  return 0;
+}
+
+export function scoreSceneForNavigation(entry: SceneIndexEntry, now: Date): number {
+  const heatBucket = getSceneNavigationHeatBucket(entry.heat);
+  const recencyBucket = getSceneNavigationRecencyBucket(entry.updated, now);
+  const summaryBucket = entry.summary.trim().length > 0 ? 1 : 0;
+  return heatBucket * 10 + recencyBucket * 2 + summaryBucket;
+}
+
+export function selectTopScenesForNavigation(
+  entries: SceneIndexEntry[],
+  options?: SceneNavigationOptions,
+): SceneIndexEntry[] {
+  const topN = normalizePositiveInteger(options?.topN, DEFAULT_SCENE_NAV_TOP_N);
+  const now = options?.now ?? new Date();
+
+  return [...entries]
+    .sort((a, b) => {
+      const scoreDiff = scoreSceneForNavigation(b, now) - scoreSceneForNavigation(a, now);
+      if (scoreDiff !== 0) return scoreDiff;
+      return a.filename.localeCompare(b.filename);
+    })
+    .slice(0, topN);
 }
 
 /**
@@ -35,22 +77,35 @@ function heatEmoji(heat: number): string {
  *                  scene paths are rendered as absolute paths so the agent can
  *                  call read_file directly without path concatenation.
  */
-export function generateSceneNavigation(entries: SceneIndexEntry[], dataDir?: string): string {
+export function generateSceneNavigation(
+  entries: SceneIndexEntry[],
+  dataDir?: string,
+  options?: SceneNavigationOptions,
+): string {
   if (entries.length === 0) return "";
 
-  const sorted = [...entries].sort((a, b) => b.heat - a.heat);
+  const topScenes = selectTopScenesForNavigation(entries, options);
+  const topN = normalizePositiveInteger(options?.topN, DEFAULT_SCENE_NAV_TOP_N);
+  const maxChars = normalizePositiveInteger(options?.maxChars, DEFAULT_SCENE_NAV_MAX_CHARS);
 
-  const blocks = sorted.map((e) => {
+  const blocks = topScenes.map((e) => {
     const scenePath = dataDir
       ? path.join(dataDir, "scene_blocks", e.filename)
       : `scene_blocks/${e.filename}`;
     const pathLine = `### Path: ${scenePath}`;
-    const heatLine = `**热度**: ${e.heat}${heatEmoji(e.heat)}${e.updated ? ` | **更新**: ${e.updated}` : ""}`;
+    const heatLine = `**热度**: ${e.heat} | **热度档位**: ${getSceneNavigationHeatBucket(e.heat)}`;
     const summaryLine = `Summary: ${e.summary}`;
     return `${pathLine}\n${heatLine}\n${summaryLine}`;
   });
 
-  return `${NAV_HEADER}\n*以下是当前场景记忆的索引，可根据需要 read_file 读取详细内容。*\n\n${blocks.join("\n\n")}\n\n${NAV_FOOTER}`;
+  const intro = [
+    `Showing top ${Math.min(topN, entries.length)} scenes out of ${entries.length}.`,
+    "Only high-value scenes are listed here to keep the system prompt cache-friendly.",
+    "More scenes remain available in the existing scene index and scene block files.",
+    "Use memory/search/read tools when the listed scenes are insufficient.",
+  ].join("\n");
+
+  return buildNavigationWithinBudget(intro, blocks, maxChars, topScenes.length < entries.length);
 }
 
 /**
@@ -60,4 +115,47 @@ export function stripSceneNavigation(personaContent: string): string {
   const idx = personaContent.indexOf(NAV_HEADER);
   if (idx === -1) return personaContent;
   return personaContent.slice(0, idx).trimEnd();
+}
+
+function buildNavigationWithinBudget(
+  intro: string,
+  blocks: string[],
+  maxChars: number,
+  hasUnlistedScenes: boolean,
+): string {
+  const selectedBlocks: string[] = [];
+  let omitted = hasUnlistedScenes;
+
+  for (const block of blocks) {
+    const candidateBlocks = [...selectedBlocks, block];
+    const candidate = renderNavigation(intro, candidateBlocks, omitted);
+    if (candidate.length <= maxChars) {
+      selectedBlocks.push(block);
+      continue;
+    }
+    omitted = true;
+    break;
+  }
+
+  let output = renderNavigation(intro, selectedBlocks, omitted || selectedBlocks.length < blocks.length);
+  if (output.length <= maxChars) return output;
+
+  while (selectedBlocks.length > 0 && output.length > maxChars) {
+    selectedBlocks.pop();
+    output = renderNavigation(intro, selectedBlocks, true);
+  }
+
+  if (output.length <= maxChars) return output;
+  return renderNavigation(intro, [], false);
+}
+
+function renderNavigation(intro: string, blocks: string[], omitted: boolean): string {
+  const body = blocks.length > 0 ? `\n\n${blocks.join("\n\n")}` : "";
+  const omittedText = omitted ? `\n\n${NAV_OMITTED_NOTICE}` : "";
+  return `${NAV_HEADER}\n${intro}${body}${omittedText}\n\n${NAV_FOOTER}`;
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
 }


### PR DESCRIPTION
## 描述 | Description

本 PR 面向 [#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120)，在当前 main 已有缓存友好结构上，继续稳定 `memory-tencentdb` 的召回注入文本，减少 OpenAI-compatible provider 的 prefix cache 抖动。

Issue #120 的原始问题链包括：

- 动态 `<relevant-memories>` 每轮注入到用户消息前。
- 如果注入内容进入 history，多轮后会造成上下文膨胀。
- 上下文膨胀可能触发 tool result truncation，截断量每轮不同，破坏 prefix matching cache。
- 稳定内容如果没有处在 `CACHE_BOUNDARY` 前，也会被重复当作新 token 计费。

结合当前 main 分支，部分问题已经解决：

- 动态 `<relevant-memories>` 只给本轮模型看，不写入持久化 history。
- persona / scene navigation / memory tools guide 已放入 `prependSystemContext`，位于 OpenClaw `CACHE_BOUNDARY` 之前。
- L1 recall 已有 `maxCharsPerMemory` / `maxTotalRecallChars` 预算能力。

因此，本 PR 不重复实现这些已有能力，也不采用“隐藏记忆内容 / `<memory-omitted>` 指针”的方案。本次目标是：**在保留本轮完整召回记忆可见性的前提下，减少 L1 召回和 scene navigation 带来的非必要文本抖动。**

提交：

```text
d68de0f fix: stabilize cache-aware recall for issue 120
```

## 相关问题 | Related Issue

Fixes [#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120)

## 变更类型 | Change Type

- Bug 修复
- 性能优化
- 代码稳定性优化
- 测试覆盖补充

## 核心改动 | Key Changes

| 改动 | 文件 | 说明 |
|---|---|---|
| L1 canonical ordering | `src/core/hooks/auto-recall.ts` | 搜索结果改为结构化 `RecallDisplayItem[]`，注入前按稳定 key 排序 |
| 结构化预算截断 | `src/core/hooks/auto-recall.ts` | 预算截断基于 item 内容字段，避免破坏格式化行 |
| Scene Navigation Top N | `src/core/scene/scene-navigation.ts` | 默认只注入 Top 5，并用 `maxChars=2000` 控制长度 |
| Scene 稳定评分 | `src/core/scene/scene-navigation.ts` | 用 heat / recency bucket 排序，降低小幅变化导致的 system prompt 抖动 |
| Stable context ordering | `src/core/hooks/auto-recall.ts` | `memory tools guide -> user persona -> scene navigation` |

### 1. L1 Canonical Ordering

之前 `searchMemories()` 返回格式化后的 `string[]`，后续预算截断和 metric 上报都依赖文本行。这有两个问题：

- 相同 records 如果搜索路径、RRF 分数或底层返回顺序轻微变化，最终 `<relevant-memories>` 文本顺序可能不同。
- `recalledL1Memories` 需要从格式化文本中正则反解析，结构信息容易丢失。

本 PR 引入结构化展示对象：

```ts
export interface RecallDisplayItem {
  recordId: string;
  type: string;
  priority: number;
  sceneName: string;
  content: string;
  score: number;
  activityStartTime?: string;
  activityEndTime?: string;
  timestamp?: string;
}
```

搜索阶段仍保持原有 topK 选择逻辑：

```text
keyword / embedding / hybrid -> selected records
```

只在注入展示前进行 canonical sort：

```text
typeRank asc
priority desc
sceneName asc
recordId asc
contentHash asc
```

`typeRank`：

```text
instruction = 0
persona     = 1
episodic    = 2
unknown     = 9
```

取舍：

- 不改变召回集合，只改变展示顺序，降低行为回归风险。
- 不使用 embedding score / RRF score / FTS rank 作为最终展示主排序，因为这些分数更容易随 query 和检索细节变化。
- 预算截断也改为基于结构化 item，避免截断破坏格式化行结构。

### 2. Scene Navigation Tiering

Scene navigation 已在 system prompt 中，属于半稳定内容。如果全量注入所有 scene，并按精确 `heat desc` 排序，scene 数量增长和 heat 小幅变化都会扰动 system prefix。

本 PR 调整为：

```text
DEFAULT_SCENE_NAV_TOP_N = 5
DEFAULT_SCENE_NAV_MAX_CHARS = 2000
```

评分规则：

```text
score = heatBucket * 10 + recencyBucket * 2 + summaryBucket
```

| 字段 | 规则 |
|---|---|
| `heatBucket` | `heat <= 0 ? 0 : floor(heat / 10) + 1` |
| `recencyBucket` | `<=12h: 3`, `<=24h: 2`, `<=7d: 1`, `else: 0` |
| `summaryBucket` | summary 非空为 1，否则 0 |
| tie-breaker | `filename asc` |

取舍：

- `heat` 仍是主信号，但每累计 10 次才跨一个 bucket，避免 heat 每 +1 都改变排序。
- `recency` 只做弱辅助，最大 6 分，低于一个 heat bucket 的 10 分。
- 同分按 `filename asc`，保证稳定顺序。
- 不新增 hysteresis 状态文件，避免扩大并发和状态管理范围。
- 完整 scene index 仍保留在 `.metadata/scene_index.json`，完整 scene block 仍可通过 `scene_blocks/*.md` 按需读取。

输出上会明确说明只展示 Top N：

```text
Showing top X scenes out of Y.
Only high-value scenes are listed here to keep the system prompt cache-friendly.
```

当内容超过 `maxChars` 时，按 scene block 边界截断，并追加 omitted 提示，避免在 markdown block 中间截断。

### 3. Stable Context Ordering

即使内容都在 `prependSystemContext`，内部顺序也会影响 prefix cache。越稳定的内容越应该靠前。

本 PR 将 stable context 顺序调整为：

```text
memory tools guide
user persona
scene navigation
```

原因：

- `memory tools guide` 基本是静态文本，最适合放最前。
- `persona` 较稳定，但可能随 L3 更新。
- `scene navigation` 受 L2 更新和 Top N 变化影响，更适合放最后。

动态 L1 recall 仍只放在 `prependContext`，不进入 system prompt。

## 上下文结构 | Prompt Shape

本 PR 后的上下文结构：

```text
System prompt:
  prependSystemContext
    <memory-tools-guide>
    <user-persona>
    <scene-navigation>
  CACHE_BOUNDARY

User prompt:
  prependContext
    <relevant-memories>
  original user prompt

Persisted history / L0:
  不保存本轮注入的 <relevant-memories>
```

缓存影响：

- 稳定内容继续位于 system prefix，参与 prefix matching cache。
- 动态 L1 recall 保持在当前 user prompt，不污染 system prefix。
- L1 输出和 scene navigation 更稳定，减少非必要 hash 变化。

## 验收标准覆盖 | Acceptance Coverage

### 基础：上下文结构与缓存影响

已覆盖。

- 梳理了 memory 注入后的 system / user / history 三段结构。
- 标注了稳定内容、半稳定内容、动态内容对 prefix cache 的影响。
- prompt-shape 验证中 `systemHasRelevantMemories=false`。

### 进阶：分析 showInjected 导致的对话膨胀趋势

已覆盖。

当前 main 已经避免动态记忆默认写入 history。本 PR 将其作为回归约束，不作为新增优化点；新增优化点聚焦在剩余的排序稳定性和 scene navigation 稳定性。

### 深入：实现优化并测量缓存命中率变化

已覆盖。

本地 OpenClaw + DeepSeek 验证：

```text
OpenClaw: 2026.6.11
Provider / model: deepseek / deepseek-v4-flash
baseline plugin:  D:\tmp\issue-120-baseline-plugin\dist\index.mjs
optimized plugin: D:\projects\TencentDB-Agent-Memory\dist\index.mjs
baseline session:  1c3e265e-2307-490d-b569-360dcb54ba63
optimized session: 8a608ee5-17af-4f22-b16a-74d3b6210852
```

统计口径：

```text
turnCacheHitRate = sum(cacheRead) / (sum(cacheRead) + sum(input))
```

说明：
- 每轮用户问题可能触发多次 DeepSeek 请求，尤其是存在 tool call 的轮次。
- 因此按“单个用户问题内所有 DeepSeek 请求合计”计算该轮缓存利用率。
- 第 1 轮包含冷启动请求，不作为主要结论口径；同时保留全量数据便于审查。

8 轮 A/B 测试结果：

| group | turns | overall hit rate | avg hit rate | overall hit rate excl. turn1 | avg hit rate excl. turn1 | last3 avg |
|---|---:|---:|---:|---:|---:|---:|
| baseline | 8 | 88.54% | 84.72% | 89.55% | 86.19% | 86.04% |
| optimized | 8 | 91.94% | 87.78% | 93.05% | 88.12% | 94.71% |

2-8 轮 token 汇总：

| group | input | cacheRead | miss/input tokens |
|---|---:|---:|---:|
| baseline | 112,675 | 965,632 | 112,675 |
| optimized | 108,333 | 1,450,112 | 108,333 |

提升：

```text
overallHitRate: +3.40 pct points
avgTurnHitRate: +3.06 pct points
overallHitRateExcludingTurn1: +3.50 pct points
avgTurnHitRateExcludingTurn1: +1.93 pct points
last3TurnsAvgHitRate: +8.67 pct points
```

Prompt shape 结果：

```text
optimized systemPrompt hash: 40c364cf643a054f
8 轮全部一致
systemPromptHashChangeCount = 0
systemHasRelevantMemories = false
```

说明：

- 本轮 baseline 和 optimized 使用同一组 8 个问题，均为 DeepSeek。
- 两组工具调用数量不完全一致：baseline 为 30 次 DeepSeek 请求，optimized 为 36 次 DeepSeek 请求。
- 第 3 轮 optimized 只有 1 次模型请求，且 fresh input 较大，缓存利用率为 57.75%，属于本轮主要异常点。
- 第 6-8 轮 optimized 均为无工具单次请求，平均缓存利用率达到 94.71%，较 baseline 最后 3 轮提升 8.67 个百分点。
- 因此该测试结果支持优化方向有效，但仍应避免将其表述为完全隔离所有变量后的严格因果结论。

### 拓展：provider 差异或 session 级系统提示去重

部分覆盖。

本 PR 固定 DeepSeek 做主要验证，避免混合不同 provider 的 usage 字段口径；未实现 session 级 dedupe，因为它会引入 TTL、重启恢复、主题切换和记忆可见性问题。当前先通过 canonical ordering 为未来 dedupe 或摘要压缩提供稳定基础。

## 自测清单 | Self-test Checklist

### 新增测试覆盖

- Scene Navigation:
  - Top N 默认 5。
  - heat / recency bucket。
  - `score desc + filename asc`。
  - 小幅变化不改变排序。
  - maxChars 按 block 边界截断。

- L1 canonical ordering:
  - 同集合不同输入顺序输出一致。
  - type / priority / sceneName / recordId 排序。
  - 缺 recordId 时使用 content hash 兜底。
  - 预算截断后仍保持确定性。

- Stable context ordering:
  - tools guide 在 persona 前。
  - persona 在 scene navigation 前。
  - stable context 不包含 `<relevant-memories>`。

### 命令验证

```powershell
npx vitest run src/core/scene/scene-navigation.test.ts src/core/hooks/auto-recall.test.ts
```

```text
2 test files passed
14 tests passed
```

```powershell
npm test
```

```text
6 test files passed
81 tests passed
```

```powershell
npm run build:plugin
```

```text
Build complete
```

## Reviewer Notes

本 PR 的边界：

- 不隐藏召回记忆。
- 不新增用户配置项。
- 不引入 session 级 dedupe 状态。
- 不修改 L1/L2/L3 生成链路。

建议重点 review：

- `canonicalSortRecallItems()` 的排序优先级是否符合预期。
- `applyRecallBudgetToItems()` 是否保持原有预算语义。
- `scoreSceneForNavigation()` 的权重是否足够稳定。
- Top N / maxChars 是否后续需要暴露为配置项。

后续可选增强：

- Scene Navigation Top N hysteresis。
- 无工具 A/B 复测，排除工具调用差异。
- 在不牺牲记忆可见性的前提下探索 L1 摘要压缩。
