### PR TITLE
fix(store): sanitize FTS5 query input

### DIFF
--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,137 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _setJiebaForTest,
+  buildFtsQuery,
+  sanitizeFtsQueryInput,
+} from "./sqlite.js";
+
+interface ContentRow {
+  content: string;
+}
+
+function searchFts(documents: string[], rawQuery: string): string[] {
+  const db = new DatabaseSync(":memory:");
+
+  try {
+    db.exec("CREATE VIRTUAL TABLE documents USING fts5(content)");
+    const insert = db.prepare("INSERT INTO documents(content) VALUES (?)");
+    for (const document of documents) insert.run(document);
+
+    const query = buildFtsQuery(rawQuery);
+    if (!query) return [];
+
+    return db
+      .prepare("SELECT content FROM documents WHERE documents MATCH ? ORDER BY rowid")
+      .all(query)
+      .map((row) => (row as unknown as ContentRow).content);
+  } finally {
+    db.close();
+  }
+}
+
+afterEach(() => {
+  _setJiebaForTest(null);
+});
+
+describe("sanitizeFtsQueryInput", () => {
+  it("removes FTS5 syntax while preserving searchable words", () => {
+    expect(
+      sanitizeFtsQueryInput(
+        `^"alpha" + 'beta' (gamma) AND OR NOT NEAR delta* column:epsilon {zeta eta} -theta,10`,
+      ),
+    ).toBe(
+      "alpha beta gamma AND OR NOT NEAR delta column epsilon zeta eta theta 10",
+    );
+  });
+
+  it("preserves normal Unicode keywords and normalizes separators", () => {
+    expect(sanitizeFtsQueryInput("TypeScript  记忆_search\nO'Reilly")).toBe(
+      "TypeScript 记忆_search O Reilly",
+    );
+  });
+
+  it("returns an empty string for syntax-only input", () => {
+    expect(sanitizeFtsQueryInput(`"'()[]{}:+-^*,`)).toBe("");
+  });
+});
+
+describe("buildFtsQuery FTS5 safety", () => {
+  it("quotes operator names as literal search terms", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta OR NOT NEAR")).toBe(
+      `"alpha" OR "AND" OR "beta" OR "OR" OR "NOT" OR "NEAR"`,
+    );
+  });
+
+  it("sanitizes tokens returned by the segmenter", () => {
+    _setJiebaForTest({
+      cutForSearch: () => [`alpha" OR beta*`, "(gamma)", "O'Reilly"],
+    });
+
+    expect(buildFtsQuery("ignored")).toBe(
+      `"alpha" OR "OR" OR "beta" OR "gamma" OR "O" OR "Reilly"`,
+    );
+  });
+
+  it("returns null when no searchable token remains", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery(`"'()***`)).toBeNull();
+  });
+
+  it("does not allow boolean operators to exclude matches", () => {
+    _setJiebaForTest(null);
+
+    expect(searchFts(["alpha", "beta", "alpha beta"], "alpha NOT beta")).toEqual([
+      "alpha",
+      "beta",
+      "alpha beta",
+    ]);
+  });
+
+  it("preserves ordinary multi-keyword OR recall", () => {
+    _setJiebaForTest(null);
+
+    expect(
+      searchFts(
+        [
+          "typescript memory plugin",
+          "typescript compiler",
+          "memory storage",
+          "unrelated document",
+        ],
+        "typescript memory",
+      ),
+    ).toEqual([
+      "typescript memory plugin",
+      "typescript compiler",
+      "memory storage",
+    ]);
+  });
+
+  it("does not allow prefix, phrase, grouping, or NEAR semantics", () => {
+    _setJiebaForTest(null);
+    const documents = ["alpha", "alphabet", "beta", "alpha beta", "alpha far beta"];
+
+    expect(searchFts(documents, "alpha*")).toEqual([
+      "alpha",
+      "alpha beta",
+      "alpha far beta",
+    ]);
+    expect(searchFts(documents, `"alpha beta"`)).toEqual([
+      "alpha",
+      "beta",
+      "alpha beta",
+      "alpha far beta",
+    ]);
+    expect(searchFts(documents, "NEAR(alpha beta)")).toEqual([
+      "alpha",
+      "beta",
+      "alpha beta",
+      "alpha far beta",
+    ]);
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,6 +175,21 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * Remove FTS5 query syntax while retaining Unicode words, numbers, and
+ * underscores. Boolean operator names remain searchable text; buildFtsQuery()
+ * quotes every resulting token so they cannot act as operators.
+ */
+export function sanitizeFtsQueryInput(raw: string): string {
+  return raw.replace(/[^\p{L}\p{N}_]+/gu, " ").trim();
+}
+
+function extractSafeFtsTokens(raw: string): string[] {
+  const sanitized = sanitizeFtsQueryInput(raw);
+  if (!sanitized) return [];
+  return sanitized.split(/\s+/u).filter((token) => /[\p{L}\p{N}]/u.test(token));
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -196,6 +211,9 @@ const ZH_STOP_WORDS = new Set([
  *   "旅行计划 API" → '"旅行计划" OR "API"'
  */
 export function buildFtsQuery(raw: string): string | null {
+  const sanitizedRaw = sanitizeFtsQueryInput(raw);
+  if (!sanitizedRaw) return null;
+
   const jieba = getJieba();
 
   let tokens: string[];
@@ -203,12 +221,9 @@ export function buildFtsQuery(raw: string): string | null {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
-      .cutForSearch(raw, true)
-      .map((t) => t.trim())
+      .cutForSearch(sanitizedRaw, true)
+      .flatMap(extractSafeFtsTokens)
       .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
         // Remove common Chinese stop-words to reduce noise
         if (ZH_STOP_WORDS.has(t)) return false;
         return true;
@@ -216,16 +231,12 @@ export function buildFtsQuery(raw: string): string | null {
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
-    // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    // Fallback: split the already-sanitized input on whitespace.
+    tokens = extractSafeFtsTokens(sanitizedRaw);
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map((t) => `"${t.replaceAll('"', '""')}"`);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述
- Sanitize raw search input with a Unicode keyword whitelist before FTS5 tokenization.
- Re-sanitize segmenter output and quote every token so FTS5 operators remain literal search terms.
- Preserve the existing OR-based recall behavior for normal multi-keyword searches.
- Add unit and real SQLite FTS5 integration tests for operators, malformed input, and recall.

## Related Issue | 关联 Issue
Closes #160

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
- 9 focused FTS5 tests passed, including execution against an in-memory SQLite FTS5 table.
- Full test suite passed: 80 tests.
- Production build passed: plugin bundle and all TypeScript script builds.