### PR TITLE
fix(data): recalibrate checkpoint counters

### DIFF
--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager counter recalibration", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("tracks L0 message records using the same unit as the backing store", async () => {
+    const manager = new CheckpointManager(dataDir);
+
+    await manager.captureAtomically("session-1", undefined, async () => ({
+      maxTimestamp: 1_700_000_000_000,
+      messageCount: 3,
+    }));
+
+    const checkpoint = await manager.read();
+    expect(checkpoint.total_processed).toBe(3);
+    expect(checkpoint.l0_conversations_count).toBe(3);
+  });
+
+  it("replaces drifted counters from the active store without changing session state", async () => {
+    const manager = new CheckpointManager(dataDir);
+    const checkpoint = await manager.read();
+    checkpoint.total_processed = 8;
+    checkpoint.l0_conversations_count = 8;
+    checkpoint.total_memories_extracted = 5;
+    checkpoint.memories_since_last_persona = 3;
+    checkpoint.last_persona_at = 6;
+    checkpoint.runner_states["session-1"] = {
+      last_captured_timestamp: 123,
+      last_l1_cursor: 456,
+      last_scene_name: "scene",
+    };
+    await manager.write(checkpoint);
+
+    const store = {
+      isDegraded: () => false,
+      countL0: vi.fn().mockResolvedValue(2),
+      countL1: vi.fn().mockResolvedValue(3),
+    } as unknown as IMemoryStore;
+
+    await manager.recalibrate(store);
+
+    const recalibrated = await manager.read();
+    expect(recalibrated.total_processed).toBe(2);
+    expect(recalibrated.l0_conversations_count).toBe(2);
+    expect(recalibrated.total_memories_extracted).toBe(3);
+    expect(recalibrated.memories_since_last_persona).toBe(1);
+    expect(recalibrated.last_persona_at).toBe(6);
+    expect(recalibrated.runner_states["session-1"]).toEqual(
+      checkpoint.runner_states["session-1"],
+    );
+  });
+
+  it("recounts valid JSONL records after manual pruning and a full reset", async () => {
+    const manager = new CheckpointManager(dataDir);
+    const checkpoint = await manager.read();
+    checkpoint.total_processed = 20;
+    checkpoint.l0_conversations_count = 20;
+    checkpoint.total_memories_extracted = 10;
+    checkpoint.memories_since_last_persona = 7;
+    await manager.write(checkpoint);
+
+    const conversationsDir = path.join(dataDir, "conversations");
+    const recordsDir = path.join(dataDir, "records");
+    await fs.mkdir(conversationsDir, { recursive: true });
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(conversationsDir, "2026-07-24.jsonl"),
+      [
+        JSON.stringify({ role: "user", content: "first" }),
+        "{malformed",
+        JSON.stringify({ role: "assistant", content: "second" }),
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-24.jsonl"),
+      `${JSON.stringify({ id: "memory-1", content: "remember this" })}\n{malformed\n`,
+      "utf-8",
+    );
+
+    await manager.recalibrate();
+
+    let recalibrated = await manager.read();
+    expect(recalibrated.total_processed).toBe(2);
+    expect(recalibrated.l0_conversations_count).toBe(2);
+    expect(recalibrated.total_memories_extracted).toBe(1);
+    expect(recalibrated.memories_since_last_persona).toBe(0);
+
+    await fs.rm(conversationsDir, { recursive: true });
+    await fs.rm(recordsDir, { recursive: true });
+    await manager.recalibrate();
+
+    recalibrated = await manager.read();
+    expect(recalibrated.total_processed).toBe(0);
+    expect(recalibrated.l0_conversations_count).toBe(0);
+    expect(recalibrated.total_memories_extracted).toBe(0);
+    expect(recalibrated.memories_since_last_persona).toBe(0);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -82,7 +82,7 @@ export interface Checkpoint {
   // ═══ Global counters ═══
   /** Epoch ms of the newest message successfully uploaded. Messages with ts > this are new. */
   last_captured_timestamp: number;
-  /** Total messages processed across all time */
+  /** Total L0 message records currently retained */
   total_processed: number;
   last_persona_at: number;
   last_persona_time: string;
@@ -100,11 +100,11 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /** Total L0 message records currently retained */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /** Total L1 memory records currently retained */
   total_memories_extracted: number;
 }
 
@@ -142,6 +142,16 @@ const DEFAULT_CHECKPOINT: Checkpoint = {
 export interface CheckpointLogger {
   info(msg: string): void;
   warn?(msg: string): void;
+}
+
+/**
+ * Minimal storage contract used to recalibrate data-derived counters.
+ * Kept structural so CheckpointManager does not depend on a concrete store.
+ */
+export interface CheckpointCounterSource {
+  isDegraded?(): boolean;
+  countL0(): number | Promise<number>;
+  countL1(): number | Promise<number>;
 }
 
 const noopLogger: CheckpointLogger = { info() {} };
@@ -291,6 +301,42 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Recount retained L0/L1 records and replace counters that can drift after
+   * cleanup, manual JSONL pruning, or data rollback.
+   *
+   * The active store is authoritative when available because it is the
+   * pipeline's primary read path. In degraded mode, valid records in the
+   * local JSONL shards are counted instead.
+   */
+  async recalibrate(source?: CheckpointCounterSource): Promise<void> {
+    await this.mutate(async (checkpoint) => {
+      const counts = await this.readActualCounts(source);
+      const previousTotalProcessed = checkpoint.total_processed;
+      const previousL0Count = checkpoint.l0_conversations_count;
+      const previousMemoriesExtracted = checkpoint.total_memories_extracted;
+      const memoryDelta = counts.l1 - previousMemoriesExtracted;
+
+      checkpoint.total_processed = counts.l0;
+      checkpoint.l0_conversations_count = counts.l0;
+      checkpoint.total_memories_extracted = counts.l1;
+
+      // Preserve the relationship to the last persona checkpoint while
+      // keeping the derived counters within the currently retained data.
+      checkpoint.memories_since_last_persona = Math.min(
+        counts.l1,
+        Math.max(0, checkpoint.memories_since_last_persona + memoryDelta),
+      );
+
+      this.logger.info(
+        `[checkpoint] recalibrate source=${counts.source}: ` +
+        `total_processed=${previousTotalProcessed}->${counts.l0}, ` +
+        `l0_conversations_count=${previousL0Count}->${counts.l0}, ` +
+        `total_memories_extracted=${previousMemoriesExtracted}->${counts.l1}`,
+      );
+    });
   }
 
   // ============================
@@ -449,7 +495,7 @@ export class CheckpointManager {
    *   - `{ maxTimestamp, messageCount }` to advance the cursor, or
    *   - `null` to leave the cursor unchanged (nothing captured).
    *
-   * L0 conversation count is also incremented inside the lock when messages
+   * L0 message record count is also incremented inside the lock when messages
    * are captured, removing the need for a separate `incrementL0ConversationCount()` call.
    *
    * @param sessionKey   Per-session identifier
@@ -479,10 +525,105 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        // Keep this counter in the same unit as countL0() and JSONL records.
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }
 
+  private async readActualCounts(
+    source?: CheckpointCounterSource,
+  ): Promise<{ l0: number; l1: number; source: "store" | "jsonl" }> {
+    if (source) {
+      try {
+        if (!source.isDegraded?.()) {
+          const [l0, l1] = await Promise.all([source.countL0(), source.countL1()]);
+          return {
+            l0: normalizeCount(l0, "L0"),
+            l1: normalizeCount(l1, "L1"),
+            source: "store",
+          };
+        }
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] Store recount failed, falling back to JSONL: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const [l0, l1] = await Promise.all([
+      this.countJsonlRecords("conversations", isL0Record),
+      this.countJsonlRecords("records", isL1Record),
+    ]);
+    return { l0, l1, source: "jsonl" };
+  }
+
+  private async countJsonlRecords(
+    directoryName: string,
+    isRecord: (value: unknown) => boolean,
+  ): Promise<number> {
+    const directory = path.join(path.dirname(path.dirname(this.filePath)), directoryName);
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(directory, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    let count = 0;
+    let skipped = 0;
+    const files = entries.filter(
+      (entry) => entry.isFile() && /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(entry.name),
+    );
+
+    for (const entry of files) {
+      const filePath = path.join(directory, entry.name);
+      try {
+        const raw = await fs.readFile(filePath, "utf-8");
+        for (const line of raw.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            if (isRecord(JSON.parse(line))) {
+              count++;
+            } else {
+              skipped++;
+            }
+          } catch {
+            skipped++;
+          }
+        }
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] Failed to count ${filePath}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    if (skipped > 0) {
+      this.logger.warn?.(
+        `[checkpoint] Ignored ${skipped} malformed ${directoryName} JSONL record(s) during recalibration`,
+      );
+    }
+    return count;
+  }
+}
+
+function normalizeCount(value: number, layer: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Invalid ${layer} record count: ${value}`);
+  }
+  return Math.floor(value);
+}
+
+function isL0Record(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.role === "string" && typeof record.content === "string";
+}
+
+function isL1Record(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return typeof (value as Record<string, unknown>).content === "string";
 }

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+describe("LocalMemoryCleaner checkpoint reconciliation", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-cleaner-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("recalibrates checkpoint counters after automatic store cleanup", async () => {
+    const checkpointManager = new CheckpointManager(dataDir);
+    const checkpoint = await checkpointManager.read();
+    checkpoint.total_processed = 60;
+    checkpoint.l0_conversations_count = 60;
+    checkpoint.total_memories_extracted = 30;
+    checkpoint.memories_since_last_persona = 10;
+    checkpoint.last_persona_at = 55;
+    await checkpointManager.write(checkpoint);
+
+    const countL0 = vi.fn()
+      .mockResolvedValueOnce(60)
+      .mockResolvedValueOnce(50);
+    const countL1 = vi.fn()
+      .mockResolvedValueOnce(30)
+      .mockResolvedValueOnce(25);
+    const deleteL0Expired = vi.fn().mockResolvedValue(10);
+    const deleteL1Expired = vi.fn().mockResolvedValue(5);
+    const vectorStore = {
+      isDegraded: () => false,
+      countL0,
+      countL1,
+      deleteL0Expired,
+      deleteL1Expired,
+    } as unknown as IMemoryStore;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore,
+    });
+
+    await cleaner.runOnce(Date.UTC(2026, 6, 24, 12));
+
+    expect(deleteL0Expired).toHaveBeenCalledOnce();
+    expect(deleteL1Expired).toHaveBeenCalledOnce();
+    expect(countL0).toHaveBeenCalledTimes(2);
+    expect(countL1).toHaveBeenCalledTimes(2);
+
+    const recalibrated = await checkpointManager.read();
+    expect(recalibrated.total_processed).toBe(50);
+    expect(recalibrated.l0_conversations_count).toBe(50);
+    expect(recalibrated.total_memories_extracted).toBe(25);
+    expect(recalibrated.memories_since_last_persona).toBe(5);
+    expect(recalibrated.last_persona_at).toBe(55);
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
@@ -178,6 +179,15 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await checkpoint.recalibrate(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint recalibration failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -238,6 +238,18 @@ async function _doInitStores(
     embeddingService = undefined;
   }
 
+  // Reconcile data-derived checkpoint counters once on startup. The store is
+  // preferred when healthy; JSONL is used automatically in degraded mode.
+  try {
+    const checkpoint = new CheckpointManager(pluginDataDir, logger);
+    await checkpoint.recalibrate(vectorStore);
+  } catch (err) {
+    logger.warn(
+      `${TAG} Checkpoint recalibration failed (non-fatal): ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   return { vectorStore, embeddingService, needsReindex, reindexReason };
 }
 


### PR DESCRIPTION
## Description | 描述
Fix checkpoint counters that drift after automatic cleanup, manual JSONL pruning, session data reset, or rollback.

### Checkpoint data flow

```mermaid
flowchart LR
  Capture["L0 capture"] --> L0["JSONL / active store"]
  Extract["L1 extraction"] --> L1["JSONL / active store"]
  L0 --> Increment["increment checkpoint counters"]
  L1 --> Increment
  Cleaner["memory-cleaner"] --> Delete["delete expired L0 / L1 data"]
  Delete --> Recalibrate["CheckpointManager.recalibrate()"]
  Startup["store initialization"] --> Recalibrate
  Recalibrate --> Checkpoint["recall_checkpoint.json"]
```

### Changes
- Add atomic `CheckpointManager.recalibrate()`, using the active store when healthy and valid JSONL records as the degraded fallback.
- Reconcile `total_processed`, `l0_conversations_count`, `total_memories_extracted`, and `memories_since_last_persona`.
- Align L0 increments with the store/JSONL message-record unit.
- Recalibrate once at store startup and after each memory-cleaner run.
- Preserve runner/pipeline session state and persona history markers.

## Related Issue | 关联 Issue
Fixes #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
- Added tests for active-store cleanup, manual JSONL pruning, full reset, malformed JSONL, and session-state preservation.
- Full result: 6 test files / 71 tests passed.
- Plugin build and all three script TypeScript builds passed.
- Incremental selection is cursor-based, not counter-based; recalibration intentionally preserves runner cursors to avoid replaying retained data.