### PR TITLE
fix(queue): recover from synchronous task throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **SerialQueue 同步异常导致队列永久死锁** ([#518](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/518))：将任务调用纳入 Promise 链，确保任务在返回 Promise 前同步抛错时仍会执行队列清理、继续处理后续任务，并正确触发 `onIdle()`。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/utils/serial-queue.test.ts
+++ b/src/utils/serial-queue.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { SerialQueue } from "./serial-queue.js";
+
+describe("SerialQueue", () => {
+  it("continues processing and reaches idle after a task throws synchronously", async () => {
+    const queue = new SerialQueue("sync-throw");
+    const executionOrder: string[] = [];
+
+    await expect(
+      queue.add(() => {
+        executionOrder.push("first");
+        throw new Error("sync failure");
+      }),
+    ).rejects.toThrow("sync failure");
+
+    const nextTask = queue.add(async () => {
+      executionOrder.push("second");
+      return "completed";
+    });
+    const idle = queue.onIdle();
+
+    await expect(nextTask).resolves.toBe("completed");
+    await expect(idle).resolves.toBeUndefined();
+    expect(executionOrder).toEqual(["first", "second"]);
+    expect(queue.size).toBe(0);
+    expect(queue.pending).toBe(false);
+    expect(queue.idle).toBe(true);
+  });
+});

--- a/src/utils/serial-queue.ts
+++ b/src/utils/serial-queue.ts
@@ -105,8 +105,8 @@ export class SerialQueue {
 
     this.debugFn?.(`[queue:${this.name}] dequeued, starting execution (remaining=${this.queue.length})`);
 
-    entry
-      .task()
+    Promise.resolve()
+      .then(() => entry.task())
       .then((result) => entry.resolve(result))
       .catch((err) => entry.reject(err))
       .finally(() => {


### PR DESCRIPTION
﻿## Description | ??

`SerialQueue.drain()` previously invoked `entry.task()` before attaching the promise cleanup chain. A synchronous exception therefore escaped without running `.finally()`, leaving `running = true` forever. Later tasks stopped executing and `onIdle()` never resolved.

This PR starts each task from a resolved promise so both synchronous throws and asynchronous rejections follow the same rejection and cleanup path. It also adds a regression test covering error propagation, continued FIFO processing, and the final idle state.

## Related Issue | ?? Issue

Fixes #518

## Change Type | ????

- [x] Bug fix | Bug ??
- [ ] New feature | ???
- [ ] Documentation update | ????
- [ ] Code optimization | ????

## Self-test Checklist | ????

- [x] Verified locally | ??????
- [x] No existing features affected | ???????

## Additional Notes | ????

- `npm test` ? 5 test files / 68 tests passed
- `npm run build` ? plugin and all three scripts built successfully
- `git diff --check` ? passed
- Commit includes the required DCO sign-off
