### PR TITLE
fix(recall): harden cache-aware OpenClaw injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **Prompt cache 友好的 auto-recall 注入** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：
+  - 记录 issue 后续更正：最严重的 webchat 缓存回退来自 OpenClaw run 行为，并非 TencentDB 插件本身。
+  - 新增 `recall.injectionMode`（默认 `prepend`）与 `recall.showInjected`（默认 `false`）。
+  - OpenClaw v2026.4.27+ 可选择把动态 L1 召回放到 `appendContext`；旧版或版本未知时安全回退，避免召回内容丢失。
+  - OpenClaw v2026.4.26+ 将稳定 persona / scene / memory-tools 上下文映射到 `prependSystemContext`，使其位于动态 system suffix 之前。
+  - 历史清理只识别插件固定免责声明生成的召回块，不再误删用户自己编写的 `<relevant-memories>` 示例；新增 5 轮 prompt shape 与 100 轮历史增长回归测试。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+| `recall.injectionMode` | `"prepend"` | Dynamic L1 placement: `prepend` preserves current behavior; `append` uses OpenClaw `appendContext` on v2026.4.27+ and safely falls back on older/unknown hosts |
+| `recall.showInjected` | `false` | Persist plugin-generated `<relevant-memories>` for debugging; keep `false` to prevent stale recall replay and history growth |
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/README_CN.md
+++ b/README_CN.md
@@ -436,6 +436,8 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | `timezone` | `"system"` | 时区：`"system"`（跟随系统）/ IANA 名（`Asia/Shanghai`）/ offset 串（`+08:00`） |
 | `storeBackend` | `"sqlite"` | 存储后端：`sqlite` |
 | `recall.strategy` | `"hybrid"` | 召回策略：`keyword` / `embedding` / `hybrid`（RRF 融合，推荐） |
+| `recall.injectionMode` | `"prepend"` | 动态 L1 注入位置：`prepend` 保持当前行为；`append` 在 OpenClaw v2026.4.27+ 使用 `appendContext`，旧版或版本未知时安全回退 |
+| `recall.showInjected` | `false` | 是否把插件生成的 `<relevant-memories>` 保存进历史用于调试；建议保持 `false`，避免旧召回重复回放和历史膨胀 |
 | `recall.maxResults` | `5` | 每次召回条数 |
 | `recall.maxCharsPerMemory` | `0` | 单条 L1 记忆注入的最大字符数；`0` 表示不限制 |
 | `recall.maxTotalRecallChars` | `0` | 每轮 auto-recall 注入的 L1 记忆总字符预算；`0` 表示不限制 |

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,11 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import {
+  resolveOpenClawRecallCompatibility,
+  shapeOpenClawRecallResult,
+} from "./src/adapters/openclaw/recall-injection.js";
+import { stripInjectedRecallFromMessage } from "./src/utils/recall-injection.js";
 
 const TAG = "[memory-tdai]";
 
@@ -88,13 +93,17 @@ const pendingRecallCache = new Map<string, {
  */
 const pendingRecallEndTimestamps = new Map<string, number>();
 
+const pendingInjectedRecallBlocks = new Map<string, {
+  context: string;
+  placement: "prepend" | "append";
+  ts: number;
+}>();
+
 // 进程级单例，避免同一进程重复启动清理器导致并发清理竞态
 let sharedMemoryCleaner: LocalMemoryCleaner | undefined;
 
 /**
- * Sweep both pendingOriginalPrompts and pendingRecallCache for stale entries.
- * Unified from the original sweepStalePromptCache() to cover both Maps
- * with identical TTL + hard-cap logic.
+ * Sweep pending per-session hook state for stale entries.
  */
 function sweepStaleCaches(): void {
   const now = Date.now();
@@ -111,6 +120,11 @@ function sweepStaleCaches(): void {
       pendingRecallCache.delete(key);
     }
   }
+  for (const [key, entry] of pendingInjectedRecallBlocks) {
+    if (now - entry.ts > PROMPT_CACHE_TTL_MS) {
+      pendingInjectedRecallBlocks.delete(key);
+    }
+  }
   // Hard limit: evict oldest entries if either Map exceeds cap
   if (pendingOriginalPrompts.size > PROMPT_CACHE_MAX_SIZE) {
     const entries = [...pendingOriginalPrompts.entries()].sort((a, b) => a[1].ts - b[1].ts);
@@ -125,6 +139,13 @@ function sweepStaleCaches(): void {
     const toEvict = entries.slice(0, entries.length - PROMPT_CACHE_MAX_SIZE);
     for (const [key] of toEvict) {
       pendingRecallCache.delete(key);
+    }
+  }
+  if (pendingInjectedRecallBlocks.size > PROMPT_CACHE_MAX_SIZE) {
+    const entries = [...pendingInjectedRecallBlocks.entries()].sort((a, b) => a[1].ts - b[1].ts);
+    const toEvict = entries.slice(0, entries.length - PROMPT_CACHE_MAX_SIZE);
+    for (const [key] of toEvict) {
+      pendingInjectedRecallBlocks.delete(key);
     }
   }
 }
@@ -179,7 +200,7 @@ export default function register(api: OpenClawPluginApi) {
     api.logger.debug?.(
       `${TAG} Config parsed: ` +
       `capture=${cfg.capture.enabled}, ` +
-      `recall=${cfg.recall.enabled}(maxResults=${cfg.recall.maxResults}), ` +
+      `recall=${cfg.recall.enabled}(maxResults=${cfg.recall.maxResults}, injectionMode=${cfg.recall.injectionMode}, showInjected=${cfg.recall.showInjected}), ` +
       `extraction=${cfg.extraction.enabled}(dedup=${cfg.extraction.enableDedup}, maxMem=${cfg.extraction.maxMemoriesPerSession}), ` +
       `pipeline=(everyN=${cfg.pipeline.everyNConversations}, warmup=${cfg.pipeline.enableWarmup}, l1Idle=${cfg.pipeline.l1IdleTimeoutSeconds}s, l2DelayAfterL1=${cfg.pipeline.l2DelayAfterL1Seconds}s, l2Min=${cfg.pipeline.l2MinIntervalSeconds}s, l2Max=${cfg.pipeline.l2MaxIntervalSeconds}s, activeWindow=${cfg.pipeline.sessionActiveWindowHours}h), ` +
       `persona(triggerEvery=${cfg.persona.triggerEveryN}, backupCount=${cfg.persona.backupCount}, sceneBackupCount=${cfg.persona.sceneBackupCount}), ` +
@@ -193,6 +214,18 @@ export default function register(api: OpenClawPluginApi) {
 
   // Initialize unified time module (must happen before any timestamp formatting)
   initTimeModule({ timezone: cfg.timezone }, api.logger);
+  const rawOpenClawVersion = (api.runtime as { version?: unknown } | undefined)?.version;
+  const recallCompatibility = resolveOpenClawRecallCompatibility(
+    cfg.recall.injectionMode,
+    rawOpenClawVersion,
+  );
+  if (recallCompatibility.fallbackReason) {
+    api.logger.warn(
+      `${TAG} recall.injectionMode=append is unavailable ` +
+      `(hostVersion=${JSON.stringify(rawOpenClawVersion)}, reason=${recallCompatibility.fallbackReason}); ` +
+      `falling back to prependContext`,
+    );
+  }
 
   // ============================
   // Hook policy auto-patch (v2026.4.24+ compat)
@@ -212,7 +245,7 @@ export default function register(api: OpenClawPluginApi) {
     // version we cannot parse — which is the safe default on old hosts
     // that don't expose `api.runtime.version`. See ensure-hook-policy.ts
     // for the full policy + co-located unit tests.
-    const rawVersion = (api.runtime as any)?.version;
+    const rawVersion = rawOpenClawVersion;
     const decision = decideHookPolicy(rawVersion);
     const parsedStr = decision.parsedXYZ ? decision.parsedXYZ.join(".") : "<unparsable>";
     const minStr = decision.minXYZ.join(".");
@@ -584,17 +617,36 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
-          const appendLen = result.appendSystemContext?.length ?? 0;
-          const prependLen = result.prependContext?.length ?? 0;
+        const hookResult = shapeOpenClawRecallResult(result, recallCompatibility);
+        if (sessionKey) {
+          if (!cfg.recall.showInjected && result?.prependContext) {
+            pendingInjectedRecallBlocks.set(sessionKey, {
+              context: result.prependContext,
+              placement: recallCompatibility.effectiveMode,
+              ts: Date.now(),
+            });
+          } else {
+            pendingInjectedRecallBlocks.delete(sessionKey);
+          }
+        }
+
+        if (hookResult) {
+          const stableLen = result?.appendSystemContext?.length ?? 0;
+          const dynamicLen = result?.prependContext?.length ?? 0;
+          const stablePlacement = recallCompatibility.supportsPrependSystemContext
+            ? "prependSystemContext"
+            : "appendSystemContext";
+          const dynamicPlacement = recallCompatibility.effectiveMode === "append"
+            ? "appendContext"
+            : "prependContext";
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `${stablePlacement}=${stableLen} chars, ${dynamicPlacement}=${dynamicLen} chars`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return hookResult;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -612,42 +664,37 @@ export default function register(api: OpenClawPluginApi) {
     });
   }
 
-  // Strip <relevant-memories> from user messages before they are persisted to
-  // the session JSONL.  The current-turn LLM already saw the full prompt
-  // (effectivePrompt lives in memory), but we don't want recall artifacts
-  // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
-  api.on("before_message_write", (event) => {
+  // The current-turn LLM already saw generated recall. Remove it before
+  // persistence unless the user explicitly opts into debugging visibility.
+  api.logger.debug?.(
+    `${TAG} Registering before_message_write hook ` +
+    `(showInjected=${cfg.recall.showInjected}, generated recall cleanup)`,
+  );
+  api.on("before_message_write", (event, ctx) => {
     const msg = event.message as { role?: string; content?: unknown };
+    const eventSessionKey = (event as { sessionKey?: string }).sessionKey;
+    const sessionKey = eventSessionKey ?? ctx?.sessionKey;
+    const pendingInjection = sessionKey
+      ? pendingInjectedRecallBlocks.get(sessionKey)
+      : undefined;
     const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
     api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
 
-    if (msg.role !== "user") return;
-
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
+    const stripped = stripInjectedRecallFromMessage(msg, {
+      generatedContext: pendingInjection?.context,
+      showInjected: cfg.recall.showInjected,
+      placement: pendingInjection?.placement ?? recallCompatibility.effectiveMode,
+    });
+    if (msg.role === "user" && sessionKey) {
+      pendingInjectedRecallBlocks.delete(sessionKey);
     }
+    if (!stripped) return;
 
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
+    api.logger.debug?.(
+      `${TAG} [before_message_write] Stripped generated recall from ${stripped.contentType}: ` +
+      `removed ${stripped.strippedChars} chars`,
+    );
+    return { message: stripped.message as typeof event.message };
   });
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -74,6 +74,8 @@
         "description": "记忆召回设置",
         "properties": {
           "enabled": { "type": "boolean", "default": true, "description": "是否启用自动召回" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 召回注入位置：prepend 保持兼容行为；append 在 OpenClaw >= 2026.4.27 中把召回内容放到用户输入之后，旧版或版本未知时安全回退到 prepend" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否将插件生成的 <relevant-memories> 保存进历史。默认 false：当前轮仍可见，但写入历史前剥离以避免多轮膨胀；true 仅建议调试使用" },
           "maxResults": { "type": "number", "default": 5, "description": "召回最大结果数" },
           "maxCharsPerMemory": { "type": "number", "default": 0, "description": "单条 L1 记忆注入的最大字符数；填 0 表示不限制" },
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },

--- a/src/adapters/openclaw/index.ts
+++ b/src/adapters/openclaw/index.ts
@@ -5,3 +5,12 @@ export { OpenClawHostAdapter } from "./host-adapter.js";
 export type { OpenClawHostAdapterOptions } from "./host-adapter.js";
 export { OpenClawLLMRunner, OpenClawLLMRunnerFactory } from "./llm-runner.js";
 export type { OpenClawLLMRunnerFactoryOptions } from "./llm-runner.js";
+export {
+  resolveOpenClawRecallCompatibility,
+  shapeOpenClawRecallResult,
+} from "./recall-injection.js";
+export type {
+  OpenClawRecallCompatibility,
+  OpenClawRecallHookResult,
+  RecallInjectionFallbackReason,
+} from "./recall-injection.js";

--- a/src/adapters/openclaw/recall-injection.test.ts
+++ b/src/adapters/openclaw/recall-injection.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveOpenClawRecallCompatibility,
+  shapeOpenClawRecallResult,
+} from "./recall-injection.js";
+
+describe("resolveOpenClawRecallCompatibility", () => {
+  it("keeps prepend mode on old and unknown hosts", () => {
+    expect(resolveOpenClawRecallCompatibility("prepend", undefined)).toMatchObject({
+      effectiveMode: "prepend",
+      hostVersion: null,
+      supportsPrependSystemContext: false,
+    });
+
+    expect(resolveOpenClawRecallCompatibility("append", "2026.4.26")).toMatchObject({
+      effectiveMode: "prepend",
+      hostVersion: [2026, 4, 26],
+      supportsPrependSystemContext: true,
+      fallbackReason: "append-context-unsupported",
+    });
+
+    expect(resolveOpenClawRecallCompatibility("append", undefined)).toMatchObject({
+      effectiveMode: "prepend",
+      fallbackReason: "unknown-host-version",
+    });
+  });
+
+  it("enables appendContext at the v2026.4.27 boundary", () => {
+    expect(resolveOpenClawRecallCompatibility("append", "2026.4.27-beta.1")).toEqual({
+      requestedMode: "append",
+      effectiveMode: "append",
+      hostVersion: [2026, 4, 27],
+      supportsPrependSystemContext: true,
+    });
+  });
+});
+
+describe("shapeOpenClawRecallResult", () => {
+  const recallResult = {
+    appendSystemContext: "<user-persona>stable</user-persona>",
+    prependContext: "<relevant-memories>dynamic</relevant-memories>",
+    recalledL1Memories: [{ content: "dynamic", score: 0.9, type: "fact" }],
+    recalledL3Persona: "stable",
+    recallStrategy: "hybrid",
+  };
+
+  it("maps stable and dynamic context to cache-aware fields on supported hosts", () => {
+    const compatibility = resolveOpenClawRecallCompatibility("append", "2026.4.27");
+    const result = shapeOpenClawRecallResult(recallResult, compatibility);
+
+    expect(result).toEqual({
+      prependSystemContext: "<user-persona>stable</user-persona>",
+      appendContext: "<relevant-memories>dynamic</relevant-memories>",
+      recalledL1Memories: [{ content: "dynamic", score: 0.9, type: "fact" }],
+      recalledL3Persona: "stable",
+      recallStrategy: "hybrid",
+    });
+  });
+
+  it("falls back without losing recall on older hosts", () => {
+    const compatibility = resolveOpenClawRecallCompatibility("append", "2026.4.26");
+    const result = shapeOpenClawRecallResult(recallResult, compatibility);
+
+    expect(result?.prependSystemContext).toBe("<user-persona>stable</user-persona>");
+    expect(result?.prependContext).toBe("<relevant-memories>dynamic</relevant-memories>");
+    expect(result?.appendContext).toBeUndefined();
+  });
+
+  it("keeps legacy stable placement when the host version is unknown", () => {
+    const compatibility = resolveOpenClawRecallCompatibility("prepend", undefined);
+    const result = shapeOpenClawRecallResult(recallResult, compatibility);
+
+    expect(result?.appendSystemContext).toBe("<user-persona>stable</user-persona>");
+    expect(result?.prependSystemContext).toBeUndefined();
+  });
+
+  it("returns undefined when there is no prompt context", () => {
+    const compatibility = resolveOpenClawRecallCompatibility("prepend", "2026.4.27");
+    expect(shapeOpenClawRecallResult({}, compatibility)).toBeUndefined();
+    expect(shapeOpenClawRecallResult(undefined, compatibility)).toBeUndefined();
+  });
+
+  it("keeps the stable system shape byte-identical across five append-mode turns", () => {
+    const compatibility = resolveOpenClawRecallCompatibility("append", "2026.5.28");
+    const systemPrompts = new Set<string>();
+
+    for (let turn = 1; turn <= 5; turn++) {
+      const shaped = shapeOpenClawRecallResult(
+        {
+          appendSystemContext: "<user-persona>stable</user-persona>",
+          prependContext: `<relevant-memories>turn-${turn}</relevant-memories>`,
+        },
+        compatibility,
+      );
+
+      const systemPrompt = [
+        shaped?.prependSystemContext,
+        "BASE SYSTEM PREFIX",
+        "<!-- OPENCLAW_CACHE_BOUNDARY -->",
+        "dynamic host suffix",
+      ].join("\n");
+      systemPrompts.add(systemPrompt);
+      expect(shaped?.prependContext).toBeUndefined();
+      expect(`question-${turn}\n\n${shaped?.appendContext}`).toMatch(
+        new RegExp(`^question-${turn}`),
+      );
+    }
+
+    expect(systemPrompts.size).toBe(1);
+  });
+});
+

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,109 @@
+import type { RecallInjectionMode } from "../../config.js";
+import type { RecallResult } from "../../core/types.js";
+import {
+  compareVersionXYZ,
+  parseVersionXYZ,
+} from "../../utils/ensure-hook-policy.js";
+
+export const PREPEND_SYSTEM_CONTEXT_MIN_VERSION = [2026, 4, 26] as const;
+export const APPEND_CONTEXT_MIN_VERSION = [2026, 4, 27] as const;
+
+export type RecallInjectionFallbackReason =
+  | "unknown-host-version"
+  | "append-context-unsupported";
+
+export interface OpenClawRecallCompatibility {
+  requestedMode: RecallInjectionMode;
+  effectiveMode: RecallInjectionMode;
+  hostVersion: [number, number, number] | null;
+  supportsPrependSystemContext: boolean;
+  fallbackReason?: RecallInjectionFallbackReason;
+}
+
+export interface OpenClawRecallHookResult
+  extends Omit<RecallResult, "prependContext" | "appendSystemContext"> {
+  prependContext?: string;
+  appendContext?: string;
+  prependSystemContext?: string;
+  appendSystemContext?: string;
+}
+
+export function resolveOpenClawRecallCompatibility(
+  requestedMode: RecallInjectionMode,
+  rawHostVersion: unknown,
+): OpenClawRecallCompatibility {
+  const hostVersion = parseVersionXYZ(rawHostVersion);
+  const supportsPrependSystemContext =
+    hostVersion !== null &&
+    compareVersionXYZ(hostVersion, PREPEND_SYSTEM_CONTEXT_MIN_VERSION) >= 0;
+
+  if (requestedMode === "prepend") {
+    return {
+      requestedMode,
+      effectiveMode: "prepend",
+      hostVersion,
+      supportsPrependSystemContext,
+    };
+  }
+
+  if (!hostVersion) {
+    return {
+      requestedMode,
+      effectiveMode: "prepend",
+      hostVersion,
+      supportsPrependSystemContext,
+      fallbackReason: "unknown-host-version",
+    };
+  }
+
+  if (compareVersionXYZ(hostVersion, APPEND_CONTEXT_MIN_VERSION) < 0) {
+    return {
+      requestedMode,
+      effectiveMode: "prepend",
+      hostVersion,
+      supportsPrependSystemContext,
+      fallbackReason: "append-context-unsupported",
+    };
+  }
+
+  return {
+    requestedMode,
+    effectiveMode: "append",
+    hostVersion,
+    supportsPrependSystemContext,
+  };
+}
+
+export function shapeOpenClawRecallResult(
+  result: RecallResult | undefined,
+  compatibility: OpenClawRecallCompatibility,
+): OpenClawRecallHookResult | undefined {
+  if (!result) return undefined;
+
+  const { prependContext, appendSystemContext, ...metrics } = result;
+  const hookResult: OpenClawRecallHookResult = { ...metrics };
+
+  if (prependContext) {
+    if (compatibility.effectiveMode === "append") {
+      hookResult.appendContext = prependContext;
+    } else {
+      hookResult.prependContext = prependContext;
+    }
+  }
+
+  if (appendSystemContext) {
+    if (compatibility.supportsPrependSystemContext) {
+      hookResult.prependSystemContext = appendSystemContext;
+    } else {
+      hookResult.appendSystemContext = appendSystemContext;
+    }
+  }
+
+  const hasPromptContext =
+    hookResult.prependContext ||
+    hookResult.appendContext ||
+    hookResult.prependSystemContext ||
+    hookResult.appendSystemContext;
+  return hasPromptContext ? hookResult : undefined;
+}
+

--- a/src/adapters/openclaw/register-recall.integration.test.ts
+++ b/src/adapters/openclaw/register-recall.integration.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildGeneratedRecallContext } from "../../utils/recall-injection.js";
+
+const coreMocks = vi.hoisted(() => ({
+  handleBeforeRecall: vi.fn(),
+}));
+
+vi.mock("../../core/tdai-core.js", () => ({
+  TdaiCore: class {
+    initialize = vi.fn(async () => undefined);
+    getVectorStore = vi.fn(() => undefined);
+    getEmbeddingService = vi.fn(() => undefined);
+    setInstanceId = vi.fn();
+    handleBeforeRecall = coreMocks.handleBeforeRecall;
+    isSchedulerStarted = vi.fn(() => true);
+    handleTurnCommitted = vi.fn(async () => ({
+      l0RecordedCount: 0,
+      schedulerNotified: false,
+      l0VectorsWritten: 0,
+      capturedMessages: [],
+    }));
+    searchMemories = vi.fn(async () => ({ results: [] }));
+    searchConversations = vi.fn(async () => ({ results: [] }));
+    destroy = vi.fn(async () => undefined);
+  },
+}));
+
+vi.mock("./host-adapter.js", () => ({
+  OpenClawHostAdapter: class {},
+}));
+
+vi.mock("../../utils/clean-context-runner.js", () => ({
+  setPreferredEmbeddedAgentRuntime: vi.fn(),
+  prewarmEmbeddedAgent: vi.fn(),
+}));
+
+vi.mock("../../utils/pipeline-factory.js", () => ({
+  initDataDirectories: vi.fn(),
+  resetStores: vi.fn(),
+}));
+
+vi.mock("../../core/report/reporter.js", () => ({
+  getOrCreateInstanceId: vi.fn(async () => "test-instance"),
+  initReporter: vi.fn(),
+  report: vi.fn(),
+  resetReporter: vi.fn(),
+}));
+
+vi.mock("../../core/profile/profile-sync.js", () => ({
+  ensureL2L3Local: vi.fn(async () => undefined),
+}));
+
+import register from "../../../index.js";
+
+type HookHandler = (event: Record<string, unknown>, ctx?: Record<string, unknown>) => unknown;
+
+interface FakeOpenClawApi {
+  config: Record<string, unknown>;
+  logger: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  on: (name: string, handler: HookHandler) => void;
+  pluginConfig: Record<string, unknown>;
+  registerCli: ReturnType<typeof vi.fn>;
+  registerTool: ReturnType<typeof vi.fn>;
+  registrationMode: string;
+  runtime: {
+    agent: Record<string, unknown>;
+    state: { resolveStateDir: () => string };
+    version?: string;
+  };
+}
+
+function createFakeApi(params: {
+  version?: string;
+  injectionMode: "prepend" | "append";
+  showInjected?: boolean;
+}): {
+  api: FakeOpenClawApi;
+  getHook: (name: string) => HookHandler;
+} {
+  const hooks = new Map<string, HookHandler>();
+  const api: FakeOpenClawApi = {
+    config: {
+      plugins: {
+        entries: {
+          "memory-tencentdb": {
+            hooks: { allowConversationAccess: true },
+          },
+        },
+      },
+    },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    on: (name, handler) => {
+      hooks.set(name, handler);
+    },
+    pluginConfig: {
+      capture: { enabled: false },
+      embedding: { enabled: false, provider: "none" },
+      offload: { enabled: false },
+      recall: {
+        enabled: true,
+        injectionMode: params.injectionMode,
+        showInjected: params.showInjected ?? false,
+      },
+    },
+    registerCli: vi.fn(),
+    registerTool: vi.fn(),
+    registrationMode: "runtime",
+    runtime: {
+      agent: {},
+      state: { resolveStateDir: () => "/tmp/memory-tencentdb-register-test" },
+      ...(params.version ? { version: params.version } : {}),
+    },
+  };
+
+  register(api as unknown as Parameters<typeof register>[0]);
+  return {
+    api,
+    getHook: (name) => {
+      const hook = hooks.get(name);
+      if (!hook) throw new Error(`Hook not registered: ${name}`);
+      return hook;
+    },
+  };
+}
+
+describe("OpenClaw register recall integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    coreMocks.handleBeforeRecall.mockResolvedValue({
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: buildGeneratedRecallContext(["- [fact] dynamic"]),
+      recallStrategy: "hybrid",
+    });
+  });
+
+  it.each([
+    {
+      version: "2026.4.25",
+      expectedStable: "appendSystemContext",
+      expectedDynamic: "prependContext",
+    },
+    {
+      version: "2026.4.26",
+      expectedStable: "prependSystemContext",
+      expectedDynamic: "prependContext",
+    },
+    {
+      version: "2026.4.27",
+      expectedStable: "prependSystemContext",
+      expectedDynamic: "appendContext",
+    },
+    {
+      version: undefined,
+      expectedStable: "appendSystemContext",
+      expectedDynamic: "prependContext",
+    },
+  ])(
+    "shapes hooks safely for host version $version",
+    async ({ version, expectedStable, expectedDynamic }) => {
+      const { getHook } = createFakeApi({
+        version,
+        injectionMode: "append",
+      });
+
+      const result = await getHook("before_prompt_build")(
+        { prompt: "question", messages: [] },
+        { sessionKey: `session-${version ?? "unknown"}` },
+      ) as Record<string, unknown>;
+
+      expect(result[expectedStable]).toBe("<user-persona>stable</user-persona>");
+      expect(result[expectedDynamic]).toContain("<relevant-memories>");
+      expect(result.recallStrategy).toBe("hybrid");
+    },
+  );
+
+  it.each([
+    { version: "2026.4.25", placement: "prepend" as const },
+    { version: "2026.4.27", placement: "append" as const },
+  ])(
+    "cleans persisted generated recall using the effective $placement placement",
+    ({ version, placement }) => {
+      const { getHook } = createFakeApi({
+        version,
+        injectionMode: "append",
+      });
+      const recall = buildGeneratedRecallContext(["- [fact] dynamic"]);
+      const content = placement === "append"
+        ? `question\n\n${recall}`
+        : `${recall}\n\nquestion`;
+
+      const result = getHook("before_message_write")({
+        message: { role: "user", content },
+      }) as { message?: { content?: unknown } } | undefined;
+
+      expect(result?.message?.content).toBe("question");
+    },
+  );
+
+  it("preserves injected recall when showInjected is enabled", () => {
+    const { getHook } = createFakeApi({
+      version: "2026.4.27",
+      injectionMode: "append",
+      showInjected: true,
+    });
+    const recall = buildGeneratedRecallContext(["- [fact] dynamic"]);
+
+    expect(
+      getHook("before_message_write")({
+        message: { role: "user", content: `question\n\n${recall}` },
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    {
+      version: "2026.4.25",
+      placement: "prepend" as const,
+      content: (recall: string) => `other prepend\n\n${recall}\n\nquestion`,
+      expected: "other prepend\n\nquestion",
+    },
+    {
+      version: "2026.4.27",
+      placement: "append" as const,
+      content: (recall: string) => `question\n\n${recall}\n\nother append`,
+      expected: "question\n\nother append",
+    },
+  ])(
+    "removes tracked recall surrounded by other hooks in $placement mode",
+    async ({ version, content, expected }) => {
+      const { getHook } = createFakeApi({
+        version,
+        injectionMode: "append",
+      });
+      const sessionKey = `merged-${version}`;
+      const promptResult = await getHook("before_prompt_build")(
+        { prompt: "question", messages: [] },
+        { sessionKey },
+      ) as Record<string, unknown>;
+      const recall = String(promptResult.prependContext ?? promptResult.appendContext);
+
+      const result = getHook("before_message_write")(
+        { message: { role: "user", content: content(recall) } },
+        { sessionKey },
+      ) as { message?: { content?: unknown } } | undefined;
+
+      expect(result?.message?.content).toBe(expected);
+    },
+  );
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig recall injection options", () => {
+  it("uses backward-compatible cache-safe defaults", () => {
+    const cfg = parseConfig({});
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+    expect(cfg.recall.showInjected).toBe(false);
+  });
+
+  it("accepts append placement and injected-history visibility", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "append",
+        showInjected: true,
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("append");
+    expect(cfg.recall.showInjected).toBe(true);
+  });
+
+  it("falls back to prepend for an unknown injection mode", () => {
+    const cfg = parseConfig({
+      recall: {
+        injectionMode: "unsupported",
+      },
+    });
+
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,14 @@ export interface PipelineTriggerConfig {
 export interface RecallConfig {
   /** Enable auto-recall (default: true) */
   enabled: boolean;
+  /**
+   * Where OpenClaw places dynamic L1 recall.
+   * - "prepend": legacy behavior, before the user prompt
+   * - "append": after the user prompt on OpenClaw v2026.4.27+
+   */
+  injectionMode: RecallInjectionMode;
+  /** Preserve generated recall blocks in persisted history (default: false). */
+  showInjected: boolean;
   /** Max results to return (default: 5) */
   maxResults: number;
   /** Max characters injected for a single recalled L1 memory. 0 disables the per-memory limit. */
@@ -94,6 +102,8 @@ export interface RecallConfig {
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
 }
+
+export type RecallInjectionMode = "prepend" | "append";
 
 /** Embedding service configuration for vector search. */
 export interface EmbeddingConfig {
@@ -529,6 +539,8 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     recall: {
       enabled: bool(recallGroup, "enabled") ?? true,
+      injectionMode: validateRecallInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
+      showInjected: bool(recallGroup, "showInjected") ?? false,
       maxResults: num(recallGroup, "maxResults") ?? 5,
       maxCharsPerMemory: num(recallGroup, "maxCharsPerMemory") ?? 0,
       maxTotalRecallChars: num(recallGroup, "maxTotalRecallChars") ?? 0,
@@ -634,6 +646,7 @@ function strArray(src: Record<string, unknown>, key: string): string[] | undefin
 }
 
 const VALID_STRATEGIES: RecallConfig["strategy"][] = ["embedding", "keyword", "hybrid"];
+const VALID_RECALL_INJECTION_MODES: RecallInjectionMode[] = ["prepend", "append"];
 
 /**
  * Validate recall strategy against whitelist.
@@ -643,6 +656,13 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   if (!value) return undefined;
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
+    : undefined;
+}
+
+function validateRecallInjectionMode(value: string | undefined): RecallInjectionMode | undefined {
+  if (!value) return undefined;
+  return VALID_RECALL_INJECTION_MODES.includes(value as RecallInjectionMode)
+    ? (value as RecallInjectionMode)
     : undefined;
 }
 

--- a/src/core/hooks/auto-recall.test.ts
+++ b/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "../../config.js";
+import { applyRecallBudget } from "./auto-recall.js";
+
+describe("applyRecallBudget", () => {
+  it("accounts for separators across multiple recalled memories", () => {
+    const recall = parseConfig({
+      recall: {
+        maxTotalRecallChars: 90,
+      },
+    }).recall;
+    const lines = [
+      `- [fact] ${"a".repeat(35)}`,
+      `- [fact] ${"b".repeat(35)}`,
+      `- [fact] ${"c".repeat(35)}`,
+    ];
+
+    const result = applyRecallBudget(lines, recall);
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(result.join("\n").length).toBeLessThanOrEqual(90);
+  });
+});
+

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -21,6 +21,7 @@ import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.j
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
+import { buildGeneratedRecallContext } from "../../utils/recall-injection.js";
 import type { Logger } from "../types.js";
 
 const TAG = "[memory-tdai] [recall]";
@@ -202,11 +203,7 @@ async function performAutoRecallInner(params: {
   }
 
   // Dynamic part: L1 relevant memories (changes every turn) → prependContext (user prompt)
-  let prependContext: string | undefined;
-  if (memoryLines.length > 0) {
-    prependContext =
-      `<relevant-memories>\n以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：\n\n${memoryLines.join(RECALL_LINE_SEPARATOR)}\n</relevant-memories>`;
-  }
+  const prependContext = buildGeneratedRecallContext(memoryLines);
 
   // Append memory tools usage guide to the stable part so the agent knows
   // how to actively retrieve deeper context when the injected snippets
@@ -705,7 +702,7 @@ function formatMemoryLine(m: FormatableMemory): string {
   return line;
 }
 
-function applyRecallBudget(
+export function applyRecallBudget(
   lines: string[],
   recall: MemoryTdaiConfig["recall"],
   logger?: Logger,

--- a/src/utils/recall-injection.multiturn.test.ts
+++ b/src/utils/recall-injection.multiturn.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGeneratedRecallContext,
+  stripInjectedRecallFromMessage,
+} from "./recall-injection.js";
+
+const LONG_TURN_COUNT = 100;
+
+function recallForTurn(turn: number): string {
+  return buildGeneratedRecallContext([
+    `- [fact] dynamic memory ${turn} ${"x".repeat(1_000)}`,
+  ]) ?? "";
+}
+
+describe("recall injection long-session matrix", () => {
+  it("keeps append-mode string history bounded across 100 turns", () => {
+    const persisted: string[] = [];
+
+    for (let turn = 1; turn <= LONG_TURN_COUNT; turn++) {
+      const result = stripInjectedRecallFromMessage(
+        {
+          role: "user",
+          content: `question-${turn}\n\n${recallForTurn(turn)}`,
+        },
+        { placement: "append" },
+      );
+      persisted.push(String(result?.message.content));
+    }
+
+    expect(persisted).toHaveLength(LONG_TURN_COUNT);
+    expect(persisted.join("\n")).not.toContain("<relevant-memories>");
+    expect(persisted[0]).toBe("question-1");
+    expect(persisted[99]).toBe("question-100");
+  });
+
+  it("keeps multipart history bounded while preserving image parts", () => {
+    const persisted: unknown[] = [];
+
+    for (let turn = 1; turn <= 50; turn++) {
+      const imagePart = {
+        type: "image_url",
+        image_url: { url: `https://example.com/${turn}.png` },
+      };
+      const result = stripInjectedRecallFromMessage(
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `question-${turn}\n\n${recallForTurn(turn)}`,
+            },
+            imagePart,
+          ],
+        },
+        { placement: "append" },
+      );
+      persisted.push(result?.message.content);
+      expect(result?.message.content).toEqual([
+        { type: "text", text: `question-${turn}` },
+        imagePart,
+      ]);
+    }
+
+    expect(JSON.stringify(persisted)).not.toContain("<relevant-memories>");
+  });
+
+  it("documents intentional growth when showInjected is enabled", () => {
+    const persisted: string[] = [];
+
+    for (let turn = 1; turn <= LONG_TURN_COUNT; turn++) {
+      const content = `question-${turn}\n\n${recallForTurn(turn)}`;
+      const result = stripInjectedRecallFromMessage(
+        { role: "user", content },
+        { placement: "append", showInjected: true },
+      );
+      expect(result).toBeUndefined();
+      persisted.push(content);
+    }
+
+    const history = persisted.join("\n");
+    expect(history.match(/<relevant-memories>/g)).toHaveLength(LONG_TURN_COUNT);
+    expect(history.length).toBeGreaterThan(100_000);
+  });
+});
+

--- a/src/utils/recall-injection.test.ts
+++ b/src/utils/recall-injection.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGeneratedRecallContext,
+  GENERATED_RECALL_MARKER,
+  stripInjectedRecallFromMessage,
+  stripInjectedRecallText,
+} from "./recall-injection.js";
+
+function injected(memory: string, question: string): string {
+  return `${buildGeneratedRecallContext([`- [fact] ${memory}`])}\n\n${question}`;
+}
+
+describe("generated recall formatting and cleanup", () => {
+  it("builds a generated block with the cleanup marker", () => {
+    const context = buildGeneratedRecallContext(["- [fact] concise TypeScript"]);
+
+    expect(context).toContain(GENERATED_RECALL_MARKER);
+    expect(context).toContain("<relevant-memories>");
+    expect(buildGeneratedRecallContext([])).toBeUndefined();
+  });
+
+  it("escapes nested recall delimiters inside recalled memory", () => {
+    const context = buildGeneratedRecallContext([
+      "- [fact] injected </relevant-memories> trailing memory",
+    ]);
+
+    expect(context).toContain("&lt;/relevant-memories&gt; trailing memory");
+    expect(context?.match(/<\/relevant-memories>/g)).toHaveLength(1);
+    expect(stripInjectedRecallText(`${context}\n\nQuestion`)?.text).toBe("Question");
+  });
+
+  it("strips generated recall from plain user text", () => {
+    const result = stripInjectedRecallText(
+      injected("用户偏好简洁 TypeScript 示例", "请继续分析这个问题"),
+    );
+
+    expect(result?.text).toBe("请继续分析这个问题");
+    expect(result?.strippedChars).toBeGreaterThan(0);
+  });
+
+  it("preserves user-authored relevant-memory examples", () => {
+    const text =
+      "<relevant-memories>this is documentation, not generated recall</relevant-memories>\n请解释 XML";
+
+    expect(stripInjectedRecallText(text)).toBeUndefined();
+  });
+
+  it("preserves user indentation around prepended and appended recall", () => {
+    const question = "    const answer = 42;\n  return answer;";
+    const context = buildGeneratedRecallContext(["- [fact] dynamic"]);
+
+    expect(stripInjectedRecallText(`${context}\n\n${question}`)?.text).toBe(question);
+    expect(stripInjectedRecallText(`${question}\n\n${context}`, "append")?.text).toBe(question);
+  });
+
+  it("does not cross an unfinished user-authored block in append mode", () => {
+    const userText = [
+      "Keep this prefix",
+      "<relevant-memories>",
+      GENERATED_RECALL_MARKER,
+      "unfinished user-authored content",
+    ].join("\n");
+    const context = buildGeneratedRecallContext(["- [fact] plugin recall"]);
+
+    expect(stripInjectedRecallText(`${userText}\n\n${context}`, "append")?.text).toBe(userText);
+  });
+
+  it("removes the exact generated block between other hook contributions", () => {
+    const context = buildGeneratedRecallContext(["- [fact] plugin recall"]) ?? "";
+
+    expect(
+      stripInjectedRecallText(
+        `other prepend\n\n${context}\n\nquestion`,
+        "prepend",
+        context,
+      )?.text,
+    ).toBe("other prepend\n\nquestion");
+    expect(
+      stripInjectedRecallText(
+        `question\n\n${context}\n\nother append`,
+        "append",
+        context,
+      )?.text,
+    ).toBe("question\n\nother append");
+  });
+
+  it("only rewrites generated user content unless visibility is enabled", () => {
+    const user = {
+      role: "user",
+      content: injected("dynamic", "What changed?"),
+    };
+    const assistant = {
+      role: "assistant",
+      content: injected("dynamic", "Answer"),
+    };
+
+    expect(stripInjectedRecallFromMessage(user)?.message.content).toBe("What changed?");
+    expect(stripInjectedRecallFromMessage(assistant)).toBeUndefined();
+    expect(
+      stripInjectedRecallFromMessage(user, { showInjected: true }),
+    ).toBeUndefined();
+  });
+
+  it("strips text parts while preserving non-text multipart content", () => {
+    const imagePart = {
+      type: "image_url",
+      image_url: { url: "https://example.com/image.png" },
+    };
+    const message = {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: injected("dynamic", "Describe this image"),
+        },
+        imagePart,
+      ],
+    };
+
+    const result = stripInjectedRecallFromMessage(message);
+    expect(result?.message.content).toEqual([
+      { type: "text", text: "Describe this image" },
+      imagePart,
+    ]);
+    expect(result?.contentType).toBe("parts");
+  });
+
+  it("keeps persisted history bounded across 100 generated recalls", () => {
+    const persisted: string[] = [];
+    let removedChars = 0;
+
+    for (let turn = 1; turn <= 100; turn++) {
+      const message = {
+        role: "user",
+        content: injected(`dynamic memory ${turn} ${"x".repeat(1_000)}`, `question-${turn}`),
+      };
+      const result = stripInjectedRecallFromMessage(message);
+      expect(result).toBeDefined();
+      persisted.push(String(result?.message.content));
+      removedChars += result?.strippedChars ?? 0;
+    }
+
+    expect(persisted).toHaveLength(100);
+    expect(persisted.join("\n")).not.toContain("<relevant-memories>");
+    expect(persisted[0]).toBe("question-1");
+    expect(persisted[99]).toBe("question-100");
+    expect(removedChars).toBeGreaterThan(100_000);
+  });
+});

--- a/src/utils/recall-injection.ts
+++ b/src/utils/recall-injection.ts
@@ -1,0 +1,171 @@
+export const GENERATED_RECALL_MARKER =
+  "以下是当前对话召回的相关记忆，不代表当前任务进程，仅作为参考：";
+
+const RELEVANT_MEMORIES_OPEN = "<relevant-memories>";
+const RELEVANT_MEMORIES_CLOSE = "</relevant-memories>";
+const INJECTED_SEPARATOR = "\n\n";
+const INJECTED_SEPARATOR_CRLF = "\r\n\r\n";
+const GENERATED_RECALL_PREFIX = `${RELEVANT_MEMORIES_OPEN}\n${GENERATED_RECALL_MARKER}`;
+
+function escapeRecallDelimiters(value: string): string {
+  return value
+    .replaceAll(RELEVANT_MEMORIES_OPEN, "&lt;relevant-memories&gt;")
+    .replaceAll(RELEVANT_MEMORIES_CLOSE, "&lt;/relevant-memories&gt;");
+}
+
+export function buildGeneratedRecallContext(memoryLines: readonly string[]): string | undefined {
+  if (memoryLines.length === 0) return undefined;
+  const escapedLines = memoryLines.map(escapeRecallDelimiters);
+  return `${RELEVANT_MEMORIES_OPEN}\n${GENERATED_RECALL_MARKER}\n\n${escapedLines.join("\n")}\n${RELEVANT_MEMORIES_CLOSE}`;
+}
+
+export interface StripInjectedRecallTextResult {
+  text: string;
+  strippedChars: number;
+}
+
+export type GeneratedRecallPlacement = "prepend" | "append";
+
+function stripExactGeneratedRecallText(
+  text: string,
+  generatedContext: string,
+  placement: GeneratedRecallPlacement,
+): StripInjectedRecallTextResult | undefined {
+  if (!generatedContext) return undefined;
+
+  let removeStart = placement === "prepend"
+    ? text.indexOf(generatedContext)
+    : text.lastIndexOf(generatedContext);
+  if (removeStart < 0) return undefined;
+
+  let removeEnd = removeStart + generatedContext.length;
+  if (placement === "prepend") {
+    if (text.startsWith(INJECTED_SEPARATOR_CRLF, removeEnd)) {
+      removeEnd += INJECTED_SEPARATOR_CRLF.length;
+    } else if (text.startsWith(INJECTED_SEPARATOR, removeEnd)) {
+      removeEnd += INJECTED_SEPARATOR.length;
+    }
+  } else if (
+    text.slice(removeStart - INJECTED_SEPARATOR_CRLF.length, removeStart) ===
+    INJECTED_SEPARATOR_CRLF
+  ) {
+    removeStart -= INJECTED_SEPARATOR_CRLF.length;
+  } else if (
+    text.slice(removeStart - INJECTED_SEPARATOR.length, removeStart) === INJECTED_SEPARATOR
+  ) {
+    removeStart -= INJECTED_SEPARATOR.length;
+  }
+
+  const cleaned = `${text.slice(0, removeStart)}${text.slice(removeEnd)}`;
+  return {
+    text: cleaned,
+    strippedChars: text.length - cleaned.length,
+  };
+}
+
+export function stripInjectedRecallText(
+  text: string,
+  placement: GeneratedRecallPlacement = "prepend",
+  generatedContext?: string,
+): StripInjectedRecallTextResult | undefined {
+  if (generatedContext) {
+    return stripExactGeneratedRecallText(text, generatedContext, placement);
+  }
+
+  let removeStart: number;
+  if (placement === "prepend") {
+    if (!text.startsWith(GENERATED_RECALL_PREFIX)) return undefined;
+    removeStart = 0;
+  } else {
+    removeStart = text.lastIndexOf(GENERATED_RECALL_PREFIX);
+    if (removeStart < 0) return undefined;
+  }
+
+  const closingIndex = text.indexOf(RELEVANT_MEMORIES_CLOSE, removeStart + GENERATED_RECALL_PREFIX.length);
+  if (closingIndex < 0) return undefined;
+
+  let removeEnd = closingIndex + RELEVANT_MEMORIES_CLOSE.length;
+  if (placement === "append" && removeEnd !== text.length) return undefined;
+
+  if (placement === "prepend") {
+    if (text.startsWith(INJECTED_SEPARATOR_CRLF, removeEnd)) {
+      removeEnd += INJECTED_SEPARATOR_CRLF.length;
+    } else if (text.startsWith(INJECTED_SEPARATOR, removeEnd)) {
+      removeEnd += INJECTED_SEPARATOR.length;
+    }
+  } else if (
+    text.slice(removeStart - INJECTED_SEPARATOR_CRLF.length, removeStart) ===
+    INJECTED_SEPARATOR_CRLF
+  ) {
+    removeStart -= INJECTED_SEPARATOR_CRLF.length;
+  } else if (
+    text.slice(removeStart - INJECTED_SEPARATOR.length, removeStart) === INJECTED_SEPARATOR
+  ) {
+    removeStart -= INJECTED_SEPARATOR.length;
+  }
+
+  const cleaned = `${text.slice(0, removeStart)}${text.slice(removeEnd)}`;
+  return {
+    text: cleaned,
+    strippedChars: text.length - cleaned.length,
+  };
+}
+
+export interface StripInjectedRecallMessageResult<
+  TMessage extends { role?: string; content?: unknown },
+> {
+  message: TMessage;
+  strippedChars: number;
+  contentType: "string" | "parts";
+}
+
+export function stripInjectedRecallFromMessage<
+  TMessage extends { role?: string; content?: unknown },
+>(
+  message: TMessage,
+  options: {
+    generatedContext?: string;
+    showInjected?: boolean;
+    placement?: GeneratedRecallPlacement;
+  } = {},
+): StripInjectedRecallMessageResult<TMessage> | undefined {
+  if (options.showInjected || message.role !== "user") return undefined;
+
+  if (typeof message.content === "string") {
+    const stripped = stripInjectedRecallText(
+      message.content,
+      options.placement,
+      options.generatedContext,
+    );
+    if (!stripped) return undefined;
+    return {
+      message: { ...message, content: stripped.text } as TMessage,
+      strippedChars: stripped.strippedChars,
+      contentType: "string",
+    };
+  }
+
+  if (!Array.isArray(message.content)) return undefined;
+
+  let strippedChars = 0;
+  const cleanedParts = message.content.map((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return item;
+    const part = item as Record<string, unknown>;
+    if (part.type !== "text" || typeof part.text !== "string") return item;
+    const stripped = stripInjectedRecallText(
+      part.text,
+      options.placement,
+      options.generatedContext,
+    );
+    if (!stripped) return item;
+    strippedChars += stripped.strippedChars;
+    return { ...part, text: stripped.text };
+  });
+
+  if (strippedChars === 0) return undefined;
+  return {
+    message: { ...message, content: cleanedParts } as TMessage,
+    strippedChars,
+    contentType: "parts",
+  };
+}


### PR DESCRIPTION
## Description | 描述

This PR hardens OpenClaw auto-recall injection and persisted-history cleanup, following the scoped mitigation proposed for #120.

### Changes

- Add `recall.injectionMode`:
  - `prepend` remains the backward-compatible default.
  - `append` uses OpenClaw `appendContext` on v2026.4.27+.
  - Older or unknown hosts safely fall back to `prependContext`.
- Add `recall.showInjected`, defaulting to `false`.
- Map stable persona, scene, and memory-tool context to `prependSystemContext` on OpenClaw v2026.4.26+, with legacy fallback.
- Track the exact generated recall block per session and remove it before persistence.
- Preserve surrounding contributions from other prompt hooks.
- Avoid deleting user-authored `<relevant-memories>` content.
- Preserve multipart non-text content and user formatting.
- Add version-boundary, real `register()` integration, multi-plugin, multipart, and long-session regression tests.

This PR does not claim that `appendContext` improves provider cache-hit rates. Real DeepSeek and MiMo pilots found no stable improvement, so `append` remains opt-in.

## Related Issue | 关联 Issue

Refs #120

Related implementation: #375

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [ ] No existing features affected | 无影响现有功能

## Verification | 验证

```bash
COREPACK_ENABLE_AUTO_PIN=0 pnpm test
COREPACK_ENABLE_AUTO_PIN=0 pnpm run build:plugin
git diff --check
```

Results:

- 10 test files passed
- 100 tests passed
- Plugin build passed
- Manifest JSON validation passed
- Final structured review found no blocking issues

### Live provider pilots

OpenClaw 2026.7.1, fixed L1 fixtures, 3 sessions × 6 turns per variant:

| Provider | prepend warm hit rate | append warm hit rate | Result |
| --- | ---: | ---: | --- |
| DeepSeek V4 Flash | 94.270% | 94.325% | Effectively neutral |
| MiMo V2.5 Pro | 93.990% | 94.907% aggregate | No stable paired improvement |

MiMo's aggregate difference came from one 4096-token cache block; the paired median difference was `-0.006pp`.

All 72 live turns used the expected recalled memory, and persisted histories contained no generated recall residue.

## Additional Notes | 其他说明

The severe webchat cache regression originally reported in #120 was later attributed to OpenClaw webchat behavior rather than this plugin.

This PR therefore focuses on:

- safe, configurable prompt placement;
- backward compatibility;
- bounded persisted history;
- precise cleanup under multiple prompt hooks.

It intentionally uses `Refs #120` rather than claiming to fully fix the original provider cache regression.
