### PR TITLE
fix(checkpoint): recalibrate counters from live storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **Checkpoint 计数器启动校准** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：Gateway 在首次 capture 前使用实时存储的 L0/L1 行数修正只增不减的 `l0_conversations_count` 与 `total_memories_extracted`，使 cleaner 或人工清理后的统计恢复准确。校准与 capture/L1 更新共用 checkpoint 文件锁；strict 计数可区分合法空库与读取故障，故障或无效计数不会覆盖已有统计。
+  - L0 增量改为按实际写入的 `messageCount` 累加，与数据库行数保持同一口径；降级存储不会触发校准，append-only 的 L1 JSONL 也不会被误作实时记录数。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -26,6 +26,7 @@ import type { MemoryRecord } from "../record/l1-writer.js";
 import type { EmbeddingProviderInfo } from "./embedding.js";
 import type {
   IMemoryStore,
+  CountOptions,
   StoreCapabilities,
   L0Record,
   L1SearchResult,
@@ -1335,8 +1336,13 @@ export class VectorStore implements IMemoryStore {
   /**
    * Get the total number of records in the store.
    */
-  countL1(): number {
-    if (this.degraded) return 0;
+  countL1(options: CountOptions = {}): number {
+    if (this.degraded) {
+      if (options.strict) {
+        throw new Error("Cannot count L1 records: store is degraded");
+      }
+      return 0;
+    }
     try {
       const row = this.db
         .prepare("SELECT COUNT(*) AS cnt FROM l1_records")
@@ -1345,8 +1351,9 @@ export class VectorStore implements IMemoryStore {
       return row.cnt;
     } catch (err) {
       this.logger?.warn(
-        `${TAG} count failed (non-fatal, returning 0): ${err instanceof Error ? err.message : String(err)}`,
+        `${TAG} count failed${options.strict ? "" : " (non-fatal, returning 0)"}: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (options.strict) throw err;
       return 0;
     }
   }
@@ -1742,8 +1749,13 @@ export class VectorStore implements IMemoryStore {
    *
    * **Fault-tolerant**: returns 0 on failure.
    */
-  countL0(): number {
-    if (this.degraded) return 0;
+  countL0(options: CountOptions = {}): number {
+    if (this.degraded) {
+      if (options.strict) {
+        throw new Error("Cannot count L0 records: store is degraded");
+      }
+      return 0;
+    }
     try {
       const row = this.db
         .prepare("SELECT COUNT(*) AS cnt FROM l0_conversations")
@@ -1752,8 +1764,9 @@ export class VectorStore implements IMemoryStore {
       return row.cnt;
     } catch (err) {
       this.logger?.warn(
-        `${TAG} countL0 failed (non-fatal, returning 0): ${err instanceof Error ? err.message : String(err)}`,
+        `${TAG} countL0 failed${options.strict ? "" : " (non-fatal, returning 0)"}: ${err instanceof Error ? err.message : String(err)}`,
       );
+      if (options.strict) throw err;
       return 0;
     }
   }

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -15,6 +15,7 @@ import type { MemoryRecord } from "../record/l1-writer.js";
 import type { EmbeddingProviderInfo } from "./embedding.js";
 import type {
   IMemoryStore,
+  CountOptions,
   StoreCapabilities,
   StoreInitResult,
   L1SearchResult,
@@ -555,13 +556,17 @@ export class TcvdbMemoryStore implements IMemoryStore {
 
   // ── L1 Read Operations ───────────────────────────────────
 
-  async countL1(): Promise<number> {
+  async countL1(options: CountOptions = {}): Promise<number> {
     try {
       await this._ensureInit();
-      if (this.degraded) return 0;
+      if (this.degraded) {
+        if (options.strict) throw new Error("Cannot count L1 records: store is degraded");
+        return 0;
+      }
       return await this.client.count(this.l1Collection);
     } catch (err) {
       this.logger?.warn(`${TAG} [L1-count] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      if (options.strict) throw err;
       return 0;
     }
   }
@@ -857,13 +862,17 @@ export class TcvdbMemoryStore implements IMemoryStore {
 
   // ── L0 Read Operations ───────────────────────────────────
 
-  async countL0(): Promise<number> {
+  async countL0(options: CountOptions = {}): Promise<number> {
     try {
       await this._ensureInit();
-      if (this.degraded) return 0;
+      if (this.degraded) {
+        if (options.strict) throw new Error("Cannot count L0 records: store is degraded");
+        return 0;
+      }
       return await this.client.count(this.l0Collection);
     } catch (err) {
       this.logger?.warn(`${TAG} [L0-count] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      if (options.strict) throw err;
       return 0;
     }
   }

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -232,6 +232,15 @@ export interface ProfileSyncRecord extends ProfileRecord {
  */
 export type MaybePromise<T> = T | Promise<T>;
 
+/** Controls whether count operations preserve their legacy fault-tolerant fallback. */
+export interface CountOptions {
+  /**
+   * Throw when the count cannot be read instead of returning zero.
+   * Use this when zero and an unavailable store must be distinguished.
+   */
+  strict?: boolean;
+}
+
 export interface IMemoryStore {
   // ── Capabilities ───────────────────────────────────────────
 
@@ -260,7 +269,7 @@ export interface IMemoryStore {
 
   // ── L1 Read ──────────────────────────────────────────────
 
-  countL1(): MaybePromise<number>;
+  countL1(options?: CountOptions): MaybePromise<number>;
   queryL1Records(filter?: L1QueryFilter): MaybePromise<L1RecordRow[]>;
   getAllL1Texts(): MaybePromise<Array<{ record_id: string; content: string; updated_time: string }>>;
 
@@ -285,7 +294,7 @@ export interface IMemoryStore {
 
   // ── L0 Read ──────────────────────────────────────────────
 
-  countL0(): MaybePromise<number>;
+  countL0(options?: CountOptions): MaybePromise<number>;
   queryL0ForL1(sessionKey: string, afterRecordedAtMs?: number, limit?: number): MaybePromise<L0QueryRow[]>;
   queryL0GroupedBySessionId(sessionKey: string, afterRecordedAtMs?: number, limit?: number): MaybePromise<L0SessionGroup[]>;
   getAllL0Texts(): MaybePromise<Array<{ record_id: string; message_text: string; recorded_at: string }>>;

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -104,6 +104,8 @@ export class TdaiCore {
    * (effectively a no-op).
    */
   private schedulerStartPromise?: Promise<void>;
+  /** One-shot gate that repairs checkpoint counters before the first capture. */
+  private checkpointRecalibrationPromise?: Promise<void>;
   private storeReady?: Promise<void>;
 
   /**
@@ -264,6 +266,7 @@ export class TdaiCore {
    */
   async handleTurnCommitted(turn: CompletedTurn): Promise<CaptureResult> {
     await this.storeReady?.catch(() => {});
+    await this.ensureCheckpointRecalibrated();
     await this.ensureSchedulerStarted();
 
     return performAutoCapture({
@@ -498,6 +501,32 @@ export class TdaiCore {
     });
 
     this.logger.debug?.(`${TAG} Pipeline runners wired`);
+  }
+
+  private ensureCheckpointRecalibrated(): Promise<void> {
+    if (this.checkpointRecalibrationPromise) {
+      return this.checkpointRecalibrationPromise;
+    }
+
+    const source = this.vectorStore;
+    if (!source || source.isDegraded()) {
+      this.logger.debug?.(`${TAG} Checkpoint recalibration skipped: store unavailable`);
+      this.checkpointRecalibrationPromise = Promise.resolve();
+      return this.checkpointRecalibrationPromise;
+    }
+
+    const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+    this.checkpointRecalibrationPromise = checkpoint
+      .recalibrate(source)
+      .then(() => undefined)
+      .catch((err) => {
+        this.logger.warn(
+          `${TAG} Checkpoint recalibration failed; will retry before the next capture: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        this.checkpointRecalibrationPromise = undefined;
+      });
+
+    return this.checkpointRecalibrationPromise;
   }
 
   private ensureSchedulerStarted(): Promise<void> {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CheckpointManager, type CheckpointCountSource } from "./checkpoint.js";
+
+describe("CheckpointManager recalibration", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "tdai-checkpoint-"));
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  const source = (l0: number, l1: number): CheckpointCountSource => ({
+    countL0: vi.fn((options?: { strict?: boolean }) => {
+      expect(options).toEqual({ strict: true });
+      return l0;
+    }),
+    countL1: vi.fn((options?: { strict?: boolean }) => {
+      expect(options).toEqual({ strict: true });
+      return l1;
+    }),
+  });
+
+  async function seed(manager: CheckpointManager): Promise<void> {
+    await manager.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 100,
+      messageCount: 5,
+    }));
+    await manager.markL1ExtractionComplete("session-a", 10, 90, "scene-a");
+    await manager.setPersonaUpdateRequest("keep-me");
+    await manager.incrementScenesProcessed();
+  }
+
+  it("repairs downward drift while preserving unrelated checkpoint state", async () => {
+    const manager = new CheckpointManager(dataDir);
+    await seed(manager);
+
+    const result = await manager.recalibrate(source(2, 3));
+    const checkpoint = await manager.read();
+
+    expect(result).toEqual({
+      l0: { before: 5, observed: 2, after: 2 },
+      l1: { before: 10, observed: 3, after: 3 },
+      changed: true,
+    });
+    expect(checkpoint.l0_conversations_count).toBe(2);
+    expect(checkpoint.total_memories_extracted).toBe(3);
+    expect(checkpoint.total_processed).toBe(5);
+    expect(checkpoint.request_persona_update).toBe(true);
+    expect(checkpoint.persona_update_reason).toBe("keep-me");
+    expect(checkpoint.scenes_processed).toBe(1);
+    expect(checkpoint.runner_states["session-a"]?.last_scene_name).toBe("scene-a");
+  });
+
+  it("applies a legitimate empty-store count and is idempotent", async () => {
+    const manager = new CheckpointManager(dataDir);
+    await seed(manager);
+
+    const first = await manager.recalibrate(source(0, 0));
+    const second = await manager.recalibrate(source(0, 0));
+    const checkpoint = await manager.read();
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(checkpoint.l0_conversations_count).toBe(0);
+    expect(checkpoint.total_memories_extracted).toBe(0);
+  });
+
+  it.each([Number.NaN, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid store count %s without changing the checkpoint",
+    async (invalidCount) => {
+      const manager = new CheckpointManager(dataDir);
+      await seed(manager);
+      const before = await manager.read();
+
+      await expect(manager.recalibrate(source(invalidCount, 3))).rejects.toThrow(
+        "Invalid L0 count from store",
+      );
+
+      expect(await manager.read()).toEqual(before);
+    },
+  );
+
+  it("leaves the checkpoint unchanged when a strict store count fails", async () => {
+    const manager = new CheckpointManager(dataDir);
+    await seed(manager);
+    const before = await manager.read();
+    const failingSource: CheckpointCountSource = {
+      countL0: () => {
+        throw new Error("store unavailable");
+      },
+      countL1: () => 3,
+    };
+
+    await expect(manager.recalibrate(failingSource)).rejects.toThrow("store unavailable");
+    expect(await manager.read()).toEqual(before);
+  });
+
+  it("serializes recalibration with capture so neither update is lost", async () => {
+    const recalibrator = new CheckpointManager(dataDir);
+    const capturer = new CheckpointManager(dataDir);
+    let releaseCount!: () => void;
+    let countStarted!: () => void;
+    const countStartedPromise = new Promise<void>((resolve) => { countStarted = resolve; });
+    const releaseCountPromise = new Promise<void>((resolve) => { releaseCount = resolve; });
+
+    const recalibration = recalibrator.recalibrate({
+      countL0: async () => {
+        countStarted();
+        await releaseCountPromise;
+        return 4;
+      },
+      countL1: () => 0,
+    });
+    await countStartedPromise;
+
+    const capture = capturer.captureAtomically("session-b", undefined, async () => ({
+      maxTimestamp: 200,
+      messageCount: 2,
+    }));
+    releaseCount();
+    await Promise.all([recalibration, capture]);
+
+    const checkpoint = await recalibrator.read();
+    expect(checkpoint.l0_conversations_count).toBe(6);
+    expect(checkpoint.total_processed).toBe(2);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -144,6 +144,25 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+/** Live store counts used to repair checkpoint drift at startup. */
+export interface CheckpointCountSource {
+  countL0(options?: { strict?: boolean }): number | Promise<number>;
+  countL1(options?: { strict?: boolean }): number | Promise<number>;
+}
+
+export interface RecalibrationResult {
+  l0: { before: number; observed: number; after: number };
+  l1: { before: number; observed: number; after: number };
+  changed: boolean;
+}
+
+function validateObservedCount(value: number, label: "L0" | "L1"): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Invalid ${label} count from store: ${String(value)}`);
+  }
+  return value;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -449,8 +468,9 @@ export class CheckpointManager {
    *   - `{ maxTimestamp, messageCount }` to advance the cursor, or
    *   - `null` to leave the cursor unchanged (nothing captured).
    *
-   * L0 conversation count is also incremented inside the lock when messages
-   * are captured, removing the need for a separate `incrementL0ConversationCount()` call.
+   * L0 record count is incremented by `messageCount` inside the lock when
+   * messages are captured. This keeps the checkpoint aligned with the L0
+   * store row count used by startup recalibration.
    *
    * @param sessionKey   Per-session identifier
    * @param pluginStartTimestamp  Cold-start floor (used when no cursor exists yet)
@@ -479,10 +499,56 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        // Count persisted L0 message rows, not capture callbacks.
+        cp.l0_conversations_count += result.messageCount;
       }
     });
+  }
+
+  // ============================
+  // Startup recalibration (issue #157)
+  // ============================
+
+  /**
+   * Reconcile incremented counters with live store rows before capture starts.
+   *
+   * Store reads happen while holding the same checkpoint lock used by capture
+   * and L1 completion. This method is intentionally a startup operation: the
+   * caller must run it before starting pipeline work.
+   *
+   * Strict counts distinguish a legitimately empty store from a read failure:
+   * zero is applied, while failures and invalid, negative, fractional, or
+   * unsafe counts abort the mutation and leave the checkpoint unchanged.
+   */
+  async recalibrate(source: CheckpointCountSource): Promise<RecalibrationResult> {
+    let result: RecalibrationResult | undefined;
+
+    await this.mutate(async (cp) => {
+      const [l0Value, l1Value] = await Promise.all([
+        source.countL0({ strict: true }),
+        source.countL1({ strict: true }),
+      ]);
+      const observedL0 = validateObservedCount(l0Value, "L0");
+      const observedL1 = validateObservedCount(l1Value, "L1");
+      const beforeL0 = cp.l0_conversations_count;
+      const beforeL1 = cp.total_memories_extracted;
+
+      cp.l0_conversations_count = observedL0;
+      cp.total_memories_extracted = observedL1;
+      result = {
+        l0: { before: beforeL0, observed: observedL0, after: observedL0 },
+        l1: { before: beforeL1, observed: observedL1, after: observedL1 },
+        changed: beforeL0 !== observedL0 || beforeL1 !== observedL1,
+      };
+    });
+
+    if (!result) throw new Error("Checkpoint recalibration did not produce a result");
+    this.logger.info(
+      "[checkpoint] recalibrate: l0 " + result.l0.before + "→" + result.l0.after +
+      ", l1 " + result.l1.before + "→" + result.l1.after +
+      (result.changed ? "" : " (no drift)"),
+    );
+    return result;
   }
 
 }


### PR DESCRIPTION
## Description | 描述

Fix checkpoint counter drift after cleaner runs or manual record deletion.

- Recalibrate `l0_conversations_count` and `total_memories_extracted` from live storage once after store readiness and before the first capture.
- Serialize recalibration with capture and L1 checkpoint updates through the existing per-file lock, preventing stale overwrites.
- Add an opt-in strict count mode for SQLite and TencentDB VectorDB so a legitimate empty store is distinguishable from a count failure. Existing callers keep the fault-tolerant zero fallback.
- Count persisted L0 message rows using the actual `messageCount`, matching the storage count used for recalibration.
- Reject invalid counts without modifying the checkpoint and retry a failed startup recalibration before a later capture.

## Related Issue | 关联 Issue

Fixes #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation completed locally:

- `npm test`: 5 test files, 75 tests passed.
- `npm run build`: plugin and all scripts built successfully.
- `npm pack --dry-run --json --ignore-scripts`: package dry-run succeeded.
- `git diff --check`: no whitespace errors.

The focused checkpoint suite covers downward drift, a legitimate zero-count store, idempotency, invalid values, strict count failures, preservation of unrelated checkpoint state, and recalibration/capture concurrency.
