### PR TITLE
feat(adapters): add Pi coding agent memory adapter

### DIFF
--- a/__tests__/pi-plugin/capture-utils.test.ts
+++ b/__tests__/pi-plugin/capture-utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contentToText,
+  extractRound,
+} from "../../pi-plugin/tdai-memory/capture-utils.js";
+
+describe("contentToText", () => {
+  it("passes plain string content through", () => {
+    expect(contentToText("hello")).toBe("hello");
+  });
+
+  it("joins text blocks and ignores non-text blocks", () => {
+    expect(
+      contentToText([
+        { type: "text", text: "line one" },
+        { type: "image", data: "..." },
+        { type: "text", text: "line two" },
+      ]),
+    ).toBe("line one\nline two");
+  });
+
+  it("returns empty string for undefined / non-array content", () => {
+    expect(contentToText(undefined)).toBe("");
+    expect(contentToText(42)).toBe("");
+    expect(contentToText({ type: "text", text: "not-an-array" })).toBe("");
+  });
+});
+
+describe("extractRound", () => {
+  it("extracts the last user message and the assistant reply after it", () => {
+    const round = extractRound([
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: [{ type: "text", text: "earlier answer" }] },
+      { role: "user", content: "current question" },
+      { role: "assistant", content: [{ type: "text", text: "current answer" }] },
+    ]);
+    expect(round.userContent).toBe("current question");
+    expect(round.assistantContent).toBe("current answer");
+  });
+
+  it("concatenates multiple assistant messages after the last user message", () => {
+    const round = extractRound([
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "text", text: "thinking done, calling tool" }] },
+      { role: "toolResult", content: [{ type: "text", text: "tool output" }] },
+      { role: "assistant", content: [{ type: "text", text: "final answer" }] },
+    ]);
+    expect(round.userContent).toBe("question");
+    expect(round.assistantContent).toBe("thinking done, calling tool\nfinal answer");
+  });
+
+  it("excludes toolResult and custom messages from the captured round", () => {
+    const round = extractRound([
+      { role: "user", content: "question" },
+      { role: "custom", content: "[recalled memories] user likes Rust" },
+      { role: "toolResult", content: [{ type: "text", text: "secret tool output" }] },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+    expect(round.assistantContent).toBe("answer");
+    expect(round.assistantContent).not.toContain("secret tool output");
+    expect(round.assistantContent).not.toContain("recalled memories");
+  });
+
+  it("returns empty round when there is no user message", () => {
+    expect(extractRound([{ role: "assistant", content: "orphan answer" }])).toEqual({
+      userContent: "",
+      assistantContent: "",
+    });
+    expect(extractRound([])).toEqual({ userContent: "", assistantContent: "" });
+  });
+
+  it("skips assistant messages with only non-text content", () => {
+    const round = extractRound([
+      { role: "user", content: "question" },
+      { role: "assistant", content: [{ type: "toolCall", id: "t1", name: "bash" }] },
+      { role: "assistant", content: [{ type: "text", text: "real answer" }] },
+    ]);
+    expect(round.assistantContent).toBe("real answer");
+  });
+});

--- a/__tests__/pi-plugin/gateway-client.test.ts
+++ b/__tests__/pi-plugin/gateway-client.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GatewayClient } from "../../pi-plugin/tdai-memory/gateway-client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetch(response: Response | Error): ReturnType<typeof vi.fn> {
+  const mock =
+    response instanceof Error
+      ? vi.fn().mockRejectedValue(response)
+      : vi.fn().mockResolvedValue(response);
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GatewayClient request shape", () => {
+  it("POSTs /recall with query and session_key", async () => {
+    const fetchMock = mockFetch(jsonResponse({ context: "ctx", memory_count: 1 }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    const result = await client.recall("what language?", "pi_abc");
+
+    expect(result).toEqual({ context: "ctx", memory_count: 1 });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://gw:8420/recall");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ query: "what language?", session_key: "pi_abc" });
+  });
+
+  it("POSTs /capture with the full round", async () => {
+    const fetchMock = mockFetch(jsonResponse({ l0_recorded: 2, scheduler_notified: true }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    await client.capture("user says", "assistant says", "pi_abc");
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://gw:8420/capture");
+    expect(JSON.parse(init.body)).toEqual({
+      user_content: "user says",
+      assistant_content: "assistant says",
+      session_key: "pi_abc",
+    });
+  });
+
+  it("POSTs /search/memories and omits limit when not given", async () => {
+    const fetchMock = mockFetch(jsonResponse({ results: "r", total: 0, strategy: "fts" }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    await client.searchMemories("rust");
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body)).toEqual({ query: "rust" });
+
+    await client.searchMemories("rust", 3);
+    expect(JSON.parse(fetchMock.mock.calls[1]![1].body)).toEqual({ query: "rust", limit: 3 });
+  });
+
+  it("POSTs /session/end with session_key", async () => {
+    const fetchMock = mockFetch(jsonResponse({ flushed: true }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    const result = await client.sessionEnd("pi_abc");
+
+    expect(result).toEqual({ flushed: true });
+    expect(fetchMock.mock.calls[0]![0]).toBe("http://gw:8420/session/end");
+  });
+
+  it("strips trailing slashes from the base URL", async () => {
+    const fetchMock = mockFetch(jsonResponse({ context: "" }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420///" });
+
+    await client.recall("q", "s");
+
+    expect(fetchMock.mock.calls[0]![0]).toBe("http://gw:8420/recall");
+  });
+});
+
+describe("GatewayClient auth", () => {
+  it("sends Authorization: Bearer when apiKey is set", async () => {
+    const fetchMock = mockFetch(jsonResponse({ context: "" }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420", apiKey: "sekrit" });
+
+    await client.recall("q", "s");
+
+    expect(fetchMock.mock.calls[0]![1].headers["Authorization"]).toBe("Bearer sekrit");
+  });
+
+  it("sends no Authorization header when apiKey is unset", async () => {
+    const fetchMock = mockFetch(jsonResponse({ context: "" }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    await client.recall("q", "s");
+
+    expect(fetchMock.mock.calls[0]![1].headers["Authorization"]).toBeUndefined();
+  });
+});
+
+describe("GatewayClient fault tolerance", () => {
+  it("returns null (never throws) when the gateway is unreachable", async () => {
+    mockFetch(new TypeError("fetch failed: ECONNREFUSED"));
+    const client = new GatewayClient({ baseUrl: "http://gw:9999" });
+
+    await expect(client.recall("q", "s")).resolves.toBeNull();
+    await expect(client.capture("u", "a", "s")).resolves.toBeNull();
+    await expect(client.searchMemories("q")).resolves.toBeNull();
+    await expect(client.sessionEnd("s")).resolves.toBeNull();
+  });
+
+  it("returns null on non-2xx responses and reports via onError", async () => {
+    mockFetch(jsonResponse({ error: "Unauthorized" }, 401));
+    const onError = vi.fn();
+    const client = new GatewayClient({ baseUrl: "http://gw:8420", onError });
+
+    const result = await client.recall("q", "s");
+
+    expect(result).toBeNull();
+    expect(onError).toHaveBeenCalledWith("/recall", expect.any(Error));
+    expect(String(onError.mock.calls[0]![1])).toContain("401");
+  });
+
+  it("returns null on malformed JSON bodies", async () => {
+    mockFetch(new Response("not json{", { status: 200 }));
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    await expect(client.recall("q", "s")).resolves.toBeNull();
+  });
+
+  it("aborts via the caller-provided signal", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new GatewayClient({ baseUrl: "http://gw:8420" });
+
+    const pending = client.recall("q", "s", controller.signal);
+    controller.abort();
+
+    await expect(pending).resolves.toBeNull();
+  });
+});

--- a/pi-plugin/tdai-memory/README.md
+++ b/pi-plugin/tdai-memory/README.md
@@ -1,0 +1,94 @@
+# TencentDB Agent Memory — Pi Adapter
+
+A [Pi coding agent](https://github.com/earendil-works/pi) extension that gives Pi persistent, cross-session memory backed by the TDAI Memory Gateway.
+
+**Adapter lane** (per [`docs/adapters/contribution-guide.md`](../../docs/adapters/contribution-guide.md)): coding-agent adapter. Talks to the existing Gateway HTTP API; does not add platform SDK dependencies to core.
+
+## How it works
+
+```
+┌────────────────────── Pi (TUI / print / RPC) ──────────────────────┐
+│                                                                    │
+│  user prompt                                                       │
+│    │                                                               │
+│    ├─ before_agent_start ──► POST /recall ──► inject memories      │
+│    │                          as a custom context message          │
+│    ▼                                                               │
+│  LLM turn(s)…  ── may call memory_search ──► POST /search/memories │
+│    │                                                               │
+│    ├─ agent_end ───────────► POST /capture (user + assistant round)│
+│    │                          Gateway archives L0, schedules L1    │
+│    ▼                          extraction asynchronously            │
+│  session exit / switch ────► POST /session/end (flush)             │
+└────────────────────────────────────────────────────────────────────┘
+                     TDAI Gateway (standalone sidecar, port 8420)
+```
+
+- **Recall**: before each agent run, memories relevant to the prompt are fetched and injected into LLM context (hidden by default; the current conversation is instructed to take precedence on conflict).
+- **Capture**: after each run, the user/assistant round is archived (L0) and structured facts are extracted asynchronously (L1) by the Gateway's pipeline.
+- **Explicit search**: a `memory_search` tool lets the LLM proactively query long-term memories.
+- **Session identity**: `session_key` is `pi_<sessionId>` from Pi's SessionManager — stable across `/resume` of the same session file, distinct across `/new`.
+
+## Setup
+
+### 1. Start the Gateway
+
+```bash
+cd TencentDB-Agent-Memory
+TDAI_LLM_BASE_URL="https://api.deepseek.com/v1" \
+TDAI_LLM_API_KEY="sk-..." \
+TDAI_LLM_MODEL="deepseek-chat" \
+node --import tsx/esm src/gateway/server.ts
+```
+
+Any OpenAI-compatible chat endpoint works for L1/L2/L3 extraction. See the repository README for full Gateway configuration (embedding service, hybrid recall, auth, etc.).
+
+### 2. Install the extension
+
+Copy (or symlink) this directory into Pi's extension path:
+
+```bash
+# global (all projects)
+cp -r pi-plugin/tdai-memory ~/.pi/agent/extensions/
+
+# or project-local
+cp -r pi-plugin/tdai-memory .pi/extensions/
+```
+
+For a quick trial without installing:
+
+```bash
+pi -e pi-plugin/tdai-memory/index.ts
+```
+
+### 3. Configure (optional)
+
+| Environment variable | Default | Purpose |
+| :--- | :--- | :--- |
+| `MEMORY_TENCENTDB_GATEWAY_URL` | `http://127.0.0.1:8420` | Gateway base URL |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` | (unset) | Bearer token when the Gateway sets `TDAI_GATEWAY_API_KEY` |
+| `MEMORY_TENCENTDB_TIMEOUT_MS` | `5000` | Per-request timeout |
+| `MEMORY_TENCENTDB_RECALL_DISPLAY` | (hidden) | `1` to render recalled memories in the TUI |
+
+## Fault tolerance
+
+Every Gateway call is best-effort: when the Gateway is down, recall injection is skipped (one warning per session), capture is dropped, and `memory_search` reports the outage to the LLM instead of throwing. Pi never breaks because memory is unavailable — mirroring the degradation philosophy of the core plugin.
+
+## Verified flow
+
+Tested end-to-end with `pi 0.80.8` + DeepSeek:
+
+1. Session A: "我叫小明，最喜欢的编程语言是 Rust，在研究 Hopfield 网络" → `/capture` recorded L0, Gateway extracted 2 L1 memories (persona + episodic).
+2. Session B (fresh process): "我最喜欢的编程语言是什么？" → `/recall` injected the memories; Pi answered "Rust … Hopfield 网络记忆容量" correctly.
+3. `memory_search` tool: callable by the LLM, returns formatted memory list.
+4. Gateway stopped: Pi still answers normally, exit code 0, one-line warning.
+
+## Files
+
+| File | Purpose |
+| :--- | :--- |
+| `index.ts` | Extension entry — lifecycle hooks + `memory_search` tool |
+| `gateway-client.ts` | Dependency-free typed HTTP client for the Gateway API |
+| `capture-utils.ts` | Pure round-extraction helpers (unit-tested without the Pi runtime) |
+
+Unit tests live in [`__tests__/pi-plugin/`](../../__tests__/pi-plugin/) and run with the repository's standard `npm test`.

--- a/pi-plugin/tdai-memory/capture-utils.ts
+++ b/pi-plugin/tdai-memory/capture-utils.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the Pi adapter — kept dependency-free so they can be
+ * unit-tested without the Pi runtime (`@earendil-works/pi-coding-agent`
+ * and `typebox` are provided by Pi when the extension is loaded, and are
+ * intentionally not dependencies of this repository).
+ */
+
+/** Minimal structural view of a Pi AgentMessage for capture purposes. */
+export interface MessageLike {
+  role?: string;
+  content?: unknown;
+}
+
+/** Flatten a message content field (string or content-block array) to plain text. */
+export function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((block) => {
+      if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
+        return (block as { text?: string }).text ?? "";
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Extract the round to capture from an `agent_end` messages array:
+ * the last real user message and every assistant text after it.
+ *
+ * Custom messages (role "custom", e.g. the adapter's own recall injection)
+ * and toolResult messages are excluded — the Gateway's L1 extraction works
+ * on the dialogue itself, and echoing recalled memories back into /capture
+ * would create feedback loops.
+ */
+export function extractRound(messages: MessageLike[]): {
+  userContent: string;
+  assistantContent: string;
+} {
+  let lastUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") {
+      lastUserIndex = i;
+      break;
+    }
+  }
+  if (lastUserIndex === -1) return { userContent: "", assistantContent: "" };
+
+  const userContent = contentToText(messages[lastUserIndex]?.content);
+  const assistantParts: string[] = [];
+  for (let i = lastUserIndex + 1; i < messages.length; i++) {
+    const message = messages[i];
+    if (message?.role === "assistant") {
+      const text = contentToText(message.content);
+      if (text) assistantParts.push(text);
+    }
+  }
+  return { userContent, assistantContent: assistantParts.join("\n") };
+}

--- a/pi-plugin/tdai-memory/gateway-client.ts
+++ b/pi-plugin/tdai-memory/gateway-client.ts
@@ -1,0 +1,171 @@
+/**
+ * TDAI Gateway HTTP client for the Pi coding agent extension.
+ *
+ * A minimal, dependency-free typed client for the subset of Gateway
+ * endpoints the Pi adapter needs:
+ *
+ *   POST /recall               — memory recall before each agent run
+ *   POST /capture              — conversation capture after each agent run
+ *   POST /search/memories      — explicit L1 memory search (agent tool)
+ *   POST /session/end          — session end + flush
+ *
+ * Design:
+ * - Every method is **fault-tolerant**: network errors, timeouts, and
+ *   non-2xx responses resolve to `null` instead of throwing, so the host
+ *   agent never breaks when the Gateway is down. Callers decide how to
+ *   degrade (skip injection, skip capture, report tool error).
+ * - Auth: when `apiKey` is set, requests carry `Authorization: Bearer <key>`
+ *   (matching `TDAI_GATEWAY_API_KEY` on the Gateway side).
+ * - Timeouts use `AbortSignal.timeout()` per call; an optional outer signal
+ *   (e.g. Pi's `ctx.signal`) is combined via `AbortSignal.any()` so Esc can
+ *   cancel in-flight recalls.
+ */
+
+// ============================
+// Request/response types (mirrors src/gateway/types.ts)
+// ============================
+
+export interface RecallResult {
+  context: string;
+  strategy?: string;
+  memory_count?: number;
+}
+
+export interface CaptureResult {
+  l0_recorded: number;
+  scheduler_notified: boolean;
+}
+
+export interface MemorySearchResult {
+  results: string;
+  total: number;
+  strategy: string;
+}
+
+export interface SessionEndResult {
+  flushed: boolean;
+}
+
+export interface GatewayClientOptions {
+  /** Gateway base URL, e.g. "http://127.0.0.1:8420" (no trailing slash needed). */
+  baseUrl: string;
+  /** Optional Bearer token (must match the Gateway's TDAI_GATEWAY_API_KEY). */
+  apiKey?: string;
+  /** Per-request timeout in milliseconds (default: 5000). */
+  timeoutMs?: number;
+  /** Optional error sink for diagnostics (e.g. Pi status line). */
+  onError?: (operation: string, error: unknown) => void;
+}
+
+// ============================
+// Client
+// ============================
+
+export class GatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly onError?: (operation: string, error: unknown) => void;
+
+  constructor(options: GatewayClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? 5000;
+    this.onError = options.onError;
+  }
+
+  /** Recall memories relevant to `query`. Returns null on any failure. */
+  async recall(
+    query: string,
+    sessionKey: string,
+    signal?: AbortSignal,
+  ): Promise<RecallResult | null> {
+    return this.post<RecallResult>(
+      "/recall",
+      { query, session_key: sessionKey },
+      signal,
+    );
+  }
+
+  /** Capture one user/assistant round. Returns null on any failure. */
+  async capture(
+    userContent: string,
+    assistantContent: string,
+    sessionKey: string,
+    signal?: AbortSignal,
+  ): Promise<CaptureResult | null> {
+    return this.post<CaptureResult>(
+      "/capture",
+      {
+        user_content: userContent,
+        assistant_content: assistantContent,
+        session_key: sessionKey,
+      },
+      signal,
+    );
+  }
+
+  /** Explicit L1 memory search. Returns null on any failure. */
+  async searchMemories(
+    query: string,
+    limit?: number,
+    signal?: AbortSignal,
+  ): Promise<MemorySearchResult | null> {
+    return this.post<MemorySearchResult>(
+      "/search/memories",
+      limit === undefined ? { query } : { query, limit },
+      signal,
+    );
+  }
+
+  /** Notify the Gateway that a session ended (flush pending pipeline work). */
+  async sessionEnd(
+    sessionKey: string,
+    signal?: AbortSignal,
+  ): Promise<SessionEndResult | null> {
+    return this.post<SessionEndResult>(
+      "/session/end",
+      { session_key: sessionKey },
+      signal,
+    );
+  }
+
+  // ============================
+  // Internals
+  // ============================
+
+  private async post<T>(
+    path: string,
+    body: unknown,
+    outerSignal?: AbortSignal,
+  ): Promise<T | null> {
+    const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+    const signal = outerSignal
+      ? AbortSignal.any([outerSignal, timeoutSignal])
+      : timeoutSignal;
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!response.ok) {
+        this.onError?.(path, new Error(`HTTP ${response.status}`));
+        return null;
+      }
+      return (await response.json()) as T;
+    } catch (error) {
+      this.onError?.(path, error);
+      return null;
+    }
+  }
+}

--- a/pi-plugin/tdai-memory/index.ts
+++ b/pi-plugin/tdai-memory/index.ts
@@ -1,0 +1,177 @@
+/**
+ * TencentDB Agent Memory — Pi coding agent adapter.
+ *
+ * A Pi extension (https://github.com/earendil-works/pi) that connects Pi to
+ * the TDAI Memory Gateway, giving Pi persistent cross-session memory:
+ *
+ * - **Recall** (`before_agent_start` → POST /recall): before each agent run,
+ *   memories relevant to the user prompt are fetched and injected into the
+ *   LLM context as a custom message.
+ * - **Capture** (`agent_end` → POST /capture): after each agent run, the
+ *   user/assistant round is sent to the Gateway, which archives it (L0) and
+ *   schedules structured fact extraction (L1) asynchronously.
+ * - **Session end** (`session_shutdown` → POST /session/end): flushes any
+ *   pending pipeline work when Pi exits or switches sessions.
+ * - **Explicit search** (`memory_search` tool → POST /search/memories): the
+ *   LLM can proactively search long-term memories on demand.
+ *
+ * Lifecycle mapping (Pi ⇄ Gateway):
+ *
+ *   session_start        → derive stable session_key from Pi's session id
+ *   before_agent_start   → /recall (inject context)
+ *   agent_end            → /capture (user + assistant round)
+ *   session_shutdown     → /session/end
+ *   memory_search (tool) → /search/memories
+ *
+ * Configuration (environment variables):
+ *
+ *   MEMORY_TENCENTDB_GATEWAY_URL      Gateway base URL (default: http://127.0.0.1:8420)
+ *   MEMORY_TENCENTDB_GATEWAY_API_KEY  Bearer token, when the Gateway sets TDAI_GATEWAY_API_KEY
+ *   MEMORY_TENCENTDB_TIMEOUT_MS       Per-request timeout (default: 5000)
+ *   MEMORY_TENCENTDB_RECALL_DISPLAY   "1"/"true" to show recalled memories in the TUI
+ *                                     (default: hidden — context-only injection)
+ *
+ * Fault tolerance: every Gateway call is best-effort. When the Gateway is
+ * unreachable, Pi keeps working without memory — recall injection is
+ * skipped, capture is dropped, and the `memory_search` tool reports the
+ * outage to the LLM instead of throwing.
+ *
+ * Install: copy this directory to `~/.pi/agent/extensions/tdai-memory/`
+ * (global) or `.pi/extensions/tdai-memory/` (project), or test with
+ * `pi -e ./pi-plugin/tdai-memory/index.ts`.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { GatewayClient } from "./gateway-client.js";
+import { extractRound } from "./capture-utils.js";
+
+const CUSTOM_MESSAGE_TYPE = "tdai-memory-recall";
+
+// ============================
+// Config
+// ============================
+
+function readConfig() {
+  const env = process.env;
+  const flag = (v: string | undefined) =>
+    v !== undefined && ["1", "true", "yes"].includes(v.toLowerCase());
+  const timeoutRaw = Number.parseInt(env.MEMORY_TENCENTDB_TIMEOUT_MS ?? "", 10);
+  return {
+    gatewayUrl: env.MEMORY_TENCENTDB_GATEWAY_URL?.trim() || "http://127.0.0.1:8420",
+    apiKey: env.MEMORY_TENCENTDB_GATEWAY_API_KEY?.trim() || undefined,
+    timeoutMs: Number.isFinite(timeoutRaw) ? timeoutRaw : 5000,
+    displayRecall: flag(env.MEMORY_TENCENTDB_RECALL_DISPLAY),
+  };
+}
+
+// ============================
+// Extension
+// ============================
+
+export default function tdaiMemoryExtension(pi: ExtensionAPI) {
+  const config = readConfig();
+
+  let sessionKey = `pi_${Date.now()}`;
+  let gatewayWarned = false;
+
+  const client = new GatewayClient({
+    baseUrl: config.gatewayUrl,
+    apiKey: config.apiKey,
+    timeoutMs: config.timeoutMs,
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    // Pi session ids are stable across resume/fork of the same session file,
+    // which is exactly the "conversation identity" the Gateway expects.
+    sessionKey = `pi_${ctx.sessionManager.getSessionId()}`;
+    gatewayWarned = false;
+  });
+
+  // ── Recall: inject relevant memories before each agent run ──
+  pi.on("before_agent_start", async (event, ctx) => {
+    const recall = await client.recall(event.prompt, sessionKey, ctx.signal);
+    if (recall === null) {
+      // Gateway unreachable — warn once per session, then degrade silently.
+      if (!gatewayWarned && ctx.hasUI) {
+        ctx.ui.notify(
+          `tdai-memory: Gateway unreachable at ${config.gatewayUrl} — running without memory`,
+          "warning",
+        );
+        gatewayWarned = true;
+      }
+      return;
+    }
+    if (!recall.context) return;
+
+    return {
+      message: {
+        customType: CUSTOM_MESSAGE_TYPE,
+        content:
+          "[TencentDB Agent Memory — recalled context]\n" +
+          "The following long-term memories about this user/project may be relevant. " +
+          "Treat them as background knowledge from earlier sessions; the current " +
+          "conversation always takes precedence when they conflict.\n\n" +
+          recall.context,
+        display: config.displayRecall,
+      },
+    };
+  });
+
+  // ── Capture: archive the round after each agent run ──
+  pi.on("agent_end", async (event, ctx) => {
+    const { userContent, assistantContent } = extractRound(
+      event.messages as Array<{ role?: string; content?: unknown }>,
+    );
+    if (!userContent || !assistantContent) return;
+
+    const result = await client.capture(userContent, assistantContent, sessionKey);
+    if (result && ctx.hasUI) {
+      ctx.ui.setStatus("tdai-memory", `memory: captured (L0 ${result.l0_recorded})`);
+    }
+  });
+
+  // ── Session end: flush pending pipeline work ──
+  pi.on("session_shutdown", async () => {
+    await client.sessionEnd(sessionKey);
+  });
+
+  // ── Explicit search tool for the LLM ──
+  pi.registerTool({
+    name: "memory_search",
+    label: "Memory Search",
+    description:
+      "Search the user's long-term memories (facts, preferences, past decisions " +
+      "from earlier sessions) stored in TencentDB Agent Memory. Use when the user " +
+      "refers to something from a previous conversation or when past context would help.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Keywords or a question to search memories for" }),
+      limit: Type.Optional(
+        Type.Number({ description: "Maximum memories to return (default 5)" }),
+      ),
+    }),
+    async execute(_toolCallId, params, signal) {
+      const result = await client.searchMemories(
+        params.query,
+        params.limit,
+        signal ?? undefined,
+      );
+      if (result === null) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Memory gateway unreachable at ${config.gatewayUrl}; memory search unavailable.`,
+            },
+          ],
+          isError: true,
+          details: {},
+        };
+      }
+      return {
+        content: [{ type: "text" as const, text: result.results }],
+        details: { total: result.total, strategy: result.strategy },
+      };
+    },
+  });
+}


### PR DESCRIPTION
## Description | 描述

Adds a [Pi coding agent](https://github.com/earendil-works/pi) adapter under
`pi-plugin/tdai-memory/`, giving Pi persistent cross-session memory via the
existing TDAI Gateway HTTP API — the same sidecar pattern as the Hermes provider.

新增 Pi coding agent 适配器（`pi-plugin/tdai-memory/`），通过现有 TDAI Gateway
HTTP API 为 Pi 提供跨会话长期记忆，架构上与 Hermes provider 的 sidecar 模式一致。

**Lifecycle mapping | 生命周期映射：**

| Pi hook | Gateway endpoint | 作用 |
| :--- | :--- | :--- |
| `before_agent_start` | `POST /recall` | 每轮前召回相关记忆，注入 LLM 上下文（默认隐藏） |
| `agent_end` | `POST /capture` | 归档本轮对话（L0），Gateway 异步提取 L1 |
| `session_shutdown` | `POST /session/end` | 冲刷未完成的管道任务 |
| `memory_search` (tool) | `POST /search/memories` | LLM 主动查询长期记忆 |

- Session identity: `session_key = pi_<sessionId>`（Pi SessionManager 提供，
  `/resume` 同一会话稳定不变，`/new` 自动区分）
- Fault tolerance: Gateway 不可达时所有调用降级为 no-op（每会话仅警告一次），
  Pi 正常工作不受影响 — 与核心插件的优雅降级哲学一致

**Adapter lane**: coding-agent adapter (per `docs/adapters/contribution-guide.md`
proposed in #441). This PR intentionally does **not** ship a shared Gateway SDK —
that lane is covered by #316; the bundled client is minimal and adapter-local.

## Related Issue | 关联 Issue

Relates to #235

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能（`npm test` 86/86 passing, 19 new）

## Additional Notes | 其他说明

### A/B verification: same pi, same model, same prompt — the only variable is `-e` | 控制变量对比实验

The adapter is loaded via Pi's `-e` flag, so "installed vs. not installed" is a
one-flag difference. Both runs use `-p` (print mode: **a fresh process per run**,
which rules out "the model just remembers this conversation" — only cross-process
persistent memory can answer) and pin the same model to eliminate model variance.

适配器通过 Pi 的 `-e` 参数加载，因此"装/没装"只差一个参数。两次运行都用 `-p`
（print 模式：**每次运行都是全新进程**，排除"模型记得本次会话"的解释——只有跨
进程持久记忆才能答对），并锁定同一模型排除模型差异。

**Control (without adapter) | 对照组（未装）:**

```console
$ pi -p --model deepseek/deepseek-v4-flash "根据你对我的记忆：我叫什么名字？\
我在研究什么方向？我最喜欢的编程语言是什么？如果没有记忆请直接说不知道。"

不知道。我没有关于你个人信息（姓名、研究方向、最喜欢的编程语言）的任何记忆。
目前我只有当前工作目录（`/Users/heptazero`）和项目相关的 `AGENTS.md` 文件内容，
但其中并没有记录你的个人身份信息或偏好。
```

Note the control group is not blind — it has all of Pi's built-in context
(cwd, `AGENTS.md`), it just has no cross-session personal memory.

**Experiment (with adapter) | 实验组（已装，唯一差异是 `-e`）:**

```console
$ pi -p --model deepseek/deepseek-v4-flash \
    -e ~/Documents/project/TencentDB-Agent-Memory/pi-plugin/tdai-memory/index.ts \
    "根据你对我的记忆：我叫什么名字？我在研究什么方向？我最喜欢的编程语言是什么？\
如果没有记忆请直接说不知道。"

根据我对你的记忆：

1. **名字**: 小明
2. **研究方向**: 你是一名在读计算机本科生，当前暑假跟导师研究 **Hopfield 网络和联想记忆容量分析**。
3. **最喜欢的编程语言**: **Rust** 🦀

不过，这些记忆的置信度不算特别高（分数在 0.5-0.85 之间）。如果以上信息有误，欢迎更正！
```

The facts were captured in an earlier, separate pi session via `/capture`
(L0 archived, then L1 facts extracted asynchronously by the Gateway), and
recalled here through `before_agent_start` → `POST /recall`.

A detail worth noting: the "confidence 0.5–0.85" in the answer is not
hallucinated — those are the Gateway's own retrieval scores (BM25 rank
normalized to 0–1 by `bm25RankToScore()` in `src/core/store/sqlite.ts`),
which ride along with the injected memories, so the retrieval layer's
internal scoring is transparently visible in the final answer.

值得一提：回答末尾的「置信度 0.5-0.85」不是模型幻觉——这是 Gateway 返回的
检索得分（`src/core/store/sqlite.ts` 中 `bm25RankToScore()` 将 BM25 rank
归一化到 0-1 的分数），随注入的记忆一起进入上下文，检索层的内部评分对最终
回答全程透明。

**Degradation (adapter loaded, Gateway down) | 容错组（装了适配器但 Gateway 未运行）:**

```console
$ pi -p --model deepseek/deepseek-v4-flash -e .../tdai-memory/index.ts "（同一问题）"

抱歉，记忆系统目前无法访问，我没有任何关于你的身份、研究方向或偏好的存储记忆。
能直接告诉我吗？我很乐意重新认识你并记录下来的 😊
```

Pi exits 0 and keeps working normally — recall is skipped, capture is dropped,
one warning line per session. This matches the review-checklist requirement that
an adapter must not take the host down with the Gateway.

<!-- screenshot: terminal capture of the control + experiment runs goes here -->

### Test & environment notes

- `npm test`: 86/86 passing (19 new in `__tests__/pi-plugin/` covering request
  shape, auth headers, fault tolerance, abort signals, and round extraction)
- Pure logic (`capture-utils.ts` / `gateway-client.ts`) is unit-tested without
  the Pi runtime — `@earendil-works/pi-coding-agent` and `typebox` are provided
  by Pi at load time and are **not** added as dependencies of this repository
- E2E environment: pi 0.80.8, DeepSeek (deepseek-v4-flash for Pi,
  deepseek-chat for Gateway L1 extraction), Gateway run standalone via
  `node --import tsx/esm src/gateway/server.ts`, macOS / Node 25
