### PR TITLE
docs(checkpoint): clarify lifetime counter semantics

### DIFF
--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -100,11 +100,11 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /** Lifetime count of successful L0 capture batches */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /** Lifetime count of successfully stored L1 memories */
   total_memories_extracted: number;
 }
 


### PR DESCRIPTION
Clarify that L0 capture batches and stored L1 memories are lifetime counters, not retained-storage counts.

Refs #157

## Description | 描述

Clarifies that `l0_conversations_count` and `total_memories_extracted` are lifetime counters:

- `l0_conversations_count` counts successful L0 capture batches.
- `total_memories_extracted` counts successfully stored L1 memories.

They are not retained-storage counts and are not expected to decrease when retention cleanup removes old L0/L1 data.

## Related Issue | 关联 Issue

Refs #157

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过 (`git diff --check`)
- [x] No existing features affected | 无影响现有功能（仅注释变更）

## Additional Notes | 其他说明

This PR intentionally does not add counter decrement/recalibration logic.