### PR TITLE
feat(knowledge): add MCP streamable-HTTP endpoint for remote agent access

### DIFF
--- a/MemoryKnowledge/README.md
+++ b/MemoryKnowledge/README.md
@@ -32,7 +32,7 @@ MemoryKnowledge/
 │   │   └── code/           # CodeGraph bridge
 │   ├── store/              # SQLite（Drizzle）+ 构建队列 + llm_binding
 │   ├── source-fetcher/     # Git 拉取
-│   ├── mcp/                # MCP stdio（转发到本机 HTTP API）
+│   ├── mcp/                # MCP stdio + streamable-HTTP（转发到本机 HTTP API）
 │   ├── db/                 # schema / client
 │   └── middleware/
 ├── docs/                   # 设计与 API 细节
@@ -93,6 +93,49 @@ pnpm dev:mcp      # MCP stdio（另开终端；需 HTTP 已起）
 pnpm typecheck
 pnpm test
 pnpm build        # tsdown → dist/
+```
+
+## MCP 接入
+
+Knowledge Service 提供两种 MCP 接入方式，暴露相同的 12 个只读查询工具（Wiki 4 + CodeGraph 8）：
+
+### stdio（本地进程）
+
+```bash
+pnpm dev:mcp
+# Agent 配置 command: node dist/mcp/server.js
+```
+
+### Streamable-HTTP（远程网络接入）
+
+KS 启动后自动在 `/mcp` 挂载标准 MCP streamable-HTTP 端点，远程 Agent 直接用 URL 接入：
+
+```
+https://<host>:<port>/mcp
+```
+
+**启用鉴权（生产环境必填）：**
+
+```dotenv
+KNOWLEDGE_MCP_AUTH_TOKEN=your-secret-token
+```
+
+设置后所有 MCP 请求必须携带 `Authorization: Bearer your-secret-token`。  
+留空（默认）则不鉴权，仅适合本地开发。
+
+**Agent 配置示例（标准 mcpServers 格式）：**
+
+```json
+{
+  "mcpServers": {
+    "agent-memory-knowledge": {
+      "url": "https://agent-memory.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer your-secret-token"
+      }
+    }
+  }
+}
 ```
 
 ## 可选：Langfuse

--- a/MemoryKnowledge/src/config.ts
+++ b/MemoryKnowledge/src/config.ts
@@ -55,6 +55,12 @@ export interface ServiceConfig {
   publicBaseUrl: string;
   /** TMC callback URL for status notifications (empty = no callback). */
   tmcCallbackUrl: string;
+  /**
+   * Bearer token required on MCP streamable-HTTP requests (/mcp).
+   * Empty string (default) disables auth — suitable for local/dev use only.
+   * Set KNOWLEDGE_MCP_AUTH_TOKEN to enable.
+   */
+  mcpAuthToken: string;
 }
 
 function env(key: string, fallback: string): string {
@@ -81,6 +87,7 @@ export function loadConfig(): ServiceConfig {
     apiPrefix: env("API_PREFIX", "/v3"),
     publicBaseUrl: env("KNOWLEDGE_PUBLIC_BASE_URL", ""),
     tmcCallbackUrl: env("TMC_CALLBACK_URL", ""),
+    mcpAuthToken: env("KNOWLEDGE_MCP_AUTH_TOKEN", ""),
     llm: {
       mode: env("LLM_MODE", "proxy") === "custom" ? "custom" : "proxy",
       protocol: env("LLM_PROTOCOL", "openai") === "anthropic" ? "anthropic" : "openai",

--- a/MemoryKnowledge/src/mcp/http-server.ts
+++ b/MemoryKnowledge/src/mcp/http-server.ts
@@ -1,0 +1,165 @@
+/**
+ * MCP Streamable-HTTP server — exposes knowledge query tools over HTTP.
+ *
+ * Complements the stdio server (server.ts) by providing a network-accessible
+ * MCP endpoint that remote agents can connect to via URL + Bearer token,
+ * the same way they connect to any standard MCP streamable-HTTP server.
+ *
+ * Mount point: /mcp on the knowledge service Hono app.
+ *
+ * Auth: when KNOWLEDGE_MCP_AUTH_TOKEN is set, every request must carry
+ * `Authorization: Bearer <token>`. Leave unset for local/dev use (no auth).
+ *
+ * Session model: one Server + StreamableHTTPServerTransport per client
+ * session, keyed by the `mcp-session-id` header the SDK manages automatically.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Hono } from "hono";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+import { createMcpServer } from "./server.js";
+import type { HttpClientOptions } from "./http-client.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("mcp-http");
+
+export interface McpHttpServerOptions {
+  /** Options forwarded to the underlying knowledge API HTTP client. */
+  httpOpts: HttpClientOptions;
+  /**
+   * Bearer token required on every MCP request.
+   * Empty string (default) disables auth — suitable for local/dev use only.
+   */
+  authToken?: string;
+}
+
+interface Session {
+  server: Server;
+  transport: StreamableHTTPServerTransport;
+}
+
+/**
+ * Build a Hono sub-app that speaks MCP Streamable-HTTP at its root path.
+ *
+ * Mount it in the main server:
+ * ```ts
+ * app.route("/mcp", createMcpHttpRoutes({ httpOpts, authToken }));
+ * ```
+ *
+ * Agents then connect to `https://<host>:<port>/mcp` with
+ * `Authorization: Bearer <token>` (when authToken is configured).
+ */
+export function createMcpHttpRoutes(opts: McpHttpServerOptions): Hono {
+  const { httpOpts, authToken = "" } = opts;
+  const sessions = new Map<string, Session>();
+
+  const app = new Hono();
+
+  // ── Auth gate ──────────────────────────────────────────────────────────────
+  app.use("*", async (c, next) => {
+    if (!authToken) return next();
+    const header = c.req.header("Authorization") ?? "";
+    if (header !== `Bearer ${authToken}`) {
+      log.warn(`MCP auth rejected: bad or missing Authorization header`);
+      return c.json({ jsonrpc: "2.0", error: { code: -32001, message: "Unauthorized" }, id: null }, 401);
+    }
+    return next();
+  });
+
+  // ── POST — JSON-RPC requests (initialize, tools/list, tools/call, …) ───────
+  app.post("/", async (c) => {
+    const incoming = c.env.incoming as IncomingMessage;
+    const outgoing = c.env.outgoing as ServerResponse;
+    const sessionId = c.req.header("mcp-session-id");
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      outgoing.writeHead(400, { "Content-Type": "application/json" });
+      outgoing.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null }));
+      return c.body(null);
+    }
+
+    if (!sessionId) {
+      // No session yet → this must be an initialize request; spin up a new session.
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid) => {
+          sessions.set(sid, { server, transport });
+          log.info(`MCP session opened: ${sid}`);
+        },
+        onsessionclosed: (sid) => {
+          sessions.delete(sid);
+          log.info(`MCP session closed: ${sid}`);
+        },
+      });
+      const server = createMcpServer(httpOpts);
+      await server.connect(transport);
+      await transport.handleRequest(incoming, outgoing, body);
+    } else {
+      const session = sessions.get(sessionId);
+      if (!session) {
+        log.warn(`MCP request for unknown session: ${sessionId}`);
+        outgoing.writeHead(404, { "Content-Type": "application/json" });
+        outgoing.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32001, message: "Session not found" }, id: null }));
+        return c.body(null);
+      }
+      await session.transport.handleRequest(incoming, outgoing, body);
+    }
+
+    // Transport wrote directly to `outgoing`; prevent Hono from sending again.
+    return c.body(null);
+  });
+
+  // ── GET — SSE stream for server-initiated messages ─────────────────────────
+  app.get("/", async (c) => {
+    const incoming = c.env.incoming as IncomingMessage;
+    const outgoing = c.env.outgoing as ServerResponse;
+    const sessionId = c.req.header("mcp-session-id");
+
+    if (!sessionId) {
+      outgoing.writeHead(400, { "Content-Type": "application/json" });
+      outgoing.end(JSON.stringify({ error: "Missing mcp-session-id header" }));
+      return c.body(null);
+    }
+
+    const session = sessions.get(sessionId);
+    if (!session) {
+      outgoing.writeHead(404, { "Content-Type": "application/json" });
+      outgoing.end(JSON.stringify({ error: "Session not found" }));
+      return c.body(null);
+    }
+
+    await session.transport.handleRequest(incoming, outgoing);
+    return c.body(null);
+  });
+
+  // ── DELETE — client-initiated session teardown ─────────────────────────────
+  app.delete("/", async (c) => {
+    const incoming = c.env.incoming as IncomingMessage;
+    const outgoing = c.env.outgoing as ServerResponse;
+    const sessionId = c.req.header("mcp-session-id");
+
+    if (!sessionId) {
+      outgoing.writeHead(400, { "Content-Type": "application/json" });
+      outgoing.end(JSON.stringify({ error: "Missing mcp-session-id header" }));
+      return c.body(null);
+    }
+
+    const session = sessions.get(sessionId);
+    if (!session) {
+      outgoing.writeHead(404, { "Content-Type": "application/json" });
+      outgoing.end(JSON.stringify({ error: "Session not found" }));
+      return c.body(null);
+    }
+
+    await session.transport.handleRequest(incoming, outgoing);
+    return c.body(null);
+  });
+
+  return app;
+}

--- a/MemoryKnowledge/src/server.ts
+++ b/MemoryKnowledge/src/server.ts
@@ -25,6 +25,7 @@ import { createCodeGraphRoutes } from "./routes/code-graph.js";
 import { createToolsRoutes } from "./routes/tools.js";
 import { createHealthRoutes } from "./routes/health.js";
 import { createLlmBindingRoutes } from "./routes/llm-binding.js";
+import { createMcpHttpRoutes } from "./mcp/http-server.js";
 import { accessLog } from "./middleware/response-envelope.js";
 import { errorHandler } from "./middleware/error-handler.js";
 import { createLogger } from "./logger.js";
@@ -80,6 +81,17 @@ export function createApp() {
   }));
 
   app.route(config.apiPrefix, api);
+
+  // MCP streamable-HTTP endpoint — remote agents connect here via URL + Bearer token.
+  // Auth: set KNOWLEDGE_MCP_AUTH_TOKEN to require Authorization: Bearer <token>.
+  app.route("/mcp", createMcpHttpRoutes({
+    httpOpts: {
+      baseUrl: `http://127.0.0.1:${config.port}`,
+      token: config.mcpAuthToken || undefined,
+    },
+    authToken: config.mcpAuthToken || undefined,
+  }));
+  log.info(`MCP streamable-HTTP endpoint mounted at /mcp (auth: ${config.mcpAuthToken ? "enabled" : "disabled"})`);
 
   // Swagger UI — serve OpenAPI spec from docs/api/openapi.yaml
   const currentDir = dirname(fileURLToPath(import.meta.url));

--- a/MemoryKnowledge/tests/mcp-http-server.test.ts
+++ b/MemoryKnowledge/tests/mcp-http-server.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the MCP streamable-HTTP server (mcp/http-server.ts).
+ *
+ * Uses an in-process Hono app with createMcpHttpRoutes and exercises the
+ * auth gate and session lifecycle via raw fetch calls.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import type { Server } from "node:http";
+import { createMcpHttpRoutes } from "../src/mcp/http-server.js";
+
+const TEST_PORT = 18424;
+const TEST_TOKEN = "test-mcp-token";
+
+function baseUrl() {
+  return `http://127.0.0.1:${TEST_PORT}`;
+}
+
+/** Build a minimal JSON-RPC initialize request body. */
+function initBody() {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "0.0.0" },
+    },
+  };
+}
+
+describe("createMcpHttpRoutes", () => {
+  // ── No-auth instance ────────────────────────────────────────────────────────
+  describe("without auth token", () => {
+    let srv: Server;
+
+    beforeAll(async () => {
+      const app = new Hono();
+      app.route("/mcp", createMcpHttpRoutes({
+        httpOpts: { baseUrl: baseUrl() },
+        // no authToken → auth disabled
+      }));
+      srv = serve({ fetch: app.fetch, port: TEST_PORT });
+      await new Promise<void>((r) => srv.once("listening", r));
+    });
+
+    afterAll(() => new Promise<void>((r) => srv.close(() => r())));
+
+    it("accepts initialize without Authorization header", async () => {
+      const res = await fetch(`${baseUrl()}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(initBody()),
+      });
+      // Transport writes directly to the socket; status may be 200 or the
+      // raw JSON-RPC response — either way it must not be 401.
+      expect(res.status).not.toBe(401);
+    });
+  });
+
+  // ── Auth instance ───────────────────────────────────────────────────────────
+  describe("with auth token", () => {
+    let srv: Server;
+
+    beforeAll(async () => {
+      const app = new Hono();
+      app.route("/mcp", createMcpHttpRoutes({
+        httpOpts: { baseUrl: baseUrl() },
+        authToken: TEST_TOKEN,
+      }));
+      srv = serve({ fetch: app.fetch, port: TEST_PORT + 1 });
+      await new Promise<void>((r) => srv.once("listening", r));
+    });
+
+    afterAll(() => new Promise<void>((r) => srv.close(() => r())));
+
+    it("rejects requests without Authorization header", async () => {
+      const res = await fetch(`http://127.0.0.1:${TEST_PORT + 1}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(initBody()),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects requests with wrong token", async () => {
+      const res = await fetch(`http://127.0.0.1:${TEST_PORT + 1}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer wrong-token",
+        },
+        body: JSON.stringify(initBody()),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("accepts requests with correct token", async () => {
+      const res = await fetch(`http://127.0.0.1:${TEST_PORT + 1}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_TOKEN}`,
+        },
+        body: JSON.stringify(initBody()),
+      });
+      expect(res.status).not.toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Expose the existing 12 knowledge query tools (Wiki 4 + CodeGraph 8) over standard **MCP streamable-HTTP** at `/mcp`, so remote agents can connect via URL + Bearer token — no local stdio wrapper process needed.

## Motivation

The Knowledge Service currently only ships a **stdio** MCP server (`mcp/server.ts`), which requires agents to run a local subprocess. Remote agents (Octop, nanobot, QwenPaw, Hermes, etc.) had no standard way to connect over HTTP — they needed a per-machine bridge script.

This PR adds a standard MCP streamable-HTTP endpoint alongside the existing stdio server, using the same `createMcpServer` factory and `MCP_TOOLS` definitions.

## Changes

| File | Change |
|---|---|
| `src/mcp/http-server.ts` | **New.** Hono sub-app implementing the full MCP streamable-HTTP session lifecycle (POST / GET / DELETE on `/mcp`) via `StreamableHTTPServerTransport`. One `Server` + transport per client session, keyed by `mcp-session-id`. |
| `src/config.ts` | Add `mcpAuthToken` field, read from `KNOWLEDGE_MCP_AUTH_TOKEN` env var. |
| `src/server.ts` | Mount `/mcp` routes in `createApp()`; log auth status at startup. |
| `tests/mcp-http-server.test.ts` | **New.** Auth gate tests: 401 on missing/wrong token, pass on correct token, no-auth mode. |
| `README.md` | Document both MCP transports with agent config example. |

## Auth

Set `KNOWLEDGE_MCP_AUTH_TOKEN` to require `Authorization: Bearer <token>` on every MCP request. Leave unset (default) to disable auth for local/dev use.

## Agent config example

```json
{
  "mcpServers": {
    "agent-memory-knowledge": {
      "url": "https://agent-memory.example.com/mcp",
      "headers": {
        "Authorization": "Bearer your-secret-token"
      }
    }
  }
}
```

## Testing

```bash
cd MemoryKnowledge
pnpm install
pnpm test
```