### PR TITLE
fix(search): harden FTS5 sanitization without recall loss

### DIFF
--- a/src/core/store/sqlite-fts-query.test.ts
+++ b/src/core/store/sqlite-fts-query.test.ts
@@ -1,0 +1,239 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+  sanitizeFts5Input,
+} from "./sqlite.js";
+
+const SAFE_LITERAL_QUERY = /^"(?:[^"]|"")+"(?: OR "(?:[^"]|"")+")*$/;
+
+function createFtsIndex(contents: string[]): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  const insert = db.prepare("INSERT INTO docs(content) VALUES (?)");
+  for (const content of contents) insert.run(content);
+  return db;
+}
+
+function searchQueryRowIds(db: DatabaseSync, query: string | null): number[] {
+  if (!query) return [];
+  return (
+    db
+      .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+      .all(query) as Array<{ rowid: number }>
+  ).map((row) => row.rowid);
+}
+
+function searchRowIds(db: DatabaseSync, raw: string): number[] {
+  return searchQueryRowIds(db, buildFtsQuery(raw));
+}
+
+function buildLegacyFallbackQuery(raw: string): string | null {
+  const tokens =
+    raw
+      .match(/[\p{L}\p{N}_]+/gu)
+      ?.map((token) => token.trim())
+      .filter(Boolean) ?? [];
+  if (tokens.length === 0) return null;
+  return tokens.map((token) => `"${token.replaceAll('"', "")}"`).join(" OR ");
+}
+
+afterEach(() => {
+  _resetJiebaForTest();
+});
+
+describe("sanitizeFts5Input", () => {
+  it("removes standalone uppercase FTS5 boolean and proximity operators", () => {
+    const sanitized = sanitizeFts5Input(
+      "alpha AND beta OR NOT gamma NEAR(delta)",
+    );
+
+    expect(sanitized.replace(/\s+/g, " ").trim()).toBe(
+      "alpha beta gamma (delta)",
+    );
+  });
+
+  it("preserves non-operator words and lowercase prose for recall quality", () => {
+    const input =
+      "and or not near And Or Not Near android origin notable nearby 中文AND测试";
+
+    expect(sanitizeFts5Input(input)).toBe(input);
+  });
+});
+
+describe("buildFtsQuery sanitization", () => {
+  it("sanitizes operators before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta or gamma")).toBe(
+      '"alpha" OR "beta" OR "or" OR "gamma"',
+    );
+    expect(buildFtsQuery("中文AND测试")).toBe('"中文AND测试"');
+  });
+
+  it("sanitizes operators before jieba tokenization", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        seen.push(text);
+        return text.split(/\s+/);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe(
+      '"用户" OR "TypeScript" OR "记忆"',
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).not.toMatch(/\b(?:AND|OR|NOT|NEAR)\b/);
+  });
+
+  it("escapes hostile tokenizer output before it crosses MATCH", () => {
+    _setJiebaForTest({
+      cutForSearch: () => [
+        'alpha" OR beta',
+        "gamma*",
+        "NEAR(alpha beta)",
+        "NOT",
+        "(delta)",
+      ],
+    });
+    const db = createFtsIndex([
+      "alpha OR beta",
+      "gamma",
+      "delta",
+      "unrelated",
+    ]);
+
+    try {
+      const query = buildFtsQuery("ignored raw input");
+      expect(query).toBe(
+        '"alpha"" OR beta" OR "gamma*" OR "NEAR(alpha beta)" OR "(delta)"',
+      );
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("buildFtsQuery real FTS5 execution", () => {
+  it.each([
+    ['alpha" OR beta', "double quote and OR"],
+    ["alpha' AND beta", "apostrophe and AND"],
+    ["(alpha) NOT beta", "parentheses and NOT"],
+    ["NEAR(alpha beta, 5)", "NEAR expression"],
+    ["alpha*", "prefix operator"],
+    ["content:alpha", "column filter"],
+    ["alpha ^ beta", "caret syntax"],
+    ['alpha OR "" OR * beta', "combined syntax"],
+  ])("keeps %s inside quoted literal terms (%s)", (raw) => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex(["alpha beta", "content alpha", "unrelated"]);
+
+    try {
+      const query = buildFtsQuery(raw);
+      expect(query).not.toBeNull();
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("prevents operator text from recovering raw FTS5 semantics", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "alpha only",
+      "beta only",
+      "alpha beta",
+      "AND boolean operator",
+      "near field",
+      "unrelated",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "alpha AND missing")).toEqual([1, 3]);
+      expect(searchRowIds(db, "alpha NOT beta")).toEqual([1, 2, 3]);
+      expect(searchRowIds(db, "NEAR(alpha beta)")).toEqual([1, 2, 3]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves lowercase operator words used as ordinary search terms", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "research and development",
+      "meet near the station",
+      "unrelated",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "and")).toEqual([1]);
+      expect(searchRowIds(db, "near")).toEqual([2]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps pre-sanitizer recall for benign fallback queries", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "alpha beta project",
+      "research and development",
+      "android origin nearby",
+      "中文AND测试",
+      "北京 烤鸭",
+      "unrelated",
+    ]);
+    const benignQueries = [
+      "alpha beta",
+      "research and development",
+      "android origin nearby",
+      "中文AND测试",
+      "北京 烤鸭",
+    ];
+
+    try {
+      for (const raw of benignQueries) {
+        const before = searchQueryRowIds(db, buildLegacyFallbackQuery(raw));
+        const after = searchRowIds(db, raw);
+        expect(after, raw).toEqual(before);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves jieba search tokens for normal Chinese recall", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["北京", "烤鸭", "北京烤鸭"],
+    });
+    const db = createFtsIndex(["北京 烤鸭 北京烤鸭", "上海 小笼包"]);
+
+    try {
+      expect(buildFtsQuery("北京烤鸭")).toBe(
+        '"北京" OR "烤鸭" OR "北京烤鸭"',
+      );
+      expect(searchRowIds(db, "北京烤鸭")).toEqual([1]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each(["", "   ", "\"'()***", "！@#￥%……&*（）", "AND OR NOT NEAR"])(
+    "returns null when no searchable token remains: %j",
+    (raw) => {
+      _setJiebaForTest(null);
+      expect(buildFtsQuery(raw)).toBeNull();
+    },
+  );
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,41 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+// FTS5 operators are case-sensitive. Match only standalone uppercase operator
+// words, using Unicode-aware boundaries so normal terms such as "android",
+// lowercase prose such as "research and development", and mixed CJK terms are
+// not damaged before tokenization.
+const FTS5_OPERATOR_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:AND|OR|NOT|NEAR)(?![\p{L}\p{N}_])/gu;
+
+/**
+ * Remove raw FTS5 boolean/proximity operators before tokenization.
+ *
+ * Punctuation syntax (`*`, `^`, `:`, parentheses, and quotes) is neutralized
+ * by the tokenizers and the final quoted-phrase boundary. Keeping punctuation
+ * handling there avoids changing ordinary user text more than necessary.
+ */
+export function sanitizeFts5Input(raw: string): string {
+  return raw.replace(FTS5_OPERATOR_PATTERN, " ");
+}
+
+function sanitizeFts5Token(token: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed || !/[\p{L}\p{N}]/u.test(trimmed)) return null;
+
+  // Defense in depth for custom/tokenizer output: a tokenizer must not be able
+  // to reintroduce a reserved word that was removed from the raw input.
+  if (FTS5_RESERVED_OPERATORS.has(trimmed)) return null;
+  return trimmed;
+}
+
+function quoteFts5Phrase(token: string): string {
+  // FTS5 strings use SQL-style escaping for embedded double quotes.
+  return `"${token.replaceAll('"', '""')}"`;
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -183,6 +218,10 @@ const ZH_STOP_WORDS = new Set([
  *
  * Falls back to Unicode-regex splitting (`/[\p{L}\p{N}_]+/gu`) if
  * jieba is not installed.
+ *
+ * Standalone uppercase FTS5 operators are removed before tokenization. Every
+ * remaining token is emitted as an escaped, quoted FTS5 phrase so tokenizer
+ * output cannot reintroduce query syntax.
  *
  * Tokens are OR-joined as quoted FTS5 phrase terms so that a document
  * matching *any* token is returned.  BM25 naturally ranks documents that
@@ -196,6 +235,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = sanitizeFts5Input(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,29 +243,24 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .cutForSearch(cleaned, true)
+      .map(sanitizeFts5Token)
+      .filter((t): t is string => t !== null)
+      // Remove common Chinese stop-words to reduce noise
+      .filter((t) => !ZH_STOP_WORDS.has(t));
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        ?.map(sanitizeFts5Token)
+        .filter((t): t is string => t !== null) ?? [];
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map(quoteFts5Phrase);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

Harden `buildFtsQuery()` against FTS5 query-syntax injection while preserving ordinary keyword recall.

This implements the progressive acceptance criteria from #160 in one self-contained change:

- remove standalone uppercase FTS5 boolean/proximity operators before both jieba and fallback tokenization
- use Unicode-aware boundaries so embedded terms such as `android`, `origin`, `nearby`, and `中文AND测试` are preserved
- preserve lowercase `and/or/not/near` as ordinary search words because FTS5 operators are case-sensitive
- sanitize tokenizer output again as defense in depth
- escape embedded double quotes using FTS5/SQL-style `""` escaping before every token crosses the `MATCH ?` boundary
- retain the builder's intentional quoted-token `OR` recall strategy

## Related Issue | 关联 Issue

Fixes #160

## Coordination With Existing PRs | 与现有 PR 的协调

PR #178 is the approved narrow production fix, and PR #503 adds execution-level tests. This PR goes beyond a duplicate raw regex replacement by combining the production hardening with:

- case-sensitive and Unicode-aware recall preservation
- hostile tokenizer-output coverage
- real in-memory SQLite FTS5 `MATCH` execution for every special syntax class
- fallback and jieba path coverage
- a before/after recall comparison over benign English, Chinese, and embedded-operator queries

If maintainers prefer to retain #178 as the production patch, the additional recall-preserving logic and regression suite here can still be reviewed or adopted independently.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Commit includes DCO sign-off

## Verification | 验证

- `npm exec vitest run src/core/store/sqlite-fts-query.test.ts` - 22 passed
- `npm test` - 5 files / 89 tests passed
- `npm run build` - passed
- `npm pack --dry-run --ignore-scripts --json` - passed; the new test is excluded from the package
- `git diff --check` / `git show --check` - passed

## Additional Notes | 其他说明

The test suite executes generated queries against a real `node:sqlite` FTS5 table instead of asserting strings only. It covers quotes, apostrophes, parentheses, `AND`, `OR`, `NOT`, `NEAR`, prefix `*`, column `:`, caret `^`, empty input, hostile jieba output, and normal English/Chinese recall.
