### PR TITLE
test(search): cover FTS5 query injection boundaries

### DIFF
--- a/src/core/store/sqlite-fts-security.test.ts
+++ b/src/core/store/sqlite-fts-security.test.ts
@@ -1,0 +1,150 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+} from "./sqlite.js";
+
+const SAFE_LITERAL_QUERY = /^"[^"]+"(?: OR "[^"]+")*$/;
+
+function createFtsIndex(contents: string[]): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  const insert = db.prepare("INSERT INTO docs(content) VALUES (?)");
+  for (const content of contents) insert.run(content);
+  return db;
+}
+
+function searchRowIds(db: DatabaseSync, raw: string): number[] {
+  const query = buildFtsQuery(raw);
+  if (!query) return [];
+  return (
+    db
+      .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+      .all(query) as Array<{ rowid: number }>
+  ).map((row) => row.rowid);
+}
+
+afterEach(() => {
+  _resetJiebaForTest();
+});
+
+describe("buildFtsQuery FTS5 security", () => {
+  it.each([
+    ['alpha" OR beta', "double quote and OR"],
+    ["alpha' AND beta", "apostrophe and AND"],
+    ["(alpha) NOT beta", "parentheses and NOT"],
+    ["NEAR(alpha beta, 5)", "NEAR expression"],
+    ["alpha*", "prefix operator"],
+    ["content:alpha", "column filter"],
+    ["alpha ^ beta", "caret syntax"],
+    ['alpha OR "" OR * beta', "combined syntax"],
+  ])("keeps %s as quoted literal terms (%s)", (raw) => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex(["alpha beta", "content alpha", "unrelated"]);
+
+    try {
+      const query = buildFtsQuery(raw);
+      expect(query).not.toBeNull();
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("quotes hostile jieba tokens before they cross the MATCH boundary", () => {
+    _setJiebaForTest({
+      cutForSearch: () => [
+        'alpha" OR beta',
+        "gamma*",
+        "NEAR(alpha beta)",
+        "NOT",
+        "(delta)",
+      ],
+    });
+    const db = createFtsIndex(["alpha beta", "gamma", "delta"]);
+
+    try {
+      const query = buildFtsQuery("ignored raw input");
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("prevents boolean and proximity words from changing query semantics", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "alpha only",
+      "beta only",
+      "alpha beta",
+      "unrelated",
+    ]);
+
+    try {
+      // Raw FTS5 semantics would make the first query return no rows and the
+      // second exclude beta matches. Literal tokenization keeps broad OR
+      // recall instead.
+      expect(searchRowIds(db, "alpha AND missing")).toEqual([1, 3]);
+      expect(searchRowIds(db, "alpha NOT beta")).toEqual([1, 2, 3]);
+      expect(searchRowIds(db, "NEAR(alpha beta)")).toEqual([1, 2, 3]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves embedded operator substrings and ordinary keyword recall", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "android origin nearby",
+      "android device",
+      "unrelated",
+    ]);
+
+    try {
+      expect(buildFtsQuery("android origin nearby")).toBe(
+        '"android" OR "origin" OR "nearby"',
+      );
+      expect(searchRowIds(db, "android origin nearby")).toEqual([1, 2]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves jieba search tokens for normal Chinese recall", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["北京", "烤鸭", "北京烤鸭"],
+    });
+    const db = createFtsIndex([
+      "北京 烤鸭 北京烤鸭",
+      "上海 小笼包",
+    ]);
+
+    try {
+      expect(buildFtsQuery("北京烤鸭")).toBe(
+        '"北京" OR "烤鸭" OR "北京烤鸭"',
+      );
+      expect(searchRowIds(db, "北京烤鸭")).toEqual([1]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    "",
+    "   ",
+    "\"'()***",
+    "！@#￥%……&*（）",
+  ])("returns null when no searchable token remains: %j", (raw) => {
+    _setJiebaForTest(null);
+    expect(buildFtsQuery(raw)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description | 描述

Adds execution-level regression coverage for the SQLite FTS5 query boundary described in #160.

This is intentionally a test-only complement to canonical fix #178. It does not introduce another sanitization implementation or change production behavior.

The new suite verifies:

- every generated MATCH expression remains a sequence of quoted literal terms joined by the builder's own `OR`
- quotes, apostrophes, parentheses, `AND`, `OR`, `NOT`, `NEAR`, prefix `*`, column `:`, and caret syntax execute safely through a real in-memory SQLite FTS5 table
- boolean and proximity text cannot recover raw FTS5 semantics
- hostile jieba token output is still quoted before crossing the `MATCH ?` boundary
- the Unicode-regex fallback and jieba paths both retain normal English and Chinese keyword recall
- punctuation-only and empty inputs return no query

## Related Issue | 关联 Issue

Related to #160

## Coordination With #178 | 与 #178 的关系

PR #178 remains the approved canonical production fix for operator sanitization. This PR adds broader security and search-quality regression coverage around that fix and the existing quoted-token defense.

The tests pass against current `main` and are designed to remain valid after #178 lands. They verify safety properties and real FTS5 behavior instead of locking the suite to one exact sanitizer implementation.

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化
- [x] Test coverage | 测试覆盖

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Commit includes the required DCO sign-off

## Verification | 验证

- `npm exec vitest run src/core/store/sqlite-fts-security.test.ts` - 16 passed
- `npm test` - 83 passed
- `npm run build` - passed
- `npm pack --dry-run --json --cache /tmp/tencentdb-agent-memory-160-npm-cache` - passed; the new test is excluded from the package
- `git diff --check` and `git diff --cached --check` - passed

## Additional Notes | 其他说明

An isolated `tsc --noEmit` command that starts from this test reaches the repository's existing optional `node-llama-cpp` peer import and reports its missing type declaration. The repository's supported full build completed successfully.
