### PR TITLE
fix(config): ignore invalid offload dataDir overrides

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig offload.dataDir", () => {
+  it("treats an empty offload.dataDir as omitted", () => {
+    expect(parseConfig({ offload: { dataDir: "" } }).offload.dataDir).toBeUndefined();
+  });
+
+  it("treats a relative offload.dataDir as omitted", () => {
+    expect(parseConfig({ offload: { dataDir: "relative-root" } }).offload.dataDir).toBeUndefined();
+  });
+
+  it("preserves an explicit absolute offload.dataDir", () => {
+    const absoluteRoot = join(tmpdir(), "memory-tdai-offload");
+
+    expect(parseConfig({ offload: { dataDir: absoluteRoot } }).offload.dataDir).toBe(absoluteRoot);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@
 
 import type { DisableThinkingStrategy } from "./utils/no-think-fetch.js";
 import { normalizeDisableThinking } from "./utils/no-think-fetch.js";
+import path from "node:path";
 
 // ============================
 // Type definitions
@@ -481,7 +482,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     temperature: num(offloadGroup, "temperature") ?? 0.2,
     disableThinking: normalizeDisableThinking(boolOrStr(offloadGroup, "disableThinking")),
     forceTriggerThreshold: num(offloadGroup, "forceTriggerThreshold") ?? 4,
-    dataDir: optStr(offloadGroup, "dataDir"),
+    dataDir: normalizeOffloadDataDir(optStr(offloadGroup, "dataDir")),
     defaultContextWindow: num(offloadGroup, "defaultContextWindow") ?? 200000,
     maxPairsPerBatch: num(offloadGroup, "maxPairsPerBatch") ?? 20,
     l2NullThreshold: num(offloadGroup, "l2NullThreshold") ?? 4,
@@ -607,6 +608,12 @@ function str(src: Record<string, unknown>, key: string): string | undefined {
 function optStr(src: Record<string, unknown>, key: string): string | undefined {
   const v = src[key];
   return typeof v === "string" ? v : undefined;
+}
+
+function normalizeOffloadDataDir(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return path.isAbsolute(trimmed) ? trimmed : undefined;
 }
 
 function num(src: Record<string, unknown>, key: string): number | undefined {


### PR DESCRIPTION
## Description | 描述

This PR makes `offload.dataDir` honor its documented absolute-path contract.

Before this change, `parseConfig()` assigned `dataDir: optStr(offloadGroup, "dataDir")`. Because `optStr()` preserves any string verbatim, invalid values such as `""` and `"relative-root"` could bypass the default offload data root. Later, `registerOffload()` uses `offloadConfig.dataDir ?? DEFAULT_DATA_ROOT`, so those invalid string values could make context-offload storage depend on the process cwd.

Changes:

- Treat blank `offload.dataDir` values as omitted.
- Treat relative `offload.dataDir` values as invalid overrides.
- Preserve explicit absolute `offload.dataDir` values.
- Add parser-level regression tests for all three cases.

## Related Issue | 关联 Issue

Fixes #521

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Validation:

- `npx.cmd vitest run src/config.test.ts` -> 3 passed
- `npm.cmd test` -> 5 files passed, 70 tests passed
- `npm.cmd run build` -> passed

## Additional Notes | 其他说明

The reproduction is parser-level and does not require OpenClaw startup, network access, model API keys, or production data directories.