### PR TITLE
fix(recall): prompt-cache-friendly injection mode and history strippi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
   - 环境变量 `TDAI_LLM_DISABLE_THINKING` 支持策略名（如 `deepseek`）和布尔值。
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
+- **提示词缓存友好性：`recall.injectionMode` + `recall.showInjected`** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：为召回注入增加显式的缓存控制，默认行为完全向后兼容。
+  - 新增 `recall.injectionMode`（默认 `"prepend"`，旧行为）：`"append"` 模式经宿主 `appendContext` 把动态 L1 召回放到用户消息之后，使用户消息前缀跨轮稳定，利于 DeepSeek / MiMo 等 prefix-matching 缓存（依赖宿主支持 `appendContext` 字段）。
+  - 新增 `recall.showInjected`（默认 `false`，即现有行为）：`before_message_write` 在持久化前剥离 `<relevant-memories>`，防止召回内容冻结进历史导致膨胀；`true` 可 opt-in 保留以供审计（会膨胀历史、不利缓存）。
+  - 新增轻量前缀诊断：每轮 `before_prompt_build` 日志输出稳定块哈希与动态注入位置（`stable=Nchars(hash=…)`、`dynamic=prepend|append/Nchars`），便于运维验证前缀稳定性与 `injectionMode` 效果，不改变注入行为。
+  - 结构：剥离逻辑放宿主无关的 `src/utils/relevant-memories.ts`；注入位置路由放 OpenClaw 适配器 `src/adapters/openclaw/recall-injection.ts`；诊断放 `src/utils/recall-shape-diagnostics.ts`。
+  - 说明：#120 报告的主要命中率退化经更正确认根因在宿主（OpenClaw webchat）侧；本仓库侧仅提供可控的注入位置与历史剥离开关。稳定系统提示块（persona / 场景导航）在源文件不变时本就跨轮字节稳定（`generateSceneNavigation` 为确定性函数，`heat` 仅在 L2 提取时更新），无需额外冻结。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 recall placement: `prepend` (legacy, before user prompt) / `append` (after user prompt via host `appendContext`, keeps the user-prompt prefix stable for prefix-matching caches; requires host support) |
+| `recall.showInjected` | `false` | Preserve injected `<relevant-memories>` in persisted history. Keep `false` to avoid replaying stale dynamic recall and growing the prompt prefix |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/README_CN.md
+++ b/README_CN.md
@@ -436,6 +436,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 召回注入位置：`prepend`（旧行为，用户消息前）/ `append`（用户消息后，经宿主 `appendContext`，保持用户消息前缀稳定以利于前缀缓存；依赖宿主支持） |
+| `recall.showInjected` | `false` | 是否将注入的 `<relevant-memories>` 保留到持久化历史；建议保持 `false`，避免历史膨胀与前缀增长 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,9 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { stripRelevantMemories, hasRelevantMemories } from "./src/utils/relevant-memories.js";
+import { shapeRecallForOpenClawHook } from "./src/adapters/openclaw/recall-injection.js";
+import { describeRecallShape } from "./src/utils/recall-shape-diagnostics.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -584,17 +587,19 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
-          const appendLen = result.appendSystemContext?.length ?? 0;
-          const prependLen = result.prependContext?.length ?? 0;
+        const hookResult = shapeRecallForOpenClawHook(result, cfg.recall.injectionMode);
+        const shape = describeRecallShape(hookResult);
+        if (hookResult?.appendSystemContext || hookResult?.prependContext || hookResult?.appendContext) {
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `injectionMode=${cfg.recall.injectionMode}, ` +
+            `stable=${shape.stableChars}chars(hash=${shape.stableHash}), ` +
+            `dynamic=${shape.dynamicPlacement}/${shape.dynamicChars}chars`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -624,12 +629,13 @@ export default function register(api: OpenClawPluginApi) {
 
     if (msg.role !== "user") return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+    // showInjected=true keeps injected blocks in history for auditing, at the
+    // cost of cache-hostile history bloat.
+    if (cfg.recall.showInjected) return;
 
     if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
+      if (!hasRelevantMemories(msg.content)) return;
+      const cleaned = stripRelevantMemories(msg.content);
       if (cleaned === msg.content) return;
       api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
       return { message: { ...event.message, content: cleaned } as typeof event.message };
@@ -639,9 +645,9 @@ export default function register(api: OpenClawPluginApi) {
       let totalStripped = 0;
       const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
         if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
+        if (!hasRelevantMemories(part.text)) return part;
+        const cleaned = stripRelevantMemories(part.text);
+        totalStripped += part.text.length - cleaned.length;
         return { ...part, text: cleaned };
       });
       if (totalStripped === 0) return;

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,12 +74,14 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回注入位置：prepend(默认，用户消息前，旧行为)；append(用户消息后，依赖宿主 appendContext，保持用户消息前缀稳定以利于前缀缓存)" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
-          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }
+          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否在持久化历史中保留 <relevant-memories> 注入块：false(默认)持久化前剥离，保持历史干净、利于缓存；true 保留以供审计（会膨胀历史）" }
         }
       },
       "embedding": {

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { shapeRecallForOpenClawHook } from "./recall-injection.js";
+
+describe("shapeRecallForOpenClawHook", () => {
+  it("prepend mode keeps prependContext unchanged", () => {
+    const result = shapeRecallForOpenClawHook(
+      { appendSystemContext: "stable", prependContext: "dynamic" },
+      "prepend",
+    );
+
+    expect(result).toEqual({ appendSystemContext: "stable", prependContext: "dynamic" });
+    expect(result?.appendContext).toBeUndefined();
+  });
+
+  it("append mode moves prependContext to appendContext", () => {
+    const result = shapeRecallForOpenClawHook(
+      { appendSystemContext: "stable", prependContext: "dynamic", recallStrategy: "hybrid" },
+      "append",
+    );
+
+    expect(result?.prependContext).toBeUndefined();
+    expect(result?.appendContext).toBe("dynamic");
+    expect(result?.appendSystemContext).toBe("stable");
+    expect(result?.recallStrategy).toBe("hybrid");
+  });
+
+  it("append mode with no prependContext leaves result unchanged", () => {
+    const result = shapeRecallForOpenClawHook({ appendSystemContext: "stable" }, "append");
+
+    expect(result).toEqual({ appendSystemContext: "stable" });
+    expect(result?.appendContext).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(shapeRecallForOpenClawHook(undefined, "append")).toBeUndefined();
+  });
+});

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,33 @@
+import type { RecallResult } from "../../core/types.js";
+import type { RecallInjectionMode } from "../../config.js";
+
+/**
+ * OpenClaw prompt-build hook result. Adds `appendContext` (content placed
+ * after the user prompt) on top of the core RecallResult fields.
+ */
+export interface OpenClawRecallHookResult extends RecallResult {
+  /** Dynamic recall appended after the user prompt (append mode, host-supported). */
+  appendContext?: string;
+}
+
+/**
+ * Shape core recall output for OpenClaw's prompt-build hook.
+ *
+ * Core always emits dynamic L1 recall as `prependContext` (host-neutral).
+ * OpenClaw supports an `appendContext` field, so `append` mode moves dynamic
+ * recall after the user prompt — keeping the user-prompt prefix byte-stable
+ * for prefix-matching cache providers. `prepend` mode leaves it unchanged.
+ *
+ * Placeholder — real routing driven by the failing tests.
+ */
+export function shapeRecallForOpenClawHook(
+  result: RecallResult | undefined,
+  injectionMode: RecallInjectionMode,
+): OpenClawRecallHookResult | undefined {
+  if (!result) return undefined;
+  if (injectionMode !== "append" || !result.prependContext) {
+    return result;
+  }
+  const { prependContext, ...rest } = result;
+  return { ...rest, appendContext: prependContext };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall prompt-cache options", () => {
+  it("defaults injectionMode to prepend and showInjected to false", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+    expect(cfg.recall.showInjected).toBe(false);
+  });
+
+  it("accepts append injection mode and explicit showInjected opt-in", () => {
+    const cfg = parseConfig({
+      recall: { injectionMode: "append", showInjected: true },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("append");
+    expect(cfg.recall.showInjected).toBe(true);
+  });
+
+  it("falls back to prepend for unknown injection modes", () => {
+    const cfg = parseConfig({ recall: { injectionMode: "prefix-cache-magic" } });
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,13 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /**
+   * Where dynamic L1 recall is placed in the prompt.
+   * - "prepend" (default): before the user prompt (legacy behavior)
+   * - "append": after the user prompt via the host's appendContext, keeping the
+   *   user-prompt prefix stable for prefix-matching caches (requires host support)
+   */
+  injectionMode: RecallInjectionMode;
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -93,7 +100,17 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /**
+   * When false (default), <relevant-memories> blocks are stripped from user
+   * messages before persistence, keeping history clean and prompt-cache
+   * friendly. When true, blocks are retained for auditing (bloats history and
+   * hurts cache — not recommended).
+   */
+  showInjected: boolean;
 }
+
+/** Dynamic L1 recall placement in the prompt. */
+export type RecallInjectionMode = "prepend" | "append";
 
 /** Embedding service configuration for vector search. */
 export interface EmbeddingConfig {
@@ -529,12 +546,14 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: validateRecallInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      showInjected: bool(recallGroup, "showInjected") ?? false,
     },
     embedding: {
       enabled: embeddingEnabled,
@@ -643,6 +662,15 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+const VALID_RECALL_INJECTION_MODES: RecallInjectionMode[] = ["prepend", "append"];
+
+function validateRecallInjectionMode(value: string | undefined): RecallInjectionMode | undefined {
+  if (!value) return undefined;
+  return VALID_RECALL_INJECTION_MODES.includes(value as RecallInjectionMode)
+    ? (value as RecallInjectionMode)
     : undefined;
 }
 

--- a/src/utils/recall-shape-diagnostics.test.ts
+++ b/src/utils/recall-shape-diagnostics.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { describeRecallShape } from "./recall-shape-diagnostics.js";
+
+describe("describeRecallShape", () => {
+  it("reports stable hash + prepend placement when prependContext present", () => {
+    const snap = describeRecallShape({ appendSystemContext: "persona", prependContext: "mem" });
+
+    expect(snap.stableChars).toBe(7);
+    expect(snap.stableHash).toMatch(/^[0-9a-f]{8}$/);
+    expect(snap.dynamicPlacement).toBe("prepend");
+    expect(snap.dynamicChars).toBe(3);
+  });
+
+  it("reports append placement when appendContext present", () => {
+    const snap = describeRecallShape({ appendContext: "mem" });
+
+    expect(snap.dynamicPlacement).toBe("append");
+    expect(snap.dynamicChars).toBe(3);
+    expect(snap.stableHash).toBe("-");
+  });
+
+  it("reports none when no dynamic recall", () => {
+    const snap = describeRecallShape({ appendSystemContext: "persona" });
+
+    expect(snap.dynamicPlacement).toBe("none");
+    expect(snap.dynamicChars).toBe(0);
+  });
+
+  it("stable hash is stable for identical content, differs when changed", () => {
+    const a = describeRecallShape({ appendSystemContext: "persona" }).stableHash;
+    const b = describeRecallShape({ appendSystemContext: "persona" }).stableHash;
+    const c = describeRecallShape({ appendSystemContext: "persona2" }).stableHash;
+
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+});

--- a/src/utils/recall-shape-diagnostics.ts
+++ b/src/utils/recall-shape-diagnostics.ts
@@ -1,0 +1,33 @@
+/**
+ * Lightweight, observation-only diagnostics for recall prompt-cache shape.
+ * Snapshots the stable system context hash + dynamic recall placement so
+ * operators can verify prefix stability and injectionMode effect from logs.
+ * Never changes injection behaviour.
+ */
+
+import { createHash } from "node:crypto";
+
+export interface RecallShapeSnapshot {
+  /** Short hash of the stable system context (appendSystemContext); "-" when empty. */
+  stableHash: string;
+  /** Length of the stable block. */
+  stableChars: number;
+  /** Where dynamic recall landed this turn. */
+  dynamicPlacement: "prepend" | "append" | "none";
+  /** Length of the dynamic recall block. */
+  dynamicChars: number;
+}
+
+export function describeRecallShape(
+  result: { appendSystemContext?: string; prependContext?: string; appendContext?: string } | undefined,
+): RecallShapeSnapshot {
+  const stable = result?.appendSystemContext ?? "";
+  const prepend = result?.prependContext?.length ?? 0;
+  const append = result?.appendContext?.length ?? 0;
+  return {
+    stableHash: stable ? createHash("sha256").update(stable).digest("hex").slice(0, 8) : "-",
+    stableChars: stable.length,
+    dynamicPlacement: append > 0 ? "append" : prepend > 0 ? "prepend" : "none",
+    dynamicChars: Math.max(prepend, append),
+  };
+}

--- a/src/utils/relevant-memories.test.ts
+++ b/src/utils/relevant-memories.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for relevant-memories strip helpers — used before persisting user
+ * messages so recalled-memory blocks don't bloat frozen conversation history.
+ */
+import { describe, expect, test } from "vitest";
+import { stripRelevantMemories, hasRelevantMemories } from "./relevant-memories.js";
+
+describe("stripRelevantMemories", () => {
+  test("removes a single <relevant-memories> block and surrounding whitespace", () => {
+    const text = "<relevant-memories>\nmem\n</relevant-memories>\nhello";
+    expect(stripRelevantMemories(text)).toBe("hello");
+  });
+
+  test("removes multiple blocks", () => {
+    const text = "a<relevant-memories>x</relevant-memories>b<relevant-memories>y</relevant-memories>c";
+    expect(stripRelevantMemories(text)).toBe("abc");
+  });
+
+  test("leaves text without blocks unchanged", () => {
+    expect(stripRelevantMemories("just user text")).toBe("just user text");
+  });
+
+  test("preserves surrounding text", () => {
+    expect(stripRelevantMemories("before<relevant-memories>mem</relevant-memories>after")).toBe("beforeafter");
+  });
+});
+
+describe("hasRelevantMemories", () => {
+  test("true when a block is present", () => {
+    expect(hasRelevantMemories("x<relevant-memories>y</relevant-memories>")).toBe(true);
+  });
+
+  test("false when absent", () => {
+    expect(hasRelevantMemories("plain text")).toBe(false);
+  });
+});

--- a/src/utils/relevant-memories.ts
+++ b/src/utils/relevant-memories.ts
@@ -1,0 +1,20 @@
+/**
+ * Helpers for stripping <relevant-memories>...</relevant-memories> blocks
+ * from user messages before they are persisted, so recalled-memory injections
+ * don't bloat the frozen conversation history (which would push prefix-matching
+ * caches toward more truncation jitter).
+ */
+
+// /g is used only with String.replace (which resets lastIndex); never call
+// .test/.exec on this instance.
+const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+/** Remove all <relevant-memories> blocks (and trailing whitespace), then trim. */
+export function stripRelevantMemories(text: string): string {
+  return text.replace(RELEVANT_MEMORIES_RE, "").trim();
+}
+
+/** Quick check so callers can skip when there is nothing to strip. */
+export function hasRelevantMemories(text: string): boolean {
+  return text.includes("<relevant-memories>");
+}


### PR DESCRIPTION
## Description

Fixes #120.

Adds explicit, backward-compatible prompt-cache controls for TencentDB recall injection. **Default behaviour is unchanged** (`injectionMode="prepend"` + `showInjected=false`), so this is a zero-impact upgrade unless the operator opts in.

- **`recall.injectionMode`** (default `"prepend"`): opt-in `"append"` routes dynamic L1 recall to the host's `appendContext` (after the user prompt) instead of `prependContext` (before it), so the user-prompt prefix stays byte-stable across turns — the primary lever for prefix-matching cache providers (DeepSeek, MiMo). Requires a host that consumes `appendContext`.
- **`recall.showInjected`** (default `false`): makes the existing `before_message_write` stripping of `<relevant-memories>` explicit and opt-in, so persisted history doesn't replay stale dynamic recall and keep growing the prompt prefix.
- **Lightweight prefix diagnostics**: each `before_prompt_build` logs the stable-block hash and dynamic placement (`stable=Nchars(hash=…)`, `dynamic=prepend|append/Nchars`). Observation-only — no behaviour change — lets operators verify prefix stability and the effect of `injectionMode`.
- **Layering**: the strip helper is host-neutral (`src/utils/relevant-memories.ts`); injection routing is OpenClaw-specific (`src/adapters/openclaw/recall-injection.ts`); diagnostics live in `src/utils/recall-shape-diagnostics.ts`.

## Scope decisions

- **No session-level freeze / dedupe of the stable block.** The "stable block byte drift" chain does not exist in this repo: `generateSceneNavigation` is deterministic (sort by heat, no timestamps/random) and `heat` is updated only during L2 scene extraction — not on the recall path. Therefore `appendSystemContext` (persona + scene nav + tools guide) is already byte-stable across turns while source files are unchanged. A freeze would add no value and would additionally delay L2/L3 persona updates.
- **No persona relocation to `prependSystemContext`.** Final placement relative to the host's cache boundary depends on host-side semantics that cannot be verified offline, so it is intentionally left out of scope.

## Cache impact

- `injectionMode="append"`: dynamic L1 recall moves out of the user-prompt prefix → prefix-matching cache stays warm (on hosts supporting `appendContext`).
- `showInjected=false` (default): persisted history avoids dynamic-recall growth → less truncation jitter over multi-turn conversations.
- Default config = legacy behaviour.

## Verification

```bash
npx vitest run          # 8 files / 84 tests passed
npm run build:plugin    # passed
