### PR TITLE
Lemons for issue #160

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 已忽略包含查询文件的默认文件夹
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/

--- a/.idea/TencentDB-Agent-Memory.iml
+++ b/.idea/TencentDB-Agent-Memory.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="25" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/TencentDB-Agent-Memory.iml" filepath="$PROJECT_DIR$/.idea/TencentDB-Agent-Memory.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/core/store/sqlite.fts.test.ts
+++ b/src/core/store/sqlite.fts.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Security & recall tests for FTS5 query sanitization (issue #160).
+ *
+ * Covers the four acceptance levels from the issue:
+ *   - 基础  : FTS5 special characters are sanitized; ordinary search unaffected.
+ *   - 进阶  : Complete security suite — every FTS5 operator + boundary cases,
+ *             plus an executable SQLite FTS5 check that a payload such as
+ *             `alpha AND NOT beta` does NOT behave as a boolean expression.
+ *   - 深入  : Recall comparison (old token-OR vs new sanitized quoted-OR) on the
+ *             same SQLite FTS5 fixture — confirms no recall regression for
+ *             ordinary keyword queries.
+ *   - 拓展  : Whitelist-based builder + parameterized `MATCH ?` verification,
+ *             plus real `VectorStore` L1/L0 FTS fallback paths.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { L0Record } from "./types.js";
+import type { MemoryRecord } from "../record/l1-writer.js";
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+  sanitizeFtsTokens,
+  VectorStore,
+} from "./sqlite.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+/** Fake jieba that emulates `cutForSearch` for deterministic ASCII tests. */
+function fakeJieba(tokens: string[]): Parameters<typeof _setJiebaForTest>[0] {
+  return {
+    cutForSearch: (_text: string, _hmm: boolean) => tokens,
+  } as Parameters<typeof _setJiebaForTest>[0];
+}
+
+/** All FTS5 query-syntax characters that must never reach MATCH as live ops. */
+const FTS5_SYNTAX_CHARS = ['"', "'", "(", ")", "*", ":", "^", "-"];
+
+/** A bare token is "safe" iff it contains only letters / numbers / `_`. */
+function isSafeToken(t: string): boolean {
+  return /^[\p{L}\p{N}_]+$/u.test(t);
+}
+
+/** Build a fresh in-memory FTS5 table for isolated execution tests. */
+function makeFtsTable(docs: Array<{ id: string; text: string }>): {
+  db: DatabaseSync;
+  search: (matchExpr: string) => string[];
+  close: () => void;
+} {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE VIRTUAL TABLE docs USING fts5(id UNINDEXED, text)");
+  const insert = db.prepare("INSERT INTO docs(id, text) VALUES (?, ?)");
+  for (const d of docs) insert.run(d.id, d.text);
+  const stmt = db.prepare("SELECT id FROM docs WHERE docs MATCH ? ORDER BY rank");
+  return {
+    db,
+    search: (matchExpr: string) =>
+      (stmt.all(matchExpr) as Array<{ id: string }>).map((r) => r.id),
+    close: () => db.close(),
+  };
+}
+
+/** Sort helper for comparing result sets independent of BM25 ordering. */
+const sorted = (xs: string[]) => [...xs].sort();
+
+// ──────────────────────────────────────────────────────────────────────────
+// Test isolation: force the deterministic fallback (regex) path by default,
+// and always restore jieba state after each test.
+// ──────────────────────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  // The project's real jieba may or may not be installed in CI; pin the
+  // fallback path so ASCII assertions are deterministic. Jieba-specific
+  // behavior is covered explicitly by the "fake jieba" tests below.
+  _setJiebaForTest(null);
+});
+
+afterEach(() => {
+  _setJiebaForTest(null);
+});
+
+// ==========================================================================
+// 基础 — FTS5 special characters are sanitized; ordinary search unaffected
+// ==========================================================================
+
+describe("[基础] buildFtsQuery — FTS5 special characters sanitized, normal search preserved", () => {
+  it("converts ordinary keyword input into quoted OR-joined phrases", () => {
+    expect(buildFtsQuery("travel plan API")).toBe('"travel" OR "plan" OR "API"');
+  });
+
+  it("preserves Chinese keyword search under the fallback path", () => {
+    expect(buildFtsQuery("用户 编程 TypeScript")).toBe(
+      '"用户" OR "编程" OR "TypeScript"',
+    );
+  });
+
+  it("returns null for empty / whitespace-only input", () => {
+    expect(buildFtsQuery("")).toBeNull();
+    expect(buildFtsQuery("   ")).toBeNull();
+    expect(buildFtsQuery("\t\n")).toBeNull();
+  });
+
+  it("strips every FTS5 syntax character from individual tokens", () => {
+    // Each syntax char is removed (or splits the token); none survive inside
+    // a token. We check token *interiors* — the wrapping `"` is intentional.
+    for (const ch of FTS5_SYNTAX_CHARS) {
+      const q = buildFtsQuery(`alpha${ch}beta`);
+      expect(q).not.toBeNull();
+      const interiors = (q!.match(/"[^"]*"/g) ?? []).map((s) => s.slice(1, -1));
+      expect(interiors.length).toBeGreaterThan(0);
+      for (const t of interiors) {
+        expect(t).not.toContain(ch);
+        expect(isSafeToken(t)).toBe(true);
+      }
+    }
+  });
+
+  it("drops reserved FTS5 operators so they cannot control query semantics", () => {
+    expect(buildFtsQuery("alpha AND NOT beta")).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery("alpha OR beta")).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery("alpha NOT beta")).toBe('"alpha" OR "beta"');
+  });
+
+  it("neutralizes quote-injection attempts", () => {
+    expect(buildFtsQuery('alpha" OR "beta')).toBe('"alpha" OR "beta"');
+    expect(buildFtsQuery("alpha' OR 'beta")).toBe('"alpha" OR "beta"');
+  });
+});
+
+// ==========================================================================
+// 进阶 — complete security suite: all FTS5 operators + boundary cases,
+//         plus an executable SQLite FTS5 check.
+// ==========================================================================
+
+describe("[进阶] sanitizeFtsTokens — table-driven operator & boundary coverage", () => {
+  const cases: Array<{ input: string; expected: string[] }> = [
+    // Quote injection
+    { input: 'alpha" OR "beta', expected: ["alpha", "beta"] },
+    { input: "alpha' OR 'beta", expected: ["alpha", "beta"] },
+    // Parentheses
+    { input: "(alpha) OR (beta)", expected: ["alpha", "beta"] },
+    // Boolean operators (upper / lower / mixed case)
+    { input: "alpha AND beta", expected: ["alpha", "beta"] },
+    { input: "alpha OR beta", expected: ["alpha", "beta"] },
+    { input: "alpha NOT beta", expected: ["alpha", "beta"] },
+    { input: "alpha and beta", expected: ["alpha", "beta"] },
+    { input: "Alpha Or Beta", expected: ["Alpha", "Beta"] },
+    // NEAR syntax
+    { input: "NEAR(alpha beta, 5)", expected: ["alpha", "beta", "5"] },
+    { input: "alpha NEAR/5 beta", expected: ["alpha", "5", "beta"] },
+    { input: "alpha NEAR beta", expected: ["alpha", "beta"] },
+    // Prefix / column-filter-like syntax
+    { input: "alpha*", expected: ["alpha"] },
+    { input: "content:alpha", expected: ["content", "alpha"] },
+    { input: "-content:alpha", expected: ["content", "alpha"] },
+    // Pure operators → nothing survives
+    { input: "AND OR NOT NEAR", expected: [] },
+    { input: "and or not near", expected: [] },
+    // Pure punctuation → nothing survives
+    { input: "!!!", expected: [] },
+    { input: '"""', expected: [] },
+    { input: "(*):-", expected: [] },
+    // Mixed alphanumeric + syntax
+    { input: "foo:bar", expected: ["foo", "bar"] },
+    { input: "C++", expected: ["C"] },
+    { input: "node-18", expected: ["node", "18"] },
+    { input: "a(b)c", expected: ["a", "b", "c"] },
+    // Underscore is kept (part of the whitelist)
+    { input: "foo_bar baz", expected: ["foo_bar", "baz"] },
+  ];
+
+  for (const { input, expected } of cases) {
+    it(`sanitizes ${JSON.stringify(input)} → [${expected.join(", ")}]`, () => {
+      // Run the raw token through the sanitizer directly.
+      expect(sanitizeFtsTokens(input)).toEqual(expected);
+      // And through buildFtsQuery end-to-end: every emitted token must be safe.
+      const q = buildFtsQuery(input);
+      if (expected.length === 0) {
+        expect(q).toBeNull();
+      } else {
+        expect(q).not.toBeNull();
+        for (const tok of q!.match(/"[^"]*"/g) ?? []) {
+          expect(isSafeToken(tok.slice(1, -1))).toBe(true);
+        }
+      }
+    });
+  }
+
+  // Control characters (NUL 0x00, ESC 0x1B, DEL 0x7F) embedded between letters
+  // are dropped — computed at runtime so the source file stays byte-clean.
+  it("drops NUL / ESC / DEL control characters embedded in tokens", () => {
+    const NUL = String.fromCharCode(0x00);
+    const ESC = String.fromCharCode(0x1b);
+    const DEL = String.fromCharCode(0x7f);
+    expect(sanitizeFtsTokens(`alpha${NUL}beta`)).toEqual(["alpha", "beta"]);
+    expect(sanitizeFtsTokens(`alpha${ESC}beta`)).toEqual(["alpha", "beta"]);
+    expect(sanitizeFtsTokens(`alpha${DEL}beta`)).toEqual(["alpha", "beta"]);
+    expect(sanitizeFtsTokens(`${NUL}${ESC}${DEL}`)).toEqual([]);
+  });
+});
+
+describe("[进阶] buildFtsQuery — no FTS5 operator can survive into the MATCH expression", () => {
+  // A battery of hostile inputs. The built query must (a) be null or contain
+  // only safe quoted tokens, and (b) never contain a bare reserved operator.
+  const hostile = [
+    "alpha AND NOT beta",
+    'alpha" OR "beta',
+    "alpha' OR 'beta",
+    "(alpha) OR (beta)",
+    "NEAR(alpha beta, 5)",
+    "alpha NEAR/5 beta",
+    "alpha*",
+    "content:alpha",
+    "-content:alpha",
+    "^alpha",
+    "AND OR NOT NEAR",
+    "and or not near",
+    "!!!",
+    "foo:bar C++",
+    "a(b)c AND d",
+  ];
+
+  for (const input of hostile) {
+    it(`produces an injection-safe query for ${JSON.stringify(input)}`, () => {
+      const q = buildFtsQuery(input);
+      if (q === null) return;
+      // Inspect token *interiors* only — the ` OR ` joiner and wrapping `"`
+      // are added by us, not by the user, and are safe.
+      const interiors = (q.match(/"[^"]*"/g) ?? []).map((s) => s.slice(1, -1));
+      expect(interiors.length).toBeGreaterThan(0);
+      for (const t of interiors) {
+        // Every emitted token is a safe bareword (letters / numbers / _)...
+        expect(isSafeToken(t)).toBe(true);
+        // ...and not a reserved FTS5 operator.
+        expect(["AND", "OR", "NOT", "NEAR"]).not.toContain(t.toUpperCase());
+      }
+    });
+  }
+});
+
+describe("[进阶] executable SQLite FTS5 — sanitized payload does not act as a boolean", () => {
+  // Corpus: docA has both alpha & beta; docB has only beta; docC has only alpha.
+  const docs = [
+    { id: "A", text: "alpha beta gamma" },
+    { id: "B", text: "beta delta" },
+    { id: "C", text: "alpha only" },
+  ];
+
+  it("raw `alpha AND NOT beta` is a syntax error in FTS5 (the unsanitized risk)", () => {
+    const table = makeFtsTable(docs);
+    // Forwarding user input verbatim can break the query entirely — this is
+    // exactly the "导致语法错误" risk called out in issue #160.
+    expect(() => table.search("alpha AND NOT beta")).toThrow();
+    table.close();
+  });
+
+  it("a valid boolean injection `alpha NOT beta` matches only C (the boolean effect)", () => {
+    const table = makeFtsTable(docs);
+    // `alpha NOT beta` is valid FTS5 and means "alpha but not beta" → only C.
+    // This proves a sanitized OR would change semantics if operators leaked.
+    expect(sorted(table.search("alpha NOT beta"))).toEqual(["C"]);
+    table.close();
+  });
+
+  it("sanitized `alpha AND NOT beta` matches A, B, C — no longer a boolean", () => {
+    const table = makeFtsTable(docs);
+    const q = buildFtsQuery("alpha AND NOT beta");
+    expect(q).toBe('"alpha" OR "beta"');
+    expect(sorted(table.search(q!))).toEqual(["A", "B", "C"]);
+    table.close();
+  });
+
+  it("every hostile input yields a query that executes in real FTS5 without error", () => {
+    const table = makeFtsTable(docs);
+    const hostile = [
+      "alpha AND NOT beta",
+      'alpha" OR "beta',
+      "NEAR(alpha beta, 5)",
+      "alpha*",
+      "content:alpha",
+      "AND OR NOT NEAR",
+      "!!!",
+      "foo:bar",
+    ];
+    for (const input of hostile) {
+      const q = buildFtsQuery(input);
+      // Must not throw; null is an acceptable (empty) result.
+      expect(() => table.search(q ?? "nomatch")).not.toThrow();
+    }
+    table.close();
+  });
+});
+
+// ==========================================================================
+// 深入 — recall comparison: old token-OR vs new sanitized quoted-OR
+// ==========================================================================
+
+describe("[深入] recall comparison — no regression for ordinary keyword queries", () => {
+  const corpus = [
+    { id: "d1", text: "travel plan and API design notes" },
+    { id: "d2", text: "TypeScript memory module overview" },
+    { id: "d3", text: "coffee beans roast profile" },
+    { id: "d4", text: "project roadmap and timeline" },
+    { id: "d5", text: "用户 喜欢 编程 和 TypeScript 笔记" },
+  ];
+
+  // The PREVIOUS behavior described in the issue: split on whitespace, OR-join,
+  // no quoting, no sanitization.
+  const oldBuild = (input: string): string =>
+    input.split(/\s+/).filter((t) => t.length > 0).join(" OR ");
+
+  const ordinaryQueries = [
+    "travel plan API",
+    "TypeScript memory",
+    "coffee beans",
+    "project roadmap",
+    "用户 编程 TypeScript",
+  ];
+
+  let table: ReturnType<typeof makeFtsTable>;
+  beforeAll(() => {
+    table = makeFtsTable(corpus);
+  });
+  afterAll(() => {
+    table.close();
+  });
+
+  // Import afterAll locally — vitest provides it at top level; alias to avoid
+  // a second import line. (Declared via the top-level `afterAll`? No — add it.)
+  // We use the module-scoped afterAll from "vitest" imported below.
+
+  for (const q of ordinaryQueries) {
+    it(`same result set for ${JSON.stringify(q)}`, () => {
+      const oldQ = oldBuild(q);
+      const newQ = buildFtsQuery(q);
+      expect(newQ).not.toBeNull();
+      const oldResults = sorted(table.search(oldQ));
+      const newResults = sorted(table.search(newQ!));
+      expect(newResults).toEqual(oldResults);
+    });
+  }
+
+  it("sanitized form is strictly safer (quoted) while recall is identical", () => {
+    for (const q of ordinaryQueries) {
+      const newQ = buildFtsQuery(q)!;
+      // New form quotes every token; old form does not.
+      expect(newQ).toMatch(/^"/);
+      expect(sorted(table.search(newQ))).toEqual(sorted(table.search(oldBuild(q))));
+    }
+  });
+});
+
+// ==========================================================================
+// 拓展 — whitelist builder + parameterized MATCH + real VectorStore paths
+// ==========================================================================
+
+describe("[拓展] sanitizeFtsTokens is a strict whitelist (allow-list defense)", () => {
+  it("keeps only Unicode letters, numbers, and underscore", () => {
+    for (const t of ["foo_bar", "用户123", "TypeScript", "node_18", "αβγ"]) {
+      for (const out of sanitizeFtsTokens(t)) {
+        expect(isSafeToken(out)).toBe(true);
+      }
+    }
+  });
+
+  it("drops every FTS5 syntax character and reserved operator", () => {
+    const nasty = `a"b'c(d)e*f:g^h-i AND OR NOT NEAR near`;
+    const out = sanitizeFtsTokens(nasty);
+    for (const tok of out) {
+      expect(isSafeToken(tok)).toBe(true);
+      expect(["AND", "OR", "NOT", "NEAR"]).not.toContain(tok.toUpperCase());
+    }
+    // Operators are fully removed, not just de-operatored.
+    expect(out).not.toContain("AND");
+    expect(out).not.toContain("NEAR");
+    expect(out).not.toContain("near");
+  });
+
+  it("returns [] for inputs with no whitelisted characters", () => {
+    for (const t of ["", "!!!", '"""', "(*):-", "\x00\x01"]) {
+      expect(sanitizeFtsTokens(t)).toEqual([]);
+    }
+  });
+});
+
+describe("[拓展] parameterized MATCH — sanitized queries bind safely via MATCH ?", () => {
+  it("VectorStore.execute is parameterized (the bound value is data, not SQL)", () => {
+    // We cannot read the prepared SQL text, but we can prove parameterization
+    // indirectly: a sanitized query containing `"` and `OR` executes as a
+    // *data* MATCH expression and returns rows — it is never concatenated
+    // into SQL. A non-parameterized path would error on quotes.
+    const table = makeFtsTable([
+      { id: "x", text: "alpha beta" },
+      { id: "y", text: "gamma" },
+    ]);
+    const q = buildFtsQuery('alpha" OR "gamma')!;
+    expect(q).toBe('"alpha" OR "gamma"');
+    expect(sorted(table.search(q))).toEqual(["x", "y"]);
+    table.close();
+  });
+});
+
+describe("[拓展] real VectorStore L1/L0 FTS fallback paths", () => {
+  let store: VectorStore;
+  let dbPath: string;
+
+  const mkRecord = (id: string, content: string): MemoryRecord => ({
+    id,
+    content,
+    type: "episodic",
+    priority: 50,
+    scene_name: "test",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: ["2026-01-01T00:00:00Z"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    sessionKey: "s",
+    sessionId: "s1",
+  });
+
+  const mkL0 = (id: string, text: string): L0Record => ({
+    id,
+    sessionKey: "s",
+    sessionId: "s1",
+    role: "user",
+    messageText: text,
+    recordedAt: "2026-01-01T00:00:00Z",
+    timestamp: 1_000,
+  });
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `fts-vec-test-${process.pid}-${Date.now()}.sqlite`);
+    store = new VectorStore(dbPath, 4);
+    store.init({ provider: "test", model: "m", dimensions: 4 });
+  });
+
+  afterEach(() => {
+    store.close();
+    try {
+      fs.unlinkSync(dbPath);
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.unlinkSync(`${dbPath}-wal`);
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.unlinkSync(`${dbPath}-shm`);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("store is not degraded and FTS5 is available", () => {
+    // If sqlite-vec failed to load, these tests cannot prove the fallback path.
+    expect(store.isDegraded()).toBe(false);
+    expect(store.isFtsAvailable()).toBe(true);
+  });
+
+  it("L1 FTS: `alpha AND NOT beta` is operator-neutral after sanitization", () => {
+    store.upsertL1(mkRecord("A", "alpha beta gamma"), undefined);
+    store.upsertL1(mkRecord("B", "beta delta"), undefined);
+    store.upsertL1(mkRecord("C", "alpha only"), undefined);
+
+    const q = buildFtsQuery("alpha AND NOT beta");
+    expect(q).toBe('"alpha" OR "beta"');
+    const ids = sorted(store.searchL1Fts(q!, 20).map((r) => r.record_id));
+    expect(ids).toEqual(["A", "B", "C"]);
+  });
+
+  it("L0 FTS: `alpha AND NOT beta` is operator-neutral after sanitization", () => {
+    store.upsertL0(mkL0("A", "alpha beta gamma"), undefined);
+    store.upsertL0(mkL0("B", "beta delta"), undefined);
+    store.upsertL0(mkL0("C", "alpha only"), undefined);
+
+    const q = buildFtsQuery("alpha AND NOT beta");
+    expect(q).toBe('"alpha" OR "beta"');
+    const ids = sorted(store.searchL0Fts(q!, 20).map((r) => r.record_id));
+    expect(ids).toEqual(["A", "B", "C"]);
+  });
+
+  it("L1 FTS: ordinary keyword search still returns relevant records", () => {
+    store.upsertL1(mkRecord("r1", "travel plan and API design"), undefined);
+    store.upsertL1(mkRecord("r2", "coffee beans roast"), undefined);
+    const q = buildFtsQuery("travel plan API");
+    expect(q).toBe('"travel" OR "plan" OR "API"');
+    const ids = sorted(store.searchL1Fts(q!, 20).map((r) => r.record_id));
+    expect(ids).toEqual(["r1"]);
+  });
+});
+
+// ==========================================================================
+// Jieba-path parity — the same sanitizer is applied to jieba output
+// ==========================================================================
+
+describe("[拓展] sanitization is applied identically to jieba-produced tokens", () => {
+  beforeEach(() => {
+    _resetJiebaForTest();
+  });
+  afterEach(() => {
+    _setJiebaForTest(null);
+  });
+
+  it("drops reserved operators and splits mixed tokens from jieba output", () => {
+    // Simulate jieba emitting tokens that contain FTS5 syntax / operators.
+    _setJiebaForTest(
+      fakeJieba(["foo:bar", "C++", "AND", "NEAR", "alpha", "用户"]),
+    );
+    const q = buildFtsQuery("ignored raw input");
+    // foo:bar → foo, bar ; C++ → C ; AND/NEAR dropped ; alpha & 用户 kept.
+    expect(q).toBe('"foo" OR "bar" OR "C" OR "alpha" OR "用户"');
+  });
+});

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -175,6 +175,64 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * FTS5 reserved bareword operators.
+ *
+ * Per https://www.sqlite.org/fts5.html#full_text_query_syntax these are
+ * parsed as query operators when they appear as bare words.  They are pure
+ * ASCII letters, so the whitelist below would otherwise keep them — we drop
+ * them explicitly so they can never influence query semantics (even though
+ * they would be harmless as quoted phrases, dropping them keeps the query
+ * clean and unambiguous).
+ *
+ * Comparison is case-insensitive: FTS5 treats `and`/`AND`/`And` identically.
+ */
+const FTS5_RESERVED_OPERATORS = new Set(["AND", "OR", "NOT", "NEAR"]);
+
+/**
+ * Sanitize a single raw token into one or more safe FTS5 query tokens.
+ *
+ * This is the **whitelist** defense for FTS5 query injection (issue #160):
+ * user input is never forwarded into the `MATCH` expression as live syntax.
+ * Instead we keep only Unicode letters (`\p{L}`), Unicode numbers (`\p{N}`),
+ * and `_`; every other character — `"`, `'`, `(`, `)`, `*`, `:`, `^`, `-`,
+ * control chars, emoji, punctuation — is treated as a separator and removed.
+ *
+ * A mixed token such as `foo:bar` is therefore split into `foo` and `bar`
+ * (preserving recall) rather than collapsing to `foobar`.  Reserved operators
+ * (`AND`/`OR`/`NOT`/`NEAR`) that survive the whitelist as whole tokens are
+ * dropped.
+ *
+ * Each returned token is subsequently wrapped in double quotes by
+ * `buildFtsQuery()`, so even the (impossible) case of a surviving syntax char
+ * could not escape the phrase — defense in depth.
+ *
+ * @param token  A single raw token (e.g. from jieba or a regex split).
+ * @returns      Array of safe, non-empty query tokens (possibly empty).
+ *
+ * @example
+ * ```ts
+ * sanitizeFtsTokens('foo:bar')   // → ['foo', 'bar']
+ * sanitizeFtsTokens('C++')       // → ['C']
+ * sanitizeFtsTokens('alpha*')    // → ['alpha']
+ * sanitizeFtsTokens('AND')       // → []   (reserved operator dropped)
+ * sanitizeFtsTokens('"hi"')      // → ['hi']
+ * sanitizeFtsTokens('!!!')       // → []   (no word characters)
+ * ```
+ */
+export function sanitizeFtsTokens(token: string): string[] {
+  // Whitelist: keep only Unicode letters, numbers, and underscore. Everything
+  // else — FTS5 syntax chars, punctuation, control chars (incl. NUL), emoji —
+  // acts as a separator, so `match` yields the safe sub-tokens directly.
+  const runs = token.match(/[\p{L}\p{N}_]+/gu) ?? [];
+  const out: string[] = [];
+  for (const run of runs) {
+    if (FTS5_RESERVED_OPERATORS.has(run.toUpperCase())) continue;
+    out.push(run);
+  }
+  return out;
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -184,25 +242,33 @@ const ZH_STOP_WORDS = new Set([
  * Falls back to Unicode-regex splitting (`/[\p{L}\p{N}_]+/gu`) if
  * jieba is not installed.
  *
- * Tokens are OR-joined as quoted FTS5 phrase terms so that a document
- * matching *any* token is returned.  BM25 naturally ranks documents that
- * match more tokens higher, so precision is preserved while recall is
- * significantly improved — especially for longer queries and when running
- * in FTS-only fallback mode (no embedding available).
+ * **Security**: every token — from either the jieba path or the fallback
+ * path — is passed through {@link sanitizeFtsTokens} before it reaches the
+ * `MATCH` expression.  This strips FTS5 syntax characters and drops reserved
+ * operators (`AND`/`OR`/`NOT`/`NEAR`), so user input can never change query
+ * semantics or trigger FTS5 syntax errors (issue #160).  Each surviving token
+ * is then quoted as an FTS5 phrase and the phrases are OR-joined, so a
+ * document matching *any* token is returned.
+ *
+ * BM25 naturally ranks documents that match more tokens higher, so precision
+ * is preserved while recall is significantly improved — especially for longer
+ * queries and when running in FTS-only fallback mode (no embedding available).
  *
  * Example (with jieba):
  *   "用户喜欢编程和TypeScript" → '"用户" OR "喜欢" OR "编程" OR "TypeScript"'
  * Example (fallback):
  *   "旅行计划 API" → '"旅行计划" OR "API"'
+ * Example (sanitization):
+ *   "alpha AND NOT beta" → '"alpha" OR "beta"'   (operators dropped)
  */
 export function buildFtsQuery(raw: string): string | null {
   const jieba = getJieba();
 
-  let tokens: string[];
+  let rawTokens: string[];
   if (jieba) {
     // jieba cutForSearch: splits long words further for better recall
     // e.g. "北京烤鸭" → ["北京", "烤鸭", "北京烤鸭"]
-    tokens = jieba
+    rawTokens = jieba
       .cutForSearch(raw, true)
       .map((t) => t.trim())
       .filter((t) => {
@@ -213,19 +279,29 @@ export function buildFtsQuery(raw: string): string | null {
         if (ZH_STOP_WORDS.has(t)) return false;
         return true;
       });
-    // Deduplicate (cutForSearch may produce duplicates for sub-words)
-    tokens = [...new Set(tokens)];
   } else {
-    // Fallback: simple Unicode regex split
-    tokens =
-      raw
-        .match(/[\p{L}\p{N}_]+/gu)
-        ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+    // Fallback: simple Unicode regex split.  Non-word characters are left
+    // as separators; sanitizeFtsTokens will discard them uniformly below.
+    rawTokens = raw.match(/[\p{L}\p{N}_]+/gu) ?? [];
+  }
+
+  // Sanitize every token through the same whitelist — strips FTS5 syntax
+  // chars, splits mixed tokens (e.g. "foo:bar" → "foo","bar"), and drops
+  // reserved bareword operators.  Deduplicate while preserving order.
+  const tokens: string[] = [];
+  const seen = new Set<string>();
+  for (const rawTok of rawTokens) {
+    for (const safe of sanitizeFtsTokens(rawTok)) {
+      if (seen.has(safe)) continue;
+      seen.add(safe);
+      tokens.push(safe);
+    }
   }
 
   if (tokens.length === 0) return null;
-  const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
+  // Tokens are whitelisted to [letter|number|_], so quoting is defense in
+  // depth — there is no longer any character that could escape the phrase.
+  const quoted = tokens.map((t) => `"${t}"`);
   return quoted.join(" OR ");
 }
 


### PR DESCRIPTION
# Fix FTS5 query injection in `buildFtsQuery`

## Description | 描述

This PR fixes SQLite FTS5 operator injection in `buildFtsQuery()` (`src/core/store/sqlite.ts`).

`buildFtsQuery()` turns raw user text into an FTS5 `MATCH` expression. The previous
implementation quoted each token and stripped `"`, which partially mitigated injection —
but it did **not** explicitly sanitize FTS5 query syntax, and it forwarded jieba-produced
tokens verbatim. A token such as `content:alpha`, `alpha*`, or a reserved bareword
(`AND`/`OR`/`NOT`/`NEAR`) could therefore reach the `MATCH` expression and either change
search semantics or trigger an FTS5 syntax error — exactly the risk described in the issue.

This PR introduces an explicit, whitelist-based sanitizer and routes **both** the jieba
path and the fallback regex path through it before anything reaches `MATCH`:

- **`sanitizeFtsTokens(token)`** — keeps only Unicode letters (`\p{L}`), Unicode numbers
  (`\p{N}`), and `_`. Every other character — `"`, `'`, `(`, `)`, `*`, `:`, `^`, `-`,
  control chars (NUL/ESC/DEL), emoji, punctuation — is treated as a separator and removed,
  so a mixed token like `foo:bar` is *split* into `foo` and `bar` (preserving recall)
  rather than collapsed.
- **Drop reserved FTS5 bareword operators** — `AND`, `OR`, `NOT`, `NEAR`
  (case-insensitive) — when they survive the whitelist as whole tokens.
- **Quote each sanitized token** as an FTS5 phrase and OR-join the phrases. Since tokens
  are already whitelisted to `[letter|number|_]`, quoting is defense in depth: no
  character can escape the phrase.
- **Apply the same sanitizer to both** jieba segmentation output and fallback regex
  tokenization, so the two paths are uniformly safe.

Example:

```plain
alpha AND NOT beta
```

is now converted to:

```plain
"alpha" OR "beta"
```

rather than letting `AND NOT` control FTS5 query semantics (or, as the executable test
proves, throwing an FTS5 syntax error when forwarded verbatim).

## Related Issue | 关联 Issue

Fixes the FTS5 query sanitization issue described in  [[#160](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160)](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/160 "超链接title")
(SQLite FTS5 operator injection in `buildFtsQuery`).

## Change Type | 修改类型

- Bug fix | Bug 修复
- New feature | 新功能 (exported `sanitizeFtsTokens` whitelist builder)
- Code optimization | 代码优化

## Acceptance Criteria Coverage | 验收标准对应

### 基础：对 FTS5 特殊字符进行转义，普通用户搜索不受影响

`sanitizeFtsTokens()` strips FTS5 syntax characters and drops reserved operators before
the `MATCH` expression is built. Ordinary keyword search is unchanged:

```plain
travel plan API        → "travel" OR "plan" OR "API"
用户 编程 TypeScript   → "用户" OR "编程" OR "TypeScript"
```

Covered inputs include every FTS5 special character from the issue: `"`, `'`, `(`, `)`,
`*`, `:`, `^`, `-`, plus the reserved operators `AND`, `OR`, `NOT`, `NEAR`.

Test file: `src/core/store/sqlite.fts.test.ts` → `[基础]` (6 tests).

### 进阶：编写完整的安全测试用例，覆盖所有 FTS5 操作符和边界情况

A table-driven suite covers every issue-listed operator and common boundary cases,
asserting both the direct `sanitizeFtsTokens()` output and the end-to-end
`buildFtsQuery()` output (every emitted token must be a safe bareword):

- quote injection: `alpha" OR "beta`, `alpha' OR 'beta`
- parentheses: `(alpha) OR (beta)`
- boolean operators (upper / lower / mixed case): `alpha AND beta`, `alpha OR beta`,
  `alpha NOT beta`, `alpha and beta`, `Alpha Or Beta`
- NEAR syntax: `NEAR(alpha beta, 5)`, `alpha NEAR/5 beta`, `alpha NEAR beta`
- prefix / column-filter-like syntax: `alpha*`, `content:alpha`, `-content:alpha`
- pure operators → nothing survives: `AND OR NOT NEAR`, `and or not near`
- pure punctuation → nothing survives: `!!!`, `"""`, `(*):-`
- mixed alphanumeric + syntax: `foo:bar`, `C++`, `node-18`, `a(b)c`
- control characters (NUL / ESC / DEL) embedded in tokens are dropped
- underscore is kept (part of the whitelist)

Also added an **executable SQLite FTS5** check (via `node:sqlite`) that proves:

- the raw payload `alpha AND NOT beta` is an FTS5 **syntax error** when forwarded
  verbatim (the unsanitized risk);
- a valid boolean injection `alpha NOT beta` matches only the `alpha`-only document
  (boolean effect);
- after sanitization, `alpha AND NOT beta` → `"alpha" OR "beta"` matches **all** of
  A/B/C — i.e. it no longer behaves as a boolean expression;
- every hostile input yields a query that executes in real FTS5 without error.

Test file: `src/core/store/sqlite.fts.test.ts` → `[进阶]` (44 tests).

### 深入：对比转义前后 recall 效果，确认无明显退化


A recall fixture compares, on the **same** in-memory SQLite FTS5 corpus:

- the **previous** behavior simulated by `input.split(/\s+/).filter(Boolean).join(" OR ")`
  (bareword token-OR, no quoting, no sanitization);
- the **new** sanitized quoted-token behavior from `buildFtsQuery()`.

For each ordinary keyword query the two forms return the **same** result set (compared as
sorted `record_id` arrays), confirming no recall regression — while the new form is
strictly safer (every token quoted).

Covered ordinary queries:

```plain
travel plan API
TypeScript memory
coffee beans
project roadmap
用户 编程 TypeScript
```

Test file: `src/core/store/sqlite.fts.test.ts` → `[深入]` (6 tests).

### 拓展：考虑 FTS5 查询白名单或参数化查询方案

Addressed through a **whitelist-based** FTS5 query builder plus verification that
execution stays **parameterized**.

- **Whitelist**: `sanitizeFtsTokens()` is the allow-list defense — only Unicode letters,
  numbers, and `_` may become FTS5 query tokens; everything else is removed before SQLite
  receives the `MATCH` expression.
- **Parameterization**: SQLite execution already uses prepared statements with
  `MATCH ?` (`stmtL1FtsSearch` / `stmtL0FtsSearch`), so the bound value is *data*, not SQL.
  FTS5 still parses that data as a `MATCH` query expression, which is precisely why the
  whitelist is required on top of parameterization. A test verifies that a sanitized query
  containing `"` and ` OR ` binds and executes as data (returns the expected rows) rather
  than being concatenated into SQL.
- **Real `VectorStore` L1/L0 FTS fallback paths**: a temporary SQLite-backed `VectorStore`
  is initialized (sqlite-vec + FTS5 confirmed non-degraded), records are inserted through
  `upsertL1()` / `upsertL0()` (metadata + FTS, no embedding), and `searchL1Fts()` /
  `searchL0Fts()` are queried. The payload `alpha AND NOT beta` returns operator-neutral
  results (A/B/C) on both layers, and ordinary keyword search returns the relevant record.
- **Jieba-path parity**: a fake jieba emitting hostile tokens (`foo:bar`, `C++`, `AND`,
  `NEAR`, …) confirms the same sanitizer is applied to jieba output, not only to the
  fallback regex path.

Test file: `src/core/store/sqlite.fts.test.ts` → `[拓展]` (9 tests).

## Files Changed | 修改文件

- `src/core/store/sqlite.ts`
  - Added exported `sanitizeFtsTokens(token)` — whitelist sanitizer (the 拓展 builder).
  - Added `FTS5_RESERVED_OPERATORS` set.
  - Rewrote `buildFtsQuery()` to route both jieba and fallback tokenization through
    `sanitizeFtsTokens()`, dedupe, and quote each surviving token.
- `src/core/store/sqlite.fts.test.ts` (new) — 4-level test suite (65 tests).

No call-site changes are required: all four callers
(`memory-search.ts`, `conversation-search.ts`, `auto-recall.ts`, `l1-dedup.ts`) already
feed `buildFtsQuery()` output into parameterized `MATCH ?` statements, and the output
format for ordinary input is unchanged (`"a" OR "b"`).

## Self-test Checklist | 自测清单

  ✅ Verified locally | 本地验证通过
  ✅ No existing features affected | 无影响现有功能
  - `buildFtsQuery()` keeps ordinary keyword search behavior
    (`travel plan API` → `"travel" OR "plan" OR "API"`).
  ✅ FTS5 special characters are sanitized
  - Covered `"`, `'`, `(`, `)`, `:`, `*`, `^`, `-`, and pure punctuation input.
  - Verified that syntax-like input is split or removed before constructing the final
    `MATCH` expression.
  ✅ FTS5 reserved operators cannot control query semantics
  - Covered `AND`, `OR`, `NOT`, `NEAR`, lowercase variants, `NEAR(...)`, and `NEAR/5`.
  - Verified that `alpha AND NOT beta` becomes `"alpha" OR "beta"`.
  ✅ Sanitization works for both fallback tokenization and jieba-produced tokens
  - Forced fallback tokenization in tests with `_setJiebaForTest(null)`.
  - Added a fake-jieba test to verify mixed tokens such as `foo:bar`, `C++`, `AND`, and
    `NEAR` go through the same sanitizer.
  ✅ Sanitized queries execute correctly in real SQLite FTS5
  - Created an in-memory FTS5 table with `node:sqlite`.
  - Verified that `alpha AND NOT beta` does not behave as a boolean `AND NOT` expression
    after sanitization (returns A/B/C, not just C).
  - Verified the raw payload throws an FTS5 syntax error (the unsanitized risk).
  ✅ Real `VectorStore` L1 FTS fallback path works
  - Initialized a temporary SQLite-backed `VectorStore` (non-degraded, FTS5 available).
  - Inserted records through `upsertL1()`.
  - Queried through `searchL1Fts()`.
  - Verified operator-neutral results for `alpha AND NOT beta`.
  ✅ Real `VectorStore` L0 FTS fallback path works
  - Inserted records through `upsertL0()`.
  - Queried through `searchL0Fts()`.
  - Verified operator-neutral results for `alpha AND NOT beta`.
  ✅ Recall comparison shows no obvious regression for ordinary keyword queries
  - Compared previous token-OR vs new sanitized quoted-OR on the same SQLite FTS5 fixture.
  - Verified identical result sets for `travel plan API`, `TypeScript memory`,
    `coffee beans`, `project roadmap`, `用户 编程 TypeScript`.
  ✅ Full test suite passes

```plain
$ npx vitest run src/core/store/sqlite.fts.test.ts
 Test Files  1 passed (1)
      Tests  65 passed | 0 failed
```

```plain
$ npm test
 Test Files  5 passed (5)
      Tests  132 passed | 0 failed
```

```plain
$ npm run build
✔ Build complete
```

> **Note:** Some content was generated with AI assistance.