### PR TITLE
test(checkpoint): cover recalculation edge cases

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -409,11 +409,29 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      try {
+        await new CheckpointManager(this.dataDir, this.logger).recalculateCounters(this.vectorStore);
+      } catch (checkpointErr) {
+        this.logger.warn(
+          `${TAG} Checkpoint counter recalculation failed: ${
+            checkpointErr instanceof Error ? checkpointErr.message : String(checkpointErr)
+          }`,
+        );
+      }
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
       );
+      try {
+        await new CheckpointManager(this.dataDir, this.logger).recalculateCounters();
+      } catch (checkpointErr) {
+        this.logger.warn(
+          `${TAG} Checkpoint counter recalculation failed: ${
+            checkpointErr instanceof Error ? checkpointErr.message : String(checkpointErr)
+          }`,
+        );
+      }
     }
   }
 

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -54,6 +54,18 @@ function makeStore(params: {
   } as unknown as IMemoryStore;
 }
 
+function makeThrowingStore(): IMemoryStore {
+  return {
+    isDegraded: () => false,
+    countL0: () => {
+      throw new Error("l0 count unavailable");
+    },
+    countL1: () => {
+      throw new Error("l1 count unavailable");
+    },
+  } as unknown as IMemoryStore;
+}
+
 describe("CheckpointManager counter recalculation", () => {
   afterEach(async () => {
     await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
@@ -77,6 +89,103 @@ describe("CheckpointManager counter recalculation", () => {
     const actual = await checkpoint.read();
     expect(actual.l0_conversations_count).toBe(2);
     expect(actual.total_memories_extracted).toBe(1);
+  });
+
+  it("falls back to JSONL counts when vector store count calls fail", async () => {
+    const dataDir = await makeDataDir();
+    const warnings: string[] = [];
+    const checkpoint = new CheckpointManager(dataDir, {
+      info() {},
+      warn(message) {
+        warnings.push(message);
+      },
+    });
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-1" },
+      { id: "l0-2" },
+      { id: "l0-3" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-1" },
+      { id: "l1-2" },
+    ]);
+
+    await checkpoint.recalculateCounters(makeThrowingStore());
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(3);
+    expect(actual.total_memories_extracted).toBe(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("falling back to JSONL");
+  });
+
+  it("preserves unrelated checkpoint state while recalculating storage-derived counters", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint({
+      last_captured_timestamp: 123,
+      total_processed: 45,
+      last_persona_at: 40,
+      last_persona_time: "2026-01-01T00:00:00.000Z",
+      request_persona_update: true,
+      persona_update_reason: "threshold",
+      memories_since_last_persona: 6,
+      scenes_processed: 2,
+      runner_states: {
+        sessionA: {
+          last_captured_timestamp: 111,
+          last_l1_cursor: 222,
+          last_scene_name: "work",
+        },
+      },
+      pipeline_states: {
+        sessionA: {
+          conversation_count: 3,
+          last_extraction_time: "2026-01-01T01:00:00.000Z",
+          last_extraction_updated_time: "2026-01-01T01:00:01.000Z",
+          last_active_time: 456,
+          l2_pending_l1_count: 1,
+          warmup_threshold: 4,
+          l2_last_extraction_time: "2026-01-01T02:00:00.000Z",
+        },
+      },
+    }));
+
+    await checkpoint.recalculateCounters(makeStore({ l0: 7, l1: 3 }));
+
+    const actual = await checkpoint.read();
+    expect(actual).toMatchObject({
+      last_captured_timestamp: 123,
+      total_processed: 45,
+      last_persona_at: 40,
+      last_persona_time: "2026-01-01T00:00:00.000Z",
+      request_persona_update: true,
+      persona_update_reason: "threshold",
+      memories_since_last_persona: 6,
+      scenes_processed: 2,
+      l0_conversations_count: 7,
+      total_memories_extracted: 3,
+      runner_states: {
+        sessionA: {
+          last_captured_timestamp: 111,
+          last_l1_cursor: 222,
+          last_scene_name: "work",
+        },
+      },
+      pipeline_states: {
+        sessionA: {
+          conversation_count: 3,
+          last_extraction_time: "2026-01-01T01:00:00.000Z",
+          last_extraction_updated_time: "2026-01-01T01:00:01.000Z",
+          last_active_time: 456,
+          l2_pending_l1_count: 1,
+          warmup_threshold: 4,
+          l2_last_extraction_time: "2026-01-01T02:00:00.000Z",
+        },
+      },
+    });
   });
 
   it("prefers vector store counts over JSONL counts", async () => {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import type { Checkpoint } from "./checkpoint.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(filePath: string, rows: unknown[]): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(
+    filePath,
+    rows.map((row) => JSON.stringify(row)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    last_captured_timestamp: 0,
+    total_processed: 0,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 0,
+    runner_states: {},
+    pipeline_states: {},
+    l0_conversations_count: 999,
+    total_memories_extracted: 888,
+    ...overrides,
+  };
+}
+
+function makeStore(params: {
+  l0: number;
+  l1: number;
+  degraded?: boolean;
+}): IMemoryStore {
+  return {
+    isDegraded: () => params.degraded ?? false,
+    countL0: () => params.l0,
+    countL1: () => params.l1,
+  } as unknown as IMemoryStore;
+}
+
+describe("CheckpointManager counter recalculation", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recalculates counters from JSONL files when no vector store is available", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-1", content: "first" },
+      { id: "l0-2", content: "second" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-1", content: "memory" },
+    ]);
+
+    await checkpoint.recalculateCounters();
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(2);
+    expect(actual.total_memories_extracted).toBe(1);
+  });
+
+  it("prefers vector store counts over JSONL counts", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-jsonl" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-jsonl" },
+    ]);
+
+    await checkpoint.recalculateCounters(makeStore({ l0: 7, l1: 3 }));
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(7);
+    expect(actual.total_memories_extracted).toBe(3);
+  });
+
+  it("falls back to JSONL counts when vector store is degraded", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-1" },
+      { id: "l0-2" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-1" },
+    ]);
+
+    await checkpoint.recalculateCounters(makeStore({ l0: 100, l1: 50, degraded: true }));
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(2);
+    expect(actual.total_memories_extracted).toBe(1);
+  });
+
+  it("reflects manual JSONL deletion after recalculation", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    const l0Path = path.join(dataDir, "conversations", "2026-01-01.jsonl");
+    const l1Path = path.join(dataDir, "records", "2026-01-01.jsonl");
+
+    await checkpoint.write(makeCheckpoint({ l0_conversations_count: 5, total_memories_extracted: 4 }));
+    await writeJsonl(l0Path, [{ id: "l0-1" }, { id: "l0-2" }]);
+    await writeJsonl(l1Path, [{ id: "l1-1" }]);
+    await fs.rm(l0Path);
+
+    await checkpoint.recalculateCounters();
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(0);
+    expect(actual.total_memories_extracted).toBe(1);
+  });
+});

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -135,4 +135,25 @@ describe("CheckpointManager counter recalculation", () => {
     expect(actual.l0_conversations_count).toBe(0);
     expect(actual.total_memories_extracted).toBe(1);
   });
+
+  it("resets counters to zero when storage is cleared but checkpoint remains", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write(makeCheckpoint({ l0_conversations_count: 12, total_memories_extracted: 6 }));
+    await writeJsonl(path.join(dataDir, "conversations", "2026-01-01.jsonl"), [
+      { id: "l0-before-reset" },
+    ]);
+    await writeJsonl(path.join(dataDir, "records", "2026-01-01.jsonl"), [
+      { id: "l1-before-reset" },
+    ]);
+    await fs.rm(path.join(dataDir, "conversations"), { recursive: true, force: true });
+    await fs.rm(path.join(dataDir, "records"), { recursive: true, force: true });
+
+    await checkpoint.recalculateCounters();
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(0);
+    expect(actual.total_memories_extracted).toBe(0);
+  });
 });

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -179,10 +180,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -291,6 +294,28 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Recalculate storage-derived counters from the current source of truth.
+   *
+   * The two counters below are derived state: capture/extraction paths increment
+   * them, while cleanup/manual deletion/reset paths can remove the underlying
+   * records. Recalculation restores them from VectorStore when available, or
+   * from local JSONL shards as a fallback.
+   */
+  async recalculateCounters(vectorStore?: IMemoryStore): Promise<void> {
+    const counts = await this.readStorageCounts(vectorStore);
+    const cp = await this.mutate((cp) => {
+      cp.l0_conversations_count = counts.l0;
+      cp.total_memories_extracted = counts.l1;
+    });
+    this.logger.info(
+      `[checkpoint] recalculateCounters: ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `source=${counts.source}`,
+    );
   }
 
   // ============================
@@ -485,4 +510,62 @@ export class CheckpointManager {
     });
   }
 
+  private async readStorageCounts(
+    vectorStore?: IMemoryStore,
+  ): Promise<{ l0: number; l1: number; source: "vectorStore" | "jsonl" }> {
+    if (vectorStore && !vectorStore.isDegraded()) {
+      try {
+        const [l0, l1] = await Promise.all([
+          vectorStore.countL0(),
+          vectorStore.countL1(),
+        ]);
+        return { l0, l1, source: "vectorStore" };
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] vectorStore count failed, falling back to JSONL: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const [l0, l1] = await Promise.all([
+      countJsonLines(path.join(this.dataDir, "conversations")),
+      countJsonLines(path.join(this.dataDir, "records")),
+    ]);
+    return { l0, l1, source: "jsonl" };
+  }
+
+}
+
+async function countJsonLines(dirPath: string): Promise<number> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".jsonl") && !entry.name.endsWith(".json")) continue;
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+    } catch {
+      continue;
+    }
+
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        JSON.parse(line);
+        count += 1;
+      } catch {
+        // Keep recalculation tolerant of partially corrupt local shards.
+      }
+    }
+  }
+  return count;
 }

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import type { Checkpoint } from "./checkpoint.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+async function makeDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    last_captured_timestamp: 0,
+    total_processed: 0,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 0,
+    runner_states: {},
+    pipeline_states: {},
+    l0_conversations_count: 100,
+    total_memories_extracted: 40,
+    ...overrides,
+  };
+}
+
+function makeCleaningStore(): IMemoryStore {
+  let l0CountCalls = 0;
+  let l1CountCalls = 0;
+
+  return {
+    isDegraded: () => false,
+    countL0: () => {
+      l0CountCalls += 1;
+      return l0CountCalls === 1 ? 100 : 4;
+    },
+    countL1: () => {
+      l1CountCalls += 1;
+      return l1CountCalls === 1 ? 40 : 2;
+    },
+    deleteL0Expired: () => 96,
+    deleteL1Expired: () => 38,
+  } as unknown as IMemoryStore;
+}
+
+describe("LocalMemoryCleaner checkpoint counter refresh", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("recalculates checkpoint counters after automatic cleanup", async () => {
+    const dataDir = await makeDataDir();
+    const checkpoint = new CheckpointManager(dataDir);
+    await checkpoint.write(makeCheckpoint());
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: makeCleaningStore(),
+      logger: {
+        info() {},
+        warn() {},
+        error() {},
+      },
+    });
+
+    await cleaner.runOnce(new Date("2026-01-03T12:00:00Z").getTime());
+
+    const actual = await checkpoint.read();
+    expect(actual.l0_conversations_count).toBe(4);
+    expect(actual.total_memories_extracted).toBe(2);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -178,6 +179,14 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    try {
+      await new CheckpointManager(this.opts.baseDir, this.opts.logger).recalculateCounters(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint counter recalculation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(


### PR DESCRIPTION
## Description | 描述
Add focused regression coverage for checkpoint counter recalculation edge cases:

- Verify `CheckpointManager.recalculateCounters()` falls back to local JSONL counts when the vector store is present and not marked degraded, but `countL0()` / `countL1()` throw.
- Verify recalculation only updates storage-derived counters (`l0_conversations_count`, `total_memories_extracted`) and preserves unrelated checkpoint state such as persona flags, runner states, and pipeline states.

This is intended as supplemental coverage for #157 and existing checkpoint recalculation PRs, without changing runtime behavior.

## Related Issue | 关联 Issue
Related to #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Validation:

- `npm.cmd test -- src/utils/checkpoint.test.ts src/utils/memory-cleaner.test.ts` — 2 files / 8 tests passed
- `git diff --check` — no whitespace errors

The branch contains only test coverage changes in `src/utils/checkpoint.test.ts`.