### PR TITLE
feat(adapters): add Claude Code adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test-offload-sessions.sh
 
 # Claude Code adapter local experiment artifacts
 .claude-tdai-experiments/
+.pi-tdai-experiments/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ test-offload-sessions.sh
 
 # log files
 *.log
+
+# Claude Code adapter local experiment artifacts
+.claude-tdai-experiments/

--- a/docs/adapters/architecture.md
+++ b/docs/adapters/architecture.md
@@ -1,0 +1,370 @@
+﻿# Adapter Architecture: TdaiCore, OpenClaw, and Hermes
+
+This document completes the foundation-stage adapter analysis for TencentDB-Agent-Memory. It explains the two memory subsystems, the host-neutral long-term core boundary, the current OpenClaw and Hermes adapter paths, and the data flow that a new platform adapter should preserve.
+
+## Scope
+
+The current project contains two parallel memory subsystems:
+
+- Short-term memory: context offload for long-running tasks. It externalizes bulky tool results, summarizes them into JSONL entries, aggregates them into Mermaid task canvases, and injects compact symbolic context back into the active prompt.
+- Long-term memory: the L0-L3 user-understanding pipeline. It records conversations, extracts atoms, builds scenarios, synthesizes persona, and recalls relevant user context across sessions.
+
+The long-term subsystem exposes one memory engine through two host integrations:
+
+- OpenClaw: an in-process TypeScript plugin registered from `index.ts`.
+- Hermes: a Python `MemoryProvider` that talks to a local Node.js Gateway over HTTP.
+
+Both long-term integrations ultimately call the same host-neutral core facade, `TdaiCore`. A new platform adapter should therefore start from the host lifecycle events and map them into the same long-term core capabilities, either directly in process or through the Gateway API.
+
+The short-term subsystem is different: it currently lives in `src/offload/` and is registered only from the OpenClaw plugin path through `registerOffload()`. It is not part of `TdaiCore` and is not currently exposed through the Hermes Gateway API.
+
+## Two-System Overview
+
+```mermaid
+flowchart TB
+  Project["TencentDB Agent Memory"]
+  Short["Short-term memory\nContext offload / symbolic canvas"]
+  Long["Long-term memory\nL0-L3 personalization pipeline"]
+
+  ShortL0["refs/*.md\nfull tool results"]
+  ShortL1["offload-<session>.jsonl\nstep summaries + result_ref"]
+  ShortL2["mmds/*.mmd\nMermaid task canvas + node_id"]
+  ShortL3["active/history MMD injection\ncompact agent context"]
+
+  LongL0["L0 Conversation\nraw dialogue"]
+  LongL1["L1 Atom\nstructured facts"]
+  LongL2["L2 Scenario\nscene blocks"]
+  LongL3["L3 Persona\nuser profile"]
+
+  Project --> Short
+  Project --> Long
+  Short --> ShortL0 --> ShortL1 --> ShortL2 --> ShortL3
+  Long --> LongL0 --> LongL1 --> LongL2 --> LongL3
+```
+
+The shared design rule is progressive disclosure. Lower layers preserve evidence; upper layers preserve structure. The two systems differ in time scale and host surface:
+
+- Short-term memory manages the current long task and token pressure.
+- Long-term memory manages cross-session recall and user understanding.
+- Short-term currently requires deep OpenClaw hooks over messages, tool calls, and context compaction.
+- Long-term can run either in process through OpenClaw or out of process through the Gateway.
+
+## Long-Term Core Boundary
+
+`TdaiCore` is the stable boundary between platform adapters and the long-term memory engine. It depends on a `HostAdapter`, configuration, and optional session filtering. Platform-specific code should stay outside the core and provide only runtime context, logging, and LLM execution.
+
+```mermaid
+flowchart TB
+  Platform["Host platform\nOpenClaw / Hermes / future agent"]
+  Adapter["HostAdapter\nruntime context, logger, LLM runner"]
+  Core["TdaiCore\nhost-neutral memory facade"]
+  Recall["handleBeforeRecall()\nturn-before memory recall"]
+  Capture["handleTurnCommitted()\nturn-after capture"]
+  MemorySearch["searchMemories()\nL1 structured memory search"]
+  ConversationSearch["searchConversations()\nL0 conversation search"]
+  SessionEnd["handleSessionEnd() / destroy()\nflush or shutdown"]
+  Store["Storage + pipeline\nL0 JSONL / vector store / L1 / L2 / L3"]
+  LLM["LLMRunnerFactory\nOpenClaw runner or standalone AI SDK runner"]
+
+  Platform --> Adapter
+  Adapter --> Core
+  Adapter --> LLM
+  Core --> Recall
+  Core --> Capture
+  Core --> MemorySearch
+  Core --> ConversationSearch
+  Core --> SessionEnd
+  Recall --> Store
+  Capture --> Store
+  MemorySearch --> Store
+  ConversationSearch --> Store
+  SessionEnd --> Store
+  Core --> LLM
+```
+
+Key source files:
+
+- `src/core/types.ts`: `RuntimeContext`, `LLMRunner`, `LLMRunnerFactory`, `HostAdapter`, turn and search types.
+- `src/core/tdai-core.ts`: core facade for recall, capture, search, session flush, and resource teardown.
+- `src/adapters/openclaw/host-adapter.ts`: OpenClaw implementation of `HostAdapter`.
+- `src/adapters/standalone/host-adapter.ts`: Gateway/Hermes implementation of `HostAdapter`.
+
+## Core Capabilities
+
+| Capability | Core method | Input shape | Output / effect | Current host mapping |
+|---|---|---|---|---|
+| Turn-before recall | `handleBeforeRecall(userText, sessionKey)` | Current user text and stable session key | `RecallResult` with prompt/system context and recall metadata | OpenClaw `before_prompt_build`; Hermes `prefetch()` through `POST /recall` |
+| Turn-after capture | `handleTurnCommitted(turn)` | `CompletedTurn` with user/assistant text, messages, session identifiers | Records L0 messages, writes embeddings when available, notifies extraction pipeline | OpenClaw `agent_end`; Hermes `sync_turn()` through `POST /capture` |
+| L1 memory search | `searchMemories(params)` | Query, limit, optional type and scene | Formatted search text, total count, strategy | OpenClaw `tdai_memory_search`; Hermes `memory_tencentdb_memory_search` through `POST /search/memories` |
+| L0 conversation search | `searchConversations(params)` | Query, limit, optional session key | Formatted raw conversation matches | OpenClaw `tdai_conversation_search`; Hermes `memory_tencentdb_conversation_search` through `POST /search/conversations` |
+| Session flush | `handleSessionEnd(sessionKey)` | One session key | Flushes buffered pipeline work for that session only | Hermes `on_session_end` / `shutdown()` through `POST /session/end` |
+| Process teardown | `destroy()` | None | Drains background tasks, stops scheduler, closes stores and embedding service | OpenClaw `gateway_stop`; Gateway process shutdown |
+
+## OpenClaw Adapter
+
+OpenClaw uses a deep, in-process plugin integration. The root `index.ts` registers tools and lifecycle hooks directly with the OpenClaw Plugin SDK, creates `OpenClawHostAdapter`, then creates one `TdaiCore` instance for the plugin process.
+
+```mermaid
+sequenceDiagram
+  participant OC as OpenClaw runtime
+  participant Plugin as index.ts plugin shell
+  participant Adapter as OpenClawHostAdapter
+  participant Core as TdaiCore
+  participant Store as Memory stores + pipeline
+
+  OC->>Plugin: register(api)
+  Plugin->>Adapter: new OpenClawHostAdapter(api, dataDir, config)
+  Plugin->>Core: new TdaiCore(adapter, config)
+  Plugin->>Core: initialize()
+
+  OC->>Plugin: before_prompt_build(event, ctx)
+  Plugin->>Plugin: cache raw prompt and message count
+  Plugin->>Core: handleBeforeRecall(event.prompt, ctx.sessionKey)
+  Core->>Store: search L1/L2/L3 context
+  Store-->>Core: recall result
+  Core-->>Plugin: RecallResult
+  Plugin-->>OC: prependContext / appendSystemContext
+
+  OC->>Plugin: before_message_write(message)
+  Plugin-->>OC: strip injected relevant memories before persistence
+
+  OC->>Plugin: agent_end(event, ctx)
+  Plugin->>Plugin: recover cached original prompt
+  Plugin->>Core: handleTurnCommitted(messages, sessionKey, sessionId)
+  Core->>Store: record L0, vectorize, notify L1/L2/L3 scheduler
+
+  OC->>Plugin: tool call
+  Plugin->>Core: searchMemories() or searchConversations()
+  Core->>Store: query memory or conversation index
+  Core-->>Plugin: formatted result
+  Plugin-->>OC: tool result
+
+  OC->>Plugin: gateway_stop
+  Plugin->>Core: destroy()
+```
+
+OpenClaw-specific responsibilities:
+
+- Parse plugin config and resolve the OpenClaw state/data directory.
+- Register OpenClaw tools: `tdai_memory_search` and `tdai_conversation_search`.
+- Register lifecycle hooks: `before_prompt_build`, `before_message_write`, `agent_end`, and `gateway_stop`.
+- Cache the original user prompt before recall injection so captured history is not polluted by injected memory text.
+- Use `OpenClawLLMRunnerFactory`, which wraps OpenClaw's embedded agent runtime through `CleanContextRunner`.
+- Optionally register the short-term context offload module through `registerOffload()`.
+
+OpenClaw's main strength is fidelity. It can access prompt-build timing, full message arrays, session context, tool registration, and message persistence hooks in the same process.
+
+## Short-Term Context Offload
+
+Short-term memory is implemented as the context offload module under `src/offload/`. It is registered from `index.ts` only when `cfg.offload.enabled` is true. Unlike long-term memory, it does not go through `TdaiCore`; it hooks directly into OpenClaw's prompt, tool-call, and context-engine surfaces.
+
+```mermaid
+sequenceDiagram
+  participant OC as OpenClaw runtime
+  participant Plugin as index.ts
+  participant Offload as registerOffload()
+  participant State as OffloadStateManager
+  participant FS as refs/jsonl/mmd storage
+  participant LLM as Offload LLM pipeline
+  participant Prompt as Active agent context
+
+  Plugin->>Offload: registerOffload(api, cfg.offload)
+  Offload->>OC: register contextEngine + hooks
+
+  OC->>Offload: after_tool_call(event, ctx)
+  Offload->>State: buffer ToolPair(toolName, params, result)
+  State->>FS: write refs/*.md with full tool result
+  State->>LLM: L1 summarize tool pair
+  LLM-->>State: summary + replaceability score
+  State->>FS: append offload-<session>.jsonl
+
+  Offload->>LLM: L1.5 task boundary judgment
+  LLM-->>State: long/short task + active MMD target
+
+  Offload->>LLM: L2 Mermaid generation when threshold/timeout hits
+  LLM-->>FS: create or patch mmds/*.mmd
+  FS-->>State: backfill node_id into JSONL entries
+
+  OC->>Offload: before_prompt_build / contextEngine.assemble
+  Offload->>FS: read offload JSONL and active/history MMD
+  Offload->>Prompt: replace old tool results with summaries
+  Offload->>Prompt: inject compact Mermaid task canvas
+  Offload->>Prompt: run mild/aggressive/emergency compression by token pressure
+```
+
+Short-term storage layers:
+
+| Layer | Artifact | Purpose | Traceability key |
+|---|---|---|---|
+| Raw evidence | `refs/*.md` | Full tool outputs and bulky logs, kept outside the model context | `result_ref` |
+| Step summaries | `offload-<session>.jsonl` | LLM-generated summary, tool call metadata, replaceability score, and later `node_id` | `tool_call_id`, `result_ref`, `node_id` |
+| Task canvas | `mmds/*.mmd` | Mermaid representation of long-task state and progress | `node_id` |
+| Runtime context | injected current/history MMD messages | Compact symbolic memory seen by the agent | MMD filename and node IDs |
+
+Important adapter implications:
+
+- A platform must expose post-tool-call events with tool name, call ID, parameters, result, duration, and preferably current messages.
+- A platform must allow mutation or replacement of messages before prompt build; otherwise L3 compression cannot reliably remove bulky history.
+- A platform should provide a context-engine-like compaction owner if it has one. In OpenClaw this is registered as `openclaw-context-offload` with `ownsCompaction: true`.
+- The OpenClaw patch script for after-tool-call messages matters because L3 compression depends on `event.messages` being populated.
+- Hermes currently has no equivalent short-term adapter path in this repository. Its Provider/Gateway integration covers long-term recall/capture/search, not symbolic context offload.
+## Hermes Adapter
+
+Hermes uses a lighter, cross-process adapter. The Python provider implements Hermes' `MemoryProvider` interface, supervises a local Node.js Gateway sidecar, and calls Gateway endpoints through `MemoryTencentdbSdkClient`. The Gateway owns `TdaiCore`.
+
+```mermaid
+sequenceDiagram
+  participant Hermes as Hermes MemoryManager
+  participant Provider as MemoryTencentdbProvider
+  participant Supervisor as GatewaySupervisor
+  participant Client as MemoryTencentdbSdkClient
+  participant Gateway as Node.js Gateway
+  participant Core as TdaiCore
+  participant Store as Memory stores + pipeline
+
+  Hermes->>Provider: initialize(session_id, user_id)
+  Provider->>Supervisor: ensure_running()
+  Supervisor->>Gateway: start or attach to 127.0.0.1:8420
+  Gateway->>Core: new TdaiCore(StandaloneHostAdapter, config)
+  Gateway->>Core: initialize()
+  Provider->>Provider: start watchdog and circuit breaker state
+
+  Hermes->>Provider: prefetch(query)
+  Provider->>Client: recall(query, session_key, user_id)
+  Client->>Gateway: POST /recall
+  Gateway->>Core: handleBeforeRecall(query, session_key)
+  Core->>Store: search memory context
+  Store-->>Core: recall result
+  Core-->>Gateway: RecallResult
+  Gateway-->>Client: context, strategy, memory_count
+  Client-->>Provider: response
+  Provider-->>Hermes: memory prompt block
+
+  Hermes->>Provider: sync_turn(user, assistant)
+  Provider->>Provider: spawn bounded background sync thread
+  Provider->>Client: capture(user, assistant, session_key)
+  Client->>Gateway: POST /capture
+  Gateway->>Core: handleTurnCommitted(completed turn)
+  Core->>Store: record L0 and notify pipeline
+
+  Hermes->>Provider: handle_tool_call(name, args)
+  Provider->>Client: POST /search/memories or /search/conversations
+  Client->>Gateway: search endpoint
+  Gateway->>Core: searchMemories() or searchConversations()
+  Core->>Store: query index
+  Gateway-->>Provider: JSON result
+  Provider-->>Hermes: JSON string result
+
+  Hermes->>Provider: on_session_end() / shutdown()
+  Provider->>Client: end_session(session_key)
+  Client->>Gateway: POST /session/end
+  Gateway->>Core: handleSessionEnd(session_key)
+```
+
+Hermes-specific responsibilities:
+
+- Register `MemoryTencentdbProvider` through `ctx.register_memory_provider(...)`.
+- Advertise Hermes tool schemas: `memory_tencentdb_memory_search` and `memory_tencentdb_conversation_search`.
+- Convert Hermes lifecycle calls to Gateway HTTP calls.
+- Start or attach to the Gateway, including auto-discovery of `src/gateway/server.ts`.
+- Keep Gateway operation resilient through health checks, a circuit breaker, a watchdog, recovery throttling, and bounded background capture threads.
+- Mirror legacy Hermes LLM environment names into Gateway-native `TDAI_LLM_*` names when spawning the Gateway.
+
+Hermes' main strength is portability. A host only needs a way to run a provider-like shim and call HTTP endpoints. The cost is lower integration fidelity: the provider normally sees `user_content` and `assistant_content`, not necessarily the same full prompt-build and message-write surface that OpenClaw exposes.
+
+## Gateway API Data Flow
+
+The Gateway is the reusable adapter target for platforms that cannot import `TdaiCore` directly.
+
+```mermaid
+flowchart LR
+  Host["New platform adapter\nProvider / plugin / bridge"]
+  Health["GET /health"]
+  Recall["POST /recall\nquery, session_key, user_id?"]
+  Capture["POST /capture\nuser_content, assistant_content,\nsession_key, session_id?, messages?"]
+  SearchMemory["POST /search/memories\nquery, limit?, type?, scene?"]
+  SearchConversation["POST /search/conversations\nquery, limit?, session_key?"]
+  End["POST /session/end\nsession_key"]
+  Gateway["TdaiGatewayServer"]
+  Core["TdaiCore"]
+  Store["L0/L1/L2/L3 storage"]
+
+  Host --> Health
+  Host --> Recall
+  Host --> Capture
+  Host --> SearchMemory
+  Host --> SearchConversation
+  Host --> End
+  Health --> Gateway
+  Recall --> Gateway
+  Capture --> Gateway
+  SearchMemory --> Gateway
+  SearchConversation --> Gateway
+  End --> Gateway
+  Gateway --> Core
+  Core --> Store
+```
+
+Endpoint behavior:
+
+- `GET /health` is always open and used by supervisors, liveness checks, and operators.
+- `POST /recall` requires `query` and `session_key`; it calls `handleBeforeRecall()` and returns a compact `context` string plus metadata.
+- `POST /capture` requires `user_content`, `assistant_content`, and `session_key`; it can optionally accept `messages`, which is useful for platforms that can provide richer turn structure.
+- `POST /search/memories` and `POST /search/conversations` expose the agent-callable search surface.
+- `POST /session/end` flushes one session. It must not be confused with process shutdown.
+- Non-health routes pass through optional Bearer auth when `TDAI_GATEWAY_API_KEY` or Gateway config `server.apiKey` is set.
+
+## OpenClaw vs Hermes Differences
+
+| Dimension | OpenClaw | Hermes |
+|---|---|---|
+| Integration style | In-process plugin | Python provider plus Node.js HTTP sidecar |
+| Core ownership | `index.ts` owns `TdaiCore` directly | Gateway owns `TdaiCore`; provider is a client |
+| Adapter implementation | `OpenClawHostAdapter` | `StandaloneHostAdapter` inside Gateway |
+| LLM runner | `OpenClawLLMRunnerFactory` via `CleanContextRunner` and embedded agent runtime | `StandaloneLLMRunnerFactory` via Vercel AI SDK and OpenAI-compatible HTTP |
+| Turn-before hook | `before_prompt_build` | `prefetch(query)` |
+| Turn-after hook | `agent_end` | `sync_turn(user, assistant)` |
+| Message persistence control | Has `before_message_write` to strip injected long-term recall context and offload hooks that rewrite prompt messages | No equivalent in provider layer |
+| Tool names | `tdai_memory_search`, `tdai_conversation_search` | `memory_tencentdb_memory_search`, `memory_tencentdb_conversation_search` |
+| Capture payload fidelity | Can pass full `event.messages` and cached original prompt metadata | Currently sends user/assistant text; Gateway supports optional `messages` for richer adapters |
+| Failure isolation | Plugin errors are handled inside OpenClaw hook paths | Provider has circuit breaker, watchdog, sidecar recovery, and bounded background threads |
+| Short-term context offload | Supported through `registerOffload()`, contextEngine, after-tool-call, before-prompt-build, and L3 compression hooks | Not currently exposed through Hermes Provider or Gateway |
+| Deployment concern | OpenClaw plugin install and gateway restart | Provider install plus Gateway process/runtime/env management |
+
+## New Adapter Guidance
+
+For the next platform, split the adapter decision into two tracks. For long-term memory, prefer the Gateway pattern unless the platform provides OpenClaw-level plugin hooks and can safely import the TypeScript core in process. For short-term memory, only claim parity when the platform can observe tool calls and rewrite prompt messages before the next model call.
+
+The minimum adapter surface should provide:
+
+- A stable `session_key` for every conversation.
+- Long-term: a turn-before recall point that can call `/recall` and inject returned context into the model input.
+- Long-term: a turn-after capture point that can call `/capture`.
+- Long-term: a tool surface for L1 and L0 search, or at least a documented manual search path.
+- Long-term: a session-end or shutdown event that can call `/session/end`.
+
+The ideal adapter surface additionally provides:
+
+- Long-term: full message arrays, including tool-call messages, passed through `/capture.messages`.
+- Long-term: a way to strip injected recall context before the host persists user messages.
+- Long-term: a clear user identity field mapped to `user_id`.
+- Long-term: Gateway auth configuration when the adapter is not loopback-only.
+- Long-term: back-pressure and recovery behavior similar to the Hermes provider if capture is asynchronous.
+- Short-term: post-tool-call access to tool results and call IDs.
+- Short-term: before-prompt-build access to mutable message arrays.
+- Short-term: storage for refs, offload JSONL, MMD files, and state per agent/session.
+- Short-term: a compaction policy that can replace or delete old tool-result messages without breaking tool-use/tool-result pairing.
+
+## Foundation Stage Status
+
+This document satisfies the foundation-stage issue criteria:
+
+- Read the source around `TdaiCore`, `HostAdapter`, OpenClaw, Hermes, Gateway, and `src/offload`.
+- Identified the long-term core capabilities and the separate short-term context-offload capability surface.
+- Mapped OpenClaw and Hermes host events to long-term core methods, and mapped OpenClaw offload hooks to the short-term symbolic canvas pipeline.
+- Documented the data flow for long-term recall, capture, search, session flush, shutdown, and short-term context offload.
+- Compared the two existing adapter strategies and recorded guidance for choosing the next platform.
+
+
+
+

--- a/docs/adapters/claude-code-design-review.md
+++ b/docs/adapters/claude-code-design-review.md
@@ -1,0 +1,175 @@
+﻿# Claude Code Adapter Design Review
+
+This document reviews the proposed Claude Code adapter design against the current TencentDB-Agent-Memory source tree and the Claude Code hook/MCP surface.
+
+For the implementation-ready v1 plan, see [Claude Code Adapter v1 Technical Design](./claude-code-v1-technical-design.md).
+
+## Verdict
+
+Claude Code is a reasonable next platform for the advanced stage, but the proposal must be split into two tracks:
+
+- Long-term memory can be adapted first through the existing Gateway API.
+- Short-term symbolic context offload can only be partially adapted through Claude Code hooks unless Claude Code exposes a deeper message-compaction surface than ordinary hooks.
+
+The proposal's main architectural instinct is sound: keep `TdaiCore` unchanged and make the new adapter a protocol translator. The biggest correction is that the Gateway API assumed by the proposal does not exist.
+
+## What The Proposal Gets Right
+
+- It treats the adapter as a thin translation layer rather than a new memory engine.
+- It keeps `TdaiCore` unchanged.
+- It identifies session boundaries, tool filtering, and MCP-vs-hooks overlap as real design risks.
+- It separates explicit search tools from automatic memory capture/injection.
+- It correctly treats unfiltered tool capture as a pollution risk.
+
+## Main Corrections
+
+### Gateway API
+
+The proposal assumes APIs such as `recallMemory`, `captureConversation`, `captureEpisode`, `updateScene`, `updateContext`, `restoreContext`, and `offloadContext`. The current Gateway does not expose these routes.
+
+Current Gateway endpoints:
+
+| Endpoint | Purpose | Backing method |
+|---|---|---|
+| `GET /health` | Liveness and health | Gateway-only |
+| `POST /recall` | Long-term recall | `TdaiCore.handleBeforeRecall()` |
+| `POST /capture` | Long-term turn capture | `TdaiCore.handleTurnCommitted()` |
+| `POST /search/memories` | L1 memory search | `TdaiCore.searchMemories()` |
+| `POST /search/conversations` | L0 conversation search | `TdaiCore.searchConversations()` |
+| `POST /session/end` | Session-scoped flush | `TdaiCore.handleSessionEnd()` |
+| `POST /seed` | Batch historical import | seed runtime |
+
+So the adapter cannot be designed against a broad generic Gateway object. It should either:
+
+- use the existing HTTP endpoints exactly, or
+- explicitly add new Gateway endpoints as a separate upstream design decision.
+
+For the advanced issue, the safer path is to avoid Gateway changes and implement only against the existing endpoints.
+
+### Hook Names And Hook Semantics
+
+The proposal uses generic names like `AfterToolUse`. Claude Code's current documented hook event is `PostToolUse`, with related events such as `PreToolUse`, `PostToolUseFailure`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreCompact`, and `PostCompact`.
+
+Claude Code hooks can inject `additionalContext` into Claude's context. That is enough for long-term recall injection and lightweight short-term canvas reminders. It is not the same as OpenClaw's ability to rewrite full mutable message arrays during prompt build.
+
+### Short-Term Offload Parity
+
+OpenClaw short-term memory depends on:
+
+- post-tool-call access to tool name, tool call ID, parameters, result, duration, and current messages;
+- before-prompt-build access to mutable messages;
+- contextEngine ownership of compaction;
+- local storage layers: `refs/*.md`, `offload-*.jsonl`, `mmds/*.mmd`, and state.
+
+Claude Code `PostToolUse` can provide tool input, tool response, tool use ID, duration, cwd, session ID, and transcript path. That is enough to collect tool events and build a symbolic canvas. It does not appear sufficient for true OpenClaw-style L3 compression, because hooks do not expose a normal "replace arbitrary old tool-result messages before model call" capability.
+
+Therefore short-term support should be described as partial in the first adapter:
+
+- capture tool results;
+- summarize and store refs/jsonl/MMD;
+- inject compact current-task MMD via hook `additionalContext`;
+- do not claim full transcript compaction or old-message replacement unless a deeper Claude Code API is available.
+
+## Corrected Architecture
+
+```mermaid
+flowchart TB
+  CC["Claude Code"]
+  Hooks["Claude Code hooks\nSessionStart / UserPromptSubmit / PostToolUse / SessionEnd"]
+  MCP["MCP server\nexplicit search tools"]
+  Adapter["Claude Code adapter\nthin protocol translator"]
+  Gateway["memory-tencentdb Gateway\nexisting HTTP API"]
+  Core["TdaiCore\nlong-term memory"]
+  Short["Local short-term offload store\nrefs / jsonl / mmd"]
+
+  CC --> Hooks --> Adapter
+  CC --> MCP --> Adapter
+  Adapter --> Gateway --> Core
+  Adapter --> Short
+  Short --> Hooks
+```
+
+## Long-Term Memory MVP
+
+The first implementation should target long-term memory only, because it maps cleanly to the existing Gateway.
+
+| Claude Code surface | Adapter action | Gateway endpoint |
+|---|---|---|
+| `UserPromptSubmit` or `SessionStart` | Build recall query from prompt/workspace context, inject returned context through `additionalContext` | `POST /recall` |
+| `SessionEnd` | Read transcript or extracted turn summary, capture conversation/turn data | `POST /capture` or `POST /seed` |
+| MCP `memory_search` | Search L1 memories | `POST /search/memories` |
+| MCP `conversation_search` | Search L0 conversations | `POST /search/conversations` |
+| `SessionEnd` after capture | Flush session pipeline work | `POST /session/end` |
+
+Key decisions:
+
+- Use Claude Code `session_id` as the first candidate for `session_key`.
+- Include `cwd` or workspace root in adapter metadata and search queries, but do not invent new Gateway fields unless the Gateway accepts them.
+- Prefer `UserPromptSubmit` for recall injection because it is closer to the actual user query than `SessionStart`.
+- Keep MCP tools explicit and named differently from hook-side automatic recall to avoid duplicate context.
+
+## Short-Term Memory MVP
+
+Short-term MVP should not depend on `TdaiCore` or the current Gateway.
+
+```mermaid
+sequenceDiagram
+  participant CC as Claude Code
+  participant Hook as PostToolUse hook
+  participant Adapter as Claude adapter
+  participant FS as refs/jsonl/mmd store
+  participant Inject as UserPromptSubmit hook
+
+  CC->>Hook: PostToolUse(tool_input, tool_response, tool_use_id)
+  Hook->>Adapter: filter tool event
+  Adapter->>FS: write refs/*.md for selected bulky result
+  Adapter->>FS: append offload-<session>.jsonl summary row
+  Adapter->>FS: update mmds/*.mmd task canvas
+  CC->>Inject: UserPromptSubmit(prompt)
+  Inject->>FS: read active MMD
+  Inject-->>CC: additionalContext with compact task canvas
+```
+
+Recommended first scope:
+
+- Capture only high-signal tools at first: write/edit operations, shell commands, failed tools, and very large outputs.
+- Keep read/search tool events out by default unless they are huge or error-producing.
+- Store raw evidence and summaries with `tool_use_id`, `result_ref`, and later `node_id`.
+- Inject active MMD context only when it is small enough and relevant to the current prompt.
+- Treat `PreCompact`/`PostCompact` as possible future hooks for preserving symbolic state around Claude Code compaction.
+
+## MCP vs Hooks
+
+Hooks and MCP should not compete.
+
+- Hooks should perform automatic, low-noise operations: recall injection, capture, flush, and short-term canvas maintenance.
+- MCP should expose explicit tools: memory search, conversation search, and possibly current task canvas retrieval.
+
+This avoids feeding Claude both automatically recalled memory and a large search result unless Claude explicitly asks for more.
+
+## Implementation Plan
+
+1. Add a Claude Code adapter design doc and config examples.
+2. Implement a small Gateway client for the existing HTTP endpoints.
+3. Implement MCP search tools over `/search/memories` and `/search/conversations`.
+4. Implement hook scripts for long-term recall/capture using Claude Code hook JSON input.
+5. Add optional short-term tool capture as a separate module with a clear "partial parity" label.
+6. Add tests for endpoint mapping, tool filtering, and formatter output.
+
+## Open Questions
+
+- Should the first implementation live inside this repo as `src/adapters/claude-code/`, or should it be packaged as a Claude Code plugin/hook bundle?
+- Should `SessionEnd` capture use `/capture` turn-by-turn or `/seed` for transcript import?
+- What exact transcript JSONL schema should the adapter support?
+- How aggressive should `UserPromptSubmit` recall be before it becomes context pollution?
+- Do we want short-term offload in v1, or do we ship long-term first and document short-term as a follow-up?
+
+## Recommendation
+
+Proceed with Claude Code as the new platform, but narrow the advanced-stage implementation target:
+
+- Phase 1: long-term memory via Gateway plus MCP search tools.
+- Phase 2: lightweight short-term symbolic canvas through `PostToolUse` capture and `additionalContext` injection.
+- Phase 3: revisit full short-term compaction only if Claude Code exposes a deeper mutable-message or compaction-owner interface.
+
+

--- a/docs/adapters/claude-code-design-review.md
+++ b/docs/adapters/claude-code-design-review.md
@@ -166,10 +166,10 @@ This avoids feeding Claude both automatically recalled memory and a large search
 
 ## Recommendation
 
-Proceed with Claude Code as the new platform, but narrow the advanced-stage implementation target:
+Proceed with Claude Code as the new platform, narrowing the advanced-stage implementation target. The v1 implementation follows this recommendation:
 
-- Phase 1: long-term memory via Gateway plus MCP search tools.
-- Phase 2: lightweight short-term symbolic canvas through `PostToolUse` capture and `additionalContext` injection.
-- Phase 3: revisit full short-term compaction only if Claude Code exposes a deeper mutable-message or compaction-owner interface.
+- Phase 1: long-term memory via Gateway plus MCP search tools — implemented in `src/adapters/claude-code/` and validated in the [Long-term Memory E2E Experiment Report](./claude-code-long-term-e2e-experiment-report.md).
+- Phase 2: lightweight short-term symbolic canvas through `PostToolUse` capture and `additionalContext` injection — implemented and validated in the [E2E Experiment Report](./claude-code-e2e-experiment-report.md).
+- Phase 3: full short-term compaction — explicitly out of scope unless Claude Code exposes a deeper mutable-message or compaction-owner interface.
 
 

--- a/docs/adapters/claude-code-e2e-experiment-report.md
+++ b/docs/adapters/claude-code-e2e-experiment-report.md
@@ -1,0 +1,156 @@
+# Claude Code Adapter E2E Experiment Report
+
+Date: 2026-07-22
+
+This report validates the Claude Code adapter with real Claude Code runtime hooks inside the project workspace.
+
+## Scope
+
+The experiment focuses on the short-term memory path:
+
+```text
+Claude Code PowerShell tool use
+  -> PostToolUse hook
+  -> short-term JSONL/ref/Mermaid store
+  -> UserPromptSubmit hook
+  -> injected short-term task canvas
+  -> Claude response without tools
+```
+
+Long-term Gateway recall/capture was intentionally disabled for this experiment so the result isolates the Claude Code hook and short-term canvas behavior.
+
+## Workspace Boundary
+
+All experiment artifacts were constrained to the repository:
+
+```text
+.claude-tdai-experiments/
+  settings.json
+  logs/
+  storage/
+  tmp/
+```
+
+`.claude-tdai-experiments/` is gitignored. The only PR-worthy artifact is this report.
+
+## Environment
+
+- Repository: `D:\Users\zzh\Desktop\腾讯开源计划\TencentDB-Agent-Memory-main`
+- Claude Code: `2.1.126`
+- Model: `claude-sonnet-4-6`
+- Settings file: `.claude-tdai-experiments/settings.json`
+- Storage root: `.claude-tdai-experiments/storage`
+- Long-term recall: disabled with `MEMORY_TENCENTDB_AUTO_RECALL=false`
+- Short-term canvas: enabled with `MEMORY_TENCENTDB_SHORT_TERM=true`
+
+## Experiment Matrix
+
+| ID | Purpose | Claude Code mode | Tool constraints | Acceptance criteria | Result |
+|---|---|---|---|---|---|
+| E1 | Minimal runtime smoke | `claude -p`, Sonnet | `PowerShell(echo *)` only | `PostToolUse` hook fires, exits 0, writes JSONL/MMD under project | PASS |
+| E2 | Real project read-only task | `claude -p`, Sonnet | `PowerShell(Get-ChildItem *)`, `PowerShell(Get-Content *)` | multiple real tool calls captured as JSONL rows and Mermaid nodes | PASS |
+| E3 | Canvas reinjection across turns | `claude -p --resume`, Sonnet | tools disabled | `UserPromptSubmit` injects canvas; Claude answers from canvas without tools | PASS |
+
+## Results
+
+### E1: Minimal Runtime Smoke
+
+Prompt asked Claude Code to run exactly:
+
+```powershell
+echo tdai-project-e2e-smoke
+```
+
+Observed:
+
+- `UserPromptSubmit` hook fired.
+- `PostToolUse:PowerShell` hook fired.
+- Hook response: `exit_code=0`, `outcome=success`.
+- JSONL and MMD were written under `.claude-tdai-experiments/storage`.
+
+Cost reported by Claude Code: `$0.19912575`.
+
+### E2: Real Project Read-Only Task
+
+Prompt asked Claude Code to run exactly:
+
+```powershell
+Get-ChildItem src/adapters/claude-code -Recurse -Filter *.ts
+Get-Content src/adapters/claude-code/README.md -TotalCount 40
+```
+
+Observed:
+
+- Both PowerShell calls completed successfully.
+- Both `PostToolUse` hooks fired and returned success.
+- `offload-22222222-2222-4222-8222-222222222222.jsonl` contains two records.
+- `mmds/22222222-2222-4222-8222-222222222222.mmd` contains two nodes and one edge.
+- Claude's final answer correctly summarized recall, capture, and short-term canvas implementation files.
+
+Generated canvas:
+
+```mermaid
+flowchart TD
+  n1["OK PowerShell: Get-ChildItem src/adapters/claude-code ..."]
+  n2["OK PowerShell: Get-Content src/adapters/claude-code/README.md ..."]
+  n1 --> n2
+```
+
+Cost reported by Claude Code: `$0.12297825`.
+
+### E3: Canvas Reinjection Across Turns
+
+The experiment resumed the E2 session and disabled tools. The prompt asked Claude to answer `CANVAS_OK` only if the injected short-term task canvas mentioned both previous commands.
+
+Observed:
+
+- `UserPromptSubmit` hook returned `additionalContext` containing `TencentDB-Agent-Memory Short-term Task Canvas`.
+- The injected Mermaid canvas contained both captured steps from E2.
+- Claude answered exactly `CANVAS_OK` without tools.
+
+Cost reported by Claude Code: `$0.0047337`.
+
+## Evidence Files
+
+Raw logs are intentionally gitignored but available locally:
+
+```text
+.claude-tdai-experiments/logs/exp1-smoke.jsonl
+.claude-tdai-experiments/logs/exp2-project-read.jsonl
+.claude-tdai-experiments/logs/exp3-canvas-injection.jsonl
+```
+
+Short-term artifacts are also local-only:
+
+```text
+.claude-tdai-experiments/storage/ddec694c69/offload-11111111-1111-4111-8111-111111111111.jsonl
+.claude-tdai-experiments/storage/ddec694c69/offload-22222222-2222-4222-8222-222222222222.jsonl
+.claude-tdai-experiments/storage/ddec694c69/mmds/22222222-2222-4222-8222-222222222222.mmd
+.claude-tdai-experiments/storage/ddec694c69/refs/*.md
+```
+
+## Findings
+
+The experiment validates the core adapter premise:
+
+1. Claude Code can invoke the adapter through real hook events.
+2. `PostToolUse` can capture real project tool activity into short-term storage.
+3. The generated Mermaid canvas can be injected through `UserPromptSubmit` on a later turn.
+4. Claude can use the injected canvas without any tool access.
+
+This is stronger than a unit test or isolated hook payload: it verifies the actual Claude Code runtime path over a small real repository task.
+
+## Limitations
+
+- The experiment validates short-term memory only. Long-term Gateway recall/capture still needs a separate E2E with a running Gateway.
+- Claude Code explicit `--session-id` could report the session as already in use immediately after a previous run. `--resume <session-id>` worked for the reinjection test.
+- Raw PowerShell output can be noisy for Mermaid labels. Long directory listings are currently truncated, and Windows console encoding can render Chinese path segments inconsistently in local log viewing.
+- Current short-term summarization is deterministic, not LLM-based. It is stable and cheap, but less semantic than OpenClaw's deeper short-term pipeline.
+
+## Recommendation
+
+The Claude Code adapter design is reasonable enough to include as an advanced-stage implementation:
+
+- Ship current v1 as partial short-term parity with OpenClaw.
+- Document that Claude Code lacks OpenClaw-style mutable prompt/context-engine control, so the adapter uses hook-based `additionalContext` injection.
+- Add a follow-up issue for long-term Gateway E2E and for improving short-term summaries on noisy Windows PowerShell output.

--- a/docs/adapters/claude-code-e2e-experiment-report.md
+++ b/docs/adapters/claude-code-e2e-experiment-report.md
@@ -142,7 +142,7 @@ This is stronger than a unit test or isolated hook payload: it verifies the actu
 
 ## Limitations
 
-- The experiment validates short-term memory only. Long-term Gateway recall/capture still needs a separate E2E with a running Gateway.
+- The experiment validates the short-term memory path in isolation; long-term Gateway recall/capture was intentionally disabled here (see Scope). The long-term path is validated separately in the [Claude Code Adapter Long-term Memory E2E Experiment Report](./claude-code-long-term-e2e-experiment-report.md).
 - Claude Code explicit `--session-id` could report the session as already in use immediately after a previous run. `--resume <session-id>` worked for the reinjection test.
 - Raw PowerShell output can be noisy for Mermaid labels. Long directory listings are currently truncated, and Windows console encoding can render Chinese path segments inconsistently in local log viewing.
 - Current short-term summarization is deterministic, not LLM-based. It is stable and cheap, but less semantic than OpenClaw's deeper short-term pipeline.
@@ -153,4 +153,4 @@ The Claude Code adapter design is reasonable enough to include as an advanced-st
 
 - Ship current v1 as partial short-term parity with OpenClaw.
 - Document that Claude Code lacks OpenClaw-style mutable prompt/context-engine control, so the adapter uses hook-based `additionalContext` injection.
-- Add a follow-up issue for long-term Gateway E2E and for improving short-term summaries on noisy Windows PowerShell output.
+- Add a follow-up issue for improving short-term summaries on noisy Windows PowerShell output. The long-term Gateway E2E is already covered by the [Long-term Memory E2E Experiment Report](./claude-code-long-term-e2e-experiment-report.md).

--- a/docs/adapters/claude-code-long-term-e2e-experiment-report.md
+++ b/docs/adapters/claude-code-long-term-e2e-experiment-report.md
@@ -1,0 +1,114 @@
+# Claude Code Adapter Long-term Memory E2E Experiment Report
+
+Date: 2026-07-22
+
+This report validates the Claude Code adapter's long-term memory path against a real project-local TencentDB-Agent-Memory Gateway and one real Claude Code runtime invocation.
+
+## Scope
+
+The experiment focuses on adapter and Gateway/Core data flow, not L1 extraction quality.
+
+Long-term memory in this project has multiple layers:
+
+- L0 Conversation: raw user/assistant messages persisted by capture/seed.
+- L1 Atom: structured facts extracted from conversations by the memory pipeline.
+- L2 Scenario: scene-level organization.
+- L3 Persona: stable profile/context injected during recall.
+
+Because L1/L2/L3 generation normally requires an LLM runner, this experiment disables extraction and uses a controlled L3 `persona.md` fixture to validate the recall injection path without spending extraction tokens or depending on external model credentials.
+
+## Isolated environment
+
+All artifacts were created under the repository-local directory:
+
+```text
+.claude-tdai-experiments/long-term/
+  tdai-gateway.yaml
+  settings.json
+  data/
+  gateway/
+  logs/
+  tmp/
+```
+
+Gateway config summary:
+
+- host: `127.0.0.1`
+- port: `18420`
+- data dir: `.claude-tdai-experiments/long-term/data`
+- store backend: SQLite
+- embedding: disabled (`provider: none`)
+- extraction: disabled
+- recall strategy: `keyword`
+
+Claude Code settings used only a `UserPromptSubmit` hook:
+
+```powershell
+$env:MEMORY_TENCENTDB_GATEWAY_URL = 'http://127.0.0.1:18420'; $env:MEMORY_TENCENTDB_AUTO_RECALL = 'true'; $env:MEMORY_TENCENTDB_SHORT_TERM = 'false'; $env:MEMORY_TENCENTDB_RECALL_MAX_CHARS = '8000'; npx tsx src/adapters/claude-code/hooks/user-prompt-submit.ts
+```
+
+## Data flow under test
+
+```mermaid
+sequenceDiagram
+    participant CC as Claude Code Runtime
+    participant Hook as UserPromptSubmit Hook
+    participant GW as TDAI Gateway
+    participant Core as TdaiCore
+    participant Store as Project-local Long-term Store
+
+    CC->>Hook: UserPromptSubmit(prompt, cwd, session_id)
+    Hook->>Hook: derive session_key from cwd + session_id
+    Hook->>GW: POST /recall { query, session_key }
+    GW->>Core: handleBeforeRecall(query, session_key)
+    Core->>Store: search L1 + read persona.md + scene navigation
+    Store-->>Core: L3 persona fixture
+    Core-->>GW: appendSystemContext
+    GW-->>Hook: { context, strategy, memory_count }
+    Hook-->>CC: additionalContext <tencentdb-agent-memory>...</tencentdb-agent-memory>
+    CC-->>CC: model answers using injected long-term context
+```
+
+## Experiment matrix
+
+| ID | Goal | Method | Expected result | Actual result |
+| --- | --- | --- | --- | --- |
+| LT-01 | Start isolated Gateway | `npx tsx src/gateway/server.ts` with project-local config | `/health` returns OK | PASS: `stores.vectorStore=true`, `stores.embeddingService=false` |
+| LT-02 | Check `/seed` behavior | `POST /seed` with one conversation containing `cobalt-penguin` | Seed persists L0 records | PASS for seed itself: `l0_recorded=2`; observed that output goes to timestamped `data/seed-*` subdir |
+| LT-03 | Runtime L0 capture/search | `POST /capture` new messages containing `amber-otter`, then `POST /search/conversations` | L0 search returns captured messages | PASS: `l0_recorded=2`, search returned 2 matching messages |
+| LT-04 | Long-term recall HTTP path | Create project-local `data/persona.md`, then `POST /recall` | Recall context contains persona fixture | PASS: context contains `cobalt-penguin` and memory tools guide |
+| LT-05 | Adapter hook path | Run `src/adapters/claude-code/hooks/user-prompt-submit.ts` with hook JSON | Hook emits `additionalContext` | PASS: emitted `<tencentdb-agent-memory>` with long-term recall context |
+| LT-06 | Real Claude Code runtime path | `claude -p ... --settings long-term/settings.json --model sonnet --tools "" --max-budget-usd 0.20` | Claude sees injected long-term context and answers `LONGTERM_OK` | PASS: result `LONGTERM_OK`, cost `$0.02966775` |
+
+## Evidence files
+
+```text
+.claude-tdai-experiments/long-term/logs/gateway.stdout.log
+.claude-tdai-experiments/long-term/logs/gateway.stderr.log
+.claude-tdai-experiments/long-term/logs/exp-longterm-01-seed.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-02-search-conversations.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-03-recall-persona.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-06-capture-new-message.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-07-search-conversations-after-new-capture.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-08-user-prompt-hook.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-09-claude-runtime-recall.json
+.claude-tdai-experiments/long-term/logs/exp-longterm-09-claude-runtime-debug.log
+```
+
+## Observations
+
+1. The Claude Code adapter's long-term recall injection path is functional with a real Claude Code runtime.
+2. `/capture` is the right endpoint for validating live L0 writes into the active Gateway Core data directory.
+3. `/seed` succeeded but wrote to a timestamped `data/seed-*` subdirectory. That is useful for offline imports, but the active Gateway search did not immediately see those records because the running Core was bound to the root data directory.
+4. The first `/capture` attempt with old timestamps recorded `0` messages. This matches the cold-start duplicate-protection behavior: the runtime capture path filters messages older than the startup/cursor floor.
+5. With embedding disabled, L0 conversation search still works through SQLite FTS. L1 memory recall was not validated in this run because extraction was intentionally disabled to avoid external LLM calls.
+6. The real Claude Code invocation proved the platform-facing contract: `UserPromptSubmit` can inject Gateway recall output into Claude Code and influence the model answer.
+
+## Follow-up experiments
+
+Recommended next experiments, after configuring a real low-cost extraction model in a project-local Gateway config:
+
+1. L1 extraction E2E: `/capture` or `/seed` -> pipeline L1 -> `/search/memories`.
+2. L1 auto-recall E2E: query matching an extracted atom -> `/recall` returns `memory_count > 0` and L1 snippets.
+3. SessionEnd import E2E: real Claude transcript -> adapter `SessionEnd` hook -> `/seed` import -> subsequent L0/L1 search.
+4. MCP long-term search E2E: real Claude Code MCP tool call -> Gateway `/search/conversations` and `/search/memories`.

--- a/docs/adapters/claude-code-v1-technical-design.md
+++ b/docs/adapters/claude-code-v1-technical-design.md
@@ -1,0 +1,374 @@
+﻿# Claude Code Adapter v1 Technical Design
+
+This document turns the Claude Code adapter review into an implementation-ready v1 plan.
+
+The core decision is to keep TencentDB-Agent-Memory's long-term memory engine unchanged and build a Claude Code adapter as a thin protocol layer around the existing Gateway, plus a local short-term canvas store that is intentionally scoped as partial OpenClaw parity.
+
+## Goals
+
+Claude Code v1 should provide:
+
+- automatic long-term recall before a user prompt is submitted;
+- conversation import at session end;
+- explicit memory search tools through MCP;
+- lightweight short-term symbolic canvas injection based on high-signal tool events;
+- no changes to `TdaiCore` and no new Gateway endpoints.
+
+The adapter must make the two memory systems visible and separate:
+
+| System | v1 status | Source of truth | Injection path |
+|---|---:|---|---|
+| Long-term memory | Required | Gateway + `TdaiCore` | `UserPromptSubmit` `additionalContext` |
+| Short-term memory | Partial | Claude Code adapter local files | `UserPromptSubmit` `additionalContext` |
+
+## Non-Goals
+
+v1 does not attempt to:
+
+- replace or mutate arbitrary old Claude Code transcript messages;
+- claim full OpenClaw short-term context-engine parity;
+- add `updateContext`, `restoreContext`, `captureEpisode`, `updateScene`, or other new Gateway APIs;
+- supervise the Gateway process like Hermes does;
+- change core L0/L1/L2/L3 pipeline behavior.
+
+## Current Gateway Contract
+
+The adapter must use only the current Gateway API:
+
+| Endpoint | Request fields used by Claude Code v1 | Adapter use |
+|---|---|---|
+| `GET /health` | none | startup/config check |
+| `POST /recall` | `query`, `session_key`, `user_id?` | automatic long-term recall |
+| `POST /seed` | `data`, `session_key?`, `strict_round_role?`, `auto_fill_timestamps?`, `config_override?` | session-end transcript import |
+| `POST /capture` | `user_content`, `assistant_content`, `session_key`, `session_id?`, `user_id?`, `messages?` | optional latest-turn fallback |
+| `POST /search/memories` | `query`, `limit?`, `type?`, `scene?` | MCP memory search |
+| `POST /search/conversations` | `query`, `limit?`, `session_key?` | MCP conversation search |
+| `POST /session/end` | `session_key`, `user_id?` | flush after import/capture |
+
+`/seed` is the preferred v1 capture path because Claude Code's session transcript is easier to import as a batch than to reliably reconstruct every turn in hook state.
+
+## Architecture
+
+```mermaid
+flowchart TB
+  User["User prompt"] --> CC["Claude Code"]
+
+  subgraph Adapter["Claude Code adapter"]
+    UPS["UserPromptSubmit hook"]
+    PTU["PostToolUse hook"]
+    SE["SessionEnd hook"]
+    MCP["MCP server"]
+    Client["Gateway client"]
+    ST["Short-term local store\nrefs / jsonl / mmd"]
+  end
+
+  subgraph Gateway["memory-tencentdb Gateway"]
+    HTTP["HTTP API"]
+    Core["TdaiCore\nL0-L3 long-term memory"]
+  end
+
+  CC --> UPS
+  CC --> PTU
+  CC --> SE
+  CC --> MCP
+  UPS --> Client
+  MCP --> Client
+  SE --> Client
+  Client --> HTTP --> Core
+  PTU --> ST
+  ST --> UPS
+```
+
+## Data Flow
+
+### 1. Automatic recall before prompt
+
+```mermaid
+sequenceDiagram
+  participant CC as Claude Code
+  participant Hook as UserPromptSubmit hook
+  participant Store as Short-term store
+  participant Gateway as TDAI Gateway
+  participant Core as TdaiCore
+
+  CC->>Hook: hook input with prompt/session/cwd
+  Hook->>Hook: derive session_key
+  Hook->>Gateway: POST /recall {query,session_key,user_id?}
+  Gateway->>Core: handleBeforeRecall()
+  Core-->>Gateway: context
+  Hook->>Store: read active task canvas if present
+  Hook-->>CC: additionalContext = long-term recall + bounded short-term canvas
+```
+
+Rules:
+
+- use `UserPromptSubmit`, not `SessionStart`, as the primary recall point because it has the concrete user query;
+- cap automatic recall text to a small budget, initially 2-4 KB;
+- include short-term canvas only when it exists and is under budget;
+- label both sections clearly so Claude can distinguish durable memory from current-task scratch state.
+
+### 2. Explicit memory search
+
+```mermaid
+sequenceDiagram
+  participant CC as Claude Code
+  participant MCP as Adapter MCP server
+  participant Gateway as TDAI Gateway
+
+  CC->>MCP: memory_tencentdb_memory_search(query,limit,type,scene)
+  MCP->>Gateway: POST /search/memories
+  Gateway-->>MCP: results,total,strategy
+  MCP-->>CC: formatted result
+
+  CC->>MCP: memory_tencentdb_conversation_search(query,limit,session_key?)
+  MCP->>Gateway: POST /search/conversations
+  Gateway-->>MCP: results,total
+  MCP-->>CC: formatted result
+```
+
+Rules:
+
+- MCP tools are explicit, user/model-invoked search paths;
+- hooks should not call search endpoints except `/recall`;
+- tool output should include endpoint strategy/total metadata but avoid injecting huge result sets by default.
+
+### 3. Session-end capture
+
+```mermaid
+sequenceDiagram
+  participant CC as Claude Code
+  participant Hook as SessionEnd hook
+  participant Parser as Transcript mapper
+  participant Gateway as TDAI Gateway
+
+  CC->>Hook: hook input with session_id/transcript_path/cwd
+  Hook->>Parser: read and normalize Claude transcript
+  Parser-->>Hook: seed data with sessions/conversations/messages
+  Hook->>Gateway: POST /seed {data,session_key,auto_fill_timestamps:true}
+  Gateway-->>Hook: seed result
+  Hook->>Gateway: POST /session/end {session_key}
+```
+
+Fallback:
+
+- if transcript parsing fails but the hook input has enough latest-turn data, call `/capture`;
+- if neither path is possible, still call `/session/end` and log a warning.
+
+### 4. Lightweight short-term canvas
+
+```mermaid
+sequenceDiagram
+  participant CC as Claude Code
+  participant Hook as PostToolUse hook
+  participant Filter as Tool filter
+  participant FS as Short-term files
+  participant Prompt as UserPromptSubmit hook
+
+  CC->>Hook: tool event
+  Hook->>Filter: classify event
+  alt selected high-signal event
+    Filter-->>Hook: capture
+    Hook->>FS: write refs/<tool_use_id>.md
+    Hook->>FS: append offload-<session>.jsonl
+    Hook->>FS: update mmds/<session>.mmd
+  else low-signal event
+    Filter-->>Hook: skip
+  end
+  Prompt->>FS: read active mmd
+  Prompt-->>CC: additionalContext short-term canvas
+```
+
+This is partial parity with OpenClaw. It preserves a symbolic current-task map, but it does not own Claude Code's compaction pipeline.
+
+## Session Key
+
+Use one canonical derivation everywhere:
+
+```text
+agent:claude-code-<workspace_hash>:<session_id>
+```
+
+Where:
+
+- `workspace_hash` is a stable short hash of normalized `cwd` or workspace root;
+- `session_id` comes from Claude Code hook input;
+- if `session_id` is unavailable, use a date-scoped fallback such as `manual-YYYYMMDD-<short-random>`.
+
+Do not put absolute paths, user names, tokens, or secrets directly into the session key.
+
+## Local Storage
+
+Claude Code short-term files should not reuse OpenClaw's storage directory.
+
+Recommended layout:
+
+```text
+~/.memory-tencentdb/claude-code-offload/
+  <workspace_hash>/
+    refs/
+      <tool_use_id>.md
+    mmds/
+      <session_id>.mmd
+    offload-<session_id>.jsonl
+    state.json
+```
+
+Each JSONL row should contain:
+
+- `session_key`
+- `session_id`
+- `cwd_hash`
+- `tool_use_id`
+- `tool_name`
+- `started_at`
+- `ended_at`
+- `status`
+- `input_summary`
+- `result_summary`
+- `result_ref`
+- `node_id?`
+
+## Tool Filtering
+
+Default v1 policy:
+
+| Tool event | Default action | Reason |
+|---|---|---|
+| failed tool calls | capture | failures explain task state |
+| shell commands | capture summary; ref if large | often state-changing or diagnostic |
+| write/edit operations | capture | source of durable task changes |
+| very large outputs | capture ref + summary | avoid context bloat |
+| read/list/search tools | skip unless large/error | usually low-signal and noisy |
+| secret-bearing outputs | redact or skip | safety |
+
+The filter must be configurable with allow/deny lists.
+
+## Config
+
+Initial config can be environment-based:
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `MEMORY_TENCENTDB_GATEWAY_URL` | `http://127.0.0.1:8420` | Gateway base URL |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` | unset | Bearer token for Gateway |
+| `TDAI_GATEWAY_API_KEY` | unset | fallback API key name |
+| `MEMORY_TENCENTDB_CLAUDE_STORAGE_DIR` | `~/.memory-tencentdb/claude-code-offload` | short-term store root |
+| `MEMORY_TENCENTDB_AUTO_RECALL` | `true` | enable `UserPromptSubmit` recall |
+| `MEMORY_TENCENTDB_SHORT_TERM` | `true` | enable lightweight short-term canvas |
+| `MEMORY_TENCENTDB_RECALL_MAX_CHARS` | `4000` | auto recall budget |
+| `MEMORY_TENCENTDB_CANVAS_MAX_CHARS` | `3000` | short-term canvas budget |
+
+If the Gateway is configured with an API key, the adapter must send:
+
+```text
+Authorization: Bearer <key>
+```
+
+## Proposed File Layout
+
+```text
+src/adapters/claude-code/
+  README.md
+  config.ts
+  types.ts
+  gateway-client.ts
+  session-key.ts
+  context-format.ts
+  hooks/
+    user-prompt-submit.ts
+    post-tool-use.ts
+    session-end.ts
+  mappers/
+    transcript.ts
+    tool-event.ts
+  short-term/
+    store.ts
+    filter.ts
+    canvas.ts
+  mcp/
+    server.ts
+    tools.ts
+```
+
+This layout keeps host-specific logic out of `src/core`.
+
+## Implementation Order
+
+1. Add `gateway-client.ts` with typed methods for the real Gateway endpoints.
+2. Add `session-key.ts` and `config.ts`.
+3. Add MCP tools for memory and conversation search.
+4. Add `UserPromptSubmit` recall hook and bounded context formatter.
+5. Add `SessionEnd` transcript parser and `/seed` import path.
+6. Add `PostToolUse` capture, filter, local refs/jsonl/mmd store.
+7. Add README setup instructions for Claude Code hook and MCP configuration.
+
+After step 4, long-term recall is usable. After step 5, long-term capture is usable. Step 6 adds the short-term current-task canvas.
+
+## Test Plan
+
+Unit tests:
+
+- session key derivation is stable and does not leak absolute paths;
+- Gateway client sends exact request bodies;
+- recall formatter respects max-character budgets;
+- MCP tools map to `/search/memories` and `/search/conversations`;
+- transcript parser converts Claude Code transcript records into seed format;
+- tool filter captures/skips expected tool event categories.
+
+Integration tests:
+
+- mock Gateway server receives `/recall`, `/seed`, `/session/end`;
+- hook scripts accept representative Claude Code hook JSON through stdin;
+- short-term store creates `refs`, JSONL rows, and an MMD file for selected tool events.
+
+Manual smoke test:
+
+1. start Gateway on `127.0.0.1:8420`;
+2. run the MCP search server and verify both search tools;
+3. run `UserPromptSubmit` hook with sample JSON and confirm `additionalContext`;
+4. run `SessionEnd` hook with a small transcript and confirm `/seed` import;
+5. run `PostToolUse` hook with a large shell output and confirm ref/jsonl/mmd files.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Claude Code hook JSON fields differ by version | isolate parsing in mappers and keep fixtures close to docs |
+| automatic recall pollutes context | strict max chars, clear section labels, opt-out env var |
+| duplicate automatic recall and MCP search | reserve hooks for recall, MCP for explicit search |
+| transcript import duplicates previous import | keep `state.json` with last imported transcript offset/hash |
+| tool results expose secrets | default redaction and configurable deny list |
+| Gateway is not running | health check with clear warning; v1 does not auto-start |
+
+## Ready-To-Implement Decision
+
+Yes: after this design, implementation can start without changing core memory architecture.
+
+The first implementation slice should be:
+
+```text
+Gateway client + session key + MCP search tools + UserPromptSubmit recall
+```
+
+That slice proves Claude Code can read from TencentDB-Agent-Memory through the existing Gateway. Capture and short-term canvas can then be added incrementally without reopening the API design.
+## Implementation Status
+
+Implemented in `src/adapters/claude-code/`:
+
+- Gateway client for `/recall`, `/search/memories`, `/search/conversations`, `/seed`, and `/session/end`.
+- Stable Claude Code session key derivation.
+- `UserPromptSubmit` recall hook with bounded `additionalContext` formatting.
+- `SessionEnd` transcript import hook that conservatively maps user/assistant text pairs into seed input.
+- `PostToolUse` short-term refs/jsonl/mmd symbolic canvas capture and `UserPromptSubmit` canvas injection.
+- MCP search tool handlers and a minimal stdio server.
+
+Still pending:
+
+- `PostToolUse` short-term refs/jsonl/mmd symbolic canvas.
+- Long-term Gateway E2E with a running Gateway.
+- Packaging/setup instructions beyond development `tsx` invocation.
+
+## E2E Experiment
+
+A real Claude Code runtime E2E for the short-term memory path passed on Windows with Claude Code 2.1.126 and `claude-sonnet-4-6`. See [Claude Code Adapter E2E Experiment Report](./claude-code-e2e-experiment-report.md).
+

--- a/docs/adapters/claude-code-v1-technical-design.md
+++ b/docs/adapters/claude-code-v1-technical-design.md
@@ -1,4 +1,4 @@
-﻿# Claude Code Adapter v1 Technical Design
+# Claude Code Adapter v1 Technical Design
 
 This document turns the Claude Code adapter review into an implementation-ready v1 plan.
 
@@ -364,11 +364,10 @@ Implemented in `src/adapters/claude-code/`:
 
 Still pending:
 
-- `PostToolUse` short-term refs/jsonl/mmd symbolic canvas.
-- Long-term Gateway E2E with a running Gateway.
 - Packaging/setup instructions beyond development `tsx` invocation.
 
-## E2E Experiment
+## E2E Experiments
 
-A real Claude Code runtime E2E for the short-term memory path passed on Windows with Claude Code 2.1.126 and `claude-sonnet-4-6`. See [Claude Code Adapter E2E Experiment Report](./claude-code-e2e-experiment-report.md).
+- Short-term memory path: a real Claude Code runtime E2E passed on Windows with Claude Code 2.1.126 and `claude-sonnet-4-6`. See [Claude Code Adapter E2E Experiment Report](./claude-code-e2e-experiment-report.md).
+- Long-term memory path: a real Claude Code runtime plus project-local Gateway E2E passed (LT-01 through LT-06). See [Claude Code Adapter Long-term Memory E2E Experiment Report](./claude-code-long-term-e2e-experiment-report.md).
 

--- a/docs/adapters/platform-adapter-comparison.md
+++ b/docs/adapters/platform-adapter-comparison.md
@@ -1,0 +1,175 @@
+# Cross-Platform Adapter Comparison
+
+This document summarizes the adapter differences discovered while implementing issue #235. It complements `architecture.md` by focusing on how each host platform maps its own runtime model to TencentDB-Agent-Memory.
+
+## Scope
+
+Covered platforms:
+
+- OpenClaw plugin integration
+- Hermes / Gateway provider integration
+- Claude Code adapter
+- Pi Agent adapter
+
+Memory systems considered:
+
+- Long-term memory: L0 Conversation -> L1 Atom -> L2 Scenario -> L3 Persona
+- Short-term memory: tool output refs -> JSONL summaries -> Mermaid symbolic canvas
+
+## High-level comparison
+
+| Platform | Integration shape | Memory entry point | Search surface | Capture surface | Short-term memory | Key isolation |
+| --- | --- | --- | --- | --- | --- | --- |
+| OpenClaw | In-process plugin SDK | `before_prompt_build` recall through host hooks | OpenClaw tools: `tdai_memory_search`, `tdai_conversation_search` | `agent_end` hook commits turns to TdaiCore | Optional offload via host `contextEngine` and after-tool-call patch | Host session key |
+| Hermes | HTTP Gateway + Python provider | Provider calls Gateway/Core over HTTP | Gateway/provider tools over HTTP | Gateway endpoints such as `/seed` and `/session/end` | Not host-native; mainly long-term memory sidecar | Gateway session key |
+| Claude Code | Hook scripts + MCP server | `UserPromptSubmit` hook calls Gateway `/recall` and injects context | MCP tools for memory/conversation search | `SessionEnd` transcript import through `/seed` + `/session/end` | Implemented with `PostToolUse` refs/jsonl/mmd symbolic canvas | `claude-code:` derived key |
+| Pi Agent | Pi Extension lifecycle + custom tools | `before_agent_start` returns a custom memory message from Gateway `/recall` | Pi custom tools: `memory_search`, `conversation_search`, `context_get` | `session_shutdown` maps session history to `/seed` + `/session/end` | Reserved for Pi-native follow-up; not copied from Claude Code | `pi-agent:` derived key |
+
+## Data-flow comparison
+
+```mermaid
+flowchart TD
+  subgraph Core["TencentDB-Agent-Memory Core"]
+    Gateway["Gateway HTTP API"]
+    TdaiCore["TdaiCore"]
+    LT["Long-term Memory\nL0 -> L1 -> L2 -> L3"]
+    ST["Short-term Memory\nrefs -> jsonl -> mermaid canvas"]
+    Gateway --> TdaiCore
+    TdaiCore --> LT
+    TdaiCore --> ST
+  end
+
+  OpenClaw["OpenClaw Plugin\nSDK hooks/tools"] --> TdaiCore
+  Hermes["Hermes Provider\nHTTP sidecar"] --> Gateway
+  Claude["Claude Code\nHooks + MCP"] --> Gateway
+  Pi["Pi Agent\nExtension + custom tools"] --> Gateway
+```
+
+The important design point is that OpenClaw can call TdaiCore in-process, while Hermes, Claude Code, and Pi Agent use Gateway as the stable cross-process boundary. This lets new platforms integrate without importing OpenClaw-specific internals.
+
+## Platform-specific observations
+
+### OpenClaw
+
+OpenClaw is the most native integration. It owns the original plugin entrypoint and can directly register tools and lifecycle hooks with the host runtime. Because it runs in-process, it can delegate directly to TdaiCore and can use host features such as `contextEngine` for short-term offload.
+
+Best fit:
+
+- deep host integration;
+- automatic capture and recall;
+- full access to OpenClaw session state;
+- short-term offload using OpenClaw runtime primitives.
+
+Trade-off:
+
+- this integration style is not portable to external agents, because it relies on OpenClaw plugin APIs.
+
+### Hermes / Gateway
+
+Hermes demonstrates the sidecar pattern. The Python provider does not need to embed TdaiCore. Instead, it talks to the HTTP Gateway, which becomes the platform-neutral boundary around recall, search, seed, and session-end behavior.
+
+Best fit:
+
+- external runtimes;
+- language-agnostic integration;
+- decoupling memory engine lifecycle from the host agent process.
+
+Trade-off:
+
+- the adapter must serialize host events into Gateway requests;
+- host-native short-term memory is limited unless the host exposes additional lifecycle/tool hooks.
+
+### Claude Code
+
+Claude Code requires a split adapter because different capabilities live in different surfaces:
+
+- hooks are best for lifecycle events such as prompt recall and session-end transcript import;
+- MCP is best for agent-callable search tools;
+- `PostToolUse` is the natural insertion point for short-term context capture.
+
+Best fit:
+
+- real coding-agent workflow validation;
+- active memory search through MCP;
+- short-term memory capture from tool results;
+- project-local experiments that do not modify global Claude Code configuration.
+
+Trade-off:
+
+- the adapter is necessarily multi-surface: hooks + MCP + local short-term artifacts;
+- the short-term canvas design is Claude Code specific and should not be blindly reused by other platforms.
+
+### Pi Agent
+
+Pi Agent validates that the adapter architecture can support another coding-agent runtime without copying the Claude Code design. Pi has its own Extension lifecycle and custom tool registration model:
+
+- `before_agent_start` is used for pre-turn recall;
+- `session_shutdown` is used for end-of-session capture;
+- `registerTool({ ... })` exposes memory search as Pi-native tools.
+
+Best fit:
+
+- Pi-native extension integration;
+- long-term memory recall/capture through Gateway;
+- active memory search during reasoning;
+- clean separation from Claude Code hooks/MCP assumptions.
+
+Trade-off:
+
+- v1 validates extension loading and adapter registration with Pi CLI, but a full Gateway-backed Pi conversation E2E should be added next;
+- Pi-specific short-term memory should be designed separately instead of reusing Claude Code's symbolic canvas files directly.
+
+## Key differences
+
+| Dimension | OpenClaw | Hermes | Claude Code | Pi Agent |
+| --- | --- | --- | --- | --- |
+| Primary boundary | Plugin SDK | HTTP provider/Gateway | Hooks + MCP | Extension lifecycle |
+| Core access | Direct TdaiCore | Gateway | Gateway | Gateway |
+| Recall timing | Before prompt build | Provider/Gateway request | `UserPromptSubmit` | `before_agent_start` |
+| Capture timing | Agent end | Gateway endpoint | `SessionEnd` | `session_shutdown` |
+| Tool model | Host tools | Provider tools | MCP tools | Pi custom tools |
+| Short-term strategy | Host context engine/offload | Not first-class | Implemented via `PostToolUse` canvas | Reserved for Pi-native design |
+| Adapter risk | Host API coupling | Network/process boundary | Multi-surface complexity | Runtime API compatibility |
+
+## Adapter design lessons
+
+1. Keep TdaiCore host-neutral.
+
+   Platform adapters should translate lifecycle events and tool calls into memory operations. They should not duplicate L0-L3 extraction, recall, search, or persona logic.
+
+2. Treat Gateway as the cross-platform contract.
+
+   For external runtimes, Gateway is the most stable boundary. It prevents each adapter from importing internal OpenClaw-specific code.
+
+3. Separate long-term and short-term memory decisions.
+
+   Long-term memory maps cleanly across platforms through recall/search/seed/session-end. Short-term memory depends heavily on each runtime's tool event model and should be designed per platform.
+
+4. Use explicit session-key namespaces.
+
+   Prefixes such as `claude-code:` and `pi-agent:` keep memory records debuggable and prevent cross-platform session collisions.
+
+5. Prefer native host affordances.
+
+   Claude Code should use hooks/MCP because those are its native extension points. Pi Agent should use Extension lifecycle events and custom tools. This makes each adapter smaller and more maintainable.
+
+## Current acceptance mapping
+
+| Issue stage | Evidence in this PR |
+| --- | --- |
+| Basic | `docs/adapters/architecture.md` explains the core engine, OpenClaw, Hermes/Gateway, memory layers, and data flow |
+| Intermediate | `src/adapters/claude-code/` implements a working Claude Code adapter with tests and E2E experiment reports |
+| Advanced | `src/adapters/pi-agent/` adds a second new platform adapter; this document compares OpenClaw, Hermes, Claude Code, and Pi Agent |
+| Challenge | Not included yet; the natural follow-up is a unified Adapter SDK |
+
+## Recommended next step
+
+The next architectural step is to extract a small adapter SDK around common operations:
+
+- derive stable session key;
+- normalize host messages into L0 seed conversations;
+- call recall/search/seed/session-end through Gateway;
+- expose host-native tools;
+- optionally plug in platform-specific short-term memory capture.
+
+That would make future platforms implement one small interface instead of recreating the full adapter pattern.

--- a/src/adapters/claude-code/README.md
+++ b/src/adapters/claude-code/README.md
@@ -1,0 +1,149 @@
+﻿# Claude Code Adapter
+
+This adapter connects Claude Code to TencentDB-Agent-Memory through the existing Gateway.
+
+Current scope:
+
+- Gateway client for the existing HTTP API.
+- Stable Claude Code session key derivation.
+- `UserPromptSubmit` recall hook.
+- `SessionEnd` transcript import through `/seed` and `/session/end`.
+- `PostToolUse` short-term refs/jsonl/mmd symbolic canvas capture.
+- MCP search tool handlers and a minimal stdio server.
+
+Not included yet:
+
+- Gateway process supervision.
+- Production packaging/setup beyond development `tsx` invocation.
+
+## Environment
+
+```bash
+MEMORY_TENCENTDB_GATEWAY_URL=http://127.0.0.1:8420
+MEMORY_TENCENTDB_GATEWAY_API_KEY=
+MEMORY_TENCENTDB_AUTO_RECALL=true
+MEMORY_TENCENTDB_SHORT_TERM=true
+MEMORY_TENCENTDB_RECALL_MAX_CHARS=4000
+MEMORY_TENCENTDB_CANVAS_MAX_CHARS=3000
+```
+
+`MEMORY_TENCENTDB_GATEWAY_API_KEY` can be omitted when the Gateway is running without auth on loopback. If the Gateway uses `TDAI_GATEWAY_API_KEY`, the adapter also accepts that variable as a fallback.
+
+## UserPromptSubmit Recall Hook
+
+Development invocation:
+
+```bash
+npx tsx src/adapters/claude-code/hooks/user-prompt-submit.ts
+```
+
+The hook reads Claude Code hook JSON from stdin and writes a JSON response. On success it returns:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "<tencentdb-agent-memory>...</tencentdb-agent-memory>"
+  }
+}
+```
+
+The hook calls:
+
+```text
+POST /recall { query, session_key, user_id? }
+```
+
+If short-term memory is enabled, it also reads the active Mermaid canvas and includes it in `additionalContext`.
+
+## SessionEnd Capture Hook
+
+Development invocation:
+
+```bash
+npx tsx src/adapters/claude-code/hooks/session-end.ts
+```
+
+The hook reads Claude Code `SessionEnd` JSON from stdin. It expects `session_id`, `cwd`, and `transcript_path` when available.
+
+It imports parsed transcript turns through:
+
+```text
+POST /seed { data, session_key, strict_round_role:false, auto_fill_timestamps:true }
+POST /session/end { session_key }
+```
+
+Transcript import is conservative: it keeps user/assistant text pairs and skips tool-only blocks such as `tool_result` and `tool_use`.
+
+## PostToolUse Short-term Canvas Hook
+
+Development invocation:
+
+```bash
+npx tsx src/adapters/claude-code/hooks/post-tool-use.ts
+```
+
+The hook reads Claude Code `PostToolUse` JSON from stdin. It captures high-signal tool events and writes:
+
+```text
+~/.memory-tencentdb/claude-code-offload/
+  <workspace_hash>/
+    refs/<tool_use_id>.md
+    offload-<session_id>.jsonl
+    mmds/<session_id>.mmd
+    state.json
+```
+
+Default capture policy:
+
+- capture failed tools;
+- capture shell/edit/write/patch tools;
+- capture very large outputs;
+- skip ordinary read/list/search tools unless they are large or failed.
+
+
+### Windows hook command note
+
+Claude Code runs hook commands through the platform shell. On Windows, prefer PowerShell-native environment assignment:
+
+```powershell
+$env:MEMORY_TENCENTDB_CLAUDE_STORAGE_DIR = 'C:\tmp\tdai-claude-runtime-smoke'; npx tsx src/adapters/claude-code/hooks/post-tool-use.ts
+```
+
+Avoid relying on `cmd /c set VAR=...&& ...` inside the hook command, because it can be parsed as PowerShell and fail before the adapter receives the hook payload.
+## MCP Tools
+
+Development invocation:
+
+```bash
+npx tsx src/adapters/claude-code/mcp/server.ts
+```
+
+Exposed tools:
+
+- `memory_tencentdb_memory_search`
+- `memory_tencentdb_conversation_search`
+
+They map directly to:
+
+- `POST /search/memories`
+- `POST /search/conversations`
+
+## Smoke Test
+
+1. Start the TencentDB-Agent-Memory Gateway on `127.0.0.1:8420`.
+2. Run the targeted tests:
+
+   ```bash
+   npm test -- --run src/adapters/claude-code
+   ```
+
+3. Feed sample hook payloads to `user-prompt-submit.ts`, `post-tool-use.ts`, or `session-end.ts` through stdin.
+
+## Next Slices
+
+Recommended order:
+
+1. Run a real Claude Code hook smoke test with project-scoped settings.
+2. Package the adapter as a documented Claude Code setup bundle.
+

--- a/src/adapters/claude-code/config.ts
+++ b/src/adapters/claude-code/config.ts
@@ -1,0 +1,38 @@
+import os from "node:os";
+import path from "node:path";
+import type { ClaudeCodeAdapterConfig } from "./types.js";
+
+function envFlag(value: string | undefined, fallback: boolean): boolean {
+  if (value == null || value.trim() === "") return fallback;
+  return !["0", "false", "no", "off"].includes(value.trim().toLowerCase());
+}
+
+function envInt(value: string | undefined, fallback: number): number {
+  if (value == null || value.trim() === "") return fallback;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function normalizeGatewayUrl(value: string | undefined): string {
+  const raw = value?.trim() || "http://127.0.0.1:8420";
+  return raw.replace(/\/+$/, "");
+}
+
+function defaultStorageDir(): string {
+  return path.join(os.homedir(), ".memory-tencentdb", "claude-code-offload");
+}
+
+export function loadClaudeCodeAdapterConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ClaudeCodeAdapterConfig {
+  return {
+    gatewayUrl: normalizeGatewayUrl(env.MEMORY_TENCENTDB_GATEWAY_URL),
+    gatewayApiKey: env.MEMORY_TENCENTDB_GATEWAY_API_KEY || env.TDAI_GATEWAY_API_KEY || undefined,
+    autoRecall: envFlag(env.MEMORY_TENCENTDB_AUTO_RECALL, true),
+    recallMaxChars: envInt(env.MEMORY_TENCENTDB_RECALL_MAX_CHARS, 4000),
+    canvasMaxChars: envInt(env.MEMORY_TENCENTDB_CANVAS_MAX_CHARS, 3000),
+    shortTermEnabled: envFlag(env.MEMORY_TENCENTDB_SHORT_TERM, true),
+    storageDir: env.MEMORY_TENCENTDB_CLAUDE_STORAGE_DIR || defaultStorageDir(),
+  };
+}
+

--- a/src/adapters/claude-code/context-format.test.ts
+++ b/src/adapters/claude-code/context-format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatClaudeCodeAdditionalContext } from "./context-format.js";
+
+describe("formatClaudeCodeAdditionalContext", () => {
+  it("formats long-term recall and short-term canvas separately", () => {
+    const text = formatClaudeCodeAdditionalContext({
+      recall: { context: "User likes concise answers.", strategy: "hybrid", memory_count: 2 },
+      shortTermCanvas: "graph TD\n  A-->B",
+      options: { recallMaxChars: 1000, canvasMaxChars: 1000 },
+    });
+
+    expect(text).toContain("Long-term Recall");
+    expect(text).toContain("Short-term Task Canvas");
+    expect(text).toContain("memory_count=2");
+    expect(text).toContain("User likes concise answers.");
+  });
+
+  it("returns empty string when there is no context", () => {
+    expect(formatClaudeCodeAdditionalContext({
+      recall: { context: "" },
+      options: { recallMaxChars: 1000, canvasMaxChars: 1000 },
+    })).toBe("");
+  });
+});
+

--- a/src/adapters/claude-code/context-format.ts
+++ b/src/adapters/claude-code/context-format.ts
@@ -1,0 +1,44 @@
+import type { ContextFormatOptions, RecallResponse } from "./types.js";
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n... [truncated]`;
+}
+
+export function formatClaudeCodeAdditionalContext(input: {
+  recall?: RecallResponse;
+  shortTermCanvas?: string;
+  options: ContextFormatOptions;
+}): string {
+  const sections: string[] = [];
+
+  const recallContext = input.recall?.context?.trim();
+  if (recallContext) {
+    const meta: string[] = [];
+    if (input.recall?.strategy) meta.push(`strategy=${input.recall.strategy}`);
+    if (typeof input.recall?.memory_count === "number") meta.push(`memory_count=${input.recall.memory_count}`);
+    sections.push(
+      [
+        "## TencentDB-Agent-Memory Long-term Recall",
+        meta.length > 0 ? `Metadata: ${meta.join(", ")}` : undefined,
+        truncateText(recallContext, input.options.recallMaxChars),
+      ].filter(Boolean).join("\n\n"),
+    );
+  }
+
+  const canvas = input.shortTermCanvas?.trim();
+  if (canvas) {
+    sections.push(
+      [
+        "## TencentDB-Agent-Memory Short-term Task Canvas",
+        "This is current-task scratch context captured from recent tool activity.",
+        truncateText(canvas, input.options.canvasMaxChars),
+      ].join("\n\n"),
+    );
+  }
+
+  return sections.length > 0
+    ? `<tencentdb-agent-memory>\n\n${sections.join("\n\n---\n\n")}\n\n</tencentdb-agent-memory>`
+    : "";
+}
+

--- a/src/adapters/claude-code/gateway-client.test.ts
+++ b/src/adapters/claude-code/gateway-client.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { TdaiGatewayClient } from "./gateway-client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("TdaiGatewayClient", () => {
+  it("posts recall requests to the existing Gateway endpoint", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = new TdaiGatewayClient({
+      baseUrl: "http://127.0.0.1:8420/",
+      apiKey: "secret",
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return jsonResponse({ context: "remember this", strategy: "hybrid", memory_count: 1 });
+      },
+    });
+
+    const result = await client.recall({
+      query: "what do I prefer?",
+      session_key: "agent:claude-code-x:s",
+    });
+
+    expect(result.context).toBe("remember this");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://127.0.0.1:8420/recall");
+    expect(calls[0].init.method).toBe("POST");
+    expect((calls[0].init.headers as Record<string, string>).Authorization).toBe("Bearer secret");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      query: "what do I prefer?",
+      session_key: "agent:claude-code-x:s",
+    });
+  });
+
+  it("maps memory and conversation search endpoints", async () => {
+    const urls: string[] = [];
+    const client = new TdaiGatewayClient({
+      baseUrl: "http://gateway",
+      fetchImpl: async (url) => {
+        urls.push(String(url));
+        return jsonResponse({ results: "ok", total: 1, strategy: "hybrid" });
+      },
+    });
+
+    await client.searchMemories({ query: "memory" });
+    await client.searchConversations({ query: "conversation" });
+
+    expect(urls).toEqual([
+      "http://gateway/search/memories",
+      "http://gateway/search/conversations",
+    ]);
+  });
+});
+

--- a/src/adapters/claude-code/gateway-client.ts
+++ b/src/adapters/claude-code/gateway-client.ts
@@ -1,0 +1,94 @@
+﻿import type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  GatewayClientOptions,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "./types.js";
+
+export class TdaiGatewayClientError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly body?: string,
+  ) {
+    super(message);
+    this.name = "TdaiGatewayClientError";
+  }
+}
+
+export class TdaiGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: GatewayClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  recall(body: RecallRequest): Promise<RecallResponse> {
+    return this.request<RecallResponse>("POST", "/recall", body);
+  }
+
+  searchMemories(body: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.request<MemorySearchResponse>("POST", "/search/memories", body);
+  }
+
+  searchConversations(body: ConversationSearchRequest): Promise<ConversationSearchResponse> {
+    return this.request<ConversationSearchResponse>("POST", "/search/conversations", body);
+  }
+
+  seed(body: SeedRequest): Promise<SeedResponse> {
+    return this.request<SeedResponse>("POST", "/seed", body);
+  }
+
+  sessionEnd(body: SessionEndRequest): Promise<SessionEndResponse> {
+    return this.request<SessionEndResponse>("POST", "/session/end", body);
+  }
+
+  private async request<T>(method: "GET" | "POST", endpoint: string, body?: unknown): Promise<T> {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    const response = await this.fetchImpl(`${this.baseUrl}${endpoint}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new TdaiGatewayClientError(
+        `TDAI Gateway ${method} ${endpoint} failed with HTTP ${response.status}`,
+        response.status,
+        text,
+      );
+    }
+
+    try {
+      return (text ? JSON.parse(text) : {}) as T;
+    } catch (err) {
+      throw new TdaiGatewayClientError(
+        `TDAI Gateway ${method} ${endpoint} returned invalid JSON`,
+        response.status,
+        text,
+      );
+    }
+  }
+}

--- a/src/adapters/claude-code/hooks/post-tool-use.test.ts
+++ b/src/adapters/claude-code/hooks/post-tool-use.test.ts
@@ -1,0 +1,31 @@
+﻿import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { getShortTermPaths } from "../short-term/store.js";
+import { handlePostToolUse } from "./post-tool-use.js";
+
+describe("handlePostToolUse", () => {
+  it("captures high-signal tool events into the short-term store", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tdai-cc-post-tool-"));
+    try {
+      await handlePostToolUse({
+        hook_event_name: "PostToolUse",
+        session_id: "s1",
+        cwd: "C:/tmp/project",
+        tool_name: "Bash",
+        tool_use_id: "toolu_1",
+        tool_input: { command: "npm test" },
+        tool_response: { stdout: "passed" },
+      }, {
+        env: { MEMORY_TENCENTDB_CLAUDE_STORAGE_DIR: dir },
+      });
+
+      const paths = getShortTermPaths({ storageDir: dir, cwd: "C:/tmp/project", sessionId: "s1" });
+      expect(existsSync(paths.jsonlPath)).toBe(true);
+      expect(existsSync(paths.mmdPath)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/adapters/claude-code/hooks/post-tool-use.ts
+++ b/src/adapters/claude-code/hooks/post-tool-use.ts
@@ -1,0 +1,43 @@
+﻿import { pathToFileURL } from "node:url";
+import { loadClaudeCodeAdapterConfig } from "../config.js";
+import { mapPostToolUseInput } from "../mappers/tool-event.js";
+import { shouldCaptureToolEvent } from "../short-term/filter.js";
+import { recordShortTermToolEvent } from "../short-term/store.js";
+import type { ClaudeCodeHookInput } from "../types.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function handlePostToolUse(
+  input: ClaudeCodeHookInput,
+  options?: { env?: NodeJS.ProcessEnv },
+): Promise<Record<string, never>> {
+  const config = loadClaudeCodeAdapterConfig(options?.env);
+  if (!config.shortTermEnabled) return {};
+
+  const event = mapPostToolUseInput(input);
+  const decision = shouldCaptureToolEvent(event);
+  recordShortTermToolEvent({
+    event,
+    decision,
+    storageDir: config.storageDir,
+  });
+  return {};
+}
+
+export async function runPostToolUseHook(): Promise<void> {
+  const raw = await readStdin();
+  const input = raw.trim() ? JSON.parse(raw) as ClaudeCodeHookInput : {};
+  const output = await handlePostToolUse(input);
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runPostToolUseHook().catch((err) => {
+    console.error(`[memory-tencentdb:claude-code] PostToolUse hook failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/adapters/claude-code/hooks/session-end.test.ts
+++ b/src/adapters/claude-code/hooks/session-end.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { handleSessionEnd } from "./session-end.js";
+
+describe("handleSessionEnd", () => {
+  it("seeds parsed transcript conversations and flushes the session", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tdai-claude-session-end-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    const calls: Array<{ name: string; body: unknown }> = [];
+
+    try {
+      writeFileSync(transcript, [
+        JSON.stringify({ type: "user", message: { role: "user", content: "hello" } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "hi" } }),
+      ].join("\n"));
+
+      await handleSessionEnd(
+        {
+          hook_event_name: "SessionEnd",
+          session_id: "s1",
+          cwd: "C:/tmp/project",
+          transcript_path: transcript,
+          reason: "clear",
+        },
+        {
+          client: {
+            seed: async (body) => {
+              calls.push({ name: "seed", body });
+              return {
+                sessions_processed: 1,
+                rounds_processed: 1,
+                messages_processed: 2,
+                l0_recorded: 2,
+                duration_ms: 1,
+                output_dir: "out",
+              };
+            },
+            sessionEnd: async (body) => {
+              calls.push({ name: "sessionEnd", body });
+              return { flushed: true };
+            },
+          },
+        },
+      );
+
+      expect(calls.map((call) => call.name)).toEqual(["seed", "sessionEnd"]);
+      expect(calls[0].body).toMatchObject({
+        data: {
+          sessions: [{
+            sessionId: "s1",
+            conversations: [[
+              { role: "user", content: "hello" },
+              { role: "assistant", content: "hi" },
+            ]],
+          }],
+        },
+        strict_round_role: false,
+        auto_fill_timestamps: true,
+      });
+      expect(calls[1].body).toMatchObject({ session_key: expect.stringMatching(/^agent:claude-code-/) });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still flushes when transcript is missing", async () => {
+    const calls: string[] = [];
+
+    await handleSessionEnd(
+      {
+        hook_event_name: "SessionEnd",
+        session_id: "s1",
+        cwd: "C:/tmp/project",
+        transcript_path: "C:/does/not/exist.jsonl",
+      },
+      {
+        client: {
+          seed: async () => {
+            calls.push("seed");
+            throw new Error("should not seed");
+          },
+          sessionEnd: async () => {
+            calls.push("sessionEnd");
+            return { flushed: true };
+          },
+        },
+      },
+    );
+
+    expect(calls).toEqual(["sessionEnd"]);
+  });
+});
+

--- a/src/adapters/claude-code/hooks/session-end.ts
+++ b/src/adapters/claude-code/hooks/session-end.ts
@@ -1,0 +1,76 @@
+﻿import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { loadClaudeCodeAdapterConfig } from "../config.js";
+import { TdaiGatewayClient } from "../gateway-client.js";
+import { parseClaudeCodeTranscriptFile } from "../mappers/transcript.js";
+import { deriveClaudeCodeSessionKey } from "../session-key.js";
+import type { ClaudeCodeHookInput } from "../types.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function handleSessionEnd(
+  input: ClaudeCodeHookInput,
+  options?: {
+    client?: Pick<TdaiGatewayClient, "seed" | "sessionEnd">;
+    env?: NodeJS.ProcessEnv;
+  },
+): Promise<Record<string, never>> {
+  const config = loadClaudeCodeAdapterConfig(options?.env);
+  const sessionKey = deriveClaudeCodeSessionKey({
+    cwd: input.cwd,
+    sessionId: input.session_id,
+  });
+  const client = options?.client ?? new TdaiGatewayClient({
+    baseUrl: config.gatewayUrl,
+    apiKey: config.gatewayApiKey,
+  });
+
+  try {
+    if (typeof input.transcript_path === "string" && existsSync(input.transcript_path)) {
+      const session = parseClaudeCodeTranscriptFile({
+        transcriptPath: input.transcript_path,
+        sessionKey,
+        sessionId: input.session_id,
+      });
+
+      if (session.conversations.length > 0) {
+        await client.seed({
+          data: { sessions: [session] },
+          session_key: sessionKey,
+          strict_round_role: false,
+          auto_fill_timestamps: true,
+        });
+      }
+    } else {
+      console.error("[memory-tencentdb:claude-code] SessionEnd transcript_path missing or unreadable; skipping /seed");
+    }
+  } catch (err) {
+    console.error(`[memory-tencentdb:claude-code] SessionEnd seed failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  try {
+    await client.sessionEnd({ session_key: sessionKey });
+  } catch (err) {
+    console.error(`[memory-tencentdb:claude-code] SessionEnd flush failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return {};
+}
+
+export async function runSessionEndHook(): Promise<void> {
+  const raw = await readStdin();
+  const input = raw.trim() ? JSON.parse(raw) as ClaudeCodeHookInput : {};
+  const output = await handleSessionEnd(input);
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runSessionEndHook().catch((err) => {
+    console.error(`[memory-tencentdb:claude-code] SessionEnd hook failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/adapters/claude-code/hooks/user-prompt-submit-canvas.test.ts
+++ b/src/adapters/claude-code/hooks/user-prompt-submit-canvas.test.ts
@@ -1,0 +1,70 @@
+﻿import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { recordShortTermToolEvent } from "../short-term/store.js";
+import { handleUserPromptSubmit } from "./user-prompt-submit.js";
+
+describe("UserPromptSubmit short-term canvas injection", () => {
+  it("reads the active canvas from the short-term store", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tdai-cc-canvas-inject-"));
+    try {
+      recordShortTermToolEvent({
+        storageDir: dir,
+        decision: { capture: true, reason: "high_signal_tool", writeRef: false },
+        event: {
+          sessionKey: "agent:claude-code-x:s1",
+          sessionId: "s1",
+          cwd: "C:/tmp/project",
+          toolUseId: "toolu_1",
+          toolName: "Bash",
+          status: "success",
+          endedAt: "2026-07-22T00:00:00Z",
+          inputSummary: "npm test",
+          resultSummary: "passed",
+        },
+      });
+
+      const output = await handleUserPromptSubmit(
+        { prompt: "continue", session_id: "s1", cwd: "C:/tmp/project" },
+        {
+          env: {
+            MEMORY_TENCENTDB_CLAUDE_STORAGE_DIR: dir,
+            MEMORY_TENCENTDB_SHORT_TERM: "true",
+          },
+          client: {
+            recall: async () => ({ context: "long memory" }),
+          },
+        },
+      );
+
+      expect(output.hookSpecificOutput?.additionalContext).toContain("Long-term Recall");
+      expect(output.hookSpecificOutput?.additionalContext).toContain("Short-term Task Canvas");
+      expect(output.hookSpecificOutput?.additionalContext).toContain("flowchart TD");
+      expect(output.hookSpecificOutput?.additionalContext).toContain("Bash");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("works when auto recall is disabled", async () => {
+    const output = await handleUserPromptSubmit(
+      { prompt: "continue", session_id: "s1", cwd: "C:/tmp/project" },
+      {
+        env: {
+          MEMORY_TENCENTDB_AUTO_RECALL: "false",
+          MEMORY_TENCENTDB_SHORT_TERM: "true",
+        },
+        shortTermCanvas: "flowchart TD\n  n1[\"OK PowerShell\"]",
+        client: {
+          recall: async () => {
+            throw new Error("should not be called");
+          },
+        },
+      },
+    );
+
+    expect(output.hookSpecificOutput?.additionalContext).toContain("Short-term Task Canvas");
+    expect(output.hookSpecificOutput?.additionalContext).toContain("OK PowerShell");
+  });
+});

--- a/src/adapters/claude-code/hooks/user-prompt-submit.test.ts
+++ b/src/adapters/claude-code/hooks/user-prompt-submit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { handleUserPromptSubmit } from "./user-prompt-submit.js";
+
+describe("handleUserPromptSubmit", () => {
+  it("injects additionalContext from Gateway recall", async () => {
+    const output = await handleUserPromptSubmit(
+      {
+        prompt: "What should I remember?",
+        session_id: "s1",
+        cwd: "C:/tmp/project",
+      },
+      {
+        env: {
+          MEMORY_TENCENTDB_AUTO_RECALL: "true",
+          MEMORY_TENCENTDB_SHORT_TERM: "false",
+        },
+        client: {
+          recall: async (body) => ({
+            context: `query=${body.query} session=${body.session_key}`,
+            strategy: "hybrid",
+            memory_count: 1,
+          }),
+        },
+      },
+    );
+
+    expect(output.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
+    expect(output.hookSpecificOutput?.additionalContext).toContain("query=What should I remember?");
+    expect(output.hookSpecificOutput?.additionalContext).toContain("agent:claude-code-");
+  });
+
+  it("does nothing when auto recall is disabled", async () => {
+    const output = await handleUserPromptSubmit(
+      { prompt: "hello", session_id: "s1" },
+      {
+        env: { MEMORY_TENCENTDB_AUTO_RECALL: "false" },
+        client: {
+          recall: async () => {
+            throw new Error("should not be called");
+          },
+        },
+      },
+    );
+
+    expect(output).toEqual({});
+  });
+});
+

--- a/src/adapters/claude-code/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude-code/hooks/user-prompt-submit.ts
@@ -1,0 +1,101 @@
+﻿import { pathToFileURL } from "node:url";
+import { loadClaudeCodeAdapterConfig } from "../config.js";
+import { formatClaudeCodeAdditionalContext } from "../context-format.js";
+import { TdaiGatewayClient } from "../gateway-client.js";
+import { deriveClaudeCodeSessionKey } from "../session-key.js";
+import { readActiveShortTermCanvas } from "../short-term/store.js";
+import type {
+  ClaudeCodeHookInput,
+  ClaudeCodeUserPromptSubmitOutput,
+  RecallResponse,
+} from "../types.js";
+
+function extractPrompt(input: ClaudeCodeHookInput): string {
+  return (
+    input.prompt ||
+    input.user_prompt ||
+    input.message?.content ||
+    ""
+  ).trim();
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function handleUserPromptSubmit(
+  input: ClaudeCodeHookInput,
+  options?: {
+    client?: Pick<TdaiGatewayClient, "recall">;
+    env?: NodeJS.ProcessEnv;
+    shortTermCanvas?: string;
+  },
+): Promise<ClaudeCodeUserPromptSubmitOutput> {
+  const config = loadClaudeCodeAdapterConfig(options?.env);
+  const prompt = extractPrompt(input);
+  if (!prompt) return {};
+
+  const sessionKey = deriveClaudeCodeSessionKey({
+    cwd: input.cwd,
+    sessionId: input.session_id,
+  });
+
+  const shortTermCanvas = config.shortTermEnabled
+    ? options?.shortTermCanvas ?? readActiveShortTermCanvas({
+        storageDir: config.storageDir,
+        cwd: input.cwd,
+        sessionId: input.session_id,
+      })
+    : undefined;
+
+  let recall: RecallResponse | undefined;
+  if (config.autoRecall) {
+    const client = options?.client ?? new TdaiGatewayClient({
+      baseUrl: config.gatewayUrl,
+      apiKey: config.gatewayApiKey,
+    });
+
+    try {
+      recall = await client.recall({
+        query: prompt,
+        session_key: sessionKey,
+      });
+    } catch (err) {
+      console.error(`[memory-tencentdb:claude-code] recall failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const additionalContext = formatClaudeCodeAdditionalContext({
+    recall,
+    shortTermCanvas,
+    options: {
+      recallMaxChars: config.recallMaxChars,
+      canvasMaxChars: config.canvasMaxChars,
+    },
+  });
+
+  return additionalContext
+    ? {
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext,
+        },
+      }
+    : {};
+}
+
+export async function runUserPromptSubmitHook(): Promise<void> {
+  const raw = await readStdin();
+  const input = raw.trim() ? JSON.parse(raw) as ClaudeCodeHookInput : {};
+  const output = await handleUserPromptSubmit(input);
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runUserPromptSubmitHook().catch((err) => {
+    console.error(`[memory-tencentdb:claude-code] hook failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -1,0 +1,15 @@
+﻿export { loadClaudeCodeAdapterConfig } from "./config.js";
+export { formatClaudeCodeAdditionalContext } from "./context-format.js";
+export { TdaiGatewayClient, TdaiGatewayClientError } from "./gateway-client.js";
+export { deriveClaudeCodeSessionKey, hashWorkspaceId } from "./session-key.js";
+export { handleUserPromptSubmit, runUserPromptSubmitHook } from "./hooks/user-prompt-submit.js";
+export { handleSessionEnd, runSessionEndHook } from "./hooks/session-end.js";
+export { handlePostToolUse, runPostToolUseHook } from "./hooks/post-tool-use.js";
+export { parseClaudeCodeTranscriptFile, transcriptRecordsToSeedSession } from "./mappers/transcript.js";
+export { mapPostToolUseInput } from "./mappers/tool-event.js";
+export { callClaudeCodeMcpTool, CLAUDE_CODE_MCP_TOOLS } from "./mcp/tools.js";
+export { runClaudeCodeMcpServer } from "./mcp/server.js";
+export { renderShortTermCanvas } from "./short-term/canvas.js";
+export { shouldCaptureToolEvent } from "./short-term/filter.js";
+export { getShortTermPaths, readActiveShortTermCanvas, recordShortTermToolEvent } from "./short-term/store.js";
+export type * from "./types.js";

--- a/src/adapters/claude-code/mappers/tool-event.test.ts
+++ b/src/adapters/claude-code/mappers/tool-event.test.ts
@@ -1,0 +1,33 @@
+﻿import { describe, expect, it } from "vitest";
+import { mapPostToolUseInput } from "./tool-event.js";
+
+describe("mapPostToolUseInput", () => {
+  it("maps Claude Code PostToolUse fields into a normalized event", () => {
+    const event = mapPostToolUseInput({
+      hook_event_name: "PostToolUse",
+      session_id: "s1",
+      cwd: "C:/tmp/project",
+      tool_name: "Bash",
+      tool_use_id: "toolu_1",
+      tool_input: { command: "npm test" },
+      tool_response: { stdout: "ok" },
+      duration_ms: 123,
+    });
+
+    expect(event.toolName).toBe("Bash");
+    expect(event.toolUseId).toBe("toolu_1");
+    expect(event.status).toBe("success");
+    expect(event.sessionKey).toMatch(/^agent:claude-code-/);
+    expect(event.inputSummary).toContain("npm test");
+  });
+
+  it("marks failure events as errors", () => {
+    const event = mapPostToolUseInput({
+      hook_event_name: "PostToolUseFailure",
+      tool_name: "Bash",
+      tool_response: { error: "boom" },
+    });
+
+    expect(event.status).toBe("error");
+  });
+});

--- a/src/adapters/claude-code/mappers/tool-event.ts
+++ b/src/adapters/claude-code/mappers/tool-event.ts
@@ -1,0 +1,49 @@
+﻿import { deriveClaudeCodeSessionKey } from "../session-key.js";
+import type { ClaudeCodeHookInput, ClaudeCodeToolEvent } from "../types.js";
+
+function compact(value: unknown, maxChars = 240): string {
+  if (value == null) return "";
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  return text.replace(/\s+/g, " ").trim().slice(0, maxChars);
+}
+
+function pickString(input: Record<string, unknown>, keys: string[], fallback: string): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return fallback;
+}
+
+function hasError(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return obj.error != null || obj.is_error === true || obj.status === "error";
+}
+
+export function mapPostToolUseInput(input: ClaudeCodeHookInput): ClaudeCodeToolEvent {
+  const raw = input as Record<string, unknown>;
+  const toolName = pickString(raw, ["tool_name", "toolName", "name"], "unknown");
+  const toolUseId = pickString(raw, ["tool_use_id", "toolUseID", "id"], `${toolName}-${Date.now()}`);
+  const rawResult = input.tool_response ?? raw.tool_output ?? raw.response ?? raw.result;
+  const status = input.hook_event_name === "PostToolUseFailure" || hasError(rawResult) ? "error" : "success";
+  const endedAt = new Date().toISOString();
+
+  return {
+    sessionKey: deriveClaudeCodeSessionKey({
+      cwd: input.cwd,
+      sessionId: input.session_id,
+    }),
+    sessionId: input.session_id,
+    cwd: input.cwd,
+    toolUseId,
+    toolName,
+    status,
+    endedAt,
+    durationMs: typeof input.duration_ms === "number" ? input.duration_ms : undefined,
+    inputSummary: compact(input.tool_input),
+    resultSummary: compact(rawResult),
+    rawInput: input.tool_input,
+    rawResult,
+  };
+}

--- a/src/adapters/claude-code/mappers/transcript.test.ts
+++ b/src/adapters/claude-code/mappers/transcript.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseClaudeCodeTranscriptFile, transcriptRecordsToSeedSession } from "./transcript.js";
+
+describe("Claude Code transcript mapper", () => {
+  it("maps user/assistant text records into seed conversations", () => {
+    const session = transcriptRecordsToSeedSession({
+      sessionKey: "agent:claude-code-x:s1",
+      sessionId: "s1",
+      records: [
+        {
+          type: "user",
+          timestamp: "2026-07-22T10:00:00Z",
+          message: { role: "user", content: "remember this" },
+        },
+        {
+          type: "assistant",
+          timestamp: "2026-07-22T10:00:01Z",
+          message: { role: "assistant", content: [{ type: "text", text: "got it" }] },
+        },
+      ],
+    });
+
+    expect(session).toEqual({
+      sessionKey: "agent:claude-code-x:s1",
+      sessionId: "s1",
+      conversations: [[
+        { role: "user", content: "remember this", timestamp: "2026-07-22T10:00:00Z" },
+        { role: "assistant", content: "got it", timestamp: "2026-07-22T10:00:01Z" },
+      ]],
+    });
+  });
+
+  it("skips tool-only records and corrupt JSONL lines", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tdai-claude-transcript-"));
+    const file = path.join(dir, "transcript.jsonl");
+    try {
+      writeFileSync(file, [
+        JSON.stringify({ type: "user", message: { role: "user", content: [{ type: "tool_result", content: "huge output" }] } }),
+        "not-json",
+        JSON.stringify({ type: "user", message: { role: "user", content: [{ type: "text", text: "actual prompt" }] } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", name: "Bash" }, { type: "text", text: "actual answer" }] } }),
+      ].join("\n"));
+
+      const session = parseClaudeCodeTranscriptFile({
+        transcriptPath: file,
+        sessionKey: "agent:claude-code-x:s1",
+      });
+
+      expect(session.conversations).toEqual([[
+        { role: "user", content: "actual prompt" },
+        { role: "assistant", content: "actual answer" },
+      ]]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/src/adapters/claude-code/mappers/transcript.ts
+++ b/src/adapters/claude-code/mappers/transcript.ts
@@ -1,0 +1,104 @@
+﻿import fs from "node:fs";
+import type { ClaudeCodeSeedMessage, ClaudeCodeSeedSession } from "../types.js";
+
+interface TranscriptRecord {
+  type?: string;
+  timestamp?: number | string;
+  message?: {
+    role?: string;
+    content?: unknown;
+  };
+  role?: string;
+  content?: unknown;
+  [key: string]: unknown;
+}
+
+function parseJsonl(content: string): TranscriptRecord[] {
+  const records: TranscriptRecord[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed) as TranscriptRecord);
+    } catch {
+      // Best-effort import: skip corrupt lines, keep later valid rounds.
+    }
+  }
+  return records;
+}
+
+function blockText(block: unknown): string {
+  if (!block || typeof block !== "object") return "";
+  const obj = block as Record<string, unknown>;
+  if (obj.type !== "text") return "";
+  return typeof obj.text === "string" ? obj.text : "";
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map(blockText)
+      .filter(Boolean)
+      .join("\n\n")
+      .trim();
+  }
+  return "";
+}
+
+function normalizeRecord(record: TranscriptRecord): ClaudeCodeSeedMessage | undefined {
+  const role = record.message?.role ?? record.role ?? record.type;
+  if (role !== "user" && role !== "assistant") return undefined;
+
+  const content = extractText(record.message?.content ?? record.content);
+  if (!content) return undefined;
+
+  return {
+    role,
+    content,
+    timestamp: record.timestamp,
+  };
+}
+
+export function transcriptRecordsToSeedSession(input: {
+  records: TranscriptRecord[];
+  sessionKey: string;
+  sessionId?: string;
+}): ClaudeCodeSeedSession {
+  const conversations: ClaudeCodeSeedMessage[][] = [];
+  let pendingUser: ClaudeCodeSeedMessage | undefined;
+
+  for (const record of input.records) {
+    const message = normalizeRecord(record);
+    if (!message) continue;
+
+    if (message.role === "user") {
+      pendingUser = message;
+      continue;
+    }
+
+    if (pendingUser) {
+      conversations.push([pendingUser, message]);
+      pendingUser = undefined;
+    }
+  }
+
+  return {
+    sessionKey: input.sessionKey,
+    sessionId: input.sessionId,
+    conversations,
+  };
+}
+
+export function parseClaudeCodeTranscriptFile(input: {
+  transcriptPath: string;
+  sessionKey: string;
+  sessionId?: string;
+}): ClaudeCodeSeedSession {
+  const content = fs.readFileSync(input.transcriptPath, "utf-8");
+  return transcriptRecordsToSeedSession({
+    records: parseJsonl(content),
+    sessionKey: input.sessionKey,
+    sessionId: input.sessionId,
+  });
+}

--- a/src/adapters/claude-code/mcp/server.ts
+++ b/src/adapters/claude-code/mcp/server.ts
@@ -1,0 +1,109 @@
+﻿import { pathToFileURL } from "node:url";
+import { loadClaudeCodeAdapterConfig } from "../config.js";
+import { TdaiGatewayClient } from "../gateway-client.js";
+import { callClaudeCodeMcpTool, CLAUDE_CODE_MCP_TOOLS } from "./tools.js";
+
+interface JsonRpcRequest {
+  jsonrpc?: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+function makeResponse(id: JsonRpcRequest["id"], result: unknown): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function makeError(id: JsonRpcRequest["id"], code: number, message: string): string {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function writeFramed(json: string): void {
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(json, "utf-8")}\r\n\r\n${json}`);
+}
+
+async function handleRequest(req: JsonRpcRequest, client: TdaiGatewayClient): Promise<string | undefined> {
+  if (req.method === "initialize") {
+    return makeResponse(req.id, {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: {
+        name: "memory-tencentdb-claude-code",
+        version: "0.1.0",
+      },
+    });
+  }
+  if (req.method === "notifications/initialized") return undefined;
+  if (req.method === "tools/list") {
+    return makeResponse(req.id, { tools: CLAUDE_CODE_MCP_TOOLS });
+  }
+  if (req.method === "tools/call") {
+    const name = typeof req.params?.name === "string" ? req.params.name : "";
+    const args = req.params?.arguments;
+    const result = await callClaudeCodeMcpTool(client, name, args);
+    return makeResponse(req.id, result);
+  }
+  return makeError(req.id, -32601, `Method not found: ${req.method}`);
+}
+
+async function dispatchMessage(json: string, client: TdaiGatewayClient): Promise<void> {
+  let request: JsonRpcRequest;
+  try {
+    request = JSON.parse(json) as JsonRpcRequest;
+  } catch {
+    writeFramed(makeError(null, -32700, "Parse error"));
+    return;
+  }
+  try {
+    const response = await handleRequest(request, client);
+    if (response) writeFramed(response);
+  } catch (err) {
+    writeFramed(makeError(request.id, -32000, err instanceof Error ? err.message : String(err)));
+  }
+}
+
+export async function runClaudeCodeMcpServer(): Promise<void> {
+  const config = loadClaudeCodeAdapterConfig();
+  const client = new TdaiGatewayClient({
+    baseUrl: config.gatewayUrl,
+    apiKey: config.gatewayApiKey,
+  });
+
+  let buffer = Buffer.alloc(0);
+  for await (const chunk of process.stdin) {
+    buffer = Buffer.concat([buffer, Buffer.from(chunk)]);
+
+    while (buffer.length > 0) {
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd >= 0) {
+        const header = buffer.slice(0, headerEnd).toString("utf-8");
+        const match = /content-length:\s*(\d+)/i.exec(header);
+        if (!match) {
+          buffer = buffer.slice(headerEnd + 4);
+          continue;
+        }
+        const length = Number.parseInt(match[1], 10);
+        const bodyStart = headerEnd + 4;
+        const bodyEnd = bodyStart + length;
+        if (buffer.length < bodyEnd) break;
+        const body = buffer.slice(bodyStart, bodyEnd).toString("utf-8");
+        buffer = buffer.slice(bodyEnd);
+        await dispatchMessage(body, client);
+        continue;
+      }
+
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) break;
+      const line = buffer.slice(0, newline).toString("utf-8").trim();
+      buffer = buffer.slice(newline + 1);
+      if (line) await dispatchMessage(line, client);
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runClaudeCodeMcpServer().catch((err) => {
+    console.error(`[memory-tencentdb:claude-code] MCP server failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/adapters/claude-code/mcp/tools.test.ts
+++ b/src/adapters/claude-code/mcp/tools.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { callClaudeCodeMcpTool, CLAUDE_CODE_MCP_TOOLS } from "./tools.js";
+
+describe("Claude Code MCP tools", () => {
+  it("declares the expected search tools", () => {
+    expect(CLAUDE_CODE_MCP_TOOLS.map((tool) => tool.name)).toEqual([
+      "memory_tencentdb_memory_search",
+      "memory_tencentdb_conversation_search",
+    ]);
+  });
+
+  it("calls memory search with normalized args", async () => {
+    const calls: unknown[] = [];
+    const result = await callClaudeCodeMcpTool(
+      {
+        searchMemories: async (args) => {
+          calls.push(args);
+          return { results: "memory result", total: 1, strategy: "hybrid" };
+        },
+        searchConversations: async () => {
+          throw new Error("wrong endpoint");
+        },
+      },
+      "memory_tencentdb_memory_search",
+      { query: "  q  ", limit: 3, type: "preference", scene: "coding" },
+    );
+
+    expect(calls).toEqual([{ query: "q", limit: 3, type: "preference", scene: "coding" }]);
+    expect(result.content[0].text).toContain("memory result");
+  });
+
+  it("calls conversation search with normalized args", async () => {
+    const calls: unknown[] = [];
+    const result = await callClaudeCodeMcpTool(
+      {
+        searchMemories: async () => {
+          throw new Error("wrong endpoint");
+        },
+        searchConversations: async (args) => {
+          calls.push(args);
+          return { results: "conversation result", total: 2 };
+        },
+      },
+      "memory_tencentdb_conversation_search",
+      { query: "history", limit: 2, session_key: "agent:claude-code-x:s" },
+    );
+
+    expect(calls).toEqual([{ query: "history", limit: 2, session_key: "agent:claude-code-x:s" }]);
+    expect(result.content[0].text).toContain("conversation result");
+  });
+});
+

--- a/src/adapters/claude-code/mcp/tools.ts
+++ b/src/adapters/claude-code/mcp/tools.ts
@@ -1,0 +1,109 @@
+import { TdaiGatewayClient } from "../gateway-client.js";
+import type {
+  ClaudeCodeMcpToolName,
+  ConversationSearchToolArgs,
+  MemorySearchToolArgs,
+} from "../types.js";
+
+export interface ClaudeCodeMcpToolDefinition {
+  name: ClaudeCodeMcpToolName;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export const CLAUDE_CODE_MCP_TOOLS: ClaudeCodeMcpToolDefinition[] = [
+  {
+    name: "memory_tencentdb_memory_search",
+    description: "Search TencentDB-Agent-Memory long-term L1 memories.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query." },
+        limit: { type: "number", description: "Maximum result count." },
+        type: { type: "string", description: "Optional memory type filter." },
+        scene: { type: "string", description: "Optional scene filter." },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "memory_tencentdb_conversation_search",
+    description: "Search TencentDB-Agent-Memory L0 conversation history.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query." },
+        limit: { type: "number", description: "Maximum result count." },
+        session_key: { type: "string", description: "Optional session key filter." },
+      },
+      required: ["query"],
+    },
+  },
+];
+
+function requireQuery(args: unknown): string {
+  if (!args || typeof args !== "object") throw new Error("Tool arguments must be an object");
+  const query = (args as { query?: unknown }).query;
+  if (typeof query !== "string" || query.trim() === "") throw new Error("`query` is required");
+  return query.trim();
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+export async function callClaudeCodeMcpTool(
+  client: Pick<TdaiGatewayClient, "searchMemories" | "searchConversations">,
+  name: string,
+  args: unknown,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  if (name === "memory_tencentdb_memory_search") {
+    const query = requireQuery(args);
+    const raw = args as Partial<MemorySearchToolArgs>;
+    const result = await client.searchMemories({
+      query,
+      limit: optionalNumber(raw.limit),
+      type: optionalString(raw.type),
+      scene: optionalString(raw.scene),
+    });
+    return {
+      content: [{
+        type: "text",
+        text: [
+          `TencentDB-Agent-Memory memory search`,
+          `total=${result.total} strategy=${result.strategy}`,
+          "",
+          result.results,
+        ].join("\n"),
+      }],
+    };
+  }
+
+  if (name === "memory_tencentdb_conversation_search") {
+    const query = requireQuery(args);
+    const raw = args as Partial<ConversationSearchToolArgs>;
+    const result = await client.searchConversations({
+      query,
+      limit: optionalNumber(raw.limit),
+      session_key: optionalString(raw.session_key),
+    });
+    return {
+      content: [{
+        type: "text",
+        text: [
+          `TencentDB-Agent-Memory conversation search`,
+          `total=${result.total}`,
+          "",
+          result.results,
+        ].join("\n"),
+      }],
+    };
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+}
+

--- a/src/adapters/claude-code/session-key.test.ts
+++ b/src/adapters/claude-code/session-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { deriveClaudeCodeSessionKey, hashWorkspaceId } from "./session-key.js";
+
+describe("Claude Code session key", () => {
+  it("derives a stable agent-scoped key", () => {
+    const key = deriveClaudeCodeSessionKey({
+      cwd: "C:/Users/example/project",
+      sessionId: "abc-123",
+    });
+
+    expect(key).toMatch(/^agent:claude-code-[a-f0-9]{10}:abc-123$/);
+  });
+
+  it("does not leak the raw workspace path", () => {
+    const cwd = "C:/Users/example/secret-workspace";
+    const key = deriveClaudeCodeSessionKey({ cwd, sessionId: "session" });
+
+    expect(key).not.toContain("secret-workspace");
+    expect(key).not.toContain("Users");
+  });
+
+  it("sanitizes unusual session ids", () => {
+    const key = deriveClaudeCodeSessionKey({
+      cwd: "C:/tmp/project",
+      sessionId: "session id/with spaces",
+    });
+
+    expect(key.endsWith(":session-id-with-spaces")).toBe(true);
+  });
+
+  it("hashes the same cwd consistently", () => {
+    expect(hashWorkspaceId("C:/tmp/project")).toBe(hashWorkspaceId("C:/tmp/project"));
+  });
+});
+

--- a/src/adapters/claude-code/session-key.ts
+++ b/src/adapters/claude-code/session-key.ts
@@ -1,0 +1,23 @@
+import { createHash, randomBytes } from "node:crypto";
+import path from "node:path";
+
+export function hashWorkspaceId(cwd: string | undefined): string {
+  const normalized = path.resolve(cwd || process.cwd()).toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 10);
+}
+
+function sanitizeSessionId(sessionId: string | undefined): string {
+  if (!sessionId || sessionId.trim() === "") {
+    const day = new Date().toISOString().slice(0, 10).replaceAll("-", "");
+    return `manual-${day}-${randomBytes(4).toString("hex")}`;
+  }
+  return sessionId.trim().replace(/[^a-zA-Z0-9_.:-]/g, "-").slice(0, 96);
+}
+
+export function deriveClaudeCodeSessionKey(input: {
+  cwd?: string;
+  sessionId?: string;
+}): string {
+  return `agent:claude-code-${hashWorkspaceId(input.cwd)}:${sanitizeSessionId(input.sessionId)}`;
+}
+

--- a/src/adapters/claude-code/short-term/canvas.ts
+++ b/src/adapters/claude-code/short-term/canvas.ts
@@ -1,0 +1,27 @@
+﻿import type { ShortTermRecord } from "../types.js";
+
+function mermaidLabel(record: ShortTermRecord): string {
+  const status = record.status === "error" ? "ERR" : "OK";
+  const summary = record.result_summary || record.input_summary || record.tool_name;
+  return `${status} ${record.tool_name}: ${summary}`
+    .replace(/["<>]/g, "")
+    .replace(/\s+/g, " ")
+    .slice(0, 96);
+}
+
+export function renderShortTermCanvas(records: ShortTermRecord[]): string {
+  const recent = records.slice(-20);
+  const lines = ["flowchart TD"];
+  if (recent.length === 0) {
+    lines.push('  empty["No captured tool events yet"]');
+    return lines.join("\n");
+  }
+
+  for (const record of recent) {
+    lines.push(`  ${record.node_id}["${mermaidLabel(record)}"]`);
+  }
+  for (let i = 1; i < recent.length; i++) {
+    lines.push(`  ${recent[i - 1]!.node_id} --> ${recent[i]!.node_id}`);
+  }
+  return lines.join("\n");
+}

--- a/src/adapters/claude-code/short-term/filter.test.ts
+++ b/src/adapters/claude-code/short-term/filter.test.ts
@@ -1,0 +1,36 @@
+﻿import { describe, expect, it } from "vitest";
+import type { ClaudeCodeToolEvent } from "../types.js";
+import { shouldCaptureToolEvent } from "./filter.js";
+
+function event(overrides: Partial<ClaudeCodeToolEvent>): ClaudeCodeToolEvent {
+  return {
+    sessionKey: "agent:claude-code-x:s",
+    toolUseId: "t1",
+    toolName: "Read",
+    status: "success",
+    endedAt: "2026-07-22T00:00:00Z",
+    inputSummary: "",
+    resultSummary: "",
+    ...overrides,
+  };
+}
+
+describe("shouldCaptureToolEvent", () => {
+  it("captures failures", () => {
+    expect(shouldCaptureToolEvent(event({ status: "error" }))).toMatchObject({ capture: true, reason: "tool_error" });
+  });
+
+  it("captures shell and edit tools", () => {
+    expect(shouldCaptureToolEvent(event({ toolName: "Bash" })).capture).toBe(true);
+    expect(shouldCaptureToolEvent(event({ toolName: "Edit" })).capture).toBe(true);
+  });
+
+  it("skips low-signal read/search tools by default", () => {
+    expect(shouldCaptureToolEvent(event({ toolName: "Read" })).capture).toBe(false);
+    expect(shouldCaptureToolEvent(event({ toolName: "Grep" })).capture).toBe(false);
+  });
+
+  it("captures large outputs", () => {
+    expect(shouldCaptureToolEvent(event({ toolName: "Read", rawResult: "x".repeat(5000) })).reason).toBe("large_result");
+  });
+});

--- a/src/adapters/claude-code/short-term/filter.ts
+++ b/src/adapters/claude-code/short-term/filter.ts
@@ -1,0 +1,42 @@
+﻿import type { ClaudeCodeToolEvent, ToolCaptureDecision } from "../types.js";
+
+const DEFAULT_CAPTURE_TOOL_PATTERNS = [
+  /bash/i,
+  /shell/i,
+  /terminal/i,
+  /edit/i,
+  /write/i,
+  /patch/i,
+  /notebookedit/i,
+];
+
+const DEFAULT_SKIP_TOOL_PATTERNS = [
+  /^read$/i,
+  /^ls$/i,
+  /glob/i,
+  /grep/i,
+  /search/i,
+];
+
+const LARGE_RESULT_CHARS = 4000;
+
+export function shouldCaptureToolEvent(event: ClaudeCodeToolEvent): ToolCaptureDecision {
+  if (event.status === "error") {
+    return { capture: true, reason: "tool_error", writeRef: true };
+  }
+
+  const resultLength = event.resultSummary.length + JSON.stringify(event.rawResult ?? "").length;
+  if (resultLength >= LARGE_RESULT_CHARS) {
+    return { capture: true, reason: "large_result", writeRef: true };
+  }
+
+  if (DEFAULT_CAPTURE_TOOL_PATTERNS.some((pattern) => pattern.test(event.toolName))) {
+    return { capture: true, reason: "high_signal_tool", writeRef: resultLength > 1000 };
+  }
+
+  if (DEFAULT_SKIP_TOOL_PATTERNS.some((pattern) => pattern.test(event.toolName))) {
+    return { capture: false, reason: "low_signal_read_only_tool", writeRef: false };
+  }
+
+  return { capture: false, reason: "default_skip", writeRef: false };
+}

--- a/src/adapters/claude-code/short-term/store.test.ts
+++ b/src/adapters/claude-code/short-term/store.test.ts
@@ -1,0 +1,41 @@
+﻿import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { getShortTermPaths, readActiveShortTermCanvas, recordShortTermToolEvent } from "./store.js";
+
+describe("Claude Code short-term store", () => {
+  it("writes refs, jsonl, mmd, and state for captured tool events", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "tdai-cc-store-"));
+    try {
+      const record = recordShortTermToolEvent({
+        storageDir: dir,
+        decision: { capture: true, reason: "high_signal_tool", writeRef: true },
+        event: {
+          sessionKey: "agent:claude-code-x:s1",
+          sessionId: "s1",
+          cwd: "C:/tmp/project",
+          toolUseId: "toolu_1",
+          toolName: "Bash",
+          status: "success",
+          endedAt: "2026-07-22T00:00:00Z",
+          inputSummary: "npm test",
+          resultSummary: "passed",
+          rawInput: { command: "npm test" },
+          rawResult: { stdout: "passed" },
+        },
+      });
+
+      const paths = getShortTermPaths({ storageDir: dir, cwd: "C:/tmp/project", sessionId: "s1" });
+      expect(record?.node_id).toBe("n1");
+      expect(existsSync(paths.jsonlPath)).toBe(true);
+      expect(existsSync(paths.mmdPath)).toBe(true);
+      expect(existsSync(paths.statePath)).toBe(true);
+      expect(readFileSync(paths.jsonlPath, "utf-8")).toContain("toolu_1");
+      expect(readActiveShortTermCanvas({ storageDir: dir, cwd: "C:/tmp/project", sessionId: "s1" })).toContain("flowchart TD");
+      expect(record?.result_ref).toBe("refs/toolu_1.md");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/adapters/claude-code/short-term/store.ts
+++ b/src/adapters/claude-code/short-term/store.ts
@@ -1,0 +1,143 @@
+﻿import fs from "node:fs";
+import path from "node:path";
+import { hashWorkspaceId } from "../session-key.js";
+import type { ClaudeCodeToolEvent, ShortTermRecord, ToolCaptureDecision } from "../types.js";
+import { renderShortTermCanvas } from "./canvas.js";
+
+function safePart(value: string | undefined, fallback: string): string {
+  const raw = value && value.trim() ? value.trim() : fallback;
+  return raw.replace(/[^a-zA-Z0-9_.:-]/g, "-").slice(0, 96);
+}
+
+export function getShortTermPaths(input: {
+  storageDir: string;
+  cwd?: string;
+  sessionId?: string;
+}): {
+  workspaceHash: string;
+  workspaceDir: string;
+  refsDir: string;
+  mmdsDir: string;
+  jsonlPath: string;
+  mmdPath: string;
+  statePath: string;
+} {
+  const workspaceHash = hashWorkspaceId(input.cwd);
+  const sessionId = safePart(input.sessionId, "manual");
+  const workspaceDir = path.join(input.storageDir, workspaceHash);
+  return {
+    workspaceHash,
+    workspaceDir,
+    refsDir: path.join(workspaceDir, "refs"),
+    mmdsDir: path.join(workspaceDir, "mmds"),
+    jsonlPath: path.join(workspaceDir, `offload-${sessionId}.jsonl`),
+    mmdPath: path.join(workspaceDir, "mmds", `${sessionId}.mmd`),
+    statePath: path.join(workspaceDir, "state.json"),
+  };
+}
+
+function ensureDirs(paths: ReturnType<typeof getShortTermPaths>): void {
+  fs.mkdirSync(paths.refsDir, { recursive: true });
+  fs.mkdirSync(paths.mmdsDir, { recursive: true });
+}
+
+function readRecords(jsonlPath: string): ShortTermRecord[] {
+  if (!fs.existsSync(jsonlPath)) return [];
+  const text = fs.readFileSync(jsonlPath, "utf-8");
+  const records: ShortTermRecord[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed) as ShortTermRecord);
+    } catch {
+      // Keep the canvas usable even if one line is corrupt.
+    }
+  }
+  return records;
+}
+
+function writeRef(paths: ReturnType<typeof getShortTermPaths>, event: ClaudeCodeToolEvent): string {
+  const file = `${safePart(event.toolUseId, "tool")}.md`;
+  const refPath = path.join(paths.refsDir, file);
+  const body = [
+    `# Tool result: ${event.toolName}`,
+    "",
+    `- tool_use_id: ${event.toolUseId}`,
+    `- status: ${event.status}`,
+    `- ended_at: ${event.endedAt}`,
+    "",
+    "## Input",
+    "",
+    "```json",
+    JSON.stringify(event.rawInput ?? null, null, 2),
+    "```",
+    "",
+    "## Result",
+    "",
+    "```json",
+    JSON.stringify(event.rawResult ?? null, null, 2),
+    "```",
+    "",
+  ].join("\n");
+  fs.writeFileSync(refPath, body, "utf-8");
+  return path.relative(paths.workspaceDir, refPath).replaceAll("\\", "/");
+}
+
+export function recordShortTermToolEvent(input: {
+  event: ClaudeCodeToolEvent;
+  decision: ToolCaptureDecision;
+  storageDir: string;
+}): ShortTermRecord | undefined {
+  if (!input.decision.capture) return undefined;
+
+  const paths = getShortTermPaths({
+    storageDir: input.storageDir,
+    cwd: input.event.cwd,
+    sessionId: input.event.sessionId,
+  });
+  ensureDirs(paths);
+
+  const records = readRecords(paths.jsonlPath);
+  const nodeId = `n${records.length + 1}`;
+  const resultRef = input.decision.writeRef ? writeRef(paths, input.event) : undefined;
+
+  const record: ShortTermRecord = {
+    session_key: input.event.sessionKey,
+    session_id: input.event.sessionId,
+    cwd_hash: paths.workspaceHash,
+    node_id: nodeId,
+    tool_use_id: input.event.toolUseId,
+    tool_name: input.event.toolName,
+    status: input.event.status,
+    started_at: input.event.startedAt,
+    ended_at: input.event.endedAt,
+    duration_ms: input.event.durationMs,
+    input_summary: input.event.inputSummary,
+    result_summary: input.event.resultSummary,
+    result_ref: resultRef,
+    capture_reason: input.decision.reason,
+  };
+
+  fs.appendFileSync(paths.jsonlPath, `${JSON.stringify(record)}\n`, "utf-8");
+  const nextRecords = [...records, record];
+  fs.writeFileSync(paths.mmdPath, renderShortTermCanvas(nextRecords), "utf-8");
+  fs.writeFileSync(paths.statePath, JSON.stringify({
+    updated_at: input.event.endedAt,
+    last_session_id: input.event.sessionId,
+    last_node_id: nodeId,
+  }, null, 2), "utf-8");
+
+  return record;
+}
+
+export function readActiveShortTermCanvas(input: {
+  storageDir: string;
+  cwd?: string;
+  sessionId?: string;
+}): string | undefined {
+  const paths = getShortTermPaths(input);
+  if (!fs.existsSync(paths.mmdPath)) return undefined;
+  const text = fs.readFileSync(paths.mmdPath, "utf-8").trim();
+  return text || undefined;
+}

--- a/src/adapters/claude-code/types.ts
+++ b/src/adapters/claude-code/types.ts
@@ -1,0 +1,143 @@
+﻿import type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+};
+
+export interface ClaudeCodeAdapterConfig {
+  gatewayUrl: string;
+  gatewayApiKey?: string;
+  autoRecall: boolean;
+  recallMaxChars: number;
+  canvasMaxChars: number;
+  shortTermEnabled: boolean;
+  storageDir: string;
+}
+
+export interface ClaudeCodeHookInput {
+  hook_event_name?: string;
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  prompt?: string;
+  user_prompt?: string;
+  message?: {
+    content?: string;
+  };
+  reason?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_response?: unknown;
+  tool_use_id?: string;
+  duration_ms?: number;
+  [key: string]: unknown;
+}
+
+export interface ClaudeCodeUserPromptSubmitOutput {
+  hookSpecificOutput?: {
+    hookEventName: "UserPromptSubmit";
+    additionalContext?: string;
+  };
+}
+
+export interface ContextFormatOptions {
+  recallMaxChars: number;
+  canvasMaxChars: number;
+}
+
+export interface GatewayClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface MemorySearchToolArgs {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface ConversationSearchToolArgs {
+  query: string;
+  limit?: number;
+  session_key?: string;
+}
+
+export type ClaudeCodeMcpToolName =
+  | "memory_tencentdb_memory_search"
+  | "memory_tencentdb_conversation_search";
+
+export interface ClaudeCodeSeedMessage {
+  role: "user" | "assistant";
+  content: string;
+  timestamp?: number | string;
+}
+
+export interface ClaudeCodeSeedSession {
+  sessionKey: string;
+  sessionId?: string;
+  conversations: ClaudeCodeSeedMessage[][];
+}
+
+export interface ClaudeCodeToolEvent {
+  sessionKey: string;
+  sessionId?: string;
+  cwd?: string;
+  toolUseId: string;
+  toolName: string;
+  status: "success" | "error";
+  startedAt?: string;
+  endedAt: string;
+  durationMs?: number;
+  inputSummary: string;
+  resultSummary: string;
+  rawInput?: unknown;
+  rawResult?: unknown;
+  resultRef?: string;
+}
+
+export interface ToolCaptureDecision {
+  capture: boolean;
+  reason: string;
+  writeRef: boolean;
+}
+
+export interface ShortTermRecord {
+  session_key: string;
+  session_id?: string;
+  cwd_hash: string;
+  node_id: string;
+  tool_use_id: string;
+  tool_name: string;
+  status: "success" | "error";
+  started_at?: string;
+  ended_at: string;
+  duration_ms?: number;
+  input_summary: string;
+  result_summary: string;
+  result_ref?: string;
+  capture_reason: string;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,6 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Claude Code adapter
+export * from "./claude-code/index.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,13 +1,15 @@
 /**
- * TDAI Adapters — barrel re-export for all host adapter implementations.
+ * TDAI Adapters - barrel re-export for all host adapter implementations.
  *
- * Each adapter translates a specific host environment's API into
- * the host-neutral HostAdapter interface consumed by TdaiCore.
+ * Each adapter translates a specific host environment API into the integration
+ * shape needed to reach TdaiCore.
  *
  * Directory structure:
  *   adapters/
- *   ├── openclaw/      — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
- *   └── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   - openclaw/     OpenClaw plugin host (in-process, runEmbeddedPiAgent)
+ *   - standalone/   Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   - claude-code/  Claude Code hooks, MCP search tools, and short-term canvas capture
+ *   - pi-agent/     Pi Agent extension lifecycle hooks and custom memory tools
  */
 
 // OpenClaw adapter
@@ -20,3 +22,6 @@ export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRu
 
 // Claude Code adapter
 export * from "./claude-code/index.js";
+
+// Pi Agent adapter
+export * from "./pi-agent/index.js";

--- a/src/adapters/pi-agent/README.md
+++ b/src/adapters/pi-agent/README.md
@@ -1,0 +1,78 @@
+# Pi Agent Adapter
+
+This adapter maps Pi Agent Extension lifecycle events and custom tools to the existing TencentDB-Agent-Memory Gateway.
+
+The adapter is intentionally separate from `src/adapters/claude-code/`:
+
+- Claude Code uses hooks plus MCP.
+- Pi Agent v1 uses Pi Extension lifecycle events plus custom tool definitions.
+- Pi Agent v1 does not copy Claude Code short-term canvas/offload internals; `tool_result` and `context_get` are reserved for the next stage.
+- Pi Agent memory keys use the `pi-agent:` prefix, so Pi sessions do not collide with Claude Code sessions.
+
+## Current v1 scope
+
+Supported:
+
+- `before_agent_start` -> Gateway `/recall` -> returns a Pi custom message containing recalled memory context
+- `session_shutdown` -> Gateway `/seed` + `/session/end`
+- `memory_search` custom tool -> Gateway `/search/memories`
+- `conversation_search` custom tool -> Gateway `/search/conversations`
+- `context_get` custom tool -> reserved response explaining that short-term context is not implemented in v1
+
+Compatibility aliases are kept for the earlier draft names `session_start` and `session_end`, but the default extension registration follows the official Pi lifecycle names.
+
+Not included yet:
+
+- tool trajectory persistence
+- short-term context offload/compression
+- automatic Pi-specific context restore
+
+## Usage sketch
+
+```ts
+import registerPiAgentMemoryExtension from "@tencentdb-agent-memory/memory-tencentdb/src/adapters/pi-agent";
+
+export default function register(pi) {
+  registerPiAgentMemoryExtension(pi, {
+    config: {
+      gatewayUrl: "http://127.0.0.1:8420",
+    },
+  });
+}
+```
+
+The adapter expects the Pi Extension runtime shape:
+
+```ts
+pi.on("before_agent_start", handler);
+pi.on("session_shutdown", handler);
+pi.on("tool_result", handler);
+pi.registerTool({ name: "memory_search", parameters, execute });
+pi.registerTool({ name: "conversation_search", parameters, execute });
+pi.registerTool({ name: "context_get", parameters, execute });
+```
+
+## Environment
+
+```text
+MEMORY_TENCENTDB_PI_GATEWAY_URL=http://127.0.0.1:8420
+MEMORY_TENCENTDB_PI_GATEWAY_API_KEY=
+MEMORY_TENCENTDB_PI_AUTO_RECALL=true
+MEMORY_TENCENTDB_PI_AUTO_CAPTURE=true
+MEMORY_TENCENTDB_PI_RECALL_MAX_CHARS=4000
+MEMORY_TENCENTDB_PI_USER_ID=default_user
+```
+
+The generic `MEMORY_TENCENTDB_GATEWAY_URL`, `MEMORY_TENCENTDB_GATEWAY_API_KEY`, and `TDAI_GATEWAY_API_KEY` variables are accepted as fallbacks.
+
+## Design boundary
+
+Pi Agent v1 proves the lifecycle loop:
+
+```text
+Pi before_agent_start -> recall -> custom memory message
+Pi session_shutdown   -> seed/capture -> session end
+Pi tools              -> memory/conversation search
+```
+
+Short-term memory should be designed as a Pi-native follow-up instead of reusing Claude Code's canvas/offload files directly.

--- a/src/adapters/pi-agent/adapter.ts
+++ b/src/adapters/pi-agent/adapter.ts
@@ -1,0 +1,71 @@
+import { loadPiAgentAdapterConfig } from "./config.js";
+import { PiAgentGatewayClient } from "./gateway-client.js";
+import { PiAgentLifecycleAdapter } from "./lifecycle.js";
+import { PiAgentMemoryTools } from "./tools.js";
+import type {
+  PiAgentAdapterConfig,
+  PiAgentBeforeAgentStartEvent,
+  PiAgentContextInjector,
+  PiAgentExtensionContext,
+  PiAgentSessionEvent,
+  PiAgentToolEvent,
+} from "./types.js";
+
+export interface PiAgentMemoryAdapterOptions {
+  config?: Partial<PiAgentAdapterConfig>;
+  env?: NodeJS.ProcessEnv;
+  client?: PiAgentGatewayClient;
+  injectContext?: PiAgentContextInjector;
+}
+
+export class PiAgentMemoryAdapter {
+  readonly config: PiAgentAdapterConfig;
+  readonly client: PiAgentGatewayClient;
+  readonly lifecycle: PiAgentLifecycleAdapter;
+  readonly tools: PiAgentMemoryTools;
+
+  constructor(options: PiAgentMemoryAdapterOptions = {}) {
+    this.config = { ...loadPiAgentAdapterConfig(options.env), ...(options.config ?? {}) };
+    this.client = options.client ?? new PiAgentGatewayClient({
+      baseUrl: this.config.gatewayUrl,
+      apiKey: this.config.gatewayApiKey,
+    });
+    this.lifecycle = new PiAgentLifecycleAdapter(this.client, this.config, options.injectContext);
+    this.tools = new PiAgentMemoryTools(this.client);
+  }
+
+  onBeforeAgentStart(event: PiAgentBeforeAgentStartEvent, ctx?: PiAgentExtensionContext) {
+    return this.lifecycle.onBeforeAgentStart(event, ctx);
+  }
+
+  onSessionShutdown(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext) {
+    return this.lifecycle.onSessionShutdown(event, ctx);
+  }
+
+  onSessionStart(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext) {
+    return this.lifecycle.onSessionStart(event, ctx);
+  }
+
+  onSessionEnd(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext) {
+    return this.lifecycle.onSessionEnd(event, ctx);
+  }
+
+  onToolResult(_event: PiAgentToolEvent) {
+    return {
+      captured: false,
+      skippedReason: "Pi Agent v1 reserves tool_result short-term capture for the next stage.",
+    };
+  }
+
+  memorySearch(args: Parameters<PiAgentMemoryTools["memorySearch"]>[0]) {
+    return this.tools.memorySearch(args);
+  }
+
+  conversationSearch(args: Parameters<PiAgentMemoryTools["conversationSearch"]>[0]) {
+    return this.tools.conversationSearch(args);
+  }
+
+  contextGet(args: Parameters<PiAgentMemoryTools["contextGet"]>[0]) {
+    return this.tools.contextGet(args);
+  }
+}

--- a/src/adapters/pi-agent/config.ts
+++ b/src/adapters/pi-agent/config.ts
@@ -1,0 +1,24 @@
+import os from "node:os";
+import type { PiAgentAdapterConfig } from "./types.js";
+
+function envFlag(value: string | undefined, fallback: boolean): boolean {
+  if (value == null || value === "") return fallback;
+  return !["0", "false", "no", "off"].includes(value.toLowerCase());
+}
+
+function envNumber(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function loadPiAgentAdapterConfig(env: NodeJS.ProcessEnv = process.env): PiAgentAdapterConfig {
+  return {
+    gatewayUrl: env.MEMORY_TENCENTDB_PI_GATEWAY_URL || env.MEMORY_TENCENTDB_GATEWAY_URL || "http://127.0.0.1:8420",
+    gatewayApiKey: env.MEMORY_TENCENTDB_PI_GATEWAY_API_KEY || env.MEMORY_TENCENTDB_GATEWAY_API_KEY || env.TDAI_GATEWAY_API_KEY,
+    autoRecall: envFlag(env.MEMORY_TENCENTDB_PI_AUTO_RECALL, true),
+    autoCapture: envFlag(env.MEMORY_TENCENTDB_PI_AUTO_CAPTURE, true),
+    recallMaxChars: envNumber(env.MEMORY_TENCENTDB_PI_RECALL_MAX_CHARS, 4000),
+    defaultUserId: env.MEMORY_TENCENTDB_PI_USER_ID || env.TDAI_USER_ID || os.userInfo().username || "default_user",
+  };
+}

--- a/src/adapters/pi-agent/context.test.ts
+++ b/src/adapters/pi-agent/context.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatPiAgentMemoryContext } from "./context.js";
+
+describe("formatPiAgentMemoryContext", () => {
+  it("formats recall context for Pi Agent injection", () => {
+    const context = formatPiAgentMemoryContext({
+      recall: { context: "remember cobalt", strategy: "keyword", memory_count: 1 },
+      maxChars: 1000,
+    });
+
+    expect(context).toContain("Long-term Memory Recall for Pi Agent");
+    expect(context).toContain("strategy=keyword");
+    expect(context).toContain("remember cobalt");
+  });
+
+  it("returns empty string when recall has no context", () => {
+    expect(formatPiAgentMemoryContext({ recall: { context: "" }, maxChars: 1000 })).toBe("");
+  });
+});

--- a/src/adapters/pi-agent/context.ts
+++ b/src/adapters/pi-agent/context.ts
@@ -1,0 +1,26 @@
+import type { RecallResponse } from "./types.js";
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n... [truncated]`;
+}
+
+export function formatPiAgentMemoryContext(input: {
+  recall?: RecallResponse;
+  maxChars: number;
+}): string {
+  const recallContext = input.recall?.context?.trim();
+  if (!recallContext) return "";
+
+  const metadata: string[] = [];
+  if (input.recall?.strategy) metadata.push(`strategy=${input.recall.strategy}`);
+  if (typeof input.recall?.memory_count === "number") metadata.push(`memory_count=${input.recall.memory_count}`);
+
+  return [
+    "<tencentdb-agent-memory>",
+    "## Long-term Memory Recall for Pi Agent",
+    metadata.length > 0 ? `Metadata: ${metadata.join(", ")}` : undefined,
+    truncateText(recallContext, input.maxChars),
+    "</tencentdb-agent-memory>",
+  ].filter(Boolean).join("\n\n");
+}

--- a/src/adapters/pi-agent/extension.test.ts
+++ b/src/adapters/pi-agent/extension.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerPiAgentMemoryExtension } from "./extension.js";
+import { PiAgentGatewayClient } from "./gateway-client.js";
+
+function mockClient() {
+  return new PiAgentGatewayClient({ baseUrl: "http://127.0.0.1:8420", fetchImpl: vi.fn() as unknown as typeof fetch });
+}
+
+describe("registerPiAgentMemoryExtension", () => {
+  it("registers Pi lifecycle hooks and custom tool definitions without MCP", () => {
+    const hooks = new Map<string, unknown>();
+    const tools = new Map<string, unknown>();
+    const pi = {
+      on: vi.fn((name: string, handler: unknown) => hooks.set(name, handler)),
+      registerTool: vi.fn((definition: { name: string }) => tools.set(definition.name, definition)),
+    };
+
+    registerPiAgentMemoryExtension(pi, { client: mockClient() });
+
+    expect([...hooks.keys()]).toEqual(["before_agent_start", "session_shutdown", "tool_result"]);
+    expect([...tools.keys()]).toEqual(["memory_search", "conversation_search", "context_get"]);
+    expect(tools.get("memory_search")).toMatchObject({
+      name: "memory_search",
+      parameters: expect.objectContaining({ type: "object" }),
+      execute: expect.any(Function),
+    });
+  });
+});

--- a/src/adapters/pi-agent/extension.ts
+++ b/src/adapters/pi-agent/extension.ts
@@ -1,0 +1,110 @@
+import { PiAgentMemoryAdapter, type PiAgentMemoryAdapterOptions } from "./adapter.js";
+import type {
+  PiAgentConversationSearchArgs,
+  PiAgentContextGetArgs,
+  PiAgentMemorySearchArgs,
+  PiAgentRuntime,
+  PiAgentToolDefinition,
+  PiAgentToolResult,
+} from "./types.js";
+
+function textResult(text: string): PiAgentToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function stringParam(description: string) {
+  return { type: "string", description };
+}
+
+function numberParam(description: string) {
+  return { type: "number", description };
+}
+
+function makeMemorySearchTool(adapter: PiAgentMemoryAdapter): PiAgentToolDefinition {
+  return {
+    name: "memory_search",
+    label: "Search TencentDB long-term memory",
+    description: "Search TencentDB-Agent-Memory long-term semantic memories for Pi Agent.",
+    promptSnippet: "Use memory_search when the user asks about durable preferences, project history, or prior decisions.",
+    promptGuidelines: [
+      "Call memory_search before answering questions that may depend on durable memory.",
+      "Keep queries concise and include project-specific terms when available.",
+    ],
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: {
+        query: stringParam("Search query."),
+        limit: numberParam("Maximum number of memories to return. Defaults to 5, capped at 20."),
+        type: stringParam("Optional memory type filter, such as atom, scenario, or persona."),
+        scene: stringParam("Optional scenario or scene filter."),
+      },
+    },
+    execute: async (_toolCallId, params) => textResult(await adapter.memorySearch(params as PiAgentMemorySearchArgs)),
+  };
+}
+
+function makeConversationSearchTool(adapter: PiAgentMemoryAdapter): PiAgentToolDefinition {
+  return {
+    name: "conversation_search",
+    label: "Search TencentDB conversations",
+    description: "Search raw L0 conversations captured by TencentDB-Agent-Memory.",
+    promptSnippet: "Use conversation_search when exact previous conversation evidence is needed.",
+    promptGuidelines: [
+      "Prefer conversation_search for quoted or chronology-sensitive recall.",
+      "Use memory_search for synthesized long-term facts.",
+    ],
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query"],
+      properties: {
+        query: stringParam("Search query."),
+        limit: numberParam("Maximum number of conversations to return. Defaults to 5, capped at 20."),
+        sessionKey: stringParam("Optional TencentDB-Agent-Memory session key."),
+        session_key: stringParam("Optional TencentDB-Agent-Memory session key."),
+      },
+    },
+    execute: async (_toolCallId, params) => textResult(await adapter.conversationSearch(params as PiAgentConversationSearchArgs)),
+  };
+}
+
+function makeContextGetTool(adapter: PiAgentMemoryAdapter): PiAgentToolDefinition {
+  return {
+    name: "context_get",
+    label: "Get Pi Agent short-term context",
+    description: "Reserved entry point for Pi Agent short-term context retrieval.",
+    promptSnippet: "context_get is currently reserved and reports that short-term Pi context is not enabled in v1.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        sessionId: stringParam("Optional Pi session id."),
+        session_id: stringParam("Optional Pi session id."),
+        workspace: stringParam("Optional workspace path."),
+        cwd: stringParam("Optional working directory."),
+      },
+    },
+    execute: (_toolCallId, params) => textResult(adapter.contextGet(params as PiAgentContextGetArgs)),
+  };
+}
+
+export function registerPiAgentMemoryExtension(
+  pi: PiAgentRuntime,
+  options: PiAgentMemoryAdapterOptions = {},
+): PiAgentMemoryAdapter {
+  const adapter = new PiAgentMemoryAdapter(options);
+
+  pi.on?.("before_agent_start", (event, ctx) => adapter.onBeforeAgentStart(event as Parameters<typeof adapter.onBeforeAgentStart>[0], ctx));
+  pi.on?.("session_shutdown", (event, ctx) => adapter.onSessionShutdown(event as Parameters<typeof adapter.onSessionShutdown>[0], ctx));
+  pi.on?.("tool_result", (event) => adapter.onToolResult(event as Parameters<typeof adapter.onToolResult>[0]));
+
+  pi.registerTool?.(makeMemorySearchTool(adapter));
+  pi.registerTool?.(makeConversationSearchTool(adapter));
+  pi.registerTool?.(makeContextGetTool(adapter));
+
+  return adapter;
+}
+
+export default registerPiAgentMemoryExtension;

--- a/src/adapters/pi-agent/gateway-client.ts
+++ b/src/adapters/pi-agent/gateway-client.ts
@@ -1,0 +1,92 @@
+import type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  PiAgentGatewayClientOptions,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "./types.js";
+
+export class PiAgentGatewayClientError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly body?: string,
+  ) {
+    super(message);
+    this.name = "PiAgentGatewayClientError";
+  }
+}
+
+export class PiAgentGatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: PiAgentGatewayClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  recall(body: RecallRequest): Promise<RecallResponse> {
+    return this.request<RecallResponse>("POST", "/recall", body);
+  }
+
+  seed(body: SeedRequest): Promise<SeedResponse> {
+    return this.request<SeedResponse>("POST", "/seed", body);
+  }
+
+  sessionEnd(body: SessionEndRequest): Promise<SessionEndResponse> {
+    return this.request<SessionEndResponse>("POST", "/session/end", body);
+  }
+
+  searchMemories(body: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.request<MemorySearchResponse>("POST", "/search/memories", body);
+  }
+
+  searchConversations(body: ConversationSearchRequest): Promise<ConversationSearchResponse> {
+    return this.request<ConversationSearchResponse>("POST", "/search/conversations", body);
+  }
+
+  private async request<T>(method: "GET" | "POST", endpoint: string, body?: unknown): Promise<T> {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    const response = await this.fetchImpl(`${this.baseUrl}${endpoint}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new PiAgentGatewayClientError(
+        `TDAI Gateway ${method} ${endpoint} failed with HTTP ${response.status}`,
+        response.status,
+        text,
+      );
+    }
+
+    try {
+      return (text ? JSON.parse(text) : {}) as T;
+    } catch {
+      throw new PiAgentGatewayClientError(
+        `TDAI Gateway ${method} ${endpoint} returned invalid JSON`,
+        response.status,
+        text,
+      );
+    }
+  }
+}

--- a/src/adapters/pi-agent/index.ts
+++ b/src/adapters/pi-agent/index.ts
@@ -1,0 +1,11 @@
+export { PiAgentMemoryAdapter } from "./adapter.js";
+export type { PiAgentMemoryAdapterOptions } from "./adapter.js";
+export { loadPiAgentAdapterConfig } from "./config.js";
+export { formatPiAgentMemoryContext } from "./context.js";
+export { registerPiAgentMemoryExtension } from "./extension.js";
+export { default } from "./extension.js";
+export { PiAgentGatewayClient, PiAgentGatewayClientError } from "./gateway-client.js";
+export { PiAgentLifecycleAdapter } from "./lifecycle.js";
+export { derivePiAgentSessionKey } from "./session-key.js";
+export { PiAgentMemoryTools } from "./tools.js";
+export type * from "./types.js";

--- a/src/adapters/pi-agent/lifecycle.test.ts
+++ b/src/adapters/pi-agent/lifecycle.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { PiAgentLifecycleAdapter } from "./lifecycle.js";
+import type { PiAgentAdapterConfig } from "./types.js";
+
+const config: PiAgentAdapterConfig = {
+  gatewayUrl: "http://127.0.0.1:8420",
+  autoRecall: true,
+  autoCapture: true,
+  recallMaxChars: 1000,
+  defaultUserId: "default_user",
+};
+
+describe("PiAgentLifecycleAdapter", () => {
+  it("recalls and injects context on session_start", async () => {
+    const client = {
+      recall: vi.fn(async () => ({ context: "persona: use architecture-first design", strategy: "keyword", memory_count: 1 })),
+      seed: vi.fn(),
+      sessionEnd: vi.fn(),
+    };
+    const injected: unknown[] = [];
+    const adapter = new PiAgentLifecycleAdapter(client, config, async (ctx) => injected.push(ctx));
+
+    const result = await adapter.onSessionStart({ sessionId: "s1", workspace: "D:/repo", prompt: "continue adapter work" });
+
+    expect(client.recall).toHaveBeenCalledWith(expect.objectContaining({ query: "continue adapter work" }));
+    expect(result?.message?.content).toContain("architecture-first");
+    expect(injected).toHaveLength(1);
+  });
+
+  it("imports complete user/assistant turns on session_end", async () => {
+    const client = {
+      recall: vi.fn(),
+      seed: vi.fn(async () => ({ l0_recorded: 2 })),
+      sessionEnd: vi.fn(async () => ({ flushed: true })),
+    };
+    const adapter = new PiAgentLifecycleAdapter(client, config);
+
+    const result = await adapter.onSessionEnd({
+      sessionId: "s1",
+      workspace: "D:/repo",
+      messages: [
+        { role: "user", content: "build pi adapter", timestamp: 1 },
+        { role: "assistant", content: "done", timestamp: 2 },
+      ],
+    });
+
+    expect(result).toEqual({ captured: true, l0Recorded: 2 });
+    expect(client.seed).toHaveBeenCalledWith(expect.objectContaining({
+      strict_round_role: false,
+      auto_fill_timestamps: true,
+      data: expect.objectContaining({ sessions: expect.any(Array) }),
+    }));
+    expect(client.sessionEnd).toHaveBeenCalledWith(expect.objectContaining({ session_key: expect.stringMatching(/^pi-agent:/) }));
+  });
+
+  it("skips session_end when there are no complete turns", async () => {
+    const client = { recall: vi.fn(), seed: vi.fn(), sessionEnd: vi.fn() };
+    const adapter = new PiAgentLifecycleAdapter(client, config);
+
+    await expect(adapter.onSessionEnd({ messages: [{ role: "user", content: "only user" }] })).resolves.toEqual({
+      captured: false,
+      skippedReason: "no complete user/assistant turns",
+    });
+    expect(client.seed).not.toHaveBeenCalled();
+  });
+});

--- a/src/adapters/pi-agent/lifecycle.ts
+++ b/src/adapters/pi-agent/lifecycle.ts
@@ -1,0 +1,116 @@
+import type { PiAgentGatewayClient } from "./gateway-client.js";
+import { formatPiAgentMemoryContext } from "./context.js";
+import { derivePiAgentSessionKey } from "./session-key.js";
+import {
+  getPiQuery,
+  getPiSessionId,
+  getPiUserId,
+  getPiWorkspace,
+  normalizePiMessages,
+  piMessagesToSeedConversations,
+} from "./mapper.js";
+import type {
+  PiAgentAdapterConfig,
+  PiAgentBeforeAgentStartEvent,
+  PiAgentBeforeAgentStartResult,
+  PiAgentContextInjection,
+  PiAgentContextInjector,
+  PiAgentExtensionContext,
+  PiAgentSessionEndResult,
+  PiAgentSessionEvent,
+} from "./types.js";
+
+export class PiAgentLifecycleAdapter {
+  constructor(
+    private readonly client: Pick<PiAgentGatewayClient, "recall" | "seed" | "sessionEnd">,
+    private readonly config: PiAgentAdapterConfig,
+    private readonly injectContext?: PiAgentContextInjector,
+  ) {}
+
+  deriveSessionKey(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext): string {
+    return derivePiAgentSessionKey({
+      workspace: getPiWorkspace(event, ctx),
+      sessionId: getPiSessionId(event, ctx),
+      userId: getPiUserId(event) ?? this.config.defaultUserId,
+    });
+  }
+
+  async onBeforeAgentStart(
+    event: PiAgentBeforeAgentStartEvent,
+    ctx?: PiAgentExtensionContext,
+  ): Promise<PiAgentBeforeAgentStartResult | undefined> {
+    if (!this.config.autoRecall) return undefined;
+
+    const query = getPiQuery(event) || "Restore relevant project and user memory for this Pi Agent session.";
+    const sessionKey = this.deriveSessionKey(event, ctx);
+    const recall = await this.client.recall({
+      query,
+      session_key: sessionKey,
+      user_id: getPiUserId(event) ?? this.config.defaultUserId,
+    });
+    const context = formatPiAgentMemoryContext({ recall, maxChars: this.config.recallMaxChars });
+    if (!context) return undefined;
+
+    const injection: PiAgentContextInjection = {
+      context,
+      sessionKey,
+      source: "tencentdb-agent-memory",
+    };
+    await this.injectContext?.(injection, event, ctx);
+
+    return {
+      message: {
+        customType: "tencentdb-agent-memory",
+        content: context,
+        display: true,
+        details: {
+          sessionKey,
+          source: "tencentdb-agent-memory",
+        },
+      },
+    };
+  }
+
+  async onSessionShutdown(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext): Promise<PiAgentSessionEndResult> {
+    if (!this.config.autoCapture) return { captured: false, skippedReason: "auto capture disabled" };
+
+    const messages = normalizePiMessages(event, ctx);
+    const conversations = piMessagesToSeedConversations(messages);
+    if (conversations.length === 0) {
+      return { captured: false, skippedReason: "no complete user/assistant turns" };
+    }
+
+    const sessionKey = this.deriveSessionKey(event, ctx);
+    const seed = await this.client.seed({
+      session_key: sessionKey,
+      strict_round_role: false,
+      auto_fill_timestamps: true,
+      data: {
+        sessions: [{
+          sessionKey,
+          sessionId: getPiSessionId(event, ctx),
+          conversations,
+        }],
+      },
+    });
+    await this.client.sessionEnd({
+      session_key: sessionKey,
+      user_id: getPiUserId(event) ?? this.config.defaultUserId,
+    });
+
+    return {
+      captured: true,
+      l0Recorded: seed.l0_recorded,
+    };
+  }
+
+  /** Backward-compatible alias for earlier draft integrations. */
+  onSessionStart(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext) {
+    return this.onBeforeAgentStart(event, ctx);
+  }
+
+  /** Backward-compatible alias for earlier draft integrations. */
+  onSessionEnd(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext) {
+    return this.onSessionShutdown(event, ctx);
+  }
+}

--- a/src/adapters/pi-agent/mapper.test.ts
+++ b/src/adapters/pi-agent/mapper.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { normalizePiMessages, piMessagesToSeedConversations } from "./mapper.js";
+
+describe("Pi Agent mapper", () => {
+  it("normalizes text and block-style messages", () => {
+    const messages = normalizePiMessages({
+      messages: [
+        { role: "system", content: "ignore" },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "world" }] },
+      ],
+    });
+
+    expect(messages).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "world" },
+    ]);
+  });
+
+  it("pairs user/assistant turns for seed input", () => {
+    const conversations = piMessagesToSeedConversations([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+      { role: "assistant", content: "a2" },
+    ]);
+
+    expect(conversations).toEqual([
+      { user: "u1", assistant: "a1", timestamp: undefined },
+      { user: "u2", assistant: "a2", timestamp: undefined },
+    ]);
+  });
+});

--- a/src/adapters/pi-agent/mapper.ts
+++ b/src/adapters/pi-agent/mapper.ts
@@ -1,0 +1,82 @@
+import type { PiAgentExtensionContext, PiAgentMessage, PiAgentSessionEntry, PiAgentSessionEvent } from "./types.js";
+
+export function getPiSessionId(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext): string | undefined {
+  return event.sessionId
+    ?? event.session_id
+    ?? event.sessionFile
+    ?? ctx?.sessionManager?.getSessionFile?.();
+}
+
+export function getPiWorkspace(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext): string | undefined {
+  return event.workspace
+    ?? event.cwd
+    ?? event.systemPromptOptions?.cwd
+    ?? ctx?.cwd;
+}
+
+export function getPiUserId(event: PiAgentSessionEvent): string | undefined {
+  return event.userId ?? event.user_id;
+}
+
+export function getPiQuery(event: PiAgentSessionEvent): string | undefined {
+  const value = event.prompt ?? event.query;
+  return typeof value === "string" ? value : undefined;
+}
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (!block || typeof block !== "object") return "";
+        const typed = block as { type?: unknown; text?: unknown; content?: unknown; thinking?: unknown };
+        if (typeof typed.text === "string") return typed.text;
+        if (typeof typed.content === "string") return typed.content;
+        if (typeof typed.thinking === "string") return typed.thinking;
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+function messagesFromEntries(entries: PiAgentSessionEntry[] | undefined): PiAgentMessage[] {
+  if (!entries) return [];
+  return entries
+    .filter((entry) => entry.type === "message" && entry.message)
+    .map((entry) => entry.message!)
+    .filter((message) => message.role === "user" || message.role === "assistant");
+}
+
+export function normalizePiMessages(event: PiAgentSessionEvent, ctx?: PiAgentExtensionContext): PiAgentMessage[] {
+  const raw = event.messages ?? event.conversation ?? messagesFromEntries(event.entries ?? ctx?.sessionManager?.getEntries?.());
+  return raw
+    .map((message) => ({
+      ...message,
+      content: contentToText(message.content),
+    }))
+    .filter((message) => (message.role === "user" || message.role === "assistant") && typeof message.content === "string" && message.content.trim().length > 0);
+}
+
+export function piMessagesToSeedConversations(messages: PiAgentMessage[]) {
+  const conversations: Array<{ user: string; assistant: string; timestamp?: string | number }> = [];
+  let pendingUser: PiAgentMessage | undefined;
+
+  for (const message of messages) {
+    if (message.role === "user") {
+      pendingUser = message;
+      continue;
+    }
+    if (message.role === "assistant" && pendingUser) {
+      conversations.push({
+        user: String(pendingUser.content),
+        assistant: String(message.content),
+        timestamp: message.timestamp ?? pendingUser.timestamp,
+      });
+      pendingUser = undefined;
+    }
+  }
+
+  return conversations;
+}

--- a/src/adapters/pi-agent/session-key.test.ts
+++ b/src/adapters/pi-agent/session-key.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { derivePiAgentSessionKey } from "./session-key.js";
+
+describe("derivePiAgentSessionKey", () => {
+  it("is stable for the same workspace/session/user", () => {
+    const input = { workspace: "D:/repo", sessionId: "s1", userId: "u1" };
+    expect(derivePiAgentSessionKey(input)).toBe(derivePiAgentSessionKey(input));
+  });
+
+  it("separates different workspaces", () => {
+    const a = derivePiAgentSessionKey({ workspace: "D:/repo-a", sessionId: "s1", userId: "u1" });
+    const b = derivePiAgentSessionKey({ workspace: "D:/repo-b", sessionId: "s1", userId: "u1" });
+    expect(a).not.toBe(b);
+    expect(a.startsWith("pi-agent:")).toBe(true);
+  });
+});

--- a/src/adapters/pi-agent/session-key.ts
+++ b/src/adapters/pi-agent/session-key.ts
@@ -1,0 +1,22 @@
+import crypto from "node:crypto";
+
+function normalizePart(value: string | undefined): string {
+  return (value || "").trim().replace(/\\/g, "/");
+}
+
+export function derivePiAgentSessionKey(input: {
+  workspace?: string;
+  cwd?: string;
+  sessionId?: string;
+  userId?: string;
+}): string {
+  const workspace = normalizePart(input.workspace ?? input.cwd) || "unknown-workspace";
+  const sessionId = normalizePart(input.sessionId) || "unknown-session";
+  const userId = normalizePart(input.userId) || "default_user";
+  const digest = crypto
+    .createHash("sha256")
+    .update(`${workspace}\n${sessionId}\n${userId}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `pi-agent:${digest}`;
+}

--- a/src/adapters/pi-agent/tools.test.ts
+++ b/src/adapters/pi-agent/tools.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { PiAgentMemoryTools } from "./tools.js";
+
+describe("PiAgentMemoryTools", () => {
+  it("maps memory_search to Gateway searchMemories", async () => {
+    const client = {
+      searchMemories: vi.fn(async () => ({ results: "memory result", total: 1, strategy: "fts" })),
+      searchConversations: vi.fn(),
+    };
+    const tools = new PiAgentMemoryTools(client);
+
+    await expect(tools.memorySearch({ query: "adapter", limit: 100 })).resolves.toBe("memory result");
+    expect(client.searchMemories).toHaveBeenCalledWith({ query: "adapter", limit: 20, type: undefined, scene: undefined });
+  });
+
+  it("maps conversation_search to Gateway searchConversations", async () => {
+    const client = {
+      searchMemories: vi.fn(),
+      searchConversations: vi.fn(async () => ({ results: "conversation result", total: 1 })),
+    };
+    const tools = new PiAgentMemoryTools(client);
+
+    await expect(tools.conversationSearch({ query: "why", sessionKey: "s" })).resolves.toBe("conversation result");
+    expect(client.searchConversations).toHaveBeenCalledWith({ query: "why", limit: 5, session_key: "s" });
+  });
+
+  it("keeps context_get explicitly reserved in v1", () => {
+    const client = { searchMemories: vi.fn(), searchConversations: vi.fn() };
+    const tools = new PiAgentMemoryTools(client);
+
+    expect(tools.contextGet({})).toContain("reserved for the next stage");
+  });
+});

--- a/src/adapters/pi-agent/tools.ts
+++ b/src/adapters/pi-agent/tools.ts
@@ -1,0 +1,42 @@
+import type { PiAgentGatewayClient } from "./gateway-client.js";
+import type {
+  PiAgentContextGetArgs,
+  PiAgentConversationSearchArgs,
+  PiAgentMemorySearchArgs,
+} from "./types.js";
+
+function clampLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) return 5;
+  return Math.max(1, Math.min(20, Math.trunc(limit!)));
+}
+
+export class PiAgentMemoryTools {
+  constructor(
+    private readonly client: Pick<PiAgentGatewayClient, "searchMemories" | "searchConversations">,
+  ) {}
+
+  async memorySearch(args: PiAgentMemorySearchArgs): Promise<string> {
+    if (!args.query?.trim()) return "Missing required argument: query";
+    const result = await this.client.searchMemories({
+      query: args.query,
+      limit: clampLimit(args.limit),
+      type: args.type,
+      scene: args.scene,
+    });
+    return result.results || "No matching memories found.";
+  }
+
+  async conversationSearch(args: PiAgentConversationSearchArgs): Promise<string> {
+    if (!args.query?.trim()) return "Missing required argument: query";
+    const result = await this.client.searchConversations({
+      query: args.query,
+      limit: clampLimit(args.limit),
+      session_key: args.session_key ?? args.sessionKey,
+    });
+    return result.results || "No matching conversation messages found.";
+  }
+
+  contextGet(_args: PiAgentContextGetArgs): string {
+    return "Pi Agent short-term context_get is reserved for the next stage; v1 does not persist tool trajectory context.";
+  }
+}

--- a/src/adapters/pi-agent/types.ts
+++ b/src/adapters/pi-agent/types.ts
@@ -1,0 +1,193 @@
+import type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+export type {
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+};
+
+export interface PiAgentAdapterConfig {
+  gatewayUrl: string;
+  gatewayApiKey?: string;
+  autoRecall: boolean;
+  autoCapture: boolean;
+  recallMaxChars: number;
+  defaultUserId: string;
+}
+
+export interface PiAgentGatewayClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface PiAgentSessionEvent {
+  sessionId?: string;
+  session_id?: string;
+  sessionFile?: string;
+  workspace?: string;
+  cwd?: string;
+  userId?: string;
+  user_id?: string;
+  prompt?: string;
+  query?: string;
+  messages?: PiAgentMessage[];
+  conversation?: PiAgentMessage[];
+  entries?: PiAgentSessionEntry[];
+  systemPromptOptions?: {
+    cwd?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface PiAgentBeforeAgentStartEvent extends PiAgentSessionEvent {
+  prompt?: string;
+  systemPrompt?: string;
+}
+
+export interface PiAgentMessage {
+  role: "user" | "assistant" | "toolResult" | "custom" | string;
+  content: unknown;
+  timestamp?: number | string;
+  [key: string]: unknown;
+}
+
+export interface PiAgentSessionEntry {
+  type: string;
+  id?: string;
+  timestamp?: string;
+  message?: PiAgentMessage;
+  [key: string]: unknown;
+}
+
+export interface PiAgentSessionManager {
+  getSessionFile?: () => string | undefined;
+  getEntries?: () => PiAgentSessionEntry[];
+  [key: string]: unknown;
+}
+
+export interface PiAgentExtensionContext {
+  cwd?: string;
+  sessionManager?: PiAgentSessionManager;
+  ui?: {
+    notify?: (message: string, kind?: string) => void | Promise<void>;
+  };
+  [key: string]: unknown;
+}
+
+export interface PiAgentToolEvent {
+  sessionId?: string;
+  session_id?: string;
+  workspace?: string;
+  cwd?: string;
+  toolName?: string;
+  tool_name?: string;
+  result?: unknown;
+  output?: unknown;
+  error?: unknown;
+  [key: string]: unknown;
+}
+
+export interface PiAgentContextInjection {
+  context: string;
+  sessionKey: string;
+  source: "tencentdb-agent-memory";
+}
+
+export interface PiAgentCustomMessage {
+  customType: "tencentdb-agent-memory";
+  content: string;
+  display: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface PiAgentBeforeAgentStartResult {
+  message?: PiAgentCustomMessage;
+  systemPrompt?: string;
+}
+
+export interface PiAgentSessionEndResult {
+  captured: boolean;
+  l0Recorded?: number;
+  skippedReason?: string;
+}
+
+export interface PiAgentMemorySearchArgs {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface PiAgentConversationSearchArgs {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+  session_key?: string;
+}
+
+export interface PiAgentContextGetArgs {
+  sessionId?: string;
+  session_id?: string;
+  workspace?: string;
+  cwd?: string;
+}
+
+export type PiAgentToolName =
+  | "memory_search"
+  | "conversation_search"
+  | "context_get";
+
+export interface PiAgentToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  details?: Record<string, unknown>;
+}
+
+export interface PiAgentToolDefinition {
+  name: PiAgentToolName;
+  label: string;
+  description: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
+  parameters: Record<string, unknown>;
+  execute: (
+    toolCallId: string,
+    params: unknown,
+    signal?: AbortSignal,
+    onUpdate?: (result: PiAgentToolResult) => void,
+    ctx?: PiAgentExtensionContext,
+  ) => PiAgentToolResult | Promise<PiAgentToolResult>;
+}
+
+export interface PiAgentRuntime {
+  on?: (eventName: string, handler: (event: unknown, ctx?: PiAgentExtensionContext) => unknown | Promise<unknown>) => void;
+  registerTool?: (definition: PiAgentToolDefinition) => void;
+  registerCommand?: (name: string, options: { description?: string; handler: (args: string, ctx: PiAgentExtensionContext) => unknown | Promise<unknown> }) => void;
+}
+
+export type PiAgentContextInjector = (
+  context: PiAgentContextInjection,
+  event: PiAgentSessionEvent,
+  ctx?: PiAgentExtensionContext,
+) => void | Promise<void>;


### PR DESCRIPTION
## Description | 描述

This PR addresses issue #235 in a staged way and moves TencentDB-Agent-Memory toward a clearer cross-platform adapter architecture. It now covers the **Basic**, **Intermediate**, and **Advanced** stages of the issue:

- **Basic**: read and documented the core memory engine, existing OpenClaw integration, Hermes/Gateway integration, short-term memory, long-term L0-L3 pipeline, and data flow.
- **Intermediate**: implemented and validated a Claude Code adapter with hooks, MCP memory tools, short-term capture, long-term recall/capture, and real runtime experiments.
- **Advanced**: added an independent Pi Agent adapter as a third platform integration, using Pi-native Extension lifecycle events and custom tools instead of copying the Claude Code design.

本 PR 按照 issue #235 的渐进式验收标准推进 TencentDB-Agent-Memory 的跨平台适配能力，目前覆盖了 **基础、进阶、深入** 三个阶段：

- **基础阶段**：阅读并整理核心记忆引擎、OpenClaw 集成、Hermes/Gateway 集成、短期记忆、长期 L0-L3 管线以及数据链路。
- **进阶阶段**：实现并验证 Claude Code adapter，包括 hooks、MCP 记忆工具、短期捕获、长期 recall/capture，以及真实 Claude Code runtime 实验。
- **深入阶段**：新增独立的 Pi Agent adapter，作为第三个平台适配实践；该 adapter 使用 Pi 原生 Extension 生命周期与 custom tools，而不是复制 Claude Code 的设计。


## Architecture Design | 架构设计

The central design idea is to keep **TdaiCore host-neutral** and move all platform-specific behavior into thin adapters. Each adapter translates its own host lifecycle, message format, and tool model into the same memory operations: recall, search, seed, session end, and optional short-term capture.

核心设计思想是保持 **TdaiCore 平台无关**，把所有平台差异都收敛到薄适配层中。每个 adapter 只负责把宿主平台的生命周期、消息格式、工具模型翻译成统一的记忆操作：recall、search、seed、session end，以及可选的短期捕获。

```mermaid
flowchart LR
  subgraph Hosts["Agent Platforms / Agent 平台"]
    OpenClaw["OpenClaw\nPlugin SDK"]
    Hermes["Hermes\nProvider"]
    Claude["Claude Code\nHooks + MCP"]
    Pi["Pi Agent\nExtension + Tools"]
  end

  subgraph AdapterLayer["Adapter Layer / 适配层"]
    OpenClawAdapter["OpenClaw HostAdapter"]
    HermesGateway["Gateway Provider Adapter"]
    ClaudeAdapter["Claude Code Adapter"]
    PiAdapter["Pi Agent Adapter"]
  end

  subgraph MemoryCore["TencentDB-Agent-Memory Core"]
    Gateway["Gateway HTTP API"]
    TdaiCore["TdaiCore"]
    LongTerm["Long-term Memory\nL0 Conversation -> L1 Atom -> L2 Scenario -> L3 Persona"]
    ShortTerm["Short-term Memory\nrefs/*.md -> jsonl -> Mermaid Canvas"]
  end

  OpenClaw --> OpenClawAdapter --> TdaiCore
  Hermes --> HermesGateway --> Gateway
  Claude --> ClaudeAdapter --> Gateway
  Pi --> PiAdapter --> Gateway
  Gateway --> TdaiCore
  TdaiCore --> LongTerm
  TdaiCore --> ShortTerm
```

Important architectural points:

- **One core, multiple surfaces**: OpenClaw, Hermes, Claude Code, and Pi Agent share the same memory engine instead of each reimplementing memory logic.
- **Gateway as the cross-process contract**: external agents can integrate through HTTP without importing OpenClaw-specific internals.
- **Adapter-level isolation**: Claude Code uses `claude-code:` keys; Pi Agent uses `pi-agent:` keys, making multi-agent memory easier to debug and preventing accidental session collision.
- **Native integration per platform**: Claude Code uses hooks/MCP; Pi Agent uses Extension lifecycle/custom tools; OpenClaw uses plugin hooks/tools; Hermes uses Gateway/provider sidecar.

重要架构点：

- **一个核心，多种入口**：OpenClaw、Hermes、Claude Code、Pi Agent 共享同一套记忆引擎，而不是各自重复实现记忆逻辑。
- **Gateway 作为跨进程契约**：外部 Agent 可以通过 HTTP 接入，不需要导入 OpenClaw 专属内部实现。
- **适配层级别的记忆隔离**：Claude Code 使用 `claude-code:` key，Pi Agent 使用 `pi-agent:` key，便于多 Agent 并行时排查和避免会话污染。
- **尊重平台原生模型**：Claude Code 使用 hooks/MCP；Pi Agent 使用 Extension lifecycle/custom tools；OpenClaw 使用 plugin hooks/tools；Hermes 使用 Gateway/provider sidecar。

## Data Flow | 数据链路

### Long-term memory flow | 长期记忆链路

Long-term memory follows the existing L0-L3 pipeline and is exposed consistently across platforms:

长期记忆沿用现有 L0-L3 管线，并在不同平台上保持一致的能力边界：

```mermaid
sequenceDiagram
  participant Agent as Agent Platform
  participant Adapter as Platform Adapter
  participant Gateway as Gateway / HostAdapter
  participant Core as TdaiCore
  participant Memory as L0-L3 Memory

  Agent->>Adapter: session starts / user prompt
  Adapter->>Gateway: recall(query, session_key)
  Gateway->>Core: handle recall
  Core->>Memory: search L1/L2/L3 + optional L0 evidence
  Memory-->>Core: relevant memory context
  Core-->>Gateway: recall result
  Gateway-->>Adapter: memory context
  Adapter-->>Agent: inject custom/system context

  Agent->>Adapter: session ends / transcript ready
  Adapter->>Gateway: seed(conversations)
  Adapter->>Gateway: session/end(session_key)
  Gateway->>Core: capture and schedule pipeline
  Core->>Memory: L0 conversation -> L1 atom -> L2 scenario -> L3 persona
```

For Claude Code, this maps to `UserPromptSubmit` and `SessionEnd`. For Pi Agent, it maps to `before_agent_start` and `session_shutdown`. The host events are different, but the memory operations remain the same.

在 Claude Code 中，这条链路对应 `UserPromptSubmit` 与 `SessionEnd`；在 Pi Agent 中，对应 `before_agent_start` 与 `session_shutdown`。宿主事件不同，但记忆操作保持一致。

### Short-term memory flow | 短期记忆链路

Short-term memory is intentionally treated separately because it depends heavily on each agent runtime's tool-event model.

短期记忆被有意单独处理，因为它强依赖各 Agent runtime 的工具事件模型。

```mermaid
flowchart TD
  ToolResult["Tool result / 工具输出"] --> Ref["refs/*.md\nraw evidence"]
  Ref --> Jsonl["step summaries\nJSONL"]
  Jsonl --> Canvas["Mermaid symbolic canvas\ncompact task state"]
  Canvas --> AgentContext["Agent context restore\n上下文恢复"]
```

Current status:

- Claude Code implements this path through `PostToolUse` capture.
- Pi Agent keeps `tool_result` and `context_get` as reserved extension points, because Pi should get a Pi-native short-term design instead of inheriting Claude Code's file layout blindly.

当前状态：

- Claude Code 已通过 `PostToolUse` 实现该路径。
- Pi Agent 预留 `tool_result` 与 `context_get`，因为 Pi 应该有 Pi-native 的短期记忆设计，而不是直接照搬 Claude Code 的文件结构。

## Stage Coverage | 阶段完成情况

| Stage | Issue expectation | Current coverage |
| --- | --- | --- |
| Basic | Read source code, draw core engine and adapter architecture, annotate data flow | Added architecture/design docs covering TdaiCore, OpenClaw, Hermes/Gateway, Claude Code, short-term memory, long-term L0-L3 memory, and data flow |
| Intermediate | Pick one platform and implement basic memory read/write | Added Claude Code adapter with recall hook, session capture, MCP search tools, short-term capture, long-term E2E experiments, and validation docs |
| Advanced | Adapt two or more platforms and compare differences | Added Pi Agent adapter as a separate third-platform adapter; contrasted Claude Code hooks/MCP with Pi Extension lifecycle/custom tools |
| Challenge | Package a unified adapter SDK | Not included in this PR; left as follow-up work |

| 阶段 | Issue 期望 | 当前覆盖 |
| --- | --- | --- |
| 基础 | 阅读源码，画出核心引擎和适配层架构，标注数据流 | 已补充架构/设计文档，覆盖 TdaiCore、OpenClaw、Hermes/Gateway、Claude Code、短期记忆、长期 L0-L3 记忆和数据链路 |
| 进阶 | 选择一个平台实现基础记忆读写 | 已实现 Claude Code adapter，包括 recall hook、session capture、MCP 检索工具、短期捕获、长期 E2E 实验和验证文档 |
| 深入 | 适配两个或以上平台，并分析平台差异 | 已新增 Pi Agent adapter 作为第三个平台适配，并明确对比 Claude Code hooks/MCP 与 Pi Extension lifecycle/custom tools 的差异 |
| 拓展 | 封装统一 adapter SDK | 本 PR 暂不包含，作为后续工作 |

## What Changed | 主要改动

### 1. Architecture and design documentation | 架构与设计文档

Added adapter architecture documentation under `docs/adapters/`, including `platform-adapter-comparison.md`:

- the relationship between TdaiCore, HostAdapter, Gateway, and platform-specific adapters;
- OpenClaw vs Hermes/Gateway integration differences;
- short-term memory vs long-term L0-L3 memory data flow;
- cross-platform comparison across OpenClaw, Hermes/Gateway, Claude Code, and Pi Agent;
- Claude Code adapter technical design;
- Claude Code short-term and long-term E2E experiment reports.

在 `docs/adapters/` 下补充适配层架构文档，覆盖：

- TdaiCore、HostAdapter、Gateway 与平台适配层之间的关系；
- OpenClaw 与 Hermes/Gateway 两种已有接入方式的差异；
- 短期记忆与长期 L0-L3 记忆的数据链路；
- Claude Code adapter 技术设计；
- Claude Code 短期与长期 E2E 实验报告。

### 2. Claude Code adapter | Claude Code 适配层

Added `src/adapters/claude-code/` with:

- `UserPromptSubmit` recall hook;
- `SessionEnd` transcript import through `/seed` + `/session/end`;
- MCP memory search tools;
- `PostToolUse` short-term context capture;
- project-local experiment setup and reports;
- session key isolation for Claude Code sessions.

新增 `src/adapters/claude-code/`，包括：

- `UserPromptSubmit` recall hook；
- 通过 `/seed` + `/session/end` 导入会话 transcript；
- MCP 记忆检索工具；
- `PostToolUse` 短期上下文捕获；
- 项目内实验配置与报告；
- Claude Code 会话级 session key 隔离。

### 3. Pi Agent adapter | Pi Agent 适配层

Added `src/adapters/pi-agent/` as an independent adapter, separate from the Claude Code implementation:

- `before_agent_start` -> Gateway `/recall` -> inject recalled memory as a Pi custom message;
- `session_shutdown` -> Gateway `/seed` + `/session/end` -> persist conversation history;
- `memory_search` custom tool -> Gateway `/search/memories`;
- `conversation_search` custom tool -> Gateway `/search/conversations`;
- `context_get` reserved for future Pi-native short-term memory;
- `pi-agent:` session key prefix to keep Pi memory isolated from Claude Code/OpenClaw/Hermes sessions.

新增独立的 `src/adapters/pi-agent/`，不与 Claude Code adapter 混用：

- `before_agent_start` -> Gateway `/recall` -> 以 Pi custom message 注入召回记忆；
- `session_shutdown` -> Gateway `/seed` + `/session/end` -> 持久化会话历史；
- `memory_search` custom tool -> Gateway `/search/memories`；
- `conversation_search` custom tool -> Gateway `/search/conversations`；
- `context_get` 为后续 Pi-native 短期记忆预留入口；
- 使用 `pi-agent:` session key 前缀，避免与 Claude Code/OpenClaw/Hermes 会话记忆混淆。

## Highlights / Innovation | 亮点与创新点

### 1. From plugin-specific memory to a cross-agent memory substrate | 从插件记忆走向跨 Agent 记忆底座

This PR is not just adding one more adapter. It demonstrates that TencentDB-Agent-Memory can act as a shared memory substrate across very different agent runtimes:

- OpenClaw: in-process plugin integration;
- Hermes: Gateway/provider sidecar integration;
- Claude Code: hooks + MCP + short-term canvas capture;
- Pi Agent: Extension lifecycle + custom memory tools.

This shows that the core memory engine can stay stable while platform-specific adapters remain thin and replaceable.

本 PR 不只是“多加一个 adapter”，而是在验证 TencentDB-Agent-Memory 可以成为不同 Agent runtime 之间共享的记忆底座：

- OpenClaw：进程内 plugin 集成；
- Hermes：Gateway/provider sidecar 集成；
- Claude Code：hooks + MCP + short-term canvas capture；
- Pi Agent：Extension lifecycle + custom memory tools。

这说明核心记忆引擎可以保持稳定，而平台差异被收敛到薄适配层里。

### 2. Pi-native adapter instead of copied Claude Code logic | Pi 原生适配，而不是复制 Claude Code 逻辑

The Pi Agent adapter follows Pi's own Extension API (`before_agent_start`, `session_shutdown`, `registerTool({ ... })`). It does not reuse Claude Code hooks, MCP server code, or short-term canvas internals. This makes the adapter boundary much cleaner and proves that new platforms can be integrated according to their own runtime model.

Pi Agent adapter 遵循 Pi 自身的 Extension API（`before_agent_start`、`session_shutdown`、`registerTool({ ... })`），没有复用 Claude Code 的 hooks、MCP server 或短期 canvas 内部实现。这样适配边界更干净，也证明后续新平台可以按照自身 runtime 模型接入。

### 3. Two memory modes are treated explicitly | 明确区分短期记忆与长期记忆

The work separates the two parallel memory systems instead of blending them together:

- Long-term memory: L0 conversation -> L1 atom -> L2 scenario -> L3 persona, exposed through recall/search/capture.
- Short-term memory: tool outputs -> refs/jsonl -> Mermaid symbolic canvas, implemented for Claude Code and reserved for Pi follow-up design.

This distinction makes the architecture easier to reason about and avoids forcing a Claude-specific short-term memory shape onto Pi Agent.

本 PR 明确区分两个并行记忆系统，而不是混在一起：

- 长期记忆：L0 conversation -> L1 atom -> L2 scenario -> L3 persona，通过 recall/search/capture 暴露；
- 短期记忆：tool outputs -> refs/jsonl -> Mermaid symbolic canvas，目前在 Claude Code 中实现，Pi 侧预留后续设计。

这样的划分让架构更清晰，也避免把 Claude 专属的短期记忆形态强行套到 Pi Agent 上。

### 4. Active memory tools, not only passive context injection | 不只是被动注入，也支持主动记忆检索

Both Claude Code and Pi Agent expose memory retrieval tools. This allows agents to actively query memory during reasoning instead of relying only on pre-turn context injection.

Claude Code 与 Pi Agent 都暴露了记忆检索工具，使 Agent 不只依赖 turn 开始前的上下文注入，也可以在推理过程中主动查询长期记忆和原始对话证据。

### 5. Real runtime experiments, not only unit tests | 不只写单测，也做真实运行实验

The Claude Code adapter was validated with real Claude Code runtime smoke tests, including short-term and long-term memory experiments. The Pi Agent adapter was checked against local Pi CLI `0.80.6`, confirming that the extension can be loaded, the adapter can be registered, and a Pi command can reach the extension code path.

Claude Code adapter 已通过真实 Claude Code runtime smoke test，包括短期与长期记忆实验。Pi Agent adapter 也用本地 Pi CLI `0.80.6` 做了 smoke test，确认扩展可加载、adapter 可注册，并且 Pi command 能触达扩展代码路径。

## Expected Impact | 预期效果

This PR makes TencentDB-Agent-Memory visibly more portable. It provides a practical path for using the same memory engine across multiple agent platforms while preserving each platform's native integration style.

本 PR 显著提升了 TencentDB-Agent-Memory 的可移植性：同一套记忆引擎可以服务多个 Agent 平台，同时保留各平台自身的原生接入方式。

For users, this means agents can gradually share durable project context, user preferences, historical decisions, and raw conversation evidence across sessions. For maintainers, it gives a clearer adapter boundary for future platforms such as Dify, other coding agents, or a unified Adapter SDK.

对用户来说，这意味着不同 Agent 可以逐步共享长期项目上下文、用户偏好、历史决策和原始对话证据。对维护者来说，这也给未来接入 Dify、其他 coding agent 或封装统一 Adapter SDK 提供了更清晰的边界。

## Related Issue | 关联 Issue

Part of #235

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Validation | 验证

- `npm test -- --run src/adapters/claude-code`
  - 12 files / 27 tests passed
- `npm test -- --run src/adapters/pi-agent`
  - 6 files / 13 tests passed
- `npm test -- --run src/adapters/claude-code src/adapters/pi-agent`
  - 18 files / 40 tests passed
- `npm test`
  - 22 files / 107 tests passed
- `npm run build`
  - passed
- Claude Code real runtime smoke test
  - short-term capture validated
  - long-term recall/capture validated
- Pi Agent local CLI smoke test with Pi CLI `0.80.6`
  - extension loaded
  - adapter registered
  - command invoked

## Additional Notes | 其他说明

This PR intentionally stops before the Challenge stage. The next step could be packaging a unified Adapter SDK so future platforms only implement a small, stable interface instead of writing a full adapter from scratch.

本 PR 有意停在深入阶段，暂不进入拓展阶段。下一步可以继续封装统一 Adapter SDK，让后续平台只需实现一个小而稳定的接口，而不必从零编写完整 adapter。