### PR TITLE
fix(seed): flush pending L1 batches

### DIFF
--- a/src/core/seed/seed-runtime.test.ts
+++ b/src/core/seed/seed-runtime.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NormalizedInput } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  createPipeline: vi.fn(),
+  createL2Runner: vi.fn(() => vi.fn()),
+  createL3Runner: vi.fn(() => vi.fn()),
+  performAutoCapture: vi.fn(),
+  readManifest: vi.fn(() => null),
+  writeManifest: vi.fn(),
+}));
+
+vi.mock("../../utils/pipeline-factory.js", () => ({
+  createPipeline: mocks.createPipeline,
+  createL2Runner: mocks.createL2Runner,
+  createL3Runner: mocks.createL3Runner,
+}));
+
+vi.mock("../hooks/auto-capture.js", () => ({
+  performAutoCapture: mocks.performAutoCapture,
+}));
+
+vi.mock("../../utils/manifest.js", () => ({
+  readManifest: mocks.readManifest,
+  writeManifest: mocks.writeManifest,
+}));
+
+vi.mock("../../adapters/standalone/llm-runner.js", () => ({
+  StandaloneLLMRunnerFactory: class {
+    createRunner() {
+      return undefined;
+    }
+  },
+}));
+
+import { executeSeed } from "./seed-runtime.js";
+
+function createInput(rounds: number): NormalizedInput {
+  const conversations = Array.from({ length: rounds }, (_, i) => ({
+    messages: [
+      { role: "user", content: `user ${i + 1}`, timestamp: 1_700_000_000_000 + i * 2 },
+      { role: "assistant", content: `assistant ${i + 1}`, timestamp: 1_700_000_000_001 + i * 2 },
+    ],
+  }));
+
+  return {
+    sessions: [{
+      sessionKey: "test-migration",
+      sessionId: "seed-session-id",
+      rounds: conversations,
+      sourceIndex: 0,
+    }],
+    totalRounds: rounds,
+    totalMessages: rounds * 2,
+    hasTimestamps: true,
+  };
+}
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("executeSeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flushes L1 at seed batch boundaries and flushes the tail round without waiting for idle timeout", async () => {
+    const scheduler = {
+      start: vi.fn(),
+      setL2Runner: vi.fn(),
+      setL3Runner: vi.fn(),
+      flushSession: vi.fn(async () => undefined),
+    };
+    const pipeline = {
+      scheduler,
+      vectorStore: undefined,
+      embeddingService: undefined,
+      destroy: vi.fn(async () => undefined),
+    };
+    const captureWarmupValues: boolean[] = [];
+
+    mocks.createPipeline.mockResolvedValue(pipeline);
+    mocks.performAutoCapture.mockImplementation(async (params: { cfg: { pipeline: { enableWarmup: boolean } }; messages: unknown[] }) => {
+      captureWarmupValues.push(params.cfg.pipeline.enableWarmup);
+      return {
+        schedulerNotified: true,
+        l0RecordedCount: params.messages.length,
+        l0VectorsWritten: 0,
+        filteredMessages: [],
+      };
+    });
+
+    const summary = await executeSeed(createInput(6), {
+      outputDir: "seed-output",
+      openclawConfig: {},
+      pluginConfig: {
+        pipeline: {
+          everyNConversations: 5,
+          enableWarmup: true,
+          l1IdleTimeoutSeconds: 600,
+        },
+      },
+      logger: createLogger(),
+    });
+
+    expect(mocks.performAutoCapture).toHaveBeenCalledTimes(6);
+    expect(captureWarmupValues).toEqual([false, false, false, false, false, false]);
+    expect(scheduler.flushSession).toHaveBeenCalledTimes(2);
+    expect(scheduler.flushSession).toHaveBeenNthCalledWith(1, "test-migration");
+    expect(scheduler.flushSession).toHaveBeenNthCalledWith(2, "test-migration");
+    expect(pipeline.destroy).toHaveBeenCalledTimes(1);
+    expect(summary).toMatchObject({
+      sessionsProcessed: 1,
+      roundsProcessed: 6,
+      messagesProcessed: 12,
+      l0RecordedCount: 12,
+      outputDir: "seed-output",
+    });
+  });
+});

--- a/src/core/seed/seed-runtime.ts
+++ b/src/core/seed/seed-runtime.ts
@@ -5,10 +5,10 @@
  * L1 runner, L2 runner, L3 runner, and persister wiring — keeping this
  * module focused on seed-specific concerns:
  * - Synchronous per-round L0 capture with progress reporting
- * - waitForL1Idle polling (L1 only — see FIXME below)
+ * - Explicit L1 flushes at seed batch/session boundaries
  * - Ctrl+C graceful shutdown
  *
- * FIXME: Currently we only wait for L1 to become idle before destroying the
+ * FIXME: Currently we only flush and wait for L1 before destroying the
  * pipeline.  L2 (scene extraction) and L3 (persona generation) may still be
  * in-flight when `pipeline.destroy()` is called.  This is intentional for now
  * to avoid excessively long seed runs, but means seed output may not include
@@ -24,7 +24,6 @@ import { createPipeline, createL2Runner, createL3Runner } from "../../utils/pipe
 import type { PipelineInstance, PipelineLogger } from "../../utils/pipeline-factory.js";
 import { readManifest, writeManifest } from "../../utils/manifest.js";
 import { StandaloneLLMRunnerFactory } from "../../adapters/standalone/llm-runner.js";
-import type { MemoryPipelineManager } from "../../utils/pipeline-manager.js";
 import type { LLMRunner } from "../types.js";
 import type {
   NormalizedInput,
@@ -66,6 +65,8 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
 
   // Parse config — all values come from pluginConfig (or parseConfig defaults)
   const cfg = parseConfig(pluginConfig);
+  // Seed feeds historical rounds synchronously and flushes at explicit batch boundaries.
+  cfg.pipeline.enableWarmup = false;
 
   logger.info(
     `${TAG} Creating seed pipeline: outputDir=${outputDir}, ` +
@@ -126,74 +127,6 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
   }));
 
   return { pipeline, cfg };
-}
-
-// ============================
-// waitForL1Idle
-// ============================
-
-/**
- * Poll pipeline queue status until L1 is idle for a given session.
- * Modeled after benchmark-ingest.ts waitForPipelineIdle() but focused on L1 only.
- */
-async function waitForL1Idle(
-  scheduler: MemoryPipelineManager,
-  sessionKeys: string[],
-  logger: PipelineLogger,
-  opts: {
-    pollIntervalMs?: number;
-    stableRounds?: number;
-    maxWaitMs?: number;
-  } = {},
-): Promise<void> {
-  const pollInterval = opts.pollIntervalMs ?? 1_000;
-  const stableRounds = opts.stableRounds ?? 3;
-  const maxWait = opts.maxWaitMs ?? 300_000; // 5 min default
-
-  const startTime = Date.now();
-  let consecutiveIdle = 0;
-
-  while (true) {
-    const elapsed = Date.now() - startTime;
-    if (elapsed > maxWait) {
-      logger.warn(`${TAG} [waitL1] Max wait time reached (${(maxWait / 1000).toFixed(0)}s), proceeding`);
-      break;
-    }
-
-    const queues = scheduler.getQueueSizes();
-
-    // Check per-session: buffered messages + conversation count
-    let totalBuffered = 0;
-    let totalConversationCount = 0;
-    for (const key of sessionKeys) {
-      totalBuffered += scheduler.getBufferedMessageCount(key);
-      const state = scheduler.getSessionState(key);
-      if (state) {
-        totalConversationCount += state.conversation_count;
-      }
-    }
-
-    const isIdle =
-      queues.l1Idle &&
-      totalBuffered === 0 &&
-      totalConversationCount === 0;
-
-    if (isIdle) {
-      consecutiveIdle++;
-      if (consecutiveIdle >= stableRounds) {
-        logger.debug?.(`${TAG} [waitL1] L1 stable for ${stableRounds} consecutive polls`);
-        return;
-      }
-    } else {
-      consecutiveIdle = 0;
-      logger.debug?.(
-        `${TAG} [waitL1] Waiting: l1Queue=${queues.l1}, l1Pending=${queues.l1Pending}, l1Idle=${queues.l1Idle}, ` +
-        `buffered=${totalBuffered}, convCount=${totalConversationCount}`,
-      );
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, pollInterval));
-  }
 }
 
 // ============================
@@ -324,12 +257,7 @@ export async function executeSeed(
             `for session="${session.sessionKey}" — waiting for L1 to drain`,
           );
 
-          await waitForL1Idle(
-            pipeline.scheduler,
-            [session.sessionKey],
-            logger,
-            { pollIntervalMs: 500, stableRounds: 2, maxWaitMs: 120_000 },
-          );
+          await pipeline.scheduler.flushSession(session.sessionKey);
         }
       }
 
@@ -343,28 +271,12 @@ export async function executeSeed(
           stage: "l1_waiting",
         });
 
-        await waitForL1Idle(
-          pipeline.scheduler,
-          [session.sessionKey],
-          logger,
-          { pollIntervalMs: 1_000, stableRounds: 3, maxWaitMs: 300_000 },
-        );
+        await pipeline.scheduler.flushSession(session.sessionKey);
 
-        logger.info(`${TAG} L1 idle for session="${session.sessionKey}"`);
+        logger.info(`${TAG} L1 flushed for session="${session.sessionKey}"`);
       }
     }
 
-    // Final wait for all sessions
-    if (!interrupted) {
-      const allKeys = input.sessions.map((s) => s.sessionKey);
-      logger.info(`${TAG} Final L1 idle wait for all sessions...`);
-      await waitForL1Idle(
-        pipeline.scheduler,
-        allKeys,
-        logger,
-        { pollIntervalMs: 1_000, stableRounds: 3, maxWaitMs: 300_000 },
-      );
-    }
   } finally {
     process.removeListener("SIGINT", onSigint);
 

--- a/src/utils/pipeline-manager.test.ts
+++ b/src/utils/pipeline-manager.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { MemoryPipelineManager } from "./pipeline-manager.js";
+import type { L1Runner } from "./pipeline-manager.js";
+
+const baseConfig = {
+  everyNConversations: 5,
+  enableWarmup: false,
+  l1: {
+    idleTimeoutSeconds: 600,
+  },
+  l2: {
+    delayAfterL1Seconds: 600,
+    minIntervalSeconds: 900,
+    maxIntervalSeconds: 3600,
+    sessionActiveWindowHours: 24,
+  },
+};
+
+describe("MemoryPipelineManager", () => {
+  it("flushSession flushes DB-backed pending conversations even when the message buffer is empty", async () => {
+    const scheduler = new MemoryPipelineManager(baseConfig);
+    const calls: Parameters<L1Runner>[0][] = [];
+
+    scheduler.setL1Runner(async (params) => {
+      calls.push(params);
+      return { processedCount: 0 };
+    });
+
+    try {
+      await scheduler.notifyConversation("seed-session", []);
+
+      expect(scheduler.getBufferedMessageCount("seed-session")).toBe(0);
+      expect(scheduler.getSessionState("seed-session")?.conversation_count).toBe(1);
+
+      await scheduler.flushSession("seed-session");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual({
+        sessionKey: "seed-session",
+        msg: [],
+        bg_msg: [],
+      });
+      expect(scheduler.getSessionState("seed-session")?.conversation_count).toBe(0);
+      expect(scheduler.getSessionState("seed-session")?.l2_pending_l1_count).toBe(1);
+    } finally {
+      await scheduler.destroy();
+    }
+  });
+});

--- a/src/utils/pipeline-manager.ts
+++ b/src/utils/pipeline-manager.ts
@@ -473,17 +473,19 @@ export class MemoryPipelineManager {
     if (this.sessionFilter.shouldSkip(sessionKey)) return;
 
     const timers = this.sessionTimers.get(sessionKey);
-    const buffer = this.messageBuffers.get(sessionKey);
+    const { bufferedCount, pendingConversationCount } = this.getPendingL1Work(sessionKey);
 
     // Step 1: cancel the idle timer so it won't fire after we return.
     if (timers?.l1Idle.pending) {
       timers.l1Idle.cancel();
     }
 
-    // Step 2: flush pending buffered messages through L1 if any.
-    if (buffer && buffer.length > 0) {
+    // Step 2: flush pending L1 work. In DB-backed capture paths the in-memory
+    // buffer is intentionally empty because L1 reads from persisted L0.
+    if (bufferedCount > 0 || pendingConversationCount > 0) {
       this.logger?.debug?.(
-        `${TAG} [${sessionKey}] flushSession: enqueuing L1 for ${buffer.length} buffered message(s)`,
+        `${TAG} [${sessionKey}] flushSession: enqueuing L1 ` +
+        `(buffered=${bufferedCount}, conversations=${pendingConversationCount})`,
       );
       this.enqueueL1(sessionKey, "flush");
     }
@@ -561,11 +563,14 @@ export class MemoryPipelineManager {
     for (const [sessionKey, timers] of this.sessionTimers) {
       if (timers.l1Idle.pending) {
         timers.l1Idle.cancel(); // don't fire the idle callback directly
-        const buffer = this.messageBuffers.get(sessionKey);
-        if (buffer && buffer.length > 0) {
-          this.logger?.debug?.(`${TAG} [${sessionKey}] Flush: enqueuing L1 for ${buffer.length} buffered messages`);
-          this.enqueueL1(sessionKey, "flush");
-        }
+      }
+      const { bufferedCount, pendingConversationCount } = this.getPendingL1Work(sessionKey);
+      if (bufferedCount > 0 || pendingConversationCount > 0) {
+        this.logger?.debug?.(
+          `${TAG} [${sessionKey}] Flush: enqueuing L1 ` +
+          `(buffered=${bufferedCount}, conversations=${pendingConversationCount})`,
+        );
+        this.enqueueL1(sessionKey, "flush");
       }
     }
 
@@ -1002,6 +1007,13 @@ export class MemoryPipelineManager {
   // ============================
   // Internal: state management
   // ============================
+
+  private getPendingL1Work(sessionKey: string): { bufferedCount: number; pendingConversationCount: number } {
+    return {
+      bufferedCount: this.messageBuffers.get(sessionKey)?.length ?? 0,
+      pendingConversationCount: this.sessionStates.get(sessionKey)?.conversation_count ?? 0,
+    };
+  }
 
   private getOrCreateState(sessionKey: string): PipelineSessionState {
     let state = this.sessionStates.get(sessionKey);


### PR DESCRIPTION
﻿## Description | 描述
Fix `/seed` hanging during historical imports and ensure tail rounds are flushed through L1.

The seed runtime now uses explicit L1 flushes at seed batch/session boundaries instead of polling `waitForL1Idle`. Seed runs also disable live warmup behavior so historical rounds are processed according to the configured `everyNConversations` batching semantics.

`flushSession()` now treats DB-backed pending conversations as L1 work even when the in-memory message buffer is empty, matching the current design where L1 reads persisted L0 records.

## Related Issue | 关联 Issue
Fix #505

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Validation:
- `./node_modules/.bin/vitest.CMD run src/core/seed/seed-runtime.test.ts src/utils/pipeline-manager.test.ts`
- `./node_modules/.bin/vitest.CMD run`
- `./node_modules/.bin/tsdown.CMD`
- `git diff --check`
