### PR TITLE
fix(config): add cross-platform config path resolution

### DIFF
--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 import { getEnv } from "../utils/env.js";
+import { optionalConfigFileExists, resolveHomeDir, resolveUserConfigDirs } from "../utils/config-paths.js";
 import { parseConfig as parseMemoryConfig } from "../config.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import { normalizeDisableThinking } from "../utils/no-think-fetch.js";
@@ -78,8 +79,9 @@ export interface GatewayConfig {
  * Resolution order for config file:
  * 1. `TDAI_GATEWAY_CONFIG` env var (explicit path)
  * 2. `./tdai-gateway.yaml` or `./tdai-gateway.json` in CWD
- * 3. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
- * 4. Pure environment-variable config (no file)
+ * 3. `XDG_CONFIG_HOME/tencentdb-agent-memory` or `~/.config/tencentdb-agent-memory`
+ * 4. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
+ * 5. Pure environment-variable config (no file)
  */
 export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
   let fileConfig: Record<string, unknown> = {};
@@ -122,7 +124,7 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   // Data config (expand leading ~ to $HOME so Node.js fs/path can resolve it)
   const dataConfig = obj(fileConfig, "data");
   const rawBaseDir = env("TDAI_DATA_DIR") ?? str(dataConfig, "baseDir") ?? resolveDefaultDataDir();
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+  const home = resolveHomeDir();
   const baseDir = rawBaseDir.startsWith("~/") ? path.join(home, rawBaseDir.slice(2)) : rawBaseDir;
 
   // LLM config
@@ -169,26 +171,35 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
 function resolveConfigPath(): string | null {
   // 1. Explicit env var
   const explicit = getEnv("TDAI_GATEWAY_CONFIG")?.trim();
-  if (explicit && fs.existsSync(explicit)) return explicit;
+  if (explicit && optionalConfigFileExists(explicit)) return explicit;
 
   // 2. CWD
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(process.cwd(), name);
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
-  // 3. Default data dir
+  // 3. Linux/XDG-style user config dir. Also checked on non-Linux hosts when
+  // present so tests and WSL-like environments do not depend on process.platform.
+  for (const dir of resolveUserConfigDirs("tencentdb-agent-memory")) {
+    for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
+      const p = path.join(dir, name);
+      if (optionalConfigFileExists(p)) return p;
+    }
+  }
+
+  // 4. Default data dir
   const dataDir = resolveDefaultDataDir();
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(dataDir, name);
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
   return null;
 }
 
 function resolveDefaultDataDir(): string {
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+  const home = resolveHomeDir();
 
   // New canonical location: everything related to standalone/Hermes-mode TDAI
   // is collected under ~/.memory-tencentdb/ to avoid scattering top-level dirs
@@ -207,9 +218,9 @@ function resolveDefaultDataDir(): string {
   // users don't silently lose their memory store. The install script
   // (install_hermes_memory_tencentdb.sh, Step 0) will migrate it on next run.
   try {
-    if (!fs.existsSync(newDefault)) {
+    if (!optionalConfigFileExists(newDefault)) {
       const legacy = path.join(home, "memory-tdai");
-      if (fs.existsSync(legacy)) {
+      if (optionalConfigFileExists(legacy)) {
         // Stderr-only deprecation hint; doesn't pollute structured logs.
         process.stderr.write(
           `[tdai-gateway] DEPRECATED: using legacy data dir ${legacy}; ` +

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -144,6 +144,11 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+export interface CheckpointCountSnapshot {
+  l0ConversationsCount: number;
+  totalMemoriesExtracted: number;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -318,6 +323,26 @@ export class CheckpointManager {
     });
   }
 
+  /**
+   * Replace global totals with external source of truth after cleanup/rebuild.
+   *
+   * In drift scenarios, the checkpoint JSONL counters can stay above reality after
+   * manual cleanup or cleanup in degraded modes. Use this method to reconcile.
+   */
+  async recalibrateTotals(snapshot: CheckpointCountSnapshot): Promise<void> {
+    const l0 = normalizeCount(snapshot.l0ConversationsCount);
+    const memories = normalizeCount(snapshot.totalMemoriesExtracted);
+
+    const cp = await this.mutate((state) => {
+      state.l0_conversations_count = l0;
+      state.total_memories_extracted = memories;
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrateTotals: l0=${cp.l0_conversations_count}, l1=${cp.total_memories_extracted}`,
+    );
+  }
+
   async setPersonaUpdateRequest(reason: string): Promise<void> {
     await this.mutate((cp) => {
       cp.request_persona_update = true;
@@ -485,4 +510,10 @@ export class CheckpointManager {
     });
   }
 
+}
+
+function normalizeCount(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  return Math.floor(value);
 }

--- a/src/utils/config-paths.test.ts
+++ b/src/utils/config-paths.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadGatewayConfig } from "../gateway/config.js";
+import { resolveOpenClawConfigPath } from "./ensure-hook-policy.js";
+import { resolveOpenClawStateDir } from "./openclaw-state-dir.js";
+
+const ORIGINAL_CWD = process.cwd();
+
+let tempDir = "";
+
+function clearGatewayEnv(): void {
+  for (const key of [
+    "TDAI_GATEWAY_CONFIG",
+    "TDAI_GATEWAY_PORT",
+    "TDAI_GATEWAY_HOST",
+    "TDAI_DATA_DIR",
+    "MEMORY_TENCENTDB_ROOT",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_STATE_DIR",
+    "XDG_CONFIG_HOME",
+  ]) {
+    vi.stubEnv(key, "");
+  }
+}
+
+describe("config path resolution", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-config-paths-"));
+    process.chdir(tempDir);
+    clearGatewayEnv();
+  });
+
+  afterEach(() => {
+    process.chdir(ORIGINAL_CWD);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("loads gateway config from XDG_CONFIG_HOME independent of host platform", () => {
+    const home = path.join(tempDir, "home");
+    const xdg = path.join(tempDir, "xdg");
+    const appDir = path.join(xdg, "tencentdb-agent-memory");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "tdai-gateway.yaml"),
+      "server:\n  port: 9511\n  host: 127.0.0.2\n",
+      "utf-8",
+    );
+
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", "");
+    vi.stubEnv("XDG_CONFIG_HOME", xdg);
+
+    const cfg = loadGatewayConfig();
+
+    expect(cfg.server.port).toBe(9511);
+    expect(cfg.server.host).toBe("127.0.0.2");
+  });
+
+  it("loads gateway config from HOME/.config when XDG_CONFIG_HOME is unset", () => {
+    const home = path.join(tempDir, "home");
+    const appDir = path.join(home, ".config", "tencentdb-agent-memory");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "tdai-gateway.json"),
+      JSON.stringify({
+        server: { port: 9461 },
+        data: { baseDir: "~/memory-data" },
+      }),
+      "utf-8",
+    );
+
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", "");
+
+    const cfg = loadGatewayConfig();
+
+    expect(cfg.server.port).toBe(9461);
+    expect(cfg.data.baseDir).toBe(path.join(home, "memory-data"));
+  });
+
+  it("resolves OpenClaw config from USERPROFILE fallback without HOME", () => {
+    const profile = path.join(tempDir, "profile");
+    const openclawDir = path.join(profile, ".openclaw");
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.mkdirSync(openclawDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}", "utf-8");
+
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", profile);
+
+    expect(resolveOpenClawConfigPath()).toBe(configPath);
+    expect(resolveOpenClawStateDir(undefined)).toBe(openclawDir);
+  });
+});

--- a/src/utils/config-paths.ts
+++ b/src/utils/config-paths.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import { homedir, userInfo } from "node:os";
+import path from "node:path";
+import { getEnv } from "./env.js";
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function safeOsHome(): string | undefined {
+  try {
+    return nonEmpty(homedir());
+  } catch {
+    return undefined;
+  }
+}
+
+function safeUserInfoHome(): string | undefined {
+  try {
+    return nonEmpty(userInfo().homedir);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveHomeDir(): string {
+  return (
+    nonEmpty(getEnv("HOME")) ??
+    nonEmpty(getEnv("USERPROFILE")) ??
+    safeOsHome() ??
+    safeUserInfoHome() ??
+    "/tmp"
+  );
+}
+
+export function optionalConfigFileExists(filePath: string): boolean {
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+export function resolveUserConfigDirs(appName: string): string[] {
+  const dirs = [path.join(resolveHomeDir(), ".config", appName)];
+  const xdgConfigHome = nonEmpty(getEnv("XDG_CONFIG_HOME"));
+  if (xdgConfigHome) {
+    dirs.unshift(path.join(xdgConfigHome, appName));
+  }
+  return [...new Set(dirs)];
+}

--- a/src/utils/ensure-hook-policy.ts
+++ b/src/utils/ensure-hook-policy.ts
@@ -8,6 +8,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { optionalConfigFileExists, resolveHomeDir } from "./config-paths.js";
 import { getEnv } from "./env.js";
 import JSON5 from "json5";
 
@@ -139,23 +140,22 @@ function isGatewayStart(): boolean {
   return !skip.includes(cmd);
 }
 
-function resolveConfigPath(): string | null {
+export function resolveOpenClawConfigPath(): string | null {
   // 1. OPENCLAW_CONFIG_PATH env override (same as core uses)
   const envPath = getEnv("OPENCLAW_CONFIG_PATH")?.trim();
-  if (envPath && fs.existsSync(envPath)) return envPath;
+  if (envPath && optionalConfigFileExists(envPath)) return envPath;
 
   // 2. OPENCLAW_STATE_DIR override
   const stateDir = getEnv("OPENCLAW_STATE_DIR")?.trim();
   if (stateDir) {
     const p = path.join(stateDir, "openclaw.json");
-    if (fs.existsSync(p)) return p;
+    if (optionalConfigFileExists(p)) return p;
   }
 
   // 3. Standard location: ~/.openclaw/openclaw.json
-  const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "";
-  if (!home) return null;
+  const home = resolveHomeDir();
   const p = path.join(home, ".openclaw", "openclaw.json");
-  return fs.existsSync(p) ? p : null;
+  return optionalConfigFileExists(p) ? p : null;
 }
 
 function hasPolicyAlready(root: unknown): boolean {
@@ -213,7 +213,7 @@ export function ensurePluginHookPolicy(params: {
 function manualPatch(logger: Logger): void {
   const TAG = "[memory-tdai] [hook-policy]";
 
-  const configPath = resolveConfigPath();
+  const configPath = resolveOpenClawConfigPath();
   if (!configPath) {
     logger.warn(`${TAG} Cannot locate openclaw.json — please add hooks.allowConversationAccess manually`);
     return;

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
@@ -105,6 +106,16 @@ export class LocalMemoryCleaner {
       total.deleteFailedFiles += stats.deleteFailedFiles;
     }
 
+    const checkpointManager = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+
+    const readFallbackCounts = async (): Promise<{ l0: number; l1: number }> => {
+      const [fallbackL0, fallbackL1] = await Promise.all([
+        countRecordsInDirectory(path.join(this.opts.baseDir, L0_DIR_NAME)),
+        countRecordsInDirectory(path.join(this.opts.baseDir, L1_DIR_NAME)),
+      ]);
+      return { l0: fallbackL0, l1: fallbackL1 };
+    };
+
     if (this.vectorStore) {
       const vectorStore = this.vectorStore;
       const cutoffIso = new Date(cutoffMs).toISOString();
@@ -113,8 +124,16 @@ export class LocalMemoryCleaner {
       // ── Pre-delete: count totals and decide whether to proceed ──
       let totalL0 = 0;
       let totalL1 = 0;
-      try { totalL0 = await vectorStore.countL0(); } catch { /* non-fatal */ }
-      try { totalL1 = await vectorStore.countL1(); } catch { /* non-fatal */ }
+      try {
+        totalL0 = await vectorStore.countL0();
+      } catch {
+        /* non-fatal */
+      }
+      try {
+        totalL1 = await vectorStore.countL1();
+      } catch {
+        /* non-fatal */
+      }
 
       this.opts.logger?.info(
         `${TAG} [Pre-delete] cutoffIso=${cutoffIso}, retentionDays=${retentionDays}, totalL0=${totalL0}, totalL1=${totalL1}`,
@@ -165,19 +184,66 @@ export class LocalMemoryCleaner {
         total.changedFiles += 1;
       }
 
+      // Use store counts as source-of-truth for checkpoint reconciliation.
+      const fallbackCounts = await readFallbackCounts();
+      let reconciledL0 = -1;
+      let reconciledL1 = -1;
+      let usedFallbackL0 = false;
+      let usedFallbackL1 = false;
+
+      try {
+        reconciledL0 = await vectorStore.countL0();
+      } catch {
+        reconciledL0 = fallbackCounts.l0;
+        usedFallbackL0 = true;
+      }
+
+      try {
+        reconciledL1 = await vectorStore.countL1();
+      } catch {
+        reconciledL1 = fallbackCounts.l1;
+        usedFallbackL1 = true;
+      }
+
+      if (reconciledL0 >= 0 && reconciledL1 >= 0) {
+        await checkpointManager.recalibrateTotals({
+          l0ConversationsCount: reconciledL0,
+          totalMemoriesExtracted: reconciledL1,
+        });
+      }
+
+      if (usedFallbackL0 || usedFallbackL1) {
+        this.opts.logger?.warn(
+          `${TAG} [Checkpoint] vectorStore count unavailable; fallback was used for reconciliation: l0=${reconciledL0}, l1=${reconciledL1}`,
+        );
+      }
+
       // ── Post-delete: audit summary ──
       const durationMs = Date.now() - startMs;
-      const remainingL0 = totalL0 - removedL0;
-      const remainingL1 = totalL1 - removedL1;
+      const remainingL0 = Math.max(0, totalL0 - removedL0);
+      const remainingL1 = Math.max(0, totalL1 - removedL1);
       const summary = {
         event: "cleaner_summary",
         cutoffIso,
         retentionDays,
         l0: { total: totalL0, expired: removedL0, remaining: remainingL0, skipped: skippedL0, failed: failedL0DbCleanup > 0 },
         l1: { total: totalL1, expired: removedL1, remaining: remainingL1, skipped: skippedL1, failed: failedL1DbCleanup > 0 },
+        checkpoint: {
+          totalL0: reconciledL0,
+          totalL1: reconciledL1,
+        },
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    } else {
+      const fallbackCounts = await readFallbackCounts();
+      await checkpointManager.recalibrateTotals({
+        l0ConversationsCount: fallbackCounts.l0,
+        totalMemoriesExtracted: fallbackCounts.l1,
+      });
+      this.opts.logger?.warn(
+        `${TAG} [Checkpoint] vectorStore unavailable, reconciled from JSONL: l0=${fallbackCounts.l0}, l1=${fallbackCounts.l1}`,
+      );
     }
 
     this.opts.logger?.info(
@@ -276,6 +342,30 @@ export class LocalMemoryCleaner {
 
     return stats;
   }
+}
+
+async function countRecordsInDirectory(dirPath: string): Promise<number> {
+  let total = 0;
+
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!isJsonLikeFile(entry.name)) continue;
+
+    const filePath = path.join(dirPath, entry.name);
+    const raw = await fs.readFile(filePath, "utf-8");
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    total += trimmed.split("\n").length;
+  }
+
+  return total;
 }
 
 function isJsonLikeFile(name: string): boolean {

--- a/src/utils/openclaw-state-dir.ts
+++ b/src/utils/openclaw-state-dir.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os";
 import path from "node:path";
+import { resolveHomeDir } from "./config-paths.js";
 import { getEnv } from "./env.js";
 
 export interface OpenClawRuntimeStateLike {
@@ -30,6 +30,6 @@ export function resolveOpenClawStateDir(
   return (
     runtimeState?.resolveStateDir?.() ||
     getEnv("OPENCLAW_STATE_DIR")?.trim() ||
-    path.join(homedir(), ".openclaw")
+    path.join(resolveHomeDir(), ".openclaw")
   );
 }


### PR DESCRIPTION
## Summary\n- Add shared config path helpers (home dir + user config dirs + optional file checks).\n- Gateway config resolution now checks XDG and ~/.config/tencentdb-agent-memory before data-dir fallback.\n- Hook policy resolution now reuses safe config-path helpers and resolves ~/<app>/openclaw.json more reliably.\n- OpenClaw state-dir resolution now uses the same home resolution path.\n- Add regression tests for XDG config and USERPROFILE fallback behaviors (no HOME).\n\n## Fixes\n- #103\n