### PR TITLE
docs: use canonical TencentCloud repo URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This project requires no build step. Node.js 22.16+ natively supports TypeScript
 
 ```bash
 # Clone the repository
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory
 
 # Install dependencies

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -23,7 +23,7 @@
 
 ```bash
 # 克隆仓库
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory
 
 # 安装依赖

--- a/README.md
+++ b/README.md
@@ -546,8 +546,8 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 We welcome every kind of contribution — bug reports, feature ideas, doc fixes, benchmark reproductions, ecosystem integrations, or a Pull Request. Agent memory is far from a solved problem, and we'd love to figure it out together.
 
-- 🐞 **Found a bug or have a question?** Open an issue at [GitHub Issues](https://github.com/Tencent/TencentDB-Agent-Memory/issues) — we respond within 24 hours.
-- 💡 **Have an idea to share?** Start a thread in [GitHub Discussions](https://github.com/Tencent/TencentDB-Agent-Memory/discussions).
+- 🐞 **Found a bug or have a question?** Open an issue at [GitHub Issues](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues) — we respond within 24 hours.
+- 💡 **Have an idea to share?** Start a thread in [GitHub Discussions](https://github.com/TencentCloud/TencentDB-Agent-Memory/discussions).
 - 🛠️ **Want to contribute code?** Please read [CONTRIBUTING.md](./CONTRIBUTING.md) first.
 - 💬 **Want to chat with us?** Join our [Discord community](https://discord.gg/kDtHb5RW2) and talk to the early developers directly.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -546,8 +546,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 我们欢迎一切形式的贡献——Bug 反馈、功能建议、文档勘误、Benchmark 复现、生态集成，或者一个 Pull Request 都可以。Agent 记忆这件事远未有定论，希望和大家一起把它做出来。
 
-- 🐞 **发现 Bug 或有疑问？** 欢迎到 [GitHub Issues](https://github.com/Tencent/TencentDB-Agent-Memory/issues) 提交，我们会在 24 小时内响应。
-- 💡 **有想法想交流？** 欢迎在 [GitHub Discussions](https://github.com/Tencent/TencentDB-Agent-Memory/discussions) 发起讨论。
+- 🐞 **发现 Bug 或有疑问？** 欢迎到 [GitHub Issues](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues) 提交，我们会在 24 小时内响应。
+- 💡 **有想法想交流？** 欢迎在 [GitHub Discussions](https://github.com/TencentCloud/TencentDB-Agent-Memory/discussions) 发起讨论。
 - 🛠️ **想贡献代码？** 请先阅读 [CONTRIBUTING.md](./CONTRIBUTING_CN.md)。
 - 💬 **想加入交流群？** 扫码加入 **Agent Memory 微信社群**，与早期开发者直接对话。
 <p align="center"><img src="https://github.com/user-attachments/assets/c9b7072e-ee47-48b6-9c25-c27a9e884718" width="200" alt="Agent Memory 微信社群二维码" />


### PR DESCRIPTION
## Description | 描述

The repository now lives at `github.com/TencentCloud/TencentDB-Agent-Memory`, but several docs still reference the old `github.com/Tencent/TencentDB-Agent-Memory` org path. Those old URLs currently resolve **only through a 301 redirect**, so they will break if the redirect is ever removed (e.g. if a repo of that name is later created under the `Tencent` org).

This PR points the user-facing docs at the canonical org:

- `CONTRIBUTING.md` / `CONTRIBUTING_CN.md`: the `git clone` command new contributors copy-paste.
- `README.md` / `README_CN.md`: the **GitHub Issues** and **GitHub Discussions** links in the "Community & Contributing" section.

6 URL occurrences across 4 files; no content or behavior changes. Historical links in `CHANGELOG.md` are intentionally left untouched to avoid rewriting past release notes.

## Related Issue | 关联 Issue

N/A (documentation correctness).

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified `https://github.com/TencentCloud/TencentDB-Agent-Memory` returns HTTP 200 (canonical), while `https://github.com/Tencent/...` only 301-redirects to it.
- [x] No remaining `github.com/Tencent/TencentDB-Agent-Memory` references in the four edited docs.
- [x] No source/behavior changes; docs-only.