### PR TITLE
fix(recall): make memory injection cache-aware end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **稳定记忆上下文位于缓存边界之后** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：将 persona、scene navigation 与 memory tools guide 从 `appendSystemContext` 移至 `prependSystemContext`，使其位于 OpenClaw 系统提示的动态尾部和缓存边界之前；动态 L1 记忆继续保留在当前轮用户上下文，Gateway/Hermes 返回内容保持兼容。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 🐛 修复
 
-- **稳定记忆上下文位于缓存边界之后** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：将 persona、scene navigation 与 memory tools guide 从 `appendSystemContext` 移至 `prependSystemContext`，使其位于 OpenClaw 系统提示的动态尾部和缓存边界之前；动态 L1 记忆继续保留在当前轮用户上下文，Gateway/Hermes 返回内容保持兼容。
+- **记忆注入影响提示词前缀缓存** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：将 persona、scene navigation 与 memory tools guide 移至 `prependSystemContext`；新增兼容回退的 `recall.injectionMode`（动态 L1 可选择 `appendContext`）和默认安全的 `recall.showInjected=false` 历史清理；增加 DeepSeek/MiMo 统一缓存 usage 指标、多轮膨胀回归测试及完整上下文结构文档，Gateway/Hermes 返回内容保持兼容。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 placement: `prepend` preserves legacy behavior; `append` uses OpenClaw `appendContext` on v2026.4.27+ to keep the original user prompt first |
+| `recall.showInjected` | `false` | Preserve injected `<relevant-memories>` in persisted history. Keep `false` to prevent stale recall replay and multi-turn history growth |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/README_CN.md
+++ b/README_CN.md
@@ -436,6 +436,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 注入位置：`prepend` 保持兼容行为；`append` 在 OpenClaw v2026.4.27+ 中使用 `appendContext`，让原始用户输入保持在前 |
+| `recall.showInjected` | `false` | 是否将 `<relevant-memories>` 保留到持久化历史；建议保持 `false`，避免旧召回反复回放和多轮历史膨胀 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |

--- a/docs/prompt-cache-layout.md
+++ b/docs/prompt-cache-layout.md
@@ -162,6 +162,21 @@ A credentialed run of commit `8f693ce` against an OpenAI-compatible MiMo endpoin
 
 The optimized warm aggregate was 2,048 cache-hit tokens and 1,234 cache-miss tokens, or 62.40%. The provider did not expose hit/miss details for any legacy sample, so the runner correctly emitted `hitRateDelta: null`; this report does not reinterpret a missing field as a zero-token hit. The controlled run nevertheless demonstrates that the optimized layout produced a repeatable 1,024-token reusable prefix where the legacy layout produced no reportable cache reuse under the same endpoint, model, request count, and delay.
 
+### Observed DeepSeek official A/B
+
+A credentialed run of the same benchmark protocol against the official DeepSeek API on 2026-07-17T18:47:11Z used `deepseek-v4-pro`, three turns per variant, and the same three-second inter-request delay.
+
+| Layout | Sample | Prompt tokens | Cache hit | Cache miss | Hit rate |
+|---|---:|---:|---:|---:|---:|
+| Legacy | cold | 1,630 | 0 | 1,630 | 0% |
+| Legacy | warm 1 | 1,630 | 0 | 1,630 | 0% |
+| Legacy | warm 2 | 1,630 | 0 | 1,630 | 0% |
+| Optimized | cold | 1,632 | 0 | 1,632 | 0% |
+| Optimized | warm 1 | 1,632 | 0 | 1,632 | 0% |
+| Optimized | warm 2 | 1,632 | 1,408 | 224 | 86.27% |
+
+After excluding the cold requests, the legacy aggregate was 0 cache-hit and 3,260 cache-miss tokens (0%). The optimized aggregate was 1,408 cache-hit and 1,856 cache-miss tokens (43.14%), an observed improvement of 43.14 percentage points. In this run DeepSeek did not report a hit on the first warm request but reused a larger 1,408-token prefix on the second; the MiMo-compatible endpoint reported a 1,024-token hit on both warm requests. This is a controlled comparison of the observed endpoints, not a claim about provider-wide cache latency or production traffic.
+
 ## References
 
 - [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/)

--- a/docs/prompt-cache-layout.md
+++ b/docs/prompt-cache-layout.md
@@ -136,6 +136,17 @@ Variant B: recall.injectionMode="append",  recall.showInjected=false
 
 Exclude the cold first request, repeat each variant several times, aggregate `prompt_cache_usage` by provider/model, and report tool-call counts because different tool paths alter the prefix independently. Run the comparison on OpenClaw v2026.4.27 or newer so both variants are actually distinct.
 
+For a direct provider A/B without modifying an OpenClaw installation, the repository includes a controlled runner. It sends three or more requests per variant, changes the volatile host tail and recalled L1 block each turn, excludes the cold first request, and prints only usage statistics (never the API key or response text):
+
+```bash
+PROMPT_CACHE_BENCH_BASE_URL="https://api.deepseek.com/v1" \
+PROMPT_CACHE_BENCH_API_KEY="..." \
+PROMPT_CACHE_BENCH_MODEL="deepseek-chat" \
+npm run benchmark:prompt-cache
+```
+
+Use the corresponding MiMo OpenAI-compatible base URL and model for the second provider. If an endpoint does not return cache token details, the runner reports the sample as unavailable instead of deriving a hit rate from billing assumptions.
+
 ## References
 
 - [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/)

--- a/docs/prompt-cache-layout.md
+++ b/docs/prompt-cache-layout.md
@@ -1,0 +1,108 @@
+# Prompt-cache layout for memory recall
+
+This note documents the TencentDB-specific scope of [Issue #120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120).
+The issue reporter later confirmed that the observed webchat collapse was caused by an OpenClaw regression, not by this plugin. The layout below therefore addresses the remaining, independently reproducible optimization: stable memory context should be part of the reusable system-prompt prefix.
+
+## Context structure
+
+OpenClaw composes hook-provided system context in this order:
+
+```text
+prependSystemContext + baseSystemPrompt + appendSystemContext
+```
+
+`prependSystemContext` is present in the project's declared minimum supported OpenClaw release (`v2026.3.13-1`), so this placement change does not require a host-version bump.
+
+The base prompt itself contains a cache boundary followed by volatile runtime context. Before this change, stable memory context was appended after that volatile tail:
+
+```text
+System prompt (before)
+├─ OpenClaw stable system sections                 reusable
+├─ CACHE_BOUNDARY
+├─ volatile runtime/session sections               changes between turns
+└─ appendSystemContext
+   ├─ user persona                                 stable, but behind volatility
+   ├─ scene navigation                             semi-stable, but behind volatility
+   └─ memory tools guide                           static, but behind volatility
+
+User prompt
+├─ prependContext: <relevant-memories>             dynamic per query
+└─ original user text                              dynamic per turn
+
+Persisted history
+└─ original user text                              injected block is stripped
+```
+
+A prefix-matching provider stops reusing tokens at the first changed token. Stable content placed after the volatile runtime section is consequently outside the common prefix.
+
+After this change:
+
+```text
+System prompt (after)
+├─ prependSystemContext
+│  ├─ user persona                                 stable and reusable
+│  ├─ scene navigation                             semi-stable and reusable until L2 changes
+│  └─ memory tools guide                           static and reusable
+├─ OpenClaw stable system sections                 reusable
+├─ CACHE_BOUNDARY
+└─ volatile runtime/session sections               changes between turns
+
+User prompt
+├─ prependContext: <relevant-memories>             dynamic per query
+└─ original user text                              dynamic per turn
+
+Persisted history
+└─ original user text                              injected block is stripped
+```
+
+The Gateway/Hermes response still joins the stable system-context fields, so moving the OpenClaw placement does not remove persona or scene content from other hosts.
+
+## `showInjected` growth model
+
+If a dynamic recall block of `R` tokens is persisted on every turn, the final request carries approximately `R × (N - 1)` stale recall tokens after `N` turns. The aggregate replay across the session grows quadratically:
+
+```text
+aggregate replay = R × N × (N - 1) / 2
+```
+
+For the issue's reported 500–1,700 tokens per recall and a 100-turn session:
+
+| Measure | 500 tokens/turn | 1,700 tokens/turn |
+|---|---:|---:|
+| Extra recall in the final request | 49,500 | 168,300 |
+| Aggregate recall replay | 2,475,000 | 8,415,000 |
+
+Current `main` removes `<relevant-memories>` before message persistence. The canonical runtime mitigation in PR #375 retains that safe default and makes history visibility an explicit option. This change does not duplicate that injection-mode work.
+
+## Options considered
+
+1. **Move stable memory context to the cacheable prefix — implemented here.** It has no per-session state, preserves prompt content, and directly fixes a deterministic placement problem.
+2. **Append dynamic L1 recall after the user query — PR #375.** This can improve automatic prefix reuse but is host-specific and should remain an explicit compatibility mode.
+3. **Session-level recall deduplication — not selected.** It needs invalidation rules for topic changes, memory updates, restarts, and parallel turns; stale recall can cost more correctness than it saves tokens.
+4. **Hide recall behind a pointer — not selected.** This reduces tokens but changes model-visible information and recall quality.
+
+## Measurement
+
+`auto-recall.test.ts` builds two turns with:
+
+- the same persona/tools block of more than 4,000 characters;
+- different recalled L1 memories;
+- different volatile OpenClaw runtime tails.
+
+It measures the longest common system-prompt prefix before and after placement. Moving the stable block from `appendSystemContext` to `prependSystemContext` increases reusable prefix span by exactly the stable block length plus its separator, while dynamic L1 recall remains outside the system prompt.
+
+This is a deterministic prefix-reuse measurement, not a fabricated provider hit-rate claim. A controlled provider A/B should use the same model, tool schemas, session seed, and prompt sequence, then aggregate provider usage as:
+
+```text
+hit rate = cache-hit input tokens / (cache-hit input tokens + cache-miss input tokens)
+```
+
+Exclude the cold first turn, run multiple repetitions, and report tool-call counts because different tool paths change the prompt independently of memory injection.
+
+DeepSeek documents automatic prefix caching and exposes `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens`. MiMo should be evaluated from its returned usage fields rather than assuming identical persistence or accounting behavior.
+
+## References
+
+- [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache)
+- [OpenClaw system-prompt composition](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts)
+- [OpenClaw cache boundary placement](https://github.com/openclaw/openclaw/blob/main/src/agents/system-prompt.ts)

--- a/docs/prompt-cache-layout.md
+++ b/docs/prompt-cache-layout.md
@@ -147,6 +147,21 @@ npm run benchmark:prompt-cache
 
 Use the corresponding MiMo OpenAI-compatible base URL and model for the second provider. If an endpoint does not return cache token details, the runner reports the sample as unavailable instead of deriving a hit rate from billing assumptions.
 
+### Observed MiMo-compatible A/B
+
+A credentialed run of commit `8f693ce` against an OpenAI-compatible MiMo endpoint on 2026-07-17T18:40:17Z used `mimo-v2.5`, three turns per variant, and a three-second inter-request delay. The first request in each variant was treated as cold and excluded from warm aggregation.
+
+| Layout | Sample | Prompt tokens | Cache hit | Cache miss | Hit rate |
+|---|---:|---:|---:|---:|---:|
+| Legacy | cold | 1,640 | unavailable | unavailable | unavailable |
+| Legacy | warm 1 | 1,640 | unavailable | unavailable | unavailable |
+| Legacy | warm 2 | 1,640 | unavailable | unavailable | unavailable |
+| Optimized | cold | 1,641 | unavailable | unavailable | unavailable |
+| Optimized | warm 1 | 1,641 | 1,024 | 617 | 62.40% |
+| Optimized | warm 2 | 1,641 | 1,024 | 617 | 62.40% |
+
+The optimized warm aggregate was 2,048 cache-hit tokens and 1,234 cache-miss tokens, or 62.40%. The provider did not expose hit/miss details for any legacy sample, so the runner correctly emitted `hitRateDelta: null`; this report does not reinterpret a missing field as a zero-token hit. The controlled run nevertheless demonstrates that the optimized layout produced a repeatable 1,024-token reusable prefix where the legacy layout produced no reportable cache reuse under the same endpoint, model, request count, and delay.
+
 ## References
 
 - [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/)

--- a/docs/prompt-cache-layout.md
+++ b/docs/prompt-cache-layout.md
@@ -1,65 +1,77 @@
-# Prompt-cache layout for memory recall
+# Prompt-cache behavior of memory recall
 
-This note documents the TencentDB-specific scope of [Issue #120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120).
-The issue reporter later confirmed that the observed webchat collapse was caused by an OpenClaw regression, not by this plugin. The layout below therefore addresses the remaining, independently reproducible optimization: stable memory context should be part of the reusable system-prompt prefix.
+This note documents the complete TencentDB-specific scope of [Issue #120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120).
+The reporter later confirmed that the observed 29% webchat collapse came from an OpenClaw regression rather than this plugin. The changes below therefore target independently reproducible prompt-shape and history-growth problems without claiming to fix that host regression.
 
 ## Context structure
 
-OpenClaw composes hook-provided system context in this order:
+OpenClaw composes hook-provided context in this order:
 
 ```text
 prependSystemContext + baseSystemPrompt + appendSystemContext
+prependContext + currentUserPrompt + appendContext
 ```
 
-`prependSystemContext` is present in the project's declared minimum supported OpenClaw release (`v2026.3.13-1`), so this placement change does not require a host-version bump.
-
-The base prompt itself contains a cache boundary followed by volatile runtime context. Before this change, stable memory context was appended after that volatile tail:
+Before this change, stable memory context was placed after the host's volatile system-prompt tail, while dynamic recall could only be prepended to the user prompt:
 
 ```text
 System prompt (before)
-├─ OpenClaw stable system sections                 reusable
+├─ OpenClaw stable sections                         reusable
 ├─ CACHE_BOUNDARY
-├─ volatile runtime/session sections               changes between turns
+├─ volatile runtime/session sections                changes between turns
 └─ appendSystemContext
-   ├─ user persona                                 stable, but behind volatility
-   ├─ scene navigation                             semi-stable, but behind volatility
-   └─ memory tools guide                           static, but behind volatility
+   ├─ user persona                                  stable, behind volatility
+   ├─ scene navigation                              semi-stable, behind volatility
+   └─ memory tools guide                            static, behind volatility
 
-User prompt
-├─ prependContext: <relevant-memories>             dynamic per query
-└─ original user text                              dynamic per turn
+Current user prompt
+├─ prependContext: <relevant-memories>              dynamic per query
+└─ original user text                               dynamic per turn
 
 Persisted history
-└─ original user text                              injected block is stripped
+└─ behavior was implicit: injected blocks were always removed
 ```
-
-A prefix-matching provider stops reusing tokens at the first changed token. Stable content placed after the volatile runtime section is consequently outside the common prefix.
 
 After this change:
 
 ```text
-System prompt (after)
+System prompt (all modes)
 ├─ prependSystemContext
-│  ├─ user persona                                 stable and reusable
-│  ├─ scene navigation                             semi-stable and reusable until L2 changes
-│  └─ memory tools guide                           static and reusable
-├─ OpenClaw stable system sections                 reusable
+│  ├─ user persona                                  stable and reusable
+│  ├─ scene navigation                              reusable until L2 changes
+│  └─ memory tools guide                            static and reusable
+├─ OpenClaw stable sections                         reusable
 ├─ CACHE_BOUNDARY
-└─ volatile runtime/session sections               changes between turns
+└─ volatile runtime/session sections                changes between turns
 
-User prompt
-├─ prependContext: <relevant-memories>             dynamic per query
-└─ original user text                              dynamic per turn
+Current user prompt (recall.injectionMode="prepend", default)
+├─ prependContext: <relevant-memories>              dynamic per query
+└─ original user text
 
-Persisted history
-└─ original user text                              injected block is stripped
+Current user prompt (recall.injectionMode="append", opt-in)
+├─ original user text
+└─ appendContext: <relevant-memories>               dynamic per query
+
+Persisted history (recall.showInjected=false, default)
+└─ original user text                               injected block is stripped
 ```
 
-The Gateway/Hermes response still joins the stable system-context fields, so moving the OpenClaw placement does not remove persona or scene content from other hosts.
+`appendContext` became part of the OpenClaw prompt-hook contract in v2026.4.27. The plugin checks `api.runtime.version` and falls back to `prepend` when append support is old or cannot be established. Stable system-context fields are left intact by this shaping step. The Gateway/Hermes response joins both stable system-context fields, so persona and scene content remain available outside OpenClaw.
+
+## Runtime controls
+
+| Setting | Default | Effect |
+|---|---|---|
+| `recall.injectionMode="prepend"` | yes | Backward-compatible placement before the current user text |
+| `recall.injectionMode="append"` | no | Places dynamic L1 recall after the current user text on OpenClaw v2026.4.27+ |
+| `recall.showInjected=false` | yes | Removes `<relevant-memories>` before the user message is persisted |
+| `recall.showInjected=true` | no | Preserves injected markup for debugging; this intentionally increases future request size |
+
+The append mode is opt-in because changing the order of model-visible text can affect instruction interpretation. History cleanup remains the default in both modes.
 
 ## `showInjected` growth model
 
-If a dynamic recall block of `R` tokens is persisted on every turn, the final request carries approximately `R × (N - 1)` stale recall tokens after `N` turns. The aggregate replay across the session grows quadratically:
+If a dynamic recall block of `R` tokens is persisted on every turn, the final request carries approximately `R × (N - 1)` stale recall tokens after `N` turns. Aggregate replay across the session grows quadratically:
 
 ```text
 aggregate replay = R × N × (N - 1) / 2
@@ -72,37 +84,63 @@ For the issue's reported 500–1,700 tokens per recall and a 100-turn session:
 | Extra recall in the final request | 49,500 | 168,300 |
 | Aggregate recall replay | 2,475,000 | 8,415,000 |
 
-Current `main` removes `<relevant-memories>` before message persistence. The canonical runtime mitigation in PR #375 retains that safe default and makes history visibility an explicit option. This change does not duplicate that injection-mode work.
+The default `showInjected=false` makes persisted growth from recall zero. The multipart cleanup path edits only text parts and preserves images or other structured content. `showInjected=true` is retained as an explicit debugging option rather than an accidental behavior.
 
-## Options considered
+## Session-level deduplication
 
-1. **Move stable memory context to the cacheable prefix — implemented here.** It has no per-session state, preserves prompt content, and directly fixes a deterministic placement problem.
-2. **Append dynamic L1 recall after the user query — PR #375.** This can improve automatic prefix reuse but is host-specific and should remain an explicit compatibility mode.
-3. **Session-level recall deduplication — not selected.** It needs invalidation rules for topic changes, memory updates, restarts, and parallel turns; stale recall can cost more correctness than it saves tokens.
-4. **Hide recall behind a pointer — not selected.** This reduces tokens but changes model-visible information and recall quality.
+Suppressing a stable system block merely because it was returned on a previous turn is not safe: hook output is request-scoped, and omitting it removes persona/scene guidance from the next model request. Likewise, skipping a repeated L1 memory while `showInjected=false` would make that memory invisible to the current turn.
 
-## Measurement
+The safe equivalent of session deduplication is therefore:
 
-`auto-recall.test.ts` builds two turns with:
+1. keep stable content byte-identical and before volatile host content so the provider can reuse its prefix;
+2. keep dynamic L1 recall request-scoped;
+3. remove dynamic recall before persistence so it is not replayed by history;
+4. invalidate the reusable prefix naturally when persona or scene content actually changes.
 
-- the same persona/tools block of more than 4,000 characters;
-- different recalled L1 memories;
-- different volatile OpenClaw runtime tails.
+This avoids per-session invalidation state for topic changes, memory writes, restarts, and parallel turns while preserving model-visible information.
 
-It measures the longest common system-prompt prefix before and after placement. Moving the stable block from `appendSystemContext` to `prependSystemContext` increases reusable prefix span by exactly the stable block length plus its separator, while dynamic L1 recall remains outside the system prompt.
+## Provider comparison and live measurement
 
-This is a deterministic prefix-reuse measurement, not a fabricated provider hit-rate claim. A controlled provider A/B should use the same model, tool schemas, session seed, and prompt sequence, then aggregate provider usage as:
+DeepSeek enables disk context caching automatically. Its current documentation describes complete persisted prefix units and exposes `prompt_cache_hit_tokens` plus `prompt_cache_miss_tokens`. A matching earlier request can be reused, but caching remains best-effort.
+
+MiMo also bills matching request prefixes as Prompt Cache hits and distinguishes hit and miss prices. Its OpenAI-compatible API may expose cache detail differently by endpoint/model; the published chat example currently shows `prompt_tokens_details: null`. The plugin therefore does not invent MiMo hit counts when the host supplies none.
+
+On OpenClaw versions exposing `llm_output` usage, enabling `report.enabled` emits a `prompt_cache_usage` metric for each model call with:
 
 ```text
-hit rate = cache-hit input tokens / (cache-hit input tokens + cache-miss input tokens)
+provider, model
+uncachedInputTokens
+cacheReadTokens
+cacheWriteTokens
+cacheMissTokens = uncachedInputTokens + cacheWriteTokens
+promptTokens = cacheMissTokens + cacheReadTokens
+cacheHitRate = cacheReadTokens / promptTokens
 ```
 
-Exclude the cold first turn, run multiple repetitions, and report tool-call counts because different tool paths change the prompt independently of memory injection.
+OpenClaw normalizes provider-specific responses into `input`, `cacheRead`, and `cacheWrite`; the plugin emits a sample only when at least one numeric field exists. This makes DeepSeek/MiMo comparisons observable without parsing provider-specific response JSON in the memory plugin.
 
-DeepSeek documents automatic prefix caching and exposes `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens`. MiMo should be evaluated from its returned usage fields rather than assuming identical persistence or accounting behavior.
+## Verification strategy
+
+The automated tests cover three independent claims:
+
+1. **Stable prefix placement:** two turns use the same persona/tools block of more than 4,000 characters and different volatile host tails. Moving the block to `prependSystemContext` increases the deterministic common-prefix span by exactly the stable block length plus its separator.
+2. **Dynamic injection and history:** append mode moves only L1 recall, old/unknown hosts fall back to prepend, and five persisted turns with cleanup contain no injected markup.
+3. **Provider accounting:** DeepSeek and MiMo-shaped normalized usage fixtures verify hit/miss/write arithmetic and reject missing or malformed usage rather than reporting fabricated rates.
+
+Deterministic prefix length proves placement, not a production cache-hit percentage. A controlled provider A/B should use the same model, channel, tool schemas, session seed, and prompt sequence:
+
+```text
+Variant A: recall.injectionMode="prepend", recall.showInjected=false
+Variant B: recall.injectionMode="append",  recall.showInjected=false
+```
+
+Exclude the cold first request, repeat each variant several times, aggregate `prompt_cache_usage` by provider/model, and report tool-call counts because different tool paths alter the prefix independently. Run the comparison on OpenClaw v2026.4.27 or newer so both variants are actually distinct.
 
 ## References
 
-- [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache)
+- [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/)
+- [Xiaomi MiMo API pricing and prefix-cache billing](https://mimo.mi.com/docs/zh-CN/price/pay-as-you-go)
+- [Xiaomi MiMo OpenAI-compatible Chat API](https://mimo.mi.com/docs/en-US/api/chat/openai-api)
+- [OpenClaw plugin prompt and model hooks](https://docs.openclaw.ai/plugins/hooks)
 - [OpenClaw system-prompt composition](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts)
 - [OpenClaw cache boundary placement](https://github.com/openclaw/openclaw/blob/main/src/agents/system-prompt.ts)

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,10 @@ import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
+import {
+  normalizePromptCacheUsage,
+  supportsPromptCacheUsageHook,
+} from "./src/core/report/prompt-cache-usage.js";
 import { ensureL2L3Local } from "./src/core/profile/profile-sync.js";
 
 // Core abstractions (host-neutral)
@@ -44,6 +48,11 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import {
+  resolveRecallInjectionMode,
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./src/adapters/openclaw/recall-injection.js";
 
 const TAG = "[memory-tdai]";
 
@@ -179,7 +188,7 @@ export default function register(api: OpenClawPluginApi) {
     api.logger.debug?.(
       `${TAG} Config parsed: ` +
       `capture=${cfg.capture.enabled}, ` +
-      `recall=${cfg.recall.enabled}(maxResults=${cfg.recall.maxResults}), ` +
+      `recall=${cfg.recall.enabled}(maxResults=${cfg.recall.maxResults}, injectionMode=${cfg.recall.injectionMode}, showInjected=${cfg.recall.showInjected}), ` +
       `extraction=${cfg.extraction.enabled}(dedup=${cfg.extraction.enableDedup}, maxMem=${cfg.extraction.maxMemoriesPerSession}), ` +
       `pipeline=(everyN=${cfg.pipeline.everyNConversations}, warmup=${cfg.pipeline.enableWarmup}, l1Idle=${cfg.pipeline.l1IdleTimeoutSeconds}s, l2DelayAfterL1=${cfg.pipeline.l2DelayAfterL1Seconds}s, l2Min=${cfg.pipeline.l2MinIntervalSeconds}s, l2Max=${cfg.pipeline.l2MaxIntervalSeconds}s, activeWindow=${cfg.pipeline.sessionActiveWindowHours}h), ` +
       `persona(triggerEvery=${cfg.persona.triggerEveryN}, backupCount=${cfg.persona.backupCount}, sceneBackupCount=${cfg.persona.sceneBackupCount}), ` +
@@ -189,6 +198,18 @@ export default function register(api: OpenClawPluginApi) {
   } catch (err) {
     api.logger.error(`${TAG} Config parsing failed: ${err instanceof Error ? err.message : String(err)}`);
     throw err;
+  }
+
+  const recallInjection = resolveRecallInjectionMode(
+    cfg.recall.injectionMode,
+    (api.runtime as any)?.version,
+  );
+  if (recallInjection.fallbackReason) {
+    api.logger.warn(
+      `${TAG} recall.injectionMode=${cfg.recall.injectionMode} requested, but ` +
+      `host version ${JSON.stringify((api.runtime as any)?.version)} cannot be confirmed to support ` +
+      `appendContext (${recallInjection.fallbackReason}); falling back to prepend`,
+    );
   }
 
   // Initialize unified time module (must happen before any timestamp formatting)
@@ -584,19 +605,29 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.prependSystemContext || result?.appendSystemContext || result?.prependContext) {
-          const prependSystemLen = result.prependSystemContext?.length ?? 0;
-          const appendLen = result.appendSystemContext?.length ?? 0;
-          const prependLen = result.prependContext?.length ?? 0;
+        const hookResult = shapeOpenClawRecallResult(result, recallInjection.effective);
+
+        if (
+          hookResult?.prependSystemContext ||
+          hookResult?.appendSystemContext ||
+          hookResult?.prependContext ||
+          hookResult?.appendContext
+        ) {
+          const prependSystemLen = hookResult.prependSystemContext?.length ?? 0;
+          const appendSystemLen = hookResult.appendSystemContext?.length ?? 0;
+          const prependLen = hookResult.prependContext?.length ?? 0;
+          const appendLen = hookResult.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
             `prependSystemContext=${prependSystemLen} chars, ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendSystemLen} chars, ` +
+            `prependContext=${prependLen} chars, appendContext=${appendLen} chars, ` +
+            `injectionMode=${recallInjection.effective}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -614,11 +645,13 @@ export default function register(api: OpenClawPluginApi) {
     });
   }
 
-  // Strip <relevant-memories> from user messages before they are persisted to
-  // the session JSONL.  The current-turn LLM already saw the full prompt
-  // (effectivePrompt lives in memory), but we don't want recall artifacts
-  // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
+  // By default, strip <relevant-memories> before persistence. The current
+  // model call has already seen the hook mutation, while later turns should
+  // not replay stale recall unless the operator explicitly enables it.
+  api.logger.debug?.(
+    `${TAG} Registering before_message_write recall cleanup ` +
+    `(showInjected=${cfg.recall.showInjected})`,
+  );
   api.on("before_message_write", (event) => {
     const msg = event.message as { role?: string; content?: unknown };
     const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
@@ -626,31 +659,47 @@ export default function register(api: OpenClawPluginApi) {
 
     if (msg.role !== "user") return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
+    const stripped = stripInjectedRecallFromMessage(msg, cfg.recall.showInjected);
+    if (!stripped) {
+      if (cfg.recall.showInjected && typeof msg.content === "string" && msg.content.includes("<relevant-memories>")) {
+        api.logger.debug?.(`${TAG} [before_message_write] Preserving injected recall because recall.showInjected=true`);
+      }
+      return;
     }
 
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
+    api.logger.debug?.(
+      `${TAG} [before_message_write] Stripped injected recall from ${stripped.contentType}: ` +
+      `removed ${stripped.removedChars} chars`,
+    );
+    return { message: stripped.message as typeof event.message };
   });
+
+  // Provider-normalized prompt-cache accounting is exposed by newer
+  // OpenClaw hosts through llm_output. Keep this behind report.enabled and a
+  // version gate so the plugin remains loadable on its older supported line.
+  if (cfg.report.enabled) {
+    const rawHostVersion = (api.runtime as any)?.version;
+    if (supportsPromptCacheUsageHook(rawHostVersion)) {
+      const typedApi = api as unknown as { on: (
+        name: string,
+        handler: (event: Record<string, unknown>, ctx: Record<string, unknown>) => void,
+      ) => void };
+      typedApi.on("llm_output", (event, ctx) => {
+        const usage = normalizePromptCacheUsage(event);
+        if (!usage || !instanceId) return;
+        report("prompt_cache_usage", {
+          sessionKey: typeof ctx.sessionKey === "string" ? ctx.sessionKey : null,
+          runId: typeof event.runId === "string" ? event.runId : null,
+          ...usage,
+        });
+      });
+      api.logger.debug?.(`${TAG} Registered llm_output prompt-cache usage metrics`);
+    } else {
+      api.logger.debug?.(
+        `${TAG} Prompt-cache usage metrics unavailable on host version ${JSON.stringify(rawHostVersion)}`,
+      );
+    }
+  }
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule
   if (cfg.capture.enabled) {

--- a/index.ts
+++ b/index.ts
@@ -584,11 +584,13 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
+        if (result?.prependSystemContext || result?.appendSystemContext || result?.prependContext) {
+          const prependSystemLen = result.prependSystemContext?.length ?? 0;
           const appendLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
+            `prependSystemContext=${prependSystemLen} chars, ` +
             `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
           );
         } else {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,6 +74,8 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回注入位置：prepend 保持兼容行为；append 在 OpenClaw >= 2026.4.27 中将召回内容放到用户输入之后，减少对前缀的扰动" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否将 <relevant-memories> 保留到持久化历史；默认 false，避免旧召回内容在后续轮次反复回放并导致历史膨胀" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "benchmark:prompt-cache": "node scripts/benchmark-prompt-cache.mjs",
     "postinstall": "node scripts/postinstall.mjs"
   },
   "files": [
@@ -38,6 +39,7 @@
     "scripts/migrate-sqlite-to-tcvdb/dist/",
     "scripts/export-tencent-vdb/dist/",
     "scripts/read-local-memory/dist/",
+    "scripts/benchmark-prompt-cache.mjs",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",
     "scripts/setup-hermes-memory-tencentdb.bat",

--- a/scripts/benchmark-prompt-cache.mjs
+++ b/scripts/benchmark-prompt-cache.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+/**
+ * Controlled prompt-cache A/B runner for OpenAI-compatible providers.
+ *
+ * Required environment variables:
+ *   PROMPT_CACHE_BENCH_BASE_URL
+ *   PROMPT_CACHE_BENCH_API_KEY
+ *   PROMPT_CACHE_BENCH_MODEL
+ *
+ * Optional:
+ *   PROMPT_CACHE_BENCH_TURNS       default 3, minimum 3
+ *   PROMPT_CACHE_BENCH_DELAY_MS    default 3000
+ */
+
+const baseUrl = process.env.PROMPT_CACHE_BENCH_BASE_URL?.trim();
+const apiKey = process.env.PROMPT_CACHE_BENCH_API_KEY?.trim();
+const model = process.env.PROMPT_CACHE_BENCH_MODEL?.trim();
+const turns = Math.max(3, Number.parseInt(process.env.PROMPT_CACHE_BENCH_TURNS ?? "3", 10) || 3);
+const delayMs = Math.max(0, Number.parseInt(process.env.PROMPT_CACHE_BENCH_DELAY_MS ?? "3000", 10) || 0);
+
+if (!baseUrl || !apiKey || !model) {
+  console.error(
+    "Set PROMPT_CACHE_BENCH_BASE_URL, PROMPT_CACHE_BENCH_API_KEY, and " +
+    "PROMPT_CACHE_BENCH_MODEL before running this benchmark.",
+  );
+  process.exitCode = 2;
+} else {
+  await main();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeUsage(usage) {
+  if (!usage || typeof usage !== "object") return { available: false };
+
+  const promptTokens = readNumber(usage.prompt_tokens);
+  const directHit = readNumber(usage.prompt_cache_hit_tokens);
+  const detailHit = readNumber(usage.prompt_tokens_details?.cached_tokens);
+  const hitTokens = directHit ?? detailHit;
+  const directMiss = readNumber(usage.prompt_cache_miss_tokens);
+  const missTokens = directMiss ?? (
+    promptTokens !== undefined && hitTokens !== undefined
+      ? Math.max(0, promptTokens - hitTokens)
+      : undefined
+  );
+
+  if (hitTokens === undefined || missTokens === undefined) {
+    return {
+      available: false,
+      promptTokens: promptTokens ?? null,
+      reason: "provider response did not expose cache hit/miss token details",
+    };
+  }
+
+  const total = hitTokens + missTokens;
+  return {
+    available: true,
+    promptTokens: promptTokens ?? total,
+    hitTokens,
+    missTokens,
+    hitRate: total > 0 ? hitTokens / total : null,
+  };
+}
+
+function buildRequest(variant, turn, experimentId) {
+  const stableMemory = [
+    "<user-persona>",
+    "The user expects cache-stable implementation guidance. ".repeat(160),
+    "</user-persona>",
+    "<memory-tools-guide>Use memory search when deeper context is required.</memory-tools-guide>",
+  ].join("\n");
+  const hostStable = "# Host instructions\nAnswer with exactly OK.";
+  const volatileHostTail = `# Runtime\nrequest=${turn}\nchannel=benchmark`;
+  const experimentMarker = `<experiment>${experimentId}</experiment>`;
+  const dynamicRecall = [
+    "<relevant-memories>",
+    `Turn-specific recalled fact ${turn}. ` + "dynamic ".repeat(80),
+    "</relevant-memories>",
+  ].join("\n");
+  const userPrompt = "Confirm the benchmark request with exactly OK.";
+
+  const optimized = variant === "optimized";
+  return {
+    model,
+    messages: [
+      {
+        role: "system",
+        content: optimized
+          ? `${experimentMarker}\n\n${stableMemory}\n\n${hostStable}\n\n${volatileHostTail}`
+          : `${experimentMarker}\n\n${hostStable}\n\n${volatileHostTail}\n\n${stableMemory}`,
+      },
+      {
+        role: "user",
+        content: optimized
+          ? `${userPrompt}\n\n${dynamicRecall}`
+          : `${dynamicRecall}\n\n${userPrompt}`,
+      },
+    ],
+    temperature: 0,
+    max_tokens: 8,
+    stream: false,
+  };
+}
+
+async function callProvider(body) {
+  const endpoint = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const payload = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    const message = payload?.error?.message ?? payload?.message ?? `HTTP ${response.status}`;
+    throw new Error(`Provider request failed: ${message}`);
+  }
+  return normalizeUsage(payload?.usage);
+}
+
+function aggregate(samples) {
+  const measured = samples.slice(1).filter((sample) => sample.available);
+  if (measured.length === 0) {
+    return {
+      available: false,
+      reason: samples.find((sample) => sample.reason)?.reason ?? "no measurable warm requests",
+    };
+  }
+  const hitTokens = measured.reduce((sum, sample) => sum + sample.hitTokens, 0);
+  const missTokens = measured.reduce((sum, sample) => sum + sample.missTokens, 0);
+  const total = hitTokens + missTokens;
+  return {
+    available: true,
+    measuredTurns: measured.length,
+    hitTokens,
+    missTokens,
+    hitRate: total > 0 ? hitTokens / total : null,
+  };
+}
+
+async function runVariant(variant) {
+  const experimentId = `${variant}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const samples = [];
+  for (let turn = 1; turn <= turns; turn += 1) {
+    if (turn > 1 && delayMs > 0) await sleep(delayMs);
+    const usage = await callProvider(buildRequest(variant, turn, experimentId));
+    samples.push({ turn, ...usage });
+  }
+  return { variant, samples, warmAggregate: aggregate(samples) };
+}
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  const legacy = await runVariant("legacy");
+  const optimized = await runVariant("optimized");
+  const before = legacy.warmAggregate;
+  const after = optimized.warmAggregate;
+  const hitRateDelta = before.available && after.available
+    ? after.hitRate - before.hitRate
+    : null;
+
+  console.log(JSON.stringify({
+    startedAt,
+    providerEndpoint: baseUrl,
+    model,
+    turns,
+    delayMs,
+    variants: [legacy, optimized],
+    hitRateDelta,
+  }, null, 2));
+}

--- a/scripts/benchmark-prompt-cache.mjs
+++ b/scripts/benchmark-prompt-cache.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from "node:url";
+
 /**
  * Controlled prompt-cache A/B runner for OpenAI-compatible providers.
  *
@@ -19,14 +21,20 @@ const model = process.env.PROMPT_CACHE_BENCH_MODEL?.trim();
 const turns = Math.max(3, Number.parseInt(process.env.PROMPT_CACHE_BENCH_TURNS ?? "3", 10) || 3);
 const delayMs = Math.max(0, Number.parseInt(process.env.PROMPT_CACHE_BENCH_DELAY_MS ?? "3000", 10) || 0);
 
-if (!baseUrl || !apiKey || !model) {
-  console.error(
-    "Set PROMPT_CACHE_BENCH_BASE_URL, PROMPT_CACHE_BENCH_API_KEY, and " +
-    "PROMPT_CACHE_BENCH_MODEL before running this benchmark.",
-  );
-  process.exitCode = 2;
-} else {
-  await main();
+const invokedDirectly = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (invokedDirectly) {
+  if (!baseUrl || !apiKey || !model) {
+    console.error(
+      "Set PROMPT_CACHE_BENCH_BASE_URL, PROMPT_CACHE_BENCH_API_KEY, and " +
+      "PROMPT_CACHE_BENCH_MODEL before running this benchmark.",
+    );
+    process.exitCode = 2;
+  } else {
+    await main();
+  }
 }
 
 function sleep(ms) {
@@ -37,7 +45,7 @@ function readNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function normalizeUsage(usage) {
+export function normalizeUsage(usage) {
   if (!usage || typeof usage !== "object") return { available: false };
 
   const promptTokens = readNumber(usage.prompt_tokens);
@@ -69,7 +77,7 @@ function normalizeUsage(usage) {
   };
 }
 
-function buildRequest(variant, turn, experimentId) {
+export function buildRequest(variant, turn, experimentId, modelId = model) {
   const stableMemory = [
     "<user-persona>",
     "The user expects cache-stable implementation guidance. ".repeat(160),
@@ -88,7 +96,7 @@ function buildRequest(variant, turn, experimentId) {
 
   const optimized = variant === "optimized";
   return {
-    model,
+    model: modelId,
     messages: [
       {
         role: "system",
@@ -128,7 +136,7 @@ async function callProvider(body) {
   return normalizeUsage(payload?.usage);
 }
 
-function aggregate(samples) {
+export function aggregate(samples) {
   const measured = samples.slice(1).filter((sample) => sample.available);
   if (measured.length === 0) {
     return {

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveRecallInjectionMode,
+  shapeOpenClawRecallResult,
+  stripInjectedRecallFromMessage,
+} from "./recall-injection.js";
+
+describe("resolveRecallInjectionMode", () => {
+  it("keeps prepend mode independent of host capability", () => {
+    expect(resolveRecallInjectionMode("prepend", undefined)).toEqual({
+      requested: "prepend",
+      effective: "prepend",
+      hostVersion: null,
+    });
+  });
+
+  it("uses appendContext on supported hosts", () => {
+    expect(resolveRecallInjectionMode("append", "2026.4.27-beta.1")).toEqual({
+      requested: "append",
+      effective: "append",
+      hostVersion: [2026, 4, 27],
+    });
+  });
+
+  it("falls back safely for old or unknown hosts", () => {
+    expect(resolveRecallInjectionMode("append", "2026.4.26").fallbackReason)
+      .toBe("append-context-unsupported");
+    expect(resolveRecallInjectionMode("append", undefined).fallbackReason)
+      .toBe("unknown-host-version");
+  });
+});
+
+describe("shapeOpenClawRecallResult", () => {
+  const coreResult = {
+    prependSystemContext: "<user-persona>stable</user-persona>",
+    prependContext: "<relevant-memories>dynamic</relevant-memories>",
+    recallStrategy: "hybrid",
+  } as const;
+
+  it("preserves the legacy hook shape in prepend mode", () => {
+    expect(shapeOpenClawRecallResult(coreResult, "prepend")).toEqual(coreResult);
+  });
+
+  it("moves only dynamic L1 recall in append mode", () => {
+    expect(shapeOpenClawRecallResult(coreResult, "append")).toEqual({
+      prependSystemContext: "<user-persona>stable</user-persona>",
+      appendContext: "<relevant-memories>dynamic</relevant-memories>",
+      recallStrategy: "hybrid",
+    });
+  });
+});
+
+describe("stripInjectedRecallFromMessage", () => {
+  it("strips injected recall from persisted string content by default", () => {
+    const result = stripInjectedRecallFromMessage({
+      role: "user",
+      content: "<relevant-memories>stale recall</relevant-memories>\n\nCurrent question",
+    }, false);
+
+    expect(result?.message.content).toBe("Current question");
+    expect(result?.removedChars).toBeGreaterThan(0);
+  });
+
+  it("preserves injected recall only when explicitly requested", () => {
+    const message = {
+      role: "user",
+      content: "<relevant-memories>debug</relevant-memories>\nQuestion",
+    };
+
+    expect(stripInjectedRecallFromMessage(message, true)).toBeUndefined();
+  });
+
+  it("cleans text parts without changing non-text content", () => {
+    const image = { type: "image_url", image_url: { url: "https://example.com/a.png" } };
+    const result = stripInjectedRecallFromMessage({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "<relevant-memories>dynamic</relevant-memories>\nInspect this image",
+        },
+        image,
+      ],
+    }, false);
+
+    expect(result?.message.content).toEqual([
+      { type: "text", text: "Inspect this image" },
+      image,
+    ]);
+    expect(result?.contentType).toBe("parts");
+  });
+
+  it("prevents injected-history growth across multiple turns", () => {
+    const recall = `<relevant-memories>${"memory ".repeat(100)}</relevant-memories>\n`;
+    const storedWithCleanup: string[] = [];
+    const storedWithVisibility: string[] = [];
+
+    for (let turn = 1; turn <= 5; turn += 1) {
+      const content = `${recall}Question ${turn}`;
+      const cleaned = stripInjectedRecallFromMessage({ role: "user", content }, false);
+      storedWithCleanup.push(String(cleaned?.message.content));
+      storedWithVisibility.push(content);
+    }
+
+    const cleanedChars = storedWithCleanup.join("\n").length;
+    const visibleChars = storedWithVisibility.join("\n").length;
+    expect(storedWithCleanup.every((text) => !text.includes("<relevant-memories>"))).toBe(true);
+    expect(visibleChars - cleanedChars).toBeGreaterThan(recall.length * 4);
+  });
+});

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,115 @@
+import type { RecallInjectionMode } from "../../config.js";
+import type { RecallResult } from "../../core/types.js";
+import { compareVersionXYZ, parseVersionXYZ } from "../../utils/ensure-hook-policy.js";
+
+/** First stable OpenClaw release whose prompt hook accepts appendContext. */
+export const APPEND_CONTEXT_MIN_VERSION = [2026, 4, 27] as const;
+
+export interface OpenClawRecallHookResult extends RecallResult {
+  /** Dynamic recall placed after the current user prompt on compatible hosts. */
+  appendContext?: string;
+}
+
+export interface RecallInjectionDecision {
+  requested: RecallInjectionMode;
+  effective: RecallInjectionMode;
+  hostVersion: [number, number, number] | null;
+  fallbackReason?: "unknown-host-version" | "append-context-unsupported";
+}
+
+export interface StrippedRecallMessage<TMessage extends { role?: string; content?: unknown }> {
+  message: TMessage;
+  removedChars: number;
+  contentType: "string" | "parts";
+}
+
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+/**
+ * Resolve the requested injection placement without sending an unsupported
+ * hook field to older OpenClaw releases. Unknown versions use the safe legacy
+ * path because those hosts commonly predate api.runtime.version itself.
+ */
+export function resolveRecallInjectionMode(
+  requested: RecallInjectionMode,
+  rawHostVersion: unknown,
+): RecallInjectionDecision {
+  const hostVersion = parseVersionXYZ(rawHostVersion);
+  if (requested === "prepend") {
+    return { requested, effective: "prepend", hostVersion };
+  }
+  if (!hostVersion) {
+    return {
+      requested,
+      effective: "prepend",
+      hostVersion,
+      fallbackReason: "unknown-host-version",
+    };
+  }
+  if (compareVersionXYZ(hostVersion, APPEND_CONTEXT_MIN_VERSION) < 0) {
+    return {
+      requested,
+      effective: "prepend",
+      hostVersion,
+      fallbackReason: "append-context-unsupported",
+    };
+  }
+  return { requested, effective: "append", hostVersion };
+}
+
+/** Convert host-neutral recall output to OpenClaw's prompt-hook contract. */
+export function shapeOpenClawRecallResult(
+  result: RecallResult | undefined,
+  mode: RecallInjectionMode,
+): OpenClawRecallHookResult | undefined {
+  if (!result || mode === "prepend" || !result.prependContext) return result;
+
+  const { prependContext, ...stableAndMetrics } = result;
+  return {
+    ...stableAndMetrics,
+    appendContext: prependContext,
+  };
+}
+
+/**
+ * Remove model-visible recall markup before a user message is persisted.
+ * The current model call has already consumed the hook mutation; retaining the
+ * block only replays stale recall in later requests and grows history.
+ */
+export function stripInjectedRecallFromMessage<
+  TMessage extends { role?: string; content?: unknown },
+>(
+  message: TMessage,
+  showInjected: boolean,
+): StrippedRecallMessage<TMessage> | undefined {
+  if (showInjected || message.role !== "user") return undefined;
+
+  if (typeof message.content === "string") {
+    if (!message.content.includes("<relevant-memories>")) return undefined;
+    const cleaned = message.content.replace(RELEVANT_MEMORIES_RE, "").trim();
+    if (cleaned === message.content) return undefined;
+    return {
+      message: { ...message, content: cleaned },
+      removedChars: message.content.length - cleaned.length,
+      contentType: "string",
+    };
+  }
+
+  if (!Array.isArray(message.content)) return undefined;
+
+  let removedChars = 0;
+  const cleanedParts = (message.content as Array<Record<string, unknown>>).map((part) => {
+    if (part.type !== "text" || typeof part.text !== "string") return part;
+    if (!part.text.includes("<relevant-memories>")) return part;
+    const cleaned = part.text.replace(RELEVANT_MEMORIES_RE, "").trim();
+    removedChars += part.text.length - cleaned.length;
+    return { ...part, text: cleaned };
+  });
+
+  if (removedChars === 0) return undefined;
+  return {
+    message: { ...message, content: cleanedParts },
+    removedChars,
+    contentType: "parts",
+  };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall prompt-cache controls", () => {
+  it("uses backward-compatible injection and safe history defaults", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+    expect(cfg.recall.showInjected).toBe(false);
+  });
+
+  it("accepts explicit append placement and history visibility", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "append",
+        showInjected: true,
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("append");
+    expect(cfg.recall.showInjected).toBe(true);
+  });
+
+  it("falls back when an unknown injection mode is configured", () => {
+    const cfg = parseConfig({ recall: { injectionMode: "cache-magic" } });
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,14 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /**
+   * Placement of dynamic L1 recall in the OpenClaw prompt mutation.
+   * "prepend" preserves legacy behavior; "append" requires a host with
+   * appendContext support and keeps the original user prompt at the front.
+   */
+  injectionMode: RecallInjectionMode;
+  /** Preserve injected recall blocks in persisted user history (default: false). */
+  showInjected: boolean;
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -94,6 +102,8 @@ export interface RecallConfig {
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
 }
+
+export type RecallInjectionMode = "prepend" | "append";
 
 /** Embedding service configuration for vector search. */
 export interface EmbeddingConfig {
@@ -529,6 +539,8 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: validateRecallInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
+      showInjected: bool(recallGroup, "showInjected") ?? false,
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
@@ -634,6 +646,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_RECALL_INJECTION_MODES: RecallInjectionMode[] = ["prepend", "append"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +656,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateRecallInjectionMode(value: string | undefined): RecallInjectionMode | undefined {
+  if (!value) return undefined;
+  return VALID_RECALL_INJECTION_MODES.includes(value as RecallInjectionMode)
+    ? (value as RecallInjectionMode)
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import type { IMemoryStore, L1FtsResult, StoreCapabilities } from "../store/types.js";
+import { performAutoRecall } from "./auto-recall.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-prompt-cache-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function ftsResult(id: string, content: string): L1FtsResult {
+  return {
+    record_id: id,
+    content,
+    type: "instruction",
+    priority: 80,
+    scene_name: "cache test",
+    score: 0.95,
+    timestamp_str: "2026-07-01T01:00:00.000Z",
+    timestamp_start: "2026-07-01T01:00:00.000Z",
+    timestamp_end: "2026-07-01T01:00:00.000Z",
+    session_key: "session-1",
+    session_id: "session-1",
+    metadata_json: "{}",
+  };
+}
+
+function createFtsStore(results: L1FtsResult[]): IMemoryStore {
+  const capabilities: StoreCapabilities = {
+    vectorSearch: false,
+    ftsSearch: true,
+    nativeHybridSearch: false,
+    sparseVectors: false,
+  };
+
+  return {
+    init: () => ({ needsReindex: false }),
+    isDegraded: () => false,
+    getCapabilities: () => capabilities,
+    close() {},
+    isFtsAvailable: () => true,
+    searchL1Fts: () => results,
+  } as unknown as IMemoryStore;
+}
+
+function composeSystemPrompt(params: {
+  base: string;
+  prepend?: string;
+  append?: string;
+}): string {
+  return [params.prepend, params.base, params.append]
+    .filter((part): part is string => Boolean(part))
+    .join("\n\n");
+}
+
+function commonPrefixLength(left: string, right: string): number {
+  const max = Math.min(left.length, right.length);
+  let index = 0;
+  while (index < max && left[index] === right[index]) index += 1;
+  return index;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("performAutoRecall prompt-cache layout", () => {
+  it("keeps stable system context ahead of dynamic L1 recall", async () => {
+    const dataDir = await makeTempDir();
+    await fs.writeFile(
+      path.join(dataDir, "persona.md"),
+      "# Persona\n\nThe user prefers concise implementation notes.",
+      "utf-8",
+    );
+    const cfg = parseConfig({
+      recall: { strategy: "keyword", maxResults: 1, scoreThreshold: 0.1 },
+    });
+
+    const result = await performAutoRecall({
+      userText: "How should I write the implementation note?",
+      actorId: "agent",
+      sessionKey: "session-1",
+      cfg,
+      pluginDataDir: dataDir,
+      vectorStore: createFtsStore([
+        ftsResult("memory-1", "Include the verification commands."),
+      ]),
+    });
+
+    expect(result?.prependSystemContext).toContain("<user-persona>");
+    expect(result?.prependSystemContext).toContain("<memory-tools-guide>");
+    expect(result?.prependSystemContext).not.toContain("<relevant-memories>");
+    expect(result?.appendSystemContext).toBeUndefined();
+    expect(result?.prependContext).toContain("<relevant-memories>");
+    expect(result?.prependContext).toContain("verification commands");
+  });
+
+  it("moves the stable memory block into the reusable prefix across turns", async () => {
+    const dataDir = await makeTempDir();
+    const persona = `# Persona\n\n${"Stable preference and profile context. ".repeat(120)}`;
+    await fs.writeFile(path.join(dataDir, "persona.md"), persona, "utf-8");
+    const cfg = parseConfig({
+      recall: { strategy: "keyword", maxResults: 1, scoreThreshold: 0.1 },
+    });
+
+    const first = await performAutoRecall({
+      userText: "first query",
+      actorId: "agent",
+      sessionKey: "session-1",
+      cfg,
+      pluginDataDir: dataDir,
+      vectorStore: createFtsStore([ftsResult("memory-1", "First dynamic memory")]),
+    });
+    const second = await performAutoRecall({
+      userText: "second query",
+      actorId: "agent",
+      sessionKey: "session-1",
+      cfg,
+      pluginDataDir: dataDir,
+      vectorStore: createFtsStore([ftsResult("memory-2", "Second dynamic memory")]),
+    });
+
+    const stable = first?.prependSystemContext;
+    expect(stable).toBeDefined();
+    expect(second?.prependSystemContext).toBe(stable);
+    expect(second?.prependContext).not.toBe(first?.prependContext);
+
+    // OpenClaw composes system context as prepend + base + append. Its base
+    // contains a stable section, a cache boundary, then volatile runtime data.
+    const basePrefix = "# OpenClaw system\n<!-- CACHE_BOUNDARY -->\n# Runtime\nrequest=";
+    const firstBase = `${basePrefix}first`;
+    const secondBase = `${basePrefix}second`;
+
+    const legacyFirst = composeSystemPrompt({ base: firstBase, append: stable });
+    const legacySecond = composeSystemPrompt({ base: secondBase, append: stable });
+    const optimizedFirst = composeSystemPrompt({ base: firstBase, prepend: stable });
+    const optimizedSecond = composeSystemPrompt({ base: secondBase, prepend: stable });
+
+    const legacyReusableChars = commonPrefixLength(legacyFirst, legacySecond);
+    const optimizedReusableChars = commonPrefixLength(optimizedFirst, optimizedSecond);
+    const reusableGain = optimizedReusableChars - legacyReusableChars;
+
+    expect(reusableGain).toBe(stable!.length + 2);
+    expect(reusableGain).toBeGreaterThan(4_000);
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -57,7 +57,9 @@ export interface RecalledMemory {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn) */
   prependContext?: string;
-  /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
+  /** Stable recall context placed before the host's cache boundary. */
+  prependSystemContext?: string;
+  /** Optional system-prompt suffix for host-specific non-cacheable context. */
   appendSystemContext?: string;
 
   // ── Metric payload (for pendingRecallCache in index.ts) ──
@@ -185,10 +187,10 @@ async function performAutoRecallInner(params: {
 
   // Split recall context into stable and dynamic parts to optimize prompt caching.
   //
-  // appendSystemContext (system prompt end — stable, cacheable):
+  // prependSystemContext (before the host system prompt and CACHE_BOUNDARY):
   //   persona, scene navigation, memory tools guide
-  //   These change infrequently; when content is identical across turns,
-  //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
+  //   These change infrequently and form a reusable prefix for providers with
+  //   automatic prefix matching (DeepSeek/MiMo) or explicit cache boundaries.
   //
   // prependContext (user prompt prefix — dynamic, per-turn):
   //   L1 relevant memories — different every turn, moved out of system prompt
@@ -215,7 +217,7 @@ async function performAutoRecallInner(params: {
     stableParts.push(MEMORY_TOOLS_GUIDE);
   }
 
-  const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  const prependSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(
@@ -227,13 +229,13 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
-  if (!appendSystemContext && !prependContext) {
+  if (!prependSystemContext && !prependContext) {
     return undefined;
   }
 
   return {
     prependContext,
-    appendSystemContext,
+    prependSystemContext,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,
     recallStrategy: effectiveStrategy,

--- a/src/core/report/prompt-cache-benchmark.test.ts
+++ b/src/core/report/prompt-cache-benchmark.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+interface BenchmarkModule {
+  normalizeUsage: (usage: unknown) => Record<string, unknown>;
+  buildRequest: (
+    variant: "legacy" | "optimized",
+    turn: number,
+    experimentId: string,
+    model: string,
+  ) => {
+    model: string;
+    messages: Array<{ role: string; content: string }>;
+  };
+  aggregate: (samples: Array<Record<string, unknown>>) => Record<string, unknown>;
+}
+
+const benchmark = await import("../../../scripts/benchmark-prompt-cache.mjs") as BenchmarkModule;
+
+describe("prompt-cache provider benchmark", () => {
+  it("isolates stable and volatile sections in the two prompt variants", () => {
+    const legacy = benchmark.buildRequest("legacy", 1, "legacy-run", "deepseek-chat");
+    const optimized = benchmark.buildRequest("optimized", 1, "optimized-run", "deepseek-chat");
+    const legacySystem = legacy.messages[0].content;
+    const optimizedSystem = optimized.messages[0].content;
+    const legacyUser = legacy.messages[1].content;
+    const optimizedUser = optimized.messages[1].content;
+
+    expect(legacy.model).toBe("deepseek-chat");
+    expect(legacySystem.indexOf("# Runtime")).toBeLessThan(legacySystem.indexOf("<user-persona>"));
+    expect(optimizedSystem.indexOf("<user-persona>"))
+      .toBeLessThan(optimizedSystem.indexOf("# Runtime"));
+    expect(legacyUser.indexOf("<relevant-memories>"))
+      .toBeLessThan(legacyUser.indexOf("Confirm the benchmark"));
+    expect(optimizedUser.indexOf("Confirm the benchmark"))
+      .toBeLessThan(optimizedUser.indexOf("<relevant-memories>"));
+  });
+
+  it("parses both DeepSeek and OpenAI-compatible cache detail shapes", () => {
+    expect(benchmark.normalizeUsage({
+      prompt_tokens: 1000,
+      prompt_cache_hit_tokens: 800,
+      prompt_cache_miss_tokens: 200,
+    })).toMatchObject({ available: true, hitTokens: 800, missTokens: 200, hitRate: 0.8 });
+
+    expect(benchmark.normalizeUsage({
+      prompt_tokens: 1000,
+      prompt_tokens_details: { cached_tokens: 700 },
+    })).toMatchObject({ available: true, hitTokens: 700, missTokens: 300, hitRate: 0.7 });
+  });
+
+  it("excludes the cold sample when aggregating provider results", () => {
+    expect(benchmark.aggregate([
+      { turn: 1, available: true, hitTokens: 0, missTokens: 1000 },
+      { turn: 2, available: true, hitTokens: 800, missTokens: 200 },
+      { turn: 3, available: true, hitTokens: 900, missTokens: 100 },
+    ])).toEqual({
+      available: true,
+      measuredTurns: 2,
+      hitTokens: 1700,
+      missTokens: 300,
+      hitRate: 0.85,
+    });
+  });
+});

--- a/src/core/report/prompt-cache-usage.test.ts
+++ b/src/core/report/prompt-cache-usage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizePromptCacheUsage,
+  supportsPromptCacheUsageHook,
+} from "./prompt-cache-usage.js";
+
+describe("supportsPromptCacheUsageHook", () => {
+  it("gates llm_output usage telemetry by host version", () => {
+    expect(supportsPromptCacheUsageHook("2026.4.24")).toBe(true);
+    expect(supportsPromptCacheUsageHook("2026.5.28-1")).toBe(true);
+    expect(supportsPromptCacheUsageHook("2026.4.23")).toBe(false);
+    expect(supportsPromptCacheUsageHook(undefined)).toBe(false);
+  });
+});
+
+describe("normalizePromptCacheUsage", () => {
+  it("normalizes DeepSeek cache reads and misses", () => {
+    expect(normalizePromptCacheUsage({
+      provider: "deepseek",
+      model: "deepseek-chat",
+      usage: { input: 100, cacheRead: 900, cacheWrite: 0 },
+    })).toEqual({
+      provider: "deepseek",
+      model: "deepseek-chat",
+      uncachedInputTokens: 100,
+      cacheReadTokens: 900,
+      cacheWriteTokens: 0,
+      cacheMissTokens: 100,
+      promptTokens: 1000,
+      cacheHitRate: 0.9,
+    });
+  });
+
+  it("accounts for MiMo cache writes as misses", () => {
+    const result = normalizePromptCacheUsage({
+      provider: "xiaomi",
+      model: "mimo-v2.5-pro",
+      usage: { input: 200, cacheRead: 700, cacheWrite: 100 },
+    });
+
+    expect(result?.cacheMissTokens).toBe(300);
+    expect(result?.promptTokens).toBe(1000);
+    expect(result?.cacheHitRate).toBe(0.7);
+  });
+
+  it("rejects usage without numeric cache accounting", () => {
+    expect(normalizePromptCacheUsage({ usage: { input: "100" } })).toBeUndefined();
+    expect(normalizePromptCacheUsage({ usage: undefined })).toBeUndefined();
+  });
+
+  it("clamps invalid negative counts and preserves a zero-token sample", () => {
+    expect(normalizePromptCacheUsage({
+      provider: " ",
+      usage: { input: -1, cacheRead: 0, cacheWrite: 0 },
+    })).toEqual({
+      provider: "unknown",
+      model: "unknown",
+      uncachedInputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      cacheMissTokens: 0,
+      promptTokens: 0,
+      cacheHitRate: null,
+    });
+  });
+});

--- a/src/core/report/prompt-cache-usage.ts
+++ b/src/core/report/prompt-cache-usage.ts
@@ -1,0 +1,80 @@
+import { compareVersionXYZ, parseVersionXYZ } from "../../utils/ensure-hook-policy.js";
+
+/** First release in the supported line exposing llm_output cache usage. */
+export const PROMPT_CACHE_USAGE_HOOK_MIN_VERSION = [2026, 4, 24] as const;
+
+export interface NormalizedPromptCacheUsage {
+  provider: string;
+  model: string;
+  uncachedInputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  cacheMissTokens: number;
+  promptTokens: number;
+  cacheHitRate: number | null;
+}
+
+export interface PromptCacheUsageEvent {
+  provider?: unknown;
+  model?: unknown;
+  usage?: unknown;
+}
+
+export function supportsPromptCacheUsageHook(rawHostVersion: unknown): boolean {
+  const parsed = parseVersionXYZ(rawHostVersion);
+  return parsed !== null && compareVersionXYZ(parsed, PROMPT_CACHE_USAGE_HOOK_MIN_VERSION) >= 0;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function tokenCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : undefined;
+}
+
+function label(value: unknown): string {
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+/**
+ * Normalize OpenClaw's provider-independent LLM usage fields.
+ *
+ * OpenClaw exposes uncached input, cache reads, and cache writes separately.
+ * Cache writes are misses for hit-rate accounting even when a provider bills
+ * them differently.
+ */
+export function normalizePromptCacheUsage(
+  event: PromptCacheUsageEvent,
+): NormalizedPromptCacheUsage | undefined {
+  const usage = asRecord(event.usage);
+  if (!usage) return undefined;
+
+  const input = tokenCount(usage.input);
+  const cacheRead = tokenCount(usage.cacheRead);
+  const cacheWrite = tokenCount(usage.cacheWrite);
+  if (input === undefined && cacheRead === undefined && cacheWrite === undefined) {
+    return undefined;
+  }
+
+  const uncachedInputTokens = input ?? 0;
+  const cacheReadTokens = cacheRead ?? 0;
+  const cacheWriteTokens = cacheWrite ?? 0;
+  const cacheMissTokens = uncachedInputTokens + cacheWriteTokens;
+  const promptTokens = cacheMissTokens + cacheReadTokens;
+
+  return {
+    provider: label(event.provider),
+    model: label(event.model),
+    uncachedInputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    cacheMissTokens,
+    promptTokens,
+    cacheHitRate: promptTokens > 0 ? cacheReadTokens / promptTokens : null,
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -199,7 +199,9 @@ export interface CompletedTurn {
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
   prependContext?: string;
-  /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
+  /** Stable recall context placed before the host's cache boundary. */
+  prependSystemContext?: string;
+  /** Optional system-prompt suffix for host-specific non-cacheable context. */
   appendSystemContext?: string;
   /** Recalled L1 memories with scores (for metrics). */
   recalledL1Memories?: Array<{ content: string; score: number; type: string }>;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -379,11 +379,14 @@ export class TdaiGateway {
     const startMs = Date.now();
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
+    const systemContext = [result.prependSystemContext, result.appendSystemContext]
+      .filter((part): part is string => Boolean(part))
+      .join("\n\n");
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    this.logger.info(`Recall completed in ${elapsed}ms: context=${systemContext.length} chars`);
 
     const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
+      context: systemContext,
       strategy: result.recallStrategy,
       memory_count: result.recalledL1Memories?.length ?? 0,
     };


### PR DESCRIPTION
## Summary

This PR now covers the complete TencentDB-specific acceptance scope of #120:

- place stable persona, scene navigation, and memory-tools guidance in `prependSystemContext`, ahead of the volatile host tail
- add `recall.injectionMode`: backward-compatible `prepend` plus opt-in `appendContext`
- detect OpenClaw host capability and safely fall back to `prepend` before v2026.4.27 or when the version is unknown
- add explicit `recall.showInjected` control, defaulting to safe history cleanup
- preserve Gateway/Hermes stable context while changing OpenClaw placement
- emit provider-normalized `prompt_cache_usage` metrics from `llm_output` when reporting is enabled
- document context structure, quadratic history growth, provider differences, session-dedup safety, and a controlled A/B procedure

## Corrected issue scope

The reporter later established that the observed 29% webchat collapse was caused by an OpenClaw regression, not this plugin. This PR does not claim to fix that host bug. It addresses the independently reproducible plugin concerns that remain: stable-context placement, optional dynamic-context placement, persisted recall growth, and cache observability.

## Acceptance mapping

| Issue stage | Evidence in this PR |
|---|---|
| Basic: context diagram and cache impact | `docs/prompt-cache-layout.md` shows before/after system, user, and persisted-history layout |
| Advanced: analyze `showInjected` growth and optimize | derives `R × N × (N-1) / 2`; `showInjected=false` remains the default and multipart cleanup is tested |
| Deep: implement and measure | stable prefix gain is measured deterministically (>4,000 reusable chars); credentialed MiMo and official DeepSeek runs record real warm-prefix reuse, with DeepSeek improving from 0% to 43.14% in the warm aggregate |
| Extension: provider/session analysis | compares DeepSeek and MiMo reporting, emits normalized usage, and documents why request-scoped system text must not be omitted as unsafe “dedup” |

## Runtime behavior

```text
System: prependSystemContext(stable memory) + OpenClaw base + volatile tail

prepend mode (default): relevant memories + current user prompt
append mode (opt-in):   current user prompt + relevant memories

persisted history (default): original user prompt only
```

`appendContext` entered the OpenClaw prompt-hook contract in v2026.4.27. On older or unidentifiable hosts, an append request logs a warning and uses the legacy prepend path instead of silently dropping recall.

The dynamic injection controls follow the maintainer-scoped design identified in #375, integrated here with the stable-system fix, explicit host-version fallback, Gateway/Hermes compatibility, and live provider cache accounting.

## Measurement

Automated verification covers:

- identical stable persona/tools (>4,000 characters), different L1 recall, and different volatile host tails
- exact reusable common-prefix gain equal to the stable block plus separator
- five-turn persistence with zero `<relevant-memories>` growth under the default
- DeepSeek and MiMo-shaped usage accounting, including cache writes as misses
- rejection of missing/malformed usage rather than fabricated hit rates
- credential-driven direct provider A/B runner that excludes cold samples and never logs keys or response text
- benchmark-protocol tests for legacy/optimized layout isolation, DeepSeek/OpenAI-compatible usage parsing, and cold-sample exclusion

With `report.enabled=true`, supported OpenClaw hosts emit per-call metrics containing `cacheReadTokens`, `cacheMissTokens`, `promptTokens`, and `cacheHitRate`, grouped by provider/model in downstream analysis. A credentialed `mimo-v2.5` run used three turns per variant and excluded each cold first request. Both optimized warm requests reported 1,024 cache-hit and 617 cache-miss tokens (62.40%); legacy samples omitted cache detail fields, so the runner correctly kept `hitRateDelta: null` instead of inventing a zero baseline. The same 3+3 protocol on the official `deepseek-v4-pro` API measured legacy warm requests at 0 hit / 3,260 miss tokens (0%) and optimized warm requests at 1,408 hit / 1,856 miss tokens (43.14%), a +43.14 percentage-point delta. Full sanitized tables are documented, and these controlled results are not presented as production-wide rates.

## Verification

- `npm test` — 9 files, 89 tests passed
- `npm run build` — plugin and all scripts passed
- `npm pack --dry-run --ignore-scripts --json` — passed (731,036-byte package; benchmark artifact included)
- manifest JSON parse — passed
- `git diff --check` — passed

Fixes #120.