### PR TITLE
Fix 160 fts5 operator escape

### DIFF
--- a/docs/fts-query-safety.md
+++ b/docs/fts-query-safety.md
@@ -1,0 +1,175 @@
+# FTS Query Safety Design
+
+## Background
+
+The memory plugin supports keyword recall through two store implementations:
+
+- SQLite: local FTS5 tables queried with `MATCH ?`.
+- TCVDB: remote hybrid search using raw natural-language `queryText` for dense embedding and BM25 sparse matching.
+
+Historically, callers built an SQLite FTS5 expression with `buildFtsQuery()` and passed that string into `searchL1Fts()` / `searchL0Fts()`. This leaked SQLite-specific query syntax outside the SQLite store. It also created an unsafe abstraction: the same parameter was a valid SQLite `MATCH` expression for `sqlite.ts`, but natural language for `tcvdb.ts`.
+
+The fix should protect SQLite FTS5 from operator injection while preserving natural-language recall quality for TCVDB.
+
+## Options
+
+### Option 1: Query Whitelist
+
+Whitelist-based sanitization removes or escapes characters and keywords known to have FTS5 syntax meaning, such as:
+
+- `"`
+- `'`
+- `(`
+- `)`
+- `*`
+- `^`
+- `AND` / `OR` / `NOT` / `NEAR`, case-insensitive
+- field filters such as `title:apple`
+- exclusion syntax such as `apple -banana`
+- punctuation and symbols that can affect `MATCH` parsing
+
+Advantages:
+
+- Small patch surface.
+- Easy to understand.
+- Useful as defense in depth before tokenization.
+
+Limitations:
+
+- It is a string-filtering strategy, so it depends on continuously knowing which syntax is dangerous.
+- It can accidentally remove legitimate user text if the rule is too broad.
+- It does not fix the abstraction leak where non-SQLite stores receive SQLite query syntax.
+- It is harder to prove correct as FTS syntax or tokenizer behavior changes.
+
+### Option 2: Parameterized Query Boundary
+
+Parameterized querying keeps user text as data until the store implementation reaches its own query boundary.
+
+In this codebase, that means:
+
+- Callers pass raw natural-language query strings to `IMemoryStore.searchL1Fts()` and `searchL0Fts()`.
+- SQLite owns FTS5 expression construction internally.
+- SQLite binds the generated FTS5 expression through prepared statements: `WHERE l1_fts MATCH ?` and `WHERE l0_fts MATCH ?`.
+- TCVDB receives the unchanged raw query text for BM25 and embedding.
+- Sanitization still exists inside SQLite, but it is defense in depth rather than the primary contract.
+
+Advantages:
+
+- Store-specific syntax no longer leaks into hooks, tools, or dedup logic.
+- TCVDB no longer risks receiving `"term" OR "term2"` as BM25 input.
+- The SQL statement remains parameterized; user input is never concatenated into SQL text.
+- The caller contract is simpler: pass raw query text, receive ranked results.
+- It is easier to test because SQLite-specific behavior is isolated in `sqlite.ts`.
+
+Limitations:
+
+- SQLite FTS5 accepts a single `MATCH` expression parameter, so individual terms cannot be bound as separate SQL placeholders.
+- SQLite still needs to generate a valid FTS5 expression internally. The important boundary is that this expression is generated from tokenized terms and then bound as data to the prepared statement.
+
+## Recommendation
+
+Use the parameterized query boundary.
+
+Whitelist sanitization alone is not enough because the main bug is architectural: callers were required to understand SQLite FTS5 query syntax even when the active store could be TCVDB. The safer design is to make raw query text the cross-store API and keep FTS5 syntax generation private to the SQLite implementation.
+
+Sanitization should remain inside SQLite as defense in depth:
+
+- Remove FTS5 operators before tokenization, including lowercase user input.
+- Treat non-token punctuation and symbols as separators before tokenization.
+- Tokenize with jieba when available.
+- Drop punctuation-only tokens and stop words.
+- Quote each token as an FTS5 phrase term.
+- Bind the final expression to `MATCH ?`.
+
+## Implemented Design
+
+### Store Interface
+
+`IMemoryStore` now treats FTS search input as raw text:
+
+```ts
+searchL1Fts(query: string, limit?: number): MaybePromise<L1FtsResult[]>;
+searchL0Fts(query: string, limit?: number): MaybePromise<L0FtsResult[]>;
+```
+
+The interface no longer exposes the SQLite-specific `ftsQuery` concept.
+
+### SQLite Store
+
+`sqlite.ts` keeps `buildFtsQuery()` local to the SQLite implementation path:
+
+1. `searchL1Fts(query, limit)` receives raw user text.
+2. It calls `buildFtsQuery(query)`.
+3. If tokenization produces no usable tokens, it returns an empty result.
+4. It executes the existing prepared statement with bound parameters:
+
+```sql
+WHERE l1_fts MATCH ?
+LIMIT ?
+```
+
+The same flow applies to `searchL0Fts()`.
+
+`buildFtsQuery()` sanitizes before tokenization:
+
+- removes standalone FTS5 operators case-insensitively: `AND`, `OR`, `NOT`, `NEAR`
+- treats non-token punctuation and symbols as separators, including `:`, `-`, `\`, commas, CJK punctuation, and emoji
+- preserves operator substrings inside ordinary words such as `ordinary` and `northeast`
+
+### TCVDB Store
+
+`tcvdb.ts` receives the same raw `query` parameter and passes it directly to hybrid search:
+
+```ts
+this.searchL1HybridAsync({ queryText: query, topK: limit });
+this.searchL0HybridAsync({ queryText: query, topK: limit });
+```
+
+This preserves TCVDB recall quality because BM25 and embedding both see natural-language input instead of an SQLite FTS5 expression.
+
+### Callers
+
+The following layers now pass raw query text directly to the store:
+
+- `auto-recall.ts`
+- `memory-search.ts`
+- `conversation-search.ts`
+- `l1-dedup.ts`
+
+These files no longer import `buildFtsQuery()` and no longer log or manipulate SQLite FTS5 expressions.
+
+## Test Plan
+
+Unit tests cover:
+
+- basic syntax character removal
+- all supported FTS5 operators
+- embedded operator substrings that must not be removed
+- lowercase FTS5 operators such as `and`, `or`, `not`, and `near`
+- field filters, exclusion syntax, backslashes, commas, CJK punctuation, emoji, and repeated quotes
+- empty result when input contains only FTS syntax
+- jieba path sanitization before tokenization
+- recall-relevant token equivalence after sanitization
+- real SQLite `MATCH ?` execution for L1 and L0 FTS search
+- write-side `tokenizeForFts()` and query-side `buildFtsQuery()` compatibility
+- FTS index rebuild from metadata tables
+- FTS v1 to v2 migration and rebuild
+
+Very long input and repeated-token performance optimization are intentionally out of scope for this security fix.
+
+Validation commands:
+
+```bash
+npm.cmd test -- src/core/store/sqlite.test.ts
+npm.cmd test
+npm.cmd run build
+```
+
+## Rollout Notes
+
+This change is source-compatible for in-repo callers because they now pass raw query text. It is behaviorally safer for both stores:
+
+- SQLite keeps the same BM25 FTS5 search behavior but with FTS5 syntax stripped before tokenization.
+- TCVDB no longer receives SQLite-specific `OR` expressions as natural-language query text.
+
+No schema migration is required.

--- a/docs/fts-query-safety.md
+++ b/docs/fts-query-safety.md
@@ -1,21 +1,21 @@
-# FTS Query Safety Design
+# FTS 查询安全设计
 
-## Background
+## 背景
 
-The memory plugin supports keyword recall through two store implementations:
+记忆插件目前通过两类存储实现关键字召回：
 
-- SQLite: local FTS5 tables queried with `MATCH ?`.
-- TCVDB: remote hybrid search using raw natural-language `queryText` for dense embedding and BM25 sparse matching.
+- SQLite：本地 FTS5 表，使用 `MATCH ?` 查询。
+- TCVDB：远端 hybrid search，使用原始自然语言 `queryText` 做 dense embedding 和 BM25 sparse matching。
 
-Historically, callers built an SQLite FTS5 expression with `buildFtsQuery()` and passed that string into `searchL1Fts()` / `searchL0Fts()`. This leaked SQLite-specific query syntax outside the SQLite store. It also created an unsafe abstraction: the same parameter was a valid SQLite `MATCH` expression for `sqlite.ts`, but natural language for `tcvdb.ts`.
+历史实现中，上层调用方会先通过 `buildFtsQuery()` 构造 SQLite FTS5 表达式，然后把该字符串传给 `searchL1Fts()` / `searchL0Fts()`。这导致 SQLite 专属查询语法泄漏到 store 抽象之外，也造成了接口语义不一致：同一个参数对 `sqlite.ts` 来说是合法的 SQLite `MATCH` 表达式，但对 `tcvdb.ts` 来说却应该是自然语言文本。
 
-The fix should protect SQLite FTS5 from operator injection while preserving natural-language recall quality for TCVDB.
+本次修复目标是：防止 SQLite FTS5 查询语法被用户输入篡改，同时保留 TCVDB 自然语言召回质量。
 
-## Options
+## 方案对比
 
-### Option 1: Query Whitelist
+### 方案一：查询白名单
 
-Whitelist-based sanitization removes or escapes characters and keywords known to have FTS5 syntax meaning, such as:
+白名单/清洗方案会移除或转义已知具有 FTS5 语法含义的字符和关键字，例如：
 
 - `"`
 - `'`
@@ -23,141 +23,141 @@ Whitelist-based sanitization removes or escapes characters and keywords known to
 - `)`
 - `*`
 - `^`
-- `AND` / `OR` / `NOT` / `NEAR`, case-insensitive
-- field filters such as `title:apple`
-- exclusion syntax such as `apple -banana`
-- punctuation and symbols that can affect `MATCH` parsing
+- `AND` / `OR` / `NOT` / `NEAR`，大小写不敏感
+- `title:apple` 这类字段限定语法
+- `apple -banana` 这类排除语法
+- 其他可能影响 `MATCH` 解析的标点和符号
 
-Advantages:
+优点：
 
-- Small patch surface.
-- Easy to understand.
-- Useful as defense in depth before tokenization.
+- 改动面小。
+- 容易理解。
+- 适合作为分词前的纵深防御。
 
-Limitations:
+局限：
 
-- It is a string-filtering strategy, so it depends on continuously knowing which syntax is dangerous.
-- It can accidentally remove legitimate user text if the rule is too broad.
-- It does not fix the abstraction leak where non-SQLite stores receive SQLite query syntax.
-- It is harder to prove correct as FTS syntax or tokenizer behavior changes.
+- 本质是字符串过滤，依赖我们持续维护“哪些语法危险”的规则。
+- 规则过宽时可能误删合法用户文本。
+- 无法解决非 SQLite store 收到 SQLite 查询语法的抽象泄漏问题。
+- 随着 FTS 语法或分词器行为变化，正确性更难证明。
 
-### Option 2: Parameterized Query Boundary
+### 方案二：参数化查询边界
 
-Parameterized querying keeps user text as data until the store implementation reaches its own query boundary.
+参数化查询边界的核心是：用户输入在跨 store 接口层始终保持为“数据”，直到具体 store 实现进入自己的查询边界。
 
-In this codebase, that means:
+在当前代码结构中，这意味着：
 
-- Callers pass raw natural-language query strings to `IMemoryStore.searchL1Fts()` and `searchL0Fts()`.
-- SQLite owns FTS5 expression construction internally.
-- SQLite binds the generated FTS5 expression through prepared statements: `WHERE l1_fts MATCH ?` and `WHERE l0_fts MATCH ?`.
-- TCVDB receives the unchanged raw query text for BM25 and embedding.
-- Sanitization still exists inside SQLite, but it is defense in depth rather than the primary contract.
+- 调用方只把原始自然语言查询传给 `IMemoryStore.searchL1Fts()` 和 `searchL0Fts()`。
+- SQLite 内部负责构造 FTS5 `MATCH` 表达式。
+- SQLite 通过 prepared statement 绑定生成后的 FTS5 表达式：`WHERE l1_fts MATCH ?` / `WHERE l0_fts MATCH ?`。
+- TCVDB 接收未经 SQLite 语法污染的原始 query，用于 BM25 和 embedding。
+- SQLite 内部仍保留清洗逻辑，但它是纵深防御，不再是跨 store 接口契约。
 
-Advantages:
+优点：
 
-- Store-specific syntax no longer leaks into hooks, tools, or dedup logic.
-- TCVDB no longer risks receiving `"term" OR "term2"` as BM25 input.
-- The SQL statement remains parameterized; user input is never concatenated into SQL text.
-- The caller contract is simpler: pass raw query text, receive ranked results.
-- It is easier to test because SQLite-specific behavior is isolated in `sqlite.ts`.
+- store 专属语法不再泄漏到 hook、tool、dedup 等上层逻辑。
+- TCVDB 不再收到 `"term" OR "term2"` 这类 SQLite 表达式作为 BM25 输入。
+- SQL 语句保持参数化，用户输入不会拼接进 SQL 文本。
+- 调用方契约更简单：传 raw query，拿 ranked results。
+- SQLite 专属行为集中在 `sqlite.ts`，测试边界更清晰。
 
-Limitations:
+局限：
 
-- SQLite FTS5 accepts a single `MATCH` expression parameter, so individual terms cannot be bound as separate SQL placeholders.
-- SQLite still needs to generate a valid FTS5 expression internally. The important boundary is that this expression is generated from tokenized terms and then bound as data to the prepared statement.
+- SQLite FTS5 的 `MATCH` 只接受一个表达式参数，无法把每个 term 都拆成独立 SQL placeholder。
+- SQLite 仍然需要内部生成合法 FTS5 表达式；关键边界是：表达式由受控分词结果生成，并作为参数绑定到 prepared statement。
 
-## Recommendation
+## 推荐方案
 
-Use the parameterized query boundary.
+采用“参数化查询边界”方案。
 
-Whitelist sanitization alone is not enough because the main bug is architectural: callers were required to understand SQLite FTS5 query syntax even when the active store could be TCVDB. The safer design is to make raw query text the cross-store API and keep FTS5 syntax generation private to the SQLite implementation.
+仅做白名单清洗不够，因为核心问题是架构层面的：上层调用方被迫理解 SQLite FTS5 查询语法，即使当前实际 store 可能是 TCVDB。更稳妥的设计是把 raw query 作为跨 store API，SQLite FTS5 表达式生成只保留在 SQLite 实现内部。
 
-Sanitization should remain inside SQLite as defense in depth:
+SQLite 内部仍应保留清洗逻辑作为纵深防御：
 
-- Remove FTS5 operators before tokenization, including lowercase user input.
-- Treat non-token punctuation and symbols as separators before tokenization.
-- Tokenize with jieba when available.
-- Drop punctuation-only tokens and stop words.
-- Quote each token as an FTS5 phrase term.
-- Bind the final expression to `MATCH ?`.
+- 分词前移除 FTS5 操作符，包括用户输入的小写 operator。
+- 分词前把非 token 标点和符号当作分隔符。
+- 优先使用 jieba 分词。
+- 丢弃纯标点 token 和停用词。
+- 将每个 token 包成 FTS5 phrase term。
+- 最终表达式通过 `MATCH ?` 绑定执行。
 
-## Implemented Design
+## 已实现设计
 
-### Store Interface
+### Store 接口
 
-`IMemoryStore` now treats FTS search input as raw text:
+`IMemoryStore` 现在把 FTS 搜索输入视为原始文本：
 
 ```ts
 searchL1Fts(query: string, limit?: number): MaybePromise<L1FtsResult[]>;
 searchL0Fts(query: string, limit?: number): MaybePromise<L0FtsResult[]>;
 ```
 
-The interface no longer exposes the SQLite-specific `ftsQuery` concept.
+接口不再暴露 SQLite 专属的 `ftsQuery` 概念。
 
 ### SQLite Store
 
-`sqlite.ts` keeps `buildFtsQuery()` local to the SQLite implementation path:
+`sqlite.ts` 将 `buildFtsQuery()` 收敛到 SQLite 实现路径内：
 
-1. `searchL1Fts(query, limit)` receives raw user text.
-2. It calls `buildFtsQuery(query)`.
-3. If tokenization produces no usable tokens, it returns an empty result.
-4. It executes the existing prepared statement with bound parameters:
+1. `searchL1Fts(query, limit)` 接收原始用户文本。
+2. 内部调用 `buildFtsQuery(query)`。
+3. 如果分词后没有可用 token，返回空结果。
+4. 使用现有 prepared statement 绑定参数执行：
 
 ```sql
 WHERE l1_fts MATCH ?
 LIMIT ?
 ```
 
-The same flow applies to `searchL0Fts()`.
+`searchL0Fts()` 使用同样流程。
 
-`buildFtsQuery()` sanitizes before tokenization:
+`buildFtsQuery()` 在分词前做清洗：
 
-- removes standalone FTS5 operators case-insensitively: `AND`, `OR`, `NOT`, `NEAR`
-- treats non-token punctuation and symbols as separators, including `:`, `-`, `\`, commas, CJK punctuation, and emoji
-- preserves operator substrings inside ordinary words such as `ordinary` and `northeast`
+- 独立 FTS5 操作符大小写不敏感清理：`AND`、`OR`、`NOT`、`NEAR`
+- 将非 token 标点和符号作为分隔符，包括 `:`、`-`、`\`、逗号、CJK 标点、emoji
+- 保留普通单词内部的 operator 子串，例如 `ordinary`、`northeast`
 
 ### TCVDB Store
 
-`tcvdb.ts` receives the same raw `query` parameter and passes it directly to hybrid search:
+`tcvdb.ts` 接收同样的原始 `query` 参数，并直接传给 hybrid search：
 
 ```ts
 this.searchL1HybridAsync({ queryText: query, topK: limit });
 this.searchL0HybridAsync({ queryText: query, topK: limit });
 ```
 
-This preserves TCVDB recall quality because BM25 and embedding both see natural-language input instead of an SQLite FTS5 expression.
+这样可以保持 TCVDB 召回质量，因为 BM25 和 embedding 看到的是自然语言输入，而不是 SQLite FTS5 表达式。
 
-### Callers
+### 上层调用方
 
-The following layers now pass raw query text directly to the store:
+以下层级现在都直接把 raw query 传给 store：
 
 - `auto-recall.ts`
 - `memory-search.ts`
 - `conversation-search.ts`
 - `l1-dedup.ts`
 
-These files no longer import `buildFtsQuery()` and no longer log or manipulate SQLite FTS5 expressions.
+这些文件不再导入 `buildFtsQuery()`，也不再记录或操作 SQLite FTS5 表达式。
 
-## Test Plan
+## 测试计划
 
-Unit tests cover:
+单元测试覆盖：
 
-- basic syntax character removal
-- all supported FTS5 operators
-- embedded operator substrings that must not be removed
-- lowercase FTS5 operators such as `and`, `or`, `not`, and `near`
-- field filters, exclusion syntax, backslashes, commas, CJK punctuation, emoji, and repeated quotes
-- empty result when input contains only FTS syntax
-- jieba path sanitization before tokenization
-- recall-relevant token equivalence after sanitization
-- real SQLite `MATCH ?` execution for L1 and L0 FTS search
-- write-side `tokenizeForFts()` and query-side `buildFtsQuery()` compatibility
-- FTS index rebuild from metadata tables
-- FTS v1 to v2 migration and rebuild
+- 基础语法字符清理
+- 所有支持的 FTS5 操作符
+- 普通单词内部 operator 子串不应被误删
+- 小写 FTS5 操作符，例如 `and`、`or`、`not`、`near`
+- 字段限定、排除语法、反斜杠、逗号、CJK 标点、emoji、连续引号
+- 输入仅包含 FTS 语法时返回空结果
+- jieba 路径在分词前完成清洗
+- 清洗前后 recall 相关 token 等价
+- L1 / L0 真实 SQLite `MATCH ?` FTS 搜索执行
+- 写入侧 `tokenizeForFts()` 与查询侧 `buildFtsQuery()` 的分词一致性
+- 从 metadata 表重建 FTS index
+- FTS v1 到 v2 的迁移和重建
 
-Very long input and repeated-token performance optimization are intentionally out of scope for this security fix.
+超长输入和重复 token 的性能优化不属于本次安全修复范围。
 
-Validation commands:
+验证命令：
 
 ```bash
 npm.cmd test -- src/core/store/sqlite.test.ts
@@ -165,11 +165,11 @@ npm.cmd test
 npm.cmd run build
 ```
 
-## Rollout Notes
+## 发布说明
 
-This change is source-compatible for in-repo callers because they now pass raw query text. It is behaviorally safer for both stores:
+该变更对仓库内调用方是源码兼容的，因为调用方现在统一传 raw query。行为上对两个 store 都更安全：
 
-- SQLite keeps the same BM25 FTS5 search behavior but with FTS5 syntax stripped before tokenization.
-- TCVDB no longer receives SQLite-specific `OR` expressions as natural-language query text.
+- SQLite 保持原有 BM25 FTS5 搜索能力，但在分词前清理 FTS5 语法。
+- TCVDB 不再收到 SQLite 专属 `OR` 表达式作为自然语言 query。
 
-No schema migration is required.
+不需要数据库 schema migration。

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -18,7 +18,6 @@ import { readSceneIndex } from "../scene/scene-index.js";
 import { generateSceneNavigation, stripSceneNavigation } from "../scene/scene-navigation.js";
 import type { MemoryRecord } from "../record/l1-reader.js";
 import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.js";
-import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
 import type { Logger } from "../types.js";
@@ -405,36 +404,33 @@ async function searchByKeyword(
 ): Promise<string[]> {
   // Prefer FTS5 if available
   if (vectorStore?.isFtsAvailable()) {
-    const ftsQuery = buildFtsQuery(userText);
-    if (ftsQuery) {
-      logger?.debug?.(`${TAG} [keyword-fts] Using FTS5 BM25 search: query="${ftsQuery}"`);
-      const ftsResults = await vectorStore.searchL1Fts(ftsQuery, maxResults * 2);
-      if (ftsResults.length > 0) {
-        logger?.debug?.(
-          `${TAG} [keyword-fts] FTS5 raw results (${ftsResults.length}): ` +
-          ftsResults.map((r) => `id=${r.record_id} score=${r.score.toFixed(6)}`).join(", "),
-        );
-        const filtered = ftsResults
-          .filter((r) => r.score >= threshold)
-          .slice(0, maxResults);
+    logger?.debug?.(`${TAG} [keyword-fts] Using FTS search`);
+    const ftsResults = await vectorStore.searchL1Fts(userText, maxResults * 2);
+    if (ftsResults.length > 0) {
+      logger?.debug?.(
+        `${TAG} [keyword-fts] FTS5 raw results (${ftsResults.length}): ` +
+        ftsResults.map((r) => `id=${r.record_id} score=${r.score.toFixed(6)}`).join(", "),
+      );
+      const filtered = ftsResults
+        .filter((r) => r.score >= threshold)
+        .slice(0, maxResults);
 
-        if (filtered.length > 0) {
-          logger?.debug?.(`${TAG} [keyword-fts] FTS5 found ${filtered.length} results (from ${ftsResults.length} raw, threshold=${threshold})`);
-          return filtered.map((r) => formatMemoryLine(ftsResultToFormatable(r)));
-        }
-
-        // BM25 absolute scores are unreliable when the document set is very
-        // small (e.g. 1–3 records) because IDF approaches 0.  In that case,
-        // trust FTS5's MATCH + rank ordering and return the top results anyway.
-        if (ftsResults.length <= maxResults) {
-          logger?.debug?.(
-            `${TAG} [keyword-fts] All ${ftsResults.length} results below threshold=${threshold} ` +
-            `but document set is small — returning all matched results`,
-          );
-          return ftsResults.slice(0, maxResults).map((r) => formatMemoryLine(ftsResultToFormatable(r)));
-        }
-        logger?.debug?.(`${TAG} [keyword-fts] FTS5 returned 0 results above threshold (from ${ftsResults.length} raw)`);
+      if (filtered.length > 0) {
+        logger?.debug?.(`${TAG} [keyword-fts] FTS5 found ${filtered.length} results (from ${ftsResults.length} raw, threshold=${threshold})`);
+        return filtered.map((r) => formatMemoryLine(ftsResultToFormatable(r)));
       }
+
+      // BM25 absolute scores are unreliable when the document set is very
+      // small (e.g. 1–3 records) because IDF approaches 0.  In that case,
+      // trust FTS5's MATCH + rank ordering and return the top results anyway.
+      if (ftsResults.length <= maxResults) {
+        logger?.debug?.(
+          `${TAG} [keyword-fts] All ${ftsResults.length} results below threshold=${threshold} ` +
+          `but document set is small — returning all matched results`,
+        );
+        return ftsResults.slice(0, maxResults).map((r) => formatMemoryLine(ftsResultToFormatable(r)));
+      }
+      logger?.debug?.(`${TAG} [keyword-fts] FTS5 returned 0 results above threshold (from ${ftsResults.length} raw)`);
     }
   }
 
@@ -528,31 +524,28 @@ async function searchHybrid(
       try {
         // Try FTS5 first
         if (vectorStore.isFtsAvailable()) {
-          const ftsQuery = buildFtsQuery(userText);
-          if (ftsQuery) {
-            const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
-            if (ftsResults.length > 0) {
-              logger?.debug?.(`${TAG} [hybrid-keyword-fts] FTS5 found ${ftsResults.length} candidates`);
-              // Convert FtsSearchResult to ScoredRecord for RRF merge
-              const records = ftsResults.map((r): ScoredRecord => ({
-                record: {
-                  id: r.record_id,
-                  content: r.content,
-                  type: r.type as MemoryRecord["type"],
-                  priority: r.priority,
-                  scene_name: r.scene_name,
-                  source_message_ids: [],
-                  metadata: r.metadata_json ? (() => { try { return JSON.parse(r.metadata_json); } catch { return {}; } })() : {},
-                  timestamps: [r.timestamp_str].filter(Boolean),
-                  createdAt: "",
-                  updatedAt: "",
-                  sessionKey: r.session_key,
-                  sessionId: r.session_id,
-                },
-                score: r.score,
-              }));
-              return { records, ms: performance.now() - tStart };
-            }
+          const ftsResults = await vectorStore.searchL1Fts(userText, candidateK);
+          if (ftsResults.length > 0) {
+            logger?.debug?.(`${TAG} [hybrid-keyword-fts] FTS5 found ${ftsResults.length} candidates`);
+            // Convert FtsSearchResult to ScoredRecord for RRF merge
+            const records = ftsResults.map((r): ScoredRecord => ({
+              record: {
+                id: r.record_id,
+                content: r.content,
+                type: r.type as MemoryRecord["type"],
+                priority: r.priority,
+                scene_name: r.scene_name,
+                source_message_ids: [],
+                metadata: r.metadata_json ? (() => { try { return JSON.parse(r.metadata_json); } catch { return {}; } })() : {},
+                timestamps: [r.timestamp_str].filter(Boolean),
+                createdAt: "",
+                updatedAt: "",
+                sessionKey: r.session_key,
+                sessionId: r.session_id,
+              },
+              score: r.score,
+            }));
+            return { records, ms: performance.now() - tStart };
           }
         }
         // FTS5 not available or returned no results — skip in-memory fallback

--- a/src/core/record/l1-dedup.ts
+++ b/src/core/record/l1-dedup.ts
@@ -17,7 +17,6 @@ import type { CandidateMatch } from "../prompts/l1-dedup.js";
 import { CleanContextRunner } from "../../utils/clean-context-runner.js";
 import { sanitizeJsonForParse } from "../../utils/sanitize.js";
 import type { IMemoryStore } from "../store/types.js";
-import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import type { LLMRunner, Logger } from "../types.js";
 
@@ -265,9 +264,8 @@ async function findCandidatesByFts(
   const matches: CandidateMatch[] = [];
 
   for (const mem of memories) {
-    const ftsQuery = buildFtsQuery(mem.content);
-    if (ftsQuery) {
-      const ftsResults = await vectorStore.searchL1Fts(ftsQuery, 10);
+    const ftsResults = await vectorStore.searchL1Fts(mem.content, 10);
+    if (ftsResults.length > 0) {
       // Filter out records from the current batch
       const candidates: MemoryRecord[] = ftsResults
         .filter((r) => !newRecordIds.has(r.record_id))

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,267 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { MemoryRecord } from "../record/l1-writer.js";
+import type { L0Record } from "./types.js";
+import { _resetJiebaForTest, _setJiebaForTest, buildFtsQuery, tokenizeForFts, VectorStore } from "./sqlite.js";
+
+function tempDbPath(): { dir: string; dbPath: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), "tc-memory-sqlite-"));
+  return { dir, dbPath: path.join(dir, "memory.db") };
+}
+
+function cleanupTempDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function sqliteDb(store: VectorStore): { exec(sql: string): void } {
+  return (store as unknown as { db: { exec(sql: string): void } }).db;
+}
+
+function l1Record(id: string, content: string): MemoryRecord {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    id,
+    content,
+    type: "persona",
+    priority: 50,
+    scene_name: "default",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [now],
+    createdAt: now,
+    updatedAt: now,
+    sessionKey: "session-key",
+    sessionId: "session-id",
+  };
+}
+
+function l0Record(id: string, messageText: string): L0Record {
+  return {
+    id,
+    sessionKey: "session-key",
+    sessionId: "session-id",
+    role: "user",
+    messageText,
+    recordedAt: "2026-01-01T00:00:00.000Z",
+    timestamp: 1_767_225_600_000,
+  };
+}
+
+describe("buildFtsQuery", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("removes FTS5 syntax characters while preserving normal keyword search", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('TypeScript (SQLite) AND memory*')).toBe('"TypeScript" OR "SQLite" OR "memory"');
+  });
+
+  it("removes all FTS5 operators without treating them as searchable tokens", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta or gamma Not delta near epsilon")).toBe(
+      '"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon"',
+    );
+  });
+
+  it("does not remove operator text embedded inside ordinary words", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("candy ordinary oracle northeast")).toBe(
+      '"candy" OR "ordinary" OR "oracle" OR "northeast"',
+    );
+  });
+
+  it("returns null when input only contains FTS5 operators and syntax", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('"(" AND or NOT near - : \\ , ， 🍎 *)"')).toBeNull();
+  });
+
+  it("removes field filters, exclusion operators, backslashes, commas, CJK punctuation, and emoji", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery('title:苹果 -香蕉 \\路径,测试，emoji🍎 "连续""引号"')).toBe(
+      '"title" OR "苹果" OR "香蕉" OR "路径" OR "测试" OR "emoji" OR "连续" OR "引号"',
+    );
+  });
+
+  it("sanitizes raw text before jieba tokenization", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string) {
+        seen.push(text);
+        return text.split(/\s+/).filter(Boolean);
+      },
+    });
+
+    expect(buildFtsQuery("北京 AND 烤鸭 (TypeScript*)")).toBe('"北京" OR "烤鸭" OR "TypeScript"');
+    expect(seen).toEqual(["北京   烤鸭  TypeScript  "]);
+  });
+
+  it("keeps recall-relevant tokens equivalent after operator sanitization", () => {
+    _setJiebaForTest(null);
+
+    const normal = buildFtsQuery("TypeScript SQLite memory");
+    const withOperators = buildFtsQuery('"TypeScript" AND (SQLite OR memory*)');
+
+    expect(withOperators).toBe(normal);
+  });
+});
+
+describe("VectorStore FTS search", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("executes sanitized L1 FTS queries through SQLite MATCH and returns raw content", () => {
+    _setJiebaForTest(null);
+    const { dir, dbPath } = tempDbPath();
+    const store = new VectorStore(dbPath, 3);
+
+    try {
+      store.init();
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL1(l1Record("l1-apple", "用户喜欢 苹果 TypeScript"), undefined)).toBe(true);
+      expect(store.upsertL1(l1Record("l1-banana", "用户讨厌 香蕉"), undefined)).toBe(true);
+
+      const results = store.searchL1Fts('title:苹果 -香蕉 or TypeScript \\路径,测试，emoji🍎 "连续""引号"', 10);
+
+      expect(results.map((r) => r.record_id)).toContain("l1-apple");
+      expect(results.find((r) => r.record_id === "l1-apple")?.content).toBe("用户喜欢 苹果 TypeScript");
+    } finally {
+      store.close();
+      cleanupTempDir(dir);
+    }
+  });
+
+  it("executes sanitized L0 FTS queries through SQLite MATCH and returns raw message text", () => {
+    _setJiebaForTest(null);
+    const { dir, dbPath } = tempDbPath();
+    const store = new VectorStore(dbPath, 3);
+
+    try {
+      store.init();
+      expect(store.isDegraded()).toBe(false);
+      expect(store.isFtsAvailable()).toBe(true);
+
+      expect(store.upsertL0(l0Record("l0-sqlite", "SQLite FTS5 可以搜索 原始消息"), undefined)).toBe(true);
+
+      const results = store.searchL0Fts("message:SQLite and FTS5 -ignored", 10);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].record_id).toBe("l0-sqlite");
+      expect(results[0].message_text).toBe("SQLite FTS5 可以搜索 原始消息");
+    } finally {
+      store.close();
+      cleanupTempDir(dir);
+    }
+  });
+
+  it("keeps write-side and query-side fallback tokenization compatible", () => {
+    _setJiebaForTest(null);
+
+    const indexed = tokenizeForFts("TypeScript SQLite memory");
+    const query = buildFtsQuery(indexed);
+
+    expect(query).toBe('"TypeScript" OR "SQLite" OR "memory"');
+  });
+
+  it("keeps write-side and query-side jieba tokenization compatible", () => {
+    _setJiebaForTest({
+      cutForSearch(text: string) {
+        if (text === "北京烤鸭 TypeScript") return ["北京", "烤鸭", "北京烤鸭", "TypeScript"];
+        return text.split(/\s+/).filter(Boolean);
+      },
+    });
+
+    const indexed = tokenizeForFts("北京烤鸭 TypeScript");
+    const query = buildFtsQuery(indexed);
+
+    expect(indexed).toBe("北京 烤鸭 北京烤鸭 TypeScript");
+    expect(query).toBe('"北京" OR "烤鸭" OR "北京烤鸭" OR "TypeScript"');
+  });
+
+  it("rebuilds FTS indexes from L1 and L0 metadata tables", () => {
+    _setJiebaForTest(null);
+    const { dir, dbPath } = tempDbPath();
+    const store = new VectorStore(dbPath, 3);
+
+    try {
+      store.init();
+      expect(store.isFtsAvailable()).toBe(true);
+      expect(store.upsertL1(l1Record("l1-rebuild", "rebuild keyword memory"), undefined)).toBe(true);
+      expect(store.upsertL0(l0Record("l0-rebuild", "rebuild keyword conversation"), undefined)).toBe(true);
+
+      sqliteDb(store).exec("DELETE FROM l1_fts");
+      sqliteDb(store).exec("DELETE FROM l0_fts");
+      expect(store.searchL1Fts("rebuild", 10)).toHaveLength(0);
+      expect(store.searchL0Fts("rebuild", 10)).toHaveLength(0);
+
+      store.rebuildFtsIndex();
+
+      expect(store.searchL1Fts("rebuild", 10).map((r) => r.record_id)).toEqual(["l1-rebuild"]);
+      expect(store.searchL0Fts("rebuild", 10).map((r) => r.record_id)).toEqual(["l0-rebuild"]);
+    } finally {
+      store.close();
+      cleanupTempDir(dir);
+    }
+  });
+
+  it("migrates old FTS v1 tables and rebuilds searchable v2 indexes", () => {
+    _setJiebaForTest(null);
+    const { dir, dbPath } = tempDbPath();
+    const firstStore = new VectorStore(dbPath, 3);
+    let firstStoreClosed = false;
+
+    try {
+      firstStore.init();
+      expect(firstStore.isFtsAvailable()).toBe(true);
+      expect(firstStore.upsertL1(l1Record("l1-migrate", "migration keyword memory"), undefined)).toBe(true);
+      expect(firstStore.upsertL0(l0Record("l0-migrate", "migration keyword conversation"), undefined)).toBe(true);
+      firstStore.close();
+      firstStoreClosed = true;
+
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec("DROP TABLE IF EXISTS l1_fts");
+        db.exec("DROP TABLE IF EXISTS l0_fts");
+        db.exec(`
+          CREATE VIRTUAL TABLE l1_fts USING fts5(
+            content,
+            record_id UNINDEXED
+          )
+        `);
+        db.exec(`
+          CREATE VIRTUAL TABLE l0_fts USING fts5(
+            message_text,
+            record_id UNINDEXED
+          )
+        `);
+      } finally {
+        db.close();
+      }
+
+      const migratedStore = new VectorStore(dbPath, 3);
+      try {
+        migratedStore.init();
+        expect(migratedStore.isFtsAvailable()).toBe(true);
+        expect(migratedStore.searchL1Fts("migration", 10).map((r) => r.record_id)).toEqual(["l1-migrate"]);
+        expect(migratedStore.searchL0Fts("migration", 10).map((r) => r.record_id)).toEqual(["l0-migrate"]);
+      } finally {
+        migratedStore.close();
+      }
+    } finally {
+      if (!firstStoreClosed) firstStore.close();
+      cleanupTempDir(dir);
+    }
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,19 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_OPERATORS = /\b(?:AND|OR|NOT|NEAR)\b/gi;
+const FTS5_NON_TOKEN_CHARS = /[^\p{L}\p{N}_\s]/gu;
+
+/**
+ * Remove FTS5 query syntax before tokenization.
+ *
+ * `buildFtsQuery()` constructs the final MATCH expression itself; raw user
+ * input must not be allowed to smuggle operators that alter query semantics.
+ */
+function sanitizeFtsInput(raw: string): string {
+  return raw.replace(FTS5_OPERATORS, " ").replace(FTS5_NON_TOKEN_CHARS, " ");
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -197,13 +210,14 @@ const ZH_STOP_WORDS = new Set([
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
+  const sanitized = sanitizeFtsInput(raw);
 
   let tokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
+      .cutForSearch(sanitized, true)
       .map((t) => t.trim())
       .filter((t) => {
         if (!t) return false;
@@ -218,7 +232,7 @@ export function buildFtsQuery(raw: string): string | null {
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      sanitized
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
         .filter(Boolean) ?? [];
@@ -2049,13 +2063,15 @@ export class VectorStore implements IMemoryStore {
    * FTS5 keyword search on L1 records.
    * Returns top-`limit` results sorted by BM25 relevance (highest first).
    *
-   * @param ftsQuery  A pre-built FTS5 MATCH expression (from `buildFtsQuery()`).
+   * @param query Raw user query. The SQLite store builds and binds the MATCH expression.
    * @param limit     Maximum number of results to return.
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL1Fts(ftsQuery: string, limit = 20): FtsSearchResult[] {
+  searchL1Fts(query: string, limit = 20): FtsSearchResult[] {
     if (this.degraded || !this.ftsAvailable) return [];
+    const ftsQuery = buildFtsQuery(query);
+    if (!ftsQuery) return [];
     try {
       const rows = this.stmtL1FtsSearch.all(ftsQuery, limit) as Array<{
         record_id: string;
@@ -2098,13 +2114,15 @@ export class VectorStore implements IMemoryStore {
    * FTS5 keyword search on L0 conversation messages.
    * Returns top-`limit` results sorted by BM25 relevance (highest first).
    *
-   * @param ftsQuery  A pre-built FTS5 MATCH expression (from `buildFtsQuery()`).
+   * @param query Raw user query. The SQLite store builds and binds the MATCH expression.
    * @param limit     Maximum number of results to return.
    *
    * **Fault-tolerant**: returns an empty array on any error.
    */
-  searchL0Fts(ftsQuery: string, limit = VectorStore.FTS_DEFAULT_LIMIT): L0FtsSearchResult[] {
+  searchL0Fts(query: string, limit = VectorStore.FTS_DEFAULT_LIMIT): L0FtsSearchResult[] {
     if (this.degraded || !this.ftsAvailable) return [];
+    const ftsQuery = buildFtsQuery(query);
+    if (!ftsQuery) return [];
     try {
       const rows = this.stmtL0FtsSearch.all(ftsQuery, limit) as Array<{
         record_id: string;

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -644,11 +644,11 @@ export class TcvdbMemoryStore implements IMemoryStore {
     return [];
   }
 
-  async searchL1Fts(ftsQuery: string, limit?: number): Promise<L1FtsResult[]> {
+  async searchL1Fts(query: string, limit?: number): Promise<L1FtsResult[]> {
     // TCVDB has no pure FTS — use hybrid search with sparse-only path
-    // The ftsQuery is raw text, use it as queryText for hybrid
-    if (!ftsQuery) return [];
-    const results = await this.searchL1HybridAsync({ queryText: ftsQuery, topK: limit });
+    // The query is raw text; keep it that way for BM25 and server-side embedding.
+    if (!query) return [];
+    const results = await this.searchL1HybridAsync({ queryText: query, topK: limit });
     // L1SearchResult and L1FtsResult have identical shapes
     return results;
   }
@@ -975,10 +975,10 @@ export class TcvdbMemoryStore implements IMemoryStore {
     return [];
   }
 
-  async searchL0Fts(ftsQuery: string, limit?: number): Promise<L0FtsResult[]> {
-    if (!ftsQuery) return [];
+  async searchL0Fts(query: string, limit?: number): Promise<L0FtsResult[]> {
+    if (!query) return [];
     // Use hybrid search; L0SearchResult and L0FtsResult have identical shapes
-    return this.searchL0HybridAsync({ queryText: ftsQuery, topK: limit });
+    return this.searchL0HybridAsync({ queryText: query, topK: limit });
   }
 
   /**

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -267,7 +267,7 @@ export interface IMemoryStore {
   // ── L1 Search ────────────────────────────────────────────
 
   searchL1Vector(queryEmbedding: Float32Array, topK?: number, queryText?: string): MaybePromise<L1SearchResult[]>;
-  searchL1Fts(ftsQuery: string, limit?: number): MaybePromise<L1FtsResult[]>;
+  searchL1Fts(query: string, limit?: number): MaybePromise<L1FtsResult[]>;
   searchL1Hybrid?(params: {
     query?: string;
     queryEmbedding?: Float32Array;
@@ -293,7 +293,7 @@ export interface IMemoryStore {
   // ── L0 Search ────────────────────────────────────────────
 
   searchL0Vector(queryEmbedding: Float32Array, topK?: number, queryText?: string): MaybePromise<L0SearchResult[]>;
-  searchL0Fts(ftsQuery: string, limit?: number): MaybePromise<L0FtsResult[]>;
+  searchL0Fts(query: string, limit?: number): MaybePromise<L0FtsResult[]>;
 
   pullProfiles?(): Promise<ProfileRecord[]>;
   syncProfiles?(records: ProfileSyncRecord[]): Promise<void>;

--- a/src/core/tools/conversation-search.ts
+++ b/src/core/tools/conversation-search.ts
@@ -11,7 +11,6 @@
  */
 
 import type { IMemoryStore, L0SearchResult } from "../store/types.js";
-import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import type { Logger } from "../types.js";
 
@@ -140,13 +139,7 @@ export async function executeConversationSearch(params: {
     (async (): Promise<ConversationSearchResultItem[]> => {
       if (!hasFts) return [];
       try {
-        const ftsQuery = buildFtsQuery(query);
-        if (!ftsQuery) {
-          logger?.debug?.(`${TAG} [hybrid-fts] No usable FTS tokens from query`);
-          return [];
-        }
-        logger?.debug?.(`${TAG} [hybrid-fts] FTS5 query: "${ftsQuery}"`);
-        const ftsResults = await vectorStore.searchL0Fts(ftsQuery, candidateK);
+        const ftsResults = await vectorStore.searchL0Fts(query, candidateK);
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 returned ${ftsResults.length} candidates`);
         return ftsResults.map((r) => ({
           id: r.record_id,

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -11,7 +11,6 @@
  */
 
 import type { IMemoryStore, L1SearchResult } from "../store/types.js";
-import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import type { Logger } from "../types.js";
 
@@ -141,13 +140,7 @@ export async function executeMemorySearch(params: {
     (async (): Promise<MemorySearchResultItem[]> => {
       if (!hasFts) return [];
       try {
-        const ftsQuery = buildFtsQuery(query);
-        if (!ftsQuery) {
-          logger?.debug?.(`${TAG} [hybrid-fts] No usable FTS tokens from query`);
-          return [];
-        }
-        logger?.debug?.(`${TAG} [hybrid-fts] FTS5 query: "${ftsQuery}"`);
-        const ftsResults = await vectorStore.searchL1Fts(ftsQuery, candidateK);
+        const ftsResults = await vectorStore.searchL1Fts(query, candidateK);
         logger?.debug?.(`${TAG} [hybrid-fts] FTS5 returned ${ftsResults.length} candidates`);
         return ftsResults.map((r) => ({
           id: r.record_id,


### PR DESCRIPTION
## Description | 描述

This PR fixes the SQLite FTS5 query syntax injection issue and refactors the FTS search boundary between SQLite and TCVDB.

本 PR 修复 SQLite FTS5 查询语法注入问题，并重构 SQLite 与 TCVDB 之间的 FTS 搜索边界。

Core highlights | 核心亮点：

- Fixes the architectural ambiguity of `searchL1Fts(ftsQuery)` / `searchL0Fts(ftsQuery)`: the same string used to be treated as a SQLite FTS5 `MATCH` expression by SQLite, but as natural-language query text by TCVDB.
- Refactors the store API so upper layers pass only raw user query text. SQLite-specific `MATCH` expression construction is now isolated inside `sqlite.ts`.
- Keeps SQLite FTS5 execution parameterized through prepared statements with `MATCH ?`, instead of exposing FTS5 syntax to hooks/tools/dedup logic.
- Prevents SQLite expressions such as `"term" OR "term2"` from polluting TCVDB BM25 / vector search input.
- Add FTS5 syntax sanitization before tokenization. Besides case-insensitive operators, field qualifiers, exclusion operators and consecutive quotation marks, this also covers backslashes, commas, CJK punctuation and emojis to improve retrieval experience.
- Preserves recall quality by keeping TCVDB input as natural-language text while SQLite receives a store-local FTS5 `MATCH` expression.
- Adds real SQLite FTS tests for L1/L0 `MATCH ?` execution, raw content return, write/query tokenization consistency, FTS rebuild, and FTS v1/v2 migration.
- Adds a Chinese design document explaining why the parameterized query-boundary approach is preferred over whitelist-only sanitization.

中文概要：

- 修复 `searchL1Fts(ftsQuery)` / `searchL0Fts(ftsQuery)` 的接口语义缺陷：同一份字符串过去既被 SQLite 当作 FTS5 `MATCH` 表达式，又被 TCVDB 当作自然语言 query，容易串场。
- 上层调用方现在只传 raw user query；SQLite 专属 `MATCH` 表达式只在 `sqlite.ts` 内部构造。
- SQLite 继续通过 prepared statement 的 `MATCH ?` 参数绑定执行 FTS5 查询。
- 避免 `"term" OR "term2"` 这类 SQLite 表达式污染 TCVDB BM25 / 向量召回。
- 分词前补充 FTS5 语法清洗，除了覆盖大小写 operator、字段限定、排除符、连续引号，还覆盖反斜杠、逗号、CJK 标点和 emoji 以优化体验。
- 保持 TCVDB 自然语言召回质量，同时让 SQLite 使用本地私有的 FTS5 MATCH 表达式。
- 补齐真实 SQLite FTS 执行、L1/L0 搜索、写入/查询分词一致性、rebuild、v1/v2 migration 测试。
- 新增中文设计文档，说明为什么参数化查询边界优于单纯查询白名单。

## Related Issue | 关联 Issue

Fix #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verified with | 已验证：

```bash
npm.cmd test -- src/core/store/sqlite.test.ts
npm.cmd test
npm.cmd run build
git diff --check