### PR TITLE
fix(hermes): bound Gateway sidecar logs

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/supervisor.py
+++ b/hermes-plugin/memory/memory_tencentdb/supervisor.py
@@ -13,8 +13,9 @@ import os
 import shlex
 import signal
 import subprocess
+import threading
 import time
-from typing import IO, Optional
+from typing import IO, Optional, Set
 
 from .client import MemoryTencentdbSdkClient
 
@@ -29,8 +30,12 @@ HEALTH_CHECK_INTERVAL = 0.5  # seconds between checks
 HEALTH_CHECK_MAX_WAIT = 30   # max seconds to wait for Gateway to start
 HEALTH_CHECK_RETRIES = 3     # retries for is_running check
 
-# Log file rotation parameters
+# Log file guard parameters
 LOG_TAIL_BYTES_ON_CRASH = 2048  # bytes of stderr log to surface on startup crash
+LOG_FILE_MAX_BYTES = 10 * 1024 * 1024  # hard target per active stdout/stderr file
+LOG_FILE_RETAIN_BYTES = 1 * 1024 * 1024  # diagnostic tail preserved as <path>.1
+LOG_GUARD_INTERVAL_SECS = 0.25
+LOG_GUARD_SHUTDOWN_TIMEOUT_SECS = 2.0
 
 
 class GatewaySupervisor:
@@ -76,7 +81,14 @@ class GatewaySupervisor:
         # Gateway's event loop would block on write() after ~64 KB of logs).
         self._stdout_log: Optional[IO[bytes]] = None
         self._stderr_log: Optional[IO[bytes]] = None
+        self._stdout_log_path: Optional[str] = None
         self._stderr_log_path: Optional[str] = None
+        self._log_guard_thread: Optional[threading.Thread] = None
+        self._log_guard_stop = threading.Event()
+        # A persistent filesystem failure must not emit a warning every 250ms.
+        # Clear a path from this set after a successful guard pass so a later,
+        # distinct failure is still visible.
+        self._log_guard_failed_paths: Set[str] = set()
 
         # Resolve Gateway command
         # Priority: explicit arg > MEMORY_TENCENTDB_GATEWAY_CMD env
@@ -212,10 +224,17 @@ class GatewaySupervisor:
                 # Append mode: preserve previous runs for postmortem.
                 self._stdout_log = open(stdout_path, "ab", buffering=0)
                 self._stderr_log = open(stderr_path, "ab", buffering=0)
+                self._stdout_log_path = stdout_path
                 self._stderr_log_path = stderr_path
+                # Bound files left by previous runs before the child starts.
+                # The same in-place truncation method is then used at runtime,
+                # preserving the inode referenced by the inherited handles.
+                self._enforce_log_limits()
                 stdout_target: object = self._stdout_log
                 stderr_target: object = self._stderr_log
             else:
+                self._stdout_log_path = None
+                self._stderr_log_path = None
                 stdout_target = subprocess.DEVNULL
                 stderr_target = subprocess.DEVNULL
 
@@ -239,6 +258,7 @@ class GatewaySupervisor:
                     stderr=stderr_target,
                     start_new_session=True,  # Detach from parent process group
                 )
+            self._start_log_guard()
         except Exception as e:
             logger.error("Failed to start memory-tencentdb Gateway: %s", e)
             self._close_log_handles()
@@ -270,7 +290,8 @@ class GatewaySupervisor:
         return os.path.join(os.getcwd(), ".memory-tencentdb-logs")
 
     def _close_log_handles(self) -> None:
-        """Close log file handles; safe to call multiple times."""
+        """Stop the log guard, then close handles; safe to call repeatedly."""
+        self._stop_log_guard()
         for attr in ("_stdout_log", "_stderr_log"):
             handle: Optional[IO[bytes]] = getattr(self, attr, None)
             if handle is not None:
@@ -279,6 +300,106 @@ class GatewaySupervisor:
                 except Exception:
                     pass
                 setattr(self, attr, None)
+
+    def _start_log_guard(self) -> None:
+        """Start the runtime log-size guard when file logging is active."""
+        if self._log_guard_thread is not None and self._log_guard_thread.is_alive():
+            return
+        if not any((self._stdout_log_path, self._stderr_log_path)):
+            return
+
+        self._log_guard_stop.clear()
+        thread = threading.Thread(
+            target=self._log_guard_loop,
+            name="memory-tencentdb-log-guard",
+            daemon=True,
+        )
+        self._log_guard_thread = thread
+        thread.start()
+
+    def _stop_log_guard(self) -> None:
+        """Signal and join the log guard before its file handles are closed."""
+        self._log_guard_stop.set()
+        thread = self._log_guard_thread
+        self._log_guard_thread = None
+        if thread is None or thread is threading.current_thread():
+            return
+
+        thread.join(timeout=LOG_GUARD_SHUTDOWN_TIMEOUT_SECS)
+        if thread.is_alive():
+            logger.warning(
+                "memory-tencentdb Gateway log guard did not exit within %.1fs; "
+                "continuing shutdown.",
+                LOG_GUARD_SHUTDOWN_TIMEOUT_SECS,
+            )
+
+    def _log_guard_loop(self) -> None:
+        """Periodically cap active Gateway logs without replacing their inode."""
+        while not self._log_guard_stop.wait(timeout=LOG_GUARD_INTERVAL_SECS):
+            self._enforce_log_limits()
+
+    def _enforce_log_limits(self) -> None:
+        """Preserve a bounded tail and truncate oversized active logs in place."""
+        pairs = (
+            (self._stdout_log_path, self._stdout_log),
+            (self._stderr_log_path, self._stderr_log),
+        )
+        for path, handle in pairs:
+            if not path or handle is None or handle.closed:
+                continue
+            try:
+                self._enforce_log_limit(path, handle)
+                self._log_guard_failed_paths.discard(path)
+            except Exception as e:
+                if path not in self._log_guard_failed_paths:
+                    logger.warning(
+                        "memory-tencentdb Gateway: failed to bound log file %s (%s); "
+                        "child logging remains active.",
+                        path,
+                        e,
+                    )
+                    self._log_guard_failed_paths.add(path)
+
+    @staticmethod
+    def _enforce_log_limit(path: str, handle: IO[bytes]) -> None:
+        """Rotate one oversized file while keeping ``handle`` and its inode live."""
+        size = os.path.getsize(path)
+        if size <= LOG_FILE_MAX_BYTES:
+            return
+
+        retain_bytes = min(LOG_FILE_RETAIN_BYTES, size)
+        with open(path, "rb") as source:
+            if retain_bytes < size:
+                source.seek(-retain_bytes, os.SEEK_END)
+            tail = source.read(retain_bytes)
+
+        rotated_path = f"{path}.1"
+        temporary_path = (
+            f"{rotated_path}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
+        try:
+            with open(temporary_path, "wb") as rotated:
+                rotated.write(tail)
+            os.replace(temporary_path, rotated_path)
+        finally:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+
+        # Truncate through the parent's existing handle. The child inherited
+        # the same open file description, so it keeps writing to this inode
+        # after truncation on both POSIX and Windows.
+        handle.flush()
+        handle.truncate(0)
+        logger.info(
+            "memory-tencentdb Gateway: bounded oversized log %s "
+            "(size=%d, retained=%d at %s)",
+            path,
+            size,
+            retain_bytes,
+            rotated_path,
+        )
 
     def _tail_stderr_log(self, max_bytes: int = LOG_TAIL_BYTES_ON_CRASH) -> str:
         """Return the last `max_bytes` of the stderr log for crash diagnostics."""
@@ -301,6 +422,9 @@ class GatewaySupervisor:
             # Check if process died
             if self._process and self._process.poll() is not None:
                 rc = self._process.returncode
+                # Freeze log rotation before reading the crash tail so the
+                # diagnostic does not race a concurrent truncate.
+                self._stop_log_guard()
                 # stderr was redirected to a log file; tail it for diagnostics.
                 stderr = self._tail_stderr_log()[:500]
                 logger.error(
@@ -333,6 +457,7 @@ class GatewaySupervisor:
     def shutdown(self) -> None:
         """Shut down the managed Gateway process (if we started it)."""
         if self._process is None:
+            self._close_log_handles()
             return
 
         logger.info("Shutting down memory-tencentdb Gateway...")

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_gateway_log_bounds.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_gateway_log_bounds.py
@@ -1,0 +1,226 @@
+"""Regression tests for bounded Hermes Gateway stdout/stderr logs.
+
+The tests load ``supervisor.py`` without requiring a Hermes checkout, then use
+real files and a real child process so the inherited-descriptor behavior is
+covered rather than mocked.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from unittest import mock
+
+
+_TEST_FILE = pathlib.Path(__file__).resolve()
+_PACKAGE_DIR = _TEST_FILE.parents[1]
+_SUPERVISOR_PATH = _PACKAGE_DIR / "supervisor.py"
+_TEST_PACKAGE = "_tdai_gateway_log_guard_test_package"
+
+
+def _load_supervisor_module():
+    """Load the supervisor and its relative ``client`` import in isolation."""
+    package = types.ModuleType(_TEST_PACKAGE)
+    package.__path__ = [str(_PACKAGE_DIR)]
+    sys.modules.setdefault(_TEST_PACKAGE, package)
+
+    module_name = f"{_TEST_PACKAGE}.supervisor"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+
+    spec = importlib.util.spec_from_file_location(module_name, _SUPERVISOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {_SUPERVISOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+supervisor_module = _load_supervisor_module()
+
+
+class GatewayLogBoundsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="tdai-log-bounds-"))
+        self._supervisors = []
+
+    def tearDown(self) -> None:
+        for supervisor in self._supervisors:
+            supervisor._close_log_handles()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _new_supervisor(self):
+        supervisor = supervisor_module.GatewaySupervisor(gateway_cmd="")
+        self._supervisors.append(supervisor)
+        return supervisor
+
+    @staticmethod
+    def _attach_log(supervisor, attr: str, path: pathlib.Path) -> None:
+        setattr(supervisor, f"_{attr}_log_path", str(path))
+        setattr(supervisor, f"_{attr}_log", open(path, "ab", buffering=0))
+
+    @staticmethod
+    def _file_identity(path: pathlib.Path):
+        stat = path.stat()
+        return stat.st_dev, stat.st_ino
+
+    def test_rotation_preserves_tail_inode_and_open_descriptor(self) -> None:
+        path = self._tmpdir / "gateway.stdout.log"
+        original = b"old-prefix-" + bytes(range(128))
+        path.write_bytes(original)
+
+        supervisor = self._new_supervisor()
+        self._attach_log(supervisor, "stdout", path)
+        identity_before = self._file_identity(path)
+
+        with (
+            mock.patch.object(supervisor_module, "LOG_FILE_MAX_BYTES", 64),
+            mock.patch.object(supervisor_module, "LOG_FILE_RETAIN_BYTES", 32),
+        ):
+            supervisor._enforce_log_limits()
+
+        rotated = pathlib.Path(f"{path}.1")
+        self.assertEqual(rotated.read_bytes(), original[-32:])
+        self.assertEqual(path.read_bytes(), b"")
+        self.assertEqual(self._file_identity(path), identity_before)
+        self.assertEqual(list(path.parent.glob(f"{path.name}.1.*.tmp")), [])
+
+        # The same handle that existed before truncation remains writable.
+        supervisor._stdout_log.write(b"after-truncate")
+        self.assertEqual(path.read_bytes(), b"after-truncate")
+
+    def test_guard_bounds_real_child_output_while_control_grows(self) -> None:
+        max_bytes = 32 * 1024
+        retain_bytes = 8 * 1024
+        child_code = (
+            "import os,time\n"
+            "chunk=b'x'*4096\n"
+            "for _ in range(256):\n"
+            " os.write(1,chunk)\n"
+            " time.sleep(0.001)\n"
+            "time.sleep(0.2)\n"
+            "os.write(1,b'CHILD_DONE\\n')\n"
+        )
+
+        control_path = self._tmpdir / "control.log"
+        with open(control_path, "ab", buffering=0) as control:
+            result = subprocess.run(
+                [sys.executable, "-c", child_code],
+                stdout=control,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=10,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr.decode(errors="replace"))
+        self.assertGreater(control_path.stat().st_size, max_bytes * 10)
+
+        experiment_path = self._tmpdir / "experiment.log"
+        supervisor = self._new_supervisor()
+        self._attach_log(supervisor, "stdout", experiment_path)
+        identity_before = self._file_identity(experiment_path)
+
+        with (
+            mock.patch.object(supervisor_module, "LOG_FILE_MAX_BYTES", max_bytes),
+            mock.patch.object(supervisor_module, "LOG_FILE_RETAIN_BYTES", retain_bytes),
+            mock.patch.object(supervisor_module, "LOG_GUARD_INTERVAL_SECS", 0.005),
+            mock.patch.object(supervisor_module, "LOG_GUARD_SHUTDOWN_TIMEOUT_SECS", 1.0),
+        ):
+            supervisor._start_log_guard()
+            thread = supervisor._log_guard_thread
+            self.assertIsNotNone(thread)
+
+            child = subprocess.Popen(
+                [sys.executable, "-c", child_code],
+                stdout=supervisor._stdout_log,
+                stderr=subprocess.PIPE,
+            )
+            rotated_path = pathlib.Path(f"{experiment_path}.1")
+            deadline = time.monotonic() + 5
+            rotated_while_alive = False
+            while time.monotonic() < deadline:
+                if rotated_path.exists() and child.poll() is None:
+                    rotated_while_alive = True
+                    break
+                if child.poll() is not None:
+                    break
+                time.sleep(0.005)
+
+            _, child_stderr = child.communicate(timeout=10)
+            self.assertEqual(child.returncode, 0, child_stderr.decode(errors="replace"))
+            self.assertTrue(rotated_while_alive, "guard never rotated while child was still writing")
+
+            # Let the guard process the final chunk, then freeze it for stable
+            # assertions and run one final synchronous pass.
+            time.sleep(0.05)
+            supervisor._stop_log_guard()
+            supervisor._enforce_log_limits()
+
+        rotated_path = pathlib.Path(f"{experiment_path}.1")
+        self.assertLessEqual(experiment_path.stat().st_size, max_bytes)
+        self.assertEqual(rotated_path.stat().st_size, retain_bytes)
+        self.assertEqual(self._file_identity(experiment_path), identity_before)
+        self.assertFalse(thread.is_alive())
+
+        bounded_output = experiment_path.read_bytes() + rotated_path.read_bytes()
+        self.assertIn(b"CHILD_DONE\n", bounded_output)
+
+    def test_guard_failure_is_fail_open_and_warns_once(self) -> None:
+        path = self._tmpdir / "gateway.stderr.log"
+        path.write_bytes(b"existing")
+        supervisor = self._new_supervisor()
+        self._attach_log(supervisor, "stderr", path)
+
+        with (
+            mock.patch.object(
+                supervisor_module.os.path,
+                "getsize",
+                side_effect=PermissionError("denied"),
+            ),
+            self.assertLogs(supervisor_module.logger, level="WARNING") as captured,
+        ):
+            supervisor._enforce_log_limits()
+            supervisor._enforce_log_limits()
+
+        failure_logs = [
+            line for line in captured.output
+            if "failed to bound log file" in line
+        ]
+        self.assertEqual(len(failure_logs), 1)
+        self.assertIn(str(path), supervisor._log_guard_failed_paths)
+
+        # Guard errors do not close or replace the child's logging target.
+        supervisor._stderr_log.write(b"-still-writable")
+        self.assertEqual(path.read_bytes(), b"existing-still-writable")
+
+    def test_close_stops_guard_before_closing_handles(self) -> None:
+        path = self._tmpdir / "gateway.stdout.log"
+        supervisor = self._new_supervisor()
+        self._attach_log(supervisor, "stdout", path)
+
+        with (
+            mock.patch.object(supervisor_module, "LOG_GUARD_INTERVAL_SECS", 0.01),
+            mock.patch.object(supervisor_module, "LOG_GUARD_SHUTDOWN_TIMEOUT_SECS", 1.0),
+        ):
+            supervisor._start_log_guard()
+            thread = supervisor._log_guard_thread
+            self.assertIsNotNone(thread)
+            self.assertTrue(thread.is_alive())
+            supervisor._close_log_handles()
+
+        self.assertFalse(thread.is_alive())
+        self.assertIsNone(supervisor._log_guard_thread)
+        self.assertIsNone(supervisor._stdout_log)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description | 描述

Bound the Hermes-managed Gateway's append-only stdout/stderr logs at runtime.

- guard each active log every 250 ms;
- when a file exceeds 10 MiB, atomically preserve its final 1 MiB as `<path>.1`;
- truncate through the existing parent handle so the inode inherited by the child remains live;
- bound leftovers from previous runs before spawning a new child;
- stop/join the guard before closing handles or reading a startup-crash tail;
- fail open on filesystem errors, warning once per failing path without interrupting child logging.

The regression tests use real files and a real child process rather than mocked `Popen` output. Their A/B case writes about 1 MiB:

- control (no guard): grows beyond 10× the 32 KiB test threshold;
- experiment (guard enabled): rotates while the child is still writing, leaves the active file at or below 32 KiB, retains exactly 8 KiB in `.1`, preserves the active inode, and captures the child's final sentinel.

Production defaults remain the issue's proposed 10 MiB active limit, 1 MiB retained tail, and 250 ms interval.

## Related Issue | 关联 Issue

Fixes #583

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `python3 hermes-plugin/memory/memory_tencentdb/tests/test_gateway_log_bounds.py` — 4/4 passed
- `python3 -m py_compile .../supervisor.py .../test_gateway_log_bounds.py` — passed
- `npm test` — 67/67 passed
- `npm run build` — passed
- `npm pack --dry-run --ignore-scripts --json` — passed; no `__pycache__`/`.pyc` artifacts
- broader Hermes pytest probe: 6 passed, 3 skipped, and one pre-existing `test_second_provider_does_not_reuse_stale_gateway` failure reproduced unchanged on `origin/main`

## Additional Notes | 其他说明

The active path is deliberately not renamed during rotation: renaming alone would leave the Gateway's inherited descriptor writing to the old inode and would not enforce a runtime disk bound.
