### PR TITLE
docs: add CodeBuddy integration guide and version restrictions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,6 +146,9 @@ claude --model <whatever PROXY_UPSTREAM_MODEL is set to>
 - `--model` uses the upstream model name you configured in
   `PROXY_UPSTREAM_MODEL` (proxy forwards to `PROXY_UPSTREAM_URL`)
 
+> 💡 **You can also use CodeBuddy with the Proxy** — see the
+> [Using Proxy with CodeBuddy](#using-proxy-with-codebuddy) section below.
+
 ### Step 4: First CC turn — pick Team → Agent → Task
 
 **Every new CC session**, the proxy uses CC's native `AskUserQuestion`
@@ -273,6 +276,51 @@ knowledge blended into the system prompt) → forward to the upstream LLM.
 
 Disable the full pipeline (passthrough only): `PROXY_FULL_STACK=0 ./start-proxy.sh`.
 
+## Using Proxy with CodeBuddy
+
+[CodeBuddy](https://www.codebuddy.ai/) is Tencent's AI coding assistant IDE plugin. By configuring a custom model, you can route CodeBuddy's chat requests through the Proxy to get the same memory capabilities as Claude Code, directly within your IDE.
+
+### Configuration
+
+Create or edit `~/.codebuddy/models.json` on your development machine (replace the API key):
+
+```json
+{
+  "models": [
+    {
+      "id": "claude-sonnet-4-20250514",
+      "name": "proxy-memory-agent",
+      "vendor": "claude",
+      "apiKey": "<business user's sk-mem-... user_key>",
+      "maxInputTokens": 200000,
+      "url": "http://127.0.0.1:8096/codebuddy/default",
+      "supportsToolCall": true,
+      "supportsImages": true
+    }
+  ]
+}
+```
+
+- `id`: a model ID supported by the Proxy's upstream LLM (must match `PROXY_UPSTREAM_MODEL`
+  or one of the models in the upstream configuration, e.g. `claude-sonnet-4-20250514`)
+- `name`: display name shown in the CodeBuddy chat panel (can be customized freely, e.g. `proxy-memory-agent`)
+- `vendor`: model provider label, used only for UI display (e.g. `claude`, `openai`) — does not affect actual requests
+- `apiKey`: the **business user's** `user_key` (same one used as
+  `ANTHROPIC_AUTH_TOKEN` for Claude Code; do not use the admin key)
+- `url`: Proxy address + `/codebuddy/default` path (same port as Claude Code,
+  default `8096`); `default` is the memory instance ID
+
+Once configured, select the model name in CodeBuddy's chat panel and start chatting.
+The session init flow is the same as Claude Code (pick Team → Agent → Task).
+
+### ⚠️ Version Restrictions
+
+> CodeBuddy versions **4.10.2, 4.10.3, and 4.10.4** have a known bug: these
+> versions do not send a `sessionId` in requests, preventing the Proxy from
+> completing session initialization.
+>
+> **Use CodeBuddy ≥ 4.10.5 or ≤ 4.10.1.**
+
 ## Stop / cleanup
 
 ```bash
@@ -282,7 +330,7 @@ Disable the full pipeline (passthrough only): `PROXY_FULL_STACK=0 ./start-proxy.
 
 ## More
 
-Additional installation modes (OpenClaw, Hermes, SDK, running from source,
+Additional installation modes (OpenClaw, Hermes, CodeBuddy, SDK, running from source,
 K8s, platform notes) — see
 [`deploy/global-images/README.md`](./deploy/global-images/README.md) and
 [`MemoryCore/README.md`](./MemoryCore/README.md).

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -134,6 +134,9 @@ claude --model <PROXY_UPSTREAM_MODEL 里配的上游模型>
 - `--model` 用你在 `.env` 里 `PROXY_UPSTREAM_MODEL` 配的那个上游模型名
   （proxy 会把请求转发到 `PROXY_UPSTREAM_URL`）
 
+> 💡 **也可以用 CodeBuddy 走 Proxy**——配置方式见下方
+> [通过 Proxy 使用 CodeBuddy](#通过-proxy-使用-codebuddy) 章节。
+
 ### 第 4 步：CC 首次会话，选 Team → Agent → Task
 
 **每开一个新的 CC 会话**，proxy 会用 CC 自带的 `AskUserQuestion` 工具
@@ -254,6 +257,50 @@ Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/age
 
 关掉完整流水线（只做透传）：`PROXY_FULL_STACK=0 ./start-proxy.sh`。
 
+## 通过 Proxy 使用 CodeBuddy
+
+[CodeBuddy](https://www.codebuddy.ai/) 是腾讯推出的 AI 编程助手 IDE 插件。通过自定义模型配置，你可以把 CodeBuddy 的对话请求路由到 Proxy，在 IDE 内获得与 Claude Code 相同的记忆能力。
+
+### 配置
+
+在开发机的 `~/.codebuddy/models.json` 文件中写入以下内容（注意替换 API Key）：
+
+```json
+{
+  "models": [
+    {
+      "id": "claude-sonnet-4-20250514",
+      "name": "proxy-memory-agent",
+      "vendor": "claude",
+      "apiKey": "<业务用户的 sk-mem-... user_key>",
+      "maxInputTokens": 200000,
+      "url": "http://127.0.0.1:8096/codebuddy/default",
+      "supportsToolCall": true,
+      "supportsImages": true
+    }
+  ]
+}
+```
+
+- `id`：Proxy 上游 LLM 支持的模型 ID（必须与 Proxy 配置的 `PROXY_UPSTREAM_MODEL`
+  或 upstream 模型列表中的某个模型匹配，如 `claude-sonnet-4-20250514`）
+- `name`：在 CodeBuddy 对话框中显示的名称，可自定义（如 `proxy-memory-agent`）
+- `vendor`：模型供应商标识，仅用于 UI 展示（如 `claude`、`openai`），不影响实际请求
+- `apiKey`：使用**业务用户**的 `user_key`（与 Claude Code 的
+  `ANTHROPIC_AUTH_TOKEN` 相同；不要用 admin key）
+- `url`：Proxy 地址 + `/codebuddy/default` 路径（端口与 Claude Code 一致，
+  默认 `8096`）；`default` 是 memory 实例 ID
+
+配置完成后，在 CodeBuddy 对话框中选择刚才配置的模型名称即可开始对话。
+Session init 流程与 Claude Code 一致（选 Team → Agent → Task）。
+
+### ⚠️ 版本限制
+
+> CodeBuddy **4.10.2、4.10.3、4.10.4** 存在已知 Bug：这些版本不会在请求中
+> 携带 `sessionId`，导致 Proxy 无法完成 Session 初始化。
+>
+> **请使用 CodeBuddy ≥ 4.10.5 或 ≤ 4.10.1。**
+
 ## 停止 / 清理
 
 ```bash
@@ -263,6 +310,6 @@ Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/age
 
 ## 更多
 
-其它安装形态（OpenClaw、Hermes、SDK、源码启动、K8s、平台说明），参见
+其它安装形态（OpenClaw、Hermes、CodeBuddy、SDK、源码启动、K8s、平台说明），参见
 [`deploy/global-images/README.md`](./deploy/global-images/README.md) 与
 [`MemoryCore/README_CN.md`](./MemoryCore/README_CN.md)。

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $EDITOR .env       # Fill in two sets of LLM parameters (memory group + proxy gr
 
 Open the panel: [http://localhost:8125](http://localhost:8125).
 
-Complete installation documentation (standalone Memory Hub deployment, Proxy + Claude Code usage, stop and cleanup, port reference, etc.) is available in [**INSTALL.md**](./INSTALL.md) (中文: [INSTALL_CN.md](./INSTALL_CN.md)).
+Complete installation documentation (standalone Memory Hub deployment, Proxy + Claude Code / CodeBuddy usage, stop and cleanup, port reference, etc.) is available in [**INSTALL.md**](./INSTALL.md) (中文: [INSTALL_CN.md](./INSTALL_CN.md)).
 
 ### Migrating data from an older version
 
@@ -255,7 +255,7 @@ PersonaMem tests whether an Agent can correctly understand and apply user inform
 - Wiki and CodeGraph are built asynchronously; allow some processing time before they reach `ready` status.
 - CodeGraph currently prioritizes public HTTPS repositories; support for private repositories and SSH credentials is still being refined.
 - The Hub supports manual asset binding; fully automated memory routing is still under iteration.
-- TencentDB Agent Memory currently supports OpenClaw, Hermes, and SDK integration; broader cross-framework migration is on the roadmap.
+- TencentDB Agent Memory currently supports OpenClaw, Hermes, Claude Code, CodeBuddy, and SDK integration; broader cross-framework migration is on the roadmap.
 
 ## Related Documentation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,7 +43,7 @@ $EDITOR .env       # 填入两组 LLM 参数（memory 组 + proxy 组）
 
 打开 Panel：[http://localhost:8125](http://localhost:8125)。
 
-完整安装文档（Memory Hub 单独部署 / Proxy + Claude Code 用法 / 停止清理 / 端口
+完整安装文档（Memory Hub 单独部署 / Proxy + Claude Code / CodeBuddy 用法 / 停止清理 / 端口
 说明等）见 [**INSTALL_CN.md**](./INSTALL_CN.md)（English: [INSTALL.md](./INSTALL.md)）。
 
 ### 从旧版本迁移数据
@@ -257,7 +257,7 @@ PersonaMem 检验 Agent 能否在长期交互后正确理解和运用用户信�
 - Wiki 和 CodeGraph 异步构建，需要等待一定时间处理才能 `ready`。
 - CodeGraph 当前首先支持公开 HTTPS 仓库；私有仓库和 SSH 凭证接入仍在完善。
 - Hub 已支持人工绑定资产；全自动记忆路由仍在迭代。
-- 当前提供 OpenClaw、Hermes 和 SDK 接入；更广泛的跨框架迁移仍在 Roadmap 中。
+- 当前提供 OpenClaw、Hermes、Claude Code、CodeBuddy 和 SDK 接入；更广泛的跨框架迁移仍在 Roadmap 中。
 
 ## 相关文档
 


### PR DESCRIPTION
## What

Add CodeBuddy setup docs alongside the existing Claude Code section. Pure documentation change — the Proxy already supports CodeBuddy via the `/codebuddy/<spaceId>/v1/...` route (see `MemoryProxy/src/server.ts`, `MemoryProxy/src/session/codebuddy/init.ts`, `MemoryProxy/src/injection/agents/codebuddy/profile.ts`); this PR just documents how to point CodeBuddy at it.

## Changes

- **`INSTALL.md` / `INSTALL_CN.md`**: new **Using Proxy with CodeBuddy** section — `~/.codebuddy/models.json` sample with field-by-field explanation (`id`, `name`, `vendor`, `apiKey`, `url`), plus a version-restriction warning for the known `sessionId`-missing bug in CodeBuddy `4.10.2` / `4.10.3` / `4.10.4` (use `≥ 4.10.5` or `≤ 4.10.1`).
- **`INSTALL.md` / `INSTALL_CN.md`**: cross-link from the Claude Code section to the new CodeBuddy section, and mention CodeBuddy in the "More" tail.
- **`README.md` / `README_CN.md`**: mention CodeBuddy in the install-doc pointer and the supported-integration list.

## Scope

Docs only. No code, no config, no scripts touched.

```
 INSTALL.md    | 50 +++++++++++++++++++++++++++++++++++++++++++++++++-
 INSTALL_CN.md | 49 ++++++++++++++++++++++++++++++++++++++++++++++++-
 README.md     |  4 ++--
 README_CN.md  |  4 ++--
```