### PR TITLE
feat: cross-platform adapter SDK for Claude Code, Cursor, Codex and Dify (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Hermes](https://img.shields.io/badge/Hermes-Gateway-7B61FF)](https://hermes-agent.nousresearch.com/docs/)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/dJQM6mKMF)
 
-[Highlights](#-highlights) · [Overview](#overview) · [Core Technology](#core-technology-reject-flat-storage-embrace-layering-and-symbolization) · [Features](#-features) · [Quick Start](#quick-start)
+[Highlights](#-highlights) · [Overview](#overview) · [Core Technology](#core-technology-reject-flat-storage-embrace-layering-and-symbolization) · [Features](#-features) · [Quick Start](#quick-start) · [Platform Adapters](#platform-adapters) · [Architecture](./docs/architecture.md)
 
 <div align="center">
 
@@ -132,6 +132,22 @@ graph LR
 
 ---
 
+## Platform Adapters
+
+TencentDB-Agent-Memory supports multiple agent platforms. Each platform has a dedicated adapter that bridges the platform's event model to the core memory engine.
+
+| Platform | Transport | Capture | Setup guide |
+|---|---|---|---|
+| **OpenClaw** | In-process SDK hooks | Automatic (`agent_end` hook) | Below ↓ |
+| **Hermes** | HTTP Gateway (localhost) | Automatic (`sync_turn()` call) | Below ↓ |
+| **Claude Code** | MCP stdio JSON-RPC | Automatic (Stop hook) or explicit tool | [claude-code-adapter.md](./docs/claude-code-adapter.md) |
+| **Cursor** | MCP stdio JSON-RPC | Explicit tool call (`tdai_memory_capture`) | [cursor-adapter.md](./docs/cursor-adapter.md) |
+| **Codex CLI** | MCP stdio JSON-RPC | Explicit tool call (`tdai_memory_capture`) | [codex-adapter.md](./docs/codex-adapter.md) |
+| **Dify / n8n** | HTTP (localhost) | Explicit HTTP request node | [dify-adapter.md](./docs/dify-adapter.md) |
+
+For a full architecture diagram, data flow explanation, per-platform comparison, and a guide to adding new platforms, see **[docs/architecture.md](./docs/architecture.md)**.
+
+---
 
 ### 1. OpenClaw
 ### 1.1 Install the plugin

--- a/bin/env-common.ts
+++ b/bin/env-common.ts
@@ -1,0 +1,98 @@
+/**
+ * Environment variables shared by every TDAI entry point, MCP and HTTP alike.
+ *
+ * Transport-specific variables live in the loader that owns them:
+ *   bin/shared.ts       — TDAI_SESSION_KEY (MCP)
+ *   bin/shared-http.ts  — TDAI_PORT, TDAI_HOST, TDAI_GATEWAY_API_KEY,
+ *                         TDAI_CORS_ORIGINS (HTTP)
+ *
+ * Required:
+ *   TDAI_LLM_BASE_URL            — OpenAI-compatible API base URL
+ *   TDAI_LLM_API_KEY             — API key for the LLM endpoint
+ *   TDAI_LLM_MODEL               — model name (e.g. "gpt-4o", "deepseek-chat")
+ *
+ * Optional:
+ *   TDAI_DATA_DIR                — storage root (default: ~/.tdai/<platform>)
+ *   TDAI_LLM_MAX_TOKENS          — max output tokens for extraction pipelines
+ *   TDAI_LLM_TIMEOUT_MS          — LLM request timeout in ms
+ *   TDAI_LLM_DISABLE_THINKING    — disable reasoning tokens:
+ *                                   false / true / vllm / deepseek / dashscope /
+ *                                   openai / anthropic / kimi / gemini
+ *   TDAI_USER_ID                 — default user identifier (default: "default_user").
+ *                                  Reserved: recorded in RuntimeContext but not
+ *                                  yet used to scope storage. Running two users
+ *                                  against one server shares one memory store.
+ *   TDAI_MEMORY_CONFIG           — JSON string with MemoryTdaiConfig overrides
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { normalizeDisableThinking } from "../src/utils/no-think-fetch.js";
+import type { StandaloneLLMConfig } from "../src/adapters/standalone/llm-runner.js";
+
+/** The subset of server options derivable from transport-neutral env vars. */
+export interface CommonEnvOptions {
+  dataDir: string;
+  llmConfig: StandaloneLLMConfig;
+  memoryConfigOverride?: Record<string, unknown>;
+  userId?: string;
+}
+
+/**
+ * Read an integer env var.
+ * Returns undefined when unset, and warns-then-ignores when unparseable —
+ * a silent NaN would otherwise reach `listen()` or the LLM client.
+ */
+export function parseIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    process.stderr.write(`[tdai] Warning: ${name}="${raw}" is not an integer — ignored.\n`);
+    return undefined;
+  }
+  return value;
+}
+
+/** Load the env vars every entry point needs, exiting on missing required ones. */
+export function loadCommonEnv(defaultDirName: string): CommonEnvOptions {
+  const baseUrl = process.env["TDAI_LLM_BASE_URL"];
+  const apiKey = process.env["TDAI_LLM_API_KEY"];
+  const model = process.env["TDAI_LLM_MODEL"];
+
+  if (!baseUrl || !apiKey || !model) {
+    process.stderr.write(
+      "[tdai] Fatal: TDAI_LLM_BASE_URL, TDAI_LLM_API_KEY, and TDAI_LLM_MODEL are required.\n",
+    );
+    process.exit(1);
+  }
+
+  const dataDir = path.resolve(
+    process.env["TDAI_DATA_DIR"] ?? path.join(os.homedir(), ".tdai", defaultDirName),
+  );
+
+  let memoryConfigOverride: Record<string, unknown> | undefined;
+  const rawMemoryConfig = process.env["TDAI_MEMORY_CONFIG"];
+  if (rawMemoryConfig) {
+    try {
+      memoryConfigOverride = JSON.parse(rawMemoryConfig) as Record<string, unknown>;
+    } catch {
+      process.stderr.write("[tdai] Warning: TDAI_MEMORY_CONFIG is not valid JSON — ignored.\n");
+    }
+  }
+
+  return {
+    dataDir,
+    llmConfig: {
+      baseUrl,
+      apiKey,
+      model,
+      maxTokens: parseIntEnv("TDAI_LLM_MAX_TOKENS"),
+      timeoutMs: parseIntEnv("TDAI_LLM_TIMEOUT_MS"),
+      disableThinking: normalizeDisableThinking(process.env["TDAI_LLM_DISABLE_THINKING"]),
+    },
+    memoryConfigOverride,
+    userId: process.env["TDAI_USER_ID"],
+  };
+}

--- a/bin/shared-http.ts
+++ b/bin/shared-http.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared environment loader for all HTTP server entry points.
+ *
+ * See bin/env-common.ts for the transport-neutral variables (LLM config,
+ * data dir, memory overrides, user id). This module adds only:
+ *
+ *   TDAI_PORT              — HTTP listen port (default: the caller's defaultPort)
+ *   TDAI_HOST              — HTTP bind address (default: "127.0.0.1")
+ *   TDAI_GATEWAY_API_KEY   — Bearer auth token (TDAI_API_KEY also accepted)
+ *   TDAI_CORS_ORIGINS      — comma-separated CORS allow-list
+ */
+
+import { loadCommonEnv, parseIntEnv } from "./env-common.js";
+import type { HttpServerBaseOptions } from "../src/adapters/http-server-base.js";
+
+export function loadHttpEnvOptions(
+  defaultDirName: string,
+  defaultPort = 8420,
+): HttpServerBaseOptions {
+  const corsRaw = process.env["TDAI_CORS_ORIGINS"];
+  const corsOrigins = corsRaw
+    ? corsRaw.split(",").map((o) => o.trim()).filter(Boolean)
+    : undefined;
+
+  return {
+    ...loadCommonEnv(defaultDirName),
+    port: parseIntEnv("TDAI_PORT") ?? defaultPort,
+    host: process.env["TDAI_HOST"] ?? "127.0.0.1",
+    apiKey: process.env["TDAI_GATEWAY_API_KEY"] ?? process.env["TDAI_API_KEY"],
+    corsOrigins,
+  };
+}

--- a/bin/shared.ts
+++ b/bin/shared.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared environment loader for all MCP server entry points.
+ *
+ * See bin/env-common.ts for the transport-neutral variables (LLM config,
+ * data dir, memory overrides, user id). This module adds only:
+ *
+ *   TDAI_SESSION_KEY   — default session key
+ *                        (falls back to the platform's own session env var,
+ *                         then to a process-stable UUID)
+ */
+
+import { loadCommonEnv } from "./env-common.js";
+import type { McpServerBaseOptions } from "../src/adapters/mcp-server-base.js";
+
+export function loadEnvOptions(defaultDirName: string): McpServerBaseOptions {
+  return {
+    ...loadCommonEnv(defaultDirName),
+    defaultSessionKey: process.env["TDAI_SESSION_KEY"],
+  };
+}

--- a/bin/tdai-capture-hook.mjs
+++ b/bin/tdai-capture-hook.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Launcher for the Claude Code Stop hook.
+ * Runs tdai-capture-hook.ts via tsx (production dependency).
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const tsxLocal = path.resolve(thisDir, "../node_modules/.bin/tsx");
+const tsxBin = fs.existsSync(tsxLocal) ? tsxLocal : "tsx";
+const entry = path.resolve(thisDir, "./tdai-capture-hook.ts");
+
+if (!fs.existsSync(entry)) {
+  process.stderr.write(`[tdai-hook] Fatal: entry not found: ${entry}\n`);
+  process.exit(0); // Always exit 0 — hooks must not block Claude Code
+}
+
+const child = spawn(tsxBin, [entry], { stdio: "inherit", env: process.env });
+child.on("exit", () => process.exit(0)); // always exit 0 — hooks must not block Claude Code

--- a/bin/tdai-capture-hook.ts
+++ b/bin/tdai-capture-hook.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * tdai-capture-hook — Claude Code Stop hook for automatic turn capture.
+ *
+ * Claude Code fires this script after every assistant response. The hook
+ * reads the session transcript, extracts the last user/assistant exchange,
+ * and appends it to a pending-queue file that ClaudeCodeMcpServer drains
+ * on the next recall. This keeps the hook fast (<100 ms) and avoids any
+ * SQLite concurrency conflict with the running MCP server.
+ *
+ * Register in .claude/settings.json:
+ *   {
+ *     "hooks": {
+ *       "Stop": [{
+ *         "hooks": [{ "type": "command", "command": "tdai-capture-hook" }]
+ *       }]
+ *     }
+ *   }
+ *
+ * The hook inherits env vars from the shell, not from mcpServers.env.
+ * If you set a custom TDAI_DATA_DIR for the MCP server, export it in your
+ * shell profile or prefix the command:
+ *   "command": "TDAI_DATA_DIR=/your/path tdai-capture-hook"
+ *
+ * Required env (must match the MCP server):
+ *   TDAI_DATA_DIR   — defaults to ~/.tdai/claude-code if unset
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// ============================
+// Types
+// ============================
+
+interface StopHookPayload {
+  hook_event_name?: string;
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+}
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+}
+
+/** One entry appended to the pending queue. */
+interface QueueEntry {
+  sessionKey: string;
+  userText: string;
+  assistantText: string;
+  ts: number;
+}
+
+// ============================
+// Transcript parsing
+// ============================
+
+/**
+ * Flatten a message content value to plain text.
+ * Handles both string content and content-block arrays (rich messages).
+ * Tool-use blocks and image blocks are silently dropped.
+ */
+function extractText(content: string | ContentBlock[] | undefined): string {
+  if (!content) return "";
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => (b.text as string).trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Parse a single JSONL line from the Claude Code transcript.
+ *
+ * Claude Code uses (at minimum) two transcript shapes depending on version:
+ *   Shape A (≥ 1.x):  { "type": "user"|"assistant", "message": { "role": ..., "content": ... } }
+ *   Shape B (legacy): { "role": "user"|"assistant", "content": ... }
+ *
+ * Returns { role, text } or null if the line is not a conversation message.
+ */
+function parseLine(line: string): { role: string; text: string } | null {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  // Shape A
+  if (typeof obj["type"] === "string" && obj["message"] && typeof obj["message"] === "object") {
+    const msg = obj["message"] as Record<string, unknown>;
+    const role = msg["role"] as string | undefined;
+    if (!role) return null;
+    const text = extractText(msg["content"] as string | ContentBlock[] | undefined);
+    return { role, text };
+  }
+
+  // Shape B
+  if (typeof obj["role"] === "string") {
+    const text = extractText(obj["content"] as string | ContentBlock[] | undefined);
+    return { role: obj["role"] as string, text };
+  }
+
+  return null;
+}
+
+/**
+ * Scan the transcript file and return the last user+assistant pair.
+ * We scan all lines and keep the most recent occurrence of each role,
+ * which guarantees we get the current turn even when the file contains
+ * the full session history.
+ */
+function extractLastTurn(
+  transcriptPath: string,
+): { userText: string; assistantText: string } | null {
+  if (!fs.existsSync(transcriptPath)) return null;
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(transcriptPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  let lastUser = "";
+  let lastAssistant = "";
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const parsed = parseLine(trimmed);
+    if (!parsed) continue;
+
+    if (parsed.role === "user" && parsed.text) {
+      lastUser = parsed.text;
+    } else if (parsed.role === "assistant" && parsed.text) {
+      lastAssistant = parsed.text;
+    }
+  }
+
+  if (!lastUser && !lastAssistant) return null;
+  return { userText: lastUser, assistantText: lastAssistant };
+}
+
+// ============================
+// Queue file helpers
+// ============================
+
+/**
+ * Append one capture entry to the pending queue.
+ * Uses appendFileSync — each JSONL line is written atomically on Linux/macOS.
+ */
+function enqueue(queuePath: string, entry: QueueEntry): void {
+  const dir = path.dirname(queuePath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(queuePath, JSON.stringify(entry) + "\n", "utf8");
+}
+
+// ============================
+// Main
+// ============================
+
+function main(): void {
+  // Read hook payload (Claude Code writes JSON to stdin and closes it)
+  let raw = "";
+  try {
+    raw = fs.readFileSync("/dev/stdin", "utf8").trim();
+  } catch {
+    // stdin not available or empty — nothing to do
+    process.exit(0);
+  }
+
+  if (!raw) process.exit(0);
+
+  let payload: StopHookPayload;
+  try {
+    payload = JSON.parse(raw) as StopHookPayload;
+  } catch {
+    process.exit(0);
+  }
+
+  const { session_id, transcript_path } = payload;
+
+  if (!transcript_path) {
+    // Some Claude Code versions omit transcript_path — nothing we can parse
+    process.exit(0);
+  }
+
+  const turn = extractLastTurn(transcript_path);
+  if (!turn || (!turn.userText && !turn.assistantText)) {
+    process.exit(0);
+  }
+
+  const dataDir = path.resolve(
+    process.env["TDAI_DATA_DIR"] ?? path.join(os.homedir(), ".tdai", "claude-code"),
+  );
+
+  const sessionKey =
+    session_id ??
+    process.env["CLAUDE_CODE_SESSION_ID"] ??
+    "default";
+
+  const queuePath = path.join(dataDir, "hook-queue.jsonl");
+
+  enqueue(queuePath, {
+    sessionKey,
+    userText: turn.userText,
+    assistantText: turn.assistantText,
+    ts: Date.now(),
+  });
+
+  process.stderr.write(
+    `[tdai-hook] queued 1 turn for session=${sessionKey} ` +
+    `(${turn.userText.slice(0, 40).replace(/\n/g, " ")}…)\n`,
+  );
+
+  process.exit(0);
+}
+
+main();

--- a/bin/tdai-claude-code-mcp.mjs
+++ b/bin/tdai-claude-code-mcp.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Launcher for the Claude Code MCP server.
+ *
+ * Uses tsx (a production dependency of this package) to execute the
+ * TypeScript entry point without a separate pre-compilation step.
+ *
+ * All configuration is read from environment variables — see
+ * bin/tdai-claude-code-mcp.ts for the full list.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Prefer the local tsx binary; fall back to PATH resolution
+const tsxLocal = path.resolve(thisDir, "../node_modules/.bin/tsx");
+const tsxBin = fs.existsSync(tsxLocal) ? tsxLocal : "tsx";
+
+const entry = path.resolve(thisDir, "./tdai-claude-code-mcp.ts");
+
+if (!fs.existsSync(entry)) {
+  process.stderr.write(
+    `[tdai] Fatal: entry point not found: ${entry}\n` +
+    `[tdai] Ensure the package is installed correctly.\n`,
+  );
+  process.exit(1);
+}
+
+const child = spawn(tsxBin, [entry], {
+  stdio: "inherit",
+  env: process.env,
+});
+
+process.on("SIGTERM", () => { child.kill("SIGTERM"); });
+process.on("SIGINT", () => { child.kill("SIGINT"); });
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/bin/tdai-claude-code-mcp.ts
+++ b/bin/tdai-claude-code-mcp.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Claude Code MCP server entry point.
+ * All configuration via TDAI_* env vars — see bin/shared.ts for the complete list.
+ *
+ * Example .claude/settings.json:
+ *   {
+ *     "mcpServers": {
+ *       "tdai-memory": {
+ *         "command": "npx",
+ *         "args": ["tdai-claude-code-mcp"],
+ *         "env": {
+ *           "TDAI_LLM_BASE_URL": "https://api.openai.com/v1",
+ *           "TDAI_LLM_API_KEY": "sk-...",
+ *           "TDAI_LLM_MODEL": "gpt-4o"
+ *         }
+ *       }
+ *     }
+ *   }
+ */
+
+import { ClaudeCodeMcpServer } from "../src/adapters/claude-code/index.js";
+import { loadEnvOptions } from "./shared.js";
+
+new ClaudeCodeMcpServer(loadEnvOptions("claude-code")).start().catch((err: unknown) => {
+  process.stderr.write(
+    `[tdai-claude-code-mcp] Fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/bin/tdai-codex-mcp.mjs
+++ b/bin/tdai-codex-mcp.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Launcher for the Codex CLI MCP server.
+ * Runs tdai-codex-mcp.ts via tsx (production dependency).
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const tsxLocal = path.resolve(thisDir, "../node_modules/.bin/tsx");
+const tsxBin = fs.existsSync(tsxLocal) ? tsxLocal : "tsx";
+const entry = path.resolve(thisDir, "./tdai-codex-mcp.ts");
+
+if (!fs.existsSync(entry)) {
+  process.stderr.write(`[tdai-codex-mcp] Fatal: entry not found: ${entry}\n`);
+  process.exit(1);
+}
+
+const child = spawn(tsxBin, [entry], { stdio: "inherit", env: process.env });
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/bin/tdai-codex-mcp.ts
+++ b/bin/tdai-codex-mcp.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * Codex CLI MCP server entry point.
+ * All configuration via TDAI_* env vars — see bin/shared.ts for the complete list.
+ *
+ * Example ~/.codex/config.toml:
+ *   [mcp_servers.tdai-memory]
+ *   command = "tdai-codex-mcp"
+ *   env = { TDAI_LLM_BASE_URL = "...", TDAI_LLM_API_KEY = "...", TDAI_LLM_MODEL = "..." }
+ */
+
+import { CodexMcpServer } from "../src/adapters/codex/index.js";
+import { loadEnvOptions } from "./shared.js";
+
+new CodexMcpServer(loadEnvOptions("codex")).start().catch((err: unknown) => {
+  process.stderr.write(
+    `[tdai-codex-mcp] Fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/bin/tdai-cursor-mcp.mjs
+++ b/bin/tdai-cursor-mcp.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Launcher for the Cursor MCP server.
+ * Runs tdai-cursor-mcp.ts via tsx (production dependency).
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const tsxLocal = path.resolve(thisDir, "../node_modules/.bin/tsx");
+const tsxBin = fs.existsSync(tsxLocal) ? tsxLocal : "tsx";
+const entry = path.resolve(thisDir, "./tdai-cursor-mcp.ts");
+
+if (!fs.existsSync(entry)) {
+  process.stderr.write(`[tdai-cursor-mcp] Fatal: entry not found: ${entry}\n`);
+  process.exit(1);
+}
+
+const child = spawn(tsxBin, [entry], { stdio: "inherit", env: process.env });
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/bin/tdai-cursor-mcp.ts
+++ b/bin/tdai-cursor-mcp.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * Cursor MCP server entry point.
+ * All configuration via TDAI_* env vars — see bin/shared.ts for the complete list.
+ *
+ * Example ~/.cursor/mcp.json:
+ *   {
+ *     "mcpServers": {
+ *       "tdai-memory": {
+ *         "command": "tdai-cursor-mcp",
+ *         "env": { "TDAI_LLM_BASE_URL": "...", "TDAI_LLM_API_KEY": "...", "TDAI_LLM_MODEL": "..." }
+ *       }
+ *     }
+ *   }
+ */
+
+import { CursorMcpServer } from "../src/adapters/cursor/index.js";
+import { loadEnvOptions } from "./shared.js";
+
+new CursorMcpServer(loadEnvOptions("cursor")).start().catch((err: unknown) => {
+  process.stderr.write(
+    `[tdai-cursor-mcp] Fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/bin/tdai-dify-http.mjs
+++ b/bin/tdai-dify-http.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Launcher for the Dify HTTP server.
+ * Runs tdai-dify-http.ts via tsx (production dependency).
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const tsxLocal = path.resolve(thisDir, "../node_modules/.bin/tsx");
+const tsxBin = fs.existsSync(tsxLocal) ? tsxLocal : "tsx";
+const entry = path.resolve(thisDir, "./tdai-dify-http.ts");
+
+if (!fs.existsSync(entry)) {
+  process.stderr.write(`[tdai-dify-http] Fatal: entry not found: ${entry}\n`);
+  process.exit(1);
+}
+
+const child = spawn(tsxBin, [entry], { stdio: "inherit", env: process.env });
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/bin/tdai-dify-http.ts
+++ b/bin/tdai-dify-http.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Dify HTTP server entry point.
+ * All configuration via TDAI_* env vars — see bin/shared-http.ts for the complete list.
+ *
+ * Example Dify Plugin manifest (tools/memory.yaml):
+ *   http_request_node:
+ *     url: http://127.0.0.1:8420/recall
+ *     method: POST
+ *     headers:
+ *       Authorization: "Bearer ${TDAI_GATEWAY_API_KEY}"
+ */
+
+import { DifyHttpServer } from "../src/adapters/dify/index.js";
+import { loadHttpEnvOptions } from "./shared-http.js";
+
+new DifyHttpServer(loadHttpEnvOptions("dify", 8420)).start().catch((err: unknown) => {
+  process.stderr.write(
+    `[tdai-dify-http] Fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,531 @@
+# Architecture Overview
+
+This document is the single authoritative reference for how TencentDB-Agent-Memory is structured internally and how each platform adapter plugs into the core engine. Individual platform setup guides live alongside this doc; come here first to understand the overall design.
+
+**Platform setup guides:** [Claude Code](./claude-code-adapter.md) · [Cursor](./cursor-adapter.md) · [Codex CLI](./codex-adapter.md) · [Dify / n8n](./dify-adapter.md)
+
+**Adding a platform:** [new-platform-guide.md](./new-platform-guide.md)
+
+---
+
+## Full Platform Overview
+
+```
+ ┌──────────────┐  ┌──────────────────────────────┐  ┌─────────────────┐  ┌─────────────┐  ┌─────────────┐
+ │  OpenClaw    │  │           Hermes             │  │  Claude Code    │  │   Cursor    │  │  Codex CLI  │
+ │   Agent      │  │         (Python)             │  │    Agent        │  │    Agent    │  │   Agent     │
+ └──────┬───────┘  └──────────────┬───────────────┘  └────────┬────────┘  └──────┬──────┘  └──────┬──────┘
+        │                         │                            │                  │                 │
+ transport:               transport:                   transport:          transport:         transport:
+ in-process               HTTP POST                    MCP stdio           MCP stdio          MCP stdio
+ SDK hooks                localhost:8420               JSON-RPC            JSON-RPC           JSON-RPC
+        │                         │                            │                  │                 │
+        │          ┌──────────────▼────────────┐              │                  │                 │
+        │          │   Node.js Gateway          │              │                  │                 │
+        │          │   StandaloneHostAdapter    │              │                  │                 │
+        │          └──────────────┬────────────┘              │                  │                 │
+        │                         │                            │                  │                 │
+ capture:                 capture:                     capture:            capture:           capture:
+ agent_end hook           sync_turn()                  Stop hook           tdai_memory        tdai_memory
+ (automatic)              (automatic)                  (automatic)         _capture tool      _capture tool
+        │                         │                            │           (explicit)          (explicit)
+        └─────────────────────────┴────────────────────────────┴──────────────────┴─────────────────┘
+                                                               │
+                                                    ┌──────────▼──────────┐
+                                                    │      TdaiCore        │
+                                                    │  ┌────────────────┐  │
+                                                    │  │ L0  Raw Turns  │  │
+                                                    │  │ L1  Atoms      │  │
+                                                    │  │ L2  Scenes     │  │
+                                                    │  │ L3  Persona    │  │
+                                                    │  └────────────────┘  │
+                                                    └──────────┬──────────┘
+                                                               │
+                                              ┌────────────────┴───────────────┐
+                                              │                                 │
+                                     ┌────────▼────────┐               ┌───────▼───────┐
+                                     │  SQLite-vec     │               │ TencentDB     │
+                                     │  (local)        │               │ VectorDB      │
+                                     └─────────────────┘               └───────────────┘
+```
+
+---
+
+## Memory Layers (L0 → L3)
+
+The engine organises all conversational data into a four-layer semantic pyramid. Lower layers preserve raw evidence; upper layers preserve structure.
+
+```
+                        ┌──────────────────┐
+              L3        │   User Persona   │  preferences, habits, identity
+                        └────────┬─────────┘
+                                 │ distilled from
+                        ┌────────▼─────────┐
+              L2        │  Scene Blocks    │  recurring contexts, topic clusters
+                        └────────┬─────────┘
+                                 │ extracted from
+                        ┌────────▼─────────┐
+              L1        │  Episodic Atoms  │  discrete facts, skills, instructions
+                        └────────┬─────────┘
+                                 │ structured from
+                        ┌────────▼─────────┐
+              L0        │  Raw Turns       │  verbatim user ↔ assistant exchanges
+                        └──────────────────┘
+```
+
+**Write path:** every captured turn lands in L0 first. A scheduler then runs L1 extraction (per N turns), L2 scene inference (per N L1 atoms), and L3 persona synthesis (periodically). All pipelines are asynchronous and non-blocking — the adapter does not wait for them.
+
+**Read path:** `handleBeforeRecall` queries L1 atoms and the L3 persona, merges them into a context string, and returns it to the adapter to prepend to the system prompt. L0 is only queried explicitly via `searchConversations`.
+
+---
+
+## Core Engine: TdaiCore
+
+`TdaiCore` is the host-neutral memory engine. It exposes five operations that every adapter calls:
+
+| Method | When to call | What it does |
+|---|---|---|
+| `handleBeforeRecall(query, sessionKey)` | Start of every turn | Queries L1 + L3, returns formatted context |
+| `handleTurnCommitted(turn)` | End of every turn | Writes L0, schedules L1/L2/L3 pipelines |
+| `searchMemories(params)` | On demand | Searches L1 atoms with optional type/scene filters |
+| `searchConversations(params)` | On demand | Searches L0 raw history, optionally scoped to a session |
+| `handleSessionEnd(sessionKey)` | Conversation ends | Flushes pending L1/L2/L3 pipelines for the session |
+
+`TdaiCore` depends only on a `HostAdapter` and a parsed config — it has no knowledge of any specific platform.
+
+Adapters do not call these methods directly. Both transport base classes go through
+`MemoryOperations` (`src/adapters/memory-operations.ts`), a transport-neutral facade that
+owns argument validation, the `TdaiCore` call and timing logs. Only the wire format differs
+between transports — MCP renders markdown for an LLM, HTTP emits JSON — so an operation added
+to the facade reaches every platform on both transports at once.
+
+---
+
+## Adapter Model
+
+### The HostAdapter Contract
+
+Every platform must provide one class that implements `HostAdapter`:
+
+```typescript
+interface HostAdapter {
+  readonly hostType: string;         // platform identifier
+  getRuntimeContext(): RuntimeContext; // session + user identity
+  getLogger(): Logger;
+  getLLMRunnerFactory(): LLMRunnerFactory;
+}
+
+interface RuntimeContext {
+  userId: string;
+  sessionKey: string;   // groups turns into a named conversation
+  sessionId: string;    // sub-session (can equal sessionKey)
+  platform: string;
+  dataDir: string;
+  workspaceDir: string;
+}
+```
+
+The adapter bridges three things: **identity** (who is the user, what is the session), **logging** (where do diagnostic messages go), and **LLM access** (which model runs the extraction pipelines).
+
+### General Data Flow
+
+```
+  Platform runtime
+       │
+       │  trigger (hook / HTTP call / MCP tool)
+       ▼
+  Adapter layer
+  ┌──────────────────────────────────────────────┐
+  │  translate platform event → TdaiCore call    │
+  │  translate TdaiCore result → platform format │
+  └──────────────────────────────────────────────┘
+       │
+       │  handleBeforeRecall / handleTurnCommitted / search*
+       ▼
+  TdaiCore
+  ┌──────────────────────────────────────────────┐
+  │  L0 write → L1/L2/L3 pipeline scheduling     │
+  │  L1 + L3 recall → context string             │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  Storage (SQLite-vec local  /  TencentDB VectorDB)
+```
+
+---
+
+## Platform Adapters
+
+### 1 · OpenClaw (in-process TypeScript plugin)
+
+```
+┌──────────────────────────────────────────────────────┐
+│  OpenClaw Agent process                               │
+│                                                       │
+│  ┌─────────────┐   before_prompt_build hook           │
+│  │   OpenClaw  │──────────────────────────────────┐  │
+│  │   runtime   │   agent_end hook                 │  │
+│  └─────────────┘──────────────────────────────┐   │  │
+│                                               │   │  │
+│  ┌────────────────────────────────────────┐   │   │  │
+│  │  index.ts  (plugin entry)              │   │   │  │
+│  │    OpenClawHostAdapter                 │◄──┘   │  │
+│  │    TdaiCore                            │◄──────┘  │
+│  └────────────────────────────────────────┘          │
+└──────────────────────────────────────────────────────┘
+```
+
+**Transport:** in-process function calls — no network, no subprocess.
+
+**Recall trigger:** `before_prompt_build` SDK hook fires automatically before each prompt assembly. The adapter calls `handleBeforeRecall` and injects the returned context into the prompt.
+
+**Capture trigger:** `agent_end` SDK hook fires automatically when the agent finishes a turn. The adapter calls `handleTurnCommitted`.
+
+**LLM runner:** `OpenClawLLMRunnerFactory` wraps the OpenClaw agent's own LLM runtime (`api.runtime.agent`), so the extraction pipelines reuse the same model connection that the agent itself uses.
+
+**Session key:** taken from the OpenClaw session context passed to each hook invocation.
+
+**Key files:**
+```
+src/adapters/openclaw/
+├── host-adapter.ts   # OpenClawHostAdapter
+├── llm-runner.ts     # OpenClawLLMRunnerFactory (wraps OpenClaw's LLM API)
+└── index.ts          # barrel + OpenClaw plugin registration
+index.ts              # plugin entry point (registers hooks with OpenClaw SDK)
+```
+
+---
+
+### 2 · Hermes / HTTP Gateway (Python provider + Node.js sidecar)
+
+```
+┌──────────────────────┐          ┌───────────────────────────────────────┐
+│  Hermes Agent        │          │  Node.js Gateway sidecar (port 8420)  │
+│  (Python process)    │          │                                       │
+│                      │          │  ┌───────────────────────────────┐   │
+│  ┌────────────────┐  │  HTTP    │  │  TdaiGateway                  │   │
+│  │MemoryProvider  │──┼─────────►│  │  (extends HttpServerBase)     │   │
+│  │  prefetch()    │  │  POST    │  │  StandaloneHostAdapter        │   │
+│  │  sync_turn()   │◄─┼──────── │  │  TdaiCore                     │   │
+│  └────────────────┘  │  JSON    │  └───────────────────────────────┘   │
+│                      │          └───────────────────────────────────────┘
+│  GatewaySupervisor   │  (spawns the Gateway on startup, health-checks it)
+└──────────────────────┘
+```
+
+**Transport:** HTTP POST — the Python provider (`memory_tencentdb/`) sends JSON requests to the Node.js Gateway over localhost. The `GatewaySupervisor` manages the Gateway subprocess lifetime.
+
+**Recall trigger:** `prefetch()` — Hermes calls this before each agent turn. The provider sends a `POST /recall` to the Gateway.
+
+**Capture trigger:** `sync_turn()` — called after each completed turn. The provider sends a `POST /capture` to the Gateway.
+
+**LLM runner:** `StandaloneLLMRunnerFactory` — calls any OpenAI-compatible API (configured via env vars). The Gateway process owns its own LLM connection.
+
+**Session key:** passed in from Hermes session kwargs at `initialize()`.
+
+**Key files:**
+```
+hermes-plugin/memory/memory_tencentdb/
+├── __init__.py       # MemoryProvider (prefetch, sync_turn, initialize, shutdown)
+├── client.py         # HTTP client for all Gateway endpoints
+└── supervisor.py     # GatewaySupervisor (spawns + health-checks the Gateway)
+
+src/adapters/standalone/
+├── host-adapter.ts   # StandaloneHostAdapter (32 lines: adds `platform` option)
+├── llm-runner.ts     # StandaloneLLMRunnerFactory (OpenAI-compatible API)
+└── index.ts          # barrel
+
+src/gateway/
+├── server.ts         # TdaiGateway (extends HttpServerBase; /seed in handleCustomRoute)
+├── config.ts         # loadGatewayConfig — YAML + env vars → GatewayConfig
+└── types.ts          # Request/response types for all Gateway HTTP endpoints
+```
+
+---
+
+### 2a · Dify Plugin (HTTP)
+
+```
+┌────────────────────────┐          ┌───────────────────────────────┐
+│  Dify Workflow / Agent │          │  Node.js Dify sidecar         │
+│                        │  HTTP    │  (port 8420 by default)       │
+│  ┌──────────────────┐  │  POST    │  ┌───────────────────────┐   │
+│  │ HTTP Request node│──┼─────────►│  │  DifyHttpServer       │   │
+│  │ /recall, /capture│◄─┼──────── │  │  (extends HttpServer  │   │
+│  └──────────────────┘  │  JSON   │  │   Base)               │   │
+│                        │          │  │  DifyHostAdapter      │   │
+└────────────────────────┘          │  │  TdaiCore             │   │
+                                    │  └───────────────────────┘   │
+                                    └───────────────────────────────┘
+```
+
+**Transport:** HTTP POST — same API surface as the Hermes Gateway. Dify uses built-in "HTTP Request" nodes to call `/recall` and `/capture`.
+
+**Key files:**
+```
+src/adapters/dify/
+├── host-adapter.ts   # DifyHostAdapter (9 lines: 2 members)
+├── http-server.ts    # DifyHttpServer  (12 lines: extends HttpServerBase)
+├── types.ts          # type aliases
+└── index.ts          # barrel
+
+bin/
+├── tdai-dify-http.ts   # entry point (start DifyHttpServer from env vars)
+└── tdai-dify-http.mjs  # launcher (runs .ts via tsx)
+```
+
+---
+
+### 3 · MCP Adapters (Claude Code + Cursor + Codex CLI)
+
+All three MCP adapters share the same transport and tool surface. They differ only in session identity and capture trigger.
+
+```
+  Claude Code                    Cursor                       Codex CLI
+  ┌──────────────┐               ┌──────────────┐             ┌──────────────┐
+  │ Agent        │               │ Composer /   │             │ Agent task   │
+  │ (per session)│               │ Agent        │             │ (per session)│
+  └──────┬───────┘               └──────┬───────┘             └──────┬───────┘
+         │ MCP stdio JSON-RPC           │ MCP stdio JSON-RPC         │ MCP stdio JSON-RPC
+         ▼                              ▼                             ▼
+  ┌──────────────────────┐      ┌──────────────────────┐    ┌──────────────────────┐
+  │ ClaudeCodeMcpServer  │      │   CursorMcpServer    │    │   CodexMcpServer     │
+  │ (extends McpServer   │      │ (extends McpServer   │    │ (extends McpServer   │
+  │  Base + hook queue)  │      │  Base, no extras)    │    │  Base, no extras)    │
+  └──────────┬───────────┘      └──────────┬───────────┘    └──────────┬───────────┘
+             │                             │                            │
+             └──────────────┬──────────────┘                           │
+                            │                                           │
+                            └───────────────────┬───────────────────────┘
+                                                │ McpServerBase
+                                                │ (shared JSON-RPC + 5 tools)
+                                                ▼
+                                       ┌─────────────────┐
+                                       │    TdaiCore     │
+                                       └─────────────────┘
+
+  ── Stop hook (Claude Code only) ──────────────────────────────────
+  Claude Code runtime
+      │  fires tdai-capture-hook after every response
+      ▼
+  tdai-capture-hook (short-lived process)
+      │  appends turn to hook-queue.jsonl
+      ▼
+  ClaudeCodeMcpServer.drainHookQueue()
+      │  rename → parse → handleTurnCommitted × N
+      ▼
+  TdaiCore
+```
+
+**Transport:** MCP JSON-RPC 2.0 over stdio. One server process per agent session (Claude Code, Codex) or per workspace (Cursor).
+
+**MCP tools exposed:**
+
+| Tool | Triggered by |
+|---|---|
+| `tdai_memory_recall` | LLM, at the start of each turn |
+| `tdai_memory_capture` | LLM, after each response (manual mode) |
+| `tdai_memory_search` | LLM, on demand |
+| `tdai_conversation_search` | LLM, on demand |
+| `tdai_session_end` | LLM, when the conversation ends — flushes pending L1/L2/L3 pipelines |
+
+**Capture trigger (Claude Code):** automatic via Stop hook (`tdai-capture-hook`) — the hook writes to `hook-queue.jsonl`; the MCP server drains it before each recall and on a 30-second background timer. An explicit `tdai_memory_capture` call also works but **must not be combined with the Stop hook** (double-write).
+
+**Capture trigger (Cursor / Codex CLI):** explicit only — the LLM calls `tdai_memory_capture` as instructed by the Cursor Rule / Codex system prompt. Neither Cursor nor Codex has a Stop hook equivalent.
+
+**LLM runner:** `StandaloneLLMRunnerFactory` (same as Hermes/Gateway) — calls any OpenAI-compatible API.
+
+**Session key:**
+
+| Platform | Default | Override |
+|---|---|---|
+| Claude Code | `CLAUDE_CODE_SESSION_ID` env (set by Claude Code) | explicit `session_key` arg |
+| Cursor | UUID stable for server process lifetime | `TDAI_SESSION_KEY` env or explicit arg |
+| Codex CLI | UUID (Codex does not set a per-session env var) | `CODEX_SESSION_ID` or `TDAI_SESSION_KEY` env |
+
+**Shared MCP infrastructure:**
+
+```
+src/adapters/
+├── utils.ts                   # makeStderrLogger (shared)
+├── mcp-host-adapter-base.ts   # McpHostAdapterBase — constructor, RuntimeContext,
+│                              #   getLogger, getLLMRunnerFactory, getDataDir, …
+│                              #   Abstract: hostType, platformId, resolveSessionKey()
+├── mcp-server-base.ts         # McpServerBase — full MCP JSON-RPC machinery,
+│                              #   4 tool implementations, lifecycle management
+│                              #   Hooks: onAfterInit / onBeforeRecall / onBeforeShutdown
+
+├── claude-code/
+│   ├── host-adapter.ts        # ClaudeCodeHostAdapter (11 lines: 3 overrides)
+│   ├── mcp-server.ts          # ClaudeCodeMcpServer (adds hook queue)
+│   ├── types.ts               # type aliases → base types
+│   └── index.ts
+├── cursor/
+│   ├── host-adapter.ts        # CursorHostAdapter (11 lines: 3 overrides)
+│   ├── mcp-server.ts          # CursorMcpServer (thin: createAdapter only)
+│   ├── types.ts               # type aliases → base types
+│   └── index.ts
+└── codex/
+    ├── host-adapter.ts        # CodexHostAdapter (11 lines: 3 overrides)
+    ├── mcp-server.ts          # CodexMcpServer (thin: createAdapter only)
+    ├── types.ts               # type aliases → base types
+    └── index.ts
+```
+
+**Shared HTTP infrastructure** (symmetric to MCP for HTTP/Plugin platforms):
+
+```
+src/adapters/
+├── host-adapter-base.ts       # HostAdapterBase — shared by ALL platforms:
+│                              #   getRuntimeContext, getLogger, getLLMRunnerFactory
+│                              #   Abstract: hostType, platformId
+├── memory-operations.ts       # MemoryOperations — transport-neutral facade over
+│                              #   TdaiCore: validation + the 5 operations, shared
+│                              #   by McpServerBase and HttpServerBase
+├── http-server-base.ts        # HttpServerBase — http.Server + TdaiCore,
+│                              #   6 standard endpoints (health/recall/capture/search×2/session/end),
+│                              #   auth (Bearer) + CORS, lifecycle management
+│                              #   Hooks: onAfterInit / onBeforeShutdown /
+│                              #          handleCustomRoute / buildMemoryConfig
+
+├── standalone/
+│   ├── host-adapter.ts        # StandaloneHostAdapter (32 lines: adds `platform` option)
+│   └── …
+├── dify/
+│   ├── host-adapter.ts        # DifyHostAdapter (9 lines: 2 members)
+│   ├── http-server.ts         # DifyHttpServer  (12 lines: createAdapter only)
+│   ├── types.ts               # type aliases → base types
+│   └── index.ts
+└── …
+```
+
+HTTP adapters extend `HostAdapterBase` directly — there is no separate HTTP
+adapter base, because HTTP platforms need nothing beyond the shared behaviour.
+`McpHostAdapterBase` is that same class plus default-session-key resolution,
+which only stdio needs (one session per process).
+
+**Identity is not tenancy.** `TdaiCore` reads only `dataDir` from
+`RuntimeContext`; `userId`, `sessionKey` and `platform` are recorded but do not
+scope storage. A single HTTP server therefore shares one memory store across
+all callers, and the endpoints deliberately expose no `user_id` field. Per-user
+isolation would require threading a user id through `TdaiCore` into the L0–L3
+storage paths and vector-store filters.
+
+---
+
+## Full Platform Comparison
+
+| | OpenClaw | Hermes / Gateway | Dify Plugin | Claude Code MCP | Cursor MCP | Codex CLI MCP |
+|---|---|---|---|---|---|---|
+| **Language** | TypeScript | Python + TypeScript | TypeScript | TypeScript | TypeScript | TypeScript |
+| **Transport** | In-process SDK hooks | HTTP (localhost) | HTTP (localhost) | MCP stdio JSON-RPC | MCP stdio JSON-RPC | MCP stdio JSON-RPC |
+| **Process model** | Same process as agent | Python provider + Node.js sidecar | Node.js sidecar | Subprocess per session | One server per workspace | Subprocess per session |
+| **Recall trigger** | `before_prompt_build` (automatic) | `prefetch()` (automatic) | HTTP Request node (workflow) | `tdai_memory_recall` tool (LLM) | `tdai_memory_recall` tool (LLM) | `tdai_memory_recall` tool (LLM) |
+| **Capture trigger** | `agent_end` (automatic) | `sync_turn()` (automatic) | HTTP Request node (workflow) | Stop hook (auto) or tool | `tdai_memory_capture` tool | `tdai_memory_capture` tool |
+| **Session key source** | OpenClaw session ctx | Hermes session kwargs | Request body | `CLAUDE_CODE_SESSION_ID` env | `TDAI_SESSION_KEY` or UUID | `CODEX_SESSION_ID` env or UUID |
+| **LLM runner** | OpenClawLLMRunner (in-agent) | StandaloneLLMRunner | StandaloneLLMRunner | StandaloneLLMRunner | StandaloneLLMRunner | StandaloneLLMRunner |
+| **Config format** | `openclaw.plugin.json` | `plugin.yaml` + env | env vars (`TDAI_*`) | `.claude/settings.json` | `~/.cursor/mcp.json` | `~/.codex/config.toml` |
+| **Memory instructions** | Plugin config | Plugin config | Dify workflow nodes | `.claude/CLAUDE.md` | `.cursor/rules/*.mdc` | Codex system prompt |
+| **Infrastructure** | None | Gateway subprocess | Dify sidecar subprocess | None | None | None |
+| **Recall reliability** | Always (hook-driven) | Always (code-driven) | Always (workflow-driven) | Depends on LLM following instructions | Depends on LLM following instructions | Depends on LLM following instructions |
+| **Capture reliability** | Always (hook-driven) | Always (code-driven) | Always (workflow-driven) | High (Stop hook) or LLM-dependent | LLM-dependent | LLM-dependent |
+| **Added in** | v0.1 | v0.2 | v0.3.7 | v0.3.6 | v0.3.6 | v0.3.6 |
+
+### When to use which
+
+- **OpenClaw** — you are running OpenClaw and want zero-configuration memory with automatic recall and capture.
+- **Hermes** — you are running a Hermes-based Python agent and want memory via the Gateway sidecar; OpenClaw is not available.
+- **Dify** — you are building a Dify workflow or agent and want deterministic memory via HTTP Request nodes; no LLM instruction needed for recall/capture.
+- **Claude Code** — you are using Claude Code CLI/IDE extension and want persistent memory across coding sessions. Use the Stop hook for automatic capture.
+- **Cursor** — you are using Cursor and are comfortable adding a Cursor Rule that instructs the LLM to call the memory tools explicitly.
+- **Codex CLI** — you are using OpenAI Codex CLI and want persistent memory; configure via `~/.codex/config.toml` with instructions in the system prompt.
+
+---
+
+## Capture Reliability at a Glance
+
+```
+Reliability →   Low                               High
+                │                                   │
+  Cursor        ├── LLM may skip capture ──────────►│
+  Codex CLI     ├── LLM may skip capture ──────────►│
+  Claude Code   │   (with Stop hook) ───────────────►│
+  Dify          │                    ────────────────►│ workflow-driven, always fires
+  Hermes        │                    ────────────────►│ code-driven, always fires
+  OpenClaw      │                    ────────────────►│ hook-driven, always fires
+```
+
+The MCP adapters rely on the LLM following instructions in CLAUDE.md / Cursor Rules. This introduces a failure mode — the LLM may skip a capture under token pressure or instruction override. The Stop hook mitigates this for Claude Code by capturing outside the LLM loop entirely. OpenClaw, Hermes, and Dify are fully deterministic because capture is initiated by code or workflow nodes, not by the model.
+
+---
+
+## Adding a New MCP Platform
+
+The shared base classes make adding a new MCP-based platform (e.g. Windsurf, Zed, Amp) a ~25-line exercise:
+
+**1. Host adapter** (`src/adapters/{platform}/host-adapter.ts`, ~11 lines):
+
+```typescript
+import { McpHostAdapterBase, sessionKeyFromEnv } from "../mcp-host-adapter-base.js";
+
+export class WindsurfHostAdapter extends McpHostAdapterBase {
+  readonly hostType = "windsurf" as const;
+  protected readonly platformId = "windsurf";
+
+  protected resolveSessionKey(explicit: string | undefined): string {
+    return sessionKeyFromEnv(explicit, "WINDSURF_SESSION_ID");
+  }
+}
+```
+
+**2. MCP server** (`src/adapters/{platform}/mcp-server.ts`, ~10 lines):
+
+```typescript
+import { McpServerBase } from "../mcp-server-base.js";
+import { WindsurfHostAdapter } from "./host-adapter.js";
+
+export class WindsurfMcpServer extends McpServerBase {
+  protected createAdapter() {
+    return new WindsurfHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}
+```
+
+**3.** Add `types.ts` (2-line aliases), `index.ts` (3-line barrel), a `bin/tdai-{platform}-mcp.ts` entry point (copy `bin/tdai-cursor-mcp.ts`, change class name and default data dir), and wire into `src/adapters/index.ts` + `package.json`.
+
+---
+
+## Adding a New HTTP Platform
+
+The `HostAdapterBase` + `HttpServerBase` pair makes adding a new HTTP/Plugin platform (e.g. n8n, Coze, FastGPT) equally cheap — the Dify adapter is 21 lines total:
+
+**1. Host adapter** (`src/adapters/{platform}/host-adapter.ts`, ~9 lines):
+
+```typescript
+import { HostAdapterBase } from "../host-adapter-base.js";
+import type { HostAdapterBaseOptions } from "../host-adapter-base.js";
+
+export class N8nHostAdapter extends HostAdapterBase {
+  readonly hostType = "n8n" as const;
+  protected readonly platformId = "n8n";
+}
+```
+
+**2. HTTP server** (`src/adapters/{platform}/http-server.ts`, ~10 lines):
+
+```typescript
+import { HttpServerBase } from "../http-server-base.js";
+import { N8nHostAdapter } from "./host-adapter.js";
+
+export class N8nHttpServer extends HttpServerBase {
+  protected createAdapter() {
+    return new N8nHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}
+```
+
+**3.** Add `types.ts` (2-line aliases), `index.ts` (3-line barrel), `bin/tdai-n8n-http.ts` (copy `bin/tdai-dify-http.ts`, change class name and default port), `bin/tdai-n8n-http.mjs` launcher, and wire into `src/adapters/index.ts` + `package.json`.
+
+The 6 standard endpoints (`/recall`, `/capture`, `/search/memories`, `/search/conversations`, `/session/end`, `/health`) and all auth/CORS logic are inherited. Custom endpoints go in `handleCustomRoute()`.
+
+The entry point reads all configuration from `TDAI_*` env vars via `bin/shared-http.ts` — no config file needed.

--- a/docs/claude-code-adapter.md
+++ b/docs/claude-code-adapter.md
@@ -1,0 +1,328 @@
+# Claude Code Adapter
+
+This document describes how to integrate TencentDB-Agent-Memory with **Claude Code** using the MCP (Model Context Protocol) server adapter.
+
+## Architecture
+
+```
+Claude Code (Agent)
+      │
+      │  MCP JSON-RPC / stdio
+      ▼
+┌─────────────────────────────────────────┐
+│       ClaudeCodeMcpServer               │
+│  ┌──────────────────────────────────┐   │
+│  │  MCP Tools exposed:              │   │
+│  │  • tdai_memory_recall            │   │
+│  │  • tdai_memory_capture           │   │
+│  │  • tdai_memory_search            │   │
+│  │  • tdai_conversation_search      │   │
+│  │  • tdai_session_end              │   │
+│  └──────────────────────────────────┘   │
+│             │                           │
+│  ┌──────────▼──────────────────────┐   │
+│  │  ClaudeCodeHostAdapter          │   │
+│  │  (session key from env/UUID)    │   │
+│  └──────────┬───────────────────────┘   │
+│             │                           │
+│  ┌──────────▼───────────────────────┐   │
+│  │  TdaiCore                        │   │
+│  │  L0 capture → L1 extraction      │   │
+│  │  L2 scene   → L3 persona         │   │
+│  └──────────┬────────────────────────┘   │
+│             │                           │
+│  ┌──────────▼────────────────────────┐   │
+│  │  SQLite-vec / TencentDB VectorDB  │   │
+│  └───────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+```
+
+**Data flow** (per conversation turn):
+
+1. Claude calls `tdai_memory_recall` → MCP server drains any pending hook captures → TdaiCore queries L1 memories + L3 persona → Claude injects context
+2. Claude converses with the user
+3. **Capture — pick one mode (do not use both):**
+   - **Automatic (Stop hook):** Claude Code fires the hook → `tdai-capture-hook` appends to `hook-queue.jsonl` → MCP server drains the queue on next recall or every 30 s in the background
+   - **Manual (explicit tool call):** Claude calls `tdai_memory_capture` → TdaiCore records L0 + schedules pipelines
+
+> **Warning — do not enable both modes at once.** If the Stop hook is active and CLAUDE.md also instructs Claude to call `tdai_memory_capture`, every turn is written twice. TdaiCore deduplicates at the L1 level, not L0, so duplicate raw records accumulate. Choose one mode and stick to it.
+
+## Prerequisites
+
+- Node.js ≥ 18
+- An OpenAI-compatible LLM endpoint (OpenAI, DeepSeek, local vLLM, etc.)
+- Claude Code ≥ 1.x with MCP support
+
+## Quick Start
+
+### 1. Install the package
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+# or from source:
+cd TencentDB-Agent-Memory && npm install
+```
+
+### 2. Add the MCP server and Stop hook to Claude Code
+
+Edit `~/.claude/settings.json` (or `.claude/settings.json` in your project).
+Add both the MCP server and the Stop hook so captures happen automatically:
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "tdai-claude-code-mcp",
+      "env": {
+        "TDAI_DATA_DIR": "/Users/you/.tdai",
+        "TDAI_LLM_BASE_URL": "https://api.openai.com/v1",
+        "TDAI_LLM_API_KEY": "sk-your-key",
+        "TDAI_LLM_MODEL": "gpt-4o"
+      }
+    }
+  },
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "TDAI_DATA_DIR=/Users/you/.tdai tdai-capture-hook"
+      }]
+    }]
+  }
+}
+```
+
+> **Why `TDAI_DATA_DIR` in the hook command?**
+> The Stop hook runs as a separate shell process and does not inherit `mcpServers.env`.
+> Prefix the command with the env var, or `export TDAI_DATA_DIR=...` in your shell profile.
+> Both must point to the **same directory** so the hook queue is visible to the MCP server.
+
+When running from source, use full paths:
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "node",
+      "args": ["/path/to/TencentDB-Agent-Memory/bin/tdai-claude-code-mcp.mjs"],
+      "env": {
+        "TDAI_DATA_DIR": "/Users/you/.tdai",
+        "TDAI_LLM_BASE_URL": "https://api.openai.com/v1",
+        "TDAI_LLM_API_KEY": "sk-your-key",
+        "TDAI_LLM_MODEL": "gpt-4o"
+      }
+    }
+  },
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "TDAI_DATA_DIR=/Users/you/.tdai node /path/to/TencentDB-Agent-Memory/bin/tdai-capture-hook.mjs"
+      }]
+    }]
+  }
+}
+```
+
+### 3. Add memory instructions to CLAUDE.md
+
+Create or update `.claude/CLAUDE.md` in your project. Choose the template that
+matches your capture mode.
+
+**Automatic mode (Stop hook active — recommended):**
+
+```markdown
+## Memory
+
+You have access to a persistent memory system via the `tdai-memory` MCP tools.
+Turns are captured automatically via the Stop hook — do NOT call
+`tdai_memory_capture` (it would create duplicate records).
+
+**At the start of every conversation turn**, call `tdai_memory_recall` with the
+user's message as the query. Inject the returned context into your reasoning
+before responding.
+
+Use `tdai_memory_search` when the user asks about past decisions, preferences,
+or any topic where historical knowledge would help.
+
+Use `tdai_conversation_search` to find specific past exchanges when
+`tdai_memory_search` doesn't return sufficient results.
+```
+
+**Manual mode (no Stop hook):**
+
+```markdown
+## Memory
+
+You have access to a persistent memory system via the `tdai-memory` MCP tools.
+
+**At the start of every conversation turn**, call `tdai_memory_recall` with the
+user's message as the query. Inject the returned context into your reasoning
+before responding.
+
+**After producing your final response**, call `tdai_memory_capture` with both
+the user's message and your response. Use the same `session_key` across the
+entire conversation (you can use `CLAUDE_CODE_SESSION_ID` from your environment
+or any stable string).
+
+Use `tdai_memory_search` when the user asks about past decisions, preferences,
+or any topic where historical knowledge would help.
+
+Use `tdai_conversation_search` to find specific past exchanges when
+`tdai_memory_search` doesn't return sufficient results.
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `TDAI_DATA_DIR` | No | `~/.tdai/claude-code` | Storage directory for all memory data |
+| `TDAI_LLM_BASE_URL` | **Yes** | — | OpenAI-compatible API base URL |
+| `TDAI_LLM_API_KEY` | **Yes** | — | API key for the LLM endpoint |
+| `TDAI_LLM_MODEL` | **Yes** | — | Model name (e.g. `gpt-4o`, `deepseek-chat`) |
+| `TDAI_LLM_MAX_TOKENS` | No | `8192` | Max output tokens for extraction pipelines |
+| `TDAI_LLM_TIMEOUT_MS` | No | `120000` | LLM request timeout in milliseconds |
+| `TDAI_LLM_DISABLE_THINKING` | No | — | Disable reasoning tokens: `vllm`, `deepseek`, `anthropic`, … |
+| `TDAI_USER_ID` | No | `default_user` | Reserved — recorded but **not yet used to scope storage** |
+| `TDAI_SESSION_KEY` | No | `CLAUDE_CODE_SESSION_ID` or UUID | Default session key |
+| `TDAI_MEMORY_CONFIG` | No | — | JSON string with `MemoryTdaiConfig` overrides |
+| `TDAI_API_KEY` | No | — | Bearer token to authenticate MCP clients |
+
+## MCP Tools Reference
+
+### `tdai_memory_recall`
+
+Retrieve relevant memories before a conversation turn.
+
+```json
+{
+  "query": "the user's current message",
+  "session_key": "my-session-123"
+}
+```
+
+Returns formatted memory context (L1 episodic facts + L3 persona) ready to inject into the system prompt.
+
+### `tdai_memory_capture`
+
+Record a completed conversation turn.
+
+```json
+{
+  "user_text": "How do I set up authentication?",
+  "assistant_text": "You can use JWT tokens with the following steps...",
+  "session_key": "my-session-123",
+  "session_id": "optional-sub-session"
+}
+```
+
+Returns capture metrics. Background L1/L2/L3 extraction runs asynchronously.
+
+### `tdai_memory_search`
+
+Search L1 structured memories with filters.
+
+```json
+{
+  "query": "user's preferred coding style",
+  "limit": 5,
+  "type": "episodic",
+  "scene": "coding"
+}
+```
+
+`type` can be `persona`, `episodic`, or `instruction`. `scene` is a topic label.
+
+### `tdai_conversation_search`
+
+Search raw L0 conversation history.
+
+```json
+{
+  "query": "database migration last week",
+  "limit": 5,
+  "session_key": "my-session-123"
+}
+```
+
+Omit `session_key` to search across all sessions.
+
+### `tdai_session_end`
+
+Flush pending L1/L2/L3 extraction pipelines so this session's memories become
+durable immediately instead of waiting for the background scheduler.
+
+```json
+{
+  "session_key": "my-session-123"
+}
+```
+
+Omit `session_key` to use `CLAUDE_CODE_SESSION_ID`. Call this when the user says
+goodbye or explicitly ends the conversation.
+
+## Comparison: OpenClaw vs Hermes vs MCP Adapters
+
+| Aspect | OpenClaw Plugin | Hermes Provider | **Claude Code MCP** | **Cursor MCP** |
+|---|---|---|---|---|
+| Language | TypeScript | Python | TypeScript | TypeScript |
+| Transport | In-process SDK hooks | HTTP Gateway | MCP stdio JSON-RPC | MCP stdio JSON-RPC |
+| Recall trigger | `before_prompt_build` hook | `prefetch()` call | `tdai_memory_recall` tool | `tdai_memory_recall` tool |
+| Capture trigger | `agent_end` hook | `sync_turn()` call | Stop hook (auto) or tool | `tdai_memory_capture` tool |
+| Session ID source | OpenClaw session key | Hermes session kwargs | `CLAUDE_CODE_SESSION_ID` env | `TDAI_SESSION_KEY` or UUID |
+| Infrastructure | None (in-process) | Separate HTTP process | None (subprocess per session) | None (one server per workspace) |
+| Config format | `openclaw.plugin.json` | `plugin.yaml` + env | `.claude/settings.json` | `~/.cursor/mcp.json` |
+| LLM runner | `OpenClawLLMRunner` | `StandaloneLLMRunner` | `StandaloneLLMRunner` | `StandaloneLLMRunner` |
+
+The key architectural difference is that Claude Code uses the MCP protocol (JSON-RPC over stdio) rather than an in-process SDK or an HTTP intermediary. The adapter exposes the same five TdaiCore operations (`recall`, `capture`, `search_memories`, `search_conversations`, `session_end`) as MCP tools that Claude can call within its reasoning loop. Those five operations live in a single transport-neutral facade (`MemoryOperations`) shared with the HTTP adapters, so both transports always expose the same capability set.
+
+## Implementation Details
+
+### File structure
+
+```
+src/adapters/claude-code/
+├── index.ts           # Barrel re-exports
+├── types.ts           # ClaudeCodeHostAdapterOptions, ClaudeCodeMcpServerOptions
+├── host-adapter.ts    # ClaudeCodeHostAdapter (implements HostAdapter)
+└── mcp-server.ts      # ClaudeCodeMcpServer (MCP JSON-RPC stdio server)
+
+bin/
+├── tdai-claude-code-mcp.ts   # TypeScript entry: reads env vars, starts server
+└── tdai-claude-code-mcp.mjs  # Thin launcher: runs .ts via tsx
+```
+
+### Session key strategy
+
+Claude Code sets `CLAUDE_CODE_SESSION_ID` in the environment for each session. The adapter reads this variable automatically as the default session key, so the same key is used consistently across all tool calls within one conversation — no manual key management required.
+
+### LLM runner
+
+The adapter reuses `StandaloneLLMRunnerFactory` (same as the Gateway/Hermes adapter), which calls any OpenAI-compatible API. This means L1/L2/L3 extraction pipelines work identically to the Gateway adapter.
+
+### Adding embedding support
+
+Embedding-based recall requires an embedding provider. Add to `TDAI_MEMORY_CONFIG`:
+
+```json
+{
+  "embedding": {
+    "provider": "openai",
+    "baseUrl": "https://api.openai.com/v1",
+    "apiKey": "sk-...",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536
+  },
+  "recall": {
+    "strategy": "hybrid"
+  }
+}
+```
+
+## Troubleshooting
+
+**Server does not start**: Check that `tsx` is installed (`npm ls tsx`) and that all required env vars are set.
+
+**No memories returned**: The first few turns only write to L0. L1 extraction runs after `pipeline.everyNConversations` turns (default: 5). Use `tdai_conversation_search` for immediate access to raw history.
+
+**High latency on recall**: Set `recall.timeoutMs` to a lower value via `TDAI_MEMORY_CONFIG` to cap the maximum wait time. Keyword-only strategy (`recall.strategy: "keyword"`) is faster when embedding is not needed.

--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -1,0 +1,126 @@
+# Codex CLI Adapter
+
+Connects OpenAI Codex CLI to TencentDB-Agent-Memory over MCP stdio.
+
+```
+┌─────────────────────────────────────────┐
+│       CodexMcpServer                    │
+│  ┌──────────────────────────────────┐   │
+│  │  MCP Tools exposed:              │   │
+│  │  • tdai_memory_recall            │   │
+│  │  • tdai_memory_capture           │   │
+│  │  • tdai_memory_search            │   │
+│  │  • tdai_conversation_search      │   │
+│  │  • tdai_session_end              │   │
+│  └──────────────────────────────────┘   │
+│             │                           │
+│  ┌──────────▼──────────────────────┐   │
+│  │  CodexHostAdapter               │   │
+│  │  (session key: env or UUID)     │   │
+│  └──────────┬──────────────────────┘   │
+└─────────────┼───────────────────────────┘
+              ▼
+        ┌───────────┐
+        │ TdaiCore  │
+        └───────────┘
+```
+
+Both classes together are under 40 lines — everything else comes from
+`McpServerBase` and `McpHostAdapterBase`.
+
+## Install
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+```
+
+## Configure
+
+Codex CLI reads MCP servers from `~/.codex/config.toml`:
+
+```toml
+[mcp_servers]
+
+[mcp_servers.tdai-memory]
+command = "tdai-codex-mcp"
+
+[mcp_servers.tdai-memory.env]
+TDAI_DATA_DIR = "~/.tdai/codex"
+TDAI_LLM_BASE_URL = "https://api.deepseek.com/v1"
+TDAI_LLM_API_KEY = "sk-..."
+TDAI_LLM_MODEL = "deepseek-chat"
+```
+
+See [`bin/env-common.ts`](../bin/env-common.ts) for every supported variable.
+
+## Capture is explicit
+
+Codex CLI has no Stop-hook equivalent, so nothing captures turns automatically.
+The model must call `tdai_memory_capture` itself. Instruct it in
+`~/.codex/instructions.md`:
+
+```markdown
+## Memory
+
+At the start of each task, call `tdai_memory_recall` with the user's request
+to load relevant prior context.
+
+After completing a substantive exchange, call `tdai_memory_capture` with the
+user's message and your response.
+
+When the user ends the conversation, call `tdai_session_end` to flush pending
+extraction pipelines.
+```
+
+Capture reliability therefore depends on the model following instructions —
+the same tier as Cursor, and weaker than Claude Code's hook-driven capture.
+
+## Session keys
+
+Codex CLI does not currently expose a per-session environment variable. The
+adapter resolves the session key in this order:
+
+```
+explicit session_key tool arg  →  CODEX_SESSION_ID  →  process-stable UUID
+```
+
+With the UUID fallback, each server restart begins a new session. Set
+`TDAI_SESSION_KEY` to a fixed value for continuity across restarts:
+
+```toml
+[mcp_servers.tdai-memory.env]
+TDAI_SESSION_KEY = "my-project-main"
+```
+
+## Verify
+
+```bash
+TDAI_LLM_BASE_URL=https://api.deepseek.com/v1 \
+TDAI_LLM_API_KEY=sk-... \
+TDAI_LLM_MODEL=deepseek-chat \
+npx tdai-codex-mcp
+```
+
+The server logs `[mcp] MCP server started — listening on stdin` and waits for
+JSON-RPC. Send `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` to confirm all
+five tools are advertised.
+
+## Tool reference
+
+Identical across all MCP platforms — see
+[claude-code-adapter.md](claude-code-adapter.md#tool-reference) for request
+shapes.
+
+## Comparison with the other MCP platforms
+
+| Aspect | Claude Code | Cursor | **Codex CLI** |
+|---|---|---|---|
+| Server binary | `tdai-claude-code-mcp` | `tdai-cursor-mcp` | `tdai-codex-mcp` |
+| Config file | `.claude/settings.json` | `~/.cursor/mcp.json` | `~/.codex/config.toml` |
+| Config format | JSON | JSON | TOML |
+| Capture trigger | Stop hook (automatic) | LLM tool call | LLM tool call |
+| Capture reliability | High | LLM-dependent | LLM-dependent |
+| Session env var | `CLAUDE_CODE_SESSION_ID` | `TDAI_SESSION_KEY` | none (UUID fallback) |
+| Instruction file | `CLAUDE.md` | Cursor Rule | `~/.codex/instructions.md` |
+
+See [architecture.md](architecture.md) for the full cross-platform picture.

--- a/docs/cursor-adapter.md
+++ b/docs/cursor-adapter.md
@@ -1,0 +1,248 @@
+# Cursor Adapter
+
+This document describes how to integrate TencentDB-Agent-Memory with **Cursor** using the MCP (Model Context Protocol) server adapter.
+
+## Architecture
+
+```
+Cursor (Composer / Agent)
+      │
+      │  MCP JSON-RPC / stdio
+      ▼
+┌─────────────────────────────────────────┐
+│       CursorMcpServer                   │
+│  ┌──────────────────────────────────┐   │
+│  │  MCP Tools exposed:              │   │
+│  │  • tdai_memory_recall            │   │
+│  │  • tdai_memory_capture           │   │
+│  │  • tdai_memory_search            │   │
+│  │  • tdai_conversation_search      │   │
+│  │  • tdai_session_end              │   │
+│  └──────────────────────────────────┘   │
+│             │                           │
+│  ┌──────────▼──────────────────────┐   │
+│  │  CursorHostAdapter              │   │
+│  │  (session key: env or UUID)     │   │
+│  └──────────┬───────────────────────┘   │
+│             │                           │
+│  ┌──────────▼───────────────────────┐   │
+│  │  TdaiCore                        │   │
+│  │  L0 capture → L1 extraction      │   │
+│  │  L2 scene   → L3 persona         │   │
+│  └──────────┬────────────────────────┘   │
+│             │                           │
+│  ┌──────────▼────────────────────────┐   │
+│  │  SQLite-vec / TencentDB VectorDB  │   │
+│  └───────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+```
+
+**Data flow** (per conversation turn):
+
+1. Cursor calls `tdai_memory_recall` → TdaiCore queries L1 memories + L3 persona → context injected
+2. Cursor converses with the user
+3. Cursor calls `tdai_memory_capture` → TdaiCore records L0 + schedules pipelines
+
+> **No Stop hook.** Cursor does not provide a post-response hook equivalent to Claude Code's Stop hook, so all captures must be triggered explicitly via the `tdai_memory_capture` tool. Include the capture instruction in your Cursor Rule.
+
+## Session identity
+
+Cursor runs one MCP server per workspace (not per conversation). The default session key is a **UUID stable for the lifetime of the server process** — all conversations within one Cursor window share a session until the server restarts.
+
+For stricter isolation you can:
+- **Per-project key**: Set `TDAI_SESSION_KEY` in the MCP server env to a fixed string (e.g. `my-project-2026`). All conversations in that project share this key across restarts.
+- **Per-conversation key**: Instruct Cursor (via the Rule below) to generate a timestamp-based key at the start of each conversation and pass it on every tool call.
+
+## Quick Start
+
+### 1. Install the package
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+# or from source:
+cd TencentDB-Agent-Memory && npm install
+```
+
+### 2. Add the MCP server to Cursor
+
+Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-scoped):
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "tdai-cursor-mcp",
+      "env": {
+        "TDAI_DATA_DIR": "/Users/you/.tdai/cursor",
+        "TDAI_LLM_BASE_URL": "https://api.openai.com/v1",
+        "TDAI_LLM_API_KEY": "sk-your-key",
+        "TDAI_LLM_MODEL": "gpt-4o"
+      }
+    }
+  }
+}
+```
+
+When running from source, use full paths:
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "node",
+      "args": ["/path/to/TencentDB-Agent-Memory/bin/tdai-cursor-mcp.mjs"],
+      "env": {
+        "TDAI_DATA_DIR": "/Users/you/.tdai/cursor",
+        "TDAI_LLM_BASE_URL": "https://api.openai.com/v1",
+        "TDAI_LLM_API_KEY": "sk-your-key",
+        "TDAI_LLM_MODEL": "gpt-4o"
+      }
+    }
+  }
+}
+```
+
+After saving, open the Cursor Settings → MCP panel and verify the server shows a green status dot.
+
+### 3. Add a Cursor Rule
+
+Create `.cursor/rules/memory.mdc` in your project:
+
+```markdown
+---
+description: Persistent memory via TencentDB-Agent-Memory
+alwaysApply: true
+---
+
+## Memory
+
+You have access to a persistent memory system via the `tdai-memory` MCP tools.
+
+**At the start of every conversation**, call `tdai_memory_recall` with the
+user's first message as the query. Inject the returned context into your
+reasoning before responding.
+
+**After producing your final response**, call `tdai_memory_capture` with both
+the user's message and your response. Pass a stable `session_key` for this
+conversation — use the format `cursor-{YYYYMMDD-HHMMSS}` (generate it once at
+the start of the conversation and reuse it for all subsequent tool calls).
+
+Use `tdai_memory_search` when the user asks about past decisions, preferences,
+or any topic where historical knowledge would help.
+
+Use `tdai_conversation_search` to find specific past exchanges when
+`tdai_memory_search` doesn't return sufficient results.
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `TDAI_DATA_DIR` | No | `~/.tdai/cursor` | Storage directory for all memory data |
+| `TDAI_LLM_BASE_URL` | **Yes** | — | OpenAI-compatible API base URL |
+| `TDAI_LLM_API_KEY` | **Yes** | — | API key for the LLM endpoint |
+| `TDAI_LLM_MODEL` | **Yes** | — | Model name (e.g. `gpt-4o`, `deepseek-chat`) |
+| `TDAI_LLM_MAX_TOKENS` | No | `8192` | Max output tokens for extraction pipelines |
+| `TDAI_LLM_TIMEOUT_MS` | No | `120000` | LLM request timeout in milliseconds |
+| `TDAI_LLM_DISABLE_THINKING` | No | — | Disable reasoning tokens: `vllm`, `deepseek`, `anthropic`, … |
+| `TDAI_USER_ID` | No | `default_user` | Reserved — recorded but **not yet used to scope storage** |
+| `TDAI_SESSION_KEY` | No | UUID per process | Fixed session key for cross-session continuity |
+| `TDAI_MEMORY_CONFIG` | No | — | JSON string with `MemoryTdaiConfig` overrides |
+| `TDAI_API_KEY` | No | — | Bearer token to authenticate MCP clients |
+
+## MCP Tools Reference
+
+### `tdai_memory_recall`
+
+Retrieve relevant memories before a conversation turn.
+
+```json
+{
+  "query": "the user's current message",
+  "session_key": "cursor-20260125-143000"
+}
+```
+
+Returns formatted memory context (L1 episodic facts + L3 persona) ready to inject into the system prompt.
+
+### `tdai_memory_capture`
+
+Record a completed conversation turn.
+
+```json
+{
+  "user_text": "How do I set up authentication?",
+  "assistant_text": "You can use JWT tokens with the following steps...",
+  "session_key": "cursor-20260125-143000"
+}
+```
+
+Returns capture metrics. Background L1/L2/L3 extraction runs asynchronously.
+
+### `tdai_memory_search`
+
+Search L1 structured memories with filters.
+
+```json
+{
+  "query": "user's preferred coding style",
+  "limit": 5,
+  "type": "episodic",
+  "scene": "coding"
+}
+```
+
+`type` can be `persona`, `episodic`, or `instruction`. `scene` is a topic label.
+
+### `tdai_conversation_search`
+
+Search raw L0 conversation history.
+
+```json
+{
+  "query": "database migration last week",
+  "limit": 5,
+  "session_key": "cursor-20260125-143000"
+}
+```
+
+Omit `session_key` to search across all sessions.
+
+### `tdai_session_end`
+
+Flush pending L1/L2/L3 extraction pipelines so this session's memories become
+durable immediately instead of waiting for the background scheduler.
+
+```json
+{
+  "session_key": "cursor-20260125-143000"
+}
+```
+
+Omit `session_key` to use the session key from the environment. Call this when
+the user says goodbye or explicitly ends the conversation.
+
+## Comparison: Claude Code vs Cursor Adapters
+
+| Aspect | **Claude Code MCP** | **Cursor MCP** |
+|---|---|---|
+| Server binary | `tdai-claude-code-mcp` | `tdai-cursor-mcp` |
+| Config location | `.claude/settings.json` | `~/.cursor/mcp.json` |
+| Memory instructions | `.claude/CLAUDE.md` | `.cursor/rules/memory.mdc` |
+| Session ID source | `CLAUDE_CODE_SESSION_ID` env | `TDAI_SESSION_KEY` or UUID per process |
+| Automatic capture | Stop hook (`tdai-capture-hook`) | Not available — explicit only |
+| Capture mode | Automatic (hook) or explicit (tool) | Explicit tool call only |
+| Default data dir | `~/.tdai/claude-code` | `~/.tdai/cursor` |
+| Host type | `claude-code` | `cursor` |
+
+The Cursor adapter inherits all MCP infrastructure from `McpServerBase` and adds no platform-specific logic — the only difference is the session key strategy and the absence of Stop hook support.
+
+## Troubleshooting
+
+**Server does not appear in Cursor Settings → MCP**: Check that `tsx` is installed (`npm ls tsx`) and all required env vars are set. Verify the `.cursor/mcp.json` is valid JSON.
+
+**No memories returned**: The first few turns only write to L0. L1 extraction runs after `pipeline.everyNConversations` turns (default: 5). Use `tdai_conversation_search` for immediate access to raw history.
+
+**Sessions not persisting across restarts**: Set `TDAI_SESSION_KEY` to a fixed value (e.g. your project name) in the MCP server env. Without it, the server generates a new UUID on each restart.
+
+**High latency on recall**: Set `recall.timeoutMs` to a lower value via `TDAI_MEMORY_CONFIG` to cap the maximum wait time. Keyword-only strategy (`recall.strategy: "keyword"`) is faster when embedding is not needed.

--- a/docs/dify-adapter.md
+++ b/docs/dify-adapter.md
@@ -1,0 +1,168 @@
+# Dify Adapter
+
+Connects Dify (and any other HTTP-driven workflow platform) to
+TencentDB-Agent-Memory over HTTP.
+
+```
+┌──────────────────────────────────────────┐
+│            DifyHttpServer                │
+│  ┌────────────────────────────────────┐  │
+│  │  HTTP endpoints:                   │  │
+│  │  GET  /health                      │  │
+│  │  POST /recall                      │  │
+│  │  POST /capture                     │  │
+│  │  POST /search/memories             │  │
+│  │  POST /search/conversations        │  │
+│  │  POST /session/end                 │  │
+│  └────────────────────────────────────┘  │
+│             │                            │
+│  ┌──────────▼───────────────────────┐   │
+│  │  DifyHostAdapter                 │   │
+│  │  (per-request RuntimeContext)    │   │
+│  └──────────┬───────────────────────┘   │
+└─────────────┼────────────────────────────┘
+              ▼
+        ┌───────────┐
+        │ TdaiCore  │
+        └───────────┘
+```
+
+The entire adapter is under 30 lines across four files — everything else comes
+from `HttpServerBase` and `HostAdapterBase`. It is the reference example
+for [Path B](new-platform-guide.md#path-b--http-platform-30-lines-total).
+
+## Run the server
+
+```bash
+npm install -g @tencentdb-agent-memory/memory-tencentdb
+```
+
+```bash
+TDAI_LLM_BASE_URL=https://api.deepseek.com/v1 \
+TDAI_LLM_API_KEY=sk-... \
+TDAI_LLM_MODEL=deepseek-chat \
+TDAI_GATEWAY_API_KEY=choose-a-strong-token \
+tdai-dify-http
+```
+
+Defaults to `127.0.0.1:8420`. Configuration variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TDAI_PORT` | `8420` | Listen port |
+| `TDAI_HOST` | `127.0.0.1` | Bind address |
+| `TDAI_GATEWAY_API_KEY` | unset | Bearer token; **unset means no auth** |
+| `TDAI_CORS_ORIGINS` | unset | Comma-separated allow-list |
+| `TDAI_DATA_DIR` | `~/.tdai/dify` | Storage root |
+
+Shared LLM and memory variables are documented in
+[`bin/env-common.ts`](../bin/env-common.ts).
+
+### Security
+
+With `TDAI_GATEWAY_API_KEY` unset, every endpoint except `GET /health` is open
+to anyone who can reach the port. Set a token before binding to anything other
+than loopback, and prefer a concrete CORS allow-list over `*`.
+
+### No per-user isolation
+
+One server instance keeps **one** memory store shared by every caller. There is
+no `user_id` on any endpoint, because `TdaiCore` does not scope storage by user
+and accepting the field would imply an isolation guarantee that does not exist.
+
+`session_key` separates conversations, not tenants: a search can surface
+memories captured under a different session. If you need real separation
+between end users today, run one server per tenant with its own `TDAI_DATA_DIR`
+and port.
+
+## Wire it into a Dify workflow
+
+Use an **HTTP Request** node. Recall before the LLM node:
+
+```
+POST http://127.0.0.1:8420/recall
+Authorization: Bearer {{ env.TDAI_GATEWAY_API_KEY }}
+Content-Type: application/json
+
+{
+  "query": "{{ sys.query }}",
+  "session_key": "{{ sys.conversation_id }}"
+}
+```
+
+Response:
+
+```json
+{
+  "context": "…memories to inject…",
+  "strategy": "hybrid",
+  "memory_count": 4
+}
+```
+
+Feed `context` into the LLM node's system prompt. Then capture after it:
+
+```
+POST http://127.0.0.1:8420/capture
+Authorization: Bearer {{ env.TDAI_GATEWAY_API_KEY }}
+Content-Type: application/json
+
+{
+  "user_content": "{{ sys.query }}",
+  "assistant_content": "{{ llm.text }}",
+  "session_key": "{{ sys.conversation_id }}"
+}
+```
+
+Using `sys.conversation_id` as the session key is what keeps memories grouped
+per Dify conversation.
+
+## Endpoints
+
+All request and response bodies use `snake_case`.
+
+| Endpoint | Required fields | Returns |
+|---|---|---|
+| `POST /recall` | `query`, `session_key` | `context`, `strategy`, `memory_count` |
+| `POST /capture` | `user_content`, `assistant_content`, `session_key` | `l0_recorded`, `scheduler_notified` |
+| `POST /search/memories` | `query` | `results`, `total`, `strategy` |
+| `POST /search/conversations` | `query` | `results`, `total` |
+| `POST /session/end` | `session_key` | `flushed` |
+| `GET /health` | — | `status`, `version`, `uptime`, `stores` |
+
+`POST /capture` also accepts `session_id` and a full `messages` array.
+`POST /search/*` accept `limit`; `/search/memories` also accepts `type` and
+`scene`.
+
+A missing required field returns `400`; a bad or absent bearer token returns
+`401`.
+
+## Verify
+
+```bash
+curl -s http://127.0.0.1:8420/health
+```
+
+```bash
+curl -s -X POST http://127.0.0.1:8420/recall \
+  -H "Authorization: Bearer $TDAI_GATEWAY_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"what did we decide","session_key":"test-1"}'
+```
+
+## Relationship to the Gateway
+
+`DifyHttpServer` and `TdaiGateway` are siblings — both extend `HttpServerBase`
+and serve the same six endpoints. They differ only in configuration and extras:
+
+| | `DifyHttpServer` | `TdaiGateway` |
+|---|---|---|
+| Config source | `TDAI_*` env vars | `tdai-gateway.yaml` + env |
+| Extra endpoints | none | `POST /seed` |
+| Startup warnings | none | Security posture logging |
+| Intended caller | Dify, n8n, any HTTP client | Hermes Python provider |
+
+Any HTTP platform can use `tdai-dify-http` as-is; the name reflects its first
+consumer, not a Dify-specific protocol.
+
+See [architecture.md](architecture.md) for the full cross-platform picture.

--- a/docs/new-platform-guide.md
+++ b/docs/new-platform-guide.md
@@ -1,0 +1,335 @@
+# New Platform Adapter Guide
+
+This guide explains how to add TencentDB-Agent-Memory support to a new agent platform. Read [architecture.md](./architecture.md) first to understand the overall design.
+
+There are two integration paths depending on how the platform communicates with tools:
+
+| Path | Use when | Reference implementation |
+|---|---|---|
+| **MCP (stdio)** | Platform supports MCP servers (JSON-RPC over stdin/stdout) | Claude Code, Cursor, Codex |
+| **HTTP / in-process** | Platform uses its own plugin SDK or HTTP calls | OpenClaw (in-process), Hermes (HTTP) |
+
+---
+
+## Path A — MCP Platform (recommended, ~25 lines total)
+
+Platforms that support the Model Context Protocol only need to implement two small classes. All MCP JSON-RPC machinery, tool dispatch, session management, and lifecycle handling live in the shared base classes.
+
+### What you need to implement
+
+**`McpHostAdapterBase` — 3 abstract members:**
+
+| Member | Type | Purpose |
+|---|---|---|
+| `hostType` | `string` constant | Identifies the platform in TdaiCore internals |
+| `platformId` | `string` constant | Written into `RuntimeContext.platform` |
+| `resolveSessionKey(explicit)` | method | Derives the default session key (env var strategy) |
+
+**`McpServerBase` — 1 abstract method:**
+
+| Method | Purpose |
+|---|---|
+| `createAdapter()` | Instantiates the platform's `McpHostAdapterBase` subclass |
+
+Everything else — JSON-RPC framing, tool schemas, `handleBeforeRecall` / `handleTurnCommitted` calls, stdin/stdout lifecycle, SIGTERM handling — is inherited.
+
+---
+
+### Step-by-step
+
+#### 1 · Host adapter (`src/adapters/{platform}/host-adapter.ts`)
+
+```typescript
+import { McpHostAdapterBase, sessionKeyFromEnv } from "../mcp-host-adapter-base.js";
+
+export class WindsurfHostAdapter extends McpHostAdapterBase {
+  readonly hostType = "windsurf" as const;   // unique per platform
+  protected readonly platformId = "windsurf"; // written into RuntimeContext
+
+  protected resolveSessionKey(explicit: string | undefined): string {
+    // Priority: explicit arg → platform env var → process-stable UUID
+    return sessionKeyFromEnv(explicit, "WINDSURF_SESSION_ID");
+  }
+}
+```
+
+`sessionKeyFromEnv(explicit, envVar)` implements the standard fallback chain:
+`explicit ?? process.env[envVar] ?? randomUUID()`. Use it for every MCP platform.
+If the platform doesn't set a session env var, just omit the `envVar` argument —
+the UUID fallback keeps things working.
+
+#### 2 · MCP server (`src/adapters/{platform}/mcp-server.ts`)
+
+```typescript
+import { McpServerBase } from "../mcp-server-base.js";
+import { WindsurfHostAdapter } from "./host-adapter.js";
+import type { McpHostAdapter } from "../mcp-server-base.js";
+
+export class WindsurfMcpServer extends McpServerBase {
+  protected createAdapter(): McpHostAdapter {
+    // { ...this.opts, logger: this.logger } passes all options and ensures
+    // the server and adapter share the same logger instance.
+    return new WindsurfHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}
+```
+
+If the platform has an automatic capture mechanism (like Claude Code's Stop hook),
+override `onBeforeRecall()`, `onAfterInit()`, and `onBeforeShutdown()` in this class.
+See `ClaudeCodeMcpServer` as the reference for hook queue draining.
+
+#### 3 · Types (`src/adapters/{platform}/types.ts`, 2 lines)
+
+```typescript
+export type { McpHostAdapterOptions as WindsurfHostAdapterOptions } from "../mcp-host-adapter-base.js";
+export type { McpServerBaseOptions as WindsurfMcpServerOptions } from "../mcp-server-base.js";
+```
+
+These are type aliases — they don't duplicate any field definitions. If `McpServerBaseOptions`
+gains a new field, `WindsurfMcpServerOptions` picks it up automatically.
+
+#### 4 · Barrel (`src/adapters/{platform}/index.ts`, 3 lines)
+
+```typescript
+export { WindsurfHostAdapter } from "./host-adapter.js";
+export { WindsurfMcpServer } from "./mcp-server.js";
+export type { WindsurfHostAdapterOptions, WindsurfMcpServerOptions } from "./types.js";
+```
+
+#### 5 · Wire into the adapters barrel (`src/adapters/index.ts`)
+
+```typescript
+export { WindsurfHostAdapter, WindsurfMcpServer } from "./windsurf/index.js";
+export type { WindsurfHostAdapterOptions, WindsurfMcpServerOptions } from "./windsurf/index.js";
+```
+
+#### 6 · Extend core type unions (`src/core/types.ts`)
+
+```typescript
+// Add to HostAdapter.hostType union:
+readonly hostType: "openclaw" | "hermes" | "standalone" | "claude-code" | "cursor" | "codex" | "windsurf";
+
+// Add to RuntimeContext.platform union:
+platform: "openclaw" | "hermes" | "cli" | "gateway" | "claude-code" | "cursor" | "codex" | "windsurf" | string;
+```
+
+#### 7 · CLI entry point (`bin/tdai-{platform}-mcp.ts`)
+
+Copy `bin/tdai-cursor-mcp.ts` and change:
+- The import to use `WindsurfMcpServer`
+- The default `dataDir` to `~/.tdai/windsurf`
+- The env var prefix documentation comment
+
+Then create `bin/tdai-{platform}-mcp.mjs` (copy `bin/tdai-cursor-mcp.mjs`, change the entry path).
+
+#### 8 · Register the binary (`package.json`)
+
+```json
+"bin": {
+  "tdai-windsurf-mcp": "./bin/tdai-windsurf-mcp.mjs"
+}
+```
+
+#### 9 · Platform configuration
+
+Create a platform-specific settings snippet for the docs (e.g. `~/.windsurf/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "tdai-memory": {
+      "command": "tdai-windsurf-mcp",
+      "env": {
+        "TDAI_DATA_DIR": "/Users/you/.tdai/windsurf",
+        "TDAI_LLM_BASE_URL": "https://api.openai.com/v1",
+        "TDAI_LLM_API_KEY": "sk-...",
+        "TDAI_LLM_MODEL": "gpt-4o"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Path B — HTTP Platform (~30 lines total)
+
+For platforms that talk HTTP rather than MCP stdio — Dify, n8n, Coze, or any
+workflow tool with an HTTP request node — the base layer is symmetric with
+Path A. You do **not** write an HTTP server; `HttpServerBase` already provides
+one.
+
+### What you need to implement
+
+| File | Purpose | Members to write |
+|---|---|---|
+| `host-adapter.ts` | Extends `HostAdapterBase` | `hostType`, `platformId` |
+| `http-server.ts` | Extends `HttpServerBase` | `createAdapter()` |
+| `types.ts` | Option type aliases | — |
+| `index.ts` | Barrel | — |
+
+`src/adapters/dify/` is the complete reference — all four files together are
+under 30 lines.
+
+### Step 1 — the host adapter
+
+```typescript
+import { HostAdapterBase } from "../host-adapter-base.js";
+import type { HostAdapterBaseOptions } from "../host-adapter-base.js";
+
+export type { HostAdapterBaseOptions as MyPlatformHostAdapterOptions };
+
+export class MyPlatformHostAdapter extends HostAdapterBase {
+  readonly hostType = "my-platform" as const;
+  protected readonly platformId = "my-platform";
+}
+```
+
+Two members, no methods. `HostAdapterBase` supplies `getRuntimeContext()`,
+`getLogger()` and `getLLMRunnerFactory()`, and is shared with the MCP adapters
+— `McpHostAdapterBase` is the same class plus session-key resolution.
+
+> **On identity:** `TdaiCore` currently reads only `dataDir` from
+> `RuntimeContext`. `userId` is recorded but does not scope storage, so a
+> single server instance shares one memory store across all callers. Do not
+> build per-tenant isolation on it until that lands.
+
+### Step 2 — the server
+
+```typescript
+import { HttpServerBase } from "../http-server-base.js";
+import { MyPlatformHostAdapter } from "./host-adapter.js";
+import type { HostAdapter } from "../../core/types.js";
+
+export class MyPlatformHttpServer extends HttpServerBase {
+  protected createAdapter(): HostAdapter {
+    return new MyPlatformHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}
+```
+
+That is the whole server. You inherit six endpoints, Bearer auth, a CORS
+allow-list, graceful shutdown and health reporting:
+
+| Endpoint | Auth | Notes |
+|---|---|---|
+| `GET /health` | none | Always open, for probes and health-checks |
+| `POST /recall` | required | |
+| `POST /capture` | required | |
+| `POST /search/memories` | required | |
+| `POST /search/conversations` | required | |
+| `POST /session/end` | required | Flushes pending pipelines |
+
+### Step 3 — the entry point
+
+```typescript
+#!/usr/bin/env node
+import { MyPlatformHttpServer } from "../src/adapters/my-platform/index.js";
+import { loadHttpEnvOptions } from "./shared-http.js";
+
+new MyPlatformHttpServer(loadHttpEnvOptions("my-platform", 8420)).start().catch((err: unknown) => {
+  process.stderr.write(`[tdai] Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});
+```
+
+`loadHttpEnvOptions` reads the shared `TDAI_*` variables plus `TDAI_PORT`,
+`TDAI_HOST`, `TDAI_GATEWAY_API_KEY` and `TDAI_CORS_ORIGINS`. `start()` installs
+its own `SIGTERM`/`SIGINT` handlers, so do not add any.
+
+Register the `.mjs` launcher under `bin` in `package.json`, mirroring
+`tdai-dify-http`.
+
+### Optional hooks
+
+| Hook | Use it for |
+|---|---|
+| `onAfterInit()` | Background timers, startup warnings |
+| `onBeforeShutdown()` | Final flush |
+| `handleCustomRoute(method, pathname, req, res)` | Extra endpoints; return `true` if you responded |
+| `buildMemoryConfig()` | Supply an already-parsed `MemoryTdaiConfig` instead of raw overrides |
+
+`TdaiGateway` (`src/gateway/server.ts`) uses all four: YAML config through
+`buildMemoryConfig()`, `POST /seed` through `handleCustomRoute()`, and security
+posture logging through `onAfterInit()`. It is the reference for a
+non-trivial HTTP platform.
+
+### Path C — in-process platform
+
+If the platform runs in the same process (an SDK plugin rather than a network
+service), skip both base classes and implement `HostAdapter` directly, then
+drive `TdaiCore` from the platform's own hooks:
+
+```typescript
+const core = new TdaiCore({ hostAdapter: new MyHostAdapter(opts), config: parseConfig({}) });
+await core.initialize();
+
+const recall = await core.handleBeforeRecall(userMessage, sessionKey);
+// → inject recall.prependContext / recall.appendSystemContext
+
+await core.handleTurnCommitted({ userText, assistantText, messages, sessionKey, sessionId, startedAt });
+```
+
+Use `StandaloneLLMRunnerFactory` unless the platform has its own LLM runtime —
+see `src/adapters/standalone/llm-runner.ts`. `src/adapters/openclaw/` is the
+reference implementation.
+
+For the **Hermes pattern** (Python process + Node.js sidecar), the sidecar is
+just `TdaiGateway`; the Python provider calls it over HTTP and
+`GatewaySupervisor` manages the subprocess. See
+`hermes-plugin/memory/memory_tencentdb/`.
+
+---
+
+## Design Decisions
+
+### Session key strategy
+
+MCP servers are long-lived (one process per workspace or per session depending on the platform). Session key resolution follows this priority chain for all MCP adapters:
+
+```
+explicit session_key arg   →   platform session env var   →   process-stable UUID
+```
+
+The UUID fallback means: all conversations in one server process share a session until restart. This is acceptable for project-focused tools (Cursor, Windsurf) where workspace = context. For session-focused tools like Claude Code, the platform provides `CLAUDE_CODE_SESSION_ID` so each conversation gets its own key automatically.
+
+If the platform provides a per-conversation ID, pass it as the env var name to `sessionKeyFromEnv`. If it doesn't, document that users can set `TDAI_SESSION_KEY` for cross-session continuity.
+
+### Capture mode
+
+| Mode | When to use |
+|---|---|
+| **Automatic** | Platform fires a post-response hook (e.g. Claude Code Stop hook). Write a capture hook script + queue file; drain in `onBeforeRecall`. |
+| **Explicit tool** | Platform has no hooks. Instruct the LLM via platform-specific rules/config to call `tdai_memory_capture` after each turn. |
+
+Never use both modes simultaneously — it causes duplicate L0 records.
+
+### Logger sharing
+
+Pass `{ ...this.opts, logger: this.logger }` to the host adapter constructor in `createAdapter()`. This ensures the server and adapter share the same logger instance, so a user-supplied custom logger reaches both layers.
+
+### `onBeforeRecall` / `onAfterInit` / `onBeforeShutdown` hooks
+
+Override these in `McpServerBase` subclasses to add platform-specific behaviour without duplicating lifecycle code:
+
+| Hook | Use for |
+|---|---|
+| `onAfterInit()` | Start background timers (e.g. periodic queue drain) |
+| `onBeforeRecall()` | Drain a capture queue before recall |
+| `onBeforeShutdown()` | Final flush, clear timers |
+
+Default implementations are no-ops, so platforms that don't need them pay zero overhead.
+
+---
+
+## Common Pitfalls
+
+**Double-capture.** If the platform has both an automatic capture hook AND the LLM is instructed to call `tdai_memory_capture`, every turn is written to L0 twice. TdaiCore deduplicates at L1 (not L0), so raw records accumulate. Use one mode only.
+
+**Session key mismatch.** The MCP server and any capture hook script must derive the session key from the same source. If the hook reads `PLATFORM_SESSION_ID` and the server reads `TDAI_SESSION_KEY`, a session key mismatch silently splits history into two sessions. Always use `sessionKeyFromEnv` with the same env var in both places.
+
+**Hook must always exit 0.** Post-response hooks must not block the agent. Always `process.exit(0)` in hook scripts, even on error — a non-zero exit code can block or abort the agent's turn in some platforms.
+
+**MCP env var isolation.** Many platforms do not inherit `mcpServers.env` values in hook/subprocess environments. Any env var your hook needs (especially `TDAI_DATA_DIR`) must be prefixed directly in the hook command string or exported in the shell profile.
+
+**SQLite concurrency.** `TdaiCore` holds an open SQLite connection. A hook script that also writes to the same database risks lock contention. Use a queue file (like Claude Code's `hook-queue.jsonl`) and let the MCP server drain it — the hook does only fast file I/O and never touches SQLite directly.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "tdai-claude-code-mcp": "./bin/tdai-claude-code-mcp.mjs",
+    "tdai-capture-hook": "./bin/tdai-capture-hook.mjs",
+    "tdai-cursor-mcp": "./bin/tdai-cursor-mcp.mjs",
+    "tdai-codex-mcp": "./bin/tdai-codex-mcp.mjs",
+    "tdai-dify-http": "./bin/tdai-dify-http.mjs"
   },
   "exports": {
     ".": {

--- a/src/adapters/claude-code/host-adapter.ts
+++ b/src/adapters/claude-code/host-adapter.ts
@@ -1,0 +1,11 @@
+import { McpHostAdapterBase, sessionKeyFromEnv } from "../mcp-host-adapter-base.js";
+
+export class ClaudeCodeHostAdapter extends McpHostAdapterBase {
+  readonly hostType = "claude-code" as const;
+  protected readonly platformId = "claude-code";
+
+  protected resolveSessionKey(explicit: string | undefined): string {
+    return sessionKeyFromEnv(explicit, "CLAUDE_CODE_SESSION_ID");
+  }
+}
+

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Claude Code adapter — barrel exports.
+ *
+ * Re-exports all public API surfaces for the Claude Code MCP server adapter.
+ * Consumers typically only need ClaudeCodeMcpServer to start the server.
+ *
+ * Example:
+ *   import { ClaudeCodeMcpServer } from "tencentdb-agent-memory/adapters/claude-code";
+ *   const server = new ClaudeCodeMcpServer({ dataDir, llmConfig });
+ *   await server.start();
+ */
+
+export { ClaudeCodeHostAdapter } from "./host-adapter.js";
+export { ClaudeCodeMcpServer } from "./mcp-server.js";
+export type { ClaudeCodeHostAdapterOptions, ClaudeCodeMcpServerOptions } from "./types.js";

--- a/src/adapters/claude-code/mcp-server.ts
+++ b/src/adapters/claude-code/mcp-server.ts
@@ -1,0 +1,144 @@
+/**
+ * ClaudeCodeMcpServer — MCP server adapter for Claude Code.
+ *
+ * Extends McpServerBase with Stop-hook queue support: the separate
+ * `tdai-capture-hook` process writes captured turns to hook-queue.jsonl,
+ * and this server drains that queue on each recall and every 30 seconds
+ * in the background.
+ *
+ * Usage (in .claude/settings.json):
+ *   {
+ *     "mcpServers": {
+ *       "tdai-memory": {
+ *         "command": "tdai-claude-code-mcp",
+ *         "env": { "TDAI_DATA_DIR": "~/.tdai", ... }
+ *       }
+ *     }
+ *   }
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { McpServerBase } from "../mcp-server-base.js";
+import { ClaudeCodeHostAdapter } from "./host-adapter.js";
+import type { McpHostAdapter } from "../mcp-server-base.js";
+
+// ============================
+// Hook queue types
+// ============================
+
+interface HookQueueEntry {
+  sessionKey: string;
+  userText: string;
+  assistantText: string;
+  ts: number;
+}
+
+// ============================
+// ClaudeCodeMcpServer
+// ============================
+
+export class ClaudeCodeMcpServer extends McpServerBase {
+  private drainTimer?: ReturnType<typeof setInterval>;
+
+  protected createAdapter(): McpHostAdapter {
+    return new ClaudeCodeHostAdapter({ ...this.opts, logger: this.logger });
+  }
+
+  private get hookQueuePath(): string {
+    return path.join(this.opts.dataDir, "hook-queue.jsonl");
+  }
+
+  protected async onAfterInit(): Promise<void> {
+    this.drainTimer = setInterval(() => {
+      this.drainHookQueue().catch((err) => {
+        this.logger.warn(
+          `[mcp] background drain failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, 30_000);
+    this.drainTimer.unref();
+  }
+
+  protected async onBeforeRecall(): Promise<void> {
+    try {
+      await this.drainHookQueue();
+    } catch (err) {
+      this.logger.warn(
+        `[mcp] hook queue drain failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  protected async onBeforeShutdown(): Promise<void> {
+    clearInterval(this.drainTimer);
+    await this.drainHookQueue().catch(() => {});
+  }
+
+  // ============================
+  // Hook queue draining
+  // ============================
+
+  /**
+   * Consume all entries written by the Stop hook since the last drain.
+   *
+   * Atomic rename pattern: hook always appends to hook-queue.jsonl;
+   * we rename it to hook-queue.processing.jsonl, process, then delete.
+   * A concurrent hook write during processing starts a fresh queue file
+   * that will be picked up on the next drain.
+   */
+  private async drainHookQueue(): Promise<void> {
+    const src = this.hookQueuePath;
+    if (!fs.existsSync(src)) return;
+
+    const dst = src.replace(/\.jsonl$/, ".processing.jsonl");
+    try {
+      fs.renameSync(src, dst);
+    } catch {
+      return;
+    }
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(dst, "utf8");
+    } catch {
+      return;
+    } finally {
+      try { fs.unlinkSync(dst); } catch { /* ignore */ }
+    }
+
+    const entries = raw
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((l) => {
+        try { return JSON.parse(l) as HookQueueEntry; }
+        catch { return null; }
+      })
+      .filter((e): e is HookQueueEntry => e !== null);
+
+    if (entries.length === 0) return;
+
+    this.logger.info(`[mcp] draining ${entries.length} queued hook capture(s)`);
+
+    for (const entry of entries) {
+      try {
+        await this.core.handleTurnCommitted({
+          userText: entry.userText,
+          assistantText: entry.assistantText,
+          messages: [
+            { role: "user", content: entry.userText },
+            { role: "assistant", content: entry.assistantText },
+          ],
+          sessionKey: entry.sessionKey,
+          sessionId: entry.sessionKey,
+          startedAt: entry.ts,
+        });
+      } catch (err) {
+        this.logger.warn(
+          `[mcp] hook queue entry capture failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+}

--- a/src/adapters/claude-code/types.ts
+++ b/src/adapters/claude-code/types.ts
@@ -1,0 +1,2 @@
+export type { McpHostAdapterOptions as ClaudeCodeHostAdapterOptions } from "../mcp-host-adapter-base.js";
+export type { McpServerBaseOptions as ClaudeCodeMcpServerOptions } from "../mcp-server-base.js";

--- a/src/adapters/claude-code/utils.ts
+++ b/src/adapters/claude-code/utils.ts
@@ -1,0 +1,1 @@
+export { makeStderrLogger } from "../utils.js";

--- a/src/adapters/codex/host-adapter.ts
+++ b/src/adapters/codex/host-adapter.ts
@@ -1,0 +1,13 @@
+import { McpHostAdapterBase, sessionKeyFromEnv } from "../mcp-host-adapter-base.js";
+
+export class CodexHostAdapter extends McpHostAdapterBase {
+  readonly hostType = "codex" as const;
+  protected readonly platformId = "codex";
+
+  protected resolveSessionKey(explicit: string | undefined): string {
+    // Codex CLI does not currently set a per-session env var.
+    // Falls back to a process-stable UUID (one session per server restart).
+    // Users can set TDAI_SESSION_KEY for cross-session continuity.
+    return sessionKeyFromEnv(explicit, "CODEX_SESSION_ID");
+  }
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,0 +1,3 @@
+export { CodexHostAdapter } from "./host-adapter.js";
+export { CodexMcpServer } from "./mcp-server.js";
+export type { CodexHostAdapterOptions, CodexMcpServerOptions } from "./types.js";

--- a/src/adapters/codex/mcp-server.ts
+++ b/src/adapters/codex/mcp-server.ts
@@ -1,0 +1,23 @@
+/**
+ * CodexMcpServer — MCP server adapter for OpenAI Codex CLI.
+ *
+ * Codex CLI supports MCP servers via ~/.codex/config.toml.
+ * Capture is explicit: the LLM calls tdai_memory_capture as instructed
+ * by the Codex instructions config (~/.codex/instructions.md).
+ *
+ * Usage (in ~/.codex/config.toml):
+ *   [mcp_servers]
+ *   [mcp_servers.tdai-memory]
+ *   command = "tdai-codex-mcp"
+ *   env = { TDAI_DATA_DIR = "~/.tdai/codex", TDAI_LLM_BASE_URL = "...", ... }
+ */
+
+import { McpServerBase } from "../mcp-server-base.js";
+import { CodexHostAdapter } from "./host-adapter.js";
+import type { McpHostAdapter } from "../mcp-server-base.js";
+
+export class CodexMcpServer extends McpServerBase {
+  protected createAdapter(): McpHostAdapter {
+    return new CodexHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}

--- a/src/adapters/codex/types.ts
+++ b/src/adapters/codex/types.ts
@@ -1,0 +1,2 @@
+export type { McpHostAdapterOptions as CodexHostAdapterOptions } from "../mcp-host-adapter-base.js";
+export type { McpServerBaseOptions as CodexMcpServerOptions } from "../mcp-server-base.js";

--- a/src/adapters/cursor/host-adapter.ts
+++ b/src/adapters/cursor/host-adapter.ts
@@ -1,0 +1,11 @@
+import { McpHostAdapterBase, sessionKeyFromEnv } from "../mcp-host-adapter-base.js";
+
+export class CursorHostAdapter extends McpHostAdapterBase {
+  readonly hostType = "cursor" as const;
+  protected readonly platformId = "cursor";
+
+  protected resolveSessionKey(explicit: string | undefined): string {
+    return sessionKeyFromEnv(explicit, "CURSOR_SESSION_ID");
+  }
+}
+

--- a/src/adapters/cursor/index.ts
+++ b/src/adapters/cursor/index.ts
@@ -1,0 +1,3 @@
+export { CursorHostAdapter } from "./host-adapter.js";
+export { CursorMcpServer } from "./mcp-server.js";
+export type { CursorHostAdapterOptions, CursorMcpServerOptions } from "./types.js";

--- a/src/adapters/cursor/mcp-server.ts
+++ b/src/adapters/cursor/mcp-server.ts
@@ -1,0 +1,28 @@
+/**
+ * CursorMcpServer — MCP server adapter for Cursor.
+ *
+ * Cursor does not provide a Stop-hook equivalent, so capture must be done
+ * explicitly via `tdai_memory_capture` (or the user includes that instruction
+ * in their Cursor Rule). This class inherits all MCP JSON-RPC machinery
+ * from McpServerBase without any additional platform logic.
+ *
+ * Usage (in ~/.cursor/mcp.json or .cursor/mcp.json):
+ *   {
+ *     "mcpServers": {
+ *       "tdai-memory": {
+ *         "command": "tdai-cursor-mcp",
+ *         "env": { "TDAI_DATA_DIR": "~/.tdai/cursor", ... }
+ *       }
+ *     }
+ *   }
+ */
+
+import { McpServerBase } from "../mcp-server-base.js";
+import { CursorHostAdapter } from "./host-adapter.js";
+import type { McpHostAdapter } from "../mcp-server-base.js";
+
+export class CursorMcpServer extends McpServerBase {
+  protected createAdapter(): McpHostAdapter {
+    return new CursorHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}

--- a/src/adapters/cursor/types.ts
+++ b/src/adapters/cursor/types.ts
@@ -1,0 +1,2 @@
+export type { McpHostAdapterOptions as CursorHostAdapterOptions } from "../mcp-host-adapter-base.js";
+export type { McpServerBaseOptions as CursorMcpServerOptions } from "../mcp-server-base.js";

--- a/src/adapters/dify/host-adapter.ts
+++ b/src/adapters/dify/host-adapter.ts
@@ -1,0 +1,9 @@
+import { HostAdapterBase } from "../host-adapter-base.js";
+import type { HostAdapterBaseOptions } from "../host-adapter-base.js";
+
+export type { HostAdapterBaseOptions as DifyHostAdapterOptions };
+
+export class DifyHostAdapter extends HostAdapterBase {
+  readonly hostType = "dify" as const;
+  protected readonly platformId = "dify";
+}

--- a/src/adapters/dify/http-server.ts
+++ b/src/adapters/dify/http-server.ts
@@ -1,0 +1,12 @@
+import { HttpServerBase } from "../http-server-base.js";
+import { DifyHostAdapter } from "./host-adapter.js";
+import type { HostAdapter } from "../../core/types.js";
+import type { HttpServerBaseOptions } from "../http-server-base.js";
+
+export type { HttpServerBaseOptions as DifyHttpServerOptions };
+
+export class DifyHttpServer extends HttpServerBase {
+  protected createAdapter(): HostAdapter {
+    return new DifyHostAdapter({ ...this.opts, logger: this.logger });
+  }
+}

--- a/src/adapters/dify/index.ts
+++ b/src/adapters/dify/index.ts
@@ -1,0 +1,3 @@
+export { DifyHostAdapter } from "./host-adapter.js";
+export { DifyHttpServer } from "./http-server.js";
+export type { DifyHostAdapterOptions, DifyHttpServerOptions } from "./types.js";

--- a/src/adapters/dify/types.ts
+++ b/src/adapters/dify/types.ts
@@ -1,0 +1,2 @@
+export type { DifyHostAdapterOptions } from "./host-adapter.js";
+export type { DifyHttpServerOptions } from "./http-server.js";

--- a/src/adapters/host-adapter-base.ts
+++ b/src/adapters/host-adapter-base.ts
@@ -1,0 +1,103 @@
+/**
+ * HostAdapterBase — shared HostAdapter implementation for every platform.
+ *
+ * All adapters, MCP and HTTP alike, need the same four things: a data
+ * directory, a logger, an LLM runner factory, and a RuntimeContext. Those live
+ * here. Transport-specific behaviour is a thin subclass:
+ *
+ *   McpHostAdapterBase  — adds default-session-key resolution (stdio is
+ *                         one session per process, so the key comes from an
+ *                         env var at startup)
+ *   HTTP adapters       — extend this class directly; they need nothing extra
+ *
+ * Subclasses provide `hostType` and `platformId`.
+ *
+ * A note on RuntimeContext: TdaiCore currently reads only `dataDir` from it.
+ * `userId`, `sessionKey` and `platform` are populated for completeness but are
+ * not yet used to scope storage — per-user isolation is not implemented. Do
+ * not rely on them for tenancy.
+ */
+
+import { StandaloneLLMRunnerFactory } from "./standalone/llm-runner.js";
+import type { StandaloneLLMConfig } from "./standalone/llm-runner.js";
+import type {
+  HostAdapter,
+  RuntimeContext,
+  Logger,
+  LLMRunnerFactory,
+} from "../core/types.js";
+import { makeStderrLogger } from "./utils.js";
+
+// ============================
+// Shared options
+// ============================
+
+export interface HostAdapterBaseOptions {
+  /** Base data directory for TDAI storage. */
+  dataDir: string;
+  /** LLM configuration for memory extraction / persona pipelines. */
+  llmConfig: StandaloneLLMConfig;
+  /** Logger (defaults to stderr-based console logger). */
+  logger?: Logger;
+  /** Default user identifier (defaults to "default_user"). */
+  userId?: string;
+}
+
+export type { StandaloneLLMConfig };
+
+// ============================
+// HostAdapterBase
+// ============================
+
+export abstract class HostAdapterBase implements HostAdapter {
+  /** Platform identifier passed to TdaiCore. */
+  abstract readonly hostType: HostAdapter["hostType"];
+  /** Platform label written into RuntimeContext. */
+  protected abstract readonly platformId: string;
+
+  protected readonly dataDir: string;
+  protected readonly userId: string;
+  private readonly _logger: Logger;
+  private readonly runnerFactory: StandaloneLLMRunnerFactory;
+
+  constructor(opts: HostAdapterBaseOptions) {
+    this.dataDir = opts.dataDir;
+    this.userId = opts.userId ?? "default_user";
+    this._logger = opts.logger ?? makeStderrLogger();
+
+    this.runnerFactory = new StandaloneLLMRunnerFactory({
+      config: opts.llmConfig,
+      logger: this._logger,
+    });
+  }
+
+  /**
+   * Session key for the process-level context.
+   * Base default is the platform id; MCP adapters override with a resolved
+   * per-process key. Deliberately not called from the constructor so that
+   * subclass field initializers have already run by the time it is used.
+   */
+  protected contextSessionKey(): string {
+    return this.platformId;
+  }
+
+  getRuntimeContext(): RuntimeContext {
+    const sessionKey = this.contextSessionKey();
+    return {
+      userId: this.userId,
+      sessionId: sessionKey,
+      sessionKey,
+      platform: this.platformId,
+      workspaceDir: this.dataDir,
+      dataDir: this.dataDir,
+    };
+  }
+
+  getLogger(): Logger {
+    return this._logger;
+  }
+
+  getLLMRunnerFactory(): LLMRunnerFactory {
+    return this.runnerFactory;
+  }
+}

--- a/src/adapters/http-server-base.test.ts
+++ b/src/adapters/http-server-base.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type http from "node:http";
+import { HttpServerBase } from "./http-server-base.js";
+import type { HttpServerBaseOptions } from "./http-server-base.js";
+import type { HostAdapter } from "../core/types.js";
+import { MemoryOperations } from "./memory-operations.js";
+import type { TdaiCore } from "../core/tdai-core.js";
+
+// ============================
+// Harness
+// ============================
+
+function makeCore() {
+  return {
+    handleBeforeRecall: vi.fn().mockResolvedValue({
+      appendSystemContext: "remembered context",
+      recalledL1Memories: [{ content: "m", score: 1, type: "episodic" }],
+      recallStrategy: "hybrid",
+    }),
+    handleTurnCommitted: vi.fn().mockResolvedValue({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 2,
+      filteredMessages: [],
+    }),
+    searchMemories: vi.fn().mockResolvedValue({ text: "hit", total: 1, strategy: "vector" }),
+    searchConversations: vi.fn().mockResolvedValue({ text: "conv", total: 3 }),
+    handleSessionEnd: vi.fn().mockResolvedValue(undefined),
+    getVectorStore: vi.fn().mockReturnValue({}),
+    getEmbeddingService: vi.fn().mockReturnValue({}),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+type FakeCore = ReturnType<typeof makeCore>;
+
+/** Substitutes a prepared core so no storage stack is booted. */
+class TestServer extends HttpServerBase {
+  readonly fakeCore: FakeCore;
+  seedCalls = 0;
+
+  constructor(opts: HttpServerBaseOptions, fakeCore: FakeCore) {
+    super(opts);
+    this.fakeCore = fakeCore;
+  }
+
+  protected createAdapter(): HostAdapter {
+    throw new Error("not reached — initCore is overridden");
+  }
+
+  protected async initCore(): Promise<void> {
+    this.core = this.fakeCore as unknown as TdaiCore;
+    this.ops = new MemoryOperations(this.core, this.logger, "[test]");
+  }
+
+  protected async handleCustomRoute(
+    method: string,
+    pathname: string,
+    _req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<boolean> {
+    if (method === "POST" && pathname === "/seed") {
+      this.seedCalls++;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ seeded: true }));
+      return true;
+    }
+    return false;
+  }
+}
+
+const silentLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+let server: TestServer | null = null;
+let baseUrl = "";
+let tmpDir = "";
+
+async function startServer(extra: Partial<HttpServerBaseOptions> = {}): Promise<TestServer> {
+  const core = makeCore();
+  const s = new TestServer(
+    {
+      dataDir: tmpDir,
+      llmConfig: { baseUrl: "http://x", apiKey: "k", model: "m" } as never,
+      // Port 0 lets the OS pick a free port — parallel test files never collide.
+      port: 0,
+      host: "127.0.0.1",
+      logger: silentLogger,
+      ...extra,
+    },
+    core,
+  );
+  await s.start();
+  const addr = s["server"]!.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+  server = s;
+  return s;
+}
+
+describe("HttpServerBase", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-http-test-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (server) await server.stop();
+    server = null;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ============================
+  // Auth gate
+  // ============================
+
+  describe("auth", () => {
+    it("leaves routes open when no apiKey is configured", async () => {
+      await startServer();
+      const res = await fetch(`${baseUrl}/recall`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "q", session_key: "s1" }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects a request with no Authorization header", async () => {
+      await startServer({ apiKey: "secret" });
+      const res = await fetch(`${baseUrl}/recall`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "q", session_key: "s1" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects a wrong bearer token", async () => {
+      await startServer({ apiKey: "secret" });
+      const res = await fetch(`${baseUrl}/recall`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer wrong" },
+        body: JSON.stringify({ query: "q", session_key: "s1" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("accepts the correct bearer token", async () => {
+      const s = await startServer({ apiKey: "secret" });
+      const res = await fetch(`${baseUrl}/recall`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer secret" },
+        body: JSON.stringify({ query: "q", session_key: "s1" }),
+      });
+      expect(res.status).toBe(200);
+      expect(s.fakeCore.handleBeforeRecall).toHaveBeenCalledWith("q", "s1");
+    });
+
+    it("keeps /health reachable without auth so probes still work", async () => {
+      await startServer({ apiKey: "secret" });
+      const res = await fetch(`${baseUrl}/health`);
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { status: string }).status).toBe("ok");
+    });
+  });
+
+  // ============================
+  // Routing
+  // ============================
+
+  describe("routing", () => {
+    it("dispatches each standard endpoint to its core method", async () => {
+      const s = await startServer();
+      const post = (p: string, body: unknown) =>
+        fetch(`${baseUrl}${p}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+      expect((await post("/capture", {
+        user_content: "u", assistant_content: "a", session_key: "s1",
+      })).status).toBe(200);
+      expect((await post("/search/memories", { query: "q" })).status).toBe(200);
+      expect((await post("/search/conversations", { query: "q" })).status).toBe(200);
+      expect((await post("/session/end", { session_key: "s1" })).status).toBe(200);
+
+      expect(s.fakeCore.handleTurnCommitted).toHaveBeenCalledTimes(1);
+      expect(s.fakeCore.searchMemories).toHaveBeenCalledTimes(1);
+      expect(s.fakeCore.searchConversations).toHaveBeenCalledTimes(1);
+      expect(s.fakeCore.handleSessionEnd).toHaveBeenCalledWith("s1");
+    });
+
+    it("returns 404 for an unknown route", async () => {
+      await startServer();
+      const res = await fetch(`${baseUrl}/nope`, { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+
+    it("lets handleCustomRoute claim a path the base does not know", async () => {
+      const s = await startServer();
+      const res = await fetch(`${baseUrl}/seed`, { method: "POST" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ seeded: true });
+      expect(s.seedCalls).toBe(1);
+    });
+
+    it("applies the auth gate to custom routes too", async () => {
+      const s = await startServer({ apiKey: "secret" });
+      const res = await fetch(`${baseUrl}/seed`, { method: "POST" });
+      expect(res.status).toBe(401);
+      expect(s.seedCalls).toBe(0);
+    });
+  });
+
+  // ============================
+  // Error mapping
+  // ============================
+
+  describe("error mapping", () => {
+    it("maps a missing required field to 400, not 500", async () => {
+      await startServer();
+      const res = await fetch(`${baseUrl}/recall`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_key: "s1" }),
+      });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(await res.json())).toContain("query");
+    });
+
+    it("maps an unexpected core failure to 500", async () => {
+      const s = await startServer();
+      s.fakeCore.handleBeforeRecall.mockRejectedValue(new Error("store exploded"));
+      const res = await fetch(`${baseUrl}/recall`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "q", session_key: "s1" }),
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ============================
+  // CORS
+  // ============================
+
+  describe("CORS", () => {
+    it("sends no allow-origin header when the list is empty", async () => {
+      await startServer();
+      const res = await fetch(`${baseUrl}/health`, { headers: { Origin: "https://evil.test" } });
+      expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    });
+
+    it("echoes an allow-listed origin only", async () => {
+      await startServer({ corsOrigins: ["https://ok.test"] });
+
+      const allowed = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "https://ok.test" },
+      });
+      expect(allowed.headers.get("access-control-allow-origin")).toBe("https://ok.test");
+
+      const denied = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "https://evil.test" },
+      });
+      expect(denied.headers.get("access-control-allow-origin")).toBeNull();
+    });
+
+    it("answers preflight with 204", async () => {
+      await startServer({ corsOrigins: ["*"] });
+      const res = await fetch(`${baseUrl}/recall`, { method: "OPTIONS" });
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    });
+  });
+
+  // ============================
+  // Lifecycle
+  // ============================
+
+  it("detaches its signal handlers on stop so restarts do not leak listeners", async () => {
+    const before = process.listenerCount("SIGTERM");
+    const s = await startServer();
+    expect(process.listenerCount("SIGTERM")).toBe(before + 1);
+    await s.stop();
+    server = null;
+    expect(process.listenerCount("SIGTERM")).toBe(before);
+  });
+});

--- a/src/adapters/http-server-base.ts
+++ b/src/adapters/http-server-base.ts
@@ -1,0 +1,449 @@
+/**
+ * HttpServerBase — shared HTTP server logic for all HTTP-based TDAI platforms.
+ *
+ * Symmetric counterpart to McpServerBase for HTTP/Plugin platforms
+ * (Hermes/Gateway, Dify, n8n, …). Owns http.Server + TdaiCore.
+ *
+ * Subclasses provide:
+ *   createAdapter()      — platform-specific HostAdapter
+ *   onAfterInit()        — post-init setup (start background tasks, log posture, …)
+ *   onBeforeShutdown()   — pre-shutdown flush
+ *   handleCustomRoute()  — extra routes beyond the 6 standard ones
+ *   buildMemoryConfig()  — override when you have a pre-parsed MemoryTdaiConfig
+ *
+ * Standard endpoints (handled in base):
+ *   GET  /health
+ *   POST /recall
+ *   POST /capture
+ *   POST /search/memories
+ *   POST /search/conversations
+ *   POST /session/end
+ *
+ * Note: request/response types are defined inline here to avoid a circular
+ * dependency with src/gateway/types.ts (gateway imports adapters; adapters
+ * must not import gateway).
+ */
+
+import http from "node:http";
+import { URL } from "node:url";
+import { timingSafeEqual } from "node:crypto";
+import { TdaiCore } from "../core/tdai-core.js";
+import { parseConfig } from "../config.js";
+import type { MemoryTdaiConfig } from "../config.js";
+import { initDataDirectories } from "../utils/pipeline-factory.js";
+import { SessionFilter } from "../utils/session-filter.js";
+import type { Logger, HostAdapter } from "../core/types.js";
+import { makeStderrLogger } from "./utils.js";
+import type { StandaloneLLMConfig } from "./standalone/llm-runner.js";
+import { MemoryOperations, MemoryOperationError } from "./memory-operations.js";
+
+export type { StandaloneLLMConfig };
+
+const VERSION = "0.1.0";
+const TAG = "[tdai-http]";
+
+// ============================
+// Options
+// ============================
+
+export interface HttpServerBaseOptions {
+  dataDir: string;
+  llmConfig: StandaloneLLMConfig;
+  port: number;
+  /** Bind address (default "127.0.0.1"). */
+  host?: string;
+  /** Bearer auth token. When unset, all routes are open (log warns at startup). */
+  apiKey?: string;
+  /** CORS allow-list. Empty = no CORS headers. `["*"]` = wildcard. */
+  corsOrigins?: string[];
+  memoryConfigOverride?: Record<string, unknown>;
+  userId?: string;
+  logger?: Logger;
+  sessionFilter?: SessionFilter;
+}
+
+// ============================
+// Inline request body types
+// (private to this file — avoids importing from src/gateway/types.ts)
+// ============================
+
+// Note: there is deliberately no `user_id` field. TdaiCore does not scope
+// storage by user, so accepting one would silently imply isolation that does
+// not exist. See docs/architecture.md before adding per-user tenancy.
+
+interface RecallReqBody {
+  query: string;
+  session_key: string;
+}
+
+interface CaptureReqBody {
+  user_content: string;
+  assistant_content: string;
+  session_key: string;
+  session_id?: string;
+  messages?: unknown[];
+}
+
+interface MemSearchReqBody {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+interface ConvSearchReqBody {
+  query: string;
+  limit?: number;
+  session_key?: string;
+}
+
+interface SessionEndReqBody {
+  session_key: string;
+}
+
+// ============================
+// HttpServerBase
+// ============================
+
+export abstract class HttpServerBase {
+  protected readonly opts: HttpServerBaseOptions;
+  protected readonly logger: Logger;
+  protected adapter!: HostAdapter;
+  protected core!: TdaiCore;
+  /** Transport-neutral memory operations — shared with McpServerBase. */
+  protected ops!: MemoryOperations;
+  private server: http.Server | null = null;
+  private signalHandler: (() => void) | null = null;
+  private startTime = Date.now();
+
+  constructor(opts: HttpServerBaseOptions) {
+    this.opts = opts;
+    this.logger = opts.logger ?? makeStderrLogger();
+  }
+
+  /** Create the platform-specific HTTP host adapter. */
+  protected abstract createAdapter(): HostAdapter;
+
+  /** Called after TdaiCore is initialized — start timers, log posture, etc. */
+  protected async onAfterInit(): Promise<void> {}
+
+  /** Called before http.Server.close() and core.destroy(). */
+  protected async onBeforeShutdown(): Promise<void> {}
+
+  /**
+   * Handle a route not covered by the 6 standard endpoints.
+   * Called for every unmatched `{METHOD} {pathname}`.
+   * Return true if the response was sent; false to respond 404.
+   */
+  protected async handleCustomRoute(
+    _method: string,
+    _pathname: string,
+    _req: http.IncomingMessage,
+    _res: http.ServerResponse,
+  ): Promise<boolean> {
+    return false;
+  }
+
+  /**
+   * Build the MemoryTdaiConfig for TdaiCore.
+   * Default: parse opts.memoryConfigOverride.
+   * Override in subclasses with a pre-parsed config (e.g. TdaiGateway with YAML).
+   */
+  protected buildMemoryConfig(): MemoryTdaiConfig {
+    return parseConfig(this.opts.memoryConfigOverride ?? {});
+  }
+
+  // ============================
+  // Lifecycle
+  // ============================
+
+  async start(): Promise<void> {
+    initDataDirectories(this.opts.dataDir);
+    await this.initCore();
+    await this.onAfterInit();
+
+    const { port, host = "127.0.0.1" } = this.opts;
+    this.server = http.createServer((req, res) => {
+      this.handleRequest(req, res).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (err instanceof MemoryOperationError) {
+          sendError(res, err.statusCode, msg);
+          return;
+        }
+        this.logger.error(`${TAG} Unhandled request error: ${msg}`);
+        sendError(res, 500, msg);
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.listen(port, host, () => {
+        this.startTime = Date.now();
+        this.logger.info(`${TAG} Server listening on http://${host}:${port}`);
+        resolve();
+      });
+      this.server!.on("error", reject);
+    });
+
+    this.signalHandler = () => {
+      this.logger.info(`${TAG} Signal received — shutting down`);
+      void this.stop().then(() => process.exit(0));
+    };
+    process.on("SIGTERM", this.signalHandler);
+    process.on("SIGINT", this.signalHandler);
+  }
+
+  async stop(): Promise<void> {
+    this.logger.info(`${TAG} Shutting down...`);
+
+    // Detach before closing — a server that is started and stopped repeatedly
+    // in one process must not accumulate process-level listeners.
+    if (this.signalHandler) {
+      process.off("SIGTERM", this.signalHandler);
+      process.off("SIGINT", this.signalHandler);
+      this.signalHandler = null;
+    }
+
+    await this.onBeforeShutdown();
+    if (this.server) {
+      await new Promise<void>((resolve) => {
+        this.server!.close(() => resolve());
+      });
+      this.server = null;
+    }
+    await this.core.destroy();
+    this.logger.info(`${TAG} Stopped`);
+  }
+
+  // ============================
+  // Core initialisation
+  // ============================
+
+  /**
+   * Build the adapter, TdaiCore and the operations facade.
+   * Protected so a harness can substitute a prepared core without booting
+   * the real storage stack.
+   */
+  protected async initCore(): Promise<void> {
+    this.adapter = this.createAdapter();
+    const memoryConfig = this.buildMemoryConfig();
+    const sessionFilter = this.opts.sessionFilter ?? new SessionFilter([]);
+
+    this.core = new TdaiCore({
+      hostAdapter: this.adapter,
+      config: memoryConfig,
+      sessionFilter,
+    });
+
+    await this.core.initialize();
+    this.ops = new MemoryOperations(this.core, this.logger, TAG);
+    this.logger.info(`${TAG} TdaiCore initialized (dataDir=${this.opts.dataDir})`);
+  }
+
+  // ============================
+  // Request router
+  // ============================
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const method = req.method?.toUpperCase() ?? "GET";
+    const pathname = url.pathname;
+
+    this.applyCorsHeaders(req, res);
+
+    if (method === "OPTIONS") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // Health is always reachable without auth (k8s probes, docker health-check).
+    if (method === "GET" && pathname === "/health") {
+      this.handleHealth(res);
+      return;
+    }
+
+    if (!this.checkAuth(req, res)) return;
+
+    switch (`${method} ${pathname}`) {
+      case "POST /recall":
+        await this.handleRecall(req, res);
+        break;
+      case "POST /capture":
+        await this.handleCapture(req, res);
+        break;
+      case "POST /search/memories":
+        await this.handleSearchMemories(req, res);
+        break;
+      case "POST /search/conversations":
+        await this.handleSearchConversations(req, res);
+        break;
+      case "POST /session/end":
+        await this.handleSessionEnd(req, res);
+        break;
+      default: {
+        const handled = await this.handleCustomRoute(method, pathname, req, res);
+        if (!handled) sendError(res, 404, `Not found: ${method} ${pathname}`);
+        break;
+      }
+    }
+  }
+
+  // ============================
+  // Auth & CORS gates
+  // ============================
+
+  /**
+   * Verify `Authorization: Bearer <apiKey>` using constant-time comparison.
+   * When apiKey is unset the gate is a no-op (documented default — logged as WARN
+   * by subclasses that care, e.g. TdaiGateway.logSecurityPosture).
+   */
+  private checkAuth(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+    const expected = this.opts.apiKey;
+    if (!expected) return true;
+
+    const header = req.headers["authorization"];
+    if (typeof header !== "string" || !header.startsWith("Bearer ")) {
+      sendError(res, 401, "Unauthorized: missing Bearer token");
+      return false;
+    }
+    const provided = header.slice("Bearer ".length).trim();
+    if (!provided || !safeEqual(provided, expected)) {
+      sendError(res, 401, "Unauthorized: invalid token");
+      return false;
+    }
+    return true;
+  }
+
+  private applyCorsHeaders(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const allow = this.opts.corsOrigins ?? [];
+    if (allow.length === 0) return;
+
+    if (allow.includes("*")) {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+      return;
+    }
+
+    const requestOrigin = req.headers["origin"];
+    if (typeof requestOrigin !== "string" || !allow.includes(requestOrigin)) {
+      res.setHeader("Vary", "Origin");
+      return;
+    }
+    res.setHeader("Access-Control-Allow-Origin", requestOrigin);
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    res.setHeader("Vary", "Origin");
+  }
+
+  // ============================
+  // Standard route handlers
+  // ============================
+
+  private handleHealth(res: http.ServerResponse): void {
+    sendJson(res, 200, {
+      status: this.core.getVectorStore() ? "ok" : "degraded",
+      version: VERSION,
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      stores: {
+        vectorStore: !!this.core.getVectorStore(),
+        embeddingService: !!this.core.getEmbeddingService(),
+      },
+    });
+  }
+
+  private async handleRecall(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<RecallReqBody>(req);
+    const result = await this.ops.recall({
+      query: body.query,
+      sessionKey: body.session_key,
+    });
+    sendJson(res, 200, {
+      context: result.appendSystemContext ?? "",
+      strategy: result.recallStrategy,
+      memory_count: result.recalledL1Memories?.length ?? 0,
+    });
+  }
+
+  private async handleCapture(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<CaptureReqBody>(req);
+    const result = await this.ops.capture({
+      userText: body.user_content,
+      assistantText: body.assistant_content,
+      sessionKey: body.session_key,
+      sessionId: body.session_id,
+      messages: body.messages,
+    });
+    sendJson(res, 200, {
+      l0_recorded: result.l0RecordedCount,
+      scheduler_notified: result.schedulerNotified,
+    });
+  }
+
+  private async handleSearchMemories(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<MemSearchReqBody>(req);
+    const result = await this.ops.searchMemories({
+      query: body.query,
+      limit: body.limit,
+      type: body.type,
+      scene: body.scene,
+    });
+    sendJson(res, 200, { results: result.text, total: result.total, strategy: result.strategy });
+  }
+
+  private async handleSearchConversations(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<ConvSearchReqBody>(req);
+    const result = await this.ops.searchConversations({
+      query: body.query,
+      limit: body.limit,
+      sessionKey: body.session_key,
+    });
+    sendJson(res, 200, { results: result.text, total: result.total });
+  }
+
+  private async handleSessionEnd(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<SessionEndReqBody>(req);
+    await this.ops.sessionEnd(body.session_key);
+    sendJson(res, 200, { flushed: true });
+  }
+}
+
+// ============================
+// Exported utilities
+// (also usable by handleCustomRoute implementations in subclasses)
+// ============================
+
+export async function parseJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf-8")) as T);
+      } catch {
+        reject(new Error("Invalid JSON body"));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+export function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+export function sendError(res: http.ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { error: message });
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf-8");
+  const bb = Buffer.from(b, "utf-8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -17,3 +17,30 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Claude Code MCP adapter
+export { ClaudeCodeHostAdapter, ClaudeCodeMcpServer } from "./claude-code/index.js";
+export type { ClaudeCodeHostAdapterOptions, ClaudeCodeMcpServerOptions } from "./claude-code/index.js";
+
+// Cursor MCP adapter
+export { CursorHostAdapter, CursorMcpServer } from "./cursor/index.js";
+export type { CursorHostAdapterOptions, CursorMcpServerOptions } from "./cursor/index.js";
+
+// Codex CLI MCP adapter
+export { CodexHostAdapter, CodexMcpServer } from "./codex/index.js";
+export type { CodexHostAdapterOptions, CodexMcpServerOptions } from "./codex/index.js";
+
+// Shared adapter base (all platforms)
+export { HostAdapterBase } from "./host-adapter-base.js";
+export type { HostAdapterBaseOptions } from "./host-adapter-base.js";
+
+// Transport-neutral memory operations facade
+export { MemoryOperations, MemoryOperationError } from "./memory-operations.js";
+
+// HTTP base layer (for HTTP/Plugin platforms)
+export { HttpServerBase, parseJsonBody, sendJson, sendError } from "./http-server-base.js";
+export type { HttpServerBaseOptions } from "./http-server-base.js";
+
+// Dify HTTP adapter
+export { DifyHostAdapter, DifyHttpServer } from "./dify/index.js";
+export type { DifyHostAdapterOptions, DifyHttpServerOptions } from "./dify/index.js";

--- a/src/adapters/mcp-host-adapter-base.ts
+++ b/src/adapters/mcp-host-adapter-base.ts
@@ -1,0 +1,78 @@
+/**
+ * McpHostAdapterBase — HostAdapter for MCP/stdio platforms.
+ *
+ * An MCP server is one session per process, so the default session key is
+ * resolved once from the platform's own environment variable. That resolution
+ * is the only thing MCP adapters add over HostAdapterBase.
+ *
+ * Subclasses (ClaudeCodeHostAdapter, CursorHostAdapter, CodexHostAdapter)
+ * provide:
+ *   hostType          — platform identifier for TdaiCore routing
+ *   platformId        — platform label written into RuntimeContext
+ *   resolveSessionKey — the env var strategy for this platform
+ */
+
+import { randomUUID } from "node:crypto";
+import { HostAdapterBase } from "./host-adapter-base.js";
+import type { HostAdapterBaseOptions } from "./host-adapter-base.js";
+
+export type { StandaloneLLMConfig } from "./host-adapter-base.js";
+
+// ============================
+// Options
+// ============================
+
+export interface McpHostAdapterOptions extends HostAdapterBaseOptions {
+  /**
+   * Session key to use when a per-request key is not provided.
+   * If omitted, falls back to the platform's session env var,
+   * then to a process-scoped UUID.
+   */
+  defaultSessionKey?: string;
+}
+
+// ============================
+// McpHostAdapterBase
+// ============================
+
+export abstract class McpHostAdapterBase extends HostAdapterBase {
+  /**
+   * Derive the default session key for this platform.
+   * Receives the explicit option (may be undefined).
+   * Typical fallback chain: explicit → env var → randomUUID().
+   */
+  protected abstract resolveSessionKey(explicit: string | undefined): string;
+
+  private readonly explicitSessionKey: string | undefined;
+  private _defaultSessionKey?: string;
+
+  constructor(opts: McpHostAdapterOptions) {
+    super(opts);
+    this.explicitSessionKey = opts.defaultSessionKey;
+  }
+
+  /**
+   * Resolved once on first use rather than in the constructor, so that a
+   * subclass `resolveSessionKey` may safely read its own instance fields.
+   */
+  getDefaultSessionKey(): string {
+    this._defaultSessionKey ??= this.resolveSessionKey(this.explicitSessionKey);
+    return this._defaultSessionKey;
+  }
+
+  protected override contextSessionKey(): string {
+    return this.getDefaultSessionKey();
+  }
+}
+
+// ============================
+// Shared session key helpers
+// ============================
+
+/** Fall back to env var then a new UUID. */
+export function sessionKeyFromEnv(
+  explicit: string | undefined,
+  envVar: string,
+): string {
+  return explicit ?? process.env[envVar] ?? randomUUID();
+}

--- a/src/adapters/mcp-server-base.test.ts
+++ b/src/adapters/mcp-server-base.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { McpServerBase } from "./mcp-server-base.js";
+import type { McpServerBaseOptions, McpHostAdapter } from "./mcp-server-base.js";
+import { MemoryOperations } from "./memory-operations.js";
+import type { TdaiCore } from "../core/tdai-core.js";
+
+// ============================
+// Harness
+// ============================
+
+function makeCore() {
+  return {
+    handleBeforeRecall: vi.fn().mockResolvedValue({
+      prependContext: "prior facts",
+      appendSystemContext: "persona",
+      recalledL1Memories: [{ content: "m", score: 1, type: "episodic" }],
+      recallStrategy: "hybrid",
+    }),
+    handleTurnCommitted: vi.fn().mockResolvedValue({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 2,
+      filteredMessages: [],
+    }),
+    searchMemories: vi.fn().mockResolvedValue({ text: "hit", total: 1, strategy: "vector" }),
+    searchConversations: vi.fn().mockResolvedValue({ text: "conv", total: 3 }),
+    handleSessionEnd: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+type FakeCore = ReturnType<typeof makeCore>;
+
+const DEFAULT_SESSION = "env-session-key";
+
+class TestMcpServer extends McpServerBase {
+  readonly fakeCore: FakeCore;
+
+  constructor(opts: McpServerBaseOptions, fakeCore: FakeCore) {
+    super(opts);
+    this.fakeCore = fakeCore;
+  }
+
+  protected createAdapter(): McpHostAdapter {
+    throw new Error("not reached — initCore is overridden");
+  }
+
+  protected async initCore(): Promise<void> {
+    this.core = this.fakeCore as unknown as TdaiCore;
+    this.ops = new MemoryOperations(this.core, this.opts.logger!, "[test]");
+    this.adapter = {
+      hostType: "cursor",
+      getDefaultSessionKey: () => DEFAULT_SESSION,
+      getRuntimeContext: () => ({}) as never,
+      getLogger: () => this.opts.logger!,
+      getLLMRunnerFactory: () => ({}) as never,
+    };
+    this.initialized = true;
+  }
+
+  /** Drive the private tool dispatcher the way handleToolCall does. */
+  callTool(name: string, args: Record<string, unknown> = {}): Promise<string> {
+    return this["executeTool"](name, args);
+  }
+}
+
+// Read the schemas the way an MCP client would — via tools/list.
+let TOOLS: ReadonlyArray<{ name: string; inputSchema: { required?: readonly string[] } }> = [];
+
+const silentLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+async function makeServer(): Promise<TestMcpServer> {
+  const s = new TestMcpServer(
+    {
+      dataDir: "/tmp/tdai-test",
+      llmConfig: { baseUrl: "http://x", apiKey: "k", model: "m" } as never,
+      logger: silentLogger,
+    },
+    makeCore(),
+  );
+  await s["initCore"]();
+
+  // Capture the advertised tool list off the JSON-RPC surface.
+  const sent: unknown[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  (process.stdout.write as unknown) = (chunk: string) => {
+    sent.push(JSON.parse(chunk));
+    return true;
+  };
+  try {
+    s["handleToolsList"]({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+  } finally {
+    (process.stdout.write as unknown) = origWrite;
+  }
+  TOOLS = (sent[0] as { result: { tools: typeof TOOLS } }).result.tools;
+  return s;
+}
+
+describe("McpServerBase", () => {
+  let server: TestMcpServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    server = await makeServer();
+  });
+
+  // ============================
+  // Advertised surface
+  // ============================
+
+  describe("tools/list", () => {
+    it("advertises all five memory tools", () => {
+      expect(TOOLS.map((t) => t.name)).toEqual([
+        "tdai_memory_recall",
+        "tdai_memory_capture",
+        "tdai_memory_search",
+        "tdai_conversation_search",
+        "tdai_session_end",
+      ]);
+    });
+
+    it("reaches parity with the HTTP transport on session end", () => {
+      // HTTP has always exposed POST /session/end; MCP platforms previously
+      // had no way to flush a session at all.
+      expect(TOOLS.some((t) => t.name === "tdai_session_end")).toBe(true);
+    });
+
+    it("makes session_key optional on session end so the env default applies", () => {
+      const tool = TOOLS.find((t) => t.name === "tdai_session_end")!;
+      expect(tool.inputSchema.required ?? []).toEqual([]);
+    });
+  });
+
+  // ============================
+  // Dispatch
+  // ============================
+
+  describe("executeTool", () => {
+    it("routes recall and renders both context sections", async () => {
+      const out = await server.callTool("tdai_memory_recall", { query: "what did I say" });
+      expect(server.fakeCore.handleBeforeRecall).toHaveBeenCalledWith(
+        "what did I say",
+        DEFAULT_SESSION,
+      );
+      expect(out).toContain("prior facts");
+      expect(out).toContain("persona");
+    });
+
+    it("routes capture and reports what was persisted", async () => {
+      const out = await server.callTool("tdai_memory_capture", {
+        user_text: "u",
+        assistant_text: "a",
+      });
+      expect(server.fakeCore.handleTurnCommitted).toHaveBeenCalledTimes(1);
+      expect(out).toContain("2 message(s) recorded");
+    });
+
+    it("routes both search tools", async () => {
+      await server.callTool("tdai_memory_search", { query: "q" });
+      await server.callTool("tdai_conversation_search", { query: "q" });
+      expect(server.fakeCore.searchMemories).toHaveBeenCalledTimes(1);
+      expect(server.fakeCore.searchConversations).toHaveBeenCalledTimes(1);
+    });
+
+    it("routes session end using the adapter's default session key", async () => {
+      const out = await server.callTool("tdai_session_end");
+      expect(server.fakeCore.handleSessionEnd).toHaveBeenCalledWith(DEFAULT_SESSION);
+      expect(out).toContain("ended");
+    });
+
+    it("prefers an explicit session_key over the adapter default", async () => {
+      await server.callTool("tdai_session_end", { session_key: "explicit-key" });
+      expect(server.fakeCore.handleSessionEnd).toHaveBeenCalledWith("explicit-key");
+    });
+
+    it("rejects an unknown tool", async () => {
+      await expect(server.callTool("tdai_not_a_tool")).rejects.toThrow("Unknown tool");
+    });
+  });
+
+  // ============================
+  // Validation reaches the caller
+  // ============================
+
+  describe("validation", () => {
+    it("surfaces a missing query rather than calling core", async () => {
+      await expect(server.callTool("tdai_memory_recall", {})).rejects.toThrow("query");
+      expect(server.fakeCore.handleBeforeRecall).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a missing assistant_text on capture", async () => {
+      await expect(
+        server.callTool("tdai_memory_capture", { user_text: "u" }),
+      ).rejects.toThrow("assistant_text");
+      expect(server.fakeCore.handleTurnCommitted).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================
+  // Empty-result rendering
+  // ============================
+
+  it("reports no memories found instead of an empty string", async () => {
+    server.fakeCore.handleBeforeRecall.mockResolvedValue({});
+    const out = await server.callTool("tdai_memory_recall", { query: "q" });
+    expect(out).toBe("No relevant memories found.");
+  });
+});

--- a/src/adapters/mcp-server-base.ts
+++ b/src/adapters/mcp-server-base.ts
@@ -1,0 +1,512 @@
+/**
+ * McpServerBase — shared MCP JSON-RPC stdio server logic for all platforms.
+ *
+ * Subclasses provide:
+ *   createAdapter()      — platform-specific HostAdapter
+ *   onAfterInit()        — post-init setup (e.g. start timers)
+ *   onBeforeRecall()     — pre-recall hook (e.g. drain a capture queue)
+ *   onBeforeShutdown()   — pre-exit flush (e.g. final queue drain)
+ *
+ * Concrete implementations:
+ *   ClaudeCodeMcpServer  — adds Stop-hook queue draining
+ *   CursorMcpServer      — no extras; inherits base behaviour directly
+ */
+
+import { TdaiCore } from "../core/tdai-core.js";
+import { parseConfig } from "../config.js";
+import type { HostAdapter, Logger } from "../core/types.js";
+import { makeStderrLogger } from "./utils.js";
+import type { StandaloneLLMConfig } from "./standalone/llm-runner.js";
+import { MemoryOperations } from "./memory-operations.js";
+export type { McpHostAdapterOptions } from "./mcp-host-adapter-base.js";
+
+// ============================
+// Shared options / adapter interface
+// ============================
+
+export interface McpServerBaseOptions {
+  dataDir: string;
+  llmConfig: StandaloneLLMConfig;
+  memoryConfigOverride?: Record<string, unknown>;
+  userId?: string;
+  defaultSessionKey?: string;
+  logger?: Logger;
+}
+
+export interface McpHostAdapter extends HostAdapter {
+  getDefaultSessionKey(): string;
+}
+
+// ============================
+// MCP JSON-RPC types (minimal subset)
+// ============================
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+// ============================
+// Tool schema definitions
+// ============================
+
+const TOOL_SCHEMAS = [
+  {
+    name: "tdai_memory_recall",
+    description:
+      "Retrieve relevant memories from TencentDB-Agent-Memory before processing a user message. " +
+      "Returns L1 structured memories and L3 persona context that can be injected into the system prompt. " +
+      "Call this at the start of each conversation turn to ground the response in past context.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The user's current message or a summary of their intent.",
+        },
+        session_key: {
+          type: "string",
+          description:
+            "Stable session identifier (use the same value across turns in the same conversation). " +
+            "Defaults to the platform session environment variable if omitted.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "tdai_memory_capture",
+    description:
+      "Record a completed conversation turn to TencentDB-Agent-Memory. " +
+      "Call this after the assistant response is finalized to persist the exchange for future recall. " +
+      "Background extraction pipelines (L1 episodic, L2 scene, L3 persona) run automatically.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        user_text: {
+          type: "string",
+          description: "The user's message for this turn.",
+        },
+        assistant_text: {
+          type: "string",
+          description: "The assistant's response for this turn.",
+        },
+        session_key: {
+          type: "string",
+          description: "Session identifier (must match the key used in recall).",
+        },
+        session_id: {
+          type: "string",
+          description: "Optional sub-session identifier for grouping turns.",
+        },
+      },
+      required: ["user_text", "assistant_text"],
+    },
+  },
+  {
+    name: "tdai_memory_search",
+    description:
+      "Search L1 structured memories (episodic facts, skills, instructions, user preferences). " +
+      "Use this when the user asks about past decisions, preferences, or learned knowledge.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Natural-language search query.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (1–20, default 5).",
+        },
+        type: {
+          type: "string",
+          enum: ["persona", "episodic", "instruction"],
+          description: "Filter by memory type.",
+        },
+        scene: {
+          type: "string",
+          description: "Filter by scene / topic label.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "tdai_conversation_search",
+    description:
+      "Search raw L0 conversation history when structured memories are insufficient. " +
+      "Returns individual message excerpts ranked by relevance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Natural-language search query.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (1–20, default 5).",
+        },
+        session_key: {
+          type: "string",
+          description: "Restrict search to a specific conversation session. Omit to search all sessions.",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "tdai_session_end",
+    description:
+      "Signal that the current conversation session is finished. " +
+      "Flushes pending L1/L2/L3 extraction pipelines so memories from this session " +
+      "become durable immediately instead of waiting for the background scheduler. " +
+      "Call this when the user says goodbye or explicitly ends the conversation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        session_key: {
+          type: "string",
+          description:
+            "Session identifier to flush (must match the key used in recall/capture). " +
+            "Defaults to the platform session environment variable if omitted.",
+        },
+      },
+      required: [],
+    },
+  },
+] as const;
+
+// ============================
+// McpServerBase
+// ============================
+
+export abstract class McpServerBase {
+  protected readonly opts: McpServerBaseOptions;
+  protected readonly logger: Logger;
+  protected adapter!: McpHostAdapter;
+  protected core!: TdaiCore;
+  /** Transport-neutral memory operations — shared with HttpServerBase. */
+  protected ops!: MemoryOperations;
+  protected initialized = false;
+
+  constructor(opts: McpServerBaseOptions) {
+    this.opts = opts;
+    this.logger = opts.logger ?? makeStderrLogger();
+  }
+
+  /** Create the platform-specific host adapter. */
+  protected abstract createAdapter(): McpHostAdapter;
+
+  /** Called after TdaiCore is initialised — start background tasks here. */
+  protected async onAfterInit(): Promise<void> {}
+  /** Called before each recall — drain queued captures, etc. */
+  protected async onBeforeRecall(): Promise<void> {}
+  /** Called before process exit — flush any pending state. */
+  protected async onBeforeShutdown(): Promise<void> {}
+
+  // ============================
+  // Lifecycle
+  // ============================
+
+  async start(): Promise<void> {
+    await this.initCore();
+    await this.onAfterInit();
+
+    process.stdin.setEncoding("utf8");
+    let buffer = "";
+
+    process.stdin.on("data", (chunk: string) => {
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed) this.handleLine(trimmed);
+      }
+    });
+
+    const shutdown = async () => {
+      await this.onBeforeShutdown();
+      await this.core.destroy();
+      process.exit(0);
+    };
+
+    process.stdin.on("end", async () => {
+      this.logger.info("[mcp] stdin closed — shutting down");
+      await shutdown();
+    });
+
+    process.on("SIGTERM", async () => {
+      this.logger.info("[mcp] SIGTERM received — shutting down");
+      await shutdown();
+    });
+
+    process.on("SIGINT", async () => {
+      this.logger.info("[mcp] SIGINT received — shutting down");
+      await shutdown();
+    });
+
+    this.logger.info("[mcp] MCP server started — listening on stdin");
+  }
+
+  // ============================
+  // Core initialisation
+  // ============================
+
+  /**
+   * Build the adapter, TdaiCore and the operations facade.
+   * Protected so a harness can substitute a prepared core without booting
+   * the real storage stack.
+   */
+  protected async initCore(): Promise<void> {
+    const rawConfig: Record<string, unknown> = this.opts.memoryConfigOverride ?? {};
+    const memoryConfig = parseConfig(rawConfig);
+
+    this.adapter = this.createAdapter();
+
+    this.core = new TdaiCore({
+      hostAdapter: this.adapter,
+      config: memoryConfig,
+    });
+
+    await this.core.initialize();
+    this.ops = new MemoryOperations(this.core, this.logger, "[mcp]");
+    this.initialized = true;
+    this.logger.info(`[mcp] TdaiCore initialized (dataDir=${this.opts.dataDir})`);
+  }
+
+  // ============================
+  // JSON-RPC dispatch
+  // ============================
+
+  private handleLine(line: string): void {
+    let msg: JsonRpcRequest | JsonRpcNotification;
+    try {
+      msg = JSON.parse(line) as JsonRpcRequest | JsonRpcNotification;
+    } catch {
+      this.sendError(null, -32700, "Parse error");
+      return;
+    }
+
+    if (!("id" in msg) || msg.id === undefined) {
+      this.handleNotification(msg as JsonRpcNotification);
+      return;
+    }
+
+    const req = msg as JsonRpcRequest;
+    this.dispatchRequest(req).catch((err: unknown) => {
+      this.logger.error(`[mcp] Unhandled error in ${req.method}: ${String(err)}`);
+      this.sendError(req.id, -32603, "Internal error", String(err));
+    });
+  }
+
+  private handleNotification(msg: JsonRpcNotification): void {
+    if (msg.method === "notifications/initialized") {
+      this.logger.info("[mcp] Client initialized");
+    }
+  }
+
+  private async dispatchRequest(req: JsonRpcRequest): Promise<void> {
+    switch (req.method) {
+      case "initialize":
+        this.handleInitialize(req);
+        break;
+      case "tools/list":
+        this.handleToolsList(req);
+        break;
+      case "tools/call":
+        await this.handleToolCall(req);
+        break;
+      default:
+        this.sendError(req.id, -32601, `Method not found: ${req.method}`);
+    }
+  }
+
+  // ============================
+  // MCP method handlers
+  // ============================
+
+  private handleInitialize(req: JsonRpcRequest): void {
+    this.sendResult(req.id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      serverInfo: {
+        name: "tdai-memory",
+        version: "1.0.0",
+        description: "TencentDB-Agent-Memory",
+      },
+    });
+  }
+
+  private handleToolsList(req: JsonRpcRequest): void {
+    this.sendResult(req.id, { tools: TOOL_SCHEMAS });
+  }
+
+  private async handleToolCall(req: JsonRpcRequest): Promise<void> {
+    if (!this.initialized) {
+      this.sendError(req.id, -32002, "Server not ready");
+      return;
+    }
+
+    const params = req.params as { name?: string; arguments?: Record<string, unknown> } | undefined;
+    const toolName = params?.name;
+    const args = params?.arguments ?? {};
+
+    if (!toolName) {
+      this.sendError(req.id, -32602, "Missing tool name");
+      return;
+    }
+
+    try {
+      const result = await this.executeTool(toolName, args);
+      this.sendResult(req.id, {
+        content: [{ type: "text", text: result }],
+        isError: false,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(`[mcp] Tool ${toolName} failed: ${message}`);
+      this.sendResult(req.id, {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      });
+    }
+  }
+
+  // ============================
+  // Tool dispatch
+  // ============================
+
+  private async executeTool(name: string, args: Record<string, unknown>): Promise<string> {
+    const sessionKey =
+      (args["session_key"] as string | undefined) ?? this.adapter.getDefaultSessionKey();
+
+    switch (name) {
+      case "tdai_memory_recall":
+        return this.toolRecall(args, sessionKey);
+      case "tdai_memory_capture":
+        return this.toolCapture(args, sessionKey);
+      case "tdai_memory_search":
+        return this.toolSearchMemories(args);
+      case "tdai_conversation_search":
+        return this.toolSearchConversations(args);
+      case "tdai_session_end":
+        return this.toolSessionEnd(sessionKey);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+
+  // ============================
+  // Tool implementations
+  // ============================
+
+  private async toolRecall(args: Record<string, unknown>, sessionKey: string): Promise<string> {
+    await this.onBeforeRecall();
+
+    const result = await this.ops.recall({
+      query: String(args["query"] ?? ""),
+      sessionKey,
+    });
+
+    const parts: string[] = [];
+    if (result.prependContext) {
+      parts.push(`## Relevant Memories\n${result.prependContext}`);
+    }
+    if (result.appendSystemContext) {
+      parts.push(`## Context\n${result.appendSystemContext}`);
+    }
+    if (parts.length === 0) return "No relevant memories found.";
+
+    const count = result.recalledL1Memories?.length ?? 0;
+    const strategy = result.recallStrategy ?? "unknown";
+    parts.push(`\n_(recalled ${count} memor${count === 1 ? "y" : "ies"} via ${strategy})_`);
+    return parts.join("\n\n");
+  }
+
+  private async toolCapture(args: Record<string, unknown>, sessionKey: string): Promise<string> {
+    const result = await this.ops.capture({
+      userText: String(args["user_text"] ?? ""),
+      assistantText: String(args["assistant_text"] ?? ""),
+      sessionKey,
+      sessionId: args["session_id"] as string | undefined,
+    });
+
+    return (
+      `Captured: ${result.l0RecordedCount} message(s) recorded, ` +
+      `pipeline scheduled=${result.schedulerNotified}, ` +
+      `vectors written=${result.l0VectorsWritten}.`
+    );
+  }
+
+  private async toolSearchMemories(args: Record<string, unknown>): Promise<string> {
+    const result = await this.ops.searchMemories({
+      query: String(args["query"] ?? ""),
+      limit: typeof args["limit"] === "number" ? args["limit"] : 5,
+      type: args["type"] as string | undefined,
+      scene: args["scene"] as string | undefined,
+    });
+
+    if (result.total === 0) return "No matching memories found.";
+    return `${result.text}\n\n_(${result.total} result(s) via ${result.strategy})_`;
+  }
+
+  private async toolSearchConversations(args: Record<string, unknown>): Promise<string> {
+    const sessionKey = args["session_key"] as string | undefined;
+
+    const result = await this.ops.searchConversations({
+      query: String(args["query"] ?? ""),
+      limit: typeof args["limit"] === "number" ? args["limit"] : 5,
+      sessionKey,
+    });
+
+    if (result.total === 0) return "No matching conversation records found.";
+    return `${result.text}\n\n_(${result.total} result(s)${sessionKey ? ` in session ${sessionKey}` : ""})_`;
+  }
+
+  private async toolSessionEnd(sessionKey: string): Promise<string> {
+    await this.ops.sessionEnd(sessionKey);
+    return (
+      `Session ${sessionKey} ended. Pending L1/L2/L3 extraction pipelines were ` +
+      `flushed — memories from this conversation are now durable.`
+    );
+  }
+
+  // ============================
+  // JSON-RPC helpers
+  // ============================
+
+  private send(msg: JsonRpcResponse): void {
+    process.stdout.write(JSON.stringify(msg) + "\n");
+  }
+
+  private sendResult(id: string | number | null, result: unknown): void {
+    this.send({ jsonrpc: "2.0", id, result });
+  }
+
+  private sendError(
+    id: string | number | null,
+    code: number,
+    message: string,
+    data?: unknown,
+  ): void {
+    this.send({ jsonrpc: "2.0", id, error: { code, message, data } });
+  }
+}

--- a/src/adapters/memory-operations.test.ts
+++ b/src/adapters/memory-operations.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MemoryOperations, MemoryOperationError } from "./memory-operations.js";
+import type { TdaiCore } from "../core/tdai-core.js";
+import type { Logger } from "../core/types.js";
+
+// ============================
+// Test doubles
+// ============================
+
+function makeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+/**
+ * Minimal TdaiCore stand-in — only the five methods MemoryOperations calls.
+ * Cast through unknown because TdaiCore's real surface is much larger.
+ */
+function makeCore() {
+  return {
+    handleBeforeRecall: vi.fn().mockResolvedValue({
+      appendSystemContext: "ctx",
+      recalledL1Memories: [{ content: "m", score: 1, type: "episodic" }],
+      recallStrategy: "hybrid",
+    }),
+    handleTurnCommitted: vi.fn().mockResolvedValue({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 2,
+      filteredMessages: [],
+    }),
+    searchMemories: vi.fn().mockResolvedValue({ text: "hit", total: 1, strategy: "vector" }),
+    searchConversations: vi.fn().mockResolvedValue({ text: "conv", total: 3 }),
+    handleSessionEnd: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+type FakeCore = ReturnType<typeof makeCore>;
+
+function makeOps(core: FakeCore) {
+  return new MemoryOperations(core as unknown as TdaiCore, makeLogger(), "[test]");
+}
+
+describe("MemoryOperations", () => {
+  let core: FakeCore;
+  let ops: MemoryOperations;
+
+  beforeEach(() => {
+    core = makeCore();
+    ops = makeOps(core);
+  });
+
+  // ============================
+  // Validation — the contract both transports rely on
+  // ============================
+
+  describe("validation", () => {
+    it("rejects a missing query on recall", async () => {
+      await expect(ops.recall({ query: "", sessionKey: "s1" })).rejects.toThrow(
+        MemoryOperationError,
+      );
+      expect(core.handleBeforeRecall).not.toHaveBeenCalled();
+    });
+
+    it("rejects a whitespace-only query", async () => {
+      await expect(ops.recall({ query: "   ", sessionKey: "s1" })).rejects.toThrow(
+        "Missing required field: query",
+      );
+    });
+
+    it("rejects a missing session key on recall", async () => {
+      await expect(ops.recall({ query: "q", sessionKey: "" })).rejects.toThrow(
+        "Missing required field: session_key",
+      );
+    });
+
+    it("reports each missing capture field by name", async () => {
+      await expect(
+        ops.capture({ userText: "", assistantText: "a", sessionKey: "s1" }),
+      ).rejects.toThrow("Missing required field: user_text");
+
+      await expect(
+        ops.capture({ userText: "u", assistantText: "", sessionKey: "s1" }),
+      ).rejects.toThrow("Missing required field: assistant_text");
+
+      await expect(
+        ops.capture({ userText: "u", assistantText: "a", sessionKey: "" }),
+      ).rejects.toThrow("Missing required field: session_key");
+    });
+
+    it("rejects an empty query on both search operations", async () => {
+      await expect(ops.searchMemories({ query: "" })).rejects.toThrow(MemoryOperationError);
+      await expect(ops.searchConversations({ query: "" })).rejects.toThrow(MemoryOperationError);
+    });
+
+    it("rejects an empty session key on sessionEnd", async () => {
+      await expect(ops.sessionEnd("")).rejects.toThrow(MemoryOperationError);
+      expect(core.handleSessionEnd).not.toHaveBeenCalled();
+    });
+
+    it("carries a 400 status so HTTP can map it without re-deriving intent", async () => {
+      const err = await ops.recall({ query: "", sessionKey: "s" }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(MemoryOperationError);
+      expect((err as MemoryOperationError).statusCode).toBe(400);
+    });
+  });
+
+  // ============================
+  // Delegation
+  // ============================
+
+  describe("recall", () => {
+    it("passes query and session key through and returns the core result", async () => {
+      const result = await ops.recall({ query: "what did I say", sessionKey: "s1" });
+      expect(core.handleBeforeRecall).toHaveBeenCalledWith("what did I say", "s1");
+      expect(result.appendSystemContext).toBe("ctx");
+      expect(result.recallStrategy).toBe("hybrid");
+    });
+  });
+
+  describe("capture", () => {
+    it("synthesizes a user/assistant message pair when none is given", async () => {
+      await ops.capture({ userText: "u", assistantText: "a", sessionKey: "s1" });
+      const turn = core.handleTurnCommitted.mock.calls[0]![0];
+      expect(turn.messages).toEqual([
+        { role: "user", content: "u" },
+        { role: "assistant", content: "a" },
+      ]);
+    });
+
+    it("preserves an explicit message list instead of synthesizing one", async () => {
+      const messages = [{ role: "user", content: "one" }, { role: "tool", content: "two" }];
+      await ops.capture({ userText: "u", assistantText: "a", sessionKey: "s1", messages });
+      expect(core.handleTurnCommitted.mock.calls[0]![0].messages).toBe(messages);
+    });
+
+    it("defaults sessionId to sessionKey", async () => {
+      await ops.capture({ userText: "u", assistantText: "a", sessionKey: "s1" });
+      expect(core.handleTurnCommitted.mock.calls[0]![0].sessionId).toBe("s1");
+    });
+
+    it("keeps an explicit sessionId distinct from the session key", async () => {
+      await ops.capture({
+        userText: "u",
+        assistantText: "a",
+        sessionKey: "s1",
+        sessionId: "sub-7",
+      });
+      const turn = core.handleTurnCommitted.mock.calls[0]![0];
+      expect(turn.sessionId).toBe("sub-7");
+      expect(turn.sessionKey).toBe("s1");
+    });
+
+    it("honours a caller-supplied startedAt (hook replay keeps original timing)", async () => {
+      await ops.capture({
+        userText: "u",
+        assistantText: "a",
+        sessionKey: "s1",
+        startedAt: 1234,
+      });
+      expect(core.handleTurnCommitted.mock.calls[0]![0].startedAt).toBe(1234);
+    });
+  });
+
+  describe("search", () => {
+    it("forwards all memory search filters", async () => {
+      const result = await ops.searchMemories({
+        query: "q",
+        limit: 3,
+        type: "episodic",
+        scene: "work",
+      });
+      expect(core.searchMemories).toHaveBeenCalledWith({
+        query: "q",
+        limit: 3,
+        type: "episodic",
+        scene: "work",
+      });
+      expect(result.total).toBe(1);
+      expect(result.strategy).toBe("vector");
+    });
+
+    it("maps session_key to sessionKey for conversation search", async () => {
+      await ops.searchConversations({ query: "q", limit: 2, sessionKey: "s9" });
+      expect(core.searchConversations).toHaveBeenCalledWith({
+        query: "q",
+        limit: 2,
+        sessionKey: "s9",
+      });
+    });
+  });
+
+  describe("sessionEnd", () => {
+    it("flushes the given session", async () => {
+      await ops.sessionEnd("s1");
+      expect(core.handleSessionEnd).toHaveBeenCalledWith("s1");
+    });
+  });
+
+  // ============================
+  // Error propagation
+  // ============================
+
+  it("lets core failures propagate rather than swallowing them", async () => {
+    core.handleBeforeRecall.mockRejectedValue(new Error("vector store down"));
+    await expect(ops.recall({ query: "q", sessionKey: "s" })).rejects.toThrow(
+      "vector store down",
+    );
+  });
+});

--- a/src/adapters/memory-operations.ts
+++ b/src/adapters/memory-operations.ts
@@ -1,0 +1,162 @@
+/**
+ * MemoryOperations — transport-neutral facade over TdaiCore.
+ *
+ * Both McpServerBase (stdio JSON-RPC) and HttpServerBase (HTTP) expose the
+ * same five memory operations. Only the wire format differs: MCP renders
+ * markdown for an LLM to read, HTTP emits JSON for a program to parse.
+ *
+ * Everything that is *not* wire format — argument validation, the TdaiCore
+ * call, timing logs — lives here so it is written once. Each transport takes
+ * the structured result and formats it.
+ *
+ * Adding an operation here makes it available to every platform on both
+ * transports, which is what keeps the two sides from drifting apart.
+ */
+
+import type { TdaiCore } from "../core/tdai-core.js";
+import type { Logger, RecallResult, CaptureResult } from "../core/types.js";
+
+// ============================
+// Errors
+// ============================
+
+/**
+ * A caller-fault error (missing/invalid argument).
+ * HTTP maps this to 400; MCP renders it as tool error text.
+ */
+export class MemoryOperationError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode = 400) {
+    super(message);
+    this.name = "MemoryOperationError";
+    this.statusCode = statusCode;
+  }
+}
+
+/** Throw a 400 unless `value` is a non-empty string. */
+function requireText(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new MemoryOperationError(`Missing required field: ${field}`);
+  }
+  return value;
+}
+
+// ============================
+// Parameter types
+// ============================
+
+export interface RecallParams {
+  query: string;
+  sessionKey: string;
+}
+
+export interface CaptureParams {
+  userText: string;
+  assistantText: string;
+  sessionKey: string;
+  sessionId?: string;
+  /** Full message list. Defaults to a user/assistant pair built from the texts. */
+  messages?: unknown[];
+  startedAt?: number;
+}
+
+export interface SearchMemoriesParams {
+  query: string;
+  limit?: number;
+  type?: string;
+  scene?: string;
+}
+
+export interface SearchConversationsParams {
+  query: string;
+  limit?: number;
+  sessionKey?: string;
+}
+
+export interface SearchResult {
+  text: string;
+  total: number;
+}
+
+export interface MemorySearchResult extends SearchResult {
+  strategy: string;
+}
+
+// ============================
+// MemoryOperations
+// ============================
+
+export class MemoryOperations {
+  private readonly core: TdaiCore;
+  private readonly logger: Logger;
+  private readonly tag: string;
+
+  constructor(core: TdaiCore, logger: Logger, tag = "[tdai]") {
+    this.core = core;
+    this.logger = logger;
+    this.tag = tag;
+  }
+
+  async recall(params: RecallParams): Promise<RecallResult> {
+    const query = requireText(params.query, "query");
+    const sessionKey = requireText(params.sessionKey, "session_key");
+
+    const startMs = Date.now();
+    const result = await this.core.handleBeforeRecall(query, sessionKey);
+    this.logger.info(
+      `${this.tag} Recall completed in ${Date.now() - startMs}ms: ` +
+        `context=${result.appendSystemContext?.length ?? 0} chars, ` +
+        `memories=${result.recalledL1Memories?.length ?? 0}`,
+    );
+    return result;
+  }
+
+  async capture(params: CaptureParams): Promise<CaptureResult> {
+    const userText = requireText(params.userText, "user_text");
+    const assistantText = requireText(params.assistantText, "assistant_text");
+    const sessionKey = requireText(params.sessionKey, "session_key");
+
+    const startMs = Date.now();
+    const result = await this.core.handleTurnCommitted({
+      userText,
+      assistantText,
+      messages: params.messages ?? [
+        { role: "user", content: userText },
+        { role: "assistant", content: assistantText },
+      ],
+      sessionKey,
+      sessionId: params.sessionId ?? sessionKey,
+      startedAt: params.startedAt ?? Date.now(),
+    });
+    this.logger.info(
+      `${this.tag} Capture completed in ${Date.now() - startMs}ms: l0=${result.l0RecordedCount}`,
+    );
+    return result;
+  }
+
+  async searchMemories(params: SearchMemoriesParams): Promise<MemorySearchResult> {
+    const query = requireText(params.query, "query");
+    return this.core.searchMemories({
+      query,
+      limit: params.limit,
+      type: params.type,
+      scene: params.scene,
+    });
+  }
+
+  async searchConversations(params: SearchConversationsParams): Promise<SearchResult> {
+    const query = requireText(params.query, "query");
+    return this.core.searchConversations({
+      query,
+      limit: params.limit,
+      sessionKey: params.sessionKey,
+    });
+  }
+
+  async sessionEnd(sessionKey: string): Promise<void> {
+    const key = requireText(sessionKey, "session_key");
+    await this.core.handleSessionEnd(key);
+    this.logger.info(`${this.tag} Session ended: ${key}`);
+  }
+}

--- a/src/adapters/standalone/host-adapter.ts
+++ b/src/adapters/standalone/host-adapter.ts
@@ -1,33 +1,19 @@
 /**
  * StandaloneHostAdapter — HostAdapter for the TDAI Gateway (Hermes sidecar).
  *
- * Does NOT depend on OpenClaw. Context is constructed from Gateway config
- * and per-request parameters (session_id, user_id, etc.).
+ * Adds the `platform` option that lets the gateway label its RuntimeContext
+ * (defaults to "gateway"); everything else comes from HostAdapterBase.
  */
 
-import { StandaloneLLMRunnerFactory } from "./llm-runner.js";
-import type { StandaloneLLMConfig } from "./llm-runner.js";
-import type {
-  HostAdapter,
-  RuntimeContext,
-  Logger,
-  LLMRunnerFactory,
-} from "../../core/types.js";
+import { HostAdapterBase } from "../host-adapter-base.js";
+import type { HostAdapterBaseOptions } from "../host-adapter-base.js";
 
 // ============================
 // Options
 // ============================
 
-export interface StandaloneHostAdapterOptions {
-  /** Base data directory for TDAI storage. */
-  dataDir: string;
-  /** LLM configuration for model calls. */
-  llmConfig: StandaloneLLMConfig;
-  /** Logger instance. */
-  logger: Logger;
-  /** Default user ID (can be overridden per-request). */
-  defaultUserId?: string;
-  /** Platform identifier. */
+export interface StandaloneHostAdapterOptions extends HostAdapterBaseOptions {
+  /** Platform label written into RuntimeContext (default "gateway"). */
   platform?: string;
 }
 
@@ -35,63 +21,12 @@ export interface StandaloneHostAdapterOptions {
 // StandaloneHostAdapter
 // ============================
 
-export class StandaloneHostAdapter implements HostAdapter {
+export class StandaloneHostAdapter extends HostAdapterBase {
   readonly hostType = "standalone" as const;
-
-  private dataDir: string;
-  private logger: Logger;
-  private runnerFactory: StandaloneLLMRunnerFactory;
-  private defaultUserId: string;
-  private platform: string;
+  protected readonly platformId: string;
 
   constructor(opts: StandaloneHostAdapterOptions) {
-    this.dataDir = opts.dataDir;
-    this.logger = opts.logger;
-    this.defaultUserId = opts.defaultUserId ?? "default_user";
-    this.platform = opts.platform ?? "gateway";
-
-    this.runnerFactory = new StandaloneLLMRunnerFactory({
-      config: opts.llmConfig,
-      logger: opts.logger,
-    });
-  }
-
-  getRuntimeContext(): RuntimeContext {
-    return {
-      userId: this.defaultUserId,
-      sessionId: "",
-      sessionKey: "",
-      platform: this.platform,
-      workspaceDir: this.dataDir,
-      dataDir: this.dataDir,
-    };
-  }
-
-  /**
-   * Build a RuntimeContext for a specific request.
-   * Used by Gateway route handlers to scope each request to the correct user/session.
-   */
-  buildRuntimeContextForRequest(params: {
-    userId?: string;
-    sessionId?: string;
-    sessionKey?: string;
-    platform?: string;
-  }): RuntimeContext {
-    return {
-      userId: params.userId ?? this.defaultUserId,
-      sessionId: params.sessionId ?? "",
-      sessionKey: params.sessionKey ?? params.sessionId ?? "",
-      platform: params.platform ?? this.platform,
-      workspaceDir: this.dataDir,
-      dataDir: this.dataDir,
-    };
-  }
-
-  getLogger(): Logger {
-    return this.logger;
-  }
-
-  getLLMRunnerFactory(): LLMRunnerFactory {
-    return this.runnerFactory;
+    super(opts);
+    this.platformId = opts.platform ?? "gateway";
   }
 }

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -1,0 +1,10 @@
+import type { Logger } from "../core/types.js";
+
+export function makeStderrLogger(): Logger {
+  return {
+    debug: (msg) => process.stderr.write(`[tdai:debug] ${msg}\n`),
+    info: (msg) => process.stderr.write(`[tdai:info]  ${msg}\n`),
+    warn: (msg) => process.stderr.write(`[tdai:warn]  ${msg}\n`),
+    error: (msg) => process.stderr.write(`[tdai:error] ${msg}\n`),
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -46,7 +46,7 @@ export interface RuntimeContext {
   /** Session key (stable across reconnects, used for L0/L1 grouping). */
   sessionKey: string;
   /** Host platform identifier. */
-  platform: "openclaw" | "hermes" | "cli" | "gateway" | string;
+  platform: "openclaw" | "hermes" | "cli" | "gateway" | "claude-code" | "cursor" | "codex" | string;
   /** Agent identity / profile name (optional). */
   agentIdentity?: string;
   /** Agent execution context — primary agent, subagent, cron job, or flush task. */
@@ -153,7 +153,7 @@ export interface LLMRunnerFactory {
  */
 export interface HostAdapter {
   /** Identifies the host type for conditional behavior (should be rare). */
-  readonly hostType: "openclaw" | "hermes" | "standalone";
+  readonly hostType: "openclaw" | "hermes" | "standalone" | "claude-code" | "cursor" | "codex" | string;
 
   /** Get the unified runtime context for the current session. */
   getRuntimeContext(): RuntimeContext;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1,51 +1,31 @@
 /**
  * TDAI Gateway — HTTP server for the Hermes sidecar.
  *
- * Exposes TDAI Core capabilities as HTTP endpoints:
- *   GET  /health              — Health check
- *   POST /recall              — Memory recall (prefetch)
- *   POST /capture             — Conversation capture (sync_turn)
- *   POST /search/memories     — L1 memory search
- *   POST /search/conversations — L0 conversation search
- *   POST /session/end         — Session end + flush
- *   POST /seed               — Batch seed historical conversations (L0 → L1)
+ * Extends HttpServerBase with:
+ *   - YAML-based config via loadGatewayConfig
+ *   - POST /seed endpoint (handleCustomRoute override)
+ *   - Security posture logging at startup (onAfterInit override)
+ *   - buildMemoryConfig override to pass pre-parsed MemoryTdaiConfig
  *
- * Built with Node.js native `http` module — no Express/Fastify dependency.
- * Designed to run as a managed sidecar alongside Hermes.
+ * External API is unchanged: new TdaiGateway(overrides?), start(), stop().
  */
 
 import http from "node:http";
-import { URL } from "node:url";
-import { timingSafeEqual } from "node:crypto";
-import { TdaiCore } from "../core/tdai-core.js";
+import { HttpServerBase, parseJsonBody, sendJson } from "../adapters/http-server-base.js";
 import { StandaloneHostAdapter } from "../adapters/standalone/host-adapter.js";
 import { loadGatewayConfig } from "./config.js";
 import type { GatewayConfig } from "./config.js";
-import { initDataDirectories } from "../utils/pipeline-factory.js";
 import { SessionFilter } from "../utils/session-filter.js";
+import type { HostAdapter } from "../core/types.js";
+import type { MemoryTdaiConfig } from "../config.js";
 import type {
-  HealthResponse,
-  RecallRequest,
-  RecallResponse,
-  CaptureRequest,
-  CaptureResponse,
-  MemorySearchRequest,
-  MemorySearchResponse,
-  ConversationSearchRequest,
-  ConversationSearchResponse,
-  SessionEndRequest,
-  SessionEndResponse,
   SeedRequest,
   SeedResponse,
-  GatewayErrorResponse,
 } from "./types.js";
-import type { Logger } from "../core/types.js";
-import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
+import { validateAndNormalizeRaw, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
-
-const TAG = "[tdai-gateway]";
-const VERSION = "0.1.0";
+import type { Logger } from "../core/types.js";
 
 // ============================
 // Console logger (for standalone gateway — no OpenClaw logger available)
@@ -53,440 +33,80 @@ const VERSION = "0.1.0";
 
 function createConsoleLogger(): Logger {
   return {
-    debug: (msg: string) => console.debug(`${TAG} ${msg}`),
-    info: (msg: string) => console.info(`${TAG} ${msg}`),
-    warn: (msg: string) => console.warn(`${TAG} ${msg}`),
-    error: (msg: string) => console.error(`${TAG} ${msg}`),
+    debug: (msg: string) => console.debug(msg),
+    info: (msg: string) => console.info(msg),
+    warn: (msg: string) => console.warn(msg),
+    error: (msg: string) => console.error(msg),
   };
 }
 
 // ============================
-// Request body parser
+// TdaiGateway
 // ============================
 
-async function parseJsonBody<T>(req: http.IncomingMessage): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => {
-      try {
-        const body = Buffer.concat(chunks).toString("utf-8");
-        resolve(JSON.parse(body) as T);
-      } catch (err) {
-        reject(new Error("Invalid JSON body"));
-      }
-    });
-    req.on("error", reject);
-  });
-}
-
-function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
-  const json = JSON.stringify(body);
-  res.writeHead(status, {
-    "Content-Type": "application/json",
-    "Content-Length": Buffer.byteLength(json),
-  });
-  res.end(json);
-}
-
-function sendError(res: http.ServerResponse, status: number, message: string): void {
-  sendJson(res, status, { error: message } satisfies GatewayErrorResponse);
-}
-
-/**
- * Constant-time string equality for secrets.
- *
- * Returns `false` on any length mismatch (without comparing bytes), and uses
- * `crypto.timingSafeEqual` for the equal-length case so that an attacker
- * probing the API key cannot use response timing to learn a prefix match.
- */
-function safeEqual(a: string, b: string): boolean {
-  const ab = Buffer.from(a, "utf-8");
-  const bb = Buffer.from(b, "utf-8");
-  if (ab.length !== bb.length) return false;
-  return timingSafeEqual(ab, bb);
-}
-
-// ============================
-// Gateway Server
-// ============================
-
-export class TdaiGateway {
+export class TdaiGateway extends HttpServerBase {
   private config: GatewayConfig;
-  private logger: Logger;
-  private core: TdaiCore;
-  private server: http.Server | null = null;
-  private startTime = Date.now();
 
   constructor(configOverrides?: Partial<GatewayConfig>) {
-    this.config = loadGatewayConfig(configOverrides);
-    this.logger = createConsoleLogger();
+    const config = loadGatewayConfig(configOverrides);
 
-    // Create host adapter
-    const adapter = new StandaloneHostAdapter({
+    super({
+      dataDir: config.data.baseDir,
+      llmConfig: config.llm,
+      port: config.server.port,
+      host: config.server.host,
+      apiKey: config.server.apiKey,
+      corsOrigins: config.server.corsOrigins,
+      userId: undefined,
+      logger: createConsoleLogger(),
+      sessionFilter: new SessionFilter(config.memory.capture.excludeAgents),
+    });
+
+    this.config = config;
+  }
+
+  protected createAdapter(): HostAdapter {
+    return new StandaloneHostAdapter({
       dataDir: this.config.data.baseDir,
       llmConfig: this.config.llm,
       logger: this.logger,
       platform: "gateway",
     });
-
-    // Create core
-    this.core = new TdaiCore({
-      hostAdapter: adapter,
-      config: this.config.memory,
-      sessionFilter: new SessionFilter(this.config.memory.capture.excludeAgents),
-    });
   }
 
-  /**
-   * Start the Gateway HTTP server.
-   */
-  async start(): Promise<void> {
-    // Initialize data directories
-    initDataDirectories(this.config.data.baseDir);
-
-    // Initialize core
-    await this.core.initialize();
-
-    // Create HTTP server
-    this.server = http.createServer((req, res) => this.handleRequest(req, res));
-
-    const { port, host } = this.config.server;
-
-    await new Promise<void>((resolve, reject) => {
-      this.server!.listen(port, host, () => {
-        this.startTime = Date.now();
-        this.logger.info(`Gateway listening on http://${host}:${port}`);
-        this.logSecurityPosture();
-        resolve();
-      });
-      this.server!.on("error", reject);
-    });
+  protected buildMemoryConfig(): MemoryTdaiConfig {
+    return this.config.memory;
   }
 
-  /**
-   * Emit a one-shot security posture summary at startup.
-   *
-   * Goals:
-   *   1. Make the "auth disabled" state highly visible to anyone reading logs
-   *      (this is the documented default, but operators must know it before
-   *      they expose the port).
-   *   2. Loudly warn when the gateway is bound to anything other than the
-   *      loopback interface without an API key — that exact combination is
-   *      what the security audit flagged as a real exposure.
-   *   3. Never log the key itself.
-   */
-  private logSecurityPosture(): void {
-    const { host, apiKey, corsOrigins } = this.config.server;
-    const authOn = !!apiKey;
-    const loopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
-
-    this.logger.info(
-      `Security posture: auth=${authOn ? "ENABLED (Bearer)" : "disabled"} ` +
-      `host=${host} cors=${corsOrigins.length === 0 ? "no-headers" : corsOrigins.includes("*") ? "wildcard(*)" : `allowlist(${corsOrigins.length})`}`
-    );
-
-    if (!authOn) {
-      this.logger.warn(
-        "TDAI_GATEWAY_API_KEY is NOT set — all routes except GET /health are " +
-        "open to anyone who can reach this port. This is the legacy default. " +
-        "Set TDAI_GATEWAY_API_KEY (or server.apiKey in tdai-gateway.yaml) and " +
-        "pass `Authorization: Bearer <key>` from clients before exposing the " +
-        "gateway beyond the loopback interface."
-      );
-    }
-    if (!loopback && !authOn) {
-      this.logger.warn(
-        `Gateway is bound to ${host} (non-loopback) WITHOUT an API key. ` +
-        "Every /capture, /search/conversations, /recall, /seed call from the " +
-        "network is currently unauthenticated. Bind to 127.0.0.1, or set " +
-        "TDAI_GATEWAY_API_KEY, before continuing."
-      );
-    }
-    if (corsOrigins.includes("*")) {
-      this.logger.warn(
-        "CORS allow-list contains '*' — every browser origin can call this " +
-        "gateway. Restrict server.corsOrigins to a concrete allow-list for any " +
-        "non-local deployment."
-      );
-    }
-  }
-
-  /**
-   * Gracefully stop the Gateway.
-   */
-  async stop(): Promise<void> {
-    this.logger.info("Shutting down gateway...");
-
-    if (this.server) {
-      await new Promise<void>((resolve) => {
-        this.server!.close(() => resolve());
-      });
-    }
-
-    await this.core.destroy();
-    this.logger.info("Gateway stopped");
+  protected async onAfterInit(): Promise<void> {
+    this.logSecurityPosture();
   }
 
   // ============================
-  // Request router
+  // /seed custom route
   // ============================
 
-  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-    const method = req.method?.toUpperCase() ?? "GET";
-    const pathname = url.pathname;
-
-    // Apply CORS headers based on configured allow-list (empty → no headers).
-    this.applyCorsHeaders(req, res);
-
-    if (method === "OPTIONS") {
-      res.writeHead(204);
-      res.end();
-      return;
+  protected async handleCustomRoute(
+    method: string,
+    pathname: string,
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<boolean> {
+    if (method === "POST" && pathname === "/seed") {
+      await this.handleSeed(req, res);
+      return true;
     }
-
-    try {
-      // GET /health is always reachable without auth — operators and
-      // orchestrators (k8s liveness, docker health-check) rely on it being
-      // an unconditionally cheap probe.
-      if (method === "GET" && pathname === "/health") {
-        return this.handleHealth(res);
-      }
-
-      // All other routes go through the optional auth gate. When apiKey is
-      // unset the gate is a no-op (preserves legacy open behaviour) — the
-      // startup WARN in `logSecurityPosture` covers that case.
-      if (!this.checkAuth(req, res)) return;
-
-      switch (`${method} ${pathname}`) {
-        case "POST /recall":
-          return await this.handleRecall(req, res);
-        case "POST /capture":
-          return await this.handleCapture(req, res);
-        case "POST /search/memories":
-          return await this.handleSearchMemories(req, res);
-        case "POST /search/conversations":
-          return await this.handleSearchConversations(req, res);
-        case "POST /session/end":
-          return await this.handleSessionEnd(req, res);
-        case "POST /seed":
-          return await this.handleSeed(req, res);
-        default:
-          sendError(res, 404, `Not found: ${method} ${pathname}`);
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Request error [${method} ${pathname}]: ${msg}`);
-      sendError(res, 500, msg);
-    }
-  }
-
-  // ============================
-  // Auth & CORS gates (opt-in, off by default)
-  // ============================
-
-  /**
-   * Verify the `Authorization: Bearer <apiKey>` header against the configured
-   * shared secret using a constant-time comparison.
-   *
-   * When `server.apiKey` is unset (`undefined`), this returns `true` without
-   * inspecting the request — this is the documented default and matches the
-   * pre-existing open behaviour. Operators are reminded of this at startup
-   * via `logSecurityPosture`.
-   *
-   * Returns `false` (and writes 401) when the token is missing, malformed, or
-   * does not match. Callers must short-circuit on `false`.
-   */
-  private checkAuth(req: http.IncomingMessage, res: http.ServerResponse): boolean {
-    const expected = this.config.server.apiKey;
-    if (!expected) return true; // auth disabled — default behaviour
-
-    const header = req.headers["authorization"];
-    if (typeof header !== "string" || !header.startsWith("Bearer ")) {
-      sendError(res, 401, "Unauthorized: missing Bearer token");
-      return false;
-    }
-    const provided = header.slice("Bearer ".length).trim();
-    if (!provided || !safeEqual(provided, expected)) {
-      sendError(res, 401, "Unauthorized: invalid token");
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Echo `Access-Control-Allow-Origin` (and friends) only for whitelisted
-   * origins. With no list configured we emit no CORS headers at all, which
-   * makes the browser refuse the cross-origin request as desired.
-   *
-   * The single-entry list `["*"]` opts back into permissive CORS (development
-   * use only; the startup log flags this loudly).
-   */
-  private applyCorsHeaders(req: http.IncomingMessage, res: http.ServerResponse): void {
-    const allow = this.config.server.corsOrigins ?? [];
-    if (allow.length === 0) return; // strict default — no headers
-
-    if (allow.includes("*")) {
-      // Wildcard — preserves the legacy permissive behaviour for callers that
-      // opt in explicitly via config. Note: with wildcard we deliberately do
-      // not echo back the request Origin and do not send `Vary: Origin`,
-      // mirroring how the gateway behaved before this change.
-      res.setHeader("Access-Control-Allow-Origin", "*");
-      res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-      res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-      return;
-    }
-
-    const requestOrigin = req.headers["origin"];
-    if (typeof requestOrigin !== "string" || !allow.includes(requestOrigin)) {
-      // Origin not in allow-list — emit no CORS headers; browser will block.
-      // Always set Vary so caches don't poison responses across origins.
-      res.setHeader("Vary", "Origin");
-      return;
-    }
-    res.setHeader("Access-Control-Allow-Origin", requestOrigin);
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-    res.setHeader("Vary", "Origin");
-  }
-
-  // ============================
-  // Route handlers
-  // ============================
-
-  private handleHealth(res: http.ServerResponse): void {
-    const response: HealthResponse = {
-      status: this.core.getVectorStore() ? "ok" : "degraded",
-      version: VERSION,
-      uptime: Math.floor((Date.now() - this.startTime) / 1000),
-      stores: {
-        vectorStore: !!this.core.getVectorStore(),
-        embeddingService: !!this.core.getEmbeddingService(),
-      },
-    };
-    sendJson(res, 200, response);
-  }
-
-  private async handleRecall(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const body = await parseJsonBody<RecallRequest>(req);
-
-    if (!body.query || !body.session_key) {
-      sendError(res, 400, "Missing required fields: query, session_key");
-      return;
-    }
-
-    const startMs = Date.now();
-    const result = await this.core.handleBeforeRecall(body.query, body.session_key);
-    const elapsed = Date.now() - startMs;
-
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
-
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
-    sendJson(res, 200, response);
-  }
-
-  private async handleCapture(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const body = await parseJsonBody<CaptureRequest>(req);
-
-    if (!body.user_content || !body.assistant_content || !body.session_key) {
-      sendError(res, 400, "Missing required fields: user_content, assistant_content, session_key");
-      return;
-    }
-
-    const startMs = Date.now();
-    const result = await this.core.handleTurnCommitted({
-      userText: body.user_content,
-      assistantText: body.assistant_content,
-      messages: body.messages ?? [
-        { role: "user", content: body.user_content },
-        { role: "assistant", content: body.assistant_content },
-      ],
-      sessionKey: body.session_key,
-      sessionId: body.session_id,
-    });
-    const elapsed = Date.now() - startMs;
-
-    this.logger.info(`Capture completed in ${elapsed}ms: l0=${result.l0RecordedCount}`);
-
-    const response: CaptureResponse = {
-      l0_recorded: result.l0RecordedCount,
-      scheduler_notified: result.schedulerNotified,
-    };
-    sendJson(res, 200, response);
-  }
-
-  private async handleSearchMemories(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const body = await parseJsonBody<MemorySearchRequest>(req);
-
-    if (!body.query) {
-      sendError(res, 400, "Missing required field: query");
-      return;
-    }
-
-    const result = await this.core.searchMemories({
-      query: body.query,
-      limit: body.limit,
-      type: body.type,
-      scene: body.scene,
-    });
-
-    const response: MemorySearchResponse = {
-      results: result.text,
-      total: result.total,
-      strategy: result.strategy,
-    };
-    sendJson(res, 200, response);
-  }
-
-  private async handleSearchConversations(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const body = await parseJsonBody<ConversationSearchRequest>(req);
-
-    if (!body.query) {
-      sendError(res, 400, "Missing required field: query");
-      return;
-    }
-
-    const result = await this.core.searchConversations({
-      query: body.query,
-      limit: body.limit,
-      sessionKey: body.session_key,
-    });
-
-    const response: ConversationSearchResponse = {
-      results: result.text,
-      total: result.total,
-    };
-    sendJson(res, 200, response);
-  }
-
-  private async handleSessionEnd(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const body = await parseJsonBody<SessionEndRequest>(req);
-
-    if (!body.session_key) {
-      sendError(res, 400, "Missing required field: session_key");
-      return;
-    }
-
-    await this.core.handleSessionEnd(body.session_key);
-
-    const response: SessionEndResponse = { flushed: true };
-    sendJson(res, 200, response);
+    return false;
   }
 
   private async handleSeed(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     const body = await parseJsonBody<SeedRequest>(req);
 
     if (!body.data) {
-      sendError(res, 400, "Missing required field: data");
+      sendJson(res, 400, { error: "Missing required field: data" });
       return;
     }
 
-    // Validate and normalize input (reuses seed CLI's validation layers 2-6)
     let input;
     try {
       input = validateAndNormalizeRaw(body.data, {
@@ -510,7 +130,6 @@ export class TdaiGateway {
       `${input.totalRounds} round(s), ${input.totalMessages} message(s)`,
     );
 
-    // Resolve output directory: use gateway's data dir with a timestamped subfolder
     const now = new Date();
     const pad = (n: number) => String(n).padStart(2, "0");
     const ts =
@@ -518,8 +137,6 @@ export class TdaiGateway {
       `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
     const outputDir = `${this.config.data.baseDir}/seed-${ts}`;
 
-    // Merge config overrides if provided
-    // Start with the base memory config + inject llm config from gateway settings
     const baseConfig = this.config.memory as unknown as Record<string, unknown>;
     let pluginConfig: Record<string, unknown> = {
       ...baseConfig,
@@ -546,7 +163,6 @@ export class TdaiGateway {
       }
     }
 
-    // Execute seed pipeline (blocking — this may take minutes for large inputs)
     const summary = await executeSeed(input, {
       outputDir,
       openclawConfig: {},
@@ -575,31 +191,66 @@ export class TdaiGateway {
     };
     sendJson(res, 200, response);
   }
+
+  // ============================
+  // Security posture logging
+  // ============================
+
+  /**
+   * Emit a one-shot security posture summary at startup.
+   *
+   * Goals:
+   *   1. Make the "auth disabled" state highly visible to anyone reading logs.
+   *   2. Loudly warn when the gateway is bound to anything other than loopback
+   *      without an API key — that combination is the real exposure.
+   *   3. Never log the key itself.
+   */
+  private logSecurityPosture(): void {
+    const { host, apiKey, corsOrigins } = this.config.server;
+    const authOn = !!apiKey;
+    const loopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
+
+    this.logger.info(
+      `Security posture: auth=${authOn ? "ENABLED (Bearer)" : "disabled"} ` +
+      `host=${host} cors=${corsOrigins.length === 0 ? "no-headers" : corsOrigins.includes("*") ? "wildcard(*)" : `allowlist(${corsOrigins.length})`}`,
+    );
+
+    if (!authOn) {
+      this.logger.warn(
+        "TDAI_GATEWAY_API_KEY is NOT set — all routes except GET /health are " +
+        "open to anyone who can reach this port. This is the legacy default. " +
+        "Set TDAI_GATEWAY_API_KEY (or server.apiKey in tdai-gateway.yaml) and " +
+        "pass `Authorization: Bearer <key>` from clients before exposing the " +
+        "gateway beyond the loopback interface.",
+      );
+    }
+    if (!loopback && !authOn) {
+      this.logger.warn(
+        `Gateway is bound to ${host} (non-loopback) WITHOUT an API key. ` +
+        "Every /capture, /search/conversations, /recall, /seed call from the " +
+        "network is currently unauthenticated. Bind to 127.0.0.1, or set " +
+        "TDAI_GATEWAY_API_KEY, before continuing.",
+      );
+    }
+    if (corsOrigins.includes("*")) {
+      this.logger.warn(
+        "CORS allow-list contains '*' — every browser origin can call this " +
+        "gateway. Restrict server.corsOrigins to a concrete allow-list for any " +
+        "non-local deployment.",
+      );
+    }
+  }
 }
 
 // ============================
 // CLI entry point
 // ============================
 
-/**
- * Start the gateway from the command line.
- * Usage: node --import tsx src/gateway/server.ts
- */
 async function main(): Promise<void> {
   const gateway = new TdaiGateway();
-
-  // Graceful shutdown
-  const shutdown = async () => {
-    await gateway.stop();
-    process.exit(0);
-  };
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
-
   await gateway.start();
 }
 
-// Auto-start when run directly
 const isMain = process.argv[1]?.endsWith("server.ts") || process.argv[1]?.endsWith("server.js");
 if (isMain) {
   main().catch((err) => {


### PR DESCRIPTION
Closes #235.

Adds four platform adapters plus the shared base layer underneath them. Goal was to make a new platform cheap — roughly 20–30 lines — instead of copying the gateway again.

Scope is adapters only. No other modules touched, no repo-wide config changes. (Typecheck setup and leftover type fixes that used to live on this branch were split out into #592; the two PRs don't depend on each other.)

## Acceptance checklist

| Stage | Deliverable |
|---|---|
| Basic | [`docs/architecture.md`](https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/02837cd49227f1b923b45c92b8aca2b079f4f8b3/docs/architecture.md) — cross-platform diagram, L0→L3 layering, read/write data flow |
| Intermediate | Claude Code adapter (Stop-hook auto capture) |
| Advanced | Cursor, Codex CLI, and Dify as well; comparison table + per-platform setup docs ([Claude Code](https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/02837cd49227f1b923b45c92b8aca2b079f4f8b3/docs/claude-code-adapter.md), [Cursor](https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/02837cd49227f1b923b45c92b8aca2b079f4f8b3/docs/cursor-adapter.md), [Codex](https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/02837cd49227f1b923b45c92b8aca2b079f4f8b3/docs/codex-adapter.md), [Dify](https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/02837cd49227f1b923b45c92b8aca2b079f4f8b3/docs/dify-adapter.md), [new platform guide](https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/02837cd49227f1b923b45c92b8aca2b079f4f8b3/docs/new-platform-guide.md)) |
| Stretch | `HostAdapterBase` / `McpServerBase` / `HttpServerBase` — new platforms only need to implement 1–2 members |

## Shared adapter SDK

- **`HostAdapterBase`** — shared `dataDir`, logger, LLM runner factory, and `RuntimeContext` for every platform. `McpHostAdapterBase` is the same thing plus default session-key resolution (only needed for stdio, one session per process). HTTP adapters subclass the shared base directly.

- **`MemoryOperations`** — transport-neutral facade over `TdaiCore`. Owns arg validation, the call, and timing logs. The two transports only differ in wire format (markdown for an LLM on MCP, JSON for programs on HTTP), so adding an operation here reaches every platform on both sides.

  This also closed a real gap: HTTP already had `POST /session/end`, but MCP had no matching tool, so the three MCP platforms could never flush a session on their own. All five operations are now available on both transports.

- **`HttpServerBase`** — `http.Server` + `TdaiCore`, six standard endpoints, Bearer auth, CORS allow-list, graceful shutdown, plus hooks: `onAfterInit` / `onBeforeShutdown` / `handleCustomRoute` / `buildMemoryConfig`. `TdaiGateway` now extends it and keeps `/seed` as a custom route; external API unchanged.

Measured cost to add a platform: Dify (HTTP) 26 lines, Codex (MCP) 41 lines, including barrel + type aliases.

## Two things worth calling out

**Identity ≠ tenancy.** `TdaiCore` only reads `dataDir` from `RuntimeContext` — `userId` does not participate in storage isolation. So the HTTP endpoints deliberately do **not** expose `user_id`. Better to omit it than accept it and silently drop it, which would make callers think isolation works. Documented in architecture.md and dify-adapter.md. For multi-tenant setups, run one instance per tenant with its own `TDAI_DATA_DIR`.

**Integer env vars are validated at entry points now.** A non-numeric `TDAI_PORT` used to become `NaN`, and `listen(NaN)` silently binds a random port.

## Verification

- `npm run build` passes
- 111 tests pass, 44 of them new in this PR: `MemoryOperations` facade, HTTP routing/auth/CORS/error mapping against a real socket, MCP tool dispatch
- Manual checks: Dify HTTP service — health / 401 / 400 / 404 / graceful shutdown behave as expected; Codex MCP over real stdio — all five tools advertised
