### PR TITLE
fix(gateway): add opt-in recall context dedup

### DIFF
--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1,0 +1,134 @@
+import { Readable } from "node:stream";
+import type http from "node:http";
+import { describe, expect, it } from "vitest";
+
+import { TdaiGateway } from "./server.js";
+
+type JsonObject = Record<string, unknown>;
+
+function createRequest(pathname: string, body: JsonObject): http.IncomingMessage {
+  const payload = JSON.stringify(body);
+  const req = new Readable({
+    read() {
+      this.push(payload);
+      this.push(null);
+    },
+  }) as http.IncomingMessage;
+  req.method = "POST";
+  req.url = pathname;
+  req.headers = { host: "127.0.0.1" };
+  return req;
+}
+
+function createResponse(): {
+  res: http.ServerResponse;
+  result: Promise<{ status: number; body: JsonObject }>;
+} {
+  let status = 200;
+  let resolveResult!: (value: { status: number; body: JsonObject }) => void;
+
+  const result = new Promise<{ status: number; body: JsonObject }>((resolve) => {
+    resolveResult = resolve;
+  });
+
+  const res = {
+    setHeader: () => undefined,
+    writeHead: (nextStatus: number) => {
+      status = nextStatus;
+    },
+    end: (chunk?: unknown) => {
+      const rawBody = typeof chunk === "string" ? chunk : "";
+      resolveResult({ status, body: JSON.parse(rawBody) as JsonObject });
+    },
+  } as unknown as http.ServerResponse;
+
+  return { res, result };
+}
+
+function createGateway(context: string): TdaiGateway {
+  const gateway = new TdaiGateway({
+    data: { baseDir: "/tmp/tdai-gateway-test" },
+    server: { host: "127.0.0.1", port: 0, apiKey: undefined, corsOrigins: [] },
+  });
+
+  (gateway as unknown as { logger: Record<string, () => void> }).logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+
+  (gateway as unknown as { core: unknown }).core = {
+    handleBeforeRecall: async () => ({
+      appendSystemContext: context,
+      recallStrategy: "keyword",
+      recalledL1Memories: [{ content: "remember me", score: 0.9, type: "fact" }],
+    }),
+    handleSessionEnd: async () => undefined,
+    getVectorStore: () => undefined,
+    getEmbeddingService: () => undefined,
+    destroy: async () => undefined,
+  };
+
+  return gateway;
+}
+
+async function post(gateway: TdaiGateway, pathname: string, body: JsonObject): Promise<JsonObject> {
+  const req = createRequest(pathname, body);
+  const { res, result } = createResponse();
+  await (gateway as unknown as { handleRequest: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void> }).handleRequest(req, res);
+  const response = await result;
+
+  expect(response.status, JSON.stringify(response.body)).toBe(200);
+  return response.body;
+}
+
+describe("TdaiGateway recall dedup", () => {
+  it("keeps recall responses unchanged unless dedup is requested", async () => {
+    const gateway = createGateway("<user-persona>stable</user-persona>");
+
+    const first = await post(gateway, "/recall", { query: "hello", session_key: "s1" });
+    const second = await post(gateway, "/recall", { query: "hello again", session_key: "s1" });
+
+    expect(first).toMatchObject({
+      context: "<user-persona>stable</user-persona>",
+      strategy: "keyword",
+      memory_count: 1,
+    });
+    expect(second).toEqual(first);
+    expect(first).not.toHaveProperty("deduped");
+  });
+
+  it("suppresses repeated recall context only for dedup-enabled requests", async () => {
+    const gateway = createGateway("<user-persona>stable</user-persona>");
+
+    const first = await post(gateway, "/recall", { query: "hello", session_key: "s1", dedup: true });
+    const second = await post(gateway, "/recall", { query: "hello again", session_key: "s1", dedup: true });
+
+    expect(first).toMatchObject({
+      context: "<user-persona>stable</user-persona>",
+      memory_count: 1,
+      deduped: false,
+    });
+    expect(second).toMatchObject({
+      context: "",
+      memory_count: 0,
+      deduped: true,
+    });
+  });
+
+  it("clears dedup state when the session ends", async () => {
+    const gateway = createGateway("<user-persona>stable</user-persona>");
+
+    await post(gateway, "/recall", { query: "hello", session_key: "s1", dedup: true });
+    await post(gateway, "/recall", { query: "hello again", session_key: "s1", dedup: true });
+    await post(gateway, "/session/end", { session_key: "s1" });
+    const afterSessionEnd = await post(gateway, "/recall", { query: "new turn", session_key: "s1", dedup: true });
+
+    expect(afterSessionEnd).toMatchObject({
+      context: "<user-persona>stable</user-persona>",
+      memory_count: 1,
+      deduped: false,
+    });
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -16,7 +16,7 @@
 
 import http from "node:http";
 import { URL } from "node:url";
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { TdaiCore } from "../core/tdai-core.js";
 import { StandaloneHostAdapter } from "../adapters/standalone/host-adapter.js";
 import { loadGatewayConfig } from "./config.js";
@@ -107,6 +107,10 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(ab, bb);
 }
 
+function recallContextHash(context: string): string {
+  return createHash("sha256").update(context, "utf-8").digest("hex");
+}
+
 // ============================
 // Gateway Server
 // ============================
@@ -117,6 +121,7 @@ export class TdaiGateway {
   private core: TdaiCore;
   private server: http.Server | null = null;
   private startTime = Date.now();
+  private recallDedupLedger = new Map<string, Set<string>>();
 
   constructor(configOverrides?: Partial<GatewayConfig>) {
     this.config = loadGatewayConfig(configOverrides);
@@ -382,11 +387,26 @@ export class TdaiGateway {
 
     this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
 
+    let context = result.appendSystemContext ?? "";
+    let deduped = false;
+    if (body.dedup && context.length > 0) {
+      const contextHash = recallContextHash(context);
+      const seen = this.recallDedupLedger.get(body.session_key) ?? new Set<string>();
+      if (seen.has(contextHash)) {
+        context = "";
+        deduped = true;
+      } else {
+        seen.add(contextHash);
+        this.recallDedupLedger.set(body.session_key, seen);
+      }
+    }
+
     const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
+      context,
       strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
+      memory_count: deduped ? 0 : result.recalledL1Memories?.length ?? 0,
     };
+    if (body.dedup) response.deduped = deduped;
     sendJson(res, 200, response);
   }
 
@@ -473,6 +493,7 @@ export class TdaiGateway {
     }
 
     await this.core.handleSessionEnd(body.session_key);
+    this.recallDedupLedger.delete(body.session_key);
 
     const response: SessionEndResponse = { flushed: true };
     sendJson(res, 200, response);

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -33,12 +33,14 @@ export interface RecallRequest {
   query: string;
   session_key: string;
   user_id?: string;
+  dedup?: boolean;
 }
 
 export interface RecallResponse {
   context: string;
   strategy?: string;
   memory_count?: number;
+  deduped?: boolean;
 }
 
 // ============================


### PR DESCRIPTION
## Description

Add request-level opt-in deduplication for Gateway `/recall` responses. Push + persistent HTTP adapters can now send `dedup: true` when they already persist previously injected recall context in conversation history.

Behavior:

- Requests without `dedup` keep the existing byte-for-byte response shape.
- Requests with `dedup: true` return the first stable recall `context` normally.
- Subsequent calls in the same `session_key` suppress an identical already-returned `context`, returning `context: ""`, `memory_count: 0`, and `deduped: true`.
- `POST /session/end` clears the per-session dedup ledger.
- Gateway restart remains fail-open because the ledger is in-memory only.

The ledger uses a SHA-256 hash of the returned context, so updated persona/scene/tool context is returned again instead of being incorrectly suppressed.

Fixes #523

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] `COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run src/gateway/server.test.ts` -> 1 file / 3 tests passed
- [x] `COREPACK_ENABLE_AUTO_PIN=0 pnpm test` -> 5 files / 70 tests passed
- [x] `COREPACK_ENABLE_AUTO_PIN=0 pnpm build:plugin` -> passed
- [x] `git diff --check` -> passed

## Notes

The local verification environment uses Node v22.14.0, so pnpm/tsdown prints an engine/deprecation warning because the package targets Node >=22.16.0. The commands above still exited successfully.