### PR TITLE
fix(search): literalize FTS5 query tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 ### 🐛 修复
 
+- **SQLite FTS5 查询字面量边界** ([#160](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160))：`buildFtsQuery()` 现在按 FTS5 quoted phrase 规则将 tokenizer 输出中的双引号编码为 `""`，使用户输入与 tokenizer 输出只能成为字面搜索词；`MATCH ?` 的 SQL 参数绑定之外，不再允许内容逃逸为 FTS5 查询语法。保留 `AND` / `OR` / `NOT` / `NEAR` 等真实文本词的召回，最终 `OR` 查询结构仅由代码生成。
+
 #### 数据安全 / 数据隔离
 - **L2 LLM 提取失败导致 `scene_blocks/` 被清空 / 半写入** ([#88](https://github.com/Tencent/TencentDB-Agent-Memory/issues/88))：Phase 1 已对 `scene_blocks/` 做完整快照，但 LLM 抛错时 `catch` 直接 `return`，沙箱里的部分写入 / 删除不会回滚，后续 recall 因此看不到场景导航，降级为碎片召回。新增 `BackupManager.findLatestBackup` + `restoreLatestDirectory`，在 LLM 失败时自动从最新备份恢复；采用 fail-soft 设计：无备份时不动目标目录，恢复过程自身的错误也不会替换原始 LLM 错误。
 - **Cleaner 安全加固**：`computeCutoffMsByLocalDay` 拒绝无效 cutoff（未来时间 / 距今不足 24h）；SQLite 与 TCVDB 在 `expired/total > 80%` 时阻止删除；`runOnce` 增加最小保留护栏（L0:50 / L1:20）并产出 `cleaner_summary` JSON 审计日志；新增 `__tests__/cleaner/verify-cleaner-safety.ts` E2E 校验。

--- a/src/core/store/sqlite.test.ts
+++ b/src/core/store/sqlite.test.ts
@@ -1,0 +1,322 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+} from "./sqlite.js";
+
+const SAFE_LITERAL_QUERY = /^"(?:[^"]|"")+"(?: OR "(?:[^"]|"")+")*$/;
+
+function createFtsDatabase(contents: string[]): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(content)");
+
+  const insert = db.prepare("INSERT INTO docs(content) VALUES (?)");
+  for (const content of contents) insert.run(content);
+
+  return db;
+}
+
+function searchQueryRowIds(db: DatabaseSync, query: string | null): number[] {
+  if (!query) return [];
+
+  return (
+    db
+      .prepare("SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY rowid")
+      .all(query) as Array<{ rowid: number }>
+  ).map((row) => row.rowid);
+}
+
+function searchRowIds(db: DatabaseSync, raw: string): number[] {
+  return searchQueryRowIds(db, buildFtsQuery(raw));
+}
+
+function searchTopRowIds(
+  db: DatabaseSync,
+  raw: string,
+  limit: number,
+): number[] {
+  const query = buildFtsQuery(raw);
+  if (!query) return [];
+
+  return (
+    db
+      .prepare(
+        "SELECT rowid FROM docs WHERE docs MATCH ? ORDER BY bm25(docs), rowid LIMIT ?",
+      )
+      .all(query, limit) as Array<{ rowid: number }>
+  ).map((row) => row.rowid);
+}
+
+function recallAtK(actual: number[], expected: number[]): number {
+  const expectedIds = new Set(expected);
+  return actual.filter((rowId) => expectedIds.has(rowId)).length / expected.length;
+}
+
+function buildLegacyFallbackQuery(raw: string): string | null {
+  const tokens =
+    raw
+      .match(/[\p{L}\p{N}_]+/gu)
+      ?.map((token) => token.trim())
+      .filter(Boolean) ?? [];
+  if (tokens.length === 0) return null;
+  return tokens.map((token) => `"${token.replaceAll('"', "")}"`).join(" OR ");
+}
+
+afterEach(() => {
+  // Force the next test to initialise its own tokenizer path.
+  _resetJiebaForTest();
+});
+
+describe("buildFtsQuery", () => {
+  it("builds a quoted OR query for ordinary Chinese and English text", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("北京 TypeScript")).toBe(
+      '"北京" OR "TypeScript"',
+    );
+  });
+
+  it("keeps FTS5 operator words as quoted literal search terms", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("alpha AND beta OR NOT gamma NEAR delta")).toBe(
+      '"alpha" OR "AND" OR "beta" OR "OR" OR "NOT" OR "gamma" OR "NEAR" OR "delta"',
+    );
+  });
+
+  it("preserves lowercase prose and embedded operator substrings", () => {
+    _setJiebaForTest(null);
+
+    expect(
+      buildFtsQuery(
+        "research and development android origin notable nearby 中文AND测试",
+      ),
+    ).toBe(
+      '"research" OR "and" OR "development" OR "android" OR "origin" OR "notable" OR "nearby" OR "中文AND测试"',
+    );
+  });
+
+  it("passes raw text to jieba and quotes its operator tokens", () => {
+    const seen: string[] = [];
+    _setJiebaForTest({
+      cutForSearch(text: string): string[] {
+        seen.push(text);
+        return text.split(/\s+/);
+      },
+    });
+
+    expect(buildFtsQuery("用户 AND TypeScript OR 记忆")).toBe(
+      '"用户" OR "AND" OR "TypeScript" OR "OR" OR "记忆"',
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe("用户 AND TypeScript OR 记忆");
+  });
+
+  it("escapes embedded double quotes with FTS5 quoted-string escaping", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ['alpha"beta'],
+    });
+
+    expect(buildFtsQuery("ignored raw input")).toBe('"alpha""beta"');
+  });
+
+  it("escapes hostile tokenizer output before MATCH execution", () => {
+    _setJiebaForTest({
+      cutForSearch: () => [
+        'alpha" OR beta',
+        "gamma*",
+        "NEAR(alpha beta)",
+        "NOT",
+        "(delta)",
+      ],
+    });
+    const db = createFtsDatabase(["alpha beta", "gamma", "delta"]);
+
+    try {
+      const query = buildFtsQuery("ignored raw input");
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    ["alpha", "BNF phrase"],
+    ["alpha*", "BNF prefix phrase"],
+    ["alpha + beta", "BNF phrase concatenation"],
+    ["NEAR(alpha beta, 5)", "BNF NEAR group"],
+    ["(alpha OR beta)", "BNF parenthesized query"],
+    ["alpha AND beta OR NOT gamma", "BNF boolean operators"],
+    ["title:alpha", "BNF column filter"],
+    ["{title body}:alpha", "BNF multi-column filter"],
+    ["-title:alpha", "BNF excluded-column filter"],
+    ["^alpha", "BNF initial-token marker"],
+    ['alpha" OR beta', "quote breakout attempt"],
+    ["alpha' AND beta", "apostrophe"],
+  ])("literalizes %s safely through a real FTS5 MATCH (%s)", (raw) => {
+    _setJiebaForTest(null);
+    const db = createFtsDatabase(["alpha beta", "content alpha", "unrelated"]);
+
+    try {
+      const query = buildFtsQuery(raw);
+      expect(query).not.toBeNull();
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("prevents operator text from recovering raw FTS5 semantics", () => {
+    _setJiebaForTest(null);
+    const db = createFtsDatabase([
+      "alpha only",
+      "beta only",
+      "alpha beta",
+      "unrelated",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "alpha AND missing")).toEqual([1, 3]);
+      expect(searchRowIds(db, "alpha NOT beta")).toEqual([1, 2, 3]);
+      expect(searchRowIds(db, "NEAR(alpha beta)")).toEqual([1, 2, 3]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("can recall a literal uppercase FTS5 operator word", () => {
+    _setJiebaForTest(null);
+    const db = createFtsDatabase([
+      "AND is a conjunction",
+      "unrelated document",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "AND")).toEqual([1]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves ordinary lowercase English recall", () => {
+    _setJiebaForTest(null);
+    const db = createFtsDatabase([
+      "research and development",
+      "meet near the station",
+      "unrelated",
+    ]);
+
+    try {
+      expect(searchRowIds(db, "and")).toEqual([1]);
+      expect(searchRowIds(db, "near")).toEqual([2]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("preserves normal Chinese recall through jieba tokens", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["北京", "烤鸭", "北京烤鸭"],
+    });
+    const db = createFtsDatabase(["北京 烤鸭 北京烤鸭", "上海 小笼包"]);
+
+    try {
+      expect(searchRowIds(db, "北京烤鸭")).toEqual([1]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("executes a query through the installed tokenizer path", () => {
+    _resetJiebaForTest();
+    const db = createFtsDatabase(["北京烤鸭 TypeScript", "上海小笼包"]);
+
+    try {
+      const query = buildFtsQuery("北京烤鸭 AND TypeScript");
+      expect(query).toMatch(SAFE_LITERAL_QUERY);
+      expect(() =>
+        db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?").all(query),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps fallback recall results for benign English and Chinese queries", () => {
+    _setJiebaForTest(null);
+    const db = createFtsDatabase([
+      "alpha beta project",
+      "research and development",
+      "android origin nearby",
+      "中文AND测试",
+      "北京 烤鸭",
+      "unrelated",
+    ]);
+    const benignQueries = [
+      "alpha beta",
+      "research and development",
+      "android origin nearby",
+      "中文AND测试",
+      "北京 烤鸭",
+    ];
+
+    try {
+      for (const raw of benignQueries) {
+        const before = searchQueryRowIds(db, buildLegacyFallbackQuery(raw));
+        const after = searchRowIds(db, raw);
+        expect(after, raw).toEqual(before);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps a quantified Recall@1 baseline on a fixed micro-corpus", () => {
+    _setJiebaForTest(null);
+    const db = createFtsDatabase([
+      "alpha beta project planning", // expected for alpha beta project
+      "alpha only status update",
+      "北京烤鸭 restaurant", // expected for 北京烤鸭 fallback token
+      "AND is a conjunction in documentation", // expected for AND
+      "TypeScript sqlite memory plugin", // expected for TypeScript sqlite
+      "unrelated travel note",
+    ]);
+    const cases = [
+      { query: "alpha beta project", expected: [1] },
+      { query: "北京烤鸭", expected: [3] },
+      { query: "AND", expected: [4] },
+      { query: "TypeScript sqlite", expected: [5] },
+    ];
+
+    try {
+      const scores = cases.map(({ query, expected }) => {
+        const actual = searchTopRowIds(db, query, 1);
+        return recallAtK(actual, expected);
+      });
+
+      expect(scores).toEqual([1, 1, 1, 1]);
+      expect(scores.reduce((sum, score) => sum + score, 0) / scores.length)
+        .toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each(["", "   ", `"'()***`, "！@#￥%……&*（）"])(
+    "returns no query when no searchable token remains: %j",
+    (raw) => {
+      _setJiebaForTest(null);
+
+      expect(buildFtsQuery(raw)).toBeNull();
+    },
+  );
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,6 +175,28 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * Keep only non-empty tokenizer output that can contribute a searchable term.
+ * FTS5 syntax is made harmless by `quoteFts5Phrase`, rather than by deleting
+ * words such as `AND` that a user may genuinely want to search for.
+ */
+function toFts5LiteralToken(token: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed || !/[\p{L}\p{N}]/u.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Quote an FTS5 phrase and escape embedded double quotes SQL-style.
+ *
+ * `MATCH ?` binds the value safely as SQL, but FTS5 still parses the bound
+ * value as its own query language. Phrase encoding is the boundary that keeps
+ * tokenizer output from becoming user-controlled FTS5 syntax.
+ */
+function quoteFts5Phrase(token: string): string {
+  return `"${token.replaceAll('"', '""')}"`;
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -183,6 +205,11 @@ const ZH_STOP_WORDS = new Set([
  *
  * Falls back to Unicode-regex splitting (`/[\p{L}\p{N}_]+/gu`) if
  * jieba is not installed.
+ *
+ * Every tokenizer term is emitted as an escaped, quoted FTS5 phrase. User
+ * input therefore contributes literal search terms only: FTS5 query syntax
+ * (including `AND`, `OR`, `NOT`, and `NEAR`) is introduced solely by this
+ * function when it joins terms with its fixed `OR` recall strategy.
  *
  * Tokens are OR-joined as quoted FTS5 phrase terms so that a document
  * matching *any* token is returned.  BM25 naturally ranks documents that
@@ -204,15 +231,10 @@ export function buildFtsQuery(raw: string): string | null {
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
     tokens = jieba
       .cutForSearch(raw, true)
-      .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .map(toFts5LiteralToken)
+      .filter((t): t is string => t !== null)
+      // Remove common Chinese stop-words to reduce noise
+      .filter((t) => !ZH_STOP_WORDS.has(t));
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
@@ -220,12 +242,12 @@ export function buildFtsQuery(raw: string): string | null {
     tokens =
       raw
         .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        ?.map(toFts5LiteralToken)
+        .filter((t): t is string => t !== null) ?? [];
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  const quoted = tokens.map(quoteFts5Phrase);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
## Description | 描述

修复 `buildFtsQuery()` 的 FTS5 查询语义边界问题。

`MATCH ?` 可以防止 SQL 注入，但绑定后的字符串仍会被 FTS5 当作查询表达式解析。本 PR 将 tokenizer 输出统一编码为 FTS5 quoted phrase：

- token 中的双引号按 FTS5 规则转义为 `""`；
- 用户输入只能作为字面搜索词出现；
- `AND` / `OR` / `NOT` / `NEAR` 等词保留为可检索文本，不能改变查询结构；
- 最终 `OR` 查询结构只由代码生成。

同时新增真实内存 SQLite FTS5 测试，覆盖：

- FTS5 BNF 常见结构：前缀、短语连接、NEAR、布尔操作、括号、列过滤、`^` 等；
- 引号逃逸与恶意 tokenizer 输出；
- fallback、模拟 jieba 与已安装 tokenizer 路径；
- 字面量 `AND` 召回；
- 固定微型语料的 Recall@1 基线。

## Related Issue | 关联 Issue

Fixes #160

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

本地验证结果：

```text
npx vitest run src/core/store/sqlite.test.ts
29 passed

npm test
96 passed

npm run build
passed