### PR TITLE
fix(memory): optimize prompt cache stability for recall injection

### DIFF
--- a/docs/prompt-cache-context-structure.md
+++ b/docs/prompt-cache-context-structure.md
@@ -1,0 +1,115 @@
+# Memory 注入后的上下文结构与缓存优化分析
+
+本文先展示 memory 注入后的上下文结构图，再分析开启 showInjected 引发的对话膨胀趋势，并对比两套优化实现方案。
+
+## 源码依据
+
+- `index.ts` 注册 `before_prompt_build` hook，缓存原始用户输入，调用 `core.handleBeforeRecall()`，并把 recall 结果返回给 OpenClaw。
+- `src/core/tdai-core.ts` 将 `handleBeforeRecall()` 委托给 `performAutoRecall()`。
+- `src/core/hooks/auto-recall.ts` 将 recall 结果拆成两类：
+  - `appendSystemContext`：L3 persona、L2 scene navigation、memory tools guide，属于相对稳定内容。
+  - `prependContext`：L1 relevant memories，随每轮用户输入变化，属于动态内容。
+- `index.ts` 注册 `before_message_write`，在写入历史前清理 `<relevant-memories>`，避免召回片段污染持久化对话。
+
+## Mermaid 图
+
+```mermaid
+flowchart TB
+  classDef cached fill:#e8f5e9,stroke:#2e7d32,color:#0b3d16
+  classDef dynamic fill:#fff3e0,stroke:#ef6c00,color:#4a2600
+  classDef boundary fill:#e3f2fd,stroke:#1565c0,color:#062d5f
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#202124
+  classDef risk fill:#ffebee,stroke:#c62828,color:#5f1111
+
+  U["用户输入<br/>event.prompt"]:::neutral --> H["before_prompt_build<br/>index.ts"]:::neutral
+  H --> C["TdaiCore<br/>handleBeforeRecall"]:::neutral
+  C --> R["performAutoRecall<br/>读取 persona / scene / memory"]:::neutral
+
+  R --> L1["L1 recalled memories<br/>每轮动态变化"]:::dynamic
+  R --> L3["L3 persona<br/>低频变化"]:::cached
+  R --> L2["L2 scene navigation<br/>场景更新时变化"]:::cached
+  R --> TG["memory tools guide<br/>静态工具说明"]:::cached
+
+  L3 --> AS["appendSystemContext<br/>稳定系统侧内容"]:::cached
+  L2 --> AS
+  TG --> AS
+  L1 --> PC["prependContext<br/>动态用户侧记忆"]:::dynamic
+
+  AS --> PA["OpenClaw<br/>prompt assembly<br/>拼装最终请求"]:::neutral
+  PC --> PA
+
+  subgraph Request["memory 注入后的最终请求结构"]
+    direction TB
+    SYS["基础 system prompt<br/>模型 / persona / runtime<br/>规则"]:::cached
+    CB["CACHE_BOUNDARY<br/>provider prefix-match<br/>边界"]:::boundary
+    APP["appendSystemContext<br/>persona + scene<br/>tools guide"]:::cached
+    HIST["conversation history<br/>随轮次增长"]:::risk
+    PRE["prependContext<br/>本轮 L1<br/>recalled memories"]:::dynamic
+    CUR["当前用户输入<br/>clean prompt"]:::neutral
+
+    SYS --> CB --> APP --> HIST --> PRE --> CUR
+  end
+
+  PA --> SYS
+
+  CB -.-> I1["缓存友好的稳定前缀"]:::cached
+  APP -.-> I2["稳定 memory context<br/>不应随 L1 动态记忆<br/>抖动"]:::cached
+  PRE -.-> I3["动态尾部<br/>预期不命中缓存"]:::dynamic
+  HIST -.-> I4["showInjected=true 风险<br/>历史膨胀<br/>截断漂移"]:::risk
+```
+
+## 各段内容对缓存的影响
+
+| 段落 | 来源 | 稳定性 | 缓存影响 |
+| --- | --- | --- | --- |
+| 基础 `system prompt` | OpenClaw runtime | 高 | 最适合放在 provider prefix-cache 区域。 |
+| `appendSystemContext`: L3 persona | `persona.md` | 较高 | 应作为稳定系统侧内容，避免被 L1 动态召回带着变化。 |
+| `appendSystemContext`: L2 scene navigation | scene index | 中等 | 场景更新时变化，但多轮内通常稳定，适合参与缓存。 |
+| `appendSystemContext`: memory tools guide | 常量 `MEMORY_TOOLS_GUIDE` | 高 | 静态内容，适合参与缓存。 |
+| `prependContext`: L1 recalled memories | 当前用户输入召回结果 | 低 | 每轮变化，应该留在动态区。 |
+| conversation history | OpenClaw 会话历史 | 持续增长 | 如果 `showInjected=true`，动态记忆会进入可见历史，造成历史膨胀。 |
+| 当前用户输入 | `event.prompt` | 低 | 动态内容，不应作为缓存前缀优化目标。 |
+
+## `showInjected` 导致的对话膨胀趋势
+
+`showInjected` 影响的是“注入内容是否进入可见/持久历史”，不是“本轮模型是否能看到注入内容”。当 `showInjected=true` 时，每轮注入的 L1 recalled memories 可能作为用户消息的一部分进入后续历史。随着轮次增加，历史里会积累多份动态记忆片段：
+
+- 单轮注入 500-1700 tokens 时，短期看成本不高。
+- 多轮后，历史中重复出现不同 recall 片段，动态尾部变长。
+- 历史变长后更容易触发 truncation。
+- truncation 截断点每轮可能不同，导致 provider 看到的 prefix 发生漂移。
+- prefix 漂移会降低 OpenAI-compatible provider 的 prompt cache 命中率。
+
+本 PR 新增的本地估算器使用同一组长度输入比较两种形态：
+
+- `legacy`：假设 `showInjected=true`，动态记忆进入可见历史，历史膨胀随轮次增长。
+- `optimized`：`showInjected=false`，动态记忆只参与本轮请求，不进入后续可见历史。
+
+运行时会在 recall 日志和 `agent_turn` metric 中输出 `promptCacheImpact`，包括估算的 `legacyEstimatedHitRate`、`optimizedEstimatedHitRate` 和 `estimatedHitRateDelta`。其中 `turns` 由 `before_prompt_build` 的 `event.messages` 中历史 user message 数量估算，当前轮按 `+1` 计入；没有历史消息时回退为 1。
+
+## `showInjected` 策略调优常见的三种细分手段
+
+| 手段 | 是否本 PR 落地 | 说明 |
+| --- | --- | --- |
+| 自动降级 | 已落地 | 只要存在 `prependContext`，返回 `showInjected=false`，原因标记为 `memory_auto_degrade`。 |
+| 记忆长度截断 | 已有能力 | `applyRecallBudget()` 已按 `maxCharsPerMemory` / `maxTotalRecallChars` 控制单条和总召回长度。该能力降低单轮注入体积，是 `showInjected` 调优的配套手段。 |
+| 长会话分级展示 | 暂不新增代码 | 在“有记忆即 `showInjected=false`”策略下，长会话阈值逻辑冗余。建议保留为后续可选策略：如果未来允许短会话展示 injected 内容，再按 message count / turn count 自动关闭。 |
+
+## 两种优化方案对比
+
+| 方案 | 做法 | 改动范围 | 指标预期 | 风险 |
+| --- | --- | --- | --- | --- |
+| 方案 A：缓存分区 + `showInjected` 策略调优 | 稳定内容留在 `appendSystemContext`，动态 L1 留在 `prependContext`，有记忆时强制 `showInjected=false`。 | 小，集中在 recall hook、类型和 metric。 | 降低可见历史膨胀，提升稳定前缀复用率。 | 低，宿主不支持 `showInjected` 时仍保持兼容。 |
+| 方案 B：session 级静态去重 + `showInjected` 策略调优 | 对 persona / scene / tools guide 等稳定系统片段做 session 级 hash 去重，重复片段不再每轮完整发出。 | 中到大，需要 session 状态、hash、版本和失效机制。 | 长会话收益更高，可进一步减少重复稳定 token。 | 中，需要处理 persona / scene 更新、恢复和 replay。 |
+
+## 本 PR 选择方案 A 的原因
+
+方案 A 是更适合本次合入的最低风险方案：
+
+- 不改变 memory 检索算法。
+- 不引入新的持久化状态。
+- 与现有 `appendSystemContext` / `prependContext` 分区一致。
+- 能直接缓解 `showInjected=true` 导致的历史膨胀。
+- 新增 `promptCacheImpact` 指标后，可以在真实流量里观察优化前后的估算命中率变化。
+
+方案 B 适合作为后续增强，详见 `docs/session-system-prompt-dedup.md`。

--- a/docs/provider-cache-comparison-deepseek-vs-mimo.md
+++ b/docs/provider-cache-comparison-deepseek-vs-mimo.md
@@ -1,0 +1,58 @@
+# Provider 缓存策略对比：DeepSeek vs MiMo
+
+本文对比 DeepSeek 和 MiMo 在 prompt caching 上的公开信息与工程影响。结论用于解释为什么本 PR 选择“缓存分区 + `showInjected` 策略调优”作为低风险主实现。
+
+## 资料来源
+
+- DeepSeek Context Caching: https://api-docs.deepseek.com/guides/kv_cache/
+- DeepSeek Pricing: https://api-docs.deepseek.com/quick_start/pricing/
+- MiMo OpenAI-compatible Chat API: https://mimo.mi.com/docs/en-US/api/chat/openai-api
+- MiMo Pay-as-you-go Pricing: https://mimo.mi.com/docs/price/pay-as-you-go
+
+说明：DeepSeek 官方文档对 context caching 的前缀匹配机制描述更直接；MiMo 官方文档重点暴露 OpenAI-compatible API 和 cache-hit / cache-miss 价格差异，但未像 DeepSeek 一样展开完整 prefix unit 规则。因此本文对 MiMo 的缓存行为只做工程侧推断，不把未公开细节写成确定事实。
+
+## DeepSeek
+
+DeepSeek 官方文档说明 context caching 默认启用，并且缓存命中依赖请求前缀复用。其文档提到 cache prefix unit 的概念，后续请求只有完整复用对应前缀单元时才更容易命中。
+
+工程影响：
+
+- prompt 前缀越稳定，越有利于命中缓存。
+- 动态内容越早出现在 prompt 中，越容易破坏后续 prefix matching。
+- 将 L3 persona、L2 scene navigation、tools guide 这类稳定内容与 L1 recalled memories 分区，是符合 DeepSeek 缓存模型的。
+- `showInjected=true` 导致动态 L1 记忆进入历史后，会使后续 prompt prefix 更容易漂移。
+
+## MiMo
+
+MiMo 官方文档提供 OpenAI-compatible Chat API；价格页列出了 cache-hit input 和 cache-miss input 的不同价格，说明 MiMo 也存在缓存命中带来的成本差异。
+
+工程影响：
+
+- MiMo 与 OpenAI-compatible message array 对齐，因此消息顺序和前缀稳定性仍然重要。
+- 价格页显示 cache-hit 与 cache-miss 成本不同，因此优化缓存命中率有直接成本意义。
+- 公开文档未详细说明 prefix unit / cache boundary 规则，所以实现上应采用 provider 无关的稳妥策略：稳定内容尽量靠前、动态内容尽量靠后、避免动态注入进入 durable history。
+
+## 对比表
+
+| 维度 | DeepSeek | MiMo |
+| --- | --- | --- |
+| API 形态 | OpenAI-compatible | OpenAI-compatible |
+| 缓存公开信息 | 官方文档明确讲 context caching 和 cache prefix unit | 官方价格页体现 cache-hit / cache-miss 成本差异 |
+| 工程重点 | 保持可复用前缀稳定 | 保持 message array 前缀稳定，降低 cache-miss 成本 |
+| `showInjected` 风险 | 动态记忆进入历史会造成 prefix drift | 同样会造成历史膨胀和动态前缀漂移 |
+| 本 PR 策略适配性 | 高 | 高 |
+
+## 为什么不能只针对单一 provider 优化
+
+本仓库面向 OpenAI-compatible provider，不应把某个 provider 的私有细节写死到 memory 注入逻辑里。更稳妥的策略是优化 prompt shape：
+
+1. 稳定系统侧内容保持稳定。
+2. 动态 L1 recall 保持在当前轮动态区。
+3. `showInjected=false` 阻止动态记忆进入后续历史。
+4. 用 `promptCacheImpact` 指标观察稳定 token、动态 token 和估算命中率变化。
+
+## 结论
+
+DeepSeek 和 MiMo 的公开文档细节不同，但工程结论一致：缓存命中依赖稳定前缀，动态记忆不应污染后续历史。
+
+因此本 PR 的 provider-agnostic 方案是合理的：不绑定 DeepSeek 或 MiMo 的内部实现，只保证 prompt 结构更缓存友好，并通过指标体现优化效果。

--- a/docs/session-system-prompt-dedup.md
+++ b/docs/session-system-prompt-dedup.md
@@ -1,0 +1,155 @@
+# Session 级系统提示去重设计
+
+本文说明“session 级系统提示去重”作为后续增强方案应该如何实现。本 PR 不实现该方案，只把它作为方案 B 进行技术储备和对比。
+
+## 目标
+
+减少同一 session 内重复发送的稳定系统提示内容，尤其是：
+
+- L3 persona
+- L2 scene navigation
+- memory tools guide
+- 其他稳定 policy / instruction block
+
+该方案不针对 L1 recalled memories。L1 召回结果每轮动态变化，应继续留在 `prependContext` 动态区。
+
+## 适用场景
+
+session 级去重适合以下情况：
+
+- 长会话。
+- 稳定系统提示较大。
+- persona / scene navigation 多轮不变。
+- provider cache-hit 与 cache-miss 价格差明显。
+- 宿主层能够稳定维护 session 状态。
+
+如果只是短会话或稳定系统提示很小，收益有限，复杂度不一定值得。
+
+## 核心思路
+
+对稳定系统提示片段做规范化、hash 和 session 级记录。每轮构建 prompt 时，只完整注入当前 session 没见过或已失效的稳定片段。
+
+流程：
+
+1. 收集稳定片段：persona、scene navigation、tools guide。
+2. 对片段做 normalize：去除多余空白、统一换行、保留语义标签。
+3. 计算 hash，例如 `sha256(normalizedBlock)`。
+4. 查询 session 状态，判断该 hash 是否已注入。
+5. 未注入过：完整放入 `appendSystemContext`。
+6. 已注入过：跳过完整内容，或替换成极短的引用标记。
+7. persona / scene 更新时，清理对应 hash，使新版本重新注入。
+
+## 建议数据结构
+
+按 `sessionKey` 维护：
+
+```ts
+interface StablePromptDedupState {
+  sessionKey: string;
+  emittedHashes: Set<string>;
+  personaHash?: string;
+  sceneNavigationHash?: string;
+  toolsGuideHash?: string;
+  updatedAt: number;
+}
+```
+
+如果需要跨进程恢复，可以持久化为 JSON：
+
+```json
+{
+  "sessionKey": "xxx",
+  "emittedHashes": ["sha256:..."],
+  "personaHash": "sha256:...",
+  "sceneNavigationHash": "sha256:...",
+  "toolsGuideHash": "sha256:...",
+  "updatedAt": 1717200000000
+}
+```
+
+## 失效规则
+
+必须在以下场景重置或部分失效：
+
+- `persona.md` 内容变化。
+- scene index 或 scene navigation 内容变化。
+- memory tools guide 版本变化。
+- sessionKey 变化。
+- 用户手动触发 memory repair / refresh。
+- 宿主恢复历史时发现 session 状态丢失。
+
+失效粒度建议按 block 处理，不要整段系统提示一起失效。这样 persona 更新不会影响 tools guide 的去重状态。
+
+## 与 `showInjected` 的关系
+
+session 级去重和 `showInjected` 不是替代关系。
+
+- session 去重解决“稳定系统提示重复发送”的问题。
+- `showInjected=false` 解决“动态 L1 记忆进入历史”的问题。
+
+两者应该组合使用：
+
+1. 稳定内容通过 session 级去重减少重复 token。
+2. 动态内容通过 `showInjected=false` 避免进入 durable history。
+
+## 与缓存分区的关系
+
+缓存分区是基础，session 去重是增强。
+
+先做缓存分区：
+
+- 稳定内容在 `appendSystemContext`。
+- 动态 L1 recall 在 `prependContext`。
+
+再做 session 去重：
+
+- 对 `appendSystemContext` 中的稳定 block 做 hash。
+- 已注入过且未失效的 block 不再完整注入。
+
+## 实现步骤
+
+1. 新增 `stable-prompt-dedup.ts`，提供 `normalizeStableBlock()`、`hashStableBlock()`、`dedupStableBlocks()`。
+2. 在 `performAutoRecall()` 中将 persona、scene navigation、tools guide 从字符串数组升级为结构化 block：
+
+```ts
+interface StablePromptBlock {
+  kind: "persona" | "scene_navigation" | "tools_guide";
+  content: string;
+}
+```
+
+3. 根据 `sessionKey` 读取 dedup state。
+4. 对每个 block 计算 hash。
+5. 未命中 hash 时追加到 `appendSystemContext`。
+6. 命中 hash 时跳过或写入短引用。
+7. 在 agent_end 或定时清理中清理过期 session state。
+
+## 风险点
+
+- 如果 dedup state 丢失，下一轮会重新完整注入稳定内容；这是可接受的安全退化。
+- 如果失效规则漏掉 persona / scene 更新，可能导致模型继续使用旧稳定提示；这是主要风险。
+- 如果只用短引用替代完整内容，必须确认宿主和 provider 不会丢失语义上下文；否则应选择“跳过去重但不写引用”的更保守方案。
+
+## 为什么不在本 PR 实现
+
+本 PR 的目标是低风险修复 prompt cache regression。session 级去重需要新增状态、hash、失效和恢复机制，改动面更大。
+
+当前更合适的顺序是：
+
+1. 先合入缓存分区 + `showInjected=false` 自动降级。
+2. 观察 `promptCacheImpact` 指标和 provider 实际账单 / cache-hit 数据。
+3. 如果长会话中稳定系统提示仍然占比过高，再实现 session 级去重。
+
+## 验收指标
+
+后续实现时建议关注：
+
+- 平均 prompt input tokens。
+- stable tokens 占比。
+- dynamic tokens 占比。
+- provider cache-hit rate。
+- cache-hit input token cost。
+- session state 命中率。
+- persona / scene 更新后的失效率。
+
+这些指标能判断 session 级去重是否真的带来收益，而不是只增加系统复杂度。

--- a/index.ts
+++ b/index.ts
@@ -66,6 +66,15 @@ const pendingOriginalPrompts = new Map<string, { text: string; ts: number; messa
 const PROMPT_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const PROMPT_CACHE_MAX_SIZE = 10_000; // Hard limit to prevent unbounded growth in high-concurrency scenarios
 
+function estimateConversationTurns(messages: unknown[] | undefined): number {
+  if (!messages || messages.length === 0) return 1;
+  const userMessageCount = messages.reduce((count, msg) => {
+    const role = typeof msg === "object" && msg !== null ? (msg as { role?: unknown }).role : undefined;
+    return role === "user" ? count + 1 : count;
+  }, 0);
+  return Math.max(1, userMessageCount + 1);
+}
+
 /**
  * Cache recall results (L1 memories + L3 Persona) from before_prompt_build
  * for retrieval at agent_end, enabling the agent_turn metric event.
@@ -77,6 +86,20 @@ const pendingRecallCache = new Map<string, {
   l3Persona: string | null;
   strategy: string;
   durationMs: number;
+  showInjected?: boolean;
+  showInjectedReason?: "memory_auto_degrade";
+  promptCacheImpact?: {
+    turns: number;
+    stableContextChars: number;
+    dynamicContextChars: number;
+    estimatedStableTokens: number;
+    estimatedDynamicTokens: number;
+    legacyVisibleHistoryChars: number;
+    optimizedVisibleHistoryChars: number;
+    legacyEstimatedHitRate: number;
+    optimizedEstimatedHitRate: number;
+    estimatedHitRateDelta: number;
+  };
   ts: number;
 }>();
 
@@ -564,7 +587,8 @@ export default function register(api: OpenClawPluginApi) {
       try {
         await coreReady;
         const recallStartMs = Date.now();
-        const result = await core.handleBeforeRecall(userText, resolvedSessionKey);
+        const estimatedTurns = estimateConversationTurns(messages);
+        const result = await core.handleBeforeRecall(userText, resolvedSessionKey, { estimatedTurns });
         const elapsedMs = Date.now() - startMs;
         const recallDurationMs = Date.now() - recallStartMs;
 
@@ -575,6 +599,9 @@ export default function register(api: OpenClawPluginApi) {
             l3Persona: result.recalledL3Persona ?? null,
             strategy: result.recallStrategy ?? "unknown",
             durationMs: recallDurationMs,
+            showInjected: result.showInjected,
+            showInjectedReason: result.showInjectedReason,
+            promptCacheImpact: result.promptCacheImpact,
             ts: Date.now(),
           });
         }
@@ -587,9 +614,11 @@ export default function register(api: OpenClawPluginApi) {
         if (result?.appendSystemContext || result?.prependContext) {
           const appendLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;
+          const showInjected = result.showInjected === false ? `false/${result.showInjectedReason ?? "unknown"}` : "default";
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars, ` +
+            `showInjected=${showInjected}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
@@ -729,6 +758,9 @@ export default function register(api: OpenClawPluginApi) {
             recalledL3Persona: cachedRecall?.l3Persona ?? null,
             recallStrategy: cachedRecall?.strategy ?? null,
             recallDurationMs: cachedRecall?.durationMs ?? 0,
+            cachePartition: cachedRecall?.promptCacheImpact ?? null,
+            showInjected: cachedRecall?.showInjected ?? null,
+            showInjectedReason: cachedRecall?.showInjectedReason ?? null,
             l0CapturedMessages: captureResult.filteredMessages.map((m) => ({
               role: m.role,
               content: m.content,

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -22,6 +22,7 @@ import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
 import type { Logger } from "../types.js";
+import { estimatePromptCacheImpact, formatPercent, type PromptCacheImpact } from "./prompt-cache-metrics.js";
 
 const TAG = "[memory-tdai] [recall]";
 const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
@@ -59,6 +60,12 @@ export interface RecallResult {
   prependContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
   appendSystemContext?: string;
+  /** Hide injected context from visible history when the host supports it. */
+  showInjected?: boolean;
+  /** Reason for the showInjected decision, used for metrics and PR diagnostics. */
+  showInjectedReason?: "memory_auto_degrade";
+  /** Local deterministic cache-impact estimate for logging and metric reporting. */
+  promptCacheImpact?: PromptCacheImpact;
 
   // ── Metric payload (for pendingRecallCache in index.ts) ──
   /** L1 memories that were recalled (with scores), for metric reporting */
@@ -73,6 +80,7 @@ export async function performAutoRecall(params: {
   userText: string;
   actorId: string;
   sessionKey: string;
+  estimatedTurns?: number;
   cfg: MemoryTdaiConfig;
   pluginDataDir: string;
   logger?: Logger;
@@ -103,13 +111,14 @@ async function performAutoRecallInner(params: {
   userText: string;
   actorId: string;
   sessionKey: string;
+  estimatedTurns?: number;
   cfg: MemoryTdaiConfig;
   pluginDataDir: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
 }): Promise<RecallResult | undefined> {
-  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
+  const { userText, estimatedTurns, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
   const tRecallStart = performance.now();
 
   // Search relevant memories (L1 layer) — skip only when userText is empty/undefined
@@ -216,6 +225,13 @@ async function performAutoRecallInner(params: {
   }
 
   const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  const showInjected = prependContext ? false : undefined;
+  const showInjectedReason = prependContext ? "memory_auto_degrade" : undefined;
+  const promptCacheImpact = estimatePromptCacheImpact({
+    stableContextChars: appendSystemContext?.length ?? 0,
+    dynamicContextChars: prependContext?.length ?? 0,
+    turns: estimatedTurns ?? 8,
+  });
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(
@@ -227,6 +243,17 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
+  if (appendSystemContext || prependContext) {
+    logger?.info(
+      `${TAG} Cache partition: stable=${promptCacheImpact.estimatedStableTokens}tok, ` +
+      `dynamic=${promptCacheImpact.estimatedDynamicTokens}tok, ` +
+      `showInjected=${showInjected === false ? `false/${showInjectedReason}` : "default"}, ` +
+      `estimatedHitRate ${formatPercent(promptCacheImpact.legacyEstimatedHitRate)} -> ` +
+      `${formatPercent(promptCacheImpact.optimizedEstimatedHitRate)} ` +
+      `(delta=${formatPercent(promptCacheImpact.estimatedHitRateDelta)})`,
+    );
+  }
+
   if (!appendSystemContext && !prependContext) {
     return undefined;
   }
@@ -234,6 +261,9 @@ async function performAutoRecallInner(params: {
   return {
     prependContext,
     appendSystemContext,
+    showInjected,
+    showInjectedReason,
+    promptCacheImpact,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,
     recallStrategy: effectiveStrategy,

--- a/src/core/hooks/prompt-cache-metrics.test.ts
+++ b/src/core/hooks/prompt-cache-metrics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { estimatePromptCacheImpact, formatPercent } from "./prompt-cache-metrics.js";
+
+describe("estimatePromptCacheImpact", () => {
+  it("reduces visible history growth when showInjected is treated as false", () => {
+    const impact = estimatePromptCacheImpact({
+      stableContextChars: 2400,
+      dynamicContextChars: 900,
+      turns: 8,
+    });
+
+    expect(impact.legacyVisibleHistoryChars).toBe(6300);
+    expect(impact.optimizedVisibleHistoryChars).toBe(0);
+    expect(impact.optimizedEstimatedHitRate).toBeGreaterThan(impact.legacyEstimatedHitRate);
+    expect(formatPercent(impact.optimizedEstimatedHitRate)).toMatch(/%$/);
+  });
+
+  it("degrades the legacy hit rate faster as turns grow", () => {
+    const turn3 = estimatePromptCacheImpact({
+      stableContextChars: 2400,
+      dynamicContextChars: 900,
+      turns: 3,
+    });
+    const turn8 = estimatePromptCacheImpact({
+      stableContextChars: 2400,
+      dynamicContextChars: 900,
+      turns: 8,
+    });
+
+    expect(turn8.legacyEstimatedHitRate).toBeLessThan(turn3.legacyEstimatedHitRate);
+    expect(turn8.estimatedHitRateDelta).toBeGreaterThan(0);
+  });
+});

--- a/src/core/hooks/prompt-cache-metrics.ts
+++ b/src/core/hooks/prompt-cache-metrics.ts
@@ -1,0 +1,77 @@
+export interface PromptCacheImpactInput {
+  stableContextChars: number;
+  dynamicContextChars: number;
+  turns: number;
+}
+
+export interface PromptCacheImpact {
+  turns: number;
+  stableContextChars: number;
+  dynamicContextChars: number;
+  estimatedStableTokens: number;
+  estimatedDynamicTokens: number;
+  legacyVisibleHistoryChars: number;
+  optimizedVisibleHistoryChars: number;
+  legacyEstimatedHitRate: number;
+  optimizedEstimatedHitRate: number;
+  estimatedHitRateDelta: number;
+}
+
+const CHARS_PER_TOKEN = 4;
+
+function estimateTokens(chars: number): number {
+  return Math.ceil(Math.max(0, chars) / CHARS_PER_TOKEN);
+}
+
+function ratio(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return numerator / denominator;
+}
+
+/**
+ * Estimate the prompt-cache effect of partitioning stable memory context away
+ * from per-turn recalled memories and hiding injected snippets from visible
+ * history.
+ *
+ * This is a deterministic approximation for local validation. Provider-side
+ * cache accounting is reported by the provider, but this estimate lets us
+ * compare two prompt shapes with the same input sizes:
+ *
+ * - legacy: showInjected=true, so each previous turn can carry one more copy
+ *   of dynamic recalled memories in visible history.
+ * - optimized: showInjected=false, so previous injected snippets are not added
+ *   to visible history.
+ */
+export function estimatePromptCacheImpact(input: PromptCacheImpactInput): PromptCacheImpact {
+  const turns = Math.max(1, Math.floor(input.turns));
+  const stableContextChars = Math.max(0, input.stableContextChars);
+  const dynamicContextChars = Math.max(0, input.dynamicContextChars);
+  const estimatedStableTokens = estimateTokens(stableContextChars);
+  const estimatedDynamicTokens = estimateTokens(dynamicContextChars);
+
+  const legacyVisibleHistoryChars = dynamicContextChars * Math.max(0, turns - 1);
+  const optimizedVisibleHistoryChars = 0;
+
+  const legacyDynamicTokens = estimateTokens(dynamicContextChars + legacyVisibleHistoryChars);
+  const optimizedDynamicTokens = estimateTokens(dynamicContextChars + optimizedVisibleHistoryChars);
+
+  const legacyEstimatedHitRate = ratio(estimatedStableTokens, estimatedStableTokens + legacyDynamicTokens);
+  const optimizedEstimatedHitRate = ratio(estimatedStableTokens, estimatedStableTokens + optimizedDynamicTokens);
+
+  return {
+    turns,
+    stableContextChars,
+    dynamicContextChars,
+    estimatedStableTokens,
+    estimatedDynamicTokens,
+    legacyVisibleHistoryChars,
+    optimizedVisibleHistoryChars,
+    legacyEstimatedHitRate,
+    optimizedEstimatedHitRate,
+    estimatedHitRateDelta: optimizedEstimatedHitRate - legacyEstimatedHitRate,
+  };
+}
+
+export function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -241,13 +241,14 @@ export class TdaiCore {
    * Handle recall (memory retrieval) before an LLM turn.
    * Maps to: OpenClaw `before_prompt_build` / Hermes `prefetch()`.
    */
-  async handleBeforeRecall(userText: string, sessionKey: string): Promise<RecallResult> {
+  async handleBeforeRecall(userText: string, sessionKey: string, opts?: { estimatedTurns?: number }): Promise<RecallResult> {
     await this.storeReady?.catch(() => {});
 
     const result = await performAutoRecall({
       userText,
       actorId: "default_user",
       sessionKey,
+      estimatedTurns: opts?.estimatedTurns,
       cfg: this.cfg,
       pluginDataDir: this.dataDir,
       logger: this.logger,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -201,6 +201,23 @@ export interface RecallResult {
   prependContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
   appendSystemContext?: string;
+  /** Hide injected context from visible history when the host supports it. */
+  showInjected?: boolean;
+  /** Reason for the showInjected decision, used for metrics and diagnostics. */
+  showInjectedReason?: "memory_auto_degrade";
+  /** Local deterministic cache-impact estimate for logging and metric reporting. */
+  promptCacheImpact?: {
+    turns: number;
+    stableContextChars: number;
+    dynamicContextChars: number;
+    estimatedStableTokens: number;
+    estimatedDynamicTokens: number;
+    legacyVisibleHistoryChars: number;
+    optimizedVisibleHistoryChars: number;
+    legacyEstimatedHitRate: number;
+    optimizedEstimatedHitRate: number;
+    estimatedHitRateDelta: number;
+  };
   /** Recalled L1 memories with scores (for metrics). */
   recalledL1Memories?: Array<{ content: string; score: number; type: string }>;
   /** L3 Persona content (for metrics). */


### PR DESCRIPTION
## Description | 描述

Optimize memory recall injection to reduce prompt cache regression on OpenAI-compatible providers.

优化 memory recall 注入结构，降低 OpenAI-compatible provider 上的 prompt cache 命中率退化风险。

Main changes:
主要改动：

- Split stable and dynamic memory context more clearly:
  - `appendSystemContext`: stable content such as L3 persona, L2 scene navigation, and memory tools guide.
  - `prependContext`: dynamic L1 recalled memories for the current turn.
- Add `showInjected=false` auto-degrade when `prependContext` exists, preventing dynamic recalled memories from entering visible/persistent conversation history.
- Add `promptCacheImpact` estimation metrics to compare legacy vs optimized prompt shapes.
- Document the context structure, `showInjected` expansion trend, provider cache differences, and session-level system prompt dedup design.

- 更清晰地区分稳定和动态 memory context：
  - `appendSystemContext`：L3 persona、L2 scene navigation、memory tools guide 等稳定内容。
  - `prependContext`：当前轮动态 L1 recalled memories。
- 当存在 `prependContext` 时自动返回 `showInjected=false`，避免动态召回记忆进入可见/持久对话历史。
- 新增 `promptCacheImpact` 估算指标，用于对比 legacy 与 optimized prompt 结构。
- 补充上下文结构、`showInjected` 膨胀趋势、provider 缓存差异和 session 级系统提示去重设计文档。

## Related Issue | 关联 Issue

Fix #120

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verified with:
验证方式：

- `npm.cmd test`
- `npm.cmd run build:plugin`

## Additional Notes | 其他说明

This PR implements the low-risk cache partition + `showInjected` tuning path. Session-level system prompt dedup is documented as a follow-up option but intentionally not implemented in this PR.

本 PR 落地低风险的“缓存分区 + `showInjected` 策略调优”方案。session 级系统提示去重作为后续拓展方案已补充设计文档，本 PR 不实现该方案。