### PR TITLE
fix(memory): repair stale checkpoint cursors after cleanup

### DIFF
--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,442 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { initTimeModule, _resetTimeModuleForTest } from "./time.js";
+import { CheckpointManager, type Checkpoint } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { readConversationMessagesGroupedBySessionId } from "../core/conversation/l0-recorder.js";
+import { readMemoryRecords } from "../core/record/l1-reader.js";
+
+function makeLogger() {
+  const logs = { info: [] as string[], warn: [] as string[], debug: [] as string[], error: [] as string[] };
+  return {
+    logs,
+    logger: {
+      info: (msg: string) => logs.info.push(msg),
+      warn: (msg: string) => logs.warn.push(msg),
+      debug: (msg: string) => logs.debug.push(msg),
+      error: (msg: string) => logs.error.push(msg),
+    },
+  };
+}
+
+async function createTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-test-"));
+}
+
+async function writeJsonl(filePath: string, lines: Array<Record<string, unknown>>): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const raw = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+  await fs.writeFile(filePath, raw, "utf-8");
+}
+
+async function writeCheckpoint(manager: CheckpointManager, checkpoint: Checkpoint): Promise<void> {
+  await manager.write(checkpoint);
+}
+
+async function readL1RecordsAfter(sessionKey: string, baseDir: string, cursor: string) {
+  const records = await readMemoryRecords(sessionKey, baseDir);
+  return records.filter((record) => {
+    const t = record.updatedAt || record.createdAt || "";
+    return t > cursor;
+  });
+}
+
+afterEach(() => {
+  _resetTimeModuleForTest();
+});
+
+describe("CheckpointManager reconciliation", () => {
+  it("repairs counters and cursors after manual JSONL trimming", async () => {
+    initTimeModule({ timezone: "UTC" });
+
+    const baseDir = await createTempDir();
+    const { logger } = makeLogger();
+    const manager = new CheckpointManager(baseDir, logger);
+
+    try {
+      await writeJsonl(path.join(baseDir, "conversations", "2026-07-17.jsonl"), [
+        {
+          sessionKey: "session-a",
+          sessionId: "session-a-1",
+          recordedAt: "2026-07-14T10:00:00.000Z",
+          id: "l0-1",
+          role: "user",
+          content: "hello",
+          timestamp: 1000,
+        },
+        {
+          sessionKey: "session-a",
+          sessionId: "session-a-1",
+          recordedAt: "2026-07-15T10:00:00.000Z",
+          id: "l0-2",
+          role: "assistant",
+          content: "world",
+          timestamp: 2000,
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "records", "2026-07-17.jsonl"), [
+        {
+          sessionKey: "session-a",
+          sessionId: "session-a-1",
+          id: "m-1",
+          content: "memory one",
+          type: "episodic",
+          priority: 50,
+          scene_name: "scene-a",
+          source_message_ids: ["l0-1"],
+          metadata: {},
+          timestamps: ["2026-07-14T11:00:00.000Z"],
+          createdAt: "2026-07-14T11:00:00.000Z",
+          updatedAt: "2026-07-14T11:00:00.000Z",
+        },
+        {
+          sessionKey: "session-a",
+          sessionId: "session-a-1",
+          id: "m-2",
+          content: "memory two",
+          type: "episodic",
+          priority: 50,
+          scene_name: "scene-a",
+          source_message_ids: ["l0-2"],
+          metadata: {},
+          timestamps: ["2026-07-15T11:00:00.000Z"],
+          createdAt: "2026-07-15T11:00:00.000Z",
+          updatedAt: "2026-07-15T11:00:00.000Z",
+        },
+      ]);
+
+      const inflated: Checkpoint = {
+        last_captured_timestamp: 9_999_999_999_999,
+        total_processed: 999,
+        last_persona_at: 999,
+        last_persona_time: "2026-07-14T12:00:00.000Z",
+        request_persona_update: false,
+        persona_update_reason: "",
+        memories_since_last_persona: 999,
+        scenes_processed: 999,
+        runner_states: {
+          "session-a": {
+            last_captured_timestamp: 9_999_999_999_999,
+            last_l1_cursor: 9_999_999_999_999,
+            last_scene_name: "scene-a",
+          },
+        },
+        pipeline_states: {
+          "session-a": {
+            conversation_count: 9,
+            last_extraction_time: "2026-07-15T11:00:00.000Z",
+            last_extraction_updated_time: "2026-07-15T11:00:00.000Z",
+            last_active_time: 1,
+            l2_pending_l1_count: 0,
+            warmup_threshold: 0,
+            l2_last_extraction_time: "2026-07-15T11:00:00.000Z",
+          },
+        },
+        l0_conversations_count: 999,
+        total_memories_extracted: 999,
+      };
+      await writeCheckpoint(manager, inflated);
+
+      await writeJsonl(path.join(baseDir, "conversations", "2026-07-17.jsonl"), [
+        {
+          sessionKey: "session-a",
+          sessionId: "session-a-1",
+          recordedAt: "2026-07-14T10:00:00.000Z",
+          id: "l0-1",
+          role: "user",
+          content: "hello",
+          timestamp: 1000,
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "records", "2026-07-17.jsonl"), [
+        {
+          sessionKey: "session-a",
+          sessionId: "session-a-1",
+          id: "m-1",
+          content: "memory one",
+          type: "episodic",
+          priority: 50,
+          scene_name: "scene-a",
+          source_message_ids: ["l0-1"],
+          metadata: {},
+          timestamps: ["2026-07-14T11:00:00.000Z"],
+          createdAt: "2026-07-14T11:00:00.000Z",
+          updatedAt: "2026-07-14T11:00:00.000Z",
+        },
+      ]);
+
+      const result = await manager.recalculateFromStorage({ repairCursors: true });
+      const checkpoint = await manager.read();
+
+      expect(result.after.total_processed).toBe(1);
+      expect(result.after.l0_conversations_count).toBe(1);
+      expect(result.after.total_memories_extracted).toBe(1);
+      expect(result.after.memories_since_last_persona).toBe(0);
+      expect(result.after.scenes_processed).toBe(0);
+      expect(result.repairedCursors).toBeGreaterThanOrEqual(3);
+
+      expect(checkpoint.total_processed).toBe(1);
+      expect(checkpoint.l0_conversations_count).toBe(1);
+      expect(checkpoint.total_memories_extracted).toBe(1);
+      expect(checkpoint.memories_since_last_persona).toBe(0);
+      expect(checkpoint.last_persona_at).toBe(1);
+      expect(checkpoint.last_captured_timestamp).toBe(1000);
+      expect(checkpoint.runner_states["session-a"].last_captured_timestamp).toBe(1000);
+      expect(checkpoint.runner_states["session-a"].last_l1_cursor).toBe(new Date("2026-07-14T10:00:00.000Z").getTime());
+      expect(checkpoint.pipeline_states["session-a"].last_extraction_updated_time).toBe("2026-07-14T11:00:00.000Z");
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reconciles checkpoint after memory-cleaner deletes expired shards", async () => {
+    initTimeModule({ timezone: "UTC" });
+
+    const baseDir = await createTempDir();
+    const { logger } = makeLogger();
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+    });
+    const manager = new CheckpointManager(baseDir, logger);
+
+    try {
+      await writeJsonl(path.join(baseDir, "conversations", "2026-07-14.jsonl"), [
+        {
+          sessionKey: "session-b",
+          sessionId: "session-b-1",
+          recordedAt: "2026-07-14T10:00:00.000Z",
+          id: "l0-old",
+          role: "user",
+          content: "old",
+          timestamp: 1000,
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "conversations", "2026-07-17.jsonl"), [
+        {
+          sessionKey: "session-b",
+          sessionId: "session-b-1",
+          recordedAt: "2026-07-17T10:00:00.000Z",
+          id: "l0-new",
+          role: "assistant",
+          content: "new",
+          timestamp: 2000,
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "records", "2026-07-14.jsonl"), [
+        {
+          sessionKey: "session-b",
+          sessionId: "session-b-1",
+          id: "m-old",
+          content: "memory old",
+          type: "episodic",
+          priority: 40,
+          scene_name: "scene-b",
+          source_message_ids: ["l0-old"],
+          metadata: {},
+          timestamps: ["2026-07-14T11:00:00.000Z"],
+          createdAt: "2026-07-14T11:00:00.000Z",
+          updatedAt: "2026-07-14T11:00:00.000Z",
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "records", "2026-07-17.jsonl"), [
+        {
+          sessionKey: "session-b",
+          sessionId: "session-b-1",
+          id: "m-new",
+          content: "memory new",
+          type: "episodic",
+          priority: 40,
+          scene_name: "scene-b",
+          source_message_ids: ["l0-new"],
+          metadata: {},
+          timestamps: ["2026-07-17T11:00:00.000Z"],
+          createdAt: "2026-07-17T11:00:00.000Z",
+          updatedAt: "2026-07-17T11:00:00.000Z",
+        },
+      ]);
+
+      await writeCheckpoint(manager, {
+        last_captured_timestamp: 9_999_999_999_999,
+        total_processed: 500,
+        last_persona_at: 400,
+        last_persona_time: "2026-07-14T12:00:00.000Z",
+        request_persona_update: false,
+        persona_update_reason: "",
+        memories_since_last_persona: 400,
+        scenes_processed: 20,
+        runner_states: {
+          "session-b": {
+            last_captured_timestamp: 9_999_999_999_999,
+            last_l1_cursor: 9_999_999_999_999,
+            last_scene_name: "",
+          },
+        },
+        pipeline_states: {
+          "session-b": {
+            conversation_count: 8,
+            last_extraction_time: "2026-07-17T11:00:00.000Z",
+            last_extraction_updated_time: "2026-07-17T11:00:00.000Z",
+            last_active_time: 1,
+            l2_pending_l1_count: 0,
+            warmup_threshold: 0,
+            l2_last_extraction_time: "2026-07-17T11:00:00.000Z",
+          },
+        },
+        l0_conversations_count: 500,
+        total_memories_extracted: 400,
+      });
+
+      await cleaner.runOnce(new Date("2026-07-17T12:00:00.000Z").getTime());
+      const checkpoint = await manager.read();
+
+      await expect(fs.access(path.join(baseDir, "conversations", "2026-07-14.jsonl"))).rejects.toBeDefined();
+      await expect(fs.access(path.join(baseDir, "records", "2026-07-14.jsonl"))).rejects.toBeDefined();
+
+      expect(checkpoint.total_processed).toBe(1);
+      expect(checkpoint.l0_conversations_count).toBe(1);
+      expect(checkpoint.total_memories_extracted).toBe(1);
+      expect(checkpoint.memories_since_last_persona).toBe(1);
+      expect(checkpoint.runner_states["session-b"].last_captured_timestamp).toBe(2000);
+      expect(checkpoint.runner_states["session-b"].last_l1_cursor).toBe(new Date("2026-07-17T10:00:00.000Z").getTime());
+      expect(checkpoint.pipeline_states["session-b"].last_extraction_updated_time).toBe("2026-07-17T11:00:00.000Z");
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("makes backfilled records visible to real incremental readers after stale cursor repair", async () => {
+    initTimeModule({ timezone: "UTC" });
+
+    const baseDir = await createTempDir();
+    const { logger } = makeLogger();
+    const manager = new CheckpointManager(baseDir, logger);
+    const sessionKey = "session-c";
+    const staleL1Cursor = new Date("2026-07-15T00:00:00.000Z").getTime();
+    const staleL2Cursor = "2026-07-15T00:00:00.000Z";
+
+    try {
+      await writeJsonl(path.join(baseDir, "conversations", "2026-07-10.jsonl"), [
+        {
+          sessionKey,
+          sessionId: "session-c-1",
+          recordedAt: "2026-07-10T10:00:00.000Z",
+          id: "l0-baseline",
+          role: "user",
+          content: "baseline l0",
+          timestamp: 1000,
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "records", "2026-07-10.jsonl"), [
+        {
+          sessionKey,
+          sessionId: "session-c-1",
+          id: "m-baseline",
+          content: "baseline memory",
+          type: "episodic",
+          priority: 40,
+          scene_name: "scene-c",
+          source_message_ids: ["l0-baseline"],
+          metadata: {},
+          timestamps: ["2026-07-10T11:00:00.000Z"],
+          createdAt: "2026-07-10T11:00:00.000Z",
+          updatedAt: "2026-07-10T11:00:00.000Z",
+        },
+      ]);
+
+      await writeCheckpoint(manager, {
+        last_captured_timestamp: 9_999_999_999_999,
+        total_processed: 1,
+        last_persona_at: 0,
+        last_persona_time: "",
+        request_persona_update: false,
+        persona_update_reason: "",
+        memories_since_last_persona: 1,
+        scenes_processed: 0,
+        runner_states: {
+          [sessionKey]: {
+            last_captured_timestamp: 9_999_999_999_999,
+            last_l1_cursor: staleL1Cursor,
+            last_scene_name: "",
+          },
+        },
+        pipeline_states: {
+          [sessionKey]: {
+            conversation_count: 0,
+            last_extraction_time: "",
+            last_extraction_updated_time: staleL2Cursor,
+            last_active_time: 1,
+            l2_pending_l1_count: 0,
+            warmup_threshold: 0,
+            l2_last_extraction_time: "",
+          },
+        },
+        l0_conversations_count: 1,
+        total_memories_extracted: 1,
+      });
+
+      const repair = await manager.repairStaleCursorsFromStorage();
+      const repaired = await manager.read();
+      const repairedL1Cursor = repaired.runner_states[sessionKey].last_l1_cursor;
+      const repairedL2Cursor = repaired.pipeline_states[sessionKey].last_extraction_updated_time;
+
+      expect(repair.repairedCursors).toBe(4);
+      expect(repairedL1Cursor).toBe(new Date("2026-07-10T10:00:00.000Z").getTime());
+      expect(repairedL2Cursor).toBe("2026-07-10T11:00:00.000Z");
+
+      await writeJsonl(path.join(baseDir, "conversations", "2026-07-12.jsonl"), [
+        {
+          sessionKey,
+          sessionId: "session-c-1",
+          recordedAt: "2026-07-12T10:00:00.000Z",
+          id: "l0-backfilled",
+          role: "assistant",
+          content: "backfilled l0",
+          timestamp: 2000,
+        },
+      ]);
+      await writeJsonl(path.join(baseDir, "records", "2026-07-12.jsonl"), [
+        {
+          sessionKey,
+          sessionId: "session-c-1",
+          id: "m-backfilled",
+          content: "backfilled memory",
+          type: "episodic",
+          priority: 40,
+          scene_name: "scene-c",
+          source_message_ids: ["l0-backfilled"],
+          metadata: {},
+          timestamps: ["2026-07-12T11:00:00.000Z"],
+          createdAt: "2026-07-12T11:00:00.000Z",
+          updatedAt: "2026-07-12T11:00:00.000Z",
+        },
+      ]);
+
+      const l0SkippedByStale = await readConversationMessagesGroupedBySessionId(
+        sessionKey,
+        baseDir,
+        staleL1Cursor,
+      );
+      const l1SkippedByStale = await readL1RecordsAfter(sessionKey, baseDir, staleL2Cursor);
+      expect(l0SkippedByStale).toHaveLength(0);
+      expect(l1SkippedByStale).toHaveLength(0);
+
+      const l0VisibleAfterRepair = await readConversationMessagesGroupedBySessionId(
+        sessionKey,
+        baseDir,
+        repairedL1Cursor,
+      );
+      const l1VisibleAfterRepair = await readL1RecordsAfter(sessionKey, baseDir, repairedL2Cursor);
+      expect(l0VisibleAfterRepair).toHaveLength(1);
+      expect(l0VisibleAfterRepair[0].messages.map((message) => message.id)).toEqual(["l0-backfilled"]);
+      expect(l1VisibleAfterRepair.map((record) => record.id)).toEqual(["m-backfilled"]);
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -146,6 +147,99 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+export interface CheckpointRecalculateOptions {
+  /**
+   * Optional primary store. When available, L0/L1 counts follow the same
+   * source used by the live incremental pipeline; JSONL is still scanned as a
+   * fallback and as a cursor-safety source.
+   */
+  vectorStore?: Pick<
+    IMemoryStore,
+    "isDegraded" | "countL0" | "countL1" | "queryL0GroupedBySessionId" | "queryL1Records"
+  >;
+  /**
+   * Also clamp per-session incremental cursors down to the newest record that
+   * still exists in storage. This is intended for cleanup/reset/rollback flows
+   * where the checkpoint may point past the retained data.
+   */
+  repairCursors?: boolean;
+}
+
+export interface CheckpointCursorRepairOptions {
+  /**
+   * Optional primary store. JSONL is still scanned as a fallback and as a
+   * cursor-safety source.
+   */
+  vectorStore?: CheckpointRecalculateOptions["vectorStore"];
+}
+
+export interface CheckpointRecalculateResult {
+  before: Pick<
+    Checkpoint,
+    "total_processed" | "l0_conversations_count" | "total_memories_extracted" |
+    "memories_since_last_persona" | "scenes_processed"
+  >;
+  after: Pick<
+    Checkpoint,
+    "total_processed" | "l0_conversations_count" | "total_memories_extracted" |
+    "memories_since_last_persona" | "scenes_processed"
+  >;
+  storage: {
+    l0MessageCount: number;
+    l0BatchCount: number;
+    l1RecordCount: number;
+    memoriesSinceLastPersona: number;
+    sceneCount: number;
+    l0Source: "vectorStore" | "jsonl" | "none";
+    l1Source: "vectorStore" | "jsonl" | "none";
+  };
+  repairedCursors: number;
+}
+
+export interface CheckpointCursorSnapshot {
+  last_captured_timestamp: number;
+  runner_states: Record<string, Pick<RunnerSessionState, "last_captured_timestamp" | "last_l1_cursor">>;
+  pipeline_states: Record<string, Pick<PipelineSessionState, "last_extraction_updated_time">>;
+}
+
+export interface CheckpointCursorRepairResult {
+  before: CheckpointCursorSnapshot;
+  after: CheckpointCursorSnapshot;
+  storage: Pick<
+    CheckpointRecalculateResult["storage"],
+    "l0MessageCount" | "l1RecordCount" | "l0Source" | "l1Source"
+  >;
+  repairedCursors: number;
+}
+
+interface StorageStats {
+  l0MessageCount: number;
+  l0BatchCount: number;
+  l1RecordCount: number;
+  memoriesSinceLastPersona: number;
+  sceneCount: number;
+  l0Source: "vectorStore" | "jsonl" | "none";
+  l1Source: "vectorStore" | "jsonl" | "none";
+  l0MaxMessageTimestampBySession: Map<string, number>;
+  l0MaxRecordedAtMsBySession: Map<string, number>;
+  l1MaxUpdatedAtBySession: Map<string, string>;
+}
+
+interface L0ScanStats {
+  messageCount: number;
+  batchCount: number;
+  maxMessageTimestampBySession: Map<string, number>;
+  maxRecordedAtMsBySession: Map<string, number>;
+}
+
+interface L1ScanStats {
+  recordCount: number;
+  memoriesSinceLastPersona: number;
+  maxUpdatedAtBySession: Map<string, string>;
+}
+
+const RECALCULATE_QUERY_LIMIT = 1_000_000;
+
 // ============================
 // Per-file async lock
 // ============================
@@ -178,11 +272,82 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
   }
 }
 
+function setMaxNumber(map: Map<string, number>, key: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) return;
+  const current = map.get(key) ?? 0;
+  if (value > current) {
+    map.set(key, value);
+  }
+}
+
+function setMaxString(map: Map<string, string>, key: string, value: string): void {
+  if (!value) return;
+  const current = map.get(key) ?? "";
+  if (value > current) {
+    map.set(key, value);
+  }
+}
+
+function mergeMaxNumberMaps(...maps: Array<Map<string, number>>): Map<string, number> {
+  const merged = new Map<string, number>();
+  for (const map of maps) {
+    for (const [key, value] of map) {
+      setMaxNumber(merged, key, value);
+    }
+  }
+  return merged;
+}
+
+function mergeMaxStringMaps(...maps: Array<Map<string, string>>): Map<string, string> {
+  const merged = new Map<string, string>();
+  for (const map of maps) {
+    for (const [key, value] of map) {
+      setMaxString(merged, key, value);
+    }
+  }
+  return merged;
+}
+
+function counterSnapshot(cp: Checkpoint): CheckpointRecalculateResult["before"] {
+  return {
+    total_processed: cp.total_processed,
+    l0_conversations_count: cp.l0_conversations_count,
+    total_memories_extracted: cp.total_memories_extracted,
+    memories_since_last_persona: cp.memories_since_last_persona,
+    scenes_processed: cp.scenes_processed,
+  };
+}
+
+function cursorSnapshot(cp: Checkpoint): CheckpointCursorSnapshot {
+  const runner_states: CheckpointCursorSnapshot["runner_states"] = {};
+  for (const [key, state] of Object.entries(cp.runner_states ?? {})) {
+    runner_states[key] = {
+      last_captured_timestamp: state.last_captured_timestamp,
+      last_l1_cursor: state.last_l1_cursor,
+    };
+  }
+
+  const pipeline_states: CheckpointCursorSnapshot["pipeline_states"] = {};
+  for (const [key, state] of Object.entries(cp.pipeline_states ?? {})) {
+    pipeline_states[key] = {
+      last_extraction_updated_time: state.last_extraction_updated_time,
+    };
+  }
+
+  return {
+    last_captured_timestamp: cp.last_captured_timestamp,
+    runner_states,
+    pipeline_states,
+  };
+}
+
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -293,6 +458,416 @@ export class CheckpointManager {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
   }
 
+  /**
+   * Recalculate aggregate checkpoint counters from the data that actually
+   * exists on disk / in the primary store.
+   *
+   * This repairs drift after retention cleanup, manual JSONL trimming, session
+   * reset, or historical rollback. With `repairCursors=true`, per-session
+   * incremental cursors are also clamped to the newest retained record so the
+   * next incremental pass does not skip records that were rolled back.
+   */
+  async recalculateFromStorage(
+    options: CheckpointRecalculateOptions = {},
+  ): Promise<CheckpointRecalculateResult> {
+    return withFileLock(this.filePath, async () => {
+      const cp = await this.readRaw();
+      const before = counterSnapshot(cp);
+      const stats = await this.collectStorageStats(cp, options);
+
+      cp.total_processed = stats.l0MessageCount;
+      cp.l0_conversations_count = stats.l0BatchCount;
+      cp.total_memories_extracted = stats.l1RecordCount;
+      cp.memories_since_last_persona = stats.memoriesSinceLastPersona;
+      cp.scenes_processed = stats.sceneCount;
+      if (cp.last_persona_at > cp.total_processed) {
+        cp.last_persona_at = cp.total_processed;
+      }
+
+      const repairedCursors = options.repairCursors
+        ? this.repairIncrementalCursors(cp, stats)
+        : 0;
+
+      await this.writeRaw(cp);
+      const after = counterSnapshot(cp);
+
+      this.logger.info(
+        `[checkpoint] recalculateFromStorage: ` +
+        `L0 messages=${stats.l0MessageCount} (${stats.l0Source}), ` +
+        `L0 batches=${stats.l0BatchCount}, ` +
+        `L1 records=${stats.l1RecordCount} (${stats.l1Source}), ` +
+        `memories_since_persona=${stats.memoriesSinceLastPersona}, ` +
+        `scenes=${stats.sceneCount}, repairedCursors=${repairedCursors}`,
+      );
+
+      return {
+        before,
+        after,
+        storage: {
+          l0MessageCount: stats.l0MessageCount,
+          l0BatchCount: stats.l0BatchCount,
+          l1RecordCount: stats.l1RecordCount,
+          memoriesSinceLastPersona: stats.memoriesSinceLastPersona,
+          sceneCount: stats.sceneCount,
+          l0Source: stats.l0Source,
+          l1Source: stats.l1Source,
+        },
+        repairedCursors,
+      };
+    });
+  }
+
+  /**
+   * Repair only stale incremental cursors, leaving aggregate counters untouched.
+   *
+   * A cursor is considered stale when it points past the newest record that
+   * still exists in storage. This can happen after retention cleanup, manual
+   * JSONL trimming, session reset, or historical rollback. Clamping these
+   * cursors back to the retained data boundary prevents future backfilled or
+   * restored records from being filtered out by an unreachable old checkpoint.
+   */
+  async repairStaleCursorsFromStorage(
+    options: CheckpointCursorRepairOptions = {},
+  ): Promise<CheckpointCursorRepairResult> {
+    return withFileLock(this.filePath, async () => {
+      const cp = await this.readRaw();
+      const before = cursorSnapshot(cp);
+      const stats = await this.collectStorageStats(cp, { vectorStore: options.vectorStore });
+      const repairedCursors = this.repairIncrementalCursors(cp, stats);
+
+      if (repairedCursors > 0) {
+        await this.writeRaw(cp);
+      }
+
+      const after = cursorSnapshot(cp);
+      this.logger.info(
+        `[checkpoint] repairStaleCursorsFromStorage: ` +
+        `L0 messages=${stats.l0MessageCount} (${stats.l0Source}), ` +
+        `L1 records=${stats.l1RecordCount} (${stats.l1Source}), ` +
+        `repairedCursors=${repairedCursors}`,
+      );
+
+      return {
+        before,
+        after,
+        storage: {
+          l0MessageCount: stats.l0MessageCount,
+          l1RecordCount: stats.l1RecordCount,
+          l0Source: stats.l0Source,
+          l1Source: stats.l1Source,
+        },
+        repairedCursors,
+      };
+    });
+  }
+
+  private async collectStorageStats(
+    cp: Checkpoint,
+    options: CheckpointRecalculateOptions,
+  ): Promise<StorageStats> {
+    const jsonlL0 = await this.scanL0Jsonl();
+    const jsonlL1 = await this.scanL1Jsonl(cp.last_persona_time);
+    const sceneCount = await this.countSceneBlocks();
+    const jsonlSessionKeys = new Set<string>([
+      ...jsonlL0.maxMessageTimestampBySession.keys(),
+      ...jsonlL0.maxRecordedAtMsBySession.keys(),
+      ...jsonlL1.maxUpdatedAtBySession.keys(),
+    ]);
+    const vector = await this.scanVectorStore(cp, options.vectorStore, jsonlSessionKeys);
+
+    const l0Source = vector ? "vectorStore" : jsonlL0.messageCount > 0 ? "jsonl" : "none";
+    const l1Source = vector ? "vectorStore" : jsonlL1.recordCount > 0 ? "jsonl" : "none";
+
+    const l0MessageCount = vector?.l0.messageCount ?? jsonlL0.messageCount;
+    const l0BatchCount = jsonlL0.batchCount > 0
+      ? jsonlL0.batchCount
+      : vector?.l0.batchCount ?? (l0MessageCount > 0 ? l0MessageCount : 0);
+    const l1RecordCount = vector?.l1.recordCount ?? jsonlL1.recordCount;
+    const memoriesSinceLastPersona = vector?.l1.memoriesSinceLastPersona
+      ?? jsonlL1.memoriesSinceLastPersona;
+
+    return {
+      l0MessageCount,
+      l0BatchCount,
+      l1RecordCount,
+      memoriesSinceLastPersona,
+      sceneCount,
+      l0Source,
+      l1Source,
+      // Use the union of primary and fallback maxima to avoid rewinding cursors
+      // behind data that still exists in either store.
+      l0MaxMessageTimestampBySession: mergeMaxNumberMaps(
+        jsonlL0.maxMessageTimestampBySession,
+        vector?.l0.maxMessageTimestampBySession ?? new Map(),
+      ),
+      l0MaxRecordedAtMsBySession: mergeMaxNumberMaps(
+        jsonlL0.maxRecordedAtMsBySession,
+        vector?.l0.maxRecordedAtMsBySession ?? new Map(),
+      ),
+      l1MaxUpdatedAtBySession: mergeMaxStringMaps(
+        jsonlL1.maxUpdatedAtBySession,
+        vector?.l1.maxUpdatedAtBySession ?? new Map(),
+      ),
+    };
+  }
+
+  private async scanVectorStore(
+    cp: Checkpoint,
+    vectorStore: CheckpointRecalculateOptions["vectorStore"],
+    additionalSessionKeys: Set<string>,
+  ): Promise<{ l0: L0ScanStats; l1: L1ScanStats } | undefined> {
+    if (!vectorStore || vectorStore.isDegraded()) {
+      return undefined;
+    }
+
+    const l0: L0ScanStats = {
+      messageCount: 0,
+      batchCount: 0,
+      maxMessageTimestampBySession: new Map(),
+      maxRecordedAtMsBySession: new Map(),
+    };
+    const l1: L1ScanStats = {
+      recordCount: 0,
+      memoriesSinceLastPersona: 0,
+      maxUpdatedAtBySession: new Map(),
+    };
+
+    try {
+      l0.messageCount = await vectorStore.countL0();
+    } catch (err) {
+      this.logger.warn?.(`[checkpoint] recalculate: countL0 failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const batchKeys = new Set<string>();
+    let queriedL0Messages = 0;
+    for (const sessionKey of this.getKnownSessionKeys(cp, additionalSessionKeys)) {
+      try {
+        const groups = await vectorStore.queryL0GroupedBySessionId(
+          sessionKey,
+          undefined,
+          RECALCULATE_QUERY_LIMIT,
+        );
+        for (const group of groups) {
+          for (const message of group.messages) {
+            queriedL0Messages += 1;
+            setMaxNumber(l0.maxMessageTimestampBySession, sessionKey, message.timestamp);
+            setMaxNumber(l0.maxRecordedAtMsBySession, sessionKey, message.recordedAtMs);
+            if (message.recordedAtMs > 0) {
+              batchKeys.add(`${sessionKey}\0${group.sessionId}\0${message.recordedAtMs}`);
+            }
+          }
+        }
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalculate: queryL0GroupedBySessionId failed for ${sessionKey}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    if (l0.messageCount === 0 && queriedL0Messages > 0) {
+      l0.messageCount = queriedL0Messages;
+    }
+    l0.batchCount = batchKeys.size;
+
+    let l1Rows: Awaited<ReturnType<IMemoryStore["queryL1Records"]>> = [];
+    try {
+      l1Rows = await vectorStore.queryL1Records({});
+    } catch (err) {
+      this.logger.warn?.(`[checkpoint] recalculate: queryL1Records failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    try {
+      l1.recordCount = await vectorStore.countL1();
+    } catch (err) {
+      this.logger.warn?.(`[checkpoint] recalculate: countL1 failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (l1.recordCount === 0 && l1Rows.length > 0) {
+      l1.recordCount = l1Rows.length;
+    }
+
+    for (const row of l1Rows) {
+      const sessionKey = row.session_key || "";
+      if (!sessionKey) continue;
+      const updated = row.updated_time || row.created_time || "";
+      setMaxString(l1.maxUpdatedAtBySession, sessionKey, updated);
+      if (!cp.last_persona_time || updated > cp.last_persona_time) {
+        l1.memoriesSinceLastPersona += 1;
+      }
+    }
+    if (l1Rows.length === 0 && l1.recordCount > 0 && !cp.last_persona_time) {
+      l1.memoriesSinceLastPersona = l1.recordCount;
+    }
+
+    return { l0, l1 };
+  }
+
+  private getKnownSessionKeys(cp: Checkpoint, additionalSessionKeys: Set<string>): string[] {
+    const keys = new Set<string>(additionalSessionKeys);
+    for (const key of Object.keys(cp.runner_states ?? {})) keys.add(key);
+    for (const key of Object.keys(cp.pipeline_states ?? {})) keys.add(key);
+    return Array.from(keys).filter(Boolean).sort();
+  }
+
+  private async scanL0Jsonl(): Promise<L0ScanStats> {
+    const stats: L0ScanStats = {
+      messageCount: 0,
+      batchCount: 0,
+      maxMessageTimestampBySession: new Map(),
+      maxRecordedAtMsBySession: new Map(),
+    };
+    const batchKeys = new Set<string>();
+
+    await this.forEachJsonRecord("conversations", (record) => {
+      const sessionKey = typeof record.sessionKey === "string" ? record.sessionKey : "";
+      if (!sessionKey) return;
+      const recordedAt = typeof record.recordedAt === "string" ? record.recordedAt : "";
+      const recordedAtMs = Date.parse(recordedAt) || 0;
+      const messageTs = typeof record.timestamp === "number" ? record.timestamp : 0;
+      const sessionId = typeof record.sessionId === "string" ? record.sessionId : "";
+
+      stats.messageCount += 1;
+      setMaxNumber(stats.maxMessageTimestampBySession, sessionKey, messageTs);
+      setMaxNumber(stats.maxRecordedAtMsBySession, sessionKey, recordedAtMs);
+      if (recordedAt) {
+        batchKeys.add(`${sessionKey}\0${sessionId}\0${recordedAt}`);
+      }
+    });
+
+    stats.batchCount = batchKeys.size;
+    return stats;
+  }
+
+  private async scanL1Jsonl(lastPersonaTime: string): Promise<L1ScanStats> {
+    const stats: L1ScanStats = {
+      recordCount: 0,
+      memoriesSinceLastPersona: 0,
+      maxUpdatedAtBySession: new Map(),
+    };
+
+    await this.forEachJsonRecord("records", (record) => {
+      const sessionKey = typeof record.sessionKey === "string" ? record.sessionKey : "";
+      if (!sessionKey) return;
+      const updated = typeof record.updatedAt === "string"
+        ? record.updatedAt
+        : typeof record.createdAt === "string"
+          ? record.createdAt
+          : "";
+
+      stats.recordCount += 1;
+      setMaxString(stats.maxUpdatedAtBySession, sessionKey, updated);
+      if (!lastPersonaTime || updated > lastPersonaTime) {
+        stats.memoriesSinceLastPersona += 1;
+      }
+    });
+
+    return stats;
+  }
+
+  private async forEachJsonRecord(
+    subdir: "conversations" | "records",
+    fn: (record: Record<string, unknown>) => void,
+  ): Promise<void> {
+    const dir = path.join(this.dataDir, subdir);
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const files = entries
+      .filter((entry) => entry.isFile() && (entry.name.endsWith(".jsonl") || entry.name.endsWith(".json")))
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const fileName of files) {
+      let raw: string;
+      try {
+        raw = await fs.readFile(path.join(dir, fileName), "utf-8");
+      } catch {
+        continue;
+      }
+
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+
+      if (fileName.endsWith(".json") && (trimmed.startsWith("[") || trimmed.startsWith("{"))) {
+        try {
+          const parsed = JSON.parse(trimmed) as unknown;
+          const records = Array.isArray(parsed) ? parsed : [parsed];
+          for (const record of records) {
+            if (record && typeof record === "object") {
+              fn(record as Record<string, unknown>);
+            }
+          }
+          continue;
+        } catch {
+          // Fall through to line-by-line parsing; some .json files are JSONL.
+        }
+      }
+
+      for (const line of raw.split("\n")) {
+        const lineTrimmed = line.trim();
+        if (!lineTrimmed) continue;
+        try {
+          const record = JSON.parse(lineTrimmed) as unknown;
+          if (record && typeof record === "object") {
+            fn(record as Record<string, unknown>);
+          }
+        } catch {
+          // Ignore malformed lines during repair; normal readers already log them.
+        }
+      }
+    }
+  }
+
+  private async countSceneBlocks(): Promise<number> {
+    const dir = path.join(this.dataDir, "scene_blocks");
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".md")).length;
+    } catch {
+      return 0;
+    }
+  }
+
+  private repairIncrementalCursors(cp: Checkpoint, stats: StorageStats): number {
+    let repaired = 0;
+    let globalMaxCapturedTimestamp = 0;
+    for (const value of stats.l0MaxMessageTimestampBySession.values()) {
+      if (value > globalMaxCapturedTimestamp) globalMaxCapturedTimestamp = value;
+    }
+
+    if (cp.last_captured_timestamp > globalMaxCapturedTimestamp) {
+      cp.last_captured_timestamp = globalMaxCapturedTimestamp;
+      repaired += 1;
+    }
+
+    for (const [sessionKey, state] of Object.entries(cp.runner_states ?? {})) {
+      const maxCaptured = stats.l0MaxMessageTimestampBySession.get(sessionKey) ?? 0;
+      if (state.last_captured_timestamp > maxCaptured) {
+        state.last_captured_timestamp = maxCaptured;
+        repaired += 1;
+      }
+
+      const maxRecordedAt = stats.l0MaxRecordedAtMsBySession.get(sessionKey) ?? 0;
+      if (state.last_l1_cursor > maxRecordedAt) {
+        state.last_l1_cursor = maxRecordedAt;
+        repaired += 1;
+      }
+    }
+
+    for (const [sessionKey, state] of Object.entries(cp.pipeline_states ?? {})) {
+      const maxUpdatedAt = stats.l1MaxUpdatedAtBySession.get(sessionKey) ?? "";
+      if (state.last_extraction_updated_time && state.last_extraction_updated_time > maxUpdatedAt) {
+        state.last_extraction_updated_time = maxUpdatedAt;
+        repaired += 1;
+      }
+    }
+
+    return repaired;
+  }
+
   // ============================
   // Public API — mutating (all serialized via file lock)
   // ============================
@@ -330,6 +905,38 @@ export class CheckpointManager {
       cp.scenes_processed += 1;
     });
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
+  }
+
+  async decrementTotalProcessed(amount = 1): Promise<void> {
+    const delta = Math.max(0, Math.floor(amount));
+    if (delta === 0) return;
+    const cp = await this.mutate((cp) => {
+      cp.total_processed = Math.max(0, cp.total_processed - delta);
+      cp.last_persona_at = Math.min(cp.last_persona_at, cp.total_processed);
+    });
+    this.logger.info(`[checkpoint] decrementTotalProcessed: total_processed=${cp.total_processed}`);
+  }
+
+  async decrementL0ConversationCount(amount = 1): Promise<void> {
+    const delta = Math.max(0, Math.floor(amount));
+    if (delta === 0) return;
+    const cp = await this.mutate((cp) => {
+      cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count - delta);
+    });
+    this.logger.info(`[checkpoint] decrementL0ConversationCount: l0_conversations_count=${cp.l0_conversations_count}`);
+  }
+
+  async decrementTotalMemoriesExtracted(amount = 1): Promise<void> {
+    const delta = Math.max(0, Math.floor(amount));
+    if (delta === 0) return;
+    const cp = await this.mutate((cp) => {
+      cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted - delta);
+      cp.memories_since_last_persona = Math.max(0, cp.memories_since_last_persona - delta);
+    });
+    this.logger.info(
+      `[checkpoint] decrementTotalMemoriesExtracted: total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
   }
 
   // ============================

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -178,6 +179,24 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      const result = await checkpoint.recalculateFromStorage({
+        vectorStore: this.vectorStore,
+        repairCursors: true,
+      });
+      this.opts.logger?.info(
+        `${TAG} Checkpoint reconciled: ` +
+        `L0 ${result.before.total_processed}->${result.after.total_processed}, ` +
+        `L1 ${result.before.total_memories_extracted}->${result.after.total_memories_extracted}, ` +
+        `repairedCursors=${result.repairedCursors}`,
+      );
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint reconciliation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(


### PR DESCRIPTION
## Description | 描述

### English

This PR repairs stale checkpoint cursors after local memory cleanup, trimming, or rollback.

- Adds checkpoint storage reconciliation that can recalculate L0/L1 counters from actual persisted data.
- Adds dedicated stale cursor repair for per-session incremental cursors:
  - `last_captured_timestamp`
  - `runner_states[session].last_captured_timestamp`
  - `runner_states[session].last_l1_cursor`
  - `pipeline_states[session].last_extraction_updated_time`
- Runs checkpoint reconciliation after `memory-cleaner` cleanup so deleted L0/L1 data does not leave checkpoint cursors pointing past the retained storage boundary.
- Adds regression tests proving that a stale cursor can hide backfilled records from the real incremental readers, and that cursor repair makes those records visible again.

### 中文

此 PR 修复本地记忆数据清理、裁剪或回滚后 checkpoint 增量游标过期的问题。

- 新增 checkpoint 存储校准逻辑，可根据实际持久化数据重新计算 L0/L1 计数器。
- 新增 stale cursor 修复逻辑，用于修复以下 per-session 增量游标：
  - `last_captured_timestamp`
  - `runner_states[session].last_captured_timestamp`
  - `runner_states[session].last_l1_cursor`
  - `pipeline_states[session].last_extraction_updated_time`
- 在 `memory-cleaner` 清理完成后执行 checkpoint reconciliation，避免被删除的 L0/L1 数据让 checkpoint 游标继续指向已不存在的数据边界之后。
- 新增回归测试，验证 stale cursor 会导致真实增量 reader 跳过 backfilled records，并验证修复后这些记录可以重新被读取。

## Related Issue | 关联 Issue

Related to #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
  - `git diff --check origin/main..HEAD`: passed
  - `npx vitest run src/utils/checkpoint.test.ts`: 1 file, 3 tests passed
  - `npm test`: 5 files, 70 tests passed
  - `npm run build:plugin`: passed
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

### English

This PR intentionally focuses on stale incremental cursors, not only aggregate counter drift. Counter recalibration keeps checkpoint statistics aligned with retained data, while cursor repair prevents future incremental L0/L1/L2 reads from filtering out records that still need processing after cleanup, trimming, or rollback.

### 中文

此 PR 的重点不仅是修复聚合计数器漂移，更关注 stale incremental cursor。计数器校准用于让 checkpoint 统计与保留数据保持一致；游标修复用于避免清理、裁剪或回滚后，后续 L0/L1/L2 增量读取因旧游标过高而过滤掉仍需处理的记录。