### PR TITLE
build: add typecheck to the main source tree, and fix the 19 pre-existing errors it surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "npm run build:plugin && npm run build:scripts",
+    "typecheck": "tsc -p tsconfig.json",
     "build:plugin": "tsdown",
     "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
     "prepack": "npm run build",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   },
   "scripts": {
-    "build": "npm run build:plugin && npm run build:scripts",
+    "build": "npm run typecheck && npm run build:plugin && npm run build:scripts",
     "typecheck": "tsc -p tsconfig.json",
     "build:plugin": "tsdown",
     "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",

--- a/src/adapters/standalone/llm-runner.ts
+++ b/src/adapters/standalone/llm-runner.ts
@@ -197,13 +197,12 @@ export class StandaloneLLMRunner implements LLMRunner {
       `tools=${this.enableTools}, timeout=${timeoutMs}ms`,
     );
 
-    // Create OpenAI-compatible provider via AI SDK
-    // Use "compatible" mode to call /chat/completions (not Responses API),
-    // which works with all OpenAI-compatible backends (DeepSeek, Qwen, etc.)
+    // Create OpenAI-compatible provider via AI SDK.
+    // `provider.chat()` below targets /chat/completions (not the Responses
+    // API), which works with all OpenAI-compatible backends (DeepSeek, Qwen…).
     const provider = createOpenAI({
       baseURL: this.config.baseUrl,
       apiKey: this.config.apiKey,
-      compatibility: "compatible",
       ...(this.customFetch ? { fetch: this.customFetch } : {}),
     });
 

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -374,7 +374,10 @@ async function searchMemories(
     // Hybrid: if the store natively supports hybrid search (e.g. TCVDB does
     // server-side dense + sparse + RRF in a single API call), short-circuit
     // to avoid a redundant second HTTP request and a wasted local embed().
-    if (vectorStore?.getCapabilities().nativeHybridSearch) {
+    // `searchL1Hybrid` is optional on IMemoryStore, so trust the method's
+    // presence rather than the capability flag alone — a store that advertises
+    // the capability without implementing it would otherwise crash here.
+    if (vectorStore?.getCapabilities().nativeHybridSearch && vectorStore.searchL1Hybrid) {
       const tNative = performance.now();
       const results = await vectorStore.searchL1Hybrid({ query: cleanText, topK: maxResults });
       const nativeMs = performance.now() - tNative;

--- a/src/offload/benchmark-token-estimate.ts
+++ b/src/offload/benchmark-token-estimate.ts
@@ -1,7 +1,7 @@
 /**
  * Benchmark: fastEstimateTokens vs tiktoken cl100k_base
  */
-import { fastEstimateTokens } from "../src/offload/fast-token-estimate.ts";
+import { fastEstimateTokens } from "./fast-token-estimate.js";
 import { getEncoding } from "js-tiktoken";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";

--- a/src/offload/index.ts
+++ b/src/offload/index.ts
@@ -1310,17 +1310,19 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
 // ─── OffloadContextEngine ────────────────────────────────────────────────────
 
 class OffloadContextEngine {
-  private _sessions: SessionRegistry;
-  private _logger: PluginLogger;
-  private _pCfg: Partial<PluginConfig>;
-  private _getContextWindow: () => number;
-  private _notifyL2NewNullEntries: (count: number) => void;
-  private _clearL2Timeout: () => void;
-  private _l4State: { pendingResult: any };
-  private _flushL1: (mgr: OffloadStateManager, triggerSource: string, fireAndForget?: boolean, maxCount?: number) => Promise<void>;
-  private _backendClient: BackendClient | null;
-  private _judgeL15: (mgr: OffloadStateManager, event: any, ctx: any) => Promise<void>;
-  private _disposeL15: () => void;
+  // All assigned via update() from the constructor — the `!` tells TypeScript
+  // that the indirection through a method still guarantees initialization.
+  private _sessions!: SessionRegistry;
+  private _logger!: PluginLogger;
+  private _pCfg!: Partial<PluginConfig>;
+  private _getContextWindow!: () => number;
+  private _notifyL2NewNullEntries!: (count: number) => void;
+  private _clearL2Timeout!: () => void;
+  private _l4State!: { pendingResult: any };
+  private _flushL1!: (mgr: OffloadStateManager, triggerSource: string, fireAndForget?: boolean, maxCount?: number) => Promise<void>;
+  private _backendClient!: BackendClient | null;
+  private _judgeL15!: (mgr: OffloadStateManager, event: any, ctx: any) => Promise<void>;
+  private _disposeL15!: () => void;
 
   constructor(opts: any) {
     this.update(opts);

--- a/src/offload/local-llm/llm-caller.ts
+++ b/src/offload/local-llm/llm-caller.ts
@@ -60,10 +60,10 @@ export async function callLlm(
     config.disableThinking ? createNoThinkFetch(config.disableThinking) : undefined
   );
 
+  // `provider.chat()` below targets /chat/completions (not the Responses API).
   const provider = createOpenAI({
     baseURL: config.baseUrl,
     apiKey: config.apiKey,
-    compatibility: "compatible",
     ...(customFetch ? { fetch: customFetch } : {}),
   });
 

--- a/src/offload/local-llm/parsers/l1-parser.ts
+++ b/src/offload/local-llm/parsers/l1-parser.ts
@@ -34,6 +34,9 @@ export function parseL1Response(raw: string): OffloadEntry[] {
       timestamp: item.timestamp ?? "",
       score: typeof item.score === "number" ? item.score : 5,
       node_id: null,
+      // Backfilled by the offload writer once the raw result is persisted
+      // (see src/offload/index.ts — refByToolCallId lookup).
+      result_ref: "",
     });
   }
 

--- a/src/offload/session-registry.ts
+++ b/src/offload/session-registry.ts
@@ -30,8 +30,8 @@ const MAX_CACHED_SESSIONS = 20;
 export class SessionRegistry {
   private _sessions = new Map<string, SessionCtx>();
   private _dataRoot: string;
-  readonly _registryId = ++SessionRegistry._registryCounter;
   private static _registryCounter = 0;
+  readonly _registryId = ++SessionRegistry._registryCounter;
 
   constructor(dataRoot: string) {
     this._dataRoot = dataRoot;

--- a/src/offload/state-manager.ts
+++ b/src/offload/state-manager.ts
@@ -53,8 +53,8 @@ export class OffloadStateManager {
    *  L2 must wait for this to be true before triggering. */
   l15Settled = false;
   /** Unique instance ID for debugging (each new OffloadStateManager gets a new id). */
-  readonly _instanceId = ++OffloadStateManager._instanceCounter;
   private static _instanceCounter = 0;
+  readonly _instanceId = ++OffloadStateManager._instanceCounter;
 
   /** Set of toolCallIds confirmed offloaded in previous rounds. */
   confirmedOffloadIds = new Set<string>();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "bin/**/*.ts", "types/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "scripts"]
+}

--- a/types/peers.d.ts
+++ b/types/peers.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Ambient declarations for peerDependencies that are not installed in this
+ * repo's dev environment.
+ *
+ * `openclaw` and `node-llama-cpp` are declared in package.json under
+ * `peerDependencies` — the consuming host installs them, and tsdown marks both
+ * as external so they are never bundled. Without these stubs `tsc` reports
+ * TS2307 for every import of them, which would drown out real findings.
+ *
+ * These are deliberately untyped (`any`). If a peer is ever added as a real
+ * devDependency, delete the matching block so the package's own types win —
+ * an ambient declaration here would otherwise shadow them silently.
+ */
+
+// The only thing this repo imports from the OpenClaw SDK is the plugin API
+// type. Widening it to `any` keeps the OpenClaw adapter checkable against the
+// rest of the codebase without vendoring the SDK's type surface.
+declare module "openclaw/plugin-sdk/core" {
+  /**
+   * Structural stand-in for the real plugin API.
+   *
+   * The index signature keeps every property accessible as `any`, while the
+   * two explicit members give hook and CLI callbacks a contextual type — a
+   * bare `any` would make each of their parameters an implicit-any error.
+   */
+  export type OpenClawPluginApi = {
+    [key: string]: any;
+    on(event: string, handler: (...args: any[]) => any): any;
+    registerCli(register: (ctx: any) => any, options?: any): any;
+  };
+}
+
+// Imported dynamically in src/core/store/embedding.ts and immediately cast,
+// so a shorthand ambient module is sufficient here.
+declare module "node-llama-cpp";


### PR DESCRIPTION
主源码树此前从不做类型检查，本 PR 补上，并修掉它暴露出来的存量错误。

与 #591 无依赖关系，两边独立、任意顺序合并均可（已实测：各自在 main 上 `npm run build` 通过，合并到一起 typecheck 0 错误、111 测试通过、`package.json` 自动合并无冲突）。

## 为什么之前没发现

`tsdown` 走 rolldown 构建，只剥类型不做校验；仓库根目录没有 tsconfig，只有 `scripts/` 下三个辅助脚本各自带配置。所以主源码树的类型错误一直不会让任何命令失败。

加根 tsconfig 后暴露 19 个错误，全部为存量问题，非回归。

## 两个 commit

1. `build:` 加 `tsconfig.json`、`types/peers.d.ts`、`typecheck` script
2. `fix:` 修掉 19 个错误，并把 `typecheck` 接进 `build`

拆成两个是为了每个 commit 都能 `npm run build` 通过：第一个只提供工具不设门禁，第二个修完再上门禁。

## 其中 4 个是真缺陷，不只是类型噪音

- **`auto-recall`** — `searchL1Hybrid` 在 `IMemoryStore` 上是可选方法，但调用处只判断了另一个能力位 `nativeHybridSearch`。声明了能力却没实现该方法的 store 会直接崩。改为判断方法本身是否存在。
- **`l1-parser`** — 漏了 `OffloadEntry` 的必填字段 `result_ref`。确认过 `src/offload/index.ts` 的 `refByToolCallId` 会回填它，所以 `""` 是正确默认值，与该处其他字段一致。
- **`benchmark-token-estimate`** — import 路径解析到 `src/src/offload/`，且用了 `.ts` 后缀。就是坏的。
- **`compatibility: "compatible"`** ×2 — `@ai-sdk/openai` v3 已从 `OpenAIProviderSettings` 移除该选项。两处调用都已经用 `provider.chat()`，正是该选项原本的作用，因此移除是行为中性的。

## 其余是编译器保守判断，从源头改而非抑制

- `session-registry` / `state-manager`：实例字段初始化引用了写在其下方的静态字段。运行时安全（静态字段在类定义时初始化），调整声明顺序即可，比加 `!` 更清楚。
- `offload/index`：11 个字段经构造函数调用 `update()` 赋值，TypeScript 看不穿这层间接，用明确赋值断言。

## 关于 tsconfig 严格度

最初开了 `noUncheckedIndexedAccess`，报出 263 个错误——其中 218 个来自这一个开关。那是给仓库引入一套新标准，应当单独讨论、单独治理，不该夹带在这里。所以退回普通 `strict`，即代码本来就在遵循的标准，实际错误数 19。

`openclaw` 和 `node-llama-cpp` 是 peerDependencies，开发环境不安装，导致所有 import 报未解析。用 `types/peers.d.ts` 声明为外部模块；OpenClaw 那个用结构化声明而非裸 `any`，以保住 hook 与 CLI 回调的上下文类型。注释里写明了：将来若把 peer 装成真 devDependency，要删掉对应声明，否则会静默遮蔽真类型。
