### PR TITLE
fix(search): sanitize FTS5 operators and syntax in buildFtsQuery (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🔒 安全
+
+- **FTS5 查询操作符注入防御加固** ([#160](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160))：`buildFtsQuery()` 此前仅靠双引号包裹 token 来中和 FTS5 操作符，缺少显式的纵深防御。现增加三道净化：(1) **NFKC 归一化**——使全角 `ＡＮＤ` 等变体也能被后续规则捕获；(2) **Unicode 白名单** `[\p{L}\p{N}_]+` 切 token——一次性丢弃 `* " ' ( ) : ^` 等全部 FTS5 语法字符；(3) **token 级抑制** `AND`/`OR`/`NOT`/`NEAR`（大小写不敏感，且不误伤 `android`/`orange`/`notebook` 等含操作符子串的正常词）。用户输入无法再改变 MATCH 查询语义。新增 `src/core/store/sqlite.test.ts`（14 个用例），覆盖 fallback / jieba 双路径单元测试，以及基于 `node:sqlite` 内存 FTS5 的真实 MATCH 集成测试（验证操作符语义被中和、benign 查询召回不退化、对抗性输入不抛错）。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// node:sqlite gives us a real in-memory FTS5 virtual table for integration
+// tests — cross-platform (no system sqlite3 CLI dependency), and exercises the
+// actual SQLite MATCH parser the production code relies on.
+import { DatabaseSync } from "node:sqlite";
+
+import {
+  buildFtsQuery,
+  _resetJiebaForTest,
+  _setJiebaForTest,
+} from "./sqlite.js";
+
+// Keep jieba singleton state independent across tests.
+afterEach(() => {
+  _resetJiebaForTest();
+});
+
+describe("buildFtsQuery — FTS5 operator sanitization (issue #160)", () => {
+  describe("regex fallback path (jieba disabled)", () => {
+    beforeEach(() => {
+      _setJiebaForTest(null);
+    });
+
+    it("strips uppercase FTS5 operators", () => {
+      const q = buildFtsQuery("alpha AND beta OR gamma NOT delta NEAR epsilon");
+      expect(q).not.toMatch(/"(?:AND|OR|NOT|NEAR)"/);
+      expect(q).toBe('"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon"');
+    });
+
+    it("strips lowercase / mixed-case operators", () => {
+      // Operators are stripped regardless of case (compared via toUpperCase).
+      const q = buildFtsQuery("alpha and beta Or gamma");
+      expect(q).toBe('"alpha" OR "beta" OR "gamma"');
+    });
+
+    it("strips full-width operator variants via NFKC", () => {
+      // ＡＮＤ = full-width AND (U+FF21 U+FF2E U+FF24) — must collapse to AND
+      // and be stripped, otherwise it bypasses the ASCII operator set.
+      const q = buildFtsQuery("alpha ＡＮＤ beta");
+      expect(q).toBe('"alpha" OR "beta"');
+    });
+
+    it("does NOT strip operator substrings embedded in normal words", () => {
+      const q = buildFtsQuery("android orange notebook scotland nearshore");
+      expect(q).toContain('"android"');
+      expect(q).toContain('"orange"');
+      expect(q).toContain('"notebook"');
+      expect(q).toContain('"scotland"');
+      expect(q).toContain('"nearshore"');
+    });
+
+    it("drops FTS5 structural syntax chars (* \" ( ) : ^)", () => {
+      const q = buildFtsQuery('foo* "bar" (baz) content:qux ^x');
+      expect(q).toBe('"foo" OR "bar" OR "baz" OR "content" OR "qux" OR "x"');
+    });
+
+    it("handles NEAR(...) function syntax by keeping inner terms", () => {
+      // NEAR(alpha beta, 5) → operators/syntax stripped, alpha/beta preserved.
+      const q = buildFtsQuery("NEAR(alpha beta, 5)");
+      expect(q).toContain('"alpha"');
+      expect(q).toContain('"beta"');
+      expect(q).not.toMatch(/NEAR/);
+    });
+
+    it("returns null when input reduces to operators only", () => {
+      expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+    });
+
+    it("returns null for empty / symbol-only input", () => {
+      expect(buildFtsQuery("")).toBeNull();
+      expect(buildFtsQuery("   * ( ) : ")).toBeNull();
+    });
+  });
+
+  describe("jieba path", () => {
+    it("preserves normal Chinese segmentation (regression)", () => {
+      // Real jieba — keep the assertion loose: segmentation output must be a
+      // non-empty OR-join of quoted tokens, unchanged by sanitization.
+      const q = buildFtsQuery("用户喜欢编程");
+      expect(q).not.toBeNull();
+      expect(q!.startsWith('"')).toBe(true);
+      expect(q!.includes(" OR ")).toBe(true);
+      // No quoted operator token should leak into the output.
+      expect(q).not.toMatch(/"(?:AND|OR|NOT|NEAR)"/);
+    });
+
+    it("strips operators and cleans dirty tokens from jieba output", () => {
+      // Stub jieba to emit a token list containing an operator and a dirty
+      // token carrying FTS5 syntax — both must be neutralised.
+      _setJiebaForTest({
+        cutForSearch: () => ["用户", "AND", "NEAR(beta", "编程"],
+      } as never);
+      const q = buildFtsQuery("ignored-by-stub");
+      expect(q).toBe('"用户" OR "beta" OR "编程"');
+    });
+  });
+});
+
+describe("buildFtsQuery — real FTS5 MATCH integration (node:sqlite)", () => {
+  // Force the fallback path so buildFtsQuery output is deterministic and
+  // independent of jieba's English tokenisation quirks.
+  beforeEach(() => {
+    _setJiebaForTest(null);
+  });
+
+  // ponytail: in-memory FTS5 via node:sqlite — cross-platform, no system CLI.
+  function withFts5Fixture(
+    docs: string[],
+    run: (search: (q: string) => Set<string>) => void,
+  ): void {
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE VIRTUAL TABLE t USING fts5(content)");
+    const insert = db.prepare("INSERT INTO t(content) VALUES (?)");
+    for (const d of docs) insert.run(d);
+    const search = (matchExpr: string): Set<string> => {
+      const rows = db
+        .prepare("SELECT content FROM t WHERE content MATCH ? ORDER BY rank")
+        .all(matchExpr) as Array<{ content: string }>;
+      return new Set(rows.map((r) => r.content));
+    };
+    try {
+      run(search);
+    } finally {
+      db.close();
+    }
+  }
+
+  const DOCS = ["foo bar", "foo", "bar", "foo bar baz", "unrelated"];
+
+  it("AND is neutralised — same recall as plain OR", () => {
+    withFts5Fixture(DOCS, (search) => {
+      // "foo AND bar" must NOT narrow to docs containing both; it behaves like
+      // "foo OR bar" because the operator is stripped before MATCH.
+      const withOp = search(buildFtsQuery("foo AND bar")!);
+      const without = search(buildFtsQuery("foo bar")!);
+      expect(withOp).toEqual(without);
+      expect(without.size).toBe(4); // all docs containing foo or bar
+    });
+  });
+
+  it("NOT is neutralised — does not exclude matches", () => {
+    withFts5Fixture(DOCS, (search) => {
+      // "foo NOT bar" must not drop bar-containing docs.
+      const hits = search(buildFtsQuery("foo NOT bar")!);
+      expect(hits.has("bar")).toBe(true);
+      expect(hits).toEqual(search(buildFtsQuery("foo bar")!));
+    });
+  });
+
+  it("benign query recall is preserved (no regression)", () => {
+    withFts5Fixture(DOCS, (search) => {
+      const hits = search(buildFtsQuery("foo bar")!);
+      expect(hits.size).toBe(4);
+      expect(hits.has("unrelated")).toBe(false);
+    });
+  });
+
+  it("adversarial input never throws and yields a valid MATCH expr", () => {
+    withFts5Fixture(DOCS, (search) => {
+      const cases = [
+        'foo" OR "1',
+        "*",
+        ")(",
+        "content:foo",
+        "ＡＮＤ",
+        "a^b",
+        "NEAR(x y,5)",
+      ];
+      for (const c of cases) {
+        const q = buildFtsQuery(c);
+        if (q === null) continue; // reduced to nothing — fine
+        expect(() => search(q)).not.toThrow();
+      }
+    });
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,7 +175,43 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * FTS5 boolean operators that could alter MATCH semantics if injected verbatim
+ * (issue #160). Per FTS5 §3.7 these are case-sensitive keywords, but we compare
+ * via `toUpperCase()` and strip all case variants — this both kills operator
+ * noise (a bare `AND` token would otherwise match documents literally
+ * containing the word "AND") and aligns with the upstream narrow fix (#178)
+ * instead of debating case sensitivity.
+ */
+const FTS5_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+/**
+ * Unicode whitelist: keeps only letters / digits / underscore. Any FTS5 syntax
+ * character (`* " ' ( ) : ^ { } -`) becomes a token separator and is dropped —
+ * so a single regex covers both operator injection and structural syntax
+ * injection (column filters, prefix globs, phrase grouping, …).
+ */
+const FTS_TOKEN_PARTS_RE = /[\p{L}\p{N}_]+/gu;
+
+/**
+ * Reduce one tokenizer-emitted token to literal whitelist sub-parts.
+ *
+ * The whitelist match drops any residual FTS5 syntax characters a tokenizer may
+ * emit (e.g. `NEAR(beta` → `["NEAR", "beta"]`, `C++` → `["C"]`), guaranteeing
+ * every emitted token is a clean phrase literal that needs no `""` escaping.
+ */
+function toFtsLiteralParts(token: string): string[] {
+  return token.match(FTS_TOKEN_PARTS_RE) ?? [];
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
+ *
+ * **Sanitization (issue #160, defense-in-depth):** raw input is NFKC-normalised
+ * first (defeats full-width operator variants like `ＡＮＤ`), every token is
+ * reduced to Unicode whitelist parts (drops all FTS5 syntax chars), and FTS5
+ * operators (`AND`/`OR`/`NOT`/`NEAR`) are stripped at the token level — so user
+ * input can never alter MATCH semantics. Tokens carry no quotes after
+ * whitelisting, so they are safe to emit as FTS5 phrase literals.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
  * (`cutForSearch`) for accurate Chinese word segmentation, producing
@@ -196,37 +232,37 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  // ponytail: NFKC first (ＡＮＤ→AND) so the ASCII Set below catches full-width
+  // variants; then segment; then token-level operator strip + dedup. Input is
+  // normalised once, so tokenizer output is already NFKC — no per-token repeat.
+  const input = raw.normalize("NFKC");
   const jieba = getJieba();
 
-  let tokens: string[];
-  if (jieba) {
-    // jieba cutForSearch: splits long words further for better recall
-    // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
-    // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
-  } else {
-    // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+  const rawTokens = jieba
+    ? jieba.cutForSearch(input, true).map((t) => t.trim())
+    : input.match(FTS_TOKEN_PARTS_RE) ?? [];
+
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const rt of rawTokens) {
+    // Re-sanitise each token: tokenizer output may carry residual syntax chars
+    // (jieba) — the whitelist match guarantees clean literal parts in both paths.
+    for (const part of toFtsLiteralParts(rt)) {
+      if (FTS5_OPERATORS.has(part.toUpperCase())) continue; // strip FTS5 operators (all cases)
+      if (!/[\p{L}\p{N}]/u.test(part)) continue;            // drop symbol-only parts
+      // Chinese stop-words only filtered on the jieba path (fallback stays as-is
+      // pre-#160); keeps this change focused on operator/syntax injection.
+      if (jieba && ZH_STOP_WORDS.has(part)) continue;
+      if (seen.has(part)) continue;                          // dedup
+      seen.add(part);
+      tokens.push(part);
+    }
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
-  return quoted.join(" OR ");
+  // Tokens are whitelist-extracted → contain no quotes → safe to phrase-quote
+  // without FTS5 "" escaping.
+  return tokens.map((t) => `"${t}"`).join(" OR ");
 }
 
 /**


### PR DESCRIPTION
## Description | 描述

Sanitize user input before it reaches the FTS5 MATCH expression in
`buildFtsQuery()`, closing the defense-in-depth gap from #160 where the only
protection was double-quoting individual tokens.

Three layers, applied before the MATCH string is assembled:

1. **NFKC normalisation** — full-width operator variants (e.g. `ＡＮＤ`,
   U+FF21 U+FF2E U+FF24) collapse to ASCII so they cannot bypass the operator
   filter.
2. **Unicode whitelist tokenisation** (`[\p{L}\p{N}_]+`) — every FTS5 syntax
   character (`* " ' ( ) : ^ { } -`) becomes a token separator and is dropped.
   A single regex covers both operator injection and structural syntax
   injection (column filters, prefix globs, phrase grouping).
3. **Token-level operator suppression** — `AND`/`OR`/`NOT`/`NEAR` are stripped
   (case-insensitive) only when they appear as standalone tokens, so normal
   words containing operator substrings (`android`, `orange`, `notebook`,
   `scotland`, `nearshore`) are preserved.

Because every emitted token is whitelist-extracted, it carries no quotes and
is safe to emit as an FTS5 phrase literal without `""` escaping.

The index side (`tokenizeForFts`) is intentionally untouched — this change is
scoped to query construction only.

## Related Issue | 关联 Issue

Fixes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

### Relationship to #178

This PR builds on the direction of #178 (strip FTS5 operators before
tokenisation) and adds two defences its narrow regex does not cover, while
keeping the code surface minimal (~25 lines, no new exports, no new files):

- **NFKC normalisation** — #178's ASCII regex `/\b(?:AND|OR|NOT|NEAR)\b/gi`
  does not catch full-width variants; this PR normalises first.
- **Unicode whitelist** — drops all FTS5 syntax characters, not just the four
  boolean operators, so `content:foo`, `foo*`, `"phrase"`, `(group)` cannot
  reach MATCH either.
- **Recall-superset invariant** — backed by a real `node:sqlite` FTS5
  integration test proving benign-query recall is preserved.

### Sanitization behaviour

| User input | Generated MATCH | Why it is safe |
| --- | --- | --- |
| `foo AND bar` | `"foo" OR "bar"` | `AND` stripped — cannot narrow to "both" |
| `foo NOT bar` | `"foo" OR "bar"` | `NOT` stripped — cannot exclude |
| `content:foo` | `"content" OR "foo"` | column-filter syntax dropped by whitelist |
| `foo*` / `(baz)` / `"q"` | `"foo"` / `"baz"` / `"q"` | wildcard / group / quote syntax dropped |
| full-width `ＡＮＤ` | normalised to `AND`, then stripped | NFKC defeats the Unicode bypass |
| `android orange notebook` | `"android" OR "orange" OR "notebook"` | operator substrings are not mangled |

### Test coverage

New `src/core/store/sqlite.test.ts` — 14 cases:

- **Fallback path:** uppercase / lowercase / mixed-case operators, full-width
  NFKC bypass, embedded-word regression, structural syntax chars, `NEAR(...)`
  function syntax, operators-only → `null`, empty → `null`.
- **Jieba path:** normal Chinese segmentation regression; dirty-token
  re-sanitisation (e.g. `NEAR(beta` → `beta`).
- **Real `node:sqlite` in-memory FTS5 integration:** `AND` neutralisation
  (same recall as plain OR), `NOT` neutralisation (no exclusion), benign-query
  recall preservation, adversarial input never throws.

### Verification

- `npm test` — **81 passed (81)** across 5 files
- `npm run build` — clean (tsdown + tsc, no type errors)
- Node v22.16.0

### Files

- `src/core/store/sqlite.ts` — `buildFtsQuery()` refactor + inline
  `FTS5_OPERATORS` / `FTS_TOKEN_PARTS_RE` / `toFtsLiteralParts` (no new exports)
- `src/core/store/sqlite.test.ts` — new
- `CHANGELOG.md` — `[Unreleased]` security entry
