### PR TITLE
fix(checkpoint): repair counter drift after cleanup operations

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { CheckpointManager } from "./src/utils/checkpoint.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -305,6 +306,9 @@ export default function register(api: OpenClawPluginApi) {
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
+        // Wire checkpoint reconciliation so counters stay accurate after cleanup (#157).
+        // CheckpointManager constructor is synchronous (just builds a file path), safe to inline.
+        checkpointManager: new CheckpointManager(pluginDataDir, api.logger),
       });
       sharedMemoryCleaner.start();
       api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,566 @@
+/**
+ * Tests for CheckpointManager counter-drift fix (issue #157).
+ *
+ * These tests cover the "red phase" of TDD: they assert the existence and
+ * correctness of `decrementCounters`, `recalculateCounters`, and
+ * `removePipelineState` methods on CheckpointManager. None of these methods
+ * exist yet — the tests are expected to FAIL until the implementation lands.
+ *
+ * Drift problem being solved:
+ *   Counters (total_processed, l0_conversations_count, total_memories_extracted,
+ *   memories_since_last_persona, scenes_processed) only ever increment. After
+ *   cleanup operations (memory-cleaner, manual JSONL pruning, pipeline-state
+ *   deletion, session reset) the counters permanently overestimate actual data,
+ *   causing downstream logic (persona trigger, L2 corruption check, backup
+ *   naming) to drift from reality.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+// ============================
+// Test harness
+// ============================
+
+async function makeTempDataDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cp-test-"));
+  // CheckpointManager expects <dataDir>/.metadata/recall_checkpoint.json
+  return dir;
+}
+
+async function cleanupDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+describe("CheckpointManager — counter drift fix (#157)", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await makeTempDataDir();
+  });
+
+  afterEach(async () => {
+    await cleanupDir(dataDir);
+  });
+
+  // ============================================================
+  // decrementCounters
+  // ============================================================
+
+  describe("decrementCounters", () => {
+    it("decrements total_processed by the given delta", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Seed: simulate 10 messages captured
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 10,
+      }));
+
+      await cm.decrementCounters({ total_processed: 3 });
+
+      const cp = await cm.read();
+      expect(cp.total_processed).toBe(7);
+    });
+
+    it("decrements l0_conversations_count", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 5,
+      }));
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 2000,
+        messageCount: 5,
+      }));
+      // Two captures → l0_conversations_count = 2
+      expect((await cm.read()).l0_conversations_count).toBe(2);
+
+      // Memory-cleaner removed 1 conversation file
+      await cm.decrementCounters({ l0_conversations_count: 1 });
+
+      const cp = await cm.read();
+      expect(cp.l0_conversations_count).toBe(1);
+    });
+
+    it("decrements total_memories_extracted and memories_since_last_persona", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.markL1ExtractionComplete("sess-a", 10);
+
+      // Cleaner removed 4 L1 records
+      await cm.decrementCounters({
+        total_memories_extracted: 4,
+        memories_since_last_persona: 4,
+      });
+
+      const cp = await cm.read();
+      expect(cp.total_memories_extracted).toBe(6);
+      expect(cp.memories_since_last_persona).toBe(6);
+    });
+
+    it("decrements scenes_processed", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.incrementScenesProcessed();
+      await cm.incrementScenesProcessed();
+      await cm.incrementScenesProcessed();
+      expect((await cm.read()).scenes_processed).toBe(3);
+
+      await cm.decrementCounters({ scenes_processed: 2 });
+
+      expect((await cm.read()).scenes_processed).toBe(1);
+    });
+
+    it("floors counters at 0 and warns on over-decrement", async () => {
+      const warnings: string[] = [];
+      const cm = new CheckpointManager(dataDir, {
+        info() {},
+        warn: (msg) => warnings.push(msg),
+      });
+      await cm.markL1ExtractionComplete("sess-a", 5);
+
+      // Decrement by more than what exists
+      await cm.decrementCounters({
+        total_memories_extracted: 100,
+        memories_since_last_persona: 100,
+        total_processed: 100,
+        l0_conversations_count: 100,
+        scenes_processed: 100,
+      });
+
+      const cp = await cm.read();
+      expect(cp.total_memories_extracted).toBe(0);
+      expect(cp.memories_since_last_persona).toBe(0);
+      expect(cp.total_processed).toBe(0);
+      expect(cp.l0_conversations_count).toBe(0);
+      expect(cp.scenes_processed).toBe(0);
+      // Over-decrement should be surfaced via warn (one per clamped field)
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings.some((w) => w.includes("total_memories_extracted"))).toBe(true);
+    });
+
+    it("does not warn when decrement stays above 0", async () => {
+      const warnings: string[] = [];
+      const cm = new CheckpointManager(dataDir, {
+        info() {},
+        warn: (msg) => warnings.push(msg),
+      });
+      await cm.markL1ExtractionComplete("sess-a", 10);
+
+      await cm.decrementCounters({ total_memories_extracted: 3 });
+
+      expect((await cm.read()).total_memories_extracted).toBe(7);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("is a no-op when delta is 0 or fields are omitted", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.markL1ExtractionComplete("sess-a", 5);
+
+      await cm.decrementCounters({});
+
+      const cp = await cm.read();
+      expect(cp.total_memories_extracted).toBe(5);
+    });
+
+    it("is atomic — concurrent decrements do not lose updates", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Seed 100 memories
+      await cm.markL1ExtractionComplete("sess-a", 100);
+
+      // Fire 10 concurrent decrements of 5 each = 50 total
+      const decrements = Array.from({ length: 10 }, () =>
+        cm.decrementCounters({ total_memories_extracted: 5 }),
+      );
+      await Promise.all(decrements);
+
+      const cp = await cm.read();
+      // Must be exactly 50 — no lost updates despite concurrent read-modify-write
+      expect(cp.total_memories_extracted).toBe(50);
+    });
+  });
+
+  // ============================================================
+  // recalculateCounters
+  // ============================================================
+
+  describe("recalculateCounters", () => {
+    it("sets counters to the provided authoritative values", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Drifted state: checkpoint thinks there are 100 memories but only 30 exist
+      await cm.markL1ExtractionComplete("sess-a", 100);
+
+      // Reconcile with actual count from vector store
+      await cm.recalculateCounters({
+        total_memories_extracted: 30,
+        memories_since_last_persona: 30,
+      });
+
+      const cp = await cm.read();
+      expect(cp.total_memories_extracted).toBe(30);
+      expect(cp.memories_since_last_persona).toBe(30);
+    });
+
+    it("only updates provided fields — leaves others unchanged", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 10,
+      }));
+      await cm.markL1ExtractionComplete("sess-a", 5);
+      await cm.incrementScenesProcessed();
+
+      // Recalculate only total_memories_extracted
+      await cm.recalculateCounters({ total_memories_extracted: 3 });
+
+      const cp = await cm.read();
+      expect(cp.total_memories_extracted).toBe(3);
+      // Untouched fields keep their original values
+      expect(cp.total_processed).toBe(10);
+      expect(cp.l0_conversations_count).toBe(1);
+      expect(cp.scenes_processed).toBe(1);
+    });
+
+    it("supports full reconciliation across all counters", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Seed drifted state
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 50,
+      }));
+      await cm.markL1ExtractionComplete("sess-a", 20);
+      await cm.incrementScenesProcessed();
+
+      // Bulk reconciliation after memory-cleaner run
+      await cm.recalculateCounters({
+        total_processed: 30,
+        l0_conversations_count: 3,
+        total_memories_extracted: 12,
+        memories_since_last_persona: 12,
+        scenes_processed: 2,
+      });
+
+      const cp = await cm.read();
+      expect(cp.total_processed).toBe(30);
+      expect(cp.l0_conversations_count).toBe(3);
+      expect(cp.total_memories_extracted).toBe(12);
+      expect(cp.memories_since_last_persona).toBe(12);
+      expect(cp.scenes_processed).toBe(2);
+    });
+
+    it("is atomic — concurrent recalculate + increment do not corrupt", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.markL1ExtractionComplete("sess-a", 10);
+
+      // Interleave recalculate with increments
+      await Promise.all([
+        cm.recalculateCounters({ total_memories_extracted: 5 }),
+        cm.markL1ExtractionComplete("sess-a", 3),
+        cm.recalculateCounters({ memories_since_last_persona: 2 }),
+      ]);
+
+      const cp = await cm.read();
+      // recalculate(total_memories_extracted=5) and markL1(+3) both touch
+      // total_memories_extracted. Either ordering is acceptable, but the
+      // result must be one of {5, 8} — never a corrupted/garbage value.
+      expect([5, 8]).toContain(cp.total_memories_extracted);
+    });
+
+    it("throws RangeError on negative input", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await expect(cm.recalculateCounters({ total_processed: -1 })).rejects.toThrow(RangeError);
+      await expect(cm.recalculateCounters({ total_memories_extracted: -5 })).rejects.toThrow(RangeError);
+      // Original state untouched after a throw
+      const cp = await cm.read();
+      expect(cp.total_processed).toBe(0);
+    });
+
+    it("accepts 0 (store legitimately empty)", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.markL1ExtractionComplete("sess-a", 50);
+
+      await cm.recalculateCounters({
+        total_memories_extracted: 0,
+        memories_since_last_persona: 0,
+      });
+
+      const cp = await cm.read();
+      expect(cp.total_memories_extracted).toBe(0);
+      expect(cp.memories_since_last_persona).toBe(0);
+    });
+
+    it("warns when recalculate decreases a value (drift detected)", async () => {
+      const warnings: string[] = [];
+      const cm = new CheckpointManager(dataDir, {
+        info() {},
+        warn: (msg) => warnings.push(msg),
+      });
+      await cm.markL1ExtractionComplete("sess-a", 100);
+
+      await cm.recalculateCounters({ total_memories_extracted: 30 });
+
+      // Drift detected: 100 → 30
+      expect(warnings.some((w) => w.includes("total_memories_extracted") && w.includes("drift"))).toBe(true);
+    });
+
+    it("does not warn when recalculate increases or keeps a value", async () => {
+      const warnings: string[] = [];
+      const cm = new CheckpointManager(dataDir, {
+        info() {},
+        warn: (msg) => warnings.push(msg),
+      });
+      await cm.markL1ExtractionComplete("sess-a", 10);
+
+      // Same value — no drift
+      await cm.recalculateCounters({ total_memories_extracted: 10 });
+      expect(warnings).toHaveLength(0);
+
+      // Higher value — no drift (e.g. missed increments being corrected up)
+      await cm.recalculateCounters({ total_memories_extracted: 15 });
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  // ============================================================
+  // removeRunnerState — drift path: session reset (runner-owned state)
+  // ============================================================
+
+  describe("removeRunnerState", () => {
+    it("removes a session's runner state entry", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 5000,
+        messageCount: 3,
+      }));
+
+      expect((await cm.read()).runner_states["sess-a"]).toBeDefined();
+
+      await cm.removeRunnerState("sess-a");
+
+      const cp = await cm.read();
+      expect(cp.runner_states["sess-a"]).toBeUndefined();
+    });
+
+    it("is a no-op for unknown session keys", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.removeRunnerState("never-existed");
+      expect(Object.keys((await cm.read()).runner_states)).toHaveLength(0);
+    });
+
+    it("does not touch pipeline_states for the same session", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 1,
+      }));
+      await cm.mergePipelineStates({
+        "sess-a": {
+          conversation_count: 1,
+          last_extraction_time: "",
+          last_extraction_updated_time: "",
+          last_active_time: Date.now(),
+          l2_pending_l1_count: 0,
+          warmup_threshold: 1,
+          l2_last_extraction_time: "",
+        },
+      });
+
+      await cm.removeRunnerState("sess-a");
+
+      const cp = await cm.read();
+      expect(cp.runner_states["sess-a"]).toBeUndefined();
+      // Pipeline state must survive runner-state removal
+      expect(cp.pipeline_states["sess-a"]).toBeDefined();
+      expect(cp.pipeline_states["sess-a"]!.conversation_count).toBe(1);
+    });
+
+    it("resets L0 capture cursor — next capture re-pulls from start", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 9999,
+        messageCount: 5,
+      }));
+      expect((await cm.read()).runner_states["sess-a"]!.last_captured_timestamp).toBe(9999);
+
+      await cm.removeRunnerState("sess-a");
+
+      // After removal, a new capture starts fresh (cursor absent → treated as 0)
+      await cm.captureAtomically("sess-a", 0, async (afterTs) => {
+        expect(afterTs).toBe(0); // cursor reset → full re-pull
+        return { maxTimestamp: 100, messageCount: 1 };
+      });
+    });
+  });
+
+  // ============================================================
+  // removePipelineState — drift path: "deleting pipeline state"
+  // ============================================================
+
+  describe("removePipelineState", () => {
+    it("removes a session's pipeline state entry", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.mergePipelineStates({
+        "sess-a": {
+          conversation_count: 3,
+          last_extraction_time: "2026-07-19T00:00:00.000Z",
+          last_extraction_updated_time: "2026-07-19T00:00:00.000Z",
+          last_active_time: Date.now(),
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      });
+
+      expect(Object.keys((await cm.read()).pipeline_states)).toContain("sess-a");
+
+      await cm.removePipelineState("sess-a");
+
+      const cp = await cm.read();
+      expect(cp.pipeline_states["sess-a"]).toBeUndefined();
+    });
+
+    it("is a no-op for unknown session keys", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Should not throw
+      await cm.removePipelineState("never-existed");
+      expect(Object.keys((await cm.read()).pipeline_states)).toHaveLength(0);
+    });
+
+    it("does not touch runner_states for the same session", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Seed runner state via captureAtomically (writes runner_states)
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 1,
+      }));
+      // Seed pipeline state
+      await cm.mergePipelineStates({
+        "sess-a": {
+          conversation_count: 1,
+          last_extraction_time: "",
+          last_extraction_updated_time: "",
+          last_active_time: Date.now(),
+          l2_pending_l1_count: 0,
+          warmup_threshold: 1,
+          l2_last_extraction_time: "",
+        },
+      });
+
+      await cm.removePipelineState("sess-a");
+
+      const cp = await cm.read();
+      expect(cp.pipeline_states["sess-a"]).toBeUndefined();
+      // Runner cursor must survive pipeline-state removal
+      expect(cp.runner_states["sess-a"]).toBeDefined();
+      expect(cp.runner_states["sess-a"].last_captured_timestamp).toBe(1000);
+    });
+  });
+
+  // ============================================================
+  // End-to-end drift scenarios (acceptance criteria #2 & #3)
+  // ============================================================
+
+  describe("cleanup drift scenarios", () => {
+    it("memory-cleaner removes L1 records → counters reflect actual data", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Simulate normal pipeline progress
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 10,
+      }));
+      await cm.markL1ExtractionComplete("sess-a", 8);
+
+      // memory-cleaner deletes 5 L1 records from the vector store
+      // (LocalMemoryCleaner.runOnce does NOT currently update checkpoint)
+      const deletedL1Count = 5;
+      await cm.decrementCounters({
+        total_memories_extracted: deletedL1Count,
+        memories_since_last_persona: deletedL1Count,
+      });
+
+      const cp = await cm.read();
+      // Counters now match reality: 8 - 5 = 3 memories remain
+      expect(cp.total_memories_extracted).toBe(3);
+      expect(cp.memories_since_last_persona).toBe(3);
+    });
+
+    it("manual JSONL pruning → l0_conversations_count matches file count", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // 5 conversations captured
+      for (let i = 0; i < 5; i++) {
+        await cm.captureAtomically("sess-a", i * 1000, async () => ({
+          maxTimestamp: (i + 1) * 1000,
+          messageCount: 2,
+        }));
+      }
+      expect((await cm.read()).l0_conversations_count).toBe(5);
+
+      // Admin manually prunes 2 old JSONL files
+      await cm.decrementCounters({ l0_conversations_count: 2 });
+
+      expect((await cm.read()).l0_conversations_count).toBe(3);
+    });
+
+    it("pipeline-state deletion → session no longer tracked in pipeline_states", async () => {
+      const cm = new CheckpointManager(dataDir);
+      await cm.mergePipelineStates({
+        "test-sess": {
+          conversation_count: 5,
+          last_extraction_time: "",
+          last_extraction_updated_time: "",
+          last_active_time: Date.now(),
+          l2_pending_l1_count: 5,
+          warmup_threshold: 1,
+          l2_last_extraction_time: "",
+        },
+        "real-sess": {
+          conversation_count: 2,
+          last_extraction_time: "",
+          last_extraction_updated_time: "",
+          last_active_time: Date.now(),
+          l2_pending_l1_count: 0,
+          warmup_threshold: 1,
+          l2_last_extraction_time: "",
+        },
+      });
+
+      // Delete test pipeline state
+      await cm.removePipelineState("test-sess");
+
+      const cp = await cm.read();
+      expect(Object.keys(cp.pipeline_states)).toEqual(["real-sess"]);
+    });
+
+    it("full reconciliation after bulk cleanup → checkpoint matches ground truth", async () => {
+      const cm = new CheckpointManager(dataDir);
+      // Long-running system with drifted counters
+      await cm.captureAtomically("sess-a", 0, async () => ({
+        maxTimestamp: 1000,
+        messageCount: 1000,
+      }));
+      await cm.markL1ExtractionComplete("sess-a", 500);
+      for (let i = 0; i < 10; i++) await cm.incrementScenesProcessed();
+
+      // After major cleanup, vector store reports actual counts
+      const actualL0 = 12;
+      const actualL1 = 87;
+      const actualScenes = 3;
+
+      await cm.recalculateCounters({
+        total_processed: actualL0,
+        l0_conversations_count: actualL0,
+        total_memories_extracted: actualL1,
+        memories_since_last_persona: actualL1,
+        scenes_processed: actualScenes,
+      });
+
+      const cp = await cm.read();
+      expect(cp.total_processed).toBe(actualL0);
+      expect(cp.l0_conversations_count).toBe(actualL0);
+      expect(cp.total_memories_extracted).toBe(actualL1);
+      expect(cp.memories_since_last_persona).toBe(actualL1);
+      expect(cp.scenes_processed).toBe(actualScenes);
+    });
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -147,6 +147,47 @@ export interface CheckpointLogger {
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
+// Counter delta / recalculate types
+// ============================
+
+/**
+ * Delta applied to global counters via {@link CheckpointManager.decrementCounters}.
+ * Only the five global monotonic counters can be decremented; omitted fields are
+ * left untouched.
+ *
+ * Counters covered:
+ * - `total_processed` — total L0 messages processed (maps to `countL0()`)
+ * - `l0_conversations_count` — total L0 conversation captures (no authoritative source)
+ * - `total_memories_extracted` — total L1 memories extracted (maps to `countL1()`)
+ * - `memories_since_last_persona` — L1 memories since last persona generation (delta, no source)
+ * - `scenes_processed` — total scene block extractions (maps to `scene_blocks/*.md` file count)
+ */
+export interface CounterDelta {
+  total_processed?: number;
+  l0_conversations_count?: number;
+  total_memories_extracted?: number;
+  memories_since_last_persona?: number;
+  scenes_processed?: number;
+}
+
+/**
+ * Authoritative counter values applied via {@link CheckpointManager.recalculateCounters}.
+ * Same shape as {@link CounterDelta} but semantically a "set to this absolute value"
+ * operation rather than a delta. All provided values must be `>= 0` (negative values
+ * throw `RangeError`).
+ */
+export type CounterActuals = CounterDelta;
+
+/** List of counter keys for iteration. */
+const COUNTER_KEYS: ReadonlyArray<keyof CounterDelta> = [
+  "total_processed",
+  "l0_conversations_count",
+  "total_memories_extracted",
+  "memories_since_last_persona",
+  "scenes_processed",
+];
+
+// ============================
 // Per-file async lock
 // ============================
 // Keyed by resolved file path. Multiple CheckpointManager instances pointing
@@ -330,6 +371,170 @@ export class CheckpointManager {
       cp.scenes_processed += 1;
     });
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
+  }
+
+  // ============================
+  // Counter drift repair (issue #157)
+  // ============================
+  //
+  // Counters historically only incremented. After cleanup operations
+  // (memory-cleaner, manual JSONL pruning, session reset, pipeline-state
+  // deletion) the counters permanently overestimated actual data, causing
+  // downstream drift (persona trigger, L2 corruption check, backup naming).
+  //
+  // - decrementCounters: subtract a known delta (manual cleanup where the
+  //   exact number of removed records is known). Floors at 0 + warns on
+  //   over-decrement so caller bugs surface.
+  // - recalculateCounters: set absolute authoritative values (used by
+  //   memory-cleaner which queries the vector store for ground-truth counts).
+  //   Throws on negative input (programming error). Warns when a value
+  //   decreases (drift detection signal).
+  //
+  // Concurrency: both are serialized via the per-file lock. recalculate is a
+  // "best-effort snapshot reconciliation" — the caller reads authoritative
+  // counts outside the lock, so there is an inherent TOCTOU window between
+  // the count read and the locked set. For memory-cleaner (daily, quiet time)
+  // this is acceptable; callers needing exact accuracy should quiesce the
+  // pipeline first.
+
+  /**
+   * Decrement global counters by the given delta after a cleanup operation.
+   *
+   * Each field is floored at 0 — over-decrementing (delta exceeds current
+   * value) is treated as best-effort and surfaces a `warn` log per clamped
+   * field so caller miscalculations are visible. Fields not present in
+   * `delta` are left unchanged.
+   *
+   * @example
+   * // After manually deleting 3 L1 records from the store:
+   * await cm.decrementCounters({
+   *   total_memories_extracted: 3,
+   *   memories_since_last_persona: 3,
+   * });
+   */
+  async decrementCounters(delta: CounterDelta): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      for (const key of COUNTER_KEYS) {
+        const amount = delta[key];
+        if (amount == null) continue;
+        const current = cp[key] as number;
+        const next = current - amount;
+        if (next < 0) {
+          this.logger.warn?.(
+            `[checkpoint] decrementCounters: ${key} delta=${amount} exceeds current=${current}, clamped to 0`,
+          );
+          (cp[key] as number) = 0;
+        } else {
+          (cp[key] as number) = next;
+        }
+      }
+    });
+    const changed = COUNTER_KEYS
+      .filter((k) => delta[k] != null)
+      .map((k) => `${k}=${cp[k]}`)
+      .join(", ");
+    this.logger.info(`[checkpoint] decrementCounters: ${changed}`);
+  }
+
+  /**
+   * Recalculate (reconcile) global counters to authoritative values.
+   *
+   * Used by memory-cleaner after cleanup: it queries the vector store for
+   * ground-truth counts and passes them here to replace the (possibly
+   * drifted) checkpoint values. Only fields present in `actuals` are
+   * overwritten; others are left unchanged.
+   *
+   * Negative values are rejected with `RangeError` (authoritative counts
+   * cannot be negative — this is a programming error). When a value
+   * decreases relative to the current checkpoint, a `warn` log is emitted
+   * as a drift-detection signal.
+   *
+   * @example
+   * // After memory-cleaner deletes expired records:
+   * const [l0, l1] = await Promise.all([store.countL0(), store.countL1()]);
+   * const scenes = await countSceneFiles(dataDir);
+   * await cm.recalculateCounters({
+   *   total_processed: l0,
+   *   total_memories_extracted: l1,
+   *   scenes_processed: scenes,
+   * });
+   */
+  async recalculateCounters(actuals: CounterActuals): Promise<void> {
+    // Validate inputs up front (before acquiring the lock).
+    for (const key of COUNTER_KEYS) {
+      const v = actuals[key];
+      if (v != null && v < 0) {
+        throw new RangeError(
+          `[checkpoint] recalculateCounters: ${key} must be >= 0, got ${v}`,
+        );
+      }
+    }
+
+    const cp = await this.mutate((cp) => {
+      for (const key of COUNTER_KEYS) {
+        const newVal = actuals[key];
+        if (newVal == null) continue;
+        const oldVal = cp[key] as number;
+        if (newVal < oldVal) {
+          this.logger.warn?.(
+            `[checkpoint] recalculateCounters: ${key} drift detected: ${oldVal} → ${newVal}`,
+          );
+        }
+        (cp[key] as number) = newVal;
+      }
+    });
+    const changed = COUNTER_KEYS
+      .filter((k) => actuals[k] != null)
+      .map((k) => `${k}=${cp[k]}`)
+      .join(", ");
+    this.logger.info(`[checkpoint] recalculateCounters: ${changed}`);
+  }
+
+  /**
+   * Remove a session's pipeline-managed state entry.
+   *
+   * Drift path: when a session's pipeline state is deleted (e.g. test
+   * sessions, reset operations) the entry should be removed from
+   * `pipeline_states` so the PipelineManager no longer tracks it.
+   *
+   * This writes ONLY to `pipeline_states` — `runner_states` for the same
+   * session is untouched (see {@link removeRunnerState} for the symmetric
+   * runner-state removal).
+   *
+   * No-op if the session key does not exist.
+   */
+  async removePipelineState(sessionKey: string): Promise<void> {
+    await this.mutate((cp) => {
+      if (cp.pipeline_states && sessionKey in cp.pipeline_states) {
+        delete cp.pipeline_states[sessionKey];
+      }
+    });
+    this.logger.info(`[checkpoint] removePipelineState: session=${sessionKey}`);
+  }
+
+  /**
+   * Remove a session's runner-managed state entry (L0 capture cursor,
+   * L1 cursor, scene name).
+   *
+   * ⚠️ **Warning**: clearing `last_captured_timestamp` resets the per-session
+   * L0 capture cursor to 0. The next `captureAtomically` call will re-pull
+   * ALL historical messages for this session from the beginning. Callers
+   * MUST ensure the store has already been cleaned for this session
+   * (otherwise duplicate upserts will occur).
+   *
+   * This writes ONLY to `runner_states` — `pipeline_states` for the same
+   * session is untouched (see {@link removePipelineState} for the symmetric
+   * pipeline-state removal).
+   *
+   * No-op if the session key does not exist.
+   */
+  async removeRunnerState(sessionKey: string): Promise<void> {
+    await this.mutate((cp) => {
+      if (cp.runner_states && sessionKey in cp.runner_states) {
+        delete cp.runner_states[sessionKey];
+      }
+    });
+    this.logger.info(`[checkpoint] removeRunnerState: session=${sessionKey}`);
   }
 
   // ============================

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Integration tests for LocalMemoryCleaner counter reconciliation (#157).
+ *
+ * Verifies that after `runOnce()` cleans up expired records, the checkpoint
+ * counters are recalculated against authoritative sources (vectorStore counts
+ * + scene_blocks file count) so they no longer drift from actual data.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { CheckpointManager } from "./checkpoint.js";
+import type { IMemoryStore, StoreInitResult, StoreCapabilities, L0Record, MemoryRecord, L1RecordRow, L0QueryRow, L0SessionGroup, L1SearchResult, L0SearchResult, L1FtsResult, EmbeddingProviderInfo } from "../core/store/types.js";
+
+// ============================
+// Fake vector store for testing
+// ============================
+
+/**
+ * Minimal in-memory IMemoryStore that only implements the methods the cleaner
+ * and tests touch: countL0, countL1, deleteL0Expired, deleteL1Expired.
+ * All other IMemoryStore methods throw "not implemented" so we don't accidentally
+ * rely on defaults that might mask test failures.
+ */
+class FakeVectorStore implements IMemoryStore {
+  private l0Count = 0;
+  private l1Count = 0;
+
+  constructor(opts: { l0Count: number; l1Count: number }) {
+    this.l0Count = opts.l0Count;
+    this.l1Count = opts.l1Count;
+  }
+
+  // ── Capabilities ──
+  readonly supportsDeferredEmbedding?: boolean;
+  init(_providerInfo?: EmbeddingProviderInfo): MaybePromise<StoreInitResult> {
+    throw new Error("not implemented");
+  }
+  isDegraded(): boolean { return false; }
+  getCapabilities(): StoreCapabilities {
+    throw new Error("not implemented");
+  }
+  close(): void { /* noop */ }
+
+  // ── L1 Write ──
+  upsertL1(_record: MemoryRecord, _embedding?: Float32Array): MaybePromise<boolean> {
+    throw new Error("not implemented");
+  }
+  deleteL1(_recordId: string): MaybePromise<boolean> {
+    throw new Error("not implemented");
+  }
+  deleteL1Batch(_recordIds: string[]): MaybePromise<boolean> {
+    throw new Error("not implemented");
+  }
+  deleteL1Expired(_cutoffIso: string): MaybePromise<number> {
+    // Simulate deleting half of L1 records (the "expired" ones)
+    const removed = Math.floor(this.l1Count / 2);
+    this.l1Count -= removed;
+    return removed;
+  }
+
+  // ── L1 Read ──
+  countL1(): MaybePromise<number> { return this.l1Count; }
+  queryL1Records(_filter?: unknown): MaybePromise<L1RecordRow[]> {
+    throw new Error("not implemented");
+  }
+  getAllL1Texts(): MaybePromise<Array<{ record_id: string; content: string; updated_time: string }>> {
+    throw new Error("not implemented");
+  }
+
+  // ── L1 Search ──
+  searchL1Vector(_queryEmbedding: Float32Array, _topK?: number, _queryText?: string): MaybePromise<L1SearchResult[]> {
+    throw new Error("not implemented");
+  }
+  searchL1Fts(_ftsQuery: string, _limit?: number): MaybePromise<L1FtsResult[]> {
+    throw new Error("not implemented");
+  }
+
+  // ── L0 Write ──
+  upsertL0(_record: L0Record, _embedding?: Float32Array): MaybePromise<boolean> {
+    throw new Error("not implemented");
+  }
+  updateL0Embedding?(_recordId: string, _embedding: Float32Array): MaybePromise<boolean> {
+    throw new Error("not implemented");
+  }
+  deleteL0(_recordId: string): MaybePromise<boolean> {
+    throw new Error("not implemented");
+  }
+  deleteL0Expired(_cutoffIso: string): MaybePromise<number> {
+    const removed = Math.floor(this.l0Count / 2);
+    this.l0Count -= removed;
+    return removed;
+  }
+
+  // ── L0 Read ──
+  countL0(): MaybePromise<number> { return this.l0Count; }
+  queryL0ForL1(_sessionKey: string, _afterRecordedAtMs?: number, _limit?: number): MaybePromise<L0QueryRow[]> {
+    throw new Error("not implemented");
+  }
+  queryL0GroupedBySessionId(_sessionKey: string, _afterRecordedAtMs?: number, _limit?: number): MaybePromise<L0SessionGroup[]> {
+    throw new Error("not implemented");
+  }
+  getAllL0Texts(): MaybePromise<Array<{ record_id: string; message_text: string; recorded_at: string }>> {
+    throw new Error("not implemented");
+  }
+
+  // ── L0 Search ──
+  searchL0Vector(_queryEmbedding: Float32Array, _topK?: number, _queryText?: string): MaybePromise<L0SearchResult[]> {
+    throw new Error("not implemented");
+  }
+  searchL0Fts(_ftsQuery: string, _limit?: number): MaybePromise<L0SearchResult[]> {
+    throw new Error("not implemented");
+  }
+
+  pullProfiles?(): Promise<import("../core/store/types.js").ProfileRecord[]> {
+    throw new Error("not implemented");
+  }
+  syncProfiles?(_records: import("../core/store/types.js").ProfileSyncRecord[]): Promise<void> {
+    throw new Error("not implemented");
+  }
+  deleteProfiles?(_recordIds: string[]): Promise<void> {
+    throw new Error("not implemented");
+  }
+
+  reindexAll(
+    _embedFn: (text: string) => Promise<Float32Array>,
+    _onProgress?: (done: number, total: number, layer: "L1" | "L0") => void,
+  ): Promise<{ l1Count: number; l0Count: number }> {
+    throw new Error("not implemented");
+  }
+}
+
+// Need MaybePromise type import
+import type { MaybePromise } from "../core/store/types.js";
+
+// ============================
+// Test harness
+// ============================
+
+async function makeTempBaseDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "cleaner-test-"));
+}
+
+async function cleanupDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+/**
+ * Create scene_blocks/*.md files under baseDir to test scenes_processed reconciliation.
+ */
+async function writeSceneBlocks(baseDir: string, count: number): Promise<void> {
+  const blocksDir = path.join(baseDir, "scene_blocks");
+  await fs.mkdir(blocksDir, { recursive: true });
+  for (let i = 0; i < count; i++) {
+    await fs.writeFile(path.join(blocksDir, `scene-${i}.md`), `# Scene ${i}\n`);
+  }
+}
+
+describe("LocalMemoryCleaner — counter reconciliation (#157)", () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await makeTempBaseDir();
+  });
+
+  afterEach(async () => {
+    await cleanupDir(baseDir);
+  });
+
+  it("recalculates counters after cleanup using vectorStore counts + scene files", async () => {
+    // Pre-state: checkpoint thinks there are 100 L0, 200 L1, 5 scenes (drifted high)
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.captureAtomically("sess-a", 0, async () => ({
+      maxTimestamp: 1000,
+      messageCount: 100,
+    }));
+    await checkpoint.markL1ExtractionComplete("sess-a", 200);
+    for (let i = 0; i < 5; i++) await checkpoint.incrementScenesProcessed();
+
+    // Reality: vector store has 60 L0, 120 L1 (after half deleted); fs has 3 scene files
+    const fakeStore = new FakeVectorStore({ l0Count: 60, l1Count: 120 });
+    await writeSceneBlocks(baseDir, 3);
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: fakeStore,
+      checkpointManager: checkpoint,
+    });
+
+    await cleaner.runOnce();
+
+    const cp = await checkpoint.read();
+    // Counters recalculated to authoritative values (after deleteL0Expired/deleteL1Expired halved counts)
+    // FakeVectorStore starts at 60/120, deleteL*Expired removes half → 30/60 remain
+    expect(cp.total_processed).toBe(30);
+    expect(cp.total_memories_extracted).toBe(60);
+    expect(cp.scenes_processed).toBe(3);
+  });
+
+  it("skips reconciliation when checkpointManager is not provided (legacy behavior)", async () => {
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.markL1ExtractionComplete("sess-a", 50);
+
+    const fakeStore = new FakeVectorStore({ l0Count: 10, l1Count: 20 });
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: fakeStore,
+      // checkpointManager intentionally omitted
+    });
+
+    await cleaner.runOnce();
+
+    // Counters unchanged — no reconciliation
+    const cp = await checkpoint.read();
+    expect(cp.total_memories_extracted).toBe(50);
+  });
+
+  it("reconciles scenes_processed from fs even without vectorStore", async () => {
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.incrementScenesProcessed();
+    await checkpoint.incrementScenesProcessed();
+    await checkpoint.incrementScenesProcessed();
+    await checkpoint.incrementScenesProcessed();
+    // Checkpoint thinks 4 scenes; fs has 2
+    await writeSceneBlocks(baseDir, 2);
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      // vectorStore intentionally omitted
+      checkpointManager: checkpoint,
+    });
+
+    await cleaner.runOnce();
+
+    const cp = await checkpoint.read();
+    // scenes_processed recalculated from fs (2); total_processed/memories default to 0 (no store)
+    expect(cp.scenes_processed).toBe(2);
+    expect(cp.total_processed).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+  });
+
+  it("setCheckpointManager allows late wiring after construction", async () => {
+    const checkpoint = new CheckpointManager(baseDir);
+    await checkpoint.markL1ExtractionComplete("sess-a", 100);
+
+    // Use counts above MIN_RETAIN thresholds (L0>50, L1>20) so deletion actually runs
+    const fakeStore = new FakeVectorStore({ l0Count: 60, l1Count: 30 });
+    await writeSceneBlocks(baseDir, 1);
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: fakeStore,
+      // checkpointManager not passed in constructor
+    });
+
+    // Late-wire checkpoint (mirrors setVectorStore pattern)
+    cleaner.setCheckpointManager(checkpoint);
+
+    await cleaner.runOnce();
+
+    const cp = await checkpoint.read();
+    // 30 → deleteL1Expired halves → 15; 60 → deleteL0Expired halves → 30
+    expect(cp.total_memories_extracted).toBe(15);
+    expect(cp.total_processed).toBe(30);
+    expect(cp.scenes_processed).toBe(1);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -12,6 +13,16 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  /**
+   * Optional CheckpointManager used to reconcile global counters after cleanup.
+   * When provided, {@link LocalMemoryCleaner.runOnce} will recalculate
+   * `total_processed`, `total_memories_extracted`, and `scenes_processed`
+   * against authoritative sources (vectorStore counts + scene_blocks file count)
+   * after the deletion pass, fixing the counter-drift issue (#157).
+   *
+   * If absent, cleanup proceeds but counters are NOT recalculated (legacy behavior).
+   */
+  checkpointManager?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -33,14 +44,25 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpointManager?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpointManager = opts.checkpointManager;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  /**
+   * Inject (or replace) the CheckpointManager used for post-cleanup counter
+   * reconciliation. Mirrors the {@link setVectorStore} pattern so callers can
+   * wire the checkpoint after async store init completes.
+   */
+  setCheckpointManager(cm: CheckpointManager | undefined): void {
+    this.checkpointManager = cm;
   }
 
   start(): void {
@@ -184,6 +206,72 @@ export class LocalMemoryCleaner {
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+    // ── Counter reconciliation (issue #157) ──────────────────────────
+    // After cleanup, global counters (total_processed, total_memories_extracted,
+    // scenes_processed) may have drifted from actual data. Recalculate them
+    // against authoritative sources so downstream logic (persona trigger, L2,
+    // backup naming) operates on accurate counts.
+    //
+    // Only the 3 counters with authoritative sources are auto-recalculated:
+    //   total_processed         ← vectorStore.countL0()   (L0 message count)
+    //   total_memories_extracted ← vectorStore.countL1()  (L1 record count)
+    //   scenes_processed        ← fs count of scene_blocks/*.md
+    //
+    // l0_conversations_count and memories_since_last_persona have no
+    // authoritative source and are left for manual recalculate/decrement.
+    //
+    // NOTE: This is a best-effort snapshot reconciliation. The counts are read
+    // outside the checkpoint file lock, so there is an inherent TOCTOU window
+    // between the count read and the locked set. Acceptable for a daily cleaner
+    // running during quiescent periods.
+    await this.reconcileCheckpointCounters();
+
+  }
+
+  /**
+   * Recalculate checkpoint counters against authoritative sources after cleanup.
+   * No-op if neither checkpointManager nor vectorStore is available.
+   */
+  private async reconcileCheckpointCounters(): Promise<void> {
+    if (!this.checkpointManager) {
+      this.opts.logger?.debug?.(`${TAG} Skip counter reconciliation: no checkpointManager`);
+      return;
+    }
+
+    // Read authoritative counts. countL0/countL1 are best-effort (return 0 on failure).
+    let actualL0 = 0;
+    let actualL1 = 0;
+    if (this.vectorStore) {
+      try { actualL0 = await this.vectorStore.countL0(); } catch { /* non-fatal */ }
+      try { actualL1 = await this.vectorStore.countL1(); } catch { /* non-fatal */ }
+    } else {
+      this.opts.logger?.debug?.(`${TAG} Counter reconciliation: no vectorStore, L0/L1 counts default to 0`);
+    }
+
+    // Count scene block files (fs-based, no vectorStore dependency).
+    let actualScenes = 0;
+    try {
+      actualScenes = await countSceneBlockFiles(this.opts.baseDir);
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `${TAG} Failed to count scene_blocks for reconciliation: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    try {
+      await this.checkpointManager.recalculateCounters({
+        total_processed: actualL0,
+        total_memories_extracted: actualL1,
+        scenes_processed: actualScenes,
+      });
+      this.opts.logger?.info?.(
+        `${TAG} Counter reconciliation done: total_processed=${actualL0}, total_memories_extracted=${actualL1}, scenes_processed=${actualScenes}`,
+      );
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `${TAG} Counter reconciliation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private scheduleNext(): void {
@@ -381,4 +469,24 @@ function nextRunAt(cleanTime: string, nowMs: number): number {
   }
 
   return next.getTime();
+}
+
+/**
+ * Count `.md` scene block files in `<baseDir>/scene_blocks/`.
+ * Used as the authoritative source for `scenes_processed` during reconciliation.
+ * Returns 0 if the directory does not exist.
+ */
+async function countSceneBlockFiles(baseDir: string): Promise<number> {
+  const blocksDir = path.join(baseDir, "scene_blocks");
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(blocksDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith(".md")) count += 1;
+  }
+  return count;
 }

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -532,24 +532,24 @@ export function createL2Runner(opts: {
     if (extractResult.success && extractResult.memoriesProcessed > 0) {
       const checkpoint = new CheckpointManager(pluginDataDir, logger);
       const postState = await checkpoint.read();
+
+      // ── Counter decrease is no longer treated as corruption (#157) ──
+      // Previously, a decrease in total_processed / scenes_processed between
+      // pre and post read was "repaired" via Math.max (restore old value).
+      // This assumed counters only ever increase. With the new decrementCounters
+      // / recalculateCounters methods (called by memory-cleaner and manual
+      // cleanup), a decrease is a legitimate reconciliation — the max-repair
+      // would actively undo the fix. We now only log the change for observability.
       if (
         postState.scenes_processed < preScenesProcessed ||
         postState.total_processed < preTotalProcessed
       ) {
-        logger.warn(
-          `${TAG} [L2] ⚠️ Checkpoint corruption detected! ` +
+        logger.debug?.(
+          `${TAG} [L2] Counter decrease detected during extraction (legitimate reconciliation, not repaired): ` +
           `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
           `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
-          `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
-          `Repairing...`,
+          `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}.`,
         );
-        await checkpoint.write({
-          ...postState,
-          scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
-          total_processed: Math.max(postState.total_processed, preTotalProcessed),
-          memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
-        });
-        logger.info(`${TAG} [L2] Checkpoint repaired`);
       }
 
       if (vectorStore && supportsProfileSyncWrite(vectorStore)) {


### PR DESCRIPTION
## Problem

Closes #157

Checkpoint counters (`total_processed`, `l0_conversations_count`, `total_memories_extracted`, `memories_since_last_persona`, `scenes_processed`) historically only incremented. After cleanup operations (memory-cleaner run, manual JSONL pruning, pipeline-state deletion, session reset) the counters permanently overestimated actual data, causing downstream drift in persona trigger thresholds and L2 corruption checks.

## Solution

This PR implements the acceptance criteria from the issue and [comment-4978122846](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157#issuecomment-4978122846):

### 1. `CheckpointManager.decrementCounters(delta)`
Subtract a known delta after manual cleanup. Floored at 0; over-decrement surfaces a `warn` log per clamped field so caller miscalculations are visible. Fields not in `delta` are left unchanged.

### 2. `CheckpointManager.recalculateCounters(actuals)`
Set authoritative absolute values (used by memory-cleaner). Throws `RangeError` on negative input (programming error). Emits a `warn` log when a value decreases as a drift-detection signal.

### 3. `CheckpointManager.removePipelineState()` / `removeRunnerState()`
Clean removal of per-session state entries. Each method writes ONLY to its own namespace — `removePipelineState` never touches `runner_states` and vice versa, preserving the split-state invariant.

### 4. LocalMemoryCleaner reconciliation
After each cleanup pass, `runOnce()` recalculates `total_processed`, `total_memories_extracted`, and `scenes_processed` against authoritative sources:
- `total_processed` ← `vectorStore.countL0()`
- `total_memories_extracted` ← `vectorStore.countL1()`
- `scenes_processed` ← fs count of `scene_blocks/*.md`

Late-wiring supported via `setCheckpointManager()` (mirrors the `setVectorStore` pattern). Legacy behavior preserved when `checkpointManager` is absent.

### 5. L2 runner: remove the `Math.max` repair
The L2 runner previously "repaired" counter decreases by restoring old values via `Math.max`. This actively **undid** legitimate reconciliation from the new decrement/recalculate methods. Now it only logs the change for observability.

## Concurrency & Safety
- All mutating methods are serialized via the existing per-file async lock.
- `recalculateCounters` is a best-effort snapshot reconciliation (TOCTOU window between count read and locked set is acceptable for a daily cleaner running during quiescent periods).
- Atomic writes preserved (tmp + rename).

## Testing
- **31 new tests** across `checkpoint.test.ts` and `memory-cleaner.test.ts`:
  - decrement/recalculate correctness, flooring, warn behavior, no-op semantics
  - Atomicity under concurrent decrements and interleaved recalculate+increment
  - `RangeError` on negative input, drift-detection warnings
  - `removePipelineState`/`removeRunnerState` namespace isolation
  - End-to-end cleaner reconciliation with a fake vector store + fs scene blocks
- All tests pass: `npx vitest run src/utils/checkpoint.test.ts src/utils/memory-cleaner.test.ts` → 31 passed
- No new lint errors introduced.

## Acceptance Criteria Check
| Criterion | Status |
|-----------|--------|
| Add `decrement` or `recalculate` method to CheckpointManager | ✅ Both added |
| Checkpoint reflects actual data after cleanup (pipeline-state deletion, memory-cleaner, manual JSONL pruning) | ✅ Via recalculate + decrement |
| Incremental processing no longer skipped due to drift | ✅ L2 max-repair removed |

## Notes
- This is an independent implementation addressing the same issue as PR #504 (referenced in [comment-4978122846](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157#issuecomment-4978122846)). Reviewers may compare approaches.
- DCO signed.