### PR TITLE
fix(memory): stabilize prompt cache for recall injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |
+| `recall.showInjected` | `false` | Preserve dynamic recall in persisted session history; disable it to keep history and cache prefixes stable |
 | `pipeline.everyNConversations` | `5` | Trigger an L1 memory extraction every N turns |
 | `extraction.maxMemoriesPerSession` | `20` | Max memories extracted per L1 pass |
 | `persona.triggerEveryN` | `50` | Generate the user persona every N new memories |

--- a/README_CN.md
+++ b/README_CN.md
@@ -439,6 +439,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |
+| `recall.showInjected` | `false` | 是否将动态 recall 保留在持久化会话历史中；关闭可保持历史和缓存前缀稳定 |
 | `pipeline.everyNConversations` | `5` | 每 N 轮对话触发一次 L1 记忆提取 |
 | `extraction.maxMemoriesPerSession` | `20` | 单次 L1 最多提取多少条 |
 | `persona.triggerEveryN` | `50` | 每 N 条新记忆触发用户画像生成 |

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,8 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import { stripInjectedRecallFromMessage } from "./src/utils/recall-injection.js";
+import { mapRecallResultToOpenClawPromptBuild } from "./src/adapters/openclaw/prompt-build.js";
 
 const TAG = "[memory-tdai]";
 
@@ -594,7 +596,7 @@ export default function register(api: OpenClawPluginApi) {
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return mapRecallResultToOpenClawPromptBuild(result);
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -612,42 +614,28 @@ export default function register(api: OpenClawPluginApi) {
     });
   }
 
-  // Strip <relevant-memories> from user messages before they are persisted to
+  // Strip injected recall context from user messages before they are persisted to
   // the session JSONL.  The current-turn LLM already saw the full prompt
   // (effectivePrompt lives in memory), but we don't want recall artifacts
   // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
+  api.logger.debug?.(
+    `${TAG} Registering before_message_write hook ` +
+    `(recall.showInjected=${cfg.recall.showInjected ? "true" : "false"})`,
+  );
   api.on("before_message_write", (event) => {
     const msg = event.message as { role?: string; content?: unknown };
     const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
     api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
 
-    if (msg.role !== "user") return;
-
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
+    if (cfg.recall.showInjected) {
+      api.logger.debug?.(`${TAG} [before_message_write] recall.showInjected=true, preserving injected recall context`);
+      return;
     }
 
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
+    const stripped = stripInjectedRecallFromMessage(event.message as { role?: string; content?: unknown });
+    if (!stripped) return;
+    api.logger.debug?.(`${TAG} [before_message_write] Stripped injected recall context: removed ${stripped.strippedChars} chars`);
+    return { message: stripped.message as typeof event.message };
   });
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -77,6 +77,7 @@
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否在会话历史中保留 auto-recall 注入的记忆上下文，便于用户查看召回内容" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
           "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }

--- a/src/adapters/openclaw/prompt-build.test.ts
+++ b/src/adapters/openclaw/prompt-build.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { mapRecallResultToOpenClawPromptBuild } from "./prompt-build.js";
+
+describe("mapRecallResultToOpenClawPromptBuild", () => {
+  it("keeps stable recall context before the OpenClaw cache boundary", () => {
+    expect(mapRecallResultToOpenClawPromptBuild({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<memory-tdai-auto-recall>dynamic</memory-tdai-auto-recall>",
+      recalledL1Memories: [{ content: "memory", score: 0.9, type: "fact" }],
+    })).toEqual({
+      prependSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<memory-tdai-auto-recall>dynamic</memory-tdai-auto-recall>",
+    });
+  });
+
+  it("does not return an empty hook result", () => {
+    expect(mapRecallResultToOpenClawPromptBuild({})).toBeUndefined();
+  });
+});

--- a/src/adapters/openclaw/prompt-build.ts
+++ b/src/adapters/openclaw/prompt-build.ts
@@ -1,0 +1,22 @@
+import type { RecallResult } from "../../core/types.js";
+
+export interface OpenClawPromptBuildResult {
+  prependContext?: string;
+  prependSystemContext?: string;
+}
+
+/**
+ * Place stable recall additions before OpenClaw's cache boundary while keeping
+ * turn-specific recall in the current user context.
+ */
+export function mapRecallResultToOpenClawPromptBuild(
+  result: RecallResult | undefined,
+): OpenClawPromptBuildResult | undefined {
+  if (!result) return undefined;
+
+  const mapped: OpenClawPromptBuildResult = {};
+  if (result.prependContext) mapped.prependContext = result.prependContext;
+  if (result.appendSystemContext) mapped.prependSystemContext = result.appendSystemContext;
+
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall.showInjected", () => {
+  it("defaults to false", () => {
+    expect(parseConfig({}).recall.showInjected).toBe(false);
+  });
+
+  it("accepts explicit true", () => {
+    expect(parseConfig({ recall: { showInjected: true } }).recall.showInjected).toBe(true);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,8 @@ export interface RecallConfig {
   maxCharsPerMemory: number;
   /** Max total characters injected for all recalled L1 memories. 0 disables the total limit. */
   maxTotalRecallChars: number;
+  /** Preserve injected recall context in persisted user messages for transparency (default: false). */
+  showInjected: boolean;
   /** Minimum score threshold (default: 0.3) */
   scoreThreshold: number;
   /** Search strategy (default: "hybrid") */
@@ -532,6 +534,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
+      showInjected: bool(recallGroup, "showInjected") ?? false,
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { composeRecallPromptContext } from "./auto-recall.js";
+
+describe("composeRecallPromptContext", () => {
+  it("keeps recall-only hit and miss turns on the same stable system prefix", () => {
+    const recallHit = composeRecallPromptContext({ memoryLines: ["- recalled memory"] });
+    const recallMiss = composeRecallPromptContext({ memoryLines: [] });
+
+    expect(recallHit.appendSystemContext).toBe(recallMiss.appendSystemContext);
+    expect(recallHit.appendSystemContext).toContain("<memory-tools-guide>");
+    expect(recallHit.prependContext).toContain("<memory-tdai-auto-recall>");
+    expect(recallHit.prependContext).toContain("<relevant-memories>");
+    expect(recallHit.prependContext).not.toContain("<memory-tools-guide>");
+  });
+
+  it("keeps the tools guide in stable system context when persona exists", () => {
+    const recallHit = composeRecallPromptContext({
+      memoryLines: ["- recalled memory"],
+      personaContent: "User prefers concise answers.",
+    });
+    const recallMiss = composeRecallPromptContext({
+      memoryLines: [],
+      personaContent: "User prefers concise answers.",
+    });
+
+    expect(recallHit.appendSystemContext).toBe(recallMiss.appendSystemContext);
+    expect(recallHit.appendSystemContext).toContain("<memory-tools-guide>");
+    expect(recallHit.prependContext).not.toContain("<memory-tools-guide>");
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -27,6 +27,7 @@ const TAG = "[memory-tdai] [recall]";
 const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
 const MIN_TRUNCATED_RECALL_LINE_CHARS = 40;
 const RECALL_LINE_SEPARATOR = "\n";
+const AUTO_RECALL_CONTEXT_TAG = "memory-tdai-auto-recall";
 
 /**
  * Memory tools usage guide — injected at the end of memory context so the
@@ -179,43 +180,14 @@ async function performAutoRecallInner(params: {
       `persona=${(tPersonaEnd - tPersonaStart).toFixed(0)}ms, ` +
       `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms — no context to inject`,
     );
-    logger?.debug?.(`${TAG} No memories/persona/scenes to inject`);
-    return undefined;
+    logger?.debug?.(`${TAG} No memories/persona/scenes; injecting only stable memory tools guidance`);
   }
 
-  // Split recall context into stable and dynamic parts to optimize prompt caching.
-  //
-  // appendSystemContext (system prompt end — stable, cacheable):
-  //   persona, scene navigation, memory tools guide
-  //   These change infrequently; when content is identical across turns,
-  //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
-  //
-  // prependContext (user prompt prefix — dynamic, per-turn):
-  //   L1 relevant memories — different every turn, moved out of system prompt
-  //   so it doesn't bust the system prompt cache.
-  const stableParts: string[] = [];
-  if (personaContent) {
-    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
-  }
-  if (sceneNavigation) {
-    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
-  }
-
-  // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
-  let prependContext: string | undefined;
-  if (memoryLines.length > 0) {
-    prependContext =
-      `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
-  }
-
-  // Append memory tools usage guide to the stable part so the agent knows
-  // how to actively retrieve deeper context when the injected snippets
-  // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
-    stableParts.push(MEMORY_TOOLS_GUIDE);
-  }
-
-  const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  const { prependContext, appendSystemContext } = composeRecallPromptContext({
+    memoryLines,
+    personaContent,
+    sceneNavigation,
+  });
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(
@@ -237,6 +209,46 @@ async function performAutoRecallInner(params: {
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,
     recallStrategy: effectiveStrategy,
+  };
+}
+
+/**
+ * Keep system additions independent from per-turn recall hits.
+ *
+ * The tools guide is always part of the stable system addition so a
+ * recall-only hit or miss cannot add or remove system text.
+ */
+export function composeRecallPromptContext(params: {
+  memoryLines: string[];
+  personaContent?: string;
+  sceneNavigation?: string;
+}): Pick<RecallResult, "prependContext" | "appendSystemContext"> {
+  const stableParts: string[] = [];
+  if (params.personaContent) {
+    stableParts.push(`<user-persona>\n${params.personaContent}\n</user-persona>`);
+  }
+  if (params.sceneNavigation) {
+    stableParts.push(`<scene-navigation>\n${params.sceneNavigation}\n</scene-navigation>`);
+  }
+  // This must be present on both recall hits and misses. Otherwise a
+  // recall-only hit changes the system prefix before the cache boundary.
+  stableParts.push(MEMORY_TOOLS_GUIDE);
+
+  let prependContext: string | undefined;
+  if (params.memoryLines.length > 0) {
+    prependContext =
+      `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${params.memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
+  }
+
+  if (prependContext) {
+    // Keep dynamic recall self-contained so persistence can remove it as one
+    // unit without touching the user's original prompt.
+    prependContext = `<${AUTO_RECALL_CONTEXT_TAG}>\n${prependContext}\n</${AUTO_RECALL_CONTEXT_TAG}>`;
+  }
+
+  return {
+    prependContext,
+    appendSystemContext: stableParts.length > 0 ? stableParts.join("\n\n") : undefined,
   };
 }
 

--- a/src/utils/recall-injection.test.ts
+++ b/src/utils/recall-injection.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { stripInjectedRecallFromMessage, stripInjectedRecallText } from "./recall-injection.js";
+
+describe("recall injection stripping", () => {
+  it("removes relevant memories from user string content", () => {
+    const text = [
+      "<relevant-memories>",
+      "memory recall:",
+      "- [instruction|work] User prefers concise updates.",
+      "</relevant-memories>",
+      "Please summarize the task.",
+    ].join("\n");
+
+    expect(stripInjectedRecallText(text)).toBe("Please summarize the task.");
+  });
+
+  it("leaves ordinary text unchanged", () => {
+    expect(stripInjectedRecallText("Please summarize the task.")).toBe("Please summarize the task.");
+  });
+
+  it("keeps persisted user prompts stable when recalled memories differ", () => {
+    const first = [
+      "<relevant-memories>",
+      "- memory A",
+      "</relevant-memories>",
+      "Please summarize the task.",
+    ].join("\n");
+    const second = [
+      "<relevant-memories>",
+      "- memory B with different length and content",
+      "</relevant-memories>",
+      "Please summarize the task.",
+    ].join("\n");
+
+    expect(stripInjectedRecallText(first)).toBe(stripInjectedRecallText(second));
+  });
+
+  it("removes the recall-only tools guide together with its injected memories", () => {
+    const text = [
+      "<memory-tdai-auto-recall>",
+      "<relevant-memories>",
+      "- recalled memory",
+      "</relevant-memories>",
+      "<memory-tools-guide>",
+      "Use tdai_memory_search when needed.",
+      "</memory-tools-guide>",
+      "</memory-tdai-auto-recall>",
+      "Actual user prompt.",
+    ].join("\n");
+
+    expect(stripInjectedRecallText(text)).toBe("Actual user prompt.");
+  });
+
+  it("removes relevant memories from text parts only", () => {
+    const result = stripInjectedRecallFromMessage({
+      role: "user",
+      content: [
+        { type: "text", text: "<relevant-memories>\nold memory\n</relevant-memories>\nActual prompt" },
+        { type: "image", data: "abc" },
+      ],
+    });
+
+    expect(result?.message.content).toEqual([
+      { type: "text", text: "Actual prompt" },
+      { type: "image", data: "abc" },
+    ]);
+    expect(result?.strippedChars).toBeGreaterThan(0);
+  });
+
+  it("does not strip assistant messages", () => {
+    const result = stripInjectedRecallFromMessage({
+      role: "assistant",
+      content: "<relevant-memories>\nold memory\n</relevant-memories>\nAnswer",
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/utils/recall-injection.ts
+++ b/src/utils/recall-injection.ts
@@ -1,0 +1,56 @@
+const AUTO_RECALL_CONTEXT_RE = /<memory-tdai-auto-recall>[\s\S]*?<\/memory-tdai-auto-recall>\s*/g;
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+export type MessageWithContent = {
+  role?: string;
+  content?: unknown;
+};
+
+/**
+ * Remove auto-recall prompt artifacts before user messages are persisted.
+ * The current LLM turn has already seen the injected context; this keeps
+ * historical transcripts stable unless recall.showInjected is enabled.
+ */
+export function stripInjectedRecallFromMessage<T extends MessageWithContent>(
+  message: T,
+): { message: T; strippedChars: number } | undefined {
+  if (message.role !== "user") return undefined;
+
+  if (typeof message.content === "string") {
+    const cleaned = stripInjectedRecallText(message.content);
+    if (cleaned === message.content) return undefined;
+    return {
+      message: { ...message, content: cleaned },
+      strippedChars: message.content.length - cleaned.length,
+    };
+  }
+
+  if (!Array.isArray(message.content)) return undefined;
+
+  let strippedChars = 0;
+  const cleanedParts = (message.content as Array<Record<string, unknown>>).map((part) => {
+    if (part.type !== "text" || typeof part.text !== "string") return part;
+    const cleaned = stripInjectedRecallText(part.text);
+    strippedChars += part.text.length - cleaned.length;
+    return cleaned === part.text ? part : { ...part, text: cleaned };
+  });
+
+  if (strippedChars === 0) return undefined;
+  return {
+    message: { ...message, content: cleanedParts },
+    strippedChars,
+  };
+}
+
+export function stripInjectedRecallText(text: string): string {
+  if (!text.includes("<memory-tdai-auto-recall>") && !text.includes("<relevant-memories>")) {
+    return text;
+  }
+
+  // Keep the legacy block fallback so existing session files remain clean
+  // after upgrading to the outer injection envelope.
+  return text
+    .replace(AUTO_RECALL_CONTEXT_RE, "")
+    .replace(RELEVANT_MEMORIES_RE, "")
+    .trim();
+}


### PR DESCRIPTION
### Description | 描述

### English

This PR stabilizes the prompt-cache prefix for memory recall on OpenAI-compatible providers.

- Keeps the memory tools guide in stable system context for both recall hits and misses.
- Maps stable recall context before OpenClaw's cache boundary while keeping recalled L1 memories dynamic.
- Adds `recall.showInjected`, defaulting to `false`, so dynamic recall is not persisted into session history by default.
- Adds regression tests for prefix stability, persistence cleanup, configuration, and OpenClaw prompt mapping.

### 中文

此 PR 修复 OpenAI-compatible 提供商使用 memory recall 时的 prompt 缓存前缀不稳定问题。

- 在召回命中和未命中时，均将记忆工具指南保留在稳定的系统上下文中。
- 将稳定 recall 上下文映射到 OpenClaw 缓存边界之前；召回到的 L1 记忆仍保持为动态用户上下文。
- 新增 `recall.showInjected` 配置，默认值为 `false`，避免动态 recall 默认写入会话历史。
- 新增缓存前缀稳定性、历史清理、配置默认值和 OpenClaw prompt 映射的回归测试。

## Related Issue | 关联 Issue

Fixes #120

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
  - `npm test`: 8 files, 79 tests passed
  - `npm run build`: passed
  - Verified `recall.showInjected=false` as the schema default
- [ ] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

### English

- The default persistence behavior intentionally changes: dynamic recall is no longer stored in session history unless `recall.showInjected=true` is explicitly configured.
- Long-session Gateway coverage that triggers actual tool-result truncation remains follow-up validation.

### 中文

- 默认持久化行为有意调整：动态 recall 不再写入会话历史；如需保留注入内容，可显式设置 `recall.showInjected=true`。
- 触发实际 tool-result truncation 的长会话 Gateway 覆盖仍作为后续验证项。