### PR TITLE
feat(adapters): add Google ADK memory service adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,28 @@ memory:
 ```
 
 
+### 4. Google ADK (Agent Development Kit)
+
+Python agents built on [Google ADK](https://google.github.io/adk-docs/) can
+use the engine through a drop-in `BaseMemoryService` implementation that
+talks to the same Gateway sidecar as Hermes:
+
+```python
+from memory_tencentdb_adk import TdaiMemoryService
+
+runner = Runner(
+    agent=agent,
+    app_name="my-app",
+    session_service=session_service,
+    memory_service=TdaiMemoryService(),  # Gateway on 127.0.0.1:8420
+)
+```
+
+See [`adk-plugin/README.md`](./adk-plugin/README.md) for setup, the
+architecture/data-flow diagram, configuration, tests, and a guide to
+writing adapters for further platforms.
+
+
 ## 🔒 Gateway Security (optional)
 
 The Hermes Gateway listens on `:8420` and exposes capture / search / recall HTTP endpoints. Two opt-in switches let you turn it from "open localhost sidecar" into "authenticated network service". **Both default to off so existing deployments keep working unchanged.**

--- a/adk-plugin/README.md
+++ b/adk-plugin/README.md
@@ -1,0 +1,194 @@
+# memory-tencentdb × Google ADK (Agent Development Kit)
+
+A cross-platform memory adapter that plugs the TencentDB Agent Memory
+engine into [Google ADK](https://google.github.io/adk-docs/) Python agents
+as a drop-in
+[`BaseMemoryService`](https://google.github.io/adk-docs/sessions/memory/).
+ADK agents get fully local four-layer long-term memory (L0 conversation →
+L1 extraction → L2 scene blocks → L3 persona) with zero external API
+dependencies.
+
+This adapter follows the same integration pattern as the Hermes provider
+(`hermes-plugin/`): it does **not** re-implement any engine logic — it
+translates the host platform's memory lifecycle into calls against the
+[HTTP Gateway](../src/gateway/server.ts) that fronts `TdaiCore`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph host["Host platforms"]
+        OC["OpenClaw<br/>(in-process plugin, index.ts)"]
+        HM["Hermes<br/>(Python MemoryProvider)"]
+        ADK["Google ADK<br/>(TdaiMemoryService — this adapter)"]
+    end
+
+    subgraph gw["Gateway sidecar (Node)"]
+        GT["TdaiGateway<br/>src/gateway/server.ts<br/>127.0.0.1:8420"]
+    end
+
+    subgraph core["Core engine (Node)"]
+        TC["TdaiCore"]
+        L0["L0 conversation log"]
+        L1["L1 extracted memories"]
+        L2["L2 scene blocks"]
+        L3["L3 persona"]
+        TC --> L0 --> L1 --> L2 --> L3
+    end
+
+    OC -- "host hooks (before_prompt_build / agent_end)" --> TC
+    HM -- "HTTP: /recall /capture /search/* /session/end" --> GT
+    ADK -- "HTTP: /capture /search/* /session/end" --> GT
+    GT --> TC
+```
+
+Data flow for an ADK agent turn:
+
+| ADK lifecycle | Adapter call | Gateway endpoint | Engine effect |
+| --- | --- | --- | --- |
+| `load_memory` / `preload_memory` tool | `search_memory(query=...)` | `POST /search/memories` + `POST /search/conversations` | L1–L3 semantic search + raw L0 search |
+| App ingests a finished session | `add_session_to_memory(session)` | `POST /capture` per completed turn | L0 write + pipeline scheduling |
+| App ingests only the latest turn | `add_events_to_memory(events=...)` | `POST /capture` | Incremental L0 write |
+| Conversation ends | `end_session(...)` (optional helper) | `POST /session/end` | Flush pending L1→L3 work |
+
+## Installation
+
+1. Start the Gateway (owns the memory data directory and the local LLM
+   pipeline). From the repository root:
+
+   ```bash
+   pnpm install
+   pnpm exec tsx src/gateway/server.ts
+   # → [tdai-gateway] Gateway listening on http://127.0.0.1:8420
+   ```
+
+   Any of the existing deployment recipes (Hermes Docker image, `memory-tencentdb-ctl`)
+   also work — the adapter only needs the HTTP port.
+
+2. Install the adapter next to your ADK app. It is dependency-free beyond
+   `google-adk` itself:
+
+   ```bash
+   pip install google-adk
+   # from this repository checkout:
+   export PYTHONPATH="/path/to/TencentDB-Agent-Memory/adk-plugin:$PYTHONPATH"
+   ```
+
+## Usage
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools import load_memory
+
+from memory_tencentdb_adk import TdaiMemoryService
+
+memory_service = TdaiMemoryService()  # Gateway on 127.0.0.1:8420
+
+agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name="assistant",
+    instruction="Answer using memory when helpful.",
+    tools=[load_memory],
+)
+
+runner = Runner(
+    agent=agent,
+    app_name="my-app",
+    session_service=InMemorySessionService(),
+    memory_service=memory_service,
+)
+
+# ... run turns ...
+
+# After a conversation finishes:
+session = await runner.session_service.get_session(
+    app_name="my-app", user_id="alice", session_id=session_id
+)
+await memory_service.add_session_to_memory(session)
+await memory_service.end_session(app_name="my-app", user_id="alice", session_id=session_id)
+```
+
+A runnable smoke script that exercises the full loop against a live
+Gateway (no LLM key required) is provided in
+[`examples/quickstart.py`](examples/quickstart.py).
+
+### Configuration
+
+| Parameter | Env fallback | Default | Meaning |
+| --- | --- | --- | --- |
+| `base_url` | `TDAI_GATEWAY_URL`, or `MEMORY_TENCENTDB_GATEWAY_HOST`/`_PORT` | `http://127.0.0.1:8420` | Gateway address |
+| `api_key` | `MEMORY_TENCENTDB_GATEWAY_API_KEY`, `TDAI_GATEWAY_API_KEY` | unset | Bearer token; required only when the Gateway enforces auth |
+| `strict` | — | `False` | `False`: fail-open (log + empty results) when the Gateway is down. `True`: raise `TdaiGatewayError` |
+| `search_limit` | — | `5` | Max hits per search backend |
+| `include_conversations` | — | `True` | Also search raw L0 history on `search_memory` |
+
+### Session identity
+
+Gateway `session_key` is derived as `adk:{app_name}:{user_id}:{session_id}`,
+so distinct ADK apps/users/sessions stay distinct in the L0 store while
+remaining greppable. `user_id` is forwarded separately on capture and
+session-end calls.
+
+### Idempotent ingestion
+
+ADK explicitly allows `add_session_to_memory` to be called repeatedly on a
+growing session. The service tracks captured event IDs per session (in
+process memory) and only forwards new completed turns; failed captures are
+un-marked so a Gateway blip is retried on the next ingestion. Across
+process restarts the guard resets — deduplication of re-ingested turns is
+then handled by the engine's own L0 layer, same as for the other hosts.
+
+## Writing an adapter for another platform
+
+The three adapters in this repository demonstrate the two supported
+integration styles:
+
+| Style | Example | When to use |
+| --- | --- | --- |
+| **In-process host adapter** (implement `HostAdapter`, embed `TdaiCore`) | `src/adapters/openclaw/` | Node platforms with a plugin SDK and process lifetime control |
+| **Gateway client** (HTTP against the sidecar) | `hermes-plugin/` (Python), `adk-plugin/` (Python) | Everything else — any language, any process model |
+
+Recommended steps for a new Gateway-client adapter:
+
+1. **Find the platform's memory seams.** You need at minimum: a hook or
+   call-site that observes completed turns (→ `/capture`) and a retrieval
+   entry point the agent can use (→ `/search/*` or `/recall`). A
+   session-end signal (→ `/session/end`) is a strong nice-to-have.
+2. **Map identity.** Decide how the platform's app/user/session IDs fold
+   into a stable `session_key`; prefix it with the platform name.
+3. **Keep the client thin and typed.** Wrap the six Gateway endpoints,
+   attach `Authorization: Bearer` only when a key is configured, and raise
+   one typed error for both transport and HTTP failures.
+4. **Fail open by default.** The memory sidecar must never break the
+   agent loop; return empty results and log on failure, with a `strict`
+   escape hatch for tests.
+5. **Test against a fake Gateway, not the real engine.** A ~100-line HTTP
+   double (see `memory_tencentdb_adk/tests/fake_gateway.py`) keeps adapter
+   tests fast and toolchain-free; reserve the real Node Gateway for an
+   opt-in end-to-end smoke test.
+
+## Limitations
+
+- The Gateway search endpoints return pre-formatted text blocks, so
+  `search_memory` yields one `MemoryEntry` per backend (structured
+  memories, conversations) rather than one per record. Per-record shapes
+  would need a Gateway API extension.
+- The local store is single-tenant: `app_name`/`user_id` scope the session
+  key, but all memories live in one data directory (same as the Hermes
+  deployment model). Run one Gateway (with its own `TDAI_DATA_DIR`) per
+  tenant if you need hard isolation.
+- ADK's `search_memory` has no ranking contract; results are returned in
+  Gateway order.
+
+## Tests
+
+```bash
+# Adapter unit tests (no google-adk required — service tests auto-skip):
+python -m unittest discover -s adk-plugin -t adk-plugin -v
+
+# Full suite including the ADK service tests:
+pip install google-adk
+python -m unittest discover -s adk-plugin -t adk-plugin -v
+```

--- a/adk-plugin/examples/quickstart.py
+++ b/adk-plugin/examples/quickstart.py
@@ -1,0 +1,80 @@
+"""End-to-end smoke test for the ADK adapter against a live Gateway.
+
+Exercises capture → conversation search → session end without any LLM
+key (L0 write and raw search work without the extraction pipeline).
+
+Prerequisites:
+    # from the repository root
+    pnpm exec tsx src/gateway/server.ts        # terminal 1
+    pip install google-adk                     # terminal 2
+    PYTHONPATH=adk-plugin python adk-plugin/examples/quickstart.py
+
+Environment:
+    TDAI_GATEWAY_URL — Gateway base URL (default http://127.0.0.1:8420)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+from google.adk.events.event import Event
+from google.adk.sessions.session import Session
+from google.genai import types
+
+from memory_tencentdb_adk import TdaiMemoryService
+
+
+def _event(author: str, text: str, seq: int) -> Event:
+    return Event(
+        id=f"quickstart-{seq}",
+        invocation_id=f"quickstart-inv-{seq}",
+        author=author,
+        content=types.Content(
+            role="user" if author == "user" else "model",
+            parts=[types.Part(text=text)],
+        ),
+    )
+
+
+async def main() -> int:
+    service = TdaiMemoryService(strict=True)
+    if not service.client.is_healthy():
+        print(f"Gateway not reachable at {service.client.base_url} — start it first.")
+        return 1
+    print(f"Gateway healthy at {service.client.base_url}")
+
+    marker = f"quickstart-{int(time.time())}"
+    session = Session(
+        id=marker,
+        app_name="adk-quickstart",
+        user_id="demo-user",
+        events=[
+            _event("user", f"Remember this token for me: {marker}", 1),
+            _event("assistant", f"Got it — I will remember {marker}.", 2),
+        ],
+    )
+
+    await service.add_session_to_memory(session)
+    print("capture: ok (1 turn)")
+
+    response = await service.search_memory(
+        app_name="adk-quickstart", user_id="demo-user", query=marker
+    )
+    hit = any(
+        marker in (part.text or "")
+        for entry in response.memories
+        for part in (entry.content.parts or [])
+    )
+    print(f"search: {len(response.memories)} entr(y/ies), marker found: {hit}")
+
+    await service.end_session(
+        app_name="adk-quickstart", user_id="demo-user", session_id=marker
+    )
+    print("session end: ok")
+    return 0 if hit else 2
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/adk-plugin/memory_tencentdb_adk/__init__.py
+++ b/adk-plugin/memory_tencentdb_adk/__init__.py
@@ -1,0 +1,37 @@
+"""memory-tencentdb adapter for Google ADK (Agent Development Kit).
+
+Bridges ADK's ``BaseMemoryService`` interface to the memory-tencentdb
+Gateway sidecar (``src/gateway/server.ts``), giving ADK agents fully local
+four-layer long-term memory (L0 conversation, L1 extraction, L2 scene
+blocks, L3 persona synthesis).
+
+Layout:
+    client.py  — stdlib HTTP client for the Gateway API (no dependencies)
+    turns.py   — pure helpers that pair ADK session events into turns
+    service.py — ``TdaiMemoryService`` (requires ``google-adk``)
+
+``client`` and ``turns`` are dependency-free so they can be reused and
+tested without installing ADK. ``service`` imports ``google.adk`` and is
+the piece you hand to ``Runner(memory_service=...)``.
+"""
+
+from .client import TdaiGatewayClient, TdaiGatewayError
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "TdaiGatewayClient",
+    "TdaiGatewayError",
+    "TdaiMemoryService",
+    "__version__",
+]
+
+
+def __getattr__(name: str):
+    # Lazy import so `import memory_tencentdb_adk` works without google-adk
+    # installed (e.g. when only the Gateway client is needed).
+    if name == "TdaiMemoryService":
+        from .service import TdaiMemoryService
+
+        return TdaiMemoryService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/adk-plugin/memory_tencentdb_adk/client.py
+++ b/adk-plugin/memory_tencentdb_adk/client.py
@@ -1,0 +1,223 @@
+"""TdaiGatewayClient — stdlib HTTP client for the memory-tencentdb Gateway.
+
+Thin, dependency-free wrapper over the Gateway REST API
+(``src/gateway/server.ts``). Mirrors the Hermes provider's
+``MemoryTencentdbSdkClient`` so the two Python adapters stay easy to diff,
+but raises a typed ``TdaiGatewayError`` instead of bare ``urllib`` errors
+so callers (the ADK service) can degrade gracefully.
+
+Thread-safe: no mutable state beyond configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8420"
+DEFAULT_TIMEOUT_SECS = 10.0
+
+
+class TdaiGatewayError(RuntimeError):
+    """Raised when the Gateway is unreachable or returns an error response.
+
+    Attributes:
+        status: HTTP status code when the Gateway answered with an error,
+            ``None`` for transport-level failures (connection refused, DNS,
+            timeout).
+        detail: Response body (truncated) or underlying error message.
+    """
+
+    def __init__(self, message: str, *, status: Optional[int] = None, detail: str = "") -> None:
+        super().__init__(message)
+        self.status = status
+        self.detail = detail
+
+
+class TdaiGatewayClient:
+    """HTTP client for the memory-tencentdb Gateway sidecar."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        *,
+        api_key: Optional[str] = None,
+        timeout: float = DEFAULT_TIMEOUT_SECS,
+    ) -> None:
+        """Construct the client.
+
+        Args:
+            base_url: Gateway base URL (default ``http://127.0.0.1:8420``).
+            api_key: Optional Bearer token. When non-empty, every request
+                attaches ``Authorization: Bearer <api_key>``. When ``None``
+                or blank, no auth header is sent — matching the Gateway's
+                open legacy default. The Gateway enforces auth only when it
+                is itself configured with ``TDAI_GATEWAY_API_KEY``.
+            timeout: Default per-request timeout in seconds.
+        """
+        self._base_url = base_url.rstrip("/")
+        # Strip whitespace defensively — env vars often pick up trailing
+        # newlines from `echo` or YAML quoting; the Gateway compares the
+        # Bearer token byte-for-byte.
+        self._api_key = (api_key or "").strip() or None
+        self._timeout = timeout
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    # -- transport ----------------------------------------------------------
+
+    def _headers(self, *, content_type: bool) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if content_type:
+            headers["Content-Type"] = "application/json"
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers=self._headers(content_type=body is not None),
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout or self._timeout) as resp:
+                raw = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            detail = ""
+            try:
+                detail = exc.read().decode("utf-8", errors="replace")[:500]
+            except Exception:  # pragma: no cover - best-effort diagnostics
+                pass
+            logger.warning("tdai gateway %s %s -> HTTP %d: %s", method, path, exc.code, detail)
+            raise TdaiGatewayError(
+                f"Gateway {method} {path} failed with HTTP {exc.code}",
+                status=exc.code,
+                detail=detail,
+            ) from exc
+        except Exception as exc:
+            logger.debug("tdai gateway %s %s failed: %s", method, path, exc)
+            raise TdaiGatewayError(
+                f"Gateway {method} {path} unreachable: {exc}",
+                detail=str(exc),
+            ) from exc
+
+        try:
+            return json.loads(raw) if raw else {}
+        except json.JSONDecodeError as exc:
+            raise TdaiGatewayError(
+                f"Gateway {method} {path} returned invalid JSON",
+                detail=raw[:200],
+            ) from exc
+
+    # -- API methods ---------------------------------------------------------
+
+    def health(self, timeout: float = 3.0) -> Dict[str, Any]:
+        """``GET /health`` — cheap liveness probe (never requires auth)."""
+        return self._request("GET", "/health", timeout=timeout)
+
+    def is_healthy(self) -> bool:
+        """True when the Gateway answers ``/health`` at all (ok or degraded)."""
+        try:
+            return bool(self.health().get("status"))
+        except TdaiGatewayError:
+            return False
+
+    def recall(self, query: str, session_key: str, user_id: str = "") -> Dict[str, Any]:
+        """``POST /recall`` — assembled prompt context for *query*.
+
+        Returns ``{"context": str, "strategy": str | None, "memory_count": int}``.
+        """
+        body: Dict[str, Any] = {"query": query, "session_key": session_key}
+        if user_id:
+            body["user_id"] = user_id
+        return self._request("POST", "/recall", body)
+
+    def capture(
+        self,
+        user_content: str,
+        assistant_content: str,
+        session_key: str,
+        *,
+        session_id: str = "",
+        user_id: str = "",
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """``POST /capture`` — persist one completed turn (L0 write).
+
+        Returns ``{"l0_recorded": int, "scheduler_notified": bool}``.
+        """
+        body: Dict[str, Any] = {
+            "user_content": user_content,
+            "assistant_content": assistant_content,
+            "session_key": session_key,
+        }
+        if session_id:
+            body["session_id"] = session_id
+        if user_id:
+            body["user_id"] = user_id
+        if messages is not None:
+            body["messages"] = messages
+        return self._request("POST", "/capture", body)
+
+    def search_memories(
+        self,
+        query: str,
+        *,
+        limit: Optional[int] = None,
+        type: Optional[str] = None,
+        scene: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """``POST /search/memories`` — L1/L2/L3 structured memory search.
+
+        Returns ``{"results": str, "total": int, "strategy": str}``.
+        """
+        body: Dict[str, Any] = {"query": query}
+        if limit is not None:
+            body["limit"] = limit
+        if type is not None:
+            body["type"] = type
+        if scene is not None:
+            body["scene"] = scene
+        return self._request("POST", "/search/memories", body)
+
+    def search_conversations(
+        self,
+        query: str,
+        *,
+        limit: Optional[int] = None,
+        session_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """``POST /search/conversations`` — raw L0 conversation search.
+
+        Returns ``{"results": str, "total": int}``.
+        """
+        body: Dict[str, Any] = {"query": query}
+        if limit is not None:
+            body["limit"] = limit
+        if session_key:
+            body["session_key"] = session_key
+        return self._request("POST", "/search/conversations", body)
+
+    def session_end(self, session_key: str, user_id: str = "") -> Dict[str, Any]:
+        """``POST /session/end`` — flush pending pipeline work for a session."""
+        body: Dict[str, Any] = {"session_key": session_key}
+        if user_id:
+            body["user_id"] = user_id
+        return self._request("POST", "/session/end", body)

--- a/adk-plugin/memory_tencentdb_adk/service.py
+++ b/adk-plugin/memory_tencentdb_adk/service.py
@@ -1,0 +1,317 @@
+"""TdaiMemoryService — google-adk BaseMemoryService backed by the TDAI Gateway.
+
+Wire-up:
+
+    from google.adk.runners import Runner
+    from memory_tencentdb_adk import TdaiMemoryService
+
+    memory_service = TdaiMemoryService()  # Gateway on 127.0.0.1:8420
+    runner = Runner(
+        agent=agent,
+        app_name="my-app",
+        session_service=session_service,
+        memory_service=memory_service,
+    )
+
+ADK calls ``add_session_to_memory`` to ingest conversations and
+``search_memory`` when the agent uses memory tools (``load_memory`` /
+``preload_memory``). Both are bridged to the Gateway REST API:
+
+    add_session_to_memory  → POST /capture   (one call per completed turn)
+    add_events_to_memory   → POST /capture   (delta ingestion)
+    search_memory          → POST /search/memories + /search/conversations
+
+The service is *fail-open* by default: when the Gateway is down, searches
+return an empty result set and ingestion logs a warning instead of
+breaking the agent turn. Pass ``strict=True`` to surface
+``TdaiGatewayError`` to the caller instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Set
+
+from google.adk.memory.base_memory_service import (
+    BaseMemoryService,
+    SearchMemoryResponse,
+)
+from google.adk.memory.memory_entry import MemoryEntry
+from google.genai import types
+
+from .client import DEFAULT_BASE_URL, TdaiGatewayClient, TdaiGatewayError
+from .turns import Turn, pair_turns
+
+if TYPE_CHECKING:
+    from google.adk.events.event import Event
+    from google.adk.sessions.session import Session
+
+logger = logging.getLogger(__name__)
+
+_MEMORY_AUTHOR = "memory-tencentdb"
+_UNKNOWN_SESSION_ID = "__unknown_session_id__"
+
+
+def _env_base_url() -> str:
+    """Resolve the Gateway base URL from the environment.
+
+    ``TDAI_GATEWAY_URL`` wins; otherwise host/port are assembled from
+    ``MEMORY_TENCENTDB_GATEWAY_HOST`` / ``MEMORY_TENCENTDB_GATEWAY_PORT``
+    (the same variables the Hermes provider reads), falling back to the
+    Gateway default ``127.0.0.1:8420``.
+    """
+    url = (os.environ.get("TDAI_GATEWAY_URL") or "").strip()
+    if url:
+        return url
+    host = (os.environ.get("MEMORY_TENCENTDB_GATEWAY_HOST") or "127.0.0.1").strip() or "127.0.0.1"
+    port = (os.environ.get("MEMORY_TENCENTDB_GATEWAY_PORT") or "8420").strip() or "8420"
+    return f"http://{host}:{port}"
+
+
+def _env_api_key() -> Optional[str]:
+    """Optional Bearer token, sourced like the Hermes provider sources it."""
+    for var in ("MEMORY_TENCENTDB_GATEWAY_API_KEY", "TDAI_GATEWAY_API_KEY"):
+        raw = os.environ.get(var)
+        if raw and raw.strip():
+            return raw.strip()
+    return None
+
+
+class TdaiMemoryService(BaseMemoryService):
+    """ADK memory service backed by the memory-tencentdb Gateway.
+
+    Args:
+        base_url: Gateway base URL. Defaults to ``TDAI_GATEWAY_URL`` or
+            ``http://127.0.0.1:8420``.
+        api_key: Optional Bearer token (defaults to the
+            ``MEMORY_TENCENTDB_GATEWAY_API_KEY`` / ``TDAI_GATEWAY_API_KEY``
+            environment variables).
+        strict: When ``True``, Gateway failures raise ``TdaiGatewayError``.
+            When ``False`` (default), ingestion failures are logged and
+            searches return empty results, so a down Gateway never breaks
+            the agent loop.
+        search_limit: Maximum hits requested per search backend.
+        include_conversations: Also search raw L0 conversation history (in
+            addition to structured L1/L2/L3 memories) on ``search_memory``.
+        client: Injectable pre-configured client (tests).
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        *,
+        api_key: Optional[str] = None,
+        strict: bool = False,
+        search_limit: int = 5,
+        include_conversations: bool = True,
+        client: Optional[TdaiGatewayClient] = None,
+    ) -> None:
+        self._client = client or TdaiGatewayClient(
+            base_url or _env_base_url(),
+            api_key=api_key if api_key is not None else _env_api_key(),
+        )
+        self._strict = strict
+        self._search_limit = search_limit
+        self._include_conversations = include_conversations
+        # Event IDs already captured, keyed per session scope — makes
+        # repeated add_session_to_memory calls over a growing session
+        # idempotent within this process (ADK explicitly allows a session
+        # to be added multiple times during its lifetime).
+        self._captured: dict[str, Set[str]] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def client(self) -> TdaiGatewayClient:
+        return self._client
+
+    # -- scoping -------------------------------------------------------------
+
+    @staticmethod
+    def _session_key(app_name: str, user_id: str, session_id: str) -> str:
+        """Stable Gateway session key for an ADK session.
+
+        The Gateway groups L0 rounds by ``session_key``; embedding app,
+        user and session IDs keeps distinct ADK sessions distinct while
+        remaining human-greppable in the store.
+        """
+        return f"adk:{app_name}:{user_id}:{session_id}"
+
+    # -- ingestion -----------------------------------------------------------
+
+    async def add_session_to_memory(self, session: Session) -> None:
+        """Ingest every completed turn of *session* into the Gateway."""
+        await self._capture_events(
+            app_name=session.app_name,
+            user_id=session.user_id,
+            session_id=session.id,
+            events=session.events,
+        )
+
+    async def add_events_to_memory(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        events: Sequence[Event],
+        session_id: str | None = None,
+        custom_metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        """Ingest an event delta (e.g. only the latest turn)."""
+        del custom_metadata  # No implementation-specific keys supported yet.
+        await self._capture_events(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id or _UNKNOWN_SESSION_ID,
+            events=events,
+        )
+
+    async def _capture_events(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        events: Sequence[Any],
+    ) -> None:
+        session_key = self._session_key(app_name, user_id, session_id)
+        turns = pair_turns(events)
+        new_turns: list[Turn] = []
+        with self._lock:
+            seen = self._captured.setdefault(session_key, set())
+            for turn in turns:
+                # A turn with no event IDs cannot be tracked — capture it
+                # unconditionally rather than silently dropping it.
+                if turn.event_ids and all(eid in seen for eid in turn.event_ids):
+                    continue
+                seen.update(turn.event_ids)
+                new_turns.append(turn)
+
+        for turn in new_turns:
+            try:
+                result = await asyncio.to_thread(
+                    self._client.capture,
+                    turn.user_text,
+                    turn.assistant_text,
+                    session_key,
+                    session_id=session_id,
+                    user_id=user_id,
+                    messages=turn.messages,
+                )
+                logger.debug(
+                    "tdai capture ok (session=%s l0=%s)",
+                    session_key,
+                    result.get("l0_recorded"),
+                )
+            except TdaiGatewayError as exc:
+                # Roll back the dedup marks so a Gateway blip does not
+                # permanently skip these turns on the next ingestion.
+                with self._lock:
+                    self._captured.get(session_key, set()).difference_update(turn.event_ids)
+                if self._strict:
+                    raise
+                logger.warning("tdai capture failed (session=%s): %s", session_key, exc)
+
+    # -- search --------------------------------------------------------------
+
+    async def search_memory(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        query: str,
+    ) -> SearchMemoryResponse:
+        """Search structured memories (and optionally raw conversations)."""
+        del app_name, user_id  # The local Gateway store is single-tenant.
+        response = SearchMemoryResponse()
+
+        try:
+            memories = await asyncio.to_thread(
+                self._client.search_memories, query, limit=self._search_limit
+            )
+        except TdaiGatewayError as exc:
+            if self._strict:
+                raise
+            logger.warning("tdai memory search failed: %s", exc)
+            return response
+        self._append_entry(
+            response,
+            text=str(memories.get("results") or ""),
+            total=memories.get("total"),
+            source="memories",
+            strategy=memories.get("strategy"),
+        )
+
+        if self._include_conversations:
+            try:
+                conversations = await asyncio.to_thread(
+                    self._client.search_conversations, query, limit=self._search_limit
+                )
+            except TdaiGatewayError as exc:
+                if self._strict:
+                    raise
+                logger.warning("tdai conversation search failed: %s", exc)
+                return response
+            self._append_entry(
+                response,
+                text=str(conversations.get("results") or ""),
+                total=conversations.get("total"),
+                source="conversations",
+                strategy=None,
+            )
+
+        return response
+
+    @staticmethod
+    def _append_entry(
+        response: SearchMemoryResponse,
+        *,
+        text: str,
+        total: Any,
+        source: str,
+        strategy: Any,
+    ) -> None:
+        """Append one MemoryEntry per non-empty Gateway result blob.
+
+        The Gateway returns pre-formatted text blocks (not per-record
+        rows), so each backend contributes at most one entry; the metadata
+        records provenance and hit counts for downstream prompt builders.
+        """
+        if not text.strip() or not total:
+            return
+        metadata: dict[str, Any] = {"tdai.source": source, "tdai.total": total}
+        if strategy:
+            metadata["tdai.strategy"] = strategy
+        response.memories.append(
+            MemoryEntry(
+                content=types.Content(role="model", parts=[types.Part(text=text)]),
+                author=_MEMORY_AUTHOR,
+                custom_metadata=metadata,
+            )
+        )
+
+    # -- session lifecycle ----------------------------------------------------
+
+    async def end_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+    ) -> None:
+        """Flush the Gateway pipeline for one session (``POST /session/end``).
+
+        ADK has no memory-service session-end hook; call this from your app
+        when a conversation finishes so L1→L3 processing runs promptly.
+        Fail-open like the rest of the service.
+        """
+        session_key = self._session_key(app_name, user_id, session_id)
+        try:
+            await asyncio.to_thread(self._client.session_end, session_key, user_id)
+        except TdaiGatewayError as exc:
+            if self._strict:
+                raise
+            logger.warning("tdai session end failed (session=%s): %s", session_key, exc)

--- a/adk-plugin/memory_tencentdb_adk/tests/fake_gateway.py
+++ b/adk-plugin/memory_tencentdb_adk/tests/fake_gateway.py
@@ -1,0 +1,109 @@
+"""In-process fake of the TDAI Gateway for adapter tests.
+
+Speaks just enough of the Gateway REST contract (``src/gateway/server.ts``)
+to exercise the Python client and the ADK service without Node/pnpm:
+
+- ``GET /health`` never requires auth.
+- Every other route returns 401 unless the configured Bearer token matches
+  (when a token is configured).
+- ``POST /capture`` / ``/recall`` / ``/search/*`` / ``/session/end`` echo
+  canned responses and record every request body for assertions.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class FakeGateway:
+    """Minimal Gateway double bound to an ephemeral loopback port."""
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key
+        self.requests: List[Tuple[str, Dict[str, Any]]] = []
+        self.responses: Dict[str, Any] = {
+            "/recall": {"context": "", "strategy": "none", "memory_count": 0},
+            "/capture": {"l0_recorded": 2, "scheduler_notified": True},
+            "/search/memories": {"results": "", "total": 0, "strategy": "vector"},
+            "/search/conversations": {"results": "", "total": 0},
+            "/session/end": {"flushed": True},
+        }
+        self.status_overrides: Dict[str, int] = {}
+        self._lock = threading.Lock()
+
+        fake = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:  # silence test output
+                pass
+
+            def _send(self, status: int, body: Dict[str, Any]) -> None:
+                payload = json.dumps(body).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def _authorized(self) -> bool:
+                if not fake.api_key:
+                    return True
+                header = self.headers.get("Authorization", "")
+                return header == f"Bearer {fake.api_key}"
+
+            def do_GET(self) -> None:
+                if self.path == "/health":
+                    self._send(200, {"status": "ok", "version": "test", "uptime": 1})
+                    return
+                self._send(404, {"error": f"Not found: GET {self.path}"})
+
+            def do_POST(self) -> None:
+                if not self._authorized():
+                    self._send(401, {"error": "Unauthorized: invalid token"})
+                    return
+                length = int(self.headers.get("Content-Length", "0"))
+                raw = self.rfile.read(length).decode("utf-8") if length else "{}"
+                try:
+                    body = json.loads(raw)
+                except json.JSONDecodeError:
+                    self._send(400, {"error": "Invalid JSON body"})
+                    return
+                with fake._lock:
+                    fake.requests.append((self.path, body))
+                    status = fake.status_overrides.get(self.path)
+                    response = fake.responses.get(self.path)
+                if status is not None:
+                    self._send(status, {"error": f"forced {status}"})
+                    return
+                if response is None:
+                    self._send(404, {"error": f"Not found: POST {self.path}"})
+                    return
+                self._send(200, response)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self) -> "FakeGateway":
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    @property
+    def base_url(self) -> str:
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}"
+
+    # -- assertion helpers -----------------------------------------------------
+
+    def bodies(self, path: str) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [body for p, body in self.requests if p == path]

--- a/adk-plugin/memory_tencentdb_adk/tests/test_client_and_turns.py
+++ b/adk-plugin/memory_tencentdb_adk/tests/test_client_and_turns.py
@@ -1,0 +1,213 @@
+"""Unit tests for the Gateway client and turn pairing (no google-adk needed).
+
+Run from the repository root::
+
+    python -m unittest discover -s adk-plugin -t adk-plugin -v
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+_PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from memory_tencentdb_adk.client import TdaiGatewayClient, TdaiGatewayError  # noqa: E402
+from memory_tencentdb_adk.turns import pair_turns, text_of_event  # noqa: E402
+from memory_tencentdb_adk.tests.fake_gateway import FakeGateway  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed stand-ins for google.adk / google.genai event shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Part:
+    text: Optional[str] = None
+
+
+@dataclass
+class _Content:
+    parts: List[_Part] = field(default_factory=list)
+
+
+@dataclass
+class _Event:
+    author: str = ""
+    content: Optional[_Content] = None
+    id: str = ""
+
+
+def _ev(author: str, text: Optional[str], event_id: str = "") -> _Event:
+    parts = [_Part(text=text)] if text is not None else []
+    return _Event(author=author, content=_Content(parts=parts), id=event_id)
+
+
+# ---------------------------------------------------------------------------
+# Turn pairing
+# ---------------------------------------------------------------------------
+
+
+class PairTurnsTest(unittest.TestCase):
+    def test_simple_pair(self) -> None:
+        turns = pair_turns([_ev("user", "hi", "u1"), _ev("agent", "hello!", "a1")])
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].user_text, "hi")
+        self.assertEqual(turns[0].assistant_text, "hello!")
+        self.assertEqual(turns[0].event_ids, ["u1", "a1"])
+        self.assertEqual(
+            turns[0].messages,
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello!"},
+            ],
+        )
+
+    def test_multiple_agent_events_merge_into_one_turn(self) -> None:
+        turns = pair_turns(
+            [
+                _ev("user", "plan a trip", "u1"),
+                _ev("planner", "step 1", "a1"),
+                _ev("booker", "step 2", "a2"),
+            ]
+        )
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].assistant_text, "step 1\n\nstep 2")
+        self.assertEqual(len(turns[0].messages), 3)
+
+    def test_two_turns(self) -> None:
+        turns = pair_turns(
+            [
+                _ev("user", "q1", "u1"),
+                _ev("agent", "a1", "e1"),
+                _ev("user", "q2", "u2"),
+                _ev("agent", "a2", "e2"),
+            ]
+        )
+        self.assertEqual([(t.user_text, t.assistant_text) for t in turns], [("q1", "a1"), ("q2", "a2")])
+
+    def test_unanswered_user_message_is_dropped(self) -> None:
+        turns = pair_turns([_ev("user", "q1", "u1"), _ev("user", "q2", "u2"), _ev("agent", "a2", "e2")])
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].user_text, "q2")
+
+    def test_leading_assistant_text_is_skipped(self) -> None:
+        turns = pair_turns([_ev("agent", "welcome!", "a0"), _ev("user", "hi", "u1"), _ev("agent", "hello", "a1")])
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].user_text, "hi")
+
+    def test_tool_only_events_are_ignored(self) -> None:
+        turns = pair_turns(
+            [
+                _ev("user", "compute", "u1"),
+                _Event(author="agent", content=_Content(parts=[])),  # function call only
+                _ev("agent", "42", "a1"),
+            ]
+        )
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].assistant_text, "42")
+
+    def test_empty_session(self) -> None:
+        self.assertEqual(pair_turns([]), [])
+
+    def test_text_of_event_joins_and_strips(self) -> None:
+        event = _Event(author="agent", content=_Content(parts=[_Part("  a  "), _Part(None), _Part("b")]))
+        self.assertEqual(text_of_event(event), "a\nb")
+        self.assertEqual(text_of_event(_Event(author="agent", content=None)), "")
+
+
+# ---------------------------------------------------------------------------
+# Gateway client against the fake gateway
+# ---------------------------------------------------------------------------
+
+
+class ClientTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gateway = FakeGateway().start()
+        self.addCleanup(self.gateway.stop)
+        self.client = TdaiGatewayClient(self.gateway.base_url)
+
+    def test_health(self) -> None:
+        self.assertEqual(self.client.health()["status"], "ok")
+        self.assertTrue(self.client.is_healthy())
+
+    def test_capture_payload_shape(self) -> None:
+        result = self.client.capture(
+            "hi",
+            "hello",
+            "adk:app:user:s1",
+            session_id="s1",
+            user_id="user",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.assertEqual(result["l0_recorded"], 2)
+        [body] = self.gateway.bodies("/capture")
+        self.assertEqual(body["user_content"], "hi")
+        self.assertEqual(body["assistant_content"], "hello")
+        self.assertEqual(body["session_key"], "adk:app:user:s1")
+        self.assertEqual(body["session_id"], "s1")
+        self.assertEqual(body["user_id"], "user")
+        self.assertEqual(body["messages"], [{"role": "user", "content": "hi"}])
+
+    def test_search_memories_optional_fields_omitted(self) -> None:
+        self.client.search_memories("query")
+        [body] = self.gateway.bodies("/search/memories")
+        self.assertEqual(body, {"query": "query"})
+
+    def test_search_conversations_with_limit(self) -> None:
+        self.client.search_conversations("query", limit=3, session_key="k")
+        [body] = self.gateway.bodies("/search/conversations")
+        self.assertEqual(body, {"query": "query", "limit": 3, "session_key": "k"})
+
+    def test_session_end(self) -> None:
+        self.assertEqual(self.client.session_end("k", "u"), {"flushed": True})
+        [body] = self.gateway.bodies("/session/end")
+        self.assertEqual(body, {"session_key": "k", "user_id": "u"})
+
+    def test_http_error_raises_typed_error_with_status(self) -> None:
+        self.gateway.status_overrides["/recall"] = 500
+        with self.assertRaises(TdaiGatewayError) as ctx:
+            self.client.recall("q", "k")
+        self.assertEqual(ctx.exception.status, 500)
+
+    def test_unreachable_gateway_raises_typed_error(self) -> None:
+        dead = TdaiGatewayClient("http://127.0.0.1:1", timeout=0.5)
+        with self.assertRaises(TdaiGatewayError) as ctx:
+            dead.health(timeout=0.5)
+        self.assertIsNone(ctx.exception.status)
+        self.assertFalse(dead.is_healthy())
+
+
+class ClientAuthTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gateway = FakeGateway(api_key="secret-key").start()
+        self.addCleanup(self.gateway.stop)
+
+    def test_bearer_token_attached(self) -> None:
+        client = TdaiGatewayClient(self.gateway.base_url, api_key="secret-key")
+        self.assertEqual(client.session_end("k"), {"flushed": True})
+
+    def test_missing_token_rejected(self) -> None:
+        client = TdaiGatewayClient(self.gateway.base_url)
+        with self.assertRaises(TdaiGatewayError) as ctx:
+            client.session_end("k")
+        self.assertEqual(ctx.exception.status, 401)
+
+    def test_whitespace_token_treated_as_unset(self) -> None:
+        client = TdaiGatewayClient(self.gateway.base_url, api_key="   ")
+        with self.assertRaises(TdaiGatewayError):
+            client.session_end("k")
+
+    def test_health_never_requires_auth(self) -> None:
+        client = TdaiGatewayClient(self.gateway.base_url)
+        self.assertEqual(client.health()["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/adk-plugin/memory_tencentdb_adk/tests/test_service.py
+++ b/adk-plugin/memory_tencentdb_adk/tests/test_service.py
@@ -1,0 +1,227 @@
+"""Tests for TdaiMemoryService (skipped when google-adk is not installed).
+
+Run from the repository root::
+
+    pip install google-adk
+    python -m unittest discover -s adk-plugin -t adk-plugin -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+import unittest
+
+_PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+try:  # pragma: no cover - environment probe
+    from google.adk.events.event import Event
+    from google.adk.sessions.session import Session
+    from google.genai import types
+
+    _HAS_ADK = True
+except ImportError:  # pragma: no cover
+    _HAS_ADK = False
+
+from memory_tencentdb_adk.client import TdaiGatewayClient, TdaiGatewayError  # noqa: E402
+from memory_tencentdb_adk.tests.fake_gateway import FakeGateway  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@unittest.skipUnless(_HAS_ADK, "google-adk is not installed")
+class TdaiMemoryServiceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        from memory_tencentdb_adk.service import TdaiMemoryService
+
+        self.gateway = FakeGateway().start()
+        self.addCleanup(self.gateway.stop)
+        self.service = TdaiMemoryService(self.gateway.base_url)
+        self._event_seq = 0
+
+    # -- fixtures -------------------------------------------------------------
+
+    def _event(self, author: str, text: str) -> "Event":
+        self._event_seq += 1
+        return Event(
+            id=f"e{self._event_seq}",
+            invocation_id=f"inv{self._event_seq}",
+            author=author,
+            content=types.Content(
+                role="user" if author == "user" else "model",
+                parts=[types.Part(text=text)],
+            ),
+        )
+
+    def _session(self, events) -> "Session":
+        return Session(
+            id="s1",
+            app_name="demo-app",
+            user_id="alice",
+            events=list(events),
+        )
+
+    # -- ingestion -------------------------------------------------------------
+
+    def test_add_session_captures_each_turn(self) -> None:
+        session = self._session(
+            [
+                self._event("user", "I prefer window seats"),
+                self._event("travel-agent", "Noted — window seats it is."),
+                self._event("user", "Book Tokyo for March"),
+                self._event("travel-agent", "Booked!"),
+            ]
+        )
+        _run(self.service.add_session_to_memory(session))
+
+        bodies = self.gateway.bodies("/capture")
+        self.assertEqual(len(bodies), 2)
+        self.assertEqual(bodies[0]["user_content"], "I prefer window seats")
+        self.assertEqual(bodies[0]["session_key"], "adk:demo-app:alice:s1")
+        self.assertEqual(bodies[0]["session_id"], "s1")
+        self.assertEqual(bodies[0]["user_id"], "alice")
+        self.assertEqual(bodies[1]["assistant_content"], "Booked!")
+
+    def test_repeated_ingestion_is_idempotent(self) -> None:
+        events = [
+            self._event("user", "hello"),
+            self._event("agent", "hi there"),
+        ]
+        session = self._session(events)
+        _run(self.service.add_session_to_memory(session))
+        _run(self.service.add_session_to_memory(session))
+        self.assertEqual(len(self.gateway.bodies("/capture")), 1)
+
+        # A grown session only captures the new turn.
+        session.events.extend(
+            [
+                self._event("user", "one more thing"),
+                self._event("agent", "sure"),
+            ]
+        )
+        _run(self.service.add_session_to_memory(session))
+        bodies = self.gateway.bodies("/capture")
+        self.assertEqual(len(bodies), 2)
+        self.assertEqual(bodies[1]["user_content"], "one more thing")
+
+    def test_add_events_delta(self) -> None:
+        events = [
+            self._event("user", "delta question"),
+            self._event("agent", "delta answer"),
+        ]
+        _run(
+            self.service.add_events_to_memory(
+                app_name="demo-app",
+                user_id="alice",
+                events=events,
+                session_id="s9",
+            )
+        )
+        [body] = self.gateway.bodies("/capture")
+        self.assertEqual(body["session_key"], "adk:demo-app:alice:s9")
+
+    def test_capture_failure_is_swallowed_and_retried_next_time(self) -> None:
+        self.gateway.status_overrides["/capture"] = 500
+        session = self._session(
+            [self._event("user", "q"), self._event("agent", "a")]
+        )
+        _run(self.service.add_session_to_memory(session))  # fail-open: no raise
+        self.assertEqual(len(self.gateway.bodies("/capture")), 1)
+
+        # Gateway recovers — the same turn is captured on the next ingestion
+        # because the dedup marks were rolled back.
+        del self.gateway.status_overrides["/capture"]
+        _run(self.service.add_session_to_memory(session))
+        self.assertEqual(len(self.gateway.bodies("/capture")), 2)
+
+    def test_capture_failure_raises_in_strict_mode(self) -> None:
+        from memory_tencentdb_adk.service import TdaiMemoryService
+
+        strict = TdaiMemoryService(self.gateway.base_url, strict=True)
+        self.gateway.status_overrides["/capture"] = 500
+        session = self._session(
+            [self._event("user", "q"), self._event("agent", "a")]
+        )
+        with self.assertRaises(TdaiGatewayError):
+            _run(strict.add_session_to_memory(session))
+
+    # -- search ----------------------------------------------------------------
+
+    def test_search_memory_maps_result_blobs_to_entries(self) -> None:
+        self.gateway.responses["/search/memories"] = {
+            "results": "- user prefers window seats",
+            "total": 1,
+            "strategy": "vector",
+        }
+        self.gateway.responses["/search/conversations"] = {
+            "results": "[2026-07-20] user: Book Tokyo for March",
+            "total": 1,
+        }
+        response = _run(
+            self.service.search_memory(app_name="demo-app", user_id="alice", query="seats")
+        )
+        self.assertEqual(len(response.memories), 2)
+
+        first, second = response.memories
+        self.assertEqual(first.author, "memory-tencentdb")
+        self.assertIn("window seats", first.content.parts[0].text)
+        self.assertEqual(first.custom_metadata["tdai.source"], "memories")
+        self.assertEqual(first.custom_metadata["tdai.strategy"], "vector")
+        self.assertEqual(second.custom_metadata["tdai.source"], "conversations")
+
+        [memories_body] = self.gateway.bodies("/search/memories")
+        self.assertEqual(memories_body["query"], "seats")
+        self.assertEqual(memories_body["limit"], 5)
+
+    def test_search_memory_empty_results_produce_no_entries(self) -> None:
+        response = _run(
+            self.service.search_memory(app_name="demo-app", user_id="alice", query="anything")
+        )
+        self.assertEqual(response.memories, [])
+
+    def test_search_memory_fail_open_on_dead_gateway(self) -> None:
+        from memory_tencentdb_adk.service import TdaiMemoryService
+
+        service = TdaiMemoryService(
+            client=TdaiGatewayClient("http://127.0.0.1:1", timeout=0.5)
+        )
+        response = _run(
+            service.search_memory(app_name="demo-app", user_id="alice", query="q")
+        )
+        self.assertEqual(response.memories, [])
+
+    def test_search_memory_strict_raises_on_dead_gateway(self) -> None:
+        from memory_tencentdb_adk.service import TdaiMemoryService
+
+        service = TdaiMemoryService(
+            strict=True,
+            client=TdaiGatewayClient("http://127.0.0.1:1", timeout=0.5),
+        )
+        with self.assertRaises(TdaiGatewayError):
+            _run(service.search_memory(app_name="demo-app", user_id="alice", query="q"))
+
+    def test_search_memory_conversations_can_be_disabled(self) -> None:
+        from memory_tencentdb_adk.service import TdaiMemoryService
+
+        service = TdaiMemoryService(self.gateway.base_url, include_conversations=False)
+        _run(service.search_memory(app_name="demo-app", user_id="alice", query="q"))
+        self.assertEqual(self.gateway.bodies("/search/conversations"), [])
+
+    # -- session lifecycle -------------------------------------------------------
+
+    def test_end_session_flushes(self) -> None:
+        _run(
+            self.service.end_session(app_name="demo-app", user_id="alice", session_id="s1")
+        )
+        [body] = self.gateway.bodies("/session/end")
+        self.assertEqual(body["session_key"], "adk:demo-app:alice:s1")
+        self.assertEqual(body["user_id"], "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/adk-plugin/memory_tencentdb_adk/turns.py
+++ b/adk-plugin/memory_tencentdb_adk/turns.py
@@ -1,0 +1,108 @@
+"""Pure helpers that turn ADK session events into Gateway capture payloads.
+
+The Gateway's ``POST /capture`` endpoint persists one *completed turn* —
+a user message plus the assistant response it produced. ADK sessions are
+flat event lists (user events, agent events, tool calls/responses), so
+this module pairs them up.
+
+Deliberately dependency-free: events are duck-typed (``author``,
+``content.parts[].text``, ``timestamp``, ``id``) so the pairing logic can
+be unit-tested without ``google-adk`` installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Sequence
+
+USER_AUTHOR = "user"
+
+
+@dataclass
+class Turn:
+    """One completed user/assistant exchange extracted from a session."""
+
+    user_text: str
+    assistant_text: str
+    #: ``[{"role": ..., "content": ...}, ...]`` in event order, for /capture.
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    #: IDs of every event folded into this turn (for idempotent re-capture).
+    event_ids: List[str] = field(default_factory=list)
+
+
+def text_of_event(event: Any) -> str:
+    """Concatenated text of all text parts of an event ("" when none).
+
+    Non-text parts (function calls, function responses, inline data) are
+    ignored — the memory pipeline works on natural-language content.
+    """
+    content = getattr(event, "content", None)
+    parts = getattr(content, "parts", None) if content is not None else None
+    if not parts:
+        return ""
+    texts = [part.text for part in parts if getattr(part, "text", None)]
+    return "\n".join(text.strip() for text in texts if text and text.strip())
+
+
+def pair_turns(events: Sequence[Any]) -> List[Turn]:
+    """Pair a flat event list into completed user→assistant turns.
+
+    Rules (chosen to match how the OpenClaw plugin and the Hermes provider
+    feed the same pipeline):
+
+    - An event authored by ``"user"`` opens a new turn (a later user event
+      before any assistant reply replaces the pending one — the pipeline
+      only wants turns that actually produced a response).
+    - Every non-user event with text after an open turn contributes to that
+      turn's assistant side; multiple agent events are joined with blank
+      lines (multi-agent runs produce several authored events per turn).
+    - Events with no text (pure tool traffic) are skipped.
+    - A turn is emitted once the next user event arrives or the list ends,
+      and only when both sides are non-empty (``/capture`` requires both).
+    """
+    turns: List[Turn] = []
+    pending_user: str = ""
+    pending_user_ids: List[str] = []
+    assistant_chunks: List[str] = []
+    assistant_ids: List[str] = []
+    messages: List[Dict[str, Any]] = []
+
+    def flush() -> None:
+        nonlocal pending_user, pending_user_ids, assistant_chunks, assistant_ids, messages
+        if pending_user and assistant_chunks:
+            turns.append(
+                Turn(
+                    user_text=pending_user,
+                    assistant_text="\n\n".join(assistant_chunks),
+                    messages=messages,
+                    event_ids=pending_user_ids + assistant_ids,
+                )
+            )
+        pending_user = ""
+        pending_user_ids = []
+        assistant_chunks = []
+        assistant_ids = []
+        messages = []
+
+    for event in events:
+        text = text_of_event(event)
+        if not text:
+            continue
+        author = getattr(event, "author", "") or ""
+        event_id = str(getattr(event, "id", "") or "")
+
+        if author == USER_AUTHOR:
+            flush()
+            pending_user = text
+            pending_user_ids = [event_id] if event_id else []
+            messages = [{"role": "user", "content": text}]
+        elif pending_user:
+            assistant_chunks.append(text)
+            if event_id:
+                assistant_ids.append(event_id)
+            messages.append({"role": "assistant", "content": text})
+        # Assistant text before any user message has no turn to attach to —
+        # skip it (greeting banners, warm-up messages).
+
+    flush()
+    return turns

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "adk-plugin/",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",


### PR DESCRIPTION
## What

Adds `adk-plugin/` — a cross-platform memory adapter that exposes the engine to [Google ADK](https://google.github.io/adk-docs/) (Agent Development Kit) Python agents as a drop-in [`BaseMemoryService`](https://google.github.io/adk-docs/sessions/memory/) implementation.

This targets the **进阶 (intermediate) stage** of #235: one new platform with working memory read/write, plus adapter documentation. It deliberately follows the existing **Gateway-client lane** (same style as the Hermes provider under `hermes-plugin/`) and does not introduce a new SDK abstraction, so it stays out of the way of the shared-client work in #316 and the MCP bridge in #372:

- ADK is a Python host, so the in-process TS `HostAdapter` path doesn't apply — the adapter talks to the existing Gateway sidecar (`src/gateway/server.ts`) over HTTP.
- No changes to core / gateway / existing adapters. New code + docs only (plus two one-line wiring edits: npm `files` entry and a root README link).

### Layout

| File | Role |
| --- | --- |
| `adk-plugin/memory_tencentdb_adk/client.py` | Dependency-free stdlib HTTP client for the Gateway REST API (typed `TdaiGatewayError`, optional Bearer auth) — mirrors the Hermes `MemoryTencentdbSdkClient` |
| `adk-plugin/memory_tencentdb_adk/turns.py` | Pure helpers pairing flat ADK event lists into completed user/assistant turns for `POST /capture` (testable without `google-adk`) |
| `adk-plugin/memory_tencentdb_adk/service.py` | `TdaiMemoryService(BaseMemoryService)`: `add_session_to_memory` / `add_events_to_memory` → `/capture` per turn; `search_memory` → `/search/memories` + `/search/conversations`; `end_session` helper → `/session/end` |
| `adk-plugin/memory_tencentdb_adk/tests/` | 30 unittest cases against an in-process fake Gateway |
| `adk-plugin/README.md` | Architecture + data-flow diagram (OpenClaw / Hermes / ADK), config reference, limitations, and a "writing an adapter for another platform" guide |
| `adk-plugin/examples/quickstart.py` | Runnable smoke script against a live Gateway (no LLM key needed) |

### Behaviour notes

- **Session identity:** Gateway `session_key` = `adk:{app_name}:{user_id}:{session_id}`; `user_id` forwarded separately.
- **Idempotent ingestion:** ADK allows `add_session_to_memory` to be called repeatedly on a growing session; captured event IDs are tracked per session so only new turns are forwarded, and failed captures are un-marked for retry.
- **Fail-open by default:** a down Gateway degrades to empty search results / logged capture warnings instead of breaking the agent loop; `strict=True` surfaces `TdaiGatewayError`.

## Testing

Run in docker containers on Ubuntu 26.04 (no host toolchain):

- `python:3.12` — `python -m unittest discover -s adk-plugin -t adk-plugin -v` → **30/30 pass** with `google-adk` installed; **19 pass + 11 skip** without it (service tests auto-skip so repo CI needs no new dependency).
- `node:22` — `npx vitest run` → existing **67/67 pass** (no core changes); `npm install` + `npm pack` OK, tarball **721 KB** (size guard limit 2048 KB) with `adk-plugin/` included.

Test coverage: turn pairing (merging multi-agent replies, unanswered user messages, tool-only events), capture payload shapes, Bearer auth attach/reject, HTTP error and unreachable-gateway typing, idempotent re-ingestion incl. rollback on capture failure, fail-open vs strict search/capture, conversation-search toggle, session flush.

## Scope boundary (per the triage discussion in #235)

This PR intentionally ships a **thin, platform-specific wrapper over the existing Gateway API**. If/when the shared `GatewayMemoryClient` kit (#316) merges, `client.py` can be retired in favour of it with no public API change to `TdaiMemoryService`.

Updates #235
