### PR TITLE
feat(adapters): add Claude Code + Dify adapters, unified adapter SDK, and architecture docs (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,27 @@ curl http://127.0.0.1:8420/health
 ---
 
 
+## 🔌 Cross-Platform Adapters
+
+Beyond OpenClaw and Hermes, the memory engine now ships a unified **Adapter SDK**
+([`src/adapter-sdk/`](./src/adapter-sdk/README.md)): one `MemoryClient` interface with two
+interchangeable transports (in-process `TdaiCore` / HTTP Gateway), so a new platform only
+implements one interface. Two adapters are built on it:
+
+- **Claude Code (MCP)** — stdio server exposing `memory_recall` / `memory_capture` /
+  `memory_search` / `conversation_search` / `memory_session_end` tools:
+  `npm run adapter:claude-code` · [setup guide](./src/adapters/claude-code/README.md)
+- **Dify** — External Knowledge Base API (`POST /retrieval`) + Custom Tool endpoints with
+  auto-generated OpenAPI: `npm run adapter:dify` · [setup guide](./src/adapters/dify/README.md)
+
+Docs: [architecture & data flows](./docs/adapters/ARCHITECTURE.md) ·
+[four-platform comparison](./docs/adapters/PLATFORM-COMPARISON.md) ·
+[how to integrate a new platform](./docs/adapters/NEW-PLATFORM-GUIDE.md)
+
+
+---
+
+
 ## 🔒 Gateway Security (optional)
 
 The Hermes Gateway listens on `:8420` and exposes capture / search / recall HTTP endpoints. Two opt-in switches let you turn it from "open localhost sidecar" into "authenticated network service". **Both default to off so existing deployments keep working unchanged.**

--- a/README_CN.md
+++ b/README_CN.md
@@ -356,6 +356,26 @@ curl http://127.0.0.1:8420/health
 
 ---
 
+## 🔌 跨平台适配
+
+在 OpenClaw 与 Hermes 之外，记忆引擎现已提供统一的 **Adapter SDK**
+（[`src/adapter-sdk/`](./src/adapter-sdk/README_CN.md)）：一个 `MemoryClient` 接口、两种可互换
+传输（进程内 `TdaiCore` / HTTP Gateway），新平台只需实现一个接口即可接入。已有两个适配器
+构建于其上：
+
+- **Claude Code（MCP）** — stdio 服务器，暴露 `memory_recall` / `memory_capture` /
+  `memory_search` / `conversation_search` / `memory_session_end` 五个工具：
+  `npm run adapter:claude-code` · [部署指南](./src/adapters/claude-code/README_CN.md)
+- **Dify** — 外部知识库 API（`POST /retrieval`）+ 自定义工具端点（自动生成 OpenAPI）：
+  `npm run adapter:dify` · [部署指南](./src/adapters/dify/README_CN.md)
+
+文档：[架构与数据流](./docs/adapters/ARCHITECTURE_CN.md) ·
+[四平台对比](./docs/adapters/PLATFORM-COMPARISON_CN.md) ·
+[如何接入新平台](./docs/adapters/NEW-PLATFORM-GUIDE_CN.md)
+
+
+---
+
 ## 🔒 Gateway 安全配置（可选）
 
 Hermes Gateway 监听 `:8420`，对外提供 capture / search / recall 的 HTTP 接口。新增两个开关，可以把它从“开放的本地 sidecar”切换为“需要鉴权的网络服务”。**两个开关默认都关闭，已有部署的行为不变。**

--- a/docs/adapters/ARCHITECTURE.md
+++ b/docs/adapters/ARCHITECTURE.md
@@ -1,0 +1,253 @@
+# Memory Engine × Platform Adapters — Architecture
+
+> 中文版本见 [ARCHITECTURE_CN.md](./ARCHITECTURE_CN.md)。
+> Companion docs: [Platform Comparison](./PLATFORM-COMPARISON.md) · [New Platform Guide](./NEW-PLATFORM-GUIDE.md) · [Adapter SDK README](../../src/adapter-sdk/README.md)
+
+This document maps the real capability surface of the core memory engine (`TdaiCore`), the two
+adapter layers that already ship (OpenClaw plugin, Hermes provider via the HTTP Gateway), and the
+unified Adapter SDK that the two new adapters (Claude Code MCP, Dify) are built on — with
+annotated data flows for each path.
+
+---
+
+## 1. TdaiCore capability surface
+
+`TdaiCore` (`src/core/tdai-core.ts`) is the host-neutral facade every platform ultimately calls.
+Note the **name drift**: design docs (and issue #235) speak of `recall` / `capture` / `search`,
+but the shipped symbols are hook-flavored. The mapping:
+
+| Concept | Real symbol | Signature |
+| --- | --- | --- |
+| recall | `handleBeforeRecall` | `(userText: string, sessionKey: string) => Promise<RecallResult>` |
+| capture | `handleTurnCommitted` | `(turn: CompletedTurn) => Promise<CaptureResult>` |
+| search (L1 memories) | `searchMemories` | `(p: MemorySearchParams) => Promise<{ text; total; strategy }>` |
+| search (L1, structured) | `searchMemoriesStructured` | `(p: MemorySearchParams) => Promise<MemorySearchResult>` — per-record `items` with scores |
+| search (L0 conversations) | `searchConversations` | `(p: ConversationSearchParams) => Promise<{ text; total }>` |
+| search (L0, structured) | `searchConversationsStructured` | `(p: ConversationSearchParams) => Promise<ConversationSearchResult>` |
+| session end | `handleSessionEnd` | `(sessionKey: string) => Promise<void>` — flushes ONE session, never global teardown |
+| lifecycle | `initialize()` / `destroy()` | one-shot init / full teardown (stores, scheduler, background tasks) |
+| accessors | `getVectorStore()` `getEmbeddingService()` `getScheduler()` `getLLMRunnerFactory()` `isSchedulerStarted()` `setInstanceId()` | for bridges, health checks, metrics |
+
+Memory layers, in one paragraph: **L0** is the raw conversation archive (every captured user /
+assistant message, FTS + optionally vector-indexed). **L1** is structured memory records
+(persona / episodic / instruction facts) extracted from L0 by a background LLM pipeline. **L2**
+aggregates L1 into scene blocks; **L3** distills a stable user persona. `handleBeforeRecall`
+reads L1/L3 to build prompt context; `handleTurnCommitted` writes L0 and notifies the pipeline
+scheduler which asynchronously advances L1→L2→L3.
+
+The boundary types live in `src/core/types.ts`: a host supplies a `HostAdapter`
+(`hostType`, `getRuntimeContext()`, `getLogger()`, `getLLMRunnerFactory()`) and receives results
+as `RecallResult { prependContext?, appendSystemContext?, recalledL1Memories?, recallStrategy? }`
+and `CaptureResult { l0RecordedCount, schedulerNotified, l0VectorsWritten, filteredMessages }`.
+
+## 2. Global component map (all four platforms)
+
+```mermaid
+flowchart LR
+    subgraph OpenClawHost["OpenClaw host process"]
+        OC["OpenClaw runtime"] -->|"hooks + tools"| IDX["index.ts register(api)"]
+        IDX --> OHA["OpenClawHostAdapter"]
+    end
+
+    subgraph GatewayProc["Gateway process (Node sidecar)"]
+        GW["TdaiGateway :8420<br/>(zero-dep node:http)"] --> SHA["StandaloneHostAdapter"]
+    end
+
+    HERMES["Hermes Agent (Python)<br/>MemoryTencentdbProvider"] -->|"POST /recall /capture<br/>/search/* /session/end"| GW
+    SUP["GatewaySupervisor<br/>(spawn + watchdog)"] -.->|"manages"| GW
+
+    subgraph SDK["Adapter SDK (src/adapter-sdk)"]
+        MC["MemoryClient interface"]
+        HTTPT["HttpMemoryClient"] --- MC
+        INPROC["InProcessMemoryClient"] --- MC
+    end
+
+    CC["Claude Code<br/>(MCP client)"] -->|"stdio JSON-RPC<br/>tools/call"| MCP["TdaiMcpServer<br/>(src/adapters/claude-code)"]
+    DIFY["Dify app"] -->|"POST /retrieval<br/>POST /tools/*"| DA["DifyMemoryAdapter :8421<br/>(src/adapters/dify)"]
+    MCP --> MC
+    DA --> MC
+    HTTPT -->|"same REST wire<br/>as Hermes"| GW
+    INPROC --> CORE2["TdaiCore (embedded)"]
+
+    OHA --> CORE["TdaiCore"]
+    SHA --> CORE
+    CORE --> STORES["Stores: SQLite + sqlite-vec / TCVDB<br/>EmbeddingService · MemoryPipelineManager L1/L2/L3"]
+    CORE2 --> STORES
+```
+
+Edge annotations — what each arrow carries:
+
+| Edge | Payload |
+| --- | --- |
+| OpenClaw → `index.ts` | `before_prompt_build` (recall), `agent_end` (capture), `gateway_stop` (destroy), tool calls `tdai_memory_search` / `tdai_conversation_search`, CLI `openclaw memory-tdai …` |
+| Hermes → Gateway | snake_case JSON: `POST /recall {query, session_key}` · `POST /capture {user_content, assistant_content, session_key, messages?}` · `POST /search/memories` · `POST /search/conversations` · `POST /session/end` · `POST /seed` · `GET /health` |
+| Claude Code → MCP server | newline-delimited JSON-RPC 2.0: `initialize`, `tools/list`, `tools/call {memory_recall, memory_capture, memory_search, conversation_search, memory_session_end}` |
+| Dify → Dify adapter | `POST /retrieval {knowledge_id, query, retrieval_setting}` (External Knowledge API) · `POST /tools/capture` · `POST /tools/recall` · `GET /openapi.json` |
+| SDK http transport → Gateway | identical wire to Hermes, plus opt-in `include_items: true` on the two search routes (returns structured `items` next to the formatted text) |
+
+## 3. Data flow A — OpenClaw plugin (in-process)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant OpenClaw
+    participant Plugin as index.ts (plugin)
+    participant Core as TdaiCore
+    participant Pipe as Pipeline (L1/L2/L3)
+
+    User->>OpenClaw: message
+    OpenClaw->>Plugin: hook before_prompt_build
+    Plugin->>Core: handleBeforeRecall(userText, sessionKey)
+    Core-->>Plugin: RecallResult {prependContext, appendSystemContext}
+    Plugin-->>OpenClaw: inject prependContext into user prompt,<br/>appendSystemContext into system prompt
+    Note over OpenClaw: LLM turn runs (may call tools)
+    OpenClaw->>Plugin: tool tdai_memory_search {query, limit, type, scene}
+    Plugin->>Core: searchMemories(params)
+    Core-->>Plugin: {text, total, strategy}
+    OpenClaw->>Plugin: hook agent_end (completed turn)
+    Plugin->>Core: handleTurnCommitted(CompletedTurn)
+    Core->>Core: record L0 (+ deferred embedding)
+    Core-)Pipe: scheduler.notify(sessionKey)
+    Pipe-)Pipe: async L1 extract → L2 scenes → L3 persona
+    Core-->>Plugin: CaptureResult {l0RecordedCount, schedulerNotified}
+    OpenClaw->>Plugin: hook gateway_stop
+    Plugin->>Core: destroy()
+```
+
+Key property: everything is **in-process and hook-driven** — recall/capture are automatic,
+invisible to the model except through the injected context. The plugin also registers a CLI and
+an optional offload module; the LLM used by the extraction pipeline defaults to the *host's* runner.
+
+## 4. Data flow B — Hermes provider ⇄ HTTP Gateway (out-of-process)
+
+```mermaid
+sequenceDiagram
+    participant Hermes as Hermes Agent (Python)
+    participant Prov as MemoryTencentdbProvider
+    participant Sup as GatewaySupervisor
+    participant GW as TdaiGateway :8420
+    participant Core as TdaiCore
+
+    Note over Sup,GW: lifecycle: spawn node sidecar → poll GET /health<br/>→ watchdog resurrects on crash → circuit breaker on repeated failures
+    Hermes->>Prov: prefetch(query, session)
+    Prov->>GW: POST /recall {query, session_key}
+    GW->>Core: handleBeforeRecall(...)
+    Core-->>GW: RecallResult
+    GW-->>Prov: {context, strategy, memory_count}
+    Note over Prov: context → injected into Hermes prompt
+    Hermes->>Prov: sync_turn(user, assistant)
+    Prov-)GW: POST /capture (background thread)
+    GW->>Core: handleTurnCommitted(CompletedTurn)
+    GW-->>Prov: {l0_recorded, scheduler_notified}
+    Hermes->>Prov: handle_tool_call(memory_search)
+    Prov->>GW: POST /search/memories {query, limit}
+    GW-->>Prov: {results: "formatted text", total, strategy}
+    Hermes->>Prov: on_session_end
+    Prov->>GW: POST /session/end {session_key}
+    GW->>Core: handleSessionEnd(sessionKey) — flush ONE session
+```
+
+Key properties: the wire is **snake_case JSON**; auth is optional Bearer
+(`TDAI_GATEWAY_API_KEY`, constant-time compare); failures on the Python side are absorbed by a
+circuit breaker so memory never blocks the agent. The Gateway builds its core with
+`StandaloneHostAdapter`, so extraction uses a standalone OpenAI-compatible LLM config instead of
+a host runner.
+
+Gateway ⇄ core field mapping (the "translation table" every HTTP-based adapter inherits):
+
+| Wire (snake_case) | Core (camelCase) |
+| --- | --- |
+| `query`, `session_key` | `handleBeforeRecall(userText, sessionKey)` |
+| `context` ← | `RecallResult.appendSystemContext ?? ""` |
+| `prepend_context?` ← | `RecallResult.prependContext` (additive; sent only when non-empty — legacy clients ignore it) |
+| `memory_count` ← | `RecallResult.recalledL1Memories.length` |
+| `user_content` / `assistant_content` / `messages?` | `CompletedTurn.userText / assistantText / messages` (defaulted to the 2-message pair) |
+| `l0_recorded` / `scheduler_notified` ← | `CaptureResult.l0RecordedCount / schedulerNotified` |
+| `include_items: true` (opt-in) | routes to `search*Structured`, response gains `items[]` |
+
+## 5. Data flow C — the two new adapters on the SDK
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant MCP as TdaiMcpServer (stdio)
+    participant MC as MemoryClient (http or in-process)
+    participant D as Dify app
+    participant DA as DifyMemoryAdapter :8421
+
+    CC->>MCP: initialize {protocolVersion}
+    MCP-->>CC: {protocolVersion, capabilities.tools, serverInfo}
+    CC->>MCP: tools/call memory_recall {query}
+    MCP->>MC: recall({query, sessionKey})
+    MC-->>MCP: {context, prependContext, memoryCount}
+    MCP-->>CC: content:[{type:text}]
+    CC->>MCP: tools/call memory_capture {user_content, assistant_content}
+    MCP->>MC: capture({userContent, assistantContent, sessionKey})
+
+    D->>DA: POST /retrieval {knowledge_id: tdai-memories, query, retrieval_setting}
+    DA->>MC: searchMemories({query, limit: top_k})
+    MC-->>DA: {items: [{content, score, ...}]}
+    DA-->>D: {records: [{content, score, title, metadata}]} (filtered by score_threshold)
+    D->>DA: POST /tools/capture {user_content, assistant_content}
+    DA->>MC: capture(...)
+    DA-->>D: {l0_recorded, scheduler_notified}
+```
+
+Both adapters consume **only** the `MemoryClient` interface — they cannot tell whether it is the
+HTTP transport (Gateway sidecar, like Hermes) or the in-process transport (embedded core, like
+OpenClaw). That symmetry is the point of the SDK.
+
+## 6. Target architecture — the unified Adapter SDK
+
+```mermaid
+flowchart TD
+    subgraph Platforms["Platform adapters (one interface each)"]
+        P1["OpenClaw plugin<br/>(existing, direct)"]
+        P2["Hermes provider<br/>(existing, Python/REST)"]
+        P3["TdaiMcpServer<br/>extends BasePlatformAdapter"]
+        P4["DifyMemoryAdapter<br/>extends BasePlatformAdapter"]
+        P5["Your platform<br/>extends BasePlatformAdapter"]
+    end
+
+    subgraph SDKLayer["Adapter SDK — src/adapter-sdk"]
+        BPA["BasePlatformAdapter<br/>safeRecall / safeCapture / stop"]
+        FACT["createMemoryClient(options)<br/>resolveClientOptionsFromEnv()"]
+        MCI["MemoryClient<br/>recall · capture · searchMemories ·<br/>searchConversations · endSession · health · close"]
+        ERR["MemoryClientError<br/>transport | auth | bad_request | unavailable"]
+        T1["HttpMemoryClient"]
+        T2["InProcessMemoryClient"]
+        BPA --> MCI
+        FACT --> MCI
+        MCI --- T1
+        MCI --- T2
+        MCI -.-> ERR
+    end
+
+    P3 --> BPA
+    P4 --> BPA
+    P5 --> BPA
+    T1 -->|"REST, same wire as Hermes<br/>+ include_items"| GW["TdaiGateway"]
+    T2 --> CORE["TdaiCore"]
+    GW --> CORE
+    P1 -->|"direct (predates SDK)"| CORE
+    P2 -->|"REST"| GW
+    CORE --> L["L0 archive → L1 memories → L2 scenes → L3 persona"]
+```
+
+Contract summary:
+
+- **New platform = implement ONE interface.** `PlatformAdapter { platformName; start(); stop() }`,
+  in practice `class X extends BasePlatformAdapter` + map your platform's lifecycle onto
+  `this.client` / `this.safeRecall` / `this.safeCapture`.
+- **One client interface, two transports.** `createMemoryClient({transport: "http" | "in-process", ...})`.
+  Transport choice is deployment configuration, not adapter code.
+- **Uniform failure semantics.** All client methods throw `MemoryClientError` with a stable
+  `code`; `safeRecall`/`safeCapture` degrade instead of throwing, encoding the project rule that
+  *memory must never break the host conversation*.
+
+## 7. Where to go next
+
+- Per-platform trade-offs and how the four integrations differ: [PLATFORM-COMPARISON.md](./PLATFORM-COMPARISON.md)
+- Step-by-step onboarding for a fifth platform: [NEW-PLATFORM-GUIDE.md](./NEW-PLATFORM-GUIDE.md)
+- SDK API reference and usage: [src/adapter-sdk/README.md](../../src/adapter-sdk/README.md)
+- Adapter setup: [Claude Code](../../src/adapters/claude-code/README.md) · [Dify](../../src/adapters/dify/README.md)

--- a/docs/adapters/ARCHITECTURE_CN.md
+++ b/docs/adapters/ARCHITECTURE_CN.md
@@ -1,0 +1,246 @@
+# 记忆引擎 × 平台适配层 — 架构说明
+
+> English version: [ARCHITECTURE.md](./ARCHITECTURE.md)。
+> 配套文档：[平台对比](./PLATFORM-COMPARISON_CN.md) · [新平台接入指南](./NEW-PLATFORM-GUIDE_CN.md) · [Adapter SDK 说明](../../src/adapter-sdk/README_CN.md)
+
+本文梳理核心记忆引擎（`TdaiCore`）的真实能力边界、当前已交付的两条适配层（OpenClaw 插件、经
+HTTP Gateway 的 Hermes Provider），以及两个新适配器（Claude Code MCP、Dify）所依托的统一
+Adapter SDK，并对每条链路标注数据流。
+
+---
+
+## 1. TdaiCore 能力面
+
+`TdaiCore`（`src/core/tdai-core.ts`）是所有平台最终调用的宿主无关门面。注意**命名漂移**：
+设计文档（以及 issue #235）里说的是 `recall` / `capture` / `search`，而实际交付的符号带有
+钩子风格。对应关系如下：
+
+| 概念 | 真实符号 | 签名 |
+| --- | --- | --- |
+| recall（召回） | `handleBeforeRecall` | `(userText: string, sessionKey: string) => Promise<RecallResult>` |
+| capture（捕获） | `handleTurnCommitted` | `(turn: CompletedTurn) => Promise<CaptureResult>` |
+| search（L1 记忆） | `searchMemories` | `(p: MemorySearchParams) => Promise<{ text; total; strategy }>` |
+| search（L1 结构化） | `searchMemoriesStructured` | `(p: MemorySearchParams) => Promise<MemorySearchResult>` — 返回带分数的逐条 `items` |
+| search（L0 对话） | `searchConversations` | `(p: ConversationSearchParams) => Promise<{ text; total }>` |
+| search（L0 结构化） | `searchConversationsStructured` | `(p: ConversationSearchParams) => Promise<ConversationSearchResult>` |
+| 会话结束 | `handleSessionEnd` | `(sessionKey: string) => Promise<void>` — 只冲刷单个会话，绝非全局销毁 |
+| 生命周期 | `initialize()` / `destroy()` | 一次性初始化 / 全量销毁（存储、调度器、后台任务） |
+| 访问器 | `getVectorStore()` `getEmbeddingService()` `getScheduler()` `getLLMRunnerFactory()` `isSchedulerStarted()` `setInstanceId()` | 供桥接、健康检查、指标上报使用 |
+
+一段话讲清记忆分层：**L0** 是原始对话档案（每条被捕获的 user / assistant 消息，FTS 索引 +
+可选向量索引）。**L1** 是由后台 LLM 流水线从 L0 提取的结构化记忆（persona / episodic /
+instruction 事实）。**L2** 把 L1 聚合成场景块；**L3** 蒸馏出稳定的用户画像。
+`handleBeforeRecall` 读取 L1/L3 组装提示词上下文；`handleTurnCommitted` 写入 L0 并通知
+流水线调度器，后者异步推进 L1→L2→L3。
+
+边界类型定义在 `src/core/types.ts`：宿主提供 `HostAdapter`（`hostType`、
+`getRuntimeContext()`、`getLogger()`、`getLLMRunnerFactory()`），并以
+`RecallResult { prependContext?, appendSystemContext?, recalledL1Memories?, recallStrategy? }`、
+`CaptureResult { l0RecordedCount, schedulerNotified, l0VectorsWritten, filteredMessages }` 接收结果。
+
+## 2. 全局组件图（四个平台）
+
+```mermaid
+flowchart LR
+    subgraph OpenClawHost["OpenClaw 宿主进程"]
+        OC["OpenClaw 运行时"] -->|"钩子 + 工具"| IDX["index.ts register(api)"]
+        IDX --> OHA["OpenClawHostAdapter"]
+    end
+
+    subgraph GatewayProc["Gateway 进程（Node 边车）"]
+        GW["TdaiGateway :8420<br/>（零依赖 node:http）"] --> SHA["StandaloneHostAdapter"]
+    end
+
+    HERMES["Hermes Agent（Python）<br/>MemoryTencentdbProvider"] -->|"POST /recall /capture<br/>/search/* /session/end"| GW
+    SUP["GatewaySupervisor<br/>（拉起 + 看门狗）"] -.->|"托管"| GW
+
+    subgraph SDK["Adapter SDK（src/adapter-sdk）"]
+        MC["MemoryClient 接口"]
+        HTTPT["HttpMemoryClient"] --- MC
+        INPROC["InProcessMemoryClient"] --- MC
+    end
+
+    CC["Claude Code<br/>（MCP 客户端）"] -->|"stdio JSON-RPC<br/>tools/call"| MCP["TdaiMcpServer<br/>（src/adapters/claude-code）"]
+    DIFY["Dify 应用"] -->|"POST /retrieval<br/>POST /tools/*"| DA["DifyMemoryAdapter :8421<br/>（src/adapters/dify）"]
+    MCP --> MC
+    DA --> MC
+    HTTPT -->|"与 Hermes 完全同一 REST 协议"| GW
+    INPROC --> CORE2["TdaiCore（内嵌）"]
+
+    OHA --> CORE["TdaiCore"]
+    SHA --> CORE
+    CORE --> STORES["存储：SQLite + sqlite-vec / TCVDB<br/>EmbeddingService · MemoryPipelineManager L1/L2/L3"]
+    CORE2 --> STORES
+```
+
+边注 — 每条箭头承载的内容：
+
+| 边 | 载荷 |
+| --- | --- |
+| OpenClaw → `index.ts` | `before_prompt_build`（召回）、`agent_end`（捕获）、`gateway_stop`（销毁）、工具调用 `tdai_memory_search` / `tdai_conversation_search`、CLI `openclaw memory-tdai …` |
+| Hermes → Gateway | snake_case JSON：`POST /recall {query, session_key}` · `POST /capture {user_content, assistant_content, session_key, messages?}` · `POST /search/memories` · `POST /search/conversations` · `POST /session/end` · `POST /seed` · `GET /health` |
+| Claude Code → MCP 服务器 | 换行分隔的 JSON-RPC 2.0：`initialize`、`tools/list`、`tools/call {memory_recall, memory_capture, memory_search, conversation_search, memory_session_end}` |
+| Dify → Dify 适配器 | `POST /retrieval {knowledge_id, query, retrieval_setting}`（外部知识库 API）· `POST /tools/capture` · `POST /tools/recall` · `GET /openapi.json` |
+| SDK http 传输 → Gateway | 与 Hermes 同一协议，另在两个搜索路由上可选发送 `include_items: true`（响应在格式化文本之外附带结构化 `items`） |
+
+## 3. 数据流 A — OpenClaw 插件（进程内）
+
+```mermaid
+sequenceDiagram
+    participant User as 用户
+    participant OpenClaw
+    participant Plugin as index.ts（插件）
+    participant Core as TdaiCore
+    participant Pipe as 流水线（L1/L2/L3）
+
+    User->>OpenClaw: 消息
+    OpenClaw->>Plugin: 钩子 before_prompt_build
+    Plugin->>Core: handleBeforeRecall(userText, sessionKey)
+    Core-->>Plugin: RecallResult {prependContext, appendSystemContext}
+    Plugin-->>OpenClaw: prependContext 注入用户提示词，<br/>appendSystemContext 注入系统提示词
+    Note over OpenClaw: LLM 回合执行（可调用工具）
+    OpenClaw->>Plugin: 工具 tdai_memory_search {query, limit, type, scene}
+    Plugin->>Core: searchMemories(params)
+    Core-->>Plugin: {text, total, strategy}
+    OpenClaw->>Plugin: 钩子 agent_end（回合完成）
+    Plugin->>Core: handleTurnCommitted(CompletedTurn)
+    Core->>Core: 记录 L0（+ 延迟向量化）
+    Core-)Pipe: scheduler.notify(sessionKey)
+    Pipe-)Pipe: 异步 L1 提取 → L2 场景 → L3 画像
+    Core-->>Plugin: CaptureResult {l0RecordedCount, schedulerNotified}
+    OpenClaw->>Plugin: 钩子 gateway_stop
+    Plugin->>Core: destroy()
+```
+
+关键性质：一切都是**进程内、钩子驱动** — 召回/捕获全自动，模型只能通过注入的上下文感知。
+插件还注册了 CLI 与可选的 offload 模块；提取流水线的 LLM 默认使用*宿主*的运行器。
+
+## 4. 数据流 B — Hermes Provider ⇄ HTTP Gateway（跨进程）
+
+```mermaid
+sequenceDiagram
+    participant Hermes as Hermes Agent（Python）
+    participant Prov as MemoryTencentdbProvider
+    participant Sup as GatewaySupervisor
+    participant GW as TdaiGateway :8420
+    participant Core as TdaiCore
+
+    Note over Sup,GW: 生命周期：拉起 node 边车 → 轮询 GET /health<br/>→ 看门狗崩溃复活 → 连续失败触发熔断
+    Hermes->>Prov: prefetch(query, session)
+    Prov->>GW: POST /recall {query, session_key}
+    GW->>Core: handleBeforeRecall(...)
+    Core-->>GW: RecallResult
+    GW-->>Prov: {context, strategy, memory_count}
+    Note over Prov: context → 注入 Hermes 提示词
+    Hermes->>Prov: sync_turn(user, assistant)
+    Prov-)GW: POST /capture（后台线程）
+    GW->>Core: handleTurnCommitted(CompletedTurn)
+    GW-->>Prov: {l0_recorded, scheduler_notified}
+    Hermes->>Prov: handle_tool_call(memory_search)
+    Prov->>GW: POST /search/memories {query, limit}
+    GW-->>Prov: {results: "格式化文本", total, strategy}
+    Hermes->>Prov: on_session_end
+    Prov->>GW: POST /session/end {session_key}
+    GW->>Core: handleSessionEnd(sessionKey) — 只冲刷这一个会话
+```
+
+关键性质：协议为 **snake_case JSON**；鉴权为可选 Bearer（`TDAI_GATEWAY_API_KEY`，常量时间
+比较）；Python 侧的失败由熔断器吸收，记忆永远不会阻塞 Agent。Gateway 用
+`StandaloneHostAdapter` 构建内核，因此提取用的是独立配置的 OpenAI 兼容 LLM，而非宿主运行器。
+
+Gateway ⇄ 内核字段映射（所有基于 HTTP 的适配器共享的「翻译表」）：
+
+| 协议字段（snake_case） | 内核（camelCase） |
+| --- | --- |
+| `query`、`session_key` | `handleBeforeRecall(userText, sessionKey)` |
+| `context` ← | `RecallResult.appendSystemContext ?? ""` |
+| `prepend_context?` ← | `RecallResult.prependContext`（增量字段，非空才下发；旧客户端可忽略） |
+| `memory_count` ← | `RecallResult.recalledL1Memories.length` |
+| `user_content` / `assistant_content` / `messages?` | `CompletedTurn.userText / assistantText / messages`（缺省合成双消息对） |
+| `l0_recorded` / `scheduler_notified` ← | `CaptureResult.l0RecordedCount / schedulerNotified` |
+| `include_items: true`（可选） | 路由到 `search*Structured`，响应新增 `items[]` |
+
+## 5. 数据流 C — 构建在 SDK 上的两个新适配器
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code
+    participant MCP as TdaiMcpServer（stdio）
+    participant MC as MemoryClient（http 或 in-process）
+    participant D as Dify 应用
+    participant DA as DifyMemoryAdapter :8421
+
+    CC->>MCP: initialize {protocolVersion}
+    MCP-->>CC: {protocolVersion, capabilities.tools, serverInfo}
+    CC->>MCP: tools/call memory_recall {query}
+    MCP->>MC: recall({query, sessionKey})
+    MC-->>MCP: {context, prependContext, memoryCount}
+    MCP-->>CC: content:[{type:text}]
+    CC->>MCP: tools/call memory_capture {user_content, assistant_content}
+    MCP->>MC: capture({userContent, assistantContent, sessionKey})
+
+    D->>DA: POST /retrieval {knowledge_id: tdai-memories, query, retrieval_setting}
+    DA->>MC: searchMemories({query, limit: top_k})
+    MC-->>DA: {items: [{content, score, ...}]}
+    DA-->>D: {records: [{content, score, title, metadata}]}（按 score_threshold 过滤）
+    D->>DA: POST /tools/capture {user_content, assistant_content}
+    DA->>MC: capture(...)
+    DA-->>D: {l0_recorded, scheduler_notified}
+```
+
+两个适配器**只**消费 `MemoryClient` 接口 — 它们无从分辨背后是 HTTP 传输（Gateway 边车，
+同 Hermes 部署形态）还是进程内传输（内嵌内核，同 OpenClaw 形态）。这种对称性正是 SDK 的意义。
+
+## 6. 目标架构 — 统一 Adapter SDK
+
+```mermaid
+flowchart TD
+    subgraph Platforms["平台适配器（各自只实现一个接口）"]
+        P1["OpenClaw 插件<br/>（既有，直连）"]
+        P2["Hermes Provider<br/>（既有，Python/REST）"]
+        P3["TdaiMcpServer<br/>extends BasePlatformAdapter"]
+        P4["DifyMemoryAdapter<br/>extends BasePlatformAdapter"]
+        P5["你的平台<br/>extends BasePlatformAdapter"]
+    end
+
+    subgraph SDKLayer["Adapter SDK — src/adapter-sdk"]
+        BPA["BasePlatformAdapter<br/>safeRecall / safeCapture / stop"]
+        FACT["createMemoryClient(options)<br/>resolveClientOptionsFromEnv()"]
+        MCI["MemoryClient<br/>recall · capture · searchMemories ·<br/>searchConversations · endSession · health · close"]
+        ERR["MemoryClientError<br/>transport | auth | bad_request | unavailable"]
+        T1["HttpMemoryClient"]
+        T2["InProcessMemoryClient"]
+        BPA --> MCI
+        FACT --> MCI
+        MCI --- T1
+        MCI --- T2
+        MCI -.-> ERR
+    end
+
+    P3 --> BPA
+    P4 --> BPA
+    P5 --> BPA
+    T1 -->|"REST，与 Hermes 同协议<br/>+ include_items"| GW["TdaiGateway"]
+    T2 --> CORE["TdaiCore"]
+    GW --> CORE
+    P1 -->|"直连（早于 SDK）"| CORE
+    P2 -->|"REST"| GW
+    CORE --> L["L0 档案 → L1 记忆 → L2 场景 → L3 画像"]
+```
+
+契约小结：
+
+- **新平台 = 实现一个接口。** `PlatformAdapter { platformName; start(); stop() }`，实践中即
+  `class X extends BasePlatformAdapter`，把平台生命周期映射到 `this.client` /
+  `this.safeRecall` / `this.safeCapture`。
+- **一个客户端接口，两种传输。** `createMemoryClient({transport: "http" | "in-process", ...})`。
+  传输选择是部署配置，不是适配器代码。
+- **统一失败语义。** 客户端方法统一抛 `MemoryClientError`（稳定 `code`）；
+  `safeRecall`/`safeCapture` 以降级替代抛错，落实项目铁律：*记忆永远不能弄坏宿主对话*。
+
+## 7. 延伸阅读
+
+- 四个平台的接入差异与取舍：[PLATFORM-COMPARISON_CN.md](./PLATFORM-COMPARISON_CN.md)
+- 第五个平台的分步接入指南：[NEW-PLATFORM-GUIDE_CN.md](./NEW-PLATFORM-GUIDE_CN.md)
+- SDK API 参考与用法：[src/adapter-sdk/README_CN.md](../../src/adapter-sdk/README_CN.md)
+- 适配器部署：[Claude Code](../../src/adapters/claude-code/README_CN.md) · [Dify](../../src/adapters/dify/README_CN.md)

--- a/docs/adapters/NEW-PLATFORM-GUIDE.md
+++ b/docs/adapters/NEW-PLATFORM-GUIDE.md
@@ -1,0 +1,184 @@
+# How to Integrate a New Platform (如何接入新平台)
+
+> 中文版本见 [NEW-PLATFORM-GUIDE_CN.md](./NEW-PLATFORM-GUIDE_CN.md)。
+> Background: [ARCHITECTURE.md](./ARCHITECTURE.md) · [PLATFORM-COMPARISON.md](./PLATFORM-COMPARISON.md) · [SDK reference](../../src/adapter-sdk/README.md)
+
+With the Adapter SDK (`src/adapter-sdk/`), integrating a new agent platform means implementing
+**one interface** (`PlatformAdapter`, via `BasePlatformAdapter`) against **one client**
+(`MemoryClient`). This guide is the step-by-step recipe, ending with a complete worked example
+and a test skeleton.
+
+## Step 1 — Pick a transport
+
+| Question | Yes → | No → |
+| --- | --- | --- |
+| Does your adapter run in the same Node process that should own the memory engine's lifecycle? | `in-process` | `http` |
+| Do multiple consumers (or non-Node processes) need to share one memory store? | `http` (one Gateway, many clients) | either |
+| Do you want zero extra processes during local development? | `in-process` | `http` |
+
+Rule of thumb: **`http` is the default** (matches Hermes, Claude Code, Dify deployments; the
+Gateway owns the store). Choose `in-process` only when your adapter process should *be* the
+memory engine.
+
+The transport is invisible to your adapter code — both implement `MemoryClient` with identical
+semantics (verified by mirrored unit tests in `src/adapter-sdk/transports/*.test.ts`).
+
+## Step 2 — Create the client
+
+```ts
+import { createMemoryClient, resolveClientOptionsFromEnv } from "../../adapter-sdk/index.js";
+
+// Option A: explicit
+const client = createMemoryClient({
+  transport: "http",
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+// Option B: standard env convention (TDAI_ADAPTER_TRANSPORT, TDAI_GATEWAY_URL,
+// TDAI_GATEWAY_API_KEY, TDAI_ADAPTER_TIMEOUT_MS) — what the shipped CLIs use.
+const client2 = createMemoryClient(resolveClientOptionsFromEnv(logger));
+```
+
+## Step 3 — Subclass `BasePlatformAdapter`
+
+Implement exactly three members: `platformName`, `start()`, `stop()` (the base `stop()` already
+closes the client — call `super.stop()` after your own teardown).
+
+## Step 4 — Map your platform's lifecycle onto the client
+
+The cheat-sheet — find your platform's event in column 1, call column 2:
+
+| Platform event (typical names) | MemoryClient call | Notes |
+| --- | --- | --- |
+| "before prompt build" / "pre-turn" / "prefetch" | `safeRecall({query, sessionKey})` | Inject `prependContext` near the user message, `context` into the system prompt. Use `safeRecall` — a memory outage must not break the turn. |
+| "turn finished" / "agent end" / "message committed" | `safeCapture({userContent, assistantContent, sessionKey})` | Fire-and-forget is fine; pass `messages` only if you have the full turn including tool calls. |
+| model-invoked "search memory" tool | `searchMemories({query, limit, type?, scene?})` | Return `.text` to the model; `.items` if your platform wants per-record scores. Clamp `limit` to 1..20. |
+| model-invoked "search history" tool | `searchConversations({query, limit, sessionKey?})` | `sessionKey` here is a *filter*, not a scope — leave it unset to search across sessions. |
+| "conversation closed" / "session end" | `endSession(sessionKey)` | Flushes ONE session's pipeline buffers. Never call this as a global shutdown. |
+| liveness probe | `health()` | Also useful at startup to fail fast with a clear log. |
+| process shutdown | `stop()` → `client.close()` | `close()` destroys the core only when the in-process client built it. |
+
+## Step 5 — Choose a session-key strategy
+
+The `sessionKey` groups L0 records and scopes pipeline state. Precedents:
+
+- OpenClaw: the host's stable conversation key.
+- Claude Code adapter: `TDAI_SESSION_KEY` env, defaulting to `claude-code:<cwd basename>`
+  (one memory thread per project directory).
+- Dify adapter: `session_key` field per request, defaulting to `dify:default`; flows thread a
+  conversation variable through for per-user memory.
+
+Guidelines: prefix with the platform name (`myplatform:...`), keep it stable across reconnects
+of the same logical conversation, and let callers override it per-request when your platform is
+multi-tenant.
+
+## Step 6 — Worked example (~40 lines, compiles against the SDK)
+
+A minimal adapter for a hypothetical webhook-driven platform:
+
+```ts
+import {
+  BasePlatformAdapter,
+  createMemoryClient,
+  resolveClientOptionsFromEnv,
+  type MemoryClient,
+} from "../../adapter-sdk/index.js";
+
+interface TurnEvent {
+  userText: string;
+  assistantText: string;
+  conversationId: string;
+}
+
+export class MyPlatformAdapter extends BasePlatformAdapter {
+  readonly platformName = "my-platform";
+
+  constructor(client: MemoryClient) {
+    super({ client });
+  }
+
+  async start(): Promise<void> {
+    const health = await this.client.health();
+    this.logger.info(`memory backend: ${health.status}`);
+    // ... subscribe to your platform's events here ...
+  }
+
+  /** Call before each LLM turn — returns context to inject, never throws. */
+  async beforeTurn(query: string, conversationId: string): Promise<string> {
+    const recall = await this.safeRecall({
+      query,
+      sessionKey: `my-platform:${conversationId}`,
+    });
+    return [recall.prependContext, recall.context].filter(Boolean).join("\n\n");
+  }
+
+  /** Call after each completed turn — fire and forget. */
+  async afterTurn(event: TurnEvent): Promise<void> {
+    await this.safeCapture({
+      userContent: event.userText,
+      assistantContent: event.assistantText,
+      sessionKey: `my-platform:${event.conversationId}`,
+    });
+  }
+}
+
+// Wiring:
+const adapter = new MyPlatformAdapter(createMemoryClient(resolveClientOptionsFromEnv()));
+await adapter.start();
+```
+
+## Step 7 — Test it (offline, no core, no gateway)
+
+Copy the fake-client pattern used by every shipped adapter test
+(`src/adapters/claude-code/mcp-server.test.ts`, `src/adapters/dify/server.test.ts`):
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { MemoryClient } from "../../adapter-sdk/index.js";
+
+function createFakeClient(overrides: Partial<MemoryClient> = {}): MemoryClient {
+  return {
+    recall: vi.fn(async () => ({ context: "ctx", memoryCount: 1 })),
+    capture: vi.fn(async () => ({ l0Recorded: 2, schedulerNotified: true })),
+    searchMemories: vi.fn(async () => ({ text: "", total: 0, strategy: "none", items: [] })),
+    searchConversations: vi.fn(async () => ({ text: "", total: 0, items: [] })),
+    endSession: vi.fn(async () => {}),
+    health: vi.fn(async () => ({ status: "ok" as const, vectorStore: true, embeddingService: true })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("MyPlatformAdapter", () => {
+  it("injects recalled context before a turn", async () => {
+    const client = createFakeClient();
+    const adapter = new MyPlatformAdapter(client);
+    const context = await adapter.beforeTurn("what do I like", "c1");
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "what do I like",
+      sessionKey: "my-platform:c1",
+    });
+    expect(context).toContain("ctx");
+  });
+
+  it("survives a memory outage (safeRecall degrades)", async () => {
+    const client = createFakeClient({
+      recall: vi.fn(async () => { throw new Error("down"); }),
+    });
+    const adapter = new MyPlatformAdapter(client);
+    await expect(adapter.beforeTurn("q", "c1")).resolves.toBe("");
+  });
+});
+```
+
+Conventions checklist before you ship:
+
+- [ ] Adapter lives in `src/adapters/<platform>/` with `index.ts` barrel + `main.ts` CLI entry
+      (`isMain` pattern like `src/gateway/server.ts`), runnable via `node --import tsx`.
+- [ ] Only imports from `src/adapter-sdk/` and `src/core/types.js` — never from root `index.ts`
+      or `src/adapters/index.ts` (they pull the optional `openclaw` peer dependency).
+- [ ] Env vars named `TDAI_<PLATFORM>_*`; transport via the shared `TDAI_ADAPTER_*` convention.
+- [ ] Tests use a fake `MemoryClient`; servers bind port `0` and close in `afterEach`.
+- [ ] Bilingual `README.md` + `README_CN.md` in the adapter directory.
+- [ ] Add an npm script `"adapter:<platform>"` in `package.json`.

--- a/docs/adapters/NEW-PLATFORM-GUIDE_CN.md
+++ b/docs/adapters/NEW-PLATFORM-GUIDE_CN.md
@@ -1,0 +1,181 @@
+# 如何接入新平台
+
+> English version: [NEW-PLATFORM-GUIDE.md](./NEW-PLATFORM-GUIDE.md)。
+> 背景阅读：[ARCHITECTURE_CN.md](./ARCHITECTURE_CN.md) · [PLATFORM-COMPARISON_CN.md](./PLATFORM-COMPARISON_CN.md) · [SDK 参考](../../src/adapter-sdk/README_CN.md)
+
+有了 Adapter SDK（`src/adapter-sdk/`），接入一个新的 Agent 平台 = 面向**一个客户端**
+（`MemoryClient`）实现**一个接口**（`PlatformAdapter`，实践中继承 `BasePlatformAdapter`）。
+本文是分步操作手册，最后附完整可编译示例与测试骨架。
+
+## 第 1 步 — 选传输方式
+
+| 问题 | 是 → | 否 → |
+| --- | --- | --- |
+| 你的适配器是否运行在应当拥有记忆引擎生命周期的那个 Node 进程里？ | `in-process` | `http` |
+| 是否有多个消费者（或非 Node 进程）需要共享同一份记忆存储？ | `http`（一个 Gateway，多客户端） | 皆可 |
+| 本地开发希望零额外进程？ | `in-process` | `http` |
+
+经验法则：**`http` 是默认选择**（与 Hermes、Claude Code、Dify 的部署形态一致，存储归
+Gateway 所有）。只有当你的适配器进程本身就应当*是*记忆引擎时才选 `in-process`。
+
+传输对适配器代码完全透明 — 两种实现的 `MemoryClient` 语义一致（由
+`src/adapter-sdk/transports/*.test.ts` 中互为镜像的单测保证）。
+
+## 第 2 步 — 创建客户端
+
+```ts
+import { createMemoryClient, resolveClientOptionsFromEnv } from "../../adapter-sdk/index.js";
+
+// 方式 A：显式
+const client = createMemoryClient({
+  transport: "http",
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+// 方式 B：标准环境变量约定（TDAI_ADAPTER_TRANSPORT、TDAI_GATEWAY_URL、
+// TDAI_GATEWAY_API_KEY、TDAI_ADAPTER_TIMEOUT_MS）— 内置 CLI 都用这套。
+const client2 = createMemoryClient(resolveClientOptionsFromEnv(logger));
+```
+
+## 第 3 步 — 继承 `BasePlatformAdapter`
+
+只需实现三个成员：`platformName`、`start()`、`stop()`（基类的 `stop()` 已负责关闭客户端 —
+自己的清理做完后调 `super.stop()`）。
+
+## 第 4 步 — 把平台生命周期映射到客户端
+
+对照表 — 在第 1 列找到你平台的事件，调用第 2 列：
+
+| 平台事件（常见叫法） | MemoryClient 调用 | 说明 |
+| --- | --- | --- |
+| 「构建提示词前」/「回合前」/「prefetch」 | `safeRecall({query, sessionKey})` | `prependContext` 注入到用户消息附近，`context` 注入系统提示词。务必用 `safeRecall` — 记忆故障不能弄坏回合。 |
+| 「回合结束」/「agent end」/「消息落库」 | `safeCapture({userContent, assistantContent, sessionKey})` | 可以发后不管；只有拿得到含工具调用的完整消息列表时才传 `messages`。 |
+| 模型触发的「搜记忆」工具 | `searchMemories({query, limit, type?, scene?})` | 给模型返回 `.text`；平台需要逐条分数时用 `.items`。`limit` 收敛到 1..20。 |
+| 模型触发的「搜历史」工具 | `searchConversations({query, limit, sessionKey?})` | 这里的 `sessionKey` 是*过滤器*而非作用域 — 想跨会话搜索就不要传。 |
+| 「会话关闭」/「session end」 | `endSession(sessionKey)` | 只冲刷单个会话的流水线缓冲。绝不能当全局关闭用。 |
+| 存活探针 | `health()` | 启动时也建议调一次，尽早失败并打出清晰日志。 |
+| 进程退出 | `stop()` → `client.close()` | 只有 in-process 客户端自建的内核才会被 `close()` 销毁。 |
+
+## 第 5 步 — 设计 session key 策略
+
+`sessionKey` 决定 L0 记录的分组和流水线状态的作用域。既有先例：
+
+- OpenClaw：宿主稳定的会话 key。
+- Claude Code 适配器：`TDAI_SESSION_KEY` 环境变量，缺省 `claude-code:<目录名>`
+  （每个项目目录一条记忆线）。
+- Dify 适配器：每次请求的 `session_key` 字段，缺省 `dify:default`；流程里穿一个会话变量
+  即可实现按用户记忆。
+
+准则：加平台名前缀（`myplatform:...`）；同一逻辑会话重连后保持稳定；平台多租户时允许
+每次请求覆盖。
+
+## 第 6 步 — 完整示例（约 40 行，可直接对着 SDK 编译）
+
+一个假想的 webhook 驱动平台的最小适配器：
+
+```ts
+import {
+  BasePlatformAdapter,
+  createMemoryClient,
+  resolveClientOptionsFromEnv,
+  type MemoryClient,
+} from "../../adapter-sdk/index.js";
+
+interface TurnEvent {
+  userText: string;
+  assistantText: string;
+  conversationId: string;
+}
+
+export class MyPlatformAdapter extends BasePlatformAdapter {
+  readonly platformName = "my-platform";
+
+  constructor(client: MemoryClient) {
+    super({ client });
+  }
+
+  async start(): Promise<void> {
+    const health = await this.client.health();
+    this.logger.info(`memory backend: ${health.status}`);
+    // ……在这里订阅你平台的事件……
+  }
+
+  /** 每个 LLM 回合前调用 — 返回待注入的上下文，永不抛错。 */
+  async beforeTurn(query: string, conversationId: string): Promise<string> {
+    const recall = await this.safeRecall({
+      query,
+      sessionKey: `my-platform:${conversationId}`,
+    });
+    return [recall.prependContext, recall.context].filter(Boolean).join("\n\n");
+  }
+
+  /** 每个回合结束后调用 — 发后不管。 */
+  async afterTurn(event: TurnEvent): Promise<void> {
+    await this.safeCapture({
+      userContent: event.userText,
+      assistantContent: event.assistantText,
+      sessionKey: `my-platform:${event.conversationId}`,
+    });
+  }
+}
+
+// 组装：
+const adapter = new MyPlatformAdapter(createMemoryClient(resolveClientOptionsFromEnv()));
+await adapter.start();
+```
+
+## 第 7 步 — 测试（离线，无内核、无 gateway）
+
+照抄所有内置适配器测试用的伪客户端模式
+（`src/adapters/claude-code/mcp-server.test.ts`、`src/adapters/dify/server.test.ts`）：
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { MemoryClient } from "../../adapter-sdk/index.js";
+
+function createFakeClient(overrides: Partial<MemoryClient> = {}): MemoryClient {
+  return {
+    recall: vi.fn(async () => ({ context: "ctx", memoryCount: 1 })),
+    capture: vi.fn(async () => ({ l0Recorded: 2, schedulerNotified: true })),
+    searchMemories: vi.fn(async () => ({ text: "", total: 0, strategy: "none", items: [] })),
+    searchConversations: vi.fn(async () => ({ text: "", total: 0, items: [] })),
+    endSession: vi.fn(async () => {}),
+    health: vi.fn(async () => ({ status: "ok" as const, vectorStore: true, embeddingService: true })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("MyPlatformAdapter", () => {
+  it("回合前注入召回的上下文", async () => {
+    const client = createFakeClient();
+    const adapter = new MyPlatformAdapter(client);
+    const context = await adapter.beforeTurn("我喜欢什么", "c1");
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "我喜欢什么",
+      sessionKey: "my-platform:c1",
+    });
+    expect(context).toContain("ctx");
+  });
+
+  it("记忆故障时存活（safeRecall 降级）", async () => {
+    const client = createFakeClient({
+      recall: vi.fn(async () => { throw new Error("down"); }),
+    });
+    const adapter = new MyPlatformAdapter(client);
+    await expect(adapter.beforeTurn("q", "c1")).resolves.toBe("");
+  });
+});
+```
+
+交付前的约定清单：
+
+- [ ] 适配器放在 `src/adapters/<platform>/`，含 `index.ts` barrel + `main.ts` CLI 入口
+      （`isMain` 模式参照 `src/gateway/server.ts`），可用 `node --import tsx` 运行。
+- [ ] 只从 `src/adapter-sdk/` 和 `src/core/types.js` 导入 — 绝不 import 根 `index.ts` 或
+      `src/adapters/index.ts`（它们会拖入可选的 `openclaw` peer 依赖）。
+- [ ] 环境变量命名 `TDAI_<PLATFORM>_*`；传输沿用共享的 `TDAI_ADAPTER_*` 约定。
+- [ ] 测试使用伪 `MemoryClient`；服务器绑定端口 `0` 并在 `afterEach` 关闭。
+- [ ] 适配器目录内提供双语 `README.md` + `README_CN.md`。
+- [ ] 在 `package.json` 增加 `"adapter:<platform>"` npm 脚本。

--- a/docs/adapters/PLATFORM-COMPARISON.md
+++ b/docs/adapters/PLATFORM-COMPARISON.md
@@ -1,0 +1,85 @@
+# Platform Adaptation Comparison — OpenClaw · Hermes · Claude Code · Dify
+
+> 中文版本见 [PLATFORM-COMPARISON_CN.md](./PLATFORM-COMPARISON_CN.md)。
+> Architecture context: [ARCHITECTURE.md](./ARCHITECTURE.md) · Onboarding: [NEW-PLATFORM-GUIDE.md](./NEW-PLATFORM-GUIDE.md)
+
+Four platforms now integrate with the memory engine, through four *structurally different*
+mechanisms. This document compares them dimension by dimension — the differences are exactly the
+knowledge a fifth integration needs.
+
+## 1. At a glance
+
+| Dimension | OpenClaw plugin | Hermes provider | Claude Code (MCP) | Dify |
+| --- | --- | --- | --- | --- |
+| Integration mechanism | Plugin SDK, in-process (`index.ts register(api)`) | Python `MemoryProvider` + Node HTTP sidecar | MCP stdio server (`TdaiMcpServer`) | Inbound REST: External Knowledge API + Custom Tool |
+| Direction of calls | Host calls plugin (hooks/tools) | Provider calls Gateway (outbound REST) | Client calls server (JSON-RPC over stdio) | **Dify calls us** (inbound REST) |
+| Process model | Same process as host | 2 processes (agent + sidecar), supervisor-managed | Child process of Claude Code, 1 per session | Standalone HTTP service (`:8421`), N Dify apps → 1 adapter |
+| Built on Adapter SDK | No (predates it) | No (predates it; wire reused by SDK) | **Yes** — `extends BasePlatformAdapter` | **Yes** — `extends BasePlatformAdapter` |
+| Lifecycle events available | Rich hooks: `before_prompt_build`, `agent_end`, `before_message_write`, `gateway_stop` | Provider methods: `prefetch`, `sync_turn`, `handle_tool_call`, `on_session_end` | MCP requests only: `initialize`, `tools/list`, `tools/call` (+ stdin close) | Stateless HTTP requests only |
+| Recall (read path) | **Automatic** — hook injects `prependContext` + `appendSystemContext` every turn | **Automatic** — `prefetch()` before each turn | **Model-invoked** — `memory_recall` / `memory_search` tools | **Pipeline-invoked** — Knowledge Retrieval node hits `POST /retrieval` |
+| Capture (write path) | **Automatic** — `agent_end` hook | **Automatic** — `sync_turn()` on background thread | **Model-invoked** — `memory_capture` tool (+ optional Stop-hook recipe) | **Flow-invoked** — Custom Tool `POST /tools/capture` step |
+| Session identity | Host's `sessionKey` (stable per conversation) | Hermes session → `session_key` on the wire | `TDAI_SESSION_KEY` env or `claude-code:<cwd basename>`; per-call override | `session_key` in tool body, else `dify:default`; conversation-scoped keys via flow variables |
+| Auth story | None needed (same process) | Optional Bearer to Gateway (`TDAI_GATEWAY_API_KEY`) | Inherits transport auth (Bearer to Gateway) — stdio itself is local | Dual: Dify→adapter Bearer (`TDAI_DIFY_API_KEY`, Dify error codes 1001/1002) + adapter→Gateway Bearer |
+| Failure isolation | try/catch in hooks; plugin errors surface in host logs | Circuit breaker + watchdog + background threads — agent never blocks | Tool errors → `isError: true` result (model sees it, session survives); `safeRecall`/`safeCapture` semantics | Dify-spec error bodies (`error_code`); `/health` never throws; engine failures → HTTP 500 with `error_msg` |
+| LLM for extraction pipeline | Host's model runner (OpenClaw), overridable via `cfg.llm` | Standalone OpenAI-compatible config (`TDAI_LLM_*`) | Whatever the backing core/gateway is configured with (adapter itself never touches an LLM) | Same as Claude Code — adapter is LLM-free |
+| Wire vocabulary | TypeScript camelCase (in-process) | snake_case JSON | snake_case tool args (matches gateway), camelCase inside SDK | snake_case JSON (Dify's own contract) |
+| Approx. integration surface | ~900 lines (`index.ts`, hooks + tools + CLI + offload) | ~1,400 lines Python (provider + client + supervisor) | **~360 lines** on the SDK (protocol + tools + server) | **~380 lines** on the SDK (routes + OpenAPI) |
+
+## 2. What each mechanism is good at
+
+### OpenClaw — deep in-process hooks
+The richest integration: recall and capture are invisible and automatic, tools are registered
+natively, and the plugin can even patch prompt assembly (`before_message_write`). The cost is
+maximal coupling — it needs the host's plugin SDK, its config format, its logger, and its LLM
+runner. This is the right shape when the host *offers* a plugin system with lifecycle hooks.
+
+### Hermes — sidecar REST with supervised lifecycle
+Proves the engine works cross-language: Python never links Node code, it just speaks 6 REST
+routes. All robustness lives client-side (supervisor spawns/monitors the gateway, circuit breaker
+sheds load on repeated failures, capture runs on daemon threads). The cost is operational: two
+processes, port management, health polling. This is the right shape when the platform is
+not Node and turns are high-frequency.
+
+### Claude Code — MCP tools, model-in-the-loop
+The inversion of OpenClaw: instead of hooks making memory invisible to the model, the *model
+itself* decides when to recall/capture via tools. Integration cost is tiny (stdio, no ports, no
+auth) and the same server binary serves any MCP client — but memory quality now depends on the
+model's tool discipline (mitigated by good tool descriptions, and optionally restored to
+automatic via a Claude Code `Stop` hook that POSTs `/capture`; see the
+[adapter README](../../src/adapters/claude-code/README.md)).
+
+### Dify — inbound contract, zero client code
+The only platform where **we implement someone else's API** rather than calling our own: Dify
+defines `POST /retrieval` (External Knowledge Base API) and imports our OpenAPI spec as a Custom
+Tool. Nothing runs inside Dify; a no-code user wires memory into a flow graphically. The cost:
+read path is retrieval-shaped (per-record `content`/`score`, hence the SDK's structured `items`),
+and session identity must be threaded through flow variables explicitly.
+
+## 3. Decision drivers, distilled
+
+| If the new platform… | …then copy this pattern |
+| --- | --- |
+| has a plugin SDK with prompt/turn hooks | OpenClaw (in-process transport; hooks → `safeRecall`/`safeCapture`) |
+| is non-Node or wants process isolation | Hermes (http transport against the Gateway) |
+| speaks MCP (Claude Code, Cursor, Codex, Zed, …) | Claude Code adapter — often reusable **as-is**, just change `TDAI_SESSION_KEY` |
+| defines its own inbound retrieval/tool contract | Dify (implement their contract over `MemoryClient`) |
+| is a plain REST consumer you control | Skip an adapter entirely — call the Gateway directly, like the Hermes client does |
+
+Two structural axes explain every row above:
+
+1. **Who initiates?** Hooks (platform → adapter, automatic) vs tools (model → adapter,
+   discretionary) vs inbound API (platform → adapter, flow-configured). Automatic paths give
+   consistent memory but need lifecycle hooks; tool paths work everywhere but depend on the model.
+2. **Where does the core run?** In-process (lowest latency, one lifecycle owner) vs gateway
+   sidecar (language-agnostic, shared by many consumers). The SDK makes this a config flag
+   (`TDAI_ADAPTER_TRANSPORT`), not an architecture decision — the same MCP or Dify adapter runs
+   in either mode unchanged.
+
+## 4. Before/after the SDK
+
+Before the SDK, each integration re-derived: wire mapping (camelCase⇄snake_case), the
+`CompletedTurn` default-messages rule, error taxonomy, degradation policy, env conventions, and
+core lifecycle. That is why Hermes needed ~1,400 lines. With the SDK, the Claude Code and Dify
+adapters each ship in under 400 lines, and **none of those lines touch anything below
+`MemoryClient`** — the "one interface" claim of the 拓展 tier, verified by their unit tests which
+run against a fake `MemoryClient` with no core, no gateway, no network.

--- a/docs/adapters/PLATFORM-COMPARISON_CN.md
+++ b/docs/adapters/PLATFORM-COMPARISON_CN.md
@@ -1,0 +1,76 @@
+# 平台适配对比 — OpenClaw · Hermes · Claude Code · Dify
+
+> English version: [PLATFORM-COMPARISON.md](./PLATFORM-COMPARISON.md)。
+> 架构背景：[ARCHITECTURE_CN.md](./ARCHITECTURE_CN.md) · 接入指南：[NEW-PLATFORM-GUIDE_CN.md](./NEW-PLATFORM-GUIDE_CN.md)
+
+目前已有四个平台通过四种*结构上完全不同*的机制接入记忆引擎。本文逐维度对比 — 这些差异
+正是第五个平台接入时最需要的知识。
+
+## 1. 一览表
+
+| 维度 | OpenClaw 插件 | Hermes Provider | Claude Code（MCP） | Dify |
+| --- | --- | --- | --- | --- |
+| 接入机制 | 插件 SDK，进程内（`index.ts register(api)`） | Python `MemoryProvider` + Node HTTP 边车 | MCP stdio 服务器（`TdaiMcpServer`） | 入站 REST：外部知识库 API + 自定义工具 |
+| 调用方向 | 宿主调插件（钩子/工具） | Provider 调 Gateway（出站 REST） | 客户端调服务器（stdio 上的 JSON-RPC） | **Dify 调我们**（入站 REST） |
+| 进程模型 | 与宿主同进程 | 2 个进程（Agent + 边车），由 supervisor 托管 | Claude Code 的子进程，每会话一个 | 独立 HTTP 服务（`:8421`），N 个 Dify 应用 → 1 个适配器 |
+| 是否基于 Adapter SDK | 否（早于 SDK） | 否（早于 SDK；其协议被 SDK 复用） | **是** — `extends BasePlatformAdapter` | **是** — `extends BasePlatformAdapter` |
+| 可用生命周期事件 | 丰富钩子：`before_prompt_build`、`agent_end`、`before_message_write`、`gateway_stop` | Provider 方法：`prefetch`、`sync_turn`、`handle_tool_call`、`on_session_end` | 仅 MCP 请求：`initialize`、`tools/list`、`tools/call`（+ stdin 关闭） | 仅无状态 HTTP 请求 |
+| 召回（读路径） | **全自动** — 钩子每回合注入 `prependContext` + `appendSystemContext` | **全自动** — 每回合前 `prefetch()` | **模型触发** — `memory_recall` / `memory_search` 工具 | **编排触发** — 知识检索节点调 `POST /retrieval` |
+| 捕获（写路径） | **全自动** — `agent_end` 钩子 | **全自动** — 后台线程 `sync_turn()` | **模型触发** — `memory_capture` 工具（+ 可选 Stop 钩子配方） | **流程触发** — 自定义工具 `POST /tools/capture` 节点 |
+| 会话身份 | 宿主 `sessionKey`（会话内稳定） | Hermes 会话 → 协议里的 `session_key` | `TDAI_SESSION_KEY` 环境变量，缺省 `claude-code:<目录名>`；每次调用可覆盖 | 工具请求体里的 `session_key`，缺省 `dify:default`；会话级 key 经流程变量传递 |
+| 鉴权 | 无需（同进程） | 到 Gateway 的可选 Bearer（`TDAI_GATEWAY_API_KEY`） | 继承传输层鉴权（到 Gateway 的 Bearer）— stdio 本身是本地的 | 双层：Dify→适配器 Bearer（`TDAI_DIFY_API_KEY`，Dify 错误码 1001/1002）+ 适配器→Gateway Bearer |
+| 故障隔离 | 钩子内 try/catch；插件错误进宿主日志 | 熔断器 + 看门狗 + 后台线程 — Agent 永不阻塞 | 工具错误 → `isError: true` 结果（模型可见，会话不死）；`safeRecall`/`safeCapture` 语义 | Dify 规范错误体（`error_code`）；`/health` 永不抛错；引擎故障 → HTTP 500 带 `error_msg` |
+| 提取流水线用的 LLM | 宿主模型运行器（OpenClaw），可用 `cfg.llm` 覆盖 | 独立 OpenAI 兼容配置（`TDAI_LLM_*`） | 取决于背后 core/gateway 的配置（适配器本身不碰 LLM） | 同 Claude Code — 适配器零 LLM |
+| 协议命名 | TypeScript camelCase（进程内） | snake_case JSON | 工具参数 snake_case（与 gateway 一致），SDK 内部 camelCase | snake_case JSON（Dify 自己的契约） |
+| 接入代码量级 | 约 900 行（`index.ts`：钩子 + 工具 + CLI + offload） | 约 1,400 行 Python（provider + client + supervisor） | **约 360 行**，基于 SDK（协议 + 工具 + 服务器） | **约 380 行**，基于 SDK（路由 + OpenAPI） |
+
+## 2. 各机制的长处
+
+### OpenClaw — 深度进程内钩子
+最深的集成：召回与捕获全自动且对模型透明，工具原生注册，甚至能干预提示词组装
+（`before_message_write`）。代价是耦合最大 — 依赖宿主的插件 SDK、配置格式、日志器和 LLM
+运行器。当宿主*提供*带生命周期钩子的插件系统时，这是正确形态。
+
+### Hermes — 边车 REST + 受管生命周期
+证明了引擎可跨语言：Python 完全不链接 Node 代码，只讲 6 条 REST 路由。所有健壮性都在客户
+端（supervisor 拉起并监控 gateway，熔断器在连续失败时卸载压力，捕获走守护线程）。代价是
+运维成本：两个进程、端口管理、健康轮询。当平台不是 Node、回合频率高时，这是正确形态。
+
+### Claude Code — MCP 工具，模型在环
+与 OpenClaw 相反：不是钩子让记忆对模型隐形，而是*模型自己*通过工具决定何时召回/捕获。
+集成成本极低（stdio、无端口、无鉴权），且同一个服务器二进制可服务任何 MCP 客户端 — 但记忆
+质量取决于模型的工具纪律（用好的工具描述缓解；还可用 Claude Code 的 `Stop` 钩子 POST
+`/capture` 恢复自动捕获，见[适配器 README](../../src/adapters/claude-code/README_CN.md)）。
+
+### Dify — 入站契约，客户端零代码
+唯一一个**由我们实现对方 API** 而非调用自己 API 的平台：Dify 定义了 `POST /retrieval`
+（外部知识库 API），并把我们的 OpenAPI 规范导入为自定义工具。Dify 内部不跑我们任何代码；
+无代码用户在画布上把记忆接进流程。代价：读路径是检索形态（逐条 `content`/`score`，SDK 的
+结构化 `items` 正为此而生），会话身份必须显式经流程变量传递。
+
+## 3. 选型要点提炼
+
+| 若新平台…… | ……照抄这个模式 |
+| --- | --- |
+| 有带提示词/回合钩子的插件 SDK | OpenClaw（in-process 传输；钩子 → `safeRecall`/`safeCapture`） |
+| 非 Node 或需要进程隔离 | Hermes（http 传输对接 Gateway） |
+| 讲 MCP（Claude Code、Cursor、Codex、Zed 等） | Claude Code 适配器 — 通常**原样复用**，改个 `TDAI_SESSION_KEY` 即可 |
+| 自带入站检索/工具契约 | Dify（在 `MemoryClient` 之上实现对方契约） |
+| 是你可控的普通 REST 消费者 | 干脆不写适配器 — 像 Hermes 客户端那样直接调 Gateway |
+
+上表每一行都可归结为两条结构轴：
+
+1. **谁发起？** 钩子（平台→适配器，自动）vs 工具（模型→适配器，自主决定）vs 入站 API
+   （平台→适配器，流程配置）。自动路径记忆最完整但需要生命周期钩子；工具路径处处可用但
+   依赖模型自觉。
+2. **内核跑在哪？** 进程内（延迟最低、单一生命周期所有者）vs Gateway 边车（语言无关、
+   多消费者共享）。SDK 把这变成一个配置开关（`TDAI_ADAPTER_TRANSPORT`）而非架构决策 —
+   同一个 MCP 或 Dify 适配器在两种模式下零改动运行。
+
+## 4. SDK 出现前后
+
+SDK 之前，每个集成都要重新推导：协议映射（camelCase⇄snake_case）、`CompletedTurn` 缺省
+消息规则、错误分类、降级策略、环境变量约定、内核生命周期 — Hermes 因此写了约 1,400 行。
+有了 SDK，Claude Code 和 Dify 适配器各自不到 400 行交付，且**没有一行代码触及
+`MemoryClient` 以下的层** — 这正是「拓展」档「新平台只需实现一个接口」的可验证证据：
+两者的单元测试全部针对伪 `MemoryClient` 运行，无内核、无 gateway、无网络。

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "gateway": "node --import tsx src/gateway/server.ts",
+    "adapter:claude-code": "node --import tsx src/adapters/claude-code/main.ts",
+    "adapter:dify": "node --import tsx src/adapters/dify/main.ts",
     "postinstall": "bash scripts/openclaw-after-tool-call-messages.patch.sh 2>/dev/null || true"
   },
   "files": [

--- a/src/adapter-sdk/README.md
+++ b/src/adapter-sdk/README.md
@@ -1,0 +1,108 @@
+# Adapter SDK — Unified Cross-Platform Memory Client
+
+> 中文版本见 [README_CN.md](./README_CN.md)。
+> Architecture: [docs/adapters/ARCHITECTURE.md](../../docs/adapters/ARCHITECTURE.md) ·
+> Onboarding: [docs/adapters/NEW-PLATFORM-GUIDE.md](../../docs/adapters/NEW-PLATFORM-GUIDE.md)
+
+One interface for platforms to consume (`MemoryClient`), one interface for platforms to
+implement (`PlatformAdapter` via `BasePlatformAdapter`), two interchangeable transports.
+The Claude Code MCP adapter (`src/adapters/claude-code/`) and the Dify adapter
+(`src/adapters/dify/`) are both built exclusively on this SDK.
+
+## Quick start
+
+```ts
+import {
+  createMemoryClient,
+  BasePlatformAdapter,
+  type MemoryClient,
+} from "./index.js"; // src/adapter-sdk
+
+// 1. Get a client — transport is configuration, not code.
+const client: MemoryClient = createMemoryClient({
+  transport: "http",                       // or "in-process"
+  baseUrl: "http://127.0.0.1:8420",        // TdaiGateway
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+// 2. Use the six capabilities.
+const recall = await client.recall({ query: "user prefs?", sessionKey: "app:s1" });
+await client.capture({ userContent: "hi", assistantContent: "hello!", sessionKey: "app:s1" });
+const mem = await client.searchMemories({ query: "tea", limit: 5 });
+const conv = await client.searchConversations({ query: "deploy", sessionKey: "app:s1" });
+await client.endSession("app:s1");
+await client.close();
+```
+
+## `MemoryClient` at a glance
+
+| Method | Backing capability | Returns |
+| --- | --- | --- |
+| `recall(p)` | `TdaiCore.handleBeforeRecall` / `POST /recall` | `{ context, prependContext?, strategy?, memoryCount }` |
+| `capture(p)` | `handleTurnCommitted` / `POST /capture` | `{ l0Recorded, schedulerNotified }` |
+| `searchMemories(p)` | `searchMemories(Structured)` / `POST /search/memories` | `{ text, total, strategy, items[] }` |
+| `searchConversations(p)` | `searchConversations(Structured)` / `POST /search/conversations` | `{ text, total, items[] }` |
+| `endSession(key)` | `handleSessionEnd` / `POST /session/end` | `void` — flushes ONE session |
+| `health()` | store accessors / `GET /health` | `{ status, vectorStore, embeddingService, version? }` |
+| `close()` | lifecycle | destroys the core only if this client built it |
+
+All params/results are camelCase; snake_case exists only inside the HTTP transport.
+Every failure is a `MemoryClientError` with a stable `code`:
+`"transport" | "auth" | "bad_request" | "unavailable"` (plus `httpStatus` when applicable).
+
+## Transports
+
+### `http` — `HttpMemoryClient`
+Speaks the exact TdaiGateway REST dialect the Hermes Python client uses (same endpoints, same
+snake_case bodies, Bearer only when the key is non-empty). Additionally sends
+`include_items: true` on search routes to receive structured per-record `items`; gracefully
+tolerates older gateways that ignore the flag (items default to `[]`). Options: `baseUrl`
+(default `http://127.0.0.1:8420`), `apiKey`, `timeoutMs` (default 10 s), `fetchImpl` (test DI).
+
+### `in-process` — `InProcessMemoryClient`
+Wraps a `TdaiCore` in the same process. Two modes:
+
+- **Injected core** — pass `core` (anything satisfying the structural `TdaiCoreLike` subset,
+  including a test fake). The client never manages its lifecycle.
+- **Owned core** — pass nothing; on first call the client builds a standalone core from the
+  Gateway config machinery (`TDAI_DATA_DIR`, `TDAI_LLM_*`, `tdai-gateway.yaml`), with a
+  promise-gated lazy init (concurrent first calls produce exactly one core). `close()` destroys it.
+
+The method↔core mapping is byte-identical to what `src/gateway/server.ts` does, so the two
+transports are semantically interchangeable — the e2e test
+(`transports/http-gateway.e2e.test.ts`) proves wire compatibility against a real gateway.
+
+## `BasePlatformAdapter`
+
+```ts
+class MyAdapter extends BasePlatformAdapter {
+  readonly platformName = "my-platform";
+  async start() { /* bind server / subscribe events */ }
+  // stop() inherited: closes the client. Override + super.stop() to add teardown.
+}
+```
+
+Provides `this.client`, `this.logger` (tagged console fallback), and the resilience helpers
+`safeRecall` / `safeCapture` which log-and-degrade instead of throwing — encoding the project
+rule that memory must never break the host conversation.
+
+## Environment convention (`resolveClientOptionsFromEnv`)
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `TDAI_ADAPTER_TRANSPORT` | `"http"` or `"in-process"` | `http` |
+| `TDAI_GATEWAY_URL` | gateway base URL | `http://127.0.0.1:8420` |
+| `TDAI_GATEWAY_API_KEY` | Bearer token (same var the gateway reads) | unset (no auth) |
+| `TDAI_ADAPTER_TIMEOUT_MS` | HTTP timeout | `10000` |
+
+## Testing your adapter
+
+Inject a fake: either a fake `MemoryClient` (see
+`src/adapter-sdk/base-platform-adapter.test.ts`) or a fake `TdaiCoreLike` into
+`InProcessMemoryClient` (see `transports/in-process.test.ts`). No sqlite, no LLM, no network.
+
+## Import hygiene
+
+Import from `src/adapter-sdk/index.js` (or concrete files). Never import root `index.ts` or
+`src/adapters/index.ts` from adapter code — they reference the optional `openclaw` peer
+dependency, which is absent in gateway-only installs.

--- a/src/adapter-sdk/README_CN.md
+++ b/src/adapter-sdk/README_CN.md
@@ -1,0 +1,103 @@
+# Adapter SDK — 统一跨平台记忆客户端
+
+> English version: [README.md](./README.md)。
+> 架构：[docs/adapters/ARCHITECTURE_CN.md](../../docs/adapters/ARCHITECTURE_CN.md) ·
+> 接入指南：[docs/adapters/NEW-PLATFORM-GUIDE_CN.md](../../docs/adapters/NEW-PLATFORM-GUIDE_CN.md)
+
+平台**消费**一个接口（`MemoryClient`），平台**实现**一个接口（`PlatformAdapter`，经
+`BasePlatformAdapter`），两种可互换的传输。Claude Code MCP 适配器
+（`src/adapters/claude-code/`）与 Dify 适配器（`src/adapters/dify/`）均完全构建于本 SDK 之上。
+
+## 快速上手
+
+```ts
+import {
+  createMemoryClient,
+  BasePlatformAdapter,
+  type MemoryClient,
+} from "./index.js"; // src/adapter-sdk
+
+// 1. 获取客户端 — 传输是配置项，不是代码。
+const client: MemoryClient = createMemoryClient({
+  transport: "http",                       // 或 "in-process"
+  baseUrl: "http://127.0.0.1:8420",        // TdaiGateway
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+
+// 2. 使用六大能力。
+const recall = await client.recall({ query: "用户偏好？", sessionKey: "app:s1" });
+await client.capture({ userContent: "你好", assistantContent: "你好！", sessionKey: "app:s1" });
+const mem = await client.searchMemories({ query: "喝茶", limit: 5 });
+const conv = await client.searchConversations({ query: "部署", sessionKey: "app:s1" });
+await client.endSession("app:s1");
+await client.close();
+```
+
+## `MemoryClient` 一览
+
+| 方法 | 底层能力 | 返回 |
+| --- | --- | --- |
+| `recall(p)` | `TdaiCore.handleBeforeRecall` / `POST /recall` | `{ context, prependContext?, strategy?, memoryCount }` |
+| `capture(p)` | `handleTurnCommitted` / `POST /capture` | `{ l0Recorded, schedulerNotified }` |
+| `searchMemories(p)` | `searchMemories(Structured)` / `POST /search/memories` | `{ text, total, strategy, items[] }` |
+| `searchConversations(p)` | `searchConversations(Structured)` / `POST /search/conversations` | `{ text, total, items[] }` |
+| `endSession(key)` | `handleSessionEnd` / `POST /session/end` | `void` — 只冲刷单个会话 |
+| `health()` | 存储访问器 / `GET /health` | `{ status, vectorStore, embeddingService, version? }` |
+| `close()` | 生命周期 | 仅当内核由本客户端自建时才销毁 |
+
+参数/结果一律 camelCase；snake_case 只存在于 HTTP 传输内部。所有失败统一抛
+`MemoryClientError`，其 `code` 稳定可判：
+`"transport" | "auth" | "bad_request" | "unavailable"`（HTTP 场景另附 `httpStatus`）。
+
+## 传输
+
+### `http` — `HttpMemoryClient`
+与 Hermes Python 客户端讲完全相同的 TdaiGateway REST 方言（同端点、同 snake_case 请求体、
+key 非空时才带 Bearer）。搜索路由额外发送 `include_items: true` 以获得逐条结构化 `items`；
+对忽略该字段的旧版 gateway 优雅兼容（items 缺省为 `[]`）。选项：`baseUrl`
+（默认 `http://127.0.0.1:8420`）、`apiKey`、`timeoutMs`（默认 10 秒）、`fetchImpl`（测试注入）。
+
+### `in-process` — `InProcessMemoryClient`
+包装同进程内的 `TdaiCore`。两种模式：
+
+- **注入内核** — 传入 `core`（满足结构化子集 `TdaiCoreLike` 即可，包括测试伪对象）。
+  客户端不管理其生命周期。
+- **自建内核** — 什么都不传；首次调用时用 Gateway 配置机制（`TDAI_DATA_DIR`、`TDAI_LLM_*`、
+  `tdai-gateway.yaml`）构建独立内核，Promise 门闩式懒初始化（并发首调只会产生一个内核）。
+  `close()` 时销毁。
+
+方法↔内核的映射与 `src/gateway/server.ts` 完全一致，因此两种传输在语义上可互换 —
+e2e 测试（`transports/http-gateway.e2e.test.ts`）对着真实 gateway 验证了协议兼容性。
+
+## `BasePlatformAdapter`
+
+```ts
+class MyAdapter extends BasePlatformAdapter {
+  readonly platformName = "my-platform";
+  async start() { /* 绑定服务 / 订阅事件 */ }
+  // stop() 继承自基类：负责关闭客户端。需要额外清理时覆写并调 super.stop()。
+}
+```
+
+提供 `this.client`、`this.logger`（带标签的 console 兜底），以及韧性助手
+`safeRecall` / `safeCapture` — 记日志并降级而非抛错，落实项目铁律：记忆永远不能弄坏宿主对话。
+
+## 环境变量约定（`resolveClientOptionsFromEnv`）
+
+| 变量 | 含义 | 默认 |
+| --- | --- | --- |
+| `TDAI_ADAPTER_TRANSPORT` | `"http"` 或 `"in-process"` | `http` |
+| `TDAI_GATEWAY_URL` | gateway 基础 URL | `http://127.0.0.1:8420` |
+| `TDAI_GATEWAY_API_KEY` | Bearer 令牌（与 gateway 读取的同名变量） | 未设（无鉴权） |
+| `TDAI_ADAPTER_TIMEOUT_MS` | HTTP 超时 | `10000` |
+
+## 测试你的适配器
+
+注入伪对象：伪 `MemoryClient`（见 `src/adapter-sdk/base-platform-adapter.test.ts`），或向
+`InProcessMemoryClient` 注入伪 `TdaiCoreLike`（见 `transports/in-process.test.ts`）。
+无 sqlite、无 LLM、无网络。
+
+## 导入卫生
+
+从 `src/adapter-sdk/index.js`（或具体文件）导入。适配器代码绝不 import 根 `index.ts` 或
+`src/adapters/index.ts` — 它们引用可选的 `openclaw` peer 依赖，在仅 gateway 的安装环境中不存在。

--- a/src/adapter-sdk/base-platform-adapter.test.ts
+++ b/src/adapter-sdk/base-platform-adapter.test.ts
@@ -1,0 +1,95 @@
+/**
+ * BasePlatformAdapter unit tests (offline, fake MemoryClient).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { BasePlatformAdapter } from "./base-platform-adapter.js";
+import type { MemoryClient, RecallOutcome, CaptureOutcome } from "./types.js";
+
+function createFakeClient(overrides: Partial<MemoryClient> = {}): MemoryClient {
+  return {
+    recall: vi.fn(async (): Promise<RecallOutcome> => ({ context: "ctx", memoryCount: 1 })),
+    capture: vi.fn(async (): Promise<CaptureOutcome> => ({ l0Recorded: 2, schedulerNotified: true })),
+    searchMemories: vi.fn(async () => ({ text: "", total: 0, strategy: "none", items: [] })),
+    searchConversations: vi.fn(async () => ({ text: "", total: 0, items: [] })),
+    endSession: vi.fn(async () => {}),
+    health: vi.fn(async () => ({ status: "ok" as const, vectorStore: true, embeddingService: true })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+/** Minimal concrete adapter exposing the protected helpers for testing. */
+class TestAdapter extends BasePlatformAdapter {
+  readonly platformName = "test-platform";
+  async start(): Promise<void> {}
+  recallForTest(query: string, sessionKey: string): Promise<RecallOutcome> {
+    return this.safeRecall({ query, sessionKey });
+  }
+  captureForTest(): Promise<CaptureOutcome | undefined> {
+    return this.safeCapture({ userContent: "u", assistantContent: "a", sessionKey: "s" });
+  }
+}
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+describe("BasePlatformAdapter", () => {
+  it("stop() closes the memory client", async () => {
+    const client = createFakeClient();
+    const adapter = new TestAdapter({ client, logger: silentLogger });
+
+    await adapter.stop();
+
+    expect(client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("safeRecall passes params through and returns the outcome", async () => {
+    const client = createFakeClient();
+    const adapter = new TestAdapter({ client, logger: silentLogger });
+
+    const outcome = await adapter.recallForTest("what do I like", "s1");
+
+    expect(client.recall).toHaveBeenCalledWith({ query: "what do I like", sessionKey: "s1" });
+    expect(outcome).toEqual({ context: "ctx", memoryCount: 1 });
+  });
+
+  it("safeRecall swallows errors, logs a warning, and degrades to empty context", async () => {
+    const client = createFakeClient({
+      recall: vi.fn(async () => {
+        throw new Error("gateway down");
+      }),
+    });
+    const warn = vi.fn();
+    const adapter = new TestAdapter({ client, logger: { ...silentLogger, warn } });
+
+    const outcome = await adapter.recallForTest("q", "s");
+
+    expect(outcome).toEqual({ context: "", memoryCount: 0 });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("gateway down"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("test-platform"));
+  });
+
+  it("safeCapture swallows errors and returns undefined", async () => {
+    const client = createFakeClient({
+      capture: vi.fn(async () => {
+        throw new Error("disk full");
+      }),
+    });
+    const warn = vi.fn();
+    const adapter = new TestAdapter({ client, logger: { ...silentLogger, warn } });
+
+    const outcome = await adapter.captureForTest();
+
+    expect(outcome).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("disk full"));
+  });
+
+  it("safeCapture returns the capture outcome on success", async () => {
+    const adapter = new TestAdapter({ client: createFakeClient(), logger: silentLogger });
+
+    const outcome = await adapter.captureForTest();
+
+    expect(outcome).toEqual({ l0Recorded: 2, schedulerNotified: true });
+  });
+});

--- a/src/adapter-sdk/base-platform-adapter.ts
+++ b/src/adapter-sdk/base-platform-adapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Adapter SDK — BasePlatformAdapter.
+ *
+ * Abstract convenience base for `PlatformAdapter` implementations. Provides:
+ *   - the shared `MemoryClient` reference (`this.client`)
+ *   - a tagged default logger
+ *   - `stop()` that closes the client (override + `super.stop()` to add
+ *     platform teardown)
+ *   - `safeRecall` / `safeCapture`: never-throw wrappers implementing the
+ *     project's resilience philosophy (mirrored from the Hermes provider):
+ *     **memory must never break the host conversation.** A failed recall
+ *     degrades to "no context"; a failed capture is logged and dropped.
+ *
+ * A new platform therefore only implements `platformName` and `start()`.
+ */
+
+import type { Logger } from "../core/types.js";
+import type {
+  MemoryClient,
+  PlatformAdapter,
+  RecallParams,
+  RecallOutcome,
+  CaptureParams,
+  CaptureOutcome,
+} from "./types.js";
+
+const TAG = "[tdai-adapter]";
+
+export interface BasePlatformAdapterOptions {
+  /** The memory client this adapter consumes (from `createMemoryClient`). */
+  client: MemoryClient;
+  logger?: Logger;
+}
+
+export abstract class BasePlatformAdapter implements PlatformAdapter {
+  protected readonly client: MemoryClient;
+  protected readonly logger: Logger;
+
+  constructor(opts: BasePlatformAdapterOptions) {
+    this.client = opts.client;
+    this.logger = opts.logger ?? {
+      debug: (msg: string) => console.debug(`${TAG} ${msg}`),
+      info: (msg: string) => console.info(`${TAG} ${msg}`),
+      warn: (msg: string) => console.warn(`${TAG} ${msg}`),
+      error: (msg: string) => console.error(`${TAG} ${msg}`),
+    };
+  }
+
+  abstract readonly platformName: string;
+
+  abstract start(): Promise<void>;
+
+  /** Default teardown: close the memory client. Override to add more. */
+  async stop(): Promise<void> {
+    await this.client.close();
+  }
+
+  /**
+   * Recall that never throws: on failure logs a warning and returns an empty
+   * outcome so the host turn proceeds without memory context.
+   */
+  protected async safeRecall(params: RecallParams): Promise<RecallOutcome> {
+    try {
+      return await this.client.recall(params);
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} [${this.platformName}] recall failed (degrading to empty context): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { context: "", memoryCount: 0 };
+    }
+  }
+
+  /**
+   * Capture that never throws: on failure logs a warning and returns
+   * `undefined` (the turn is simply not remembered).
+   */
+  protected async safeCapture(params: CaptureParams): Promise<CaptureOutcome | undefined> {
+    try {
+      return await this.client.capture(params);
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} [${this.platformName}] capture failed (turn dropped from memory): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+}

--- a/src/adapter-sdk/errors.ts
+++ b/src/adapter-sdk/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Adapter SDK — Error model.
+ *
+ * Every `MemoryClient` method rejects with a `MemoryClientError` so platform
+ * adapters can branch on a stable `code` instead of parsing transport-specific
+ * messages (HTTP status text vs. core exception strings).
+ */
+
+/** Machine-readable failure categories, stable across transports. */
+export type MemoryClientErrorCode =
+  /** Network / process-level failure: connection refused, timeout, 5xx, core threw. */
+  | "transport"
+  /** Authentication rejected (HTTP 401 from the gateway). */
+  | "auth"
+  /** The request was malformed or missing required fields (HTTP 400). */
+  | "bad_request"
+  /** The backing engine is not ready / not reachable in a way that may recover. */
+  | "unavailable";
+
+export class MemoryClientError extends Error {
+  /** Stable machine-readable category. */
+  readonly code: MemoryClientErrorCode;
+  /** HTTP status when the failure came off the wire (undefined in-process). */
+  readonly httpStatus?: number;
+
+  constructor(
+    code: MemoryClientErrorCode,
+    message: string,
+    opts?: { httpStatus?: number; cause?: unknown },
+  ) {
+    super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+    this.name = "MemoryClientError";
+    this.code = code;
+    this.httpStatus = opts?.httpStatus;
+  }
+}
+
+/** Map an HTTP status to the canonical error code. */
+export function codeForHttpStatus(status: number): MemoryClientErrorCode {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 400) return "bad_request";
+  if (status === 503) return "unavailable";
+  return "transport";
+}

--- a/src/adapter-sdk/factory.test.ts
+++ b/src/adapter-sdk/factory.test.ts
@@ -1,0 +1,90 @@
+/**
+ * createMemoryClient / resolveClientOptionsFromEnv unit tests (offline).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createMemoryClient, resolveClientOptionsFromEnv } from "./factory.js";
+import { HttpMemoryClient } from "./transports/http.js";
+import { InProcessMemoryClient } from "./transports/in-process.js";
+import type { MemoryClientOptions } from "./factory.js";
+
+describe("createMemoryClient", () => {
+  it("returns an HttpMemoryClient for transport 'http'", () => {
+    const client = createMemoryClient({ transport: "http", baseUrl: "http://127.0.0.1:9999" });
+    expect(client).toBeInstanceOf(HttpMemoryClient);
+  });
+
+  it("returns an InProcessMemoryClient for transport 'in-process'", () => {
+    const client = createMemoryClient({ transport: "in-process" });
+    expect(client).toBeInstanceOf(InProcessMemoryClient);
+  });
+
+  it("throws on an unknown transport (runtime misuse)", () => {
+    expect(() =>
+      createMemoryClient({ transport: "carrier-pigeon" } as unknown as MemoryClientOptions),
+    ).toThrow(/Unknown MemoryClient transport/);
+  });
+});
+
+describe("resolveClientOptionsFromEnv", () => {
+  it("defaults to http transport with no env set", () => {
+    vi.stubEnv("TDAI_ADAPTER_TRANSPORT", "");
+    vi.stubEnv("TDAI_GATEWAY_URL", "");
+    vi.stubEnv("TDAI_GATEWAY_API_KEY", "");
+    vi.stubEnv("TDAI_ADAPTER_TIMEOUT_MS", "");
+
+    const opts = resolveClientOptionsFromEnv();
+
+    expect(opts.transport).toBe("http");
+    if (opts.transport === "http") {
+      expect(opts.baseUrl).toBeUndefined();
+      expect(opts.apiKey).toBeUndefined();
+      expect(opts.timeoutMs).toBeUndefined();
+    }
+  });
+
+  it("reads http options from TDAI_GATEWAY_URL / TDAI_GATEWAY_API_KEY / TDAI_ADAPTER_TIMEOUT_MS", () => {
+    vi.stubEnv("TDAI_ADAPTER_TRANSPORT", "http");
+    vi.stubEnv("TDAI_GATEWAY_URL", "http://10.0.0.5:8420");
+    vi.stubEnv("TDAI_GATEWAY_API_KEY", "sk-test");
+    vi.stubEnv("TDAI_ADAPTER_TIMEOUT_MS", "2500");
+
+    const opts = resolveClientOptionsFromEnv();
+
+    expect(opts).toMatchObject({
+      transport: "http",
+      baseUrl: "http://10.0.0.5:8420",
+      apiKey: "sk-test",
+      timeoutMs: 2500,
+    });
+  });
+
+  it("selects in-process transport via TDAI_ADAPTER_TRANSPORT", () => {
+    vi.stubEnv("TDAI_ADAPTER_TRANSPORT", "in-process");
+
+    const opts = resolveClientOptionsFromEnv();
+
+    expect(opts.transport).toBe("in-process");
+  });
+
+  it("falls back to http (with a warning) on an unknown transport value", () => {
+    vi.stubEnv("TDAI_ADAPTER_TRANSPORT", "grpc");
+    const warn = vi.fn();
+
+    const opts = resolveClientOptionsFromEnv({ info: vi.fn(), warn, error: vi.fn() });
+
+    expect(opts.transport).toBe("http");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("grpc"));
+  });
+
+  it("ignores a non-numeric timeout", () => {
+    vi.stubEnv("TDAI_ADAPTER_TRANSPORT", "http");
+    vi.stubEnv("TDAI_ADAPTER_TIMEOUT_MS", "soon");
+
+    const opts = resolveClientOptionsFromEnv();
+
+    expect(opts.transport).toBe("http");
+    if (opts.transport === "http") expect(opts.timeoutMs).toBeUndefined();
+  });
+});

--- a/src/adapter-sdk/factory.ts
+++ b/src/adapter-sdk/factory.ts
@@ -1,0 +1,107 @@
+/**
+ * Adapter SDK — MemoryClient factory.
+ *
+ * `createMemoryClient()` is the single entry point adapters use to obtain a
+ * `MemoryClient`; the discriminated `transport` field selects the wiring:
+ *
+ *   - `"http"`       → `HttpMemoryClient` (talks to a running TdaiGateway)
+ *   - `"in-process"` → `InProcessMemoryClient` (wraps TdaiCore in this process)
+ *
+ * `resolveClientOptionsFromEnv()` implements the shared env-var convention
+ * used by the adapter CLI entries (Claude Code MCP server, Dify server):
+ *
+ *   TDAI_ADAPTER_TRANSPORT   "http" (default) | "in-process"
+ *   TDAI_GATEWAY_URL         http transport base URL (default http://127.0.0.1:8420)
+ *   TDAI_GATEWAY_API_KEY     Bearer token for the gateway (same var the gateway reads)
+ *   TDAI_ADAPTER_TIMEOUT_MS  http request timeout (default 10000)
+ */
+
+import type { Logger } from "../core/types.js";
+import { getEnv } from "../utils/env.js";
+import type { MemoryClient, TdaiCoreLike } from "./types.js";
+import { HttpMemoryClient } from "./transports/http.js";
+import { InProcessMemoryClient } from "./transports/in-process.js";
+
+// ============================
+// Options
+// ============================
+
+export interface HttpClientOptions {
+  transport: "http";
+  /** Gateway base URL. Default: `http://127.0.0.1:8420`. */
+  baseUrl?: string;
+  /** Optional Bearer token. */
+  apiKey?: string;
+  /** Request timeout in ms. Default: 10_000. */
+  timeoutMs?: number;
+  /** Injectable fetch (tests). */
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+}
+
+export interface InProcessClientOptions {
+  transport: "in-process";
+  /** Pre-built core (DI — the client will not own its lifecycle). */
+  core?: TdaiCoreLike;
+  /** Overrides for `loadGatewayConfig()` when the client builds its own core. */
+  gatewayConfigOverrides?: Record<string, unknown>;
+  logger?: Logger;
+}
+
+export type MemoryClientOptions = HttpClientOptions | InProcessClientOptions;
+
+// ============================
+// Factory
+// ============================
+
+export function createMemoryClient(opts: MemoryClientOptions): MemoryClient {
+  switch (opts.transport) {
+    case "http":
+      return new HttpMemoryClient({
+        baseUrl: opts.baseUrl,
+        apiKey: opts.apiKey,
+        timeoutMs: opts.timeoutMs,
+        fetchImpl: opts.fetchImpl,
+        logger: opts.logger,
+      });
+    case "in-process":
+      return new InProcessMemoryClient({
+        core: opts.core,
+        gatewayConfigOverrides: opts.gatewayConfigOverrides,
+        logger: opts.logger,
+      });
+    default: {
+      // Exhaustiveness guard — unreachable when callers respect the union.
+      const invalid = opts as { transport?: string };
+      throw new Error(
+        `Unknown MemoryClient transport: ${String(invalid.transport)} (expected "http" or "in-process")`,
+      );
+    }
+  }
+}
+
+/**
+ * Resolve `MemoryClientOptions` from environment variables (see module doc).
+ * Unset/blank vars fall back to defaults; an unrecognized
+ * `TDAI_ADAPTER_TRANSPORT` value falls back to "http" with a warning.
+ */
+export function resolveClientOptionsFromEnv(logger?: Logger): MemoryClientOptions {
+  const rawTransport = (getEnv("TDAI_ADAPTER_TRANSPORT") ?? "").trim().toLowerCase();
+
+  if (rawTransport === "in-process") {
+    return { transport: "in-process", logger };
+  }
+  if (rawTransport && rawTransport !== "http") {
+    logger?.warn(
+      `[tdai-adapter] Unknown TDAI_ADAPTER_TRANSPORT="${rawTransport}" — falling back to "http"`,
+    );
+  }
+
+  const baseUrl = (getEnv("TDAI_GATEWAY_URL") ?? "").trim() || undefined;
+  const apiKey = (getEnv("TDAI_GATEWAY_API_KEY") ?? "").trim() || undefined;
+  const rawTimeout = (getEnv("TDAI_ADAPTER_TIMEOUT_MS") ?? "").trim();
+  const parsedTimeout = rawTimeout ? Number.parseInt(rawTimeout, 10) : NaN;
+  const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : undefined;
+
+  return { transport: "http", baseUrl, apiKey, timeoutMs, logger };
+}

--- a/src/adapter-sdk/index.ts
+++ b/src/adapter-sdk/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Adapter SDK — barrel.
+ *
+ * One import gives a new platform everything it needs:
+ *
+ *   import {
+ *     createMemoryClient,
+ *     BasePlatformAdapter,
+ *     type MemoryClient,
+ *   } from ".../src/adapter-sdk/index.js";
+ *
+ * NOTE: this barrel intentionally never imports `src/adapters/index.ts` or
+ * root `index.ts` — those pull in the (optional, often absent) `openclaw`
+ * peer dependency. The SDK must stay loadable in gateway-only installs.
+ */
+
+export type {
+  MemoryClient,
+  PlatformAdapter,
+  TdaiCoreLike,
+  RecallParams,
+  RecallOutcome,
+  CaptureParams,
+  CaptureOutcome,
+  SearchMemoriesParams,
+  SearchMemoriesOutcome,
+  SearchConversationsParams,
+  SearchConversationsOutcome,
+  HealthOutcome,
+} from "./types.js";
+
+export { MemoryClientError, codeForHttpStatus } from "./errors.js";
+export type { MemoryClientErrorCode } from "./errors.js";
+
+export { createMemoryClient, resolveClientOptionsFromEnv } from "./factory.js";
+export type {
+  MemoryClientOptions,
+  HttpClientOptions,
+  InProcessClientOptions,
+} from "./factory.js";
+
+export { BasePlatformAdapter } from "./base-platform-adapter.js";
+export type { BasePlatformAdapterOptions } from "./base-platform-adapter.js";
+
+export { HttpMemoryClient } from "./transports/http.js";
+export type { HttpMemoryClientOptions } from "./transports/http.js";
+export { InProcessMemoryClient } from "./transports/in-process.js";
+export type { InProcessMemoryClientOptions } from "./transports/in-process.js";

--- a/src/adapter-sdk/transports/http-gateway.e2e.test.ts
+++ b/src/adapter-sdk/transports/http-gateway.e2e.test.ts
@@ -1,0 +1,110 @@
+/**
+ * HttpMemoryClient ⇄ REAL TdaiGateway wire-compatibility e2e test.
+ *
+ * Excluded from the default suite (`*.e2e.test.ts`); run with:
+ *   npx vitest run --config vitest.e2e.config.ts src/adapter-sdk
+ *
+ * Boots an actual `TdaiGateway` (real TdaiCore, sqlite store) on an ephemeral
+ * port with a temp data dir, extraction disabled, and embedding provider
+ * "none" — fully offline, no API keys. Proves the SDK's HTTP transport speaks
+ * the same wire dialect as the gateway end-to-end, including the
+ * `include_items` extension and Bearer auth.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { TdaiGateway } from "../../gateway/server.js";
+import { parseConfig } from "../../config.js";
+import { HttpMemoryClient } from "./http.js";
+import { MemoryClientError } from "../errors.js";
+
+const API_KEY = "e2e-secret";
+
+let gateway: TdaiGateway;
+let dataDir: string;
+let baseUrl: string;
+
+beforeAll(async () => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-e2e-"));
+  gateway = new TdaiGateway({
+    server: { port: 0, host: "127.0.0.1", apiKey: API_KEY, corsOrigins: [] },
+    data: { baseDir: dataDir },
+    // Extraction/persona need an LLM — disable for offline determinism.
+    memory: parseConfig({
+      extraction: { enabled: false },
+      persona: { enabled: false },
+      recall: { enabled: true },
+      capture: { enabled: true },
+    }),
+  });
+  await gateway.start();
+  baseUrl = `http://127.0.0.1:${gateway.boundPort}`;
+});
+
+afterAll(async () => {
+  await gateway?.stop();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("HttpMemoryClient against a real TdaiGateway", () => {
+  it("health reports the real store flags", async () => {
+    const client = new HttpMemoryClient({ baseUrl, apiKey: API_KEY });
+
+    const health = await client.health();
+
+    expect(["ok", "degraded"]).toContain(health.status);
+    expect(typeof health.vectorStore).toBe("boolean");
+    expect(health.version).toBeTruthy();
+  });
+
+  it("rejects a wrong Bearer token with code 'auth'", async () => {
+    const client = new HttpMemoryClient({ baseUrl, apiKey: "wrong" });
+
+    const err = await client.recall({ query: "q", sessionKey: "s" }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MemoryClientError);
+    expect((err as MemoryClientError).code).toBe("auth");
+  });
+
+  it("captures a turn, searches it back (include_items), recalls, and flushes", async () => {
+    const client = new HttpMemoryClient({ baseUrl, apiKey: API_KEY, timeoutMs: 30_000 });
+    const sessionKey = "e2e-session";
+
+    const capture = await client.capture({
+      userContent: "My favourite framework is Zephyrium",
+      assistantContent: "Zephyrium noted as your favourite framework.",
+      sessionKey,
+    });
+    expect(capture.l0Recorded).toBeGreaterThan(0);
+
+    // L0 conversation search over the freshly captured turn (FTS path —
+    // embedding provider is "none"). Wire shape must include items when the
+    // gateway supports include_items.
+    const search = await client.searchConversations({ query: "Zephyrium", limit: 5 });
+    expect(typeof search.text).toBe("string");
+    expect(Array.isArray(search.items)).toBe(true);
+    if (search.total > 0) {
+      expect(search.text).toContain("Zephyrium");
+      expect(search.items.length).toBeGreaterThan(0);
+      expect(search.items[0]).toHaveProperty("session_key");
+      expect(search.items[0]).toHaveProperty("role");
+      expect(search.items[0]).toHaveProperty("score");
+    }
+
+    // Memory (L1) search: nothing extracted (extraction off) — but the wire
+    // must still answer cleanly with the structured shape.
+    const memories = await client.searchMemories({ query: "Zephyrium" });
+    expect(typeof memories.text).toBe("string");
+    expect(Array.isArray(memories.items)).toBe(true);
+
+    // Recall + session end must round-trip without error.
+    const recall = await client.recall({ query: "What framework do I like?", sessionKey });
+    expect(typeof recall.context).toBe("string");
+    expect(typeof recall.memoryCount).toBe("number");
+
+    await expect(client.endSession(sessionKey)).resolves.toBeUndefined();
+  });
+});

--- a/src/adapter-sdk/transports/http.test.ts
+++ b/src/adapter-sdk/transports/http.test.ts
@@ -1,0 +1,304 @@
+/**
+ * HttpMemoryClient unit tests.
+ *
+ * A stub gateway (`node:http` on an ephemeral port) records every request so
+ * the tests can assert the exact wire shape (paths, snake_case bodies,
+ * headers) without touching a real TdaiCore. Fully offline.
+ */
+
+import http from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { HttpMemoryClient } from "./http.js";
+import { MemoryClientError } from "../errors.js";
+
+// ============================
+// Stub gateway
+// ============================
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  headers: http.IncomingHttpHeaders;
+  body: unknown;
+}
+
+interface StubRoute {
+  status: number;
+  body: unknown;
+  /** When true the route never responds (for timeout tests). */
+  hang?: boolean;
+}
+
+class StubGateway {
+  readonly requests: RecordedRequest[] = [];
+  private readonly routes = new Map<string, StubRoute>();
+  private server?: http.Server;
+  private port = 0;
+
+  route(method: string, path: string, status: number, body: unknown, opts?: { hang?: boolean }): void {
+    this.routes.set(`${method} ${path}`, { status, body, hang: opts?.hang });
+  }
+
+  async start(): Promise<string> {
+    this.server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf-8");
+        this.requests.push({
+          method: req.method ?? "",
+          path: req.url ?? "",
+          headers: req.headers,
+          body: raw ? JSON.parse(raw) : undefined,
+        });
+        const route = this.routes.get(`${req.method} ${req.url}`);
+        if (!route) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: `no stub for ${req.method} ${req.url}` }));
+          return;
+        }
+        if (route.hang) return; // never respond — client must time out
+        res.writeHead(route.status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(route.body));
+      });
+    });
+    await new Promise<void>((resolve) => this.server!.listen(0, "127.0.0.1", resolve));
+    this.port = (this.server!.address() as AddressInfo).port;
+    return `http://127.0.0.1:${this.port}`;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    this.server.closeAllConnections?.();
+    await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+    this.server = undefined;
+  }
+}
+
+// ============================
+// Tests
+// ============================
+
+describe("HttpMemoryClient", () => {
+  let stub: StubGateway;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    stub = new StubGateway();
+    baseUrl = await stub.start();
+  });
+
+  afterEach(async () => {
+    await stub.stop();
+  });
+
+  it("recall: POSTs snake_case body to /recall and maps the response", async () => {
+    stub.route("POST", "/recall", 200, {
+      context: "ctx",
+      strategy: "hybrid",
+      memory_count: 3,
+      prepend_context: "pre",
+    });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.recall({ query: "hello", sessionKey: "s1", userId: "u1" });
+
+    expect(outcome).toEqual({
+      context: "ctx",
+      prependContext: "pre",
+      strategy: "hybrid",
+      memoryCount: 3,
+    });
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].path).toBe("/recall");
+    expect(stub.requests[0].body).toEqual({ query: "hello", session_key: "s1", user_id: "u1" });
+    expect(stub.requests[0].headers["content-type"]).toBe("application/json");
+  });
+
+  it("recall: tolerates legacy gateways that omit prepend_context", async () => {
+    stub.route("POST", "/recall", 200, { context: "ctx", strategy: "fts", memory_count: 1 });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.recall({ query: "hello", sessionKey: "s1" });
+
+    expect(outcome.prependContext).toBeUndefined();
+    expect(outcome.context).toBe("ctx");
+  });
+
+  it("capture: maps camelCase params to gateway wire names", async () => {
+    stub.route("POST", "/capture", 200, { l0_recorded: 2, scheduler_notified: true });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.capture({
+      userContent: "u-text",
+      assistantContent: "a-text",
+      sessionKey: "s1",
+      sessionId: "sid-9",
+      messages: [{ role: "user", content: "u-text" }],
+    });
+
+    expect(outcome).toEqual({ l0Recorded: 2, schedulerNotified: true });
+    expect(stub.requests[0].body).toEqual({
+      user_content: "u-text",
+      assistant_content: "a-text",
+      session_key: "s1",
+      session_id: "sid-9",
+      messages: [{ role: "user", content: "u-text" }],
+    });
+  });
+
+  it("capture: omits optional fields not provided", async () => {
+    stub.route("POST", "/capture", 200, { l0_recorded: 0, scheduler_notified: false });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    await client.capture({ userContent: "u", assistantContent: "a", sessionKey: "s" });
+
+    expect(stub.requests[0].body).toEqual({
+      user_content: "u",
+      assistant_content: "a",
+      session_key: "s",
+    });
+  });
+
+  it("searchMemories: sends include_items:true and returns structured items", async () => {
+    const items = [
+      {
+        id: "m1", content: "likes tea", type: "persona", priority: 1,
+        scene_name: "daily", score: 0.9, created_at: "2026-01-01", updated_at: "2026-01-02",
+      },
+    ];
+    stub.route("POST", "/search/memories", 200, {
+      results: "Found 1 matching memories:", total: 1, strategy: "hybrid", items,
+    });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.searchMemories({ query: "tea", limit: 5, type: "persona", scene: "daily" });
+
+    expect(outcome.text).toBe("Found 1 matching memories:");
+    expect(outcome.total).toBe(1);
+    expect(outcome.strategy).toBe("hybrid");
+    expect(outcome.items).toEqual(items);
+    expect(stub.requests[0].body).toEqual({
+      query: "tea", limit: 5, type: "persona", scene: "daily", include_items: true,
+    });
+  });
+
+  it("searchMemories: tolerates gateways that omit items (older protocol)", async () => {
+    stub.route("POST", "/search/memories", 200, { results: "text only", total: 2, strategy: "fts" });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.searchMemories({ query: "q" });
+
+    expect(outcome.items).toEqual([]);
+    expect(outcome.total).toBe(2);
+  });
+
+  it("searchConversations: maps sessionKey → session_key and returns items", async () => {
+    const items = [
+      { id: "c1", session_key: "s1", role: "user", content: "hi", score: 0.5, recorded_at: "2026-01-01" },
+    ];
+    stub.route("POST", "/search/conversations", 200, { results: "found", total: 1, items });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.searchConversations({ query: "hi", limit: 3, sessionKey: "s1" });
+
+    expect(outcome).toEqual({ text: "found", total: 1, items });
+    expect(stub.requests[0].body).toEqual({
+      query: "hi", limit: 3, session_key: "s1", include_items: true,
+    });
+  });
+
+  it("endSession: POSTs session_key to /session/end", async () => {
+    stub.route("POST", "/session/end", 200, { flushed: true });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    await client.endSession("s-end");
+
+    expect(stub.requests[0].path).toBe("/session/end");
+    expect(stub.requests[0].body).toEqual({ session_key: "s-end" });
+  });
+
+  it("health: GETs /health and maps store flags", async () => {
+    stub.route("GET", "/health", 200, {
+      status: "ok", version: "0.1.0", uptime: 12,
+      stores: { vectorStore: true, embeddingService: false },
+    });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const outcome = await client.health();
+
+    expect(outcome).toEqual({
+      status: "ok", vectorStore: true, embeddingService: false, version: "0.1.0",
+    });
+    expect(stub.requests[0].method).toBe("GET");
+    // GET carries no body and no content-type
+    expect(stub.requests[0].headers["content-type"]).toBeUndefined();
+  });
+
+  it("attaches Authorization: Bearer only when apiKey is non-empty after trim", async () => {
+    stub.route("GET", "/health", 200, { status: "ok", stores: {} });
+    await new HttpMemoryClient({ baseUrl, apiKey: " secret-key " }).health();
+    await new HttpMemoryClient({ baseUrl, apiKey: "   " }).health();
+    await new HttpMemoryClient({ baseUrl }).health();
+
+    expect(stub.requests[0].headers["authorization"]).toBe("Bearer secret-key");
+    expect(stub.requests[1].headers["authorization"]).toBeUndefined();
+    expect(stub.requests[2].headers["authorization"]).toBeUndefined();
+  });
+
+  it("maps HTTP 401 to MemoryClientError code 'auth' and surfaces the error body", async () => {
+    stub.route("POST", "/recall", 401, { error: "Unauthorized: invalid token" });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const err = await client.recall({ query: "q", sessionKey: "s" }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MemoryClientError);
+    expect((err as MemoryClientError).code).toBe("auth");
+    expect((err as MemoryClientError).httpStatus).toBe(401);
+    expect((err as MemoryClientError).message).toContain("Unauthorized: invalid token");
+  });
+
+  it("maps HTTP 400 to 'bad_request' and HTTP 500 to 'transport'", async () => {
+    stub.route("POST", "/recall", 400, { error: "Missing required fields: query, session_key" });
+    stub.route("POST", "/capture", 500, { error: "boom" });
+    const client = new HttpMemoryClient({ baseUrl });
+
+    const badReq = await client.recall({ query: "q", sessionKey: "s" }).catch((e: unknown) => e);
+    const serverErr = await client
+      .capture({ userContent: "u", assistantContent: "a", sessionKey: "s" })
+      .catch((e: unknown) => e);
+
+    expect((badReq as MemoryClientError).code).toBe("bad_request");
+    expect((serverErr as MemoryClientError).code).toBe("transport");
+    expect((serverErr as MemoryClientError).httpStatus).toBe(500);
+  });
+
+  it("times out via AbortSignal and reports a 'transport' error", async () => {
+    stub.route("POST", "/recall", 200, {}, { hang: true });
+    const client = new HttpMemoryClient({ baseUrl, timeoutMs: 100 });
+
+    const err = await client.recall({ query: "q", sessionKey: "s" }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MemoryClientError);
+    expect((err as MemoryClientError).code).toBe("transport");
+    expect((err as MemoryClientError).message).toContain("timed out");
+  });
+
+  it("reports 'unavailable' when the gateway is unreachable", async () => {
+    // Point at the stub's port after shutting it down — connection refused.
+    await stub.stop();
+    const client = new HttpMemoryClient({ baseUrl, timeoutMs: 1_000 });
+
+    const err = await client.health().catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MemoryClientError);
+    expect((err as MemoryClientError).code).toBe("unavailable");
+  });
+
+  it("close() is a no-op that resolves", async () => {
+    const client = new HttpMemoryClient({ baseUrl });
+    await expect(client.close()).resolves.toBeUndefined();
+  });
+});

--- a/src/adapter-sdk/transports/http.ts
+++ b/src/adapter-sdk/transports/http.ts
@@ -1,0 +1,246 @@
+/**
+ * Adapter SDK — HTTP transport.
+ *
+ * `HttpMemoryClient` speaks the TDAI Gateway REST protocol
+ * (`src/gateway/server.ts`), mirroring the Hermes Python client
+ * (`hermes-plugin/memory/memory_tencentdb/client.py`) 1:1:
+ *
+ *   recall              → POST /recall
+ *   capture             → POST /capture
+ *   searchMemories      → POST /search/memories
+ *   searchConversations → POST /search/conversations
+ *   endSession          → POST /session/end
+ *   health              → GET  /health
+ *
+ * camelCase ⇄ snake_case mapping happens ONLY in this file — the SDK surface
+ * stays camelCase, the wire stays byte-compatible with the existing gateway.
+ *
+ * Search requests opportunistically send `include_items: true` (a protocol
+ * extension added together with this SDK). Older gateways ignore unknown
+ * fields and omit `items` in the response; we tolerate that by defaulting
+ * `items` to `[]`, so this client works against any gateway version.
+ */
+
+import type { Logger } from "../../core/types.js";
+import type {
+  MemoryClient,
+  RecallParams,
+  RecallOutcome,
+  CaptureParams,
+  CaptureOutcome,
+  SearchMemoriesParams,
+  SearchMemoriesOutcome,
+  SearchConversationsParams,
+  SearchConversationsOutcome,
+  HealthOutcome,
+} from "../types.js";
+import { MemoryClientError, codeForHttpStatus } from "../errors.js";
+
+const TAG = "[tdai-adapter] [http]";
+
+// ============================
+// Options
+// ============================
+
+export interface HttpMemoryClientOptions {
+  /** Gateway base URL. Default: `http://127.0.0.1:8420`. */
+  baseUrl?: string;
+  /**
+   * Optional Bearer token. Attached as `Authorization: Bearer <key>` only
+   * when non-empty after trimming — matching the Python client's behaviour.
+   */
+  apiKey?: string;
+  /** Per-request timeout in milliseconds. Default: 10_000. */
+  timeoutMs?: number;
+  /** Injectable fetch implementation (unit tests). Default: global fetch. */
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+}
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8420";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// ============================
+// HttpMemoryClient
+// ============================
+
+export class HttpMemoryClient implements MemoryClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly logger?: Logger;
+
+  constructor(opts: HttpMemoryClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    const trimmedKey = opts.apiKey?.trim();
+    this.apiKey = trimmedKey ? trimmedKey : undefined;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    // Bind to globalThis so the native fetch keeps its receiver.
+    this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
+    this.logger = opts.logger;
+  }
+
+  // ============================
+  // MemoryClient implementation
+  // ============================
+
+  async recall(params: RecallParams): Promise<RecallOutcome> {
+    const body = await this.post<{
+      context?: string;
+      strategy?: string;
+      memory_count?: number;
+      prepend_context?: string;
+    }>("/recall", {
+      query: params.query,
+      session_key: params.sessionKey,
+      user_id: params.userId ?? "",
+    });
+    return {
+      context: body.context ?? "",
+      prependContext: body.prepend_context,
+      strategy: body.strategy,
+      memoryCount: body.memory_count ?? 0,
+    };
+  }
+
+  async capture(params: CaptureParams): Promise<CaptureOutcome> {
+    const body = await this.post<{ l0_recorded?: number; scheduler_notified?: boolean }>(
+      "/capture",
+      {
+        user_content: params.userContent,
+        assistant_content: params.assistantContent,
+        session_key: params.sessionKey,
+        ...(params.sessionId !== undefined ? { session_id: params.sessionId } : {}),
+        ...(params.userId !== undefined ? { user_id: params.userId } : {}),
+        ...(params.messages !== undefined ? { messages: params.messages } : {}),
+      },
+    );
+    return {
+      l0Recorded: body.l0_recorded ?? 0,
+      schedulerNotified: body.scheduler_notified ?? false,
+    };
+  }
+
+  async searchMemories(params: SearchMemoriesParams): Promise<SearchMemoriesOutcome> {
+    const body = await this.post<{
+      results?: string;
+      total?: number;
+      strategy?: string;
+      items?: SearchMemoriesOutcome["items"];
+    }>("/search/memories", {
+      query: params.query,
+      ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      ...(params.type !== undefined ? { type: params.type } : {}),
+      ...(params.scene !== undefined ? { scene: params.scene } : {}),
+      include_items: true,
+    });
+    return {
+      text: body.results ?? "",
+      total: body.total ?? 0,
+      strategy: body.strategy ?? "none",
+      items: body.items ?? [],
+    };
+  }
+
+  async searchConversations(params: SearchConversationsParams): Promise<SearchConversationsOutcome> {
+    const body = await this.post<{
+      results?: string;
+      total?: number;
+      items?: SearchConversationsOutcome["items"];
+    }>("/search/conversations", {
+      query: params.query,
+      ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      ...(params.sessionKey !== undefined ? { session_key: params.sessionKey } : {}),
+      include_items: true,
+    });
+    return {
+      text: body.results ?? "",
+      total: body.total ?? 0,
+      items: body.items ?? [],
+    };
+  }
+
+  async endSession(sessionKey: string): Promise<void> {
+    await this.post("/session/end", { session_key: sessionKey });
+  }
+
+  async health(): Promise<HealthOutcome> {
+    const body = await this.request<{
+      status?: string;
+      version?: string;
+      stores?: { vectorStore?: boolean; embeddingService?: boolean };
+    }>("GET", "/health");
+    return {
+      status: body.status === "ok" ? "ok" : "degraded",
+      vectorStore: body.stores?.vectorStore ?? false,
+      embeddingService: body.stores?.embeddingService ?? false,
+      version: body.version,
+    };
+  }
+
+  /** No remote resources are owned by this client — closing is a no-op. */
+  async close(): Promise<void> {
+    // no-op
+  }
+
+  // ============================
+  // Wire helpers
+  // ============================
+
+  private post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+
+  private async request<T>(method: "GET" | "POST", path: string, body?: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {};
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (err) {
+      const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+      const message = isTimeout
+        ? `Gateway request timed out after ${this.timeoutMs}ms: ${method} ${url}`
+        : `Gateway unreachable: ${method} ${url}: ${err instanceof Error ? err.message : String(err)}`;
+      this.logger?.warn(`${TAG} ${message}`);
+      throw new MemoryClientError(isTimeout ? "transport" : "unavailable", message, { cause: err });
+    }
+
+    const text = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = text ? JSON.parse(text) : {};
+    } catch {
+      parsed = undefined;
+    }
+
+    if (!response.ok) {
+      // Gateway error bodies are `{ error: string }` — surface the message.
+      const detail =
+        parsed && typeof parsed === "object" && typeof (parsed as { error?: unknown }).error === "string"
+          ? (parsed as { error: string }).error
+          : text.slice(0, 200) || response.statusText;
+      const code = codeForHttpStatus(response.status);
+      this.logger?.warn(`${TAG} ${method} ${path} → HTTP ${response.status} (${code}): ${detail}`);
+      throw new MemoryClientError(code, `Gateway ${method} ${path} failed (HTTP ${response.status}): ${detail}`, {
+        httpStatus: response.status,
+      });
+    }
+
+    if (parsed === undefined) {
+      throw new MemoryClientError("transport", `Gateway ${method} ${path} returned invalid JSON`, {
+        httpStatus: response.status,
+      });
+    }
+    return parsed as T;
+  }
+}

--- a/src/adapter-sdk/transports/in-process.test.ts
+++ b/src/adapter-sdk/transports/in-process.test.ts
@@ -1,0 +1,347 @@
+/**
+ * InProcessMemoryClient unit tests.
+ *
+ * A fake `TdaiCoreLike` is injected in every test — the real TdaiCore (with
+ * sqlite-vec / embedding / LLM machinery) is never constructed here, keeping
+ * the suite offline and fast. Owned-core construction is covered indirectly
+ * by the lazy-init gating test using an injectable fake as well.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { InProcessMemoryClient } from "./in-process.js";
+import { MemoryClientError } from "../errors.js";
+import type { TdaiCoreLike } from "../types.js";
+import type { CompletedTurn } from "../../core/types.js";
+
+// ============================
+// Owned-core module mocks
+// ============================
+//
+// The owned-core path (`new InProcessMemoryClient({})` without an injected
+// core) dynamically imports gateway config + StandaloneHostAdapter + TdaiCore.
+// We mock those modules so the lazy-construction gating can be tested without
+// touching sqlite/embedding/filesystem. Plain counters (vi.hoisted) survive
+// the global clearMocks/restoreMocks config.
+
+const ownedCoreState = vi.hoisted(() => ({
+  constructed: 0,
+  initializeCalls: 0,
+  destroyCalls: 0,
+}));
+
+vi.mock("../../gateway/config.js", () => ({
+  loadGatewayConfig: () => ({
+    server: { port: 0, host: "127.0.0.1", corsOrigins: [] },
+    data: { baseDir: "/tmp/tdai-fake-never-used" },
+    llm: { baseUrl: "", apiKey: "", model: "", maxTokens: 1, timeoutMs: 1, disableThinking: false },
+    memory: { capture: { excludeAgents: [] } },
+  }),
+}));
+
+vi.mock("../../adapters/standalone/host-adapter.js", () => ({
+  StandaloneHostAdapter: class {
+    constructor(_opts: unknown) {}
+  },
+}));
+
+vi.mock("../../utils/pipeline-factory.js", () => ({
+  initDataDirectories: () => {},
+}));
+
+vi.mock("../../utils/session-filter.js", () => ({
+  SessionFilter: class {
+    constructor(_excludeAgents: unknown) {}
+  },
+}));
+
+vi.mock("../../core/tdai-core.js", () => ({
+  TdaiCore: class {
+    constructor(_opts: unknown) {
+      ownedCoreState.constructed++;
+    }
+    async initialize(): Promise<void> {
+      ownedCoreState.initializeCalls++;
+      // Yield across ticks so concurrent callers really race the gate.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    async destroy(): Promise<void> {
+      ownedCoreState.destroyCalls++;
+    }
+    async handleBeforeRecall(): Promise<Record<string, never>> {
+      return {};
+    }
+    async handleTurnCommitted(): Promise<unknown> {
+      return { l0RecordedCount: 0, schedulerNotified: false, l0VectorsWritten: 0, filteredMessages: [] };
+    }
+    async searchMemories(): Promise<unknown> {
+      return { text: "", total: 0, strategy: "none" };
+    }
+    async searchConversations(): Promise<unknown> {
+      return { text: "", total: 0 };
+    }
+    async handleSessionEnd(): Promise<void> {}
+    getVectorStore(): unknown {
+      return {};
+    }
+    getEmbeddingService(): unknown {
+      return undefined;
+    }
+  },
+}));
+
+// ============================
+// Fake core factory
+// ============================
+
+function createFakeCore(overrides: Partial<TdaiCoreLike> = {}): TdaiCoreLike {
+  return {
+    initialize: vi.fn(async () => {}),
+    destroy: vi.fn(async () => {}),
+    handleBeforeRecall: vi.fn(async () => ({
+      prependContext: "prepend",
+      appendSystemContext: "system-ctx",
+      recalledL1Memories: [
+        { content: "m1", score: 0.9, type: "persona" },
+        { content: "m2", score: 0.8, type: "episodic" },
+      ],
+      recallStrategy: "hybrid",
+    })),
+    handleTurnCommitted: vi.fn(async () => ({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 2,
+      filteredMessages: [],
+    })),
+    searchMemories: vi.fn(async () => ({ text: "facade-text", total: 1, strategy: "fts" })),
+    searchConversations: vi.fn(async () => ({ text: "conv-facade", total: 1 })),
+    handleSessionEnd: vi.fn(async () => {}),
+    getVectorStore: vi.fn(() => ({})),
+    getEmbeddingService: vi.fn(() => undefined),
+    ...overrides,
+  };
+}
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+// ============================
+// Tests
+// ============================
+
+describe("InProcessMemoryClient", () => {
+  it("recall: delegates to handleBeforeRecall and applies the gateway projection", async () => {
+    const core = createFakeCore();
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    const outcome = await client.recall({ query: "hello", sessionKey: "s1" });
+
+    expect(core.handleBeforeRecall).toHaveBeenCalledWith("hello", "s1");
+    expect(outcome).toEqual({
+      context: "system-ctx",
+      prependContext: "prepend",
+      strategy: "hybrid",
+      memoryCount: 2,
+    });
+  });
+
+  it("recall: empty RecallResult maps to empty context and zero count", async () => {
+    const core = createFakeCore({ handleBeforeRecall: vi.fn(async () => ({})) });
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    const outcome = await client.recall({ query: "q", sessionKey: "s" });
+
+    expect(outcome).toEqual({
+      context: "",
+      prependContext: undefined,
+      strategy: undefined,
+      memoryCount: 0,
+    });
+  });
+
+  it("capture: builds a CompletedTurn with default two-message list (gateway parity)", async () => {
+    const core = createFakeCore();
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    const outcome = await client.capture({
+      userContent: "u-text",
+      assistantContent: "a-text",
+      sessionKey: "s1",
+      sessionId: "sid",
+    });
+
+    expect(outcome).toEqual({ l0Recorded: 2, schedulerNotified: true });
+    const turn = (core.handleTurnCommitted as ReturnType<typeof vi.fn>).mock.calls[0][0] as CompletedTurn;
+    expect(turn.userText).toBe("u-text");
+    expect(turn.assistantText).toBe("a-text");
+    expect(turn.sessionKey).toBe("s1");
+    expect(turn.sessionId).toBe("sid");
+    expect(turn.messages).toEqual([
+      { role: "user", content: "u-text" },
+      { role: "assistant", content: "a-text" },
+    ]);
+  });
+
+  it("capture: passes explicit messages through untouched", async () => {
+    const core = createFakeCore();
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+    const messages = [{ role: "user", content: "u" }, { role: "tool", content: "t" }];
+
+    await client.capture({ userContent: "u", assistantContent: "a", sessionKey: "s", messages });
+
+    const turn = (core.handleTurnCommitted as ReturnType<typeof vi.fn>).mock.calls[0][0] as CompletedTurn;
+    expect(turn.messages).toBe(messages);
+  });
+
+  it("searchMemories: prefers the structured variant and formats its text", async () => {
+    const structuredItems = [
+      {
+        id: "m1", content: "likes tea", type: "persona", priority: 1,
+        scene_name: "", score: 0.42, created_at: "c", updated_at: "u",
+      },
+    ];
+    const core = createFakeCore({
+      searchMemoriesStructured: vi.fn(async () => ({
+        results: structuredItems, total: 1, strategy: "hybrid",
+      })),
+    });
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    const outcome = await client.searchMemories({ query: "tea", limit: 5 });
+
+    expect(core.searchMemoriesStructured).toHaveBeenCalledWith({ query: "tea", limit: 5 });
+    expect(core.searchMemories).not.toHaveBeenCalled();
+    expect(outcome.items).toEqual(structuredItems);
+    expect(outcome.total).toBe(1);
+    expect(outcome.strategy).toBe("hybrid");
+    // Text is produced by the real formatter over the structured items.
+    expect(outcome.text).toContain("likes tea");
+    expect(outcome.text).toContain("persona");
+  });
+
+  it("searchMemories: falls back to the text facade when no structured variant exists", async () => {
+    const core = createFakeCore(); // no searchMemoriesStructured
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    const outcome = await client.searchMemories({ query: "q" });
+
+    expect(core.searchMemories).toHaveBeenCalledWith({ query: "q" });
+    expect(outcome).toEqual({ text: "facade-text", total: 1, strategy: "fts", items: [] });
+  });
+
+  it("searchConversations: structured preference + fallback mirror searchMemories", async () => {
+    const items = [
+      { id: "c1", session_key: "s1", role: "user", content: "hi there", score: 0.5, recorded_at: "r" },
+    ];
+    const structuredCore = createFakeCore({
+      searchConversationsStructured: vi.fn(async () => ({ results: items, total: 1, strategy: "fts" })),
+    });
+    const structuredClient = new InProcessMemoryClient({ core: structuredCore, logger: silentLogger });
+    const structured = await structuredClient.searchConversations({ query: "hi", sessionKey: "s1" });
+    expect(structuredCore.searchConversationsStructured).toHaveBeenCalledWith({ query: "hi", sessionKey: "s1" });
+    expect(structured.items).toEqual(items);
+    expect(structured.text).toContain("hi there");
+
+    const facadeCore = createFakeCore();
+    const facadeClient = new InProcessMemoryClient({ core: facadeCore, logger: silentLogger });
+    const facade = await facadeClient.searchConversations({ query: "hi" });
+    expect(facade).toEqual({ text: "conv-facade", total: 1, items: [] });
+  });
+
+  it("endSession: delegates to handleSessionEnd", async () => {
+    const core = createFakeCore();
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    await client.endSession("s-end");
+
+    expect(core.handleSessionEnd).toHaveBeenCalledWith("s-end");
+  });
+
+  it("health: derives status from store accessors", async () => {
+    const healthy = new InProcessMemoryClient({ core: createFakeCore(), logger: silentLogger });
+    expect(await healthy.health()).toEqual({
+      status: "ok", vectorStore: true, embeddingService: false,
+    });
+
+    const degradedCore = createFakeCore({ getVectorStore: vi.fn(() => undefined) });
+    const degraded = new InProcessMemoryClient({ core: degradedCore, logger: silentLogger });
+    expect((await degraded.health()).status).toBe("degraded");
+  });
+
+  it("close(): does NOT destroy an injected core (caller owns lifecycle)", async () => {
+    const core = createFakeCore();
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    await client.close();
+
+    expect(core.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects with 'unavailable' after close()", async () => {
+    const client = new InProcessMemoryClient({ core: createFakeCore(), logger: silentLogger });
+    await client.close();
+
+    const err = await client.recall({ query: "q", sessionKey: "s" }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MemoryClientError);
+    expect((err as MemoryClientError).code).toBe("unavailable");
+  });
+
+  it("normalizes core exceptions into MemoryClientError code 'transport'", async () => {
+    const core = createFakeCore({
+      handleBeforeRecall: vi.fn(async () => {
+        throw new Error("sqlite exploded");
+      }),
+    });
+    const client = new InProcessMemoryClient({ core, logger: silentLogger });
+
+    const err = await client.recall({ query: "q", sessionKey: "s" }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MemoryClientError);
+    expect((err as MemoryClientError).code).toBe("transport");
+    expect((err as MemoryClientError).message).toContain("sqlite exploded");
+  });
+});
+
+describe("InProcessMemoryClient — owned-core lazy construction (mocked core modules)", () => {
+  it("concurrent first calls build and initialize exactly ONE core", async () => {
+    ownedCoreState.constructed = 0;
+    ownedCoreState.initializeCalls = 0;
+    ownedCoreState.destroyCalls = 0;
+
+    const client = new InProcessMemoryClient({ logger: silentLogger });
+
+    await Promise.all([client.health(), client.health(), client.health()]);
+
+    expect(ownedCoreState.constructed).toBe(1);
+    expect(ownedCoreState.initializeCalls).toBe(1);
+  });
+
+  it("close() destroys the core when this client built it (owned lifecycle)", async () => {
+    ownedCoreState.constructed = 0;
+    ownedCoreState.initializeCalls = 0;
+    ownedCoreState.destroyCalls = 0;
+
+    const client = new InProcessMemoryClient({ logger: silentLogger });
+    await client.health(); // trigger lazy build
+    await client.close();
+
+    expect(ownedCoreState.destroyCalls).toBe(1);
+    // close() is idempotent
+    await client.close();
+    expect(ownedCoreState.destroyCalls).toBe(1);
+  });
+
+  it("close() during the in-flight lazy build destroys the late-landing core (no leak)", async () => {
+    ownedCoreState.constructed = 0;
+    ownedCoreState.initializeCalls = 0;
+    ownedCoreState.destroyCalls = 0;
+
+    const client = new InProcessMemoryClient({ logger: silentLogger });
+    const inFlight = client.health(); // starts the (20ms) owned-core build
+    await client.close(); // lands while the build is still running
+
+    expect(ownedCoreState.constructed).toBe(1);
+    expect(ownedCoreState.destroyCalls).toBe(1);
+    await inFlight.catch(() => undefined); // in-flight call may resolve or reject
+  });
+});

--- a/src/adapter-sdk/transports/in-process.ts
+++ b/src/adapter-sdk/transports/in-process.ts
@@ -1,0 +1,282 @@
+/**
+ * Adapter SDK — In-process transport.
+ *
+ * `InProcessMemoryClient` wraps a `TdaiCore` instance living in the same Node
+ * process — no HTTP hop, no sidecar. Two construction modes:
+ *
+ *   1. **Injected core** (`opts.core`): the host already owns a core (or a
+ *      test injects a fake `TdaiCoreLike`). The client delegates calls and
+ *      does NOT manage the core's lifecycle — `close()` leaves it running.
+ *
+ *   2. **Owned core** (no `opts.core`): the client lazily builds a standalone
+ *      core on first use, from the same `loadGatewayConfig()` machinery the
+ *      Gateway uses (env vars `TDAI_DATA_DIR`, `TDAI_LLM_*`, config file
+ *      `tdai-gateway.yaml`). `close()` destroys it.
+ *
+ * The method → core mapping is intentionally identical to what
+ * `src/gateway/server.ts` does for the Hermes provider, so the two transports
+ * are semantically interchangeable behind `MemoryClient`.
+ */
+
+import type { Logger, CompletedTurn } from "../../core/types.js";
+import type {
+  MemoryClient,
+  TdaiCoreLike,
+  RecallParams,
+  RecallOutcome,
+  CaptureParams,
+  CaptureOutcome,
+  SearchMemoriesParams,
+  SearchMemoriesOutcome,
+  SearchConversationsParams,
+  SearchConversationsOutcome,
+  HealthOutcome,
+} from "../types.js";
+import { MemoryClientError } from "../errors.js";
+
+const TAG = "[tdai-adapter] [in-process]";
+
+// ============================
+// Options
+// ============================
+
+export interface InProcessMemoryClientOptions {
+  /**
+   * Pre-built core (dependency injection). When provided, the client never
+   * initializes or destroys it — the owner keeps the lifecycle.
+   */
+  core?: TdaiCoreLike;
+  /**
+   * Overrides forwarded to `loadGatewayConfig()` when the client builds its
+   * own core (ignored when `core` is injected). Same shape as the Gateway's
+   * `Partial<GatewayConfig>` — kept loose here to avoid a hard config import
+   * in the common injected-core path.
+   */
+  gatewayConfigOverrides?: Record<string, unknown>;
+  logger?: Logger;
+}
+
+function defaultLogger(): Logger {
+  return {
+    debug: (msg: string) => console.debug(`${TAG} ${msg}`),
+    info: (msg: string) => console.info(`${TAG} ${msg}`),
+    warn: (msg: string) => console.warn(`${TAG} ${msg}`),
+    error: (msg: string) => console.error(`${TAG} ${msg}`),
+  };
+}
+
+// ============================
+// InProcessMemoryClient
+// ============================
+
+export class InProcessMemoryClient implements MemoryClient {
+  private core?: TdaiCoreLike;
+  /** True only when this client constructed the core itself. */
+  private ownsCore = false;
+  private readonly gatewayConfigOverrides?: Record<string, unknown>;
+  private readonly logger: Logger;
+  /**
+   * Gate for the one-shot lazy build (same pattern as TdaiCore's
+   * `ensureSchedulerStarted`): concurrent first calls all await the same
+   * in-flight promise, so exactly one core is ever built/initialized.
+   */
+  private corePromise?: Promise<TdaiCoreLike>;
+  private closed = false;
+
+  constructor(opts: InProcessMemoryClientOptions = {}) {
+    this.logger = opts.logger ?? defaultLogger();
+    this.gatewayConfigOverrides = opts.gatewayConfigOverrides;
+    if (opts.core) {
+      this.core = opts.core;
+      this.corePromise = Promise.resolve(opts.core);
+      this.ownsCore = false;
+    }
+  }
+
+  // ============================
+  // MemoryClient implementation
+  // ============================
+
+  async recall(params: RecallParams): Promise<RecallOutcome> {
+    const core = await this.ensureCore();
+    const result = await this.wrap("recall", () =>
+      core.handleBeforeRecall(params.query, params.sessionKey),
+    );
+    // Same projection the Gateway applies in handleRecall().
+    return {
+      context: result.appendSystemContext ?? "",
+      prependContext: result.prependContext,
+      strategy: result.recallStrategy,
+      memoryCount: result.recalledL1Memories?.length ?? 0,
+    };
+  }
+
+  async capture(params: CaptureParams): Promise<CaptureOutcome> {
+    const core = await this.ensureCore();
+    // Same CompletedTurn construction as the Gateway's handleCapture().
+    const turn: CompletedTurn = {
+      userText: params.userContent,
+      assistantText: params.assistantContent,
+      messages: params.messages ?? [
+        { role: "user", content: params.userContent },
+        { role: "assistant", content: params.assistantContent },
+      ],
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+    };
+    const result = await this.wrap("capture", () => core.handleTurnCommitted(turn));
+    return {
+      l0Recorded: result.l0RecordedCount,
+      schedulerNotified: result.schedulerNotified,
+    };
+  }
+
+  async searchMemories(params: SearchMemoriesParams): Promise<SearchMemoriesOutcome> {
+    const core = await this.ensureCore();
+    // Prefer the structured variant (items + text) when the core provides it;
+    // fall back to the text-only facade for older/minimal cores.
+    if (core.searchMemoriesStructured) {
+      const structured = await this.wrap("searchMemories", () =>
+        core.searchMemoriesStructured!(params),
+      );
+      const { formatSearchResponse } = await import("../../core/tools/memory-search.js");
+      return {
+        text: formatSearchResponse(structured),
+        total: structured.total,
+        strategy: structured.strategy,
+        items: structured.results,
+      };
+    }
+    const result = await this.wrap("searchMemories", () => core.searchMemories(params));
+    return { text: result.text, total: result.total, strategy: result.strategy, items: [] };
+  }
+
+  async searchConversations(params: SearchConversationsParams): Promise<SearchConversationsOutcome> {
+    const core = await this.ensureCore();
+    if (core.searchConversationsStructured) {
+      const structured = await this.wrap("searchConversations", () =>
+        core.searchConversationsStructured!(params),
+      );
+      const { formatConversationSearchResponse } = await import(
+        "../../core/tools/conversation-search.js"
+      );
+      return {
+        text: formatConversationSearchResponse(structured),
+        total: structured.total,
+        items: structured.results,
+      };
+    }
+    const result = await this.wrap("searchConversations", () => core.searchConversations(params));
+    return { text: result.text, total: result.total, items: [] };
+  }
+
+  async endSession(sessionKey: string): Promise<void> {
+    const core = await this.ensureCore();
+    await this.wrap("endSession", () => core.handleSessionEnd(sessionKey));
+  }
+
+  async health(): Promise<HealthOutcome> {
+    const core = await this.ensureCore();
+    // Same derivation as the Gateway's /health handler.
+    const vectorStore = !!core.getVectorStore();
+    const embeddingService = !!core.getEmbeddingService();
+    return {
+      status: vectorStore ? "ok" : "degraded",
+      vectorStore,
+      embeddingService,
+    };
+  }
+
+  /** Destroys the core only when this client built it (owned lifecycle). */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    // An owned-core build may still be in flight — await it so the core it
+    // produces is destroyed instead of leaked (sqlite handles, scheduler).
+    // Injected cores resolve immediately and stay untouched below.
+    if (!this.core && this.corePromise) {
+      await this.corePromise.catch(() => undefined);
+    }
+    if (this.ownsCore && this.core) {
+      await this.core.destroy();
+      this.core = undefined;
+      this.corePromise = undefined;
+    }
+  }
+
+  // ============================
+  // Lazy core construction
+  // ============================
+
+  private ensureCore(): Promise<TdaiCoreLike> {
+    if (this.closed) {
+      return Promise.reject(
+        new MemoryClientError("unavailable", "InProcessMemoryClient is closed"),
+      );
+    }
+    if (this.corePromise) return this.corePromise;
+
+    this.corePromise = this.buildOwnedCore();
+    // Clear the gate on failure so a later call can retry the build.
+    this.corePromise.catch(() => {
+      this.corePromise = undefined;
+    });
+    return this.corePromise;
+  }
+
+  /**
+   * Build a standalone TdaiCore from Gateway config (env + optional yaml).
+   *
+   * Dynamic imports keep the heavy store/pipeline modules out of the module
+   * graph for the injected-core path (tests, embedding hosts) — mirroring how
+   * the Gateway itself constructs its core in `TdaiGateway`'s constructor.
+   * Concrete module paths are imported (never `src/adapters/index.ts`) so the
+   * SDK stays loadable without the optional `openclaw` peer dependency.
+   */
+  private async buildOwnedCore(): Promise<TdaiCoreLike> {
+    const [{ loadGatewayConfig }, { StandaloneHostAdapter }, { TdaiCore }, pipelineFactory, { SessionFilter }] =
+      await Promise.all([
+        import("../../gateway/config.js"),
+        import("../../adapters/standalone/host-adapter.js"),
+        import("../../core/tdai-core.js"),
+        import("../../utils/pipeline-factory.js"),
+        import("../../utils/session-filter.js"),
+      ]);
+
+    const cfg = loadGatewayConfig(this.gatewayConfigOverrides as never);
+    const hostAdapter = new StandaloneHostAdapter({
+      dataDir: cfg.data.baseDir,
+      llmConfig: cfg.llm,
+      logger: this.logger,
+      platform: "adapter-sdk",
+    });
+    const core = new TdaiCore({
+      hostAdapter,
+      config: cfg.memory,
+      sessionFilter: new SessionFilter(cfg.memory.capture.excludeAgents),
+    });
+
+    pipelineFactory.initDataDirectories(cfg.data.baseDir);
+    await core.initialize();
+
+    this.core = core;
+    this.ownsCore = true;
+    this.logger.info(`${TAG} Owned TdaiCore initialized (dataDir=${cfg.data.baseDir})`);
+    return core;
+  }
+
+  // ============================
+  // Error normalization
+  // ============================
+
+  private async wrap<T>(op: string, fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err instanceof MemoryClientError) throw err;
+      const message = `Core ${op} failed: ${err instanceof Error ? err.message : String(err)}`;
+      this.logger.warn(`${TAG} ${message}`);
+      throw new MemoryClientError("transport", message, { cause: err });
+    }
+  }
+}

--- a/src/adapter-sdk/types.ts
+++ b/src/adapter-sdk/types.ts
@@ -1,0 +1,216 @@
+/**
+ * Adapter SDK — Unified type contracts for cross-platform memory adapters.
+ *
+ * Two contracts, one boundary each:
+ *
+ *   1. `MemoryClient` — THE one client interface a platform adapter consumes.
+ *      It hides *where* the memory engine runs: `InProcessMemoryClient` wraps
+ *      `TdaiCore` directly (same Node process), `HttpMemoryClient` talks to a
+ *      remote `TdaiGateway` over REST. Adapters never see the difference.
+ *
+ *   2. `PlatformAdapter` — THE one interface a new platform must implement
+ *      (usually by extending `BasePlatformAdapter`). A "platform" here is
+ *      anything that hosts an agent and wants memory: Claude Code (MCP),
+ *      Dify (External Knowledge API), a CLI, a web service, …
+ *
+ * Design notes:
+ * - All params/results are camelCase. snake_case appears ONLY on the HTTP
+ *   wire (see transports/http.ts) so the SDK surface matches the rest of the
+ *   TypeScript codebase while staying byte-compatible with the Gateway API
+ *   consumed by the Hermes Python provider.
+ * - Result shapes are transport-invariant: both transports return the same
+ *   fields with the same semantics, verified by mirrored unit tests.
+ */
+
+import type { MemorySearchResultItem } from "../core/tools/memory-search.js";
+import type { ConversationSearchResultItem } from "../core/tools/conversation-search.js";
+import type {
+  RecallResult,
+  CaptureResult,
+  CompletedTurn,
+  MemorySearchParams,
+  ConversationSearchParams,
+} from "../core/types.js";
+import type { MemorySearchResult } from "../core/tools/memory-search.js";
+import type { ConversationSearchResult } from "../core/tools/conversation-search.js";
+
+// ============================
+// MemoryClient — params & outcomes
+// ============================
+
+/** Parameters for a recall (memory prefetch before an LLM turn). */
+export interface RecallParams {
+  /** The user's current message / query text. */
+  query: string;
+  /** Stable session identifier (groups L0 records, scopes pipeline state). */
+  sessionKey: string;
+  /**
+   * Optional user identifier. Reserved: forwarded on the HTTP wire but
+   * currently ignored by the engine (single-user).
+   */
+  userId?: string;
+}
+
+/** Outcome of a recall operation. */
+export interface RecallOutcome {
+  /**
+   * Stable recall context intended for the system prompt (persona, scene
+   * navigation, tool guidance). Mirrors `RecallResult.appendSystemContext`
+   * and the Gateway's `context` field. Empty string when nothing recalled.
+   */
+  context: string;
+  /** Per-turn dynamic context intended to precede the user message (L1 hits). */
+  prependContext?: string;
+  /** Search strategy the engine used (e.g. "hybrid", "embedding", "fts"). */
+  strategy?: string;
+  /** Number of L1 memories recalled. */
+  memoryCount: number;
+}
+
+/** Parameters for capturing one completed conversation turn. */
+export interface CaptureParams {
+  /** The user's message text for this turn. */
+  userContent: string;
+  /** The assistant's response text for this turn. */
+  assistantContent: string;
+  /** Stable session identifier. */
+  sessionKey: string;
+  /** Optional sub-session identifier. */
+  sessionId?: string;
+  /** Optional user identifier (reserved — currently ignored by the engine). */
+  userId?: string;
+  /**
+   * Optional full message list for the turn (tool calls etc.). When omitted,
+   * the transport synthesizes `[{role:"user"},{role:"assistant"}]` — the same
+   * default the Gateway applies for the Hermes provider.
+   */
+  messages?: unknown[];
+}
+
+/** Outcome of a capture operation. */
+export interface CaptureOutcome {
+  /** Number of L0 messages recorded. */
+  l0Recorded: number;
+  /** Whether the L1/L2/L3 pipeline scheduler was notified. */
+  schedulerNotified: boolean;
+}
+
+/** Parameters for searching L1 structured memories. */
+export interface SearchMemoriesParams {
+  query: string;
+  /** Max results (engine default 5, hard cap 20). */
+  limit?: number;
+  /** Filter by memory type: "persona" | "episodic" | "instruction". */
+  type?: "persona" | "episodic" | "instruction" | string;
+  /** Filter by scene name (substring match). */
+  scene?: string;
+}
+
+/** Outcome of an L1 memory search. */
+export interface SearchMemoriesOutcome {
+  /** Human/LLM-readable formatted result text. */
+  text: string;
+  total: number;
+  strategy: string;
+  /**
+   * Structured per-record results (id, score, timestamps). May be empty when
+   * the backing gateway predates the `include_items` protocol extension.
+   */
+  items: MemorySearchResultItem[];
+}
+
+/** Parameters for searching L0 raw conversation records. */
+export interface SearchConversationsParams {
+  query: string;
+  limit?: number;
+  /** Restrict results to one session. */
+  sessionKey?: string;
+}
+
+/** Outcome of an L0 conversation search. */
+export interface SearchConversationsOutcome {
+  text: string;
+  total: number;
+  /** Structured per-message results — same caveat as {@link SearchMemoriesOutcome.items}. */
+  items: ConversationSearchResultItem[];
+}
+
+/** Outcome of a health probe. */
+export interface HealthOutcome {
+  status: "ok" | "degraded";
+  vectorStore: boolean;
+  embeddingService: boolean;
+  version?: string;
+}
+
+/**
+ * THE one client interface every platform adapter consumes.
+ *
+ * Obtain an instance via `createMemoryClient()` (factory.ts). All methods
+ * reject with `MemoryClientError` on transport/engine failure — adapters that
+ * must never break their host should route calls through
+ * `BasePlatformAdapter.safeRecall` / `safeCapture`.
+ */
+export interface MemoryClient {
+  /** Retrieve relevant memory context for an upcoming LLM turn. */
+  recall(params: RecallParams): Promise<RecallOutcome>;
+  /** Persist a completed conversation turn (L0) and trigger the pipeline. */
+  capture(params: CaptureParams): Promise<CaptureOutcome>;
+  /** Search L1 structured memories (facts, preferences, instructions). */
+  searchMemories(params: SearchMemoriesParams): Promise<SearchMemoriesOutcome>;
+  /** Search L0 raw conversation history. */
+  searchConversations(params: SearchConversationsParams): Promise<SearchConversationsOutcome>;
+  /** Flush buffered pipeline work for one session (NOT a global shutdown). */
+  endSession(sessionKey: string): Promise<void>;
+  /** Probe engine/gateway health. */
+  health(): Promise<HealthOutcome>;
+  /** Release resources owned by this client (idempotent). */
+  close(): Promise<void>;
+}
+
+// ============================
+// PlatformAdapter — the one interface a new platform implements
+// ============================
+
+/**
+ * THE one interface a new platform must implement.
+ *
+ * Prefer extending `BasePlatformAdapter`, which wires a `MemoryClient`,
+ * a tagged logger, and resilience helpers; then only `platformName` and
+ * `start()` remain to be written.
+ */
+export interface PlatformAdapter {
+  /** Stable identifier, e.g. "claude-code", "dify". */
+  readonly platformName: string;
+  /** Start serving the platform (bind server / begin reading stdio / …). */
+  start(): Promise<void>;
+  /** Stop serving and release resources (must be idempotent). */
+  stop(): Promise<void>;
+}
+
+// ============================
+// TdaiCoreLike — structural core subset for DI / tests
+// ============================
+
+/**
+ * Structural subset of `TdaiCore` used by `InProcessMemoryClient`.
+ *
+ * Exists so unit tests (and embedding hosts that already own a core) can
+ * inject a lightweight fake without dragging sqlite-vec/embedding/LLM
+ * dependencies into the test process. `TdaiCore` satisfies this interface
+ * structurally — no cast needed.
+ */
+export interface TdaiCoreLike {
+  initialize(): Promise<void>;
+  destroy(): Promise<void>;
+  handleBeforeRecall(userText: string, sessionKey: string): Promise<RecallResult>;
+  handleTurnCommitted(turn: CompletedTurn): Promise<CaptureResult>;
+  searchMemories(params: MemorySearchParams): Promise<{ text: string; total: number; strategy: string }>;
+  searchConversations(params: ConversationSearchParams): Promise<{ text: string; total: number }>;
+  /** Optional structured variants (present on current TdaiCore). */
+  searchMemoriesStructured?(params: MemorySearchParams): Promise<MemorySearchResult>;
+  searchConversationsStructured?(params: ConversationSearchParams): Promise<ConversationSearchResult>;
+  handleSessionEnd(sessionKey: string): Promise<void>;
+  getVectorStore(): unknown;
+  getEmbeddingService(): unknown;
+}

--- a/src/adapters/claude-code/README.md
+++ b/src/adapters/claude-code/README.md
@@ -1,0 +1,127 @@
+# Claude Code Adapter — MCP stdio Memory Server
+
+> 中文版本见 [README_CN.md](./README_CN.md)。
+> Built on the [Adapter SDK](../../adapter-sdk/README.md) · Compared with other platforms in
+> [PLATFORM-COMPARISON.md](../../../docs/adapters/PLATFORM-COMPARISON.md)
+
+`TdaiMcpServer` exposes the TDAI memory engine to Claude Code (or any MCP client) as five tools
+over the MCP **stdio** transport. Hand-rolled protocol (initialize / ping / tools-list /
+tools-call subset of spec rev 2025-06-18) — zero new dependencies, matching the repo's
+zero-framework Gateway ethos.
+
+## Tools
+
+| Tool | Maps to | Purpose |
+| --- | --- | --- |
+| `memory_recall` | `MemoryClient.recall` | Load persona/scene/memory context for a query |
+| `memory_capture` | `MemoryClient.capture` | Save one user+assistant turn into memory |
+| `memory_search` | `MemoryClient.searchMemories` | Search L1 structured memories (type/scene filters) |
+| `conversation_search` | `MemoryClient.searchConversations` | Search raw L0 dialogue history |
+| `memory_session_end` | `MemoryClient.endSession` | Flush this session's pipeline buffers |
+
+All tools accept an optional `session_key` overriding the server default. `limit` is clamped to
+1..20 (default 5), identical to the OpenClaw tool registrations.
+
+## Setup
+
+### 1. Start the memory backend
+
+The default transport is `http` — run the Gateway first:
+
+```bash
+npm run gateway          # TdaiGateway on http://127.0.0.1:8420
+```
+
+(Or set `TDAI_ADAPTER_TRANSPORT=in-process` to embed the engine in the MCP server process —
+no gateway needed; the store lives under `TDAI_DATA_DIR`.)
+
+### 2. Register with Claude Code
+
+Project-scoped `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "node",
+      "args": ["--import", "tsx", "/absolute/path/to/repo/src/adapters/claude-code/main.ts"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420",
+        "TDAI_SESSION_KEY": "claude-code:my-project"
+      }
+    }
+  }
+}
+```
+
+CLI equivalent:
+
+```bash
+claude mcp add tdai-memory \
+  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 \
+  -- node --import tsx /absolute/path/to/repo/src/adapters/claude-code/main.ts
+```
+
+### 3. Verify
+
+Inside Claude Code run `/mcp` — `tdai-memory` should list 5 tools. Or smoke-test by hand:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | npm run -s adapter:claude-code
+```
+
+## Environment variables
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `TDAI_ADAPTER_TRANSPORT` | `http` \| `in-process` | `http` |
+| `TDAI_GATEWAY_URL` | gateway URL (http transport) | `http://127.0.0.1:8420` |
+| `TDAI_GATEWAY_API_KEY` | Bearer token if the gateway enforces auth | unset |
+| `TDAI_ADAPTER_TIMEOUT_MS` | per-request timeout toward the gateway | `10000` |
+| `TDAI_SESSION_KEY` | default memory session | `claude-code:<cwd basename>` |
+| `TDAI_USER_ID` | reserved — sent with recall/capture requests but currently ignored by the engine (single-user) | `default_user` |
+
+## Optional: hook-based auto-capture
+
+Tool-based capture depends on the model choosing to call `memory_capture`. To make capture
+automatic (OpenClaw-style), add a Claude Code **Stop hook** that posts the last exchange to the
+Gateway when a response finishes. In `~/.claude/settings.json` (or project
+`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.transcript_path' | xargs -I{} sh -c 'jq -rs '\''[.[] | select(.type==\"user\" or .type==\"assistant\")] | .[-2:] | {user_content: (map(select(.type==\"user\"))[-1].message.content // \"\" | if type==\"array\" then (map(select(.type==\"text\").text)|join(\" \")) else . end), assistant_content: (map(select(.type==\"assistant\"))[-1].message.content // \"\" | if type==\"array\" then (map(select(.type==\"text\").text)|join(\" \")) else . end), session_key: \"claude-code:hook\"}'\'' {} | curl -s -X POST \"$TDAI_GATEWAY_URL/capture\" -H \"Content-Type: application/json\" -d @-'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Honest limits of this recipe:** the Stop-hook payload and transcript JSONL schema are Claude
+Code implementation details that may evolve; text extraction above handles the common
+string/array content shapes but not every block type; and capture-on-Stop is best-effort (no
+retry/breaker like the Hermes provider). That is why this is documented as an *optional recipe*
+rather than shipped as code the adapter depends on — the supported write path is the
+`memory_capture` tool.
+
+## Design notes
+
+- **stderr-only logging.** stdout carries protocol lines exclusively; corrupting it is the
+  classic stdio-MCP failure mode. `main.ts` builds a stderr logger; the server never `console.log`s.
+- **Version negotiation** echoes any of `2025-06-18 / 2025-03-26 / 2024-11-05` and otherwise
+  answers with the newest supported revision.
+- **Tool errors vs protocol errors.** Engine/transport failures return `isError: true` results
+  (the model can see and react); only unknown tools/malformed requests produce JSON-RPC errors.
+- **`conversation_search` does not default `session_key`** — there it is a filter, and
+  defaulting it would silently hide other sessions' history.

--- a/src/adapters/claude-code/README_CN.md
+++ b/src/adapters/claude-code/README_CN.md
@@ -1,0 +1,122 @@
+# Claude Code 适配器 — MCP stdio 记忆服务器
+
+> English version: [README.md](./README.md)。
+> 构建于 [Adapter SDK](../../adapter-sdk/README_CN.md) · 与其他平台的对比见
+> [PLATFORM-COMPARISON_CN.md](../../../docs/adapters/PLATFORM-COMPARISON_CN.md)
+
+`TdaiMcpServer` 通过 MCP **stdio** 传输，把 TDAI 记忆引擎以五个工具的形式暴露给 Claude
+Code（或任何 MCP 客户端）。协议为手写实现（spec rev 2025-06-18 的 initialize / ping /
+tools-list / tools-call 子集）— 零新增依赖，延续本仓库 Gateway 的零框架风格。
+
+## 工具
+
+| 工具 | 映射到 | 用途 |
+| --- | --- | --- |
+| `memory_recall` | `MemoryClient.recall` | 按查询加载画像/场景/记忆上下文 |
+| `memory_capture` | `MemoryClient.capture` | 把一轮 user+assistant 对话存入记忆 |
+| `memory_search` | `MemoryClient.searchMemories` | 搜索 L1 结构化记忆（支持 type/scene 过滤） |
+| `conversation_search` | `MemoryClient.searchConversations` | 搜索 L0 原始对话历史 |
+| `memory_session_end` | `MemoryClient.endSession` | 冲刷本会话的流水线缓冲 |
+
+所有工具都接受可选 `session_key` 覆盖服务器默认值。`limit` 收敛到 1..20（默认 5），与
+OpenClaw 的工具注册完全一致。
+
+## 部署
+
+### 1. 启动记忆后端
+
+默认传输是 `http` — 先跑 Gateway：
+
+```bash
+npm run gateway          # TdaiGateway 监听 http://127.0.0.1:8420
+```
+
+（或设 `TDAI_ADAPTER_TRANSPORT=in-process` 把引擎内嵌进 MCP 服务器进程 — 无需 gateway；
+存储位于 `TDAI_DATA_DIR`。）
+
+### 2. 注册到 Claude Code
+
+项目级 `.mcp.json`：
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "node",
+      "args": ["--import", "tsx", "/absolute/path/to/repo/src/adapters/claude-code/main.ts"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420",
+        "TDAI_SESSION_KEY": "claude-code:my-project"
+      }
+    }
+  }
+}
+```
+
+CLI 等价写法：
+
+```bash
+claude mcp add tdai-memory \
+  --env TDAI_GATEWAY_URL=http://127.0.0.1:8420 \
+  -- node --import tsx /absolute/path/to/repo/src/adapters/claude-code/main.ts
+```
+
+### 3. 验证
+
+在 Claude Code 里执行 `/mcp` — `tdai-memory` 应列出 5 个工具。也可手工冒烟：
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | npm run -s adapter:claude-code
+```
+
+## 环境变量
+
+| 变量 | 含义 | 默认 |
+| --- | --- | --- |
+| `TDAI_ADAPTER_TRANSPORT` | `http` \| `in-process` | `http` |
+| `TDAI_GATEWAY_URL` | gateway 地址（http 传输） | `http://127.0.0.1:8420` |
+| `TDAI_GATEWAY_API_KEY` | gateway 开启鉴权时的 Bearer 令牌 | 未设 |
+| `TDAI_ADAPTER_TIMEOUT_MS` | 到 gateway 的单请求超时 | `10000` |
+| `TDAI_SESSION_KEY` | 默认记忆会话 | `claude-code:<目录名>` |
+| `TDAI_USER_ID` | 预留 — 随 recall/capture 请求发送，但当前引擎会忽略（单用户） | `default_user` |
+
+## 可选：基于钩子的自动捕获
+
+工具式捕获依赖模型主动调用 `memory_capture`。要实现（OpenClaw 式的）自动捕获，可给
+Claude Code 加一个 **Stop 钩子**，在每次响应结束时把最后一组对话 POST 给 Gateway。写在
+`~/.claude/settings.json`（或项目 `.claude/settings.json`）：
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.transcript_path' | xargs -I{} sh -c 'jq -rs '\''[.[] | select(.type==\"user\" or .type==\"assistant\")] | .[-2:] | {user_content: (map(select(.type==\"user\"))[-1].message.content // \"\" | if type==\"array\" then (map(select(.type==\"text\").text)|join(\" \")) else . end), assistant_content: (map(select(.type==\"assistant\"))[-1].message.content // \"\" | if type==\"array\" then (map(select(.type==\"text\").text)|join(\" \")) else . end), session_key: \"claude-code:hook\"}'\'' {} | curl -s -X POST \"$TDAI_GATEWAY_URL/capture\" -H \"Content-Type: application/json\" -d @-'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**这份配方的诚实边界：** Stop 钩子载荷与 transcript JSONL 格式属于 Claude Code 的实现细节，
+可能随版本演进；上面的文本提取覆盖了常见的字符串/数组 content 形态但并非所有块类型；
+Stop 时捕获是尽力而为（没有 Hermes Provider 那样的重试/熔断）。因此它以*可选配方*的形式写
+在文档里，而不是作为适配器依赖的代码交付 — 受支持的写路径是 `memory_capture` 工具。
+
+## 设计要点
+
+- **日志只走 stderr。** stdout 只承载协议行；污染 stdout 是 stdio-MCP 最经典的故障模式。
+  `main.ts` 构建 stderr 日志器；服务器本体绝不 `console.log`。
+- **版本协商**：`2025-06-18 / 2025-03-26 / 2024-11-05` 之内原样回显，否则回复最新支持版本。
+- **工具错误 vs 协议错误。** 引擎/传输失败返回 `isError: true` 结果（模型可见、可应对）；
+  只有未知工具/畸形请求才产生 JSON-RPC 错误。
+- **`conversation_search` 不默认填 `session_key`** — 在该工具里它是过滤器，默认填上会
+  悄悄屏蔽其他会话的历史。

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Claude Code adapter — barrel.
+ *
+ * MCP stdio server exposing TDAI memory tools to Claude Code (or any MCP
+ * client). Built entirely on the Adapter SDK — see ./README.md for setup.
+ */
+
+export { TdaiMcpServer, SUPPORTED_PROTOCOL_VERSIONS, SERVER_NAME } from "./mcp-server.js";
+export type { TdaiMcpServerOptions } from "./mcp-server.js";
+export { TOOL_DEFINITIONS, dispatchToolCall, clampLimit, UnknownToolError } from "./tools.js";
+export type { McpToolDefinition, ToolDispatchContext } from "./tools.js";
+export * from "./jsonrpc.js";

--- a/src/adapters/claude-code/jsonrpc.ts
+++ b/src/adapters/claude-code/jsonrpc.ts
@@ -1,0 +1,146 @@
+/**
+ * Claude Code adapter — newline-delimited JSON-RPC 2.0 framing.
+ *
+ * The MCP stdio transport (spec rev 2025-06-18) frames messages as single
+ * lines of UTF-8 JSON separated by `\n`. This module supplies the message
+ * types, error codes, and parse/serialize helpers; it deliberately implements
+ * ONLY what the MCP subset in `mcp-server.ts` needs — no batching (the 2025
+ * spec removed JSON-RPC batching), no HTTP framing.
+ *
+ * Hand-rolled instead of depending on `@modelcontextprotocol/sdk` to keep the
+ * repo's zero-framework ethos (the Gateway likewise uses raw `node:http`) and
+ * to avoid adding a dependency for ~100 lines of protocol.
+ */
+
+// ============================
+// Message types
+// ============================
+
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** A notification is a request without an `id` — it MUST NOT be answered. */
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcSuccessResponse {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result: unknown;
+}
+
+export interface JsonRpcErrorObject {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcErrorResponse {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  error: JsonRpcErrorObject;
+}
+
+export type JsonRpcResponse = JsonRpcSuccessResponse | JsonRpcErrorResponse;
+
+// ============================
+// Standard error codes (JSON-RPC 2.0 §5.1)
+// ============================
+
+export const PARSE_ERROR = -32700;
+export const INVALID_REQUEST = -32600;
+export const METHOD_NOT_FOUND = -32601;
+export const INVALID_PARAMS = -32602;
+export const INTERNAL_ERROR = -32603;
+
+// ============================
+// Helpers
+// ============================
+
+export function successResponse(id: JsonRpcId, result: unknown): JsonRpcSuccessResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+export function errorResponse(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcErrorResponse {
+  const error: JsonRpcErrorObject = { code, message };
+  if (data !== undefined) error.data = data;
+  return { jsonrpc: "2.0", id, error };
+}
+
+export type ParsedLine =
+  | { kind: "request"; request: JsonRpcRequest }
+  | { kind: "notification"; notification: JsonRpcNotification }
+  /** Malformed input — `response` is the error the server must emit (or null for none). */
+  | { kind: "invalid"; response: JsonRpcErrorResponse };
+
+/**
+ * Parse one wire line into a request / notification / invalid verdict.
+ *
+ * Rules implemented (matching JSON-RPC 2.0 + MCP stdio):
+ * - Unparseable JSON               → PARSE_ERROR with `id: null`.
+ * - JSON array (batch)             → INVALID_REQUEST (batching removed in MCP 2025-06-18).
+ * - Non-object / missing `method`  → INVALID_REQUEST (echo `id` when recoverable).
+ * - Object without `id`            → notification (never answered).
+ */
+export function parseLine(raw: string): ParsedLine {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return { kind: "invalid", response: errorResponse(null, PARSE_ERROR, "Parse error") };
+  }
+
+  if (Array.isArray(value)) {
+    return {
+      kind: "invalid",
+      response: errorResponse(null, INVALID_REQUEST, "Invalid Request: batch messages are not supported"),
+    };
+  }
+
+  if (value === null || typeof value !== "object") {
+    return { kind: "invalid", response: errorResponse(null, INVALID_REQUEST, "Invalid Request") };
+  }
+
+  const msg = value as Record<string, unknown>;
+  const id = extractId(msg);
+
+  if (typeof msg.method !== "string" || msg.method.length === 0) {
+    return { kind: "invalid", response: errorResponse(id, INVALID_REQUEST, "Invalid Request: missing method") };
+  }
+
+  const params =
+    msg.params && typeof msg.params === "object" && !Array.isArray(msg.params)
+      ? (msg.params as Record<string, unknown>)
+      : undefined;
+
+  if (!("id" in msg)) {
+    return {
+      kind: "notification",
+      notification: { jsonrpc: "2.0", method: msg.method, params },
+    };
+  }
+
+  return {
+    kind: "request",
+    request: { jsonrpc: "2.0", id, method: msg.method, params },
+  };
+}
+
+function extractId(msg: Record<string, unknown>): JsonRpcId {
+  const id = msg.id;
+  if (typeof id === "string" || typeof id === "number") return id;
+  return null;
+}
+
+export function serialize(response: JsonRpcResponse): string {
+  return JSON.stringify(response);
+}

--- a/src/adapters/claude-code/main.ts
+++ b/src/adapters/claude-code/main.ts
@@ -1,0 +1,111 @@
+/**
+ * Claude Code adapter — CLI entry point.
+ *
+ * Usage:
+ *   node --import tsx src/adapters/claude-code/main.ts
+ *
+ * Environment:
+ *   TDAI_ADAPTER_TRANSPORT   "http" (default — needs a running Gateway) | "in-process"
+ *   TDAI_GATEWAY_URL         Gateway base URL (default http://127.0.0.1:8420)
+ *   TDAI_GATEWAY_API_KEY     Bearer token when the Gateway enforces auth
+ *   TDAI_ADAPTER_TIMEOUT_MS  HTTP timeout (default 10000)
+ *   TDAI_SESSION_KEY         default session key (default "claude-code:<cwd basename>")
+ *   TDAI_USER_ID             reserved user id — sent with requests, currently
+ *                            ignored by the engine (default "default_user")
+ *
+ * stdio contract: stdout carries ONLY MCP protocol lines; every log line goes
+ * to stderr. Breaking this corrupts the client's JSON stream — the classic
+ * stdio-MCP failure mode.
+ */
+
+import path from "node:path";
+import { createRequire } from "node:module";
+import { createMemoryClient, resolveClientOptionsFromEnv } from "../../adapter-sdk/index.js";
+import type { Logger } from "../../core/types.js";
+import { getEnv } from "../../utils/env.js";
+import { isMainModule } from "../../utils/is-main.js";
+import { TdaiMcpServer } from "./mcp-server.js";
+
+const TAG = "[tdai-adapter] [mcp-main]";
+
+/**
+ * All log levels go to stderr — stdout is reserved for the protocol.
+ * No prefix of its own: messages from the SDK / server already carry a
+ * `[tdai-adapter] [...]` tag.
+ */
+function createStderrLogger(): Logger {
+  const write = (level: string, msg: string) => {
+    process.stderr.write(`[${level}] ${msg}\n`);
+  };
+  return {
+    debug: (msg: string) => write("debug", msg),
+    info: (msg: string) => write("info", msg),
+    warn: (msg: string) => write("warn", msg),
+    error: (msg: string) => write("error", msg),
+  };
+}
+
+function readPackageVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../../../package.json") as { version?: string };
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+async function main(): Promise<void> {
+  const logger = createStderrLogger();
+
+  const clientOptions = resolveClientOptionsFromEnv(logger);
+  clientOptions.logger = logger;
+  const client = createMemoryClient(clientOptions);
+
+  const sessionKey =
+    getEnv("TDAI_SESSION_KEY")?.trim() || `claude-code:${path.basename(process.cwd())}`;
+  const userId = getEnv("TDAI_USER_ID")?.trim() || "default_user";
+
+  const server = new TdaiMcpServer({
+    client,
+    sessionKey,
+    userId,
+    logger,
+    serverVersion: readPackageVersion(),
+  });
+
+  // Graceful shutdown — mirror the Gateway's main() shape.
+  let stopping = false;
+  const shutdown = async (reason: string) => {
+    if (stopping) return;
+    stopping = true;
+    logger.info(`${TAG} Shutting down (${reason})...`);
+    try {
+      await server.stop();
+    } catch (err) {
+      logger.warn(`${TAG} Shutdown error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+  logger.info(
+    `${TAG} Starting MCP stdio server: transport=${clientOptions.transport}, session_key=${sessionKey}`,
+  );
+
+  // Resolves when stdin closes (client disconnected) — then exit cleanly.
+  await server.start();
+  await shutdown("stdin closed");
+}
+
+// Auto-start when run directly. Unlike gateway/server.ts (whose "server.ts"
+// suffix contains no separator), these suffixes contain a "/" — isMainModule
+// normalizes Windows backslash argv[1] paths so the match works there too.
+const isMain = isMainModule(process.argv[1], ["claude-code/main.ts", "claude-code/main.js"]);
+if (isMain) {
+  main().catch((err) => {
+    process.stderr.write(`${TAG} [fatal] MCP server startup failed: ${String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/adapters/claude-code/mcp-server.test.ts
+++ b/src/adapters/claude-code/mcp-server.test.ts
@@ -1,0 +1,421 @@
+/**
+ * TdaiMcpServer protocol tests (offline, fake MemoryClient).
+ *
+ * Exercises the wire behaviour line-by-line through the public
+ * `handleMessage()` seam: handshake, tool listing, tool calls, and every
+ * JSON-RPC failure mode the MCP stdio transport defines.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { TdaiMcpServer, SUPPORTED_PROTOCOL_VERSIONS, SERVER_NAME } from "./mcp-server.js";
+import { TOOL_DEFINITIONS } from "./tools.js";
+import type { MemoryClient } from "../../adapter-sdk/index.js";
+
+// ============================
+// Helpers
+// ============================
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+function createFakeClient(overrides: Partial<MemoryClient> = {}): MemoryClient {
+  return {
+    recall: vi.fn(async () => ({
+      context: "system context",
+      prependContext: "relevant memories",
+      strategy: "hybrid",
+      memoryCount: 2,
+    })),
+    capture: vi.fn(async () => ({ l0Recorded: 2, schedulerNotified: true })),
+    searchMemories: vi.fn(async () => ({
+      text: "Found 1 matching memories:", total: 1, strategy: "hybrid", items: [],
+    })),
+    searchConversations: vi.fn(async () => ({
+      text: "Found 1 matching message(s):", total: 1, items: [],
+    })),
+    endSession: vi.fn(async () => {}),
+    health: vi.fn(async () => ({ status: "ok" as const, vectorStore: true, embeddingService: true })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function createServer(client: MemoryClient = createFakeClient()): TdaiMcpServer {
+  return new TdaiMcpServer({
+    client,
+    sessionKey: "claude-code:test",
+    userId: "u-test",
+    logger: silentLogger,
+    serverVersion: "9.9.9",
+  });
+}
+
+async function roundTrip(server: TdaiMcpServer, message: unknown): Promise<any> {
+  const raw = typeof message === "string" ? message : JSON.stringify(message);
+  const response = await server.handleMessage(raw);
+  return response === undefined ? undefined : JSON.parse(response);
+}
+
+function request(id: number, method: string, params?: Record<string, unknown>) {
+  return { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+}
+
+function toolCall(id: number, name: string, args?: Record<string, unknown>) {
+  return request(id, "tools/call", { name, arguments: args ?? {} });
+}
+
+// ============================
+// Handshake
+// ============================
+
+describe("TdaiMcpServer — handshake", () => {
+  it("initialize echoes a supported protocolVersion and reports serverInfo + tools capability", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, request(1, "initialize", {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "claude-code", version: "1.0.0" },
+    }));
+
+    expect(res.jsonrpc).toBe("2.0");
+    expect(res.id).toBe(1);
+    expect(res.result.protocolVersion).toBe("2025-03-26");
+    expect(res.result.capabilities).toEqual({ tools: { listChanged: false } });
+    expect(res.result.serverInfo).toEqual({ name: SERVER_NAME, version: "9.9.9" });
+  });
+
+  it("initialize downgrades an unknown protocolVersion to the latest supported", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, request(2, "initialize", { protocolVersion: "2099-01-01" }));
+
+    expect(res.result.protocolVersion).toBe(SUPPORTED_PROTOCOL_VERSIONS[0]);
+  });
+
+  it("notifications/initialized is consumed silently (no response)", async () => {
+    const server = createServer();
+
+    const res = await server.handleMessage(
+      JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    );
+
+    expect(res).toBeUndefined();
+  });
+
+  it("ping returns an empty result", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, request(3, "ping"));
+
+    expect(res.result).toEqual({});
+  });
+});
+
+// ============================
+// tools/list
+// ============================
+
+describe("TdaiMcpServer — tools/list", () => {
+  it("returns all 5 memory tools with object schemas and required fields", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, request(4, "tools/list"));
+
+    const tools = res.result.tools as typeof TOOL_DEFINITIONS;
+    expect(tools.map((t) => t.name)).toEqual([
+      "memory_recall",
+      "memory_capture",
+      "memory_search",
+      "conversation_search",
+      "memory_session_end",
+    ]);
+    for (const tool of tools) {
+      expect(tool.description.length).toBeGreaterThan(20);
+      expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.properties).toBeTypeOf("object");
+    }
+    expect(tools[0].inputSchema.required).toEqual(["query"]);
+    expect(tools[1].inputSchema.required).toEqual(["user_content", "assistant_content"]);
+  });
+});
+
+// ============================
+// tools/call — happy paths
+// ============================
+
+describe("TdaiMcpServer — tools/call", () => {
+  it("memory_recall maps args, applies the default session key, and joins contexts", async () => {
+    const client = createFakeClient();
+    const server = createServer(client);
+
+    const res = await roundTrip(server, toolCall(5, "memory_recall", { query: "what do I like" }));
+
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "what do I like",
+      sessionKey: "claude-code:test",
+      userId: "u-test",
+    });
+    expect(res.result.isError).toBeUndefined();
+    expect(res.result.content).toEqual([
+      { type: "text", text: "relevant memories\n\nsystem context" },
+    ]);
+  });
+
+  it("memory_recall reports 'No relevant memories found.' when recall is empty", async () => {
+    const client = createFakeClient({
+      recall: vi.fn(async () => ({ context: "", memoryCount: 0 })),
+    });
+    const server = createServer(client);
+
+    const res = await roundTrip(server, toolCall(6, "memory_recall", { query: "anything" }));
+
+    expect(res.result.content[0].text).toBe("No relevant memories found.");
+  });
+
+  it("memory_capture maps snake_case args and honours a session_key override", async () => {
+    const client = createFakeClient();
+    const server = createServer(client);
+
+    const res = await roundTrip(server, toolCall(7, "memory_capture", {
+      user_content: "I prefer green tea",
+      assistant_content: "Noted!",
+      session_key: "override-session",
+    }));
+
+    expect(client.capture).toHaveBeenCalledWith({
+      userContent: "I prefer green tea",
+      assistantContent: "Noted!",
+      sessionKey: "override-session",
+      userId: "u-test",
+    });
+    expect(res.result.content[0].text).toBe("Captured: l0_recorded=2, scheduler_notified=true");
+  });
+
+  it("memory_search forwards query/limit/type/scene and returns the text payload", async () => {
+    const client = createFakeClient();
+    const server = createServer(client);
+
+    const res = await roundTrip(server, toolCall(8, "memory_search", {
+      query: "tea", limit: 7, type: "persona", scene: "daily",
+    }));
+
+    expect(client.searchMemories).toHaveBeenCalledWith({
+      query: "tea", limit: 7, type: "persona", scene: "daily",
+    });
+    expect(res.result.content[0].text).toBe("Found 1 matching memories:");
+  });
+
+  it("conversation_search does NOT default session_key (it is a filter, not a scope)", async () => {
+    const client = createFakeClient();
+    const server = createServer(client);
+
+    await roundTrip(server, toolCall(9, "conversation_search", { query: "past chat" }));
+
+    expect(client.searchConversations).toHaveBeenCalledWith({
+      query: "past chat", limit: 5, sessionKey: undefined,
+    });
+  });
+
+  it("memory_session_end flushes the default session (or an override)", async () => {
+    const client = createFakeClient();
+    const server = createServer(client);
+
+    const res = await roundTrip(server, toolCall(10, "memory_session_end", {}));
+    expect(client.endSession).toHaveBeenCalledWith("claude-code:test");
+    expect(res.result.content[0].text).toBe("Session flushed: claude-code:test");
+
+    await roundTrip(server, toolCall(11, "memory_session_end", { session_key: "other" }));
+    expect(client.endSession).toHaveBeenLastCalledWith("other");
+  });
+
+  it("tool failures are reported as isError:true results, not JSON-RPC errors", async () => {
+    const client = createFakeClient({
+      searchMemories: vi.fn(async () => {
+        throw new Error("gateway unreachable");
+      }),
+    });
+    const server = createServer(client);
+
+    const res = await roundTrip(server, toolCall(12, "memory_search", { query: "q" }));
+
+    expect(res.error).toBeUndefined();
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toContain("gateway unreachable");
+  });
+
+  it("unknown tool name → JSON-RPC -32602 (protocol error per MCP spec)", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, toolCall(13, "made_up_tool", {}));
+
+    expect(res.result).toBeUndefined();
+    expect(res.error.code).toBe(-32602);
+    expect(res.error.message).toContain("made_up_tool");
+  });
+
+  it("missing tool name → -32602", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, request(14, "tools/call", { arguments: {} }));
+
+    expect(res.error.code).toBe(-32602);
+  });
+});
+
+// ============================
+// Wire-level failure modes
+// ============================
+
+describe("TdaiMcpServer — malformed input", () => {
+  it("unknown method → -32601", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, request(15, "resources/list"));
+
+    expect(res.error.code).toBe(-32601);
+  });
+
+  it("unparseable JSON → -32700 with id null", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, "this is { not json");
+
+    expect(res.error.code).toBe(-32700);
+    expect(res.id).toBeNull();
+  });
+
+  it("JSON array (batch) → -32600", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, [request(16, "ping")]);
+
+    expect(res.error.code).toBe(-32600);
+  });
+
+  it("object without method → -32600", async () => {
+    const server = createServer();
+
+    const res = await roundTrip(server, { jsonrpc: "2.0", id: 17 });
+
+    expect(res.error.code).toBe(-32600);
+    expect(res.id).toBe(17);
+  });
+
+  it("blank lines and unrelated notifications produce no response", async () => {
+    const server = createServer();
+
+    expect(await server.handleMessage("")).toBeUndefined();
+    expect(await server.handleMessage("   ")).toBeUndefined();
+    expect(
+      await server.handleMessage(JSON.stringify({ jsonrpc: "2.0", method: "notifications/cancelled" })),
+    ).toBeUndefined();
+  });
+});
+
+// ============================
+// Stream lifecycle
+// ============================
+
+describe("TdaiMcpServer — stream wiring", () => {
+  it("serves a full handshake + tool call over injected streams and closes cleanly", async () => {
+    const { PassThrough } = await import("node:stream");
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const chunks: string[] = [];
+    output.on("data", (c: Buffer) => chunks.push(c.toString("utf-8")));
+
+    const client = createFakeClient();
+    const server = new TdaiMcpServer({
+      client,
+      sessionKey: "claude-code:stream",
+      input,
+      output,
+      logger: silentLogger,
+      serverVersion: "1.0.0",
+    });
+
+    const running = server.start();
+
+    input.write(JSON.stringify(request(1, "initialize", { protocolVersion: "2025-06-18" })) + "\n");
+    input.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+    input.write(JSON.stringify(request(2, "tools/list")) + "\n");
+    input.write(JSON.stringify(toolCall(3, "memory_recall", { query: "hi" })) + "\n");
+    input.end();
+
+    await running;
+    await server.stop();
+
+    const lines = chunks.join("").trim().split("\n").map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(3); // notification produced no output
+    expect(lines[0].id).toBe(1);
+    expect(lines[0].result.protocolVersion).toBe("2025-06-18");
+    expect(lines[1].id).toBe(2);
+    expect(lines[1].result.tools).toHaveLength(5);
+    expect(lines[2].id).toBe(3);
+    expect(lines[2].result.content[0].type).toBe("text");
+    expect(client.close).toHaveBeenCalled(); // stop() released the client
+  });
+
+  it("one failing write does not poison the serialized write chain", async () => {
+    const { PassThrough } = await import("node:stream");
+    const input = new PassThrough();
+    const written: string[] = [];
+    let failNext = true;
+    // Output whose first write throws (EPIPE-style) and then recovers.
+    const output = {
+      write(chunk: string): boolean {
+        if (failNext) {
+          failNext = false;
+          throw new Error("EPIPE: broken pipe");
+        }
+        written.push(String(chunk));
+        return true;
+      },
+    } as unknown as NodeJS.WritableStream;
+
+    const server = new TdaiMcpServer({
+      client: createFakeClient(),
+      sessionKey: "claude-code:chain",
+      input,
+      output,
+      logger: silentLogger,
+    });
+
+    const running = server.start();
+    input.write(JSON.stringify(request(1, "ping")) + "\n"); // write throws
+    input.write(JSON.stringify(request(2, "ping")) + "\n"); // must still be served
+    input.end();
+    await running;
+    await server.stop();
+
+    const lines = written.join("").trim().split("\n").map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(1); // first response was lost to the throw...
+    expect(lines[0].id).toBe(2); // ...but the chain kept going.
+  });
+});
+
+// ============================
+// Logging discipline (stdio transport)
+// ============================
+
+describe("TdaiMcpServer — default logger", () => {
+  it("falls back to a stderr-only logger (never console.* / stdout)", async () => {
+    const consoleSpies = (["debug", "info", "warn", "error", "log"] as const).map((m) =>
+      vi.spyOn(console, m).mockImplementation(() => {}),
+    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const server = new TdaiMcpServer({
+      client: createFakeClient(),
+      sessionKey: "claude-code:no-logger",
+      // no logger injected — must NOT inherit the Base's console default
+    });
+    // Triggers logger.debug on the default logger.
+    await server.handleMessage(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }));
+
+    for (const spy of consoleSpies) expect(spy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(String(stderrSpy.mock.calls[0][0])).toContain("notifications/initialized");
+  });
+});

--- a/src/adapters/claude-code/mcp-server.ts
+++ b/src/adapters/claude-code/mcp-server.ts
@@ -1,0 +1,273 @@
+/**
+ * Claude Code adapter — MCP stdio server (`TdaiMcpServer`).
+ *
+ * Implements the Model Context Protocol subset Claude Code needs to consume
+ * memory tools over the stdio transport (spec rev 2025-06-18):
+ *
+ *   initialize                → capability + version negotiation
+ *   notifications/initialized → acknowledged silently
+ *   ping                      → {}
+ *   tools/list                → the 5 memory tools (tools.ts)
+ *   tools/call                → dispatch onto MemoryClient
+ *
+ * Built on the Adapter SDK: extends `BasePlatformAdapter`, consumes ONLY the
+ * `MemoryClient` interface — the same server binary works against a remote
+ * Gateway (http transport) or an embedded TdaiCore (in-process transport).
+ *
+ * stdio discipline: protocol messages are the ONLY bytes on stdout; all
+ * logging must go to stderr (see main.ts) or the client's JSON parser breaks.
+ * The server itself never calls console.* — it logs through the injected
+ * Logger only, and when no logger is injected it defaults to a stderr-only
+ * one (never BasePlatformAdapter's stdout console default).
+ */
+
+import { createInterface, type Interface } from "node:readline";
+import { BasePlatformAdapter } from "../../adapter-sdk/base-platform-adapter.js";
+import type { MemoryClient } from "../../adapter-sdk/types.js";
+import type { Logger } from "../../core/types.js";
+import {
+  parseLine,
+  serialize,
+  successResponse,
+  errorResponse,
+  METHOD_NOT_FOUND,
+  INVALID_PARAMS,
+  INTERNAL_ERROR,
+  type JsonRpcRequest,
+} from "./jsonrpc.js";
+import { TOOL_DEFINITIONS, dispatchToolCall, UnknownToolError } from "./tools.js";
+
+const TAG = "[tdai-adapter] [mcp]";
+
+/** Protocol revisions this server can speak, newest first. */
+export const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", "2024-11-05"];
+const LATEST_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+export const SERVER_NAME = "tdai-memory";
+
+/**
+ * Fallback logger when the host injects none: stderr only, because on the
+ * stdio transport any stray stdout byte corrupts the protocol stream —
+ * BasePlatformAdapter's console default would write debug/info to stdout.
+ */
+function defaultStderrLogger(): Logger {
+  const write = (level: string, msg: string) => {
+    process.stderr.write(`[${level}] ${msg}\n`);
+  };
+  return {
+    debug: (msg: string) => write("debug", msg),
+    info: (msg: string) => write("info", msg),
+    warn: (msg: string) => write("warn", msg),
+    error: (msg: string) => write("error", msg),
+  };
+}
+
+// ============================
+// Options
+// ============================
+
+export interface TdaiMcpServerOptions {
+  client: MemoryClient;
+  /** Default session key applied when a tool call omits `session_key`. */
+  sessionKey: string;
+  userId?: string;
+  /** Message source. Default: `process.stdin`. */
+  input?: NodeJS.ReadableStream;
+  /** Response sink. Default: `process.stdout`. */
+  output?: NodeJS.WritableStream;
+  logger?: Logger;
+  /** Reported in `serverInfo.version`. */
+  serverVersion?: string;
+}
+
+// ============================
+// TdaiMcpServer
+// ============================
+
+export class TdaiMcpServer extends BasePlatformAdapter {
+  readonly platformName = "claude-code";
+
+  private readonly sessionKey: string;
+  private readonly userId?: string;
+  private readonly input: NodeJS.ReadableStream;
+  private readonly output: NodeJS.WritableStream;
+  private readonly serverVersion: string;
+  private rl?: Interface;
+  /** Resolves when the input stream closes (start() awaits it). */
+  private done?: Promise<void>;
+
+  constructor(opts: TdaiMcpServerOptions) {
+    super({ client: opts.client, logger: opts.logger ?? defaultStderrLogger() });
+    this.sessionKey = opts.sessionKey;
+    this.userId = opts.userId;
+    this.input = opts.input ?? process.stdin;
+    this.output = opts.output ?? process.stdout;
+    this.serverVersion = opts.serverVersion ?? "0.0.0";
+  }
+
+  /**
+   * Begin serving: read newline-delimited JSON-RPC from `input`, write
+   * responses to `output`. Resolves when the input stream ends.
+   */
+  start(): Promise<void> {
+    if (this.done) return this.done;
+
+    this.rl = createInterface({ input: this.input, crlfDelay: Infinity });
+    this.logger.info(`${TAG} MCP server started (session_key=${this.sessionKey})`);
+
+    // Serialize response writes: each line is fully handled (possibly async
+    // tool work) before the next response is written, preserving order.
+    let writeChain: Promise<void> = Promise.resolve();
+
+    this.done = new Promise<void>((resolve) => {
+      this.rl!.on("line", (line: string) => {
+        writeChain = writeChain.then(async () => {
+          // Absorb failures inside the link: a rejected link would poison the
+          // chain — every later write would chain onto a rejected promise and
+          // never run, killing the transport for good.
+          try {
+            const response = await this.handleMessage(line);
+            if (response !== undefined) {
+              this.output.write(response + "\n");
+            }
+          } catch (err) {
+            this.logger.error(
+              `${TAG} response write failed (line dropped): ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        });
+      });
+      this.rl!.on("close", () => {
+        // Flush in-flight work before declaring the server done.
+        void writeChain.then(() => {
+          this.logger.info(`${TAG} Input stream closed — MCP server stopping`);
+          resolve();
+        });
+      });
+    });
+
+    return this.done;
+  }
+
+  /** Stop reading and release the memory client. Idempotent. */
+  async stop(): Promise<void> {
+    this.rl?.close();
+    this.rl = undefined;
+    await super.stop(); // closes this.client
+  }
+
+  // ============================
+  // Message handling (public for tests)
+  // ============================
+
+  /**
+   * Process one raw wire line. Returns the serialized response line, or
+   * `undefined` when no response must be sent (notifications).
+   */
+  async handleMessage(raw: string): Promise<string | undefined> {
+    const trimmed = raw.trim();
+    if (!trimmed) return undefined;
+
+    const parsed = parseLine(trimmed);
+
+    if (parsed.kind === "invalid") {
+      return serialize(parsed.response);
+    }
+
+    if (parsed.kind === "notification") {
+      // `notifications/initialized`, `notifications/cancelled`, … — per
+      // JSON-RPC a notification never receives a response of any kind.
+      this.logger.debug?.(`${TAG} notification: ${parsed.notification.method}`);
+      return undefined;
+    }
+
+    const request = parsed.request;
+    try {
+      switch (request.method) {
+        case "initialize":
+          return serialize(successResponse(request.id, this.handleInitialize(request)));
+        case "ping":
+          return serialize(successResponse(request.id, {}));
+        case "tools/list":
+          // Pagination cursor ignored — the full list always fits one page.
+          return serialize(successResponse(request.id, { tools: TOOL_DEFINITIONS }));
+        case "tools/call":
+          return serialize(await this.handleToolsCall(request));
+        default:
+          return serialize(
+            errorResponse(request.id, METHOD_NOT_FOUND, `Method not found: ${request.method}`),
+          );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`${TAG} Internal error handling ${request.method}: ${msg}`);
+      return serialize(errorResponse(request.id, INTERNAL_ERROR, `Internal error: ${msg}`));
+    }
+  }
+
+  // ============================
+  // Request handlers
+  // ============================
+
+  private handleInitialize(request: JsonRpcRequest): unknown {
+    const requested = request.params?.protocolVersion;
+    // Version negotiation per spec: echo the client's version when we support
+    // it; otherwise answer with the latest version we do support.
+    const protocolVersion =
+      typeof requested === "string" && SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+        ? requested
+        : LATEST_PROTOCOL_VERSION;
+
+    this.logger.debug?.(
+      `${TAG} initialize: client requested ${String(requested)} → negotiating ${protocolVersion}`,
+    );
+
+    return {
+      protocolVersion,
+      capabilities: {
+        tools: { listChanged: false },
+      },
+      serverInfo: {
+        name: SERVER_NAME,
+        version: this.serverVersion,
+      },
+    };
+  }
+
+  private async handleToolsCall(request: JsonRpcRequest) {
+    const name = request.params?.name;
+    if (typeof name !== "string" || !name) {
+      return errorResponse(request.id, INVALID_PARAMS, "Invalid params: missing tool name");
+    }
+    const rawArgs = request.params?.arguments;
+    const args =
+      rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)
+        ? (rawArgs as Record<string, unknown>)
+        : {};
+
+    try {
+      const text = await dispatchToolCall(name, args, {
+        client: this.client,
+        defaultSessionKey: this.sessionKey,
+        userId: this.userId,
+      });
+      return successResponse(request.id, {
+        content: [{ type: "text", text }],
+      });
+    } catch (err) {
+      if (err instanceof UnknownToolError) {
+        // Protocol-level error per MCP spec: unknown tool → -32602.
+        return errorResponse(request.id, INVALID_PARAMS, err.message);
+      }
+      // Tool-level failure: report inside the result with isError so the
+      // model can see and react to it (NOT a JSON-RPC error, per spec).
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`${TAG} tool ${name} failed: ${msg}`);
+      return successResponse(request.id, {
+        content: [{ type: "text", text: `Tool ${name} failed: ${msg}` }],
+        isError: true,
+      });
+    }
+  }
+}

--- a/src/adapters/claude-code/tools.test.ts
+++ b/src/adapters/claude-code/tools.test.ts
@@ -1,0 +1,135 @@
+/**
+ * MCP tool dispatch unit tests (offline, fake MemoryClient).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { clampLimit, dispatchToolCall, UnknownToolError, TOOL_DEFINITIONS } from "./tools.js";
+import type { ToolDispatchContext } from "./tools.js";
+import type { MemoryClient } from "../../adapter-sdk/index.js";
+
+function createFakeClient(overrides: Partial<MemoryClient> = {}): MemoryClient {
+  return {
+    recall: vi.fn(async () => ({ context: "", memoryCount: 0 })),
+    capture: vi.fn(async () => ({ l0Recorded: 1, schedulerNotified: false })),
+    searchMemories: vi.fn(async () => ({ text: "mem", total: 0, strategy: "none", items: [] })),
+    searchConversations: vi.fn(async () => ({ text: "conv", total: 0, items: [] })),
+    endSession: vi.fn(async () => {}),
+    health: vi.fn(async () => ({ status: "ok" as const, vectorStore: true, embeddingService: true })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function ctx(client: MemoryClient): ToolDispatchContext {
+  return { client, defaultSessionKey: "default-session", userId: "u1" };
+}
+
+describe("clampLimit", () => {
+  it("clamps to 1..20 with default 5 — identical to root index.ts tools", () => {
+    expect(clampLimit(undefined)).toBe(5);
+    expect(clampLimit(null)).toBe(5);
+    expect(clampLimit("not-a-number")).toBe(5);
+    expect(clampLimit(0)).toBe(5); // 0 is falsy → default, matching index.ts `|| 5`
+    expect(clampLimit(-3)).toBe(1);
+    expect(clampLimit(1)).toBe(1);
+    expect(clampLimit(7)).toBe(7);
+    expect(clampLimit(20)).toBe(20);
+    expect(clampLimit(999)).toBe(20);
+    expect(clampLimit("12")).toBe(12);
+  });
+});
+
+describe("dispatchToolCall — session key defaulting", () => {
+  it("memory_recall uses the default session key when none is given", async () => {
+    const client = createFakeClient();
+
+    await dispatchToolCall("memory_recall", { query: "q" }, ctx(client));
+
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "q", sessionKey: "default-session", userId: "u1",
+    });
+  });
+
+  it("session_key argument overrides the default", async () => {
+    const client = createFakeClient();
+
+    await dispatchToolCall("memory_recall", { query: "q", session_key: "s-override" }, ctx(client));
+
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "q", sessionKey: "s-override", userId: "u1",
+    });
+  });
+
+  it("a blank session_key argument falls back to the default", async () => {
+    const client = createFakeClient();
+
+    await dispatchToolCall("memory_session_end", { session_key: "   " }, ctx(client));
+
+    expect(client.endSession).toHaveBeenCalledWith("default-session");
+  });
+});
+
+describe("dispatchToolCall — argument mapping", () => {
+  it("memory_search clamps limit and drops blank filters", async () => {
+    const client = createFakeClient();
+
+    await dispatchToolCall(
+      "memory_search",
+      { query: "q", limit: 999, type: "", scene: "  " },
+      ctx(client),
+    );
+
+    expect(client.searchMemories).toHaveBeenCalledWith({
+      query: "q", limit: 20, type: undefined, scene: undefined,
+    });
+  });
+
+  it("conversation_search passes session_key as a filter only (no default)", async () => {
+    const client = createFakeClient();
+
+    await dispatchToolCall("conversation_search", { query: "q" }, ctx(client));
+    expect(client.searchConversations).toHaveBeenCalledWith({
+      query: "q", limit: 5, sessionKey: undefined,
+    });
+
+    await dispatchToolCall("conversation_search", { query: "q", session_key: "s9" }, ctx(client));
+    expect(client.searchConversations).toHaveBeenLastCalledWith({
+      query: "q", limit: 5, sessionKey: "s9",
+    });
+  });
+
+  it("memory_capture formats the outcome summary", async () => {
+    const client = createFakeClient();
+
+    const text = await dispatchToolCall(
+      "memory_capture",
+      { user_content: "u", assistant_content: "a" },
+      ctx(client),
+    );
+
+    expect(text).toBe("Captured: l0_recorded=1, scheduler_notified=false");
+  });
+
+  it("throws UnknownToolError for unregistered names", async () => {
+    await expect(dispatchToolCall("nope", {}, ctx(createFakeClient()))).rejects.toBeInstanceOf(
+      UnknownToolError,
+    );
+  });
+});
+
+describe("TOOL_DEFINITIONS", () => {
+  it("every schema property referenced in required exists", () => {
+    for (const tool of TOOL_DEFINITIONS) {
+      for (const req of tool.inputSchema.required ?? []) {
+        expect(tool.inputSchema.properties, `${tool.name}.${req}`).toHaveProperty(req);
+      }
+    }
+  });
+
+  it("memory_search type filter enumerates the three memory types", () => {
+    const memorySearch = TOOL_DEFINITIONS.find((t) => t.name === "memory_search")!;
+    const typeProp = memorySearch.inputSchema.properties.type as { enum: string[] };
+    expect(typeProp.enum).toEqual(["persona", "episodic", "instruction"]);
+  });
+});

--- a/src/adapters/claude-code/tools.ts
+++ b/src/adapters/claude-code/tools.ts
@@ -1,0 +1,247 @@
+/**
+ * Claude Code adapter — MCP tool definitions + dispatch onto `MemoryClient`.
+ *
+ * Five tools cover the full TdaiCore capability surface:
+ *
+ *   memory_recall       → client.recall              (context prefetch)
+ *   memory_capture      → client.capture             (explicit turn write)
+ *   memory_search       → client.searchMemories      (L1 structured memories)
+ *   conversation_search → client.searchConversations (L0 raw history)
+ *   memory_session_end  → client.endSession          (flush one session)
+ *
+ * Argument names are snake_case, matching the Gateway wire vocabulary
+ * (`session_key`, `user_content`, …) so operators see one consistent naming
+ * scheme across HTTP, Python, and MCP surfaces. Model-facing descriptions for
+ * the two search tools reuse the wording of the OpenClaw registrations in
+ * root `index.ts` so model guidance stays consistent across platforms.
+ */
+
+import type { MemoryClient } from "../../adapter-sdk/index.js";
+
+// ============================
+// Tool definitions (MCP `tools/list` payload)
+// ============================
+
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+const SESSION_KEY_PROPERTY = {
+  type: "string",
+  description: "Optional: override the server's default session key",
+} as const;
+
+export const TOOL_DEFINITIONS: McpToolDefinition[] = [
+  {
+    name: "memory_recall",
+    description:
+      "Retrieve the user's memory context relevant to a query — persona profile, scene navigation, " +
+      "and the most relevant long-term memories. Use this at the start of a task to load what is " +
+      "already known about the user before answering.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The user's current question or topic to recall memory context for",
+        },
+        session_key: SESSION_KEY_PROPERTY,
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "memory_capture",
+    description:
+      "Save one completed conversation turn (user message + assistant reply) into long-term memory. " +
+      "Call this after an exchange worth remembering — preferences the user stated, decisions made, " +
+      "facts learned. The memory engine will archive the raw turn and asynchronously extract " +
+      "structured memories from it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        user_content: {
+          type: "string",
+          description: "The user's message text for the turn",
+        },
+        assistant_content: {
+          type: "string",
+          description: "The assistant's reply text for the turn",
+        },
+        session_key: SESSION_KEY_PROPERTY,
+      },
+      required: ["user_content", "assistant_content"],
+    },
+  },
+  {
+    name: "memory_search",
+    description:
+      "Search through the user's long-term memories. Use this when you need to recall specific " +
+      "information about the user's preferences, past events, instructions, or context from previous " +
+      "conversations. Returns relevant memory records ranked by relevance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query describing what you want to recall about the user",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 5, max: 20)",
+        },
+        type: {
+          type: "string",
+          enum: ["persona", "episodic", "instruction"],
+          description:
+            "Optional filter by memory type: persona (identity/preferences), episodic (events/activities), " +
+            "instruction (user rules/commands)",
+        },
+        scene: {
+          type: "string",
+          description: "Optional filter by scene name",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "conversation_search",
+    description:
+      "Search through past conversation history (raw dialogue records). Use this when memory_search " +
+      "(structured memories) doesn't have the information you need, or when you want to find specific " +
+      "past conversations, dialogue context, or exact words the user said before. Returns relevant " +
+      "individual messages ranked by relevance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query describing what conversation content you want to find",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of messages to return (default: 5, max: 20)",
+        },
+        session_key: {
+          type: "string",
+          description: "Optional: filter results to a specific session",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "memory_session_end",
+    description:
+      "Flush this session's buffered memory work (finalize pending extraction for the session). " +
+      "Call when a work session is wrapping up. Other sessions are unaffected.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        session_key: SESSION_KEY_PROPERTY,
+      },
+    },
+  },
+];
+
+// ============================
+// Dispatch
+// ============================
+
+export interface ToolDispatchContext {
+  client: MemoryClient;
+  /** Session key used when a tool call does not override it. */
+  defaultSessionKey: string;
+  userId?: string;
+}
+
+export class UnknownToolError extends Error {
+  constructor(name: string) {
+    super(`Unknown tool: ${name}`);
+    this.name = "UnknownToolError";
+  }
+}
+
+/** Clamp `limit` to 1..20 with default 5 — identical to root index.ts tools. */
+export function clampLimit(raw: unknown): number {
+  return Math.min(Math.max(Number(raw) || 5, 1), 20);
+}
+
+function strArg(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+
+/**
+ * Execute one MCP tool call against the MemoryClient and return the text
+ * payload for the `tools/call` result.
+ *
+ * Throws `UnknownToolError` for unregistered names (the server maps it to
+ * JSON-RPC `-32602`); any other rejection is a tool-level failure the server
+ * reports as `isError: true` per the MCP spec.
+ */
+export async function dispatchToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: ToolDispatchContext,
+): Promise<string> {
+  const sessionKey = strArg(args, "session_key") ?? ctx.defaultSessionKey;
+
+  switch (name) {
+    case "memory_recall": {
+      const query = String(args.query ?? "");
+      const outcome = await ctx.client.recall({ query, sessionKey, userId: ctx.userId });
+      const parts = [outcome.prependContext, outcome.context].filter(
+        (p): p is string => typeof p === "string" && p.trim().length > 0,
+      );
+      if (parts.length === 0) return "No relevant memories found.";
+      return parts.join("\n\n");
+    }
+
+    case "memory_capture": {
+      const userContent = String(args.user_content ?? "");
+      const assistantContent = String(args.assistant_content ?? "");
+      const outcome = await ctx.client.capture({
+        userContent,
+        assistantContent,
+        sessionKey,
+        userId: ctx.userId,
+      });
+      return `Captured: l0_recorded=${outcome.l0Recorded}, scheduler_notified=${outcome.schedulerNotified}`;
+    }
+
+    case "memory_search": {
+      const outcome = await ctx.client.searchMemories({
+        query: String(args.query ?? ""),
+        limit: clampLimit(args.limit),
+        type: strArg(args, "type"),
+        scene: strArg(args, "scene"),
+      });
+      return outcome.text;
+    }
+
+    case "conversation_search": {
+      const outcome = await ctx.client.searchConversations({
+        query: String(args.query ?? ""),
+        limit: clampLimit(args.limit),
+        sessionKey: strArg(args, "session_key"),
+      });
+      return outcome.text;
+    }
+
+    case "memory_session_end": {
+      await ctx.client.endSession(sessionKey);
+      return `Session flushed: ${sessionKey}`;
+    }
+
+    default:
+      throw new UnknownToolError(name);
+  }
+}

--- a/src/adapters/dify/README.md
+++ b/src/adapters/dify/README.md
@@ -1,0 +1,94 @@
+# Dify Adapter — External Knowledge Base + Custom Tool
+
+> 中文版本见 [README_CN.md](./README_CN.md)。
+> Built on the [Adapter SDK](../../adapter-sdk/README.md) · Compared with other platforms in
+> [PLATFORM-COMPARISON.md](../../../docs/adapters/PLATFORM-COMPARISON.md)
+
+`DifyMemoryAdapter` connects the TDAI memory engine to [Dify](https://dify.ai) through two of
+Dify's own extension points — no code runs inside Dify:
+
+- **READ — External Knowledge Base API.** Dify calls `POST /retrieval` on this adapter during
+  Knowledge Retrieval. Two virtual knowledge bases are served:
+  `tdai-memories` (L1 structured memories) and `tdai-conversations` (L0 raw dialogue).
+- **WRITE — Custom Tool.** `POST /tools/capture` (and `POST /tools/recall`) are described by a
+  generated OpenAPI 3.1 spec at `GET /openapi.json`, importable into Dify as a Custom Tool so an
+  Agent/Workflow node can save turns into memory.
+
+## Run
+
+```bash
+npm run gateway        # memory backend (default http transport)
+TDAI_DIFY_API_KEY=dify-secret npm run adapter:dify   # adapter on http://127.0.0.1:8421
+```
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `TDAI_DIFY_PORT` / `TDAI_DIFY_HOST` | listen address | `8421` / `127.0.0.1` |
+| `TDAI_DIFY_API_KEY` | Bearer key Dify must present (strongly recommended) | unset → open + startup WARN |
+| `TDAI_DIFY_SESSION_KEY` | default session for /tools/* | `dify:default` |
+| `TDAI_ADAPTER_TRANSPORT` / `TDAI_GATEWAY_URL` / `TDAI_GATEWAY_API_KEY` / `TDAI_ADAPTER_TIMEOUT_MS` | memory backend selection (shared SDK convention) | `http` / `http://127.0.0.1:8420` / unset / `10000` |
+
+Note: when Dify runs in Docker, the adapter's address from inside the Dify container is
+`http://host.docker.internal:8421` (not `127.0.0.1`).
+
+## Dify console walkthrough
+
+### A. Memory READ (Knowledge Retrieval)
+
+1. **Knowledge → External Knowledge API → Add**: Name `tdai-memory`,
+   API Endpoint `http://host.docker.internal:8421` (Dify appends `/retrieval` itself),
+   API Key = your `TDAI_DIFY_API_KEY`.
+2. **Knowledge → Create Knowledge → Connect to an External Knowledge Base**:
+   External Knowledge ID `tdai-memories` (or `tdai-conversations` for raw history).
+3. In your app, add the knowledge base to **Context** (Chatflow: a Knowledge Retrieval node).
+   Dify now calls `/retrieval` per user query. Record `score`s are batch-normalized (each
+   divided by the batch max, so the top hit is `1.0`) because the engine's hybrid RRF ranking
+   produces raw values far below 1 — `score_threshold` therefore acts as a *relative* cutoff
+   within each batch; `top_k` works natively.
+
+### B. Memory WRITE (Custom Tool)
+
+1. **Tools → Custom → Create Custom Tool**, paste the JSON from
+   `http://127.0.0.1:8421/openapi.json` (schema import), auth = `Bearer` + your key.
+2. Two tools appear: `memory_capture` and `memory_recall`.
+3. In an Agent app: just enable the tools — the model calls `memory_capture` after
+   noteworthy exchanges. In a Workflow/Chatflow: add a tool node after the LLM node, mapping
+   `user_content` ← user query, `assistant_content` ← LLM output, and (recommended)
+   `session_key` ← your conversation variable, e.g. `dify:{{#sys.user_id#}}`.
+
+### One full chat turn (recall → answer → capture)
+
+```
+user query ──▶ Knowledge Retrieval node ──POST /retrieval──▶ adapter ──▶ memory engine
+                      │ (records with scores)
+                      ▼
+                 LLM node (context = retrieved memories)
+                      │
+                      ▼
+              memory_capture tool node ──POST /tools/capture──▶ adapter ──▶ memory engine
+```
+
+## Wire contract (implemented per Dify's External Knowledge API spec)
+
+- `POST /retrieval` request: `{ knowledge_id, query, retrieval_setting: { top_k, score_threshold } }`.
+  Response: `{ records: [{ content, score, title, metadata }] }`.
+  - `tdai-memories` records: `title` = scene name (or memory type), metadata `{id, type, scene_name, created_at}`.
+  - `tdai-conversations` records: `title` = `role@session_key`, metadata `{id, role, session_key, recorded_at}`.
+  - `top_k` clamped to 1..20; missing `retrieval_setting` defaults to `top_k=5, threshold=0`.
+  - `score`s are normalized to 0..1 per response batch (top hit = 1.0) before
+    `score_threshold` filtering, so the threshold is a relative cutoff.
+- Auth errors use Dify's mandated bodies: missing/malformed header → HTTP 403
+  `{"error_code": 1001, "error_msg": "Invalid Authorization header format..."}`; wrong key →
+  403 `{"error_code": 1002, "error_msg": "Authorization failed"}`; unknown `knowledge_id` →
+  404 `{"error_code": 2001, "error_msg": "The knowledge does not exist"}`.
+- `GET /health` (no auth): `{ status, platform: "dify", upstream }` — never throws; reports
+  `"unreachable"` when the memory backend is down.
+
+## Design notes
+
+- Built on the SDK's structured search (`items` with per-record scores) — added to the gateway
+  protocol as the backward-compatible `include_items` opt-in precisely for this adapter. If the
+  backend is an older gateway without `items`, the adapter degrades to a single formatted-text
+  record instead of failing.
+- Zero-dependency `node:http` server, constant-time key comparison, same security-posture
+  startup warnings as the Gateway.

--- a/src/adapters/dify/README_CN.md
+++ b/src/adapters/dify/README_CN.md
@@ -1,0 +1,89 @@
+# Dify 适配器 — 外部知识库 + 自定义工具
+
+> English version: [README.md](./README.md)。
+> 构建于 [Adapter SDK](../../adapter-sdk/README_CN.md) · 与其他平台的对比见
+> [PLATFORM-COMPARISON_CN.md](../../../docs/adapters/PLATFORM-COMPARISON_CN.md)
+
+`DifyMemoryAdapter` 通过 [Dify](https://dify.ai) 自身的两个扩展点接入 TDAI 记忆引擎 —
+Dify 内部不运行我们任何代码：
+
+- **读 — 外部知识库 API。** Dify 在知识检索时调用本适配器的 `POST /retrieval`。提供两个
+  虚拟知识库：`tdai-memories`（L1 结构化记忆）与 `tdai-conversations`（L0 原始对话）。
+- **写 — 自定义工具。** `POST /tools/capture`（及 `POST /tools/recall`）由 `GET /openapi.json`
+  生成的 OpenAPI 3.1 规范描述，可导入 Dify 作为自定义工具，让 Agent/工作流节点把对话
+  写入记忆。
+
+## 运行
+
+```bash
+npm run gateway        # 记忆后端（默认 http 传输）
+TDAI_DIFY_API_KEY=dify-secret npm run adapter:dify   # 适配器监听 http://127.0.0.1:8421
+```
+
+| 变量 | 含义 | 默认 |
+| --- | --- | --- |
+| `TDAI_DIFY_PORT` / `TDAI_DIFY_HOST` | 监听地址 | `8421` / `127.0.0.1` |
+| `TDAI_DIFY_API_KEY` | Dify 必须携带的 Bearer 密钥（强烈建议设置） | 未设 → 开放模式 + 启动 WARN |
+| `TDAI_DIFY_SESSION_KEY` | /tools/* 的默认会话 | `dify:default` |
+| `TDAI_ADAPTER_TRANSPORT` / `TDAI_GATEWAY_URL` / `TDAI_GATEWAY_API_KEY` / `TDAI_ADAPTER_TIMEOUT_MS` | 记忆后端选择（SDK 共享约定） | `http` / `http://127.0.0.1:8420` / 未设 / `10000` |
+
+注意：Dify 跑在 Docker 里时，从 Dify 容器内访问适配器的地址是
+`http://host.docker.internal:8421`（而不是 `127.0.0.1`）。
+
+## Dify 控制台操作指引
+
+### A. 记忆读取（知识检索）
+
+1. **知识库 → 外部知识库 API → 添加**：名称 `tdai-memory`，
+   API Endpoint `http://host.docker.internal:8421`（Dify 会自动拼上 `/retrieval`），
+   API Key 填你的 `TDAI_DIFY_API_KEY`。
+2. **知识库 → 创建知识库 → 连接外部知识库**：外部知识库 ID 填 `tdai-memories`
+   （查原始历史则填 `tdai-conversations`）。
+3. 在应用里把该知识库加入**上下文**（Chatflow 则添加知识检索节点）。此后 Dify 每次用户
+   提问都会调用 `/retrieval`。返回记录的 `score` 会按批归一化（各自除以该批最大值，
+   最高命中 = `1.0`）—— 因为引擎混合检索的 RRF 原始分远小于 1，所以 `score_threshold`
+   实际是批内的*相对*阈值；`top_k` 原生生效。
+
+### B. 记忆写入（自定义工具）
+
+1. **工具 → 自定义 → 创建自定义工具**，粘贴 `http://127.0.0.1:8421/openapi.json` 返回的
+   JSON（schema 导入），鉴权选 `Bearer` + 你的密钥。
+2. 出现两个工具：`memory_capture` 与 `memory_recall`。
+3. Agent 应用：直接启用工具 — 模型会在值得记住的交流后调用 `memory_capture`。
+   工作流/Chatflow：在 LLM 节点后加工具节点，映射 `user_content` ← 用户提问、
+   `assistant_content` ← LLM 输出，并（建议）`session_key` ← 会话变量，如
+   `dify:{{#sys.user_id#}}`。
+
+### 一次完整对话回合（召回 → 回答 → 捕获）
+
+```
+用户提问 ──▶ 知识检索节点 ──POST /retrieval──▶ 适配器 ──▶ 记忆引擎
+                  │（带分数的 records）
+                  ▼
+             LLM 节点（上下文 = 检索到的记忆）
+                  │
+                  ▼
+          memory_capture 工具节点 ──POST /tools/capture──▶ 适配器 ──▶ 记忆引擎
+```
+
+## 协议契约（按 Dify 外部知识库 API 规范实现）
+
+- `POST /retrieval` 请求：`{ knowledge_id, query, retrieval_setting: { top_k, score_threshold } }`。
+  响应：`{ records: [{ content, score, title, metadata }] }`。
+  - `tdai-memories` 记录：`title` = 场景名（无则记忆类型），metadata `{id, type, scene_name, created_at}`。
+  - `tdai-conversations` 记录：`title` = `role@session_key`，metadata `{id, role, session_key, recorded_at}`。
+  - `top_k` 收敛到 1..20；缺省 `retrieval_setting` 时默认 `top_k=5, threshold=0`。
+  - `score` 在过滤前按批归一化到 0..1（最高命中 = 1.0），`score_threshold` 是相对阈值。
+- 鉴权错误采用 Dify 规定的响应体：缺失/格式错误的头 → HTTP 403
+  `{"error_code": 1001, "error_msg": "Invalid Authorization header format..."}`；密钥错误 →
+  403 `{"error_code": 1002, "error_msg": "Authorization failed"}`；未知 `knowledge_id` →
+  404 `{"error_code": 2001, "error_msg": "The knowledge does not exist"}`。
+- `GET /health`（免鉴权）：`{ status, platform: "dify", upstream }` — 永不抛错；记忆后端
+  不可达时报告 `"unreachable"`。
+
+## 设计要点
+
+- 依托 SDK 的结构化搜索（逐条带分数的 `items`）— gateway 协议为此新增了向后兼容的
+  `include_items` 可选字段。若后端是没有 `items` 的旧版 gateway，适配器降级为返回单条
+  格式化文本记录，而不是失败。
+- 零依赖 `node:http` 服务器、常量时间密钥比较、与 Gateway 一致的安全姿态启动告警。

--- a/src/adapters/dify/index.ts
+++ b/src/adapters/dify/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Dify adapter — barrel.
+ *
+ * Inbound REST adapter implementing Dify's External Knowledge Base API
+ * (memory READ) plus Custom Tool endpoints (memory WRITE). Built entirely on
+ * the Adapter SDK — see ./README.md for the Dify console walkthrough.
+ */
+
+export { DifyMemoryAdapter } from "./server.js";
+export type { DifyMemoryAdapterOptions } from "./server.js";
+export { buildOpenApiSpec } from "./openapi.js";
+export {
+  KNOWLEDGE_ID_MEMORIES,
+  KNOWLEDGE_ID_CONVERSATIONS,
+} from "./types.js";
+export type {
+  DifyRetrievalRequest,
+  DifyRetrievalSetting,
+  DifyRetrievalRecord,
+  DifyRetrievalResponse,
+  DifyErrorBody,
+  DifyCaptureToolRequest,
+  DifyCaptureToolResponse,
+  DifyRecallToolRequest,
+  DifyRecallToolResponse,
+} from "./types.js";

--- a/src/adapters/dify/main.ts
+++ b/src/adapters/dify/main.ts
@@ -1,0 +1,84 @@
+/**
+ * Dify adapter — CLI entry point.
+ *
+ * Usage:
+ *   node --import tsx src/adapters/dify/main.ts
+ *
+ * Environment:
+ *   TDAI_ADAPTER_TRANSPORT    "http" (default — needs a running Gateway) | "in-process"
+ *   TDAI_GATEWAY_URL          Gateway base URL (default http://127.0.0.1:8420)
+ *   TDAI_GATEWAY_API_KEY      Bearer token when the Gateway enforces auth
+ *   TDAI_ADAPTER_TIMEOUT_MS   HTTP timeout toward the Gateway (default 10000)
+ *   TDAI_DIFY_PORT            listen port (default 8421)
+ *   TDAI_DIFY_HOST            bind host (default 127.0.0.1)
+ *   TDAI_DIFY_API_KEY         Bearer key Dify must present (recommended!)
+ *   TDAI_DIFY_SESSION_KEY     default session key for /tools/* (default "dify:default")
+ */
+
+import { createMemoryClient, resolveClientOptionsFromEnv } from "../../adapter-sdk/index.js";
+import type { Logger } from "../../core/types.js";
+import { getEnv } from "../../utils/env.js";
+import { isMainModule } from "../../utils/is-main.js";
+import { DifyMemoryAdapter } from "./server.js";
+
+const TAG = "[tdai-adapter] [dify-main]";
+
+/**
+ * Plain console logger — no prefix of its own, because every message from
+ * the SDK / adapter already carries a `[tdai-adapter] [...]` tag.
+ */
+function createConsoleLogger(): Logger {
+  return {
+    debug: (msg: string) => console.debug(msg),
+    info: (msg: string) => console.info(msg),
+    warn: (msg: string) => console.warn(msg),
+    error: (msg: string) => console.error(msg),
+  };
+}
+
+function envInt(key: string): number | undefined {
+  const raw = getEnv(key)?.trim();
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+async function main(): Promise<void> {
+  const logger = createConsoleLogger();
+
+  const clientOptions = resolveClientOptionsFromEnv(logger);
+  clientOptions.logger = logger;
+  const client = createMemoryClient(clientOptions);
+
+  const adapter = new DifyMemoryAdapter({
+    client,
+    port: envInt("TDAI_DIFY_PORT"),
+    host: getEnv("TDAI_DIFY_HOST")?.trim() || undefined,
+    apiKey: getEnv("TDAI_DIFY_API_KEY"),
+    defaultSessionKey: getEnv("TDAI_DIFY_SESSION_KEY")?.trim() || undefined,
+    logger,
+  });
+
+  // Graceful shutdown — mirror the Gateway's main() shape.
+  const shutdown = async () => {
+    logger.info(`${TAG} Shutting down Dify adapter...`);
+    await adapter.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown());
+  process.on("SIGTERM", () => void shutdown());
+
+  await adapter.start();
+  logger.info(`${TAG} Memory transport: ${clientOptions.transport}`);
+}
+
+// Auto-start when run directly. Unlike gateway/server.ts (whose "server.ts"
+// suffix contains no separator), these suffixes contain a "/" — isMainModule
+// normalizes Windows backslash argv[1] paths so the match works there too.
+const isMain = isMainModule(process.argv[1], ["dify/main.ts", "dify/main.js"]);
+if (isMain) {
+  main().catch((err) => {
+    console.error(`${TAG} Dify adapter startup failed:`, err);
+    process.exit(1);
+  });
+}

--- a/src/adapters/dify/openapi.test.ts
+++ b/src/adapters/dify/openapi.test.ts
@@ -1,0 +1,49 @@
+/**
+ * OpenAPI spec generator tests (offline).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildOpenApiSpec } from "./openapi.js";
+
+describe("buildOpenApiSpec", () => {
+  const spec = buildOpenApiSpec("http://127.0.0.1:8421") as {
+    openapi: string;
+    servers: Array<{ url: string }>;
+    paths: Record<string, { post?: { operationId: string; requestBody: unknown } }>;
+    components: { securitySchemes: Record<string, { type: string; scheme: string }> };
+    security: unknown[];
+  };
+
+  it("emits an OpenAPI 3.1 document pointing at the given server", () => {
+    expect(spec.openapi).toBe("3.1.0");
+    expect(spec.servers).toEqual([{ url: "http://127.0.0.1:8421" }]);
+  });
+
+  it("describes exactly the two tool operations with stable operationIds", () => {
+    expect(Object.keys(spec.paths).sort()).toEqual(["/tools/capture", "/tools/recall"]);
+    expect(spec.paths["/tools/capture"].post?.operationId).toBe("memory_capture");
+    expect(spec.paths["/tools/recall"].post?.operationId).toBe("memory_recall");
+  });
+
+  it("declares bearer auth as the global security scheme", () => {
+    expect(spec.components.securitySchemes.bearerAuth).toMatchObject({
+      type: "http",
+      scheme: "bearer",
+    });
+    expect(spec.security).toEqual([{ bearerAuth: [] }]);
+  });
+
+  it("marks the write-path required fields in the capture schema", () => {
+    const captureSchema = (
+      spec.paths["/tools/capture"].post as unknown as {
+        requestBody: { content: { "application/json": { schema: { required: string[] } } } };
+      }
+    ).requestBody.content["application/json"].schema;
+    expect(captureSchema.required).toEqual(["user_content", "assistant_content"]);
+  });
+
+  it("round-trips through JSON cleanly (importable by Dify)", () => {
+    expect(() => JSON.parse(JSON.stringify(spec))).not.toThrow();
+  });
+});

--- a/src/adapters/dify/openapi.ts
+++ b/src/adapters/dify/openapi.ts
@@ -1,0 +1,139 @@
+/**
+ * Dify adapter — OpenAPI spec generator for the /tools/* endpoints.
+ *
+ * Dify's "Custom Tool" feature imports an OpenAPI (3.x) document and turns
+ * each operation into an agent-callable tool. The adapter serves this spec at
+ * `GET /openapi.json`, so wiring the memory WRITE path into a Dify app is:
+ * paste the URL → import → done.
+ *
+ * Only the two tool operations are described here — `/retrieval` is NOT a
+ * tool (Dify calls it internally through the External Knowledge Base
+ * mechanism) and `/health` is operational.
+ */
+
+export function buildOpenApiSpec(baseUrl: string): Record<string, unknown> {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "TDAI Memory Tools",
+      description:
+        "Long-term memory tools backed by TencentDB-Agent-Memory. " +
+        "`memory_capture` saves a conversation turn; `memory_recall` retrieves relevant memory context.",
+      version: "1.0.0",
+    },
+    servers: [{ url: baseUrl }],
+    security: [{ bearerAuth: [] }],
+    paths: {
+      "/tools/capture": {
+        post: {
+          operationId: "memory_capture",
+          summary: "Save one conversation turn into long-term memory",
+          description:
+            "Records the user message and assistant reply as a completed turn. The memory engine " +
+            "archives the raw exchange (L0) and asynchronously extracts structured memories (L1/L2/L3).",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    user_content: {
+                      type: "string",
+                      description: "The user's message text for the turn",
+                    },
+                    assistant_content: {
+                      type: "string",
+                      description: "The assistant's reply text for the turn",
+                    },
+                    session_key: {
+                      type: "string",
+                      description: "Optional session key (defaults to the adapter's configured session)",
+                    },
+                    session_id: {
+                      type: "string",
+                      description: "Optional sub-session identifier",
+                    },
+                  },
+                  required: ["user_content", "assistant_content"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Capture accepted",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      l0_recorded: { type: "integer", description: "Messages archived" },
+                      scheduler_notified: { type: "boolean", description: "Extraction pipeline notified" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/tools/recall": {
+        post: {
+          operationId: "memory_recall",
+          summary: "Retrieve memory context relevant to a query",
+          description:
+            "Returns persona/scene/memory context assembled by the memory engine for the given query. " +
+            "Use at the start of a conversation turn to load what is already known about the user.",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    query: {
+                      type: "string",
+                      description: "The user's current question or topic",
+                    },
+                    session_key: {
+                      type: "string",
+                      description: "Optional session key (defaults to the adapter's configured session)",
+                    },
+                  },
+                  required: ["query"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Recall result",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      context: { type: "string", description: "Memory context text ('' when nothing recalled)" },
+                      strategy: { type: "string", description: "Search strategy used" },
+                      memory_count: { type: "integer", description: "Number of memories recalled" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description: "Set to the adapter's TDAI_DIFY_API_KEY value",
+        },
+      },
+    },
+  };
+}

--- a/src/adapters/dify/server.test.ts
+++ b/src/adapters/dify/server.test.ts
@@ -1,0 +1,411 @@
+/**
+ * DifyMemoryAdapter HTTP tests (offline).
+ *
+ * The adapter is started on an ephemeral port (port 0) with a fake
+ * MemoryClient; requests are issued with global fetch against 127.0.0.1.
+ * Covers the External Knowledge API contract (auth error codes 1001/1002,
+ * knowledge routing, 2001 for unknown knowledge, top_k clamping, batch score
+ * normalization + score_threshold filtering, no-items fallback) and the
+ * /tools/* endpoints.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DifyMemoryAdapter } from "./server.js";
+import type { MemoryClient } from "../../adapter-sdk/index.js";
+
+// ============================
+// Fixtures
+// ============================
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+const MEMORY_ITEMS = [
+  {
+    id: "m1", content: "User prefers green tea", type: "persona", priority: 1,
+    scene_name: "beverages", score: 0.92, created_at: "2026-01-01", updated_at: "2026-01-02",
+  },
+  {
+    id: "m2", content: "User visited Shenzhen in May", type: "episodic", priority: 2,
+    scene_name: "", score: 0.41, created_at: "2026-05-01", updated_at: "2026-05-01",
+  },
+];
+
+const CONVERSATION_ITEMS = [
+  {
+    id: "c1", session_key: "dify:s1", role: "user",
+    content: "How do I deploy the gateway?", score: 0.8, recorded_at: "2026-06-01",
+  },
+];
+
+function createFakeClient(overrides: Partial<MemoryClient> = {}): MemoryClient {
+  return {
+    recall: vi.fn(async () => ({
+      context: "known context", strategy: "hybrid", memoryCount: 3,
+    })),
+    capture: vi.fn(async () => ({ l0Recorded: 2, schedulerNotified: true })),
+    searchMemories: vi.fn(async () => ({
+      text: "formatted memories", total: 2, strategy: "hybrid", items: MEMORY_ITEMS,
+    })),
+    searchConversations: vi.fn(async () => ({
+      text: "formatted conversations", total: 1, items: CONVERSATION_ITEMS,
+    })),
+    endSession: vi.fn(async () => {}),
+    health: vi.fn(async () => ({ status: "ok" as const, vectorStore: true, embeddingService: true })),
+    close: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+let adapters: DifyMemoryAdapter[] = [];
+
+async function startAdapter(opts: {
+  client?: MemoryClient;
+  apiKey?: string;
+  defaultSessionKey?: string;
+} = {}): Promise<{ adapter: DifyMemoryAdapter; base: string; client: MemoryClient }> {
+  const client = opts.client ?? createFakeClient();
+  const adapter = new DifyMemoryAdapter({
+    client,
+    port: 0,
+    apiKey: opts.apiKey,
+    defaultSessionKey: opts.defaultSessionKey,
+    logger: silentLogger,
+  });
+  await adapter.start();
+  adapters.push(adapter);
+  return { adapter, base: `http://127.0.0.1:${adapter.boundPort}`, client };
+}
+
+afterEach(async () => {
+  await Promise.all(adapters.map((a) => a.stop()));
+  adapters = [];
+});
+
+function post(base: string, path: string, body: unknown, headers: Record<string, string> = {}) {
+  return fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function retrievalBody(knowledgeId: string, extra: Record<string, unknown> = {}) {
+  return {
+    knowledge_id: knowledgeId,
+    query: "tea",
+    retrieval_setting: { top_k: 5, score_threshold: 0 },
+    ...extra,
+  };
+}
+
+// ============================
+// /retrieval — happy paths
+// ============================
+
+describe("DifyMemoryAdapter — POST /retrieval", () => {
+  it("maps tdai-memories items to Dify records (content/score/title/metadata)", async () => {
+    const { base, client } = await startAdapter();
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(client.searchMemories).toHaveBeenCalledWith({ query: "tea", limit: 5 });
+    expect(body.records).toEqual([
+      {
+        content: "User prefers green tea",
+        score: 1, // batch-normalized: top hit = 1.0
+        title: "beverages",
+        metadata: { id: "m1", type: "persona", scene_name: "beverages", created_at: "2026-01-01" },
+      },
+      {
+        content: "User visited Shenzhen in May",
+        score: 0.41 / 0.92, // batch-normalized (raw / batch max)
+        title: "episodic", // no scene_name → falls back to type
+        metadata: { id: "m2", type: "episodic", scene_name: "", created_at: "2026-05-01" },
+      },
+    ]);
+  });
+
+  it("maps tdai-conversations items with role@session titles", async () => {
+    const { base, client } = await startAdapter();
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-conversations"));
+
+    const body = await res.json();
+    expect(client.searchConversations).toHaveBeenCalledWith({ query: "tea", limit: 5 });
+    expect(body.records).toEqual([
+      {
+        content: "How do I deploy the gateway?",
+        score: 1, // batch-normalized: top hit = 1.0
+        title: "user@dify:s1",
+        metadata: { id: "c1", role: "user", session_key: "dify:s1", recorded_at: "2026-06-01" },
+      },
+    ]);
+  });
+
+  it("clamps top_k into 1..20 and defaults missing retrieval_setting", async () => {
+    const { base, client } = await startAdapter();
+
+    await post(base, "/retrieval", retrievalBody("tdai-memories", {
+      retrieval_setting: { top_k: 999, score_threshold: 0 },
+    }));
+    expect(client.searchMemories).toHaveBeenLastCalledWith({ query: "tea", limit: 20 });
+
+    await post(base, "/retrieval", { knowledge_id: "tdai-memories", query: "tea" });
+    expect(client.searchMemories).toHaveBeenLastCalledWith({ query: "tea", limit: 5 });
+  });
+
+  it("filters records below score_threshold (after batch normalization)", async () => {
+    const { base } = await startAdapter();
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories", {
+      retrieval_setting: { top_k: 5, score_threshold: 0.5 },
+    }));
+
+    const body = await res.json();
+    // 0.92 → 1.0 survives; 0.41 → 0.41/0.92 ≈ 0.446 is filtered out.
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0].score).toBe(1);
+  });
+
+  it("hybrid RRF raw scores (≈0.03) survive a 0.5 threshold thanks to batch normalization", async () => {
+    // RRF replaces scores with 1/(60+rank+1) sums, capping near 2/61 ≈ 0.033.
+    // Without normalization a realistic Dify threshold would drop everything.
+    const client = createFakeClient({
+      searchMemories: vi.fn(async () => ({
+        text: "rrf", total: 2, strategy: "hybrid",
+        items: [
+          { ...MEMORY_ITEMS[0], score: 0.0328 },
+          { ...MEMORY_ITEMS[1], score: 0.0161 },
+        ],
+      })),
+    });
+    const { base } = await startAdapter({ client });
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories", {
+      retrieval_setting: { top_k: 5, score_threshold: 0.5 },
+    }));
+
+    const body = await res.json();
+    // Top hit normalizes to 1.0 and passes; 0.0161/0.0328 ≈ 0.491 < 0.5.
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0].content).toBe("User prefers green tea");
+    expect(body.records[0].score).toBe(1);
+  });
+
+  it("falls back to one formatted-text record when the backend returns no items but total > 0", async () => {
+    const client = createFakeClient({
+      searchMemories: vi.fn(async () => ({
+        text: "legacy formatted text", total: 3, strategy: "fts", items: [],
+      })),
+    });
+    const { base } = await startAdapter({ client });
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories"));
+
+    const body = await res.json();
+    expect(body.records).toEqual([
+      { content: "legacy formatted text", score: 1, title: "tdai-memories" },
+    ]);
+  });
+
+  it("returns empty records when nothing matches", async () => {
+    const client = createFakeClient({
+      searchMemories: vi.fn(async () => ({ text: "", total: 0, strategy: "none", items: [] })),
+    });
+    const { base } = await startAdapter({ client });
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories"));
+
+    expect((await res.json()).records).toEqual([]);
+  });
+
+  it("unknown knowledge_id → 404 with error_code 2001", async () => {
+    const { base } = await startAdapter();
+
+    const res = await post(base, "/retrieval", retrievalBody("someone-elses-kb"));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error_code: 2001,
+      error_msg: "The knowledge does not exist",
+    });
+  });
+
+  it("missing query → 400 with error_code 4000", async () => {
+    const { base } = await startAdapter();
+
+    const res = await post(base, "/retrieval", { knowledge_id: "tdai-memories" });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error_code).toBe(4000);
+  });
+
+  it("malformed JSON body → 400 with error_code 4000 (client fault, not a 500)", async () => {
+    const { base } = await startAdapter();
+
+    const res = await fetch(`${base}/retrieval`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{{{ not json",
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe(4000);
+    expect(body.error_msg).toContain("Invalid JSON body");
+  });
+});
+
+// ============================
+// Auth — Dify error-code semantics
+// ============================
+
+describe("DifyMemoryAdapter — auth", () => {
+  it("missing/malformed Authorization → 403 error_code 1001", async () => {
+    const { base } = await startAdapter({ apiKey: "dify-secret" });
+
+    const missing = await post(base, "/retrieval", retrievalBody("tdai-memories"));
+    expect(missing.status).toBe(403);
+    expect((await missing.json()).error_code).toBe(1001);
+
+    const malformed = await post(base, "/retrieval", retrievalBody("tdai-memories"), {
+      Authorization: "Basic dXNlcjpwYXNz",
+    });
+    expect(malformed.status).toBe(403);
+    expect((await malformed.json()).error_code).toBe(1001);
+  });
+
+  it("wrong key → 403 error_code 1002", async () => {
+    const { base } = await startAdapter({ apiKey: "dify-secret" });
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories"), {
+      Authorization: "Bearer wrong-key",
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error_code: 1002, error_msg: "Authorization failed" });
+  });
+
+  it("correct key passes; /health and /openapi.json stay open", async () => {
+    const { base } = await startAdapter({ apiKey: "dify-secret" });
+
+    const ok = await post(base, "/retrieval", retrievalBody("tdai-memories"), {
+      Authorization: "Bearer dify-secret",
+    });
+    expect(ok.status).toBe(200);
+
+    expect((await fetch(`${base}/health`)).status).toBe(200);
+    expect((await fetch(`${base}/openapi.json`)).status).toBe(200);
+  });
+
+  it("without a configured key the adapter runs open (legacy gateway posture)", async () => {
+    const { base } = await startAdapter();
+
+    const res = await post(base, "/retrieval", retrievalBody("tdai-memories"));
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ============================
+// /tools/* — memory WRITE + recall
+// ============================
+
+describe("DifyMemoryAdapter — /tools endpoints", () => {
+  it("/tools/capture maps the wire body onto client.capture", async () => {
+    const { base, client } = await startAdapter({ defaultSessionKey: "dify:app-42" });
+
+    const res = await post(base, "/tools/capture", {
+      user_content: "I moved to Chengdu",
+      assistant_content: "Congrats on the move!",
+      session_id: "run-7",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ l0_recorded: 2, scheduler_notified: true });
+    expect(client.capture).toHaveBeenCalledWith({
+      userContent: "I moved to Chengdu",
+      assistantContent: "Congrats on the move!",
+      sessionKey: "dify:app-42", // default applied
+      sessionId: "run-7",
+    });
+  });
+
+  it("/tools/capture honours an explicit session_key and validates required fields", async () => {
+    const { base, client } = await startAdapter();
+
+    await post(base, "/tools/capture", {
+      user_content: "u", assistant_content: "a", session_key: "dify:custom",
+    });
+    expect(client.capture).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionKey: "dify:custom" }),
+    );
+
+    const bad = await post(base, "/tools/capture", { user_content: "only-user" });
+    expect(bad.status).toBe(400);
+    expect((await bad.json()).error_code).toBe(4000);
+  });
+
+  it("/tools/recall returns context/strategy/memory_count", async () => {
+    const { base, client } = await startAdapter();
+
+    const res = await post(base, "/tools/recall", { query: "where do I live?" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      context: "known context", strategy: "hybrid", memory_count: 3,
+    });
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "where do I live?", sessionKey: "dify:default",
+    });
+  });
+
+  it("client failures surface as 500 with a Dify-style error body", async () => {
+    const client = createFakeClient({
+      recall: vi.fn(async () => {
+        throw new Error("gateway down");
+      }),
+    });
+    const { base } = await startAdapter({ client });
+
+    const res = await post(base, "/tools/recall", { query: "q" });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error_code).toBe(5000);
+    expect(body.error_msg).toContain("gateway down");
+  });
+});
+
+// ============================
+// /health
+// ============================
+
+describe("DifyMemoryAdapter — GET /health", () => {
+  it("reports upstream health when the client responds", async () => {
+    const { base } = await startAdapter();
+
+    const body = await (await fetch(`${base}/health`)).json();
+
+    expect(body.status).toBe("ok");
+    expect(body.platform).toBe("dify");
+    expect(body.upstream).toEqual({ status: "ok", vectorStore: true, embeddingService: true });
+  });
+
+  it("never throws — reports 'unreachable' when the upstream probe fails", async () => {
+    const client = createFakeClient({
+      health: vi.fn(async () => {
+        throw new Error("connection refused");
+      }),
+    });
+    const { base } = await startAdapter({ client });
+
+    const res = await fetch(`${base}/health`);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).upstream).toBe("unreachable");
+  });
+});

--- a/src/adapters/dify/server.ts
+++ b/src/adapters/dify/server.ts
@@ -1,0 +1,404 @@
+/**
+ * Dify adapter — inbound REST server (`DifyMemoryAdapter`).
+ *
+ * Two integration surfaces in one zero-dependency `node:http` server
+ * (mirroring the Gateway's no-Express style):
+ *
+ *   READ  — `POST /retrieval` implements Dify's External Knowledge Base API.
+ *           Dify calls us during Knowledge Retrieval; `knowledge_id` routes to
+ *           L1 memories (`tdai-memories`) or L0 conversations
+ *           (`tdai-conversations`). Per-record scores come from the SDK's
+ *           structured `items`, batch-normalized to 0..1 (top hit = 1.0)
+ *           before `score_threshold` filtering.
+ *   WRITE — `POST /tools/capture` + `POST /tools/recall`, importable into a
+ *           Dify app as a Custom Tool via `GET /openapi.json`.
+ *
+ * Auth: Dify's spec mandates specific error bodies — missing/malformed
+ * Authorization → HTTP 403 `{error_code: 1001}`, wrong key → 403
+ * `{error_code: 1002}` (used on ALL protected routes for consistency;
+ * `/health` and `/openapi.json` stay open). When no API key is configured the
+ * adapter runs open and warns loudly at startup, matching the Gateway's
+ * security posture logging.
+ *
+ * Built on the Adapter SDK: extends `BasePlatformAdapter`, consumes only
+ * `MemoryClient` — works with either transport unchanged.
+ */
+
+import http from "node:http";
+import { AddressInfo } from "node:net";
+import { timingSafeEqual } from "node:crypto";
+import { BasePlatformAdapter } from "../../adapter-sdk/base-platform-adapter.js";
+import type { MemoryClient } from "../../adapter-sdk/types.js";
+import type { Logger } from "../../core/types.js";
+import {
+  KNOWLEDGE_ID_MEMORIES,
+  KNOWLEDGE_ID_CONVERSATIONS,
+  type DifyRetrievalRequest,
+  type DifyRetrievalRecord,
+  type DifyRetrievalResponse,
+  type DifyErrorBody,
+  type DifyCaptureToolRequest,
+  type DifyCaptureToolResponse,
+  type DifyRecallToolRequest,
+  type DifyRecallToolResponse,
+} from "./types.js";
+import { buildOpenApiSpec } from "./openapi.js";
+
+const TAG = "[tdai-adapter] [dify]";
+
+// ============================
+// Options
+// ============================
+
+export interface DifyMemoryAdapterOptions {
+  client: MemoryClient;
+  /** Listen port. Default 8421 (`TDAI_DIFY_PORT`); pass 0 for ephemeral (tests). */
+  port?: number;
+  /** Bind host. Default "127.0.0.1" (`TDAI_DIFY_HOST`). */
+  host?: string;
+  /**
+   * Shared secret expected as `Authorization: Bearer <key>` on every route
+   * except `/health` and `/openapi.json`. Unset → open mode + startup WARN.
+   */
+  apiKey?: string;
+  /** Session key for /tools/* calls that omit one. Default "dify:default". */
+  defaultSessionKey?: string;
+  logger?: Logger;
+}
+
+const DEFAULT_PORT = 8421;
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_SESSION_KEY = "dify:default";
+const MAX_TOP_K = 20;
+const DEFAULT_TOP_K = 5;
+
+// ============================
+// Small HTTP helpers (gateway-style)
+// ============================
+
+/** Marker error: request body was not valid JSON (client fault → HTTP 400). */
+class InvalidJsonBodyError extends Error {
+  constructor() {
+    super("Invalid JSON body");
+    this.name = "InvalidJsonBodyError";
+  }
+}
+
+async function parseJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        const body = Buffer.concat(chunks).toString("utf-8");
+        resolve(JSON.parse(body) as T);
+      } catch {
+        reject(new InvalidJsonBodyError());
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+function difyError(res: http.ServerResponse, httpStatus: number, errorCode: number, errorMsg: string): void {
+  sendJson(res, httpStatus, { error_code: errorCode, error_msg: errorMsg } satisfies DifyErrorBody);
+}
+
+/** Constant-time comparison — same rationale as the Gateway's safeEqual. */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf-8");
+  const bb = Buffer.from(b, "utf-8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+// ============================
+// DifyMemoryAdapter
+// ============================
+
+export class DifyMemoryAdapter extends BasePlatformAdapter {
+  readonly platformName = "dify";
+
+  private readonly port: number;
+  private readonly host: string;
+  private readonly apiKey?: string;
+  private readonly defaultSessionKey: string;
+  private server?: http.Server;
+
+  constructor(opts: DifyMemoryAdapterOptions) {
+    super({ client: opts.client, logger: opts.logger });
+    this.port = opts.port ?? DEFAULT_PORT;
+    this.host = opts.host ?? DEFAULT_HOST;
+    const trimmedKey = opts.apiKey?.trim();
+    this.apiKey = trimmedKey ? trimmedKey : undefined;
+    this.defaultSessionKey = opts.defaultSessionKey ?? DEFAULT_SESSION_KEY;
+  }
+
+  /** Actual bound port once started (needed by tests that pass port 0). */
+  get boundPort(): number | undefined {
+    const addr = this.server?.address();
+    return addr && typeof addr === "object" ? (addr as AddressInfo).port : undefined;
+  }
+
+  async start(): Promise<void> {
+    this.server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.listen(this.port, this.host, () => resolve());
+      this.server!.on("error", reject);
+    });
+
+    this.logger.info(`${TAG} Dify adapter listening on http://${this.host}:${this.boundPort}`);
+    if (!this.apiKey) {
+      this.logger.warn(
+        `${TAG} TDAI_DIFY_API_KEY is NOT set — /retrieval and /tools/* are open to anyone who can ` +
+        `reach this port. Set an API key and configure the same value in the Dify console before ` +
+        `exposing the adapter beyond the loopback interface.`,
+      );
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) {
+      this.server.closeAllConnections?.();
+      await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+      this.server = undefined;
+    }
+    await super.stop(); // closes this.client
+  }
+
+  // ============================
+  // Router
+  // ============================
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const method = req.method?.toUpperCase() ?? "GET";
+    const pathname = (req.url ?? "/").split("?")[0];
+
+    try {
+      // Open routes — health probes and tool-spec import need no auth.
+      if (method === "GET" && pathname === "/health") {
+        return await this.handleHealth(res);
+      }
+      if (method === "GET" && pathname === "/openapi.json") {
+        return this.handleOpenApi(req, res);
+      }
+
+      if (!this.checkAuth(req, res)) return;
+
+      switch (`${method} ${pathname}`) {
+        case "POST /retrieval":
+          return await this.handleRetrieval(req, res);
+        case "POST /tools/capture":
+          return await this.handleToolCapture(req, res);
+        case "POST /tools/recall":
+          return await this.handleToolRecall(req, res);
+        default:
+          difyError(res, 404, 2001, `Not found: ${method} ${pathname}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (err instanceof InvalidJsonBodyError) {
+        // Client fault, not an engine failure — answer 400 like the other
+        // request-validation errors instead of a misleading 500.
+        this.logger.warn(`${TAG} Bad request [${method} ${pathname}]: ${msg}`);
+        if (!res.headersSent) difyError(res, 400, 4000, msg);
+        return;
+      }
+      this.logger.error(`${TAG} Request error [${method} ${pathname}]: ${msg}`);
+      if (!res.headersSent) {
+        difyError(res, 500, 5000, msg);
+      }
+    }
+  }
+
+  // ============================
+  // Auth (Dify error-code semantics)
+  // ============================
+
+  private checkAuth(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+    if (!this.apiKey) return true; // open mode — warned at startup
+
+    const header = req.headers["authorization"];
+    if (typeof header !== "string" || !header.startsWith("Bearer ")) {
+      difyError(
+        res, 403, 1001,
+        "Invalid Authorization header format. Expected 'Bearer <api-key>' format.",
+      );
+      return false;
+    }
+    const provided = header.slice("Bearer ".length).trim();
+    if (!provided || !safeEqual(provided, this.apiKey)) {
+      difyError(res, 403, 1002, "Authorization failed");
+      return false;
+    }
+    return true;
+  }
+
+  // ============================
+  // POST /retrieval — Dify External Knowledge Base API
+  // ============================
+
+  private async handleRetrieval(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<DifyRetrievalRequest>(req);
+
+    if (!body.query || typeof body.query !== "string") {
+      difyError(res, 400, 4000, "Missing required field: query");
+      return;
+    }
+    if (!body.knowledge_id || typeof body.knowledge_id !== "string") {
+      difyError(res, 400, 4000, "Missing required field: knowledge_id");
+      return;
+    }
+
+    // Liberal defaults when retrieval_setting is absent/partial.
+    const rawTopK = body.retrieval_setting?.top_k;
+    const topK = Math.min(Math.max(Number(rawTopK) || DEFAULT_TOP_K, 1), MAX_TOP_K);
+    const rawThreshold = Number(body.retrieval_setting?.score_threshold);
+    const threshold = Number.isFinite(rawThreshold) ? rawThreshold : 0;
+
+    let records: DifyRetrievalRecord[];
+    switch (body.knowledge_id) {
+      case KNOWLEDGE_ID_MEMORIES: {
+        const outcome = await this.client.searchMemories({ query: body.query, limit: topK });
+        records = outcome.items.map((item) => ({
+          content: item.content,
+          score: item.score,
+          title: item.scene_name || item.type,
+          metadata: {
+            id: item.id,
+            type: item.type,
+            scene_name: item.scene_name,
+            created_at: item.created_at,
+          },
+        }));
+        // Fallback for backends without structured items (older gateways):
+        // surface the formatted text as a single record so retrieval still works.
+        if (records.length === 0 && outcome.total > 0) {
+          records = [{ content: outcome.text, score: 1, title: "tdai-memories" }];
+        }
+        break;
+      }
+      case KNOWLEDGE_ID_CONVERSATIONS: {
+        const outcome = await this.client.searchConversations({ query: body.query, limit: topK });
+        records = outcome.items.map((item) => ({
+          content: item.content,
+          score: item.score,
+          title: `${item.role}@${item.session_key}`,
+          metadata: {
+            id: item.id,
+            role: item.role,
+            session_key: item.session_key,
+            recorded_at: item.recorded_at,
+          },
+        }));
+        if (records.length === 0 && outcome.total > 0) {
+          records = [{ content: outcome.text, score: 1, title: "tdai-conversations" }];
+        }
+        break;
+      }
+      default:
+        difyError(res, 404, 2001, "The knowledge does not exist");
+        return;
+    }
+
+    // Engine scores are raw ranking values — under the default hybrid
+    // strategy they are RRF sums capped near 2/61 ≈ 0.033 — while Dify's
+    // score_threshold assumes 0..1 relevance, so any realistic threshold
+    // would silently drop every record. Normalize per batch (divide by the
+    // batch max; order-preserving, top hit = 1.0) so the threshold acts as
+    // a relative cutoff within the batch.
+    const maxScore = records.reduce((max, r) => Math.max(max, r.score), 0);
+    if (maxScore > 0) {
+      records = records.map((r) => ({ ...r, score: r.score / maxScore }));
+    }
+    const filtered = records.filter((r) => r.score >= threshold);
+    this.logger.debug?.(
+      `${TAG} /retrieval knowledge_id=${body.knowledge_id} top_k=${topK} ` +
+      `threshold=${threshold} → ${filtered.length}/${records.length} records`,
+    );
+    sendJson(res, 200, { records: filtered } satisfies DifyRetrievalResponse);
+  }
+
+  // ============================
+  // POST /tools/capture — memory WRITE path (Dify Custom Tool)
+  // ============================
+
+  private async handleToolCapture(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<DifyCaptureToolRequest>(req);
+
+    if (!body.user_content || !body.assistant_content) {
+      difyError(res, 400, 4000, "Missing required fields: user_content, assistant_content");
+      return;
+    }
+
+    const outcome = await this.client.capture({
+      userContent: body.user_content,
+      assistantContent: body.assistant_content,
+      sessionKey: body.session_key?.trim() || this.defaultSessionKey,
+      sessionId: body.session_id,
+    });
+
+    sendJson(res, 200, {
+      l0_recorded: outcome.l0Recorded,
+      scheduler_notified: outcome.schedulerNotified,
+    } satisfies DifyCaptureToolResponse);
+  }
+
+  // ============================
+  // POST /tools/recall — context prefetch (Dify Custom Tool)
+  // ============================
+
+  private async handleToolRecall(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<DifyRecallToolRequest>(req);
+
+    if (!body.query) {
+      difyError(res, 400, 4000, "Missing required field: query");
+      return;
+    }
+
+    const outcome = await this.client.recall({
+      query: body.query,
+      sessionKey: body.session_key?.trim() || this.defaultSessionKey,
+    });
+
+    sendJson(res, 200, {
+      context: outcome.context,
+      strategy: outcome.strategy,
+      memory_count: outcome.memoryCount,
+    } satisfies DifyRecallToolResponse);
+  }
+
+  // ============================
+  // GET /openapi.json + GET /health
+  // ============================
+
+  private handleOpenApi(req: http.IncomingMessage, res: http.ServerResponse): void {
+    // Advertise the URL the caller actually reached us on, so a spec imported
+    // from a LAN/tunnel address points Dify back at the same address.
+    const hostHeader = req.headers.host ?? `${this.host}:${this.boundPort}`;
+    sendJson(res, 200, buildOpenApiSpec(`http://${hostHeader}`));
+  }
+
+  /** Never throws — reports upstream reachability instead. */
+  private async handleHealth(res: http.ServerResponse): Promise<void> {
+    let upstream: unknown = "unreachable";
+    try {
+      upstream = await this.client.health();
+    } catch {
+      // keep "unreachable"
+    }
+    sendJson(res, 200, { status: "ok", platform: "dify", upstream });
+  }
+}

--- a/src/adapters/dify/types.ts
+++ b/src/adapters/dify/types.ts
@@ -1,0 +1,107 @@
+/**
+ * Dify adapter — wire types for Dify's External Knowledge Base API and the
+ * adapter's custom tool endpoints.
+ *
+ * Contract source: Dify docs, "External Knowledge API" (docs.dify.ai →
+ * Knowledge Base → External Knowledge Base API). Dify acts as the CLIENT and
+ * calls the endpoint we host:
+ *
+ *   POST <endpoint>/retrieval
+ *   Authorization: Bearer <api key configured in the Dify console>
+ *
+ * Error semantics defined by that spec (returned with HTTP 403/404):
+ *   1001 — invalid/malformed Authorization header format
+ *   1002 — authorization failed (wrong key)
+ *   2001 — the knowledge base does not exist
+ */
+
+// ============================
+// POST /retrieval (Dify → adapter)
+// ============================
+
+export interface DifyRetrievalSetting {
+  /** Maximum number of records to return. */
+  top_k: number;
+  /** Minimum relevance score threshold (0..1). */
+  score_threshold: number;
+}
+
+/**
+ * Metadata filter conditions (Dify sends these when the user configures
+ * metadata filtering). The memory adapter does not index custom metadata, so
+ * conditions are accepted but not applied.
+ */
+export interface DifyMetadataCondition {
+  logical_operator?: "and" | "or";
+  conditions?: Array<{
+    name?: string[];
+    comparison_operator?: string;
+    value?: string;
+  }>;
+}
+
+export interface DifyRetrievalRequest {
+  /** Which external knowledge base to query — we route on this. */
+  knowledge_id: string;
+  /** The user's search query. */
+  query: string;
+  retrieval_setting?: DifyRetrievalSetting;
+  metadata_condition?: DifyMetadataCondition;
+}
+
+/** One retrieved chunk in the shape Dify expects. */
+export interface DifyRetrievalRecord {
+  /** Text content of the retrieved chunk. */
+  content: string;
+  /** Relevance score, 0..1 preferred (we pass the engine's score through). */
+  score: number;
+  /** Document title shown in the Dify citation UI. */
+  title: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DifyRetrievalResponse {
+  records: DifyRetrievalRecord[];
+}
+
+/** Error body per the External Knowledge API spec. */
+export interface DifyErrorBody {
+  error_code: number;
+  error_msg: string;
+}
+
+// ============================
+// Knowledge id routing
+// ============================
+
+/** knowledge_id → L1 structured memory search. */
+export const KNOWLEDGE_ID_MEMORIES = "tdai-memories";
+/** knowledge_id → L0 raw conversation search. */
+export const KNOWLEDGE_ID_CONVERSATIONS = "tdai-conversations";
+
+// ============================
+// /tools/* (Dify Custom Tool → adapter)
+// ============================
+
+export interface DifyCaptureToolRequest {
+  user_content: string;
+  assistant_content: string;
+  session_key?: string;
+  session_id?: string;
+}
+
+export interface DifyCaptureToolResponse {
+  l0_recorded: number;
+  scheduler_notified: boolean;
+}
+
+export interface DifyRecallToolRequest {
+  query: string;
+  session_key?: string;
+}
+
+export interface DifyRecallToolResponse {
+  context: string;
+  strategy?: string;
+  memory_count: number;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -21,6 +21,16 @@ export type {
   ConversationSearchParams,
 } from "./types.js";
 
+// Structured search result types (used by the Adapter SDK and Dify adapter)
+export type {
+  MemorySearchResult,
+  MemorySearchResultItem,
+} from "./tools/memory-search.js";
+export type {
+  ConversationSearchResult,
+  ConversationSearchResultItem,
+} from "./tools/conversation-search.js";
+
 // TdaiCore service facade
 export { TdaiCore } from "./tdai-core.js";
 export type { TdaiCoreOptions } from "./tdai-core.js";

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -35,7 +35,9 @@ import type { EmbeddingService } from "./store/embedding.js";
 import { performAutoRecall } from "./hooks/auto-recall.js";
 import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
+import type { MemorySearchResult } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
+import type { ConversationSearchResult } from "./tools/conversation-search.js";
 import {
   initDataDirectories,
   initStores,
@@ -323,6 +325,44 @@ export class TdaiCore {
       text: formatConversationSearchResponse(result),
       total: result.total,
     };
+  }
+
+  /**
+   * Search L1 structured memories and return the raw structured result
+   * (per-record ids/scores/timestamps) instead of the formatted text.
+   *
+   * Same search pipeline as {@link searchMemories} — this variant exists for
+   * adapters that need machine-readable records (e.g. the Dify External
+   * Knowledge API must return per-record `score` values, and the Adapter SDK
+   * exposes `items` alongside the formatted text). Callers that only need
+   * human/LLM-readable output should keep using {@link searchMemories}.
+   */
+  async searchMemoriesStructured(params: MemorySearchParams): Promise<MemorySearchResult> {
+    return executeMemorySearch({
+      query: params.query,
+      limit: params.limit ?? 5,
+      type: params.type,
+      scene: params.scene,
+      vectorStore: this.vectorStore,
+      embeddingService: this.embeddingService,
+      logger: this.logger,
+    });
+  }
+
+  /**
+   * Search L0 raw conversations and return the raw structured result.
+   * Structured counterpart of {@link searchConversations} — see
+   * {@link searchMemoriesStructured} for why this exists.
+   */
+  async searchConversationsStructured(params: ConversationSearchParams): Promise<ConversationSearchResult> {
+    return executeConversationSearch({
+      query: params.query,
+      limit: params.limit ?? 5,
+      sessionKey: params.sessionKey,
+      vectorStore: this.vectorStore,
+      embeddingService: this.embeddingService,
+      logger: this.logger,
+    });
   }
 
   /**

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -23,6 +23,8 @@ import { loadGatewayConfig } from "./config.js";
 import type { GatewayConfig } from "./config.js";
 import { initDataDirectories } from "../utils/pipeline-factory.js";
 import { SessionFilter } from "../utils/session-filter.js";
+import { formatSearchResponse } from "../core/tools/memory-search.js";
+import { formatConversationSearchResponse } from "../core/tools/conversation-search.js";
 import type {
   HealthResponse,
   RecallRequest,
@@ -213,6 +215,15 @@ export class TdaiGateway {
   }
 
   /**
+   * Actual bound port once started. Differs from `config.server.port` when
+   * the config requested an ephemeral port (`0`) — e2e tests rely on this.
+   */
+  get boundPort(): number | undefined {
+    const addr = this.server?.address();
+    return addr && typeof addr === "object" ? addr.port : undefined;
+  }
+
+  /**
    * Gracefully stop the Gateway.
    */
   async stop(): Promise<void> {
@@ -386,6 +397,10 @@ export class TdaiGateway {
       context: result.appendSystemContext ?? "",
       strategy: result.recallStrategy,
       memory_count: result.recalledL1Memories?.length ?? 0,
+      // Additive (see RecallResponse doc): keeps the SDK's http transport at
+      // recall parity with the in-process transport. Omitted when empty so
+      // legacy text-only responses stay byte-identical for old clients.
+      ...(result.prependContext ? { prepend_context: result.prependContext } : {}),
     };
     sendJson(res, 200, response);
   }
@@ -428,12 +443,30 @@ export class TdaiGateway {
       return;
     }
 
-    const result = await this.core.searchMemories({
+    const params = {
       query: body.query,
       limit: body.limit,
       type: body.type,
       scene: body.scene,
-    });
+    };
+
+    // Opt-in structured path: adapter-sdk / Dify clients send
+    // `include_items: true` to receive per-record items alongside the
+    // formatted text. Legacy clients (Hermes client.py) never send the
+    // flag and get the unchanged text-only response.
+    if (body.include_items === true) {
+      const structured = await this.core.searchMemoriesStructured(params);
+      const response: MemorySearchResponse = {
+        results: formatSearchResponse(structured),
+        total: structured.total,
+        strategy: structured.strategy,
+        items: structured.results,
+      };
+      sendJson(res, 200, response);
+      return;
+    }
+
+    const result = await this.core.searchMemories(params);
 
     const response: MemorySearchResponse = {
       results: result.text,
@@ -451,11 +484,25 @@ export class TdaiGateway {
       return;
     }
 
-    const result = await this.core.searchConversations({
+    const params = {
       query: body.query,
       limit: body.limit,
       sessionKey: body.session_key,
-    });
+    };
+
+    // Opt-in structured path — see handleSearchMemories for rationale.
+    if (body.include_items === true) {
+      const structured = await this.core.searchConversationsStructured(params);
+      const response: ConversationSearchResponse = {
+        results: formatConversationSearchResponse(structured),
+        total: structured.total,
+        items: structured.results,
+      };
+      sendJson(res, 200, response);
+      return;
+    }
+
+    const result = await this.core.searchConversations(params);
 
     const response: ConversationSearchResponse = {
       results: result.text,

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -2,6 +2,9 @@
  * TDAI Gateway — Request/Response types for the HTTP API.
  */
 
+import type { MemorySearchResultItem } from "../core/tools/memory-search.js";
+import type { ConversationSearchResultItem } from "../core/tools/conversation-search.js";
+
 // ============================
 // Common
 // ============================
@@ -39,6 +42,14 @@ export interface RecallResponse {
   context: string;
   strategy?: string;
   memory_count?: number;
+  /**
+   * Per-turn dynamic context intended to precede the user message
+   * (`RecallResult.prependContext`). Additive field introduced with the
+   * Adapter SDK so HTTP clients receive the same recall surface as
+   * in-process hosts; existing clients (Hermes `client.py` reads only
+   * `context`) ignore it.
+   */
+  prepend_context?: string;
 }
 
 // ============================
@@ -68,12 +79,20 @@ export interface MemorySearchRequest {
   limit?: number;
   type?: string;
   scene?: string;
+  /**
+   * Opt-in: when `true`, the response additionally carries structured
+   * `items` (per-record id/score/timestamps). Defaults to `false` so
+   * existing clients (Hermes `client.py`) keep the legacy text-only shape.
+   */
+  include_items?: boolean;
 }
 
 export interface MemorySearchResponse {
   results: string;
   total: number;
   strategy: string;
+  /** Present only when the request set `include_items: true`. */
+  items?: MemorySearchResultItem[];
 }
 
 // ============================
@@ -84,11 +103,15 @@ export interface ConversationSearchRequest {
   query: string;
   limit?: number;
   session_key?: string;
+  /** Opt-in structured items — see {@link MemorySearchRequest.include_items}. */
+  include_items?: boolean;
 }
 
 export interface ConversationSearchResponse {
   results: string;
   total: number;
+  /** Present only when the request set `include_items: true`. */
+  items?: ConversationSearchResultItem[];
 }
 
 // ============================

--- a/src/utils/is-main.test.ts
+++ b/src/utils/is-main.test.ts
@@ -1,0 +1,32 @@
+/**
+ * isMainModule unit tests — the Windows-backslash normalization is the whole
+ * point: adapter entry suffixes contain a "/", which a raw endsWith() check
+ * can never match against a backslash argv[1].
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isMainModule } from "./is-main.js";
+
+const SUFFIXES = ["claude-code/main.ts", "claude-code/main.js"];
+
+describe("isMainModule", () => {
+  it("matches POSIX argv[1] paths (source run via tsx)", () => {
+    expect(isMainModule("/repo/src/adapters/claude-code/main.ts", SUFFIXES)).toBe(true);
+  });
+
+  it("matches Windows backslash argv[1] paths", () => {
+    expect(isMainModule("C:\\repo\\src\\adapters\\claude-code\\main.ts", SUFFIXES)).toBe(true);
+  });
+
+  it("matches compiled output (.js suffix), including on Windows", () => {
+    expect(isMainModule("/repo/dist/adapters/claude-code/main.js", SUFFIXES)).toBe(true);
+    expect(isMainModule("C:\\repo\\dist\\adapters\\claude-code\\main.js", SUFFIXES)).toBe(true);
+  });
+
+  it("rejects other entrypoints and a missing argv[1]", () => {
+    expect(isMainModule("/repo/node_modules/vitest/dist/cli.js", SUFFIXES)).toBe(false);
+    expect(isMainModule("/repo/src/adapters/dify/main.ts", SUFFIXES)).toBe(false);
+    expect(isMainModule(undefined, SUFFIXES)).toBe(false);
+  });
+});

--- a/src/utils/is-main.ts
+++ b/src/utils/is-main.ts
@@ -1,0 +1,18 @@
+/**
+ * Entry-module detection for CLI mains (`node --import tsx src/.../main.ts`).
+ *
+ * `process.argv[1]` uses the platform's path separators — on Windows that
+ * means backslashes, so a suffix containing "/" (e.g. "claude-code/main.ts")
+ * would never match and the server would exit silently instead of starting.
+ * Backslashes are therefore normalized to "/" before the suffix check.
+ */
+
+/**
+ * True when `argv1` (usually `process.argv[1]`) ends with one of `suffixes`
+ * after normalizing Windows backslashes to forward slashes.
+ */
+export function isMainModule(argv1: string | undefined, suffixes: readonly string[]): boolean {
+  if (!argv1) return false;
+  const normalized = argv1.replace(/\\/g, "/");
+  return suffixes.some((suffix) => normalized.endsWith(suffix));
+}


### PR DESCRIPTION
# feat(adapters): Cross-Platform Adapters for the Memory Plugin — unified Adapter SDK + Claude Code & Dify adapters (#235)

> PR description for issue [#235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235) — 2026 犀牛鸟开源人才培养活动 (Tencent Rhino-Bird Open-Source Talent Program).
> Branch `feat/235-cross-platform-adapters` (1 commit on top of `main`@4339e63). 47 files changed, +6429 / −4. **Zero new npm dependencies.**

---

## 中文

### 摘要

本 PR 完成 issue #235 的全部四级验收标准（基础 / 进阶 / 深入 / 拓展）：

1. **统一适配器 SDK**（`src/adapter-sdk/`）——新平台只需实现一个接口（`PlatformAdapter`，通常继承 `BasePlatformAdapter`），只需消费一个客户端接口（`MemoryClient`），传输方式（HTTP 网关 / 进程内直连 TdaiCore）变成一个配置项。
2. **两个新平台适配器**，均构建在 SDK 之上：
   - **Claude Code**（`src/adapters/claude-code/`）：MCP stdio 服务器，暴露 5 个记忆工具（读 + 写）。
   - **Dify**（`src/adapters/dify/`）：外部知识库 API（`/retrieval`，带逐条 score）+ 自定义工具 REST 端点（`/tools/capture`、`/tools/recall`）+ 一键导入的 OpenAPI 3.1 规格。
3. **双语架构 / 对比 / 接入文档**（`docs/adapters/`，EN + CN 各一份，内容对齐）。

### 动机

核心引擎 `TdaiCore` 已有两条接入路径（OpenClaw 插件进程内、Hermes Provider 经 HTTP Gateway），但每接入一个新平台都要重新理解核心能力边界并手写适配层。本 PR 把"接入一个新平台"收敛为"实现一个接口"，并用两个真实平台（Claude Code、Dify）验证该抽象成立。

### 设计

**统一 SDK（`src/adapter-sdk/`）**

- `MemoryClient` —— 平台适配器唯一消费的接口：`recall / capture / searchMemories / searchConversations / endSession / health / close`，参数与结果全部 camelCase，跨传输语义一致。
- 两种传输，一个工厂：`createMemoryClient({ transport: "http" | "in-process", ... })`，另有 `resolveClientOptionsFromEnv()`（环境变量约定 `TDAI_ADAPTER_TRANSPORT` / `TDAI_GATEWAY_URL` / `TDAI_GATEWAY_API_KEY` / `TDAI_ADAPTER_TIMEOUT_MS`）。
  - `HttpMemoryClient`：与 Hermes Python 客户端线协议 1:1 对齐（snake_case、Bearer、超时），搜索时携带 `include_items: true`，并兼容不返回 `items` 的旧网关。
  - `InProcessMemoryClient`：注入 `TdaiCoreLike`（测试 / 宿主已持有 core）或惰性自建 core（promise 门控、并发下只构建一次）；方法到 core 的投影与 `gateway/server.ts` 逐行一致，保证两种传输结果不变。
- `BasePlatformAdapter`：带标签日志、`stop()`、以及永不抛错的 `safeRecall` / `safeCapture`（把 Hermes 熔断哲学"记忆绝不能拖垮宿主"固化进 SDK 契约）。
- `MemoryClientError`：稳定错误码 `transport | auth | bad_request | unavailable`。

**Claude Code 适配器（MCP stdio）**

- 手写 MCP 子集（约 250 行含注释）而非引入 `@modelcontextprotocol/sdk`：仓库零框架取向（网关即裸 `node:http`）+ 离线安装约束；30 个协议测试钉死行为（版本协商降级、批量拒绝、通知静默、`isError` 结果 vs `-32602` 错误的规范区分）。
- 5 个工具：`memory_recall`、`memory_capture`、`memory_search`、`conversation_search`、`memory_session_end`；参数 snake_case 与网关词汇一致，`limit` 夹取 1..20 默认 5 与 OpenClaw 注册完全相同。`conversation_search` 刻意不默认 `session_key`（跨会话过滤器，默认会静默隐藏其他会话历史——已文档化并有测试）。
- stdout 仅走协议 JSON，日志全部走 stderr（stdio-MCP 的经典故障模式已规避）。Stop-hook 自动捕获以"配方文档"形式提供（钩子载荷属 Claude Code 实现细节，不做承重代码）。

**Dify 适配器（外部知识库 + 自定义工具）**

- 零依赖 `node:http`；`POST /retrieval` 按 `knowledge_id` 路由（`tdai-memories` / `tdai-conversations`），top_k 夹取、score_threshold 过滤、逐条 score/title/metadata；旧网关无 `items` 时退化为单条格式化文本记录。
- 写路径：`POST /tools/capture`（+ `POST /tools/recall`）；`GET /openapi.json` 供 Dify 自定义工具一键导入；鉴权错误体严格按 Dify 规范（1001/1002/2001），常量时间比较。

**对现有代码的改动（全部增量、向后兼容）**

- `TdaiCore` 新增 `searchMemoriesStructured` / `searchConversationsStructured`（Dify 需要逐条 score）。
- 网关搜索接口新增可选 `include_items` 请求字段与 `items` 响应字段；`/recall` 响应补发 `prepend_context`（验证阶段发现的传输一致性修复）。Hermes `client.py` 从不发送这些字段（已 grep 验证），67 个基线测试原样全绿。

### 验收标准对照表（issue 四级全覆盖）

| 阶段 | 标准 | 满足于（文件路径） | 如何验证 |
| :--- | :--- | :--- | :--- |
| **基础** | 阅读源码，画出核心引擎与各平台适配层的架构图，标注数据流 | `docs/adapters/ARCHITECTURE.md` + `ARCHITECTURE_CN.md`：TdaiCore 能力表（含 issue 名→真实符号漂移标注：`recall`→`handleBeforeRecall`、`capture`→`handleTurnCommitted`）、L0–L3 速览、**5 幅 mermaid 图**（全局组件图、OpenClaw 时序、Hermes/Gateway 时序、新适配器时序、SDK 目标架构）、边/线注释表、snake_case⇄camelCase 映射表 | 10/10 mermaid 块（5 EN + 5 CN）经真实 `mermaid@11.16.0` `mermaid.parse()` 校验通过；能力表逐符号对照 `src/core/tdai-core.ts`、路由表对照 `src/gateway/server.ts` 复核无误 |
| **进阶** | 选择一个平台编写适配代码，实现至少基本的记忆读写功能 | Claude Code MCP 适配器：`src/adapters/claude-code/{jsonrpc,tools,mcp-server,main}.ts`。读=`memory_recall`/`memory_search`/`conversation_search`，写=`memory_capture`，另有 `memory_session_end` | `mcp-server.test.ts` + `tools.test.ts` 共 30 个测试（握手、5 工具全调度、isError、-32601/-32700/-32600、PassThrough 全流程）；端到端冒烟：管道注入 JSON-RPC 行，stdout 纯协议、5 工具列出、网关宕机时按规范返回 `isError:true` 结果 |
| **深入** | 适配两个或以上平台，并编写对比文档分析各平台的差异 | + Dify 适配器：`src/adapters/dify/{types,server,openapi,main}.ts`；对比文档 `docs/adapters/PLATFORM-COMPARISON.md` + `_CN`（OpenClaw / Hermes / Claude Code / Dify 四平台 × 15 维度 + 逐机制分析 + 选型决策表 + SDK 前后接入 LOC 对比） | `server.test.ts` + `openapi.test.ts` 共 24 个测试（双知识库 records 映射、夹取、阈值、退化、1001/1002/2001/4000/5000、/tools 映射、health 永不抛错、坏 JSON→400）；curl 实测各错误码；对比表维度已对照源码抽查 |
| **拓展** | 封装统一的适配器 SDK，让新平台接入只需实现一个接口 | `src/adapter-sdk/`（types / errors / factory / base-platform-adapter / transports/{http,in-process}）；"一个接口"的结构性证明：两个新适配器均 `extends BasePlatformAdapter` 且不触碰 `MemoryClient` 以下任何层（其测试仅注入 fake client，零 core / 零网关 / 零网络）；接入指南 `docs/adapters/NEW-PLATFORM-GUIDE.md` + `_CN` 含约 40 行可编译完整示例 | SDK 42 个单元测试（端口 0 桩网关逐字段断言 snake_case 线协议与 Bearer；fake `TdaiCoreLike` 全方法委托；并发首调仅构建一次 core；close() 所有权语义）+ 3 个真网关 e2e 测试（真实 `TdaiGateway` + sqlite 临时目录，验证 `include_items` 与鉴权线兼容）；指南示例经 `tsc --noEmit --strict` 零错误 |

### 离线运行方式

```bash
source ~/.venvs/node22.env && cd <repo>

npx vitest run                                          # 全量离线套件：13 文件 / 171 测试
npx vitest run --config vitest.e2e.config.ts src/adapter-sdk   # 真网关 e2e（3 测试，仍离线）
npm run build:plugin                                    # tsdown 打包（入口未动）

npm run gateway                                         # 记忆后端 :8420
npm run adapter:claude-code                             # MCP stdio 服务器
TDAI_DIFY_API_KEY=secret npm run adapter:dify           # Dify 适配器 :8421
```

全套测试离线运行：无 API key、无 127.0.0.1 临时端口之外的网络。

---

## English

### Summary

This PR completes all four progressive acceptance tiers of issue #235 (基础/Basic, 进阶/Intermediate, 深入/Advanced, 拓展/Challenge):

1. **A unified Adapter SDK** (`src/adapter-sdk/`) — a new platform implements exactly one interface (`PlatformAdapter`, usually via `BasePlatformAdapter`) and consumes exactly one client interface (`MemoryClient`); the transport (HTTP gateway vs in-process `TdaiCore`) is a configuration choice, not an architecture choice.
2. **Two new platform adapters** built on that SDK:
   - **Claude Code** (`src/adapters/claude-code/`): an MCP stdio server exposing 5 memory tools (read AND write).
   - **Dify** (`src/adapters/dify/`): External Knowledge Base API (`/retrieval` with per-record scores) + Custom Tool REST endpoints (`/tools/capture`, `/tools/recall`) + a one-click-import OpenAPI 3.1 spec.
3. **Bilingual architecture / comparison / onboarding docs** (`docs/adapters/`, EN + CN, content-identical).

### Motivation

`TdaiCore` already had two integration paths (OpenClaw plugin in-process; Hermes provider via the HTTP Gateway), but every new platform required re-deriving the core's capability surface and hand-writing a bespoke adapter. This PR collapses "integrate a new platform" into "implement one interface", and proves the abstraction with two real, very different platforms (stdio JSON-RPC vs inbound REST).

### Design

**Unified SDK (`src/adapter-sdk/`)**

- `MemoryClient` — the single interface adapters consume: `recall / capture / searchMemories / searchConversations / endSession / health / close`; camelCase params/outcomes, transport-invariant semantics.
- Two transports behind one factory: `createMemoryClient({ transport: "http" | "in-process", ... })` plus `resolveClientOptionsFromEnv()` (env convention `TDAI_ADAPTER_TRANSPORT`, `TDAI_GATEWAY_URL`, `TDAI_GATEWAY_API_KEY`, `TDAI_ADAPTER_TIMEOUT_MS`).
  - `HttpMemoryClient` mirrors the Hermes Python client wire 1:1 (snake_case bodies, Bearer-when-nonempty, `AbortSignal.timeout`); sends `include_items: true` on searches and tolerates old gateways that omit `items`.
  - `InProcessMemoryClient` accepts an injected `TdaiCoreLike` (tests / hosts that own a core — no double lifecycle ownership) or lazily builds an owned core (promise-gated: exactly one build under concurrent first calls); its method→core projections match `gateway/server.ts` line-for-line so the two transports return identical results.
- `BasePlatformAdapter` — tagged logger, `stop()`, and never-throw `safeRecall`/`safeCapture`, codifying the Hermes circuit-breaker philosophy ("memory must never break the host") into the SDK contract.
- `MemoryClientError` with stable codes `transport | auth | bad_request | unavailable`.

**Claude Code adapter (MCP stdio)**

- Hand-rolled MCP subset (~250 lines incl. doc-comments) instead of `@modelcontextprotocol/sdk`: matches the repo's zero-framework ethos (the gateway is raw `node:http`) and the offline-install constraint; behavior pinned by 30 protocol tests (version negotiation/downgrade across 2025-06-18/2025-03-26/2024-11-05, batch rejection, notification silence, and the spec-mandated `isError` result vs `-32602` error distinction).
- 5 tools: `memory_recall`, `memory_capture`, `memory_search`, `conversation_search`, `memory_session_end`; snake_case args matching the gateway vocabulary; `limit` clamped 1..20 default 5 identically to the OpenClaw registrations. `conversation_search` deliberately does NOT default `session_key` (it is a cross-session filter; defaulting would silently hide other sessions — documented and tested).
- stdout carries protocol JSON only; all logging goes to stderr (avoiding the classic stdio-MCP corruption failure mode). Stop-hook auto-capture ships as a documented recipe, not load-bearing code (hook payload schema is a Claude Code implementation detail).

**Dify adapter (External Knowledge + Custom Tool)**

- Zero-dep `node:http`. `POST /retrieval` routes by `knowledge_id` (`tdai-memories` / `tdai-conversations`), clamps top_k, filters by `score_threshold`, emits per-record score/title/metadata from the SDK's structured `items`; degrades to a single formatted-text record against item-less legacy backends.
- Write path: `POST /tools/capture` (+ `POST /tools/recall`); `GET /openapi.json` for one-click Dify Custom Tool import; Dify-spec auth error bodies (1001/1002/2001) with constant-time key compare; `GET /health` never throws.

**Changes to existing code (all additive, backward compatible)**

- `TdaiCore`: new `searchMemoriesStructured` / `searchConversationsStructured` (same pipeline as the text facades, raw structured results — needed for Dify's per-record scores).
- Gateway: opt-in `include_items` request field + `items` response field on both search endpoints; `/recall` response now carries `prepend_context` (a transport-parity fix found during independent verification).
- Hermes wire compat preserved: `hermes-plugin/**` untouched; `client.py` never sends the new fields (grep-verified); all 67 baseline tests pass unmodified. `package.json` gains 3 scripts and **zero dependencies**.

### Acceptance-criteria mapping (all four tiers)

| Tier | Criterion | Satisfied by (paths) | How tested |
| :--- | :--- | :--- | :--- |
| **基础 (Basic)** | Read the source; draw the architecture of the core engine + all platform adapter layers, with annotated data flows | `docs/adapters/ARCHITECTURE.md` + `ARCHITECTURE_CN.md`: verified `TdaiCore` capability table (incl. issue-name→real-symbol drift: `recall`→`handleBeforeRecall`, `capture`→`handleTurnCommitted`), L0–L3 refresher, **5 mermaid diagrams** (global component map, OpenClaw sequence, Hermes/Gateway sequence, new-adapters sequence, SDK target architecture), annotated edge/wire tables, snake_case⇄camelCase mapping | All 10 mermaid blocks (5 EN + 5 CN) parse via real `mermaid@11.16.0` `mermaid.parse()`; capability table cross-checked symbol-by-symbol against `src/core/tdai-core.ts`, route list against `src/gateway/server.ts` |
| **进阶 (Intermediate)** | Write adapter code for one platform with at least basic memory read/write | Claude Code MCP adapter: `src/adapters/claude-code/{jsonrpc,tools,mcp-server,main}.ts`. Read = `memory_recall` / `memory_search` / `conversation_search`; write = `memory_capture`; plus `memory_session_end` | 30 tests (`mcp-server.test.ts`, `tools.test.ts`): handshake, tools/list, all 5 tool dispatches on a fake client, isError semantics, -32601/-32700/-32600, full PassThrough stream lifecycle. E2E smoke: piped JSON-RPC lines → protocol-only stdout, 5 tools listed, gateway-down failures surfaced as `isError:true` results per spec |
| **深入 (Advanced)** | Adapt two or more platforms and write a comparison document analyzing platform differences | + Dify adapter: `src/adapters/dify/{types,server,openapi,main}.ts`; comparison doc `docs/adapters/PLATFORM-COMPARISON.md` + `_CN` (15 dimensions × 4 platforms: OpenClaw / Hermes / Claude Code / Dify, per-mechanism analysis, decision table, before/after-SDK LOC argument) | 24 tests (`server.test.ts`, `openapi.test.ts`): records mapping for both knowledge bases, clamps, threshold, item-less fallback, error codes 1001/1002/2001/4000/5000, /tools mapping, health never-throws, malformed JSON → 400. Live curl probes reproduced every error code; comparison dimensions spot-checked against source |
| **拓展 (Challenge)** | Package a unified adapter SDK so a new platform only implements one interface | `src/adapter-sdk/` (`types.ts`, `errors.ts`, `factory.ts`, `base-platform-adapter.ts`, `transports/http.ts`, `transports/in-process.ts`). Structural proof of "one interface": both new adapters `extend BasePlatformAdapter` and touch nothing below `MemoryClient` — their tests inject a fake client (no core, no gateway, no network). Onboarding guide `docs/adapters/NEW-PLATFORM-GUIDE.md` + `_CN` with a ~40-line complete worked example | 42 SDK unit tests (port-0 stub gateway asserting snake_case wire + Bearer per field; fake `TdaiCoreLike` delegation; concurrency gate proves exactly one owned-core build; `close()` ownership semantics) + 3 real-gateway e2e tests (real `TdaiGateway` + sqlite in a temp dir; proves `include_items` + auth wire compat). Guide example compiles under `tsc --noEmit --strict` with zero errors |

### How to run (fully offline)

```bash
source ~/.venvs/node22.env && cd <repo>

npx vitest run                                          # full offline suite: 13 files / 171 tests
npx vitest run --config vitest.e2e.config.ts src/adapter-sdk   # real-gateway e2e (3 tests, still offline)
npm run build:plugin                                    # tsdown bundle (entry untouched)

npm run gateway                                         # memory backend on :8420
npm run adapter:claude-code                             # MCP stdio server (pipe JSON-RPC lines)
TDAI_DIFY_API_KEY=secret npm run adapter:dify           # Dify adapter on :8421
```

No API keys, no network beyond 127.0.0.1 ephemeral ports created inside the tests.

### Test evidence

- `npx vitest run` → **Test Files 13 passed (13) · Tests 171 passed (171)** (baseline was 4 files / 67 tests, untouched; 104 new tests).
- `npx vitest run --config vitest.e2e.config.ts src/adapter-sdk` → 1 file / 3 tests green (real `TdaiGateway` + sqlite store, temp dir, offline).
- `npm run build:plugin` → Build complete; `dist/index.mjs` surface unchanged.
- Independent adversarial verification report: `/home/seat1163/work/Tencent/docs/verify/issue-235-verification.md` (verdict: PASS on all four tiers).

### Artifacts

| Artifact | Path |
| --- | --- |
| Patch (git am-able) | `/home/seat1163/work/Tencent/docs/patches/issue-235/0001-feat-adapters-add-Claude-Code-Dify-adapters-unified-.patch` |
| Worktree / branch | `/home/seat1163/work/Tencent/issue-235` · `feat/235-cross-platform-adapters` (HEAD 7be7a6f, base 4339e63) |
| Plan | `/home/seat1163/work/Tencent/docs/plans/issue-235-plan.md` |
| Implementation notes | `/home/seat1163/work/Tencent/docs/impl/issue-235-implementation.md` |
| Verification report | `/home/seat1163/work/Tencent/docs/verify/issue-235-verification.md` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 评审后更新 / Post-review update（2026-07-19）

独立对抗式评审证实 2 个 major + 4 个 minor,全部修复:

- **[major] Windows 启动守卫**:`claude-code/main.ts` 与 `dify/main.ts` 的 isMain 判断内嵌正斜杠,Windows 下(argv[1] 为反斜杠)服务器静默不启动 → 抽出公共 `src/utils/is-main.ts`(分隔符归一化,兼容 .ts/.js),两适配器共用,+4 单测;并更正了"与 gateway 同模式"的注释。
- **[major] Dify score_threshold 与 RRF 分数量纲**:hybrid 策略下引擎分数为 RRF 值(≤~0.033),任何常规阈值都会静默清空结果 → `/retrieval` 现在按批次最大值归一化(top hit = 1.0,保序)后再过阈值;文档改为「相对阈值」语义;+RRF 阈值回归测试。
- [minor] in-process `close()` 期间在建 owned-core 泄漏 → close 等待在建完成并销毁;+测试。
- [minor] MCP writeChain 单次写失败永久中毒 → 逐环节吸收异常保持链存活且有序;+测试。
- [minor] MCP server 默认 logger 可能污染 stdout(stdio 协议)→ 默认 stderr-only logger;+测试。
- [minor] `TDAI_USER_ID` 死配置 → 文档如实标注 reserved/暂不生效(接线需改核心签名,超出本 PR 边界)。

测试:**171/171 全绿(+8)**,adapter-sdk e2e 3/3。

*(EN) Post-review update 2026-07-19: an independent adversarial review (6 parallel judges, execution-backed verification) confirmed 2 majors (Windows isMain guard; Dify score_threshold vs RRF score scale) and 4 minors; all items fixed as listed above, full suite green (vitest 171/171 + e2e 3/3).*
