### PR TITLE
feat(adapters): add cline coding agent memory adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,22 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Cline CLI
+
+Cline CLI can connect to the Gateway through the dependency-free plugin in
+[`cline-adapter/tdai-memory`](./cline-adapter/tdai-memory). It recalls memory
+before a run, projects it into model requests, captures completed runs, and
+fails open when the Gateway is unavailable.
+
+Install the adapter as a local plugin:
+
+```bash
+cline plugin install ./cline-adapter/tdai-memory --cwd .
+```
+
+See the [Cline adapter guide](./cline-adapter/tdai-memory/README.md) for
+configuration, lifecycle details, and limitations.
+
 
 ## 🔒 Gateway Security (optional)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -385,6 +385,22 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Cline CLI
+
+Cline CLI 可通过
+[`cline-adapter/tdai-memory`](./cline-adapter/tdai-memory) 中的零依赖插件连接
+Gateway。插件会在每次运行前召回记忆、把记忆注入模型请求，并在成功结束后
+捕获对话；Gateway 不可用时自动降级，不阻断 Cline。
+
+安装为本地插件：
+
+```bash
+cline plugin install ./cline-adapter/tdai-memory --cwd .
+```
+
+配置项、生命周期和限制见
+[Cline 适配器说明](./cline-adapter/tdai-memory/README.md)。
+
 
 ## 🔒 Gateway 安全配置（可选）
 

--- a/__tests__/cline-adapter/plugin.test.ts
+++ b/__tests__/cline-adapter/plugin.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createClineMemoryPlugin } from "../../cline-adapter/tdai-memory/plugin.js";
+
+function userMessage(text: string) {
+  return {
+    id: "user-1",
+    role: "user",
+    content: [{ type: "text", text }],
+    createdAt: 1,
+  };
+}
+
+function snapshot(text: string) {
+  return {
+    agentId: "agent-1",
+    conversationId: "conversation-1",
+    status: "running",
+    iteration: 0,
+    messages: [userMessage(text)],
+    pendingToolCalls: [],
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+  };
+}
+
+describe("Cline CLI plugin", () => {
+  it("recalls before a run and projects memory into every model request", async () => {
+    const runtime = {
+      recall: vi.fn().mockResolvedValue("User prefers Rust."),
+      capture: vi.fn(),
+    };
+    const plugin = createClineMemoryPlugin({ runtime });
+    const current = snapshot("What language do I prefer?");
+
+    await plugin.hooks.beforeRun({ snapshot: current });
+    const first = plugin.hooks.beforeModel({
+      snapshot: current,
+      request: { messages: current.messages, tools: [] },
+    });
+    const second = plugin.hooks.beforeModel({
+      snapshot: current,
+      request: { messages: current.messages, tools: [] },
+    });
+
+    expect(runtime.recall).toHaveBeenCalledWith(
+      "What language do I prefer?",
+      "conversation-1",
+    );
+    expect(first.messages[0].content[1].text).toContain("User prefers Rust.");
+    expect(second.messages[0].content[1].text).toContain("User prefers Rust.");
+    expect(current.messages[0].content).toHaveLength(1);
+  });
+
+  it("captures a completed run and drops memory state afterwards", async () => {
+    const runtime = {
+      recall: vi.fn().mockResolvedValue("Earlier context"),
+      capture: vi.fn().mockResolvedValue({ l0_recorded: 2 }),
+    };
+    const plugin = createClineMemoryPlugin({ runtime });
+    const current = snapshot("Remember this.");
+
+    await plugin.hooks.beforeRun({ snapshot: current });
+    await plugin.hooks.afterRun({
+      snapshot: current,
+      result: {
+        status: "completed",
+        outputText: "Remembered.",
+        messages: current.messages,
+      },
+    });
+    const after = plugin.hooks.beforeModel({
+      snapshot: current,
+      request: { messages: current.messages, tools: [] },
+    });
+
+    expect(runtime.capture).toHaveBeenCalledWith(
+      "Remember this.",
+      "Remembered.",
+      "conversation-1",
+    );
+    expect(after).toBeUndefined();
+  });
+
+  it("does not capture aborted or failed runs", async () => {
+    const runtime = {
+      recall: vi.fn().mockResolvedValue(""),
+      capture: vi.fn(),
+    };
+    const plugin = createClineMemoryPlugin({ runtime });
+    const current = snapshot("Do work.");
+
+    await plugin.hooks.afterRun({
+      snapshot: current,
+      result: { status: "aborted", outputText: "", messages: current.messages },
+    });
+
+    expect(runtime.capture).not.toHaveBeenCalled();
+  });
+
+  it("continues normally when recall and capture return no result", async () => {
+    const runtime = {
+      recall: vi.fn().mockResolvedValue(""),
+      capture: vi.fn().mockResolvedValue(null),
+    };
+    const plugin = createClineMemoryPlugin({ runtime });
+    const current = snapshot("Continue.");
+
+    await expect(
+      plugin.hooks.beforeRun({ snapshot: current }),
+    ).resolves.toBeUndefined();
+    expect(
+      plugin.hooks.beforeModel({
+        snapshot: current,
+        request: { messages: current.messages, tools: [] },
+      }),
+    ).toBeUndefined();
+    await expect(
+      plugin.hooks.afterRun({
+        snapshot: current,
+        result: {
+          status: "completed",
+          outputText: "Done.",
+          messages: current.messages,
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails open when the memory runtime throws", async () => {
+    const runtime = {
+      recall: vi.fn().mockRejectedValue(new Error("Gateway unavailable")),
+      capture: vi.fn().mockRejectedValue(new Error("Gateway unavailable")),
+    };
+    const plugin = createClineMemoryPlugin({ runtime });
+    const current = snapshot("Continue without memory.");
+
+    await expect(
+      plugin.hooks.beforeRun({ snapshot: current }),
+    ).resolves.toBeUndefined();
+    expect(
+      plugin.hooks.beforeModel({
+        snapshot: current,
+        request: { messages: current.messages, tools: [] },
+      }),
+    ).toBeUndefined();
+    await expect(
+      plugin.hooks.afterRun({
+        snapshot: current,
+        result: {
+          status: "completed",
+          outputText: "Completed normally.",
+          messages: current.messages,
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/cline-adapter/runtime.test.ts
+++ b/__tests__/cline-adapter/runtime.test.ts
@@ -1,0 +1,110 @@
+import { createServer, type IncomingMessage } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  GatewayClient,
+  formatRecallContext,
+  injectRecallIntoMessages,
+  readConfig,
+} from "../../cline-adapter/tdai-memory/runtime.mjs";
+
+const cleanup: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanup.length > 0) await cleanup.pop()?.();
+});
+
+async function requestBody(request: IncomingMessage): Promise<unknown> {
+  let body = "";
+  for await (const chunk of request) body += chunk;
+  return JSON.parse(body);
+}
+
+describe("GatewayClient", () => {
+  it("sends Gateway-compatible recall and capture requests with Bearer auth", async () => {
+    const requests: Array<{
+      url: string;
+      body: unknown;
+      authorization?: string;
+    }> = [];
+    const server = createServer(async (request, response) => {
+      requests.push({
+        url: request.url ?? "",
+        body: await requestBody(request),
+        authorization: request.headers.authorization,
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ context: "remembered" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanup.push(
+      () => new Promise<void>((resolve) => server.close(() => resolve())),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing address");
+
+    const client = new GatewayClient({
+      baseUrl: `http://127.0.0.1:${address.port}/`,
+      apiKey: "test-token",
+      timeoutMs: 1_000,
+    });
+    await client.recall("query", "cline_task");
+    await client.capture("user turn", "assistant turn", "cline_task");
+
+    expect(requests).toEqual([
+      {
+        url: "/recall",
+        authorization: "Bearer test-token",
+        body: { query: "query", session_key: "cline_task" },
+      },
+      {
+        url: "/capture",
+        authorization: "Bearer test-token",
+        body: {
+          user_content: "user turn",
+          assistant_content: "assistant turn",
+          session_key: "cline_task",
+        },
+      },
+    ]);
+  });
+
+  it("returns null instead of throwing for network errors", async () => {
+    const client = new GatewayClient({
+      baseUrl: "http://127.0.0.1:1",
+      timeoutMs: 50,
+    });
+    await expect(client.recall("query", "session")).resolves.toBeNull();
+  });
+});
+
+describe("configuration", () => {
+  it("accepts the shared Gateway API key as a fallback", () => {
+    expect(readConfig({ TDAI_GATEWAY_API_KEY: "shared-secret" }).apiKey).toBe(
+      "shared-secret",
+    );
+  });
+});
+
+describe("recall message projection", () => {
+  it("adds recalled context to the latest user message without mutating history", () => {
+    const messages = [
+      {
+        id: "u1",
+        role: "user",
+        content: [{ type: "text", text: "Current question" }],
+        createdAt: 1,
+      },
+    ];
+    const projected = injectRecallIntoMessages(messages, "Earlier preference");
+
+    expect(projected).not.toBe(messages);
+    expect(messages[0].content).toHaveLength(1);
+    expect(projected[0].content[1].text).toBe(
+      `\n\n${formatRecallContext("Earlier preference")}`,
+    );
+    expect(injectRecallIntoMessages(projected, "Earlier preference")).toBe(
+      projected,
+    );
+  });
+});

--- a/cline-adapter/tdai-memory/README.md
+++ b/cline-adapter/tdai-memory/README.md
@@ -1,0 +1,77 @@
+# TencentDB Agent Memory — Cline Adapter
+
+This plugin gives [Cline CLI](https://github.com/cline/cline) automatic,
+cross-session memory through the existing TencentDB Agent Memory Gateway. It
+uses Cline's in-process Plugin API and has no runtime dependencies.
+
+## Lifecycle mapping
+
+```text
+beforeRun   -> POST /recall
+beforeModel -> project recalled context into the provider request
+afterRun    -> POST /capture for completed runs
+```
+
+All Gateway calls are best-effort. If the Gateway is unavailable or times out,
+Cline continues without memory; the hook never cancels a task.
+
+## Requirements
+
+- Node.js 22 or newer
+- Cline CLI 3.0.46 or newer
+- A running TencentDB Agent Memory Gateway
+
+## Start the Gateway
+
+From the repository root:
+
+```bash
+TDAI_LLM_BASE_URL="https://api.deepseek.com/v1" \
+TDAI_LLM_API_KEY="..." \
+TDAI_LLM_MODEL="deepseek-chat" \
+node --import tsx/esm src/gateway/server.ts
+```
+
+## Install
+
+Install the adapter directory as a project-scoped Cline plugin:
+
+```bash
+cline plugin install ./cline-adapter/tdai-memory --cwd .
+```
+
+The plugin automatically recalls before each run and captures successful runs.
+It does not depend on the model remembering to call a memory tool.
+
+## Configuration
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `MEMORY_TENCENTDB_GATEWAY_URL` | `http://127.0.0.1:8420` | Gateway base URL |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` | `TDAI_GATEWAY_API_KEY`, then unset | Bearer token for Gateway auth |
+| `MEMORY_TENCENTDB_TIMEOUT_MS` | `5000` | Per-request timeout |
+| `MEMORY_TENCENTDB_DEBUG` | unset | Set to `1` for error diagnostics on stderr |
+
+The adapter derives `session_key` as `cline_<conversationId>`.
+
+## Failure behavior
+
+- Recall failure: inject nothing and continue the task.
+- Capture failure: drop that capture and continue.
+- Debug logging never prints API keys or full hook payloads.
+
+## Scope
+
+This adapter targets Cline CLI's Plugin API. Current Cline file hooks run prompt
+hooks asynchronously in CLI hosts, and the current VS Code SDK adapter does not
+project `contextModification` from `UserPromptSubmit` into model requests.
+Because neither path can guarantee automatic recall injection, IDE file-hook
+support is intentionally not claimed here.
+
+Cline's Plugin API does not currently expose a uniform session-shutdown hook, so
+the adapter does not call `/session/end`. Calling it after every completed run
+would reset session-level recall deduplication on every turn.
+
+Recall requests intentionally do not set Gateway `dedup: true`. The Plugin API's
+`beforeModel` projection is ephemeral and is not saved in Cline's transcript, so
+deduplicating a later run would remove context that is no longer present.

--- a/cline-adapter/tdai-memory/package.json
+++ b/cline-adapter/tdai-memory/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tencentdb-agent-memory/cline-adapter",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./plugin.js"
+        ],
+        "capabilities": [
+          "hooks"
+        ]
+      }
+    ]
+  }
+}

--- a/cline-adapter/tdai-memory/plugin.js
+++ b/cline-adapter/tdai-memory/plugin.js
@@ -1,0 +1,59 @@
+import {
+  createMemoryRuntime,
+  injectRecallIntoMessages,
+  latestUserText,
+} from "./runtime.mjs";
+
+function conversationId(snapshot) {
+  return snapshot?.conversationId ?? snapshot?.runId ?? snapshot?.agentId ?? "";
+}
+
+export function createClineMemoryPlugin({ runtime = createMemoryRuntime() } = {}) {
+  const recalledByConversation = new Map();
+
+  return {
+    name: "tencentdb-agent-memory",
+    manifest: { capabilities: ["hooks"] },
+    hooks: {
+      async beforeRun({ snapshot }) {
+        const id = conversationId(snapshot);
+        try {
+          const prompt = latestUserText(snapshot?.messages);
+          const context = await runtime.recall(prompt, id);
+          if (context) recalledByConversation.set(id, context);
+          else recalledByConversation.delete(id);
+        } catch {
+          recalledByConversation.delete(id);
+        }
+        return undefined;
+      },
+
+      beforeModel({ snapshot, request }) {
+        const context = recalledByConversation.get(conversationId(snapshot));
+        if (!context) return undefined;
+        return {
+          messages: injectRecallIntoMessages(request.messages, context),
+        };
+      },
+
+      async afterRun({ snapshot, result }) {
+        const id = conversationId(snapshot);
+        recalledByConversation.delete(id);
+        if (result?.status !== "completed") return;
+        const userContent =
+          latestUserText(result.messages) || latestUserText(snapshot?.messages);
+        const assistantContent =
+          typeof result.outputText === "string" ? result.outputText.trim() : "";
+        try {
+          await runtime.capture(userContent, assistantContent, id);
+        } catch {
+          // Memory is best-effort and must never fail the Cline run.
+        }
+      },
+    },
+  };
+}
+
+const plugin = createClineMemoryPlugin();
+export { plugin };
+export default plugin;

--- a/cline-adapter/tdai-memory/runtime.mjs
+++ b/cline-adapter/tdai-memory/runtime.mjs
@@ -1,0 +1,181 @@
+const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const RECALL_MARKER = "[TencentDB Agent Memory — recalled context]";
+
+function flag(value) {
+  return (
+    typeof value === "string" &&
+    ["1", "true", "yes"].includes(value.toLowerCase())
+  );
+}
+
+export function readConfig(env = process.env) {
+  const parsedTimeout = Number.parseInt(env.MEMORY_TENCENTDB_TIMEOUT_MS ?? "", 10);
+  return {
+    gatewayUrl: env.MEMORY_TENCENTDB_GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL,
+    apiKey:
+      env.MEMORY_TENCENTDB_GATEWAY_API_KEY?.trim() ||
+      env.TDAI_GATEWAY_API_KEY?.trim() ||
+      undefined,
+    timeoutMs:
+      Number.isFinite(parsedTimeout) && parsedTimeout > 0
+        ? parsedTimeout
+        : DEFAULT_TIMEOUT_MS,
+    debug: flag(env.MEMORY_TENCENTDB_DEBUG),
+  };
+}
+
+export class GatewayClient {
+  constructor(options) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.onError = options.onError;
+  }
+
+  recall(query, sessionKey, signal) {
+    return this.post("/recall", { query, session_key: sessionKey }, signal);
+  }
+
+  capture(userContent, assistantContent, sessionKey, signal) {
+    return this.post(
+      "/capture",
+      {
+        user_content: userContent,
+        assistant_content: assistantContent,
+        session_key: sessionKey,
+      },
+      signal,
+    );
+  }
+
+  async post(path, body, outerSignal) {
+    const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+    const signal = outerSignal
+      ? AbortSignal.any([outerSignal, timeoutSignal])
+      : timeoutSignal;
+    const headers = { "Content-Type": "application/json" };
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!response.ok) {
+        this.onError?.(path, new Error(`HTTP ${response.status}`));
+        return null;
+      }
+      return await response.json();
+    } catch (error) {
+      this.onError?.(path, error);
+      return null;
+    }
+  }
+}
+
+export function makeSessionKey(conversationId) {
+  return `cline_${conversationId}`;
+}
+
+export function textFromContent(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+export function latestUserText(messages) {
+  if (!Array.isArray(messages)) return "";
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "user") return textFromContent(message.content).trim();
+  }
+  return "";
+}
+
+export function formatRecallContext(context) {
+  return (
+    `${RECALL_MARKER}\n` +
+    "The following long-term memories may be relevant. Treat them as background " +
+    "knowledge from earlier sessions; the current conversation takes precedence " +
+    `when they conflict.\n\n${context}`
+  );
+}
+
+export function injectRecallIntoMessages(messages, recalledContext) {
+  if (!recalledContext || !Array.isArray(messages)) return messages;
+  const formatted = formatRecallContext(recalledContext);
+  let userIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") {
+      userIndex = index;
+      break;
+    }
+  }
+  if (userIndex < 0) return messages;
+  const message = messages[userIndex];
+  const content = Array.isArray(message.content) ? message.content : [];
+  if (
+    content.some(
+      (part) =>
+        part?.type === "text" &&
+        typeof part.text === "string" &&
+        part.text.includes(RECALL_MARKER),
+    )
+  ) {
+    return messages;
+  }
+  const result = [...messages];
+  result[userIndex] = {
+    ...message,
+    content: [...content, { type: "text", text: `\n\n${formatted}` }],
+  };
+  return result;
+}
+
+export function createMemoryRuntime(options = {}) {
+  const config = options.config ?? readConfig(options.env);
+  const log = options.log ?? ((message) => console.error(message));
+  const client =
+    options.client ??
+    new GatewayClient({
+      baseUrl: config.gatewayUrl,
+      apiKey: config.apiKey,
+      timeoutMs: config.timeoutMs,
+      onError(operation, error) {
+        if (config.debug) {
+          const detail = error instanceof Error ? error.message : String(error);
+          log(`[tdai-memory] ${operation} failed: ${detail}`);
+        }
+      },
+    });
+
+  return {
+    config,
+
+    async recall(query, conversationId, signal) {
+      if (!query || !conversationId) return "";
+      const response = await client.recall(
+        query,
+        makeSessionKey(conversationId),
+        signal,
+      );
+      return typeof response?.context === "string" ? response.context : "";
+    },
+
+    async capture(userContent, assistantContent, conversationId, signal) {
+      if (!userContent || !assistantContent || !conversationId) return null;
+      return client.capture(
+        userContent,
+        assistantContent,
+        makeSessionKey(conversationId),
+        signal,
+      );
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "cline-adapter/",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
@@ -58,6 +59,7 @@
   "keywords": [
     "openclaw",
     "openclaw-plugin",
+    "cline",
     "memory",
     "ai-memory",
     "long-term-memory",


### PR DESCRIPTION
## Description | 描述

Adds a [Cline](https://github.com/cline/cline) CLI adapter under
`cline-adapter/tdai-memory/`, giving Cline persistent cross-process memory through
the existing TDAI Gateway HTTP API.

新增 Cline CLI 适配器（`cline-adapter/tdai-memory/`），通过现有 TDAI Gateway
HTTP API 为 Cline 提供跨进程长期记忆。

**Lifecycle mapping | 生命周期映射：**

| Cline hook | Gateway endpoint | 作用 |
| :--- | :--- | :--- |
| `beforeRun` | `POST /recall` | 每次 run 开始前按最新用户消息召回相关记忆 |
| `beforeModel` | — | 将召回结果临时注入本次 provider request，不写入 Cline 的 canonical transcript |
| `afterRun` | `POST /capture` | run 完成后归档本轮 user/assistant 消息（L0），供 Gateway 异步提炼 |

- Session identity: `session_key = cline_<conversationId>`；同一 Cline
  conversation 稳定复用，新的 conversation 自动隔离
- Fault tolerance: Gateway 超时、HTTP/网络错误或异常响应都降级为 no-op；
  recall 失败不阻断模型调用，capture 失败不改变 Cline run 的结果
- Configuration: supports `TDAI_GATEWAY_URL`, optional
  `TDAI_GATEWAY_TOKEN`, and bounded request timeouts

**Scope decision | 适配范围：** this PR targets the public Cline CLI/SDK Plugin
API. It does not claim support for every IDE surface: current CLI prompt-file
hooks run detached, while the current VS Code SDK adapter does not project
`contextModification` from `UserPromptSubmit` into provider requests. A single
Plugin API adapter is therefore the smallest end-to-end integration whose
lifecycle behavior can be verified today.

## Related Issue | 关联 Issue
#235

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

- `npx vitest run __tests__/cline-adapter` — 2 files, 9 tests passed
- `npm test` — 6 files, 76 tests passed
- `npm run build` — plugin bundle and all three script builds passed
- `cline@3.0.46 plugin install ... --force --json` — installed successfully,
  with no MCP sync failures
- Official `@cline/core` `loadAgentPluginFromPath()` — loaded
  `tencentdb-agent-memory` with the expected `beforeRun`, `beforeModel`, and
  `afterRun` hooks
- `npm pack --dry-run --json --ignore-scripts` — package contains only the
  manifest, plugin entry point, runtime, and guide

## Additional Notes | 其他说明

### A/B verification: same Cline, same model, same prompt — only the experiment workspace has the plugin | 控制变量对比实验

Both groups used fresh Cline processes, empty isolated workspaces, identical
provider configuration, Cline `3.0.46`, and DeepSeek `deepseek-chat`. The fixed
prompt forbade guessing, workspace reads, and tool calls. Both successful runs
finished in one iteration with **0 tool calls**.

两组均使用全新的 Cline 进程、空白隔离 workspace、完全相同的 provider 配置、
Cline `3.0.46` 和 DeepSeek `deepseek-chat`。固定 prompt 明确禁止猜测、读取
workspace 或调用工具；两次正常运行均为 1 次 iteration、0 次工具调用。唯一实验
变量是 experiment workspace 安装了本适配器。

The experiment used a real Docker Gateway at `127.0.0.1:8420`. Before either
Cline process started, its L3 persona contained:

- codename: `hz`
- research topic: `可逆元胞自动机中的守恒律`
- favorite language: `Zig`

Fixed prompt:

```text
This is a memory-control experiment. Using only long-term memory that existed
before this process started, state my experiment codename, current research
topic, and favorite programming language. If unavailable, say you do not know;
do not guess, read workspace files, or call tools.
```

**Control (without adapter) | 对照组（未安装适配器）：**

```text
I do not have access to any long-term memory from before this process started.
There is no pre-existing context about you, your experiment codename, current
research topic, or favorite programming language stored in my knowledge base.

I do not know the answers to any of those questions.
```

Result: exit code `0`, 1 iteration, 0 tool calls, 5,652 input tokens.

**Experiment (with adapter) | 实验组（已安装适配器）：**

```text
Based on the long-term memory provided in the context:

- **Experiment codename**: hz
- **Current research topic**: 可逆元胞自动机中的守恒律
  (Conservation laws in reversible cellular automata)
- **Favorite programming language**: Zig
```

Result: exit code `0`, 1 iteration, 0 tool calls, 5,993 input tokens. Gateway logs
show `beforeRun` issuing `POST /recall`, followed by `afterRun` issuing
`POST /capture`. The 341-token input increase is consistent with the recalled
context being injected through `beforeModel`.

**Degradation (adapter installed, Gateway stopped) | 容错组（已安装适配器，但 Gateway 停机）：**

```text
I do not have access to any prior long-term memory from before this process
started. Therefore, I cannot state your experiment codename, current research
topic, or favorite programming language.
```

Result: exit code `0`, 1 iteration, 0 tool calls. Cline still completed normally:
the failed recall became an empty context, and the failed capture was dropped.
This verifies that the adapter is fail-open rather than making Gateway
availability a prerequisite for Cline.

### Implementation notes

- The adapter is dependency-free at runtime and follows the public Cline Plugin
  API shape, so it can be installed directly from this repository directory.
- Debug output is opt-in and never logs API keys or complete hook/model payloads.
- Recall intentionally omits Gateway `dedup: true`. The injected context is
  ephemeral and is not persisted in Cline's transcript; suppressing the next
  run's identical recall could therefore remove context that is no longer
  present. The current Plugin API also has no uniform session-shutdown hook for
  safely clearing a dedup ledger.
