### PR TITLE
fix(recall): stabilize prompt-cache prefix under prependContext + showInjected (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### ✨ 新功能
 
+- **Prompt 前缀缓存保护（4 项 `recall.*` 新配置）** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：修复启用插件后 DeepSeek / MiMo 等前缀匹配缓存提供商命中率退化（MiMo 91.1%→63.5%、DeepSeek 95.7%→83.3%）的问题，机制分析与上游建议见新增的 [`PROMPT-CACHE-ANALYSIS.md`](./PROMPT-CACHE-ANALYSIS.md)。
+  - `recall.stableContextPolicy`（默认 `"session-frozen"`）：新增 `StableRecallContextCache`（`src/core/hooks/stable-context.ts`），persona / 场景导航 / 工具指南组成的稳定系统块按 sessionKey **字节级冻结**（60 分钟空闲滑动 TTL + LRU 上限）；L2/L3 会话中途改写 persona、召回超时闪断都不再破坏 prompt 前缀。`"latest"` 恢复旧的每轮重组行为。这也是 session 级稳定系统提示追加内容的去重实现。
+  - `recall.systemInjection`（默认 `"auto"`）：运行时探测宿主的缓存稳定放置 API `prependSystemPromptAdditionAfterCacheBoundary`（依次探测 event / ctx / api / api.runtime，`src/adapters/openclaw/stable-prompt-injector.ts`），命中则每轮以字节相同的冻结块调用之，并从 hook 返回值省略 `appendSystemContext` 防止双重注入；宿主缺失该 API 或调用抛错时自动回退旧路径（老宿主行为完全不变）。`"hook-context"` 强制旧路径。
+  - `recall.injectionMode`（默认 `"ephemeral"` = 旧行为）：新增 `"session-stable"` 模式——首轮召回的记忆折叠进冻结稳定块，后续轮次不再注入 `prependContext` 且跳过 L1 搜索，每轮请求成为上一轮的纯字节扩展（前缀缓存最友好）。
+  - `recall.stripInjectedFromHistory`（默认 `true` = 现行剥离行为，现在可配置）：`false` 恢复修复前「注入内容随 showInjected 冻结进历史」的行为（会重新引入历史膨胀）。
+  - 冻结同样作用于 Gateway `/recall`（按 `session_key` 生效）——同一会话的稳定块响应字节一致，属预期收益。
+  - 新增 `__tests__/prompt-cache-stability.test.ts`：FakeOpenClawHost 驱动真实 `register()` 跑 6 轮对话，逐轮断言序列化请求前缀字节稳定（LCP 下界）、历史零污染、注入器参数字节一致、persona 改写免疫与全部回退路径。
+
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。
   - **暴露给 LLM 的时间戳**统一为带显式 offset 的 ISO 8601（如 `2026-04-07T11:04:45+08:00`），修复 #87 报告的 UTC/本地时区混用导致 LLM 误算时间差的问题。
   - **L1 / L2 prompt 顶部**自动插入时区声明，指引 LLM 按正确时区推算"昨天"、"上周"等相对时间。
@@ -19,6 +27,17 @@
   - 环境变量 `TDAI_LLM_DISABLE_THINKING` 支持策略名（如 `deepseek`）和布尔值。
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
+
+### 🐛 修复
+
+- **前缀缓存命中率退化** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：`prependContext` 注入随 `showInjected=true` 冻结进历史导致上下文膨胀 + 截断抖动（主因），`appendSystemContext` 被宿主尾拼在 CACHE_BOUNDARY 之后的动态区下游（次因），稳定块每轮重组导致漂移/闪断（去重缺失）——三条失效链的插件侧修复见上方「Prompt 前缀缓存保护」条目。
+
+### ⚠️ 升级注意（#120 前缀缓存保护，默认开启）
+
+- 默认 `recall.stableContextPolicy="session-frozen"` 下，会话中途更新的 persona / 场景导航将从**下一个会话**（或空闲约 60 分钟后）开始生效；需要旧的每轮刷新行为请设 `"latest"`。
+- `recall.stripInjectedFromHistory` 默认 `true` 与现行代码行为一致（无变化）；显式设 `false` 可恢复更早版本「注入内容冻结进历史」的行为。
+- `recall.systemInjection="auto"` 在宿主不支持稳定放置 API 时回退到与旧版完全相同的 hook 返回值路径，老宿主升级零感。
+- `recall.injectionMode="session-stable"` 为可选进阶模式：记忆只在首轮召回，适合强依赖前缀缓存、会话较短的场景；默认 `"ephemeral"` 行为不变。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 

--- a/PROMPT-CACHE-ANALYSIS.md
+++ b/PROMPT-CACHE-ANALYSIS.md
@@ -1,0 +1,133 @@
+# Prompt 前缀缓存回归分析 / Prompt Prefix-Cache Regression Analysis
+
+> Issue [#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120) — prependContext + showInjected 导致 OpenAI-compatible provider 前缀缓存命中率退化
+
+---
+
+## 中文
+
+### 1. 现象
+
+启用 memory-tencentdb 插件（叠加 OpenClaw 5.19 → 5.28 升级）后，依赖**前缀匹配缓存**（prefix-matching cache）的 OpenAI-compatible 提供商命中率显著退化：
+
+| 日期 | OpenClaw | TencentDB | MiMo 命中率 | DeepSeek 命中率 |
+|------|----------|-----------|------------|----------------|
+| 5/29 | 5.19 | ❌ 未上线 | 91.1% | 95.7% |
+| 5/31 | 5.28 | ✅ 全量 | 63.5% | 83.3% |
+
+### 2. 机制
+
+**前缀缓存入门**：DeepSeek / MiMo（`openai-completions` API）的缓存以「本次请求序列化字节流与历史请求的最长公共前缀」计费——**第一个分歧字节之后的所有内容全部 miss**。系统提示是请求的最前部字节，其后依次是对话历史、当前用户消息。因此：越靠前的字节发生抖动，损失越是灾难性的。
+
+本插件（修复前）+ 宿主行为共同构成三条失效链：
+
+**链 A（主因）：prependContext → showInjected 冻结 → 历史膨胀 → 截断抖动**
+
+1. 插件每轮把召回记忆（`<relevant-memories>…</relevant-memories>`，约 500–1700 tokens）注入当前用户消息前缀（`prependContext`）。
+2. 宿主 `showInjected=true` 时，这些一次性内容被**永久冻结**进对话历史——此后每轮请求都要重发全部历史注入块。
+3. 上下文以远超正常速度膨胀，更早、更频繁地触发宿主的 tool-result truncation；截断量按**当轮剩余 token 预算动态计算**，每轮不同。
+4. 截断改写的是**历史前部**的字节 → 前缀在极靠前的位置分歧 → 整个请求 miss。命中率跌至 63.5%。
+
+**链 B（次因）：appendSystemContext 位于 CACHE_BOUNDARY 之后的动态尾部**
+
+宿主 `composeSystemPromptWithHookContext` 把 hook 返回的系统上下文（本插件的 persona + 场景导航 + 工具指南，约 4000 字符）**直接拼接到系统提示动态尾部**（CACHE_BOUNDARY 之后、每轮动态内容之后），从未调用已有的 `prependSystemPromptAdditionAfterCacheBoundary`。即使内容字节级稳定，也因位于每轮变化的动态区**下游**而永远无法命中缓存，每轮按全新 token 计费。
+
+**链 C（去重缺失）：稳定块每轮重组 → 漂移与闪断**
+
+修复前稳定块每轮从磁盘重组：L2/L3 管线**会话中途改写** `persona.md` / 场景索引 → 系统提示（请求最前部）字节变化 → 全请求 miss；召回超时那一轮返回空 → persona **消失一轮再出现** → 连续两次前缀失效。不存在任何会话级去重/冻结概念。
+
+### 3. 修复
+
+全部修复位于插件侧，默认开启、均有旧行为逃生门（`openclaw.plugin.json` 中的 4 个新 `recall.*` 配置项）：
+
+| 配置项 | 默认 | 切断的失效链 | 旧行为逃生门 |
+|---|---|---|---|
+| `recall.stripInjectedFromHistory` | `true` | 链 A：`before_message_write` 钩子在历史持久化前剥离 `<relevant-memories>`，注入内容仅当轮生效（ephemeral），历史零膨胀 | `false` 恢复冻结注入 |
+| `recall.stableContextPolicy` | `"session-frozen"` | 链 C：`StableRecallContextCache` 按 sessionKey 冻结首次组装的稳定块字节；中途 persona 改写被吸收、召回超时不再闪断（60 分钟空闲 TTL + LRU 上限） | `"latest"` 恢复每轮重组 |
+| `recall.systemInjection` | `"auto"` | 链 B：运行时探测宿主 `prependSystemPromptAdditionAfterCacheBoundary`（依次探测 event / ctx / api / api.runtime），命中则每轮以**字节相同**的冻结块调用之（宿主为逐轮重组的 replace 模型），并从 hook 返回值中省略 `appendSystemContext` 防止双重注入；宿主缺失该 API 或调用抛错时自动回退旧路径 | `"hook-context"` 强制旧路径 |
+| `recall.injectionMode` | `"ephemeral"` | 链 A 强化：`"session-stable"` 模式首轮召回后把记忆折叠进冻结稳定块，此后各轮 `prependContext` 为空且跳过 L1 搜索——每轮请求成为上一轮的**纯字节扩展** | 默认值即旧行为 |
+
+**完成度说明**：冻结/去重（链 C）、历史剥离（链 A）、session-stable 模式为**纯插件侧完整修复**；稳定位置放置（链 B）为**宿主协作型**——插件已就绪，宿主暴露 API 即自动生效，否则行为与修复前完全一致。
+
+**会话级去重语义**：稳定块在一个会话内解析为**唯一规范字节序列**（sha256 指纹漂移检测 + 计数），无论上游重组多少次、注入 API 每轮调用多少次，到达 provider 的字节永不改变——这正是 issue 建议 3 要求的去重。
+
+**与 offload 上下文引擎的关系**：`src/offload` 的 Context Engine 是独立且互斥的注入路径——其 `assemble()` 返回的 `systemPromptAddition` 是 L4 结果的**一次性**注入（在 L4 完成的那一轮消费一次，并非每轮重组），设计上即意味着该轮一次前缀失效，属预期成本；本修复的 4 个 `recall.*` 配置项不作用于该路径。TdaiCore 的冻结/去重作用于 `before_prompt_build` 召回路径与 Gateway `/recall`（按 `session_key` 生效）。
+
+### 4. 上游（OpenClaw）建议
+
+以下问题只能在宿主侧根治（符号名以 5.28 为准，可能随版本漂移）：
+
+1. **`composeSystemPromptWithHookContext`**（系统提示组装器）：将 hook 系统上下文改经 `prependSystemPromptAdditionAfterCacheBoundary` 放置（而非动态尾部直拼）；更理想的是提供 `beforeCacheBoundary` 变体，把会话级稳定内容放到 **CACHE_BOUNDARY 之前**，使 Anthropic 风格断点缓存也能覆盖（issue 建议 1）。
+2. **`showInjected`**：向会话历史持久化**干净的**用户原文，注入内容每轮临时渲染；或对 `openai-completions` 提供商默认 `showInjected=false`；并让 `before_message_write` 的返回值同时作用于**内存态历史**而不仅是落盘 transcript。
+3. **Tool-result truncation**：把截断量量化为稳定台阶（例如按消息序号固定 4k-token 桶，而非按当轮剩余预算连续取值），使相同历史前缀在相邻轮次序列化结果字节一致。
+4. **为插件提供文档化的「缓存稳定系统追加」hook 返回字段**（例如 `stableSystemContext`），插件无需运行时能力探测。
+
+### 5. 验证
+
+- **离线**：`__tests__/prompt-cache-stability.test.ts` 用 FakeOpenClawHost 驱动真实 `register()` 跑 6 轮对话，逐轮断言序列化请求的最长公共前缀（LCP）：ephemeral 模式分歧不早于上一轮当前用户消息；session-stable 模式为纯字节扩展（LCP ≥ 上一轮全长 − 2）；并覆盖历史清洁、注入器字节一致、persona 改写免疫、双注入防护与回退路径。运行：`npx vitest run`。
+- **线上 A/B**：对比开启修复前后 DeepSeek usage 中的 `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`（MiMo 对应字段同理）。预期：命中率回升至 ~90%+（链 A/C 消除后剩余 miss 主要来自宿主截断与链 B 未升级宿主的部分）。
+
+---
+
+## English
+
+### 1. Symptoms
+
+After enabling the memory-tencentdb plugin (compounded by the OpenClaw 5.19 → 5.28 upgrade), cache hit rates on prefix-matching OpenAI-compatible providers degraded sharply:
+
+| Date | OpenClaw | TencentDB | MiMo Hit Rate | DeepSeek Hit Rate |
+|------|----------|-----------|---------------|-------------------|
+| May 29 | 5.19 | ❌ Off | 91.1% | 95.7% |
+| May 31 | 5.28 | ✅ On | 63.5% | 83.3% |
+
+### 2. Mechanism
+
+**Prefix-cache primer**: DeepSeek / MiMo (`openai-completions` API) charge cache hits by the longest byte-identical prefix between the serialized request and previous requests — **everything after the first divergent byte is a miss**. The system prompt is the very first bytes of the request, followed by conversation history, then the current user message. The earlier a byte flutters, the more catastrophic the loss.
+
+The pre-fix plugin + host behavior formed three failure chains:
+
+**Chain A (primary): prependContext → showInjected freeze → history bloat → truncation jitter**
+
+1. The plugin prepends recalled memories (`<relevant-memories>…</relevant-memories>`, ~500–1700 tokens) to each turn's user message (`prependContext`).
+2. With host `showInjected=true`, this one-shot content is **permanently frozen** into conversation history — every later request re-sends every historical injected block.
+3. Context inflates far faster than normal, triggering the host's tool-result truncation earlier and more often; the truncation amount is computed from the **per-turn remaining token budget** and differs every turn.
+4. Truncation rewrites **early** history bytes → the prefix diverges near the top of the request → whole-request miss. Hit rate collapses to 63.5%.
+
+**Chain B (secondary): appendSystemContext placed after CACHE_BOUNDARY, at the dynamic tail**
+
+The host's `composeSystemPromptWithHookContext` tail-appends hook system context (our persona + scene navigation + tools guide, ~4000 chars) after the CACHE_BOUNDARY **and after the per-turn dynamic region**, never calling the existing `prependSystemPromptAdditionAfterCacheBoundary`. Even byte-stable content downstream of per-turn dynamic tokens can never cache-extend — it is re-billed as fresh input every turn.
+
+**Chain C (missing dedup): per-turn recompose → drift and flicker**
+
+The stable block was recomposed from disk every turn: the L2/L3 pipelines **rewrite `persona.md` / the scene index mid-session** → system-prompt bytes (the first bytes of the request) change → full-request miss; a recall timeout returned nothing for one turn → the persona **disappeared and reappeared** → two consecutive prefix busts. No session-level dedup/freeze concept existed.
+
+### 3. Fixes
+
+All fixes are plugin-side, on by default, each with a legacy escape hatch (4 new `recall.*` keys in `openclaw.plugin.json`):
+
+| Config key | Default | Chain it cuts | Legacy escape hatch |
+|---|---|---|---|
+| `recall.stripInjectedFromHistory` | `true` | Chain A: the `before_message_write` hook strips `<relevant-memories>` before history persist — injection is ephemeral (current turn only), history stays lean | `false` restores frozen injection |
+| `recall.stableContextPolicy` | `"session-frozen"` | Chain C: `StableRecallContextCache` byte-freezes the first composed stable block per sessionKey; mid-session persona rewrites are absorbed and recall timeouts no longer flicker the block out (60-min idle TTL + LRU cap) | `"latest"` restores per-turn recompose |
+| `recall.systemInjection` | `"auto"` | Chain B: runtime-probe the host for `prependSystemPromptAdditionAfterCacheBoundary` (event / ctx / api / api.runtime, in order); when found, call it every turn with the **byte-identical** frozen block (the host recomposes per build — replace model) and omit `appendSystemContext` from the hook result to prevent double injection; missing API or a throwing call falls back to the legacy path | `"hook-context"` forces the legacy path |
+| `recall.injectionMode` | `"ephemeral"` | Chain A, reinforced: `"session-stable"` folds turn-1 memories into the frozen stable block; later turns have no `prependContext` and skip the L1 search — each request becomes a **pure byte-extension** of the previous one | the default IS the legacy behavior |
+
+**Completeness**: freeze/dedup (Chain C), history strip (Chain A), and session-stable mode are **complete plugin-side fixes**; stable placement (Chain B) is **host-cooperative** — the plugin is ready and activates automatically once the host exposes the API; otherwise behavior is bit-for-bit identical to before the fix.
+
+**Session-level dedup semantics**: within a session the stable block resolves to **one canonical byte sequence** (sha256 fingerprint drift detection + counter). No matter how often it is recomposed upstream or how many times the injection API is invoked, the provider-visible bytes never change — exactly the dedup requested by issue suggestion 3.
+
+**Interplay with the offload context engine**: the Context Engine in `src/offload` is a separate, mutually exclusive injection path — its `assemble()` returns a **one-shot** L4 `systemPromptAddition` (consumed once on the turn L4 completes, not recomposed per turn), which by design costs a single prefix miss on that turn and is an accepted cost; the four `recall.*` knobs do not govern that path. The TdaiCore freeze/dedup applies to the `before_prompt_build` recall path and to Gateway `/recall` (keyed by `session_key`).
+
+### 4. Upstream (OpenClaw) recommendations
+
+These can only be fixed in the host (symbol names as of 5.28; may drift):
+
+1. **`composeSystemPromptWithHookContext`** (prompt composer): route hook system additions through `prependSystemPromptAdditionAfterCacheBoundary` instead of tail-appending; better yet, add a `beforeCacheBoundary` variant so session-stable additions land **before** CACHE_BOUNDARY and Anthropic-style breakpoint caching covers them too (issue suggestion 1).
+2. **`showInjected`**: persist the CLEAN user prompt to session history and render injected context ephemerally per turn (or default `showInjected=false` for `openai-completions` providers); honor `before_message_write` results for the in-memory history, not just the on-disk transcript.
+3. **Tool-result truncation**: quantize truncation to stable steps (e.g. fixed 4k-token buckets keyed to message index, not the continuous remaining budget) so identical history prefixes serialize byte-identically turn-over-turn.
+4. **Expose a documented hook-result field for "cache-stable system addition"** (e.g. `stableSystemContext`) so plugins do not need runtime capability probes.
+
+### 5. Verification
+
+- **Offline**: `__tests__/prompt-cache-stability.test.ts` drives the real `register()` through a FakeOpenClawHost over 6 conversation turns and asserts the longest common prefix (LCP) of the serialized requests turn-over-turn: in ephemeral mode divergence occurs no earlier than the previous turn's current user message; in session-stable mode every request is a pure byte extension (LCP ≥ previous full length − 2). It also covers history cleanliness, byte-identical injector arguments, persona-rewrite immunity, double-injection protection, and every fallback path. Run: `npx vitest run`.
+- **Production A/B**: compare `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` in DeepSeek usage (MiMo equivalents) with the fixes on vs. off. Expected: hit rate recovers to ~90%+ (with Chains A/C eliminated, residual misses come mainly from host truncation and, on hosts without the placement API, Chain B).

--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `pipeline.l1IdleTimeoutSeconds` | `600` | Trigger L1 after the user has been idle for this many seconds |
 | `pipeline.l2MinIntervalSeconds` | `900` | Minimum interval between two L2 passes within the same session |
 | `recall.timeoutMs` | `5000` | Recall timeout; on timeout, skip injection without blocking the conversation |
+| `recall.injectionMode` | `"ephemeral"` | Where recalled memories go: `ephemeral` (per-turn user-message prefix, stripped from history) / `session-stable` (recall once on turn 1, folded into the frozen stable block — friendliest to prefix caches) |
+| `recall.stableContextPolicy` | `"session-frozen"` | Stable block (persona / scene nav / tools guide) freshness: `session-frozen` (byte-frozen per session, protects prompt prefix caches) / `latest` (legacy per-turn recompose) |
+| `recall.stripInjectedFromHistory` | `true` | Strip `<relevant-memories>` from user messages before history persist; `false` restores the legacy frozen-injection behavior |
+| `recall.systemInjection` | `"auto"` | Stable block placement: `auto` (probe the host's cache-stable API `prependSystemPromptAdditionAfterCacheBoundary`, fall back automatically) / `hook-context` (always the legacy hook return) |
 | `extraction.enableDedup` | `true` | L1 vector dedup / conflict detection |
 | `capture.excludeAgents` | `[]` | Glob patterns to exclude specific agents (e.g. `bench-judge-*`) |
 | `capture.l0l1RetentionDays` | `0` | Local retention days for L0 / L1 files; `0` = never clean up |
@@ -457,6 +461,12 @@ For all fields, types, and constraints see [`openclaw.plugin.json`](./openclaw.p
 - `report.*` — metrics reporting
 
 </details>
+
+### Prompt-cache friendliness
+
+Prefix-matching providers (DeepSeek, MiMo — `openai-completions` API) invalidate everything after the first divergent byte of the serialized request. The four `recall.*` knobs above keep the request prefix byte-stable turn-over-turn: the stable persona/scene block is frozen per session and routed to the host's cache-stable placement API when available, and per-turn memory injections never pollute the persisted history. Defaults are safe; the full mechanism, hit-rate data, and upstream OpenClaw recommendations are in [`PROMPT-CACHE-ANALYSIS.md`](./PROMPT-CACHE-ANALYSIS.md).
+
+> **Upgrade note**: with the default `stableContextPolicy: "session-frozen"`, a persona updated mid-session takes effect on the NEXT session (or after ~60 min of idle). Set `"latest"` to restore the old per-turn refresh, and `stripInjectedFromHistory: false` to restore the pre-fix history contents.
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -425,6 +425,10 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `pipeline.l1IdleTimeoutSeconds` | `600` | 用户停止对话多久后触发 L1 |
 | `pipeline.l2MinIntervalSeconds` | `900` | 同 session 两次 L2 之间的最小间隔 |
 | `recall.timeoutMs` | `5000` | 召回超时阈值，超时跳过注入不阻塞对话 |
+| `recall.injectionMode` | `"ephemeral"` | 召回记忆注入方式：`ephemeral`（每轮注入用户消息前缀并从历史剥离）/ `session-stable`（首轮召回并折叠进冻结稳定块，前缀缓存最友好） |
+| `recall.stableContextPolicy` | `"session-frozen"` | 稳定块（persona / 场景导航 / 工具指南）刷新策略：`session-frozen`（会话内字节级冻结，保护 prompt 前缀缓存）/ `latest`（旧行为，每轮重组） |
+| `recall.stripInjectedFromHistory` | `true` | 历史持久化前剥离 `<relevant-memories>` 注入内容；`false` 恢复旧的冻结注入行为 |
+| `recall.systemInjection` | `"auto"` | 稳定块放置路径：`auto`（探测宿主缓存稳定 API `prependSystemPromptAdditionAfterCacheBoundary`，不可用自动回退）/ `hook-context`（固定走旧 hook 返回值） |
 | `extraction.enableDedup` | `true` | L1 向量去重 / 冲突检测 |
 | `capture.excludeAgents` | `[]` | Glob 模式排除特定 Agent（如 `bench-judge-*`） |
 | `capture.l0l1RetentionDays` | `0` | L0/L1 本地文件保留天数，`0` = 永不清理 |
@@ -460,6 +464,12 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 - `report.*` — 指标上报
 
 </details>
+
+### 提示词缓存友好性
+
+前缀匹配型提供商（DeepSeek、MiMo — `openai-completions` API）在序列化请求的第一个分歧字节之后全部缓存失效。上面 4 个 `recall.*` 配置项保证请求前缀逐轮字节级稳定：persona/场景稳定块按会话冻结、并在宿主支持时经缓存稳定 API 放置；每轮记忆注入不再污染持久化历史。默认值即安全值；完整机制、命中率数据与上游 OpenClaw 建议见 [`PROMPT-CACHE-ANALYSIS.md`](./PROMPT-CACHE-ANALYSIS.md)。
+
+> **升级注意**：默认 `stableContextPolicy: "session-frozen"` 下，会话中途更新的 persona 将从**下一个会话**（或空闲约 60 分钟后）开始生效。需要旧的每轮刷新行为可设为 `"latest"`；`stripInjectedFromHistory: false` 可恢复修复前的历史内容。
 
 ---
 

--- a/__tests__/helpers/fake-openclaw-host.ts
+++ b/__tests__/helpers/fake-openclaw-host.ts
@@ -1,0 +1,214 @@
+/**
+ * FakeOpenClawHost — deterministic offline simulation of the OpenClaw host
+ * for prompt-cache stability tests (issue #120).
+ *
+ * It drives the REAL `register()` from index.ts and mimics the parts of the
+ * host that matter for prefix-matching prompt caches:
+ *
+ *  - `before_prompt_build` hooks run before every turn; their
+ *    `{ prependContext, appendSystemContext }` results are merged.
+ *  - System prompt composition per build (replace model, like the host's
+ *    `composeSystemPromptWithHookContext`):
+ *        [base head] <CACHE_BOUNDARY/> [stable additions] [dynamic tail?] [hook context tail]
+ *    Stable additions come from `prependSystemPromptAdditionAfterCacheBoundary`
+ *    (when `supportsStableInjection`) and are inserted immediately after the
+ *    boundary, AHEAD of the per-turn dynamic tail. Legacy hook context
+ *    (`appendSystemContext`) is appended at the very tail — after the dynamic
+ *    region — which is exactly the cache-hostile placement the issue reports.
+ *  - `showInjected` semantics: when true, the user message committed to
+ *    history contains the injected `prependContext` (frozen-in); the
+ *    `before_message_write` hooks then get a chance to clean it.
+ *
+ * Fully deterministic: no timers, no network, no LLM.
+ */
+
+export interface FakeHostMessage {
+  role: string;
+  content: string;
+}
+
+export interface FakeHostTurnResult {
+  /** Composed system prompt for this build. */
+  system: string;
+  /** Messages array sent to the provider (history + current user message). */
+  messages: FakeHostMessage[];
+  /** Full serialized request — the byte sequence a prefix cache would see. */
+  serialized: string;
+  /** The current user message content as sent to the provider this turn. */
+  currentUserContent: string;
+}
+
+export interface FakeOpenClawHostOptions {
+  /** State dir handed to the plugin via runtime.state.resolveStateDir(). */
+  stateDir: string;
+  /** Raw plugin config (parsed by the real parseConfig inside register()). */
+  pluginConfig: Record<string, unknown>;
+  /** Expose prependSystemPromptAdditionAfterCacheBoundary on the api (default: false). */
+  supportsStableInjection?: boolean;
+  /** Freeze injected prependContext into committed history (default: true — the regression). */
+  showInjected?: boolean;
+  /**
+   * Append a per-turn dynamic tail to the system prompt after the boundary
+   * (simulates the host's dynamic system region — runtime info, tool results
+   * budget, etc.). Default: false so headline byte-stability tests can assert
+   * fully identical system prompts.
+   */
+  simulateDynamicTail?: boolean;
+}
+
+type HookHandler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
+
+export class FakeOpenClawHost {
+  readonly systemBase = "You are OpenClaw.\n<CACHE_BOUNDARY/>";
+
+  /** Committed conversation history (grows monotonically across turns). */
+  readonly history: FakeHostMessage[] = [];
+  /** Every arg ever passed to prependSystemPromptAdditionAfterCacheBoundary. */
+  readonly stableAdditionCalls: string[] = [];
+  /** Collected log lines by level (diagnostics for tests). */
+  readonly logs: Record<"debug" | "info" | "warn" | "error", string[]> = {
+    debug: [], info: [], warn: [], error: [],
+  };
+
+  readonly api: Record<string, unknown>;
+
+  private readonly handlers = new Map<string, HookHandler[]>();
+  private readonly opts: Required<Pick<FakeOpenClawHostOptions, "showInjected" | "supportsStableInjection" | "simulateDynamicTail">> & FakeOpenClawHostOptions;
+  private turn = 0;
+  /** Stable additions registered during the CURRENT prompt build (replace model). */
+  private buildStableAdditions: string[] = [];
+
+  constructor(options: FakeOpenClawHostOptions) {
+    this.opts = {
+      showInjected: true,
+      supportsStableInjection: false,
+      simulateDynamicTail: false,
+      ...options,
+    };
+
+    const host = this;
+    this.api = {
+      // Full registration mode (undefined = not "cli-metadata")
+      registrationMode: undefined,
+      pluginConfig: this.opts.pluginConfig,
+      config: {},
+      logger: {
+        debug: (m: string) => host.logs.debug.push(m),
+        info: (m: string) => host.logs.info.push(m),
+        warn: (m: string) => host.logs.warn.push(m),
+        error: (m: string) => host.logs.error.push(m),
+      },
+      runtime: {
+        agent: {},
+        // IMPORTANT: keep version undefined. register() gates the hook-policy
+        // auto-patch on a parsable version; a modern version string + vitest
+        // argv would send ensurePluginHookPolicy down the manual-patch path,
+        // which can touch the developer's real ~/.openclaw/openclaw.json.
+        version: undefined,
+        config: undefined,
+        state: { resolveStateDir: () => host.opts.stateDir },
+      },
+      on(name: string, fn: HookHandler) {
+        const list = host.handlers.get(name) ?? [];
+        list.push(fn);
+        host.handlers.set(name, list);
+      },
+      registerTool(_def: unknown, _opts?: unknown) { /* not needed for these tests */ },
+      registerCli(_fn: unknown, _opts?: unknown) { /* not needed for these tests */ },
+      ...(this.opts.supportsStableInjection
+        ? {
+            prependSystemPromptAdditionAfterCacheBoundary(content: string) {
+              host.stableAdditionCalls.push(content);
+              host.buildStableAdditions.push(content);
+            },
+          }
+        : {}),
+    };
+  }
+
+  handlerCount(name: string): number {
+    return this.handlers.get(name)?.length ?? 0;
+  }
+
+  /**
+   * Run one full conversation turn:
+   *  1. fire before_prompt_build hooks and merge their results;
+   *  2. compose the system prompt (replace model) + provider messages;
+   *  3. serialize the request (what a prefix-matching cache hashes);
+   *  4. commit the turn: before_message_write → history push (+ fake reply).
+   */
+  async runTurn(sessionKey: string, userText: string): Promise<FakeHostTurnResult> {
+    this.turn++;
+    this.buildStableAdditions = []; // per-build replace model
+
+    // 1. before_prompt_build
+    let prependContext: string | undefined;
+    let appendSystemContext: string | undefined;
+    const event = { prompt: userText, messages: [...this.history] };
+    const ctx = { sessionKey };
+    for (const handler of this.handlers.get("before_prompt_build") ?? []) {
+      const result = (await handler(event, ctx)) as
+        | { prependContext?: string; appendSystemContext?: string }
+        | undefined;
+      if (result?.prependContext) prependContext = result.prependContext;
+      if (result?.appendSystemContext) appendSystemContext = result.appendSystemContext;
+    }
+
+    // 2. Compose system prompt: base head, boundary, stable additions right
+    //    after the boundary, then the dynamic tail, then legacy hook context
+    //    at the very end (composeSystemPromptWithHookContext tail-append).
+    let system = this.systemBase;
+    if (this.buildStableAdditions.length > 0) {
+      system += `\n${this.buildStableAdditions.join("\n\n")}`;
+    }
+    if (this.opts.simulateDynamicTail) {
+      system += `\n<runtime-info turn="${this.turn}" budget="${1000 - this.turn * 37}"/>`;
+    }
+    if (appendSystemContext) {
+      system += `\n${appendSystemContext}`;
+    }
+
+    const currentUserContent = prependContext
+      ? `${prependContext}\n\n${userText}`
+      : userText;
+    const messages: FakeHostMessage[] = [
+      ...this.history.map((m) => ({ ...m })),
+      { role: "user", content: currentUserContent },
+    ];
+
+    // 3. Serialize the full provider request
+    const serialized = JSON.stringify({ system, messages });
+
+    // 4. Commit to history. showInjected=true freezes the injected content
+    //    into the committed message; before_message_write may clean it.
+    let committed: FakeHostMessage = {
+      role: "user",
+      content: this.opts.showInjected ? currentUserContent : userText,
+    };
+    for (const handler of this.handlers.get("before_message_write") ?? []) {
+      const result = (await handler({ message: committed }, ctx)) as
+        | { message?: FakeHostMessage }
+        | undefined;
+      if (result?.message) committed = result.message;
+    }
+    this.history.push(committed);
+    this.history.push({ role: "assistant", content: `reply-${this.turn}` });
+
+    return { system, messages, serialized, currentUserContent };
+  }
+
+  /** Fire registered gateway_stop handlers (cleanup guard for tests). */
+  async stop(): Promise<void> {
+    for (const handler of this.handlers.get("gateway_stop") ?? []) {
+      await handler({}, {});
+    }
+  }
+}
+
+/** Longest common prefix length of two strings (byte-prefix stability metric). */
+export function lcpLength(a: string, b: string): number {
+  const n = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < n && a[i] === b[i]) i++;
+  return i;
+}

--- a/__tests__/prompt-cache-stability.test.ts
+++ b/__tests__/prompt-cache-stability.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Issue #120 — prompt-cache stability harness.
+ *
+ * Drives the REAL plugin register() from index.ts through a FakeOpenClawHost
+ * over ≥5 conversation turns with memory injection enabled, and asserts the
+ * serialized provider request PREFIX is byte-stable turn-over-turn — the
+ * property prefix-matching caches (DeepSeek / MiMo `openai-completions`)
+ * depend on.
+ *
+ * Dynamic L1 memories are supplied by mocking performAutoRecall (no store
+ * seeding needed); TdaiCore's freeze cache, index.ts wiring, and the history
+ * strip — the actual fix surface — all run for real. Two tests at the bottom
+ * run fully UNMOCKED (persona-file-only recall) as end-to-end smoke coverage.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import register from "../index.js";
+import { performAutoRecall } from "../src/core/hooks/auto-recall.js";
+import { FakeOpenClawHost, lcpLength } from "./helpers/fake-openclaw-host.js";
+import type { FakeHostTurnResult } from "./helpers/fake-openclaw-host.js";
+
+// ── performAutoRecall control: mock delegates to the real implementation
+//    unless a test arms recallControl.impl (vi.hoisted → visible in factory) ──
+const recallControl = vi.hoisted(() => ({
+  impl: undefined as undefined | ((params: unknown) => Promise<unknown>),
+}));
+
+vi.mock("../src/core/hooks/auto-recall.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/core/hooks/auto-recall.js")>();
+  return {
+    ...actual,
+    performAutoRecall: vi.fn((params: unknown) =>
+      recallControl.impl
+        ? recallControl.impl(params)
+        : (actual.performAutoRecall as (p: unknown) => Promise<unknown>)(params),
+    ),
+  };
+});
+
+const mockRecall = vi.mocked(performAutoRecall);
+
+const PERSONA = "# Persona\n用户是一名后端工程师，偏好简洁中文回复。";
+const STABLE_BLOCK =
+  `<user-persona>\n${PERSONA}\n</user-persona>\n\n<memory-tools-guide>fixed guide</memory-tools-guide>`;
+
+let cleanupDirs: string[] = [];
+let hosts: FakeOpenClawHost[] = [];
+let sessionCounter = 0;
+
+function nextSessionKey(): string {
+  return `agent:main:pcache-${process.pid}-${++sessionCounter}`;
+}
+
+/** Arm the mock with per-turn dynamic memories + a (possibly drifting) stable block. */
+function armDynamicRecall(stableBlock: string | ((turn: number) => string) = STABLE_BLOCK): void {
+  let turn = 0;
+  recallControl.impl = async () => {
+    turn++;
+    return {
+      prependContext:
+        `<relevant-memories>\n以下是当前对话召回的相关记忆：\n\n- [episodic] turn-${turn} 用户提到了部署问题 #${turn}\n</relevant-memories>`,
+      appendSystemContext: typeof stableBlock === "function" ? stableBlock(turn) : stableBlock,
+      recalledL1Memories: [{ content: `turn-${turn}`, score: 0, type: "episodic" }],
+      recallStrategy: "hybrid",
+    };
+  };
+}
+
+async function createHost(opts: {
+  recall?: Record<string, unknown>;
+  supportsStableInjection?: boolean;
+  showInjected?: boolean;
+  simulateDynamicTail?: boolean;
+  persona?: boolean;
+} = {}): Promise<FakeOpenClawHost> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-120-host-"));
+  cleanupDirs.push(stateDir);
+  const dataDir = path.join(stateDir, "memory-tdai");
+  await fs.mkdir(dataDir, { recursive: true });
+  if (opts.persona !== false) {
+    await fs.writeFile(path.join(dataDir, "persona.md"), PERSONA, "utf-8");
+  }
+
+  const host = new FakeOpenClawHost({
+    stateDir,
+    pluginConfig: {
+      capture: { enabled: false },
+      extraction: { enabled: false },
+      recall: { enabled: true, ...(opts.recall ?? {}) },
+      embedding: { provider: "none" },
+      bm25: { enabled: false }, // zh BM25 dictionary load is seconds of pure test overhead
+      report: { enabled: false },
+    },
+    supportsStableInjection: opts.supportsStableInjection,
+    showInjected: opts.showInjected,
+    simulateDynamicTail: opts.simulateDynamicTail,
+  });
+  register(host.api as never);
+  hosts.push(host);
+  return host;
+}
+
+async function runTurns(
+  host: FakeOpenClawHost,
+  sessionKey: string,
+  count: number,
+): Promise<FakeHostTurnResult[]> {
+  const results: FakeHostTurnResult[] = [];
+  for (let n = 1; n <= count; n++) {
+    results.push(await host.runTurn(sessionKey, `用户第 ${n} 轮的问题：请继续任务 ${n}`));
+  }
+  return results;
+}
+
+/** Serialized length of one user message object (divergence-window bound). */
+function userMessageJsonLength(content: string): number {
+  return JSON.stringify({ role: "user", content }).length;
+}
+
+beforeEach(() => {
+  recallControl.impl = undefined;
+});
+
+afterEach(async () => {
+  for (const host of hosts) {
+    await host.stop().catch(() => {});
+  }
+  hosts = [];
+  vi.restoreAllMocks();
+  await Promise.all(cleanupDirs.map((d) => fs.rm(d, { recursive: true, force: true })));
+  cleanupDirs = [];
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// T1 (headline) — serialized prompt PREFIX byte-stable over 6 turns
+// ════════════════════════════════════════════════════════════════════════
+describe("T1: serialized prompt prefix is byte-stable turn-over-turn (6 turns)", () => {
+  it("ephemeral mode (default): system prompt frozen; divergence confined to the previous current-user message", async () => {
+    armDynamicRecall();
+    const host = await createHost({ supportsStableInjection: true });
+    const session = nextSessionKey();
+    const results = await runTurns(host, session, 6);
+
+    // (a) System prompt bytes identical on every one of the 6 turns.
+    const systems = new Set(results.map((r) => r.system));
+    expect(systems.size).toBe(1);
+
+    // (b) Prefix stability: request n may diverge from request n-1 no earlier
+    // than the serialization of turn n-1's current user message (whose
+    // ephemeral <relevant-memories> block is stripped from history).
+    for (let n = 1; n < results.length; n++) {
+      const prev = results[n - 1].serialized;
+      const curr = results[n].serialized;
+      const bound =
+        prev.length - userMessageJsonLength(results[n - 1].currentUserContent) - "]}".length;
+      expect(lcpLength(prev, curr)).toBeGreaterThanOrEqual(bound);
+    }
+
+    // (c) History entries, once committed, never change on later turns.
+    for (let n = 1; n < results.length; n++) {
+      const prevHistory = results[n - 1].messages.slice(0, -1);
+      const currHistoryPrefix = results[n].messages.slice(0, prevHistory.length);
+      expect(currHistoryPrefix).toEqual(prevHistory);
+    }
+  });
+
+  it("session-stable mode: every request is a pure byte-extension of the previous one", async () => {
+    armDynamicRecall();
+    const host = await createHost({
+      recall: { injectionMode: "session-stable" },
+      supportsStableInjection: true,
+    });
+    const session = nextSessionKey();
+    const results = await runTurns(host, session, 6);
+
+    // System prompt identical every turn (turn-1 memories folded + frozen).
+    expect(new Set(results.map((r) => r.system)).size).toBe(1);
+
+    // No per-turn user-prefix injection at all → perfect prefix extension:
+    // serialize(n) shares everything with serialize(n-1) except the closing "]}".
+    for (let n = 1; n < results.length; n++) {
+      const prev = results[n - 1].serialized;
+      const curr = results[n].serialized;
+      expect(lcpLength(prev, curr)).toBeGreaterThanOrEqual(prev.length - "]}".length);
+      expect(results[n].currentUserContent).not.toContain("<relevant-memories>");
+    }
+
+    // Turn-1 memories live in the frozen stable block.
+    expect(results[0].system).toContain("turn-1");
+    expect(results[0].system).not.toContain("turn-2");
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// T2/T3 — history bloat: strip ON (default) vs legacy escape hatch
+// ════════════════════════════════════════════════════════════════════════
+describe("T2: stripInjectedFromHistory=true (default) keeps frozen history clean under showInjected", () => {
+  it("committed user entries byte-equal the clean user text; zero injected residue", async () => {
+    armDynamicRecall();
+    const host = await createHost({ showInjected: true });
+    const session = nextSessionKey();
+    await runTurns(host, session, 6);
+
+    const userEntries = host.history.filter((m) => m.role === "user");
+    expect(userEntries).toHaveLength(6);
+    userEntries.forEach((m, i) => {
+      expect(m.content).toBe(`用户第 ${i + 1} 轮的问题：请继续任务 ${i + 1}`);
+    });
+    expect(JSON.stringify(host.history)).not.toContain("<relevant-memories>");
+  });
+});
+
+describe("T3: stripInjectedFromHistory=false reproduces the legacy bloat (regression documentation)", () => {
+  it("history freezes the injected blocks and grows by their size; warning logged", async () => {
+    armDynamicRecall();
+    const host = await createHost({
+      recall: { stripInjectedFromHistory: false },
+      showInjected: true,
+    });
+    expect(host.handlerCount("before_message_write")).toBe(0);
+    expect(host.logs.warn.some((w) => w.includes("stripInjectedFromHistory=false"))).toBe(true);
+
+    const session = nextSessionKey();
+    await runTurns(host, session, 6);
+
+    const userEntries = host.history.filter((m) => m.role === "user");
+    expect(userEntries).toHaveLength(6);
+    let bloat = 0;
+    userEntries.forEach((m, i) => {
+      const clean = `用户第 ${i + 1} 轮的问题：请继续任务 ${i + 1}`;
+      expect(m.content).toContain("<relevant-memories>");
+      expect(m.content).toContain(`turn-${i + 1}`);
+      expect(m.content.endsWith(clean)).toBe(true);
+      bloat += m.content.length - clean.length;
+    });
+    // Every turn permanently added its injected block to history (~issue's
+    // 500–1700 tokens/turn context inflation mechanism).
+    expect(bloat).toBeGreaterThan(0);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// T4 — session-level dedup / persona-drift immunity
+// ════════════════════════════════════════════════════════════════════════
+describe("T4: stable block dedup — drifting candidates never reach the provider", () => {
+  it("mid-session stable-block drift is absorbed (injector args byte-identical all 6 turns)", async () => {
+    // Candidate drifts every turn (simulates L2/L3 rewriting persona/scene).
+    armDynamicRecall((turn) => `${STABLE_BLOCK}\n<!-- rewrite-${turn} -->`);
+    const host = await createHost({ supportsStableInjection: true });
+    const session = nextSessionKey();
+    const results = await runTurns(host, session, 6);
+
+    expect(host.stableAdditionCalls).toHaveLength(6); // called every turn (replace model)
+    expect(new Set(host.stableAdditionCalls).size).toBe(1); // …with identical bytes
+    expect(host.stableAdditionCalls[0]).toContain("rewrite-1"); // turn-1 freeze won
+    expect(new Set(results.map((r) => r.system)).size).toBe(1);
+  });
+
+  it("stableContextPolicy=latest restores the legacy per-turn recompose (bytes drift)", async () => {
+    armDynamicRecall((turn) => `${STABLE_BLOCK}\n<!-- rewrite-${turn} -->`);
+    const host = await createHost({
+      recall: { stableContextPolicy: "latest" },
+      supportsStableInjection: true,
+    });
+    const session = nextSessionKey();
+    await runTurns(host, session, 6);
+
+    expect(new Set(host.stableAdditionCalls).size).toBe(6); // every turn different — legacy verified
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// T5 — stable placement via host API: position, fallback, double-injection
+// ════════════════════════════════════════════════════════════════════════
+describe("T5: systemInjection placement paths", () => {
+  it("auto + host API: stable block lands AHEAD of the dynamic tail, exactly once", async () => {
+    armDynamicRecall();
+    const host = await createHost({ supportsStableInjection: true, simulateDynamicTail: true });
+    const session = nextSessionKey();
+    const [r1] = await runTurns(host, session, 2);
+
+    const stableIdx = r1.system.indexOf("<user-persona>");
+    const dynamicIdx = r1.system.indexOf("<runtime-info");
+    const boundaryIdx = r1.system.indexOf("<CACHE_BOUNDARY/>");
+    expect(stableIdx).toBeGreaterThan(boundaryIdx);
+    expect(stableIdx).toBeLessThan(dynamicIdx); // cache-stable position
+    // No double injection: hook result must omit appendSystemContext.
+    expect(r1.system.match(/<user-persona>/g)).toHaveLength(1);
+    // Once-per-session info log, debug afterwards.
+    const infoLogs = host.logs.info.filter((l) => l.includes("cache-stable placement active"));
+    expect(infoLogs).toHaveLength(1);
+  });
+
+  it("auto without host API: legacy hook-context fallback (block at the dynamic tail)", async () => {
+    armDynamicRecall();
+    const host = await createHost({ supportsStableInjection: false, simulateDynamicTail: true });
+    const session = nextSessionKey();
+    const [r1] = await runTurns(host, session, 1);
+
+    expect(host.stableAdditionCalls).toHaveLength(0);
+    const stableIdx = r1.system.indexOf("<user-persona>");
+    const dynamicIdx = r1.system.indexOf("<runtime-info");
+    expect(stableIdx).toBeGreaterThan(dynamicIdx); // legacy tail placement preserved
+    expect(r1.system.match(/<user-persona>/g)).toHaveLength(1);
+  });
+
+  it("systemInjection=hook-context forces the legacy path even when the host API exists", async () => {
+    armDynamicRecall();
+    const host = await createHost({
+      recall: { systemInjection: "hook-context" },
+      supportsStableInjection: true,
+    });
+    const session = nextSessionKey();
+    const [r1] = await runTurns(host, session, 1);
+
+    expect(host.stableAdditionCalls).toHaveLength(0); // API present but never called
+    expect(r1.system).toContain("<user-persona>");
+  });
+
+  it("host API throwing falls back to hook context the same turn (warn, no lost block)", async () => {
+    armDynamicRecall();
+    const host = await createHost({ supportsStableInjection: true });
+    (host.api as Record<string, unknown>).prependSystemPromptAdditionAfterCacheBoundary = () => {
+      throw new Error("host exploded");
+    };
+    const session = nextSessionKey();
+    const [r1] = await runTurns(host, session, 1);
+
+    expect(r1.system).toContain("<user-persona>"); // block still delivered
+    expect(
+      host.logs.warn.some((w) => w.includes("Stable injection failed") && w.includes("falling back")),
+    ).toBe(true);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// Unmocked end-to-end smoke — real performAutoRecall (persona-file only)
+// ════════════════════════════════════════════════════════════════════════
+describe("unmocked smoke: real recall path, persona only", () => {
+  it("6 turns produce a perfectly extending byte-prefix via the real pipeline", async () => {
+    // recallControl.impl stays undefined → real performAutoRecall runs
+    // (persona.md exists; no vector store hits; no memories → no prependContext).
+    const host = await createHost({ supportsStableInjection: true });
+    const session = nextSessionKey();
+    const results = await runTurns(host, session, 6);
+
+    expect(new Set(results.map((r) => r.system)).size).toBe(1);
+    expect(results[0].system).toContain("<user-persona>");
+    expect(results[0].system).toContain("<memory-tools-guide>");
+    for (let n = 1; n < results.length; n++) {
+      const prev = results[n - 1].serialized;
+      expect(lcpLength(prev, results[n].serialized)).toBeGreaterThanOrEqual(
+        prev.length - "]}".length,
+      );
+    }
+    expect(mockRecall).toHaveBeenCalledTimes(6);
+  });
+
+  it("persona.md rewritten mid-session does not change the system prompt (session-frozen default)", async () => {
+    const host = await createHost({ supportsStableInjection: true });
+    const session = nextSessionKey();
+    const [r1] = await runTurns(host, session, 1);
+
+    // L3 pipeline rewrites the persona mid-session…
+    const personaPath = path.join(cleanupDirs[cleanupDirs.length - 1]!, "memory-tdai", "persona.md");
+    await fs.writeFile(personaPath, "# Persona\n完全不同的新画像内容。", "utf-8");
+
+    const later = await runTurns(host, session, 5);
+    for (const r of later) {
+      expect(r.system).toBe(r1.system); // byte-identical despite the rewrite
+      expect(r.system).not.toContain("完全不同的新画像内容");
+    }
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,8 @@ import { ensureL2L3Local } from "./src/core/profile/profile-sync.js";
 
 // Core abstractions (host-neutral)
 import { OpenClawHostAdapter } from "./src/adapters/openclaw/host-adapter.js";
+import { resolveStablePromptInjector } from "./src/adapters/openclaw/stable-prompt-injector.js";
+import type { ResolvedStablePromptInjector } from "./src/adapters/openclaw/stable-prompt-injector.js";
 import { TdaiCore } from "./src/core/tdai-core.js";
 import {
   ensurePluginHookPolicy,
@@ -88,6 +90,14 @@ const pendingRecallCache = new Map<string, {
  */
 const pendingRecallEndTimestamps = new Map<string, number>();
 
+/**
+ * Sessions for which the stable-injection path was already logged at info
+ * level (issue #120). Value = last-touch epoch ms so sweepStaleCaches can
+ * expire entries with the same TTL as the other per-session caches.
+ * Only controls log verbosity — never behavior.
+ */
+const stableInjectionLoggedSessions = new Map<string, number>();
+
 // 进程级单例，避免同一进程重复启动清理器导致并发清理竞态
 let sharedMemoryCleaner: LocalMemoryCleaner | undefined;
 
@@ -110,6 +120,16 @@ function sweepStaleCaches(): void {
     if (now - entry.ts > PROMPT_CACHE_TTL_MS) {
       pendingRecallCache.delete(key);
     }
+  }
+  // Clean stable-injection log-once markers (issue #120)
+  for (const [key, ts] of stableInjectionLoggedSessions) {
+    if (now - ts > PROMPT_CACHE_TTL_MS) {
+      stableInjectionLoggedSessions.delete(key);
+    }
+  }
+  if (stableInjectionLoggedSessions.size > PROMPT_CACHE_MAX_SIZE) {
+    // Log-verbosity marker only — safe to drop wholesale under pressure.
+    stableInjectionLoggedSessions.clear();
   }
   // Hard limit: evict oldest entries if either Map exceeds cap
   if (pendingOriginalPrompts.size > PROMPT_CACHE_MAX_SIZE) {
@@ -523,6 +543,24 @@ export default function register(api: OpenClawPluginApi) {
   // Lifecycle hooks — delegate to TdaiCore
   // ============================
 
+  /**
+   * Log the active stable-injection path at info level once per session,
+   * then at debug level (the injector is invoked every turn by design —
+   * per-build replace model — so per-turn info logs would be pure noise).
+   */
+  const logStableInjectionOnce = (sessionKey: string, resolved: ResolvedStablePromptInjector): void => {
+    const firstTime = !stableInjectionLoggedSessions.has(sessionKey);
+    stableInjectionLoggedSessions.set(sessionKey, Date.now());
+    const message =
+      `${TAG} [before_prompt_build] Stable block routed via host API ` +
+      `${resolved.apiName} (source=${resolved.source}) — cache-stable placement active`;
+    if (firstTime) {
+      api.logger.info(`${message} (session=${sessionKey})`);
+    } else {
+      api.logger.debug?.(message);
+    }
+  };
+
   // Before prompt build: auto-recall relevant memories
   if (cfg.recall.enabled) {
     api.logger.debug?.(`${TAG} Registering before_prompt_build hook (auto-recall)`);
@@ -584,17 +622,54 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
+        // ── Stable-placement path (issue #120) ──
+        // Hand the (session-frozen) stable block to the host's cache-stable
+        // system-prompt API when available, so it lands immediately after the
+        // CACHE_BOUNDARY, AHEAD of the per-turn dynamic tail, instead of being
+        // tail-appended by composeSystemPromptWithHookContext. The injector is
+        // called every turn with byte-identical frozen content — correct under
+        // the host's per-build compose (replace) model. When the host lacks
+        // the API (or recall.systemInjection="hook-context"), we fall back to
+        // returning appendSystemContext from the hook exactly as before.
+        //
+        // Return ONLY the injection fields — metric fields (recalledL1Memories
+        // etc.) are plugin-internal and must not leak into the host hook result.
+        let hookResult: { prependContext?: string; appendSystemContext?: string } = {
+          prependContext: result?.prependContext,
+          appendSystemContext: result?.appendSystemContext,
+        };
+        let injectionPath = "hook-context";
+        if (cfg.recall.systemInjection === "auto" && hookResult.appendSystemContext) {
+          const resolved = resolveStablePromptInjector(api, event, ctx);
+          if (resolved) {
+            try {
+              resolved.injector(hookResult.appendSystemContext);
+              injectionPath = `stable-api:${resolved.source}`;
+              logStableInjectionOnce(resolvedSessionKey, resolved);
+              // Omit appendSystemContext from the hook result to avoid double injection.
+              hookResult = { prependContext: hookResult.prependContext };
+            } catch (err) {
+              api.logger.warn(
+                `${TAG} [before_prompt_build] Stable injection failed (${resolved.apiName} via ${resolved.source}): ` +
+                `${err instanceof Error ? err.message : String(err)} — falling back to hook context`,
+              );
+            }
+          }
+        }
+
         if (result?.appendSystemContext || result?.prependContext) {
           const appendLen = result.appendSystemContext?.length ?? 0;
           const prependLen = result.prependContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars, ` +
+            `path=${injectionPath}, mode=${result?.injectionModeUsed ?? "ephemeral"}, ` +
+            `stableCacheHit=${result?.stableContextCacheHit ?? false}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -616,6 +691,13 @@ export default function register(api: OpenClawPluginApi) {
   // the session JSONL.  The current-turn LLM already saw the full prompt
   // (effectivePrompt lives in memory), but we don't want recall artifacts
   // polluting the historical transcript for future replays.
+  //
+  // Config-gated (issue #120): with showInjected-style hosts, unstripped
+  // injections are frozen into conversation history, inflating the context by
+  // ~500–1700 tokens per turn and triggering variable tool-result truncation
+  // that busts prefix-matching prompt caches. Default true; setting
+  // recall.stripInjectedFromHistory=false restores the legacy behavior.
+  if (cfg.recall.stripInjectedFromHistory) {
   api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
   api.on("before_message_write", (event) => {
     const msg = event.message as { role?: string; content?: unknown };
@@ -649,6 +731,12 @@ export default function register(api: OpenClawPluginApi) {
       return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
     }
   });
+  } else {
+    api.logger.warn(
+      `${TAG} recall.stripInjectedFromHistory=false — injected <relevant-memories> will be ` +
+      `frozen into conversation history (legacy behavior, prompt-cache hostile)`,
+    );
+  }
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule
   if (cfg.capture.enabled) {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -79,7 +79,11 @@
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
-          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }
+          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" },
+          "injectionMode": { "type": "string", "enum": ["ephemeral", "session-stable"], "default": "ephemeral", "description": "召回记忆注入方式：ephemeral=每轮注入用户消息前缀并从持久化历史剥离（默认）；session-stable=首轮召回并冻结进稳定系统块，后续轮次零变化（前缀缓存最友好）" },
+          "stableContextPolicy": { "type": "string", "enum": ["session-frozen", "latest"], "default": "session-frozen", "description": "稳定系统块（persona/场景导航/工具指南）刷新策略：session-frozen=同一会话内字节级冻结，保证 prompt 前缀缓存命中（默认）；latest=每轮重新生成（旧行为，L2/L3 中途改写 persona 会破坏缓存）" },
+          "stripInjectedFromHistory": { "type": "boolean", "default": true, "description": "持久化历史前剥离 <relevant-memories> 注入内容，避免对话历史膨胀导致前缀缓存失效；false 恢复旧行为（注入内容冻结进历史）" },
+          "systemInjection": { "type": "string", "enum": ["auto", "hook-context"], "default": "auto", "description": "稳定块的系统提示注入路径：auto=探测宿主 prependSystemPromptAdditionAfterCacheBoundary 并优先使用（缓存友好位置），不可用时自动回退 hook 返回值；hook-context=固定走 hook 返回值（旧行为）" }
         }
       },
       "embedding": {

--- a/src/adapters/openclaw/stable-prompt-injector.test.ts
+++ b/src/adapters/openclaw/stable-prompt-injector.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  STABLE_INJECTION_API_CANDIDATES,
+  resolveStablePromptInjector,
+} from "./stable-prompt-injector.js";
+
+const API_NAME = "prependSystemPromptAdditionAfterCacheBoundary";
+
+describe("resolveStablePromptInjector", () => {
+  it("exposes the documented candidate list", () => {
+    expect(STABLE_INJECTION_API_CANDIDATES).toContain(API_NAME);
+  });
+
+  it("returns undefined when no carrier exposes the API", () => {
+    expect(resolveStablePromptInjector({}, {}, {})).toBeUndefined();
+    expect(resolveStablePromptInjector(undefined, undefined, undefined)).toBeUndefined();
+    expect(resolveStablePromptInjector(null, "string-event", 42)).toBeUndefined();
+  });
+
+  it("finds the API on the plugin api object and binds `this`", () => {
+    const calls: string[] = [];
+    const api = {
+      [API_NAME](content: string) {
+        calls.push(content);
+        expect(this).toBe(api);
+      },
+    };
+    const resolved = resolveStablePromptInjector(api);
+    expect(resolved?.source).toBe("api");
+    expect(resolved?.apiName).toBe(API_NAME);
+    resolved?.injector("stable-block");
+    expect(calls).toEqual(["stable-block"]);
+  });
+
+  it("finds the API on api.runtime", () => {
+    const fn = vi.fn();
+    const api = { runtime: { [API_NAME]: fn } };
+    const resolved = resolveStablePromptInjector(api);
+    expect(resolved?.source).toBe("api.runtime");
+    resolved?.injector("x");
+    expect(fn).toHaveBeenCalledWith("x");
+  });
+
+  it("prefers request-scoped carriers: event > ctx > api > api.runtime", () => {
+    const order: string[] = [];
+    const mk = (tag: string) => ({ [API_NAME]: () => order.push(tag) });
+
+    const all = resolveStablePromptInjector(mk("api"), mk("event"), mk("ctx"));
+    expect(all?.source).toBe("event");
+    all?.injector("");
+    expect(order).toEqual(["event"]);
+
+    const noEvent = resolveStablePromptInjector(mk("api"), {}, mk("ctx"));
+    expect(noEvent?.source).toBe("ctx");
+
+    const apiRuntimeOnly = resolveStablePromptInjector({ runtime: mk("runtime") }, {}, {});
+    expect(apiRuntimeOnly?.source).toBe("api.runtime");
+  });
+
+  it("ignores non-function values under the candidate name", () => {
+    expect(
+      resolveStablePromptInjector({ [API_NAME]: "not-a-function" }, { [API_NAME]: 123 }),
+    ).toBeUndefined();
+  });
+
+  it("never throws on exotic carriers", () => {
+    expect(() =>
+      resolveStablePromptInjector(Object.create(null), Symbol("e") as unknown, () => {}),
+    ).not.toThrow();
+  });
+
+  it("never throws when a carrier property getter throws (request-scoped getter)", () => {
+    const event = {};
+    Object.defineProperty(event, API_NAME, {
+      get() {
+        throw new Error("accessed outside request scope");
+      },
+      enumerable: true,
+    });
+    // Probe must skip the hostile carrier and still find the API further down.
+    const fn = vi.fn();
+    const resolved = resolveStablePromptInjector({ [API_NAME]: fn }, event, {});
+    expect(resolved?.source).toBe("api");
+    resolved?.injector("x");
+    expect(fn).toHaveBeenCalledWith("x");
+  });
+
+  it("never throws when api.runtime itself is a throwing getter", () => {
+    const api = {};
+    Object.defineProperty(api, "runtime", {
+      get() {
+        throw new Error("no runtime outside request");
+      },
+    });
+    expect(resolveStablePromptInjector(api)).toBeUndefined();
+  });
+
+  it("propagates host API exceptions to the caller (caller owns the try/catch)", () => {
+    const api = {
+      [API_NAME]: () => {
+        throw new Error("host exploded");
+      },
+    };
+    const resolved = resolveStablePromptInjector(api);
+    expect(resolved).toBeDefined();
+    expect(() => resolved?.injector("x")).toThrow("host exploded");
+  });
+});

--- a/src/adapters/openclaw/stable-prompt-injector.ts
+++ b/src/adapters/openclaw/stable-prompt-injector.ts
@@ -1,0 +1,92 @@
+/**
+ * Stable prompt injector — runtime capability probe for the OpenClaw host API
+ * that places system-prompt additions in a cache-stable position (issue #120).
+ *
+ * Background: OpenClaw's `composeSystemPromptWithHookContext` appends hook
+ * context (our `appendSystemContext`) AFTER the CACHE_BOUNDARY marker, at the
+ * tail of the per-turn dynamic region — so even byte-stable persona content is
+ * re-billed as fresh tokens every turn on prefix-matching providers
+ * (DeepSeek / MiMo). The host also ships
+ * `prependSystemPromptAdditionAfterCacheBoundary`, which places additions
+ * immediately after the boundary, AHEAD of the dynamic tail — the position
+ * intended for per-session-constant content — but never calls it for hook
+ * context.
+ *
+ * `openclaw` is an optional peer dependency that is not installed in this
+ * repo (type-only import elsewhere), and the API surface has drifted across
+ * host versions, so nothing host-side can be imported or type-checked here.
+ * Instead we feature-probe at runtime (same idiom as the api.on /
+ * registerContextEngine probe in src/offload/index.ts) across every carrier
+ * OpenClaw has historically hung request-scoped helpers on: the hook `event`,
+ * the hook `ctx`, the plugin `api`, and `api.runtime`.
+ *
+ * The candidate list is data-driven so a future host rename is a one-line fix.
+ */
+
+export type StablePromptInjector = (content: string) => void;
+
+/** Candidate host API names, in priority order. */
+export const STABLE_INJECTION_API_CANDIDATES = [
+  "prependSystemPromptAdditionAfterCacheBoundary",
+] as const;
+
+export interface ResolvedStablePromptInjector {
+  /** Bound invoker — calls the host API with the stable block content. */
+  injector: StablePromptInjector;
+  /** Which carrier exposed the API ("event" | "ctx" | "api" | "api.runtime"). */
+  source: string;
+  /** The host API name that matched. */
+  apiName: string;
+}
+
+/**
+ * Probe `event`, `ctx`, `api`, `api.runtime` (in that order — request-scoped
+ * carriers win over process-scoped ones) for the first candidate that is a
+ * function. Returns a bound injector or undefined. Never throws.
+ *
+ * The caller must wrap the actual injector INVOCATION in try/catch and fall
+ * back to hook-context injection if the host API throws.
+ */
+export function resolveStablePromptInjector(
+  api: unknown,
+  event?: unknown,
+  ctx?: unknown,
+): ResolvedStablePromptInjector | undefined {
+  // api.runtime may be a request-scoped getter that throws outside a request
+  // context — guard the access so the probe honors its "never throws" contract.
+  let runtime: unknown;
+  try {
+    runtime = (api as { runtime?: unknown } | null | undefined)?.runtime;
+  } catch {
+    runtime = undefined;
+  }
+
+  const carriers: Array<[string, unknown]> = [
+    ["event", event],
+    ["ctx", ctx],
+    ["api", api],
+    ["api.runtime", runtime],
+  ];
+
+  for (const [source, carrier] of carriers) {
+    if (!carrier || (typeof carrier !== "object" && typeof carrier !== "function")) continue;
+    for (const apiName of STABLE_INJECTION_API_CANDIDATES) {
+      let fn: unknown;
+      try {
+        fn = (carrier as Record<string, unknown>)[apiName];
+      } catch {
+        continue; // hostile/request-scoped getter — treat as absent on this carrier
+      }
+      if (typeof fn === "function") {
+        return {
+          injector: (content: string) => {
+            (fn as (content: string) => void).call(carrier, content);
+          },
+          source,
+          apiName,
+        };
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/config.recall.test.ts
+++ b/src/config.recall.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("recall config — prompt-cache knobs (issue #120)", () => {
+  it("applies safe defaults with zero config", () => {
+    const cfg = parseConfig({});
+    expect(cfg.recall.injectionMode).toBe("ephemeral");
+    expect(cfg.recall.stableContextPolicy).toBe("session-frozen");
+    expect(cfg.recall.stripInjectedFromHistory).toBe(true);
+    expect(cfg.recall.systemInjection).toBe("auto");
+  });
+
+  it("applies safe defaults when recall group is present but keys are absent", () => {
+    const cfg = parseConfig({ recall: { enabled: true, maxResults: 3 } });
+    expect(cfg.recall.injectionMode).toBe("ephemeral");
+    expect(cfg.recall.stableContextPolicy).toBe("session-frozen");
+    expect(cfg.recall.stripInjectedFromHistory).toBe(true);
+    expect(cfg.recall.systemInjection).toBe("auto");
+  });
+
+  it("accepts every whitelisted value", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "session-stable",
+        stableContextPolicy: "latest",
+        stripInjectedFromHistory: false,
+        systemInjection: "hook-context",
+      },
+    });
+    expect(cfg.recall.injectionMode).toBe("session-stable");
+    expect(cfg.recall.stableContextPolicy).toBe("latest");
+    expect(cfg.recall.stripInjectedFromHistory).toBe(false);
+    expect(cfg.recall.systemInjection).toBe("hook-context");
+  });
+
+  it("falls back to defaults for values outside the whitelist", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "per-turn",
+        stableContextPolicy: "always-fresh",
+        stripInjectedFromHistory: "yes", // wrong type → default
+        systemInjection: "cache-boundary",
+      },
+    });
+    expect(cfg.recall.injectionMode).toBe("ephemeral");
+    expect(cfg.recall.stableContextPolicy).toBe("session-frozen");
+    expect(cfg.recall.stripInjectedFromHistory).toBe(true);
+    expect(cfg.recall.systemInjection).toBe("auto");
+  });
+
+  it("falls back to defaults for empty / whitespace strings", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "",
+        stableContextPolicy: "   ",
+        systemInjection: "",
+      },
+    });
+    expect(cfg.recall.injectionMode).toBe("ephemeral");
+    expect(cfg.recall.stableContextPolicy).toBe("session-frozen");
+    expect(cfg.recall.systemInjection).toBe("auto");
+  });
+
+  it("does not disturb pre-existing recall keys", () => {
+    const cfg = parseConfig({
+      recall: { strategy: "keyword", timeoutMs: 1234, injectionMode: "session-stable" },
+    });
+    expect(cfg.recall.strategy).toBe("keyword");
+    expect(cfg.recall.timeoutMs).toBe(1234);
+    expect(cfg.recall.injectionMode).toBe("session-stable");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,38 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /**
+   * Where dynamic recalled memories are injected (default: "ephemeral").
+   * - "ephemeral":      prependContext on the current user message every turn;
+   *                     stripped from persisted history via before_message_write.
+   * - "session-stable": recall once on the session's first turn, fold memories into
+   *                     the frozen stable system block; no per-turn prependContext
+   *                     (zero per-turn prompt variance — best for prefix-matching caches).
+   */
+  injectionMode: "ephemeral" | "session-stable";
+  /**
+   * Stable system block (persona / scene navigation / tools guide) freshness policy
+   * (default: "session-frozen").
+   * - "session-frozen": the first composed block is byte-frozen per sessionKey so the
+   *                     serialized prompt prefix never drifts mid-session.
+   * - "latest":         legacy — recompose every turn (cache-hostile when persona/scene
+   *                     files are rewritten mid-session by the L2/L3 pipelines).
+   */
+  stableContextPolicy: "session-frozen" | "latest";
+  /**
+   * Strip <relevant-memories> from user messages before they are persisted to
+   * history (default: true). Set false to restore the pre-fix behavior where
+   * injected recall content is frozen into conversation history (prompt-cache hostile).
+   */
+  stripInjectedFromHistory: boolean;
+  /**
+   * System-prompt placement path for the stable block (default: "auto").
+   * - "auto":         probe the host for a cache-stable placement API
+   *                   (prependSystemPromptAdditionAfterCacheBoundary); use it when
+   *                   available, otherwise fall back to the hook-context return value.
+   * - "hook-context": always return appendSystemContext from the hook (legacy).
+   */
+  systemInjection: "auto" | "hook-context";
 }
 
 /** Embedding service configuration for vector search. */
@@ -535,6 +567,10 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      injectionMode: validateInjectionMode(str(recallGroup, "injectionMode")) ?? "ephemeral",
+      stableContextPolicy: validateStableContextPolicy(str(recallGroup, "stableContextPolicy")) ?? "session-frozen",
+      stripInjectedFromHistory: bool(recallGroup, "stripInjectedFromHistory") ?? true,
+      systemInjection: validateSystemInjection(str(recallGroup, "systemInjection")) ?? "auto",
     },
     embedding: {
       enabled: embeddingEnabled,
@@ -643,6 +679,45 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+const VALID_INJECTION_MODES: RecallConfig["injectionMode"][] = ["ephemeral", "session-stable"];
+
+/**
+ * Validate recall injection mode against whitelist.
+ * Returns the mode if valid, undefined otherwise (caller falls back to default).
+ */
+function validateInjectionMode(value: string | undefined): RecallConfig["injectionMode"] | undefined {
+  if (!value) return undefined;
+  return VALID_INJECTION_MODES.includes(value as RecallConfig["injectionMode"])
+    ? (value as RecallConfig["injectionMode"])
+    : undefined;
+}
+
+const VALID_STABLE_CONTEXT_POLICIES: RecallConfig["stableContextPolicy"][] = ["session-frozen", "latest"];
+
+/**
+ * Validate stable context policy against whitelist.
+ * Returns the policy if valid, undefined otherwise (caller falls back to default).
+ */
+function validateStableContextPolicy(value: string | undefined): RecallConfig["stableContextPolicy"] | undefined {
+  if (!value) return undefined;
+  return VALID_STABLE_CONTEXT_POLICIES.includes(value as RecallConfig["stableContextPolicy"])
+    ? (value as RecallConfig["stableContextPolicy"])
+    : undefined;
+}
+
+const VALID_SYSTEM_INJECTIONS: RecallConfig["systemInjection"][] = ["auto", "hook-context"];
+
+/**
+ * Validate system injection path against whitelist.
+ * Returns the value if valid, undefined otherwise (caller falls back to default).
+ */
+function validateSystemInjection(value: string | undefined): RecallConfig["systemInjection"] | undefined {
+  if (!value) return undefined;
+  return VALID_SYSTEM_INJECTIONS.includes(value as RecallConfig["systemInjection"])
+    ? (value as RecallConfig["systemInjection"])
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import {
+  MEMORY_TOOLS_GUIDE,
+  composeStableParts,
+  performAutoRecall,
+} from "./auto-recall.js";
+
+const PERSONA = "# Persona\n用户是一名后端工程师，偏好简洁中文回复。";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-120-recall-"));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("composeStableParts", () => {
+  it("reproduces the legacy join byte-for-byte (persona + scene + guide)", () => {
+    const persona = "persona-body";
+    const scene = "scene-nav-body";
+    const legacy = [
+      `<user-persona>\n${persona}\n</user-persona>`,
+      `<scene-navigation>\n${scene}\n</scene-navigation>`,
+      MEMORY_TOOLS_GUIDE,
+    ].join("\n\n");
+    expect(composeStableParts(persona, scene, false)).toBe(legacy);
+    expect(composeStableParts(persona, scene, true)).toBe(legacy);
+  });
+
+  it("persona only → persona + guide", () => {
+    expect(composeStableParts("p", undefined, false)).toBe(
+      `<user-persona>\np\n</user-persona>\n\n${MEMORY_TOOLS_GUIDE}`,
+    );
+  });
+
+  it("no stable parts but dynamic context exists → guide only (legacy guard)", () => {
+    expect(composeStableParts(undefined, undefined, true)).toBe(MEMORY_TOOLS_GUIDE);
+  });
+
+  it("nothing at all → undefined", () => {
+    expect(composeStableParts(undefined, undefined, false)).toBeUndefined();
+  });
+});
+
+describe("performAutoRecall (offline, no vector store)", () => {
+  it("loads persona into appendSystemContext with no memories → no prependContext", async () => {
+    await fs.writeFile(path.join(tmpDir, "persona.md"), PERSONA, "utf-8");
+    const cfg = parseConfig({});
+
+    const result = await performAutoRecall({
+      userText: "帮我看看这个部署脚本",
+      actorId: "default_user",
+      sessionKey: "s1",
+      cfg,
+      pluginDataDir: tmpDir,
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.prependContext).toBeUndefined();
+    expect(result?.appendSystemContext).toContain("<user-persona>");
+    expect(result?.appendSystemContext).toContain("后端工程师");
+    expect(result?.appendSystemContext).toContain("<memory-tools-guide>");
+    // Byte-equality with the extracted composer (persona-only path)
+    expect(result?.appendSystemContext).toBe(
+      composeStableParts(result?.recalledL3Persona ?? undefined, undefined, false),
+    );
+  });
+
+  it("returns undefined when there is nothing to inject", async () => {
+    const cfg = parseConfig({});
+    const result = await performAutoRecall({
+      userText: "hello",
+      actorId: "default_user",
+      sessionKey: "s1",
+      cfg,
+      pluginDataDir: tmpDir,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skipMemorySearch bypasses the search but still loads persona", async () => {
+    await fs.writeFile(path.join(tmpDir, "persona.md"), PERSONA, "utf-8");
+    const cfg = parseConfig({});
+    const isFtsAvailable = vi.fn(() => false);
+    const fakeStore = { isFtsAvailable } as never;
+
+    const skipped = await performAutoRecall({
+      userText: "查一下我上周说过什么",
+      actorId: "default_user",
+      sessionKey: "s1",
+      cfg,
+      pluginDataDir: tmpDir,
+      vectorStore: fakeStore,
+      options: { skipMemorySearch: true },
+    });
+    expect(isFtsAvailable).not.toHaveBeenCalled();
+    expect(skipped?.recallStrategy).toBe("skipped");
+    expect(skipped?.appendSystemContext).toContain("<user-persona>");
+    expect(skipped?.recalledL1Memories).toEqual([]);
+
+    // Control: without the option, the keyword path probes FTS availability
+    const searched = await performAutoRecall({
+      userText: "查一下我上周说过什么",
+      actorId: "default_user",
+      sessionKey: "s1",
+      cfg,
+      pluginDataDir: tmpDir,
+      vectorStore: fakeStore,
+    });
+    expect(isFtsAvailable).toHaveBeenCalled();
+    expect(searched?.recallStrategy).not.toBe("skipped");
+  });
+});

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -32,7 +32,7 @@ const RECALL_LINE_SEPARATOR = "\n";
  * Memory tools usage guide — injected at the end of memory context so the
  * main agent knows how to actively retrieve deeper information.
  */
-const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
+export const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
 ## 记忆工具调用指南
 
 当上方注入的记忆片段不足以回答用户问题时，可主动调用以下工具获取更多信息：
@@ -69,6 +69,42 @@ export interface RecallResult {
   recallStrategy?: string;
 }
 
+/** Per-call behavior switches for performAutoRecall. */
+export interface AutoRecallOptions {
+  /**
+   * Skip the L1 memory search entirely (persona/scene/tools guide still load).
+   * Used by injectionMode="session-stable" from turn 2 on, where per-turn
+   * dynamic memories are intentionally not injected (issue #120).
+   */
+  skipMemorySearch?: boolean;
+}
+
+/**
+ * Compose the stable system block (persona + scene navigation + memory tools
+ * guide) exactly as the legacy inline code did — extracted so TdaiCore and
+ * tests can reproduce/verify the byte-identical join (issue #120).
+ *
+ * @param hasAnyContext mirrors the legacy `stableParts.length > 0 || prependContext`
+ *   guard: the tools guide is appended whenever any recall context exists.
+ */
+export function composeStableParts(
+  personaContent: string | undefined,
+  sceneNavigation: string | undefined,
+  hasAnyContext: boolean,
+): string | undefined {
+  const stableParts: string[] = [];
+  if (personaContent) {
+    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
+  }
+  if (sceneNavigation) {
+    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
+  }
+  if (stableParts.length > 0 || hasAnyContext) {
+    stableParts.push(MEMORY_TOOLS_GUIDE);
+  }
+  return stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+}
+
 export async function performAutoRecall(params: {
   userText: string;
   actorId: string;
@@ -78,6 +114,7 @@ export async function performAutoRecall(params: {
   logger?: Logger;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  options?: AutoRecallOptions;
 }): Promise<RecallResult | undefined> {
   const { cfg, logger } = params;
   const timeoutMs = cfg.recall.timeoutMs ?? 5000;
@@ -108,17 +145,21 @@ async function performAutoRecallInner(params: {
   logger?: Logger;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  options?: AutoRecallOptions;
 }): Promise<RecallResult | undefined> {
-  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService } = params;
+  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService, options } = params;
   const tRecallStart = performance.now();
 
   // Search relevant memories (L1 layer) — skip only when userText is empty/undefined
+  // or the caller explicitly opted out (session-stable mode, turn ≥ 2).
   const tSearchStart = performance.now();
   let memoryLines: string[] = [];
   let effectiveStrategy = "skipped";
   let recalledL1Memories: RecalledMemory[] = [];
   let searchTiming: SearchTiming = { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 };
-  if (!userText || userText.length === 0) {
+  if (options?.skipMemorySearch) {
+    logger?.debug?.(`${TAG} Memory search skipped by caller (session-stable mode; persona/scene still injected)`);
+  } else if (!userText || userText.length === 0) {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
@@ -193,13 +234,6 @@ async function performAutoRecallInner(params: {
   // prependContext (user prompt prefix — dynamic, per-turn):
   //   L1 relevant memories — different every turn, moved out of system prompt
   //   so it doesn't bust the system prompt cache.
-  const stableParts: string[] = [];
-  if (personaContent) {
-    stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);
-  }
-  if (sceneNavigation) {
-    stableParts.push(`<scene-navigation>\n${sceneNavigation}\n</scene-navigation>`);
-  }
 
   // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
   let prependContext: string | undefined;
@@ -208,14 +242,11 @@ async function performAutoRecallInner(params: {
       `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
   }
 
-  // Append memory tools usage guide to the stable part so the agent knows
-  // how to actively retrieve deeper context when the injected snippets
-  // are not enough. This is static content and benefits from caching.
-  if (stableParts.length > 0 || prependContext) {
-    stableParts.push(MEMORY_TOOLS_GUIDE);
-  }
-
-  const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  // Stable part: persona + scene navigation + memory tools usage guide.
+  // The guide is static content appended whenever any recall context exists,
+  // so the agent knows how to actively retrieve deeper context.
+  // composeStableParts reproduces the legacy inline join byte-for-byte.
+  const appendSystemContext = composeStableParts(personaContent, sceneNavigation, !!prependContext);
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(

--- a/src/core/hooks/stable-context.test.ts
+++ b/src/core/hooks/stable-context.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { StableRecallContextCache, hashContent } from "./stable-context.js";
+
+const S = "session-a";
+
+describe("hashContent", () => {
+  it("is deterministic and 16 hex chars", () => {
+    expect(hashContent("abc")).toBe(hashContent("abc"));
+    expect(hashContent("abc")).toMatch(/^[0-9a-f]{16}$/);
+    expect(hashContent("abc")).not.toBe(hashContent("abd"));
+  });
+});
+
+describe("StableRecallContextCache", () => {
+  it("freezes the first candidate and reports a miss", () => {
+    const cache = new StableRecallContextCache();
+    const r = cache.resolve(S, "persona-v1");
+    expect(r).toEqual({ content: "persona-v1", cacheHit: false, drifted: false });
+    expect(cache.has(S)).toBe(true);
+  });
+
+  it("returns identical bytes when the candidate drifts, and counts the drift", () => {
+    const cache = new StableRecallContextCache();
+    cache.resolve(S, "persona-v1");
+
+    const r2 = cache.resolve(S, "persona-v2-REWRITTEN-BY-L3");
+    expect(r2.content).toBe("persona-v1"); // frozen bytes win
+    expect(r2.cacheHit).toBe(true);
+    expect(r2.drifted).toBe(true);
+
+    const r3 = cache.resolve(S, "persona-v3");
+    expect(r3.content).toBe("persona-v1");
+    expect(cache.peek(S)?.driftDetected).toBe(2);
+  });
+
+  it("survives an undefined candidate after a freeze (recall-timeout resilience)", () => {
+    const cache = new StableRecallContextCache();
+    cache.resolve(S, "persona-v1");
+    const r = cache.resolve(S, undefined);
+    expect(r).toEqual({ content: "persona-v1", cacheHit: true, drifted: false });
+  });
+
+  it("returns undefined (no freeze) when the first candidate is undefined", () => {
+    const cache = new StableRecallContextCache();
+    const r = cache.resolve(S, undefined);
+    expect(r).toEqual({ content: undefined, cacheHit: false, drifted: false });
+    expect(cache.has(S)).toBe(false);
+    // A later defined candidate freezes normally
+    expect(cache.resolve(S, "late").content).toBe("late");
+    expect(cache.has(S)).toBe(true);
+  });
+
+  it("identical candidate is a clean cache hit (no drift)", () => {
+    const cache = new StableRecallContextCache();
+    cache.resolve(S, "same");
+    const r = cache.resolve(S, "same");
+    expect(r).toEqual({ content: "same", cacheHit: true, drifted: false });
+    expect(cache.peek(S)?.driftDetected).toBe(0);
+  });
+
+  it("freeze() replaces content explicitly", () => {
+    const cache = new StableRecallContextCache();
+    cache.resolve(S, "v1");
+    cache.freeze(S, "v2-folded-with-memories");
+    expect(cache.resolve(S, undefined).content).toBe("v2-folded-with-memories");
+  });
+
+  it("expires after the idle TTL and re-freezes the next candidate", () => {
+    const cache = new StableRecallContextCache({ ttlMs: 1000 });
+    const t0 = 1_000_000;
+    cache.resolve(S, "v1", t0);
+    // Within TTL → frozen bytes
+    expect(cache.resolve(S, "v2", t0 + 999).content).toBe("v1");
+    // TTL is sliding — access at t0+999 extended it
+    expect(cache.has(S, t0 + 1500)).toBe(true);
+    // Idle past TTL → expired, new candidate freezes fresh
+    const r = cache.resolve(S, "v3", t0 + 999 + 1001);
+    expect(r).toEqual({ content: "v3", cacheHit: false, drifted: false });
+  });
+
+  it("sweep() evicts idle sessions and enforces the LRU cap", () => {
+    const cache = new StableRecallContextCache({ ttlMs: 1000, maxSessions: 2 });
+    const t0 = 5_000_000;
+    cache.resolve("s1", "c1", t0);
+    cache.resolve("s2", "c2", t0 + 10);
+    cache.resolve("s3", "c3", t0 + 20);
+    expect(cache.size).toBe(3);
+
+    // Cap: oldest lastAccess (s1) evicted
+    cache.sweep(t0 + 30);
+    expect(cache.size).toBe(2);
+    expect(cache.has("s1", t0 + 30)).toBe(false);
+    expect(cache.has("s2", t0 + 30)).toBe(true);
+    expect(cache.has("s3", t0 + 30)).toBe(true);
+
+    // TTL: everything idle > 1000ms goes
+    cache.sweep(t0 + 5000);
+    expect(cache.size).toBe(0);
+  });
+
+  it("keeps sessions independent", () => {
+    const cache = new StableRecallContextCache();
+    cache.resolve("a", "content-a");
+    cache.resolve("b", "content-b");
+    expect(cache.resolve("a", "zzz").content).toBe("content-a");
+    expect(cache.resolve("b", "zzz").content).toBe("content-b");
+  });
+
+  it("clear() drops all sessions", () => {
+    const cache = new StableRecallContextCache();
+    cache.resolve("a", "1");
+    cache.resolve("b", "2");
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.has("a")).toBe(false);
+  });
+});

--- a/src/core/hooks/stable-context.ts
+++ b/src/core/hooks/stable-context.ts
@@ -1,0 +1,176 @@
+/**
+ * StableRecallContextCache — session-level freeze/dedup for the stable recall
+ * system block (persona + scene navigation + memory tools guide).
+ *
+ * Why (issue #120): prefix-matching prompt caches (DeepSeek / MiMo
+ * `openai-completions`) invalidate everything after the FIRST divergent byte.
+ * The stable block sits inside the system prompt — the very first bytes of the
+ * serialized request — so any mid-session drift (L2/L3 pipelines rewriting
+ * persona.md / the scene index, or a recall timeout dropping the block for one
+ * turn) busts the cache for the entire request, twice (drop + reappear).
+ *
+ * This cache freezes the first composed block per sessionKey and keeps
+ * returning the SAME BYTES for the rest of the session:
+ *   - drift in the candidate is detected (hash compare) but never surfaces;
+ *   - `candidate === undefined` after a freeze still returns frozen content,
+ *     so a recall timeout can no longer flicker the persona out;
+ *   - a sliding TTL (default 60 min idle) + LRU cap bound memory and let
+ *     long-idle sessions pick up fresh persona content on their next turn.
+ *
+ * This IS the "session-level dedup of repeated stable system prompt
+ * additions" the issue asks for: within a session the block resolves to one
+ * canonical byte sequence, no matter how often it is recomposed upstream.
+ */
+
+import { createHash } from "node:crypto";
+import type { Logger } from "../types.js";
+
+const TAG = "[memory-tdai] [stable-context]";
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 60 min sliding idle window
+const DEFAULT_MAX_SESSIONS = 10_000;   // hard cap, same spirit as index.ts prompt caches
+
+/** One frozen stable block, keyed by sessionKey. */
+export interface StableContextEntry {
+  /** Frozen block content (byte-canonical for the session). */
+  content: string;
+  /** hashContent(content) — used for drift detection. */
+  hash: string;
+  /** Epoch ms when the content was frozen. */
+  frozenAt: number;
+  /** Epoch ms of the last resolve/freeze (sliding TTL). */
+  lastAccess: number;
+  /** How many times a differing candidate was observed after the freeze. */
+  driftDetected: number;
+}
+
+export interface StableContextResolveResult {
+  /** The canonical content for this session (undefined only before any freeze). */
+  content: string | undefined;
+  /** True when the content was served from an existing freeze. */
+  cacheHit: boolean;
+  /** True when the candidate differed from the frozen bytes on this call. */
+  drifted: boolean;
+}
+
+export interface StableRecallContextCacheOptions {
+  /** Sliding idle TTL in ms (default: 60 min). */
+  ttlMs?: number;
+  /** Max tracked sessions before LRU eviction (default: 10 000). */
+  maxSessions?: number;
+  logger?: Logger;
+}
+
+/** sha256 hex digest, first 16 chars — cheap fingerprint for drift detection. */
+export function hashContent(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 16);
+}
+
+export class StableRecallContextCache {
+  private readonly entries = new Map<string, StableContextEntry>();
+  private readonly ttlMs: number;
+  private readonly maxSessions: number;
+  private readonly logger?: Logger;
+
+  constructor(opts?: StableRecallContextCacheOptions) {
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxSessions = opts?.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.logger = opts?.logger;
+  }
+
+  /**
+   * Resolve the canonical stable block for `sessionKey`.
+   *
+   * - No freeze yet (or the previous one expired): freezes `candidate`
+   *   (when defined) and returns it with `cacheHit: false`.
+   * - Freeze exists: returns the frozen bytes regardless of `candidate`.
+   *   A defined-but-different candidate increments the drift counter;
+   *   an undefined candidate (recall timeout / empty recall) still returns
+   *   the frozen content so the persona never flickers out mid-session.
+   */
+  resolve(sessionKey: string, candidate: string | undefined, now = Date.now()): StableContextResolveResult {
+    const existing = this.getLive(sessionKey, now);
+
+    if (!existing) {
+      if (candidate === undefined) {
+        return { content: undefined, cacheHit: false, drifted: false };
+      }
+      this.freeze(sessionKey, candidate, now);
+      return { content: candidate, cacheHit: false, drifted: false };
+    }
+
+    existing.lastAccess = now; // sliding TTL
+    let drifted = false;
+    if (candidate !== undefined && hashContent(candidate) !== existing.hash) {
+      drifted = true;
+      existing.driftDetected++;
+      this.logger?.debug?.(
+        `${TAG} drift detected for session=${sessionKey} ` +
+        `(count=${existing.driftDetected}), keeping frozen bytes (policy=session-frozen)`,
+      );
+    }
+    return { content: existing.content, cacheHit: true, drifted };
+  }
+
+  /** Explicitly (re-)freeze content for a session (used by session-stable turn-1 fold). */
+  freeze(sessionKey: string, content: string, now = Date.now()): void {
+    this.entries.delete(sessionKey); // re-insert at Map tail → true LRU order
+    this.entries.set(sessionKey, {
+      content,
+      hash: hashContent(content),
+      frozenAt: now,
+      lastAccess: now,
+      driftDetected: 0,
+    });
+    this.logger?.debug?.(
+      `${TAG} frozen stable block for session=${sessionKey} (${content.length} chars)`,
+    );
+  }
+
+  /** Whether a live (non-expired) freeze exists for the session. */
+  has(sessionKey: string, now = Date.now()): boolean {
+    return this.getLive(sessionKey, now) !== undefined;
+  }
+
+  /** Peek at an entry without touching lastAccess (diagnostics / tests). */
+  peek(sessionKey: string): StableContextEntry | undefined {
+    return this.entries.get(sessionKey);
+  }
+
+  /** TTL + LRU-cap eviction. Safe to call every turn (O(n) worst case, n bounded). */
+  sweep(now = Date.now()): void {
+    for (const [key, entry] of this.entries) {
+      if (now - entry.lastAccess > this.ttlMs) {
+        this.entries.delete(key);
+      }
+    }
+    if (this.entries.size > this.maxSessions) {
+      const sorted = [...this.entries.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess);
+      const toEvict = sorted.slice(0, sorted.length - this.maxSessions);
+      for (const [key] of toEvict) {
+        this.entries.delete(key);
+      }
+      this.logger?.debug?.(`${TAG} LRU-evicted ${toEvict.length} session(s) (cap=${this.maxSessions})`);
+    }
+  }
+
+  /** Drop everything (destroy() / tests). */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /** Number of tracked sessions (tests / diagnostics). */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  private getLive(sessionKey: string, now: number): StableContextEntry | undefined {
+    const entry = this.entries.get(sessionKey);
+    if (!entry) return undefined;
+    if (now - entry.lastAccess > this.ttlMs) {
+      this.entries.delete(sessionKey);
+      return undefined;
+    }
+    return entry;
+  }
+}

--- a/src/core/tdai-core.recall.test.ts
+++ b/src/core/tdai-core.recall.test.ts
@@ -1,0 +1,302 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TdaiCore } from "./tdai-core.js";
+import { parseConfig } from "../config.js";
+import { performAutoRecall } from "./hooks/auto-recall.js";
+import type { HostAdapter, Logger } from "./types.js";
+
+// Mock only performAutoRecall; every other export stays real.
+// TdaiCore imports the same resolved module, so this single mock covers it.
+vi.mock("./hooks/auto-recall.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./hooks/auto-recall.js")>();
+  return { ...actual, performAutoRecall: vi.fn() };
+});
+
+const mockRecall = vi.mocked(performAutoRecall);
+
+let tmpDir: string;
+let warns: string[];
+
+function makeCore(recallOverrides: Record<string, unknown> = {}): TdaiCore {
+  warns = [];
+  const logger: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (m) => warns.push(m),
+    error: () => {},
+  };
+  const hostAdapter: HostAdapter = {
+    hostType: "standalone",
+    getRuntimeContext: () => ({
+      userId: "default_user",
+      sessionId: "",
+      sessionKey: "",
+      platform: "gateway",
+      workspaceDir: tmpDir,
+      dataDir: tmpDir,
+    }),
+    getLogger: () => logger,
+    getLLMRunnerFactory: () => ({ createRunner: () => ({ run: async () => "" }) }),
+  };
+  const cfg = parseConfig({
+    capture: { enabled: false },
+    extraction: { enabled: false },
+    recall: { enabled: true, ...recallOverrides },
+  });
+  // No initialize(): handleBeforeRecall works uninitialized (no store needed here).
+  return new TdaiCore({ hostAdapter, config: cfg });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-120-core-"));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const S = "sess-1";
+
+/** Manually-resolved promise for adversarial interleaving of concurrent recalls. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe("TdaiCore.handleBeforeRecall — ephemeral + session-frozen (defaults)", () => {
+  it("freezes the stable block on turn 1 and serves identical bytes on drift", async () => {
+    const core = makeCore();
+
+    mockRecall.mockResolvedValueOnce({
+      prependContext: "<relevant-memories>\n- [episodic] m1\n</relevant-memories>",
+      appendSystemContext: "STABLE-V1",
+    });
+    const t1 = await core.handleBeforeRecall("q1", S);
+    expect(t1.appendSystemContext).toBe("STABLE-V1");
+    expect(t1.stableContextCacheHit).toBe(false);
+    expect(t1.injectionModeUsed).toBe("ephemeral");
+    expect(t1.prependContext).toContain("m1");
+
+    // Turn 2: persona.md was rewritten mid-session by L3 → candidate drifts
+    mockRecall.mockResolvedValueOnce({
+      prependContext: "<relevant-memories>\n- [episodic] m2\n</relevant-memories>",
+      appendSystemContext: "STABLE-V2-REWRITTEN",
+    });
+    const t2 = await core.handleBeforeRecall("q2", S);
+    expect(t2.appendSystemContext).toBe("STABLE-V1"); // frozen bytes win
+    expect(t2.stableContextCacheHit).toBe(true);
+    expect(t2.prependContext).toContain("m2"); // dynamic part still per-turn
+  });
+
+  it("A5 regression: recall timeout must not flicker the persona out", async () => {
+    const core = makeCore();
+
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "STABLE-V1" });
+    await core.handleBeforeRecall("q1", S);
+
+    // Turn 2: performAutoRecall times out → undefined
+    mockRecall.mockResolvedValueOnce(undefined);
+    const t2 = await core.handleBeforeRecall("q2", S);
+    expect(t2.appendSystemContext).toBe("STABLE-V1");
+    expect(t2.stableContextCacheHit).toBe(true);
+    expect(t2.prependContext).toBeUndefined();
+  });
+
+  it("keeps memory search enabled every turn (skipMemorySearch=false)", async () => {
+    const core = makeCore();
+    mockRecall.mockResolvedValue({ appendSystemContext: "S" });
+    await core.handleBeforeRecall("q1", S);
+    await core.handleBeforeRecall("q2", S);
+    for (const call of mockRecall.mock.calls) {
+      expect(call[0].options?.skipMemorySearch).toBe(false);
+    }
+  });
+
+  it("isolates sessions from each other", async () => {
+    const core = makeCore();
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "A1" });
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "B1" });
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "A2-drift" });
+
+    await core.handleBeforeRecall("q", "sess-a");
+    const b = await core.handleBeforeRecall("q", "sess-b");
+    const a2 = await core.handleBeforeRecall("q", "sess-a");
+    expect(b.appendSystemContext).toBe("B1");
+    expect(a2.appendSystemContext).toBe("A1");
+  });
+});
+
+describe("TdaiCore.handleBeforeRecall — stableContextPolicy=latest (legacy)", () => {
+  it("recomposes the stable block every turn (drift passes through)", async () => {
+    const core = makeCore({ stableContextPolicy: "latest" });
+
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "V1" });
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "V2" });
+    const t1 = await core.handleBeforeRecall("q1", S);
+    const t2 = await core.handleBeforeRecall("q2", S);
+    expect(t1.appendSystemContext).toBe("V1");
+    expect(t2.appendSystemContext).toBe("V2"); // legacy: latest bytes win
+    expect(t2.stableContextCacheHit).toBe(false);
+  });
+});
+
+describe("TdaiCore.handleBeforeRecall — injectionMode=session-stable", () => {
+  it("folds turn-1 memories into the frozen block; later turns are byte-identical with no prependContext", async () => {
+    const core = makeCore({ injectionMode: "session-stable" });
+
+    const P1 = "<relevant-memories>\n- [episodic] turn-1 memory\n</relevant-memories>";
+    mockRecall.mockResolvedValueOnce({ prependContext: P1, appendSystemContext: "STABLE" });
+
+    const t1 = await core.handleBeforeRecall("q1", S);
+    const expectedMerged = `STABLE\n\n${P1}`;
+    expect(t1.appendSystemContext).toBe(expectedMerged);
+    expect(t1.prependContext).toBeUndefined();
+    expect(t1.injectionModeUsed).toBe("session-stable");
+
+    // Turns 2..6: drifted candidates + fresh memories are all ignored
+    const later: string[] = [];
+    for (let n = 2; n <= 6; n++) {
+      mockRecall.mockResolvedValueOnce({
+        prependContext: `<relevant-memories>\n- [episodic] turn-${n}\n</relevant-memories>`,
+        appendSystemContext: `STABLE-DRIFT-${n}`,
+      });
+      const t = await core.handleBeforeRecall(`q${n}`, S);
+      expect(t.prependContext).toBeUndefined();
+      expect(t.stableContextCacheHit).toBe(true);
+      later.push(t.appendSystemContext ?? "");
+    }
+    expect(later).toEqual(Array(5).fill(expectedMerged));
+
+    // L1 search actually skipped from turn 2 on
+    const skipFlags = mockRecall.mock.calls.map((c) => c[0].options?.skipMemorySearch);
+    expect(skipFlags).toEqual([false, true, true, true, true, true]);
+  });
+
+  it("empty turn-1 recall freezes an empty sentinel — no mid-session reappearance", async () => {
+    const core = makeCore({ injectionMode: "session-stable" });
+
+    mockRecall.mockResolvedValueOnce(undefined); // turn 1: nothing at all
+    const t1 = await core.handleBeforeRecall("q1", S);
+    expect(t1.appendSystemContext).toBeUndefined();
+    expect(t1.prependContext).toBeUndefined();
+
+    // Turn 2: memories now exist, but the session already decided "no block"
+    mockRecall.mockResolvedValueOnce({
+      prependContext: "<relevant-memories>late</relevant-memories>",
+      appendSystemContext: "LATE-STABLE",
+    });
+    const t2 = await core.handleBeforeRecall("q2", S);
+    expect(t2.appendSystemContext).toBeUndefined();
+    expect(t2.prependContext).toBeUndefined();
+    expect(mockRecall.mock.calls[1][0].options?.skipMemorySearch).toBe(true);
+  });
+
+  it("session-stable + latest is coerced to frozen semantics with a warning", async () => {
+    const core = makeCore({ injectionMode: "session-stable", stableContextPolicy: "latest" });
+    expect(warns.some((w) => w.includes("session-frozen"))).toBe(true);
+
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "S1" });
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "S2-drift" });
+    const t1 = await core.handleBeforeRecall("q1", S);
+    const t2 = await core.handleBeforeRecall("q2", S);
+    expect(t1.appendSystemContext).toBe("S1");
+    expect(t2.appendSystemContext).toBe("S1"); // frozen despite "latest"
+  });
+});
+
+describe("TdaiCore.handleBeforeRecall — concurrent turn-1 recalls (TOCTOU)", () => {
+  // Gateway serves concurrent /recall HTTP requests for the same session_key:
+  // both can pass the pre-await freeze check, so the freeze decision must be
+  // re-taken after the recall await. First completed freeze wins — a slower
+  // concurrent recall must NOT overwrite it (that would hand out two different
+  // byte sequences for one session and silently repoint later turns).
+
+  it("session-stable: first completed freeze wins; the late result cannot overwrite it", async () => {
+    const core = makeCore({ injectionMode: "session-stable" });
+
+    const slow = deferred<Awaited<ReturnType<typeof performAutoRecall>>>();
+    const fast = deferred<Awaited<ReturnType<typeof performAutoRecall>>>();
+    mockRecall
+      .mockImplementationOnce(() => slow.promise)
+      .mockImplementationOnce(() => fast.promise);
+
+    // Both calls start before either recall resolves → both see "no freeze".
+    const p1 = core.handleBeforeRecall("q1", S);
+    const p2 = core.handleBeforeRecall("q1-concurrent", S);
+
+    // Adversarial order: the SECOND call completes first and freezes its bytes.
+    const P2 = "<relevant-memories>\n- [episodic] fast\n</relevant-memories>";
+    fast.resolve({ prependContext: P2, appendSystemContext: "STABLE-FAST" });
+    const t2 = await p2;
+    const winner = `STABLE-FAST\n\n${P2}`;
+    expect(t2.appendSystemContext).toBe(winner);
+    expect(t2.stableContextCacheHit).toBe(false);
+
+    // ...then the first call's slow recall lands with DIFFERENT bytes.
+    slow.resolve({
+      prependContext: "<relevant-memories>\n- [episodic] slow\n</relevant-memories>",
+      appendSystemContext: "STABLE-SLOW",
+    });
+    const t1 = await p1;
+    expect(t1.appendSystemContext).toBe(winner); // frozen bytes win, no overwrite
+    expect(t1.stableContextCacheHit).toBe(true);
+    expect(t1.prependContext).toBeUndefined();
+
+    // Every later turn keeps returning the winner's bytes.
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "STABLE-LATER" });
+    const t3 = await core.handleBeforeRecall("q3", S);
+    expect(t3.appendSystemContext).toBe(winner);
+    expect(t3.stableContextCacheHit).toBe(true);
+  });
+
+  it("ephemeral + session-frozen: first completed resolve freezes; the late candidate is drift", async () => {
+    const core = makeCore(); // defaults
+
+    const slow = deferred<Awaited<ReturnType<typeof performAutoRecall>>>();
+    const fast = deferred<Awaited<ReturnType<typeof performAutoRecall>>>();
+    mockRecall
+      .mockImplementationOnce(() => slow.promise)
+      .mockImplementationOnce(() => fast.promise);
+
+    const p1 = core.handleBeforeRecall("q1", S);
+    const p2 = core.handleBeforeRecall("q1-concurrent", S);
+
+    fast.resolve({ appendSystemContext: "STABLE-FAST" });
+    const t2 = await p2;
+    expect(t2.appendSystemContext).toBe("STABLE-FAST");
+    expect(t2.stableContextCacheHit).toBe(false);
+
+    slow.resolve({
+      prependContext: "<relevant-memories>\n- [episodic] slow\n</relevant-memories>",
+      appendSystemContext: "STABLE-SLOW",
+    });
+    const t1 = await p1;
+    expect(t1.appendSystemContext).toBe("STABLE-FAST"); // frozen bytes win
+    expect(t1.stableContextCacheHit).toBe(true);
+    expect(t1.prependContext).toContain("slow"); // dynamic part stays per-turn
+
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "STABLE-LATER" });
+    const t3 = await core.handleBeforeRecall("q3", S);
+    expect(t3.appendSystemContext).toBe("STABLE-FAST");
+  });
+});
+
+describe("TdaiCore.destroy — stable-context cleanup", () => {
+  it("clears frozen sessions so a rebuilt core starts fresh", async () => {
+    const core = makeCore();
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "V1" });
+    await core.handleBeforeRecall("q1", S);
+
+    await core.destroy();
+
+    mockRecall.mockResolvedValueOnce({ appendSystemContext: "V2" });
+    const t = await core.handleBeforeRecall("q1", S);
+    expect(t.appendSystemContext).toBe("V2"); // fresh freeze, not stale V1
+    expect(t.stableContextCacheHit).toBe(false);
+  });
+});

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -33,6 +33,7 @@ import type { MemoryTdaiConfig } from "../config.js";
 import type { IMemoryStore } from "./store/types.js";
 import type { EmbeddingService } from "./store/embedding.js";
 import { performAutoRecall } from "./hooks/auto-recall.js";
+import { StableRecallContextCache } from "./hooks/stable-context.js";
 import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
@@ -122,6 +123,17 @@ export class TdaiCore {
    */
   private readonly bgTasks = new Set<Promise<void>>();
 
+  /**
+   * Session-frozen stable recall block cache (issue #120).
+   *
+   * Guarantees the persona / scene-navigation / tools-guide system block is
+   * byte-identical across every turn of a session, even when the L2/L3
+   * pipelines rewrite persona.md mid-session or a recall times out — the
+   * per-session dedup/freeze that keeps prefix-matching prompt caches
+   * (DeepSeek / MiMo) warm.
+   */
+  private readonly stableContext: StableRecallContextCache;
+
   constructor(opts: TdaiCoreOptions) {
     this.hostAdapter = opts.hostAdapter;
     this.cfg = opts.config;
@@ -130,6 +142,20 @@ export class TdaiCore {
     this.runnerFactory = opts.hostAdapter.getLLMRunnerFactory();
     this.sessionFilter = opts.sessionFilter ?? new SessionFilter([]);
     this.instanceId = opts.instanceId;
+    this.stableContext = new StableRecallContextCache({ logger: this.logger });
+
+    // Keep the mode matrix small: session-stable REQUIRES frozen-block
+    // semantics (its whole point is zero per-turn variance), so "latest"
+    // is coerced with a warning instead of producing a hybrid nobody wants.
+    if (
+      this.cfg.recall.injectionMode === "session-stable" &&
+      this.cfg.recall.stableContextPolicy === "latest"
+    ) {
+      this.logger.warn(
+        `${TAG} recall.injectionMode="session-stable" requires stableContextPolicy="session-frozen"; ` +
+        `ignoring "latest" and using session-frozen semantics for the stable block`,
+      );
+    }
   }
 
   // ============================
@@ -229,6 +255,7 @@ export class TdaiCore {
       this.embeddingService = undefined;
     }
 
+    this.stableContext.clear();
     resetStores(this.dataDir);
     this.logger.debug?.(`${TAG} TDAI Core destroyed`);
   }
@@ -240,9 +267,30 @@ export class TdaiCore {
   /**
    * Handle recall (memory retrieval) before an LLM turn.
    * Maps to: OpenClaw `before_prompt_build` / Hermes `prefetch()`.
+   *
+   * Prompt-cache behavior (issue #120):
+   * - stableContextPolicy="session-frozen" (default): the stable system block
+   *   (persona/scene/tools guide) is byte-frozen on the session's first
+   *   composition; later turns return the SAME bytes even if persona.md was
+   *   rewritten mid-session or recall timed out (no persona flicker).
+   * - injectionMode="session-stable": turn-1 recalled memories are folded into
+   *   the frozen block and per-turn prependContext is suppressed from then on,
+   *   so the serialized request only ever grows at the tail.
+   * - injectionMode="ephemeral" (default): memories go to prependContext each
+   *   turn (host renders them ephemerally; index.ts strips them from history).
    */
   async handleBeforeRecall(userText: string, sessionKey: string): Promise<RecallResult> {
     await this.storeReady?.catch(() => {});
+
+    const { injectionMode, stableContextPolicy } = this.cfg.recall;
+    const sessionStable = injectionMode === "session-stable";
+    // session-stable implies frozen-block semantics (coercion warned at construction).
+    const frozen = sessionStable || stableContextPolicy === "session-frozen";
+    const hasFrozenBlock = this.stableContext.has(sessionKey);
+
+    // In session-stable mode the block is already frozen from turn 2 on, so
+    // the (possibly slow) L1 memory search would be thrown away — skip it.
+    const skipMemorySearch = sessionStable && hasFrozenBlock;
 
     const result = await performAutoRecall({
       userText,
@@ -253,9 +301,56 @@ export class TdaiCore {
       logger: this.logger,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
+      options: { skipMemorySearch },
     });
 
-    return result ?? {};
+    let prependContext = result?.prependContext;
+    let appendSystemContext = result?.appendSystemContext;
+    let stableContextCacheHit = false;
+
+    if (sessionStable) {
+      // Re-check the freeze AFTER the recall await (not the pre-await
+      // `hasFrozenBlock` snapshot): under the Gateway, concurrent /recall
+      // calls for the same session can all observe "no freeze" above, and
+      // the first one to complete freezes while the rest are still awaiting.
+      // Freezing again here would return different bytes AND silently
+      // repoint the session to them — the first completed freeze must win.
+      // `has()` + `freeze()` below run synchronously, so no interleaving.
+      if (!this.stableContext.has(sessionKey)) {
+        // Turn 1: fold the dynamic memories into the stable block and freeze
+        // the merged bytes for the rest of the session. An empty recall
+        // freezes an empty sentinel — deliberately no retry on later turns,
+        // because a mid-session (re)appearance of the block is exactly the
+        // prefix variance this mode exists to eliminate.
+        const merged =
+          [appendSystemContext, prependContext].filter(Boolean).join("\n\n") || undefined;
+        this.stableContext.freeze(sessionKey, merged ?? "");
+        appendSystemContext = merged;
+      } else {
+        appendSystemContext =
+          this.stableContext.resolve(sessionKey, undefined).content || undefined;
+        stableContextCacheHit = true;
+      }
+      // Never inject per-turn user-prefix content in this mode.
+      prependContext = undefined;
+    } else if (frozen) {
+      // Ephemeral memories stay per-turn, but the stable block is deduped to
+      // one canonical byte sequence per session (drift + timeout immunity).
+      const resolved = this.stableContext.resolve(sessionKey, appendSystemContext);
+      appendSystemContext = resolved.content;
+      stableContextCacheHit = resolved.cacheHit;
+    }
+    // stableContextPolicy="latest" (+ ephemeral): legacy passthrough, no freeze.
+
+    this.stableContext.sweep();
+
+    return {
+      ...(result ?? {}),
+      prependContext,
+      appendSystemContext,
+      stableContextCacheHit,
+      injectionModeUsed: injectionMode,
+    };
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -207,6 +207,10 @@ export interface RecallResult {
   recalledL3Persona?: string | null;
   /** Search strategy used. */
   recallStrategy?: string;
+  /** True when appendSystemContext was served from the session-frozen cache (issue #120). */
+  stableContextCacheHit?: boolean;
+  /** Effective injection mode used for this turn ("ephemeral" | "session-stable"). */
+  injectionModeUsed?: string;
 }
 
 /** Result from a capture (sync_turn) operation. */


### PR DESCRIPTION
# PR: fix(recall): stabilize prompt-cache prefix under prependContext + showInjected (#120)

- **Branch / 分支**: `fix/120-prompt-cache-regression` (worktree `/home/seat1163/work/Tencent/issue-120`)
- **Commit / 提交**: `dc5fa195d13150106c95705a5bd284705486b916` (base: `4339e63` = upstream default-branch tip)
- **Patch / 补丁**: `/home/seat1163/work/Tencent/docs/patches/issue-120/0001-fix-recall-stabilize-prompt-cache-prefix-under-prepe.patch`
- **Diff**: 19 files changed, +2075 / −22 (6 new test files, 2 new source modules, 1 new bilingual analysis doc)

---

## 中文

### 摘要

启用 memory-tencentdb 插件后，依赖前缀匹配缓存的 OpenAI-compatible 提供商命中率显著退化（MiMo 91.1%→63.5%，DeepSeek 95.7%→83.3%）。本 PR 在插件侧修复了全部三条失效链路，新增 4 个 `recall.*` 配置开关（默认值保持向后兼容或已在文档中说明），提供 124 个 vitest 测试（含通过真实 `register()` + FakeOpenClawHost 的离线端到端 6 轮字节级前缀稳定性测试），并附带一份双语根因分析文档，其中包含针对只能在宿主（OpenClaw）侧修复部分的精确上游建议。

### 动机（三条失效链路）

- **链 A（主因）**：每轮向用户消息前置 `prependContext`（约 500–1700 tokens 的召回记忆），`showInjected=true` 时被冻结进对话历史 → 上下文膨胀 → 更频繁且截断量逐轮不同的 tool-result truncation → 历史前缀不一致 → 前缀缓存失效。
- **链 B（次因）**：`composeSystemPromptWithHookContext` 把稳定的 persona + 场景导航（~4000 字符）拼接到 CACHE_BOUNDARY **之后**，未使用宿主已有的 `prependSystemPromptAdditionAfterCacheBoundary`，稳定内容每轮按新 token 计费。
- **链 C（放大器）**：稳定块每轮重新拼装，来源文件抖动 / 召回超时会造成字节级漂移与闪断，即使内容"语义相同"也会破坏前缀。

### 设计

1. **会话级稳定块冻结 + 去重**（`src/core/hooks/stable-context.ts`，`StableRecallContextCache`）：按 sessionKey 首轮字节冻结 persona/场景导航块，sha256 指纹检测漂移并计数；候选为 `undefined`（召回超时）时仍返回冻结值（防闪断）；滑动 60 分钟空闲 TTL + 10k LRU 上限。`recall.stableContextPolicy: "latest"` 恢复旧的每轮重拼行为。→ 消除链 C。
2. **缓存边界前注入**（`src/adapters/openclaw/stable-prompt-injector.ts` + `index.ts`）：运行时能力探测 `prependSystemPromptAdditionAfterCacheBoundary`（数据驱动候选名单，依次探测 `event → ctx → api → api.runtime` 四个载体，请求作用域优先）；探测到则把冻结块放到缓存侧、并从 hook 结果中省略 `appendSystemContext`（防双注入，测试断言 `<user-persona>` 恰好出现一次）。探测器**保证不抛出**（对恶意 getter 也逐属性 try/catch）；宿主 API 调用失败时**同轮**回退到与修复前完全一致的 hook-context 路径（内容不丢失）。`recall.systemInjection: "hook-context"` 可强制走旧路径；旧宿主（无该 API）行为与修复前逐字节一致。→ 在具备能力的宿主上消除链 B。
3. **历史去膨胀**（`recall.stripInjectedFromHistory`，默认 `true` = 现有干净历史行为，现改为可配置）：`before_message_write` 在持久化前剥离 `<relevant-memories>` 注入块，`showInjected=true` 不再使冻结历史膨胀。设为 `false` 恢复旧行为并打印"对提示词缓存不友好"警告。→ 从源头消除链 A 的插件侧诱因。
4. **可选纯扩展模式**（`recall.injectionMode: "session-stable"`，选择加入）：首轮召回结果并入冻结块，此后各轮抑制 `prependContext` 并跳过 L1 检索 → 每个请求都是上一请求的**纯字节扩展**。默认 `"ephemeral"` 保持现有语义。

**边界说明**：链 B 的最终落位与链 A 中的宿主侧 truncation 抖动只能由 OpenClaw 上游修复——`PROMPT-CACHE-ANALYSIS.md` 给出了 4 条精确到文件/函数的上游建议（含把截断量量化为稳定桶）。`src/offload` Context Engine 是独立互斥路径，不受这 4 个开关约束（分析文档 §3 有专段说明）。

### 验收标准映射

| # | 验收标准 | 实现位置 | 测试 |
|---|---|---|---|
| 1 | 稳定内容经宿主 API 置于缓存友好位置；配置门控；默认安全 | `src/adapters/openclaw/stable-prompt-injector.ts`；`index.ts` `before_prompt_build`；`src/config.ts`（`systemInjection: "auto"`） | `__tests__/prompt-cache-stability.test.ts` T5（4 个：API 在前且恰一次 / 无 API 回退 / 强制 legacy / API 抛出同轮回退）；`stable-prompt-injector.test.ts`（10 个，含恶意 getter）；`config.recall.test.ts` 默认值断言 |
| 2 | 召回记忆不再使冻结历史膨胀；向后兼容 + 迁移说明 | `src/core/hooks/auto-recall.ts` + `index.ts`（`stripInjectedFromHistory`，默认 true）；README / README_CN「提示词缓存友好性」小节；CHANGELOG ⚠️ 升级注意 | T2（6 轮 `showInjected=true` 下历史零残留）；T3（`false` 复现旧膨胀 + 警告，回归文档化） |
| 3 | 稳定系统提示追加内容的会话级去重 | `src/core/hooks/stable-context.ts`（`StableRecallContextCache`：冻结/指纹/TTL/LRU） | `stable-context.test.ts`（10 个单测）；T4（漂移候选 6 轮注入字节唯一）+ T4b（`"latest"` 恢复漂移）；未 mock 冒烟：中途改写 `persona.md` 系统提示不变 |
| 4 | vitest ≥5 轮序列化 prompt 前缀字节稳定 + 每项修复的回归测试 | `__tests__/prompt-cache-stability.test.ts`（真实 `register()` + FakeOpenClawHost，**6 轮**） | T1 ephemeral：系统提示字节集大小=1，LCP 下界断言；T1b session-stable：纯字节扩展；回归：T3、T4b、超时闪断（`tdai-core.recall.test.ts`）、抛出回退、非法配置回退默认；变异检查：禁用冻结 ⇒ 4 个测试失败 |
| 5 | 分析文档：机制 + 命中率表 + 逐修复映射 + 上游建议 | `PROMPT-CACHE-ANALYSIS.md`（仓库根，双语） | 含 issue 原始命中率表、三链机制、开关→链→默认值→逃生口映射表（标注插件可完成 vs 需宿主配合）、4 条文件/函数级上游建议、离线 + 生产 A/B（`prompt_cache_hit_tokens`）验证方案 |

### 离线运行方式

```bash
source ~/.venvs/node22.env
cd /home/seat1163/work/Tencent/issue-120
npx vitest run          # 10 文件 / 124 测试，全绿；无网络、无 API key
npm run build:plugin    # tsdown 打包 dist/index.mjs
```

所有测试使用 `embedding.provider: "none"` + 临时目录 sqlite，端到端测试通过真实 `register()` 与内存版 FakeOpenClawHost 驱动（`runtime.version: undefined` ⇒ hook 策略拒绝写真实 `~/.openclaw/openclaw.json`）。

---

## English

### Summary

After the memory-tencentdb plugin shipped, prompt-cache hit rates on prefix-matching OpenAI-compatible providers regressed sharply (MiMo 91.1%→63.5%, DeepSeek 95.7%→83.3%). This PR fixes all three failure chains on the plugin side, adds four `recall.*` config knobs (defaults backward-compatible or explicitly documented), ships 124 vitest tests — including an offline end-to-end 6-turn byte-level prefix-stability suite through the real `register()` with a FakeOpenClawHost — and a bilingual root-cause analysis doc with precise upstream recommendations for the parts only the host (OpenClaw) can fix.

### Motivation (three failure chains)

- **Chain A (primary)**: per-turn `prependContext` (~500–1700 tokens of recalled memories) is frozen into conversation history when `showInjected=true` → context bloat → more frequent tool-result truncation with per-turn variable amounts → inconsistent history prefix → prefix cache invalidated.
- **Chain B (secondary)**: `composeSystemPromptWithHookContext` appends stable persona + scene navigation (~4000 chars) **after** CACHE_BOUNDARY instead of using the host's existing `prependSystemPromptAdditionAfterCacheBoundary`; stable content is re-billed as fresh tokens every turn.
- **Chain C (amplifier)**: the stable block is recomposed every turn; source-file jitter or recall timeouts cause byte-level drift/flicker that breaks the prefix even when content is "semantically identical".

### Design

1. **Session-level freeze + dedup** (`src/core/hooks/stable-context.ts`, `StableRecallContextCache`): byte-freezes the persona/scene-nav block per sessionKey on first turn; sha256 fingerprint drift detection with a counter; an `undefined` candidate (recall timeout) still serves the frozen bytes (no flicker); sliding 60-min idle TTL, 10k-entry LRU cap. `recall.stableContextPolicy: "latest"` restores legacy per-turn recompose. → kills chain C.
2. **Cache-side injection** (`src/adapters/openclaw/stable-prompt-injector.ts` + `index.ts`): runtime capability probe for `prependSystemPromptAdditionAfterCacheBoundary` (data-driven candidate names, four carriers `event → ctx → api → api.runtime`, request-scoped first). When found, the frozen block is placed on the cached side and `appendSystemContext` is omitted from the hook result (double-injection guard; tests assert exactly one `<user-persona>`). The probe **never throws** (per-property try/catch survives hostile getters); a failing host call falls back **same-turn** to the exact pre-fix hook-context path (block never lost). `recall.systemInjection: "hook-context"` forces legacy; hosts without the API behave byte-identically to pre-fix. → kills chain B on capable hosts.
3. **History de-bloat** (`recall.stripInjectedFromHistory`, default `true` = existing clean-history behavior, now gated): `before_message_write` strips `<relevant-memories>` before persisting, so `showInjected=true` no longer bloats frozen history. `false` restores legacy with a cache-hostile warning. → removes the plugin-side trigger of chain A.
4. **Opt-in pure-extension mode** (`recall.injectionMode: "session-stable"`): turn-1 recall folded into the frozen block, per-turn `prependContext` suppressed and L1 search skipped from turn 2 → every request is a **pure byte-extension** of the previous one. Default `"ephemeral"` keeps current semantics.

**Boundary**: chain B's final placement and the host-side truncation jitter in chain A can only be fixed upstream — `PROMPT-CACHE-ANALYSIS.md` gives four file/function-level OpenClaw recommendations (including quantizing truncation into stable buckets). The `src/offload` Context Engine is a separate exclusive path not governed by these knobs (dedicated paragraph in the analysis doc, §3).

### Acceptance-criteria mapping

| # | Criterion | Where satisfied | Test |
|---|---|---|---|
| 1 | Stable content placed cache-stably via host API; config-gated; safe default | `src/adapters/openclaw/stable-prompt-injector.ts`; `index.ts` `before_prompt_build`; `src/config.ts` (`systemInjection: "auto"`) | `__tests__/prompt-cache-stability.test.ts` T5 (4 tests: ahead-of-tail exactly once / no-API fallback / forced legacy / throwing API same-turn fallback); `stable-prompt-injector.test.ts` (10 tests incl. hostile getters); defaults asserted in `config.recall.test.ts` |
| 2 | Recalled memories stop bloating frozen history; backward compat + migration note | `src/core/hooks/auto-recall.ts` + `index.ts` (`stripInjectedFromHistory`, default true); README / README_CN "Prompt-cache friendliness" sections; CHANGELOG ⚠️ upgrade block | T2 (6 turns under `showInjected=true`, zero residue in persisted history); T3 (`false` reproduces legacy bloat + warning, documented regression) |
| 3 | Session-level dedup of repeated stable system-prompt additions | `src/core/hooks/stable-context.ts` (`StableRecallContextCache`: freeze/fingerprint/TTL/LRU) | `stable-context.test.ts` (10 unit tests); T4 (drifting candidates ⇒ 6 byte-identical injections) + T4b (`"latest"` restores drift); unmocked smoke: `persona.md` rewritten mid-session, system prompt unchanged |
| 4 | vitest ≥5-turn byte-stable serialized prompt prefix + regression tests per fix | `__tests__/prompt-cache-stability.test.ts` (real `register()` + FakeOpenClawHost, **6 turns**) | T1 ephemeral: system-prompt byte-set size 1 + LCP lower bound; T1b session-stable: pure byte-extension; regressions: T3, T4b, timeout-flicker (`tdai-core.recall.test.ts`), throwing fallback, invalid-config fallback-to-default; mutation check: disabling the freeze fails 4 tests |
| 5 | Analysis doc: mechanism + hit-rate table + per-change fix mapping + upstream recommendations | `PROMPT-CACHE-ANALYSIS.md` (repo root, fully bilingual) | Contains the issue's hit-rate table verbatim, three-chain mechanism, knob→chain→default→escape-hatch table (plugin-complete vs host-cooperative marked), 4 file/function-level upstream recommendations, offline + production A/B verification via `prompt_cache_hit_tokens`/`prompt_cache_miss_tokens` |

### 给评审的一个显式问题 / One explicit question for reviewers

链 B 的修复假设宿主的 `prependSystemPromptAdditionAfterCacheBoundary` 为**每次构建重组(replace)语义**(注入不跨轮累积);该符号是宿主内部实现,离线无法验证,FakeOpenClawHost 按同一假设建模。请熟悉宿主的维护者确认 ≥2026.5.28 确为此语义;若某版本为累积语义,现成逃生门是 `recall.systemInjection: "hook-context"`(字节级回到修复前路径)。/ The chain-B fix assumes the host's `prependSystemPromptAdditionAfterCacheBoundary` follows per-build compose (replace) semantics — additions do not accumulate across turns. The symbol is host-internal and unverifiable offline; FakeOpenClawHost models the same assumption. Could a maintainer confirm this holds for ≥2026.5.28? If any version accumulates, the ready escape hatch is `recall.systemInjection: "hook-context"` (byte-identical pre-fix path).

### How to run offline

```bash
source ~/.venvs/node22.env
cd /home/seat1163/work/Tencent/issue-120
npx vitest run          # 10 files / 124 tests, all green; no network, no API keys
npm run build:plugin    # tsdown bundle → dist/index.mjs
```

All tests run with `embedding.provider: "none"` and tmp-dir sqlite; the e2e suite drives the real `register()` through an in-memory FakeOpenClawHost (`runtime.version: undefined` ⇒ hook policy refuses to touch the real `~/.openclaw/openclaw.json`).

### Sample output / artifact paths

| Artifact | Path |
|---|---|
| Patch series | `/home/seat1163/work/Tencent/docs/patches/issue-120/0001-fix-recall-stabilize-prompt-cache-prefix-under-prepe.patch` |
| Root-cause analysis (bilingual, in-repo) | `/home/seat1163/work/Tencent/issue-120/PROMPT-CACHE-ANALYSIS.md` |
| E2E prefix-stability suite | `/home/seat1163/work/Tencent/issue-120/__tests__/prompt-cache-stability.test.ts` |
| Fake host harness | `/home/seat1163/work/Tencent/issue-120/__tests__/helpers/fake-openclaw-host.ts` |
| Verification notes (independent reviewer) | `/home/seat1163/work/Tencent/docs/verify/issue-120-verification.md` |
| Plan / implementation notes | `/home/seat1163/work/Tencent/docs/plans/issue-120-plan.md`, `/home/seat1163/work/Tencent/docs/impl/issue-120-implementation.md` |

### Final test run (verbatim, 2026-07-06)

```
 RUN  v4.1.10 /home/seat1163/work/Tencent/issue-120

 Test Files  10 passed (10)
      Tests  122 passed (122)
   Start at  16:25:23
   Duration  36.44s (transform 14.79s, setup 0ms, import 38.08s, tests 10.74s, environment 2ms)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 评审后更新 / Post-review update（2026-07-19）

独立对抗式评审(6 评审并行 + 逐发现执行级复核)结论:**0 个 major**,全部头条声明经审计属实。据评审意见追加:

- 修复 `handleBeforeRecall` 会话冻结的 TOCTOU 竞态(并发 Gateway `/recall` 下可能双冻结、后者覆盖前者):await 后重查冻结状态,**首个完成者确定性胜出**;+2 个并发回归测试(已验证修复前会失败)。
- 验收映射表 `stable-prompt-injector.test.ts` 测试数 12→10 更正(诚实性修正)。
- chain-B 的宿主 replace 语义假设已在上文显式列为「给评审的问题」。

测试:**124/124 全绿**(原 122 + 2 新增)。

*(EN) Post-review update 2026-07-19: an independent adversarial review (6 parallel judges, execution-backed verification) found 0 majors (only a TOCTOU freeze race under concurrent gateway recalls, now first-completer-wins + 2 regression tests, and a 12→10 test-count correction); all items fixed as listed above, full suite green (vitest 124/124).*
