### PR TITLE
[codex] fix checkpoint counter recalibration after cleanup

### DIFF
--- a/src/core/tdai-core.test.ts
+++ b/src/core/tdai-core.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// Mock only initStores — the rest of pipeline-factory (initDataDirectories,
+// resetStores, ...) stays real so TdaiCore can run against a temp dataDir.
+vi.mock("../utils/pipeline-factory.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("../utils/pipeline-factory.js")>();
+  return { ...orig, initStores: vi.fn() };
+});
+
+import { initStores } from "../utils/pipeline-factory.js";
+import { TdaiCore } from "./tdai-core.js";
+import type { HostAdapter, Logger } from "./types.js";
+import type { IMemoryStore } from "./store/types.js";
+import { parseConfig } from "../config.js";
+import { CheckpointManager, type Checkpoint } from "../utils/checkpoint.js";
+
+const mockInitStores = vi.mocked(initStores);
+
+const silentLogger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function makeHostAdapter(dataDir: string): HostAdapter {
+  return {
+    hostType: "standalone",
+    getRuntimeContext: () => ({
+      userId: "test-user",
+      sessionId: "test-session",
+      sessionKey: "test-session",
+      platform: "cli",
+      workspaceDir: dataDir,
+      dataDir,
+    }),
+    getLogger: () => silentLogger,
+    getLLMRunnerFactory: () => ({
+      createRunner: () => {
+        throw new Error("LLM runner not needed in this test");
+      },
+    }),
+  };
+}
+
+function makeStore(overrides: Partial<IMemoryStore>): IMemoryStore {
+  return {
+    isDegraded: () => false,
+    countL1: () => 0,
+    countL0: () => 0,
+    close: () => {},
+    ...overrides,
+  } as unknown as IMemoryStore;
+}
+
+/**
+ * Startup recalibration of increment-only checkpoint counters (issue #157).
+ * TdaiCore.initStores() must recalibrate from a healthy store, and must
+ * leave the checkpoint untouched when the store is unavailable/degraded.
+ */
+describe("TdaiCore checkpoint recalibration on startup", () => {
+  let dataDir: string;
+  let core: TdaiCore | undefined;
+
+  beforeEach(async () => {
+    mockInitStores.mockReset();
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-core-test-"));
+  });
+
+  afterEach(async () => {
+    await core?.destroy().catch(() => {});
+    core = undefined;
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  async function seedCheckpoint(fields: Partial<Checkpoint>): Promise<void> {
+    const mgr = new CheckpointManager(dataDir, silentLogger);
+    const cp = await mgr.read();
+    Object.assign(cp, fields);
+    await mgr.write(cp);
+  }
+
+  async function readCheckpoint(): Promise<Checkpoint> {
+    return new CheckpointManager(dataDir, silentLogger).read();
+  }
+
+  async function initializeCore(): Promise<void> {
+    const cfg = parseConfig({});
+    cfg.extraction.enabled = false; // no scheduler/timers in this test
+    core = new TdaiCore({ hostAdapter: makeHostAdapter(dataDir), config: cfg });
+    await core.initialize();
+    // storeReady is assigned synchronously during initialize(); awaiting it
+    // also awaits the recalibration that runs at the tail of initStores().
+    await (core as unknown as { storeReady?: Promise<void> }).storeReady;
+  }
+
+  it("recalibrates counters from a healthy store at startup", async () => {
+    await seedCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+    mockInitStores.mockResolvedValue({
+      vectorStore: makeStore({ countL1: () => 42, countL0: () => 25 }),
+      embeddingService: undefined,
+      needsReindex: false,
+    });
+
+    await initializeCore();
+
+    const cp = await readCheckpoint();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(25);
+    // drift = 8 → memories_since_last_persona = 10 - 8 = 2
+    expect(cp.memories_since_last_persona).toBe(2);
+  });
+
+  it("does not touch the checkpoint when the store is unavailable", async () => {
+    await seedCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+    mockInitStores.mockResolvedValue({
+      vectorStore: undefined,
+      embeddingService: undefined,
+      needsReindex: false,
+    });
+
+    await initializeCore();
+
+    const cp = await readCheckpoint();
+    expect(cp.total_memories_extracted).toBe(50);
+    expect(cp.l0_conversations_count).toBe(30);
+    expect(cp.memories_since_last_persona).toBe(10);
+  });
+
+  it("does not zero the checkpoint when the store is degraded", async () => {
+    await seedCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+    mockInitStores.mockResolvedValue({
+      vectorStore: makeStore({ isDegraded: () => true, countL1: () => 0, countL0: () => 0 }),
+      embeddingService: undefined,
+      needsReindex: false,
+    });
+
+    await initializeCore();
+
+    const cp = await readCheckpoint();
+    expect(cp.total_memories_extracted).toBe(50);
+    expect(cp.l0_conversations_count).toBe(30);
+    expect(cp.memories_since_last_persona).toBe(10);
+  });
+
+  it("does not clear a non-empty checkpoint when healthy store counts both return zero", async () => {
+    await seedCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+    mockInitStores.mockResolvedValue({
+      vectorStore: makeStore({ countL1: () => 0, countL0: () => 0 }),
+      embeddingService: undefined,
+      needsReindex: false,
+    });
+
+    await initializeCore();
+
+    const cp = await readCheckpoint();
+    expect(cp.total_memories_extracted).toBe(50);
+    expect(cp.l0_conversations_count).toBe(30);
+    expect(cp.memories_since_last_persona).toBe(10);
+  });
+
+  it("keeps the checkpoint when store init fails entirely", async () => {
+    await seedCheckpoint({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+    mockInitStores.mockRejectedValue(new Error("cannot open database"));
+
+    await initializeCore();
+
+    const cp = await readCheckpoint();
+    expect(cp.total_memories_extracted).toBe(50);
+    expect(cp.l0_conversations_count).toBe(30);
+    expect(cp.memories_since_last_persona).toBe(10);
+  });
+});

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -410,9 +410,52 @@ export class TdaiCore {
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
+      await this.recalibrateCheckpointCounters();
     } catch (err) {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Recalibrate the increment-only checkpoint counters
+   * (`total_memories_extracted`, `l0_conversations_count`) against the real
+   * store contents — they never fall after memory cleanup, permanently
+   * overstating reality (issue #157). Runs once at startup, right after the
+   * store becomes available.
+   *
+   * Skipped entirely when the store is unavailable or degraded: `countL1()` /
+   * `countL0()` would return 0 and wrongly zero the counters.
+   */
+  private async recalibrateCheckpointCounters(): Promise<void> {
+    const store = this.vectorStore;
+    if (!store || store.isDegraded()) return;
+    try {
+      const [totalMemoriesExtracted, l0ConversationsCount] = await Promise.all([
+        store.countL1(),
+        store.countL0(),
+      ]);
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      const current = await checkpoint.read();
+      if (
+        totalMemoriesExtracted === 0 &&
+        l0ConversationsCount === 0 &&
+        (current.total_memories_extracted > 0 || current.l0_conversations_count > 0)
+      ) {
+        this.logger.warn(
+          `${TAG} Checkpoint recalibration skipped: store counts are both zero while checkpoint is non-empty. ` +
+          `This avoids clearing counters on transient count failures.`,
+        );
+        return;
+      }
+      await checkpoint.recalibrate({
+        totalMemoriesExtracted,
+        l0ConversationsCount,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CheckpointManager, type Checkpoint } from "./checkpoint.js";
+
+/**
+ * Unit tests for CheckpointManager.recalibrate() — the fix for issue #157
+ * ("total_memories_extracted / l0_conversations_count only ever increase").
+ */
+describe("CheckpointManager.recalibrate", () => {
+  let dataDir: string;
+  let mgr: CheckpointManager;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-test-"));
+    mgr = new CheckpointManager(dataDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  async function seed(fields: Partial<Checkpoint>): Promise<void> {
+    const cp = await mgr.read();
+    Object.assign(cp, fields);
+    await mgr.write(cp);
+  }
+
+  it("lowers inflated counters to the actual store counts", async () => {
+    // Issue #157 reproduction: checkpoint says 50, real store has 42.
+    await seed({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    const cp = await mgr.read();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(25);
+  });
+
+  it("reduces memories_since_last_persona by the L1 drift", async () => {
+    await seed({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    // drift = 50 - 42 = 8 → 10 - 8 = 2
+    const cp = await mgr.read();
+    expect(cp.memories_since_last_persona).toBe(2);
+  });
+
+  it("clamps memories_since_last_persona at 0 when the drift exceeds it", async () => {
+    await seed({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 5,
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    const cp = await mgr.read();
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+
+  it("never leaves memories_since_last_persona above the actual L1 total", async () => {
+    // Already-inconsistent state: since-persona counter exceeds the global total.
+    await seed({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 60,
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    const cp = await mgr.read();
+    expect(cp.memories_since_last_persona).toBeLessThanOrEqual(42);
+  });
+
+  it("raises counters when the store holds more than the checkpoint (restored backup)", async () => {
+    await seed({
+      total_memories_extracted: 10,
+      l0_conversations_count: 3,
+      memories_since_last_persona: 4,
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    const cp = await mgr.read();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(25);
+    // Persona counter is NOT raised: firing late is safer than firing early.
+    expect(cp.memories_since_last_persona).toBe(4);
+  });
+
+  it("resets counters to zero when the store was fully cleaned", async () => {
+    await seed({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 0, l0ConversationsCount: 0 });
+
+    const cp = await mgr.read();
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+
+  it("leaves all other checkpoint fields untouched", async () => {
+    await seed({
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 10,
+      total_processed: 1234,
+      scenes_processed: 7,
+      last_persona_time: "2026-06-01T00:00:00.000Z",
+      request_persona_update: true,
+      persona_update_reason: "threshold",
+      runner_states: {
+        "session-a": { last_captured_timestamp: 111, last_l1_cursor: 222, last_scene_name: "work" },
+      },
+      pipeline_states: {
+        "session-a": {
+          conversation_count: 3,
+          last_extraction_time: "2026-06-02T00:00:00.000Z",
+          last_extraction_updated_time: "2026-06-02T01:00:00.000Z",
+          last_active_time: 333,
+          l2_pending_l1_count: 1,
+          warmup_threshold: 2,
+          l2_last_extraction_time: "2026-06-03T00:00:00.000Z",
+        },
+      },
+    });
+
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    const cp = await mgr.read();
+    expect(cp.total_processed).toBe(1234);
+    expect(cp.scenes_processed).toBe(7);
+    expect(cp.last_persona_time).toBe("2026-06-01T00:00:00.000Z");
+    expect(cp.request_persona_update).toBe(true);
+    expect(cp.persona_update_reason).toBe("threshold");
+    expect(cp.runner_states["session-a"]).toEqual({
+      last_captured_timestamp: 111,
+      last_l1_cursor: 222,
+      last_scene_name: "work",
+    });
+    expect(cp.pipeline_states["session-a"].conversation_count).toBe(3);
+    expect(cp.pipeline_states["session-a"].warmup_threshold).toBe(2);
+  });
+
+  it("creates the checkpoint file from defaults when none exists yet", async () => {
+    await mgr.recalibrate({ totalMemoriesExtracted: 42, l0ConversationsCount: 25 });
+
+    const cp = await mgr.read();
+    expect(cp.total_memories_extracted).toBe(42);
+    expect(cp.l0_conversations_count).toBe(25);
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -432,6 +432,57 @@ export class CheckpointManager {
   }
 
   // ============================
+  // Recalibration (counter drift fix, issue #157)
+  // ============================
+
+  /**
+   * Recalibrate the monotonic global counters from the actual store contents.
+   *
+   * `total_memories_extracted` and `l0_conversations_count` are increment-only:
+   * memory cleanup (retention cleaner, manual pruning) deletes records from the
+   * store but never decrements these counters, so they permanently overstate
+   * reality. This method resets them to the ground-truth counts supplied by
+   * the caller — typically `store.countL1()` / `store.countL0()` sampled once
+   * at startup.
+   *
+   * `memories_since_last_persona` is corrected conservatively: reduced by the
+   * downward drift of `total_memories_extracted` and clamped to
+   * `[0, actual L1 total]`, so the persona threshold cannot fire prematurely
+   * on phantom (already-deleted) memories. When the store holds MORE than the
+   * checkpoint (e.g. checkpoint restored from an old backup), the persona
+   * counter is left unchanged — firing late is safer than firing early.
+   *
+   * The caller MUST NOT invoke this when the store is unavailable or degraded:
+   * `countL1()`/`countL0()` would return 0 and wrongly zero the counters.
+   *
+   * The update runs inside the per-file lock and is written atomically,
+   * like every other mutation.
+   */
+  async recalibrate(actual: {
+    totalMemoriesExtracted: number;
+    l0ConversationsCount: number;
+  }): Promise<void> {
+    const actualL1 = Math.max(0, Math.floor(actual.totalMemoriesExtracted));
+    const actualL0 = Math.max(0, Math.floor(actual.l0ConversationsCount));
+    const cp = await this.mutate((cp) => {
+      const l1Drift = Math.max(0, cp.total_memories_extracted - actualL1);
+      cp.total_memories_extracted = actualL1;
+      cp.l0_conversations_count = actualL0;
+      if (l1Drift > 0 || cp.memories_since_last_persona > actualL1) {
+        cp.memories_since_last_persona = Math.max(
+          0,
+          Math.min(cp.memories_since_last_persona - l1Drift, actualL1),
+        );
+      }
+    });
+    this.logger.info(
+      `[checkpoint] recalibrate: total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+  }
+
+  // ============================
   // Atomic capture (race-condition fix)
   // ============================
 


### PR DESCRIPTION
## Summary

Fixes #157.

This PR adds a startup recalibration path for checkpoint counters that can drift after memory cleanup. total_memories_extracted and l0_conversations_count were increment-only fields in recall_checkpoint.json; after records were removed from the underlying store, the checkpoint could continue reporting stale inflated totals.

## Approach

- Add CheckpointManager.recalibrate() and keep it inside the existing mutate() path, so the update still uses the per-file async lock and atomic tmp+rename write.
- Recompute the two affected counters from the existing IMemoryStore abstraction via countL1() and countL0() during TdaiCore store startup.
- Adjust memories_since_last_persona conservatively when L1 totals decrease, so persona generation thresholds do not fire early because of deleted memories.
- Skip startup recalibration when the store is unavailable, degraded, or reports both counts as zero while the checkpoint is non-empty. That avoids accidentally clearing counters if a fault-tolerant count implementation returns 0 during a transient store/count failure.

## Notes

l0_conversations_count is recalibrated from countL0(), matching the issue's expectation to count actual l0_conversations rows. This means the calibrated value reflects stored L0 records rather than historical capture rounds.

## Validation

- npm test -- src/utils/checkpoint.test.ts src/core/tdai-core.test.ts
- npm test
- npm run build