### PR TITLE
fix(data): reconcile checkpoint counters after cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **Checkpoint 计数在数据清理后持续漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：启动时从健康存储或 JSONL 分片重算 L0/L1 实际记录数，memory cleaner 按成功删除量原子递减计数，并按 persona 时间水位精确维护待处理 L1 数；手工裁剪、存储降级、状态回滚及并发清理后不再保留虚高计数或覆盖新写入，增量游标保持不变。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -144,20 +144,27 @@ export class TdaiCore {
     this.logger.debug?.(`${TAG} Initializing TDAI Core: dataDir=${this.dataDir}`);
     initDataDirectories(this.dataDir);
 
-    // Initialize stores (async)
+    // Store initialization must finish before initialize() resolves. Besides
+    // making the lifecycle contract truthful, this lets callers hand the
+    // initialized store to the cleaner without a timing race.
     this.storeReady = this.initStores();
 
-    // Create pipeline manager (sync — does not need store)
+    // Create pipeline manager (sync — runner wiring waits for store init).
     if (this.cfg.extraction.enabled) {
       this.scheduler = createPipelineManager(this.cfg, this.logger, this.sessionFilter);
-      // Wire runners after store is ready (or after store init fails — runners
-      // still work in degraded mode with JSONL fallback and no embedding)
-      this.storeReady
-        .then(() => this.wirePipelineRunners())
-        .catch((err) => {
-          this.logger.error(`${TAG} Store init failed; wiring pipeline runners in degraded mode: ${err instanceof Error ? err.message : String(err)}`);
-          this.wirePipelineRunners();
-        });
+    }
+
+    await this.storeReady;
+    this.wirePipelineRunners();
+
+    try {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.recalculateFromStorage(this.vectorStore, "core-startup");
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint recalculation failed on startup (non-fatal): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.logger.debug?.(`${TAG} TDAI Core initialized`);

--- a/src/utils/checkpoint-data.ts
+++ b/src/utils/checkpoint-data.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type CheckpointDataKind = "l0" | "l1";
+
+export interface CheckpointDataLogger {
+  warn?(message: string): void;
+}
+
+export interface CheckpointDataCounts {
+  l0Records: number;
+  l1Records: number;
+  l1RecordsSincePersona: number;
+}
+
+export interface CheckpointFileCounts {
+  records: number;
+  recordsSincePersona: number;
+  malformedLines: number;
+}
+
+const SHARD_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}\.jsonl$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingPathError(err: unknown): boolean {
+  return isObject(err) && err.code === "ENOENT";
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function countL0Record(value: unknown): number | undefined {
+  if (!isObject(value)) return undefined;
+
+  // Before the flat format, one JSONL line represented a capture batch.
+  if (Array.isArray(value.messages)) {
+    return value.messages.filter(isObject).length;
+  }
+
+  if (
+    typeof value.id !== "string"
+    || typeof value.sessionKey !== "string"
+    || parseTimestamp(value.recordedAt) === undefined
+  ) {
+    return undefined;
+  }
+
+  return 1;
+}
+
+function readL1Timestamp(value: Record<string, unknown>): number | undefined {
+  return parseTimestamp(
+    value.updatedAt
+    ?? value.updated_at
+    ?? value.updated_time
+    ?? value.createdAt
+    ?? value.created_at,
+  );
+}
+
+/** Count valid persisted records in one L0 or L1 JSONL shard. */
+export async function countCheckpointJsonlFile(
+  filePath: string,
+  kind: CheckpointDataKind,
+  lastPersonaTime = "",
+): Promise<CheckpointFileCounts> {
+  const raw = await fs.readFile(filePath, "utf-8");
+  const personaTimestamp = parseTimestamp(lastPersonaTime);
+  const result: CheckpointFileCounts = {
+    records: 0,
+    recordsSincePersona: 0,
+    malformedLines: 0,
+  };
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      result.malformedLines += 1;
+      continue;
+    }
+
+    if (kind === "l0") {
+      const recordCount = countL0Record(parsed);
+      if (recordCount === undefined) {
+        result.malformedLines += 1;
+        continue;
+      }
+      result.records += recordCount;
+      continue;
+    }
+
+    if (!isObject(parsed) || typeof parsed.id !== "string" || typeof parsed.sessionKey !== "string") {
+      result.malformedLines += 1;
+      continue;
+    }
+
+    const updatedTimestamp = readL1Timestamp(parsed);
+    if (updatedTimestamp === undefined) {
+      result.malformedLines += 1;
+      continue;
+    }
+
+    result.records += 1;
+    if (personaTimestamp === undefined || updatedTimestamp > personaTimestamp) {
+      result.recordsSincePersona += 1;
+    }
+  }
+
+  return result;
+}
+
+async function countDirectory(
+  baseDir: string,
+  subdirectory: string,
+  kind: CheckpointDataKind,
+  lastPersonaTime: string,
+  logger?: CheckpointDataLogger,
+): Promise<CheckpointFileCounts> {
+  const directory = path.join(baseDir, subdirectory);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (err) {
+    if (isMissingPathError(err)) {
+      return { records: 0, recordsSincePersona: 0, malformedLines: 0 };
+    }
+    throw err;
+  }
+
+  const total: CheckpointFileCounts = {
+    records: 0,
+    recordsSincePersona: 0,
+    malformedLines: 0,
+  };
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !SHARD_FILE_PATTERN.test(entry.name)) continue;
+
+    const filePath = path.join(directory, entry.name);
+    try {
+      const counts = await countCheckpointJsonlFile(filePath, kind, lastPersonaTime);
+      total.records += counts.records;
+      total.recordsSincePersona += counts.recordsSincePersona;
+      total.malformedLines += counts.malformedLines;
+    } catch (err) {
+      logger?.warn?.(
+        `[checkpoint] Failed to count ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
+  }
+
+  return total;
+}
+
+/** Reconstruct checkpoint counter truth from local JSONL shards. */
+export async function countCheckpointJsonlData(
+  baseDir: string,
+  lastPersonaTime: string,
+  logger?: CheckpointDataLogger,
+): Promise<CheckpointDataCounts> {
+  const [l0, l1] = await Promise.all([
+    countDirectory(baseDir, "conversations", "l0", lastPersonaTime, logger),
+    countDirectory(baseDir, "records", "l1", lastPersonaTime, logger),
+  ]);
+
+  const malformedLines = l0.malformedLines + l1.malformedLines;
+  if (malformedLines > 0) {
+    logger?.warn?.(
+      `[checkpoint] Ignored ${malformedLines} malformed or incomplete JSONL record(s) during recalculation`,
+    );
+  }
+
+  return {
+    l0Records: l0.records,
+    l1Records: l1.records,
+    l1RecordsSincePersona: l1.recordsSincePersona,
+  };
+}

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CheckpointManager, type CheckpointCountStore } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeShard(
+  baseDir: string,
+  subdirectory: "conversations" | "records",
+  lines: string[],
+): Promise<string> {
+  const directory = path.join(baseDir, subdirectory);
+  await fs.mkdir(directory, { recursive: true });
+  const filePath = path.join(directory, "2026-07-15.jsonl");
+  await fs.writeFile(filePath, `${lines.join("\n")}\n`, "utf-8");
+  return filePath;
+}
+
+function l0Line(id: string, recordedAt: string): string {
+  return JSON.stringify({
+    id,
+    sessionKey: "session-a",
+    recordedAt,
+    role: "user",
+    content: "hello",
+    timestamp: Date.parse(recordedAt),
+  });
+}
+
+function l1Line(id: string, updatedAt: string): string {
+  return JSON.stringify({
+    id,
+    sessionKey: "session-a",
+    content: "memory",
+    createdAt: updatedAt,
+    updatedAt,
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager counter reconciliation", () => {
+  it("keeps both L0 counters in persisted-message units", async () => {
+    const checkpoint = new CheckpointManager(await makeTempDir());
+
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 100,
+      messageCount: 3,
+    }));
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 3,
+      l0_conversations_count: 3,
+    });
+  });
+
+  it("uses a healthy store while preserving cursors and pipeline state", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const seeded = await checkpoint.read();
+    seeded.total_processed = 99;
+    seeded.l0_conversations_count = 12;
+    seeded.total_memories_extracted = 40;
+    seeded.memories_since_last_persona = 30;
+    seeded.last_persona_time = "2026-07-15T10:00:00.000Z";
+    seeded.last_persona_at = 77;
+    seeded.runner_states["session-a"] = {
+      last_captured_timestamp: 111,
+      last_l1_cursor: 222,
+      last_scene_name: "scene-a",
+    };
+    seeded.pipeline_states["session-a"] = {
+      conversation_count: 3,
+      last_extraction_time: "2026-07-15T09:00:00.000Z",
+      last_extraction_updated_time: "2026-07-15T09:00:00.000Z",
+      last_active_time: 333,
+      l2_pending_l1_count: 1,
+      warmup_threshold: 2,
+      l2_last_extraction_time: "",
+    };
+    await checkpoint.write(seeded);
+
+    const queryL1Records = vi.fn(() => [{}, {}]);
+    const store: CheckpointCountStore = {
+      isDegraded: () => false,
+      countL0: () => 8,
+      countL1: () => 5,
+      queryL1Records,
+    };
+
+    const result = await checkpoint.recalculateFromStorage(store, "test-rollback");
+    const current = await checkpoint.read();
+
+    expect(result.source).toBe("store");
+    expect(result.after).toEqual({
+      total_processed: 8,
+      l0_conversations_count: 8,
+      total_memories_extracted: 5,
+      memories_since_last_persona: 2,
+    });
+    expect(queryL1Records).toHaveBeenCalledWith({
+      updatedAfter: "2026-07-15T10:00:00.000Z",
+    });
+    expect(current.last_persona_at).toBe(77);
+    expect(current.runner_states["session-a"].last_l1_cursor).toBe(222);
+    expect(current.pipeline_states["session-a"].conversation_count).toBe(3);
+  });
+
+  it("recounts current and legacy JSONL data after manual pruning", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const seeded = await checkpoint.read();
+    seeded.total_processed = 20;
+    seeded.l0_conversations_count = 20;
+    seeded.total_memories_extracted = 10;
+    seeded.memories_since_last_persona = 10;
+    seeded.last_persona_time = "2026-07-15T10:00:00.000Z";
+    await checkpoint.write(seeded);
+
+    const legacyL0 = JSON.stringify({
+      recordedAt: "2026-07-15T08:00:00.000Z",
+      messages: [{ id: "legacy-1" }, { id: "legacy-2" }],
+    });
+    const l0Path = await writeShard(dataDir, "conversations", [
+      legacyL0,
+      l0Line("l0-3", "2026-07-15T11:00:00.000Z"),
+      "{bad-json",
+      JSON.stringify({ id: "incomplete" }),
+    ]);
+    const l1Path = await writeShard(dataDir, "records", [
+      l1Line("l1-old", "2026-07-15T09:00:00.000Z"),
+      l1Line("l1-new-1", "2026-07-15T11:00:00.000Z"),
+      l1Line("l1-new-2", "2026-07-15T12:00:00.000Z"),
+      "{bad-json",
+    ]);
+
+    await checkpoint.recalculateFromStorage(undefined, "before-prune");
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 3,
+      l0_conversations_count: 3,
+      total_memories_extracted: 3,
+      memories_since_last_persona: 2,
+    });
+
+    await fs.writeFile(l0Path, `${l0Line("l0-3", "2026-07-15T11:00:00.000Z")}\n`, "utf-8");
+    await fs.writeFile(l1Path, `${l1Line("l1-new-2", "2026-07-15T12:00:00.000Z")}\n`, "utf-8");
+    await checkpoint.recalculateFromStorage(undefined, "after-prune");
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 1,
+      l0_conversations_count: 1,
+      total_memories_extracted: 1,
+      memories_since_last_persona: 1,
+    });
+  });
+
+  it("falls back to JSONL when a healthy store silently reports two zeroes", async () => {
+    const dataDir = await makeTempDir();
+    await writeShard(dataDir, "conversations", [
+      l0Line("l0-1", "2026-07-15T11:00:00.000Z"),
+    ]);
+    await writeShard(dataDir, "records", [
+      l1Line("l1-1", "2026-07-15T11:00:00.000Z"),
+    ]);
+
+    const checkpoint = new CheckpointManager(dataDir);
+    const result = await checkpoint.recalculateFromStorage({
+      isDegraded: () => false,
+      countL0: () => 0,
+      countL1: () => 0,
+      queryL1Records: () => [],
+    });
+
+    expect(result.source).toBe("jsonl");
+    expect(result.after.total_processed).toBe(1);
+    expect(result.after.total_memories_extracted).toBe(1);
+  });
+
+  it("applies exact cleanup deltas without losing concurrent increments", async () => {
+    const checkpoint = new CheckpointManager(await makeTempDir());
+    await checkpoint.recalculateCounts({
+      l0Records: 10,
+      l1Records: 6,
+      l1RecordsSincePersona: 4,
+    });
+
+    await Promise.all([
+      checkpoint.applyCleanupDelta({
+        l0Records: 2,
+        l1Records: 2,
+        l1RecordsSincePersona: 1,
+      }),
+      checkpoint.captureAtomically("session-a", undefined, async () => ({
+        maxTimestamp: 100,
+        messageCount: 3,
+      })),
+      checkpoint.markL1ExtractionComplete("session-a", 1),
+    ]);
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 11,
+      l0_conversations_count: 11,
+      total_memories_extracted: 5,
+      memories_since_last_persona: 4,
+    });
+  });
+
+  it("clamps cleanup and reset reconciliation counters at zero", async () => {
+    const checkpoint = new CheckpointManager(await makeTempDir());
+    await checkpoint.recalculateCounts({
+      l0Records: 2,
+      l1Records: 1,
+      l1RecordsSincePersona: 1,
+    });
+    await checkpoint.applyCleanupDelta({
+      l0Records: 99,
+      l1Records: 99,
+      l1RecordsSincePersona: 99,
+    });
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 0,
+      l0_conversations_count: 0,
+      total_memories_extracted: 0,
+      memories_since_last_persona: 0,
+    });
+  });
+
+  it("does not subtract an old cleanup snapshot after persona generation advances", async () => {
+    const checkpoint = new CheckpointManager(await makeTempDir());
+    await checkpoint.recalculateCounts({
+      l0Records: 0,
+      l1Records: 5,
+      l1RecordsSincePersona: 3,
+    });
+    const seeded = await checkpoint.read();
+    seeded.last_persona_time = "2026-07-15T10:00:00.000Z";
+    await checkpoint.write(seeded);
+
+    await checkpoint.markPersonaGenerated(0);
+    await checkpoint.applyCleanupDelta({
+      l1Records: 2,
+      l1RecordsSincePersona: 2,
+      personaTime: "2026-07-15T10:00:00.000Z",
+    });
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_memories_extracted: 3,
+      memories_since_last_persona: 0,
+    });
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -28,6 +28,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
 
+import { countCheckpointJsonlData, type CheckpointDataCounts } from "./checkpoint-data.js";
+
 // ============================
 // Types
 // ============================
@@ -82,7 +84,7 @@ export interface Checkpoint {
   // ═══ Global counters ═══
   /** Epoch ms of the newest message successfully uploaded. Messages with ts > this are new. */
   last_captured_timestamp: number;
-  /** Total messages processed across all time */
+  /** Total persisted L0 message records */
   total_processed: number;
   last_persona_at: number;
   last_persona_time: string;
@@ -100,11 +102,11 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /** Total persisted L0 message records (legacy field name retained for compatibility) */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /** Total persisted L1 memory records */
   total_memories_extracted: number;
 }
 
@@ -144,7 +146,42 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+/** Narrow store contract used when reconstructing aggregate counters. */
+export interface CheckpointCountStore {
+  isDegraded(): boolean;
+  countL0(): number | Promise<number>;
+  countL1(): number | Promise<number>;
+  queryL1Records(filter?: { updatedAfter?: string }): unknown[] | Promise<unknown[]>;
+}
+
+export interface CheckpointCounterSnapshot {
+  total_processed: number;
+  l0_conversations_count: number;
+  total_memories_extracted: number;
+  memories_since_last_persona: number;
+}
+
+export interface CheckpointRecalculationResult {
+  source: "store" | "jsonl";
+  reason: string;
+  before: CheckpointCounterSnapshot;
+  after: CheckpointCounterSnapshot;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
+
+function normalizeCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+function counterSnapshot(cp: Checkpoint): CheckpointCounterSnapshot {
+  return {
+    total_processed: cp.total_processed,
+    l0_conversations_count: cp.l0_conversations_count,
+    total_memories_extracted: cp.total_memories_extracted,
+    memories_since_last_persona: cp.memories_since_last_persona,
+  };
+}
 
 // ============================
 // Per-file async lock
@@ -332,6 +369,157 @@ export class CheckpointManager {
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
   }
 
+  /**
+   * Rebuild derived counters from the active persistence layer.
+   *
+   * A healthy store is authoritative because retrieval and database cleanup
+   * operate on its deduplicated rows. JSONL shards are used when the store is
+   * unavailable/degraded, and also guard against a fault-tolerant store count
+   * silently returning two zeroes while local data still exists.
+   */
+  async recalculateFromStorage(
+    store?: CheckpointCountStore,
+    reason = "startup",
+  ): Promise<CheckpointRecalculationResult> {
+    const current = await this.read();
+    const lastPersonaTime = Number.isFinite(Date.parse(current.last_persona_time))
+      ? current.last_persona_time
+      : "";
+    const baseDir = path.dirname(path.dirname(this.filePath));
+
+    let source: "store" | "jsonl" = "jsonl";
+    let actual: CheckpointDataCounts | undefined;
+
+    if (store && !store.isDegraded()) {
+      try {
+        const [rawL0Records, rawL1Records] = await Promise.all([
+          Promise.resolve(store.countL0()),
+          Promise.resolve(store.countL1()),
+        ]);
+        const l0Records = normalizeCount(rawL0Records);
+        const l1Records = normalizeCount(rawL1Records);
+        const l1RecordsSincePersona = lastPersonaTime
+          ? (await Promise.resolve(store.queryL1Records({ updatedAfter: lastPersonaTime }))).length
+          : l1Records;
+
+        actual = { l0Records, l1Records, l1RecordsSincePersona };
+        source = "store";
+
+        // Store methods are intentionally fault-tolerant and may turn a read
+        // failure into 0. Avoid erasing a non-empty checkpoint in that case.
+        if (l0Records === 0 && l1Records === 0) {
+          const local = await countCheckpointJsonlData(baseDir, lastPersonaTime, this.logger);
+          if (local.l0Records > 0 || local.l1Records > 0) {
+            this.logger.warn?.(
+              `[checkpoint] Store returned no rows during ${reason} while JSONL data exists; using JSONL counts`,
+            );
+            actual = local;
+            source = "jsonl";
+          }
+        }
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] Store count failed during ${reason}; falling back to JSONL: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    if (!actual) {
+      actual = await countCheckpointJsonlData(baseDir, lastPersonaTime, this.logger);
+    }
+
+    return this.recalculateCounts(actual, source, reason);
+  }
+
+  /**
+   * Atomically replace aggregate counters with already-counted persistence
+   * truth. Runner cursors, pipeline state and persona watermarks are preserved.
+   */
+  async recalculateCounts(
+    actual: CheckpointDataCounts,
+    source: "store" | "jsonl" = "store",
+    reason = "manual",
+  ): Promise<CheckpointRecalculationResult> {
+    let before!: CheckpointCounterSnapshot;
+    const cp = await this.mutate((cp) => {
+      before = counterSnapshot(cp);
+      const l0Records = normalizeCount(actual.l0Records);
+      const l1Records = normalizeCount(actual.l1Records);
+      const l1RecordsSincePersona = Math.min(
+        l1Records,
+        normalizeCount(actual.l1RecordsSincePersona),
+      );
+
+      cp.total_processed = l0Records;
+      cp.l0_conversations_count = l0Records;
+      cp.total_memories_extracted = l1Records;
+      cp.memories_since_last_persona = l1RecordsSincePersona;
+    });
+    const after = counterSnapshot(cp);
+
+    this.logger.info(
+      `[checkpoint] recalculated (${source}, ${reason}): ` +
+      `l0=${before.total_processed}->${after.total_processed}, ` +
+      `l1=${before.total_memories_extracted}->${after.total_memories_extracted}, ` +
+      `sincePersona=${before.memories_since_last_persona}->${after.memories_since_last_persona}`,
+    );
+
+    return { source, reason, before, after };
+  }
+
+  /**
+   * Apply successful cleanup as deltas under the checkpoint lock. This avoids
+   * an absolute post-clean recount overwriting captures that finish while the
+   * cleaner is running.
+   */
+  async applyCleanupDelta(removed: {
+    l0Records?: number;
+    l1Records?: number;
+    l1RecordsSincePersona?: number;
+    /** Persona watermark used when counting l1RecordsSincePersona. */
+    personaTime?: string;
+  }): Promise<void> {
+    const removedL0 = normalizeCount(removed.l0Records ?? 0);
+    const removedL1 = normalizeCount(removed.l1Records ?? 0);
+    const removedSincePersona = Math.min(
+      removedL1,
+      normalizeCount(removed.l1RecordsSincePersona ?? removedL1),
+    );
+    if (removedL0 === 0 && removedL1 === 0) return;
+
+    let appliedRemovedSincePersona = removedSincePersona;
+    const cp = await this.mutate((cp) => {
+      // Persona generation resets the pending counter. If it completed while
+      // cleanup was running, every retention-expired row predates that newer
+      // watermark and must not be subtracted from newly accumulated memories.
+      if (removed.personaTime !== undefined && cp.last_persona_time !== removed.personaTime) {
+        appliedRemovedSincePersona = 0;
+      }
+      cp.total_processed = Math.max(0, cp.total_processed - removedL0);
+      cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count - removedL0);
+      cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted - removedL1);
+      cp.memories_since_last_persona = Math.min(
+        cp.total_memories_extracted,
+        Math.max(0, cp.memories_since_last_persona - appliedRemovedSincePersona),
+      );
+    });
+
+    this.logger.info(
+      `[checkpoint] cleanup delta: removedL0=${removedL0}, removedL1=${removedL1}, ` +
+      `removedSincePersona=${appliedRemovedSincePersona}, l0=${cp.total_processed}, ` +
+      `l1=${cp.total_memories_extracted}, sincePersona=${cp.memories_since_last_persona}`,
+    );
+  }
+
+  /** Repair only the monotonic scene counter without restoring cleanable data counters. */
+  async ensureScenesProcessedAtLeast(minimum: number): Promise<void> {
+    const normalizedMinimum = normalizeCount(minimum);
+    await this.mutate((cp) => {
+      cp.scenes_processed = Math.max(cp.scenes_processed, normalizedMinimum);
+    });
+  }
+
   // ============================
   // Per-session helpers — runner state (L0/L1 owned)
   // ============================
@@ -449,8 +637,8 @@ export class CheckpointManager {
    *   - `{ maxTimestamp, messageCount }` to advance the cursor, or
    *   - `null` to leave the cursor unchanged (nothing captured).
    *
-   * L0 conversation count is also incremented inside the lock when messages
-   * are captured, removing the need for a separate `incrementL0ConversationCount()` call.
+   * The persisted L0 record count is also incremented inside the lock when
+   * messages are captured.
    *
    * @param sessionKey   Per-session identifier
    * @param pluginStartTimestamp  Cold-start floor (used when no cursor exists yet)
@@ -479,8 +667,7 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Logger } from "../core/types.js";
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { initTimeModule, _resetTimeModuleForTest } from "./time.js";
+
+const tempDirs: string[] = [];
+const logger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeShard(
+  baseDir: string,
+  subdirectory: "conversations" | "records",
+  date: string,
+  lines: string[],
+): Promise<void> {
+  const directory = path.join(baseDir, subdirectory);
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(path.join(directory, `${date}.jsonl`), `${lines.join("\n")}\n`, "utf-8");
+}
+
+function l0Line(id: string, recordedAt: string): string {
+  return JSON.stringify({ id, sessionKey: "session", recordedAt });
+}
+
+function l1Line(id: string, updatedAt: string): string {
+  return JSON.stringify({ id, sessionKey: "session", updatedAt });
+}
+
+afterEach(async () => {
+  _resetTimeModuleForTest();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalMemoryCleaner checkpoint updates", () => {
+  it("uses successful store deletion counts and only subtracts post-persona L1 rows", async () => {
+    initTimeModule({ timezone: "UTC" });
+    const baseDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.recalculateCounts({
+      l0Records: 60,
+      l1Records: 25,
+      l1RecordsSincePersona: 10,
+    });
+    const seeded = await checkpoint.read();
+    seeded.last_persona_time = "2026-07-10T00:00:00.000Z";
+    await checkpoint.write(seeded);
+
+    const queryL1Records = vi.fn(() => [
+      { updated_time: "2026-07-12T12:00:00.000Z" },
+      { updated_time: "2026-07-13T12:00:00.000Z" },
+      { updated_time: "2026-07-15T12:00:00.000Z" },
+    ]);
+    const store = {
+      isDegraded: () => false,
+      countL0: () => 60,
+      countL1: () => 25,
+      queryL1Records,
+      deleteL0Expired: () => 8,
+      deleteL1Expired: () => 3,
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+      vectorStore: store,
+    });
+    await cleaner.runOnce(Date.parse("2026-07-15T12:00:00.000Z"));
+
+    expect(queryL1Records).toHaveBeenCalledWith({
+      updatedAfter: "2026-07-10T00:00:00.000Z",
+    });
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 52,
+      l0_conversations_count: 52,
+      total_memories_extracted: 22,
+      memories_since_last_persona: 8,
+    });
+  });
+
+  it("uses deleted JSONL records and preserves pending persona count for older history", async () => {
+    initTimeModule({ timezone: "UTC" });
+    const baseDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.recalculateCounts({
+      l0Records: 3,
+      l1Records: 3,
+      l1RecordsSincePersona: 1,
+    });
+    const seeded = await checkpoint.read();
+    seeded.last_persona_time = "2026-07-13T00:00:00.000Z";
+    await checkpoint.write(seeded);
+
+    await writeShard(baseDir, "conversations", "2026-07-12", [
+      l0Line("old-l0-1", "2026-07-12T12:00:00.000Z"),
+      l0Line("old-l0-2", "2026-07-12T12:01:00.000Z"),
+      "{bad-json",
+    ]);
+    await writeShard(baseDir, "conversations", "2026-07-15", [
+      l0Line("new-l0", "2026-07-15T12:00:00.000Z"),
+    ]);
+    await writeShard(baseDir, "records", "2026-07-12", [
+      l1Line("old-l1-1", "2026-07-12T12:00:00.000Z"),
+      l1Line("old-l1-2", "2026-07-12T12:01:00.000Z"),
+      JSON.stringify({ id: "incomplete" }),
+    ]);
+    await writeShard(baseDir, "records", "2026-07-15", [
+      l1Line("new-l1", "2026-07-15T12:00:00.000Z"),
+    ]);
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+    });
+    await cleaner.runOnce(Date.parse("2026-07-15T12:00:00.000Z"));
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 1,
+      l0_conversations_count: 1,
+      total_memories_extracted: 1,
+      memories_since_last_persona: 1,
+    });
+    await expect(fs.access(path.join(baseDir, "records", "2026-07-12.jsonl"))).rejects.toThrow();
+    await expect(fs.access(path.join(baseDir, "records", "2026-07-15.jsonl"))).resolves.toBeUndefined();
+  });
+
+  it("uses JSONL deletion counts when the configured store is degraded", async () => {
+    initTimeModule({ timezone: "UTC" });
+    const baseDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.recalculateCounts({
+      l0Records: 2,
+      l1Records: 2,
+      l1RecordsSincePersona: 2,
+    });
+    await writeShard(baseDir, "conversations", "2026-07-12", [
+      l0Line("old-l0", "2026-07-12T12:00:00.000Z"),
+    ]);
+    await writeShard(baseDir, "records", "2026-07-12", [
+      l1Line("old-l1", "2026-07-12T12:00:00.000Z"),
+    ]);
+
+    const deleteL0Expired = vi.fn();
+    const store = {
+      isDegraded: () => true,
+      deleteL0Expired,
+    } as Partial<IMemoryStore> as IMemoryStore;
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+      vectorStore: store,
+    });
+    await cleaner.runOnce(Date.parse("2026-07-15T12:00:00.000Z"));
+
+    expect(deleteL0Expired).not.toHaveBeenCalled();
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 1,
+      l0_conversations_count: 1,
+      total_memories_extracted: 1,
+      memories_since_last_persona: 1,
+    });
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,8 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { countCheckpointJsonlFile, type CheckpointDataKind } from "./checkpoint-data.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -19,6 +21,8 @@ interface CleanupStats {
   changedFiles: number;
   skippedNonShardFiles: number;
   deleteFailedFiles: number;
+  removedRecords: number;
+  removedRecordsSincePersona: number;
 }
 
 const TAG = "[memory-tdai][cleaner]";
@@ -85,28 +89,53 @@ export class LocalMemoryCleaner {
       this.opts.logger?.error(`${TAG} ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
-    const targetDirs = [
-      path.join(this.opts.baseDir, L0_DIR_NAME),
-      path.join(this.opts.baseDir, L1_DIR_NAME),
-    ];
+    const checkpointManager = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+    const checkpointBefore = await checkpointManager.read();
+    const lastPersonaTime = Number.isFinite(Date.parse(checkpointBefore.last_persona_time))
+      ? checkpointBefore.last_persona_time
+      : "";
 
     const total: CleanupStats = {
       scannedFiles: 0,
       changedFiles: 0,
       skippedNonShardFiles: 0,
       deleteFailedFiles: 0,
+      removedRecords: 0,
+      removedRecordsSincePersona: 0,
     };
 
-    for (const dirPath of targetDirs) {
-      const stats = await this.cleanDirectory(dirPath, cutoffMs);
+    const localCleanup = await Promise.all([
+      this.cleanDirectory(
+        path.join(this.opts.baseDir, L0_DIR_NAME),
+        cutoffMs,
+        "l0",
+        lastPersonaTime,
+      ),
+      this.cleanDirectory(
+        path.join(this.opts.baseDir, L1_DIR_NAME),
+        cutoffMs,
+        "l1",
+        lastPersonaTime,
+      ),
+    ]);
+
+    for (const stats of localCleanup) {
       total.scannedFiles += stats.scannedFiles;
       total.changedFiles += stats.changedFiles;
       total.skippedNonShardFiles += stats.skippedNonShardFiles;
       total.deleteFailedFiles += stats.deleteFailedFiles;
+      total.removedRecords += stats.removedRecords;
+      total.removedRecordsSincePersona += stats.removedRecordsSincePersona;
     }
 
-    if (this.vectorStore) {
-      const vectorStore = this.vectorStore;
+    let removedL0FromStore = 0;
+    let removedL1FromStore = 0;
+    let removedL1SincePersonaFromStore = 0;
+    let storePendingCountKnown = false;
+    const useStoreAsSource = !!this.vectorStore && !this.vectorStore.isDegraded();
+
+    if (useStoreAsSource) {
+      const vectorStore = this.vectorStore!;
       const cutoffIso = new Date(cutoffMs).toISOString();
       const startMs = Date.now();
 
@@ -120,8 +149,6 @@ export class LocalMemoryCleaner {
         `${TAG} [Pre-delete] cutoffIso=${cutoffIso}, retentionDays=${retentionDays}, totalL0=${totalL0}, totalL1=${totalL1}`,
       );
 
-      let removedL0 = 0;
-      let removedL1 = 0;
       let skippedL0 = false;
       let skippedL1 = false;
       let failedL0DbCleanup = 0;
@@ -135,7 +162,7 @@ export class LocalMemoryCleaner {
         );
       } else {
         try {
-          removedL0 = await vectorStore.deleteL0Expired(cutoffIso);
+          removedL0FromStore = await vectorStore.deleteL0Expired(cutoffIso);
         } catch (err) {
           failedL0DbCleanup = 1;
           this.opts.logger?.warn(
@@ -151,8 +178,35 @@ export class LocalMemoryCleaner {
           `${TAG} [L1-delete] SKIPPED: totalL1=${totalL1} <= minRetain=${MIN_RETAIN_L1}`,
         );
       } else {
+        if (!lastPersonaTime) {
+          storePendingCountKnown = true;
+        } else if (cutoffIso <= lastPersonaTime) {
+          // Every expired row predates the most recent persona.
+          storePendingCountKnown = true;
+        } else {
+          try {
+            const pendingRows = await vectorStore.queryL1Records({ updatedAfter: lastPersonaTime });
+            removedL1SincePersonaFromStore = pendingRows.filter(
+              (row) => row.updated_time < cutoffIso,
+            ).length;
+            storePendingCountKnown = true;
+          } catch (err) {
+            this.opts.logger?.warn(
+              `${TAG} [L1-delete] Could not count post-persona rows before cleanup: ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+
         try {
-          removedL1 = await vectorStore.deleteL1Expired(cutoffIso);
+          removedL1FromStore = await vectorStore.deleteL1Expired(cutoffIso);
+          if (!lastPersonaTime) {
+            removedL1SincePersonaFromStore = removedL1FromStore;
+          }
+          removedL1SincePersonaFromStore = Math.min(
+            removedL1FromStore,
+            removedL1SincePersonaFromStore,
+          );
         } catch (err) {
           failedL1DbCleanup = 1;
           this.opts.logger?.warn(
@@ -161,23 +215,47 @@ export class LocalMemoryCleaner {
         }
       }
 
-      if (removedL1 > 0 || removedL0 > 0) {
+      if (removedL1FromStore > 0 || removedL0FromStore > 0) {
         total.changedFiles += 1;
       }
 
       // ── Post-delete: audit summary ──
       const durationMs = Date.now() - startMs;
-      const remainingL0 = totalL0 - removedL0;
-      const remainingL1 = totalL1 - removedL1;
+      const remainingL0 = totalL0 - removedL0FromStore;
+      const remainingL1 = totalL1 - removedL1FromStore;
       const summary = {
         event: "cleaner_summary",
         cutoffIso,
         retentionDays,
-        l0: { total: totalL0, expired: removedL0, remaining: remainingL0, skipped: skippedL0, failed: failedL0DbCleanup > 0 },
-        l1: { total: totalL1, expired: removedL1, remaining: remainingL1, skipped: skippedL1, failed: failedL1DbCleanup > 0 },
+        l0: { total: totalL0, expired: removedL0FromStore, remaining: remainingL0, skipped: skippedL0, failed: failedL0DbCleanup > 0 },
+        l1: { total: totalL1, expired: removedL1FromStore, remaining: remainingL1, skipped: skippedL1, failed: failedL1DbCleanup > 0 },
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    const removedL0 = useStoreAsSource ? removedL0FromStore : localCleanup[0].removedRecords;
+    const removedL1 = useStoreAsSource ? removedL1FromStore : localCleanup[1].removedRecords;
+    const removedL1SincePersona = useStoreAsSource
+      ? (storePendingCountKnown
+        ? removedL1SincePersonaFromStore
+        : Math.min(removedL1, checkpointBefore.memories_since_last_persona))
+      : localCleanup[1].removedRecordsSincePersona;
+
+    if (removedL0 > 0 || removedL1 > 0) {
+      try {
+        await checkpointManager.applyCleanupDelta({
+          l0Records: removedL0,
+          l1Records: removedL1,
+          l1RecordsSincePersona: removedL1SincePersona,
+          personaTime: lastPersonaTime,
+        });
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} Checkpoint cleanup update failed (non-fatal): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     this.opts.logger?.info(
@@ -225,12 +303,19 @@ export class LocalMemoryCleaner {
     }
   }
 
-  private async cleanDirectory(dirPath: string, cutoffMs: number): Promise<CleanupStats> {
+  private async cleanDirectory(
+    dirPath: string,
+    cutoffMs: number,
+    kind: CheckpointDataKind,
+    lastPersonaTime: string,
+  ): Promise<CleanupStats> {
     const stats: CleanupStats = {
       scannedFiles: 0,
       changedFiles: 0,
       skippedNonShardFiles: 0,
       deleteFailedFiles: 0,
+      removedRecords: 0,
+      removedRecordsSincePersona: 0,
     };
 
     let entries;
@@ -260,8 +345,22 @@ export class LocalMemoryCleaner {
       const dayEndMs = localDayEndMs(shard.year, shard.month, shard.day);
       if (dayEndMs < cutoffMs) {
         try {
+          let removedRecords = 0;
+          let removedRecordsSincePersona = 0;
+          try {
+            const counts = await countCheckpointJsonlFile(filePath, kind, lastPersonaTime);
+            removedRecords = counts.records;
+            removedRecordsSincePersona = counts.recordsSincePersona;
+          } catch (err) {
+            this.opts.logger?.warn(
+              `${TAG} Failed to count expired shard before deletion ${filePath}: ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
           await fs.unlink(filePath);
           stats.changedFiles += 1;
+          stats.removedRecords += removedRecords;
+          stats.removedRecordsSincePersona += removedRecordsSincePersona;
           this.opts.logger?.info(`${TAG} Removed expired file by name: ${filePath}`);
         } catch (err) {
           stats.deleteFailedFiles += 1;

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -525,30 +525,17 @@ export function createL2Runner(opts: {
     const preCheckpoint = new CheckpointManager(pluginDataDir, logger);
     const preState = await preCheckpoint.read();
     const preScenesProcessed = preState.scenes_processed;
-    const preMemoriesSince = preState.memories_since_last_persona;
-    const preTotalProcessed = preState.total_processed;
 
     const extractResult = await extractor.extract(memories);
     if (extractResult.success && extractResult.memoriesProcessed > 0) {
       const checkpoint = new CheckpointManager(pluginDataDir, logger);
       const postState = await checkpoint.read();
-      if (
-        postState.scenes_processed < preScenesProcessed ||
-        postState.total_processed < preTotalProcessed
-      ) {
+      if (postState.scenes_processed < preScenesProcessed) {
         logger.warn(
-          `${TAG} [L2] ⚠️ Checkpoint corruption detected! ` +
-          `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
-          `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
-          `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
-          `Repairing...`,
+          `${TAG} [L2] Checkpoint scenes_processed regressed: ` +
+          `${preScenesProcessed} -> ${postState.scenes_processed}; repairing`,
         );
-        await checkpoint.write({
-          ...postState,
-          scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
-          total_processed: Math.max(postState.total_processed, preTotalProcessed),
-          memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
-        });
+        await checkpoint.ensureScenesProcessedAtLeast(preScenesProcessed);
         logger.info(`${TAG} [L2] Checkpoint repaired`);
       }
 


### PR DESCRIPTION
## Description | 描述

Fix checkpoint counter drift after cleanup by treating persisted data as the source of truth and keeping runtime cleanup updates concurrency-safe.

- Recalculate L0/L1 aggregate counters after store initialization. A healthy store is authoritative; degraded/unavailable or suspicious all-zero store counts fall back to JSONL.
- Count current flat L0 shards and legacy batched L0 shards, ignore malformed/incomplete lines, and reconstruct the post-persona L1 count from timestamps.
- Apply successful cleaner deletions as locked deltas so concurrent captures/extractions are preserved. Only deleted L1 rows newer than the active persona watermark reduce `memories_since_last_persona`.
- Normalize `l0_conversations_count` to persisted-message units, matching `countL0()` and `total_processed`.
- Preserve runner/pipeline cursors during recalculation so incremental processing does not skip or replay data.
- Stop L2 checkpoint repair from restoring legitimate cleanup decreases, while retaining atomic repair for `scenes_processed`.
- Await store initialization before `TdaiCore.initialize()` resolves, ensuring both startup reconciliation and cleaner store wiring use the initialized backend.

## Related Issue | 关联 Issue

Fixes #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `npm test` — 6 files / 77 tests passed
- `npm run build` — plugin and all scripts built successfully
- `npm pack --dry-run --ignore-scripts --json` — passed, package size 730,545 bytes
- `git diff --check` — passed

Added progressive coverage for healthy/degraded storage, manual JSONL pruning, legacy shards, malformed input, checkpoint rollback/reset, automatic cleanup, post-persona accounting, and concurrent increments.