### PR TITLE
fix(checkpoint): recalibrate counters after cleanup

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -409,6 +409,9 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      // Repair counters left stale by cleanup/manual JSONL edits before this
+      // gateway instance starts accepting turns.
+      await new CheckpointManager(this.dataDir, this.logger).recalibrate(this.vectorStore);
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+const tempDirs: string[] = [];
+
+async function createDataDir(): Promise<string> {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-test-"));
+  tempDirs.push(dataDir);
+  await Promise.all([
+    fs.mkdir(path.join(dataDir, ".metadata"), { recursive: true }),
+    fs.mkdir(path.join(dataDir, "conversations"), { recursive: true }),
+    fs.mkdir(path.join(dataDir, "records"), { recursive: true }),
+  ]);
+  return dataDir;
+}
+
+async function writeCheckpoint(manager: CheckpointManager, values: Partial<Awaited<ReturnType<CheckpointManager["read"]>>>): Promise<void> {
+  await manager.write({ ...await manager.read(), ...values });
+}
+
+function counterStore(l0: number, l1: number): IMemoryStore {
+  return {
+    isDegraded: () => false,
+    countL0: () => l0,
+    countL1: () => l1,
+  } as IMemoryStore;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager.recalibrate", () => {
+  it("uses live store counts and preserves per-session cursor state", async () => {
+    const dataDir = await createDataDir();
+    const manager = new CheckpointManager(dataDir);
+    await writeCheckpoint(manager, {
+      l0_conversations_count: 50,
+      total_memories_extracted: 50,
+      memories_since_last_persona: 50,
+      runner_states: { session: { last_captured_timestamp: 42, last_l1_cursor: 40, last_scene_name: "scene" } },
+      pipeline_states: { session: { conversation_count: 2, last_extraction_time: "", last_extraction_updated_time: "", last_active_time: 1, l2_pending_l1_count: 0, warmup_threshold: 0, l2_last_extraction_time: "" } },
+    });
+
+    await manager.recalibrate(counterStore(9, 4));
+
+    await expect(manager.read()).resolves.toMatchObject({
+      l0_conversations_count: 9,
+      total_memories_extracted: 4,
+      memories_since_last_persona: 4,
+      runner_states: { session: { last_captured_timestamp: 42, last_l1_cursor: 40, last_scene_name: "scene" } },
+      pipeline_states: { session: { conversation_count: 2 } },
+    });
+  });
+
+  it("falls back to non-empty JSONL records when a store is unavailable", async () => {
+    const dataDir = await createDataDir();
+    await fs.writeFile(path.join(dataDir, "conversations", "2026-07-27.jsonl"), "one\n\ntwo\n");
+    await fs.writeFile(path.join(dataDir, "records", "2026-07-27.jsonl"), "one\ntwo\nthree\n");
+    const manager = new CheckpointManager(dataDir);
+    await writeCheckpoint(manager, { l0_conversations_count: 50, total_memories_extracted: 50 });
+
+    await manager.recalibrate();
+
+    await expect(manager.read()).resolves.toMatchObject({
+      l0_conversations_count: 2,
+      total_memories_extracted: 3,
+    });
+  });
+
+  it("keeps cleaner-run checkpoints aligned even when no records are eligible for deletion", async () => {
+    const dataDir = await createDataDir();
+    const manager = new CheckpointManager(dataDir);
+    await writeCheckpoint(manager, { l0_conversations_count: 50, total_memories_extracted: 50 });
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: counterStore(3, 2),
+    });
+
+    await cleaner.runOnce();
+
+    await expect(manager.read()).resolves.toMatchObject({
+      l0_conversations_count: 3,
+      total_memories_extracted: 2,
+    });
+  });
+
+  it("uses the L0 record count instead of capture-batch count", async () => {
+    const dataDir = await createDataDir();
+    const manager = new CheckpointManager(dataDir);
+
+    await manager.captureAtomically("session", 0, async () => ({ maxTimestamp: 10, messageCount: 3 }));
+
+    await expect(manager.read()).resolves.toMatchObject({ l0_conversations_count: 3, total_processed: 3 });
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -27,6 +27,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import type { IMemoryStore } from "../core/store/types.js";
 
 // ============================
 // Types
@@ -179,10 +180,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -291,6 +294,90 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Reconcile the aggregate counters with the persisted L0/L1 data.
+   *
+   * Checkpoint counters are a cache for status and trigger decisions, not the
+   * source of truth. They can drift when data is removed outside the normal
+   * capture/extraction paths (for example by the cleaner or manual JSONL
+   * pruning). Prefer the active store because it represents live records; if
+   * no store is available, count non-empty JSONL lines as the degraded-mode
+   * fallback.
+   *
+   * Per-session cursors and pipeline state deliberately remain untouched:
+   * they describe processing progress, not the current number of records.
+   */
+  async recalibrate(vectorStore?: IMemoryStore): Promise<void> {
+    const useStore = vectorStore && !vectorStore.isDegraded() ? vectorStore : undefined;
+    const [storedL0, storedL1, jsonlL0, jsonlL1] = await Promise.all([
+      this.readStoreCount(useStore, "l0"),
+      this.readStoreCount(useStore, "l1"),
+      this.countJsonlRecords("conversations"),
+      this.countJsonlRecords("records"),
+    ]);
+
+    const l0Count = storedL0 ?? jsonlL0;
+    const l1Count = storedL1 ?? jsonlL1;
+    const checkpoint = await this.mutate((cp) => {
+      cp.l0_conversations_count = l0Count;
+      cp.total_memories_extracted = l1Count;
+      // A cleanup can only reduce the number of memories that remain since
+      // the last persona generation. Keep the counter in its valid range
+      // without changing the historical total_processed/persona marker.
+      cp.memories_since_last_persona = Math.min(cp.memories_since_last_persona, l1Count);
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrated: l0=${checkpoint.l0_conversations_count} ` +
+      `l1=${checkpoint.total_memories_extracted} ` +
+      `source=${useStore ? "store" : "jsonl"}`,
+    );
+  }
+
+  private async readStoreCount(
+    vectorStore: IMemoryStore | undefined,
+    layer: "l0" | "l1",
+  ): Promise<number | undefined> {
+    if (!vectorStore) return undefined;
+
+    try {
+      const count = await (layer === "l0" ? vectorStore.countL0() : vectorStore.countL1());
+      if (Number.isFinite(count) && count >= 0) return count;
+      this.logger.warn?.(`[checkpoint] Invalid ${layer.toUpperCase()} store count; using JSONL fallback`);
+    } catch (err) {
+      this.logger.warn?.(
+        `[checkpoint] Failed to count ${layer.toUpperCase()} records; using JSONL fallback: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return undefined;
+  }
+
+  private async countJsonlRecords(directory: "conversations" | "records"): Promise<number> {
+    const dirPath = path.join(this.dataDir, directory);
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(dirPath, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    let count = 0;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      try {
+        const contents = await fs.readFile(path.join(dirPath, entry.name), "utf-8");
+        count += contents.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] Failed to count JSONL file ${entry.name}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return count;
   }
 
   // ============================
@@ -449,8 +536,9 @@ export class CheckpointManager {
    *   - `{ maxTimestamp, messageCount }` to advance the cursor, or
    *   - `null` to leave the cursor unchanged (nothing captured).
    *
-   * L0 conversation count is also incremented inside the lock when messages
-   * are captured, removing the need for a separate `incrementL0ConversationCount()` call.
+   * L0 message count is also incremented inside the lock when messages are
+   * captured, removing the need for a separate counter update. Its unit is
+   * intentionally the same as the backing `l0_conversations` table.
    *
    * @param sessionKey   Per-session identifier
    * @param pluginStartTimestamp  Cold-start floor (used when no cursor exists yet)
@@ -479,8 +567,7 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -183,6 +184,19 @@ export class LocalMemoryCleaner {
     this.opts.logger?.info(
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
+
+    // Reconcile even when this run did not remove anything: a user may have
+    // pruned JSONL files manually, or a prior cleanup could have been
+    // interrupted after deleting data but before updating the checkpoint.
+    try {
+      await new CheckpointManager(this.opts.baseDir, this.opts.logger).recalibrate(this.vectorStore);
+    } catch (err) {
+      // Cleanup itself has completed; a failed status reconciliation should
+      // not turn it into a failed maintenance run.
+      this.opts.logger?.warn(
+        `${TAG} Failed to recalibrate checkpoint: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
   }
 


### PR DESCRIPTION
## Description

Fix checkpoint counters that stayed inflated after cleanup or manual data pruning.

- Add `CheckpointManager.recalibrate()` to rebuild L0/L1 counts from the live store, with JSONL fallback in degraded mode.
- Run recalibration when the Gateway store initializes and after each memory-cleaner run.
- Align normal L0 increments with the backing record unit (`messageCount`).
- Preserve per-session cursors and pipeline state; add regression coverage for store, JSONL, cleaner, and multi-message capture paths.

## Related Issue

Closes #157

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code optimization

## Self-test Checklist

- [x] Verified locally
- [x] No existing features affected

## Additional Notes

Validation completed:

- `node node_modules/vitest/vitest.mjs run` — 5 files, 71 tests passed.
- Plugin and script builds passed.
- End-to-end Gateway smoke test: capture two L0 records, remove the temporary persisted records, restart the Gateway, and confirm `recall_checkpoint.json` recalibrates from `2` to `0`.
