### PR TITLE
fix(recall): stabilize prompt-cache prefix (#120)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+﻿# Copy to .env and fill in values. Never commit .env.
+# PowerShell:  Copy-Item .env.example .env
+
+# Required: OpenAI-compatible DeepSeek relay
+DS_BASE_URL=https://api.deepseek.com/v1
+DS_API_KEY=
+DS_MODEL=deepseek-chat
+
+# Optional overrides
+# DS_TIMEOUT_MS=60000
+# DS_TURNS=4
+# DS_WARM_ONLY=true
+# DS_OUT_DIR=benchmark-runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ## [Unreleased]
 
+### 🐛 修复
+
+- **Prompt 前缀缓存友好注入** ([#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120))：
+  - OpenClaw 适配层将稳定块（persona / scene / tools guide）映射为 `prependSystemContext`，便于落在宿主 CACHE_BOUNDARY 之前。
+  - 新增 `recall.injectionMode`（`prepend` | `append`，默认 `prepend`）：动态 L1 可改为 `appendContext`。
+  - 新增 `recall.showInjected`（默认 `false`）：显式控制是否保留 `<relevant-memories>` 到会话历史；默认写入前剥离。
+  - 新增 `recall.dualEmitStable`（默认 `false`）：旧宿主忽略 `prependSystemContext` 时可双发稳定块；默认关闭避免双注入。
+  - 稳定块注入保留原始字节（不做破坏性 trim）；`injectionMode=append` 时一次性告警宿主需支持 `appendContext`。
+  - 会话级 `stable_continuity=first|same|changed` 观测日志（不冻结内容）；`prompt_cache_usage` 附带 `stableHash` 便于与命中率对照。
+  - 当 `report.enabled=true` 时，注册 `llm_output` 钩子上报归一化的 `prompt_cache_usage`（DeepSeek / OpenAI-compatible / Anthropic 风格 cache 字段；无 cache 字段则跳过，不编造命中率）。
+  - `before_prompt_build` 增加稳定块 hash + 动态注入位置诊断日志（observation-only）。
+  - 无 OpenClaw 的 layout A/B 脚本：`npm run bench:cache`（见 `scripts/README.benchmark-prompt-cache.md`）。
+
 ### ✨ 新功能
 
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,10 @@ import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
+import {
+  normalizePromptCacheUsage,
+  toPromptCacheReportPayload,
+} from "./src/core/report/prompt-cache-usage.js";
 import { ensureL2L3Local } from "./src/core/profile/profile-sync.js";
 
 // Core abstractions (host-neutral)
@@ -44,8 +48,18 @@ import {
   decideHookPolicy,
 } from "./src/utils/ensure-hook-policy.js";
 import { resolveOpenClawStateDir } from "./src/utils/openclaw-state-dir.js";
+import { shapeRecallForOpenClawHook } from "./src/adapters/openclaw/recall-injection.js";
+import {
+  describeRecallShape,
+  noteStableContinuity,
+  getLastStableHash,
+} from "./src/utils/recall-shape-diagnostics.js";
+import { stripRelevantMemoriesFromContent } from "./src/utils/relevant-memories.js";
 
 const TAG = "[memory-tdai]";
+
+/** One-shot warn when injectionMode=append (host must support appendContext). */
+let warnedAppendInjectionMode = false;
 
 /**
  * Epoch ms when the plugin was registered (cold-start timestamp).
@@ -584,17 +598,37 @@ export default function register(api: OpenClawPluginApi) {
           pendingRecallEndTimestamps.set(resolvedSessionKey, Date.now());
         }
 
-        if (result?.appendSystemContext || result?.prependContext) {
-          const appendLen = result.appendSystemContext?.length ?? 0;
-          const prependLen = result.prependContext?.length ?? 0;
+        if (cfg.recall.injectionMode === "append" && !warnedAppendInjectionMode) {
+          warnedAppendInjectionMode = true;
+          api.logger.warn(
+            `${TAG} recall.injectionMode=append requires host support for appendContext; ` +
+            `unsupported hosts will drop dynamic L1 recall silently`,
+          );
+        }
+
+        const shaped = shapeRecallForOpenClawHook(result, {
+          injectionMode: cfg.recall.injectionMode,
+          dualEmitStable: cfg.recall.dualEmitStable,
+        });
+
+        if (shaped) {
+          const shapeInfo = describeRecallShape(shaped);
+          const continuity = noteStableContinuity(sessionKey, shapeInfo.stableHash);
+          const preSys = shaped.prependSystemContext?.length ?? 0;
+          const appSys = shaped.appendSystemContext?.length ?? 0;
+          const preDyn = shaped.prependContext?.length ?? 0;
+          const appDyn = shaped.appendContext?.length ?? 0;
           api.logger.info(
             `${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), ` +
-            `appendSystemContext=${appendLen} chars, prependContext=${prependLen} chars`,
+            `prependSystemContext=${preSys} chars, appendSystemContext=${appSys} chars, ` +
+            `prependContext=${preDyn} chars, appendContext=${appDyn} chars, ` +
+            `injectionMode=${cfg.recall.injectionMode}, dualEmitStable=${cfg.recall.dualEmitStable}, ` +
+            `${shapeInfo.line}, stable_continuity=${continuity}`,
           );
         } else {
           api.logger.info(`${TAG} [before_prompt_build] Recall complete (${elapsedMs}ms), no context to inject`);
         }
-        return result;
+        return shaped;
       } catch (err) {
         const elapsedMs = Date.now() - startMs;
         api.logger.error(`${TAG} [before_prompt_build] Auto-recall failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
@@ -613,42 +647,57 @@ export default function register(api: OpenClawPluginApi) {
   }
 
   // Strip <relevant-memories> from user messages before they are persisted to
-  // the session JSONL.  The current-turn LLM already saw the full prompt
-  // (effectivePrompt lives in memory), but we don't want recall artifacts
-  // polluting the historical transcript for future replays.
-  api.logger.debug?.(`${TAG} Registering before_message_write hook (strip <relevant-memories>)`);
+  // the session JSONL (unless recall.showInjected=true). The current-turn LLM
+  // already saw the full prompt; we avoid polluting history for prefix cache.
+  api.logger.debug?.(
+    `${TAG} Registering before_message_write hook ` +
+    `(strip <relevant-memories>, showInjected=${cfg.recall.showInjected})`,
+  );
   api.on("before_message_write", (event) => {
+    if (cfg.recall.showInjected) return;
+
     const msg = event.message as { role?: string; content?: unknown };
     const contentType = typeof msg.content === "string" ? "string" : Array.isArray(msg.content) ? "parts" : typeof msg.content;
     api.logger.debug?.(`${TAG} [before_message_write] role=${msg.role}, contentType=${contentType}`);
 
     if (msg.role !== "user") return;
 
-    // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
-    if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
-      if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
-      return { message: { ...event.message, content: cleaned } as typeof event.message };
-    }
-
-    if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
-      return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
-    }
+    const stripped = stripRelevantMemoriesFromContent(msg.content);
+    if (!stripped) return;
+    api.logger.debug?.(
+      `${TAG} [before_message_write] Stripped ${stripped.strippedChars} chars from <relevant-memories>`,
+    );
+    return { message: { ...event.message, content: stripped.content } as typeof event.message };
   });
+
+  // llm_output: optional prompt-cache usage metrics (report.enabled only)
+  if (cfg.report.enabled) {
+    api.logger.debug?.(`${TAG} Registering llm_output hook (prompt_cache_usage metrics)`);
+    api.on("llm_output", (event, ctx) => {
+      try {
+        const usage = normalizePromptCacheUsage(event);
+        if (!usage) return;
+        // Skip when provider gave no cache-related signal at all
+        if (
+          usage.cacheReadTokens == null &&
+          usage.cacheMissTokens == null &&
+          usage.cacheHitRate == null
+        ) {
+          return;
+        }
+        const sk = ctx?.sessionKey ?? null;
+        report("prompt_cache_usage", toPromptCacheReportPayload(usage, {
+          sessionKey: sk,
+          sessionId: ctx?.sessionId ?? null,
+          // Join with last recall shape so cache rows can be correlated with
+          // stable-prefix drift without freezing content (#120 observability).
+          stableHash: getLastStableHash(sk),
+        }));
+      } catch {
+        /* never block the host LLM path */
+      }
+    });
+  }
 
   // After agent end: auto-capture + L0 record + L1/L2/L3 schedule
   if (cfg.capture.enabled) {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -79,7 +79,10 @@
           "maxTotalRecallChars": { "type": "number", "default": 0, "description": "本轮 auto-recall 注入的 L1 记忆总字符预算；填 0 表示不限制" },
           "scoreThreshold": { "type": "number", "default": 0.3, "description": "最低分数阈值" },
           "strategy": { "type": "string", "enum": ["embedding", "keyword", "hybrid"], "default": "hybrid", "description": "搜索策略：keyword(关键词)、embedding(向量)、hybrid(混合RRF融合，推荐)" },
-          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" }
+          "timeoutMs": { "type": "number", "default": 5000, "description": "召回整体超时（毫秒），超时后跳过记忆注入并打印警告日志" },
+          "injectionMode": { "type": "string", "enum": ["prepend", "append"], "default": "prepend", "description": "动态 L1 记忆注入位置：prepend=用户消息前缀（默认）；append=用户消息后缀（需宿主支持 appendContext，有利于 prefix cache）" },
+          "showInjected": { "type": "boolean", "default": false, "description": "是否将 <relevant-memories> 保留进会话历史。默认 false（写入前剥离，避免历史膨胀破坏前缀缓存）；true 仅用于调试" },
+          "dualEmitStable": { "type": "boolean", "default": false, "description": "是否同时向 prependSystemContext 与 appendSystemContext 注入稳定块。默认 false（避免双注入）；仅当宿主忽略 prependSystemContext 时再开启" }
         }
       },
       "embedding": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "postinstall": "node scripts/postinstall.mjs"
+    "postinstall": "node scripts/postinstall.mjs",
+    "bench:cache": "node scripts/benchmark-prompt-cache.mjs"
   },
   "files": [
     "dist/",

--- a/scripts/README.benchmark-prompt-cache.md
+++ b/scripts/README.benchmark-prompt-cache.md
@@ -1,0 +1,49 @@
+﻿# Prompt-cache layout A/B (no OpenClaw)
+
+Measures whether putting the **stable memory block before** the base system prompt improves prefix-cache hit rate vs putting it **after** (legacy `appendSystemContext`-like layout).
+
+## Setup
+
+1. Copy env template (if needed):
+
+```powershell
+cd D:\projects\TencentDB-Agent-Memory
+Copy-Item .env.example .env
+```
+
+2. Edit `.env`:
+
+| Variable | Required | Example |
+|----------|----------|---------|
+| `DS_BASE_URL` | yes | `https://your-relay.example/v1` |
+| `DS_API_KEY` | yes | your key |
+| `DS_MODEL` | yes | model id on the relay |
+| `DS_TURNS` | no | `4` (default) |
+| `DS_WARM_ONLY` | no | `true` — exclude cold first turn |
+| `DS_TIMEOUT_MS` | no | `60000` |
+
+`.env` is gitignored. Do not commit keys.
+
+## Run
+
+```powershell
+cd D:\projects\TencentDB-Agent-Memory
+npm run bench:cache
+# or
+node scripts/benchmark-prompt-cache.mjs
+```
+
+## Output
+
+- Console: legacy vs optimized hit rate summary
+- `benchmark-runs/prompt-cache-ab-latest.json` — full sanitized report (no API key, no full replies)
+
+If the relay strips cache fields (`prompt_cache_hit_tokens` / `cached_tokens`), hit rate shows `N/A` but the layout still ran.
+
+## What it does / does not
+
+| Does | Does not |
+|------|----------|
+| Call OpenAI-compatible `/chat/completions` | Install or run OpenClaw |
+| Compare system stable-prefix layouts | Test host `before_prompt_build` hooks |
+| Parse DeepSeek-style cache usage when present | Log secrets or full model output |

--- a/scripts/benchmark-prompt-cache.mjs
+++ b/scripts/benchmark-prompt-cache.mjs
@@ -1,0 +1,473 @@
+﻿/**
+ * Offline prompt-cache A/B for DeepSeek / OpenAI-compatible relays.
+ * No OpenClaw required. Loads .env from repo root.
+ *
+ * Usage:
+ *   1. Fill .env (DS_BASE_URL, DS_API_KEY, DS_MODEL)
+ *   2. node scripts/benchmark-prompt-cache.mjs
+ *
+ * Variants:
+ *   - legacy:    stable block AFTER base system (appendSystemContext-like)
+ *   - optimized: stable block BEFORE base system (prependSystemContext-like)
+ *
+ * Never logs API keys or full response text.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+// ─── env ─────────────────────────────────────────────────────────────────────
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const text = fs.readFileSync(filePath, "utf8");
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = val;
+  }
+}
+
+loadEnvFile(path.join(ROOT, ".env"));
+
+const CFG = {
+  baseUrl: (process.env.DS_BASE_URL || "").replace(/\/+$/, ""),
+  apiKey: process.env.DS_API_KEY || "",
+  model: process.env.DS_MODEL || "deepseek-chat",
+  timeoutMs: Number(process.env.DS_TIMEOUT_MS || 60_000),
+  turns: Math.max(2, Number(process.env.DS_TURNS || 4)),
+  warmOnly: String(process.env.DS_WARM_ONLY ?? "true").toLowerCase() !== "false",
+  outDir: path.resolve(ROOT, process.env.DS_OUT_DIR || "benchmark-runs"),
+};
+
+// ─── fixtures (stable vs dynamic) ────────────────────────────────────────────
+
+const STABLE_PERSONA = `<user-persona>
+用户偏好：中文简答；技术细节优先可验证事实；时间相关用 Asia/Shanghai。
+身份摘要：软件工程师，关注 Agent Memory、prompt cache 与 OpenAI-compatible 接口。
+工作习惯：喜欢可复现实验、明确配置默认值、拒绝把密钥写入仓库。
+</user-persona>`;
+
+const STABLE_SCENE = `<scene-navigation>
+## 场景索引（稳定块）
+- [开发] 本地插件调试与 vitest 回归
+- [评测] prefix-matching cache A/B（legacy vs optimized system layout）
+- [运维] 中转站 OpenAI-compatible /chat/completions
+路径占位：memory-tdai/persona.md · scene-index.json
+</scene-navigation>`;
+
+const STABLE_TOOLS = `<memory-tools-guide>
+## 记忆工具调用指南
+- tdai_memory_search：结构化 L1
+- tdai_conversation_search：原始 L0
+每轮合计最多 3 次搜索。
+</memory-tools-guide>`;
+
+const STABLE_BLOCK = [STABLE_PERSONA, STABLE_SCENE, STABLE_TOOLS].join("\n\n");
+
+const BASE_SYSTEM = `You are a helpful assistant for prompt-cache benchmark.
+Reply in one short Chinese sentence. Do not invent credentials.
+Benchmark-id: issue-120-layout-ab.`;
+
+const USER_TURNS = [
+  "请用一句话说明什么是 prompt prefix cache。",
+  "上一问里 cache 命中依赖什么前缀条件？",
+  "若系统提示尾部每轮变化，对 prefix cache 有何影响？",
+  "请对比 system 前部稳定块与尾部稳定块的缓存差异。",
+  "总结本轮评测的目的（一句）。",
+  "再给一句可执行的优化建议。",
+];
+
+function dynamicRecall(turnIndex) {
+  return `<relevant-memories>
+以下是当前对话召回的相关记忆（动态，每轮不同）：
+- [episodic|评测] 第 ${turnIndex + 1} 轮动态召回片段 #${crypto.randomBytes(3).toString("hex")}
+- [instruction] 仅作参考，不代表任务进度
+</relevant-memories>`;
+}
+
+// ─── layout builders ─────────────────────────────────────────────────────────
+
+function buildSystem(variant) {
+  if (variant === "optimized") {
+    // prependSystemContext-like: stable BEFORE base (cache-friendly prefix)
+    return `${STABLE_BLOCK}\n\n${BASE_SYSTEM}`;
+  }
+  // legacy: stable AFTER base (appendSystemContext-like, after volatile boundary)
+  return `${BASE_SYSTEM}\n\n${STABLE_BLOCK}`;
+}
+
+function buildMessages(variant, turnIndex, history) {
+  const system = buildSystem(variant);
+  const userText = USER_TURNS[turnIndex % USER_TURNS.length];
+  const recall = dynamicRecall(turnIndex);
+  // dynamic recall prepended to user (current plugin default)
+  const userContent = `${recall}\n\n${userText}`;
+  return {
+    system,
+    messages: [
+      { role: "system", content: system },
+      ...history,
+      { role: "user", content: userContent },
+    ],
+    userText,
+    userContent,
+  };
+}
+
+// ─── usage parsing (DeepSeek / OpenAI-compatible variants) ───────────────────
+
+function pickNum(...vals) {
+  for (const v of vals) {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) {
+      return Number(v);
+    }
+  }
+  return null;
+}
+
+/**
+ * Normalize provider usage into cache hit/miss when possible.
+ * DeepSeek often: prompt_cache_hit_tokens / prompt_cache_miss_tokens
+ * Some relays: cached_tokens under prompt_tokens_details
+ */
+function parseUsage(usage) {
+  if (!usage || typeof usage !== "object") {
+    return {
+      promptTokens: null,
+      completionTokens: null,
+      cacheReadTokens: null,
+      cacheMissTokens: null,
+      cacheHitRate: null,
+      rawKeys: [],
+    };
+  }
+  const details = usage.prompt_tokens_details || usage.input_tokens_details || {};
+  const promptTokens = pickNum(usage.prompt_tokens, usage.input_tokens, usage.total_tokens);
+  const completionTokens = pickNum(usage.completion_tokens, usage.output_tokens);
+
+  let cacheRead = pickNum(
+    usage.prompt_cache_hit_tokens,
+    usage.cache_read_input_tokens,
+    usage.cached_tokens,
+    details.cached_tokens,
+    details.cache_read_tokens,
+    details.cached_tokens_details?.cached_tokens,
+  );
+  let cacheMiss = pickNum(
+    usage.prompt_cache_miss_tokens,
+    usage.cache_creation_input_tokens,
+    details.cache_miss_tokens,
+  );
+
+  // If only cached_tokens + prompt_tokens: miss ≈ prompt - cached
+  if (cacheRead != null && cacheMiss == null && promptTokens != null) {
+    cacheMiss = Math.max(0, promptTokens - cacheRead);
+  }
+
+  let cacheHitRate = null;
+  if (cacheRead != null && cacheMiss != null) {
+    const denom = cacheRead + cacheMiss;
+    if (denom > 0) cacheHitRate = cacheRead / denom;
+  } else if (cacheRead != null && promptTokens != null && promptTokens > 0) {
+    cacheHitRate = cacheRead / promptTokens;
+  }
+
+  return {
+    promptTokens,
+    completionTokens,
+    cacheReadTokens: cacheRead,
+    cacheMissTokens: cacheMiss,
+    cacheHitRate,
+    rawKeys: Object.keys(usage),
+  };
+}
+
+// ─── HTTP ────────────────────────────────────────────────────────────────────
+
+function chatUrl() {
+  const base = CFG.baseUrl;
+  if (base.endsWith("/chat/completions")) return base;
+  if (base.endsWith("/v1")) return `${base}/chat/completions`;
+  return `${base}/chat/completions`;
+}
+
+async function chatCompletions(messages) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CFG.timeoutMs);
+  try {
+    const res = await fetch(chatUrl(), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${CFG.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: CFG.model,
+        messages,
+        temperature: 0,
+        max_tokens: 64,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let body;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error(`Non-JSON response HTTP ${res.status}: ${text.slice(0, 200)}`);
+    }
+    if (!res.ok) {
+      const msg = body?.error?.message || body?.message || text.slice(0, 200);
+      throw new Error(`HTTP ${res.status}: ${msg}`);
+    }
+    const content =
+      body?.choices?.[0]?.message?.content ??
+      body?.choices?.[0]?.text ??
+      "";
+    return {
+      content: typeof content === "string" ? content : JSON.stringify(content),
+      usage: parseUsage(body?.usage),
+      rawUsage: body?.usage ?? null,
+      id: body?.id ?? null,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ─── run one variant ─────────────────────────────────────────────────────────
+
+async function runVariant(variant) {
+  const history = [];
+  const turns = [];
+  for (let i = 0; i < CFG.turns; i++) {
+    const built = buildMessages(variant, i, history);
+    const t0 = Date.now();
+    let result;
+    try {
+      result = await chatCompletions(built.messages);
+    } catch (err) {
+      turns.push({
+        turn: i,
+        cold: i === 0,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        ms: Date.now() - t0,
+      });
+      break;
+    }
+    const ms = Date.now() - t0;
+    const assistantText =
+      typeof result.content === "string"
+        ? result.content.slice(0, 120)
+        : "";
+    turns.push({
+      turn: i,
+      cold: i === 0,
+      ok: true,
+      ms,
+      usage: result.usage,
+      // truncated preview only
+      assistantPreview: assistantText.replace(/\s+/g, " ").slice(0, 80),
+      systemChars: built.system.length,
+      userChars: built.userContent.length,
+      stableBlockChars: STABLE_BLOCK.length,
+    });
+    history.push({ role: "user", content: built.userContent });
+    history.push({ role: "assistant", content: result.content || "(empty)" });
+  }
+  return summarize(variant, turns);
+}
+
+function summarize(variant, turns) {
+  const okTurns = turns.filter((t) => t.ok);
+  const sample = CFG.warmOnly ? okTurns.filter((t) => !t.cold) : okTurns;
+  const withCache = sample.filter((t) => t.usage?.cacheHitRate != null);
+  const avg = (arr, f) =>
+    arr.length ? arr.reduce((s, x) => s + (f(x) ?? 0), 0) / arr.length : null;
+
+  const hitRate =
+    withCache.length > 0
+      ? withCache.reduce((s, t) => s + t.usage.cacheHitRate, 0) / withCache.length
+      : null;
+  const cacheReadSum = withCache.reduce(
+    (s, t) => s + (t.usage.cacheReadTokens ?? 0),
+    0,
+  );
+  const cacheMissSum = withCache.reduce(
+    (s, t) => s + (t.usage.cacheMissTokens ?? 0),
+    0,
+  );
+
+  return {
+    variant,
+    turns,
+    aggregate: {
+      warmOnly: CFG.warmOnly,
+      okTurns: okTurns.length,
+      sampleTurns: sample.length,
+      turnsWithCacheFields: withCache.length,
+      avgHitRate: hitRate,
+      avgHitRatePct: hitRate != null ? +(hitRate * 100).toFixed(2) : null,
+      sumCacheReadTokens: withCache.length ? cacheReadSum : null,
+      sumCacheMissTokens: withCache.length ? cacheMissSum : null,
+      avgLatencyMs: avg(sample, (t) => t.ms),
+      cacheFieldsMissing:
+        sample.length > 0 && withCache.length === 0
+          ? "Relay may strip cache usage fields — layout still exercised, hit rate N/A"
+          : null,
+    },
+  };
+}
+
+// ─── main ────────────────────────────────────────────────────────────────────
+
+function maskKey(k) {
+  if (!k) return "(empty)";
+  if (k.length <= 8) return "****";
+  return `${k.slice(0, 4)}…${k.slice(-4)}`;
+}
+
+async function main() {
+  console.log("=== prompt-cache layout A/B (no OpenClaw) ===");
+  console.log(`baseUrl : ${CFG.baseUrl || "(missing)"}`);
+  console.log(`model   : ${CFG.model}`);
+  console.log(`apiKey  : ${maskKey(CFG.apiKey)}`);
+  console.log(`turns   : ${CFG.turns} (warmOnly=${CFG.warmOnly})`);
+  console.log(`stable  : ${STABLE_BLOCK.length} chars`);
+  console.log("");
+
+  if (!CFG.baseUrl || !CFG.apiKey) {
+    console.error(
+      "Missing DS_BASE_URL or DS_API_KEY.\n" +
+        "Edit .env in repo root, then re-run:\n" +
+        "  node scripts/benchmark-prompt-cache.mjs",
+    );
+    process.exit(1);
+  }
+
+  fs.mkdirSync(CFG.outDir, { recursive: true });
+
+  const legacy = await runVariant("legacy");
+  console.log(
+    `[legacy]    sample=${legacy.aggregate.sampleTurns} ` +
+      `hitRate=${legacy.aggregate.avgHitRatePct ?? "N/A"}% ` +
+      `read=${legacy.aggregate.sumCacheReadTokens ?? "?"} ` +
+      `miss=${legacy.aggregate.sumCacheMissTokens ?? "?"} ` +
+      `avgMs=${legacy.aggregate.avgLatencyMs?.toFixed?.(0) ?? "?"}`,
+  );
+  if (legacy.aggregate.cacheFieldsMissing) {
+    console.log(`  note: ${legacy.aggregate.cacheFieldsMissing}`);
+  }
+
+  // brief pause so provider cache window is less noisy between variants
+  await new Promise((r) => setTimeout(r, 1500));
+
+  const optimized = await runVariant("optimized");
+  console.log(
+    `[optimized] sample=${optimized.aggregate.sampleTurns} ` +
+      `hitRate=${optimized.aggregate.avgHitRatePct ?? "N/A"}% ` +
+      `read=${optimized.aggregate.sumCacheReadTokens ?? "?"} ` +
+      `miss=${optimized.aggregate.sumCacheMissTokens ?? "?"} ` +
+      `avgMs=${optimized.aggregate.avgLatencyMs?.toFixed?.(0) ?? "?"}`,
+  );
+  if (optimized.aggregate.cacheFieldsMissing) {
+    console.log(`  note: ${optimized.aggregate.cacheFieldsMissing}`);
+  }
+
+  let deltaPct = null;
+  if (
+    legacy.aggregate.avgHitRate != null &&
+    optimized.aggregate.avgHitRate != null
+  ) {
+    deltaPct = +(
+      (optimized.aggregate.avgHitRate - legacy.aggregate.avgHitRate) *
+      100
+    ).toFixed(2);
+  }
+
+  console.log("");
+  console.log("=== summary ===");
+  console.log(
+    `hitRateDelta (optimized - legacy): ${
+      deltaPct != null ? `${deltaPct > 0 ? "+" : ""}${deltaPct} pp` : "N/A"
+    }`,
+  );
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outPath = path.join(CFG.outDir, `prompt-cache-ab-${stamp}.json`);
+  const report = {
+    meta: {
+      createdAt: new Date().toISOString(),
+      baseUrlHost: (() => {
+        try {
+          return new URL(CFG.baseUrl).host;
+        } catch {
+          return "(invalid-url)";
+        }
+      })(),
+      model: CFG.model,
+      turns: CFG.turns,
+      warmOnly: CFG.warmOnly,
+      stableBlockChars: STABLE_BLOCK.length,
+      // never write api key
+    },
+    legacy: {
+      aggregate: legacy.aggregate,
+      turns: legacy.turns.map((t) => ({
+        turn: t.turn,
+        cold: t.cold,
+        ok: t.ok,
+        error: t.error,
+        ms: t.ms,
+        usage: t.usage,
+        systemChars: t.systemChars,
+        userChars: t.userChars,
+      })),
+    },
+    optimized: {
+      aggregate: optimized.aggregate,
+      turns: optimized.turns.map((t) => ({
+        turn: t.turn,
+        cold: t.cold,
+        ok: t.ok,
+        error: t.error,
+        ms: t.ms,
+        usage: t.usage,
+        systemChars: t.systemChars,
+        userChars: t.userChars,
+      })),
+    },
+    hitRateDeltaPp: deltaPct,
+  };
+
+  fs.writeFileSync(outPath, JSON.stringify(report, null, 2), "utf8");
+  console.log(`report: ${outPath}`);
+
+  // also write latest pointer
+  const latest = path.join(CFG.outDir, "prompt-cache-ab-latest.json");
+  fs.writeFileSync(latest, JSON.stringify(report, null, 2), "utf8");
+  console.log(`latest: ${latest}`);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack || err.message : err);
+  process.exit(1);
+});

--- a/src/adapters/openclaw/index.ts
+++ b/src/adapters/openclaw/index.ts
@@ -5,3 +5,5 @@ export { OpenClawHostAdapter } from "./host-adapter.js";
 export type { OpenClawHostAdapterOptions } from "./host-adapter.js";
 export { OpenClawLLMRunner, OpenClawLLMRunnerFactory } from "./llm-runner.js";
 export type { OpenClawLLMRunnerFactoryOptions } from "./llm-runner.js";
+export { shapeRecallForOpenClawHook } from "./recall-injection.js";
+export type { InjectionMode, OpenClawPromptBuildResult, ShapeRecallOptions } from "./recall-injection.js";

--- a/src/adapters/openclaw/recall-injection.ts
+++ b/src/adapters/openclaw/recall-injection.ts
@@ -1,0 +1,94 @@
+/**
+ * Map Core RecallResult to OpenClaw before_prompt_build hook fields.
+ *
+ * Defaults (issue #120):
+ * - Stable persona/scene/tools -> prependSystemContext (before host cache boundary)
+ * - Dynamic L1 -> prependContext (injectionMode=prepend) or appendContext (append)
+ *
+ * dualEmitStable: when true, also set appendSystemContext = stable for hosts
+ * that only read appendSystemContext. Default false to avoid double injection.
+ */
+import type { RecallResult } from "../../core/types.js";
+
+export type InjectionMode = "prepend" | "append";
+
+export interface OpenClawPromptBuildResult {
+  /** Stable block preferred (cache-friendly when host places it before boundary). */
+  prependSystemContext?: string;
+  /** Legacy stable tail only set when dualEmitStable. */
+  appendSystemContext?: string;
+  /** Dynamic L1 before user text. */
+  prependContext?: string;
+  /** Dynamic L1 after user text (host must support appendContext). */
+  appendContext?: string;
+}
+
+export interface ShapeRecallOptions {
+  injectionMode?: InjectionMode;
+  /**
+   * If true, emit the same stable string on both prependSystemContext and
+   * appendSystemContext (max compatibility for hosts that only honor
+   * appendSystemContext). Default false — dual inject risks double persona
+   * on hosts that honor both fields.
+   */
+  dualEmitStable?: boolean;
+}
+
+/** Non-empty after trim, but return original bytes (no trim) for cache stability. */
+function nonEmpty(text: string | undefined | null): string | undefined {
+  if (typeof text !== "string") return undefined;
+  if (text.trim().length === 0) return undefined;
+  return text;
+}
+
+/**
+ * Shape a Core recall result for the OpenClaw before_prompt_build hook.
+ */
+export function shapeRecallForOpenClawHook(
+  result: RecallResult | undefined | null,
+  options: ShapeRecallOptions = {},
+): OpenClawPromptBuildResult | undefined {
+  if (!result) return undefined;
+
+  const injectionMode: InjectionMode = options.injectionMode === "append" ? "append" : "prepend";
+  const dualEmitStable = options.dualEmitStable === true;
+
+  // Core currently stores stable in appendSystemContext; also accept
+  // future/core-local prependSystemContext if present.
+  // Prefer prependSystemContext when Core already set it.
+  const stable =
+    nonEmpty((result as { prependSystemContext?: string }).prependSystemContext) ||
+    nonEmpty(result.appendSystemContext);
+
+  const dynamic =
+    nonEmpty(result.prependContext) ||
+    nonEmpty((result as { appendContext?: string }).appendContext);
+
+  const out: OpenClawPromptBuildResult = {};
+
+  if (stable) {
+    out.prependSystemContext = stable;
+    if (dualEmitStable) {
+      out.appendSystemContext = stable;
+    }
+  }
+
+  if (dynamic) {
+    if (injectionMode === "append") {
+      out.appendContext = dynamic;
+    } else {
+      out.prependContext = dynamic;
+    }
+  }
+
+  if (
+    !out.prependSystemContext &&
+    !out.appendSystemContext &&
+    !out.prependContext &&
+    !out.appendContext
+  ) {
+    return undefined;
+  }
+
+  return out;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,24 @@ export interface RecallConfig {
   strategy: "embedding" | "keyword" | "hybrid";
   /** Overall recall timeout in milliseconds (default: 5000). When exceeded, recall is skipped with a warning. */
   timeoutMs: number;
+  /**
+   * Where to place dynamic L1 recall relative to the current user prompt.
+   * - "prepend" (default): prependContext — current plugin behaviour
+   * - "append": appendContext — keeps user-prompt prefix byte-stable (host must support appendContext)
+   */
+  injectionMode: "prepend" | "append";
+  /**
+   * When false (default), strip <relevant-memories> before persisting user messages
+   * so dynamic recall does not bloat session history (prompt-cache friendly).
+   * When true, leave injected blocks in the transcript (debugging / legacy).
+   */
+  showInjected: boolean;
+  /**
+   * When true, emit stable persona/scene/tools on BOTH prependSystemContext and
+   * appendSystemContext. Use only on hosts that ignore prependSystemContext.
+   * Default false (avoids double injection on capable hosts).
+   */
+  dualEmitStable: boolean;
 }
 
 /** Embedding service configuration for vector search. */
@@ -535,6 +553,9 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       scoreThreshold: num(recallGroup, "scoreThreshold") ?? 0.3,
       strategy: validateStrategy(str(recallGroup, "strategy")) ?? "hybrid",
       timeoutMs: num(recallGroup, "timeoutMs") ?? 5000,
+      injectionMode: validateInjectionMode(str(recallGroup, "injectionMode")) ?? "prepend",
+      showInjected: bool(recallGroup, "showInjected") ?? false,
+      dualEmitStable: bool(recallGroup, "dualEmitStable") ?? false,
     },
     embedding: {
       enabled: embeddingEnabled,
@@ -644,6 +665,11 @@ function validateStrategy(value: string | undefined): RecallConfig["strategy"] |
   return VALID_STRATEGIES.includes(value as RecallConfig["strategy"])
     ? (value as RecallConfig["strategy"])
     : undefined;
+}
+
+function validateInjectionMode(value: string | undefined): "prepend" | "append" | undefined {
+  if (value === "prepend" || value === "append") return value;
+  return undefined;
 }
 
 /**

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -185,14 +185,12 @@ async function performAutoRecallInner(params: {
 
   // Split recall context into stable and dynamic parts to optimize prompt caching.
   //
-  // appendSystemContext (system prompt end — stable, cacheable):
-  //   persona, scene navigation, memory tools guide
-  //   These change infrequently; when content is identical across turns,
-  //   providers with prompt caching (Anthropic/OpenAI) can cache this region.
+  // appendSystemContext (Core field — stable: persona, scene nav, tools guide):
+  //   OpenClaw adapter maps this to prependSystemContext by default (issue #120)
+  //   so hosts can place it before CACHE_BOUNDARY for prefix-matching caches.
   //
-  // prependContext (user prompt prefix — dynamic, per-turn):
-  //   L1 relevant memories — different every turn, moved out of system prompt
-  //   so it doesn't bust the system prompt cache.
+  // prependContext (user prompt — dynamic, per-turn):
+  //   L1 relevant memories. injectionMode=append may map this to appendContext.
   const stableParts: string[] = [];
   if (personaContent) {
     stableParts.push(`<user-persona>\n${personaContent}\n</user-persona>`);

--- a/src/core/report/prompt-cache-usage.test.ts
+++ b/src/core/report/prompt-cache-usage.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractUsageObject,
+  normalizePromptCacheUsage,
+  toPromptCacheReportPayload,
+} from "./prompt-cache-usage.js";
+
+describe("normalizePromptCacheUsage", () => {
+  it("parses DeepSeek-style hit/miss tokens", () => {
+    const u = normalizePromptCacheUsage({
+      model: "deepseek-chat",
+      provider: "deepseek",
+      usage: {
+        prompt_tokens: 3260,
+        completion_tokens: 20,
+        prompt_cache_hit_tokens: 1408,
+        prompt_cache_miss_tokens: 1852,
+      },
+    });
+    expect(u).not.toBeNull();
+    expect(u!.cacheReadTokens).toBe(1408);
+    expect(u!.cacheMissTokens).toBe(1852);
+    expect(u!.cacheHitRate).toBeCloseTo(1408 / (1408 + 1852), 5);
+    expect(u!.model).toBe("deepseek-chat");
+    expect(u!.providerHint).toBe("deepseek");
+  });
+
+  it("parses OpenAI-compatible cached_tokens details", () => {
+    const u = normalizePromptCacheUsage({
+      usage: {
+        prompt_tokens: 1000,
+        prompt_tokens_details: { cached_tokens: 600 },
+        completion_tokens: 10,
+      },
+    });
+    expect(u!.cacheReadTokens).toBe(600);
+    expect(u!.cacheMissTokens).toBe(400);
+    expect(u!.cacheHitRate).toBeCloseTo(0.6, 5);
+  });
+
+  it("parses Anthropic-ish cache_read / cache_creation", () => {
+    const u = normalizePromptCacheUsage({
+      usage: {
+        input_tokens: 500,
+        cache_read_input_tokens: 300,
+        cache_creation_input_tokens: 200,
+        output_tokens: 5,
+      },
+    });
+    expect(u!.cacheReadTokens).toBe(300);
+    expect(u!.cacheMissTokens).toBe(200);
+  });
+
+  it("finds nested response.usage", () => {
+    const raw = extractUsageObject({
+      response: { usage: { prompt_tokens: 10, prompt_cache_hit_tokens: 4, prompt_cache_miss_tokens: 6 } },
+    });
+    expect(raw?.prompt_tokens).toBe(10);
+    const u = normalizePromptCacheUsage({
+      response: { usage: { prompt_tokens: 10, prompt_cache_hit_tokens: 4, prompt_cache_miss_tokens: 6 } },
+    });
+    expect(u!.cacheReadTokens).toBe(4);
+  });
+
+  it("returns null when no usage-like object", () => {
+    expect(normalizePromptCacheUsage({ foo: 1 })).toBeNull();
+    expect(normalizePromptCacheUsage(null)).toBeNull();
+  });
+
+  it("does not invent hit rate without cache fields", () => {
+    const u = normalizePromptCacheUsage({
+      usage: { prompt_tokens: 100, completion_tokens: 5 },
+    });
+    expect(u).not.toBeNull();
+    expect(u!.cacheReadTokens).toBeNull();
+    expect(u!.cacheHitRate).toBeNull();
+  });
+
+  it("toPromptCacheReportPayload is compact and numeric-safe", () => {
+    const u = normalizePromptCacheUsage({
+      usage: {
+        prompt_tokens: 100,
+        prompt_cache_hit_tokens: 25,
+        prompt_cache_miss_tokens: 75,
+      },
+    })!;
+    const p = toPromptCacheReportPayload(u, { sessionKey: "s1" });
+    expect(p.cacheHitRatePct).toBe(25);
+    expect(p.sessionKey).toBe("s1");
+    expect(p.cacheReadTokens).toBe(25);
+  });
+});

--- a/src/core/report/prompt-cache-usage.ts
+++ b/src/core/report/prompt-cache-usage.ts
@@ -1,0 +1,187 @@
+/**
+ * Normalize provider-specific prompt-cache usage fields from llm_output events.
+ * Observation-only — used when report.enabled=true.
+ *
+ * Supports common shapes:
+ * - DeepSeek: prompt_cache_hit_tokens / prompt_cache_miss_tokens
+ * - OpenAI-compatible: usage.prompt_tokens_details.cached_tokens
+ * - Anthropic-ish: cache_read_input_tokens / cache_creation_input_tokens
+ * - Nested under event.usage / event.response.usage / event.metrics
+ */
+
+export interface PromptCacheUsage {
+  promptTokens: number | null;
+  completionTokens: number | null;
+  cacheReadTokens: number | null;
+  cacheMissTokens: number | null;
+  /** cacheRead / (cacheRead + cacheMiss) when both known; else cacheRead / promptTokens */
+  cacheHitRate: number | null;
+  providerHint: string | null;
+  model: string | null;
+  /** Keys observed on the raw usage object (no values — avoids leaking payloads). */
+  usageKeys: string[];
+}
+
+function pickNum(...vals: unknown[]): number | null {
+  for (const v of vals) {
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) {
+      return Number(v);
+    }
+  }
+  return null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v !== null && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+/** Pull the most likely usage object from a loosely-typed llm_output event. */
+export function extractUsageObject(event: unknown): Record<string, unknown> | null {
+  const e = asRecord(event);
+  if (!e) return null;
+
+  const candidates: unknown[] = [
+    e.usage,
+    e.tokenUsage,
+    e.tokens,
+    asRecord(e.response)?.usage,
+    asRecord(e.result)?.usage,
+    asRecord(e.metrics)?.usage,
+    asRecord(e.data)?.usage,
+    e,
+  ];
+
+  for (const c of candidates) {
+    const r = asRecord(c);
+    if (!r) continue;
+    // Heuristic: look like a usage bag
+    if (
+      "prompt_tokens" in r ||
+      "input_tokens" in r ||
+      "prompt_cache_hit_tokens" in r ||
+      "cache_read_input_tokens" in r ||
+      "cached_tokens" in r ||
+      "prompt_tokens_details" in r ||
+      "input_tokens_details" in r ||
+      "completion_tokens" in r ||
+      "output_tokens" in r
+    ) {
+      return r;
+    }
+  }
+  return null;
+}
+
+export function extractModelHint(event: unknown): string | null {
+  const e = asRecord(event);
+  if (!e) return null;
+  const m =
+    e.model ??
+    asRecord(e.response)?.model ??
+    asRecord(e.result)?.model ??
+    asRecord(e.provider)?.model;
+  return typeof m === "string" && m.length > 0 ? m : null;
+}
+
+export function extractProviderHint(event: unknown): string | null {
+  const e = asRecord(event);
+  if (!e) return null;
+  const p =
+    e.provider ??
+    asRecord(e.providerInfo)?.id ??
+    asRecord(e.providerInfo)?.name;
+  if (typeof p === "string" && p.length > 0) return p;
+  const model = extractModelHint(event);
+  if (model && model.includes("/")) return model.split("/", 1)[0] ?? null;
+  return null;
+}
+
+/**
+ * Normalize raw usage into cache read/miss + hit rate.
+ * Returns null only when no usage object could be found at all.
+ */
+export function normalizePromptCacheUsage(event: unknown): PromptCacheUsage | null {
+  const usage = extractUsageObject(event);
+  if (!usage) return null;
+
+  const details =
+    asRecord(usage.prompt_tokens_details) ||
+    asRecord(usage.input_tokens_details) ||
+    {};
+
+  const promptTokens = pickNum(
+    usage.prompt_tokens,
+    usage.input_tokens,
+    usage.total_tokens,
+  );
+  const completionTokens = pickNum(
+    usage.completion_tokens,
+    usage.output_tokens,
+  );
+
+  let cacheRead = pickNum(
+    usage.prompt_cache_hit_tokens,
+    usage.cache_read_input_tokens,
+    usage.cached_tokens,
+    details.cached_tokens,
+    details.cache_read_tokens,
+    details.cache_read_input_tokens,
+  );
+
+  let cacheMiss = pickNum(
+    usage.prompt_cache_miss_tokens,
+    usage.cache_creation_input_tokens,
+    details.cache_miss_tokens,
+    details.cache_creation_input_tokens,
+  );
+
+  // If only cached_tokens + prompt_tokens: miss ≈ prompt - cached
+  if (cacheRead != null && cacheMiss == null && promptTokens != null) {
+    cacheMiss = Math.max(0, promptTokens - cacheRead);
+  }
+
+  let cacheHitRate: number | null = null;
+  if (cacheRead != null && cacheMiss != null) {
+    const denom = cacheRead + cacheMiss;
+    if (denom > 0) cacheHitRate = cacheRead / denom;
+  } else if (cacheRead != null && promptTokens != null && promptTokens > 0) {
+    cacheHitRate = cacheRead / promptTokens;
+  }
+
+  return {
+    promptTokens,
+    completionTokens,
+    cacheReadTokens: cacheRead,
+    cacheMissTokens: cacheMiss,
+    cacheHitRate,
+    providerHint: extractProviderHint(event),
+    model: extractModelHint(event),
+    usageKeys: Object.keys(usage).slice(0, 32),
+  };
+}
+
+/** Compact payload for report("prompt_cache_usage", ...). */
+export function toPromptCacheReportPayload(
+  usage: PromptCacheUsage,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+    cacheMissTokens: usage.cacheMissTokens,
+    cacheHitRate:
+      usage.cacheHitRate != null ? +usage.cacheHitRate.toFixed(6) : null,
+    cacheHitRatePct:
+      usage.cacheHitRate != null
+        ? +((usage.cacheHitRate * 100).toFixed(2))
+        : null,
+    provider: usage.providerHint,
+    model: usage.model,
+    usageKeys: usage.usageKeys,
+    ...extra,
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -197,9 +197,13 @@ export interface CompletedTurn {
 
 /** Result from a recall (prefetch) operation. */
 export interface RecallResult {
-  /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
+  /** L1 relevant memories — dynamic, per-turn (placement via recall.injectionMode). */
   prependContext?: string;
-  /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
+  /**
+   * Stable recall context (persona, scene nav, tools guide).
+   * Core emits this field; OpenClaw adapter maps it to prependSystemContext by default
+   * for prompt-cache friendliness (issue #120).
+   */
   appendSystemContext?: string;
   /** Recalled L1 memories with scores (for metrics). */
   recalledL1Memories?: Array<{ content: string; score: number; type: string }>;

--- a/src/utils/prompt-cache-recall.test.ts
+++ b/src/utils/prompt-cache-recall.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+
+import { parseConfig } from "../config.js";
+import { shapeRecallForOpenClawHook } from "../adapters/openclaw/recall-injection.js";
+import {
+  describeRecallShape,
+  noteStableContinuity,
+  getLastStableHash,
+  resetStableContinuityForTests,
+  longestCommonPrefixLength,
+} from "./recall-shape-diagnostics.js";
+import {
+  hasRelevantMemories,
+  stripRelevantMemories,
+  stripRelevantMemoriesFromContent,
+} from "./relevant-memories.js";
+
+describe("recall.injectionMode / showInjected config", () => {
+  it("defaults to prepend + showInjected false + dualEmitStable false", () => {
+    const cfg = parseConfig({});
+    expect(cfg.recall.injectionMode).toBe("prepend");
+    expect(cfg.recall.showInjected).toBe(false);
+    expect(cfg.recall.dualEmitStable).toBe(false);
+  });
+
+  it("accepts append injectionMode and showInjected true", () => {
+    const cfg = parseConfig({
+      recall: { injectionMode: "append", showInjected: true },
+    });
+    expect(cfg.recall.injectionMode).toBe("append");
+    expect(cfg.recall.showInjected).toBe(true);
+  });
+
+  it("falls back invalid injectionMode to prepend", () => {
+    const cfg = parseConfig({
+      recall: { injectionMode: "sideways" as unknown as string },
+    });
+    expect(cfg.recall.injectionMode).toBe("prepend");
+  });
+});
+
+describe("shapeRecallForOpenClawHook", () => {
+  const coreResult = {
+    appendSystemContext: "<user-persona>\nstable\n</user-persona>",
+    prependContext: "<relevant-memories>\ndyn\n</relevant-memories>",
+  };
+
+  it("maps stable to prependSystemContext and dynamic to prependContext by default", () => {
+    const shaped = shapeRecallForOpenClawHook(coreResult);
+    expect(shaped?.prependSystemContext).toBe(coreResult.appendSystemContext);
+    expect(shaped?.appendSystemContext).toBeUndefined();
+    expect(shaped?.prependContext).toBe(coreResult.prependContext);
+    expect(shaped?.appendContext).toBeUndefined();
+  });
+
+  it("maps dynamic to appendContext when injectionMode=append", () => {
+    const shaped = shapeRecallForOpenClawHook(coreResult, { injectionMode: "append" });
+    expect(shaped?.prependSystemContext).toBe(coreResult.appendSystemContext);
+    expect(shaped?.prependContext).toBeUndefined();
+    expect(shaped?.appendContext).toBe(coreResult.prependContext);
+  });
+
+  it("dualEmitStable also sets appendSystemContext", () => {
+    const shaped = shapeRecallForOpenClawHook(coreResult, { dualEmitStable: true });
+    expect(shaped?.prependSystemContext).toBe(coreResult.appendSystemContext);
+    expect(shaped?.appendSystemContext).toBe(coreResult.appendSystemContext);
+  });
+
+  it("preserves original stable bytes (no destructive trim)", () => {
+    const withNl = {
+      appendSystemContext: "stable-block\n",
+      prependContext: "dyn",
+    };
+    const shaped = shapeRecallForOpenClawHook(withNl);
+    expect(shaped?.prependSystemContext).toBe("stable-block\n");
+  });
+
+  it("drops whitespace-only stable/dynamic", () => {
+    expect(
+      shapeRecallForOpenClawHook({ appendSystemContext: "   ", prependContext: "\n" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty result", () => {
+    expect(shapeRecallForOpenClawHook({})).toBeUndefined();
+    expect(shapeRecallForOpenClawHook(undefined)).toBeUndefined();
+  });
+});
+
+describe("relevant-memories strip", () => {
+  it("strips string content", () => {
+    const raw =
+      "<relevant-memories>\nfoo\n</relevant-memories>\n\nhello";
+    expect(hasRelevantMemories(raw)).toBe(true);
+    expect(stripRelevantMemories(raw)).toBe("hello");
+  });
+
+  it("strips multipart parts", () => {
+    const content = [
+      { type: "text", text: "<relevant-memories>x</relevant-memories>\n\nhi" },
+      { type: "image", url: "data:..." },
+    ];
+    const out = stripRelevantMemoriesFromContent(content);
+    expect(out).toBeDefined();
+    expect((out!.content as Array<{ text?: string }>)[0].text).toBe("hi");
+    expect(out!.strippedChars).toBeGreaterThan(0);
+  });
+
+  it("no-ops when no tags", () => {
+    expect(stripRelevantMemoriesFromContent("plain")).toBeUndefined();
+  });
+});
+
+describe("describeRecallShape", () => {
+  it("hashes stable prependSystemContext and reports dynamic placement", () => {
+    const stable = "persona-block";
+    const d = describeRecallShape({
+      prependSystemContext: stable,
+      prependContext: "dyn",
+    });
+    const expected = createHash("sha256").update(stable, "utf8").digest("hex").slice(0, 12);
+    expect(d.stableHash).toBe(expected);
+    expect(d.dynamicPlacement).toBe("prepend");
+    expect(d.line).toContain("stable=");
+    expect(d.line).toContain("dynamic=prepend/");
+  });
+
+  it("is stable across identical inputs", () => {
+    const a = describeRecallShape({ prependSystemContext: "same", appendContext: "x" });
+    const b = describeRecallShape({ prependSystemContext: "same", appendContext: "x" });
+    expect(a.stableHash).toBe(b.stableHash);
+    expect(a.dynamicPlacement).toBe("append");
+  });
+});
+
+describe("stable continuity (observe-only)", () => {
+  it("tracks first → same → changed without freezing content", () => {
+    resetStableContinuityForTests();
+    expect(noteStableContinuity("s1", "aaa")).toBe("first");
+    expect(noteStableContinuity("s1", "aaa")).toBe("same");
+    expect(noteStableContinuity("s1", "bbb")).toBe("changed");
+    expect(getLastStableHash("s1")).toBe("bbb");
+    expect(noteStableContinuity("s2", "aaa")).toBe("first");
+  });
+});
+
+describe("multi-turn system prefix LCP (pure shape)", () => {
+  it("keeps full system prefix when only dynamic L1 changes", () => {
+    const stable = "<user-persona>\nP\n</user-persona>\n\n<memory-tools-guide>\nG\n</memory-tools-guide>";
+    const t1 = shapeRecallForOpenClawHook({
+      appendSystemContext: stable,
+      prependContext: "<relevant-memories>\nA\n</relevant-memories>",
+    })!;
+    const t2 = shapeRecallForOpenClawHook({
+      appendSystemContext: stable,
+      prependContext: "<relevant-memories>\nB-different\n</relevant-memories>",
+    })!;
+    // System side is byte-identical across turns (dynamic is user-side only).
+    expect(t1.prependSystemContext).toBe(t2.prependSystemContext);
+    expect(t1.prependContext).not.toBe(t2.prependContext);
+    const lcp = longestCommonPrefixLength(t1.prependSystemContext!, t2.prependSystemContext!);
+    expect(lcp).toBe(stable.length);
+  });
+
+  it("append mode keeps dynamic off the user prefix field", () => {
+    const shaped = shapeRecallForOpenClawHook(
+      {
+        appendSystemContext: "S",
+        prependContext: "D",
+      },
+      { injectionMode: "append" },
+    )!;
+    expect(shaped.prependContext).toBeUndefined();
+    expect(shaped.appendContext).toBe("D");
+    expect(shaped.prependSystemContext).toBe("S");
+  });
+});
+

--- a/src/utils/recall-shape-diagnostics.ts
+++ b/src/utils/recall-shape-diagnostics.ts
@@ -1,0 +1,111 @@
+/**
+ * Observation-only diagnostics for prompt-cache prefix stability.
+ * Logs stable-block length + short hash and dynamic placement.
+ * Optional session continuity: same|changed|first (does NOT freeze content).
+ */
+import { createHash } from "node:crypto";
+
+export type DynamicPlacement = "prepend" | "append" | "none";
+export type StableContinuity = "first" | "same" | "changed";
+
+export interface RecallShapeInput {
+  prependSystemContext?: string;
+  appendSystemContext?: string;
+  prependContext?: string;
+  appendContext?: string;
+}
+
+export interface RecallShapeDescription {
+  stableChars: number;
+  stableHash: string;
+  dynamicPlacement: DynamicPlacement;
+  dynamicChars: number;
+  line: string;
+}
+
+/** Per-session last stable hash for continuity logs (TTL + hard cap). */
+const lastStableBySession = new Map<string, { hash: string; ts: number }>();
+const CONTINUITY_TTL_MS = 30 * 60 * 1000;
+const CONTINUITY_MAX = 5_000;
+
+function shortHash(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex").slice(0, 12);
+}
+
+function sweepContinuity(now: number): void {
+  for (const [k, v] of lastStableBySession) {
+    if (now - v.ts > CONTINUITY_TTL_MS) lastStableBySession.delete(k);
+  }
+  if (lastStableBySession.size <= CONTINUITY_MAX) return;
+  const entries = [...lastStableBySession.entries()].sort((a, b) => a[1].ts - b[1].ts);
+  const drop = entries.length - CONTINUITY_MAX;
+  for (let i = 0; i < drop; i++) lastStableBySession.delete(entries[i][0]);
+}
+
+/**
+ * Prefer prependSystemContext as the stable block when present
+ * (cache-friendly placement); fall back to appendSystemContext.
+ */
+export function describeRecallShape(shape: RecallShapeInput): RecallShapeDescription {
+  const stable =
+    shape.prependSystemContext?.trim() ||
+    shape.appendSystemContext?.trim() ||
+    "";
+  const stableChars = stable.length;
+  const stableHash = stableChars > 0 ? shortHash(stable) : "empty";
+
+  let dynamicPlacement: DynamicPlacement = "none";
+  let dynamicChars = 0;
+  if (shape.prependContext && shape.prependContext.length > 0) {
+    dynamicPlacement = "prepend";
+    dynamicChars = shape.prependContext.length;
+  } else if (shape.appendContext && shape.appendContext.length > 0) {
+    dynamicPlacement = "append";
+    dynamicChars = shape.appendContext.length;
+  }
+
+  const line =
+    `stable=${stableChars}chars(hash=${stableHash}), ` +
+    `dynamic=${dynamicPlacement}/${dynamicChars}chars`;
+
+  return { stableChars, stableHash, dynamicPlacement, dynamicChars, line };
+}
+
+/**
+ * Record stable hash for a session and return continuity vs previous turn.
+ * Empty stable ("empty") still updates state so "first" is only once.
+ */
+export function noteStableContinuity(
+  sessionKey: string | undefined | null,
+  stableHash: string,
+): StableContinuity {
+  if (!sessionKey) return "first";
+  const now = Date.now();
+  sweepContinuity(now);
+  const prev = lastStableBySession.get(sessionKey);
+  lastStableBySession.set(sessionKey, { hash: stableHash, ts: now });
+  if (!prev) return "first";
+  return prev.hash === stableHash ? "same" : "changed";
+}
+
+/** Last observed stable hash for a session (for llm_output metrics join). */
+export function getLastStableHash(sessionKey: string | undefined | null): string | null {
+  if (!sessionKey) return null;
+  return lastStableBySession.get(sessionKey)?.hash ?? null;
+}
+
+/** Test-only: clear continuity map. */
+export function resetStableContinuityForTests(): void {
+  lastStableBySession.clear();
+}
+
+/**
+ * Longest common prefix length of two strings (code units).
+ * Used in tests to prove multi-turn system prefix stability when only dynamic changes.
+ */
+export function longestCommonPrefixLength(a: string, b: string): number {
+  const n = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < n && a.charCodeAt(i) === b.charCodeAt(i)) i++;
+  return i;
+}

--- a/src/utils/relevant-memories.ts
+++ b/src/utils/relevant-memories.ts
@@ -1,0 +1,47 @@
+/**
+ * Host-neutral helpers for <relevant-memories> injection blocks.
+ * Used by before_message_write stripping and unit tests.
+ */
+
+const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+export function hasRelevantMemories(text: string | undefined | null): boolean {
+  return typeof text === "string" && text.includes("<relevant-memories>");
+}
+
+/** Strip all <relevant-memories>...</relevant-memories> blocks from a string. */
+export function stripRelevantMemories(text: string): string {
+  if (!hasRelevantMemories(text)) return text;
+  return text.replace(STRIP_RE, "").trim();
+}
+
+/**
+ * Strip relevant-memories from a user message content field
+ * (string or OpenClaw multipart parts array).
+ * Returns undefined if nothing changed.
+ */
+export function stripRelevantMemoriesFromContent(
+  content: unknown,
+): { content: unknown; strippedChars: number } | undefined {
+  if (typeof content === "string") {
+    if (!hasRelevantMemories(content)) return undefined;
+    const cleaned = stripRelevantMemories(content);
+    if (cleaned === content) return undefined;
+    return { content: cleaned, strippedChars: content.length - cleaned.length };
+  }
+
+  if (Array.isArray(content)) {
+    let total = 0;
+    const parts = (content as Array<Record<string, unknown>>).map((part) => {
+      if (part.type !== "text" || typeof part.text !== "string") return part;
+      if (!hasRelevantMemories(part.text as string)) return part;
+      const cleaned = stripRelevantMemories(part.text as string);
+      total += (part.text as string).length - cleaned.length;
+      return { ...part, text: cleaned };
+    });
+    if (total === 0) return undefined;
+    return { content: parts, strippedChars: total };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## 问题

OpenAI-compatible 前缀缓存（DeepSeek / MiMo / Grok 等）在多轮对话中命中率偏低，主要有两处根因：

1. **动态 L1 污染历史**：每轮 `prependContext`（`<relevant-memories>`，约 500–1700 tokens）在 `showInjected` 场景下被写入会话 JSONL；历史膨胀后 tool-result truncation 量逐轮变化，前缀不再稳定，缓存失效。
2. **稳定块落在 CACHE_BOUNDARY 之后**：persona / scene navigation / tools guide 走 `appendSystemContext`，被宿主拼在 volatile 边界之后，稳定内容每轮当新 token 计费。

## 改动

| 项 | 说明 |
| --- | --- |
| 稳定块注入 | OpenClaw 适配层默认映射为 `prependSystemContext`（宿主可放在 CACHE_BOUNDARY 之前） |
| `recall.showInjected` | 默认 `false`：`before_message_write` 写入前剥离 `<relevant-memories>`，仅当轮 LLM 可见 |
| `recall.injectionMode` | `prepend`（默认）/ `append`：动态 L1 放用户消息前或后 |
| `recall.dualEmitStable` | 默认 `false`；仅当旧宿主忽略 `prependSystemContext` 时双发兼容 |
| 可观测性 | `stable_continuity` 日志、`stableHash`；`report.enabled` 时 `llm_output` 上报归一化 `prompt_cache_usage` |
| 基准 | `npm run bench:cache`（不依赖 OpenClaw 的 layout A/B） |

相关：`src/adapters/openclaw/recall-injection.ts`、`index.ts`（hook 注册）、`CHANGELOG.md` Unreleased。

## 验证

- 单测：`src/utils/prompt-cache-recall.test.ts`、`src/core/report/prompt-cache-usage.test.ts`
- 受控 warm A/B（relay / grok-4.5）：cache hit **86.0% → 92.5%**（+6.5pp）

## 升级注意

- 默认行为：历史不再保留召回块；调试可设 `recall.showInjected: true`。
- 若宿主尚未支持 `prependSystemContext`，可临时 `recall.dualEmitStable: true`（可能双注入 persona，仅作兼容）。