### PR TITLE
fix(checkpoint): recalibrate drift-prone counters against real data (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
-### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
+### 🐛 修复
+
+- **checkpoint 计数器只增不减，cleaner 清理后与真实数据长期漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：`l0_conversations_count` 与 `total_memories_extracted` 此前只在采集/抽取时递增，memory-cleaner 删除过期 L0/L1 记录后从不回写，导致计数持续高估真实数据量，进而使依赖这些计数的 L2/L3 persona 阈值判断提前触发或长期失真。
+  - 新增 `CheckpointManager.recalibrate(source?)`：以在线存储（`countL0()` / `countL1()`，与 cleaner 判定删除时同源）为准回填计数；无存储的降级模式下回退为统计 `conversations/`、`records/` 下 `YYYY-MM-DD.jsonl` 分片的非空行数。写入复用同一把 per-file 锁，幂等且对瞬时异常计数（NaN/负数）做钳制。
+  - **调用时机**：Gateway 启动恢复 pipeline 状态前调用一次，以及每轮 cleaner 清理结束后调用；两处均为非致命，失败不影响主流程。
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：
 

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -514,6 +514,15 @@ export class TdaiCore {
     this.schedulerStartPromise = (async () => {
       try {
         const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        // Correct increment-only counter drift before restoring pipeline state,
+        // so persona thresholds start from counts that match real data (#157).
+        // Uses the live store as source of truth, falling back to JSONL line
+        // counts in degraded mode. Non-fatal: never blocks scheduler start.
+        try {
+          await checkpoint.recalibrate(this.vectorStore);
+        } catch (err) {
+          this.logger.warn(`${TAG} Checkpoint recalibration failed (continuing): ${err instanceof Error ? err.message : String(err)}`);
+        }
         const cp = await checkpoint.read();
         scheduler.start(checkpoint.getAllPipelineStates(cp));
         this.logger.debug?.(`${TAG} Scheduler started`);

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { CheckpointManager, type RecalibrationSource } from "./checkpoint.js";
+
+/** In-memory fake store returning fixed live counts. */
+function fakeSource(l0: number, l1: number): RecalibrationSource {
+  return {
+    countL0: () => l0,
+    countL1: () => l1,
+  };
+}
+
+describe("CheckpointManager.recalibrate (#157)", () => {
+  let dataDir: string;
+  let cp: CheckpointManager;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-ckpt-"));
+    cp = new CheckpointManager(dataDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("resets inflated counters down to live store counts", async () => {
+    // Simulate drift: counters were incremented well beyond reality.
+    await cp.captureAtomically("s1", undefined, async () => ({ maxTimestamp: 100, messageCount: 1 }));
+    await cp.captureAtomically("s1", 0, async () => ({ maxTimestamp: 200, messageCount: 1 }));
+    await cp.markL1ExtractionComplete("s1", 10, 200);
+
+    let state = await cp.read();
+    expect(state.l0_conversations_count).toBe(2);
+    expect(state.total_memories_extracted).toBe(10);
+
+    // Store now only has 1 L0 and 3 L1 (cleanup happened).
+    const result = await cp.recalibrate(fakeSource(1, 3));
+
+    expect(result.source).toBe("store");
+    expect(result.changed).toBe(true);
+    expect(result.l0).toEqual({ before: 2, after: 1 });
+    expect(result.l1).toEqual({ before: 10, after: 3 });
+
+    state = await cp.read();
+    expect(state.l0_conversations_count).toBe(1);
+    expect(state.total_memories_extracted).toBe(3);
+  });
+
+  it("is idempotent when counts already match (no drift)", async () => {
+    await cp.recalibrate(fakeSource(5, 7));
+    const result = await cp.recalibrate(fakeSource(5, 7));
+
+    expect(result.changed).toBe(false);
+    expect(result.l0).toEqual({ before: 5, after: 5 });
+    expect(result.l1).toEqual({ before: 7, after: 7 });
+  });
+
+  it("counts increase as well as decrease (self-correcting in both directions)", async () => {
+    await cp.recalibrate(fakeSource(1, 1));
+    const result = await cp.recalibrate(fakeSource(9, 4));
+
+    expect(result.changed).toBe(true);
+    expect(result.l0.after).toBe(9);
+    expect(result.l1.after).toBe(4);
+  });
+
+  it("preserves unrelated checkpoint fields", async () => {
+    await cp.markPersonaGenerated(42);
+    await cp.incrementScenesProcessed();
+    await cp.recalibrate(fakeSource(3, 3));
+
+    const state = await cp.read();
+    expect(state.last_persona_at).toBe(42);
+    expect(state.scenes_processed).toBe(1);
+  });
+
+  it("clamps transient bad counts (NaN/negative) to zero", async () => {
+    await cp.recalibrate(fakeSource(5, 5));
+    const result = await cp.recalibrate({
+      countL0: () => Number.NaN,
+      countL1: () => -3,
+    });
+
+    expect(result.l0.after).toBe(0);
+    expect(result.l1.after).toBe(0);
+  });
+
+  describe("JSONL fallback (degraded mode, no store)", () => {
+    async function writeShard(subDir: string, name: string, lines: string[]): Promise<void> {
+      const dir = path.join(dataDir, subDir);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, name), lines.join("\n"), "utf-8");
+    }
+
+    it("counts non-empty lines across daily shards", async () => {
+      await writeShard("conversations", "2026-06-01.jsonl", ['{"a":1}', '{"a":2}', ""]);
+      await writeShard("conversations", "2026-06-02.jsonl", ['{"a":3}']);
+      await writeShard("records", "2026-06-01.jsonl", ['{"m":1}', "  ", '{"m":2}']);
+
+      const result = await cp.recalibrate();
+
+      expect(result.source).toBe("jsonl");
+      expect(result.l0.after).toBe(3); // 2 + 1, blank line ignored
+      expect(result.l1.after).toBe(2); // whitespace-only line ignored
+    });
+
+    it("ignores non-shard files and missing directories", async () => {
+      await writeShard("conversations", "notes.txt", ["ignored"]);
+      // records/ dir never created
+
+      const result = await cp.recalibrate();
+
+      expect(result.l0.after).toBe(0);
+      expect(result.l1.after).toBe(0);
+    });
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -144,6 +144,27 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+/**
+ * Minimal view of the memory store needed for recalibration.
+ * Kept structural (not importing IMemoryStore) so checkpoint.ts stays free of
+ * store-layer dependencies and remains trivially unit-testable with a fake.
+ */
+export interface RecalibrationSource {
+  /** Live count of L0 conversation records (source of truth). */
+  countL0(): number | Promise<number>;
+  /** Live count of L1 memory records (source of truth). */
+  countL1(): number | Promise<number>;
+}
+
+export interface RecalibrateResult {
+  l0: { before: number; after: number };
+  l1: { before: number; after: number };
+  /** "store" when live store counts were used; "jsonl" when the file-line fallback was used. */
+  source: "store" | "jsonl";
+  /** True when either counter actually changed. */
+  changed: boolean;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -483,6 +504,128 @@ export class CheckpointManager {
         cp.l0_conversations_count += 1;
       }
     });
+  }
+
+  // ============================
+  // Recalibration (drift correction) — issue #157
+  // ============================
+
+  /**
+   * Reconcile the monotonic counters (`l0_conversations_count`,
+   * `total_memories_extracted`) against reality.
+   *
+   * ## Why this is needed
+   * Both counters are increment-only: `captureAtomically()` bumps
+   * `l0_conversations_count` and `markL1ExtractionComplete()` bumps
+   * `total_memories_extracted`, but nothing ever decrements them. The
+   * memory-cleaner deletes expired L0/L1 records from the store (and their
+   * JSONL shards), so after any cleanup the checkpoint permanently overstates
+   * how much data actually exists. These counters feed L2/L3 persona
+   * thresholds, so drift makes persona generation trigger prematurely or,
+   * once the checkpoint is far ahead of reality, effectively stall.
+   *
+   * ## Source of truth
+   * The live store is authoritative: `countL0()` / `countL1()` are the same
+   * queries the cleaner uses to decide deletions, so recalibrating against them
+   * keeps the checkpoint consistent with the store. When no store is available
+   * (degraded mode), we fall back to counting non-empty lines across the
+   * `conversations/` and `records/` daily JSONL shards under `dataDir`.
+   *
+   * The write happens inside the same per-file lock as every other mutation,
+   * so a concurrent capture/extraction cannot interleave a stale read.
+   *
+   * Idempotent: calling it repeatedly with unchanged data is a no-op
+   * (`changed === false`).
+   *
+   * @param source Optional live-count provider (typically the vector store).
+   *   Omit to force the JSONL fallback.
+   */
+  async recalibrate(source?: RecalibrationSource): Promise<RecalibrateResult> {
+    // Resolve the true counts OUTSIDE the lock (store/FS I/O can be slow and
+    // must not block other checkpoint mutations). The values are re-applied
+    // atomically inside the lock below.
+    let l0True: number;
+    let l1True: number;
+    let usedSource: "store" | "jsonl";
+
+    if (source) {
+      l0True = await source.countL0();
+      l1True = await source.countL1();
+      usedSource = "store";
+    } else {
+      l0True = await this.countJsonlLines("conversations");
+      l1True = await this.countJsonlLines("records");
+      usedSource = "jsonl";
+    }
+
+    // Guard against transient failures returning nonsense (e.g. NaN/negatives).
+    l0True = Number.isFinite(l0True) && l0True >= 0 ? Math.floor(l0True) : 0;
+    l1True = Number.isFinite(l1True) && l1True >= 0 ? Math.floor(l1True) : 0;
+
+    let before = { l0: 0, l1: 0 };
+    await this.mutate((cp) => {
+      before = { l0: cp.l0_conversations_count, l1: cp.total_memories_extracted };
+      cp.l0_conversations_count = l0True;
+      cp.total_memories_extracted = l1True;
+    });
+
+    const result: RecalibrateResult = {
+      l0: { before: before.l0, after: l0True },
+      l1: { before: before.l1, after: l1True },
+      source: usedSource,
+      changed: before.l0 !== l0True || before.l1 !== l1True,
+    };
+
+    if (result.changed) {
+      this.logger.info(
+        `[checkpoint] recalibrate (source=${usedSource}): ` +
+        `l0 ${result.l0.before}→${result.l0.after}, ` +
+        `l1 ${result.l1.before}→${result.l1.after}`,
+      );
+    } else {
+      this.logger.info(
+        `[checkpoint] recalibrate (source=${usedSource}): no drift ` +
+        `(l0=${result.l0.after}, l1=${result.l1.after})`,
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Count non-empty lines across all `YYYY-MM-DD.jsonl` daily shards in a
+   * subdirectory of `dataDir` (the checkpoint lives in `dataDir/.metadata`).
+   * Used as the degraded-mode fallback for {@link recalibrate}. Missing
+   * directories and unreadable files count as zero rather than throwing.
+   */
+  private async countJsonlLines(subDir: string): Promise<number> {
+    const dirPath = path.join(path.dirname(path.dirname(this.filePath)), subDir);
+    const shardPattern = /^\d{4}-\d{2}-\d{2}\.jsonl$/;
+
+    let entries: string[];
+    try {
+      const dirEntries = await fs.readdir(dirPath, { withFileTypes: true });
+      entries = dirEntries
+        .filter((e) => e.isFile() && shardPattern.test(e.name))
+        .map((e) => e.name);
+    } catch {
+      return 0; // directory doesn't exist yet
+    }
+
+    let total = 0;
+    for (const name of entries) {
+      try {
+        const raw = await fs.readFile(path.join(dirPath, name), "utf-8");
+        for (const line of raw.split("\n")) {
+          if (line.trim()) total += 1;
+        }
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: failed to read ${name}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return total;
   }
 
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -184,6 +185,18 @@ export class LocalMemoryCleaner {
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+    // Cleanup just deleted L0/L1 records, so the increment-only checkpoint
+    // counters now overstate reality. Recalibrate them against the live store
+    // (or JSONL fallback) to keep persona thresholds accurate (#157).
+    // Non-fatal: a failed recalibration must never abort the cleanup cycle.
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await checkpoint.recalibrate(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private scheduleNext(): void {


### PR DESCRIPTION
## Description | 描述
Make the two increment-only checkpoint counters self-correcting.
`l0_conversations_count` / `total_memories_extracted` only ever grew; the
memory-cleaner deletes L0/L1 records without updating the checkpoint, so
counts drifted above reality and skewed L2/L3 persona thresholds.

Adds `CheckpointManager.recalibrate(source?)`, reconciling both counters to
live store counts (`countL0`/`countL1`) with a JSONL-line fallback in
degraded mode. Called at gateway startup (before pipeline restore) and after
each cleaner run; both non-fatal. Idempotent, lock-safe, clamps bad counts.

## Related Issue | 关联 Issue
Closes #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 (tsc clean; vitest 74/74, incl. 7 new)
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Note: PR #395 also targets #157 and is open. Happy to close this in favor of
whichever the maintainers prefer if it duplicates existing work.