### PR TITLE
fix(gateway): L1 pipeline resilience — re-enqueue on lock-conflict timeout, force L1 on session flush

### DIFF
--- a/src/services/pipeline-worker.ts
+++ b/src/services/pipeline-worker.ts
@@ -331,13 +331,27 @@ export class PipelineWorker {
         delay = Math.min(delay * 3, 5000);
       }
       if (!acquired) {
-        this.logger?.warn?.(`${TAG} Lock conflict timeout [${task.type}] (task=${task.id}): ${lockKey}, dropping task`);
-        // CR-1 fix: ACK to prevent stale recovery from re-claiming this message in an
-        // infinite loop. Without it, XPENDING keeps returning this msgId every
-        // pendingRecoveryIntervalMs, exhausting worker slots.
-        const msgId = (task as any)._msgId;
-        if (msgId) {
-          try { await this.backend.ackTask(msgId); } catch { /* best effort */ }
+        // 锁冲突超时：重入队而非丢弃。
+        // 历史行为是直接 drop + ACK（见 CR-1 注释），但 L1 drain 这类"靠上一批
+        // 入队下一批"的接力任务被丢弃后整条链会静默断裂，且没有任何监督者发现。
+        // 改为与执行失败一致的重试策略：ACK 当前消息（防止 XPENDING 重投导致
+        // 同一任务并行执行两次）→ 指数退避 → 重入队（lockRetryCount 递增），
+        // 超限进死信。lockRetryCount 独立于 retryCount，避免与执行失败计数混淆。
+        const lockRetryCount = (task.data?.lockRetryCount as number) ?? 0;
+        if (lockRetryCount < this.config.maxRetries) {
+          const lockDelay = this.config.retryBaseDelayMs * Math.pow(3, lockRetryCount);
+          this.logger?.warn?.(
+            `${TAG} Lock conflict timeout [${task.type}] (task=${task.id}): ${lockKey}, re-enqueue (lockRetry ${lockRetryCount + 1}/${this.config.maxRetries}, delay=${lockDelay}ms)`,
+          );
+          const msgId = (task as any)._msgId;
+          if (msgId) {
+            try { await this.backend.ackTask(msgId); } catch { /* best effort */ }
+          }
+          await this.sleep(lockDelay);
+          await this.reEnqueueLockRetry(task, lockRetryCount + 1);
+          this.metrics.tasksRetried++;
+        } else {
+          await this.moveToDeadLetter(task, "lock conflict timeout", lockRetryCount);
         }
         return;
       }
@@ -649,6 +663,19 @@ export class PipelineWorker {
       ...task,
       id: `${task.type}-${task.sessionId}-retry${newRetryCount}-${Date.now()}`,
       data: { ...task.data, retryCount: newRetryCount },
+      createdAt: Date.now(),
+    });
+  }
+
+  /**
+   * 锁冲突超时后的重入队：与 reEnqueue 相同，但使用独立的 lockRetryCount 计数，
+   * 避免与执行失败的 retryCount 语义混淆。
+   */
+  private async reEnqueueLockRetry(task: TaskPayload, newLockRetryCount: number): Promise<void> {
+    await this.backend.enqueueTask({
+      ...task,
+      id: `${task.type}-${task.sessionId}-lockretry${newLockRetryCount}-${Date.now()}`,
+      data: { ...task.data, lockRetryCount: newLockRetryCount },
       createdAt: Date.now(),
     });
   }

--- a/src/utils/stateful-pipeline-manager.ts
+++ b/src/utils/stateful-pipeline-manager.ts
@@ -249,18 +249,23 @@ export class StatefulPipelineManager {
     // 取消 idle timer
     await this.stateBackend.removeTimer(effectiveInstanceId, `${sessionKey}:L1_idle`);
 
-    // 入队 flush task
+    // 入队 L1 task：会话结束强制提炼已累积的消息。
+    // 恢复旧版 MemoryPipelineManager 语义（"session ends → L1 fires with whatever
+    // messages have accumulated"）。此前这里入队的是 flush task，但 Worker 的
+    // executeFlush 只是再次调用 flushSession，整条路径不会触发 runL1 —— 等于
+    // 空转，还顺带取消了上面的 idle timer，导致闲时兜底提炼失效。
+    const now = Date.now();
     await this.stateBackend.enqueueTask({
-      id: `flush-${sessionKey}-${Date.now()}`,
-      type: "flush",
+      id: `L1-flush-${sessionKey}-${now}`,
+      type: "L1",
       instanceId: effectiveInstanceId,
       sessionId: sessionKey,
       priority: 0,
-      data: { instanceId: effectiveInstanceId },
-      createdAt: Date.now(),
+      data: { instanceId: effectiveInstanceId, ...serializeTraceContext() },
+      createdAt: now,
     });
 
-    this.logger?.debug?.(`${TAG} [${sessionKey}] flushSession: flush task enqueued`);
+    this.logger?.debug?.(`${TAG} [${sessionKey}] flushSession: L1 task enqueued (forced)`);
   }
 
   // ============================


### PR DESCRIPTION
## Description | 描述

修复 standalone/stateful 模式下 L1 提炼管线的两个健壮性缺陷，二者叠加会导致 L1 提炼静默停摆（L0 捕获正常，用户难以察觉）：

Fix two robustness defects in the standalone/stateful L1 pipeline that, combined, can silently stall L1 extraction for days while L0 capture keeps working.

**Fix 1: 锁冲突超时后重入队，不再丢弃任务 | Re-enqueue on lock-conflict timeout instead of dropping**

- 问题：`processTask` 抢会话锁失败时退避重试至 `lockTtlMs` 耗尽，然后直接 `dropping task` + ACK。L1 drain 靠"上一批入队下一批"的接力模型续跑（`server.ts` 中 `hasFullBacklog → enqueueL1Drain`），且该分支故意不设 `L1_idle` 兜底定时器——任务被丢弃后整条 drain 链静默断裂，无任何自愈路径。drain 期间每次 L1 完成 90 秒后必触发 L2 抢同一把会话锁，锁冲突是常态而非异常。
- 修改：超时后复用执行失败的重试策略——ACK 当前消息（保留 CR-1 防重投语义）→ 指数退避 → 重入队（独立的 `lockRetryCount` 计数，新增 `reEnqueueLockRetry`），超限进死信。
- 实测：修复前 `Lock conflict timeout [L1] ... dropping task` 后 2 小时+ 无 L1 活动，约 33 小时 L0 积压滞留；此前同一机制已致 L1 断更 3 天。

**Fix 2: 会话 flush 强制提炼，不再空转 | Force L1 extraction on session flush**

- 问题：`/session/end` → `handleSessionEnd` → `flushSession` 在 `conversation_count > 0` 时取消 `L1_idle` 定时器并入队 `flush` 任务，但 Worker 的 `executeFlush` 只是再次调用 `flushSession`，整条路径从不触发 `runL1`——flush 空转，还顺带拆掉了闲时兜底定时器。旧版语义（"session ends → L1 fires with whatever accumulated"）在 stateful 版丢失。宿主插件空闲自动 flush 的习惯会把"闲时兜底提炼"变成"闲时取消提炼"。
- 修改：`flushSession` 在有待处理消息时直接入队 **L1 类型任务**，恢复"会话结束强制提炼"语义。
- 实测：修复前 flush 后无 `l1-extractor` 运行、定时器消失；修复后日志 `flushSession: L1 task enqueued (forced)` → L1 真实执行并推进游标。

## Related Issue | 关联 Issue

Fix #XXX

Related: #541 / PR #430（同族问题：游标越过未处理 L0 无重放路径，#430 覆盖 LLM 失败路径，未覆盖本 PR 的锁冲突丢弃路径）、#505（批处理续跑不可靠的同族症状）

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

验证环境：standalone Gateway（SQLite + sqlite-vec），Node v22，feat/server @ v1.0.1

- Fix 2 实测：`/capture` 两轮使计数到 1/2 → `POST /session/end` → 日志出现 `flushSession: L1 task enqueued (forced)` → `markL1ExtractionComplete` 真实执行（修复前同场景为 `nothing to flush` / 空转）
- Fix 1：锁冲突超时无法通过 HTTP 接口人为复现（会话锁为进程内状态），重入队逻辑复用现有执行失败重试的 ACK→退避→重入队→死信机制；修复后真实积压 drain 全程跑通、游标追平捕获时间戳、无 `dropping task` 再现
- 既有行为回归：网关启动正常，capture/recall/L2/L3 链路无异常；`executeFlush` 保留以兼容存量 flush 任务

## Additional Notes | 其他说明

- 改动范围：仅 `src/services/pipeline-worker.ts` 与 `src/utils/stateful-pipeline-manager.ts`，两个缺陷各一个 commit
- `lockRetryCount` 与执行失败的 `retryCount` 相互独立，互不影响既有重试语义
- 真实生产证据（3 天积压 + 自动 flush 场景）可附日志片段：`Lock conflict timeout [L1]`（修复前）与 `flushSession: L1 task enqueued (forced)`（修复后）