### PR TITLE
feat(recall): support configurable dynamic recall placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### ✨ 新功能
 
+- 新增 `recall.injectionMode`，可选择将动态 L1 recall 放在用户输入前或后；默认 `prepend` 保持兼容。Core 使用位置无关的 `dynamicContext`，仅由宿主适配器映射为实际注入字段。
+
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。
   - **暴露给 LLM 的时间戳**统一为带显式 offset 的 ISO 8601（如 `2026-04-07T11:04:45+08:00`），修复 #87 报告的 UTC/本地时区混用导致 LLM 误算时间差的问题。
   - **L1 / L2 prompt 顶部**自动插入时区声明，指引 LLM 按正确时区推算"昨天"、"上周"等相对时间。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### ✨ 新功能
 
-- 新增 `recall.injectionMode`，可选择将动态 L1 recall 放在用户输入前或后；默认 `prepend` 保持兼容。Core 使用位置无关的 `dynamicContext`，仅由宿主适配器映射为实际注入字段。
+- 新增 `recall.injectionMode`，可选择将动态 L1 recall 放在用户输入前或后；默认 `prepend` 保持兼容。Core 使用位置无关的 `stableContext` / `dynamicContext`；OpenClaw 原生支持 prepend/append，Gateway 结构化传输两类上下文，Hermes 完整消费后按其 `prefetch()` 能力固定 append，并对 prepend 请求输出一次降级警告。
 
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。
   - **暴露给 LLM 的时间戳**统一为带显式 offset 的 ISO 8601（如 `2026-04-07T11:04:45+08:00`），修复 #87 报告的 UTC/本地时区混用导致 LLM 误算时间差的问题。

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
-| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps compatible behavior; `append` places recall after the user input to reduce its impact on prefix caching |
+| `recall.injectionMode` | `"prepend"` | Preferred dynamic L1 recall placement: `prepend` keeps compatible behavior; `append` places recall after the user input when the host supports it |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |
@@ -448,8 +448,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 
 ### Dynamic L1 recall placement
 
-OpenClaw-compatible hosts can place per-turn L1 recall after the current user
-input, keeping the beginning of the prompt more stable for prefix caching:
+Set the preferred placement for per-turn L1 recall:
 
 ```json
 {
@@ -465,6 +464,18 @@ The default remains `prepend` for backward compatibility:
 prepend: <relevant-memories> + user question
 append:  user question + <relevant-memories>
 ```
+
+Host behavior:
+
+- **OpenClaw** supports both modes directly through `prependContext` and
+  `appendContext`.
+- **Gateway clients** receive separate `stable_context` and `dynamic_context`
+  fields plus `injection_mode`, so each framework can apply its native hook.
+  The legacy `context` field remains available and combines both parts.
+- **Hermes** exposes only `MemoryProvider.prefetch()`, whose returned context is
+  appended to the current user turn. It therefore always uses native append
+  placement; requesting `prepend` produces a one-time fallback warning instead
+  of dropping dynamic L1 recall.
 
 <details>
 <summary><b>🟡 Level 2 · Advanced tuning</b> (long task / long session)</summary>

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` keeps compatible behavior; `append` places recall after the user input to reduce its impact on prefix caching |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |
@@ -444,6 +445,26 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `offload.enabled` | `false` | Whether to enable short-term compression |
 
 </details>
+
+### Dynamic L1 recall placement
+
+OpenClaw-compatible hosts can place per-turn L1 recall after the current user
+input, keeping the beginning of the prompt more stable for prefix caching:
+
+```json
+{
+  "recall": {
+    "injectionMode": "append"
+  }
+}
+```
+
+The default remains `prepend` for backward compatibility:
+
+```text
+prepend: <relevant-memories> + user question
+append:  user question + <relevant-memories>
+```
 
 <details>
 <summary><b>🟡 Level 2 · Advanced tuning</b> (long task / long session)</summary>

--- a/README_CN.md
+++ b/README_CN.md
@@ -436,7 +436,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
-| `recall.injectionMode` | `"prepend"` | 动态 L1 召回注入位置：`prepend` 保持兼容行为；`append` 将召回内容放在用户输入后，降低对前缀缓存的影响 |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回的期望注入位置：`prepend` 保持兼容行为；宿主支持时，`append` 将召回内容放在用户输入后 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |
@@ -449,7 +449,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 ### 动态 L1 召回注入位置
 
-兼容 OpenClaw 的宿主可以把每轮 L1 召回放在当前用户输入之后，让提示词开头对前缀缓存更加稳定：
+设置每轮动态 L1 召回的期望注入位置：
 
 ```json
 {
@@ -465,6 +465,16 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 prepend: <relevant-memories> + 用户问题
 append:  用户问题 + <relevant-memories>
 ```
+
+各宿主的行为：
+
+- **OpenClaw** 通过 `prependContext` 和 `appendContext` 原生支持两种模式。
+- **Gateway 客户端**会收到独立的 `stable_context`、`dynamic_context` 和
+  `injection_mode` 字段，可按各自框架能力完成注入；兼容字段 `context`
+  仍然保留，并包含稳定和动态两部分。
+- **Hermes** 只暴露 `MemoryProvider.prefetch()`，返回内容固定追加到当前用户轮次，
+  因此始终采用宿主原生的 append 位置；配置为 `prepend` 时会输出一次降级警告，
+  但不会再丢失动态 L1 召回。
 
 <details>
 <summary><b>🟡 Level 2 · 进阶调优</b>（长任务 / 长 Session 场景）</summary>

--- a/README_CN.md
+++ b/README_CN.md
@@ -436,6 +436,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回注入位置：`prepend` 保持兼容行为；`append` 将召回内容放在用户输入后，降低对前缀缓存的影响 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |
@@ -445,6 +446,25 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `offload.enabled` | `false` | 是否启用短期记忆压缩 |
 
 </details>
+
+### 动态 L1 召回注入位置
+
+兼容 OpenClaw 的宿主可以把每轮 L1 召回放在当前用户输入之后，让提示词开头对前缀缓存更加稳定：
+
+```json
+{
+  "recall": {
+    "injectionMode": "append"
+  }
+}
+```
+
+为保持向后兼容，默认值仍为 `prepend`：
+
+```text
+prepend: <relevant-memories> + 用户问题
+append:  用户问题 + <relevant-memories>
+```
 
 <details>
 <summary><b>🟡 Level 2 · 进阶调优</b>（长任务 / 长 Session 场景）</summary>

--- a/docs/prompt-context-structure.md
+++ b/docs/prompt-context-structure.md
@@ -1,0 +1,173 @@
+# Memory 注入后的 Prompt 上下文结构
+
+本文档解释：当本插件（TencentDB Agent Memory）完成记忆注入后，最终发送给 LLM 的完整上下文长什么样、各部分从哪来、由哪段代码构造。
+
+## 总览：两条注入链路
+
+插件对上下文的影响分为两条独立链路：
+
+| 链路 | 作用对象 | 机制 | 入口代码 |
+|---|---|---|---|
+| 长期记忆召回（L1/L2/L3） | system prompt + 当前用户消息 | 通过 `before_prompt_build` hook 返回 `appendSystemContext` / `prependContext` / `appendContext` 字段，**由 OpenClaw 宿主拼接**，插件不直接改 messages | `index.ts:530` → `src/core/hooks/auto-recall.ts:80` |
+| 短期记忆 / context-offload | messages 数组本身 | **原地修改 `event.messages`**：替换 tool_result 为摘要、删除消息、插入 MMD 消息 | `src/offload/index.ts:268` → `src/offload/hooks/before-prompt-build.ts:43` |
+
+## 注入后的整体结构
+
+以默认配置（`recall.injectionMode = "prepend"`）为例，一轮请求发给 LLM 的上下文结构如下：
+
+```
+┌─ system prompt（OpenClaw 原始系统提示词）
+│   │
+│   └─ appendSystemContext（稳定部分，追加在末尾，利于 prompt cache）
+│        ├─ <user-persona>…</user-persona>            ← L3 用户画像（persona.md）
+│        ├─ <scene-navigation>…</scene-navigation>    ← L2 场景记忆索引（仅索引，全文需 read_file）
+│        ├─ <memory-tools-guide>…</memory-tools-guide>← 记忆工具调用指南
+│        └─ [<l4_skill_result>…</l4_skill_result>]    ← offload L4 skill 沉淀（可选）
+│
+├─ messages[]（历史消息，可能已被 offload 修改）
+│   ├─ 原始 user / assistant 消息
+│   ├─ 被 offload 的 tool_result：
+│   │     "[Offloaded Tool Result | node: N7]
+│   │      Summary: …
+│   │      result_ref: … (read this file for full tool call and raw result)"
+│   ├─ 被 aggressive/emergency 压缩整段删除的消息（不存在了）
+│   └─ { role: "user", <history_task_context file="…">…</history_task_context> }
+│        ↑ 历史 MMD（mermaid 流程图），作为删除补偿插入在消息中部
+│
+├─ 当前用户消息（本轮输入）
+│   ├─ prepend 模式（默认）: <relevant-memories>…</relevant-memories> + 用户原文
+│   └─ append 模式:          用户原文 + <relevant-memories>…</relevant-memories>
+│
+└─ { role: "user", <current_task_context>…mermaid…</current_task_context> }
+     ↑ 活跃任务 MMD，插入在最新用户消息之后（不拆散 tool_use/tool_result 对）
+```
+
+注入时机（hook 调用顺序）：
+
+```mermaid
+sequenceDiagram
+    participant OC as OpenClaw 宿主
+    participant P as 本插件
+    participant LLM
+
+    OC->>P: before_prompt_build (event.messages)
+    Note over P: 长期记忆召回 performAutoRecall<br/>（5s 超时保护）
+    P-->>OC: { appendSystemContext, prependContext }
+    Note over OC: 宿主把 stable 部分拼进 system prompt，<br/>dynamic 部分拼到当前用户消息前/后
+
+    Note over P: offload before_prompt_build 三阶段：<br/>① 重新应用已确认的 offload 替换/删除<br/>② token 守卫（mild/aggressive/emergency）<br/>③ 注入 MMD 消息到 messages
+
+    OC->>LLM: system prompt + 修改后的 messages
+    OC->>P: before_message_write（落盘前）
+    Note over P: 从用户消息中剥离 &lt;relevant-memories&gt;，<br/>不污染 session JSONL transcript
+```
+
+## 长期记忆注入的内容格式
+
+构造函数：`performAutoRecallInner()`（`src/core/hooks/auto-recall.ts:80-219`），在 `auto-recall.ts:164-196` 处把召回结果拆成**稳定部分**与**动态部分**：
+
+- 稳定部分 → `appendSystemContext`：内容跨轮不变，留在 system prompt 里避免 prompt cache 失效
+- 动态部分 → `prependContext`（默认）或 `appendContext`：L1 召回记忆每轮不同，贴着当前用户消息放
+
+位置适配逻辑在 `src/adapters/openclaw/recall-injection.ts:17-43`；模式配置项 `recall.injectionMode`（`src/config.ts:92`，默认 `prepend`，见 `src/config.ts:648-652`）。
+
+### stableContext（system prompt 追加，`\n\n` 连接）
+
+```xml
+<user-persona>
+{persona.md 内容，已剥离 scene navigation 段落}
+</user-persona>
+
+<scene-navigation>
+---
+## 🗺️ Scene Navigation (Scene Index)
+*以下是当前场景记忆的索引，可根据需要 read_file 读取详细内容。*
+
+### Path: /abs/path/scene_blocks/xxx.md
+**热度**: 120 🔥🔥 | **更新**: 2026-07-01
+Summary: 场景的核心要点摘要
+...
+</scene-navigation>
+
+<memory-tools-guide>
+## 记忆工具调用指南
+... tdai_memory_search / tdai_conversation_search / read_file 使用说明 ...
+</memory-tools-guide>
+```
+
+注意 L2 场景块采用 progressive disclosure：上下文中只有索引（路径 + 热度 + 摘要），全文由 agent 按需 `read_file` 读取；L0 原始对话不直接注入，靠 `tdai_conversation_search` 工具检索。
+
+### dynamicContext（当前用户消息旁）
+
+```xml
+<relevant-memories>
+以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：
+
+- [persona] 用户叫王小明，30岁，是一名软件工程师。
+- [episodic|旅行计划] 用户计划五月去日本旅行。(活动时间: 2025-05-01 ~ 2025-05-10)
+- [instruction] 用户要求回答时使用中文，保持简洁。
+</relevant-memories>
+```
+
+单条格式由 `formatMemoryLine()` 生成（`auto-recall.ts:656-684`）：`- [type|scene_name] content (活动时间: …)`。数量与质量由 `maxResults=5`、`scoreThreshold=0.3` 控制；体积由 `applyRecallBudget()`（`auto-recall.ts:686-750`）按 `recall.maxCharsPerMemory` / `recall.maxTotalRecallChars` 截断（默认 0 = 不限制），截断后缀为 `…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）`。
+
+### 持久化剥离
+
+`<relevant-memories>` 只对当轮 LLM 可见。`before_message_write` hook（`index.ts:634-665`）在消息写入 session JSONL 前用正则把它剥掉，保证历史 transcript 干净、不会在下轮被重复注入。
+
+## 短期记忆（context-offload）对 messages 的修改
+
+offload 的 `before_prompt_build` 处理（`src/offload/hooks/before-prompt-build.ts:43`）分三阶段，直接改动 `event.messages`：
+
+1. **Fast-path**：重新应用之前已确认的 offload 替换/删除（宿主可能重放原始历史）。
+2. **Token 守卫**：按剩余预算触发 mild / aggressive / emergency 三档压缩。
+3. **MMD 注入**：把任务流程图消息插进 messages。
+
+具体改动形式：
+
+- **offload 摘要替换**（`src/offload/l3-helpers.ts:224-229`）：原始 tool_result 被替换为三行摘要，全文留在磁盘文件里：
+
+  ```
+  [Offloaded Tool Result | node: 7]
+  Summary: …
+  result_ref: offload.{sessionId}.jsonl#L… (read this file for full tool call and raw result)
+  ```
+
+- **活跃 MMD**（`src/offload/mmd-injector.ts:33-122`）：以 `role: "user"` 消息插入，位置在**最新一条用户消息之后**、不拆散 tool_use/tool_result 对（`findActiveMmdInsertionPoint`，`mmd-injector.ts:200-234`）：
+
+  ````xml
+  <current_task_context>
+  【当前活跃任务的mermaid流程图】这是你最近正在执行的任务的阶段性记录...
+  **任务目标:** {taskGoal}
+  **任务文件:** {mmdFile}
+  **节点索引:** 可通过 node_id 在 offload.{sessionId}.jsonl 中查找...
+  ```mermaid
+  {mmdContent}
+  ```
+  标记为 "doing" 的节点是近期焦点...
+  </current_task_context>
+  ````
+
+- **历史 MMD**（`src/offload/hooks/llm-input-l3.ts:1181` `buildHistoryMmdInjection()`）：aggressive 删除消息后的补偿，插入在活跃 MMD **之前**，格式为 `<history_task_context file="…">…</history_task_context>`，超预算（`contextWindow × mmdMaxTokenRatio`）时退化为 `mode="meta-only"` 的精简版。
+
+- **L4 skill**（`src/offload/index.ts:831`）：生成 `<l4_skill_result>…</l4_skill_result>`，通过 `systemPromptAddition` 追加到 system prompt。
+
+MMD 消息带 `_mmdContextMessage` / `_mmdInjection` 标记，L3 压缩会跳过它们，避免把流程图本身当成可压缩内容。
+
+## 记忆分层与上下文的对应关系
+
+**长期记忆**（README 语义金字塔）：
+
+| 层 | 内容 | 在上下文中的位置 |
+|---|---|---|
+| L0 | 原始对话 JSONL | 不注入，`tdai_conversation_search` 按需检索 |
+| L1 | 原子记忆（向量/FTS） | `<relevant-memories>`，当前用户消息前/后 |
+| L2 | 场景块 `scene_blocks/*.md` | `<scene-navigation>` 索引，system prompt |
+| L3 | 用户画像 `persona.md` | `<user-persona>`，system prompt |
+
+**短期记忆（offload）流水线**：L1 flush → L1.5 任务判断 → L2 生成 Mermaid MMD → L3 上下文压缩（mild/aggressive/emergency）→ L4 skill 沉淀。
+
+## 其他路径
+
+- **Gateway / Hermes**：`POST /recall`（`src/gateway/server.ts:264`）返回 JSON `{ context, stable_context, dynamic_context, injection_mode, … }`（`src/adapters/gateway/recall-response.ts:12-30`），由 Hermes 端 Python 插件在 `prefetch()` 中消费；Hermes 只支持 append，prepend 请求会降级。
+- **CLI 模式**：offload 还通过 Context Engine 的 `assemble()`（`src/offload/index.ts:2140`）生效，返回 `{ messages, estimatedTokens, systemPromptAddition }`，与 hook 路径功能等价。

--- a/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/hermes-plugin/memory/memory_tencentdb/README.md
@@ -32,10 +32,18 @@ Hermes lifecycle → Gateway mapping:
 
 | Hermes hook / call          | Gateway endpoint | Behavior                                                   |
 |-----------------------------|------------------|------------------------------------------------------------|
-| `prefetch(query)`           | `POST /recall`   | Synchronous. Returns `<memory-context>` text for injection |
+| `prefetch(query)`           | `POST /recall`   | Synchronous. Combines structured stable + dynamic recall for Hermes injection |
 | `sync_turn(user, assistant)`| `POST /capture`  | Fire-and-forget on a background daemon thread (max 4 in-flight) |
 | `shutdown()` / `on_session_end` | `POST /session/end` | Flush pending pipeline work                             |
 | `get_tool_schemas()`        | —                | Advertises two LLM tools (see below)                       |
+
+`POST /recall` returns `stable_context`, `dynamic_context`, and the preferred
+`injection_mode`. Hermes's `MemoryProvider.prefetch()` contract exposes only a
+single per-turn context string, which Hermes appends to the current user turn.
+The provider therefore combines both structured fields and uses native append
+placement. If Gateway configuration requests `prepend`, the provider logs one
+fallback warning; it never drops dynamic L1 recall. Older Gateway responses
+that only contain `context` remain supported.
 
 Reliability features baked into the provider:
 

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -377,6 +377,22 @@ CONVERSATION_SEARCH_SCHEMA = {
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
 
+def _compose_recall_context(result: Dict[str, Any]) -> str:
+    """Prefer structured Gateway recall fields, with legacy context fallback."""
+    stable = result.get("stable_context")
+    dynamic = result.get("dynamic_context")
+    structured = [
+        value.strip()
+        for value in (stable, dynamic)
+        if isinstance(value, str) and value.strip()
+    ]
+    if structured:
+        return "\n\n".join(structured)
+
+    legacy = result.get("context")
+    return legacy.strip() if isinstance(legacy, str) else ""
+
+
 class MemoryTencentdbProvider(MemoryProvider):
     """memory-tencentdb four-layer memory via local Gateway sidecar."""
 
@@ -387,6 +403,7 @@ class MemoryTencentdbProvider(MemoryProvider):
         self._user_id = ""
         self._gateway_available = False
         self._initialized = False  # Track if initialize() has been called
+        self._warned_injection_mode_fallback = False
 
         # Background sync threads.
         # We allow at most _MAX_INFLIGHT_SYNCS in-flight sync threads at any
@@ -838,7 +855,7 @@ class MemoryTencentdbProvider(MemoryProvider):
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Synchronous recall — fetch memories in real-time for the current turn."""
+        """Synchronous recall — Hermes injects the returned block after user input."""
         if not query:
             return ""
         # Lazy probe before the short-circuit guard. If the Gateway died but
@@ -856,7 +873,18 @@ class MemoryTencentdbProvider(MemoryProvider):
                 session_key=effective_session,
                 user_id=self._user_id,
             )
-            context = result.get("context", "")
+            context = _compose_recall_context(result)
+            requested_mode = result.get("injection_mode")
+            if (
+                requested_mode == "prepend"
+                and not self._warned_injection_mode_fallback
+            ):
+                logger.warning(
+                    "memory-tencentdb recall.injectionMode=prepend cannot be "
+                    "applied by Hermes MemoryProvider.prefetch(); using Hermes "
+                    "native append placement"
+                )
+                self._warned_injection_mode_fallback = True
             self._record_success()
             if context:
                 return f"## memory-tencentdb Memory\n{context}"

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_memory_tencentdb_recovery.py
@@ -63,7 +63,10 @@ if _hermes_root and _hermes_root not in sys.path:
     sys.path.insert(0, _hermes_root)
 
 try:
-    from plugins.memory.memory_tencentdb import MemoryTencentdbProvider
+    from plugins.memory.memory_tencentdb import (
+        MemoryTencentdbProvider,
+        _compose_recall_context,
+    )
     from plugins.memory.memory_tencentdb import supervisor as supervisor_module
 except ImportError as e:  # pragma: no cover — env-dependent
     pytest.skip(
@@ -325,6 +328,61 @@ def test_watchdog_stops_on_shutdown(provider_with_fake_supervisor):
 # ---------------------------------------------------------------------------
 # Lazy probe: request path self-heals when stuck-False
 # ---------------------------------------------------------------------------
+
+
+def test_compose_recall_context_prefers_structured_fields():
+    result = _compose_recall_context(
+        {
+            "context": "legacy",
+            "stable_context": "stable",
+            "dynamic_context": "dynamic",
+        }
+    )
+
+    assert result == "stable\n\ndynamic"
+
+
+def test_compose_recall_context_falls_back_to_legacy_context():
+    assert _compose_recall_context({"context": "legacy"}) == "legacy"
+
+
+def test_prefetch_consumes_structured_gateway_context(
+    provider_with_fake_supervisor,
+):
+    provider = provider_with_fake_supervisor
+    provider._fake.client.recall.return_value = {
+        "context": "legacy",
+        "stable_context": "stable",
+        "dynamic_context": "dynamic",
+        "injection_mode": "append",
+    }
+
+    result = provider.prefetch(query="hello")
+
+    assert "stable" in result
+    assert "dynamic" in result
+    assert "legacy" not in result
+
+
+def test_prefetch_warns_once_when_prepend_falls_back_to_hermes_append(
+    provider_with_fake_supervisor,
+    caplog,
+):
+    provider = provider_with_fake_supervisor
+    provider._fake.client.recall.return_value = {
+        "dynamic_context": "dynamic",
+        "injection_mode": "prepend",
+    }
+
+    provider.prefetch(query="first")
+    provider.prefetch(query="second")
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "native append placement" in record.getMessage()
+    ]
+    assert len(messages) == 1
 
 
 def test_prefetch_recovers_when_stuck_false_and_breaker_closed(

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,7 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import { shapeOpenClawRecallResult } from "./src/adapters/openclaw/recall-injection.js";
 
 const TAG = "[memory-tdai]";
 
@@ -57,7 +58,7 @@ let pluginStartTimestamp = 0;
 
 /**
  * Cache original user prompts and message counts across hooks.
- * - text: clean user prompt before prependContext injection
+ * - text: clean user prompt before dynamic recall injection
  * - ts: cache creation time (for TTL sweep)
  * - messageCount: session message count at before_prompt_build time,
  *   used as fallback slice offset if timestamp cursor is unreliable
@@ -584,17 +585,30 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
-          const appendLen = result.appendSystemContext?.length ?? 0;
-          const prependLen = result.prependContext?.length ?? 0;
+        const hookResult = shapeOpenClawRecallResult(
+          result,
+          cfg.recall.injectionMode,
+        );
+
+        if (
+          hookResult?.appendSystemContext ||
+          hookResult?.prependContext ||
+          hookResult?.appendContext
+        ) {
+          const systemLen = hookResult.appendSystemContext?.length ?? 0;
+          const prependLen = hookResult.prependContext?.length ?? 0;
+          const appendLen = hookResult.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${systemLen} chars, ` +
+            `prependContext=${prependLen} chars, ` +
+            `appendContext=${appendLen} chars, ` +
+            `injectionMode=${cfg.recall.injectionMode}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,6 +74,7 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回注入位置：prepend 保持兼容行为；append 将召回内容放在用户输入后，降低对前缀缓存的影响" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },

--- a/src/adapters/gateway/recall-response.test.ts
+++ b/src/adapters/gateway/recall-response.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { shapeGatewayRecallResponse } from "./recall-response.js";
+
+describe("shapeGatewayRecallResponse", () => {
+  it("exposes stable and dynamic recall separately", () => {
+    expect(
+      shapeGatewayRecallResponse(
+        {
+          stableContext: "stable",
+          dynamicContext: "dynamic",
+          recallStrategy: "hybrid",
+          recalledL1Memories: [
+            { content: "memory", score: 0.8, type: "preference" },
+          ],
+        },
+        "append",
+      ),
+    ).toEqual({
+      context: "stable\n\ndynamic",
+      stable_context: "stable",
+      dynamic_context: "dynamic",
+      injection_mode: "append",
+      strategy: "hybrid",
+      memory_count: 1,
+    });
+  });
+
+  it("keeps dynamic recall in the legacy combined context", () => {
+    expect(
+      shapeGatewayRecallResponse(
+        { dynamicContext: "dynamic" },
+        "prepend",
+      ),
+    ).toMatchObject({
+      context: "dynamic",
+      stable_context: "",
+      dynamic_context: "dynamic",
+      injection_mode: "prepend",
+    });
+  });
+
+  it("supports stable-only recall", () => {
+    expect(
+      shapeGatewayRecallResponse(
+        { stableContext: "stable" },
+        "prepend",
+      ),
+    ).toMatchObject({
+      context: "stable",
+      stable_context: "stable",
+      dynamic_context: "",
+    });
+  });
+
+  it("returns empty context fields when nothing was recalled", () => {
+    expect(shapeGatewayRecallResponse({}, "prepend")).toMatchObject({
+      context: "",
+      stable_context: "",
+      dynamic_context: "",
+      memory_count: 0,
+    });
+  });
+});

--- a/src/adapters/gateway/recall-response.ts
+++ b/src/adapters/gateway/recall-response.ts
@@ -1,0 +1,30 @@
+import type { RecallInjectionMode } from "../../config.js";
+import type { RecallResult } from "../../core/types.js";
+import type { RecallResponse } from "../../gateway/types.js";
+
+/**
+ * Serialize host-neutral recall output for Gateway clients.
+ *
+ * Structured fields let each agent framework choose its native placement.
+ * `context` remains a combined fallback so older Hermes clients continue to
+ * receive both stable and dynamic recall after a Gateway upgrade.
+ */
+export function shapeGatewayRecallResponse(
+  result: RecallResult,
+  injectionMode: RecallInjectionMode,
+): RecallResponse {
+  const stableContext = result.stableContext ?? "";
+  const dynamicContext = result.dynamicContext ?? "";
+  const context = [stableContext, dynamicContext]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
+
+  return {
+    context,
+    stable_context: stableContext,
+    dynamic_context: dynamicContext,
+    injection_mode: injectionMode,
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+  };
+}

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -7,7 +7,7 @@ describe("shapeOpenClawRecallResult", () => {
     expect(
       shapeOpenClawRecallResult(
         {
-          appendSystemContext: "stable",
+          stableContext: "stable",
           dynamicContext: "dynamic",
         },
         "prepend",
@@ -22,7 +22,7 @@ describe("shapeOpenClawRecallResult", () => {
     expect(
       shapeOpenClawRecallResult(
         {
-          appendSystemContext: "stable",
+          stableContext: "stable",
           dynamicContext: "dynamic",
         },
         "append",
@@ -47,7 +47,7 @@ describe("shapeOpenClawRecallResult", () => {
     expect(
       shapeOpenClawRecallResult(
         {
-          appendSystemContext: "stable",
+          stableContext: "stable",
           dynamicContext: "",
         },
         "append",

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { shapeOpenClawRecallResult } from "./recall-injection.js";
+
+describe("shapeOpenClawRecallResult", () => {
+  it("keeps dynamic recall in prependContext", () => {
+    expect(
+      shapeOpenClawRecallResult(
+        {
+          appendSystemContext: "stable",
+          dynamicContext: "dynamic",
+        },
+        "prepend",
+      ),
+    ).toEqual({
+      appendSystemContext: "stable",
+      prependContext: "dynamic",
+    });
+  });
+
+  it("moves dynamic recall to appendContext", () => {
+    expect(
+      shapeOpenClawRecallResult(
+        {
+          appendSystemContext: "stable",
+          dynamicContext: "dynamic",
+        },
+        "append",
+      ),
+    ).toEqual({
+      appendSystemContext: "stable",
+      appendContext: "dynamic",
+    });
+  });
+
+  it("does not retain prependContext in append mode", () => {
+    const result = shapeOpenClawRecallResult(
+      { dynamicContext: "dynamic" },
+      "append",
+    );
+
+    expect(result).not.toHaveProperty("prependContext");
+    expect(result).toEqual({ appendContext: "dynamic" });
+  });
+
+  it("does not create appendContext when dynamic recall is absent", () => {
+    expect(
+      shapeOpenClawRecallResult(
+        {
+          appendSystemContext: "stable",
+          dynamicContext: "",
+        },
+        "append",
+      ),
+    ).toEqual({ appendSystemContext: "stable" });
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(shapeOpenClawRecallResult(undefined, "append")).toBeUndefined();
+  });
+
+  it("preserves recall metadata", () => {
+    const recalledL1Memories = [
+      { content: "remembered", score: 0.9, type: "preference" },
+    ];
+
+    expect(
+      shapeOpenClawRecallResult(
+        {
+          dynamicContext: "dynamic",
+          recalledL1Memories,
+          recalledL3Persona: "persona",
+          recallStrategy: "hybrid",
+        },
+        "append",
+      ),
+    ).toEqual({
+      appendContext: "dynamic",
+      recalledL1Memories,
+      recalledL3Persona: "persona",
+      recallStrategy: "hybrid",
+    });
+  });
+});

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,39 @@
+import type { RecallInjectionMode } from "../../config.js";
+import type { RecallResult } from "../../core/types.js";
+
+export interface OpenClawRecallHookResult
+  extends Omit<RecallResult, "dynamicContext"> {
+  prependContext?: string;
+  appendContext?: string;
+}
+
+/**
+ * Shape host-neutral recall output for OpenClaw's prompt-build hook.
+ *
+ * Core exposes placement-neutral dynamic L1 recall. This OpenClaw boundary
+ * maps it before or after the current user prompt according to configuration.
+ */
+export function shapeOpenClawRecallResult(
+  result: RecallResult | undefined,
+  mode: RecallInjectionMode,
+): OpenClawRecallHookResult | undefined {
+  if (!result) return undefined;
+
+  const { dynamicContext, ...rest } = result;
+
+  if (!dynamicContext) {
+    return rest;
+  }
+
+  if (mode === "append") {
+    return {
+      ...rest,
+      appendContext: dynamicContext,
+    };
+  }
+
+  return {
+    ...rest,
+    prependContext: dynamicContext,
+  };
+}

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -2,7 +2,8 @@ import type { RecallInjectionMode } from "../../config.js";
 import type { RecallResult } from "../../core/types.js";
 
 export interface OpenClawRecallHookResult
-  extends Omit<RecallResult, "dynamicContext"> {
+  extends Omit<RecallResult, "stableContext" | "dynamicContext"> {
+  appendSystemContext?: string;
   prependContext?: string;
   appendContext?: string;
 }
@@ -19,7 +20,10 @@ export function shapeOpenClawRecallResult(
 ): OpenClawRecallHookResult | undefined {
   if (!result) return undefined;
 
-  const { dynamicContext, ...rest } = result;
+  const { stableContext, dynamicContext, ...metadata } = result;
+  const rest = stableContext
+    ? { ...metadata, appendSystemContext: stableContext }
+    : metadata;
 
   if (!dynamicContext) {
     return rest;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall injection mode", () => {
+  it("defaults to prepend", () => {
+    expect(parseConfig({}).recall.injectionMode).toBe("prepend");
+  });
+
+  it("accepts append", () => {
+    expect(
+      parseConfig({
+        recall: { injectionMode: "append" },
+      }).recall.injectionMode,
+    ).toBe("append");
+  });
+
+  it("falls back to prepend for an unknown mode", () => {
+    expect(
+      parseConfig({
+        recall: { injectionMode: "nonsense" },
+      }).recall.injectionMode,
+    ).toBe("prepend");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,10 +77,19 @@ export interface PipelineTriggerConfig {
   sessionActiveWindowHours: number;
 }
 
+export type RecallInjectionMode = "prepend" | "append";
+
 /** Recall settings — controls memory retrieval for context injection. */
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /**
+   * Placement of dynamic L1 recall in the current user prompt.
+   *
+   * prepend: recalled memory before the user prompt, legacy behavior
+   * append: recalled memory after the user prompt, more prefix-cache friendly
+   */
+  injectionMode: RecallInjectionMode;
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -529,6 +538,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: normalizeRecallInjectionMode(str(recallGroup, "injectionMode")),
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
@@ -634,6 +644,12 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+
+function normalizeRecallInjectionMode(
+  value: string | undefined,
+): RecallInjectionMode {
+  return value === "append" ? "append" : "prepend";
+}
 
 /**
  * Validate recall strategy against whitelist.

--- a/src/core/conversation/l0-recorder.ts
+++ b/src/core/conversation/l0-recorder.ts
@@ -81,7 +81,7 @@ const TAG = "[memory-tdai][l0]";
  * @param rawMessages - Raw messages from the agent_end hook context (full session history)
  * @param baseDir - Base data directory (~/.openclaw/memory-tdai/)
  * @param logger - Optional logger
- * @param originalUserText - Clean original user prompt (pre-prependContext)
+ * @param originalUserText - Clean original user prompt (before dynamic recall injection)
  * @param afterTimestamp - Epoch ms cursor: only messages with timestamp > this are new.
  *                         Pass 0 or omit for the first capture of a session.
  * @returns Filtered messages (for L1 to use directly), or empty array if nothing worth recording
@@ -92,7 +92,7 @@ export async function recordConversation(params: {
   rawMessages: unknown[];
   baseDir: string;
   logger?: Logger;
-  /** Clean original user prompt (pre-prependContext) */
+  /** Clean original user prompt (before dynamic recall injection) */
   originalUserText?: string;
   /** Epoch ms cursor: only process messages with timestamp strictly greater than this. */
   afterTimestamp?: number;
@@ -100,7 +100,7 @@ export async function recordConversation(params: {
    * Number of messages in the session at before_prompt_build time.
    * Used to locate the exact user message that originalUserText corresponds to:
    * rawMessages[originalUserMessageCount] is the user message appended by the framework
-   * AFTER before_prompt_build, i.e. the one whose content was polluted by prependContext.
+   * AFTER before_prompt_build, i.e. the one whose content includes dynamic recall.
    */
   originalUserMessageCount?: number;
 }): Promise<ConversationMessage[]> {
@@ -191,7 +191,7 @@ export async function recordConversation(params: {
   //
   // Background:
   //   The framework appends the user's message to the session after before_prompt_build,
-  //   then injects prependContext into it. So the user message in rawMessages is polluted.
+  //   then injects dynamic recall into it. So the user message in rawMessages is polluted.
   //   We cached the clean prompt (originalUserText) and the message count at
   //   before_prompt_build time (originalUserMessageCount) to identify which raw message
   //   is the real user input.

--- a/src/core/hooks/auto-capture.ts
+++ b/src/core/hooks/auto-capture.ts
@@ -50,7 +50,7 @@ export async function performAutoCapture(params: {
   pluginDataDir: string;
   logger?: Logger;
   scheduler?: MemoryPipelineManager;
-  /** Clean original user prompt from before_prompt_build cache (pre-prependContext). */
+  /** Clean original user prompt from before_prompt_build cache (before dynamic recall injection). */
   originalUserText?: string;
   /**
    * Number of messages in the session at before_prompt_build time.

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -163,7 +163,7 @@ async function performAutoRecallInner(params: {
 
   // Split recall context into stable and dynamic parts to optimize prompt caching.
   //
-  // appendSystemContext (system prompt end — stable, cacheable):
+  // stableContext (host-placed, stable, cacheable):
   //   persona, scene navigation, memory tools guide
   //   These change infrequently; when content is identical across turns,
   //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
@@ -193,7 +193,7 @@ async function performAutoRecallInner(params: {
     stableParts.push(MEMORY_TOOLS_GUIDE);
   }
 
-  const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  const stableContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(
@@ -205,13 +205,13 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
-  if (!appendSystemContext && !dynamicContext) {
+  if (!stableContext && !dynamicContext) {
     return undefined;
   }
 
   return {
     dynamicContext,
-    appendSystemContext,
+    stableContext,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,
     recallStrategy: effectiveStrategy,

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -21,7 +21,7 @@ import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.j
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
-import type { Logger } from "../types.js";
+import type { Logger, RecalledMemory, RecallResult } from "../types.js";
 
 const TAG = "[memory-tdai] [recall]";
 const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
@@ -46,28 +46,6 @@ const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
 - 首次搜索无结果时，可换关键词或换工具重试，但总调用次数不要超过 3 次。
 - 若 3 次搜索后仍无结果，说明该信息不在记忆中，请直接根据已有信息回复用户，不要继续搜索。
 </memory-tools-guide>`
-
-/** A single recalled L1 memory with its search score and type. */
-export interface RecalledMemory {
-  content: string;
-  score: number;
-  type: string;
-}
-
-export interface RecallResult {
-  /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn) */
-  prependContext?: string;
-  /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
-  appendSystemContext?: string;
-
-  // ── Metric payload (for pendingRecallCache in index.ts) ──
-  /** L1 memories that were recalled (with scores), for metric reporting */
-  recalledL1Memories?: RecalledMemory[];
-  /** L3 Persona raw content loaded during recall (null if none) */
-  recalledL3Persona?: string | null;
-  /** Effective search strategy used */
-  recallStrategy?: string;
-}
 
 export async function performAutoRecall(params: {
   userText: string;
@@ -190,9 +168,9 @@ async function performAutoRecallInner(params: {
   //   These change infrequently; when content is identical across turns,
   //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
   //
-  // prependContext (user prompt prefix — dynamic, per-turn):
-  //   L1 relevant memories — different every turn, moved out of system prompt
-  //   so it doesn't bust the system prompt cache.
+  // dynamicContext (host-placed, dynamic, per-turn):
+  //   L1 relevant memories — different every turn. The host adapter decides
+  //   whether this content is placed before or after the current user prompt.
   const stableParts: string[] = [];
   if (personaContent) {
     stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
@@ -201,17 +179,17 @@ async function performAutoRecallInner(params: {
     stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
   }
 
-  // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
-  let prependContext: string | undefined;
+  // Dynamic part: L1 relevant memories (changes every turn).
+  let dynamicContext: string | undefined;
   if (memoryLines.length > 0) {
-    prependContext =
+    dynamicContext =
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
   }
 
   // Append memory tools usage guide to the stable part so the agent knows
   // how to actively retrieve deeper context when the injected snippets
   // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
+  if (stableParts.length > 0 || dynamicContext) {
     stableParts.push(MEMORY_TOOLS_GUIDE);
   }
 
@@ -227,12 +205,12 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
-  if (!appendSystemContext && !prependContext) {
+  if (!appendSystemContext && !dynamicContext) {
     return undefined;
   }
 
   return {
-    prependContext,
+    dynamicContext,
     appendSystemContext,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -15,6 +15,7 @@ export type {
   LLMRunnerFactory,
   HostAdapter,
   CompletedTurn,
+  RecalledMemory,
   RecallResult,
   CaptureResult,
   MemorySearchParams,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -186,7 +186,7 @@ export interface CompletedTurn {
   /**
    * Number of messages in the session at before_prompt_build time.
    * Used by l0-recorder to locate the exact user message that was
-   * polluted by prependContext injection.
+   * augmented by dynamic recall injection.
    */
   originalUserMessageCount?: number;
 }
@@ -196,13 +196,19 @@ export interface CompletedTurn {
 // ============================
 
 /** Result from a recall (prefetch) operation. */
+export interface RecalledMemory {
+  content: string;
+  score: number;
+  type: string;
+}
+
 export interface RecallResult {
-  /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
-  prependContext?: string;
+  /** Dynamic L1 recall content for the current turn. Placement is host-defined. */
+  dynamicContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
   appendSystemContext?: string;
   /** Recalled L1 memories with scores (for metrics). */
-  recalledL1Memories?: Array<{ content: string; score: number; type: string }>;
+  recalledL1Memories?: RecalledMemory[];
   /** L3 Persona content (for metrics). */
   recalledL3Persona?: string | null;
   /** Search strategy used. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -205,8 +205,8 @@ export interface RecalledMemory {
 export interface RecallResult {
   /** Dynamic L1 recall content for the current turn. Placement is host-defined. */
   dynamicContext?: string;
-  /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
-  appendSystemContext?: string;
+  /** Stable recall content (persona, scene nav, tools guide). Placement is host-defined. */
+  stableContext?: string;
   /** Recalled L1 memories with scores (for metrics). */
   recalledL1Memories?: RecalledMemory[];
   /** L3 Persona content (for metrics). */

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -19,6 +19,7 @@ import { URL } from "node:url";
 import { timingSafeEqual } from "node:crypto";
 import { TdaiCore } from "../core/tdai-core.js";
 import { StandaloneHostAdapter } from "../adapters/standalone/host-adapter.js";
+import { shapeGatewayRecallResponse } from "../adapters/gateway/recall-response.js";
 import { loadGatewayConfig } from "./config.js";
 import type { GatewayConfig } from "./config.js";
 import { initDataDirectories } from "../utils/pipeline-factory.js";
@@ -380,13 +381,16 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
-
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
+    const response: RecallResponse = shapeGatewayRecallResponse(
+      result,
+      this.config.memory.recall.injectionMode,
+    );
+    this.logger.info(
+      `Recall completed in ${elapsed}ms: ` +
+      `stable=${response.stable_context.length} chars, ` +
+      `dynamic=${response.dynamic_context.length} chars, ` +
+      `injectionMode=${response.injection_mode}`,
+    );
     sendJson(res, 200, response);
   }
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -2,6 +2,8 @@
  * TDAI Gateway — Request/Response types for the HTTP API.
  */
 
+import type { RecallInjectionMode } from "../config.js";
+
 // ============================
 // Common
 // ============================
@@ -36,7 +38,14 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Backward-compatible combined context for clients that do not understand structured fields. */
   context: string;
+  /** Stable recall content; clients should place it in a cache-friendly host location. */
+  stable_context: string;
+  /** Dynamic L1 recall content for the current turn. */
+  dynamic_context: string;
+  /** Preferred placement for dynamic_context. Hosts may fall back to their native capability. */
+  injection_mode: RecallInjectionMode;
   strategy?: string;
   memory_count?: number;
 }


### PR DESCRIPTION
## Description | 描述
本 PR 为每轮动态 L1 记忆召回增加可配置的注入位置，并将记忆上下文从 Core 中的宿主专属字段拆分为位置无关的结构。

### 主要修改
- Core 使用以下字段表达记忆上下文：
    - stableContext：用户画像、场景导航、记忆工具说明等相对稳定的上下文
    - dynamicContext：根据当前用户输入召回的动态 L1 记忆
- 新增 recall.injectionMode 配置：
    - prepend：将动态记忆放在当前用户输入之前，保持原有行为，也是默认值
    - append：将动态记忆放在当前用户输入之后，需要宿主支持 appendContext
- OpenClaw Adapter 根据配置将 dynamicContext 映射为：
    - prependContext
    - appendContext
- Core 不再直接依赖 OpenClaw 的上下文字段命名。
- Gateway 新增结构化响应字段：
    - stable_context
    - dynamic_context
    - injection_mode
- Gateway 继续保留原有的组合字段 context，避免破坏旧客户端。
- Hermes 优先使用结构化 Gateway 响应，并保留对旧版 context 字段的兼容。
- 补充 OpenClaw、Gateway、Hermes 和配置解析相关测试。
- 更新中英文 README、插件配置 Schema 和变更记录。

### 上下文结构

| 上下文部分 | 变化频率 | 缓存影响 |
|---|---|---|
| 基础系统提示 | 通常稳定 | 可形成长期公共前缀 |
| Persona / Scene Navigation | 低频变化 | 内容稳定时可以缓存，更新时会产生新前缀 |
| 工具定义 | 通常稳定 | 位于动态内容之后时，可能因前部变化失去命中 |
| 对话历史 | 每轮增长 | 已有历史通常可以复用，截断或重写会改变前缀 |
| 动态 L1 召回 | 每轮变化 | 放在用户输入前会提前产生前缀分叉 |
| 当前用户输入 | 每轮变化 | append 模式可以让该段在下一轮继续属于公共前缀 |

`prepend` 模式：
```text
系统提示
→ 稳定记忆上下文
→ 对话历史
→ 动态 L1 召回
→ 当前用户输入
```
`append` 模式：
```text
系统提示
→ 稳定记忆上下文
→ 对话历史
→ 当前用户输入
→ 动态 L1 召回
```
`append` 可以使当前用户输入继续成为下一次请求公共前缀的一部分，但实际收益取决于用户输入长度、Provider 缓存粒度和具体工作负载。

该信息也记录在 docs/prompt-context-structure.md 以便使用者理解插件工作方式。

### 调查结论
Issue #120 最初将严重的生产环境缓存命中率下降归因于 TencentDB 的记忆注入。Issue 作者后续已经更正，主要根因是 OpenClaw WebChat 每条消息创建新的 embedded agent run，而不是 TencentDB。

下面是本次注入位置优化的测试数据：

#### 动态召回位置实验
在刻意使用较长且稳定用户输入前缀的受控 DeepSeek 实验中：

| 模式 | Warm 缓存命中率 | 缓存未命中 tokens |
|---|---:|---:|
| `prepend` | 92.63% | 28,064 |
| `append` | 95.86% | 15,758 |

在该实验负载下，`append` 相比 `prepend`：

- Warm 缓存命中率提高 3.23 个百分点
- 缓存未命中 tokens 减少 43.85%

该结果证明动态召回位置会影响公共前缀长度，但不能作为普通短消息场景下的普遍收益预期。

#### 补充实验：条件系统上下文
另外进行了 recall hit 和 recall miss交替测试，用于验证条件出现的系统上下文是否会持续破坏缓存。
（由于实测数据表明该改进对缓存命中率几乎无影响，为了减小改动面，不包含在本PR中，实现见 [本branch](https://github.com/JunWang666/TencentDB-Agent-Memory/tree/feat/keep-stable-context-independent-of-recall-hits) 中的  [这个commit](https://github.com/JunWang666/TencentDB-Agent-Memory/commit/5a8e23a48f552baff2f64e9039e3dacc387801dd) ）

实验结果表明：
- 第二种 Prompt 结构首次出现时会产生一次额外冷启动
- 两种 Prompt 结构均预热后，可以分别命中各自的缓存
- 稳态命中率分别为约 99.33% 和 99.25%

因此，该行为更准确地说是产生了缓存分叉，而不是持续导致前缀缓存失效。

### `showInjected` 的假设性影响
公开的 v0.3.6 实现中不存在 `showInjected` 配置，动态召回内容会在写入历史前被移除，因此当前实现不会产生该膨胀。
若宿主选择将每轮召回内容保留到历史，设第 i 轮注入的召回长度为 R_i，则经过 n 轮后的额外历史长度为：
额外 R_1 + R_2 + ...... + R_n
当每轮召回长度近似为 R 时，额外上下文按 O(nR) 线性增长。历史增长可能提前触发截断或压缩，而截断边界变化会影响后续请求的公共前缀。

可选优化方案：

1. 默认在写入历史前移除动态召回内容，即当前公开实现采用的方案。
2. 仅保留召回结果的稳定 ID，而不是完整文本。


## Related Issue | 关联 Issue
Related to #120 

由于[原issue](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120#issuecomment-4594410310)已经验证缓存严重退化的原因不在本项目，所以本PR只实现并评估了 Issue 中讨论的一项局部 TencentDB 优化。

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [ ] No existing features affected | 无影响现有功能

### 已完成的验证

- 使用 OpenClaw 2026.7.1 进行了本地集成测试，使用Deepseek开放平台的deepseek-v4-flash
- 验证 `prepend` 和 `append` 两种模式均能正常召回记忆
- 验证动态 L1 记忆能够被当前轮模型读取
- 验证生成的 `<relevant-memories>` 仍会在写入历史前被移除
- 验证 `recall.injectionMode` 默认值为 `prepend`
- 验证 OpenClaw Adapter 的 prepend/append 字段映射
- 完成 DeepSeek 动态召回位置对照实验
- 完成 recall hit/miss 条件系统上下文交替实验

### 测试限制

- 仅对最新版本 OpenClaw  2026.7.1 进行了测试。
- 未人工覆盖所有历史 OpenClaw 版本。
- 未人工覆盖所有可能的 Gateway 和 Hermes 部署组合。
- 动态召回位置实验刻意使用了较长的稳定用户输入，用于放大并观察位置差异。
- 实验结果不代表所有实际会话都能获得相同幅度的缓存收益。实际收益受上下文影响交大。
- 当前实验不支持将原始严重生产退化归因于 TencentDB。

## Additional Notes | 其他说明
### 关于issue里提到的session 级系统提示去重

当前逻辑已经是每次请求：
基础系统提示
+ 一份 persona / scene / tools guide
+ 对话历史
+ 当前输入

而不是：
第 N 轮：
基础系统提示
+ N 份 persona / scene / tools guide

所以，稳定内容没有重复写入 session，每轮最终 Prompt 中也只有一份，appendSystemContext 是本轮 Prompt 组装字段，不是持久化追加操作，Provider 每次仍需收到完整 system prompt，减少发送次数也不能代替前缀缓存。

在这种架构下加 session 哈希、已注入标记、TTL 或去重集合，只会凭空增加状态管理，并带来 persona 更新失效、重试、恢复、并发等新问题。

### 关于不同Provider的缓存策略

经公开文档分析，DeepSeek 与 MiMo 在本问题涉及的应用层均采用自动前缀缓存，未发现需要不同上下文编排策略的 Provider 特有差异。两者可能在缓存粒度、持久化和服务端路由实现上存在差别，但这些差别不改变本 PR 关于动态内容位置的结论。
只要两者都是自动 KV 前缀缓存，结论必然一样：
- 稳定内容靠前
- 动态内容靠后
- 前面变动会影响后续复用

因此，未为不同 Provider 引入分支逻辑。