### PR TITLE
fix(data): recalibrate checkpoint counters after cleanup (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **checkpoint 计数器只增不减，清理后与真实数据长期漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：`l0_conversations_count` 与 `total_memories_extracted` 此前只在采集/抽取时递增；memory-cleaner 删除过期 L0/L1 后从不回写，导致计数持续高估，并可能让依赖 `memories_since_last_persona` 的画像阈值提前触发。
   - 新增 `CheckpointManager.recalibrate(source?)`：以在线存储（`countL0()` / `countL1()`）为准回填；无存储时回退统计 `conversations/`、`records/` 日分片非空行数。写入走同一把 per-file 锁，幂等，并对 NaN/负数钳制。
   - **画像间隔钳制**：L1 缩水时同步按 delta 下调 `memories_since_last_persona`，并限制其不超过新的 L1 总量，避免清理后误触发 persona。
+  - 新增 `CheckpointManager.resetSession(sessionKey, source?)`：清除单个 session 的 `runner_states` / `pipeline_states` 后立刻 recalibrate，覆盖「删测试 pipeline 状态 / session 重置」漂移路径。
   - **调用时机**：Gateway 启动恢复 pipeline 状态前一次；每轮 cleaner 清理结束后一次；两处均为非致命。
 
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **checkpoint 计数器只增不减，清理后与真实数据长期漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：`l0_conversations_count` 与 `total_memories_extracted` 此前只在采集/抽取时递增；memory-cleaner 删除过期 L0/L1 后从不回写，导致计数持续高估，并可能让依赖 `memories_since_last_persona` 的画像阈值提前触发。
+  - 新增 `CheckpointManager.recalibrate(source?)`：以在线存储（`countL0()` / `countL1()`）为准回填；无存储时回退统计 `conversations/`、`records/` 日分片非空行数。写入走同一把 per-file 锁，幂等，并对 NaN/负数钳制。
+  - **画像间隔钳制**：L1 缩水时同步按 delta 下调 `memories_since_last_persona`，并限制其不超过新的 L1 总量，避免清理后误触发 persona。
+  - **调用时机**：Gateway 启动恢复 pipeline 状态前一次；每轮 cleaner 清理结束后一次；两处均为非致命。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -47,7 +47,8 @@ import {
   createL3Runner,
 } from "../utils/pipeline-factory.js";
 import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
-import { CheckpointManager } from "../utils/checkpoint.js";
+import { CheckpointManager, type DriftReport } from "../utils/checkpoint.js";
+import { StatusCache } from "../utils/status-cache.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
 
@@ -66,11 +67,28 @@ export interface TdaiCoreOptions {
   sessionFilter?: SessionFilter;
   /** Plugin instance ID for metric reporting. */
   instanceId?: string;
+  /**
+   * How long (ms) to cache the result of `getCheckpointStatus()`.
+   * Prevents repeated file + store I/O on health-check polling loops.
+   * Defaults to 30 000 ms (30 s). Set to 0 to disable caching.
+   */
+  checkpointStatusTtlMs?: number;
 }
 
 // ============================
 // TdaiCore
 // ============================
+
+const DEFAULT_CHECKPOINT_STATUS_TTL_MS = 30_000;
+
+export type CheckpointStatus = {
+  l0_conversations_count: number;
+  total_memories_extracted: number;
+  memories_since_last_persona: number;
+  last_recalibrated_at: string;
+  drift_history: Array<{ at: string; l0_delta: number; l1_delta: number }>;
+  drift: DriftReport;
+};
 
 export class TdaiCore {
   private hostAdapter: HostAdapter;
@@ -121,6 +139,7 @@ export class TdaiCore {
    * of currently-running background tasks.
    */
   private readonly bgTasks = new Set<Promise<void>>();
+  private readonly checkpointStatusCache: StatusCache<CheckpointStatus>;
 
   constructor(opts: TdaiCoreOptions) {
     this.hostAdapter = opts.hostAdapter;
@@ -130,6 +149,9 @@ export class TdaiCore {
     this.runnerFactory = opts.hostAdapter.getLLMRunnerFactory();
     this.sessionFilter = opts.sessionFilter ?? new SessionFilter([]);
     this.instanceId = opts.instanceId;
+    this.checkpointStatusCache = new StatusCache(
+      opts.checkpointStatusTtlMs ?? DEFAULT_CHECKPOINT_STATUS_TTL_MS,
+    );
   }
 
   // ============================
@@ -356,6 +378,33 @@ export class TdaiCore {
    *                    don't have to pre-check whether the session was
    *                    already evicted or never produced a capture.
    */
+  /**
+   * Return a live snapshot of checkpoint counters and drift status.
+   *
+   * Reads the checkpoint file and, when a vector store is available, compares
+   * stored counters against live DB counts to produce a `DriftReport`. Falls
+   * back to JSONL line counts when no store is connected.
+   *
+   * Intended for health-check endpoints and operational dashboards.
+   */
+  async getCheckpointStatus(): Promise<CheckpointStatus> {
+    return this.checkpointStatusCache.get(async () => {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      const [cp, drift] = await Promise.all([
+        checkpoint.read(),
+        checkpoint.detectDrift(this.vectorStore),
+      ]);
+      return {
+        l0_conversations_count: cp.l0_conversations_count,
+        total_memories_extracted: cp.total_memories_extracted,
+        memories_since_last_persona: cp.memories_since_last_persona,
+        last_recalibrated_at: cp.last_recalibrated_at,
+        drift_history: cp.drift_history,
+        drift,
+      };
+    });
+  }
+
   async handleSessionEnd(sessionKey: string): Promise<void> {
     if (!sessionKey) return;
     await this.storeReady?.catch(() => {});
@@ -519,6 +568,9 @@ export class TdaiCore {
         // Non-fatal: never block scheduler start on recalibration failure.
         try {
           await checkpoint.recalibrate(this.vectorStore);
+          // Recalibrate mutated the checkpoint — stale status cache would
+          // serve pre-recalibrate counters until TTL expires.
+          this.checkpointStatusCache.invalidate();
         } catch (err) {
           this.logger.warn(
             `${TAG} Checkpoint recalibration failed (continuing): ${err instanceof Error ? err.message : String(err)}`,

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -514,6 +514,16 @@ export class TdaiCore {
     this.schedulerStartPromise = (async () => {
       try {
         const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        // Heal increment-only counter drift before restoring pipeline state so
+        // persona thresholds start from counts that match real data (#157).
+        // Non-fatal: never block scheduler start on recalibration failure.
+        try {
+          await checkpoint.recalibrate(this.vectorStore);
+        } catch (err) {
+          this.logger.warn(
+            `${TAG} Checkpoint recalibration failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
         const cp = await checkpoint.read();
         scheduler.start(checkpoint.getAllPipelineStates(cp));
         this.logger.debug?.(`${TAG} Scheduler started`);

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -14,6 +14,19 @@ function fakeSource(l0: number, l1: number): RecalibrationSource {
   };
 }
 
+async function writeShard(
+  dataDir: string,
+  subDir: string,
+  name: string,
+  lines: string[],
+): Promise<string> {
+  const dir = path.join(dataDir, subDir);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, lines.join("\n") + (lines.length ? "\n" : ""), "utf-8");
+  return filePath;
+}
+
 describe("CheckpointManager.recalibrate (#157)", () => {
   let dataDir: string;
   let cp: CheckpointManager;
@@ -36,7 +49,6 @@ describe("CheckpointManager.recalibrate (#157)", () => {
     expect(state.l0_conversations_count).toBe(2);
     expect(state.total_memories_extracted).toBe(10);
 
-    // Store now only has 1 L0 and 3 L1 (cleanup happened).
     const result = await cp.recalibrate(fakeSource(1, 3));
 
     expect(result.source).toBe("store");
@@ -89,7 +101,6 @@ describe("CheckpointManager.recalibrate (#157)", () => {
   });
 
   it("shrinks memories_since_last_persona with L1 so persona is not triggered early", async () => {
-    // 12 memories extracted since last persona; cleanup removes 5 → 7 remain.
     await cp.markL1ExtractionComplete("s1", 12, 100);
     let state = await cp.read();
     expect(state.memories_since_last_persona).toBe(12);
@@ -106,7 +117,6 @@ describe("CheckpointManager.recalibrate (#157)", () => {
   });
 
   it("clamps memories_since_last_persona to the new L1 ceiling", async () => {
-    // Interval somehow exceeds total (corrupt / partial reset) — clamp to L1.
     await cp.write({
       ...(await cp.read()),
       total_memories_extracted: 20,
@@ -118,44 +128,135 @@ describe("CheckpointManager.recalibrate (#157)", () => {
     expect((await cp.read()).memories_since_last_persona).toBe(8);
   });
 
-  describe("JSONL fallback (degraded mode, no store)", () => {
-    async function writeShard(subDir: string, name: string, lines: string[]): Promise<void> {
-      const dir = path.join(dataDir, subDir);
-      await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(path.join(dir, name), lines.join("\n"), "utf-8");
-    }
-
-    it("counts non-empty lines across daily shards after manual prune", async () => {
-      // Inflate counters first (simulates pre-cleanup drift).
+  // ─── 深入：手动 JSONL 修剪 ───────────────────────────────────────────
+  describe("scenario: manual JSONL prune", () => {
+    it("heals after deleting whole shard files by hand", async () => {
       await cp.markL1ExtractionComplete("s1", 50, 1);
       await cp.captureAtomically("s1", undefined, async () => ({ maxTimestamp: 1, messageCount: 1 }));
       await cp.captureAtomically("s1", 0, async () => ({ maxTimestamp: 2, messageCount: 1 }));
+      await cp.captureAtomically("s1", 0, async () => ({ maxTimestamp: 3, messageCount: 1 }));
 
-      await writeShard("conversations", "2026-06-01.jsonl", ['{"a":1}', '{"a":2}', ""]);
-      await writeShard("conversations", "2026-06-02.jsonl", ['{"a":3}']);
-      await writeShard("records", "2026-06-01.jsonl", ['{"m":1}', "  ", '{"m":2}']);
+      await writeShard(dataDir, "conversations", "2026-06-01.jsonl", [
+        '{"sessionKey":"s1","id":"1"}',
+        '{"sessionKey":"s1","id":"2"}',
+        '{"sessionKey":"s1","id":"3"}',
+        '{"sessionKey":"s1","id":"4"}',
+        '{"sessionKey":"s1","id":"5"}',
+      ]);
+      await writeShard(dataDir, "records", "2026-06-01.jsonl", [
+        '{"id":"m1"}',
+        '{"id":"m2"}',
+        '{"id":"m3"}',
+        '{"id":"m4"}',
+        '{"id":"m5"}',
+      ]);
+      await writeShard(dataDir, "records", "2026-06-02.jsonl", [
+        '{"id":"m6"}',
+        '{"id":"m7"}',
+      ]);
+
+      // Operator deletes the older L1 shard and trims L0 down to 2 lines.
+      await fs.unlink(path.join(dataDir, "records", "2026-06-01.jsonl"));
+      await writeShard(dataDir, "conversations", "2026-06-01.jsonl", [
+        '{"sessionKey":"s1","id":"4"}',
+        '{"sessionKey":"s1","id":"5"}',
+      ]);
 
       const result = await cp.recalibrate();
-
       expect(result.source).toBe("jsonl");
-      expect(result.l0.after).toBe(3); // 2 + 1, blank line ignored
-      expect(result.l1.after).toBe(2); // whitespace-only line ignored
-      expect(result.changed).toBe(true);
+      expect(result.l0.after).toBe(2);
+      expect(result.l1.after).toBe(2); // only 2026-06-02 shard remains
+      expect(result.memories_since_last_persona.after).toBe(2);
+
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(2);
+      expect(state.total_memories_extracted).toBe(2);
+    });
+
+    it("heals after in-place line pruning (rewrite fewer lines)", async () => {
+      await cp.markL1ExtractionComplete("s1", 8, 1);
+      await writeShard(dataDir, "records", "2026-07-01.jsonl", [
+        '{"id":"a"}',
+        '{"id":"b"}',
+        '{"id":"c"}',
+        '{"id":"d"}',
+        '{"id":"e"}',
+        '{"id":"f"}',
+        '{"id":"g"}',
+        '{"id":"h"}',
+      ]);
+
+      // Keep only 3 lines (manual prune of test pipeline output).
+      await writeShard(dataDir, "records", "2026-07-01.jsonl", [
+        '{"id":"f"}',
+        '{"id":"g"}',
+        '{"id":"h"}',
+      ]);
+
+      const result = await cp.recalibrate();
+      expect(result.l1).toEqual({ before: 8, after: 3 });
+      expect(result.memories_since_last_persona.after).toBe(3);
     });
 
     it("ignores non-shard files and missing directories", async () => {
-      await writeShard("conversations", "notes.txt", ["ignored"]);
-      // records/ dir never created
-
+      await writeShard(dataDir, "conversations", "notes.txt", ["ignored"]);
       const result = await cp.recalibrate();
-
       expect(result.l0.after).toBe(0);
       expect(result.l1.after).toBe(0);
     });
+
+    it("treats blank / whitespace-only lines as absent", async () => {
+      await writeShard(dataDir, "conversations", "2026-06-01.jsonl", ['{"a":1}', "", "  ", '{"a":2}']);
+      await writeShard(dataDir, "records", "2026-06-01.jsonl", ['{"m":1}', "\t", '{"m":2}']);
+
+      const result = await cp.recalibrate();
+      expect(result.l0.after).toBe(2);
+      expect(result.l1.after).toBe(2);
+    });
   });
 
-  describe("memory-cleaner integration", () => {
-    it("recalibrates checkpoint after automatic cleanup with a store", async () => {
+  // ─── 深入：自动 memory-cleaner ───────────────────────────────────────
+  describe("scenario: automatic memory-cleaner", () => {
+    const nowMs = Date.UTC(2026, 6, 23, 12, 0, 0); // 2026-07-23
+
+    it("recalibrates after cleaner removes expired JSONL shards (no store)", async () => {
+      await cp.markL1ExtractionComplete("s1", 30, 1);
+      for (let i = 0; i < 4; i++) {
+        await cp.captureAtomically(`s${i}`, undefined, async () => ({
+          maxTimestamp: i + 1,
+          messageCount: 1,
+        }));
+      }
+
+      await writeShard(dataDir, "conversations", "2026-07-22.jsonl", [
+        '{"id":"keep-l0-1"}',
+        '{"id":"keep-l0-2"}',
+      ]);
+      await writeShard(dataDir, "conversations", "2026-01-01.jsonl", ['{"id":"old-l0"}']);
+      await writeShard(dataDir, "records", "2026-07-22.jsonl", [
+        '{"id":"a"}',
+        '{"id":"b"}',
+        '{"id":"c"}',
+      ]);
+      await writeShard(dataDir, "records", "2026-01-01.jsonl", ['{"id":"old"}']);
+
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+      });
+      await cleaner.runOnce(nowMs);
+
+      await expect(fs.access(path.join(dataDir, "records", "2026-01-01.jsonl"))).rejects.toThrow();
+      await expect(fs.access(path.join(dataDir, "conversations", "2026-01-01.jsonl"))).rejects.toThrow();
+
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(2);
+      expect(state.total_memories_extracted).toBe(3);
+      expect(state.memories_since_last_persona).toBe(3);
+    });
+
+    it("recalibrates from live store counts after cleaner DB purge", async () => {
       await cp.markL1ExtractionComplete("s1", 40, 1);
       for (let i = 0; i < 5; i++) {
         await cp.captureAtomically(`s${i}`, undefined, async () => ({
@@ -164,16 +265,86 @@ describe("CheckpointManager.recalibrate (#157)", () => {
         }));
       }
 
-      let state = await cp.read();
-      expect(state.total_memories_extracted).toBe(40);
-      expect(state.l0_conversations_count).toBe(5);
-      expect(state.memories_since_last_persona).toBe(40);
-
-      // Fake store: cleanup left 2 L0 + 15 L1 (well above min-retain thresholds
-      // is irrelevant here — we inject post-cleanup counts via the store API).
+      let deletedL0 = 0;
+      let deletedL1 = 0;
+      // Start above min-retain so delete*Expired is actually invoked.
+      let liveL0 = 60;
+      let liveL1 = 40;
       const store = {
-        countL0: () => 2,
-        countL1: () => 15,
+        countL0: () => liveL0,
+        countL1: () => liveL1,
+        deleteL0Expired: async () => {
+          deletedL0 = 18;
+          liveL0 = 42;
+          return deletedL0;
+        },
+        deleteL1Expired: async () => {
+          deletedL1 = 25;
+          liveL1 = 15;
+          return deletedL1;
+        },
+      };
+
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+      });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+
+      expect(deletedL0).toBe(18);
+      expect(deletedL1).toBe(25);
+
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(42);
+      expect(state.total_memories_extracted).toBe(15);
+      expect(state.memories_since_last_persona).toBe(15);
+    });
+
+    it("still recalibrates when min-retain skips DB deletes (prior drift)", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        l0_conversations_count: 99,
+        total_memories_extracted: 88,
+        memories_since_last_persona: 88,
+      });
+
+      // Below MIN_RETAIN_L0(50) / MIN_RETAIN_L1(20) → deletes skipped, but
+      // recalibrate must still correct the inflated checkpoint.
+      const store = {
+        countL0: () => 12,
+        countL1: () => 8,
+        deleteL0Expired: async () => {
+          throw new Error("should not delete when below min-retain");
+        },
+        deleteL1Expired: async () => {
+          throw new Error("should not delete when below min-retain");
+        },
+      };
+
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+      });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(12);
+      expect(state.total_memories_extracted).toBe(8);
+      expect(state.memories_since_last_persona).toBe(8);
+    });
+
+    it("survives recalibration failure without aborting cleanup", async () => {
+      await writeShard(dataDir, "records", "2026-01-01.jsonl", ['{"id":"old"}']);
+
+      const store = {
+        countL0: async () => {
+          throw new Error("store unavailable");
+        },
+        countL1: async () => 0,
         deleteL0Expired: async () => 0,
         deleteL1Expired: async () => 0,
       };
@@ -185,48 +356,135 @@ describe("CheckpointManager.recalibrate (#157)", () => {
       });
       cleaner.setVectorStore(store as never);
 
-      // Use a far-future "now" so cutoff sanity checks pass with retentionDays=2.
-      const nowMs = Date.UTC(2026, 6, 23, 12, 0, 0);
-      await cleaner.runOnce(nowMs);
-
-      state = await cp.read();
-      expect(state.l0_conversations_count).toBe(2);
-      expect(state.total_memories_extracted).toBe(15);
-      expect(state.memories_since_last_persona).toBe(15);
+      // Must not throw — cleanup completes even if recalibrate blows up.
+      await expect(cleaner.runOnce(nowMs)).resolves.toBeUndefined();
+      await expect(fs.access(path.join(dataDir, "records", "2026-01-01.jsonl"))).rejects.toThrow();
     });
+  });
 
-    it("recalibrates from JSONL when cleaner runs without a store", async () => {
-      await cp.markL1ExtractionComplete("s1", 30, 1);
-
-      const recordsDir = path.join(dataDir, "records");
-      await fs.mkdir(recordsDir, { recursive: true });
-      // Keep a recent shard that survives retentionDays=2 cleanup.
-      await fs.writeFile(
-        path.join(recordsDir, "2026-07-22.jsonl"),
-        '{"id":"a"}\n{"id":"b"}\n{"id":"c"}\n',
-        "utf-8",
-      );
-      // Expired shard — cleaner should delete it.
-      await fs.writeFile(
-        path.join(recordsDir, "2026-01-01.jsonl"),
-        '{"id":"old"}\n',
-        "utf-8",
-      );
-
-      const cleaner = new LocalMemoryCleaner({
-        baseDir: dataDir,
-        retentionDays: 2,
-        cleanTime: "03:00",
+  // ─── 深入：session 重置 ─────────────────────────────────────────────
+  describe("scenario: session reset", () => {
+    it("clears one session's runner/pipeline state and recalibrates globals", async () => {
+      await cp.captureAtomically("keep", undefined, async () => ({ maxTimestamp: 10, messageCount: 2 }));
+      await cp.captureAtomically("drop", undefined, async () => ({ maxTimestamp: 20, messageCount: 3 }));
+      await cp.markL1ExtractionComplete("keep", 4, 10, "scene-keep");
+      await cp.markL1ExtractionComplete("drop", 6, 20, "scene-drop");
+      await cp.mergePipelineStates({
+        keep: {
+          conversation_count: 3,
+          last_extraction_time: "2026-07-01T00:00:00.000Z",
+          last_extraction_updated_time: "2026-07-01T00:00:00.000Z",
+          last_active_time: 10,
+          l2_pending_l1_count: 1,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+        drop: {
+          conversation_count: 9,
+          last_extraction_time: "2026-07-02T00:00:00.000Z",
+          last_extraction_updated_time: "2026-07-02T00:00:00.000Z",
+          last_active_time: 20,
+          l2_pending_l1_count: 2,
+          warmup_threshold: 2,
+          l2_last_extraction_time: "",
+        },
       });
 
-      const nowMs = Date.UTC(2026, 6, 23, 12, 0, 0); // 2026-07-23
-      await cleaner.runOnce(nowMs);
+      // Simulate wiping the dropped session's records from the store.
+      const result = await cp.resetSession("drop", fakeSource(5, 4));
+
+      expect(result.l0.after).toBe(5);
+      expect(result.l1.after).toBe(4);
+      expect(result.memories_since_last_persona.after).toBe(4);
 
       const state = await cp.read();
+      expect(state.runner_states.drop).toBeUndefined();
+      expect(state.pipeline_states.drop).toBeUndefined();
+      expect(state.runner_states.keep).toBeDefined();
+      expect(state.pipeline_states.keep.conversation_count).toBe(3);
+      expect(state.runner_states.keep.last_scene_name).toBe("scene-keep");
+      expect(state.l0_conversations_count).toBe(5);
+      expect(state.total_memories_extracted).toBe(4);
+    });
+
+    it("heals after manually deleting pipeline_states then pruning that session's JSONL", async () => {
+      // Reproduce the issue's exact path: delete test pipeline_states entries
+      // and corresponding JSONL lines — counters stay inflated until recalibrate.
+      await cp.captureAtomically("s-test", undefined, async () => ({ maxTimestamp: 1, messageCount: 1 }));
+      await cp.captureAtomically("s-prod", undefined, async () => ({ maxTimestamp: 2, messageCount: 1 }));
+      await cp.markL1ExtractionComplete("s-test", 8, 1);
+      await cp.markL1ExtractionComplete("s-prod", 42, 2);
+      await cp.mergePipelineStates({
+        "s-test": {
+          conversation_count: 5,
+          last_extraction_time: "t",
+          last_extraction_updated_time: "t",
+          last_active_time: 1,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 1,
+          l2_last_extraction_time: "",
+        },
+        "s-prod": {
+          conversation_count: 2,
+          last_extraction_time: "p",
+          last_extraction_updated_time: "p",
+          last_active_time: 2,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      });
+
+      await writeShard(dataDir, "conversations", "2026-07-20.jsonl", [
+        '{"sessionKey":"s-test","id":"t1"}',
+        '{"sessionKey":"s-test","id":"t2"}',
+        '{"sessionKey":"s-prod","id":"p1"}',
+        '{"sessionKey":"s-prod","id":"p2"}',
+        '{"sessionKey":"s-prod","id":"p3"}',
+      ]);
+      await writeShard(dataDir, "records", "2026-07-20.jsonl", [
+        '{"sessionKey":"s-test","id":"tm1"}',
+        '{"sessionKey":"s-test","id":"tm2"}',
+        '{"sessionKey":"s-prod","id":"pm1"}',
+        '{"sessionKey":"s-prod","id":"pm2"}',
+        '{"sessionKey":"s-prod","id":"pm3"}',
+      ]);
+
+      let state = await cp.read();
+      expect(state.total_memories_extracted).toBe(50); // 8 + 42
+      expect(state.l0_conversations_count).toBe(2);
+
+      // Manual: strip test session lines from JSONL + drop its pipeline state.
+      await writeShard(dataDir, "conversations", "2026-07-20.jsonl", [
+        '{"sessionKey":"s-prod","id":"p1"}',
+        '{"sessionKey":"s-prod","id":"p2"}',
+        '{"sessionKey":"s-prod","id":"p3"}',
+      ]);
+      await writeShard(dataDir, "records", "2026-07-20.jsonl", [
+        '{"sessionKey":"s-prod","id":"pm1"}',
+        '{"sessionKey":"s-prod","id":"pm2"}',
+        '{"sessionKey":"s-prod","id":"pm3"}',
+      ]);
+
+      const result = await cp.resetSession("s-test"); // JSONL fallback
+      expect(result.source).toBe("jsonl");
+      expect(result.l0.after).toBe(3);
+      expect(result.l1.after).toBe(3);
+
+      state = await cp.read();
+      expect(state.pipeline_states["s-test"]).toBeUndefined();
+      expect(state.runner_states["s-test"]).toBeUndefined();
+      expect(state.pipeline_states["s-prod"]).toBeDefined();
       expect(state.total_memories_extracted).toBe(3);
+      expect(state.l0_conversations_count).toBe(3);
       expect(state.memories_since_last_persona).toBe(3);
-      // Expired shard removed.
-      await expect(fs.access(path.join(recordsDir, "2026-01-01.jsonl"))).rejects.toThrow();
+    });
+
+    it("resetSession on unknown session still recalibrates globals", async () => {
+      await cp.markL1ExtractionComplete("s1", 10, 1);
+      const result = await cp.resetSession("never-existed", fakeSource(2, 4));
+      expect(result.l1.after).toBe(4);
+      expect((await cp.read()).total_memories_extracted).toBe(4);
     });
   });
 });

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -79,14 +79,31 @@ describe("CheckpointManager.recalibrate (#157)", () => {
     expect(result.l1.after).toBe(4);
   });
 
-  it("preserves unrelated checkpoint fields", async () => {
+  it("preserves unrelated checkpoint fields and recalibrates scenes from disk", async () => {
+    // Create one real scene file so countSceneFiles() returns 1
+    const sceneDir = path.join(dataDir, "scene_blocks");
+    await fs.mkdir(sceneDir, { recursive: true });
+    await fs.writeFile(path.join(sceneDir, "work.md"), "# Work\ncontent");
+
     await cp.markPersonaGenerated(42);
-    await cp.incrementScenesProcessed();
+    await cp.incrementScenesProcessed(); // stored = 1
     await cp.recalibrate(fakeSource(3, 3));
 
     const state = await cp.read();
-    expect(state.last_persona_at).toBe(42);
-    expect(state.scenes_processed).toBe(1);
+    expect(state.last_persona_at).toBe(42);       // unrelated field — must survive
+    expect(state.scenes_processed).toBe(1);        // 1 .md file on disk → correct
+  });
+
+  it("writes last_recalibrated_at as ISO timestamp after each recalibrate", async () => {
+    const before = (await cp.read()).last_recalibrated_at;
+    expect(before).toBe("");
+
+    const t0 = Date.now();
+    await cp.recalibrate(fakeSource(5, 10));
+    const after = (await cp.read()).last_recalibrated_at;
+
+    expect(after).not.toBe("");
+    expect(new Date(after).getTime()).toBeGreaterThanOrEqual(t0);
   });
 
   it("clamps transient bad counts (NaN/negative) to zero", async () => {
@@ -126,6 +143,169 @@ describe("CheckpointManager.recalibrate (#157)", () => {
     const result = await cp.recalibrate(fakeSource(0, 8));
     expect(result.memories_since_last_persona.after).toBe(8);
     expect((await cp.read()).memories_since_last_persona).toBe(8);
+  });
+
+  // ─── persona clamp: proportional shrink by deletion zone ───────────────
+  // Cleanup deletes the OLDEST records first. Only deletions that fall within
+  // the "since last persona" window should reduce memories_since_last_persona.
+
+  it("mixed deletion: only post-persona deletes reduce memories_since", async () => {
+    // total=50, memories_since=30 → 20 records predate last persona
+    // cleanup deletes 30 oldest: 20 pre-persona + 10 post-persona
+    // → memories_since should drop from 30 to 20, not to 0
+    await cp.write({
+      ...(await cp.read()),
+      total_memories_extracted: 50,
+      memories_since_last_persona: 30,
+    });
+    const result = await cp.recalibrate(fakeSource(0, 20));
+    expect(result.memories_since_last_persona).toEqual({ before: 30, after: 20 });
+  });
+
+  it("all deletions predate last persona: memories_since unchanged", async () => {
+    // total=50, memories_since=10 → 40 records predate last persona
+    // cleanup deletes 20 oldest (all pre-persona) → memories_since stays 10
+    await cp.write({
+      ...(await cp.read()),
+      total_memories_extracted: 50,
+      memories_since_last_persona: 10,
+    });
+    const result = await cp.recalibrate(fakeSource(0, 30));
+    expect(result.memories_since_last_persona).toEqual({ before: 10, after: 10 });
+  });
+
+  it("all deletions post-persona: memories_since decreases by deleted count", async () => {
+    // total=20, memories_since=20 → all records are post-persona
+    // cleanup deletes 10 → memories_since drops from 20 to 10
+    await cp.write({
+      ...(await cp.read()),
+      total_memories_extracted: 20,
+      memories_since_last_persona: 20,
+    });
+    const result = await cp.recalibrate(fakeSource(0, 10));
+    expect(result.memories_since_last_persona).toEqual({ before: 20, after: 10 });
+  });
+
+  // ─── floorGlobalCounters ──────────────────────────────────────────────
+  describe("floorGlobalCounters", () => {
+    it("raises total_processed and memories_since when below floor", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        total_processed: 10,
+        memories_since_last_persona: 5,
+      });
+
+      await cp.floorGlobalCounters({ total_processed: 20, memories_since_last_persona: 8 });
+
+      const state = await cp.read();
+      expect(state.total_processed).toBe(20);
+      expect(state.memories_since_last_persona).toBe(8);
+    });
+
+    it("leaves values untouched when already at or above floor", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        total_processed: 50,
+        memories_since_last_persona: 30,
+      });
+
+      await cp.floorGlobalCounters({ total_processed: 20, memories_since_last_persona: 10 });
+
+      const state = await cp.read();
+      expect(state.total_processed).toBe(50);
+      expect(state.memories_since_last_persona).toBe(30);
+    });
+
+    it("does not touch scenes_processed — recalibrate can legitimately lower it", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        scenes_processed: 7,
+        total_processed: 5,
+      });
+
+      await cp.floorGlobalCounters({ total_processed: 10, memories_since_last_persona: 0 });
+
+      // scenes_processed must be unchanged
+      expect((await cp.read()).scenes_processed).toBe(7);
+    });
+
+    it("is atomic — concurrent increment is not clobbered", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        total_processed: 5,
+        memories_since_last_persona: 3,
+      });
+
+      // Simulate race: floor and a capture increment run concurrently.
+      // The floor sees stored=5 and wants to raise to 20.
+      // The increment adds 10 (5 → 15), which is above the floor.
+      // Final value must be max(15, 20) = 20, not 15 or 5.
+      await Promise.all([
+        cp.floorGlobalCounters({ total_processed: 20, memories_since_last_persona: 3 }),
+        cp.write({ ...(await cp.read()), total_processed: 15 }),
+      ]);
+
+      const state = await cp.read();
+      // Either write could win; the invariant is that no value falls below the floor
+      expect(state.total_processed).toBeGreaterThanOrEqual(15);
+    });
+  });
+
+  // ─── scenes_processed recalibration ──────────────────────────────────
+  describe("scenes_processed", () => {
+    async function writeSceneFile(name: string): Promise<void> {
+      const dir = path.join(dataDir, "scene_blocks");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, name), `# ${name}\ncontent`);
+    }
+
+    it("sets scenes_processed to actual .md file count", async () => {
+      await writeSceneFile("work.md");
+      await writeSceneFile("travel.md");
+      await cp.write({ ...(await cp.read()), scenes_processed: 10 }); // inflated
+
+      const result = await cp.recalibrate(fakeSource(0, 0));
+      expect(result.scenes_processed).toEqual({ before: 10, after: 2 });
+      expect((await cp.read()).scenes_processed).toBe(2);
+    });
+
+    it("sets scenes_processed to 0 when scene_blocks dir is empty or absent", async () => {
+      await cp.write({ ...(await cp.read()), scenes_processed: 5 });
+
+      const result = await cp.recalibrate(fakeSource(0, 0));
+      expect(result.scenes_processed).toEqual({ before: 5, after: 0 });
+    });
+
+    it("ignores non-.md files in scene_blocks", async () => {
+      const dir = path.join(dataDir, "scene_blocks");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, "work.md"), "# Work");
+      await fs.writeFile(path.join(dir, "index.json"), "{}");
+      await fs.writeFile(path.join(dir, ".gitkeep"), "");
+
+      const result = await cp.recalibrate(fakeSource(0, 0));
+      expect(result.scenes_processed.after).toBe(1); // only work.md
+    });
+
+    it("includes scenes_processed in changed flag", async () => {
+      await writeSceneFile("work.md");
+      await cp.write({ ...(await cp.read()), scenes_processed: 5 });
+
+      const result = await cp.recalibrate(fakeSource(0, 0));
+      expect(result.changed).toBe(true);
+    });
+
+    it("persona trigger P3 re-enables after data reset clears scene files", async () => {
+      // Simulate: user had 5 scenes, wiped data, now has 1 new scene file
+      await writeSceneFile("new-context.md");
+      await cp.write({ ...(await cp.read()), scenes_processed: 5 });
+
+      await cp.recalibrate(fakeSource(0, 0));
+
+      // After recalibrate scenes_processed = 1 → P3 condition (=== 1) can fire again
+      const state = await cp.read();
+      expect(state.scenes_processed).toBe(1);
+    });
   });
 
   // ─── 深入：手动 JSONL 修剪 ───────────────────────────────────────────
@@ -362,6 +542,77 @@ describe("CheckpointManager.recalibrate (#157)", () => {
     });
   });
 
+  // ─── configurable min-retain thresholds ──────────────────────────────
+  describe("scenario: configurable minRetainL0 / minRetainL1", () => {
+    const nowMs = Date.UTC(2026, 6, 23, 12, 0, 0); // 2026-07-23 — past the retention window
+
+    function makeStore(totalL0: number, totalL1: number) {
+      return {
+        countL0: async () => totalL0,
+        countL1: async () => totalL1,
+        deleteL0Expired: vi.fn(async () => 1),
+        deleteL1Expired: vi.fn(async () => 1),
+      };
+    }
+
+    it("default thresholds: skips delete when below 50 L0 / 20 L1", async () => {
+      const store = makeStore(30, 10); // both below defaults
+      const cleaner = new LocalMemoryCleaner({ baseDir: dataDir, retentionDays: 2, cleanTime: "03:00" });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+      expect(store.deleteL0Expired).not.toHaveBeenCalled();
+      expect(store.deleteL1Expired).not.toHaveBeenCalled();
+    });
+
+    it("custom lower threshold: deletes even when count is below the default 50/20", async () => {
+      const store = makeStore(30, 10); // below default, above custom
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+        minRetainL0: 10, // custom: only skip if ≤ 10
+        minRetainL1: 5,  // custom: only skip if ≤ 5
+      });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+      expect(store.deleteL0Expired).toHaveBeenCalledOnce();
+      expect(store.deleteL1Expired).toHaveBeenCalledOnce();
+    });
+
+    it("custom higher threshold: skips delete even when count is above default", async () => {
+      const store = makeStore(80, 40); // above default 50/20, but below custom 100/50
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+        minRetainL0: 100,
+        minRetainL1: 50,
+      });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+      expect(store.deleteL0Expired).not.toHaveBeenCalled();
+      expect(store.deleteL1Expired).not.toHaveBeenCalled();
+    });
+
+    it("boundary: deletes when count is exactly one above threshold", async () => {
+      const store = makeStore(51, 21); // exactly one above defaults
+      const cleaner = new LocalMemoryCleaner({ baseDir: dataDir, retentionDays: 2, cleanTime: "03:00" });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+      expect(store.deleteL0Expired).toHaveBeenCalledOnce();
+      expect(store.deleteL1Expired).toHaveBeenCalledOnce();
+    });
+
+    it("boundary: skips when count is exactly at threshold", async () => {
+      const store = makeStore(50, 20); // exactly at defaults
+      const cleaner = new LocalMemoryCleaner({ baseDir: dataDir, retentionDays: 2, cleanTime: "03:00" });
+      cleaner.setVectorStore(store as never);
+      await cleaner.runOnce(nowMs);
+      expect(store.deleteL0Expired).not.toHaveBeenCalled();
+      expect(store.deleteL1Expired).not.toHaveBeenCalled();
+    });
+  });
+
   // ─── 深入：session 重置 ─────────────────────────────────────────────
   describe("scenario: session reset", () => {
     it("clears one session's runner/pipeline state and recalibrates globals", async () => {
@@ -485,6 +736,230 @@ describe("CheckpointManager.recalibrate (#157)", () => {
       const result = await cp.resetSession("never-existed", fakeSource(2, 4));
       expect(result.l1.after).toBe(4);
       expect((await cp.read()).total_memories_extracted).toBe(4);
+    });
+  });
+
+  // ─── detectDrift ──────────────────────────────────────────────────────────
+  describe("detectDrift", () => {
+    it("returns hasDrift=false when counters match actual data", async () => {
+      await cp.markL1ExtractionComplete("s1", 10, 1);
+      const report = await cp.detectDrift(fakeSource(1, 10));
+      expect(report.hasDrift).toBe(false);
+      expect(report.l1).toEqual({ stored: 10, actual: 10, delta: 0 });
+      expect(report.source).toBe("store");
+    });
+
+    it("returns hasDrift=true when stored > actual", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        l0_conversations_count: 50,
+        total_memories_extracted: 42,
+      });
+      const report = await cp.detectDrift(fakeSource(30, 30));
+      expect(report.hasDrift).toBe(true);
+      expect(report.l0).toEqual({ stored: 50, actual: 30, delta: 20 });
+      expect(report.l1).toEqual({ stored: 42, actual: 30, delta: 12 });
+    });
+
+    it("does not mutate the checkpoint", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        l0_conversations_count: 99,
+        total_memories_extracted: 88,
+      });
+      await cp.detectDrift(fakeSource(1, 1));
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(99);
+      expect(state.total_memories_extracted).toBe(88);
+    });
+
+    it("respects tolerance — hasDrift=false when delta within tolerance", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        l0_conversations_count: 12,
+        total_memories_extracted: 10,
+      });
+      // delta=2 for l0, delta=0 for l1 — within tolerance of 3
+      const report = await cp.detectDrift(fakeSource(10, 10), 3);
+      expect(report.hasDrift).toBe(false);
+    });
+
+    it("falls back to JSONL line counts when no source provided", async () => {
+      await writeShard(dataDir, "records", "2026-06-01.jsonl", [
+        '{"id":"a"}',
+        '{"id":"b"}',
+      ]);
+      await cp.write({
+        ...(await cp.read()),
+        total_memories_extracted: 99,
+      });
+      const report = await cp.detectDrift();
+      expect(report.source).toBe("jsonl");
+      expect(report.l1.actual).toBe(2);
+      expect(report.hasDrift).toBe(true);
+    });
+  });
+
+  // ─── drift_history ────────────────────────────────────────────────────────
+  describe("drift_history", () => {
+    it("appends an entry when recalibrate detects drift", async () => {
+      await cp.write({ ...(await cp.read()), l0_conversations_count: 5, total_memories_extracted: 10 });
+      await cp.recalibrate(fakeSource(5, 6)); // l0: 5→5 (no delta); l1: stored=10 actual=6 → delta=4
+
+      const state = await cp.read();
+      expect(state.drift_history).toHaveLength(1);
+      expect(state.drift_history[0].l1_delta).toBe(4);
+      expect(state.drift_history[0].l0_delta).toBe(0);
+      expect(new Date(state.drift_history[0].at).getTime()).toBeGreaterThan(0);
+    });
+
+    it("does not append when recalibrate finds no drift", async () => {
+      await cp.write({ ...(await cp.read()), l0_conversations_count: 3, total_memories_extracted: 5 });
+      // source matches stored values exactly → no drift
+      await cp.recalibrate(fakeSource(3, 5));
+
+      const state = await cp.read();
+      expect(state.drift_history).toHaveLength(0);
+    });
+
+    it("records l0 and l1 deltas independently", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        l0_conversations_count: 20,
+        total_memories_extracted: 30,
+      });
+      await cp.recalibrate(fakeSource(15, 25));
+
+      const entry = (await cp.read()).drift_history[0];
+      expect(entry.l0_delta).toBe(5);  // 20 - 15
+      expect(entry.l1_delta).toBe(5);  // 30 - 25
+    });
+
+    it("caps at DRIFT_HISTORY_MAX (10) and evicts oldest on overflow", async () => {
+      // Run 12 recalibrates that each detect drift (stored > actual)
+      for (let i = 12; i >= 1; i--) {
+        await cp.write({
+          ...(await cp.read()),
+          total_memories_extracted: i + 1,
+        });
+        await cp.recalibrate(fakeSource(0, 1));
+      }
+
+      const history = (await cp.read()).drift_history;
+      expect(history).toHaveLength(10);
+      // Most recent entry: stored was 2, actual=1, delta=1
+      expect(history[history.length - 1].l1_delta).toBe(1);
+    });
+
+    it("entries are ordered oldest-first", async () => {
+      for (let stored = 5; stored >= 3; stored--) {
+        await cp.write({ ...(await cp.read()), total_memories_extracted: stored });
+        await cp.recalibrate(fakeSource(0, 1));
+      }
+
+      const history = (await cp.read()).drift_history;
+      expect(history).toHaveLength(3);
+      // Deltas should be 4, 3, 2 in chronological order
+      expect(history[0].l1_delta).toBe(4);
+      expect(history[1].l1_delta).toBe(3);
+      expect(history[2].l1_delta).toBe(2);
+    });
+
+    it("tolerates missing drift_history field in old checkpoint files", async () => {
+      // Simulate an old checkpoint written before drift_history existed
+      await cp.write({ ...(await cp.read()), total_memories_extracted: 10 } as never);
+      // Manually strip the field by writing raw JSON
+      const rawPath = (cp as never)["filePath"] as string;
+      const raw = JSON.parse(await import("node:fs/promises").then(fs => fs.readFile(rawPath, "utf-8")));
+      delete raw.drift_history;
+      await import("node:fs/promises").then(fs => fs.writeFile(rawPath, JSON.stringify(raw)));
+
+      // recalibrate must not throw and must initialise drift_history
+      await expect(cp.recalibrate(fakeSource(0, 5))).resolves.toBeDefined();
+      const state = await cp.read();
+      expect(Array.isArray(state.drift_history)).toBe(true);
+    });
+  });
+
+  // ─── concurrency ──────────────────────────────────────────────────────────
+  describe("concurrent recalibrate", () => {
+    it("two simultaneous recalibrates produce a valid final state (no corruption)", async () => {
+      await cp.markL1ExtractionComplete("s1", 50, 1);
+
+      // Both read their counts before either acquires the write lock —
+      // the classic TOCTOU window. The lock serializes the writes, so the
+      // final checkpoint must equal one of the two valid snapshots.
+      const [r1, r2] = await Promise.all([
+        cp.recalibrate(fakeSource(10, 20)),
+        cp.recalibrate(fakeSource(10, 20)),
+      ]);
+
+      // Both calls must complete without throwing
+      expect(r1).toBeDefined();
+      expect(r2).toBeDefined();
+
+      const state = await cp.read();
+      // Counters must be a coherent snapshot — not a partial mix of two writes
+      expect(state.l0_conversations_count).toBe(10);
+      expect(state.total_memories_extracted).toBe(20);
+    });
+
+    it("recalibrate and markL1ExtractionComplete interleaved — no write lost", async () => {
+      // Seed 5 extractions, then race a recalibrate (says l1=3) against
+      // another extraction (adds 2 more). The file lock ensures the writes
+      // are serial; neither clobbers the other's unrelated fields.
+      await cp.markL1ExtractionComplete("s1", 5, 1);
+
+      await Promise.all([
+        cp.recalibrate(fakeSource(1, 3)),
+        cp.markL1ExtractionComplete("s1", 2, 1), // +2 on top of whatever is there
+      ]);
+
+      const state = await cp.read();
+      // total_memories_extracted is either 3 (recalibrate last) or 5 (mark last)
+      // — both are valid. What must NOT happen is corruption (NaN, undefined, negative).
+      expect(Number.isInteger(state.total_memories_extracted)).toBe(true);
+      expect(state.total_memories_extracted).toBeGreaterThanOrEqual(0);
+      // last_recalibrated_at must be a valid ISO string (recalibrate ran)
+      expect(new Date(state.last_recalibrated_at).getTime()).toBeGreaterThan(0);
+    });
+
+    it("recalibrate is idempotent — running it N times with same source converges", async () => {
+      await cp.markL1ExtractionComplete("s1", 99, 1);
+
+      // Run 5 sequential recalibrates with the same source
+      for (let i = 0; i < 5; i++) {
+        await cp.recalibrate(fakeSource(7, 42));
+      }
+
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(7);
+      expect(state.total_memories_extracted).toBe(42);
+    });
+
+    it("concurrent detectDrift calls all return the same snapshot", async () => {
+      await cp.write({
+        ...(await cp.read()),
+        l0_conversations_count: 30,
+        total_memories_extracted: 25,
+      });
+
+      const reports = await Promise.all([
+        cp.detectDrift(fakeSource(20, 20)),
+        cp.detectDrift(fakeSource(20, 20)),
+        cp.detectDrift(fakeSource(20, 20)),
+      ]);
+
+      // detectDrift is read-only — all three must agree on the stored values
+      for (const r of reports) {
+        expect(r.l0.stored).toBe(30);
+        expect(r.l1.stored).toBe(25);
+        expect(r.hasDrift).toBe(true);
+      }
+      // Checkpoint must be unchanged
+      const state = await cp.read();
+      expect(state.l0_conversations_count).toBe(30);
+      expect(state.total_memories_extracted).toBe(25);
     });
   });
 });

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { CheckpointManager, type RecalibrationSource } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+/** In-memory fake store returning fixed live counts. */
+function fakeSource(l0: number, l1: number): RecalibrationSource {
+  return {
+    countL0: () => l0,
+    countL1: () => l1,
+  };
+}
+
+describe("CheckpointManager.recalibrate (#157)", () => {
+  let dataDir: string;
+  let cp: CheckpointManager;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-ckpt-"));
+    cp = new CheckpointManager(dataDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("resets inflated counters down to live store counts", async () => {
+    await cp.captureAtomically("s1", undefined, async () => ({ maxTimestamp: 100, messageCount: 1 }));
+    await cp.captureAtomically("s1", 0, async () => ({ maxTimestamp: 200, messageCount: 1 }));
+    await cp.markL1ExtractionComplete("s1", 10, 200);
+
+    let state = await cp.read();
+    expect(state.l0_conversations_count).toBe(2);
+    expect(state.total_memories_extracted).toBe(10);
+
+    // Store now only has 1 L0 and 3 L1 (cleanup happened).
+    const result = await cp.recalibrate(fakeSource(1, 3));
+
+    expect(result.source).toBe("store");
+    expect(result.changed).toBe(true);
+    expect(result.l0).toEqual({ before: 2, after: 1 });
+    expect(result.l1).toEqual({ before: 10, after: 3 });
+
+    state = await cp.read();
+    expect(state.l0_conversations_count).toBe(1);
+    expect(state.total_memories_extracted).toBe(3);
+  });
+
+  it("is idempotent when counts already match (no drift)", async () => {
+    await cp.recalibrate(fakeSource(5, 7));
+    const result = await cp.recalibrate(fakeSource(5, 7));
+
+    expect(result.changed).toBe(false);
+    expect(result.l0).toEqual({ before: 5, after: 5 });
+    expect(result.l1).toEqual({ before: 7, after: 7 });
+  });
+
+  it("counts increase as well as decrease (self-correcting in both directions)", async () => {
+    await cp.recalibrate(fakeSource(1, 1));
+    const result = await cp.recalibrate(fakeSource(9, 4));
+
+    expect(result.changed).toBe(true);
+    expect(result.l0.after).toBe(9);
+    expect(result.l1.after).toBe(4);
+  });
+
+  it("preserves unrelated checkpoint fields", async () => {
+    await cp.markPersonaGenerated(42);
+    await cp.incrementScenesProcessed();
+    await cp.recalibrate(fakeSource(3, 3));
+
+    const state = await cp.read();
+    expect(state.last_persona_at).toBe(42);
+    expect(state.scenes_processed).toBe(1);
+  });
+
+  it("clamps transient bad counts (NaN/negative) to zero", async () => {
+    await cp.recalibrate(fakeSource(5, 5));
+    const result = await cp.recalibrate({
+      countL0: () => Number.NaN,
+      countL1: () => -3,
+    });
+
+    expect(result.l0.after).toBe(0);
+    expect(result.l1.after).toBe(0);
+  });
+
+  it("shrinks memories_since_last_persona with L1 so persona is not triggered early", async () => {
+    // 12 memories extracted since last persona; cleanup removes 5 → 7 remain.
+    await cp.markL1ExtractionComplete("s1", 12, 100);
+    let state = await cp.read();
+    expect(state.memories_since_last_persona).toBe(12);
+    expect(state.total_memories_extracted).toBe(12);
+
+    const result = await cp.recalibrate(fakeSource(0, 7));
+
+    expect(result.l1).toEqual({ before: 12, after: 7 });
+    expect(result.memories_since_last_persona).toEqual({ before: 12, after: 7 });
+
+    state = await cp.read();
+    expect(state.memories_since_last_persona).toBe(7);
+    expect(state.total_memories_extracted).toBe(7);
+  });
+
+  it("clamps memories_since_last_persona to the new L1 ceiling", async () => {
+    // Interval somehow exceeds total (corrupt / partial reset) — clamp to L1.
+    await cp.write({
+      ...(await cp.read()),
+      total_memories_extracted: 20,
+      memories_since_last_persona: 50,
+    });
+
+    const result = await cp.recalibrate(fakeSource(0, 8));
+    expect(result.memories_since_last_persona.after).toBe(8);
+    expect((await cp.read()).memories_since_last_persona).toBe(8);
+  });
+
+  describe("JSONL fallback (degraded mode, no store)", () => {
+    async function writeShard(subDir: string, name: string, lines: string[]): Promise<void> {
+      const dir = path.join(dataDir, subDir);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, name), lines.join("\n"), "utf-8");
+    }
+
+    it("counts non-empty lines across daily shards after manual prune", async () => {
+      // Inflate counters first (simulates pre-cleanup drift).
+      await cp.markL1ExtractionComplete("s1", 50, 1);
+      await cp.captureAtomically("s1", undefined, async () => ({ maxTimestamp: 1, messageCount: 1 }));
+      await cp.captureAtomically("s1", 0, async () => ({ maxTimestamp: 2, messageCount: 1 }));
+
+      await writeShard("conversations", "2026-06-01.jsonl", ['{"a":1}', '{"a":2}', ""]);
+      await writeShard("conversations", "2026-06-02.jsonl", ['{"a":3}']);
+      await writeShard("records", "2026-06-01.jsonl", ['{"m":1}', "  ", '{"m":2}']);
+
+      const result = await cp.recalibrate();
+
+      expect(result.source).toBe("jsonl");
+      expect(result.l0.after).toBe(3); // 2 + 1, blank line ignored
+      expect(result.l1.after).toBe(2); // whitespace-only line ignored
+      expect(result.changed).toBe(true);
+    });
+
+    it("ignores non-shard files and missing directories", async () => {
+      await writeShard("conversations", "notes.txt", ["ignored"]);
+      // records/ dir never created
+
+      const result = await cp.recalibrate();
+
+      expect(result.l0.after).toBe(0);
+      expect(result.l1.after).toBe(0);
+    });
+  });
+
+  describe("memory-cleaner integration", () => {
+    it("recalibrates checkpoint after automatic cleanup with a store", async () => {
+      await cp.markL1ExtractionComplete("s1", 40, 1);
+      for (let i = 0; i < 5; i++) {
+        await cp.captureAtomically(`s${i}`, undefined, async () => ({
+          maxTimestamp: i + 1,
+          messageCount: 1,
+        }));
+      }
+
+      let state = await cp.read();
+      expect(state.total_memories_extracted).toBe(40);
+      expect(state.l0_conversations_count).toBe(5);
+      expect(state.memories_since_last_persona).toBe(40);
+
+      // Fake store: cleanup left 2 L0 + 15 L1 (well above min-retain thresholds
+      // is irrelevant here — we inject post-cleanup counts via the store API).
+      const store = {
+        countL0: () => 2,
+        countL1: () => 15,
+        deleteL0Expired: async () => 0,
+        deleteL1Expired: async () => 0,
+      };
+
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+      });
+      cleaner.setVectorStore(store as never);
+
+      // Use a far-future "now" so cutoff sanity checks pass with retentionDays=2.
+      const nowMs = Date.UTC(2026, 6, 23, 12, 0, 0);
+      await cleaner.runOnce(nowMs);
+
+      state = await cp.read();
+      expect(state.l0_conversations_count).toBe(2);
+      expect(state.total_memories_extracted).toBe(15);
+      expect(state.memories_since_last_persona).toBe(15);
+    });
+
+    it("recalibrates from JSONL when cleaner runs without a store", async () => {
+      await cp.markL1ExtractionComplete("s1", 30, 1);
+
+      const recordsDir = path.join(dataDir, "records");
+      await fs.mkdir(recordsDir, { recursive: true });
+      // Keep a recent shard that survives retentionDays=2 cleanup.
+      await fs.writeFile(
+        path.join(recordsDir, "2026-07-22.jsonl"),
+        '{"id":"a"}\n{"id":"b"}\n{"id":"c"}\n',
+        "utf-8",
+      );
+      // Expired shard — cleaner should delete it.
+      await fs.writeFile(
+        path.join(recordsDir, "2026-01-01.jsonl"),
+        '{"id":"old"}\n',
+        "utf-8",
+      );
+
+      const cleaner = new LocalMemoryCleaner({
+        baseDir: dataDir,
+        retentionDays: 2,
+        cleanTime: "03:00",
+      });
+
+      const nowMs = Date.UTC(2026, 6, 23, 12, 0, 0); // 2026-07-23
+      await cleaner.runOnce(nowMs);
+
+      const state = await cp.read();
+      expect(state.total_memories_extracted).toBe(3);
+      expect(state.memories_since_last_persona).toBe(3);
+      // Expired shard removed.
+      await expect(fs.access(path.join(recordsDir, "2026-01-01.jsonl"))).rejects.toThrow();
+    });
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -620,6 +620,30 @@ export class CheckpointManager {
   }
 
   /**
+   * Drop per-session runner/pipeline state for one session, then recalibrate
+   * global counters against remaining data.
+   *
+   * Use after wiping a session's L0/L1 records (test teardown, `/reset`, or
+   * manual JSONL pruning for a single sessionKey). Without this, deleting
+   * `pipeline_states[session]` leaves global totals inflated — the exact
+   * drift path described in #157.
+   *
+   * @param sessionKey Session to clear from `runner_states` / `pipeline_states`
+   * @param source Optional live store; omit for JSONL fallback
+   */
+  async resetSession(
+    sessionKey: string,
+    source?: RecalibrationSource,
+  ): Promise<RecalibrateResult> {
+    await this.mutate((cp) => {
+      if (cp.runner_states) delete cp.runner_states[sessionKey];
+      if (cp.pipeline_states) delete cp.pipeline_states[sessionKey];
+    });
+    this.logger.info(`[checkpoint] resetSession: cleared state for session=${sessionKey}`);
+    return this.recalibrate(source);
+  }
+
+  /**
    * Count non-empty lines across daily `YYYY-MM-DD.jsonl|.json` shards in a
    * subdirectory of the plugin data dir. Used as the degraded-mode fallback
    * when no live store is available.

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -106,6 +106,17 @@ export interface Checkpoint {
   // ═══ L1 ═══
   /** Total L1 memories extracted across all time */
   total_memories_extracted: number;
+
+  // ═══ Recalibration audit ═══
+  /** ISO timestamp of the last successful recalibrate() call. Empty string when never run. */
+  last_recalibrated_at: string;
+  /**
+   * Rolling history of recalibrate() runs that detected drift (changed=true).
+   * Capped at DRIFT_HISTORY_MAX entries; oldest entry is evicted when full.
+   * Lets operators distinguish "normal post-cleanup drift of ~20" from
+   * "sudden spike of 500 records" without digging through logs.
+   */
+  drift_history: Array<{ at: string; l0_delta: number; l1_delta: number }>;
 }
 
 const DEFAULT_RUNNER_STATE: RunnerSessionState = {
@@ -137,6 +148,8 @@ const DEFAULT_CHECKPOINT: Checkpoint = {
   pipeline_states: {},
   l0_conversations_count: 0,
   total_memories_extracted: 0,
+  last_recalibrated_at: "",
+  drift_history: [],
 };
 
 export interface CheckpointLogger {
@@ -161,10 +174,33 @@ export interface RecalibrateResult {
   l1: { before: number; after: number };
   /** Persona-interval counter — clamped when L1 shrinks after cleanup. */
   memories_since_last_persona: { before: number; after: number };
+  /**
+   * Number of scene-block files found on disk. Recalibrated from the
+   * filesystem regardless of `source` — scene files are never stored in
+   * the vector store.
+   *
+   * Note: `total_processed` (message-capture counter) is intentionally NOT
+   * recalibrated — it is a monotonic epoch used as `last_persona_at` and
+   * changing it would corrupt the relative marker semantics.
+   */
+  scenes_processed: { before: number; after: number };
   /** "store" when live store counts were used; "jsonl" for daily-shard line counts. */
   source: "store" | "jsonl";
   /** True when any reconciled field actually changed. */
   changed: boolean;
+}
+
+/** Maximum number of entries retained in `drift_history`. */
+const DRIFT_HISTORY_MAX = 10;
+
+/** Read-only drift snapshot — does not mutate the checkpoint. */
+export interface DriftReport {
+  l0: { stored: number; actual: number; delta: number };
+  l1: { stored: number; actual: number; delta: number };
+  /** "store" when live store counts were used; "jsonl" for daily-shard line counts. */
+  source: "store" | "jsonl";
+  /** True when any counter overstates actual data by more than `tolerance`. */
+  hasDrift: boolean;
 }
 
 const noopLogger: CheckpointLogger = { info() {} };
@@ -350,6 +386,30 @@ export class CheckpointManager {
     });
   }
 
+  /**
+   * Atomically raise any global counter that has fallen below a known-good
+   * floor value. Used by the L2 runner to guard against race-condition
+   * counter rollback without resorting to a full `checkpoint.write()` that
+   * would clobber concurrent increments.
+   *
+   * Only `total_processed` and `memories_since_last_persona` are covered —
+   * `scenes_processed` is intentionally excluded because `recalibrate()` can
+   * legitimately lower it when scene files are deleted.
+   */
+  async floorGlobalCounters(floors: {
+    total_processed: number;
+    memories_since_last_persona: number;
+  }): Promise<void> {
+    await this.mutate((cp) => {
+      if (cp.total_processed < floors.total_processed) {
+        cp.total_processed = floors.total_processed;
+      }
+      if (cp.memories_since_last_persona < floors.memories_since_last_persona) {
+        cp.memories_since_last_persona = floors.memories_since_last_persona;
+      }
+    });
+  }
+
   async incrementScenesProcessed(): Promise<void> {
     const cp = await this.mutate((cp) => {
       cp.scenes_processed += 1;
@@ -511,6 +571,61 @@ export class CheckpointManager {
   }
 
   // ============================
+  // Drift detection (read-only) — issue #157
+  // ============================
+
+  /**
+   * Compare stored counters against live data without mutating anything.
+   *
+   * Use this for health-checks or periodic monitoring. When drift is detected
+   * (`hasDrift === true`), call `recalibrate()` to correct it.
+   *
+   * @param source Optional live-count provider. Omit to use JSONL fallback.
+   * @param tolerance Maximum allowed overcount before `hasDrift` is set.
+   *   Defaults to 0 (any overcount is reported).
+   */
+  async detectDrift(source?: RecalibrationSource, tolerance = 0): Promise<DriftReport> {
+    let l0Actual: number;
+    let l1Actual: number;
+    let usedSource: "store" | "jsonl";
+
+    if (source) {
+      l0Actual = await source.countL0();
+      l1Actual = await source.countL1();
+      usedSource = "store";
+    } else {
+      l0Actual = await this.countJsonlLines("conversations");
+      l1Actual = await this.countJsonlLines("records");
+      usedSource = "jsonl";
+    }
+
+    l0Actual = Number.isFinite(l0Actual) && l0Actual >= 0 ? Math.floor(l0Actual) : 0;
+    l1Actual = Number.isFinite(l1Actual) && l1Actual >= 0 ? Math.floor(l1Actual) : 0;
+
+    const cp = await this.read();
+    const l0Delta = cp.l0_conversations_count - l0Actual;
+    const l1Delta = cp.total_memories_extracted - l1Actual;
+    const hasDrift = l0Delta > tolerance || l1Delta > tolerance;
+
+    const report: DriftReport = {
+      l0: { stored: cp.l0_conversations_count, actual: l0Actual, delta: l0Delta },
+      l1: { stored: cp.total_memories_extracted, actual: l1Actual, delta: l1Delta },
+      source: usedSource,
+      hasDrift,
+    };
+
+    if (hasDrift) {
+      this.logger.warn?.(
+        `[checkpoint] drift detected (source=${usedSource}): ` +
+        `l0 stored=${report.l0.stored} actual=${report.l0.actual} delta=${l0Delta}, ` +
+        `l1 stored=${report.l1.stored} actual=${report.l1.actual} delta=${l1Delta}`,
+      );
+    }
+
+    return report;
+  }
+
+  // ============================
   // Recalibration (drift correction) — issue #157
   // ============================
 
@@ -556,6 +671,10 @@ export class CheckpointManager {
       usedSource = "jsonl";
     }
 
+    // scenes_processed is always counted from the filesystem — scene files are
+    // never stored in the vector store, so there is no store-backed alternative.
+    const scenesTrue = await this.countSceneFiles();
+
     // Guard against transient failures returning nonsense (NaN / negatives).
     l0True = Number.isFinite(l0True) && l0True >= 0 ? Math.floor(l0True) : 0;
     l1True = Number.isFinite(l1True) && l1True >= 0 ? Math.floor(l1True) : 0;
@@ -564,28 +683,66 @@ export class CheckpointManager {
       l0: 0,
       l1: 0,
       memories_since_last_persona: 0,
+      scenes_processed: 0,
     };
     let afterPersona = 0;
+    let afterScenes = 0;
 
     await this.mutate((cp) => {
       before = {
         l0: cp.l0_conversations_count,
         l1: cp.total_memories_extracted,
         memories_since_last_persona: cp.memories_since_last_persona,
+        scenes_processed: cp.scenes_processed,
       };
 
       cp.l0_conversations_count = l0True;
       cp.total_memories_extracted = l1True;
+      cp.scenes_processed = scenesTrue;
 
-      // Shrink the persona interval with L1, then clamp to the new ceiling.
+      // Shrink memories_since_last_persona proportionally when L1 shrinks.
+      //
+      // Cleanup always removes the OLDEST records first (time-based retention).
+      // Of the deleted records, only those that post-date the last persona
+      // generation reduce the interval; pre-persona deletions are irrelevant.
+      //
+      // Example: total=50, memories_since=30 (newest 30 are "since persona"),
+      //   cleanup deletes 30 oldest → 20 pre-persona + 10 post-persona deleted
+      //   → memories_since should drop from 30 to 20, not to 0.
+      //
+      // Formula:
+      //   deletedCount        = before.l1 - l1True
+      //   beforePersonaCount  = before.l1 - persona   (records pre-dating last persona)
+      //   deletedBeforePersona= min(deletedCount, max(0, beforePersonaCount))
+      //   deletedSincePersona = deletedCount - deletedBeforePersona
+      //   new persona         = max(0, persona - deletedSincePersona)
       let persona = cp.memories_since_last_persona;
       if (l1True < before.l1) {
-        persona = Math.max(0, persona - (before.l1 - l1True));
+        const deletedCount = before.l1 - l1True;
+        const beforePersonaCount = Math.max(0, before.l1 - persona);
+        const deletedBeforePersona = Math.min(deletedCount, beforePersonaCount);
+        const deletedSincePersona = deletedCount - deletedBeforePersona;
+        persona = Math.max(0, persona - deletedSincePersona);
       }
       persona = Math.min(persona, l1True);
       if (!Number.isFinite(persona) || persona < 0) persona = 0;
       cp.memories_since_last_persona = Math.floor(persona);
       afterPersona = cp.memories_since_last_persona;
+      afterScenes = cp.scenes_processed;
+
+      const now = new Date().toISOString();
+      cp.last_recalibrated_at = now;
+
+      // Append to drift_history only when something actually changed.
+      const l0Delta = before.l0 - l0True;
+      const l1Delta = before.l1 - l1True;
+      if (l0Delta !== 0 || l1Delta !== 0) {
+        if (!Array.isArray(cp.drift_history)) cp.drift_history = [];
+        cp.drift_history.push({ at: now, l0_delta: l0Delta, l1_delta: l1Delta });
+        if (cp.drift_history.length > DRIFT_HISTORY_MAX) {
+          cp.drift_history.splice(0, cp.drift_history.length - DRIFT_HISTORY_MAX);
+        }
+      }
     });
 
     const result: RecalibrateResult = {
@@ -595,11 +752,16 @@ export class CheckpointManager {
         before: before.memories_since_last_persona,
         after: afterPersona,
       },
+      scenes_processed: {
+        before: before.scenes_processed,
+        after: afterScenes,
+      },
       source: usedSource,
       changed:
         before.l0 !== l0True
         || before.l1 !== l1True
-        || before.memories_since_last_persona !== afterPersona,
+        || before.memories_since_last_persona !== afterPersona
+        || before.scenes_processed !== afterScenes,
     };
 
     if (result.changed) {
@@ -607,13 +769,15 @@ export class CheckpointManager {
         `[checkpoint] recalibrate (source=${usedSource}): ` +
         `l0 ${result.l0.before}→${result.l0.after}, ` +
         `l1 ${result.l1.before}→${result.l1.after}, ` +
-        `memories_since_last_persona ${result.memories_since_last_persona.before}→${result.memories_since_last_persona.after}`,
+        `memories_since_last_persona ${result.memories_since_last_persona.before}→${result.memories_since_last_persona.after}, ` +
+        `scenes_processed ${result.scenes_processed.before}→${result.scenes_processed.after}`,
       );
     } else {
       this.logger.info(
         `[checkpoint] recalibrate (source=${usedSource}): no drift ` +
         `(l0=${result.l0.after}, l1=${result.l1.after}, ` +
-        `memories_since_last_persona=${result.memories_since_last_persona.after})`,
+        `memories_since_last_persona=${result.memories_since_last_persona.after}, ` +
+        `scenes_processed=${result.scenes_processed.after})`,
       );
     }
     return result;
@@ -674,6 +838,22 @@ export class CheckpointManager {
       }
     }
     return total;
+  }
+
+  /**
+   * Count `.md` files in `scene_blocks/` as the source of truth for
+   * `scenes_processed`. Scene files live only on the filesystem — there is
+   * no store-backed count — so this always reads the directory directly.
+   */
+  private async countSceneFiles(): Promise<number> {
+    const dirPath = path.join(this.dataDir, "scene_blocks");
+    let entries;
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+    return entries.filter((e) => e.isFile() && e.name.endsWith(".md")).length;
   }
 
 }

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -144,6 +144,29 @@ export interface CheckpointLogger {
   warn?(msg: string): void;
 }
 
+/**
+ * Minimal view of the memory store needed for recalibration.
+ * Structural (no IMemoryStore import) so checkpoint.ts stays free of store-layer
+ * deps and unit tests can pass a tiny fake.
+ */
+export interface RecalibrationSource {
+  /** Live count of L0 conversation records (messages in `l0_conversations`). */
+  countL0(): number | Promise<number>;
+  /** Live count of L1 memory records. */
+  countL1(): number | Promise<number>;
+}
+
+export interface RecalibrateResult {
+  l0: { before: number; after: number };
+  l1: { before: number; after: number };
+  /** Persona-interval counter — clamped when L1 shrinks after cleanup. */
+  memories_since_last_persona: { before: number; after: number };
+  /** "store" when live store counts were used; "jsonl" for daily-shard line counts. */
+  source: "store" | "jsonl";
+  /** True when any reconciled field actually changed. */
+  changed: boolean;
+}
+
 const noopLogger: CheckpointLogger = { info() {} };
 
 // ============================
@@ -179,10 +202,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -483,6 +508,148 @@ export class CheckpointManager {
         cp.l0_conversations_count += 1;
       }
     });
+  }
+
+  // ============================
+  // Recalibration (drift correction) — issue #157
+  // ============================
+
+  /**
+   * Reconcile increment-only counters against reality.
+   *
+   * ## Why
+   * `l0_conversations_count` and `total_memories_extracted` only ever grow
+   * (`captureAtomically` / `markL1ExtractionComplete`). memory-cleaner (and
+   * manual JSONL pruning) delete records without updating the checkpoint, so
+   * counters permanently overstate how much data exists. Inflated values skew
+   * status reporting and L2/L3 persona thresholds (`memories_since_last_persona`).
+   *
+   * ## Source of truth
+   * Prefer the live store (`countL0` / `countL1`) — the same queries the cleaner
+   * uses. When no store is available (degraded mode), fall back to counting
+   * non-empty lines in `conversations/` and `records/` daily JSONL shards.
+   *
+   * ## Persona clamp
+   * When L1 shrinks, `memories_since_last_persona` is reduced by the same delta
+   * (floored at 0) and never allowed to exceed the new L1 total. This stops
+   * cleanup from leaving a stale interval that would prematurely trigger persona
+   * generation — a gap many naive recalibrate patches miss.
+   *
+   * Idempotent and lock-safe (write goes through `mutate`). Count resolution
+   * happens *outside* the lock so slow store/FS I/O does not block other writers.
+   *
+   * @param source Optional live-count provider (typically the vector store).
+   *   Omit to force the JSONL fallback.
+   */
+  async recalibrate(source?: RecalibrationSource): Promise<RecalibrateResult> {
+    let l0True: number;
+    let l1True: number;
+    let usedSource: "store" | "jsonl";
+
+    if (source) {
+      l0True = await source.countL0();
+      l1True = await source.countL1();
+      usedSource = "store";
+    } else {
+      l0True = await this.countJsonlLines("conversations");
+      l1True = await this.countJsonlLines("records");
+      usedSource = "jsonl";
+    }
+
+    // Guard against transient failures returning nonsense (NaN / negatives).
+    l0True = Number.isFinite(l0True) && l0True >= 0 ? Math.floor(l0True) : 0;
+    l1True = Number.isFinite(l1True) && l1True >= 0 ? Math.floor(l1True) : 0;
+
+    let before = {
+      l0: 0,
+      l1: 0,
+      memories_since_last_persona: 0,
+    };
+    let afterPersona = 0;
+
+    await this.mutate((cp) => {
+      before = {
+        l0: cp.l0_conversations_count,
+        l1: cp.total_memories_extracted,
+        memories_since_last_persona: cp.memories_since_last_persona,
+      };
+
+      cp.l0_conversations_count = l0True;
+      cp.total_memories_extracted = l1True;
+
+      // Shrink the persona interval with L1, then clamp to the new ceiling.
+      let persona = cp.memories_since_last_persona;
+      if (l1True < before.l1) {
+        persona = Math.max(0, persona - (before.l1 - l1True));
+      }
+      persona = Math.min(persona, l1True);
+      if (!Number.isFinite(persona) || persona < 0) persona = 0;
+      cp.memories_since_last_persona = Math.floor(persona);
+      afterPersona = cp.memories_since_last_persona;
+    });
+
+    const result: RecalibrateResult = {
+      l0: { before: before.l0, after: l0True },
+      l1: { before: before.l1, after: l1True },
+      memories_since_last_persona: {
+        before: before.memories_since_last_persona,
+        after: afterPersona,
+      },
+      source: usedSource,
+      changed:
+        before.l0 !== l0True
+        || before.l1 !== l1True
+        || before.memories_since_last_persona !== afterPersona,
+    };
+
+    if (result.changed) {
+      this.logger.info(
+        `[checkpoint] recalibrate (source=${usedSource}): ` +
+        `l0 ${result.l0.before}→${result.l0.after}, ` +
+        `l1 ${result.l1.before}→${result.l1.after}, ` +
+        `memories_since_last_persona ${result.memories_since_last_persona.before}→${result.memories_since_last_persona.after}`,
+      );
+    } else {
+      this.logger.info(
+        `[checkpoint] recalibrate (source=${usedSource}): no drift ` +
+        `(l0=${result.l0.after}, l1=${result.l1.after}, ` +
+        `memories_since_last_persona=${result.memories_since_last_persona.after})`,
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Count non-empty lines across daily `YYYY-MM-DD.jsonl|.json` shards in a
+   * subdirectory of the plugin data dir. Used as the degraded-mode fallback
+   * when no live store is available.
+   */
+  private async countJsonlLines(subDir: string): Promise<number> {
+    const dirPath = path.join(this.dataDir, subDir);
+    let entries;
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    let total = 0;
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      // Match memory-cleaner shard naming: YYYY-MM-DD.jsonl | YYYY-MM-DD.json
+      if (!/^\d{4}-\d{2}-\d{2}\.(?:jsonl|json)$/.test(entry.name)) continue;
+
+      let raw: string;
+      try {
+        raw = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+      } catch {
+        continue;
+      }
+      for (const line of raw.split("\n")) {
+        if (line.trim().length > 0) total += 1;
+      }
+    }
+    return total;
   }
 
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -178,6 +179,32 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    // Reconcile increment-only checkpoint counters after cleanup (#157).
+    // Prefer the live store (same source the cleaner just mutated); fall back
+    // to JSONL line counts when no store is wired (JSONL-only cleanup).
+    // Non-fatal: never fail the cleanup run because of checkpoint drift.
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, {
+        info: (msg) => this.opts.logger?.info(msg),
+        warn: (msg) => this.opts.logger?.warn?.(msg),
+      });
+      const result = this.vectorStore
+        ? await checkpoint.recalibrate(this.vectorStore)
+        : await checkpoint.recalibrate();
+      if (result.changed) {
+        this.opts.logger?.info(
+          `${TAG} Checkpoint recalibrated after cleanup (source=${result.source}): ` +
+          `l0 ${result.l0.before}→${result.l0.after}, ` +
+          `l1 ${result.l1.before}→${result.l1.after}, ` +
+          `memories_since_last_persona ${result.memories_since_last_persona.before}→${result.memories_since_last_persona.after}`,
+        );
+      }
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -13,6 +13,17 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  /**
+   * Skip L0 deletion when the total count is at or below this threshold.
+   * Prevents wiping data entirely on low-volume deployments.
+   * Defaults to 50.
+   */
+  minRetainL0?: number;
+  /**
+   * Skip L1 deletion when the total count is at or below this threshold.
+   * Defaults to 20.
+   */
+  minRetainL1?: number;
 }
 
 interface CleanupStats {
@@ -26,17 +37,21 @@ const TAG = "[memory-tdai][cleaner]";
 const L0_DIR_NAME = "conversations";
 const L1_DIR_NAME = "records";
 
-/** Minimum records to retain — skip deletion if total is at or below this threshold. */
-const MIN_RETAIN_L0 = 50;
-const MIN_RETAIN_L1 = 20;
+const DEFAULT_MIN_RETAIN_L0 = 50;
+const DEFAULT_MIN_RETAIN_L1 = 20;
 
 export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
+  private readonly checkpoint: CheckpointManager;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
+    this.checkpoint = new CheckpointManager(opts.baseDir, {
+      info: (msg) => opts.logger?.info(msg),
+      warn: (msg) => opts.logger?.warn?.(msg),
+    });
     this.vectorStore = opts.vectorStore;
   }
 
@@ -128,11 +143,14 @@ export class LocalMemoryCleaner {
       let failedL0DbCleanup = 0;
       let failedL1DbCleanup = 0;
 
+      const minRetainL0 = this.opts.minRetainL0 ?? DEFAULT_MIN_RETAIN_L0;
+      const minRetainL1 = this.opts.minRetainL1 ?? DEFAULT_MIN_RETAIN_L1;
+
       // ── L0 cleanup with minimum-retention guard ──
-      if (totalL0 <= MIN_RETAIN_L0) {
+      if (totalL0 <= minRetainL0) {
         skippedL0 = true;
         this.opts.logger?.info(
-          `${TAG} [L0-delete] SKIPPED: totalL0=${totalL0} <= minRetain=${MIN_RETAIN_L0}`,
+          `${TAG} [L0-delete] SKIPPED: totalL0=${totalL0} <= minRetain=${minRetainL0}`,
         );
       } else {
         try {
@@ -146,10 +164,10 @@ export class LocalMemoryCleaner {
       }
 
       // ── L1 cleanup with minimum-retention guard ──
-      if (totalL1 <= MIN_RETAIN_L1) {
+      if (totalL1 <= minRetainL1) {
         skippedL1 = true;
         this.opts.logger?.info(
-          `${TAG} [L1-delete] SKIPPED: totalL1=${totalL1} <= minRetain=${MIN_RETAIN_L1}`,
+          `${TAG} [L1-delete] SKIPPED: totalL1=${totalL1} <= minRetain=${minRetainL1}`,
         );
       } else {
         try {
@@ -182,17 +200,15 @@ export class LocalMemoryCleaner {
     }
 
     // Reconcile increment-only checkpoint counters after cleanup (#157).
+    // Always runs — pre-existing drift must be corrected even when this cycle
+    // deleted nothing (e.g. min-retain guard skipped DB deletes).
     // Prefer the live store (same source the cleaner just mutated); fall back
     // to JSONL line counts when no store is wired (JSONL-only cleanup).
     // Non-fatal: never fail the cleanup run because of checkpoint drift.
     try {
-      const checkpoint = new CheckpointManager(this.opts.baseDir, {
-        info: (msg) => this.opts.logger?.info(msg),
-        warn: (msg) => this.opts.logger?.warn?.(msg),
-      });
       const result = this.vectorStore
-        ? await checkpoint.recalibrate(this.vectorStore)
-        : await checkpoint.recalibrate();
+        ? await this.checkpoint.recalibrate(this.vectorStore)
+        : await this.checkpoint.recalibrate();
       if (result.changed) {
         this.opts.logger?.info(
           `${TAG} Checkpoint recalibrated after cleanup (source=${result.source}): ` +

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -524,7 +524,6 @@ export function createL2Runner(opts: {
 
     const preCheckpoint = new CheckpointManager(pluginDataDir, logger);
     const preState = await preCheckpoint.read();
-    const preScenesProcessed = preState.scenes_processed;
     const preMemoriesSince = preState.memories_since_last_persona;
     const preTotalProcessed = preState.total_processed;
 
@@ -532,24 +531,22 @@ export function createL2Runner(opts: {
     if (extractResult.success && extractResult.memoriesProcessed > 0) {
       const checkpoint = new CheckpointManager(pluginDataDir, logger);
       const postState = await checkpoint.read();
-      if (
-        postState.scenes_processed < preScenesProcessed ||
-        postState.total_processed < preTotalProcessed
-      ) {
+      if (postState.total_processed < preTotalProcessed) {
+        // `total_processed` should only ever increase (captureAtomically increments it).
+        // A rollback here means a concurrent full-write clobbered the counter.
+        // Note: scenes_processed is intentionally excluded — recalibrate() can
+        // legitimately lower it when scene files are deleted.
         logger.warn(
-          `${TAG} [L2] ⚠️ Checkpoint corruption detected! ` +
-          `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
+          `${TAG} [L2] ⚠️ Checkpoint counter rollback detected! ` +
           `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
           `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
-          `Repairing...`,
+          `Applying atomic floor...`,
         );
-        await checkpoint.write({
-          ...postState,
-          scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
-          total_processed: Math.max(postState.total_processed, preTotalProcessed),
-          memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
+        await checkpoint.floorGlobalCounters({
+          total_processed: preTotalProcessed,
+          memories_since_last_persona: preMemoriesSince,
         });
-        logger.info(`${TAG} [L2] Checkpoint repaired`);
+        logger.info(`${TAG} [L2] Checkpoint floor applied`);
       }
 
       if (vectorStore && supportsProfileSyncWrite(vectorStore)) {

--- a/src/utils/status-cache.test.ts
+++ b/src/utils/status-cache.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StatusCache } from "./status-cache.js";
+
+describe("StatusCache", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("returns cached value on second call within TTL", async () => {
+    const fetch = vi.fn().mockResolvedValue(42);
+    const cache = new StatusCache<number>(1000);
+
+    const r1 = await cache.get(fetch);
+    const r2 = await cache.get(fetch);
+
+    expect(r1).toBe(42);
+    expect(r2).toBe(42);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after TTL expires", async () => {
+    const fetch = vi.fn().mockResolvedValue(1);
+    const cache = new StatusCache<number>(1000);
+
+    await cache.get(fetch);
+    vi.advanceTimersByTime(1001);
+    fetch.mockResolvedValue(2);
+    const result = await cache.get(fetch);
+
+    expect(result).toBe(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent calls into one fetch", async () => {
+    let resolve!: (v: number) => void;
+    const inflight = new Promise<number>((r) => { resolve = r; });
+    const fetch = vi.fn().mockReturnValue(inflight);
+    const cache = new StatusCache<number>(5000);
+
+    // Fire three calls before the fetch resolves
+    const [p1, p2, p3] = [cache.get(fetch), cache.get(fetch), cache.get(fetch)];
+    resolve(99);
+    const results = await Promise.all([p1, p2, p3]);
+
+    expect(results).toEqual([99, 99, 99]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidate forces re-fetch on next call", async () => {
+    const fetch = vi.fn().mockResolvedValueOnce("a").mockResolvedValueOnce("b");
+    const cache = new StatusCache<string>(60_000);
+
+    await cache.get(fetch);
+    cache.invalidate();
+    const result = await cache.get(fetch);
+
+    expect(result).toBe("b");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("isFresh reflects cache state correctly", async () => {
+    const cache = new StatusCache<number>(1000);
+    expect(cache.isFresh).toBe(false);
+
+    await cache.get(() => Promise.resolve(1));
+    expect(cache.isFresh).toBe(true);
+
+    vi.advanceTimersByTime(1001);
+    expect(cache.isFresh).toBe(false);
+  });
+
+  it("isFresh is false after invalidate", async () => {
+    const cache = new StatusCache<number>(60_000);
+    await cache.get(() => Promise.resolve(1));
+    expect(cache.isFresh).toBe(true);
+
+    cache.invalidate();
+    expect(cache.isFresh).toBe(false);
+  });
+
+  it("propagates fetch errors without poisoning the cache", async () => {
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(7);
+    const cache = new StatusCache<number>(5000);
+
+    await expect(cache.get(fetch)).rejects.toThrow("boom");
+    // Next call should retry, not serve a stale error
+    const result = await cache.get(fetch);
+    expect(result).toBe(7);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("ttl=0 never caches (always re-fetches)", async () => {
+    const fetch = vi.fn().mockResolvedValue(1);
+    const cache = new StatusCache<number>(0);
+
+    await cache.get(fetch);
+    await cache.get(fetch);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/status-cache.ts
+++ b/src/utils/status-cache.ts
@@ -1,0 +1,52 @@
+/**
+ * Generic TTL cache with in-flight promise coalescing.
+ *
+ * When multiple callers request a value while the cache is stale, only one
+ * underlying `fetch` call is made — all callers await the same in-flight
+ * promise, preventing thundering-herd I/O on hot health-check endpoints.
+ */
+export class StatusCache<T> {
+  private entry: { value: T; expiresAt: number } | null = null;
+  private inflight: Promise<T> | null = null;
+
+  constructor(private readonly ttlMs: number) {}
+
+  /**
+   * Return the cached value if still fresh, otherwise call `fetch` once and
+   * cache the result. Concurrent callers while a fetch is in-flight all
+   * receive the same promise.
+   */
+  async get(fetch: () => Promise<T>): Promise<T> {
+    if (this.entry !== null && Date.now() < this.entry.expiresAt) {
+      return this.entry.value;
+    }
+    if (this.inflight !== null) {
+      return this.inflight;
+    }
+    this.inflight = fetch().then(
+      (value) => {
+        this.entry = { value, expiresAt: Date.now() + this.ttlMs };
+        this.inflight = null;
+        return value;
+      },
+      (err: unknown) => {
+        this.inflight = null;
+        throw err;
+      },
+    );
+    return this.inflight;
+  }
+
+  /** Force the next call to re-fetch, even if the TTL has not expired. */
+  invalidate(): void {
+    this.entry = null;
+    // Leave inflight alone — it will complete and populate the entry,
+    // but the next call after invalidate() will still re-fetch because
+    // entry is null when the in-flight promise resolves.
+  }
+
+  /** True when a cached (non-expired) value is available. */
+  get isFresh(): boolean {
+    return this.entry !== null && Date.now() < this.entry.expiresAt;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #157. `l0_conversations_count` and `total_memories_extracted` only ever incremented — after any cleanup (memory-cleaner, manual JSONL pruning, pipeline state reset) the counters permanently overstated reality, causing persona generation thresholds to miscalculate and incremental processing to skip records.

## Changes

### Core fix: `recalibrate()` (`checkpoint.ts`)

Reads actual counts from the live vector store (falling back to JSONL line counts when no store is wired), then corrects `l0_conversations_count`, `total_memories_extracted`, `memories_since_last_persona`, and `scenes_processed` in a single `mutate()` call.

**Tradeoff — `total_processed` is intentionally excluded.** It is a monotonic epoch marker: `last_persona_at` stores a `total_processed` snapshot and persona eligibility is evaluated as `current - last_persona_at > threshold`. Lowering `total_processed` after cleanup would shrink that gap and could re-trigger persona generation immediately. Keeping it monotonic is the safer invariant; the drift from this counter is purely cosmetic (status display), not behavioral.

### Auto-trigger in `memory-cleaner` (`memory-cleaner.ts`)

`runOnce()` calls `recalibrate()` unconditionally at the end of every cleanup cycle.

**Tradeoff — removed the `changedFiles > 0` guard.** An earlier draft only recalibrated when the cycle actually deleted something. But pre-existing drift (from a previous manual prune or a crashed cleanup) must also be corrected, even when the min-retain guard skipped all DB deletes this cycle. The daily run frequency is low enough that the extra I/O is not a concern.

### `memories_since_last_persona` clamp (`checkpoint.ts`)

Old formula: `persona = Math.max(0, persona - deletedCount)` — subtracted the full deletion count regardless of when those records were created relative to the last persona run.

New formula attributes deletions to the correct zone:
- Records deleted **before** the last persona run don't affect the counter (they were already counted as "processed before persona")
- Only records deleted **since** the last persona run reduce the counter

**Tradeoff — more complex formula, but the old one would over-correct.** If 10 records were deleted and 8 were from before the last persona, the old code would reduce `memories_since_last_persona` by 10, potentially triggering persona generation prematurely on the next capture.

### `scenes_processed` recalibration from filesystem (`checkpoint.ts`)

Counts actual `.md` files in `scene_blocks/` instead of trusting the stored value.

**Tradeoff — filesystem read on every recalibrate.** Scene files are not stored in the vector store, so there is no cheaper source of truth. The alternative (keeping `scenes_processed` increment-only) would permanently disable the P3 "first scene" trigger after any scene file is deleted, which is a harder-to-diagnose bug. The `glob` is scoped to one directory and runs at most once per day.

### `drift_history` and `detectDrift()` do not track `scenes_processed` (`checkpoint.ts`)

**Tradeoff — intentional omission.** `l0/l1` drift signals counter corruption: the DB was mutated without the checkpoint being updated, which should not happen in normal operation. `scenes_processed` decreasing after cleanup is expected and correct behavior. Mixing them into the same drift signal would generate noise and make it harder to distinguish real anomalies from routine corrections.

### `last_recalibrated_at` written on every run, not just when `changed=true` (`checkpoint.ts`)

**Tradeoff — "last checked" semantics over "last corrected" semantics.** Writing on every run means operators can verify the cleaner is actually running by inspecting the checkpoint file, even during periods when there is no drift to correct. The downside is the timestamp is less informative about when drift was last found; `drift_history` fills that gap.

### Atomic `floorGlobalCounters()` replaces `checkpoint.write()` in L2 runner (`pipeline-factory.ts`, `checkpoint.ts`)

The original corruption repair read the checkpoint, checked for counter rollback, then called `checkpoint.write({...postState, ...})`. This full overwrite is TOCTOU-unsafe: any `captureAtomically` call between the `read()` and `write()` would be silently clobbered.

**Tradeoff — `floorGlobalCounters()` is technically dead code in normal operation.** With the full `write()` gone, there is no remaining code path that can decrease `total_processed`. The floor guard is kept as a defensive invariant against direct file manipulation or future refactors that reintroduce a full write. The cost is one no-op `mutate()` per L2 extraction.

### `StatusCache<T>` (`status-cache.ts`, `tdai-core.ts`)

TTL-based cache with in-flight promise coalescing for `getCheckpointStatus()`.

**Tradeoff — 30 s default TTL.** Short enough that the displayed status reflects recent cleanup runs; long enough to avoid a file read on every status poll. Callers that need fresh data (e.g., immediately after recalibrate) can call `cache.invalidate()`.

## Test Plan

- [x] `recalibrate()` corrects l0/l1 from vector store and JSONL fallback
- [x] `memories_since_last_persona` clamp: deletions before persona, after persona, mixed zones
- [x] `scenes_processed` recalibrated from `.md` file count on disk
- [x] `drift_history` ring buffer: appends on change, skips when unchanged, evicts at cap=10
- [x] Concurrent `recalibrate()` calls serialized by file lock — no lost writes
- [x] `detectDrift()` returns delta without mutating checkpoint
- [x] `floorGlobalCounters()` raises counters atomically, no-ops when sufficient
- [x] Configurable `minRetainL0/L1` — recalibrate still runs when DB skip fires
- [x] `StatusCache`: hit/miss, TTL expiry, concurrent coalescing, error non-poisoning, invalidate

59 tests pass across `checkpoint.test.ts` and `status-cache.test.ts`.