### PR TITLE
docs: add Community ContextEngine Integrations section (EN/CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,18 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 ---
 
+## Community ContextEngine Integrations
+
+> ContextEngine implementations built by the community, extending TencentDB Agent Memory's context offload capabilities to additional agent frameworks.
+
+| Project | Framework | Description |
+|---------|-----------|-------------|
+| [tencentdb-offload](https://github.com/ysun0804/tencentdb-offload) | [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) | Python ContextEngine plugin using Offload V2 API. Features: L1 tool-pair ingestion with conversation context, L1.5 boundary creation for MMD canvas generation, 4-level cascade compression, adaptive body truncation. |
+
+> Want to add your integration? Open a [PR](https://github.com/TencentCloud/TencentDB-Agent-Memory/pulls) or [Issue](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues).
+
+---
+
 ## Community & Contributing
 
 We welcome every kind of contribution — bug reports, feature ideas, doc fixes, benchmark reproductions, ecosystem integrations, or a Pull Request. Agent memory is far from a solved problem, and we'd love to figure it out together.

--- a/README_CN.md
+++ b/README_CN.md
@@ -542,6 +542,18 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |
 
 ---
+## 社区 ContextEngine 集成
+
+> 由社区构建的 ContextEngine 实现，将 TencentDB Agent Memory 的上下文卸载能力扩展到更多 Agent 框架。
+
+| 项目 | 框架 | 说明 |
+|------|------|------|
+| [tencentdb-offload](https://github.com/ysun0804/tencentdb-offload) | [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) | Python ContextEngine 插件，使用 Offload V2 API。功能：L1 工具对 ingest（含对话上下文）、L1.5 边界创建（用于 MMD 画布生成）、四级级联压缩、自适应 body 截断。 |
+
+> 想添加你的集成？提交 [PR](https://github.com/TencentCloud/TencentDB-Agent-Memory/pulls) 或 [Issue](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues)。
+
+---
+
 ## 社区与贡献
 
 我们欢迎一切形式的贡献——Bug 反馈、功能建议、文档勘误、Benchmark 复现、生态集成，或者一个 Pull Request 都可以。Agent 记忆这件事远未有定论，希望和大家一起把它做出来。


### PR DESCRIPTION
## What

Add a **Community ContextEngine Integrations** section to both README.md (English) and README_CN.md (Chinese).

This section introduces [tencentdb-offload](https://github.com/ysun0804/tencentdb-offload) — a community-built Python ContextEngine plugin for **Hermes Agent** that uses TencentDB Agent Memory's Offload V2 API.

## 什么改动

在 README.md（英文）和 README_CN.md（中文）中新增**社区 ContextEngine 集成**章节。

介绍 [tencentdb-offload](https://github.com/ysun0804/tencentdb-offload) — 一个由社区构建的 **Hermes Agent** Python ContextEngine 插件，使用 TencentDB Agent Memory 的 Offload V2 API。

## Plugin Features / 插件功能

- L1 tool-pair ingestion with conversation context (ingestWithContext)
- L1.5 boundary creation for MMD canvas generation
- 4-level cascade compression (fastpath → mild → aggressive → emergency)
- Adaptive body truncation before compact API calls
- Fix for pre_llm_call hook never invoked in Hermes v0.18.0 (see #550)

## Related Issues

- Fixes #550 (pre_llm_call hook bug documentation)