### PR TITLE
feat(adapters): add Claude Code and Codex MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,33 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Claude Code and Codex (MCP)
+
+The MCP stdio adapter exposes recall, capture, L1/L0 search, health, and
+session flush tools to both Claude Code and Codex through the same binary.
+Start the Gateway first, then register the adapter:
+
+```bash
+# Claude Code
+claude mcp add --scope project --transport stdio \
+  --env TDAI_MCP_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_MCP_SESSION_KEY=my-project \
+  tencentdb-memory \
+  -- npx -y --package @tencentdb-agent-memory/memory-tencentdb tdai-memory-mcp
+
+# Codex
+codex mcp add tencentdb-memory \
+  --env TDAI_MCP_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_MCP_SESSION_KEY=my-project \
+  -- npx -y --package @tencentdb-agent-memory/memory-tencentdb tdai-memory-mcp
+```
+
+MCP has no universal before-prompt or turn-completed hooks, so recall and
+capture are model-initiated tools. The server advertises usage instructions;
+for deterministic behavior, add the same policy to `CLAUDE.md` or `AGENTS.md`.
+See the [cross-platform adapter guide](./docs/cross-platform-adapters.md) for
+architecture, data flow, environment variables, and extension practices.
+
 
 ## 🔒 Gateway Security (optional)
 
@@ -526,6 +553,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | :--- | :--- |
 | OpenClaw plugin | Automatically captures, extracts, and recalls memory once installed |
 | Hermes Gateway adapter | `TdaiCore + HostAdapter`, decoupled from the host framework |
+| MCP adapter | Shared recall/capture/search tools for Claude Code and Codex |
 | Local backend | `SQLite + sqlite-vec`, ready to use out of the box |
 | Hybrid retrieval | BM25 + vector + RRF — supports both keyword and semantic recall |
 | Agent tools | `tdai_memory_search` / `tdai_conversation_search` |
@@ -536,6 +564,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 
 | Document | Contents |
 | :--- | :--- |
+| [`docs/cross-platform-adapters.md`](./docs/cross-platform-adapters.md) | Adapter architecture, MCP setup, and platform comparison |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |

--- a/README_CN.md
+++ b/README_CN.md
@@ -385,6 +385,31 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Claude Code 与 Codex（MCP）
+
+MCP stdio 适配器通过同一个可执行入口，为 Claude Code 和 Codex 提供召回、
+写入、L1/L0 检索、健康检查与会话刷新工具。先启动 Gateway，再注册适配器：
+
+```bash
+# Claude Code
+claude mcp add --scope project --transport stdio \
+  --env TDAI_MCP_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_MCP_SESSION_KEY=my-project \
+  tencentdb-memory \
+  -- npx -y --package @tencentdb-agent-memory/memory-tencentdb tdai-memory-mcp
+
+# Codex
+codex mcp add tencentdb-memory \
+  --env TDAI_MCP_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_MCP_SESSION_KEY=my-project \
+  -- npx -y --package @tencentdb-agent-memory/memory-tencentdb tdai-memory-mcp
+```
+
+MCP 没有通用的 before-prompt 或 turn-completed 生命周期钩子，因此召回和写入
+由模型主动调用。服务端会在初始化时下发工具使用说明；如需确定性行为，请在
+`CLAUDE.md` 或 `AGENTS.md` 中加入相同规则。架构图、数据流、环境变量和后续
+平台扩展规范见[跨平台适配指南](./docs/cross-platform-adapters.md)。
+
 
 ## 🔒 Gateway 安全配置（可选）
 
@@ -527,6 +552,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | :--- | :--- |
 | OpenClaw 插件 | 安装后即可自动捕获、提取、召回记忆 |
 | Hermes Gateway 适配 | `TdaiCore + HostAdapter` 解耦宿主框架 |
+| MCP 适配器 | 为 Claude Code 与 Codex 复用召回、写入和检索工具 |
 | 本地后端 | `SQLite + sqlite-vec`，开箱即用 |
 | 混合检索 | BM25 + 向量 + RRF，兼顾关键词和语义召回 |
 | Agent 工具 | `tdai_memory_search` / `tdai_conversation_search` |
@@ -537,6 +563,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 
 | 文档 | 内容 |
 | :--- | :--- |
+| [`docs/cross-platform-adapters.md`](./docs/cross-platform-adapters.md) | 适配器架构、MCP 配置与平台差异 |
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |

--- a/docs/cross-platform-adapters.md
+++ b/docs/cross-platform-adapters.md
@@ -1,0 +1,281 @@
+# Cross-Platform Adapter Guide
+
+This document describes the stable memory boundary, the existing OpenClaw and
+Hermes integrations, and the MCP adapter for Claude Code and Codex.
+
+## Architecture
+
+TencentDB Agent Memory supports two integration styles:
+
+- **In-process:** the host supplies a `HostAdapter` and calls `TdaiCore`
+  directly. OpenClaw uses this path.
+- **Sidecar:** the host translates its lifecycle or tool protocol into the
+  Gateway HTTP API. Hermes and MCP use this path.
+
+```mermaid
+flowchart LR
+    subgraph Hosts
+        OC[OpenClaw]
+        HE[Hermes Agent]
+        CC[Claude Code]
+        CX[Codex]
+    end
+
+    OC -->|Plugin SDK hooks and tools| OCA[OpenClaw adapter]
+    OCA -->|in process| CORE[TdaiCore]
+
+    HE -->|MemoryProvider lifecycle| HP[Hermes provider]
+    HP -->|HTTP| GW[TDAI Gateway]
+
+    CC -->|MCP stdio| MCP[MCP adapter]
+    CX -->|MCP stdio| MCP
+    MCP -->|MemoryService| GC[GatewayMemoryClient]
+    GC -->|HTTP| GW
+
+    GW --> SHA[StandaloneHostAdapter]
+    SHA --> CORE
+
+    CORE --> L0[L0 conversations]
+    CORE --> L1[L1 structured memories]
+    CORE --> L2[L2 scene blocks]
+    CORE --> L3[L3 persona]
+    CORE --> STORE[(SQLite / Tencent VectorDB)]
+```
+
+### Recall data flow
+
+```mermaid
+sequenceDiagram
+    participant Host as Claude Code / Codex
+    participant MCP as MCP adapter
+    participant Client as GatewayMemoryClient
+    participant Gateway as TDAI Gateway
+    participant Core as TdaiCore
+
+    Host->>MCP: tools/call tdai_recall
+    MCP->>Client: recall(query, sessionKey, userId)
+    Client->>Gateway: POST /recall
+    Gateway->>Core: handleBeforeRecall(query, sessionKey)
+    Core-->>Gateway: RecallResult
+    Gateway-->>Client: context, strategy, memory_count
+    Client-->>MCP: RecallOutput
+    MCP-->>Host: MCP text result
+```
+
+### Capture data flow
+
+```mermaid
+sequenceDiagram
+    participant Host as Claude Code / Codex
+    participant MCP as MCP adapter
+    participant Client as GatewayMemoryClient
+    participant Gateway as TDAI Gateway
+    participant Core as TdaiCore
+
+    Host->>MCP: tools/call tdai_capture
+    MCP->>Client: capture(completed turn)
+    Client->>Gateway: POST /capture
+    Gateway->>Core: handleTurnCommitted(turn)
+    Core->>Core: write L0 and notify pipeline
+    Core-->>Gateway: CaptureResult
+    Gateway-->>Client: l0_recorded, scheduler_notified
+    Client-->>MCP: CaptureOutput
+    MCP-->>Host: MCP text result
+```
+
+## Core capability boundary
+
+`TdaiCore` is host-neutral. Platform adapters should map host concepts to this
+surface rather than importing lower-level stores or pipeline modules.
+
+| Core method | Purpose | Gateway endpoint | MCP tool |
+| :--- | :--- | :--- | :--- |
+| `handleBeforeRecall` | Build relevant L1/L3 context before a turn | `POST /recall` | `tdai_recall` |
+| `handleTurnCommitted` | Persist L0 messages and schedule extraction | `POST /capture` | `tdai_capture` |
+| `searchMemories` | Search L1 structured memories | `POST /search/memories` | `tdai_memory_search` |
+| `searchConversations` | Search L0 raw dialogue | `POST /search/conversations` | `tdai_conversation_search` |
+| `handleSessionEnd` | Flush one session without stopping shared resources | `POST /session/end` | `tdai_session_end` |
+| `destroy` | Stop the complete engine and close stores | Gateway process shutdown | Not exposed |
+
+Important boundaries:
+
+- A stable `session_key` is required for recall, capture, and session flush.
+- The Gateway owns storage and LLM configuration. MCP clients do not initialize
+  stores or call extraction models themselves.
+- `user_id` is transported for API compatibility, but the current core uses a
+  shared Gateway data directory and does not provide hard per-user isolation.
+  Use separate Gateway data directories/processes when isolation is required.
+- Session end and process shutdown are different operations. A platform must
+  not stop the shared Gateway when one conversation ends.
+
+## Adapter comparison
+
+| Property | OpenClaw | Hermes | Claude Code / Codex |
+| :--- | :--- | :--- | :--- |
+| Host binding | Plugin SDK | Python `MemoryProvider` | MCP |
+| Core location | In host process | Node.js sidecar | Node.js sidecar |
+| Transport | Direct calls | HTTP Gateway | stdio JSON-RPC, then HTTP Gateway |
+| Recall trigger | `before_prompt_build` hook | `prefetch()` | `tdai_recall` tool call |
+| Capture trigger | `agent_end` hook | `sync_turn()` | `tdai_capture` tool call |
+| Search | Registered OpenClaw tools | Provider tool schemas | MCP tools |
+| Session flush | Gateway shutdown | `on_session_end` | `tdai_session_end` tool call |
+| LLM integration | OpenClaw embedded runtime | Standalone OpenAI-compatible runner | Gateway standalone runner |
+| Automatic lifecycle | Yes | Yes | No host hooks; guided tool usage |
+
+MCP deliberately exposes explicit tools because MCP does not define universal
+"before prompt" or "turn committed" hooks. The server returns workflow
+instructions during MCP initialization, but the host model still decides when
+to call tools. Add durable host instructions when deterministic capture is
+required.
+
+## Adapter SDK
+
+The package exports a transport-neutral service contract and Gateway client:
+
+```ts
+import {
+  GatewayMemoryClient,
+  type MemoryService,
+} from "@tencentdb-agent-memory/memory-tencentdb/adapter-sdk";
+
+const memory: MemoryService = new GatewayMemoryClient({
+  baseUrl: "http://127.0.0.1:8420",
+  apiKey: process.env.TDAI_GATEWAY_API_KEY,
+  timeoutMs: 10_000,
+});
+```
+
+Protocol adapters depend only on `MemoryService`. This keeps platform-specific
+event and tool mapping separate from HTTP details and makes a fake service easy
+to inject in tests.
+
+The client:
+
+- maps camelCase SDK inputs to the Gateway's snake_case JSON API;
+- applies one timeout to every request;
+- optionally sends a Bearer token;
+- converts non-2xx and invalid JSON responses into
+  `GatewayMemoryClientError`;
+- never includes the API key in error messages.
+
+## MCP tools
+
+| Tool | Mode | Description |
+| :--- | :---: | :--- |
+| `tdai_health` | Read | Check Gateway and store availability |
+| `tdai_recall` | Read | Retrieve context relevant to the next response |
+| `tdai_capture` | Write | Persist one completed user/assistant turn |
+| `tdai_memory_search` | Read | Search L1 structured memories |
+| `tdai_conversation_search` | Read | Search L0 raw conversations |
+| `tdai_session_end` | Write | Flush pending work for one session |
+
+Read/write and idempotency hints are declared through MCP tool annotations so
+hosts can apply appropriate approval policies.
+
+## Run the MCP adapter
+
+### 1. Start the Gateway
+
+From a source checkout:
+
+```bash
+export TDAI_LLM_API_KEY="your-api-key"
+export TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+export TDAI_LLM_MODEL="gpt-4o"
+npx tsx src/gateway/server.ts
+```
+
+Verify it before configuring an MCP host:
+
+```bash
+curl http://127.0.0.1:8420/health
+```
+
+### 2. Configure Claude Code
+
+```bash
+claude mcp add \
+  --scope project \
+  --transport stdio \
+  --env TDAI_MCP_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_MCP_SESSION_KEY=my-project \
+  tencentdb-memory \
+  -- npx -y --package @tencentdb-agent-memory/memory-tencentdb tdai-memory-mcp
+```
+
+Use `claude mcp list` or `/mcp` to verify that six tools are available.
+
+### 3. Configure Codex
+
+```bash
+codex mcp add tencentdb-memory \
+  --env TDAI_MCP_GATEWAY_URL=http://127.0.0.1:8420 \
+  --env TDAI_MCP_SESSION_KEY=my-project \
+  -- npx -y --package @tencentdb-agent-memory/memory-tencentdb tdai-memory-mcp
+```
+
+Use `codex mcp list` or `/mcp` in the Codex TUI to verify the connection.
+
+### Source-checkout command
+
+When developing locally, build once and point either host at the generated
+binary:
+
+```bash
+npm install
+npm run build:plugin
+node /absolute/path/to/TencentDB-Agent-Memory/dist/mcp-server.mjs
+```
+
+Replace the `npx ... tdai-memory-mcp` command in the host examples with the
+absolute `node .../dist/mcp-server.mjs` command.
+
+### Environment variables
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `TDAI_MCP_GATEWAY_URL` | `http://127.0.0.1:8420` | Gateway root URL |
+| `TDAI_GATEWAY_API_KEY` | unset | Bearer token for protected Gateway routes |
+| `TDAI_MCP_TIMEOUT_MS` | `10000` | Positive integer request timeout |
+| `TDAI_MCP_SESSION_KEY` | unset | Default session key for tool calls |
+| `TDAI_MCP_USER_ID` | unset | Default user identifier |
+
+Tool arguments override the session key and user ID defaults. Never place an
+API key in a committed project MCP configuration; pass it through the host
+environment.
+
+### Recommended host instruction
+
+Place an equivalent rule in `CLAUDE.md` or `AGENTS.md`:
+
+```md
+Before answering requests that may depend on prior context, call
+tdai_recall. After each meaningful completed user/assistant turn, call
+tdai_capture with the original user message and final response.
+```
+
+## Adding another platform
+
+1. Choose in-process integration only when the host can provide the
+   `HostAdapter` and LLM runtime contracts. Otherwise use the Gateway.
+2. Reuse `GatewayMemoryClient` or provide another `MemoryService`
+   implementation.
+3. Map the host's pre-turn event to `recall`, completed-turn event to
+   `capture`, search tool API to the two search methods, and session close to
+   `endSession`.
+4. Keep platform dependencies inside a dedicated adapter directory.
+5. Preserve stable session keys and avoid using process shutdown for a single
+   session.
+6. Add contract tests with a fake `MemoryService`, then add one transport-level
+   test against a fake Gateway.
+7. Document automatic versus model-initiated lifecycle behavior explicitly.
+
+## Verification
+
+The MCP adapter is covered at three levels:
+
+- Gateway client unit tests for routing, authentication, response mapping, and
+  error redaction;
+- MCP tool contract tests with an injected fake `MemoryService`;
+- a stdio end-to-end test that launches the built binary, negotiates MCP,
+  discovers tools, and calls recall and capture against a fake HTTP Gateway.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./dist/index.mjs",
   "bin": {
+    "tdai-memory-mcp": "./dist/mcp-server.mjs",
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
     "read-local-memory": "./bin/read-local-memory.mjs"
@@ -13,6 +14,11 @@
     ".": {
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./adapter-sdk": {
+      "types": "./src/adapters/gateway/index.ts",
+      "import": "./dist/adapter-sdk.mjs",
+      "default": "./dist/adapter-sdk.mjs"
     }
   },
   "scripts": {
@@ -47,6 +53,7 @@
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "docs/cross-platform-adapters.md",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
@@ -60,6 +67,9 @@
     "openclaw-plugin",
     "memory",
     "ai-memory",
+    "mcp",
+    "claude-code",
+    "codex",
     "long-term-memory",
     "vector-search",
     "sqlite-vec",
@@ -119,6 +129,7 @@
     }
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^25.5.2",
     "@vitest/coverage-v8": "^4.1.2",
     "tsdown": "^0.21.10",

--- a/src/adapters/gateway/client.test.ts
+++ b/src/adapters/gateway/client.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GatewayMemoryClient, GatewayMemoryClientError } from "./client.js";
+
+describe("GatewayMemoryClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps recall to the Gateway API and attaches bearer authentication", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({
+        context: "prefers TypeScript",
+        strategy: "hybrid",
+        memory_count: 1,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const client = new GatewayMemoryClient({
+      baseUrl: "http://127.0.0.1:8420/",
+      apiKey: "gateway-secret",
+      fetch: fetchMock,
+    });
+
+    const result = await client.recall({
+      query: "What language does the user prefer?",
+      sessionKey: "session-1",
+      userId: "user-1",
+    });
+
+    expect(result.context).toBe("prefers TypeScript");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8420/recall");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer gateway-secret",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      query: "What language does the user prefer?",
+      session_key: "session-1",
+      user_id: "user-1",
+    });
+  });
+
+  it("maps capture and search operations to their host-neutral contracts", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ l0_recorded: 2, scheduler_notified: true }))
+      .mockResolvedValueOnce(Response.json({ results: "memory result", total: 1, strategy: "keyword" }))
+      .mockResolvedValueOnce(Response.json({ results: "conversation result", total: 1 }))
+      .mockResolvedValueOnce(Response.json({ flushed: true }));
+    const client = new GatewayMemoryClient({
+      baseUrl: "http://localhost:8420",
+      fetch: fetchMock,
+    });
+
+    await expect(client.capture({
+      userContent: "Remember this",
+      assistantContent: "I will",
+      sessionKey: "session-2",
+      sessionId: "turn-2",
+      messages: [{ role: "user", content: "Remember this" }],
+    })).resolves.toEqual({ l0Recorded: 2, schedulerNotified: true });
+    await expect(client.searchMemories({
+      query: "TypeScript",
+      limit: 3,
+      type: "instruction",
+      scene: "coding",
+    })).resolves.toEqual({ results: "memory result", total: 1, strategy: "keyword" });
+    await expect(client.searchConversations({
+      query: "Remember",
+      limit: 4,
+      sessionKey: "session-2",
+    })).resolves.toEqual({ results: "conversation result", total: 1 });
+    await expect(client.endSession({ sessionKey: "session-2" })).resolves.toEqual({ flushed: true });
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "http://localhost:8420/capture",
+      "http://localhost:8420/search/memories",
+      "http://localhost:8420/search/conversations",
+      "http://localhost:8420/session/end",
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      user_content: "Remember this",
+      assistant_content: "I will",
+      session_key: "session-2",
+      session_id: "turn-2",
+      messages: [{ role: "user", content: "Remember this" }],
+    });
+  });
+
+  it("surfaces structured Gateway failures without leaking the API key", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json({ error: "invalid request", code: "BAD_REQUEST" }, { status: 400 }),
+    );
+    const client = new GatewayMemoryClient({
+      baseUrl: "http://localhost:8420",
+      apiKey: "must-not-leak",
+      fetch: fetchMock,
+    });
+
+    const error = await client.searchMemories({ query: "test" }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(GatewayMemoryClientError);
+    expect(error).toMatchObject({
+      status: 400,
+      code: "BAD_REQUEST",
+      message: "Gateway request failed (400): invalid request",
+    });
+    expect(String(error)).not.toContain("must-not-leak");
+  });
+
+  it("rejects invalid transport configuration at construction time", () => {
+    expect(() => new GatewayMemoryClient({
+      baseUrl: "file:///tmp/gateway.sock",
+    })).toThrow("baseUrl must use http or https");
+    expect(() => new GatewayMemoryClient({
+      baseUrl: "http://localhost:8420?token=unsafe",
+    })).toThrow("baseUrl must not contain a query or fragment");
+    expect(() => new GatewayMemoryClient({
+      baseUrl: "http://localhost:8420",
+      timeoutMs: 0,
+    })).toThrow("timeoutMs must be a positive integer");
+  });
+});

--- a/src/adapters/gateway/client.ts
+++ b/src/adapters/gateway/client.ts
@@ -1,0 +1,214 @@
+import type {
+  CaptureInput,
+  CaptureOutput,
+  ConversationSearchInput,
+  ConversationSearchOutput,
+  EndSessionInput,
+  EndSessionOutput,
+  HealthResult,
+  MemorySearchInput,
+  MemorySearchOutput,
+  MemoryService,
+  RecallInput,
+  RecallOutput,
+} from "./types.js";
+import type {
+  CaptureResponse,
+  ConversationSearchResponse,
+  GatewayErrorResponse,
+  MemorySearchResponse,
+  RecallResponse,
+  SessionEndResponse,
+} from "../../gateway/types.js";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface GatewayMemoryClientOptions {
+  /** Gateway root URL, for example http://127.0.0.1:8420. */
+  baseUrl: string;
+  /** Optional Bearer token matching TDAI_GATEWAY_API_KEY. */
+  apiKey?: string;
+  /** Request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Injectable fetch implementation for non-Node hosts and tests. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export class GatewayMemoryClientError extends Error {
+  readonly status?: number;
+  readonly code?: string;
+
+  constructor(message: string, options?: {
+    status?: number;
+    code?: string;
+    cause?: unknown;
+  }) {
+    super(message, { cause: options?.cause });
+    this.name = "GatewayMemoryClientError";
+    this.status = options?.status;
+    this.code = options?.code;
+  }
+}
+
+/**
+ * TypeScript SDK for the host-neutral TDAI Gateway API.
+ *
+ * The client performs only transport translation. Platform lifecycle and tool
+ * semantics remain in the adapter that consumes the MemoryService interface.
+ */
+export class GatewayMemoryClient implements MemoryService {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: GatewayMemoryClientOptions) {
+    const parsedUrl = new URL(options.baseUrl);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      throw new TypeError("Gateway baseUrl must use http or https");
+    }
+    if (parsedUrl.search || parsedUrl.hash) {
+      throw new TypeError("Gateway baseUrl must not contain a query or fragment");
+    }
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new TypeError("Gateway timeoutMs must be a positive integer");
+    }
+
+    this.baseUrl = parsedUrl.toString().replace(/\/+$/, "");
+    this.apiKey = options.apiKey?.trim() || undefined;
+    this.timeoutMs = timeoutMs;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  health(): Promise<HealthResult> {
+    return this.request<HealthResult>("GET", "/health");
+  }
+
+  async recall(input: RecallInput): Promise<RecallOutput> {
+    const response = await this.request<RecallResponse>("POST", "/recall", {
+      query: input.query,
+      session_key: input.sessionKey,
+      ...(input.userId ? { user_id: input.userId } : {}),
+    });
+    return {
+      context: response.context,
+      strategy: response.strategy,
+      memoryCount: response.memory_count,
+    };
+  }
+
+  async capture(input: CaptureInput): Promise<CaptureOutput> {
+    const response = await this.request<CaptureResponse>("POST", "/capture", {
+      user_content: input.userContent,
+      assistant_content: input.assistantContent,
+      session_key: input.sessionKey,
+      ...(input.sessionId ? { session_id: input.sessionId } : {}),
+      ...(input.userId ? { user_id: input.userId } : {}),
+      ...(input.messages ? { messages: input.messages } : {}),
+    });
+    return {
+      l0Recorded: response.l0_recorded,
+      schedulerNotified: response.scheduler_notified,
+    };
+  }
+
+  async searchMemories(input: MemorySearchInput): Promise<MemorySearchOutput> {
+    const response = await this.request<MemorySearchResponse>("POST", "/search/memories", {
+      query: input.query,
+      ...(input.limit !== undefined ? { limit: input.limit } : {}),
+      ...(input.type ? { type: input.type } : {}),
+      ...(input.scene ? { scene: input.scene } : {}),
+    });
+    return {
+      results: response.results,
+      total: response.total,
+      strategy: response.strategy,
+    };
+  }
+
+  async searchConversations(input: ConversationSearchInput): Promise<ConversationSearchOutput> {
+    const response = await this.request<ConversationSearchResponse>("POST", "/search/conversations", {
+      query: input.query,
+      ...(input.limit !== undefined ? { limit: input.limit } : {}),
+      ...(input.sessionKey ? { session_key: input.sessionKey } : {}),
+    });
+    return {
+      results: response.results,
+      total: response.total,
+    };
+  }
+
+  async endSession(input: EndSessionInput): Promise<EndSessionOutput> {
+    const response = await this.request<SessionEndResponse>("POST", "/session/end", {
+      session_key: input.sessionKey,
+      ...(input.userId ? { user_id: input.userId } : {}),
+    });
+    return { flushed: response.flushed };
+  }
+
+  private async request<T>(
+    method: "GET" | "POST",
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (body) headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+      const payload = await this.parseResponse(response);
+      if (!response.ok) {
+        const gatewayError = payload as GatewayErrorResponse;
+        const detail = typeof gatewayError?.error === "string"
+          ? gatewayError.error
+          : response.statusText || "unknown error";
+        throw new GatewayMemoryClientError(
+          `Gateway request failed (${response.status}): ${detail}`,
+          {
+            status: response.status,
+            code: gatewayError?.code,
+          },
+        );
+      }
+      return payload as T;
+    } catch (error) {
+      if (error instanceof GatewayMemoryClientError) throw error;
+      const timedOut = controller.signal.aborted;
+      const detail = timedOut
+        ? `timed out after ${this.timeoutMs}ms`
+        : error instanceof Error ? error.message : String(error);
+      throw new GatewayMemoryClientError(`Gateway request failed: ${detail}`, {
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async parseResponse(response: Response): Promise<unknown> {
+    const text = await response.text();
+    if (!text) return {};
+    try {
+      return JSON.parse(text) as unknown;
+    } catch (error) {
+      throw new GatewayMemoryClientError(
+        `Gateway returned invalid JSON (${response.status})`,
+        {
+          status: response.status,
+          cause: error,
+        },
+      );
+    }
+  }
+}

--- a/src/adapters/gateway/index.ts
+++ b/src/adapters/gateway/index.ts
@@ -1,0 +1,16 @@
+export { GatewayMemoryClient, GatewayMemoryClientError } from "./client.js";
+export type { GatewayMemoryClientOptions } from "./client.js";
+export type {
+  CaptureInput,
+  CaptureOutput,
+  ConversationSearchInput,
+  ConversationSearchOutput,
+  EndSessionInput,
+  EndSessionOutput,
+  HealthResult,
+  MemorySearchInput,
+  MemorySearchOutput,
+  MemoryService,
+  RecallInput,
+  RecallOutput,
+} from "./types.js";

--- a/src/adapters/gateway/types.ts
+++ b/src/adapters/gateway/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Platform-neutral memory capability contract.
+ *
+ * Protocol adapters such as MCP depend on this interface rather than on
+ * TdaiCore or a concrete transport. A direct in-process adapter and the HTTP
+ * Gateway client can therefore expose the same capabilities.
+ */
+
+export interface HealthResult {
+  status: "ok" | "degraded";
+  version: string;
+  uptime: number;
+  stores: {
+    vectorStore: boolean;
+    embeddingService: boolean;
+  };
+}
+
+export interface RecallInput {
+  query: string;
+  sessionKey: string;
+  userId?: string;
+}
+
+export interface RecallOutput {
+  context: string;
+  strategy?: string;
+  memoryCount?: number;
+}
+
+export interface CaptureInput {
+  userContent: string;
+  assistantContent: string;
+  sessionKey: string;
+  sessionId?: string;
+  userId?: string;
+  messages?: unknown[];
+}
+
+export interface CaptureOutput {
+  l0Recorded: number;
+  schedulerNotified: boolean;
+}
+
+export interface MemorySearchInput {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface MemorySearchOutput {
+  results: string;
+  total: number;
+  strategy: string;
+}
+
+export interface ConversationSearchInput {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export interface ConversationSearchOutput {
+  results: string;
+  total: number;
+}
+
+export interface EndSessionInput {
+  sessionKey: string;
+  userId?: string;
+}
+
+export interface EndSessionOutput {
+  flushed: boolean;
+}
+
+/**
+ * The complete public capability surface required by a platform adapter.
+ */
+export interface MemoryService {
+  health(): Promise<HealthResult>;
+  recall(input: RecallInput): Promise<RecallOutput>;
+  capture(input: CaptureInput): Promise<CaptureOutput>;
+  searchMemories(input: MemorySearchInput): Promise<MemorySearchOutput>;
+  searchConversations(input: ConversationSearchInput): Promise<ConversationSearchOutput>;
+  endSession(input: EndSessionInput): Promise<EndSessionOutput>;
+}

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { runMemoryMcpServer } from "./server.js";
+
+const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function optionalEnv(name: string): string | undefined {
+  return process.env[name]?.trim() || undefined;
+}
+
+function parseTimeout(value: string | undefined): number {
+  if (!value) return DEFAULT_TIMEOUT_MS;
+  const timeout = Number(value);
+  if (!Number.isInteger(timeout) || timeout <= 0) {
+    throw new Error("TDAI_MCP_TIMEOUT_MS must be a positive integer");
+  }
+  return timeout;
+}
+
+async function main(): Promise<void> {
+  const server = await runMemoryMcpServer({
+    gateway: {
+      baseUrl: optionalEnv("TDAI_MCP_GATEWAY_URL") ?? DEFAULT_GATEWAY_URL,
+      apiKey: optionalEnv("TDAI_GATEWAY_API_KEY"),
+      timeoutMs: parseTimeout(optionalEnv("TDAI_MCP_TIMEOUT_MS")),
+    },
+    sessionKey: optionalEnv("TDAI_MCP_SESSION_KEY"),
+    userId: optionalEnv("TDAI_MCP_USER_ID"),
+  });
+
+  const shutdown = async () => {
+    await server.close();
+    process.exit(0);
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  // stdout is reserved exclusively for MCP JSON-RPC messages.
+  console.error(
+    `[tdai-mcp] ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+});

--- a/src/adapters/mcp/index.ts
+++ b/src/adapters/mcp/index.ts
@@ -1,0 +1,8 @@
+export { createMemoryMcpServer, runMemoryMcpServer } from "./server.js";
+export type { MemoryMcpServerOptions } from "./server.js";
+export { registerMemoryTools } from "./tools.js";
+export type {
+  McpToolRegistrar,
+  McpToolResult,
+  MemoryToolDefaults,
+} from "./tools.js";

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -1,0 +1,81 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import packageJson from "../../../package.json" with { type: "json" };
+
+import {
+  GatewayMemoryClient,
+  type GatewayMemoryClientOptions,
+} from "../gateway/client.js";
+import type { MemoryService } from "../gateway/types.js";
+import {
+  registerMemoryTools,
+  type McpToolRegistrar,
+  type MemoryToolDefaults,
+} from "./tools.js";
+
+const SERVER_NAME = "tencentdb-agent-memory";
+const SERVER_VERSION = packageJson.version;
+
+const SERVER_INSTRUCTIONS =
+  "Use tdai_recall before answering when prior preferences, decisions, or project context may matter. " +
+  "Use tdai_memory_search for structured long-term facts and tdai_conversation_search for exact prior dialogue. " +
+  "After a meaningful completed turn, call tdai_capture with the original user message and final assistant response. " +
+  "Call tdai_session_end when the host session is ending.";
+
+export interface MemoryMcpServerOptions extends MemoryToolDefaults {
+  /** Existing service implementation, primarily for embedding and tests. */
+  service?: MemoryService;
+  /** Gateway client options used when service is not supplied. */
+  gateway?: GatewayMemoryClientOptions;
+}
+
+/**
+ * Create an MCP server backed by the platform-neutral MemoryService contract.
+ */
+export function createMemoryMcpServer(options: MemoryMcpServerOptions): McpServer {
+  const service = options.service ?? createGatewayService(options.gateway);
+  const server = new McpServer(
+    {
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
+    },
+    {
+      instructions: SERVER_INSTRUCTIONS,
+    },
+  );
+
+  // McpServer's registerTool method is generic, while registerMemoryTools
+  // intentionally depends on a minimal structural interface for testability.
+  registerMemoryTools(
+    server as unknown as McpToolRegistrar,
+    service,
+    {
+      sessionKey: options.sessionKey,
+      userId: options.userId,
+    },
+  );
+
+  return server;
+}
+
+/**
+ * Start the local stdio transport used by Claude Code, Codex, and other MCP
+ * hosts. All diagnostic output must go to stderr so stdout remains valid MCP.
+ */
+export async function runMemoryMcpServer(
+  options: MemoryMcpServerOptions,
+): Promise<McpServer> {
+  const server = createMemoryMcpServer(options);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return server;
+}
+
+function createGatewayService(
+  options: GatewayMemoryClientOptions | undefined,
+): MemoryService {
+  if (!options) {
+    throw new Error("Gateway options are required when no MemoryService is supplied");
+  }
+  return new GatewayMemoryClient(options);
+}

--- a/src/adapters/mcp/stdio.e2e.test.ts
+++ b/src/adapters/mcp/stdio.e2e.test.ts
@@ -1,0 +1,190 @@
+import http from "node:http";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  authorization?: string;
+  body?: Record<string, unknown>;
+}
+
+function readTextContent(result: unknown): string {
+  if (typeof result !== "object" || result === null || !("content" in result)) {
+    throw new TypeError("MCP tool result must contain content");
+  }
+  if (!Array.isArray(result.content)) {
+    throw new TypeError("MCP tool result content must be an array");
+  }
+  const textItem = result.content.find((item): item is { type: "text"; text: string } => (
+    typeof item === "object" &&
+    item !== null &&
+    "type" in item &&
+    item.type === "text" &&
+    "text" in item &&
+    typeof item.text === "string"
+  ));
+  if (!textItem) throw new TypeError("MCP tool result has no text content");
+  return textItem.text;
+}
+
+describe("MCP stdio adapter", () => {
+  const requests: RecordedRequest[] = [];
+  let gateway: http.Server;
+  let gatewayUrl: string;
+
+  beforeAll(async () => {
+    gateway = http.createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const text = Buffer.concat(chunks).toString("utf-8");
+      const body = text ? JSON.parse(text) as Record<string, unknown> : undefined;
+      requests.push({
+        method: request.method ?? "",
+        path: request.url ?? "",
+        authorization: request.headers.authorization,
+        body,
+      });
+
+      response.setHeader("Content-Type", "application/json");
+      if (request.url === "/recall") {
+        response.end(JSON.stringify({
+          context: "The user prefers TypeScript.",
+          strategy: "hybrid",
+          memory_count: 1,
+        }));
+        return;
+      }
+      if (request.url === "/capture") {
+        response.end(JSON.stringify({
+          l0_recorded: 2,
+          scheduler_notified: true,
+        }));
+        return;
+      }
+      if (request.url === "/health") {
+        response.end(JSON.stringify({
+          status: "ok",
+          version: "0.1.0",
+          uptime: 1,
+          stores: { vectorStore: true, embeddingService: true },
+        }));
+        return;
+      }
+
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: "not found" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      gateway.once("error", reject);
+      gateway.listen(0, "127.0.0.1", resolve);
+    });
+    const address = gateway.address() as AddressInfo;
+    gatewayUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      gateway.close((error) => error ? reject(error) : resolve());
+    });
+  });
+
+  it("negotiates MCP and maps read/write tools to the Gateway", async () => {
+    const stderr: string[] = [];
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.resolve("dist/mcp-server.mjs")],
+      cwd: process.cwd(),
+      env: {
+        ...getDefaultEnvironment(),
+        TDAI_MCP_GATEWAY_URL: gatewayUrl,
+        TDAI_GATEWAY_API_KEY: "test-secret",
+        TDAI_MCP_SESSION_KEY: "project-session",
+        TDAI_MCP_USER_ID: "developer-1",
+      },
+      stderr: "pipe",
+    });
+    transport.stderr?.on("data", (chunk) => stderr.push(String(chunk)));
+
+    const client = new Client({
+      name: "tdai-mcp-e2e",
+      version: "1.0.0",
+    });
+
+    try {
+      await client.connect(transport);
+      expect(client.getServerVersion()?.name).toBe("tencentdb-agent-memory");
+      expect(client.getInstructions()).toContain("tdai_capture");
+
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        "tdai_health",
+        "tdai_recall",
+        "tdai_capture",
+        "tdai_memory_search",
+        "tdai_conversation_search",
+        "tdai_session_end",
+      ]);
+      expect(tools.tools.find((tool) => tool.name === "tdai_capture")?.annotations)
+        .toMatchObject({ readOnlyHint: false, destructiveHint: false });
+
+      const recall = await client.callTool({
+        name: "tdai_recall",
+        arguments: { query: "Which language should I use?" },
+      }, CallToolResultSchema);
+      expect(JSON.parse(readTextContent(recall)))
+        .toMatchObject({
+          context: "The user prefers TypeScript.",
+          memory_count: 1,
+        });
+
+      const capture = await client.callTool({
+        name: "tdai_capture",
+        arguments: {
+          user_content: "Use TypeScript",
+          assistant_content: "Understood",
+        },
+      }, CallToolResultSchema);
+      expect(JSON.parse(readTextContent(capture)))
+        .toEqual({
+          l0_recorded: 2,
+          scheduler_notified: true,
+        });
+    } finally {
+      await client.close();
+    }
+
+    expect(requests).toMatchObject([
+      {
+        method: "POST",
+        path: "/recall",
+        authorization: "Bearer test-secret",
+        body: {
+          query: "Which language should I use?",
+          session_key: "project-session",
+          user_id: "developer-1",
+        },
+      },
+      {
+        method: "POST",
+        path: "/capture",
+        authorization: "Bearer test-secret",
+        body: {
+          user_content: "Use TypeScript",
+          assistant_content: "Understood",
+          session_key: "project-session",
+          user_id: "developer-1",
+        },
+      },
+    ]);
+    expect(stderr.join("")).toBe("");
+  });
+});

--- a/src/adapters/mcp/tools.test.ts
+++ b/src/adapters/mcp/tools.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { MemoryService } from "../gateway/types.js";
+import { registerMemoryTools, type McpToolRegistrar } from "./tools.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}>;
+
+function createHarness(service: MemoryService, defaults?: {
+  sessionKey?: string;
+  userId?: string;
+}) {
+  const handlers = new Map<string, ToolHandler>();
+  const registrar: McpToolRegistrar = {
+    registerTool: vi.fn((name, _definition, handler) => {
+      handlers.set(name, handler as ToolHandler);
+    }),
+  };
+
+  registerMemoryTools(registrar, service, defaults);
+  return { handlers, registrar };
+}
+
+function createService(): MemoryService {
+  return {
+    health: vi.fn().mockResolvedValue({
+      status: "ok",
+      version: "0.1.0",
+      uptime: 10,
+      stores: { vectorStore: true, embeddingService: true },
+    }),
+    recall: vi.fn().mockResolvedValue({
+      context: "The user prefers TypeScript.",
+      strategy: "hybrid",
+      memoryCount: 1,
+    }),
+    capture: vi.fn().mockResolvedValue({
+      l0Recorded: 2,
+      schedulerNotified: true,
+    }),
+    searchMemories: vi.fn().mockResolvedValue({
+      results: "L1 result",
+      total: 1,
+      strategy: "hybrid",
+    }),
+    searchConversations: vi.fn().mockResolvedValue({
+      results: "L0 result",
+      total: 1,
+    }),
+    endSession: vi.fn().mockResolvedValue({ flushed: true }),
+  };
+}
+
+describe("registerMemoryTools", () => {
+  it("registers the complete cross-platform memory tool surface", () => {
+    const service = createService();
+    const { handlers } = createHarness(service);
+
+    expect([...handlers.keys()]).toEqual([
+      "tdai_health",
+      "tdai_recall",
+      "tdai_capture",
+      "tdai_memory_search",
+      "tdai_conversation_search",
+      "tdai_session_end",
+    ]);
+  });
+
+  it("uses configured identity defaults for recall and capture", async () => {
+    const service = createService();
+    const { handlers } = createHarness(service, {
+      sessionKey: "project-session",
+      userId: "developer-1",
+    });
+
+    const recallResult = await handlers.get("tdai_recall")!({
+      query: "What language does the user prefer?",
+    });
+    const captureResult = await handlers.get("tdai_capture")!({
+      user_content: "Use TypeScript",
+      assistant_content: "Understood",
+    });
+
+    expect(service.recall).toHaveBeenCalledWith({
+      query: "What language does the user prefer?",
+      sessionKey: "project-session",
+      userId: "developer-1",
+    });
+    expect(service.capture).toHaveBeenCalledWith({
+      userContent: "Use TypeScript",
+      assistantContent: "Understood",
+      sessionKey: "project-session",
+      sessionId: undefined,
+      userId: "developer-1",
+    });
+    expect(JSON.parse(recallResult.content[0].text)).toMatchObject({
+      context: "The user prefers TypeScript.",
+      memory_count: 1,
+    });
+    expect(JSON.parse(captureResult.content[0].text)).toEqual({
+      l0_recorded: 2,
+      scheduler_notified: true,
+    });
+  });
+
+  it("allows per-call session identity and forwards search filters", async () => {
+    const service = createService();
+    const { handlers } = createHarness(service, { sessionKey: "default-session" });
+
+    await handlers.get("tdai_memory_search")!({
+      query: "database preference",
+      limit: 8,
+      type: "instruction",
+      scene: "backend",
+    });
+    await handlers.get("tdai_conversation_search")!({
+      query: "migration",
+      limit: 6,
+      session_key: "explicit-session",
+    });
+    await handlers.get("tdai_session_end")!({
+      session_key: "explicit-session",
+      user_id: "explicit-user",
+    });
+
+    expect(service.searchMemories).toHaveBeenCalledWith({
+      query: "database preference",
+      limit: 8,
+      type: "instruction",
+      scene: "backend",
+    });
+    expect(service.searchConversations).toHaveBeenCalledWith({
+      query: "migration",
+      limit: 6,
+      sessionKey: "explicit-session",
+    });
+    expect(service.endSession).toHaveBeenCalledWith({
+      sessionKey: "explicit-session",
+      userId: "explicit-user",
+    });
+  });
+
+  it("returns an actionable tool error when no session key is available", async () => {
+    const service = createService();
+    const { handlers } = createHarness(service);
+
+    const result = await handlers.get("tdai_capture")!({
+      user_content: "Remember this",
+      assistant_content: "Stored",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("session_key");
+    expect(service.capture).not.toHaveBeenCalled();
+  });
+
+  it("converts service failures into MCP error results", async () => {
+    const service = createService();
+    vi.mocked(service.searchMemories).mockRejectedValue(new Error("Gateway unavailable"));
+    const { handlers } = createHarness(service);
+
+    const result = await handlers.get("tdai_memory_search")!({ query: "test" });
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Gateway unavailable" }],
+      isError: true,
+    });
+  });
+});

--- a/src/adapters/mcp/tools.ts
+++ b/src/adapters/mcp/tools.ts
@@ -1,0 +1,267 @@
+import { z } from "zod";
+
+import type { MemoryService } from "../gateway/types.js";
+
+export interface McpToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+export interface McpToolRegistrar {
+  registerTool(
+    name: string,
+    definition: {
+      description: string;
+      inputSchema: Record<string, z.ZodType>;
+      annotations?: {
+        readOnlyHint?: boolean;
+        destructiveHint?: boolean;
+        idempotentHint?: boolean;
+        openWorldHint?: boolean;
+      };
+    },
+    handler: (args: Record<string, unknown>) => Promise<McpToolResult>,
+  ): unknown;
+}
+
+export interface MemoryToolDefaults {
+  sessionKey?: string;
+  userId?: string;
+}
+
+const querySchema = z.string().min(1).describe("Natural-language memory query.");
+const sessionKeySchema = z.string().min(1).optional().describe(
+  "Stable conversation or project session key. Uses TDAI_MCP_SESSION_KEY when omitted.",
+);
+const userIdSchema = z.string().min(1).optional().describe(
+  "Optional user identity. Uses TDAI_MCP_USER_ID when omitted.",
+);
+const limitSchema = z.number().int().min(1).max(20).optional().describe(
+  "Maximum number of results (1-20, default 5).",
+);
+
+function jsonResult(value: unknown): McpToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function errorResult(error: unknown): McpToolResult {
+  return {
+    content: [{
+      type: "text",
+      text: error instanceof Error ? error.message : String(error),
+    }],
+    isError: true,
+  };
+}
+
+function optionalString(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function resolveSessionKey(
+  args: Record<string, unknown>,
+  defaults: MemoryToolDefaults,
+): string {
+  const sessionKey = optionalString(args, "session_key") ?? defaults.sessionKey;
+  if (!sessionKey) {
+    throw new Error(
+      "Missing session_key. Pass it to this tool or set TDAI_MCP_SESSION_KEY when starting the MCP server.",
+    );
+  }
+  return sessionKey;
+}
+
+function resolveUserId(
+  args: Record<string, unknown>,
+  defaults: MemoryToolDefaults,
+): string | undefined {
+  return optionalString(args, "user_id") ?? defaults.userId;
+}
+
+async function invoke(operation: () => Promise<unknown>): Promise<McpToolResult> {
+  try {
+    return jsonResult(await operation());
+  } catch (error) {
+    return errorResult(error);
+  }
+}
+
+/**
+ * Register the shared TDAI memory tools on any MCP-compatible registrar.
+ */
+export function registerMemoryTools(
+  registrar: McpToolRegistrar,
+  service: MemoryService,
+  defaults: MemoryToolDefaults = {},
+): void {
+  registrar.registerTool(
+    "tdai_health",
+    {
+      description: "Check whether the TencentDB Agent Memory Gateway and its stores are available.",
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => invoke(() => service.health()),
+  );
+
+  registrar.registerTool(
+    "tdai_recall",
+    {
+      description:
+        "Recall relevant long-term memory context before answering a user request. " +
+        "Use this proactively when prior preferences, decisions, or project context may matter.",
+      inputSchema: {
+        query: querySchema,
+        session_key: sessionKeySchema,
+        user_id: userIdSchema,
+      },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => invoke(async () => {
+      const result = await service.recall({
+        query: String(args.query),
+        sessionKey: resolveSessionKey(args, defaults),
+        userId: resolveUserId(args, defaults),
+      });
+      return {
+        context: result.context,
+        strategy: result.strategy,
+        memory_count: result.memoryCount,
+      };
+    }),
+  );
+
+  registrar.registerTool(
+    "tdai_capture",
+    {
+      description:
+        "Persist one completed user/assistant turn into TencentDB Agent Memory. " +
+        "Call after a meaningful turn to build cross-session memory.",
+      inputSchema: {
+        user_content: z.string().min(1).describe("The user's original message."),
+        assistant_content: z.string().min(1).describe("The assistant's completed response."),
+        session_key: sessionKeySchema,
+        session_id: z.string().min(1).optional().describe("Optional turn or sub-session identifier."),
+        user_id: userIdSchema,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (args) => invoke(async () => {
+      const result = await service.capture({
+        userContent: String(args.user_content),
+        assistantContent: String(args.assistant_content),
+        sessionKey: resolveSessionKey(args, defaults),
+        sessionId: optionalString(args, "session_id"),
+        userId: resolveUserId(args, defaults),
+      });
+      return {
+        l0_recorded: result.l0Recorded,
+        scheduler_notified: result.schedulerNotified,
+      };
+    }),
+  );
+
+  registrar.registerTool(
+    "tdai_memory_search",
+    {
+      description:
+        "Search L1 structured memories for preferences, events, instructions, or prior decisions.",
+      inputSchema: {
+        query: querySchema,
+        limit: limitSchema,
+        type: z.enum(["persona", "episodic", "instruction"]).optional().describe(
+          "Optional structured memory type.",
+        ),
+        scene: z.string().min(1).optional().describe("Optional scene name filter."),
+      },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => invoke(async () => {
+      const result = await service.searchMemories({
+        query: String(args.query),
+        limit: typeof args.limit === "number" ? args.limit : undefined,
+        type: optionalString(args, "type"),
+        scene: optionalString(args, "scene"),
+      });
+      return {
+        results: result.results,
+        total: result.total,
+        strategy: result.strategy,
+      };
+    }),
+  );
+
+  registrar.registerTool(
+    "tdai_conversation_search",
+    {
+      description:
+        "Search L0 raw conversation history when exact wording or evidence from a prior turn is needed.",
+      inputSchema: {
+        query: querySchema,
+        limit: limitSchema,
+        session_key: sessionKeySchema,
+      },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => invoke(async () => {
+      const result = await service.searchConversations({
+        query: String(args.query),
+        limit: typeof args.limit === "number" ? args.limit : undefined,
+        sessionKey: optionalString(args, "session_key") ?? defaults.sessionKey,
+      });
+      return {
+        results: result.results,
+        total: result.total,
+      };
+    }),
+  );
+
+  registrar.registerTool(
+    "tdai_session_end",
+    {
+      description:
+        "Flush pending memory pipeline work for one session when the host session is ending.",
+      inputSchema: {
+        session_key: sessionKeySchema,
+        user_id: userIdSchema,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args) => invoke(async () => {
+      const result = await service.endSession({
+        sessionKey: resolveSessionKey(args, defaults),
+        userId: resolveUserId(args, defaults),
+      });
+      return { flushed: result.flushed };
+    }),
+  );
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,11 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: {
+    index: "./index.ts",
+    "adapter-sdk": "./src/adapters/gateway/index.ts",
+    "mcp-server": "./src/adapters/mcp/cli.ts",
+  },
   outDir: "./dist",
   format: "esm",
   platform: "node",
@@ -20,6 +24,17 @@ export default defineConfig({
   dts: false,
   sourcemap: false,
   deps: {
+    // The MCP SDK is a dev dependency bundled into the stdio binary so
+    // consumers do not install its unused HTTP server dependencies.
+    onlyBundle: [
+      "@modelcontextprotocol/sdk",
+      "zod-to-json-schema",
+      "ajv",
+      "ajv-formats",
+      "fast-deep-equal",
+      "json-schema-traverse",
+      "fast-uri",
+    ],
     neverBundle: (id) => {
       // openclaw SDK — always external
       if (id === "openclaw" || id.startsWith("openclaw/")) return true;


### PR DESCRIPTION
## Summary

- add a platform-neutral TypeScript `MemoryService` contract and authenticated Gateway client
- add an MCP stdio adapter with recall, capture, L1/L0 search, health, and session-flush tools
- support both Claude Code and Codex through one packaged `tdai-memory-mcp` binary
- document core boundaries, architecture/data-flow diagrams, platform differences, setup, and extension practices

## Design

OpenClaw keeps its in-process `HostAdapter -> TdaiCore` path. The new MCP adapter follows the existing sidecar boundary: `Claude Code / Codex -> MCP stdio -> GatewayMemoryClient -> HTTP Gateway -> TdaiCore`. The MCP server depends only on the shared `MemoryService` interface.

The official MCP SDK is tree-shaken into the stdio binary as a development dependency. Consumers do not install its unused HTTP server dependencies; `npm audit --omit=dev` reports zero production vulnerabilities.

## Verification

- `vitest run`: 76 tests passed
- MCP stdio end-to-end: 1 test passed (real child process, handshake, tool discovery, recall/capture mapping)
- strict TypeScript checks passed for implementation and tests
- full `npm pack --dry-run` / prepack passed
- packed artifact installed with production dependencies only; MCP handshake exposed all 6 tools
- package size: 869 KB compressed (2 MB CI limit)
- `npm audit --omit=dev`: 0 vulnerabilities

Hermes-specific Python integration tests require a separate `hermes-agent` checkout and were skipped by their existing environment guards; the existing TypeScript suite and all changed paths passed.

## Behavioral note

MCP does not define universal before-prompt or turn-completed lifecycle hooks, so recall and capture are explicit model-initiated tools. The server publishes workflow instructions at initialization, and the guide documents durable `CLAUDE.md` / `AGENTS.md` rules for deterministic usage.

Closes #235