### PR TITLE
fix(search): harden FTS5 query sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **FTS5 查询语义防护** ([#160](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160))：`buildFtsQuery()` 现在会在分词前移除独立的全大写 FTS5 布尔/邻近运算符，并将所有剩余 token 严格转义为短语字面量，防止用户输入或异常 tokenizer 输出改变 `MATCH` 查询语义，同时保留小写自然语言及 `android`、`notebook`、`nearby` 等正常关键词的召回。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/store/sqlite-fts-query.test.ts
+++ b/src/core/store/sqlite-fts-query.test.ts
@@ -1,0 +1,179 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+  sanitizeFts5Input,
+} from "./sqlite.js";
+
+const SAFE_LITERAL_QUERY = /^"(?:[^"]|"")+"(?: OR "(?:[^"]|"")+")*$/;
+
+function createFtsIndex(contents: string[]): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+  const insert = db.prepare("INSERT INTO docs(content) VALUES (?)");
+  for (const content of contents) insert.run(content);
+  return db;
+}
+
+function searchRowIds(db: DatabaseSync, raw: string): number[] {
+  const query = buildFtsQuery(raw);
+  if (!query) return [];
+  return (
+    db
+      .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+      .all(query) as Array<{ rowid: number }>
+  ).map((row) => row.rowid);
+}
+
+afterEach(() => {
+  _resetJiebaForTest();
+});
+
+describe("sanitizeFts5Input", () => {
+  it("removes standalone uppercase boolean and proximity operators", () => {
+    const value = sanitizeFts5Input("alpha AND beta OR NOT gamma NEAR(delta)");
+    expect(value.replace(/\s+/g, " ").trim()).toBe("alpha beta gamma (delta)");
+  });
+
+  it("preserves lowercase prose and embedded operator substrings", () => {
+    const value =
+      "and or not near And Or Not Near android origin notebook nearby 中文AND测试";
+    expect(sanitizeFts5Input(value)).toBe(value);
+  });
+});
+
+describe("buildFtsQuery", () => {
+  it("sanitizes operators before fallback tokenization", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta or gamma")).toBe(
+      '"alpha" OR "beta" OR "or" OR "gamma"',
+    );
+    expect(buildFtsQuery("AND OR NOT NEAR")).toBeNull();
+  });
+
+  it("sanitizes operators before jieba tokenization", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        seen.push(text);
+        return text.split(/\s+/);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe(
+      '"用户" OR "TypeScript" OR "记忆"',
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).not.toMatch(/\b(?:AND|OR|NOT|NEAR)\b/);
+  });
+
+  it("contains hostile tokenizer output inside escaped phrase literals", () => {
+    _setJiebaForTest({
+      cutForSearch: () => [
+        'alpha" OR beta',
+        "gamma*",
+        "NEAR(alpha beta)",
+        "NOT",
+        "(delta)",
+      ],
+    });
+    const db = createFtsIndex(["alpha OR beta", "gamma", "delta", "unrelated"]);
+
+    try {
+      const query = buildFtsQuery("ignored raw input");
+      expect(query).toBe(
+        '"alpha"" OR beta" OR "gamma*" OR "NEAR(alpha beta)" OR "(delta)"',
+      );
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    ['alpha" OR beta', "quote and OR"],
+    ["alpha' AND beta", "apostrophe and AND"],
+    ["(alpha) NOT beta", "parentheses and NOT"],
+    ["NEAR(alpha beta, 5)", "NEAR expression"],
+    ["alpha*", "prefix operator"],
+    ["content:alpha", "column filter"],
+    ["alpha ^ beta", "caret syntax"],
+  ])("executes %s as literal terms (%s)", (raw) => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex(["alpha beta", "content alpha", "unrelated"]);
+
+    try {
+      const query = buildFtsQuery(raw);
+      expect(query).not.toBeNull();
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("prevents raw operator text from changing OR-recall semantics", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "alpha only",
+      "beta only",
+      "alpha beta",
+      "AND boolean operator",
+      "near field",
+      "unrelated",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "alpha AND missing")).toEqual([1, 3]);
+      expect(searchRowIds(db, "alpha NOT beta")).toEqual([1, 2, 3]);
+      expect(searchRowIds(db, "NEAR(alpha beta)")).toEqual([1, 2, 3]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves lowercase terms and benign keyword recall", () => {
+    _setJiebaForTest(null);
+    const db = createFtsIndex([
+      "research and development",
+      "meet near the station",
+      "android origin notebook nearby",
+      "中文AND测试",
+      "unrelated",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "and")).toEqual([1]);
+      expect(searchRowIds(db, "near")).toEqual([2]);
+      expect(searchRowIds(db, "android origin notebook nearby")).toEqual([3]);
+      expect(searchRowIds(db, "中文AND测试")).toEqual([4]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves normal Chinese jieba search tokens", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["北京", "烤鸭", "北京烤鸭"],
+    });
+    const db = createFtsIndex(["北京 烤鸭 北京烤鸭", "上海 小笼包"]);
+
+    try {
+      expect(buildFtsQuery("北京烤鸭")).toBe(
+        '"北京" OR "烤鸭" OR "北京烤鸭"',
+      );
+      expect(searchRowIds(db, "北京烤鸭")).toEqual([1]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -174,6 +174,34 @@ const ZH_STOP_WORDS = new Set([
   "吗", "吧", "呢", "啊", "呀", "哦", "嗯",
 ]);
 
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+// FTS5 operators are case-sensitive. Match only standalone uppercase words so
+// ordinary prose and terms such as "android", "notebook", and "nearby" keep
+// their existing recall behavior.
+const FTS5_OPERATOR_PATTERN =
+  /(?<![\p{L}\p{N}_])(?:AND|OR|NOT|NEAR)(?![\p{L}\p{N}_])/gu;
+
+/** Remove standalone raw FTS5 operators before tokenization. */
+export function sanitizeFts5Input(raw: string): string {
+  return raw.replace(FTS5_OPERATOR_PATTERN, " ");
+}
+
+function sanitizeFts5Token(token: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed || !/[\p{L}\p{N}]/u.test(trimmed)) return null;
+
+  // Defense in depth: a custom tokenizer must not reintroduce an operator
+  // removed from the raw query.
+  if (FTS5_RESERVED_OPERATORS.has(trimmed)) return null;
+  return trimmed;
+}
+
+function quoteFts5Phrase(token: string): string {
+  // FTS5 quoted strings escape embedded quotes by doubling them.
+  return `"${token.replaceAll('"', '""')}"`;
+}
+
 /**
  * Build an FTS5 MATCH query from raw text.
  *
@@ -183,6 +211,10 @@ const ZH_STOP_WORDS = new Set([
  *
  * Falls back to Unicode-regex splitting (`/[\p{L}\p{N}_]+/gu`) if
  * jieba is not installed.
+ *
+ * Standalone uppercase FTS5 operators are removed before tokenization. Every
+ * remaining token is emitted as an escaped quoted phrase, preventing tokenizer
+ * output from crossing the literal boundary and changing MATCH semantics.
  *
  * Tokens are OR-joined as quoted FTS5 phrase terms so that a document
  * matching *any* token is returned.  BM25 naturally ranks documents that
@@ -196,6 +228,7 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const cleaned = sanitizeFts5Input(raw);
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,29 +236,24 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .cutForSearch(cleaned, true)
+      .map(sanitizeFts5Token)
+      .filter((t): t is string => t !== null)
+      // Remove common Chinese stop-words to reduce noise
+      .filter((t) => !ZH_STOP_WORDS.has(t));
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
     // Fallback: simple Unicode regex split
     tokens =
-      raw
+      cleaned
         .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        ?.map(sanitizeFts5Token)
+        .filter((t): t is string => t !== null) ?? [];
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map(quoteFts5Phrase);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

This PR hardens `buildFtsQuery()` so raw FTS5 operator text cannot alter the repository's intended quoted-literal, OR-recall semantics.

### Root cause | 根因

`buildFtsQuery()` tokenizes raw user input and joins the resulting terms with `OR`. Although the existing quoted-term construction already limits most syntax injection, it does not explicitly remove standalone FTS5 operators before tokenization and removes embedded quotes instead of applying FTS5 phrase escaping. A custom or unexpected tokenizer result could therefore cross a weaker-than-necessary literal boundary.

### Changes | 修改内容

- Remove standalone uppercase `AND`, `OR`, `NOT`, and `NEAR` operators before both jieba and fallback tokenization.
- Use Unicode-aware boundaries so embedded substrings such as `android`, `notebook`, `nearby`, and `中文AND测试` are preserved.
- Preserve lowercase natural-language terms such as `and` and `near`, because FTS5 operators are case-sensitive.
- Validate tokenizer output and reject exact reserved-operator tokens as defense in depth.
- Escape embedded double quotes using FTS5 quoted-string rules before joining phrase literals with `OR`.
- Add real in-memory SQLite FTS5 regression tests covering fallback/jieba paths, hostile tokenizer output, operator semantics, English recall, and Chinese recall.
- Record the user-visible fix in `CHANGELOG.md` under `[Unreleased]`.

### Compatibility | 兼容性

The change keeps the existing broad OR-recall behavior. It does not add an AND/NOT query mode, change the FTS index schema, rebuild stored indexes, or affect the TCVDB query path.

## Related Issue | 关联 Issue

Fixes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

### Verification | 验证

```text
Targeted FTS5 suite
  1 test file / 15 tests passed
  Includes real in-memory SQLite FTS5 MATCH execution

Full repository suite
  5 test files / 82 tests passed

Build
  npm run build passed
  Plugin and all three published scripts compiled successfully

Package boundary
  npm pack --dry-run --json --ignore-scripts passed
  The new *.test.ts file is excluded from the published package

Repository hygiene
  git diff --cached --check passed before commit
  One focused commit based on current upstream/main
  Commit includes the required DCO Signed-off-by line
```

There are other submissions associated with #160. This PR is intentionally self-contained and focuses on explicit operator removal plus literal-boundary hardening without sacrificing ordinary lowercase, embedded-substring, or Chinese keyword recall.
