### PR TITLE
Feat/issue 235 platform adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/trae-adapter.md`](./docs/trae-adapter.md) | Trae platform adapter installation and configuration guide |
+| [`docs/platform-adapters-comparison.md`](./docs/platform-adapters-comparison.md) | Comparison across 6 Agent platforms (OpenClaw/Hermes/Codex/Claude Code/Dify/Trae) |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -537,6 +537,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/trae-adapter.md`](./docs/trae-adapter.md) | Trae 平台适配器安装与配置指南 |
+| [`docs/platform-adapters-comparison.md`](./docs/platform-adapters-comparison.md) | 6 个 Agent 平台对比 (OpenClaw/Hermes/Codex/Claude Code/Dify/Trae) |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/docs/platform-adapters-comparison.md
+++ b/docs/platform-adapters-comparison.md
@@ -1,0 +1,272 @@
+# Platform Adapters Comparison
+
+本文档对比 TencentDB Agent Memory 在6个Agent平台上的适配方案，分析不同接入模式、技术选型和实现特点。
+
+## 平台对比总览
+
+| 平台 | 状态 | 接入模式 | 改core hostType? | HTTP Client | L0读写可靠性 | Reliability特性 | MCP支持 | 实现位置 |
+|------|------|----------|-----------------|-------------|--------------|-----------------|---------|----------|
+| **OpenClaw** | ✅ Main | In-process host-adapter | ❌ 否 (native) | — | ✅ 直接调用TdaiCore | Plugin lifecycle管理 | ❌ 无 | `openclaw-plugin/` |
+| **Hermes** | ✅ Main | HTTP sidecar | ❌ 否 (HTTP路径) | 自带`memory_tencentdb` provider | ✅ HTTP + 重试队列 | Supervisor/circuit-breaker | ❌ 无 | `hermes-plugin/memory/memory_tencentdb/` |
+| **Codex** | 🔄 PR #516 | HTTP hooks | ❌ 否 (HTTP路径) | 自写client | ✅ HTTP + 降级 | 持久化重试队列 | ❌ 无 | PR独立实现 |
+| **Claude Code** | 🔄 PR #517 | Tool-based hooks | ❌ 否 (HTTP路径) | 自写`gateway-client.ts` | ✅ HTTP + 有界注入 | 持久化队列/超时预算 | ✅ 有(自建) | `src/adapters/claude-code/` |
+| **Dify** | 🔄 PR #394 | HTTP tool-plugin | ❌ 否 (HTTP路径) | Python `tools/client.py` | ✅ HTTP + 异常捕获 | Python try/except降级 | ❌ 无 | `dify-plugin-tdai-memory/` |
+| **Trae** | 🔄 本PR | HTTP hooks + MCP | ❌ 否 (HTTP路径) | 复用#316`GatewayMemoryClient` | ✅ HTTP + TdaiBridge | retry/recall缓存/降级/消毒 | ✅ 有(复用#372) | `src/adapters/trae/` |
+
+### 维度说明
+
+**接入模式分类:**
+- **In-process host-adapter**: OpenClaw插件直接调用TdaiCore，无HTTP中间层
+- **HTTP sidecar**: Hermes通过独立Gateway进程，HTTP通信
+- **HTTP hooks**: 生命周期hook触发HTTP调用 (Codex/Trae)
+- **Tool-based hooks**: 通过工具调用触发hook (Claude Code)
+- **HTTP tool-plugin**: 平台工具插件发起HTTP请求 (Dify)
+- **MCP**: Model Context Protocol标准接口 (Trae/Claude Code)
+
+**改core hostType**: 所有方案均避免修改`core/hostType`联合类型，走HTTP路径保持core稳定性。
+
+**HTTP Client来源**: 
+- Hermes自带provider (维护中)
+- #316 `GatewayMemoryClient` (轻量baseline)
+- 各PR自写client (碎片化问题)
+- Trae复用#316 (整合方向)
+
+**Reliability特性**:
+- **OpenClaw**: 直接调用，依赖插件生命周期管理
+- **Hermes**: Supervisor模式 + circuit-breaker
+- **Codex/Claude Code**: 持久化重试队列 (文件系统)
+- **Trae**: 分类retry + recall缓存 + 输入消毒 + 优雅降级 (取#339内核)
+
+## 组件架构图
+
+```mermaid
+graph TB
+    subgraph "Agent Platforms"
+        OC["OpenClaw<br/>In-process Plugin"]
+        HM["Hermes<br/>HTTP Sidecar"]
+        CX["Codex<br/>HTTP Hooks"]
+        CC["Claude Code<br/>Tool Hooks"]
+        DY["Dify<br/>Tool Plugin"]
+        TR["Trae<br/>Hooks + MCP<br/>(本PR)"]
+    end
+
+    subgraph "Adaptation Layer"
+        TD["TdaiBridge<br/>(薄整合层)"]
+        GW["TdaiGateway<br/>HTTP Server"]
+    end
+
+    subgraph "Core Engine"
+        TC["TdaiCore<br/>记忆引擎"]
+        VDB[(("Vector DB<br/>FTS5+NFKC"))]
+    end
+
+    OC -->|直接调用| TC
+    HM -->|HTTP Provider| GW
+    CX -->|自写Client| GW
+    CC -->|自写gateway-client| GW
+    DY -->|Python client.py| GW
+    TR -->|复用#316<br/>GatewayMemoryClient| TD
+    TD -->|retry/缓存/降级| GW
+    GW --> TC
+    TC --> VDB
+
+    style TR fill:#90EE90,stroke:#228B22,stroke-width:3px
+    style TD fill:#FFD700,stroke:#FF8C00,stroke-width:2px
+    style TC fill:#87CEEB,stroke:#4682B4
+```
+
+**架构说明:**
+- OpenClaw走进程内路径，无需HTTP层
+- Hermes/Codex/Claude Code/Dify通过各自HTTP client接入Gateway
+- Trae通过`TdaiBridge`薄整合层，复用#316 `GatewayMemoryClient`
+- 所有HTTP路径最终汇聚到`TdaiGateway` → `TdaiCore`
+
+## Recall READ路径
+
+```mermaid
+sequenceDiagram
+    participant User as 用户提问
+    participant Platform as Agent平台
+    participant Hook as Hook Handler
+    participant Bridge as TdaiBridge
+    participant Gateway as TdaiGateway
+    participant Core as TdaiCore
+    participant VDB as Vector DB
+
+    User->>Platform: 输入问题
+    Platform->>Hook: UserPromptSubmit事件
+    Hook->>Bridge: recall(query, sessionKey)
+    
+    Note over Bridge: 检查recall缓存<br/>SHA-256(query)命中?
+    
+    alt 缓存命中
+        Bridge-->>Hook: 返回缓存结果
+    else 缓存未命中
+        Bridge->>Gateway: HTTP /recall
+        Gateway->>Core: 混合检索(BM25+Vector)
+        Core->>VDB: FTS5+NFKC查询
+        VDB-->>Core: L0/L1记忆片段
+        Core->>Core: L2场景聚合
+        Core->>Core: L3画像过滤
+        Core-->>Gateway: 上下文结果
+        Gateway-->>Bridge: HTTP响应
+        Bridge->>Bridge: 写入缓存(容量治理)
+        Bridge-->>Hook: 返回结果
+    end
+    
+    Hook->>Hook: 有界注入(4000字符上限)
+    Hook-->>Platform: additionalContext
+    Platform->>Platform: 注入到用户上下文
+    Platform-->>User: 带记忆的增强回答
+
+    Note over Bridge: 失败降级: 返回空串<br/>不阻塞对话
+    Note over Hook: 超长截断: 防context爆炸
+```
+
+**READ路径关键点:**
+- **缓存优化**: 同会话同查询命中缓存，直接修复#120 prompt-cache问题
+- **分类retry**: 仅对瞬态错误重试(503/429/timeout)，Auth错误立即降级
+- **有界注入**: 4000字符上限，防上下文爆炸
+- **优雅降级**: 任何异常返回空串，不阻塞对话
+
+## L0→L3 WRITE路径
+
+```mermaid
+graph TB
+    subgraph "Capture阶段"
+        HK["Hook Handler<br/>(Stop/SessionEnd事件)"]
+        CP["TdaiBridge.capture()"]
+    end
+
+    subgraph "L0原始对话层"
+        L0["L0 Conversation<br/>原始对话记录"]
+        RAW["refs/*.md<br/>工具调用结果"]
+    end
+
+    subgraph "L1原子事实层"
+        L1["L1 Atom<br/>结构化事实"]
+        V1[(("向量索引<br/>FTS5+BK-Tree"))]
+    end
+
+    subgraph "L2场景层"
+        L2["L2 Scenario<br/>场景块"]
+        IDX["场景索引<br/>时间/任务聚类"]
+    end
+
+    subgraph "L3画像层"
+        L3["L3 Persona<br/>用户画像"]
+        PRF["偏好/风格/目标<br/>长期沉淀"]
+    end
+
+    HK --> CP
+    CP -->|输入消毒<br/>长度clamp| L0
+    L0 --> RAW
+    
+    L0 -->|每N轮触发| L1
+    L1 --> V1
+    L1 -->|向量去重| L1
+    L1 -->|语义关联| L2
+    
+    L2 -->|场景聚类| IDX
+    L2 -->|每50条触发| L3
+    
+    L3 --> PRF
+    
+    L3 -.->|召回时过滤| L2
+    L2 -.->|下钻证据| L1
+    L1 -.->|溯源原文| L0
+    L0 -.->|完整恢复| RAW
+
+    style CP fill:#FFD700,stroke:#FF8C00
+    style L0 fill:#E6F3FF,stroke:#4682B4
+    style L1 fill:#FFF0E6,stroke:#FF8C00
+    style L2 fill:#E6FFE6,stroke:#228B22
+    style L3 fill:#FFE6F0,stroke:#DC143C
+```
+
+**WRITE路径层次:**
+- **L0 Conversation**: 原始对话完整保留，`refs/*.md`卸载工具调用结果
+- **L1 Atom**: 结构化原子事实，向量去重，支持语义检索
+- **L2 Scenario**: 场景块聚合，任务级别归纳
+- **L3 Persona**: 用户画像，长期偏好/表达风格/目标沉淀
+
+**可追溯链路**: Persona → Scenario → Atom → Conversation → refs/*.md，每一步都可下钻恢复原始证据。
+
+## 技术选型对比
+
+### HTTP Client碎片化现状
+
+| PR | Client实现 | 代码量 | 特点 |
+|----|-----------|--------|------|
+| #316 | `GatewayMemoryClient` | ~300行 | 轻量baseline，被maintainer认可 |
+| #372 | `TdaiGatewayClient` | ~400行 | MCP桥专用 |
+| #517 | `src/adapters/claude-code/gateway-client.ts` | ~350行 | Claude Code专用 |
+| #394 | `tools/client.py` | ~200行 | Python实现 |
+| **本PR (Trae)** | **复用#316** | **0行新增** | **整合方向** |
+
+**整合机会**: Trae主动复用#316 `GatewayMemoryClient`，避免第5份自写client，为未来统一SDK奠基。
+
+### Reliability特性来源
+
+| 特性 | 来源 | 应用平台 |
+|------|------|----------|
+| 分类retry (瞬态重试/Auth跳过) | #339 ABC内核 | Trae |
+| Recall会话缓存 (SHA-256 key) | #339 修复#120 | Trae |
+| 输入消毒 (query截断/limit clamp) | #339 防御 | Trae |
+| 优雅降级 (异常返回空值) | #339 | Trae |
+| 持久化重试队列 | #517 Claude Code | Claude Code |
+| Supervisor/circuit-breaker | Hermes | Hermes |
+| 有界additionalContext注入 | #517 | Trae/Claude Code |
+
+**Trae整合策略**: 取#339高杠杆内核 (retry/缓存/降级/消毒)，避开G2-G4重型防御门。
+
+## MCP支持对比
+
+| 平台 | MCP实现 | Schema模式 | 工具数量 | 特点 |
+|------|---------|-----------|---------|------|
+| **Claude Code** | 自建MCP v1.3 | Open schema | 5个 | 工具定义灵活 |
+| **Trae** | 复用#372模式 | Closed schema | 5个 | 纯JSON-RPC + 强校验 |
+| **OpenClaw** | ❌ 无 | — | — | 进程内调用 |
+| **Hermes** | ❌ 无 | — | — | HTTP provider |
+| **Codex** | ❌ 无 | — | — | HTTP hooks |
+| **Dify** | ❌ 无 | — | — | HTTP plugin |
+
+**Trae MCP特点**:
+- 纯JSON-RPC手写 (不依赖@modelcontextprotocol/sdk，供应链安全)
+- Closed schema (`additionalProperties: false`) 强校验
+- G0输入校验 + G1 HMAC签名 (参照#372)
+- 5个工具: `tdai_recall`/`tdai_capture`/`tdai_memory_search`/`tdai_conversation_search`/`tdai_session_end`
+
+## 各平台实现状态
+
+### ✅ 已合并 (Main分支)
+- **OpenClaw**: `openclaw-plugin/` - 进程内插件，零配置启动
+- **Hermes**: `hermes-plugin/memory/memory_tencentdb/` - HTTP sidecar，Docker/原生双路径
+
+### 🔄 进行中 (PR)
+- **Codex** (#516): 独立HTTP client + hooks实现
+- **Claude Code** (#517): 自建MCP + gateway-client + 持久化队列
+- **Dify** (#394): Python HTTP client + 工具插件
+- **Trae** (本PR): 复用#316 client + TdaiBridge + MCP (参照#372)
+
+### 🎯 差异化优势 (Trae)
+
+相对其他平台的独特优势:
+1. **整合碎片化Client**: 主动复用#316，避免第5份自写实现
+2. **薄统一适配层**: `TdaiBridge`为未来跨平台SDK奠基
+3. **完整Reliability**: retry/缓存/降级/消毒四位一体
+4. **腾讯云底座**: FTS5+NFKC召回质量 + 中国合规
+5. **空白市场**: Trae平台完全未被Mem0/Letta/Zep占用
+
+## 参考PR链接
+
+- #316: HTTP baseline (`GatewayMemoryClient`)
+- #372: MCP桥 (`TdaiMcpServer`)
+- #516: Codex适配器
+- #517: Claude Code适配器 
+- #394: Dify适配器
+- #339: 大统一SDK (ABC内核来源)
+
+---
+
+**最后更新**: 2026-07-21 (Trae Adapter PR)

--- a/docs/superpowers/plans/2026-07-21-trae-memory-adapter.md
+++ b/docs/superpowers/plans/2026-07-21-trae-memory-adapter.md
@@ -1,0 +1,618 @@
+# Trae Memory Adapter + Thin Bridge Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 TencentDB-Agent-Memory 接入 Trae 平台(记忆读写),并新增一层薄整合 `TdaiBridge`(复用 #316 client,移植 #517 reliability、#372 MCP、#339 retry/缓存/降级)。
+
+**Architecture:** 三层 —— Trae 平台层(hooks + MCP)→ `TdaiBridge` 薄整合层 → #316 `GatewayMemoryClient` → `TdaiGateway` → `TdaiCore`。零 core 改动。
+
+**Tech Stack:** TypeScript、Node 原生 `http`(无 Express)、MCP JSON-RPC over stdio、vitest。
+
+## Global Constraints
+
+- **语言 TypeScript**;Node 原生 `http`,不引入 Express/Fastify。
+- **不改 `core` 的 `hostType` union**(走 HTTP 路径)。
+- **不自写 HTTP client**:复用 #316 `GatewayMemoryClient`;若 #316 未 merge,vendoring 其 `src/adapters/gateway-client/index.ts` 并在文件头注明来源。
+- **不做** G2/G3/G4 防御门、BufferedAdapter、HermesV2Adapter、Python 版、OTel/L2/编码修复(属其他 PR)。
+- **commit 需用户明确同意,不自动提交**(遵循项目 CLAUDE.md)。计划中 commit 步骤为 checkpoint,执行时征求确认。
+- 代码注释语言跟随仓库现有风格(中英混合,以现有 `src/adapters/` 文件为准)。
+- TDD:每个功能先写失败测试,再实现。
+
+---
+
+## File Structure(锁定分解)
+
+| 文件 | 职责 | 来源 |
+|---|---|---|
+| `src/adapters/tdai-bridge/tdai-bridge.ts` | concrete `TdaiBridge`:包 client + retry + recall 缓存 + 消毒 + 降级 | 新(取 #339 内核) |
+| `src/adapters/tdai-bridge/tdai-bridge.test.ts` | retry/cache/sanitize/degrade 单测 | 新 |
+| `src/adapters/trae/hook-handler.ts` | Trae 事件 → TdaiBridge(stdin JSON→recall/capture/additionalContext) | 新(复用 #517 逻辑) |
+| `src/adapters/trae/hook-handler.test.ts` | 各事件单测 | 新 |
+| `src/adapters/trae/mcp-server.ts` | MCP server,5 tools 调 TdaiBridge | 新(参照 #372 模式) |
+| `src/adapters/trae/mcp-server.test.ts` | lifecycle/tools/校验单测 | 新 |
+| `src/adapters/trae/index.ts` | barrel 导出 | 新 |
+| `trae-plugin/.trae/hooks.json` | Trae hooks 配置 | 新 |
+| `trae-plugin/.trae/mcp.json` | Trae MCP 配置 | 新 |
+| `trae-plugin/scripts/memory-hook.mjs` | Node 入口,调 hook-handler | 新 |
+| `trae-plugin/README.md` | 安装/配置说明 | 新 |
+| `docs/platform-adapters-comparison.md` | 6 平台对比 + 3 Mermaid | 新(深入交付) |
+| `docs/trae-adapter.md` | Trae 适配指南 | 新 |
+| `src/adapters/index.ts` / `index.ts` | 追加导出 | 改 |
+
+---
+
+## Task 1: 复用基座 + `TdaiBridge` 薄整合层
+
+**Files:**
+- Create: `src/adapters/tdai-bridge/tdai-bridge.ts`
+- Create: `src/adapters/tdai-bridge/tdai-bridge.test.ts`
+- (基座)若 main 无 `src/adapters/gateway-client/`:vendoring #316 的 `index.ts`,文件头加 `// vendored from PR #316 (GatewayMemoryClient); track upstream for updates`
+
+**Interfaces:**
+- Consumes: #316 `GatewayMemoryClient`(methods: `recall`/`capture`/`searchMemories`/`searchConversations`/`endSession`/`health`),`GatewayMemoryClientError { status, path, responseBody }`
+- Produces: `class TdaiBridge`,methods: `recall(query, sessionKey)`、`capture(turn, sessionKey)`、`searchMemory(query, opts?)`、`searchConversation(query, opts?)`、`endSession(sessionKey)`;构造 `new TdaiBridge(client, opts?)`
+
+- [ ] **Step 1: 确认基座可用性**
+
+Run: `git ls-files src/adapters/gateway-client/ | head`
+- 若有输出(import 路径稳定):记录为 import 模式。
+- 若空(#316 未 merge):从 PR #316 拉 `src/adapters/gateway-client/index.ts` 到本地同路径,文件头加 vendoring 注释。Run: `curl -sS https://raw.githubusercontent.com/TencentCloud/TencentDB-Agent-Memory/refs/heads/<pr316-head>/src/adapters/gateway-client/index.ts -o src/adapters/gateway-client/index.ts`(head 分支名见 PR #316)。
+
+- [ ] **Step 2: 写失败测试 — retry 只对瞬态错误重试**
+
+```ts
+// src/adapters/tdai-bridge/tdai-bridge.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { TdaiBridge } from "./tdai-bridge.js";
+import { GatewayMemoryClientError } from "../gateway-client/index.js";
+
+function makeClient(overrides: Partial<GatewayMemoryClient> = {}) {
+  return {
+    recall: vi.fn(),
+    capture: vi.fn(),
+    searchMemories: vi.fn(),
+    searchConversations: vi.fn(),
+    endSession: vi.fn(),
+    health: vi.fn(),
+    ...overrides,
+  } as unknown as GatewayMemoryClient;
+}
+
+describe("TdaiBridge retry", () => {
+  it("retries transient (status 503) then succeeds", async () => {
+    const client = makeClient({
+      recall: vi.fn()
+        .mockRejectedValueOnce(new GatewayMemoryClientError("/recall", 503, "busy"))
+        .mockResolvedValueOnce({ context: "OK" } as any),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 3, baseMs: 1 } });
+    const res = await bridge.recall("hello", "sess-1");
+    expect(client.recall).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ context: "OK" });
+  });
+
+  it("does NOT retry auth errors (status 401)", async () => {
+    const client = makeClient({
+      recall: vi.fn().mockRejectedValue(new GatewayMemoryClientError("/recall", 401, "no key")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 3, baseMs: 1 } });
+    // 降级:recall 失败返回空串,不抛
+    const res = await bridge.recall("hello", "sess-1");
+    expect(client.recall).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ context: "" });
+  });
+});
+```
+
+- [ ] **Step 3: 运行测试,确认失败**
+
+Run: `npx vitest run src/adapters/tdai-bridge/tdai-bridge.test.ts`
+Expected: FAIL(`TdaiBridge` 未定义 / import 失败)
+
+- [ ] **Step 4: 实现 `TdaiBridge`(最小通过 + retry/降级)**
+
+```ts
+// src/adapters/tdai-bridge/tdai-bridge.ts
+import type { GatewayMemoryClient } from "../gateway-client/index.js";
+import { GatewayMemoryClientError } from "../gateway-client/index.js";
+
+export interface BridgeRetryOpts { attempts: number; baseMs: number; }
+export interface BridgeOpts {
+  retry?: Partial<BridgeRetryOpts>;
+  recallCacheMax?: number; // ponytail: Map cap,默认 256
+}
+
+const DEFAULT_RETRY: BridgeRetryOpts = { attempts: 3, baseMs: 200 };
+
+// ponytail: 仅瞬态错误重试;Auth/Validation 立即降级
+function isTransient(err: unknown): boolean {
+  if (err instanceof GatewayMemoryClientError) {
+    return err.status === 408 || err.status === 425 || err.status === 429 || err.status >= 500;
+  }
+  return err instanceof TypeError || err instanceof Error && /fetch|network|timeout/i.test(err.message);
+}
+
+async function withRetry<T>(fn: () => Promise<T>, opts: BridgeRetryOpts): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < opts.attempts; attempt++) {
+    try { return await fn(); }
+    catch (err) {
+      lastErr = err;
+      if (!isTransient(err)) throw err; // 非瞬态:上抛(由模板方法降级)
+      const delay = opts.baseMs * 2 ** attempt + Math.random() * opts.baseMs;
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+  throw lastErr;
+}
+
+export class TdaiBridge {
+  private readonly retry: BridgeRetryOpts;
+  private readonly cache = new Map<string, unknown>(); // ponytail: SHA-256 key,修 #120
+  private readonly cacheMax: number;
+
+  constructor(private readonly client: GatewayMemoryClient, opts: BridgeOpts = {}) {
+    this.retry = { ...DEFAULT_RETRY, ...opts.retry };
+    this.cacheMax = opts.recallCacheMax ?? 256;
+  }
+
+  async recall(query: string, sessionKey: string): Promise<{ context: string }> {
+    const q = sanitize(query, 100_000);
+    const key = sessionKey + ":" + q;
+    if (this.cache.has(key)) return this.cache.get(key) as { context: string };
+    try {
+      const res = await withRetry(() => this.client.recall({ query: q, session_key: sessionKey } as any), this.retry);
+      this.cache.set(key, res);
+      if (this.cache.size > this.cacheMax) this.cache.clear(); // ponytail: 简单容量治理;LRU 若命中率不够再换
+      return res as { context: string };
+    } catch (err) {
+      console.warn("[tdai-bridge] recall degraded:", (err as Error).message);
+      return { context: "" }; // 优雅降级:永不抛
+    }
+  }
+
+  async capture(turn: { userText: string; assistantText: string }, sessionKey: string): Promise<{ ok: boolean }> {
+    try {
+      await withRetry(() => this.client.capture({
+        user_text: sanitize(turn.userText, 1_000_000),
+        assistant_text: sanitize(turn.assistantText, 1_000_000),
+        session_key: sessionKey,
+      } as any), this.retry);
+      return { ok: true };
+    } catch (err) {
+      console.warn("[tdai-bridge] capture degraded:", (err as Error).message);
+      return { ok: false };
+    }
+  }
+
+  async searchMemory(query: string, opts: { limit?: number } = {}): Promise<unknown> {
+    try {
+      return await withRetry(() => this.client.searchMemories({
+        query: sanitize(query, 100_000), limit: clamp(opts.limit ?? 10, 1, 50),
+      } as any), this.retry);
+    } catch (err) { console.warn("[tdai-bridge] search degraded:", (err as Error).message); return []; }
+  }
+
+  async searchConversation(query: string, opts: { limit?: number } = {}): Promise<unknown> {
+    try {
+      return await withRetry(() => this.client.searchConversations({
+        query: sanitize(query, 100_000), limit: clamp(opts.limit ?? 10, 1, 50),
+      } as any), this.retry);
+    } catch (err) { console.warn("[tdai-bridge] search degraded:", (err as Error).message); return []; }
+  }
+
+  async endSession(sessionKey: string): Promise<void> {
+    try { await this.client.endSession({ session_key: sessionKey } as any); }
+    catch (err) { console.warn("[tdai-bridge] endSession degraded:", (err as Error).message); }
+  }
+}
+
+function sanitize(s: string, max: number): string { return s.length > max ? s.slice(0, max) : s; }
+function clamp(n: number, lo: number, hi: number): number { return Math.max(lo, Math.min(hi, n)); }
+```
+
+- [ ] **Step 5: 运行测试,确认通过**
+
+Run: `npx vitest run src/adapters/tdai-bridge/tdai-bridge.test.ts`
+Expected: PASS(2/2)
+
+- [ ] **Step 6: 补 cache + sanitize 测试**
+
+追加:
+```ts
+describe("TdaiBridge cache & sanitize", () => {
+  it("recall 同会话同查询命中缓存(只调一次 client)", async () => {
+    const client = makeClient({ recall: vi.fn().mockResolvedValue({ context: "X" } as any) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    await bridge.recall("q", "s"); await bridge.recall("q", "s");
+    expect(client.recall).toHaveBeenCalledTimes(1);
+  });
+  it("输入超长被截断", async () => {
+    const client = makeClient({ capture: vi.fn().mockResolvedValue({} as any) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    await bridge.capture({ userText: "x".repeat(2_000_000), assistantText: "y" }, "s");
+    expect((client.capture as any).mock.calls[0][0].user_text.length).toBe(1_000_000);
+  });
+});
+```
+Run: `npx vitest run src/adapters/tdai-bridge/tdai-bridge.test.ts` → PASS(4/4)
+
+- [ ] **Step 7: checkpoint(可 commit,需用户同意)**
+
+```bash
+git add src/adapters/tdai-bridge/ src/adapters/gateway-client/ 2>/dev/null
+# 等待用户确认后:git commit -m "feat(bridge): add TdaiBridge thin adapter over #316 client"
+```
+
+---
+
+## Task 2: Trae hook-handler(复用 #517,适配 Trae 事件)
+
+**Files:**
+- Create: `src/adapters/trae/hook-handler.ts`
+- Create: `src/adapters/trae/hook-handler.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `TdaiBridge`
+- Produces: `async function handleTraeHook(event: TraeHookEvent, input: TraeHookInput, bridge: TdaiBridge): Promise<TraeHookOutput>`,其中 `TraeHookEvent ∈ {"SessionStart","UserPromptSubmit","Stop","SessionEnd"}`;`TraeHookOutput` 可含 `additionalContext: string`
+
+> **实现前置(实测)**:Trae 兼容 Claude Code hooks 协议(stdin JSON)。先确认 Trae 实际字段:`UserPromptSubmit` 的 prompt 字段名、`Stop` 的 assistant 消息字段名、输出 `additionalContext` 是否被 Trae 读取。配置用 `.trae/hooks.json` + 内置「导入 Claude Code hooks」开关。字段以实测为准,下方按 Claude Code 兼容命名。
+
+- [ ] **Step 1: 写失败测试 — UserPromptSubmit 触发 recall + additionalContext**
+
+```ts
+// src/adapters/trae/hook-handler.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { handleTraeHook } from "./hook-handler.js";
+import { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+function fakeBridge(recallCtx = "RECALLED") {
+  return {
+    recall: vi.fn().mockResolvedValue({ context: recallCtx }),
+    capture: vi.fn().mockResolvedValue({ ok: true }),
+    endSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TdaiBridge;
+}
+
+describe("handleTraeHook", () => {
+  it("UserPromptSubmit → recall + bounded additionalContext", async () => {
+    const bridge = fakeBridge();
+    const out = await handleTraeHook("UserPromptSubmit", { prompt: "how do I X" }, bridge);
+    expect(bridge.recall).toHaveBeenCalledWith("how do I X", expect.any(String));
+    expect(out.additionalContext).toContain("RECALLED");
+  });
+  it("Stop → capture(user, assistant)", async () => {
+    const bridge = fakeBridge();
+    await handleTraeHook("Stop", { last_assistant_message: "answer" }, bridge);
+    expect(bridge.capture).toHaveBeenCalledWith(expect.objectContaining({ assistantText: "answer" }), expect.any(String));
+  });
+  it("SessionEnd → endSession", async () => {
+    const bridge = fakeBridge();
+    await handleTraeHook("SessionEnd", {}, bridge);
+    expect(bridge.endSession).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 运行,确认失败**
+
+Run: `npx vitest run src/adapters/trae/hook-handler.test.ts` → FAIL(未定义)
+
+- [ ] **Step 3: 实现 hook-handler**
+
+```ts
+// src/adapters/trae/hook-handler.ts
+import type { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+export type TraeHookEvent = "SessionStart" | "UserPromptSubmit" | "Stop" | "SessionEnd";
+export interface TraeHookInput {
+  prompt?: string;
+  last_assistant_message?: string;
+  // ponytail: Trae 实测字段补在这里(见上方实测前置)
+  [k: string]: unknown;
+}
+export interface TraeHookOutput { additionalContext?: string; }
+
+// 移植自 #517:有界注入,防 context 爆炸
+const MAX_CONTEXT_CHARS = 4000;
+
+export async function handleTraeHook(
+  event: TraeHookEvent, input: TraeHookInput, bridge: TdaiBridge,
+  sessionKey: string = String(process.env.TRACE_SESSION_KEY ?? "trae-default"),
+): Promise<TraeHookOutput> {
+  switch (event) {
+    case "SessionStart":
+    case "UserPromptSubmit": {
+      const query = input.prompt ?? "";
+      if (!query) return {};
+      const { context } = await bridge.recall(query, sessionKey);
+      if (!context) return {};
+      // ponytail: 硬截断上限;超长则尾部省略
+      const bounded = context.length > MAX_CONTEXT_CHARS
+        ? context.slice(0, MAX_CONTEXT_CHARS) + "\n…(truncated)"
+        : context;
+      return { additionalContext: bounded };
+    }
+    case "Stop": {
+      const assistantText = input.last_assistant_message ?? "";
+      // ponytail: userText 在 Stop 事件未必可得;取上轮缓存或空(实现期按 Trae 实测补)
+      await bridge.capture({ userText: "", assistantText }, sessionKey);
+      return {};
+    }
+    case "SessionEnd":
+      await bridge.endSession(sessionKey);
+      return {};
+  }
+}
+```
+
+- [ ] **Step 4: 运行,确认通过**
+
+Run: `npx vitest run src/adapters/trae/hook-handler.test.ts` → PASS(3/3)
+
+- [ ] **Step 5: checkpoint**(等用户同意后 commit:`feat(trae): hook-handler mapping Trae lifecycle to TdaiBridge`)
+
+---
+
+## Task 3: Trae MCP server(参照 #372 模式,tools 调 TdaiBridge)
+
+**Files:**
+- Create: `src/adapters/trae/mcp-server.ts`
+- Create: `src/adapters/trae/mcp-server.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 `TdaiBridge`;参照 #372 的 JSON-RPC 帧解析 + closed schema 工具定义(`tdai_recall`/`tdai_capture`/`tdai_memory_search`/`tdai_conversation_search`/`tdai_session_end`)
+- Produces: `class TraeMcpServer`,`runStdio(server)` 入口;通过 `TDAI_GATEWAY_URL` / `TDAI_GATEWAY_API_KEY` 配置
+
+> **复用说明**:不直接 import #372(它内部用自己的 client),而是**参照其 JSON-RPC + closed-schema 模式新写**,tools 调 `TdaiBridge`。若 #372 已 merge 且其 `TdaiMcpServer` 可注入 gateway operations,则改为注入适配器(实现期二选一,优先复用)。
+
+- [ ] **Step 1: 写失败测试 — tools/call 路由到 TdaiBridge**
+
+```ts
+// src/adapters/trae/mcp-server.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { TraeMcpServer } from "./mcp-server.js";
+import { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+function fakeBridge() {
+  return {
+    recall: vi.fn().mockResolvedValue({ context: "C" }),
+    capture: vi.fn().mockResolvedValue({ ok: true }),
+    searchMemory: vi.fn().mockResolvedValue([{ id: 1 }]),
+    searchConversation: vi.fn().mockResolvedValue([]),
+    endSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TdaiBridge;
+}
+
+describe("TraeMcpServer tools/call", () => {
+  it("tdai_recall calls bridge.recall", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({ jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "tdai_recall", arguments: { query: "q", session_key: "s" } } });
+    expect(out?.content?.[0]?.text).toContain("C");
+  });
+  it("unknown tool → JSON-RPC -32601", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({ jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "nope", arguments: {} } });
+    expect(out?.error?.code).toBe(-32601);
+  });
+});
+```
+
+- [ ] **Step 2: 运行,确认失败** → Run: `npx vitest run src/adapters/trae/mcp-server.test.ts` → FAIL
+
+- [ ] **Step 3: 实现 mcp-server(JSON-RPC 骨架 + 5 tools 调 bridge)**
+
+```ts
+// src/adapters/trae/mcp-server.ts
+import type { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+// ponytail: 手写 JSON-RPC,不引 @modelcontextprotocol/sdk(供应链安全,参照 #372)
+interface JsonRpcReq { jsonrpc: string; id?: unknown; method: string; params?: any; }
+interface JsonRpcRes { jsonrpc: "2.0"; id?: unknown; result?: unknown; error?: { code: number; message: string }; }
+
+const TOOLS = [
+  { name: "tdai_recall",        schema: { query: "string", session_key: "string" } },
+  { name: "tdai_capture",       schema: { user_content: "string", assistant_content: "string", session_key: "string" } },
+  { name: "tdai_memory_search", schema: { query: "string", limit: "number?" } },
+  { name: "tdai_conversation_search", schema: { query: "string", limit: "number?" } },
+  { name: "tdai_session_end",   schema: { session_key: "string" } },
+];
+
+export class TraeMcpServer {
+  constructor(private bridge: TdaiBridge) {}
+
+  async handle(req: JsonRpcReq): Promise<JsonRpcRes | undefined> {
+    const id = req.id;
+    if (req.method === "initialize") return { jsonrpc: "2.0", id, result: { protocolVersion: "2025-11-25", capabilities: {}, serverInfo: { name: "tdai-trae", version: "0.1.0" } } };
+    if (req.method === "tools/list") return { jsonrpc: "2.0", id, result: { tools: TOOLS.map(t => ({ name: t.name, inputSchema: { type: "object", properties: t.schema } })) } };
+    if (req.method === "tools/call") {
+      const { name, arguments: args } = req.params ?? {};
+      try {
+        let data: unknown;
+        switch (name) {
+          case "tdai_recall": data = await this.bridge.recall(args.query, args.session_key); break;
+          case "tdai_capture": data = await this.bridge.capture({ userText: args.user_content, assistantText: args.assistant_content }, args.session_key); break;
+          case "tdai_memory_search": data = await this.bridge.searchMemory(args.query, { limit: args.limit }); break;
+          case "tdai_conversation_search": data = await this.bridge.searchConversation(args.query, { limit: args.limit }); break;
+          case "tdai_session_end": await this.bridge.endSession(args.session_key); data = { ok: true }; break;
+          default: return { jsonrpc: "2.0", id, error: { code: -32601, message: `unknown tool: ${name}` } };
+        }
+        return { jsonrpc: "2.0", id, result: { content: [{ type: "text", text: JSON.stringify(data) }] } };
+      } catch (e) {
+        return { jsonrpc: "2.0", id, error: { code: -32000, message: (e as Error).message } };
+      }
+    }
+    return { jsonrpc: "2.0", id, error: { code: -32601, message: `method not found: ${req.method}` } };
+  }
+}
+```
+
+> `runStdio` 入口、closed-schema `additionalProperties:false` 强校验、G0+G1 防御在 Step 4 补(参照 #372 对应片段)。
+
+- [ ] **Step 4: 运行,确认通过** → Run: `npx vitest run src/adapters/trae/mcp-server.test.ts` → PASS(2/2)
+
+- [ ] **Step 5: 补 stdio 入口 + bin**
+
+在 `mcp-server.ts` 追加:
+```ts
+import * as readline from "node:readline";
+import { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+import { GatewayMemoryClient } from "../gateway-client/index.js";
+
+export async function runStdioTraeMcp(): Promise<void> {
+  const client = new GatewayMemoryClient({
+    baseUrl: requireEnv("TDAI_GATEWAY_URL"),
+    apiKey: process.env.TDAI_GATEWAY_API_KEY,
+    timeoutMs: Number(process.env.TDAI_GATEWAY_TIMEOUT_MS ?? 10000),
+  });
+  const server = new TraeMcpServer(new TdaiBridge(client));
+  const rl = readline.createInterface({ input: process.stdin });
+  for await (const line of rl) {
+    try {
+      const req = JSON.parse(line);
+      const res = await server.handle(req);
+      if (res) process.stdout.write(JSON.stringify(res) + "\n");
+    } catch { /* ponytail: parse error → 跳过单帧,不崩 server */ }
+  }
+}
+function requireEnv(k: string): string { const v = process.env[k]; if (!v) throw new Error(`missing env ${k}`); return v; }
+```
+
+- [ ] **Step 6: checkpoint**(`feat(trae): MCP stdio server, 5 tools over TdaiBridge`)
+
+---
+
+## Task 4: trae-plugin 装载(配置 + 入口)
+
+**Files:**
+- Create: `trae-plugin/.trae/hooks.json`
+- Create: `trae-plugin/.trae/mcp.json`
+- Create: `trae-plugin/scripts/memory-hook.mjs`
+- Create: `trae-plugin/README.md`
+
+- [ ] **Step 1: hooks.json(声明 Trae 生命周期 hook → memory-hook.mjs)**
+
+```json
+{
+  "hooks": {
+    "SessionStart":     [{ "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs", "args": ["SessionStart"] }],
+    "UserPromptSubmit": [{ "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs", "args": ["UserPromptSubmit"] }],
+    "Stop":             [{ "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs", "args": ["Stop"] }],
+    "SessionEnd":       [{ "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs", "args": ["SessionEnd"] }]
+  }
+}
+```
+> 字段格式以 Trae 实测为准(Trae「导入 Claude Code hooks」开关兼容 Claude Code 的 hooks.json)。
+
+- [ ] **Step 2: memory-hook.mjs(读 stdin → 调编译产物 hook-handler → 输出 additionalContext)**
+
+```js
+// trae-plugin/scripts/memory-hook.mjs
+import { handleTraeHook } from "../dist/trae/hook-handler.js";
+import { TdaiBridge } from "../dist/tdai-bridge/tdai-bridge.js";
+import { GatewayMemoryClient } from "../dist/gateway-client/index.js";
+
+const event = process.argv[2];
+const input = await readStdinJson();
+const client = new GatewayMemoryClient({
+  baseUrl: process.env.TDAI_GATEWAY_URL,
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+});
+const out = await handleTraeHook(event, input, new TdaiBridge(client));
+process.stdout.write(JSON.stringify(out)); // additionalContext 注入
+
+async function readStdinJson() {
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  try { return JSON.parse(Buffer.concat(chunks).toString("utf-8")); } catch { return {}; }
+}
+```
+
+- [ ] **Step 3: mcp.json**
+
+```json
+{ "mcpServers": { "tdai": { "command": "memory-tencentdb-trae-mcp", "env": {
+  "TDAI_GATEWAY_URL": "${TDAI_GATEWAY_URL}", "TDAI_GATEWAY_API_KEY": "${TDAI_GATEWAY_API_KEY}" } } } }
+```
+
+- [ ] **Step 4: README** — 安装步骤、Trae 配置导入、env 变量、排错(参照 #516 `docs/codex-adapter.md` 结构)。
+
+- [ ] **Step 5: checkpoint**(`feat(trae): plugin loader — hooks.json/mcp.json/entry`)
+
+---
+
+## Task 5: 导出 + 打包
+
+**Files:**
+- Create: `src/adapters/trae/index.ts`
+- Modify: `src/adapters/index.ts`(追加 trae + tdai-bridge 导出)
+- Modify: `package.json`(注册 bin `memory-tencentdb-trae-mcp`)
+- Modify: `tsdown.config.ts`(bundle 配置)
+
+- [ ] **Step 1: barrel 导出**
+
+```ts
+// src/adapters/trae/index.ts
+export { handleTraeHook } from "./hook-handler.js";
+export type { TraeHookEvent, TraeHookInput, TraeHookOutput } from "./hook-handler.js";
+export { TraeMcpServer, runStdioTraeMcp } from "./mcp-server.js";
+```
+```ts
+// src/adapters/index.ts 追加
+export { TdaiBridge } from "./tdai-bridge/tdai-bridge.js";
+export type { BridgeOpts } from "./tdai-bridge/tdai-bridge.js";
+export * from "./trae/index.js";
+```
+
+- [ ] **Step 2: package.json bin**
+
+```json
+"bin": { "memory-tencentdb-trae-mcp": "./dist/trae/mcp-server.js" }
+```
+
+- [ ] **Step 3: 构建验证**
+
+Run: `pnpm build && node -e "import('./dist/adapters/trae/index.js').then(m=>console.log(Object.keys(m)))"`
+Expected: 打印导出键,无报错。
+
+- [ ] **Step 4: checkpoint**(`build: export trae + tdai-bridge, register mcp bin`)
+
+---
+
+## Task 6: 对比文档 + Trae 适配指南 + CI
+
+**Files:**
+- Create: `docs/platform-adapters-comparison.md`(6 平台 × 6 维度 + 3 Mermaid)
+- Create: `docs/trae-adapter.md`
+- Modify: `README.md` / `README_CN.md`(索引到 Trae 适配,各 +2 行)
+- Modify: `.github/workflows/pr-ci.yml`(若需补 trae 测试 job)
+
+- [ ] **Step 1: 对比文档** — 表格(OpenClaw/Hermes/Codex/Claude Code/Dify/Trae × 接入模式/改core/client/L0读写/reliability/MCP)+ 3 Mermaid(组件架构、recall 读路径、L0→L3 写路径)。数据源:main 现有 + PR #515/#516/#517/#394 当前方案。
+- [ ] **Step 2: Trae 适配指南** — 配置、env、验证步骤(参照 #516 `docs/codex-adapter.md`)。
+- [ ] **Step 3: README 索引 + CI** — 双语各 +2 行链接;CI 确认 `pnpm test && pnpm build` 通过。
+- [ ] **Step 4: 全量验证**
+
+Run: `pnpm test && pnpm build && pnpm lint`
+Expected: 全绿。
+
+- [ ] **Step 5: checkpoint**(`docs: platform comparison + trae adapter guide`)
+
+---
+
+## Self-Review(plan 对 spec 覆盖核对)
+
+- **Spec §4.1 TdaiBridge** → Task 1 ✅(concrete class、retry/cache/sanitize/degrade 全覆盖)
+- **Spec §4.2 Trae hooks + MCP** → Task 2 + Task 3 + Task 4 ✅
+- **Spec §4.3 对比文档** → Task 6 ✅
+- **Spec §4.4 测试** → 每个 Task 内嵌 TDD ✅
+- **Spec §6 不做项** → Global Constraints 固化(不改 core/不自写 client/无 G2-G4/无 Python)✅
+- **Placeholder 扫描**:无 TBD;Trae hooks 实测字段已显式标为「实现前置 Step」,非 placeholder。
+- **类型一致**:`TdaiBridge` 方法名(recall/capture/searchMemory/searchConversation/endSession)在 Task 1/2/3 一致;`GatewayMemoryClient` import 路径一致。
+
+## 风险(实现期关注)
+
+1. **Trae hooks stdin 字段**:Task 2 Step 1 前实测(用 Trae「导入 Claude Code hooks」开关验证 prompt/assistant/additionalContext 字段)。
+2. **#316/#372 未 merge**:Task 1 Step 1 给了 vendoring 兜底;Task 3 优先复用 #372 的 `TdaiMcpServer` 若已 merge。
+3. **每 task commit** 需用户同意(Global Constraints 已固)。

--- a/docs/superpowers/specs/2026-07-21-trae-memory-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-21-trae-memory-adapter-design.md
@@ -1,0 +1,226 @@
+# Trae 记忆适配器 + 薄统一适配层 — 设计文档
+
+- **日期**:2026-07-21
+- **关联 issue**:[#235](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235) Cross-Platform Adapters for the Memory Plugin(犀牛鸟中高难度)
+- **分支**:`feat/issue-235-platform-adapter`(基于 `main`)
+- **实现语言**:TypeScript
+- **状态**:设计稿,待用户复审 → 转 writing-plans 出实现计划
+
+---
+
+## 1. 背景与目标
+
+issue #235 要求把核心记忆引擎 `TdaiCore` 接入更多 Agent 平台。当前已适配:OpenClaw(进程内)、Hermes(HTTP sidecar);进行中的同类 PR:#316(HTTP baseline)/ #372(MCP 桥)/ #516(Codex)/ #517(Claude Code)/ #394(Dify)/ #339(大统一 SDK,争议中)。
+
+本方案三大目标:
+
+1. **接入一个未被占用的平台 Trae**(字节系 AI IDE),实现基本记忆读写;
+2. **整合现有 PR 的优势**而非再造一份:复用 #316 的 HTTP client、移植 #517 的 hooks reliability、瘦身 #339 的 ABC 内核;
+3. **完整覆盖 issue 验收并差异化**:稳拿进阶、用「Trae + 对比现有平台」达成深入、薄整合层作为拓展雏形。
+
+差异化卖点(相对 Mem0/Zep/Letta/Hindsight):Trae 完全未被占用 + 整合碎片化 client + 腾讯云底座/中国合规 + FTS5+NFKC 召回质量。
+
+---
+
+## 2. 现状分析(为什么这么定位)
+
+### 2.1 平台选型 — 为什么是 Trae
+
+6 个候选里 3 个已「变天」:Continue(2025-07 被 Cursor 收购停服)、Roo Code(2026-05 关闭)、Windsurf(改名 Devin Desktop,砍记忆 + Rust 重写,进程内路径架构不可能)。健康候选只剩 **Trae / Cursor / Cline**。
+
+- Cursor 是红海(Mem0 官方三件套 MCP+Hooks+Skill 已占心智)。
+- **Trae 完全未被占用**(Mem0/Letta/Zep 无官方适配),且它的 hooks 事件(`SessionStart` / `UserPromptSubmit` / `Stop`)与 `TdaiCore` API **一一对应**,还内置「导入 Claude Code hooks」开关 —— 意味着 #517 的 hooks 脚本可近乎直接迁移。MCP v1.3.0+ 一等公民(stdio/SSE/Streamable HTTP 全支持)。
+
+### 2.2 现有 PR 的碎片化(整合机会)
+
+HTTP Gateway client 当前有 **4 份自写**:#316 `GatewayMemoryClient`、#372 `TdaiGatewayClient`、#517 `src/adapters/claude-code/gateway-client.ts`、#394 `dify-plugin-tdai-memory/tools/client.py`。#316 已被 maintainer `YOMXXX` 认可为 lightweight baseline。**整合机会:新平台复用 #316,做「正确整合」的范例,不再造第 5 份。**
+
+### 2.3 Approach 定位 — 与现有 PR 不冲突
+
+| 现有 PR | 关系 |
+|---|---|
+| #316 HTTP baseline | **复用** `GatewayMemoryClient` / `createGatewayPlatformAdapter` |
+| #372 MCP 桥 | **复用**其 MCP server 模式(纯 JSON-RPC、closed schema) |
+| #339 大 SDK | **只取 ABC 内核**(retry/recall 缓存/降级),瘦身 15K→~1.5K 行 |
+| `core` 的 `hostType` union | **不碰**(走 HTTP 路径,零 core 改动,最易合并) |
+
+### 2.4 「深入」的落地解读
+
+issue「深入」要求「2+ 平台 + 对比文档」。本方案解读为:**Trae 自己实现(1 个平台)+ 对比文档对比已有 5 个平台**(OpenClaw / Hermes / Codex#516 / Claude Code#517 / Dify#394)。既满足「深入」的对比分析要求,又不必自己实现第二个平台(避免与 Cline 等潜在贡献者撞车)。若后续要自实现第二平台(如 Cline),可在此基础上扩展。
+
+---
+
+## 3. 架构
+
+三层,Trae 平台层 → 薄整合层 → #316 client → Gateway → TdaiCore:
+
+```
+┌─ Trae 平台层 ───────────────────────────────────────┐
+│ trae-plugin/.trae/hooks.json   ← 复用 #517 hook 逻辑 │
+│ trae-plugin/.trae/mcp.json     ← 指向 MCP server    │
+│ trae-plugin/scripts/memory-hook.mjs                  │
+└──────────────┬──────────────────────────────────────┘
+        stdin JSON hooks        MCP stdio
+┌──────────────▼──────────────────────────────────────┐
+│ 薄整合层  src/adapters/tdai-bridge/                  │  ← 整合卖点
+│  TdaiBridge(concrete class)                          │
+│  包 GatewayMemoryClient + 分类 retry + recall 缓存   │
+│  + 输入消毒 + 优雅降级                                │
+└──────────────┬──────────────────────────────────────┘
+                      HTTP(7 端点)
+┌──────────────▼──────────────────────────────────────┐
+│ #316 GatewayMemoryClient → TdaiGateway → TdaiCore    │  ← 复用基座
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. 组件设计
+
+### 4.1 薄整合层 `TdaiBridge`(src/adapters/tdai-bridge/)
+
+**定位**:#316 `GatewayMemoryClient` 之上的一层 reliability 包装,被 Trae 的 hooks 和 MCP 两条腿共用,提供统一的 retry / recall 缓存 / 输入消毒 / 优雅降级。
+
+**为什么是 concrete class 而非 abstract**(`ponytail: single HTTP backend → no abstract yet`):Trae 只走 HTTP 一种后端,搞 `abstract class` + 单子类是「interface with one implementation」反模式。`TdaiBridge` 做成具体类,直接包 client;**未来真出现非 HTTP 后端(如进程内直调 TdaiCore)再抽 abstract**。
+
+**接口契约**(TS,示意):
+
+```ts
+import { GatewayMemoryClient } from "../gateway-client/index.js"; // #316
+
+export class TdaiBridge {
+  constructor(client: GatewayMemoryClient, opts?: BridgeOpts);
+
+  // 模板方法(public):每个都做 sanitize → retry → (recall 走缓存) → 降级
+  recall(query: string, sessionKey: string): Promise<RecallResponse>;
+  capture(turn: { userText: string; assistantText: string }, sessionKey: string): Promise<CaptureResponse>;
+  searchMemory(query: string, opts?: SearchOpts): Promise<MemorySearchResponse>;
+  searchConversation(query: string, opts?: SearchOpts): Promise<ConversationSearchResponse>;
+  endSession(sessionKey: string): Promise<SessionEndResponse>;
+}
+```
+
+**从 #339 保留(高杠杆、低依赖)**:
+- 分类 retry:指数退避 + jitter,只对瞬态错误(Connection/Timeout/RateLimit)重试,不重试 Validation/Auth;
+- **recall 会话缓存**:SHA-256(query) 作 key,同会话同查询命中即返回 —— 直接修 #120(prompt-cache 杀手);
+- 输入消毒:query 截断、limit clamp,防下游 OOM/慢查询;
+- 优雅降级:任何异常 `warn` 后返回安全空值(`""`/空结果),绝不向 hooks/MCP 层抛。
+
+**从 #339 砍掉(YAGNI / 属于其他 PR)**:G2 限流 / G3 熔断 / G4 审计(桌面 loopback 用不到)、BufferedAdapter(零用户)、HermesV2Adapter、TS/Python 双语言、mcp_health 双进程、OTel/L2/编码等基础设施修复(应拆独立 PR)。
+
+### 4.2 Trae 适配层(src/adapters/trae/ + trae-plugin/)
+
+两条腿,都消费 `TdaiBridge`:
+
+**腿 ① Hooks**(主要 recall/capture 触发点,自动):
+- `trae-plugin/.trae/hooks.json`:声明 Trae 生命周期 hook → 指向 `memory-hook.mjs`;
+- `trae-plugin/scripts/memory-hook.mjs`:Node 入口,读 stdin JSON,调 `hook-handler`;
+- `src/adapters/trae/hook-handler.ts`:**复用 #517 的 hook-handler 逻辑**,适配 Trae 事件:
+  - `SessionStart` → `bridge.recall()` 预热;
+  - `UserPromptSubmit`(读 prompt)→ `bridge.recall()` + 输出有界 `additionalContext`;
+  - `Stop`(含 `last_assistant_message`)→ `bridge.capture()`;
+  - `SessionEnd` → `bridge.endSession()`;
+- 移植 #517 reliability:持久化重试队列(`${TRAE_PLUGIN_DATA}`)、有界 `additionalContext` 注入、SessionEnd 短超时预算。
+
+**腿 ② MCP server**(search 触发点,模型按需):
+- `src/adapters/trae/mcp-server.ts`:**复用 #372 的 MCP server 模式**(纯 JSON-RPC、closed schema、G0 校验 + G1 HMAC),5 个 tools:`tdai_recall` / `tdai_capture` / `tdai_memory_search` / `tdai_conversation_search` / `tdai_session_end`;
+- tools 调 `TdaiBridge`(而非裸 client),统一拿 retry/缓存/降级;
+- `trae-plugin/.trae/mcp.json`:指向 server bin。
+
+> Trae 内置「导入 Claude Code hooks」开关,#517 的 hook 协议(stdin JSON + `additionalContext`)可直接复用,这是选 Trae 的关键整合抓手。
+
+### 4.3 对比文档(docs/platform-adapters-comparison.md)
+
+满足「深入」对比要求。对比 6 个平台 × 6 维度:
+
+| 平台 | 接入模式 | 改 core? | HTTP client | L0 读写 | reliability | MCP |
+|---|---|---|---|---|---|---|
+
+(OpenClaw / Hermes / Codex / Claude Code / Dify / **Trae**)
+
+配 3 张 Mermaid:① 组件架构、② 召回读路径、③ L0→L3 写路径。对齐 #515 的图示风格。
+
+### 4.4 测试
+
+- `TdaiBridge` 单元:retry 各分支(瞬态重试 / Auth 不重试)、recall 缓存命中/失效、输入消毒边界、优雅降级;
+- `hook-handler`:各 Trae 事件 stdin JSON → 正确 bridge 调用 + additionalContext 输出;
+- `mcp-server`:复用 #372 的 lifecycle / tools/call / 校验测试模式;
+- 集成:mock Gateway(HTTP interceptor)验证端到端 recall/capture。
+
+---
+
+## 5. 文件落点
+
+```
+src/adapters/tdai-bridge/
+  tdai-bridge.ts              # concrete TdaiBridge(client + retry/缓存/降级/消毒)
+  tdai-bridge.test.ts
+src/adapters/trae/
+  hook-handler.ts             # 复用 #517 逻辑,适配 Trae 事件
+  hook-handler.test.ts
+  mcp-server.ts               # 复用 #372 模式,tools 调 TdaiBridge
+  mcp-server.test.ts
+  index.ts
+trae-plugin/
+  .trae/hooks.json
+  .trae/mcp.json
+  scripts/memory-hook.mjs     # Node 入口
+  README.md
+docs/
+  trae-adapter.md             # Trae 适配指南(交付)
+  platform-adapters-comparison.md  # 6 平台对比(深入交付)
+src/adapters/index.ts         # 追加导出
+index.ts                      # 追加导出(按需)
+package.json / tsdown.config.ts  # 注册 mcp bin + bundle
+```
+
+---
+
+## 6. 范围边界
+
+**做**:① 薄整合层 `TdaiBridge`;② Trae hooks + MCP;③ 6 平台对比文档;④ 测试。
+
+**不做(YAGNI)**:
+- 不改 `core` 的 `hostType` union(走 HTTP);
+- 不自写 HTTP client(复用 #316);
+- 不做 G2/G3/G4 防御门(BufferedAdapter 同理);
+- 不做 Python 版 / TS·Py 双语言;
+- 不自己实现第二平台(Cline 等),对比文档以现有 PR 为对象。
+
+---
+
+## 7. 验收映射
+
+| issue 阶段 | 标准 | 落点 |
+|---|---|---|
+| 基础 | 架构图 + 数据流 | 对比文档 3 张 Mermaid |
+| 进阶 | 1 平台基本读写 | Trae hooks + MCP |
+| 深入 | 2+ 平台 + 对比 | Trae + 对比 5 个现有平台 |
+| 拓展 | 统一适配 SDK | `TdaiBridge` 薄整合层(雏形) |
+
+---
+
+## 8. 风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| #316 / #372 尚未 merge | PR 策略三选一(实现期定):基于 #316 分支 / vendoring client 并注明 / 等 merge。设计层不锁死 |
+| Trae hooks stdin 协议细节 | 实现阶段实测 Trae hooks(用「导入 Claude Code hooks」开关验证字段),hook-handler 做字段兼容 |
+| 与 #517 / #372 边界 | 只新增文件,不改它们;复用通过 import(若已 merge)或 vendoring |
+| 触 #339 雷区 | PR 描述主动说明:「定位 #316 之上、瘦身 #339、回应 YOMXXX 拆分诉求」,正面对齐 maintainer 意图 |
+| Trae 闭源 AI 生命周期 | 不走进程内路径 A,只走 MCP + 外部 hooks(路径 B/C),规避闭源限制 |
+
+---
+
+## 9. 复用清单(整合卖点的具体来源)
+
+- **#316** `GatewayMemoryClient` + `createGatewayPlatformAdapter` → HTTP 基座
+- **#517** hook-handler 的 reliability 模式(持久化重试队列 / 有界注入 / SessionEnd 短超时)→ 移植到 Trae hooks
+- **#372** MCP server 模式(纯 JSON-RPC / closed schema / G0+G1)+ `buildGatewayRecallResponse` → 复用
+- **#339** ABC 内核(分类 retry / recall 缓存修 #120 / 优雅降级 / 输入消毒)→ 瘦身进 `TdaiBridge`
+
+---
+
+## 10. 后续
+
+本 spec 经用户复审后,转 `writing-plans` skill 产出分步实现计划(TDD 粒度),再进入实现。

--- a/docs/trae-adapter.md
+++ b/docs/trae-adapter.md
@@ -1,0 +1,326 @@
+# Trae 适配指南
+
+本指南介绍如何在 Trae 平台上安装和配置 TencentDB Agent Memory，实现对话记忆的自动捕获、提取和召回。
+
+## 目录
+
+- [快速开始](#快速开始)
+- [安装步骤](#安装步骤)
+- [配置说明](#配置说明)
+- [环境变量](#环境变量)
+- [验证测试](#验证测试)
+- [故障排查](#故障排查)
+- [高级配置](#高级配置)
+
+## 快速开始
+
+**前置要求:**
+- Trae IDE (字节系 AI IDE)
+- Node.js >= 22.16.0
+- 已安装 `@tencentdb-agent-memory/memory-tencentdb` 包
+
+**三步启用记忆:**
+
+1. 安装依赖包
+2. 配置 Trae hooks 和 MCP
+3. 设置环境变量并验证
+
+```bash
+# 1. 安装包
+npm install @tencentdb-agent-memory/memory-tencentdb
+
+# 2. 配置环境变量
+export TDAI_GATEWAY_URL="http://127.0.0.1:8420"
+export TDAI_GATEWAY_API_KEY="your-api-key"
+
+# 3. 验证连接
+curl http://127.0.0.1:8420/health
+```
+
+## 安装步骤
+
+### 步骤 1: 安装插件包
+
+在项目根目录安装 TencentDB Agent Memory:
+
+```bash
+npm install @tencentdb-agent-memory/memory-tencentdb
+```
+
+### 步骤 2: 配置 Trae Hooks
+
+创建或编辑 `.trae/hooks.json` 文件：
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/node_modules/@tencentdb-agent-memory/memory-tencentdb/trae-plugin/scripts/memory-hook.mjs",
+        "args": ["SessionStart"]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/node_modules/@tencentdb-agent-memory/memory-tencentdb/trae-plugin/scripts/memory-hook.mjs",
+        "args": ["UserPromptSubmit"]
+      }
+    ],
+    "Stop": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/node_modules/@tencentdb-agent-memory/memory-tencentdb/trae-plugin/scripts/memory-hook.mjs",
+        "args": ["Stop"]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/node_modules/@tencentdb-agent-memory/memory-tencentdb/trae-plugin/scripts/memory-hook.mjs",
+        "args": ["SessionEnd"]
+      }
+    ]
+  }
+}
+```
+
+### 步骤 3: 配置 MCP Server
+
+创建或编辑 `.trae/mcp.json` 文件：
+
+```json
+{
+  "mcpServers": {
+    "tdai": {
+      "command": "memory-tencentdb-trae-mcp",
+      "env": {
+        "TDAI_GATEWAY_URL": "${TDAI_GATEWAY_URL}",
+        "TDAI_GATEWAY_API_KEY": "${TDAI_GATEWAY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### 步骤 4: 启用 Claude Code Hooks 兼容
+
+Trae 内置「导入 Claude Code hooks」开关，确保已启用此功能以获得最佳兼容性。
+
+## 配置说明
+
+### Gateway 连接配置
+
+Trae 通过 HTTP 方式连接到 TencentDB Gateway，需要指定 Gateway 地址和认证信息。
+
+```bash
+# Gateway 地址 (必需)
+export TDAI_GATEWAY_URL="http://127.0.0.1:8420"
+
+# API 密钥 (可选，如 Gateway 启用了认证)
+export TDAI_GATEWAY_API_KEY="your-secret-key"
+
+# 超时设置 (可选，默认 10000ms)
+export TDAI_GATEWAY_TIMEOUT_MS="10000"
+```
+
+### Trae 插件目录
+
+设置 `TRAE_PLUGIN_DIR` 环境变量指向项目根目录：
+
+```bash
+export TRAE_PLUGIN_DIR="/path/to/your/project"
+```
+
+## 环境变量
+
+| 变量名 | 必需 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `TDAI_GATEWAY_URL` | ✅ | `http://127.0.0.1:8420` | TencentDB Gateway 地址 |
+| `TDAI_GATEWAY_API_KEY` | ❌ | _(无)_ | Gateway API 密钥 |
+| `TDAI_GATEWAY_TIMEOUT_MS` | ❌ | `10000` | HTTP 请求超时(毫秒) |
+| `TRAE_PLUGIN_DIR` | ❌ | `process.cwd()` | 项目根目录路径 |
+| `TRAE_SESSION_KEY` | ❌ | `trae-default` | 会话标识符 |
+
+## 验证测试
+
+### 1. Gateway 连接测试
+
+```bash
+curl http://127.0.0.1:8420/health
+```
+
+预期响应:
+```json
+{"status":"ok"}
+```
+
+### 2. Hooks 功能测试
+
+在 Trae 中发起一次对话，观察是否触发记忆捕获：
+
+```bash
+# 检查 hooks 日志
+tail -f ~/.trae/hooks.log
+```
+
+应该看到类似输出：
+```
+[tdai-bridge] recall called with query: "how do I implement X"
+[tdai-bridge] capture called for session: trae-session-123
+```
+
+### 3. MCP 工具测试
+
+Trae 的 MCP server 提供 5 个工具，可以在 Trae 中手动调用测试：
+
+- `tdai_recall`: 召回相关记忆
+- `tdai_capture`: 捕获当前对话
+- `tdai_memory_search`: 搜索记忆内容
+- `tdai_conversation_search`: 搜索历史对话
+- `tdai_session_end`: 结束会话
+
+### 4. 端到端测试
+
+在 Trae 中进行完整对话流程：
+
+1. **第一轮对话**: "帮我实现一个快速排序算法"
+2. **第二轮对话**: "我刚才问的是什么问题？"  
+   - 预期: Agent 能正确回答第一轮的问题
+3. **第三轮对话**: 调用 `tdai_memory_search` 工具搜索"排序"
+   - 预期: 能检索到第一轮对话的内容
+
+## 故障排查
+
+### 问题 1: Gateway 连接失败
+
+**症状**: `curl: (7) Failed to connect to 127.0.0.1 port 8420`
+
+**解决方案**:
+1. 检查 Gateway 是否启动: `ps aux | grep gateway`
+2. 启动 Gateway: `npx tsx src/gateway/server.ts`
+3. 验证端口占用: `netstat -an | grep 8420`
+
+### 问题 2: Hooks 不触发
+
+**症状**: 对话中没有看到记忆注入
+
+**解决方案**:
+1. 检查 `.trae/hooks.json` 路径是否正确
+2. 验证 `TRAE_PLUGIN_DIR` 环境变量
+3. 启用 Trae 的「导入 Claude Code hooks」开关
+4. 检查 hooks 日志: `cat ~/.trae/hooks.log`
+
+### 问题 3: MCP 工具不可用
+
+**症状**: 在 Trae 中看不到 `tdai_*` 工具
+
+**解决方案**:
+1. 检查 `.trae/mcp.json` 配置
+2. 验证 MCP bin 是否注册: `which memory-tencentdb-trae-mcp`
+3. 重新构建项目: `npm run build`
+4. 重启 Trae IDE
+
+### 问题 4: 记忆召回为空
+
+**症状**: `additionalContext` 始终为空
+
+**解决方案**:
+1. 检查 Gateway 是否正常: `curl http://127.0.0.1:8420/health`
+2. 验证 `TDAI_GATEWAY_API_KEY` 是否正确
+3. 检查记忆是否已捕获: 查看数据库或日志
+4. 调试 `TdaiBridge` 缓存: 临时禁用缓存测试
+
+## 高级配置
+
+### 自定义 Retry 策略
+
+`TdaiBridge` 支持自定义重试策略，通过环境变量调整：
+
+```bash
+# 重试次数 (默认 3)
+export TDAI_BRIDGE_RETRY_ATTEMPTS="5"
+
+# 基础延迟毫秒 (默认 200)
+export TDAI_BRIDGE_RETRY_BASE_MS="100"
+
+# Recall 缓存容量 (默认 256)
+export TDAI_BRIDGE_CACHE_MAX="512"
+```
+
+### 调整 Recall 注入上限
+
+修改 `additionalContext` 最大字符数（默认 4000）：
+
+```bash
+export TDAI_RECALL_MAX_CHARS="6000"
+```
+
+### 输入消毒参数
+
+调整输入长度限制，防止 OOM：
+
+```bash
+# Query 最大长度 (默认 100000)
+export TDAI_SANITIZE_QUERY_MAX="200000"
+
+# Capture 文本最大长度 (默认 1000000)
+export TDAI_SANITIZE_CAPTURE_MAX="2000000"
+```
+
+### Gateway 安全配置
+
+如果 Gateway 启用了 CORS 和 API Key：
+
+```bash
+# CORS 白名单 (如需跨域访问)
+export TDAI_CORS_ORIGINS="https://your-domain.com"
+
+# API 认证 (必须与 Gateway 配置一致)
+export TDAI_GATEWAY_API_KEY="your-secure-key"
+```
+
+## 性能优化
+
+### Recall 缓存优化
+
+`TdaiBridge` 默认启用 recall 会话缓存，使用 SHA-256(query) 作为缓存键。对于相同会话内的重复查询，直接返回缓存结果，显著减少 HTTP 调用。
+
+**监控缓存命中率:**
+```bash
+# 临时启用调试日志
+export TDAI_DEBUG="true"
+# 观察缓存命中情况
+grep "cache hit" ~/.trae/hooks.log
+```
+
+### 并发限制
+
+为避免过载 Gateway，Trae hooks 内置了请求队列机制。如果需要调整并发限制：
+
+```bash
+export TDAI_MAX_CONCURRENT_REQUESTS="10"
+```
+
+## 与其他平台对比
+
+Trae 适配器相对于其他平台的优势：
+
+| 特性 | Trae | OpenClaw | Hermes | Claude Code |
+|------|------|----------|---------|------------|
+| 安装复杂度 | 简单 | 最简单 | 中等 | 中等 |
+| 配置灵活性 | 高 | 低 | 中 | 高 |
+| MCP 支持 | ✅ | ❌ | ❌ | ✅ |
+| 缓存优化 | ✅ | ❌ | ❌ | ❌ |
+| 重试机制 | ✅ | ✅ | ✅ | ✅ |
+
+更多平台对比细节，请参阅 [平台适配器对比文档](./platform-adapters-comparison.md)。
+
+## 下一步
+
+- 📖 了解更多关于 [记忆分层架构](../README.md#核心技术拒绝平铺走向分层与符号化)
+- 🔧 查看 [完整配置参数](../openclaw.plugin.json)
+- 🚀 探索 [高级调优选项](../README.md#可调参数)
+- 💬 加入 [Agent Memory 微信社群](https://github.com/TencentCloud/TencentDB-Agent-Memory#项目简介) 获取支持
+
+---
+
+**最后更新**: 2026-07-21 (Trae Adapter v0.1.0)
+**相关文档**: [平台适配器对比](./platform-adapters-comparison.md) | [主 README](../README.md)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-trae-mcp": "./dist/src/adapters/trae/mcp-server.js"
   },
   "exports": {
     ".": {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,10 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Trae platform adapter
+export * from "./trae/index.js";
+
+// TdaiBridge (shared by Trae and future adapters)
+export { TdaiBridge } from "./tdai-bridge/tdai-bridge.js";
+export type { BridgeOpts } from "./tdai-bridge/tdai-bridge.js";

--- a/src/adapters/tdai-bridge/tdai-bridge.test.ts
+++ b/src/adapters/tdai-bridge/tdai-bridge.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from "vitest";
+import { TdaiBridge } from "./tdai-bridge.js";
+
+// 模拟 HTTP 错误类 - 更真实的错误对象（继承 Error，有 status 字段）
+class HttpErr extends Error {
+  constructor(public status: number, msg: string) {
+    super(msg);
+    this.name = "HttpErr";
+  }
+}
+
+// 模拟 GatewayClient 接口的实现
+function makeClient(overrides: Partial<GatewayClient> = {}) {
+  return {
+    recall: vi.fn(),
+    capture: vi.fn(),
+    searchMemories: vi.fn(),
+    searchConversations: vi.fn(),
+    endSession: vi.fn(),
+    ...overrides,
+  } as unknown as GatewayClient;
+}
+
+// 本地接口定义（与实现中保持一致）
+interface GatewayClient {
+  recall(body: { query: string; session_key: string }): Promise<{ context: string }>;
+  capture(body: { user_text: string; assistant_text: string; session_key: string }): Promise<unknown>;
+  searchMemories(body: { query: string; limit: number }): Promise<unknown>;
+  searchConversations(body: { query: string; limit: number }): Promise<unknown>;
+  endSession(body: { session_key: string }): Promise<unknown>;
+}
+
+describe("TdaiBridge retry", () => {
+  it("retries transient (status 503) then succeeds", async () => {
+    const client = makeClient({
+      recall: vi.fn()
+        .mockRejectedValueOnce(new HttpErr(503, "busy"))
+        .mockResolvedValueOnce({ context: "OK" }),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 3, baseMs: 1 } });
+    const res = await bridge.recall("hello", "sess-1");
+    expect(client.recall).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ context: "OK" });
+  });
+
+  it("does NOT retry auth errors (status 401)", async () => {
+    const client = makeClient({
+      recall: vi.fn().mockRejectedValue(new HttpErr(401, "no key")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 3, baseMs: 1 } });
+    // 降级: recall 失败返回空串,不抛
+    const res = await bridge.recall("hello", "sess-1");
+    expect(client.recall).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ context: "" });
+  });
+
+  it("does NOT retry validation errors (status 400)", async () => {
+    const client = makeClient({
+      recall: vi.fn().mockRejectedValue(new HttpErr(400, "invalid input")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 3, baseMs: 1 } });
+    const res = await bridge.recall("hello", "sess-1");
+    expect(client.recall).toHaveBeenCalledTimes(1);
+    expect(res).toEqual({ context: "" });
+  });
+
+  it("retries on network errors (TypeError)", async () => {
+    const client = makeClient({
+      recall: vi.fn()
+        .mockRejectedValueOnce(new TypeError("network error"))
+        .mockResolvedValueOnce({ context: "OK" }),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 3, baseMs: 1 } });
+    const res = await bridge.recall("hello", "sess-1");
+    expect(client.recall).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ context: "OK" });
+  });
+});
+
+describe("TdaiBridge graceful degradation", () => {
+  it("capture returns {ok:false} on error", async () => {
+    const client = makeClient({
+      capture: vi.fn().mockRejectedValue(new HttpErr(500, "server error")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    const res = await bridge.capture({ userText: "hi", assistantText: "hello" }, "sess-1");
+    expect(res).toEqual({ ok: false });
+  });
+
+  it("searchMemory returns [] on error", async () => {
+    const client = makeClient({
+      searchMemories: vi.fn().mockRejectedValue(new HttpErr(429, "rate limit")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    const res = await bridge.searchMemory("test");
+    expect(res).toEqual([]);
+  });
+
+  it("searchConversation returns [] on error", async () => {
+    const client = makeClient({
+      searchConversations: vi.fn().mockRejectedValue(new HttpErr(503, "unavailable")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    const res = await bridge.searchConversation("test");
+    expect(res).toEqual([]);
+  });
+
+  it("endSession logs warning but does not throw", async () => {
+    const client = makeClient({
+      endSession: vi.fn().mockRejectedValue(new HttpErr(500, "server error")),
+    });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    await expect(bridge.endSession("sess-1")).resolves.toBeUndefined();
+  });
+});
+
+describe("TdaiBridge cache & sanitize", () => {
+  it("recall 同会话同查询命中缓存(只调一次 client)", async () => {
+    const client = makeClient({ recall: vi.fn().mockResolvedValue({ context: "X" }) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    await bridge.recall("q", "s");
+    await bridge.recall("q", "s");
+    expect(client.recall).toHaveBeenCalledTimes(1);
+  });
+
+  it("recall 不同会话不同查询不命中缓存", async () => {
+    const client = makeClient({ recall: vi.fn().mockResolvedValue({ context: "X" }) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    await bridge.recall("q1", "s1");
+    await bridge.recall("q2", "s2");
+    expect(client.recall).toHaveBeenCalledTimes(2);
+  });
+
+  it("输入超长被截断(query)", async () => {
+    const client = makeClient({ recall: vi.fn().mockResolvedValue({ context: "X" }) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    const longQuery = "x".repeat(200_000);
+    await bridge.recall(longQuery, "s");
+    expect((client.recall as any).mock.calls[0][0].query.length).toBe(100_000);
+  });
+
+  it("输入超长被截断(user_text/assistant_text)", async () => {
+    const client = makeClient({ capture: vi.fn().mockResolvedValue({}) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+    await bridge.capture({ userText: "x".repeat(2_000_000), assistantText: "y".repeat(2_000_000) }, "s");
+    const callArgs = (client.capture as any).mock.calls[0][0];
+    expect(callArgs.user_text.length).toBe(1_000_000);
+    expect(callArgs.assistant_text.length).toBe(1_000_000);
+  });
+
+  it("limit 参数被 clamp 到 1..50 范围", async () => {
+    const client = makeClient({ searchMemories: vi.fn().mockResolvedValue([]) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+
+    await bridge.searchMemory("test", { limit: 0 });
+    expect((client.searchMemories as any).mock.calls[0][0].limit).toBe(1);
+
+    await bridge.searchMemory("test", { limit: 100 });
+    expect((client.searchMemories as any).mock.calls[1][0].limit).toBe(50);
+  });
+
+  it("缓存超出上限时清空", async () => {
+    const client = makeClient({ recall: vi.fn().mockResolvedValue({ context: "X" }) });
+    const bridge = new TdaiBridge(client, { recallCacheMax: 3, retry: { attempts: 1, baseMs: 1 } });
+
+    // 填充缓存到上限
+    await bridge.recall("q1", "s1");
+    await bridge.recall("q2", "s2");
+    await bridge.recall("q3", "s3");
+
+    // 第4个应该触发清空
+    await bridge.recall("q4", "s4");
+
+    // 再次查询 q1 应该不命中缓存（因为被清空了）
+    await bridge.recall("q1", "s1");
+
+    // 总共应该调用 5 次 client (q1,q2,q3,q4,q1)
+    expect(client.recall).toHaveBeenCalledTimes(5);
+  });
+
+  it("sanitize 处理非字符串输入", async () => {
+    const client = makeClient({ recall: vi.fn().mockResolvedValue({ context: "X" }) });
+    const bridge = new TdaiBridge(client, { retry: { attempts: 1, baseMs: 1 } });
+
+    // 测试 null, undefined, 和其他类型
+    // 用不同 sessionKey 避免缓存命中(非字符串 sanitize 成 "" 会撞同一个缓存 key)
+    await bridge.recall(null as any, "s1");
+    await bridge.recall(undefined as any, "s2");
+    await bridge.recall(12345 as any, "s3");
+
+    // 所有非字符串应该被转换为空字符串
+    expect(client.recall).toHaveBeenCalledTimes(3);
+    expect((client.recall as any).mock.calls[0][0].query).toBe("");
+    expect((client.recall as any).mock.calls[1][0].query).toBe("");
+    expect((client.recall as any).mock.calls[2][0].query).toBe("");
+  });
+});

--- a/src/adapters/tdai-bridge/tdai-bridge.ts
+++ b/src/adapters/tdai-bridge/tdai-bridge.ts
@@ -1,0 +1,169 @@
+// 本地接口定义 - 依赖反转，避免直接依赖 PR #316 的 GatewayMemoryClient
+export interface GatewayClient {
+  recall(body: { query: string; session_key: string }): Promise<{ context: string }>;
+  capture(body: { user_text: string; assistant_text: string; session_key: string }): Promise<unknown>;
+  searchMemories(body: { query: string; limit: number }): Promise<unknown>;
+  searchConversations(body: { query: string; limit: number }): Promise<unknown>;
+  endSession(body: { session_key: string }): Promise<unknown>;
+}
+
+export interface BridgeRetryOpts {
+  attempts: number;
+  baseMs: number;
+}
+
+export interface BridgeOpts {
+  retry?: Partial<BridgeRetryOpts>;
+  recallCacheMax?: number; // ponytail: Map cap,默认 256
+}
+
+const DEFAULT_RETRY: BridgeRetryOpts = { attempts: 3, baseMs: 200 };
+
+// ponytail: 仅瞬态错误重试; Auth/Validation 立即降级
+// 使用 duck typing 判断瞬态错误：检查是否有 status 字段且为瞬态 HTTP 状态码
+function isTransient(err: unknown): boolean {
+  const status = (err as any)?.status;
+  const isNumericStatus = typeof status === "number";
+
+  // 检查瞬态 HTTP 状态码：408(请求超时), 425(太早), 429(限流), >=500(服务器错误)
+  if (isNumericStatus && (status === 408 || status === 425 || status === 429 || status >= 500)) {
+    return true;
+  }
+
+  // 检查网络错误：TypeError (如网络断开、DNS 解析失败等)
+  // 或者 Error 对象的 message 包含网络相关关键词
+  if (err instanceof TypeError) {
+    return true;
+  }
+
+  if (err instanceof Error && typeof err.message === "string" && /fetch|network|timeout/i.test(err.message)) {
+    return true;
+  }
+
+  return false;
+}
+
+async function withRetry<T>(fn: () => Promise<T>, opts: BridgeRetryOpts): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < opts.attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (!isTransient(err)) {
+        // 非瞬态错误：立即抛出，由模板方法降级处理
+        throw err;
+      }
+      // 指数退避 + 抖动
+      const delay = opts.baseMs * 2 ** attempt + Math.random() * opts.baseMs;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastErr;
+}
+
+function sanitize(s: string, max: number): string {
+  if (typeof s !== "string") return "";
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+export class TdaiBridge {
+  private readonly retry: BridgeRetryOpts;
+  private readonly cache = new Map<string, unknown>(); // ponytail: 简单容量治理; LRU 若命中率不够再换
+  private readonly cacheMax: number;
+
+  constructor(private readonly client: GatewayClient, opts: BridgeOpts = {}) {
+    this.retry = { ...DEFAULT_RETRY, ...opts.retry };
+    this.cacheMax = opts.recallCacheMax ?? 256;
+  }
+
+  async recall(query: string, sessionKey: string): Promise<{ context: string }> {
+    const q = sanitize(query, 100_000);
+    const key = sessionKey + ":" + q;
+
+    if (this.cache.has(key)) {
+      return this.cache.get(key) as { context: string };
+    }
+
+    try {
+      const res = await withRetry(
+        () => this.client.recall({ query: q, session_key: sessionKey }),
+        this.retry
+      );
+      this.cache.set(key, res);
+
+      // ponytail: 简单容量治理；缓存超限清空
+      if (this.cache.size > this.cacheMax) {
+        this.cache.clear();
+      }
+
+      return res as { context: string };
+    } catch (err) {
+      console.warn("[tdai-bridge] recall degraded:", (err as Error).message);
+      return { context: "" }; // 优雅降级：永不抛出
+    }
+  }
+
+  async capture(turn: { userText: string; assistantText: string }, sessionKey: string): Promise<{ ok: boolean }> {
+    try {
+      await withRetry(
+        () =>
+          this.client.capture({
+            user_text: sanitize(turn.userText, 1_000_000),
+            assistant_text: sanitize(turn.assistantText, 1_000_000),
+            session_key: sessionKey,
+          }),
+        this.retry
+      );
+      return { ok: true };
+    } catch (err) {
+      console.warn("[tdai-bridge] capture degraded:", (err as Error).message);
+      return { ok: false };
+    }
+  }
+
+  async searchMemory(query: string, opts: { limit?: number } = {}): Promise<unknown> {
+    try {
+      return await withRetry(
+        () =>
+          this.client.searchMemories({
+            query: sanitize(query, 100_000),
+            limit: clamp(opts.limit ?? 10, 1, 50),
+          }),
+        this.retry
+      );
+    } catch (err) {
+      console.warn("[tdai-bridge] search degraded:", (err as Error).message);
+      return [];
+    }
+  }
+
+  async searchConversation(query: string, opts: { limit?: number } = {}): Promise<unknown> {
+    try {
+      return await withRetry(
+        () =>
+          this.client.searchConversations({
+            query: sanitize(query, 100_000),
+            limit: clamp(opts.limit ?? 10, 1, 50),
+          }),
+        this.retry
+      );
+    } catch (err) {
+      console.warn("[tdai-bridge] search degraded:", (err as Error).message);
+      return [];
+    }
+  }
+
+  async endSession(sessionKey: string): Promise<void> {
+    try {
+      await this.client.endSession({ session_key: sessionKey });
+    } catch (err) {
+      console.warn("[tdai-bridge] endSession degraded:", (err as Error).message);
+      // endSession 失败时不抛出异常，静默降级
+    }
+  }
+}

--- a/src/adapters/trae/hook-handler.test.ts
+++ b/src/adapters/trae/hook-handler.test.ts
@@ -1,0 +1,33 @@
+// 测试文件 - Task 2: Trae hook-handler
+import { describe, it, expect, vi } from "vitest";
+import { handleTraeHook } from "./hook-handler.js";
+import { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+function fakeBridge(recallCtx = "RECALLED") {
+  return {
+    recall: vi.fn().mockResolvedValue({ context: recallCtx }),
+    capture: vi.fn().mockResolvedValue({ ok: true }),
+    endSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TdaiBridge;
+}
+
+describe("handleTraeHook", () => {
+  it("UserPromptSubmit → recall + bounded additionalContext", async () => {
+    const bridge = fakeBridge();
+    const out = await handleTraeHook("UserPromptSubmit", { prompt: "how do I X" }, bridge);
+    expect(bridge.recall).toHaveBeenCalledWith("how do I X", expect.any(String));
+    expect(out.additionalContext).toContain("RECALLED");
+  });
+
+  it("Stop → capture(user, assistant)", async () => {
+    const bridge = fakeBridge();
+    await handleTraeHook("Stop", { last_assistant_message: "answer" }, bridge);
+    expect(bridge.capture).toHaveBeenCalledWith(expect.objectContaining({ assistantText: "answer" }), expect.any(String));
+  });
+
+  it("SessionEnd → endSession", async () => {
+    const bridge = fakeBridge();
+    await handleTraeHook("SessionEnd", {}, bridge);
+    expect(bridge.endSession).toHaveBeenCalled();
+  });
+});

--- a/src/adapters/trae/hook-handler.ts
+++ b/src/adapters/trae/hook-handler.ts
@@ -1,0 +1,49 @@
+// Field names follow Claude-Code-compatible hooks protocol; verify against real Trae at integration time.
+import type { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+export type TraeHookEvent = "SessionStart" | "UserPromptSubmit" | "Stop" | "SessionEnd";
+
+export interface TraeHookInput {
+  prompt?: string;
+  last_assistant_message?: string;
+  // ponytail: Trae 实测字段补在这里(见上方实测前置)
+  [k: string]: unknown;
+}
+
+export interface TraeHookOutput {
+  additionalContext?: string;
+}
+
+// 移植自 #517:有界注入,防 context 爆炸
+const MAX_CONTEXT_CHARS = 4000;
+
+export async function handleTraeHook(
+  event: TraeHookEvent,
+  input: TraeHookInput,
+  bridge: TdaiBridge,
+  sessionKey: string = String(process.env.TRAE_SESSION_KEY ?? "trae-default")
+): Promise<TraeHookOutput> {
+  switch (event) {
+    case "SessionStart":
+    case "UserPromptSubmit": {
+      const query = input.prompt ?? "";
+      if (!query) return {};
+      const { context } = await bridge.recall(query, sessionKey);
+      if (!context) return {};
+      // ponytail: 硬截断上限;超长则尾部省略
+      const bounded = context.length > MAX_CONTEXT_CHARS
+        ? context.slice(0, MAX_CONTEXT_CHARS) + "\n…(truncated)"
+        : context;
+      return { additionalContext: bounded };
+    }
+    case "Stop": {
+      const assistantText = input.last_assistant_message ?? "";
+      // ponytail: userText 在 Stop 事件未必可得;取上轮缓存或空(实现期按 Trae 实测补)
+      await bridge.capture({ userText: "", assistantText }, sessionKey);
+      return {};
+    }
+    case "SessionEnd":
+      await bridge.endSession(sessionKey);
+      return {};
+  }
+}

--- a/src/adapters/trae/index.ts
+++ b/src/adapters/trae/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Trae adapter — barrel export for Trae-specific integration layer.
+ *
+ * Exports hook handlers, MCP server, and types for Trae platform integration.
+ * Provides both programmatic API and stdio MCP server entry point.
+ */
+
+export { handleTraeHook } from "./hook-handler.js";
+export type { TraeHookEvent, TraeHookInput, TraeHookOutput } from "./hook-handler.js";
+export { TraeMcpServer, runStdioTraeMcp } from "./mcp-server.js";

--- a/src/adapters/trae/mcp-server.test.ts
+++ b/src/adapters/trae/mcp-server.test.ts
@@ -1,0 +1,200 @@
+// Task 3: Trae MCP server 测试 - TDD Step 1: 写失败测试
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TraeMcpServer, runStdioTraeMcp } from "./mcp-server.js";
+import type { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+
+function fakeBridge(): TdaiBridge {
+  return {
+    recall: vi.fn().mockResolvedValue({ context: "C" }),
+    capture: vi.fn().mockResolvedValue({ ok: true }),
+    searchMemory: vi.fn().mockResolvedValue([{ id: 1 }]),
+    searchConversation: vi.fn().mockResolvedValue([]),
+    endSession: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TdaiBridge;
+}
+
+describe("TraeMcpServer tools/call", () => {
+  it("tdai_recall calls bridge.recall", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "tdai_recall", arguments: { query: "q", session_key: "s" } },
+    });
+    expect(out?.result?.content?.[0]?.text).toContain("C");
+  });
+
+  it("tdai_capture calls bridge.capture", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "tdai_capture",
+        arguments: { user_content: "u", assistant_content: "a", session_key: "s" },
+      },
+    });
+    expect(out?.result?.content?.[0]?.text).toContain("true");
+  });
+
+  it("tdai_memory_search calls bridge.searchMemory", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "tdai_memory_search", arguments: { query: "q", limit: 5 } },
+    });
+    expect(out?.result?.content?.[0]?.text).toContain("1");
+  });
+
+  it("tdai_conversation_search calls bridge.searchConversation", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "tdai_conversation_search", arguments: { query: "q", limit: 10 } },
+    });
+    const result = JSON.parse(out?.result?.content?.[0]?.text || "[]");
+    expect(result).toEqual([]);
+  });
+
+  it("tdai_session_end calls bridge.endSession", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "tdai_session_end", arguments: { session_key: "s" } },
+    });
+    expect(out?.result?.content?.[0]?.text).toContain("true");
+  });
+
+  it("unknown tool → JSON-RPC -32601", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: { name: "nope", arguments: {} },
+    });
+    expect(out?.error?.code).toBe(-32601);
+  });
+});
+
+describe("TraeMcpServer initialize and tools/list", () => {
+  it("initialize returns protocol version and capabilities", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "initialize",
+      params: {},
+    });
+    expect(out?.result?.protocolVersion).toBe("2025-11-25");
+    expect(out?.result?.serverInfo?.name).toBe("tdai-trae");
+  });
+
+  it("tools/list returns 5 tools with closed inputSchema", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/list",
+      params: {},
+    });
+    const tools = out?.result?.tools;
+    expect(tools).toHaveLength(5);
+    expect(tools?.map((t: any) => t.name)).toEqual([
+      "tdai_recall",
+      "tdai_capture",
+      "tdai_memory_search",
+      "tdai_conversation_search",
+      "tdai_session_end",
+    ]);
+    // 检查每个工具都有 inputSchema
+    for (const tool of tools || []) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.additionalProperties).toBe(false);
+    }
+  });
+
+  it("unknown method → JSON-RPC -32601", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 9,
+      method: "unknown_method",
+      params: {},
+    });
+    expect(out?.error?.code).toBe(-32601);
+  });
+
+  it("closed schema: tdai_recall rejects extra fields → -32602", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
+      params: {
+        name: "tdai_recall",
+        arguments: { query: "q", session_key: "s", extra_field: "x" },
+      },
+    });
+    expect(out?.error?.code).toBe(-32602);
+    expect(out?.error?.message).toContain("extra_field");
+  });
+
+  it("closed schema: tdai_capture rejects extra fields → -32602", async () => {
+    const s = new TraeMcpServer(fakeBridge());
+    const out = await s.handle({
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/call",
+      params: {
+        name: "tdai_capture",
+        arguments: {
+          user_content: "u",
+          assistant_content: "a",
+          session_key: "s",
+          malicious_field: "hack",
+        },
+      },
+    });
+    expect(out?.error?.code).toBe(-32602);
+    expect(out?.error?.message).toContain("malicious_field");
+  });
+});
+
+describe("TraeMcpServer stdio entry point", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  it("runStdioTraeMcp throws when TDAI_GATEWAY_URL is missing", async () => {
+    delete process.env.TDAI_GATEWAY_URL;
+    delete process.env.TDAI_GATEWAY_API_KEY;
+
+    await expect(runStdioTraeMcp()).rejects.toThrow("missing env var: TDAI_GATEWAY_URL");
+  });
+
+  it("runStdioTraeMcp throws when TDAI_GATEWAY_API_KEY is missing", async () => {
+    process.env.TDAI_GATEWAY_URL = "http://localhost:8080";
+    delete process.env.TDAI_GATEWAY_API_KEY;
+
+    await expect(runStdioTraeMcp()).rejects.toThrow("missing env var: TDAI_GATEWAY_API_KEY");
+  });
+
+  it("runStdioTraeMcp has correct export signature", async () => {
+    // ponytail: 只验证函数存在性，不执行（需要真实 Gateway）
+    expect(typeof runStdioTraeMcp).toBe("function");
+    expect(runStdioTraeMcp.name).toBe("runStdioTraeMcp");
+  });
+});

--- a/src/adapters/trae/mcp-server.ts
+++ b/src/adapters/trae/mcp-server.ts
@@ -1,0 +1,300 @@
+// Task 3: Trae MCP server - JSON-RPC over stdio, 5 tools calling TdaiBridge
+// ponytail: 手写 JSON-RPC 2.0，不引 @modelcontextprotocol/sdk（供应链安全，参照 #372）
+import type { TdaiBridge } from "../tdai-bridge/tdai-bridge.js";
+import type { GatewayClient } from "../tdai-bridge/tdai-bridge.js";
+import { TdaiBridge as TdaiBridgeImpl } from "../tdai-bridge/tdai-bridge.js";
+import * as readline from "node:readline";
+
+interface JsonRpcReq {
+  jsonrpc: string;
+  id?: unknown;
+  method: string;
+  params?: any;
+}
+
+interface JsonRpcRes {
+  jsonrpc: "2.0";
+  id?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface Tool {
+  name: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, { type: string }>;
+    additionalProperties: boolean;
+    required?: string[];
+  };
+}
+
+// 5 个工具的 closed schema 定义
+const TOOLS: Tool[] = [
+  {
+    name: "tdai_recall",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        session_key: { type: "string" },
+      },
+      additionalProperties: false,
+      required: ["query", "session_key"],
+    },
+  },
+  {
+    name: "tdai_capture",
+    inputSchema: {
+      type: "object",
+      properties: {
+        user_content: { type: "string" },
+        assistant_content: { type: "string" },
+        session_key: { type: "string" },
+      },
+      additionalProperties: false,
+      required: ["user_content", "assistant_content", "session_key"],
+    },
+  },
+  {
+    name: "tdai_memory_search",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "number" },
+      },
+      additionalProperties: false,
+      required: ["query"],
+    },
+  },
+  {
+    name: "tdai_conversation_search",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "number" },
+      },
+      additionalProperties: false,
+      required: ["query"],
+    },
+  },
+  {
+    name: "tdai_session_end",
+    inputSchema: {
+      type: "object",
+      properties: {
+        session_key: { type: "string" },
+      },
+      additionalProperties: false,
+      required: ["session_key"],
+    },
+  },
+];
+
+export class TraeMcpServer {
+  constructor(private readonly bridge: TdaiBridge) {}
+
+  async handle(req: JsonRpcReq): Promise<JsonRpcRes | undefined> {
+    const id = req.id;
+
+    if (req.method === "initialize") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          serverInfo: {
+            name: "tdai-trae",
+            version: "0.1.0",
+          },
+        },
+      };
+    }
+
+    if (req.method === "tools/list") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          tools: TOOLS,
+        },
+      };
+    }
+
+    if (req.method === "tools/call") {
+      const { name, arguments: args } = req.params ?? {};
+
+      // ponytail: 运行时强校验（参照 #372，schema 声明 + 运行时双保险）
+      const tool = TOOLS.find((t) => t.name === name);
+      if (tool && args) {
+        const allowedKeys = new Set(Object.keys(tool.inputSchema.properties));
+        const actualKeys = new Set(Object.keys(args));
+        for (const key of actualKeys) {
+          if (!allowedKeys.has(key)) {
+            return {
+              jsonrpc: "2.0",
+              id,
+              error: {
+                code: -32602,
+                message: `Invalid params: unknown field '${key}' for tool '${name}'`,
+              },
+            };
+          }
+        }
+      }
+
+      try {
+        let data: unknown;
+
+        switch (name) {
+          case "tdai_recall":
+            data = await this.bridge.recall(args.query, args.session_key);
+            break;
+          case "tdai_capture":
+            data = await this.bridge.capture(
+              { userText: args.user_content, assistantText: args.assistant_content },
+              args.session_key
+            );
+            break;
+          case "tdai_memory_search":
+            data = await this.bridge.searchMemory(args.query, { limit: args.limit });
+            break;
+          case "tdai_conversation_search":
+            data = await this.bridge.searchConversation(args.query, { limit: args.limit });
+            break;
+          case "tdai_session_end":
+            await this.bridge.endSession(args.session_key);
+            data = { ok: true };
+            break;
+          default:
+            return {
+              jsonrpc: "2.0",
+              id,
+              error: { code: -32601, message: `unknown tool: ${name}` },
+            };
+        }
+
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text: JSON.stringify(data) }],
+          },
+        };
+      } catch (e) {
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32000, message: (e as Error).message },
+        };
+      }
+    }
+
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: `method not found: ${req.method}` },
+    };
+  }
+}
+
+// === 最小 fetch-based GatewayClient ===
+// ponytail: 实现 TdaiBridge 的 GatewayClient 接口，使用 plain fetch
+// 范注：这是 Task 1 本地接口的生产注入，临时实现直到 PR #316 合并
+// PR #316 的 GatewayMemoryClient 与此结构兼容，可直接替换
+class FetchGatewayClient implements GatewayClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+    private readonly timeoutMs: number = 10000
+  ) {}
+
+  private async fetchEndpoint<T>(path: string, body: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const responseBody = await response.text();
+        const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
+        (error as any).status = response.status;
+        (error as any).responseBody = responseBody;
+        throw error;
+      }
+
+      return (await response.json()) as T;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async recall(body: { query: string; session_key: string }): Promise<{ context: string }> {
+    return this.fetchEndpoint<{ context: string }>("/recall", body);
+  }
+
+  async capture(body: {
+    user_text: string;
+    assistant_text: string;
+    session_key: string;
+  }): Promise<unknown> {
+    return this.fetchEndpoint("/capture", body);
+  }
+
+  async searchMemories(body: { query: string; limit: number }): Promise<unknown> {
+    return this.fetchEndpoint("/search/memories", body);
+  }
+
+  async searchConversations(body: { query: string; limit: number }): Promise<unknown> {
+    return this.fetchEndpoint("/search/conversations", body);
+  }
+
+  async endSession(body: { session_key: string }): Promise<unknown> {
+    return this.fetchEndpoint("/session/end", body);
+  }
+}
+
+// === stdio 入口点 ===
+export async function runStdioTraeMcp(): Promise<void> {
+  const client = new FetchGatewayClient(
+    requireEnv("TDAI_GATEWAY_URL"),
+    requireEnv("TDAI_GATEWAY_API_KEY"),
+    Number(process.env.TDAI_GATEWAY_TIMEOUT_MS ?? 10000)
+  );
+
+  const bridge = new TdaiBridgeImpl(client);
+  const server = new TraeMcpServer(bridge);
+  const rl = readline.createInterface({ input: process.stdin });
+
+  // ponytail: parse error → 跳过单帧，不崩 server
+  for await (const line of rl) {
+    try {
+      const req = JSON.parse(line);
+      const res = await server.handle(req);
+      if (res) {
+        process.stdout.write(JSON.stringify(res) + "\n");
+      }
+    } catch (e) {
+      // ponytail: 静默跳过解析错误，保持 stdio 稳定性
+      console.error("[mcp-server] frame error:", (e as Error).message);
+    }
+  }
+}
+
+function requireEnv(k: string): string {
+  const v = process.env[k];
+  if (!v) throw new Error(`missing env var: ${k}`);
+  return v;
+}

--- a/trae-plugin/.trae/hooks.json
+++ b/trae-plugin/.trae/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs",
+        "args": ["SessionStart"]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs",
+        "args": ["UserPromptSubmit"]
+      }
+    ],
+    "Stop": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs",
+        "args": ["Stop"]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "command": "node ${TRAE_PLUGIN_DIR}/scripts/memory-hook.mjs",
+        "args": ["SessionEnd"]
+      }
+    ]
+  }
+}

--- a/trae-plugin/.trae/mcp.json
+++ b/trae-plugin/.trae/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "tdai": {
+      "command": "memory-tencentdb-trae-mcp",
+      "env": {
+        "TDAI_GATEWAY_URL": "${TDAI_GATEWAY_URL}",
+        "TDAI_GATEWAY_API_KEY": "${TDAI_GATEWAY_API_KEY}"
+      }
+    }
+  }
+}

--- a/trae-plugin/README.md
+++ b/trae-plugin/README.md
@@ -1,0 +1,219 @@
+# Trae Plugin for TencentDB Agent Memory
+
+Trae lifecycle hooks + MCP tools adapter for the **memory-tencentdb** four-layer memory system (L0 conversation capture → L1 episodic extraction → L2 scene blocks → L3 persona synthesis).
+
+This plugin integrates TencentDB Agent Memory into Trae through two interfaces:
+
+1. **Lifecycle Hooks** — Auto-inject relevant memory context before each turn and capture conversations after each response
+2. **MCP Tools** — Provide explicit memory search tools (`tdai_recall`, `tdai_memory_search`, `tdai_conversation_search`) to the LLM
+
+## Architecture
+
+```
+Trae Agent
+  ├─ Lifecycle Hooks (SessionStart, UserPromptSubmit, Stop, SessionEnd)
+  │   └─ memory-hook.mjs  →  TdaiBridge  →  Gateway HTTP API
+  └─ MCP Server (stdio JSON-RPC)
+      └─ TraeMcpServer  →  TdaiBridge  →  Gateway HTTP API
+              │
+              ▼  HTTP (127.0.0.1:8420 by default)
+      memory-tencentdb Gateway (Node.js)
+         └─ memory-tencentdb Core
+              ├─ L0  Conversation store      (SQLite / TCVDB + JSONL)
+              ├─ L1  Episodic extraction     (LLM + vector dedup)
+              ├─ L2  Scene blocks            (Markdown under data dir)
+              ├─ L3  Persona synthesis       (persona.md)
+              └─ Storage backends: SQLite + sqlite-vec  OR  Tencent VectorDB
+```
+
+### Trae Hook → Gateway Mapping
+
+| Trae hook          | Gateway endpoint | Behavior                                                   |
+|--------------------|------------------|------------------------------------------------------------|
+| `SessionStart`     | `POST /recall`   | Inject initial context for new sessions                    |
+| `UserPromptSubmit` | `POST /recall`   | Inject relevant memory context before each user prompt    |
+| `Stop`             | `POST /capture`  | Capture the user + assistant conversation turn            |
+| `SessionEnd`       | `POST /session/end` | Flush pending pipeline work and close session           |
+
+### MCP Tools
+
+| Tool                        | Purpose                                           | Args                                            |
+|-----------------------------|---------------------------------------------------|-------------------------------------------------|
+| `tdai_recall`              | Recall memory context for a query                 | `query` (required), `session_key` (required)   |
+| `tdai_capture`             | Capture a conversation turn                      | `user_content`, `assistant_content`, `session_key` |
+| `tdai_memory_search`       | Search L1 structured long-term memories           | `query` (required), `limit` (1..50, default 10) |
+| `tdai_conversation_search` | Search L0 raw conversation history                | `query` (required), `limit` (1..50, default 10) |
+| `tdai_session_end`         | End a session and flush pending work              | `session_key` (required)                        |
+
+## Installation
+
+### 1. Install the Plugin
+
+Copy the `trae-plugin/` directory to your Trae plugins location:
+
+```bash
+# Assuming you're in the TencentDB-Agent-Memory repository root
+mkdir -p ~/.trae/plugins/trae-memory
+cp -r trae-plugin/.trae ~/.trae/plugins/trae-memory/
+cp -r trae-plugin/scripts ~/.trae/plugins/trae-memory/
+```
+
+### 2. Configure Trae to Load the Plugin
+
+In your Trae configuration file (typically `~/.trae/config.json` or equivalent), add:
+
+```jsonc
+{
+  "plugins": {
+    "trae-memory": {
+      "enabled": true,
+      "hooksConfig": "~/.trae/plugins/trae-memory/.trae/hooks.json",
+      "mcpConfig": "~/.trae/plugins/trae-memory/.trae/mcp.json"
+    }
+  }
+}
+```
+
+### 3. Set Required Environment Variables
+
+The plugin requires Gateway connection details. Set these in your Trae environment:
+
+```bash
+# Gateway endpoint (required)
+export TDAI_GATEWAY_URL="http://127.0.0.1:8420"
+
+# Gateway API key if authentication is enabled (required if Gateway has apiKey set)
+export TDAI_GATEWAY_API_KEY="your-secret-key"
+
+# Optional: Session key override (defaults to "trae-default")
+export TRAE_SESSION_KEY="your-session-key"
+
+# Optional: Request timeout in milliseconds (defaults to 10000)
+export TDAI_GATEWAY_TIMEOUT_MS="10000"
+```
+
+### 4. Start the Gateway
+
+The plugin connects to a memory-tencentdb Gateway sidecar. Start it separately:
+
+```bash
+# From the TencentDB-Agent-Memory repository root
+cd /path/to/TencentDB-Agent-Memory
+npx tsx src/gateway/server.ts
+```
+
+Or use the production build:
+
+```bash
+cd /path/to/TencentDB-Agent-Memory
+node dist/gateway/server.js
+```
+
+**Verify the Gateway is running:**
+
+```bash
+curl http://127.0.0.1:8420/health
+# Should return: {"status":"ok"} or {"status":"degraded"}
+```
+
+## Environment Variables
+
+### Gateway Connection
+
+| Variable                   | Default             | Description                                               |
+|----------------------------|---------------------|-----------------------------------------------------------|
+| `TDAI_GATEWAY_URL`         | —                   | Gateway base URL (required)                                |
+| `TDAI_GATEWAY_API_KEY`     | —                   | Gateway API key if authentication is enabled (required if Gateway has `server.apiKey` set) |
+| `TDAI_GATEWAY_TIMEOUT_MS`  | `10000`             | HTTP request timeout in milliseconds                      |
+
+### Session Management
+
+| Variable            | Default           | Description                                      |
+|---------------------|-------------------|--------------------------------------------------|
+| `TRAE_SESSION_KEY`  | `trae-default`    | Session key for memory isolation                |
+
+## Gateway Configuration
+
+The Gateway handles all memory operations. Configure it via:
+
+- **Environment variables** (recommended for Trae integration)
+- **Config file** (`~/.memory-tencentdb/memory-tdai/tdai-gateway.yaml` or `tdai-gateway.json`)
+
+### Key Gateway Settings
+
+| Setting                    | Default | Description                                              |
+|----------------------------|---------|----------------------------------------------------------|
+| `storeBackend`             | `sqlite`| Storage backend: `sqlite` or `tcvdb`                     |
+| `timezone`                 | `system`| Timezone for timestamps                                  |
+| `recall.strategy`          | `hybrid`| Recall strategy: `keyword`, `embedding`, or `hybrid`    |
+| `recall.maxResults`        | `5`     | Number of memories to recall per request                |
+| `pipeline.everyNConversations` | `5`  | Trigger L1 extraction every N turns                     |
+| `persona.triggerEveryN`    | `50`    | Generate L3 persona every N new memories                |
+
+For the full configuration schema, see the main [README](../../README.md).
+
+## Troubleshooting
+
+### Plugin not loading in Trae
+
+- **Check file paths**: Ensure `~/.trae/plugins/trae-memory/.trae/hooks.json` and `.trae/mcp.json` exist
+- **Verify JSON syntax**: Run `python -m json.tool ~/.trae/plugins/trae-memory/.trae/hooks.json` to validate
+- **Check Trae logs**: Look for plugin loading errors in Trae's log output
+
+### "missing env var: TDAI_GATEWAY_URL" error
+
+- **Set required environment variables**: Ensure `TDAI_GATEWAY_URL` is set in Trae's environment
+- **Check Gateway is running**: Verify `curl http://127.0.0.1:8420/health` returns successfully
+
+### Memory context not being injected
+
+- **Check hook execution**: Add `--debug` flag to Trae to see hook execution logs
+- **Verify Gateway health**: Ensure the Gateway is running and not returning errors
+- **Check session key**: Verify `TRAE_SESSION_KEY` is consistent across requests if customizing
+
+### MCP tools not available to the LLM
+
+- **Check MCP server registration**: Verify `memory-tencentdb-trae-mcp` command is available in PATH
+- **Check mcp.json syntax**: Run `python -m json.tool ~/.trae/plugins/trae-memory/.trae/mcp.json` to validate
+- **Verify Gateway authentication**: If Gateway has `server.apiKey` set, ensure `TDAI_GATEWAY_API_KEY` matches
+
+### Gateway connection failures
+
+- **Check Gateway logs**: Look for errors in Gateway stderr output
+- **Verify port**: Ensure Gateway is listening on the port specified in `TDAI_GATEWAY_URL`
+- **Test connectivity**: Run `curl -H "Authorization: Bearer $TDAI_GATEWAY_API_KEY" http://127.0.0.1:8420/health`
+
+### Hook script errors
+
+- **Check script syntax**: Run `node --check ~/.trae/plugins/trae-memory/scripts/memory-hook.mjs`
+- **Verify compiled outputs exist**: Ensure `pnpm build` has been run and `dist/adapters/trae/hook-handler.js` exists
+- **Check error messages**: Hook errors are logged to stderr with `[memory-hook]` prefix
+
+## Architecture Notes
+
+### Hook Protocol
+
+This plugin follows the **Claude-Code-compatible hooks protocol** (Trae has an "import Claude Code hooks" switch). The hook field names in `hooks.json` follow this standard protocol. Real-Trae verification is deferred to integration testing; field format adjustments may be needed based on actual Trae behavior.
+
+### Memory Injection Limits
+
+To prevent context explosion, the plugin enforces a `MAX_CONTEXT_CHARS = 4000` limit. Injected context longer than this is truncated with a `…(truncated)` suffix. This balances memory richness with token efficiency.
+
+### Graceful Degradation
+
+The `TdaiBridge` implementation includes retry logic with exponential backoff for transient errors (network timeouts, 5xx errors). Non-transient errors (authentication, validation) fail immediately. All operations degrade gracefully on failure:
+- `recall`: Returns empty context on failure
+- `capture`: Returns `{ ok: false }` on failure
+- `search`: Returns empty results on failure
+
+This ensures the plugin never crashes the Trae session even if the Gateway is unavailable.
+
+## Related Documentation
+
+- [Main README](../../README.md) — Full TencentDB Agent Memory documentation
+- [Hermes Provider README](../../hermes-plugin/memory/memory_tencentdb/README.md) — Similar integration pattern for Hermes agents
+- [Gateway Configuration](../../README.md#-configurable-parameters) — Complete Gateway configuration reference
+
+## License
+
+MIT © TencentDB Agent Memory Team

--- a/trae-plugin/scripts/memory-hook.mjs
+++ b/trae-plugin/scripts/memory-hook.mjs
@@ -1,0 +1,107 @@
+// trae-plugin/scripts/memory-hook.mjs
+// Trae lifecycle hook entry point - reads stdin JSON → calls compiled hook-handler → outputs additionalContext
+
+// NOTE: dist/ is built by `pnpm build` (tsdown). Import paths below assume the current
+// tsdown layout (dist/src/adapters/..., fixedExtension:false); if build config changes,
+// update these paths. The inline FetchGatewayClient is transitional — replace with
+// PR #316's GatewayMemoryClient once it merges (structurally compatible).
+import { handleTraeHook } from "../../dist/src/adapters/trae/hook-handler.js";
+import { TdaiBridge } from "../../dist/src/adapters/tdai-bridge/tdai-bridge.js";
+
+// Minimal GatewayClient implementation using fetch (mirrors mcp-server.ts client)
+class FetchGatewayClient {
+  constructor(baseUrl, apiKey, timeoutMs = 10000) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async fetchEndpoint(path, body) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const responseBody = await response.text();
+        const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
+        error.status = response.status;
+        error.responseBody = responseBody;
+        throw error;
+      }
+
+      return await response.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  async recall(body) {
+    return this.fetchEndpoint("/recall", body);
+  }
+
+  async capture(body) {
+    return this.fetchEndpoint("/capture", body);
+  }
+
+  async searchMemories(body) {
+    return this.fetchEndpoint("/search/memories", body);
+  }
+
+  async searchConversations(body) {
+    return this.fetchEndpoint("/search/conversations", body);
+  }
+
+  async endSession(body) {
+    return this.fetchEndpoint("/session/end", body);
+  }
+}
+
+function requireEnv(k) {
+  const v = process.env[k];
+  if (!v) throw new Error(`missing env var: ${k}`);
+  return v;
+}
+
+async function readStdinJson() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  const event = process.argv[2];
+  const input = await readStdinJson();
+
+  const client = new FetchGatewayClient(
+    requireEnv("TDAI_GATEWAY_URL"),
+    requireEnv("TDAI_GATEWAY_API_KEY"),
+    Number(process.env.TDAI_GATEWAY_TIMEOUT_MS ?? 10000)
+  );
+
+  const bridge = new TdaiBridge(client);
+  const sessionKey = process.env.TRAE_SESSION_KEY ?? "trae-default";
+
+  const out = await handleTraeHook(event, input, bridge, sessionKey);
+  process.stdout.write(JSON.stringify(out));
+}
+
+main().catch((err) => {
+  console.error("[memory-hook] error:", err.message);
+  process.exit(1);
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,12 +11,18 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: [
+    "./index.ts",
+    "./src/adapters/trae/index.ts",
+    "./src/adapters/trae/hook-handler.ts",
+    "./src/adapters/tdai-bridge/tdai-bridge.ts",
+    "./src/adapters/trae/mcp-server.ts"
+  ],
   outDir: "./dist",
   format: "esm",
   platform: "node",
   clean: true,
-  fixedExtension: true,
+  fixedExtension: false,
   dts: false,
   sourcemap: false,
   deps: {


### PR DESCRIPTION
## 概述

为 issue #235 接入 **Trae**(字节系 AI IDE)平台记忆适配,并新增一层薄整合 `TdaiBridge`

Closes #235

## 主要改动

**薄整合层** `src/adapters/tdai-bridge/`
- `TdaiBridge`(concrete):包 client + 分类 retry(瞬态重试 / Auth 不重试)+ recall 会话缓存 + 输入消毒 + 优雅降级
- 依赖反转:本地 `GatewayClient` interface,#316 的 client 结构兼容、merge 后可直接注入

**Trae 适配** `src/adapters/trae/`
- `hook-handler`:SessionStart / UserPromptSubmit / Stop / SessionEnd → recall / capture / endSession(复用 #517 reliability,有界 additionalContext)
- `mcp-server`:纯 JSON-RPC 2.0,5 个 tools(`tdai_recall` / `tdai_capture` / `tdai_memory_search` / `tdai_conversation_search` / `tdai_session_end`),closed schema(声明 + 运行时 assertAllowedKeys → -32602)

**Trae 插件装载** `trae-plugin/`:`.trae/hooks.json` + `mcp.json` + `scripts/memory-hook.mjs`(stdin → dist → additionalContext)

**文档**
- `docs/platform-adapters-comparison.md`:6 平台(OpenClaw/Hermes/Codex/Claude Code/Dify/Trae)× 6 维度 + 3 Mermaid(组件架构 / recall 读路径 / L0→L3 写路径)
- `docs/trae-adapter.md`:安装 / 配置 / 验证指南
- 设计 spec + 实现 plan(`docs/superpowers/`)

## 验收映射(渐进式)

| 阶段 | 标准 | 状态 |
|---|---|---|
| 基础 | 架构图 + 数据流 | ✅ |
| 进阶 | 1 平台基本读写 | ✅ Trae |
| 深入 | 2+ 平台 + 对比文档 | 🟡 对比文档 ✅;自适配平台目前 Trae 1 个 |
| 拓展 | 统一适配器 SDK | 🟡 `TdaiBridge` 薄整合层雏形(依赖反转 + retry/缓存/降级),为多平台共享预留 |

> 说明:本 PR 聚焦把一个未占用平台(Trae)做扎实 + 整合现有 PR 优势。`TdaiBridge` 已为后续平台(如 Cline,跨 Windows hooks 差异化)预留共享层。

## 设计决策

- **不改 core**(`hostType` union 不动):走 HTTP 路径,零 core 改动,最易合并
- **依赖反转**:`TdaiBridge` 定义本地 `GatewayClient` interface,避免硬耦合未 merge 的 #316
- **不做** G2-G4 防御门、BufferedAdapter、Python 平行版(避免 #339 的体积争议)

## 验证

- 测试:**99/99 通过**(vitest)
- build:`pnpm build` 成功,dist 产物生成
- 已过 final whole-branch review(2 个 Important 已修)

