### PR TITLE
fix(checkpoint): recalibrate counters on startup

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -410,6 +410,17 @@ export class TdaiCore {
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
+      if (this.vectorStore && !this.vectorStore.isDegraded()) {
+        try {
+          const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+          await checkpoint.recalibrate(this.vectorStore);
+        } catch (err) {
+          this.logger.warn(
+            `${TAG} Checkpoint recalibration failed; retaining existing counters: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
     } catch (err) {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager.recalibrate", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tencentdb-checkpoint-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("replaces stale counters with JSONL records and the current L0 store total", async () => {
+    const recordsDir = path.join(dataDir, "records");
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-18.jsonl"),
+      '{"id":"a"}\n{"id":"b"}\n{"id":"c"}\n',
+    );
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-17.jsonl"),
+      '{"id":"d"}\n\n{"id":"e"}\n',
+    );
+
+    const checkpoint = new CheckpointManager(dataDir);
+    const stale = await checkpoint.read();
+    await checkpoint.write({
+      ...stale,
+      l0_conversations_count: 92,
+      total_memories_extracted: 47,
+    });
+
+    await checkpoint.recalibrate({
+      countL0: async () => 12,
+    });
+
+    await expect(checkpoint.read()).resolves.toMatchObject({
+      l0_conversations_count: 12,
+      total_memories_extracted: 5,
+    });
+  });
+
+  it("leaves the checkpoint unchanged when the L0 count fails", async () => {
+    const checkpoint = new CheckpointManager(dataDir);
+    const stale = await checkpoint.read();
+    await checkpoint.write({
+      ...stale,
+      l0_conversations_count: 92,
+      total_memories_extracted: 47,
+    });
+
+    await expect(
+      checkpoint.recalibrate({
+        countL0: async () => {
+          throw new Error("store unavailable");
+        },
+      }),
+    ).rejects.toThrow("store unavailable");
+
+    await expect(checkpoint.read()).resolves.toMatchObject({
+      l0_conversations_count: 92,
+      total_memories_extracted: 47,
+    });
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -144,6 +144,10 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+export interface CheckpointL0Counter {
+  countL0(): number | Promise<number>;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -179,10 +183,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -294,6 +300,55 @@ export class CheckpointManager {
   }
 
   // ============================
+  // Counter reconciliation
+  // ============================
+  /**
+   * Reconcile aggregate counters with the current data sources.
+   *
+   * L1 records are counted from JSONL so manual pruning is reflected; L0 uses
+   * the active store because it owns the authoritative conversation table.
+   */
+  async recalibrate(l0Counter: CheckpointL0Counter): Promise<void> {
+    const [l0ConversationsCount, totalMemoriesExtracted] = await Promise.all([
+      l0Counter.countL0(),
+      this.countJsonlRecords(path.join(this.dataDir, "records")),
+    ]);
+
+    if (
+      !Number.isSafeInteger(l0ConversationsCount) || l0ConversationsCount < 0 ||
+      !Number.isSafeInteger(totalMemoriesExtracted) || totalMemoriesExtracted < 0
+    ) {
+      throw new Error("Checkpoint recalibration received an invalid counter value");
+    }
+
+    await this.mutate((cp) => {
+      cp.l0_conversations_count = l0ConversationsCount;
+      cp.total_memories_extracted = totalMemoriesExtracted;
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrated counters: l0=${l0ConversationsCount}, ` +
+      `l1=${totalMemoriesExtracted}`,
+    );
+  }
+
+  private async countJsonlRecords(recordsDir: string): Promise<number> {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(recordsDir, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+      throw error;
+    }
+
+    let count = 0;
+    for (const entry of entries) {
+      if (!entry.isFile() || path.extname(entry.name) !== ".jsonl") continue;
+      const contents = await fs.readFile(path.join(recordsDir, entry.name), "utf-8");
+      count += contents.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+    }
+    return count;
+  }
   // Public API — mutating (all serialized via file lock)
   // ============================
 


### PR DESCRIPTION
Fixes #157

## Summary
- Add `CheckpointManager.recalibrate()` to reset stale aggregate counters.
- Recount L1 memories from `records/*.jsonl`, so manual JSONL pruning is reflected.
- Recount L0 conversations through the active store backend on startup.
- Keep existing checkpoint values when recalibration fails or the store is degraded.

## Tests
- `npm test`
- `npm run build`