### PR TITLE
fix(data): add counter reconciliation after memory cleanup, close #157

### DIFF
--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -332,6 +332,22 @@ export class CheckpointManager {
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
   }
 
+  async reconcileDataCounters(params: {
+    l0ConversationsCount?: number;
+    totalMemoriesExtracted?: number;
+    reason?: string;
+  }): Promise<void> {
+    const clean = (n: number) => Math.max(0, Math.floor(Number.isFinite(n) ? n : 0));
+    const cp = await this.mutate((cp) => {
+      if (params.l0ConversationsCount !== undefined) cp.l0_conversations_count = clean(params.l0ConversationsCount);
+      if (params.totalMemoriesExtracted !== undefined) cp.total_memories_extracted = clean(params.totalMemoriesExtracted);
+    });
+    this.logger.info(
+      `[checkpoint] reconcileDataCounters: l0_conversations_count=${cp.l0_conversations_count}, total_memories_extracted=${cp.total_memories_extracted}` +
+      `${params.reason ? `, reason=${params.reason}` : ""}`,
+    );
+  }
+
   // ============================
   // Per-session helpers — runner state (L0/L1 owned)
   // ============================

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import type { Logger } from "../core/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+const logger: Logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+describe("LocalMemoryCleaner", () => {
+  it("reconciles checkpoint counters after cleanup", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-cleaner-"));
+    tempDirs.push(baseDir);
+
+    const recordsDir = path.join(baseDir, "records");
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(path.join(recordsDir, "2026-07-12.jsonl"), makeLines(3), "utf-8");
+    await fs.writeFile(path.join(recordsDir, "2026-07-14.jsonl"), makeLines(22), "utf-8");
+
+    const checkpoint = new CheckpointManager(baseDir, logger);
+    const cp = await checkpoint.read();
+    cp.l0_conversations_count = 60;
+    cp.total_memories_extracted = 25;
+    await checkpoint.write(cp);
+
+    const vectorStore = {
+      countL0: () => 60,
+      countL1: () => 25,
+      deleteL0Expired: () => 8,
+      deleteL1Expired: () => 3,
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+      vectorStore,
+    });
+
+    await cleaner.runOnce(new Date("2026-07-14T12:00:00Z").getTime());
+
+    const updated = await checkpoint.read();
+    expect(updated.l0_conversations_count).toBe(52);
+    expect(updated.total_memories_extracted).toBe(22);
+    await expect(fs.access(path.join(recordsDir, "2026-07-12.jsonl"))).rejects.toThrow();
+  });
+});
+
+function makeLines(count: number): string {
+  return Array.from({ length: count }, (_, i) => JSON.stringify({ id: `m_${i}` })).join("\n") + "\n";
+}

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -113,8 +114,10 @@ export class LocalMemoryCleaner {
       // ── Pre-delete: count totals and decide whether to proceed ──
       let totalL0 = 0;
       let totalL1 = 0;
-      try { totalL0 = await vectorStore.countL0(); } catch { /* non-fatal */ }
-      try { totalL1 = await vectorStore.countL1(); } catch { /* non-fatal */ }
+      let countedL0 = true;
+      let countedL1 = true;
+      try { totalL0 = await vectorStore.countL0(); } catch { countedL0 = false; }
+      try { totalL1 = await vectorStore.countL1(); } catch { countedL1 = false; }
 
       this.opts.logger?.info(
         `${TAG} [Pre-delete] cutoffIso=${cutoffIso}, retentionDays=${retentionDays}, totalL0=${totalL0}, totalL1=${totalL1}`,
@@ -169,6 +172,14 @@ export class LocalMemoryCleaner {
       const durationMs = Date.now() - startMs;
       const remainingL0 = totalL0 - removedL0;
       const remainingL1 = totalL1 - removedL1;
+      const actualL1 = await this.countJsonlLines(path.join(this.opts.baseDir, L1_DIR_NAME));
+      if (countedL0 || countedL1) {
+        await new CheckpointManager(this.opts.baseDir, this.opts.logger).reconcileDataCounters({
+          ...(countedL0 ? { l0ConversationsCount: remainingL0 } : {}),
+          ...(countedL1 ? { totalMemoriesExtracted: actualL1 } : {}),
+          reason: `memory-cleaner cutoff=${cutoffIso}`,
+        });
+      }
       const summary = {
         event: "cleaner_summary",
         cutoffIso,
@@ -275,6 +286,21 @@ export class LocalMemoryCleaner {
     }
 
     return stats;
+  }
+
+  private async countJsonlLines(dirPath: string): Promise<number> {
+    try {
+      const entries = await fs.readdir(dirPath, { withFileTypes: true });
+      let count = 0;
+      for (const entry of entries) {
+        if (!entry.isFile() || !isJsonLikeFile(entry.name)) continue;
+        const raw = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+        count += raw.split("\n").filter((line) => line.trim()).length;
+      }
+      return count;
+    } catch {
+      return 0;
+    }
   }
 }
 


### PR DESCRIPTION
## Description | 描述
Fix the drift between `recall_checkpoint.json` and real data after cleanup.

This PR:
- adds `reconcileDataCounters()` to `CheckpointManager`
- recalibrates `l0_conversations_count` and `total_memories_extracted` after `memory-cleaner` deletes expired data
- adds a regression test to verify checkpoint counters decrease when data is removed

## Related Issue | 关联 Issue
Fix #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Validation | 验证
- `npx vitest run src/utils/memory-cleaner.test.ts`
- `npm test`
- `npm run build`

## Additional Notes | 其他说明
This change keeps checkpoint counters aligned with actual stored data after cleanup.