### PR TITLE
feat(adapters): add MiMo Code memory adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,24 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Xiaomi MiMo Code
+
+MiMo Code can connect to the Gateway through the dependency-free local plugin
+in [`mimo-adapter`](./mimo-adapter). It automatically recalls before each
+model run, captures completed main-agent turns, and fails open when the Gateway
+is unavailable.
+
+Install it for the current project:
+
+```bash
+mkdir -p .mimocode/plugins
+cp mimo-adapter/tdai-memory.ts .mimocode/plugins/tdai-memory.ts
+```
+
+See the [MiMo Code adapter guide](./mimo-adapter/README.md) for lifecycle
+mapping, global installation, configuration, native-memory boundaries, and
+failure behavior.
+
 
 ## 🔒 Gateway Security (optional)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -385,6 +385,22 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. 小米 MiMo Code
+
+MiMo Code 可通过 [`mimo-adapter`](./mimo-adapter) 中的零依赖本地插件连接
+Gateway。插件会在每轮模型运行前自动召回、捕获成功完成的主 Agent 对话，并在
+Gateway 不可用时 fail-open，不阻断 MiMo Code。
+
+安装到当前项目：
+
+```bash
+mkdir -p .mimocode/plugins
+cp mimo-adapter/tdai-memory.ts .mimocode/plugins/tdai-memory.ts
+```
+
+生命周期映射、全局安装、配置、与 MiMo 原生记忆的边界及故障行为见
+[MiMo Code 适配器说明](./mimo-adapter/README.md)。
+
 
 ## 🔒 Gateway 安全配置（可选）
 

--- a/__tests__/mimo-adapter/plugin.test.ts
+++ b/__tests__/mimo-adapter/plugin.test.ts
@@ -1,0 +1,377 @@
+import { createServer, type IncomingMessage } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GatewayClient,
+  createMemoryRuntime,
+  createMimoMemoryPlugin,
+  formatRecallContext,
+  latestTrajectoryText,
+  makeSessionKey,
+  readConfig,
+  textFromParts,
+  type MemoryRuntime,
+} from "../../mimo-adapter/tdai-memory.js";
+
+const cleanup: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanup.length > 0) await cleanup.pop()?.();
+});
+
+async function requestBody(request: IncomingMessage): Promise<unknown> {
+  let body = "";
+  for await (const chunk of request) body += chunk;
+  return JSON.parse(body);
+}
+
+function pluginInput() {
+  return {
+    client: {
+      app: {
+        log: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+  } as never;
+}
+
+function userMessage(text: string, synthetic = false) {
+  return {
+    role: "user" as const,
+    id: "user-1",
+    agent: "build",
+    created: 1,
+    parts: [{ type: "text", text, synthetic }],
+  };
+}
+
+function assistantMessage(text: string) {
+  return {
+    role: "assistant" as const,
+    id: "assistant-1",
+    agent: "build",
+    created: 2,
+    parts: [{ type: "text", text }],
+  };
+}
+
+function runtime(overrides: Partial<MemoryRuntime> = {}): MemoryRuntime {
+  return {
+    recall: vi.fn().mockResolvedValue(""),
+    capture: vi.fn().mockResolvedValue(null),
+    sessionEnd: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+describe("GatewayClient", () => {
+  it("sends Gateway-compatible lifecycle requests with Bearer auth", async () => {
+    const requests: Array<{
+      url: string;
+      body: unknown;
+      authorization?: string;
+    }> = [];
+    const server = createServer(async (request, response) => {
+      requests.push({
+        url: request.url ?? "",
+        body: await requestBody(request),
+        authorization: request.headers.authorization,
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ context: "remembered" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanup.push(
+      () => new Promise<void>((resolve) => server.close(() => resolve())),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing address");
+
+    const client = new GatewayClient({
+      baseUrl: `http://127.0.0.1:${address.port}/`,
+      apiKey: "test-token",
+      timeoutMs: 1_000,
+    });
+    await client.recall("query", "mimo_session");
+    await client.capture("user turn", "assistant turn", "mimo_session");
+    await client.sessionEnd("mimo_session");
+
+    expect(requests).toEqual([
+      {
+        url: "/recall",
+        authorization: "Bearer test-token",
+        body: { query: "query", session_key: "mimo_session" },
+      },
+      {
+        url: "/capture",
+        authorization: "Bearer test-token",
+        body: {
+          user_content: "user turn",
+          assistant_content: "assistant turn",
+          session_key: "mimo_session",
+        },
+      },
+      {
+        url: "/session/end",
+        authorization: "Bearer test-token",
+        body: { session_key: "mimo_session" },
+      },
+    ]);
+  });
+
+  it("returns null instead of throwing when the Gateway is unreachable", async () => {
+    const client = new GatewayClient({
+      baseUrl: "http://127.0.0.1:1",
+      timeoutMs: 50,
+    });
+
+    await expect(client.recall("query", "session")).resolves.toBeNull();
+    await expect(client.capture("user", "assistant", "session")).resolves.toBeNull();
+    await expect(client.sessionEnd("session")).resolves.toBeNull();
+  });
+});
+
+describe("runtime and text helpers", () => {
+  it("uses stable MiMo session keys and the shared API-key fallback", () => {
+    expect(makeSessionKey("ses_123")).toBe("mimo_ses_123");
+    expect(readConfig({ TDAI_GATEWAY_API_KEY: "shared-secret" }).apiKey).toBe(
+      "shared-secret",
+    );
+  });
+
+  it("keeps non-synthetic text and excludes injected/internal parts", () => {
+    const parts = [
+      { type: "text", text: "Current question" },
+      { type: "text", text: "Internal reminder", synthetic: true },
+      { type: "reasoning", text: "Private reasoning" },
+      { type: "text", text: "Ignored", ignored: true },
+    ];
+
+    expect(textFromParts(parts as never)).toBe("Current question");
+    expect(
+      latestTrajectoryText(
+        [
+          userMessage("Earlier question"),
+          userMessage("Synthetic continuation", true),
+        ],
+        "user",
+      ),
+    ).toBe("Earlier question");
+  });
+
+  it("maps raw Gateway responses into the narrow memory runtime", async () => {
+    const client = {
+      recall: vi.fn().mockResolvedValue({ context: "Remembered fact" }),
+      capture: vi.fn().mockResolvedValue({ l0_recorded: 2 }),
+      sessionEnd: vi.fn().mockResolvedValue({ flushed: true }),
+    };
+    const memory = createMemoryRuntime({ client: client as never });
+
+    await expect(memory.recall("question", "ses_1")).resolves.toBe(
+      "Remembered fact",
+    );
+    await memory.capture("user", "assistant", "ses_1");
+    await memory.sessionEnd("ses_1");
+
+    expect(client.recall).toHaveBeenCalledWith(
+      "question",
+      "mimo_ses_1",
+      undefined,
+    );
+    expect(client.capture).toHaveBeenCalledWith(
+      "user",
+      "assistant",
+      "mimo_ses_1",
+      undefined,
+    );
+    expect(client.sessionEnd).toHaveBeenCalledWith(
+      "mimo_ses_1",
+      undefined,
+    );
+  });
+});
+
+describe("MiMo Code lifecycle plugin", () => {
+  it("recalls on chat.message and projects context into every LLM step", async () => {
+    const memory = runtime({
+      recall: vi.fn().mockResolvedValue("User prefers Rust."),
+    });
+    const hooks = await createMimoMemoryPlugin({ runtime: memory })(pluginInput());
+    const message = {
+      sessionID: "ses_1",
+      agent: "build",
+      messageID: "msg_1",
+    };
+
+    await hooks["chat.message"]?.(message, {
+      message: {} as never,
+      parts: [{ type: "text", text: "What language do I prefer?" }] as never,
+    });
+    const first = { system: ["Stable base prompt"] };
+    const second = { system: ["Stable base prompt"] };
+    await hooks["experimental.chat.system.transform"]?.(
+      { sessionID: "ses_1", model: {} as never },
+      first,
+    );
+    await hooks["experimental.chat.system.transform"]?.(
+      { sessionID: "ses_1", model: {} as never },
+      second,
+    );
+
+    expect(memory.recall).toHaveBeenCalledWith(
+      "What language do I prefer?",
+      "ses_1",
+    );
+    expect(first.system).toEqual([
+      "Stable base prompt",
+      formatRecallContext("User prefers Rust."),
+    ]);
+    expect(second.system).toEqual(first.system);
+  });
+
+  it("does not duplicate an existing recall section", async () => {
+    const memory = runtime({
+      recall: vi.fn().mockResolvedValue("Earlier context"),
+    });
+    const hooks = await createMimoMemoryPlugin({ runtime: memory })(pluginInput());
+    await hooks["chat.message"]?.(
+      { sessionID: "ses_1" },
+      {
+        message: {} as never,
+        parts: [{ type: "text", text: "Question" }] as never,
+      },
+    );
+    const output = {
+      system: [formatRecallContext("Already present")],
+    };
+
+    await hooks["experimental.chat.system.transform"]?.(
+      { sessionID: "ses_1", model: {} as never },
+      output,
+    );
+
+    expect(output.system).toHaveLength(1);
+  });
+
+  it("captures only completed main-agent runs and clears recalled state", async () => {
+    const memory = runtime({
+      recall: vi.fn().mockResolvedValue("Earlier context"),
+      capture: vi.fn().mockResolvedValue({ l0_recorded: 2 }),
+    });
+    const hooks = await createMimoMemoryPlugin({ runtime: memory })(pluginInput());
+    await hooks["chat.message"]?.(
+      { sessionID: "ses_1" },
+      {
+        message: {} as never,
+        parts: [{ type: "text", text: "Remember this." }] as never,
+      },
+    );
+
+    await hooks["session.post"]?.(
+      {
+        sessionID: "ses_1",
+        agentID: "main",
+        outcome: "completed",
+        finalText: "Remembered.",
+        trajectory: [
+          userMessage("Remember this."),
+          assistantMessage("Remembered."),
+        ],
+      },
+      {},
+    );
+    const after = { system: ["Stable base prompt"] };
+    await hooks["experimental.chat.system.transform"]?.(
+      { sessionID: "ses_1", model: {} as never },
+      after,
+    );
+
+    expect(memory.capture).toHaveBeenCalledWith(
+      "Remember this.",
+      "Remembered.",
+      "ses_1",
+    );
+    expect(after.system).toEqual(["Stable base prompt"]);
+  });
+
+  it("does not capture subagents, failures, or cancelled runs", async () => {
+    const memory = runtime();
+    const hooks = await createMimoMemoryPlugin({ runtime: memory })(pluginInput());
+    const base = {
+      sessionID: "ses_1",
+      finalText: "Answer",
+      trajectory: [userMessage("Question"), assistantMessage("Answer")],
+    };
+
+    await hooks["session.post"]?.(
+      { ...base, agentID: "explore", outcome: "completed" },
+      {},
+    );
+    await hooks["session.post"]?.(
+      { ...base, agentID: "main", outcome: "error" },
+      {},
+    );
+    await hooks["session.post"]?.(
+      { ...base, agentID: "main", outcome: "cancelled" },
+      {},
+    );
+
+    expect(memory.capture).not.toHaveBeenCalled();
+  });
+
+  it("flushes the matching Gateway session when MiMo deletes a session", async () => {
+    const memory = runtime();
+    const hooks = await createMimoMemoryPlugin({ runtime: memory })(pluginInput());
+
+    await hooks.event?.({
+      event: {
+        type: "session.deleted",
+        properties: { info: { id: "ses_1" } },
+      } as never,
+    });
+
+    expect(memory.sessionEnd).toHaveBeenCalledWith("ses_1");
+  });
+
+  it("fails open when every memory operation throws", async () => {
+    const memory = runtime({
+      recall: vi.fn().mockRejectedValue(new Error("Gateway unavailable")),
+      capture: vi.fn().mockRejectedValue(new Error("Gateway unavailable")),
+      sessionEnd: vi.fn().mockRejectedValue(new Error("Gateway unavailable")),
+    });
+    const hooks = await createMimoMemoryPlugin({ runtime: memory })(pluginInput());
+
+    await expect(
+      hooks["chat.message"]?.(
+        { sessionID: "ses_1" },
+        {
+          message: {} as never,
+          parts: [{ type: "text", text: "Continue." }] as never,
+        },
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      hooks["session.post"]?.(
+        {
+          sessionID: "ses_1",
+          agentID: "main",
+          outcome: "completed",
+          finalText: "Completed normally.",
+          trajectory: [
+            userMessage("Continue."),
+            assistantMessage("Completed normally."),
+          ],
+        },
+        {},
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      hooks.event?.({
+        event: {
+          type: "session.deleted",
+          properties: { info: { id: "ses_1" } },
+        } as never,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/mimo-adapter/README.md
+++ b/mimo-adapter/README.md
@@ -1,0 +1,99 @@
+# TencentDB Agent Memory — MiMo Code Adapter
+
+This local plugin gives
+[Xiaomi MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) automatic,
+cross-session memory through the existing TencentDB Agent Memory Gateway.
+It uses MiMo Code's lifecycle hooks and has no runtime dependencies.
+
+## Lifecycle mapping
+
+```text
+chat.message                         -> POST /recall
+experimental.chat.system.transform  -> inject recalled context into the LLM request
+session.post (main agent)            -> POST /capture for completed runs
+session.deleted                      -> POST /session/end
+```
+
+Recall is automatic; the model does not need to remember to call an MCP tool.
+Recalled text is projected into the system prompt and is not written into the
+MiMo Code transcript. `session.post` supplies the original trajectory and final
+answer for capture.
+
+All Gateway requests are best-effort. If the Gateway is unavailable, slow, or
+returns an error, MiMo Code continues the run without memory.
+
+## Requirements
+
+- MiMo Code 0.1.9 or newer
+- A running TencentDB Agent Memory Gateway
+
+The adapter targets MiMo Code's TUI/server plugin runtime. MiMo Code currently
+documents the TUI as its supported primary interface, so this adapter does not
+claim separate Web or App coverage.
+
+## Start the Gateway
+
+From the TencentDB Agent Memory repository root:
+
+```bash
+TDAI_LLM_BASE_URL="https://api.deepseek.com/v1" \
+TDAI_LLM_API_KEY="..." \
+TDAI_LLM_MODEL="deepseek-chat" \
+node --import tsx/esm src/gateway/server.ts
+```
+
+## Install
+
+For the current project:
+
+```bash
+mkdir -p .mimocode/plugins
+cp mimo-adapter/tdai-memory.ts .mimocode/plugins/tdai-memory.ts
+```
+
+For every project:
+
+```bash
+mkdir -p ~/.config/mimocode/plugins
+cp mimo-adapter/tdai-memory.ts ~/.config/mimocode/plugins/tdai-memory.ts
+```
+
+MiMo Code discovers `plugin/*.ts` and `plugins/*.ts` files at startup. The
+adapter default-exports a versioned MiMo plugin module with the stable id
+`tencentdb-agent-memory`.
+
+## Configuration
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `MEMORY_TENCENTDB_GATEWAY_URL` | `http://127.0.0.1:8420` | Gateway base URL |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` | `TDAI_GATEWAY_API_KEY`, then unset | Bearer token |
+| `MEMORY_TENCENTDB_TIMEOUT_MS` | `5000` | Per-request timeout |
+| `MEMORY_TENCENTDB_DEBUG` | unset | Set to `1` for warning-level diagnostics |
+
+Session identity is stable across restarts because the adapter derives
+`session_key` as `mimo_<MiMo session id>`.
+
+## Interaction with MiMo Code memory
+
+MiMo Code has its own local memory and consolidation features. This adapter does
+not replace or modify them. TencentDB Agent Memory adds a separate L0-to-L3
+pipeline and a shared Gateway identity, allowing memories captured by other
+hosts such as Pi or Cline to be recalled in MiMo Code.
+
+Because recall injection is transient rather than stored in the MiMo
+transcript, the adapter intentionally does not request Gateway `dedup`. A later
+turn still needs its recalled context projected into that turn's model request.
+
+## Failure and privacy behavior
+
+- Recall failure: inject nothing and continue.
+- Capture failure: drop that capture and continue.
+- Session-end failure: leave normal Gateway scheduling in place and continue.
+- Only non-synthetic user text and the final assistant answer are captured.
+- Tool output, reasoning, system prompts, API keys, and full hook payloads are
+  not sent to the Gateway or written to debug logs.
+
+MiMo Code does not expose a general process-shutdown hook. `/session/end` is
+therefore sent when a session is deleted; ordinary `/capture` calls still notify
+the Gateway scheduler after every completed turn.

--- a/mimo-adapter/tdai-memory.ts
+++ b/mimo-adapter/tdai-memory.ts
@@ -1,0 +1,340 @@
+/**
+ * TencentDB Agent Memory adapter for Xiaomi MiMo Code.
+ *
+ * Lifecycle mapping:
+ *
+ *   chat.message                         -> POST /recall
+ *   experimental.chat.system.transform  -> inject recalled context
+ *   session.post (main agent)            -> POST /capture
+ *   session.deleted                      -> POST /session/end
+ *
+ * Gateway access is best-effort. A timeout, network failure, invalid response,
+ * or non-2xx status never blocks the MiMo Code session.
+ */
+
+import type {
+  Plugin,
+  PluginModule,
+  TrajectoryMessage,
+} from "@mimo-ai/plugin";
+
+const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const RECALL_MARKER = "[TencentDB Agent Memory — recalled context]";
+
+export interface GatewayClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  onError?: (operation: string, error: unknown) => void;
+}
+
+export interface MemoryRuntime {
+  recall(
+    query: string,
+    sessionID: string,
+    signal?: AbortSignal,
+  ): Promise<string>;
+  capture(
+    userContent: string,
+    assistantContent: string,
+    sessionID: string,
+    signal?: AbortSignal,
+  ): Promise<unknown>;
+  sessionEnd(sessionID: string, signal?: AbortSignal): Promise<unknown>;
+}
+
+export function readConfig(
+  env: Record<string, string | undefined> = process.env,
+) {
+  const parsedTimeout = Number.parseInt(
+    env.MEMORY_TENCENTDB_TIMEOUT_MS ?? "",
+    10,
+  );
+  return {
+    gatewayUrl:
+      env.MEMORY_TENCENTDB_GATEWAY_URL?.trim() ||
+      DEFAULT_GATEWAY_URL,
+    apiKey:
+      env.MEMORY_TENCENTDB_GATEWAY_API_KEY?.trim() ||
+      env.TDAI_GATEWAY_API_KEY?.trim() ||
+      undefined,
+    timeoutMs:
+      Number.isFinite(parsedTimeout) && parsedTimeout > 0
+        ? parsedTimeout
+        : DEFAULT_TIMEOUT_MS,
+    debug: ["1", "true", "yes"].includes(
+      env.MEMORY_TENCENTDB_DEBUG?.toLowerCase() ?? "",
+    ),
+  };
+}
+
+export class GatewayClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly onError?: (operation: string, error: unknown) => void;
+
+  constructor(options: GatewayClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.onError = options.onError;
+  }
+
+  recall(query: string, sessionKey: string, signal?: AbortSignal) {
+    return this.post<{ context?: unknown }>(
+      "/recall",
+      { query, session_key: sessionKey },
+      signal,
+    );
+  }
+
+  capture(
+    userContent: string,
+    assistantContent: string,
+    sessionKey: string,
+    signal?: AbortSignal,
+  ) {
+    return this.post(
+      "/capture",
+      {
+        user_content: userContent,
+        assistant_content: assistantContent,
+        session_key: sessionKey,
+      },
+      signal,
+    );
+  }
+
+  sessionEnd(sessionKey: string, signal?: AbortSignal) {
+    return this.post("/session/end", { session_key: sessionKey }, signal);
+  }
+
+  private async post<T = unknown>(
+    endpoint: string,
+    body: unknown,
+    outerSignal?: AbortSignal,
+  ): Promise<T | null> {
+    const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+    const signal = outerSignal
+      ? AbortSignal.any([outerSignal, timeoutSignal])
+      : timeoutSignal;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    try {
+      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!response.ok) {
+        this.onError?.(endpoint, new Error(`HTTP ${response.status}`));
+        return null;
+      }
+      return (await response.json()) as T;
+    } catch (error) {
+      this.onError?.(endpoint, error);
+      return null;
+    }
+  }
+}
+
+export function makeSessionKey(sessionID: string) {
+  return `mimo_${sessionID}`;
+}
+
+export function textFromParts(
+  parts:
+    | Array<{
+        type?: string;
+        text?: string;
+        synthetic?: boolean;
+        ignored?: boolean;
+      }>
+    | undefined,
+) {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter(
+      (part) =>
+        part.type === "text" &&
+        typeof part.text === "string" &&
+        part.synthetic !== true &&
+        part.ignored !== true,
+    )
+    .map((part) => part.text?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export function latestTrajectoryText(
+  trajectory: TrajectoryMessage[] | undefined,
+  role: "user" | "assistant",
+) {
+  if (!Array.isArray(trajectory)) return "";
+  for (let index = trajectory.length - 1; index >= 0; index -= 1) {
+    const message = trajectory[index];
+    if (message.role !== role) continue;
+    const text = textFromParts(message.parts);
+    if (text) return text;
+  }
+  return "";
+}
+
+export function formatRecallContext(context: string) {
+  return (
+    `${RECALL_MARKER}\n` +
+    "The following long-term memories may be relevant to the current request. " +
+    "Treat them as background knowledge from earlier sessions. The current " +
+    "conversation and repository state take precedence when they conflict.\n\n" +
+    context
+  );
+}
+
+export function createMemoryRuntime(options: {
+  config?: ReturnType<typeof readConfig>;
+  client?: GatewayClient;
+  onError?: (operation: string, error: unknown) => void;
+} = {}): MemoryRuntime {
+  const config = options.config ?? readConfig();
+  const client =
+    options.client ??
+    new GatewayClient({
+      baseUrl: config.gatewayUrl,
+      apiKey: config.apiKey,
+      timeoutMs: config.timeoutMs,
+      onError: options.onError,
+    });
+
+  return {
+    async recall(query, sessionID, signal) {
+      if (!query || !sessionID) return "";
+      const response = await client.recall(
+        query,
+        makeSessionKey(sessionID),
+        signal,
+      );
+      return typeof response?.context === "string" ? response.context : "";
+    },
+
+    capture(userContent, assistantContent, sessionID, signal) {
+      if (!userContent || !assistantContent || !sessionID) {
+        return Promise.resolve(null);
+      }
+      return client.capture(
+        userContent,
+        assistantContent,
+        makeSessionKey(sessionID),
+        signal,
+      );
+    },
+
+    sessionEnd(sessionID, signal) {
+      if (!sessionID) return Promise.resolve(null);
+      return client.sessionEnd(makeSessionKey(sessionID), signal);
+    },
+  };
+}
+
+export function createMimoMemoryPlugin(options: {
+  runtime?: MemoryRuntime;
+} = {}): Plugin {
+  return async (input) => {
+    const config = readConfig();
+    const reportError = (operation: string, error: unknown) => {
+      if (!config.debug) return;
+      const detail = error instanceof Error ? error.message : String(error);
+      void Promise.resolve(
+        input.client.app.log({
+          body: {
+            service: "tencentdb-agent-memory",
+            level: "warn",
+            message: `${operation} failed; continuing without memory`,
+            extra: { detail },
+          },
+        }),
+      ).catch(() => {});
+    };
+    const runtime =
+      options.runtime ??
+      createMemoryRuntime({
+        config,
+        onError: reportError,
+      });
+    const recalledBySession = new Map<string, string>();
+
+    return {
+      "chat.message": async (hookInput, output) => {
+        const query = textFromParts(output.parts);
+        if (!query) return;
+
+        try {
+          const context = await runtime.recall(query, hookInput.sessionID);
+          if (context) recalledBySession.set(hookInput.sessionID, context);
+          else recalledBySession.delete(hookInput.sessionID);
+        } catch (error) {
+          recalledBySession.delete(hookInput.sessionID);
+          reportError("/recall", error);
+        }
+      },
+
+      "experimental.chat.system.transform": async (hookInput, output) => {
+        if (!hookInput.sessionID) return;
+        const context = recalledBySession.get(hookInput.sessionID);
+        if (!context) return;
+        if (output.system.some((section) => section.includes(RECALL_MARKER))) {
+          return;
+        }
+        output.system.push(formatRecallContext(context));
+      },
+
+      "session.post": async (hookInput) => {
+        recalledBySession.delete(hookInput.sessionID);
+        if (hookInput.agentID !== "main") return;
+        if (hookInput.outcome !== "completed") return;
+
+        const userContent = latestTrajectoryText(
+          hookInput.trajectory,
+          "user",
+        );
+        const assistantContent =
+          hookInput.finalText?.trim() ||
+          latestTrajectoryText(hookInput.trajectory, "assistant");
+        if (!userContent || !assistantContent) return;
+
+        try {
+          await runtime.capture(
+            userContent,
+            assistantContent,
+            hookInput.sessionID,
+          );
+        } catch (error) {
+          reportError("/capture", error);
+        }
+      },
+
+      event: async ({ event }) => {
+        if (event.type !== "session.deleted") return;
+        recalledBySession.delete(event.properties.info.id);
+        try {
+          await runtime.sessionEnd(event.properties.info.id);
+        } catch (error) {
+          reportError("/session/end", error);
+        }
+      },
+    };
+  };
+}
+
+const plugin: PluginModule = {
+  id: "tencentdb-agent-memory",
+  server: createMimoMemoryPlugin(),
+};
+
+export default plugin;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "mimo-adapter/",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
@@ -58,6 +59,7 @@
   "keywords": [
     "openclaw",
     "openclaw-plugin",
+    "mimocode",
     "memory",
     "ai-memory",
     "long-term-memory",


### PR DESCRIPTION
## Description | 描述

Adds a native [MiMo Code](https://github.com/XiaomiMiMo/MiMo-Code) plugin adapter
under `mimo-adapter/`, giving MiMo Code automatic cross-session memory through
the existing TencentDB Agent Memory Gateway.

新增 MiMo Code 插件适配器（`mimo-adapter/`），通过现有 Gateway HTTP API
自动完成长期记忆召回、对话归档和会话结束通知。MiMo Code 原有的本地 memory
能力保持不变；本适配器补充的是可与其他宿主共享的 L0 → L3 结构化长期记忆。

**Lifecycle mapping | 生命周期映射：**

| MiMo Code hook | Gateway endpoint | 作用 |
| :--- | :--- | :--- |
| `chat.message` | `POST /recall` | 每轮开始时按最新用户消息召回记忆 |
| `experimental.chat.system.transform` | — | 将召回结果临时注入本轮 system prompt |
| `session.post` | `POST /capture` | root agent 成功完成后归档本轮 user/assistant 消息 |
| `session.deleted` | `POST /session/end` | 会话删除时通知 Gateway 冲刷后台任务 |

- Session identity: `session_key = mimo_<sessionID>`，同一 MiMo session 稳定复用
- Capture boundary: 只归档成功完成的 root-agent turn；过滤 reasoning、tool、
  synthetic/plugin-injected 内容和 subagent 轨迹
- Fault tolerance: Gateway 超时、网络/HTTP 错误、异常响应及 hook 内部异常都
  fail-open，不阻断 MiMo Code 的模型调用或最终结果
- Configuration: supports `MEMORY_TENCENTDB_GATEWAY_URL`, optional
  `MEMORY_TENCENTDB_GATEWAY_API_KEY`, bounded timeouts, and opt-in debug logging

**Adapter lane | 适配边界：** this PR contains only MiMo Code-specific lifecycle
mapping and a minimal adapter-local Gateway client. It does not introduce another
memory engine, shared SDK, MCP server, or change `TdaiCore`/Gateway behavior.

## Related Issue | 关联 Issue

Refs #235

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

- `npx vitest run __tests__/mimo-adapter/plugin.test.ts` — 1 file, 11 tests passed
- `npx vitest run` — 5 files, 78 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- `npm pack --dry-run --ignore-scripts --json` — adapter source and guide included
- Bun loaded the V1 plugin export against the official MiMo Code workspace

## Additional Notes | 其他说明

### A/B verification: same MiMo Code, same prompt and provider; only the experiment profile loads the adapter | 控制变量对比实验

The experiment ran the official MiMo Code CLI at commit
`c946f4c215aaf326036342a8c3dec6ad12d8772a` (2026-07-26). Each group used:

- a fresh MiMo Code process and an isolated `MIMOCODE_HOME`;
- the same empty workspace, model configuration, and prompt;
- the same deterministic local OpenAI-compatible provider;
- no external model service or user API key.

两组均使用全新的 MiMo Code 进程、隔离的 `MIMOCODE_HOME`、相同空白
workspace、相同 prompt 和相同确定性本地 provider。唯一实验变量是 experiment
profile 加载了本适配器。

**Control (without adapter) | 对照组（未安装适配器）：**

```text
process exit:              0
provider requests:         1
Gateway requests:          0
recall marker at provider: false
```

The provider received only MiMo Code's normal context; it did not receive the
fact prepared in the Gateway fixture.

**Experiment (with adapter) | 实验组（安装适配器）：**

```text
process exit:              0
provider requests:         1
Gateway requests:          POST /recall -> POST /capture
recall marker at provider: true
recalled fact:             Cross-host fact: the user prefers Rust.
```

The fact returned by `/recall` was present in the actual request received by the
provider. After the assistant completed, `/capture` received the user/assistant
turn with a MiMo-derived session key. This verifies both sides of the automatic
lifecycle rather than only testing the HTTP client in isolation.

**Degradation (adapter loaded, Gateway offline) | 容错组（安装适配器，但 Gateway 停机）：**

```text
Gateway endpoint:          closed local port
process exit:              0
provider requests:         1
assistant completed:       true
```

MiMo Code completed normally: failed recall became empty context and failed
capture was dropped. Gateway availability is therefore not a prerequisite for
using the host agent.

### Implementation notes

- Recall is injected only into the transient system projection and is not written
  back into MiMo Code's canonical trajectory.
- The adapter intentionally omits Gateway `dedup: true`. Because the previous
  projection is absent from the next turn's trajectory, suppressing an identical
  recall could remove context that the model no longer has.
- `session.deleted` is the current public lifecycle signal used for
  `/session/end`; MiMo Code does not expose a general process-shutdown hook.
- Debug logs never include the API key or complete conversation payloads.
