### PR TITLE
Issue 235 cross platform adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/platform-adapter-guide.md`](./docs/platform-adapter-guide.md) | Complete adapter guide: core interfaces, steps, examples, best practices, and pitfalls |
+| [`docs/platform-adapter-comparison.md`](./docs/platform-adapter-comparison.md) | Platform adapter boundary, platform differences, and the bridge contract |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -508,6 +508,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/platform-adapter-guide.zh.md`](./docs/platform-adapter-guide.zh.md) | 新平台适配完整指南：核心接口、步骤、示例、最佳实践和常见踩坑点 |
+| [`docs/platform-adapter-comparison.zh.md`](./docs/platform-adapter-comparison.zh.md) | 多平台接入边界、平台差异和统一 bridge 协议 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/docs/cross-platform-adapters.md
+++ b/docs/cross-platform-adapters.md
@@ -1,0 +1,68 @@
+# Cross-Platform Memory Adapter Architecture
+
+```mermaid
+flowchart TB
+  subgraph Host["Agent hosts"]
+    OpenClaw["OpenClaw<br/>plugin hooks and tools"]
+    Hermes["Hermes Agent<br/>memory_tencentdb provider"]
+    NewHosts["New adapters<br/>Claude Code / Codex / Dify / OpenCode"]
+  end
+
+  subgraph Adapter["Adapter layer"]
+    OpenClawAdapter["OpenClawHostAdapter<br/>OpenClawLLMRunner"]
+    HermesClient["Hermes Gateway client<br/>prefetch / sync_turn / search"]
+    PlatformBridge["MemoryPlatformBridge<br/>runtime + turn normalization"]
+    AdapterSDK["Cross-platform Adapter SDK<br/>MemoryPlatformAdapter + MemoryGatewayClient"]
+    Gateway["TDAI Gateway HTTP API<br/>/recall /capture /search /session/end /seed"]
+    StandaloneAdapter["StandaloneHostAdapter<br/>StandaloneLLMRunner"]
+  end
+
+  subgraph Core["Host-neutral memory core"]
+    TdaiCore["TdaiCore facade<br/>handleBeforeRecall<br/>handleTurnCommitted<br/>searchMemories<br/>searchConversations"]
+    Pipeline["Memory pipeline<br/>L0 Conversation -> L1 Atom -> L2 Scene -> L3 Persona"]
+    Search["Retrieval and tools<br/>hybrid search / memory search / conversation search"]
+  end
+
+  subgraph Runtime["Runtime services"]
+    LLM["LLM runner<br/>OpenClaw embedded or OpenAI-compatible API"]
+    Store[("Memory storage<br/>SQLite + sqlite-vec or TCVDB<br/>Markdown scene/persona files")]
+  end
+
+  OpenClaw -->|"before_prompt_build<br/>agent_end<br/>tdai_* tools"| OpenClawAdapter
+  Hermes -->|"provider calls"| HermesClient
+  NewHosts -->|"host-specific events"| PlatformBridge
+  PlatformBridge --> AdapterSDK
+
+  HermesClient -->|"HTTP JSON"| Gateway
+  AdapterSDK -->|"HTTP JSON"| Gateway
+  Gateway --> StandaloneAdapter
+
+  OpenClawAdapter --> TdaiCore
+  StandaloneAdapter --> TdaiCore
+
+  TdaiCore -->|"recall/search"| Search
+  TdaiCore -->|"capture/session end"| Pipeline
+  Pipeline --> Store
+  Search --> Store
+  Pipeline -->|"L1/L2/L3 extraction"| LLM
+  TdaiCore -->|"context + tool results"| OpenClaw
+  Gateway -->|"context + search results"| HermesClient
+  Gateway -->|"context + search results"| AdapterSDK
+
+  classDef host fill:#f8fafc,stroke:#64748b,color:#0f172a
+  classDef adapter fill:#ecfeff,stroke:#0891b2,color:#164e63
+  classDef core fill:#f0fdf4,stroke:#16a34a,color:#14532d
+  classDef runtime fill:#fff7ed,stroke:#ea580c,color:#7c2d12
+
+  class OpenClaw,Hermes,NewHosts host
+  class OpenClawAdapter,HermesClient,PlatformBridge,AdapterSDK,Gateway,StandaloneAdapter adapter
+  class TdaiCore,Pipeline,Search core
+  class LLM,Store runtime
+```
+
+## Boundary Summary
+
+- `TdaiCore` is the stable host-neutral boundary. New platforms should not call pipeline internals directly.
+- OpenClaw runs in-process through `OpenClawHostAdapter`; Hermes and future hosts should use the Gateway path unless they can safely embed Node and provide a `HostAdapter`.
+- The cross-platform adapter SDK should normalize host events into four gateway operations: recall, capture, memory search, and conversation search.
+- Platform-specific packages should stay thin: identity/session mapping, prompt injection, lifecycle hooks, and optional tool registration.

--- a/docs/platform-adapter-comparison.md
+++ b/docs/platform-adapter-comparison.md
@@ -1,0 +1,143 @@
+# Platform Adapter Comparison
+
+This document defines the long-term adapter boundary for TencentDB Agent Memory.
+New platforms should integrate through the platform SDK instead of calling
+`TdaiCore` or pipeline internals directly.
+
+Chinese version: [docs/platform-adapter-comparison.zh.md](./platform-adapter-comparison.zh.md)
+
+Complete adapter guide: [docs/platform-adapter-guide.md](./platform-adapter-guide.md)
+
+## Standard Adapter Boundary
+
+Every new platform implements one interface:
+
+```ts
+interface MemoryPlatformBridge {
+  getRuntime(): {
+    platform: string;
+    userId: string;
+    sessionId: string;
+    sessionKey: string;
+    workspaceDir: string;
+  };
+
+  buildTurn?(turn: {
+    userContent: string;
+    assistantContent: string;
+    messages?: unknown[];
+  }): {
+    userContent: string;
+    assistantContent: string;
+    messages?: unknown[];
+  };
+}
+```
+
+The SDK handles the rest:
+
+- `MemoryGatewayClient`: HTTP transport to the TDAI Gateway.
+- `MemoryPlatformAdapter`: recall, capture, search, session flush, seed.
+- Platform adapters: thin bridge implementations for Codex, Dify, and future hosts.
+
+The target shape is:
+
+```text
+Platform event model
+  -> MemoryPlatformBridge
+    -> MemoryPlatformAdapter
+      -> MemoryGatewayClient
+        -> TDAI Gateway
+          -> TdaiCore
+```
+
+## Platform Differences
+
+| Platform | Integration shape | Recall injection | Capture timing | Session identity | Recommended path |
+| --- | --- | --- | --- | --- | --- |
+| OpenClaw | In-process plugin | `before_prompt_build` returns `prependContext` / `appendSystemContext` | `agent_end` | Native `ctx.sessionKey` | Keep direct `OpenClawHostAdapter` path |
+| Hermes | Python memory provider + Node Gateway sidecar | `prefetch(query)` returns memory context | `sync_turn()` background capture | Hermes `session_id` | Keep Gateway HTTP path |
+| Codex | TypeScript SDK imported by host integration | `buildPromptContext(query)` returns user/system sections | `recordTurn()` after assistant output | `codex:<userId>:<sessionId>` | `CodexMemoryAdapter` |
+| Dify | Tool / workflow / backend extension using SDK | `buildPromptContext(query)` can populate prompt variables | `recordDifyTurn()` after answer generation | `dify:<appId>:<userId>:<conversationId>` | `DifyMemoryAdapter` |
+
+## What New Platforms Must Provide
+
+A new platform only needs to answer four questions:
+
+1. Who is the user?
+2. What is the current conversation/session?
+3. Where can recalled context be injected?
+4. When is a completed user/assistant turn available for capture?
+
+Everything else is shared:
+
+- HTTP auth and timeout handling
+- Gateway request/response mapping
+- Recall split between dynamic user context and stable system context
+- Capture payload normalization
+- Memory and conversation search
+- Session flush
+
+## Runtime Field Rules
+
+| Field | Meaning | Stability rule |
+| --- | --- | --- |
+| `platform` | Short platform key, for example `codex` or `dify` | Constant per adapter implementation |
+| `userId` | End-user identity | Stable across sessions for the same user |
+| `sessionId` | Platform conversation/thread/run id | Stable for one conversation |
+| `sessionKey` | Memory isolation key | Deterministic and namespaced by platform |
+| `workspaceDir` | Local workspace or data context | Best-effort; use `process.cwd()` if unavailable |
+
+Session keys must be platform namespaced to avoid collisions:
+
+```text
+codex:<userId>:<sessionId>
+dify:<appId>:<userId>:<conversationId>
+claude-code:<userId>:<projectId>:<sessionId>
+opencode:<userId>:<workspaceId>:<sessionId>
+```
+
+## Recall Contract
+
+Gateway recall now returns both legacy and split fields:
+
+```json
+{
+  "context": "...",
+  "prepend_context": "...",
+  "append_system_context": "..."
+}
+```
+
+Adapters expose this as:
+
+- `prependUserContext`: dynamic L1 snippets, injected near the current user query.
+- `appendSystemContext`: stable persona / scene / tool guide, injected into system or developer context.
+
+Do not merge these prematurely in the SDK. Different hosts have different prompt surfaces, and keeping the split preserves prompt-cache friendliness.
+
+## Dify Notes
+
+Dify deployments vary: some integrations run as a plugin/tool, some as workflow HTTP nodes, and some as a backend extension. The adapter therefore avoids depending on one Dify runtime package.
+
+Use `DifyMemoryAdapter` with the request context you have:
+
+```ts
+const memory = createDifyMemoryAdapter({
+  appId,
+  userId,
+  conversationId,
+  query,
+});
+
+const ctx = await memory.buildPromptContext();
+// Inject ctx.prependUserContext and ctx.appendSystemContext into Dify prompt variables.
+
+await memory.recordDifyTurn({
+  query,
+  answer,
+  inputs,
+});
+```
+
+If a Dify deployment lacks `conversationId`, use `workflowRunId` or `messageId` as the session fallback. For long-term personalization quality, prefer a stable conversation id whenever possible.

--- a/docs/platform-adapter-comparison.zh.md
+++ b/docs/platform-adapter-comparison.zh.md
@@ -1,0 +1,140 @@
+# 平台适配器对比与接入规范
+
+这份文档定义 TencentDB Agent Memory 的多平台接入边界。
+新平台不应直接调用 `TdaiCore` 或 pipeline 内部实现，而应通过统一的适配器 SDK 接入。
+
+完整适配指南见：[docs/platform-adapter-guide.zh.md](./platform-adapter-guide.zh.md)
+
+## 统一边界
+
+新平台只需要实现一个接口：
+
+```ts
+interface MemoryPlatformBridge {
+  getRuntime(): {
+    platform: string;
+    userId: string;
+    sessionId: string;
+    sessionKey: string;
+    workspaceDir: string;
+  };
+
+  buildTurn?(turn: {
+    userContent: string;
+    assistantContent: string;
+    messages?: unknown[];
+  }): {
+    userContent: string;
+    assistantContent: string;
+    messages?: unknown[];
+  };
+}
+```
+
+SDK 负责其余部分：
+
+- `MemoryGatewayClient`：统一 HTTP 传输层
+- `MemoryPlatformAdapter`：召回、捕获、搜索、会话结束、种子导入
+- 各平台适配器：只保留平台语义映射，不重复实现通用逻辑
+
+目标分层如下：
+
+```text
+平台事件模型
+  -> MemoryPlatformBridge
+    -> MemoryPlatformAdapter
+      -> MemoryGatewayClient
+        -> TDAI Gateway
+          -> TdaiCore
+```
+
+## 平台差异
+
+| 平台 | 接入形态 | 召回注入点 | 捕获时机 | 会话标识 | 推荐路径 |
+| --- | --- | --- | --- | --- | --- |
+| OpenClaw | 进程内插件 | `before_prompt_build` 返回 `prependContext` / `appendSystemContext` | `agent_end` | 原生 `ctx.sessionKey` | 保持现有 `OpenClawHostAdapter` |
+| Hermes | Python provider + Node Gateway sidecar | `prefetch(query)` 返回 memory context | `sync_turn()` 后台捕获 | Hermes `session_id` | 保持 Gateway HTTP 路径 |
+| Codex | TypeScript SDK | `buildPromptContext(query)` 返回用户/系统上下文 | `recordTurn()` | `codex:<userId>:<sessionId>` | `CodexMemoryAdapter` |
+| Dify | 工具 / 工作流 / 后端扩展 | `buildPromptContext(query)` 填充提示词变量 | `recordDifyTurn()` | `dify:<appId>:<userId>:<conversationId>` | `DifyMemoryAdapter` |
+
+## 新平台需要提供什么
+
+新增平台只需要回答四个问题：
+
+1. 当前用户是谁
+2. 当前会话是谁
+3. 召回内容要注入到哪里
+4. 完成的一轮对话何时可用于捕获
+
+其余能力全部复用：
+
+- HTTP 鉴权与超时
+- Gateway 请求和响应映射
+- 召回内容的动态/稳定分拆
+- 捕获 payload 归一化
+- 记忆搜索和对话搜索
+- 会话 flush
+
+## 运行时字段规范
+
+| 字段 | 含义 | 约束 |
+| --- | --- | --- |
+| `platform` | 平台标识，如 `codex`、`dify` | 每个适配器固定 |
+| `userId` | 最终用户标识 | 同一用户保持稳定 |
+| `sessionId` | 平台会话 / 对话 / 运行标识 | 单次会话内稳定 |
+| `sessionKey` | 记忆隔离 key | 必须带平台前缀，避免冲突 |
+| `workspaceDir` | 本地工作区或数据上下文 | 无法获取时可退回 `process.cwd()` |
+
+推荐的 sessionKey 形式：
+
+```text
+codex:<userId>:<sessionId>
+dify:<appId>:<userId>:<conversationId>
+claude-code:<userId>:<projectId>:<sessionId>
+opencode:<userId>:<workspaceId>:<sessionId>
+```
+
+## 召回契约
+
+Gateway 的 recall 响应同时返回旧字段和拆分字段：
+
+```json
+{
+  "context": "...",
+  "prepend_context": "...",
+  "append_system_context": "..."
+}
+```
+
+适配器应映射为：
+
+- `prependUserContext`：动态 L1 记忆，放到当前问题前
+- `appendSystemContext`：稳定 persona / scene / tool guide，放到 system 或 developer context
+
+不要在 SDK 内提前合并这两个部分。不同平台的 prompt 槽位不同，保留拆分更利于 prompt cache 和后续扩展。
+
+## Dify 接入说明
+
+Dify 部署形态差异很大，可能是工具、工作流节点或后端扩展，因此适配器不绑定单一 Dify 运行时包。
+
+推荐使用方式：
+
+```ts
+const memory = createDifyMemoryAdapter({
+  appId,
+  userId,
+  conversationId,
+  query,
+});
+
+const ctx = await memory.buildPromptContext();
+// 将 ctx.prependUserContext / ctx.appendSystemContext 注入到 Dify 提示词变量中
+
+await memory.recordDifyTurn({
+  query,
+  answer,
+  inputs,
+});
+```
+
+如果没有 `conversationId`，可以降级使用 `workflowRunId` 或 `messageId`。但如果要保证长期记忆质量，最好还是使用稳定的 conversation id。

--- a/docs/platform-adapter-guide.md
+++ b/docs/platform-adapter-guide.md
@@ -1,0 +1,213 @@
+# Platform Adapter Guide
+
+This guide describes how to connect a new Agent platform to TencentDB Agent Memory through the cross-platform adapter SDK.
+
+## Architecture
+
+The memory engine is split into three layers:
+
+```text
+Platform runtime
+  -> MemoryPlatformBridge
+    -> MemoryPlatformAdapter
+      -> MemoryGatewayClient
+        -> TDAI Gateway
+          -> TdaiCore
+```
+
+- `TdaiCore` owns memory semantics: recall, capture, search, session flush, and the L0 to L3 pipeline.
+- `MemoryGatewayClient` owns Gateway HTTP transport, auth, timeout, and response mapping.
+- `MemoryPlatformAdapter` owns the common platform-facing API.
+- `MemoryPlatformBridge` is the only piece a new platform must implement.
+
+OpenClaw remains an in-process integration because it already provides a native plugin API and embedded LLM runtime. Hermes, Codex, Dify, and future platforms should use the Gateway path unless they need to embed the Node runtime directly.
+
+## Core Engine Interface
+
+`TdaiCore` exposes the stable host-neutral capabilities:
+
+| Method | Purpose | Existing platform mapping |
+| --- | --- | --- |
+| `handleBeforeRecall(userText, sessionKey)` | Recall relevant memory before the next model turn | OpenClaw `before_prompt_build`, Hermes `prefetch`, Gateway `POST /recall` |
+| `handleTurnCommitted(turn)` | Capture a completed user/assistant turn and trigger L0 to L3 processing | OpenClaw `agent_end`, Hermes `sync_turn`, Gateway `POST /capture` |
+| `searchMemories(params)` | Search L1 structured memories | `tdai_memory_search`, Gateway `POST /search/memories` |
+| `searchConversations(params)` | Search L0 raw conversations | `tdai_conversation_search`, Gateway `POST /search/conversations` |
+| `handleSessionEnd(sessionKey)` | Flush one session without stopping the shared process | Gateway `POST /session/end`, Hermes session end |
+
+The core depends on `HostAdapter`, `LLMRunnerFactory`, and `RuntimeContext`. New remote platforms should not implement these directly; the Gateway already wraps them through `StandaloneHostAdapter`.
+
+## Platform Comparison
+
+| Platform | Adapter style | Recall injection | Capture timing | Session key |
+| --- | --- | --- | --- | --- |
+| OpenClaw | In-process `OpenClawHostAdapter` | Native hook result | `agent_end` | `ctx.sessionKey` |
+| Hermes | Python provider + Gateway sidecar | `prefetch(query)` | `sync_turn()` | Hermes `session_id` |
+| Codex | TypeScript SDK | `buildPromptContext(query)` | `recordTurn()` | `codex:<userId>:<sessionId>` |
+| Dify | TypeScript SDK for tool/workflow/backend extension | `buildPromptContext(query)` into prompt variables | `recordDifyTurn()` | `dify:<appId>:<userId>:<conversationId>` |
+
+## New Platform Integration Steps
+
+### 1. Start or reach the Gateway
+
+The platform adapter talks to the Gateway:
+
+```bash
+npx tsx src/gateway/server.ts
+```
+
+If the Gateway enforces auth, pass the same key to the adapter:
+
+```ts
+const gateway = {
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+};
+```
+
+### 2. Implement `MemoryPlatformBridge`
+
+```ts
+import {
+  createMemoryPlatformAdapter,
+  type MemoryPlatformBridge,
+  type MemoryTurnPayload,
+} from "@tencentdb-agent-memory/memory-tencentdb";
+
+class MyAgentBridge implements MemoryPlatformBridge {
+  getRuntime() {
+    return {
+      platform: "my-agent",
+      userId: "user-123",
+      sessionId: "thread-456",
+      sessionKey: "my-agent:user-123:thread-456",
+      workspaceDir: process.cwd(),
+    };
+  }
+
+  buildTurn(turn: MemoryTurnPayload): MemoryTurnPayload {
+    return {
+      ...turn,
+      messages: turn.messages ?? [
+        { role: "user", content: turn.userContent },
+        { role: "assistant", content: turn.assistantContent },
+      ],
+    };
+  }
+}
+
+const memory = createMemoryPlatformAdapter(new MyAgentBridge(), gateway);
+```
+
+### 3. Inject recalled context before the model call
+
+```ts
+const ctx = await memory.buildPromptContext(userQuery);
+
+const systemPrompt = [
+  baseSystemPrompt,
+  ctx.appendSystemContext,
+].filter(Boolean).join("\n\n");
+
+const userPrompt = [
+  ctx.prependUserContext,
+  userQuery,
+].filter(Boolean).join("\n\n");
+```
+
+`prependUserContext` contains dynamic L1 recall snippets. `appendSystemContext` contains stable persona, scene navigation, and memory tool guidance. Keep them separate until the final platform-specific prompt assembly step.
+
+### 4. Capture the completed turn
+
+```ts
+await memory.capture({
+  userContent: userQuery,
+  assistantContent: assistantAnswer,
+  messages: transcriptMessages,
+});
+```
+
+Capture after the assistant answer is complete. Do not capture partial streaming chunks as separate turns.
+
+### 5. Expose optional search tools
+
+```ts
+const result = await memory.searchMemories("user deployment preference", 5);
+const raw = await memory.searchConversations("exact phrase from last week", 5);
+```
+
+Use these for platform tool surfaces, workflow nodes, or backend debug endpoints.
+
+### 6. Flush on session end
+
+```ts
+await memory.endSession();
+```
+
+Flush the current session when the host tells you a conversation has ended. Do not stop the Gateway for a single session; the Gateway may serve concurrent sessions.
+
+## Existing SDK Adapters
+
+### Codex
+
+```ts
+import { createCodexMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb";
+
+const memory = createCodexMemoryAdapter({
+  userId,
+  sessionId,
+  workspaceDir,
+});
+
+const ctx = await memory.buildPromptContext(query);
+await memory.recordTurn({ userContent: query, assistantContent: answer, messages });
+```
+
+### Dify
+
+```ts
+import { createDifyMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb";
+
+const memory = createDifyMemoryAdapter({
+  appId,
+  userId,
+  conversationId,
+  query,
+});
+
+const ctx = await memory.buildPromptContext();
+await memory.recordDifyTurn({ query, answer, inputs });
+```
+
+Dify deployments vary across tools, workflow nodes, and backend extensions. Prefer `conversationId`; fall back to `workflowRunId` or `messageId` only when the conversation id is unavailable.
+
+## Best Practices
+
+- Namespace every `sessionKey` with the platform name.
+- Keep `userId` stable across conversations for long-term personalization.
+- Keep `sessionId` stable for one conversation, not one message.
+- Inject `appendSystemContext` into the system/developer area and `prependUserContext` near the user query.
+- Capture after the assistant turn finishes, not during streaming.
+- Preserve raw platform metadata in `messages[].metadata` when available.
+- Use Gateway auth when binding to anything beyond loopback.
+- Treat recall failure as non-blocking; continue the platform turn without memory if the Gateway is temporarily unavailable.
+
+## Common Pitfalls
+
+| Pitfall | Impact | Fix |
+| --- | --- | --- |
+| Using a random `sessionKey` per request | Memory never accumulates in one conversation | Derive a deterministic key from platform, user, and conversation |
+| Using one global `sessionKey` for all users | Cross-user memory contamination | Always include `userId` |
+| Merging recall sections too early | Worse prompt cache behavior and less control per host | Keep `prependUserContext` and `appendSystemContext` separate |
+| Capturing partial stream chunks | Fragmented L0 records and noisy L1 extraction | Capture once after the final answer |
+| Calling `destroy()` / stopping Gateway on session end | Breaks other concurrent sessions | Call `endSession()` only |
+| Calling pipeline internals from a platform adapter | Tight coupling and fragile upgrades | Use `MemoryPlatformAdapter` or Gateway APIs |
+
+## Acceptance Checklist
+
+- Core engine boundary is documented and not bypassed.
+- OpenClaw, Hermes, Codex, and Dify integration styles are compared.
+- New platforms implement `MemoryPlatformBridge` only.
+- Recall, capture, search, and session flush are covered by examples.
+- Session identity rules prevent cross-platform and cross-user collisions.
+- Best practices and failure modes are documented.
+- Adapter tests cover runtime derivation and Gateway payload mapping.

--- a/docs/platform-adapter-guide.zh.md
+++ b/docs/platform-adapter-guide.zh.md
@@ -1,0 +1,240 @@
+# 平台适配指南
+
+本文档说明如何把新的 Agent 平台接入 TencentDB Agent Memory。目标是把平台差异收敛到一个标准接口里，让后续新增平台只需要实现少量桥接代码，不需要理解或复制核心记忆 pipeline。
+
+## 总体架构
+
+多平台适配分为五层：
+
+```text
+平台运行时
+  -> MemoryPlatformBridge
+    -> MemoryPlatformAdapter
+      -> MemoryGatewayClient
+        -> TDAI Gateway
+          -> TdaiCore
+```
+
+- `TdaiCore` 负责真正的记忆语义：召回、捕获、搜索、会话 flush，以及 L0 到 L3 的记忆 pipeline。
+- `MemoryGatewayClient` 负责 Gateway HTTP 通信、鉴权、超时和响应字段映射。
+- `MemoryPlatformAdapter` 负责通用平台 API，例如 `buildPromptContext()`、`capture()`、`searchMemories()`。
+- `MemoryPlatformBridge` 是新平台唯一必须实现的接口。
+
+OpenClaw 继续走进程内插件路径，因为它已有原生插件 API 和 embedded LLM runtime。Hermes、Codex、Dify 以及后续新平台默认走 Gateway 路径，避免把平台细节耦合进核心引擎。
+
+## 核心引擎接口说明
+
+`TdaiCore` 是宿主无关的核心入口，暴露以下能力：
+
+| 方法 | 作用 | 现有平台映射 |
+| --- | --- | --- |
+| `handleBeforeRecall(userText, sessionKey)` | 模型调用前召回相关记忆 | OpenClaw `before_prompt_build`、Hermes `prefetch`、Gateway `POST /recall` |
+| `handleTurnCommitted(turn)` | 捕获一轮完整对话，并触发 L0 到 L3 处理 | OpenClaw `agent_end`、Hermes `sync_turn`、Gateway `POST /capture` |
+| `searchMemories(params)` | 搜索 L1 结构化记忆 | `tdai_memory_search`、Gateway `POST /search/memories` |
+| `searchConversations(params)` | 搜索 L0 原始对话 | `tdai_conversation_search`、Gateway `POST /search/conversations` |
+| `handleSessionEnd(sessionKey)` | flush 单个会话，不停止共享进程 | Gateway `POST /session/end`、Hermes session end |
+
+核心层依赖 `HostAdapter`、`LLMRunnerFactory` 和 `RuntimeContext`。新平台通常不需要直接实现这些接口，Gateway 已经通过 `StandaloneHostAdapter` 封装好了宿主能力。
+
+## 适配方式对比
+
+| 平台 | 适配形态 | 召回注入点 | 捕获时机 | 会话标识 | 推荐方式 |
+| --- | --- | --- | --- | --- | --- |
+| OpenClaw | 进程内 `OpenClawHostAdapter` | 原生 hook 返回 `prependContext` / `appendSystemContext` | `agent_end` | `ctx.sessionKey` | 保持现有插件路径 |
+| Hermes | Python provider + Node Gateway sidecar | `prefetch(query)` | `sync_turn()` 后台捕获 | Hermes `session_id` | 保持 Gateway HTTP 路径 |
+| Codex | TypeScript SDK | `buildPromptContext(query)` | `recordTurn()` | `codex:<userId>:<sessionId>` | `CodexMemoryAdapter` |
+| Dify | 工具 / 工作流 / 后端扩展 SDK | `buildPromptContext(query)` 填充 prompt 变量 | `recordDifyTurn()` | `dify:<appId>:<userId>:<conversationId>` | `DifyMemoryAdapter` |
+
+## 新平台接入完整步骤
+
+### 1. 启动或连接 Gateway
+
+平台适配器通过 Gateway 访问核心引擎：
+
+```bash
+npx tsx src/gateway/server.ts
+```
+
+如果 Gateway 开启了 Bearer 鉴权，适配器侧需要传同一个 key：
+
+```ts
+const gateway = {
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+};
+```
+
+### 2. 实现 `MemoryPlatformBridge`
+
+新平台只需要实现运行时信息和可选的 turn 归一化：
+
+```ts
+import {
+  createMemoryPlatformAdapter,
+  type MemoryPlatformBridge,
+  type MemoryTurnPayload,
+} from "@tencentdb-agent-memory/memory-tencentdb";
+
+class MyAgentBridge implements MemoryPlatformBridge {
+  getRuntime() {
+    return {
+      platform: "my-agent",
+      userId: "user-123",
+      sessionId: "thread-456",
+      sessionKey: "my-agent:user-123:thread-456",
+      workspaceDir: process.cwd(),
+    };
+  }
+
+  buildTurn(turn: MemoryTurnPayload): MemoryTurnPayload {
+    return {
+      ...turn,
+      messages: turn.messages ?? [
+        { role: "user", content: turn.userContent },
+        { role: "assistant", content: turn.assistantContent },
+      ],
+    };
+  }
+}
+
+const memory = createMemoryPlatformAdapter(new MyAgentBridge(), gateway);
+```
+
+`sessionKey` 必须稳定且带平台前缀。不要用随机值，也不要全平台共用一个 key。
+
+### 3. 模型调用前注入召回上下文
+
+```ts
+const ctx = await memory.buildPromptContext(userQuery);
+
+const systemPrompt = [
+  baseSystemPrompt,
+  ctx.appendSystemContext,
+].filter(Boolean).join("\n\n");
+
+const userPrompt = [
+  ctx.prependUserContext,
+  userQuery,
+].filter(Boolean).join("\n\n");
+```
+
+`prependUserContext` 是每轮动态变化的 L1 召回片段，适合放在当前问题前。`appendSystemContext` 是相对稳定的 persona、scene navigation 和工具说明，适合放到 system 或 developer context。
+
+### 4. 模型回答完成后捕获 turn
+
+```ts
+await memory.capture({
+  userContent: userQuery,
+  assistantContent: assistantAnswer,
+  messages: transcriptMessages,
+});
+```
+
+捕获时机应是 assistant 完整回答之后。不要把流式输出的中间 chunk 当成多轮对话分别写入，否则会污染 L0 和 L1。
+
+### 5. 暴露可选搜索工具
+
+```ts
+const memories = await memory.searchMemories("用户部署偏好", 5);
+const conversations = await memory.searchConversations("上周说过的原话", 5);
+```
+
+这些能力可以接到平台工具、工作流节点、后端调试接口或模型可调用工具上。
+
+### 6. 会话结束时 flush
+
+```ts
+await memory.endSession();
+```
+
+`endSession()` 只 flush 当前会话，不会停止 Gateway。不要因为单个会话结束就关闭 Gateway，因为 Gateway 可能同时服务其他会话。
+
+## 已新增平台示例
+
+### Codex
+
+```ts
+import { createCodexMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb";
+
+const memory = createCodexMemoryAdapter({
+  userId,
+  sessionId,
+  workspaceDir,
+});
+
+const ctx = await memory.buildPromptContext(query);
+
+await memory.recordTurn({
+  userContent: query,
+  assistantContent: answer,
+  messages,
+});
+```
+
+Codex 默认 session key：
+
+```text
+codex:<userId>:<sessionId>
+```
+
+### Dify
+
+```ts
+import { createDifyMemoryAdapter } from "@tencentdb-agent-memory/memory-tencentdb";
+
+const memory = createDifyMemoryAdapter({
+  appId,
+  userId,
+  conversationId,
+  query,
+});
+
+const ctx = await memory.buildPromptContext();
+
+await memory.recordDifyTurn({
+  query,
+  answer,
+  inputs,
+});
+```
+
+Dify 默认 session key：
+
+```text
+dify:<appId>:<userId>:<conversationId>
+```
+
+Dify 的部署形态可能是工具、工作流节点或后端扩展。适配器不绑定某个 Dify runtime 包，只要求调用方提供 `appId`、`userId`、`conversationId`、`query`、`answer` 等上下文。优先使用稳定的 `conversationId`；没有时再退到 `workflowRunId` 或 `messageId`。
+
+## 最佳实践
+
+- `sessionKey` 必须带平台前缀，避免跨平台冲突。
+- `userId` 必须能稳定代表同一个最终用户，避免长期画像漂移。
+- `sessionId` 应代表一段完整对话，不应每条消息变化。
+- `prependUserContext` 和 `appendSystemContext` 保持拆分，最后一步再按平台 prompt 槽位组装。
+- 捕获完整 assistant 输出，不捕获流式中间片段。
+- 尽量保留平台原始 metadata 到 `messages[].metadata`，便于后续排查。
+- Gateway 如果绑定非 loopback 地址，应开启 `TDAI_GATEWAY_API_KEY`。
+- recall 失败不应阻塞平台主流程；Gateway 短暂不可用时，平台可以无记忆继续回答。
+
+## 常见踩坑点
+
+| 问题 | 后果 | 处理方式 |
+| --- | --- | --- |
+| 每次请求随机生成 `sessionKey` | 同一会话的记忆无法累积 | 用 platform、user、conversation 派生稳定 key |
+| 所有用户共用一个 `sessionKey` | 不同用户记忆串号 | `sessionKey` 必须包含 `userId` |
+| 在 SDK 内提前合并召回上下文 | 影响 prompt cache，也削弱平台组装自由度 | 保持 `prependUserContext` / `appendSystemContext` 拆分 |
+| 捕获流式 chunk | L0 片段化，L1 提取噪声变多 | 等完整回答结束后捕获一次 |
+| 会话结束时停止 Gateway | 影响其他并发会话 | 调 `endSession()`，不要停进程 |
+| 平台适配器直接调用 pipeline 内部模块 | 后续升级容易破坏 | 通过 `MemoryPlatformAdapter` 或 Gateway API |
+| 没有配置 Gateway 鉴权就暴露到网络 | 记忆接口可被未授权访问 | 使用 loopback 绑定或配置 Bearer key |
+
+## 验收清单
+
+- 已说明 `TdaiCore` 的核心能力边界。
+- 已对比 OpenClaw、Hermes、Codex、Dify 的适配方式。
+- 新平台接入只需要实现 `MemoryPlatformBridge`。
+- 文档包含 recall、capture、search、session flush 的完整代码示例。
+- `sessionKey` 命名规则能避免跨平台和跨用户冲突。
+- 已列出最佳实践和常见踩坑点。
+- Codex / Dify 适配器有测试覆盖运行时推导和 Gateway payload 映射。

--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,21 @@ import {
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
 
+export { CodexMemoryAdapter, CodexMemoryBridge, createCodexMemoryAdapter } from "./src/adapters/codex/index.js";
+export type { CodexMemoryAdapterOptions, CodexPromptContext } from "./src/adapters/codex/index.js";
+export { DifyMemoryAdapter, DifyMemoryBridge, createDifyMemoryAdapter } from "./src/adapters/dify/index.js";
+export type { DifyMemoryAdapterOptions, DifyPromptContext, DifyRequestContext, DifyTurnPayload } from "./src/adapters/dify/index.js";
+export { MemoryGatewayClient, MemoryPlatformAdapter, createMemoryPlatformAdapter } from "./src/adapters/index.js";
+export type {
+  MemoryGatewayClientOptions,
+  MemoryRecallContext,
+  MemoryAdapterOptions,
+  MemoryAdapterRuntime,
+  MemoryPlatformBridge,
+  MemoryPromptContext,
+  MemoryTurnPayload,
+} from "./src/adapters/index.js";
+
 const TAG = "[memory-tdai]";
 
 /**

--- a/src/adapters/codex/adapter.test.ts
+++ b/src/adapters/codex/adapter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { CodexMemoryAdapter } from "./adapter.js";
+
+describe("CodexMemoryAdapter", () => {
+  it("derives a stable codex session key", () => {
+    vi.stubEnv("CODEX_USER_ID", "alice");
+    vi.stubEnv("CODEX_SESSION_ID", "thread-42");
+    vi.stubEnv("CODEX_WORKSPACE_DIR", "C:/work/project");
+
+    const adapter = new CodexMemoryAdapter({
+      fetchImpl: vi.fn(),
+      baseUrl: "http://127.0.0.1:8420",
+    });
+
+    expect(adapter.getRuntime()).toMatchObject({
+      platform: "codex",
+      userId: "alice",
+      sessionId: "thread-42",
+      sessionKey: "codex:alice:thread-42",
+      workspaceDir: "C:/work/project",
+    });
+  });
+
+  it("maps recall context into prompt sections", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({
+        context: "stable",
+        prepend_context: "dynamic",
+        append_system_context: "system",
+        strategy: "hybrid",
+        memory_count: 2,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const adapter = new CodexMemoryAdapter({
+      fetchImpl,
+      baseUrl: "http://127.0.0.1:8420",
+      userId: "alice",
+      sessionId: "thread-42",
+      workspaceDir: "C:/work/project",
+    });
+
+    const promptContext = await adapter.buildPromptContext("remember this");
+    expect(promptContext).toEqual({
+      prependUserContext: "dynamic",
+      appendSystemContext: "system",
+    });
+    expect(calls[0]?.url).toBe("http://127.0.0.1:8420/recall");
+    expect(calls[0]?.init?.method).toBe("POST");
+  });
+
+  it("records turns through the gateway client", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/capture")) {
+        const payload = JSON.parse(String(init?.body));
+        expect(payload).toMatchObject({
+          user_content: "hello",
+          assistant_content: "world",
+          session_key: "codex:alice:thread-42",
+          session_id: "thread-42",
+          user_id: "alice",
+        });
+        return new Response(JSON.stringify({ l0_recorded: 1, scheduler_notified: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const adapter = new CodexMemoryAdapter({
+      fetchImpl,
+      baseUrl: "http://127.0.0.1:8420",
+      userId: "alice",
+      sessionId: "thread-42",
+      workspaceDir: "C:/work/project",
+    });
+
+    const result = await adapter.recordTurn({
+      userContent: "hello",
+      assistantContent: "world",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(result).toEqual({ l0Recorded: 1, schedulerNotified: true });
+  });
+});

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+import { MemoryPlatformAdapter, type MemoryAdapterOptions } from "../platform/memory-adapter.js";
+import { normalizeSessionPart, type MemoryAdapterRuntime, type MemoryPlatformBridge, type MemoryPromptContext, type MemoryTurnPayload } from "../platform/bridge.js";
+import type { MemoryGatewayClientOptions } from "../platform/gateway-client.js";
+
+export interface CodexMemoryAdapterOptions extends MemoryGatewayClientOptions {
+  userId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  workspaceDir?: string;
+}
+
+export type CodexPromptContext = MemoryPromptContext;
+
+export class CodexMemoryBridge implements MemoryPlatformBridge {
+  private readonly runtime: MemoryAdapterRuntime;
+
+  constructor(opts: CodexMemoryAdapterOptions = {}) {
+    const workspaceDir = opts.workspaceDir ?? process.env.CODEX_WORKSPACE_DIR ?? process.cwd();
+    const sessionId = normalizeSessionPart(
+      opts.sessionId ?? process.env.CODEX_SESSION_ID,
+      path.basename(workspaceDir) || "default-session",
+    );
+    const userId = normalizeSessionPart(
+      opts.userId ?? process.env.CODEX_USER_ID ?? process.env.USERNAME ?? process.env.USER,
+      "default_user",
+    );
+    const sessionKey = opts.sessionKey ?? process.env.CODEX_SESSION_KEY ?? `codex:${userId}:${sessionId}`;
+
+    this.runtime = {
+      platform: "codex",
+      userId,
+      sessionId,
+      sessionKey,
+      workspaceDir,
+    };
+  }
+
+  getRuntime(): MemoryAdapterRuntime {
+    return { ...this.runtime };
+  }
+}
+
+export class CodexMemoryAdapter extends MemoryPlatformAdapter {
+  constructor(opts: CodexMemoryAdapterOptions = {}) {
+    const adapterOptions: MemoryAdapterOptions = {
+      ...opts,
+      bridge: new CodexMemoryBridge(opts),
+    };
+    super(adapterOptions);
+  }
+
+  async recordTurn(turn: MemoryTurnPayload): Promise<{ l0Recorded: number; schedulerNotified: boolean }> {
+    return this.capture(turn);
+  }
+}
+
+export function createCodexMemoryAdapter(opts: CodexMemoryAdapterOptions = {}): CodexMemoryAdapter {
+  return new CodexMemoryAdapter(opts);
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,0 +1,2 @@
+export { CodexMemoryAdapter, CodexMemoryBridge, createCodexMemoryAdapter } from "./adapter.js";
+export type { CodexMemoryAdapterOptions, CodexPromptContext } from "./adapter.js";

--- a/src/adapters/dify/adapter.test.ts
+++ b/src/adapters/dify/adapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { DifyMemoryAdapter } from "./adapter.js";
+
+describe("DifyMemoryAdapter", () => {
+  it("derives a platform-scoped session key from Dify context", () => {
+    const adapter = new DifyMemoryAdapter({
+      fetchImpl: vi.fn(),
+      baseUrl: "http://127.0.0.1:8420",
+      appId: "support-bot",
+      userId: "alice",
+      conversationId: "conv-1",
+      workflowRunId: "run-1",
+      workspaceDir: "C:/work/dify",
+    });
+
+    expect(adapter.getRuntime()).toMatchObject({
+      platform: "dify",
+      userId: "alice",
+      sessionId: "conv-1",
+      sessionKey: "dify:support-bot:alice:conv-1",
+      workspaceDir: "C:/work/dify",
+    });
+    expect(adapter.getDifyContext()).toMatchObject({
+      appId: "support-bot",
+      userId: "alice",
+      conversationId: "conv-1",
+      workflowRunId: "run-1",
+    });
+  });
+
+  it("maps recall context into Dify prompt sections", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      context: "stable",
+      prepend_context: "dynamic",
+      append_system_context: "system",
+      strategy: "hybrid",
+      memory_count: 1,
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const adapter = new DifyMemoryAdapter({
+      fetchImpl,
+      baseUrl: "http://127.0.0.1:8420",
+      appId: "support-bot",
+      userId: "alice",
+      conversationId: "conv-1",
+      query: "where is my order?",
+    });
+
+    await expect(adapter.buildPromptContext()).resolves.toEqual({
+      prependUserContext: "dynamic",
+      appendSystemContext: "system",
+    });
+  });
+
+  it("captures a Dify turn through the unified gateway payload", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(String(url)).toBe("http://127.0.0.1:8420/capture");
+      const payload = JSON.parse(String(init?.body));
+      expect(payload).toMatchObject({
+        user_content: "hello",
+        assistant_content: "world",
+        session_key: "dify:support-bot:alice:conv-1",
+        session_id: "conv-1",
+        user_id: "alice",
+      });
+      expect(payload.messages).toHaveLength(2);
+      expect(payload.messages[0].metadata.platform).toBe("dify");
+      return new Response(JSON.stringify({ l0_recorded: 2, scheduler_notified: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const adapter = new DifyMemoryAdapter({
+      fetchImpl,
+      baseUrl: "http://127.0.0.1:8420",
+      appId: "support-bot",
+      userId: "alice",
+      conversationId: "conv-1",
+    });
+
+    await expect(adapter.recordDifyTurn({
+      query: "hello",
+      answer: "world",
+      inputs: { locale: "zh-CN" },
+    })).resolves.toEqual({ l0Recorded: 2, schedulerNotified: true });
+  });
+});

--- a/src/adapters/dify/adapter.ts
+++ b/src/adapters/dify/adapter.ts
@@ -1,0 +1,161 @@
+import { MemoryPlatformAdapter, type MemoryAdapterOptions } from "../platform/memory-adapter.js";
+import {
+  normalizeSessionPart,
+  type MemoryAdapterRuntime,
+  type MemoryPlatformBridge,
+  type MemoryPromptContext,
+  type MemoryTurnPayload,
+} from "../platform/bridge.js";
+import type { MemoryGatewayClientOptions } from "../platform/gateway-client.js";
+
+export interface DifyRequestContext {
+  appId?: string;
+  userId?: string;
+  conversationId?: string;
+  workflowRunId?: string;
+  messageId?: string;
+  query?: string;
+  answer?: string;
+  inputs?: Record<string, unknown>;
+}
+
+export interface DifyMemoryAdapterOptions extends MemoryGatewayClientOptions, DifyRequestContext {
+  sessionId?: string;
+  sessionKey?: string;
+  workspaceDir?: string;
+}
+
+export type DifyPromptContext = MemoryPromptContext;
+
+export interface DifyTurnPayload {
+  query: string;
+  answer: string;
+  inputs?: Record<string, unknown>;
+  rawRequest?: unknown;
+  rawResponse?: unknown;
+}
+
+export class DifyMemoryBridge implements MemoryPlatformBridge {
+  private readonly runtime: MemoryAdapterRuntime;
+  private readonly requestContext: DifyRequestContext;
+
+  constructor(opts: DifyMemoryAdapterOptions = {}) {
+    const workspaceDir = opts.workspaceDir ?? process.env.DIFY_WORKSPACE_DIR ?? process.cwd();
+    const appId = normalizeSessionPart(opts.appId ?? process.env.DIFY_APP_ID, "default-app");
+    const userId = normalizeSessionPart(opts.userId ?? process.env.DIFY_USER_ID, "default_user");
+    const conversationId = normalizeSessionPart(
+      opts.conversationId ?? process.env.DIFY_CONVERSATION_ID,
+      opts.workflowRunId ?? process.env.DIFY_WORKFLOW_RUN_ID ?? opts.messageId ?? process.env.DIFY_MESSAGE_ID ?? "default-conversation",
+    );
+    const sessionId = normalizeSessionPart(opts.sessionId, conversationId);
+    const sessionKey = opts.sessionKey ?? process.env.DIFY_SESSION_KEY ?? `dify:${appId}:${userId}:${sessionId}`;
+
+    this.runtime = {
+      platform: "dify",
+      userId,
+      sessionId,
+      sessionKey,
+      workspaceDir,
+    };
+    this.requestContext = {
+      appId,
+      userId,
+      conversationId,
+      workflowRunId: opts.workflowRunId,
+      messageId: opts.messageId,
+      query: opts.query,
+      answer: opts.answer,
+      inputs: opts.inputs,
+    };
+  }
+
+  getRuntime(): MemoryAdapterRuntime {
+    return { ...this.runtime };
+  }
+
+  buildTurn(turn: MemoryTurnPayload): MemoryTurnPayload {
+    return {
+      ...turn,
+      messages: turn.messages ?? [
+        {
+          role: "user",
+          content: turn.userContent,
+          metadata: this.buildMessageMetadata("query"),
+        },
+        {
+          role: "assistant",
+          content: turn.assistantContent,
+          metadata: this.buildMessageMetadata("answer"),
+        },
+      ],
+    };
+  }
+
+  getRequestContext(): DifyRequestContext {
+    return { ...this.requestContext, inputs: this.requestContext.inputs ? { ...this.requestContext.inputs } : undefined };
+  }
+
+  private buildMessageMetadata(kind: "query" | "answer"): Record<string, unknown> {
+    return {
+      platform: "dify",
+      kind,
+      appId: this.requestContext.appId,
+      conversationId: this.requestContext.conversationId,
+      workflowRunId: this.requestContext.workflowRunId,
+      messageId: this.requestContext.messageId,
+      inputs: this.requestContext.inputs,
+    };
+  }
+}
+
+export class DifyMemoryAdapter extends MemoryPlatformAdapter {
+  private readonly difyBridge: DifyMemoryBridge;
+
+  constructor(opts: DifyMemoryAdapterOptions = {}) {
+    const bridge = new DifyMemoryBridge(opts);
+    const adapterOptions: MemoryAdapterOptions = {
+      ...opts,
+      bridge,
+    };
+    super(adapterOptions);
+    this.difyBridge = bridge;
+  }
+
+  getDifyContext(): DifyRequestContext {
+    return this.difyBridge.getRequestContext();
+  }
+
+  async buildPromptContext(query?: string): Promise<DifyPromptContext> {
+    const effectiveQuery = query ?? this.getDifyContext().query ?? "";
+    return super.buildPromptContext(effectiveQuery);
+  }
+
+  async recordDifyTurn(turn?: DifyTurnPayload): Promise<{ l0Recorded: number; schedulerNotified: boolean }> {
+    const ctx = this.getDifyContext();
+    const effectiveTurn = turn ?? {
+      query: ctx.query ?? "",
+      answer: ctx.answer ?? "",
+      inputs: ctx.inputs,
+    };
+    return this.capture({
+      userContent: effectiveTurn.query,
+      assistantContent: effectiveTurn.answer,
+      messages: [
+        {
+          role: "user",
+          content: effectiveTurn.query,
+          metadata: { platform: "dify", inputs: effectiveTurn.inputs, rawRequest: effectiveTurn.rawRequest },
+        },
+        {
+          role: "assistant",
+          content: effectiveTurn.answer,
+          metadata: { platform: "dify", rawResponse: effectiveTurn.rawResponse },
+        },
+      ],
+    });
+  }
+}
+
+export function createDifyMemoryAdapter(opts: DifyMemoryAdapterOptions = {}): DifyMemoryAdapter {
+  return new DifyMemoryAdapter(opts);
+}

--- a/src/adapters/dify/index.ts
+++ b/src/adapters/dify/index.ts
@@ -1,0 +1,7 @@
+export { DifyMemoryAdapter, DifyMemoryBridge, createDifyMemoryAdapter } from "./adapter.js";
+export type {
+  DifyMemoryAdapterOptions,
+  DifyPromptContext,
+  DifyRequestContext,
+  DifyTurnPayload,
+} from "./adapter.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,22 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Platform adapters
+export { MemoryGatewayClient, type MemoryGatewayClientOptions, type MemoryRecallContext } from "./platform/gateway-client.js";
+export { MemoryPlatformAdapter, createMemoryPlatformAdapter, type MemoryAdapterOptions } from "./platform/memory-adapter.js";
+export {
+  normalizeSessionPart,
+  type MemoryAdapterRuntime,
+  type MemoryPlatformBridge,
+  type MemoryPromptContext,
+  type MemoryTurnPayload,
+} from "./platform/bridge.js";
+
+// Codex adapter
+export { CodexMemoryAdapter, CodexMemoryBridge, createCodexMemoryAdapter } from "./codex/index.js";
+export type { CodexMemoryAdapterOptions, CodexPromptContext } from "./codex/index.js";
+
+// Dify adapter
+export { DifyMemoryAdapter, DifyMemoryBridge, createDifyMemoryAdapter } from "./dify/index.js";
+export type { DifyMemoryAdapterOptions, DifyPromptContext, DifyRequestContext, DifyTurnPayload } from "./dify/index.js";

--- a/src/adapters/platform/bridge.ts
+++ b/src/adapters/platform/bridge.ts
@@ -1,0 +1,31 @@
+export interface MemoryAdapterRuntime {
+  platform: string;
+  userId: string;
+  sessionId: string;
+  sessionKey: string;
+  workspaceDir: string;
+}
+
+export interface MemoryTurnPayload {
+  userContent: string;
+  assistantContent: string;
+  messages?: unknown[];
+}
+
+export interface MemoryPlatformBridge {
+  getRuntime(): MemoryAdapterRuntime;
+  buildTurn?(turn: MemoryTurnPayload): MemoryTurnPayload;
+}
+
+export interface MemoryPromptContext {
+  /** Add to the current user prompt before the raw query. */
+  prependUserContext: string;
+  /** Add to the system prompt or platform-level instruction suffix. */
+  appendSystemContext: string;
+}
+
+export function normalizeSessionPart(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return fallback;
+  return trimmed.replace(/\s+/g, "-");
+}

--- a/src/adapters/platform/gateway-client.ts
+++ b/src/adapters/platform/gateway-client.ts
@@ -1,0 +1,166 @@
+import type {
+  CaptureResponse,
+  ConversationSearchResponse,
+  MemorySearchResponse,
+  RecallResponse,
+  SeedResponse,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export interface MemoryGatewayClientOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface MemoryRecallContext {
+  context: string;
+  prependContext: string;
+  appendSystemContext: string;
+  strategy?: string;
+  memoryCount?: number;
+}
+
+export interface MemoryCapturePayload {
+  userContent: string;
+  assistantContent: string;
+  sessionKey: string;
+  sessionId?: string;
+  userId?: string;
+  messages?: unknown[];
+}
+
+export class MemoryGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: MemoryGatewayClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? "http://127.0.0.1:8420").replace(/\/+$/, "");
+    this.apiKey = opts.apiKey?.trim() || undefined;
+    this.timeoutMs = opts.timeoutMs ?? 10_000;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async health(timeoutMs = 3_000): Promise<{ status: string; version: string; uptime: number }> {
+    return this.get<{ status: string; version: string; uptime: number }>("/health", timeoutMs);
+  }
+
+  async recall(query: string, sessionKey: string, userId?: string, timeoutMs?: number): Promise<MemoryRecallContext> {
+    const body: Record<string, unknown> = { query, session_key: sessionKey };
+    if (userId) body.user_id = userId;
+    const result = await this.post<RecallResponse>("/recall", body, timeoutMs);
+    return {
+      context: result.context ?? result.append_system_context ?? "",
+      prependContext: result.prepend_context ?? "",
+      appendSystemContext: result.append_system_context ?? result.context ?? "",
+      strategy: result.strategy,
+      memoryCount: result.memory_count,
+    };
+  }
+
+  async capture(payload: MemoryCapturePayload, timeoutMs?: number): Promise<CaptureResponse> {
+    const body: Record<string, unknown> = {
+      user_content: payload.userContent,
+      assistant_content: payload.assistantContent,
+      session_key: payload.sessionKey,
+      messages: payload.messages,
+    };
+    if (payload.sessionId) body.session_id = payload.sessionId;
+    if (payload.userId) body.user_id = payload.userId;
+    return this.post<CaptureResponse>("/capture", body, timeoutMs);
+  }
+
+  async searchMemories(params: {
+    query: string;
+    limit?: number;
+    type?: string;
+    scene?: string;
+  }, timeoutMs?: number): Promise<MemorySearchResponse> {
+    return this.post<MemorySearchResponse>("/search/memories", {
+      query: params.query,
+      limit: params.limit,
+      type: params.type,
+      scene: params.scene,
+    }, timeoutMs);
+  }
+
+  async searchConversations(params: {
+    query: string;
+    limit?: number;
+    sessionKey?: string;
+  }, timeoutMs?: number): Promise<ConversationSearchResponse> {
+    return this.post<ConversationSearchResponse>("/search/conversations", {
+      query: params.query,
+      limit: params.limit,
+      session_key: params.sessionKey,
+    }, timeoutMs);
+  }
+
+  async endSession(sessionKey: string, userId?: string, timeoutMs?: number): Promise<SessionEndResponse> {
+    const body: Record<string, unknown> = { session_key: sessionKey };
+    if (userId) body.user_id = userId;
+    return this.post<SessionEndResponse>("/session/end", body, timeoutMs);
+  }
+
+  async seed(data: unknown, params?: {
+    sessionKey?: string;
+    strictRoundRole?: boolean;
+    autoFillTimestamps?: boolean;
+    configOverride?: Record<string, unknown>;
+  }, timeoutMs = 300_000): Promise<SeedResponse> {
+    const body: Record<string, unknown> = { data };
+    if (params?.sessionKey) body.session_key = params.sessionKey;
+    if (params?.strictRoundRole) body.strict_round_role = true;
+    if (params?.autoFillTimestamps === false) body.auto_fill_timestamps = false;
+    if (params?.configOverride) body.config_override = params.configOverride;
+    return this.post<SeedResponse>("/seed", body, timeoutMs);
+  }
+
+  private async get<T>(path: string, timeoutMs?: number): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await this.fetchWithTimeout(url, {
+      method: "GET",
+      headers: this.buildHeaders(false),
+    }, timeoutMs);
+    return this.parseJson<T>(res);
+  }
+
+  private async post<T>(path: string, body: Record<string, unknown>, timeoutMs?: number): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await this.fetchWithTimeout(url, {
+      method: "POST",
+      headers: this.buildHeaders(true),
+      body: JSON.stringify(body),
+    }, timeoutMs);
+    return this.parseJson<T>(res);
+  }
+
+  private buildHeaders(withJson: boolean): HeadersInit {
+    const headers: Record<string, string> = {};
+    if (withJson) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+    return headers;
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit, timeoutMs?: number): Promise<Response> {
+    const controller = new AbortController();
+    const effectiveTimeout = timeoutMs ?? this.timeoutMs;
+    const timer = setTimeout(() => controller.abort(new Error(`Request timed out after ${effectiveTimeout}ms`)), effectiveTimeout);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async parseJson<T>(res: Response): Promise<T> {
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(text || `HTTP ${res.status}`);
+    }
+    return JSON.parse(text) as T;
+  }
+}

--- a/src/adapters/platform/memory-adapter.ts
+++ b/src/adapters/platform/memory-adapter.ts
@@ -1,0 +1,104 @@
+import { MemoryGatewayClient, type MemoryGatewayClientOptions } from "./gateway-client.js";
+import type {
+  MemoryAdapterRuntime,
+  MemoryPlatformBridge,
+  MemoryPromptContext,
+  MemoryTurnPayload,
+} from "./bridge.js";
+
+export interface MemoryAdapterOptions extends MemoryGatewayClientOptions {
+  bridge: MemoryPlatformBridge;
+}
+
+export class MemoryPlatformAdapter {
+  protected readonly client: MemoryGatewayClient;
+  protected readonly bridge: MemoryPlatformBridge;
+
+  constructor(opts: MemoryAdapterOptions) {
+    this.client = new MemoryGatewayClient(opts);
+    this.bridge = opts.bridge;
+  }
+
+  getRuntime(): MemoryAdapterRuntime {
+    return { ...this.bridge.getRuntime() };
+  }
+
+  async buildPromptContext(query: string): Promise<MemoryPromptContext> {
+    const recall = await this.recall(query);
+    return {
+      prependUserContext: recall.prependContext,
+      appendSystemContext: recall.appendSystemContext,
+    };
+  }
+
+  async recall(query: string): Promise<{ prependContext: string; appendSystemContext: string; context: string }> {
+    const runtime = this.bridge.getRuntime();
+    const result = await this.client.recall(query, runtime.sessionKey, runtime.userId);
+    return {
+      context: result.context,
+      prependContext: result.prependContext,
+      appendSystemContext: result.appendSystemContext,
+    };
+  }
+
+  async capture(turn: MemoryTurnPayload): Promise<{ l0Recorded: number; schedulerNotified: boolean }> {
+    const runtime = this.bridge.getRuntime();
+    const normalizedTurn = this.bridge.buildTurn?.(turn) ?? turn;
+    const result = await this.client.capture({
+      userContent: normalizedTurn.userContent,
+      assistantContent: normalizedTurn.assistantContent,
+      sessionKey: runtime.sessionKey,
+      sessionId: runtime.sessionId,
+      userId: runtime.userId,
+      messages: normalizedTurn.messages,
+    });
+    return {
+      l0Recorded: result.l0_recorded,
+      schedulerNotified: result.scheduler_notified,
+    };
+  }
+
+  async searchMemories(query: string, limit = 5, type?: string, scene?: string): Promise<{ results: string; total: number; strategy: string }> {
+    const result = await this.client.searchMemories({ query, limit, type, scene });
+    return { results: result.results, total: result.total, strategy: result.strategy };
+  }
+
+  async searchConversations(query: string, limit = 5): Promise<{ results: string; total: number }> {
+    const runtime = this.bridge.getRuntime();
+    const result = await this.client.searchConversations({ query, limit, sessionKey: runtime.sessionKey });
+    return { results: result.results, total: result.total };
+  }
+
+  async endSession(): Promise<void> {
+    const runtime = this.bridge.getRuntime();
+    await this.client.endSession(runtime.sessionKey, runtime.userId);
+  }
+
+  async health(): Promise<{ status: string; version: string; uptime: number }> {
+    return this.client.health();
+  }
+
+  async seed(data: unknown, params?: {
+    sessionKey?: string;
+    strictRoundRole?: boolean;
+    autoFillTimestamps?: boolean;
+    configOverride?: Record<string, unknown>;
+  }): Promise<{ sessionsProcessed: number; roundsProcessed: number; messagesProcessed: number; l0Recorded: number; durationMs: number; outputDir: string }> {
+    const result = await this.client.seed(data, params);
+    return {
+      sessionsProcessed: result.sessions_processed,
+      roundsProcessed: result.rounds_processed,
+      messagesProcessed: result.messages_processed,
+      l0Recorded: result.l0_recorded,
+      durationMs: result.duration_ms,
+      outputDir: result.output_dir,
+    };
+  }
+}
+
+export function createMemoryPlatformAdapter(
+  bridge: MemoryPlatformBridge,
+  opts: MemoryGatewayClientOptions = {},
+): MemoryPlatformAdapter {
+  return new MemoryPlatformAdapter({ ...opts, bridge });
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -384,6 +384,8 @@ export class TdaiGateway {
 
     const response: RecallResponse = {
       context: result.appendSystemContext ?? "",
+      prepend_context: result.prependContext ?? "",
+      append_system_context: result.appendSystemContext ?? "",
       strategy: result.recallStrategy,
       memory_count: result.recalledL1Memories?.length ?? 0,
     };

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -36,7 +36,12 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Backward-compatible context field used by existing Hermes clients. */
   context: string;
+  /** Dynamic L1 recall snippets intended to be prepended to the user prompt. */
+  prepend_context?: string;
+  /** Stable persona / scene / tool-guide context intended for the system prompt. */
+  append_system_context?: string;
   strategy?: string;
   memory_count?: number;
 }

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -332,6 +332,22 @@ export class CheckpointManager {
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
   }
 
+  async reconcileDataCounters(params: {
+    l0ConversationsCount?: number;
+    totalMemoriesExtracted?: number;
+    reason?: string;
+  }): Promise<void> {
+    const clean = (n: number) => Math.max(0, Math.floor(Number.isFinite(n) ? n : 0));
+    const cp = await this.mutate((cp) => {
+      if (params.l0ConversationsCount !== undefined) cp.l0_conversations_count = clean(params.l0ConversationsCount);
+      if (params.totalMemoriesExtracted !== undefined) cp.total_memories_extracted = clean(params.totalMemoriesExtracted);
+    });
+    this.logger.info(
+      `[checkpoint] reconcileDataCounters: l0_conversations_count=${cp.l0_conversations_count}, total_memories_extracted=${cp.total_memories_extracted}` +
+      `${params.reason ? `, reason=${params.reason}` : ""}`,
+    );
+  }
+
   // ============================
   // Per-session helpers — runner state (L0/L1 owned)
   // ============================

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import type { Logger } from "../core/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+const logger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+describe("LocalMemoryCleaner", () => {
+  it("reconciles checkpoint counters after cleanup", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-cleaner-"));
+    tempDirs.push(baseDir);
+
+    const recordsDir = path.join(baseDir, "records");
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(path.join(recordsDir, "2026-07-12.jsonl"), makeLines(3), "utf-8");
+    await fs.writeFile(path.join(recordsDir, "2026-07-14.jsonl"), makeLines(22), "utf-8");
+
+    const checkpoint = new CheckpointManager(baseDir, logger);
+    const cp = await checkpoint.read();
+    cp.l0_conversations_count = 60;
+    cp.total_memories_extracted = 25;
+    await checkpoint.write(cp);
+
+    const vectorStore = {
+      countL0: () => 60,
+      countL1: () => 25,
+      deleteL0Expired: () => 8,
+      deleteL1Expired: () => 3,
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+      vectorStore,
+    });
+
+    await cleaner.runOnce(new Date("2026-07-14T12:00:00Z").getTime());
+
+    const updated = await checkpoint.read();
+    expect(updated.l0_conversations_count).toBe(52);
+    expect(updated.total_memories_extracted).toBe(22);
+    await expect(fs.access(path.join(recordsDir, "2026-07-12.jsonl"))).rejects.toThrow();
+  });
+});
+
+function makeLines(count: number): string {
+  return Array.from({ length: count }, (_, i) => JSON.stringify({ id: `m_${i}` })).join("\n") + "\n";
+}

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -113,8 +114,10 @@ export class LocalMemoryCleaner {
       // ── Pre-delete: count totals and decide whether to proceed ──
       let totalL0 = 0;
       let totalL1 = 0;
-      try { totalL0 = await vectorStore.countL0(); } catch { /* non-fatal */ }
-      try { totalL1 = await vectorStore.countL1(); } catch { /* non-fatal */ }
+      let countedL0 = true;
+      let countedL1 = true;
+      try { totalL0 = await vectorStore.countL0(); } catch { countedL0 = false; }
+      try { totalL1 = await vectorStore.countL1(); } catch { countedL1 = false; }
 
       this.opts.logger?.info(
         `${TAG} [Pre-delete] cutoffIso=${cutoffIso}, retentionDays=${retentionDays}, totalL0=${totalL0}, totalL1=${totalL1}`,
@@ -169,6 +172,14 @@ export class LocalMemoryCleaner {
       const durationMs = Date.now() - startMs;
       const remainingL0 = totalL0 - removedL0;
       const remainingL1 = totalL1 - removedL1;
+      const actualL1 = await this.countJsonlLines(path.join(this.opts.baseDir, L1_DIR_NAME));
+      if (countedL0 || countedL1) {
+        await new CheckpointManager(this.opts.baseDir, this.opts.logger).reconcileDataCounters({
+          ...(countedL0 ? { l0ConversationsCount: remainingL0 } : {}),
+          ...(countedL1 ? { totalMemoriesExtracted: actualL1 } : {}),
+          reason: `memory-cleaner cutoff=${cutoffIso}`,
+        });
+      }
       const summary = {
         event: "cleaner_summary",
         cutoffIso,
@@ -275,6 +286,21 @@ export class LocalMemoryCleaner {
     }
 
     return stats;
+  }
+
+  private async countJsonlLines(dirPath: string): Promise<number> {
+    try {
+      const entries = await fs.readdir(dirPath, { withFileTypes: true });
+      let count = 0;
+      for (const entry of entries) {
+        if (!entry.isFile() || !isJsonLikeFile(entry.name)) continue;
+        const raw = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+        count += raw.split("\n").filter((line) => line.trim()).length;
+      }
+      return count;
+    } catch {
+      return 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Description | 描述

This PR adds a cross-platform memory adapter SDK for TencentDB Agent Memory and implements two new platform adapters: Codex and Dify.

本 PR 为 TencentDB Agent Memory 增加跨平台记忆适配器 SDK，并新增 Codex 与 Dify 两个平台适配层。

The core goal is to make future platform integrations nearly zero-cost: a new platform only needs to implement `MemoryPlatformBridge` to provide runtime identity, session identity, workspace context, and optional turn normalization. The shared SDK then handles recall, capture, memory search, conversation search, session flush, and Gateway transport.

核心目标是把后续新平台的接入成本降到最低：新平台只需要实现 `MemoryPlatformBridge`，提供用户身份、会话身份、工作区上下文以及可选的 turn 归一化逻辑，即可复用统一的 recall、capture、memory search、conversation search、session flush 和 Gateway 通信能力。

## Related Issue | 关联 Issue

Closes #235

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## What Changed | 主要变更

### 1. Cross-platform adapter SDK | 跨平台适配器 SDK

Added a reusable adapter layer for future Agent platforms.

新增可复用的平台适配层，作为后续 Agent 平台接入的统一标准。

Key additions:

- `MemoryPlatformBridge`: the minimal interface a new platform must implement
- `MemoryGatewayClient`: shared Gateway HTTP client with auth, timeout, and response mapping
- `MemoryPlatformAdapter`: shared platform-facing API for recall, capture, search, session flush, and seed import

核心新增：

- `MemoryPlatformBridge`：新平台必须实现的最小接口
- `MemoryGatewayClient`：统一 Gateway HTTP 客户端，封装鉴权、超时和响应映射
- `MemoryPlatformAdapter`：统一的平台侧 API，提供召回、捕获、搜索、会话 flush、seed 导入等能力

The standard integration path is:

~~~text
Platform runtime
  -> MemoryPlatformBridge
    -> MemoryPlatformAdapter
      -> MemoryGatewayClient
        -> TDAI Gateway
          -> TdaiCore
~~~

标准接入路径为：

~~~text
平台运行时
  -> MemoryPlatformBridge
    -> MemoryPlatformAdapter
      -> MemoryGatewayClient
        -> TDAI Gateway
          -> TdaiCore
~~~

### 2. Codex adapter | Codex 适配器

Added Codex-specific bridge and adapter implementation.

新增 Codex 平台的 bridge 与 adapter 实现。

Key additions:

- `CodexMemoryBridge`
- `CodexMemoryAdapter`
- `createCodexMemoryAdapter()`

默认 session key 规则：

~~~text
codex:<userId>:<sessionId>
~~~

### 3. Dify adapter | Dify 适配器

Added Dify-specific bridge and adapter implementation.

新增 Dify 平台的 bridge 与 adapter 实现。

Key additions:

- `DifyMemoryBridge`
- `DifyMemoryAdapter`
- `createDifyMemoryAdapter()`

Supported Dify integration shapes:

- Tool integration
- Workflow node integration
- Backend extension integration

支持的 Dify 接入形态：

- 工具接入
- 工作流节点接入
- 后端扩展接入

默认 session key 规则：

~~~text
dify:<appId>:<userId>:<conversationId>
~~~

If `conversationId` is unavailable, the adapter can fall back to `workflowRunId` or `messageId`.

当 `conversationId` 不存在时，适配器可降级使用 `workflowRunId` 或 `messageId`。

### 4. Gateway recall response enhancement | Gateway recall 响应增强

Extended the Gateway `/recall` response while preserving backward compatibility.

在保持向后兼容的前提下，增强 Gateway `/recall` 响应。

Existing field kept:

- `context`

New fields added:

- `prepend_context`
- `append_system_context`

保留旧字段：

- `context`

新增字段：

- `prepend_context`
- `append_system_context`

This allows new platforms to distinguish between dynamic L1 recall snippets and stable system-level context.

这样新平台可以区分动态 L1 召回片段和稳定的系统级上下文。

### 5. Adapter documentation | 适配文档

Added architecture, comparison, and full integration guide documents.

新增架构图、平台对比文档和完整接入指南。

New documents:

- `docs/cross-platform-adapters.md`
- `docs/platform-adapter-comparison.md`
- `docs/platform-adapter-comparison.zh.md`
- `docs/platform-adapter-guide.md`
- `docs/platform-adapter-guide.zh.md`

Documentation covers:

- Core engine interface description
- OpenClaw / Hermes / Codex / Dify adapter comparison
- Complete steps for integrating a new platform
- Code examples
- Best practices
- Common pitfalls
- Acceptance checklist

文档覆盖：

- 核心引擎接口说明
- OpenClaw / Hermes / Codex / Dify 适配方式对比
- 新平台接入完整步骤
- 代码示例
- 最佳实践
- 常见踩坑点
- 验收清单

## Design Notes | 设计说明

OpenClaw continues to use the in-process `OpenClawHostAdapter` path because it already provides a native plugin API and embedded runtime.

OpenClaw 继续保持进程内 `OpenClawHostAdapter` 路径，因为它已有原生插件 API 和 embedded runtime。

Hermes, Codex, Dify, and future platforms use the Gateway path by default, so platform-specific details do not leak into the core memory engine.

Hermes、Codex、Dify 以及后续新平台默认走 Gateway 路径，避免平台细节耦合进核心记忆引擎。

This keeps `TdaiCore` host-neutral and makes future integrations easier to maintain.

这样可以保持 `TdaiCore` 的宿主无关性，也让后续平台接入更容易维护。

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Added Codex adapter tests | 已补充 Codex 适配器测试
- [x] Added Dify adapter tests | 已补充 Dify 适配器测试
- [x] Added complete adapter documentation | 已补充完整适配文档
- [x] Verified plugin build | 已验证插件构建通过

Commands executed | 执行命令：

~~~bash
npm.cmd test -- --run src/adapters/codex/adapter.test.ts src/adapters/dify/adapter.test.ts
npm.cmd run build:plugin
~~~

## Additional Notes | 其他说明

This PR is not only about adding one or two platform adapters. The main value is the reusable platform adapter standard.

本 PR 的重点不只是新增某一个平台适配器，而是抽象出长期可复用的多平台接入标准。

Future integrations such as Claude Code, OpenCode, or additional Dify runtime shapes only need to implement `MemoryPlatformBridge`; they do not need to duplicate Gateway calls, response mapping, capture logic, search logic, or session flush handling.

后续新增 Claude Code、OpenCode、Dify 其他运行形态等平台时，只需要实现 `MemoryPlatformBridge`，无需重复编写 Gateway 调用、字段映射、capture、search 和 session flush 逻辑。⭐