### PR TITLE
fix(checkpoint): reconcile retained record counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **Checkpoint 记录计数在数据清理后永久漂移**：`memory-cleaner` 现在会在清理完成后，从 SQLite/TCVDB 的剩余记录数（或本地 JSONL fallback 分片）重新统计 L0/L1 存量并原子写回 checkpoint，避免 `l0_conversations_count` 和 `total_memories_extracted` 长期高估。新增 `CheckpointManager.recalculateRecordCounts()`、`recalculateLocalRecordCounts()` 与 `resetSessionProgress()`：手动修剪 JSONL 时可重算存量；有意回滚某个 session、需要重新进入 L1 流程时可清除其时间 cursor 和管线状态。不会回退正常 retention cleanup 的 cursor，避免重复处理已消费的历史数据。
+
+### 🧪 测试 / 内部
+
+- 新增 `src/utils/checkpoint.test.ts` 与 `src/utils/memory-cleaner.test.ts`，覆盖 L0 消息计数、权威存量重算、手动 JSONL 修剪、指定 session 回滚，以及 VectorStore 清理后的 checkpoint 对账。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/docs/checkpoint-reconciliation.md
+++ b/docs/checkpoint-reconciliation.md
@@ -1,0 +1,65 @@
+# Checkpoint 计数对账与数据回滚
+
+`recall_checkpoint.json` 同时保存了两类状态，它们不能混为一谈：
+
+- **记录存量计数**：`l0_conversations_count` 与 `total_memories_extracted`，描述当前仍可用的 L0/L1 记录数量。
+- **处理进度与调度状态**：例如每个 session 的 `last_l1_cursor`、L0 capture cursor 和 pipeline state，决定下一次增量任务从哪里继续。
+
+删除数据后只修改第一类状态；只有需要让旧数据再次进入 L1 时，才修改第二类状态。
+
+## 自动保留清理
+
+`LocalMemoryCleaner` 完成 retention cleanup 后会自动：
+
+1. 使用 SQLite/TCVDB 的 `countL0()` 与 `countL1()` 读取剩余记录数；没有可用 VectorStore 时，扫描 `conversations/YYYY-MM-DD.jsonl` 与 `records/YYYY-MM-DD.jsonl`。
+2. 调用 `CheckpointManager.recalculateRecordCounts()`，在同一个 checkpoint 写入中更新两个存量计数。
+3. 保留所有 session cursor 不变。
+
+保留 cursor 是刻意的：retention cleanup 删除的是已经消费的历史记录，回退 cursor 会导致重复提取。
+
+## 手动修剪本地 JSONL
+
+如果部署使用本地 JSONL fallback，修剪文件后刷新存量计数：
+
+```ts
+import { CheckpointManager } from "./src/utils/checkpoint.js";
+
+const checkpoint = new CheckpointManager(dataDir, logger);
+await checkpoint.recalculateLocalRecordCounts();
+```
+
+该方法只统计回退读取器实际消费的按日 JSONL 分片，忽略 `.metadata`、备份或任意非分片 JSON 文件。
+
+使用 SQLite 或 TCVDB 时，应从数据库获取权威计数：
+
+```ts
+await checkpoint.recalculateRecordCounts({
+  l0Conversations: await vectorStore.countL0(),
+  l1Memories: await vectorStore.countL1(),
+});
+```
+
+## 回滚或替换一个 session
+
+若替换/恢复了某个 session 的 L0 数据，并希望其在下一次 L1 运行时重新处理，除了重算全局存量外，还需要清除该 session 的进度：
+
+```ts
+await checkpoint.resetSessionProgress(sessionKey);
+```
+
+此方法只删除目标 session 的 runner state 与 pipeline state，不影响其他 session，也不改变全局计数。重新处理时，L1 dedup 仍会照常运行。
+
+## 验证
+
+安装依赖后运行本次相关测试：
+
+```bash
+npm test -- src/utils/checkpoint.test.ts src/utils/memory-cleaner.test.ts
+```
+
+测试覆盖：
+
+- L0 按实际消息数量计数；
+- 清理/手动修剪后以真实存量覆盖已漂移计数；
+- VectorStore retention cleanup 后的自动对账；
+- 重置一个 session 不会影响其他 session 的 cursor。

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,110 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function createManager(): Promise<{ checkpoint: CheckpointManager; dataDir: string }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "memory-tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return { checkpoint: new CheckpointManager(dir), dataDir: dir };
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager record-count reconciliation", () => {
+  it("counts captured L0 messages rather than capture batches", async () => {
+    const { checkpoint } = await createManager();
+
+    await checkpoint.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 100,
+      messageCount: 3,
+    }));
+
+    const state = await checkpoint.read();
+    expect(state.l0_conversations_count).toBe(3);
+    expect(state.total_processed).toBe(3);
+  });
+
+  it("replaces inflated retained-record counters with authoritative counts", async () => {
+    const { checkpoint } = await createManager();
+    const initial = await checkpoint.read();
+    await checkpoint.write({
+      ...initial,
+      l0_conversations_count: 999,
+      total_memories_extracted: 888,
+      total_processed: 1234,
+      memories_since_last_persona: 42,
+    });
+
+    await checkpoint.recalculateRecordCounts({ l0Conversations: 7, l1Memories: 4 });
+
+    const state = await checkpoint.read();
+    expect(state.l0_conversations_count).toBe(7);
+    expect(state.total_memories_extracted).toBe(4);
+    // Reconciliation must not turn record inventory into a progress cursor.
+    expect(state.total_processed).toBe(1234);
+    expect(state.memories_since_last_persona).toBe(42);
+  });
+
+  it("recalculates local JSONL counts after a manual file trim", async () => {
+    const { checkpoint, dataDir } = await createManager();
+    await mkdir(path.join(dataDir, "conversations"), { recursive: true });
+    await mkdir(path.join(dataDir, "records"), { recursive: true });
+    await writeFile(
+      path.join(dataDir, "conversations", "2026-07-22.jsonl"),
+      '{"id":"l0-1"}\nnot-json\n{"id":"l0-2"}\n',
+      "utf-8",
+    );
+    await writeFile(
+      path.join(dataDir, "records", "2026-07-22.jsonl"),
+      '{"id":"l1-1"}\n',
+      "utf-8",
+    );
+
+    const counts = await checkpoint.recalculateLocalRecordCounts();
+    const state = await checkpoint.read();
+    expect(counts).toEqual({ l0Conversations: 2, l1Memories: 1 });
+    expect(state.l0_conversations_count).toBe(2);
+    expect(state.total_memories_extracted).toBe(1);
+  });
+
+  it("resets only the selected session's progress so rolled-back data can be reprocessed", async () => {
+    const { checkpoint } = await createManager();
+    await checkpoint.markL1ExtractionComplete("replace-me", 2, 100, "old scene");
+    await checkpoint.markL1ExtractionComplete("keep-me", 1, 200, "keep scene");
+    await checkpoint.mergePipelineStates({
+      "replace-me": {
+        conversation_count: 3,
+        last_extraction_time: "2026-01-01T00:00:00.000Z",
+        last_extraction_updated_time: "2026-01-01T00:00:00.000Z",
+        last_active_time: 100,
+        l2_pending_l1_count: 3,
+        warmup_threshold: 4,
+        l2_last_extraction_time: "",
+      },
+      "keep-me": {
+        conversation_count: 1,
+        last_extraction_time: "",
+        last_extraction_updated_time: "",
+        last_active_time: 200,
+        l2_pending_l1_count: 0,
+        warmup_threshold: 1,
+        l2_last_extraction_time: "",
+      },
+    });
+
+    await checkpoint.resetSessionProgress("replace-me");
+
+    const state = await checkpoint.read();
+    expect(state.runner_states["replace-me"]).toBeUndefined();
+    expect(state.pipeline_states["replace-me"]).toBeUndefined();
+    expect(state.runner_states["keep-me"].last_l1_cursor).toBe(200);
+    expect(state.pipeline_states["keep-me"].conversation_count).toBe(1);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -100,12 +100,31 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /**
+   * Best-effort count of retained L0 message records.
+   *
+   * Capture updates this optimistically.  Destructive operations must call
+   * `recalculateRecordCounts()` with counts from the authoritative store so
+   * this value does not drift from the records that are still available.
+   */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /**
+   * Best-effort count of retained L1 memory records.
+   *
+   * L1 extraction updates this optimistically.  Merge/delete/cleanup paths
+   * reconcile it through `recalculateRecordCounts()`.
+   */
   total_memories_extracted: number;
+}
+
+/** Current record inventory obtained from the active storage backend. */
+export interface CheckpointRecordCounts {
+  /** Number of retained L0 conversation message records. */
+  l0Conversations: number;
+  /** Number of retained L1 memory records. */
+  l1Memories: number;
 }
 
 const DEFAULT_RUNNER_STATE: RunnerSessionState = {
@@ -179,10 +198,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -431,6 +452,73 @@ export class CheckpointManager {
     );
   }
 
+  /**
+   * Reconcile aggregate L0/L1 record counts with an authoritative store.
+   *
+   * The checkpoint does not own the JSONL/SQLite/TCVDB data, so it cannot
+   * safely infer counts after files or rows are deleted elsewhere.  Callers
+   * that perform destructive work must obtain the remaining inventory from
+   * their source of truth and pass it here.  Updating both values in one
+   * locked mutation prevents readers from observing a half-reconciled state.
+   *
+   * This deliberately does not change progress cursors (`last_l1_cursor`,
+   * `last_captured_timestamp`) or persona scheduling counters.  Those carry
+   * different semantics: a data rollback that needs records reprocessed must
+   * explicitly reset the affected session with `resetSessionProgress()`.
+   */
+  async recalculateRecordCounts(counts: CheckpointRecordCounts): Promise<void> {
+    const l0Conversations = validateRecordCount(counts.l0Conversations, "l0Conversations");
+    const l1Memories = validateRecordCount(counts.l1Memories, "l1Memories");
+
+    await this.mutate((cp) => {
+      cp.l0_conversations_count = l0Conversations;
+      cp.total_memories_extracted = l1Memories;
+    });
+    this.logger.info(
+      `[checkpoint] recalculateRecordCounts: ` +
+      `l0_conversations_count=${l0Conversations}, total_memories_extracted=${l1Memories}`,
+    );
+  }
+
+  /**
+   * Recalculate retained-record counts from the local JSONL fallback stores.
+   *
+   * This is intended for manual JSONL edits when no SQLite/TCVDB inventory is
+   * available to query.  A vector-store deployment should instead pass its
+   * database counts to `recalculateRecordCounts()`, because the database is
+   * the active retrieval source of truth in that mode.
+   */
+  async recalculateLocalRecordCounts(): Promise<CheckpointRecordCounts> {
+    const [l0Conversations, l1Memories] = await Promise.all([
+      countLocalJsonRecords(path.join(this.dataDir, "conversations")),
+      countLocalJsonRecords(path.join(this.dataDir, "records")),
+    ]);
+    const counts = { l0Conversations, l1Memories };
+    await this.recalculateRecordCounts(counts);
+    return counts;
+  }
+
+  /**
+   * Forget persisted progress for one session.
+   *
+   * Use after intentionally replacing, rolling back, or manually pruning a
+   * session's L0 data when the next L1 run must inspect that data from the
+   * beginning.  This removes both runner-owned cursors and persisted pipeline
+   * scheduling state; it leaves global aggregate counters untouched because
+   * callers must reconcile those from storage separately.
+   */
+  async resetSessionProgress(sessionKey: string): Promise<void> {
+    if (!sessionKey) {
+      throw new Error("sessionKey must not be empty when resetting checkpoint progress");
+    }
+
+    await this.mutate((cp) => {
+      delete cp.runner_states?.[sessionKey];
+      delete cp.pipeline_states?.[sessionKey];
+    });
+    this.logger.info(`[checkpoint] resetSessionProgress: session=${sessionKey}`);
+  }
+
   // ============================
   // Atomic capture (race-condition fix)
   // ============================
@@ -479,10 +567,54 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        // Count retained L0 message records, not capture batches. This is
+        // reconciled after destructive operations such as retention cleanup.
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }
 
+}
+
+function validateRecordCount(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer, got ${value}`);
+  }
+  return value;
+}
+
+/** Count valid records visible to the local fallback readers. */
+async function countLocalJsonRecords(dirPath: string): Promise<number> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    // Keep this in sync with l0-recorder.ts and l1-reader.ts: only dated
+    // JSONL shards participate in fallback retrieval. Counting arbitrary
+    // metadata or backup JSON files would reintroduce counter drift.
+    if (!entry.isFile() || !/^\d{4}-\d{2}-\d{2}\.jsonl$/.test(entry.name)) continue;
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+    } catch {
+      continue;
+    }
+
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        JSON.parse(line);
+        count += 1;
+      } catch {
+        // The JSONL readers skip malformed lines, so reconciliation does too.
+      }
+    }
+  }
+  return count;
 }

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "memory-tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalMemoryCleaner checkpoint reconciliation", () => {
+  it("recalculates retained L0/L1 counts after vector-store cleanup", async () => {
+    const baseDir = await createTempDir();
+    const checkpoint = new CheckpointManager(baseDir);
+    const initial = await checkpoint.read();
+    await checkpoint.write({
+      ...initial,
+      l0_conversations_count: 900,
+      total_memories_extracted: 800,
+    });
+
+    let l0Count = 70;
+    let l1Count = 40;
+    const vectorStore = {
+      countL0: async () => l0Count,
+      countL1: async () => l1Count,
+      deleteL0Expired: async () => {
+        l0Count -= 12;
+        return 12;
+      },
+      deleteL1Expired: async () => {
+        l1Count -= 9;
+        return 9;
+      },
+    } as unknown as IMemoryStore;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 3,
+      cleanTime: "03:00",
+      vectorStore,
+    });
+
+    await cleaner.runOnce(new Date("2026-07-22T12:00:00.000Z").getTime());
+
+    const state = await checkpoint.read();
+    expect(state.l0_conversations_count).toBe(58);
+    expect(state.total_memories_extracted).toBe(31);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager, type CheckpointRecordCounts } from "./checkpoint.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
@@ -180,10 +181,49 @@ export class LocalMemoryCleaner {
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
     }
 
+    await this.recalculateCheckpointRecordCounts();
+
     this.opts.logger?.info(
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+  }
+
+  /**
+   * Keep checkpoint inventory counters aligned with the records that remain
+   * after cleanup.  The vector store is the retrieval source of truth when it
+   * is available; otherwise count the local JSONL fallback records.
+   *
+   * Progress cursors are intentionally not changed here. Retention cleanup
+   * removes already-processed historical data, so moving a cursor backwards
+   * would re-ingest data unnecessarily. A deliberate rollback should use
+   * CheckpointManager.resetSessionProgress() instead.
+   */
+  private async recalculateCheckpointRecordCounts(): Promise<void> {
+    let counts: CheckpointRecordCounts;
+
+    try {
+      if (this.vectorStore) {
+        const [l0Conversations, l1Memories] = await Promise.all([
+          this.vectorStore.countL0(),
+          this.vectorStore.countL1(),
+        ]);
+        counts = { l0Conversations, l1Memories };
+      } else {
+        const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+        await checkpoint.recalculateLocalRecordCounts();
+        return;
+      }
+
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await checkpoint.recalculateRecordCounts(counts);
+    } catch (err) {
+      // Cleanup itself has already completed.  Do not turn a non-critical
+      // checkpoint reconciliation failure into a failed retention job.
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint count reconciliation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private scheduleNext(): void {


### PR DESCRIPTION
## Description | 描述

Fix checkpoint record-count drift after destructive data operations.

The checkpoint contains two distinct kinds of state:

- Retained-record inventory counters: `l0_conversations_count` and `total_memories_extracted`
- Per-session progress cursors and pipeline state, such as `last_l1_cursor`

Previously, `memory-cleaner` removed L0/L1 data without reconciling retained-record counters, so the checkpoint could permanently overestimate the records that remained.

This PR:

- Adds `CheckpointManager.recalculateRecordCounts()` for atomically reconciling L0/L1 retained-record counts with an authoritative store.
- Adds `recalculateLocalRecordCounts()` for local JSONL fallback deployments.
- Adds `resetSessionProgress(sessionKey)` for an intentional session rollback or replacement, allowing restored data to enter L1 processing again.
- Reconciles checkpoint counts automatically after `memory-cleaner` completes.
- Counts L0 by captured message count rather than capture batches.
- Adds regression tests and a checkpoint recovery runbook.

Normal retention cleanup intentionally preserves session cursors because it removes historical data that has already been processed. An intentional data rollback should explicitly call `resetSessionProgress(sessionKey)`.

## Related Issue | 关联 Issue

Fixes https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157
<!-- Replace this line with: Closes #<issue-number> -->

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Targeted Vitest passed: `src/utils/checkpoint.test.ts` and `src/utils/memory-cleaner.test.ts` — 2 files / 5 tests.
- [x] Full Vitest passed: 6 files / 72 tests.
- [x] `npm pack` passed after the production build; generated package size: 727.7 kB.
- [x] `git diff --check` passed.
- [x] No intended behavior change for normal retention cleanup: session cursors remain unchanged unless rollback is explicitly requested.

## Additional Notes | 其他说明

- `total_processed`, `memories_since_last_persona`, and `scenes_processed` are historical processing/persona scheduling state, so they are intentionally not recalculated as retained-record inventory.
- Manual JSONL trimming and session rollback procedures are documented in `docs/checkpoint-reconciliation.md`.
