### PR TITLE
feat(adapters): add in-process Codex MCP memory adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### ✨ 新功能
 
+- **Codex MCP 适配器** ([#235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235))：新增本地 stdio MCP 服务与 `CodexHostAdapter`，向 Codex 暴露 L1/L2/L3 召回、结构化记忆搜索、L0 原始对话搜索、对话采集和会话刷新五个工具。基础 L0 读写无需 LLM Key；后台提取继续复用 Standalone OpenAI-compatible Runner。读取/写入工具带对应 MCP annotations，stdout 保持纯 JSON-RPC，使用与安全边界见 `docs/codex-adapter.md`。
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。
   - **暴露给 LLM 的时间戳**统一为带显式 offset 的 ISO 8601（如 `2026-04-07T11:04:45+08:00`），修复 #87 报告的 UTC/本地时区混用导致 LLM 误算时间差的问题。
   - **L1 / L2 prompt 顶部**自动插入时区声明，指引 LLM 按正确时区推算"昨天"、"上周"等相对时间。

--- a/README.md
+++ b/README.md
@@ -383,6 +383,21 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Codex (MCP)
+
+Codex can use TencentDB Agent Memory through the bundled local stdio MCP server. After building the
+package, register `dist/codex-mcp.mjs` in Codex and expose the five recall, search, capture, and flush
+tools:
+
+```bash
+npm install && npm run build
+codex mcp add tencentdb-memory -- node /absolute/path/to/TencentDB-Agent-Memory/dist/codex-mcp.mjs
+```
+
+Basic L0 capture and conversation search work without an LLM key. L1→L3 extraction uses the existing
+`TDAI_LLM_*` configuration. See the [Codex adapter guide](./docs/codex-adapter.md) for project-scoped
+configuration, tool approval settings, and a read/write verification flow.
+
 
 ## 🔒 Gateway Security (optional)
 
@@ -536,6 +551,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/codex-adapter.md`](./docs/codex-adapter.md) | Codex MCP setup, tools, configuration, and read/write verification |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -385,6 +385,19 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Codex（MCP）
+
+Codex 可以通过内置的本地 stdio MCP 服务使用 TencentDB Agent Memory。构建项目后，将
+`dist/codex-mcp.mjs` 注册到 Codex，即可使用召回、搜索、采集和会话刷新五个工具：
+
+```bash
+npm install && npm run build
+codex mcp add tencentdb-memory -- node /absolute/path/to/TencentDB-Agent-Memory/dist/codex-mcp.mjs
+```
+
+基础 L0 采集和原始对话搜索不需要 LLM Key；L1→L3 提取继续复用已有的 `TDAI_LLM_*`
+配置。项目级配置、写工具审批和读写验证流程见 [Codex 适配指南](./docs/codex-adapter.md)。
+
 
 ## 🔒 Gateway 安全配置（可选）
 
@@ -537,6 +550,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/codex-adapter.md`](./docs/codex-adapter.md) | Codex MCP 安装、工具、配置与读写验证 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -1,0 +1,104 @@
+# Codex MCP Adapter
+
+The Codex adapter runs TencentDB Agent Memory as a local
+[Model Context Protocol (MCP)](https://learn.chatgpt.com/docs/extend/mcp) stdio server. Codex starts the
+process, discovers its tools, and can read or write the same `TdaiCore` memory layers used by OpenClaw
+and Hermes. No HTTP Gateway is required for this in-process path.
+
+## Capabilities
+
+| MCP tool | Layer | Side effect | Purpose |
+| :--- | :--- | :--- | :--- |
+| `memory_recall` | L1/L2/L3 | Read-only | Build relevant task context from dynamic memories, scenes, and persona |
+| `memory_search` | L1 | Read-only | Search extracted structured memories |
+| `conversation_search` | L0 | Read-only | Search captured raw exchanges, including data not yet extracted to L1 |
+| `memory_capture` | L0 → pipeline | Durable write | Store one completed user/assistant exchange and notify the L1→L3 pipeline |
+| `memory_session_end` | Pipeline | State change | Flush pending L1 work for one session |
+
+The MCP server advertises matching tool annotations. With Codex
+`default_tools_approval_mode = "writes"`, read tools can run normally while durable writes request
+approval.
+
+## Build and connect
+
+Node.js `>=22.16.0` is required by this project.
+
+```bash
+npm install
+npm run build
+```
+
+Add the built stdio server to Codex. Use absolute paths for both the repository and memory directory:
+
+```bash
+codex mcp add tencentdb-memory \
+  --env TDAI_DATA_DIR=/absolute/path/to/memory-tdai \
+  --env TDAI_CODEX_WORKSPACE=/absolute/path/to/your/project \
+  -- node /absolute/path/to/TencentDB-Agent-Memory/dist/codex-mcp.mjs
+```
+
+Alternatively, add it to `~/.codex/config.toml` or a trusted project's `.codex/config.toml`:
+
+```toml
+[mcp_servers.tencentdb_memory]
+command = "node"
+args = ["/absolute/path/to/TencentDB-Agent-Memory/dist/codex-mcp.mjs"]
+cwd = "/absolute/path/to/your/project"
+default_tools_approval_mode = "writes"
+startup_timeout_sec = 20
+tool_timeout_sec = 120
+
+[mcp_servers.tencentdb_memory.env]
+TDAI_DATA_DIR = "/absolute/path/to/memory-tdai"
+TDAI_CODEX_WORKSPACE = "/absolute/path/to/your/project"
+```
+
+Restart Codex after changing MCP configuration. Run `codex mcp list` in the CLI or `/mcp` in an
+interactive session to verify that `tencentdb-memory` is connected.
+
+## Verify basic read/write
+
+No LLM API key is required for the basic L0 path:
+
+1. Ask Codex to call `memory_capture` with a short test exchange.
+2. Ask it to call `conversation_search` using a distinctive phrase from that exchange.
+3. The search result should include the captured content.
+
+For L1 extraction, L2 scenes, L3 persona, and semantic recall, configure an OpenAI-compatible model:
+
+```toml
+[mcp_servers.tencentdb_memory]
+env_vars = ["TDAI_LLM_API_KEY"]
+
+[mcp_servers.tencentdb_memory.env]
+TDAI_LLM_BASE_URL = "https://api.openai.com/v1"
+TDAI_LLM_MODEL = "gpt-4o"
+```
+
+Do not commit API keys into project-scoped configuration. Prefer `env_vars` or a user-only
+configuration file when the value already exists in the environment.
+
+## Configuration
+
+The adapter reuses `tdai-gateway.yaml` / `tdai-gateway.json` and all existing `TDAI_LLM_*`, memory,
+embedding, and Store settings from the standalone Gateway. These variables are specific to Codex:
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `TDAI_CODEX_WORKSPACE` | MCP process working directory | Workspace exposed to the standalone LLM runner's sandboxed file tools |
+| `TDAI_CODEX_SESSION_KEY` | `codex:<12-char workspace hash>` | Stable default session key when a tool call omits `session_key` |
+| `TDAI_CODEX_USER_ID` | `codex_user` | User identity recorded in the host runtime context |
+| `TDAI_DATA_DIR` | `~/.memory-tencentdb/memory-tdai` | Shared L0→L3 data directory |
+
+The workspace-derived session key stores only a SHA-256 prefix, not the absolute workspace path.
+Callers may pass `session_key` explicitly to isolate individual Codex conversations.
+
+## Lifecycle and safety
+
+Codex currently reaches this integration through MCP tool calls rather than OpenClaw-style
+`before_prompt_build` / `agent_end` hooks. The server's MCP instructions tell Codex when recall and
+capture are appropriate, but the model still decides whether to invoke them. Workflows that require a
+guaranteed write should explicitly request `memory_capture`.
+
+`memory_capture` must not be used for secrets, credentials, authentication tokens, or raw untrusted
+tool output. Operational logs are written only to stderr because stdout is reserved for MCP JSON-RPC.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-codex": "./dist/codex-mcp.mjs"
   },
   "exports": {
     ".": {
@@ -49,6 +50,7 @@
     "hermes-plugin/",
     "openclaw.plugin.json",
     "README.md",
+    "docs/codex-adapter.md",
     "CHANGELOG.md",
     "LICENSE",
     "!src/**/*.test.ts",
@@ -58,6 +60,8 @@
   "keywords": [
     "openclaw",
     "openclaw-plugin",
+    "codex",
+    "mcp",
     "memory",
     "ai-memory",
     "long-term-memory",
@@ -76,6 +80,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@node-rs/jieba": "^2.0.1",
     "@tencentdb-agent-memory/tcvdb-text": "^0.1.1",
     "ai": "^6.0.164",

--- a/src/adapters/codex/host-adapter.ts
+++ b/src/adapters/codex/host-adapter.ts
@@ -1,0 +1,68 @@
+/**
+ * CodexHostAdapter — HostAdapter for the Codex MCP integration.
+ *
+ * Codex starts the MCP server as a local stdio process. The adapter keeps the
+ * memory engine in that process and uses the standalone OpenAI-compatible LLM
+ * runner for optional L1/L2/L3 extraction.
+ */
+
+import { StandaloneLLMRunnerFactory } from "../standalone/llm-runner.js";
+import type { StandaloneLLMConfig } from "../standalone/llm-runner.js";
+import type {
+  HostAdapter,
+  RuntimeContext,
+  Logger,
+  LLMRunnerFactory,
+} from "../../core/types.js";
+
+export interface CodexHostAdapterOptions {
+  /** Base directory for TDAI memory data. */
+  dataDir: string;
+  /** Workspace represented by this MCP process. */
+  workspaceDir: string;
+  /** OpenAI-compatible LLM configuration for memory extraction. */
+  llmConfig: StandaloneLLMConfig;
+  /** Logger that must write to stderr so MCP stdout stays protocol-only. */
+  logger: Logger;
+  /** Stable user ID for this Codex installation. */
+  userId?: string;
+  /** Default session key used when a tool call omits one. */
+  sessionKey: string;
+}
+
+export class CodexHostAdapter implements HostAdapter {
+  readonly hostType = "codex" as const;
+
+  private readonly context: RuntimeContext;
+  private readonly logger: Logger;
+  private readonly runnerFactory: StandaloneLLMRunnerFactory;
+
+  constructor(opts: CodexHostAdapterOptions) {
+    this.context = {
+      userId: opts.userId ?? "codex_user",
+      sessionId: opts.sessionKey,
+      sessionKey: opts.sessionKey,
+      platform: "codex",
+      agentContext: "primary",
+      workspaceDir: opts.workspaceDir,
+      dataDir: opts.dataDir,
+    };
+    this.logger = opts.logger;
+    this.runnerFactory = new StandaloneLLMRunnerFactory({
+      config: opts.llmConfig,
+      logger: opts.logger,
+    });
+  }
+
+  getRuntimeContext(): RuntimeContext {
+    return this.context;
+  }
+
+  getLogger(): Logger {
+    return this.logger;
+  }
+
+  getLLMRunnerFactory(): LLMRunnerFactory {
+    return this.runnerFactory;
+  }
+}

--- a/src/adapters/codex/mcp-server.test.ts
+++ b/src/adapters/codex/mcp-server.test.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../../config.js";
+import { TdaiCore } from "../../core/tdai-core.js";
+import type { Logger } from "../../core/types.js";
+import { CodexHostAdapter } from "./host-adapter.js";
+import {
+  createCodexMcpServer,
+  createDefaultCodexSessionKey,
+  type CodexMemoryCore,
+} from "./mcp-server.js";
+
+interface ConnectedPair {
+  client: Client;
+  server: McpServer;
+}
+
+const openPairs: ConnectedPair[] = [];
+
+async function connect(core: CodexMemoryCore, defaultSessionKey = "codex:test"): Promise<ConnectedPair> {
+  const server = createCodexMcpServer(core, { defaultSessionKey });
+  const client = new Client({ name: "codex-adapter-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  const pair = { client, server };
+  openPairs.push(pair);
+  return pair;
+}
+
+function resultText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const first = result.content[0];
+  if (!first || first.type !== "text") throw new Error("Expected a text tool result");
+  return first.text;
+}
+
+function mockCore(): CodexMemoryCore {
+  return {
+    handleBeforeRecall: vi.fn(async () => ({
+      prependContext: "dynamic memory",
+      appendSystemContext: "stable memory",
+      recalledL1Memories: [{ content: "dynamic memory", score: 0.9, type: "fact" }],
+      recallStrategy: "keyword",
+    })),
+    handleTurnCommitted: vi.fn(async () => ({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 0,
+      filteredMessages: [],
+    })),
+    searchMemories: vi.fn(async () => ({ text: "memory result", total: 1, strategy: "keyword" })),
+    searchConversations: vi.fn(async () => ({ text: "conversation result", total: 1 })),
+    handleSessionEnd: vi.fn(async () => {}),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(openPairs.splice(0).map(async ({ client, server }) => {
+    await client.close().catch(() => {});
+    await server.close().catch(() => {});
+  }));
+});
+
+describe("Codex MCP adapter", () => {
+  it("registers read and write tools with matching annotations", async () => {
+    const { client } = await connect(mockCore());
+    const { tools } = await client.listTools();
+    const names = tools.map((tool) => tool.name).sort();
+
+    expect(names).toEqual([
+      "conversation_search",
+      "memory_capture",
+      "memory_recall",
+      "memory_search",
+      "memory_session_end",
+    ]);
+    expect(tools.find((tool) => tool.name === "memory_recall")?.annotations?.readOnlyHint).toBe(true);
+    expect(tools.find((tool) => tool.name === "memory_capture")?.annotations?.readOnlyHint).toBe(false);
+    expect(tools.find((tool) => tool.name === "memory_capture")?.annotations?.idempotentHint).toBe(false);
+  });
+
+  it("maps Codex capture input to a completed turn with the default session", async () => {
+    const core = mockCore();
+    const { client } = await connect(core, "codex:workspace");
+    const result = await client.callTool({
+      name: "memory_capture",
+      arguments: {
+        user_content: "Remember the selected database.",
+        assistant_content: "The project uses SQLite for local storage.",
+      },
+    });
+
+    expect(core.handleTurnCommitted).toHaveBeenCalledWith(expect.objectContaining({
+      userText: "Remember the selected database.",
+      assistantText: "The project uses SQLite for local storage.",
+      sessionKey: "codex:workspace",
+    }));
+    expect(JSON.parse(resultText(result))).toMatchObject({
+      session_key: "codex:workspace",
+      l0_recorded: 2,
+      scheduler_notified: true,
+    });
+  });
+
+  it("returns both dynamic and stable recall context", async () => {
+    const core = mockCore();
+    const { client } = await connect(core);
+    const result = await client.callTool({
+      name: "memory_recall",
+      arguments: { query: "Which database did we select?", session_key: "codex:explicit" },
+    });
+    const payload = JSON.parse(resultText(result));
+
+    expect(core.handleBeforeRecall).toHaveBeenCalledWith("Which database did we select?", "codex:explicit");
+    expect(payload.context).toBe("dynamic memory\n\nstable memory");
+    expect(payload.memory_count).toBe(1);
+  });
+
+  it("returns MCP tool errors without terminating the server", async () => {
+    const core = mockCore();
+    vi.mocked(core.searchMemories).mockRejectedValueOnce(new Error("store unavailable"));
+    const { client } = await connect(core);
+    const result = await client.callTool({
+      name: "memory_search",
+      arguments: { query: "anything" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain("store unavailable");
+  });
+
+  it("derives a stable session key without exposing the workspace path", () => {
+    const workspace = path.join("private", "customer", "project");
+    const first = createDefaultCodexSessionKey(workspace);
+    const second = createDefaultCodexSessionKey(workspace);
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^codex:[0-9a-f]{12}$/);
+    expect(first).not.toContain("customer");
+  });
+});
+
+describe("Codex MCP memory read/write", () => {
+  it("captures an L0 exchange and finds it through conversation search", async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-codex-mcp-"));
+    const logger: Logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+    const adapter = new CodexHostAdapter({
+      dataDir,
+      workspaceDir: dataDir,
+      llmConfig: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "",
+        model: "gpt-4o",
+      },
+      logger,
+      sessionKey: "codex:e2e",
+    });
+    const config = parseConfig({
+      extraction: { enabled: false },
+      embedding: { enabled: false, provider: "none" },
+      recall: { strategy: "keyword" },
+    });
+    const core = new TdaiCore({ hostAdapter: adapter, config });
+
+    try {
+      await core.initialize();
+      const { client } = await connect(core, "codex:e2e");
+      const capture = await client.callTool({
+        name: "memory_capture",
+        arguments: {
+          user_content: "Use the aurora-codex marker for this integration test.",
+          assistant_content: "Stored the aurora-codex marker in durable memory.",
+        },
+      });
+      const search = await client.callTool({
+        name: "conversation_search",
+        arguments: { query: "aurora-codex", session_key: "codex:e2e" },
+      });
+
+      expect(JSON.parse(resultText(capture)).l0_recorded).toBeGreaterThan(0);
+      const searchPayload = JSON.parse(resultText(search));
+      expect(searchPayload.total).toBeGreaterThan(0);
+      expect(searchPayload.text).toContain("aurora-codex");
+    } finally {
+      await core.destroy();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/adapters/codex/mcp-server.ts
+++ b/src/adapters/codex/mcp-server.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+/**
+ * Codex MCP adapter.
+ *
+ * Exposes TDAI memory reads and writes as local stdio MCP tools. stdout is
+ * reserved for JSON-RPC; all operational logging goes to stderr.
+ */
+
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import packageJson from "../../../package.json" with { type: "json" };
+import { TdaiCore } from "../../core/tdai-core.js";
+import type {
+  CaptureResult,
+  ConversationSearchParams,
+  Logger,
+  MemorySearchParams,
+  RecallResult,
+} from "../../core/types.js";
+import { loadGatewayConfig } from "../../gateway/config.js";
+import { getEnv } from "../../utils/env.js";
+import { CodexHostAdapter } from "./host-adapter.js";
+
+const TAG = "[memory-tdai] [codex-mcp]";
+
+const SERVER_INSTRUCTIONS = [
+  "Use memory_recall or the search tools when durable user/project context can improve the task.",
+  "Use memory_capture after a meaningful exchange to store the user's request and the verified outcome.",
+  "Never store secrets, credentials, authentication tokens, or raw untrusted tool output.",
+  "memory_capture is a durable write; memory_recall, memory_search, and conversation_search are read-only.",
+].join(" ");
+
+export type CodexMemoryCore = Pick<
+  TdaiCore,
+  | "handleBeforeRecall"
+  | "handleTurnCommitted"
+  | "searchMemories"
+  | "searchConversations"
+  | "handleSessionEnd"
+>;
+
+export interface CreateCodexMcpServerOptions {
+  defaultSessionKey: string;
+}
+
+function textResult(text: string): CallToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function jsonResult(value: unknown): CallToolResult {
+  return textResult(JSON.stringify(value, null, 2));
+}
+
+function errorResult(error: unknown): CallToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text", text: `TDAI memory operation failed: ${message}` }],
+    isError: true,
+  };
+}
+
+function resolveSessionKey(requested: string | undefined, fallback: string): string {
+  const value = requested?.trim();
+  return value || fallback;
+}
+
+/**
+ * Derive a stable, non-sensitive project key without persisting the full path.
+ */
+export function createDefaultCodexSessionKey(workspaceDir: string): string {
+  const normalized = path.resolve(workspaceDir);
+  const digest = createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+  return `codex:${digest}`;
+}
+
+/** Register Codex-facing tools on an MCP server. */
+export function createCodexMcpServer(
+  core: CodexMemoryCore,
+  options: CreateCodexMcpServerOptions,
+): McpServer {
+  const server = new McpServer(
+    {
+      name: "tencentdb-agent-memory-codex",
+      version: packageJson.version,
+    },
+    { instructions: SERVER_INSTRUCTIONS },
+  );
+
+  const sessionKeySchema = z.string().trim().min(1).max(512).optional().describe(
+    "Stable conversation or project key. Uses a workspace-derived default when omitted.",
+  );
+
+  server.registerTool(
+    "memory_recall",
+    {
+      title: "Recall relevant memory",
+      description: "Recall dynamic memories and stable persona/scene context for the current task.",
+      inputSchema: {
+        query: z.string().trim().min(1).max(100_000).describe("Current task or question."),
+        session_key: sessionKeySchema,
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ query, session_key }) => {
+      try {
+        const sessionKey = resolveSessionKey(session_key, options.defaultSessionKey);
+        const result: RecallResult = await core.handleBeforeRecall(query, sessionKey);
+        const context = [result.prependContext, result.appendSystemContext]
+          .filter((part): part is string => Boolean(part?.trim()))
+          .join("\n\n");
+        return jsonResult({
+          session_key: sessionKey,
+          context,
+          strategy: result.recallStrategy ?? "none",
+          memory_count: result.recalledL1Memories?.length ?? 0,
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "memory_search",
+    {
+      title: "Search structured memory",
+      description: "Search L1 structured memories using the configured keyword/vector strategy.",
+      inputSchema: {
+        query: z.string().trim().min(1).max(100_000),
+        limit: z.number().int().min(1).max(50).optional(),
+        type: z.string().trim().min(1).max(128).optional(),
+        scene: z.string().trim().min(1).max(256).optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => {
+      try {
+        const params: MemorySearchParams = args;
+        const result = await core.searchMemories(params);
+        return jsonResult(result);
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "conversation_search",
+    {
+      title: "Search raw conversation memory",
+      description: "Search L0 captured conversations, including data written before L1 extraction runs.",
+      inputSchema: {
+        query: z.string().trim().min(1).max(100_000),
+        limit: z.number().int().min(1).max(50).optional(),
+        session_key: sessionKeySchema,
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ query, limit, session_key }) => {
+      try {
+        const params: ConversationSearchParams = {
+          query,
+          limit,
+          sessionKey: resolveSessionKey(session_key, options.defaultSessionKey),
+        };
+        const result = await core.searchConversations(params);
+        return jsonResult(result);
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "memory_capture",
+    {
+      title: "Capture a completed exchange",
+      description: "Durably write one completed Codex exchange to L0 memory and notify the extraction pipeline.",
+      inputSchema: {
+        user_content: z.string().trim().min(1).max(200_000).describe("The user's request or decision."),
+        assistant_content: z.string().trim().min(1).max(200_000).describe(
+          "The verified answer, implementation outcome, or decision to remember.",
+        ),
+        session_key: sessionKeySchema,
+        session_id: z.string().trim().min(1).max(512).optional(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ user_content, assistant_content, session_key, session_id }) => {
+      try {
+        const sessionKey = resolveSessionKey(session_key, options.defaultSessionKey);
+        const result: CaptureResult = await core.handleTurnCommitted({
+          userText: user_content,
+          assistantText: assistant_content,
+          messages: [
+            { role: "user", content: user_content },
+            { role: "assistant", content: assistant_content },
+          ],
+          sessionKey,
+          sessionId: session_id,
+          startedAt: Date.now(),
+        });
+        return jsonResult({
+          session_key: sessionKey,
+          l0_recorded: result.l0RecordedCount,
+          scheduler_notified: result.schedulerNotified,
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "memory_session_end",
+    {
+      title: "Flush session memory",
+      description: "Flush pending L1 extraction work for one session before ending it.",
+      inputSchema: { session_key: sessionKeySchema },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ session_key }) => {
+      try {
+        const sessionKey = resolveSessionKey(session_key, options.defaultSessionKey);
+        await core.handleSessionEnd(sessionKey);
+        return jsonResult({ session_key: sessionKey, flushed: true });
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  return server;
+}
+
+export function createStderrLogger(): Logger {
+  const write = (level: string, message: string) => {
+    process.stderr.write(`${TAG} [${level}] ${message}\n`);
+  };
+  return {
+    debug: (message) => write("debug", message),
+    info: (message) => write("info", message),
+    warn: (message) => write("warn", message),
+    error: (message) => write("error", message),
+  };
+}
+
+/** Start the production stdio server. */
+export async function runCodexMcpServer(): Promise<void> {
+  const config = loadGatewayConfig();
+  const logger = createStderrLogger();
+  const workspaceDir = path.resolve(getEnv("TDAI_CODEX_WORKSPACE") ?? process.cwd());
+  const defaultSessionKey = getEnv("TDAI_CODEX_SESSION_KEY")?.trim()
+    || createDefaultCodexSessionKey(workspaceDir);
+
+  const hostAdapter = new CodexHostAdapter({
+    dataDir: config.data.baseDir,
+    workspaceDir,
+    llmConfig: config.llm,
+    logger,
+    userId: getEnv("TDAI_CODEX_USER_ID")?.trim() || undefined,
+    sessionKey: defaultSessionKey,
+  });
+  const core = new TdaiCore({ hostAdapter, config: config.memory });
+  const server = createCodexMcpServer(core, { defaultSessionKey });
+  const transport = new StdioServerTransport();
+  let closing: Promise<void> | undefined;
+
+  const shutdown = (): Promise<void> => {
+    closing ??= (async () => {
+      await server.close().catch(() => {});
+      await core.destroy().catch((error) => {
+        logger.error(`Core shutdown failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+    })();
+    return closing;
+  };
+
+  process.once("SIGINT", () => void shutdown().finally(() => process.exit(0)));
+  process.once("SIGTERM", () => void shutdown().finally(() => process.exit(0)));
+  process.stdin.once("end", () => void shutdown());
+
+  await core.initialize();
+  await server.connect(transport);
+  logger.info(`Codex MCP server ready: dataDir=${config.data.baseDir}, session=${defaultSessionKey}`);
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (entryPath && entryPath === fileURLToPath(import.meta.url)) {
+  runCodexMcpServer().catch((error) => {
+    process.stderr.write(`${TAG} fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -145,6 +145,7 @@ export interface LLMRunnerFactory {
  * Each host environment provides exactly one HostAdapter implementation:
  * - OpenClaw:    `OpenClawHostAdapter` — wraps `OpenClawPluginApi`
  * - Hermes/GW:   `StandaloneHostAdapter` — wraps Gateway HTTP request context
+ * - Codex:       `CodexHostAdapter` — exposes the core through a local MCP server
  *
  * HostAdapter answers these questions for TDAI Core:
  * - "Who is the current user/session?" → `getRuntimeContext()`
@@ -153,7 +154,7 @@ export interface LLMRunnerFactory {
  */
 export interface HostAdapter {
   /** Identifies the host type for conditional behavior (should be rare). */
-  readonly hostType: "openclaw" | "hermes" | "standalone";
+  readonly hostType: "openclaw" | "hermes" | "standalone" | "codex";
 
   /** Get the unified runtime context for the current session. */
   getRuntimeContext(): RuntimeContext;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,10 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: {
+    index: "./index.ts",
+    "codex-mcp": "./src/adapters/codex/mcp-server.ts",
+  },
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
## Scope

This PR implements the **advanced stage** of #235 for Codex: a platform adapter with working memory reads and writes.

- adds `CodexHostAdapter` as a host-neutral `TdaiCore` boundary;
- adds an official-SDK STDIO MCP server and executable `memory-tencentdb-codex`;
- exposes `memory_recall`, `memory_search`, `conversation_search`, `memory_capture`, and `memory_session_end`;
- marks read and write tools with matching MCP annotations and supplies server instructions;
- documents Codex CLI/App/IDE configuration, approval policy, identity defaults, and verification;
- adds focused tool-mapping tests and a real L0 capture/search integration test.

## Adapter lane and relation to parallel work

This is a **Codex in-process HostAdapter** lane. The MCP process constructs `CodexHostAdapter + TdaiCore` directly, so basic memory works without an HTTP Gateway sidecar.

It does not introduce another Gateway HTTP client and does not duplicate the shared Gateway-client lane in #316. It is also architecturally distinct from the Gateway-backed MCP bridge in #372: that PR keeps MCP as a transport proxy to a separately managed Gateway, while this PR exercises the issue's direct `HostAdapter` boundary for a Codex-owned local process. The executable and docs are Codex-specific (`memory-tencentdb-codex`).

This follows the source/architecture baseline in #515 but is independently based on current `main` so either review can proceed without a stacked merge dependency.

## Basic read/write behavior

The zero-key path is intentionally testable:

1. `memory_capture` writes the completed exchange to L0 and notifies the pipeline.
2. `conversation_search` immediately reads the captured L0 exchange.
3. Optional L1/L2/L3 extraction reuses the standalone OpenAI-compatible runner and existing `TDAI_LLM_*` settings.

A workspace-derived default session key stores only a 12-character SHA-256 prefix, not the absolute workspace path. Callers can override it per tool or with `TDAI_CODEX_SESSION_KEY`.

## Verification

- `npm test` — 5 files / 73 tests passed
- `npm run build` — passed; generated executable `dist/codex-mcp.mjs`
- independent STDIO MCP client — initialized and discovered all 5 tools
- built-binary STDIO read/write — `l0Recorded: 2`, `searchTotal: 2`
- `npm pack --dry-run --json --ignore-scripts` — binary, source, and guide included
- all relative Markdown links resolve
- `git diff --check` — passed

Contributes to #235 (advanced stage; does not close the full progressive issue).