### PR TITLE
fix(checkpoint): keep aggregate counters consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### 🐛 修复
+
+- **Checkpoint 聚合计数在清理后漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：启动时及 `memory-cleaner` 成功删除 L0/L1 Store 记录后，按 Store 中现存记录重新校准 `l0_conversations_count`、`total_memories_extracted` 与 `memories_since_last_persona`。`total_processed` 保持历史累计语义，不会因清理而回退。校准不会修改任何 session 的 L0/L1 增量游标或 pipeline 状态；Store 不可读取时保留原 checkpoint 并跳过本次修复。
+
 ### ✨ 新功能
 
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 修复
 
-- **Checkpoint 聚合计数在清理后漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：`memory-cleaner` 成功删除 L0/L1 Store 记录后，按 Store 中现存记录重新校准 `l0_conversations_count`、`total_memories_extracted` 与 `memories_since_last_persona`。`total_processed` 保持历史累计语义，不会因清理而回退。
+- **Checkpoint 聚合计数在清理后漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：启动、L1 完成和 `memory-cleaner` 运行后，按 Store 中当前可检索记录校准 `l0_conversations_count`、`total_memories_extracted` 与 `memories_since_last_persona`。`total_processed` 保持历史累计语义，不会因清理而回退。
 
 ### ✨ 新功能
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 修复
 
-- **Checkpoint 聚合计数在清理后漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：启动时及 `memory-cleaner` 成功删除 L0/L1 Store 记录后，按 Store 中现存记录重新校准 `l0_conversations_count`、`total_memories_extracted` 与 `memories_since_last_persona`。`total_processed` 保持历史累计语义，不会因清理而回退。校准不会修改任何 session 的 L0/L1 增量游标或 pipeline 状态；Store 不可读取时保留原 checkpoint 并跳过本次修复。
+- **Checkpoint 聚合计数在清理后漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：`memory-cleaner` 成功删除 L0/L1 Store 记录后，按 Store 中现存记录重新校准 `l0_conversations_count`、`total_memories_extracted` 与 `memories_since_last_persona`。`total_processed` 保持历史累计语义，不会因清理而回退。
 
 ### ✨ 新功能
 

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -47,10 +47,7 @@ import {
   createL3Runner,
 } from "../utils/pipeline-factory.js";
 import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
-import {
-  CheckpointManager,
-  reconcileCheckpointFromStore,
-} from "../utils/checkpoint.js";
+import { CheckpointManager } from "../utils/checkpoint.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
 
@@ -412,30 +409,10 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
-      await this.reconcileCheckpointCounters();
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  }
-
-  /** Best-effort startup repair for aggregate counters drifted by cleanup. */
-  private async reconcileCheckpointCounters(): Promise<void> {
-    const store = this.vectorStore;
-    if (!store || store.isDegraded()) return;
-
-    try {
-      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
-      await reconcileCheckpointFromStore(checkpoint, store);
-      this.logger.debug?.(`${TAG} Checkpoint aggregate counters reconciled from Store`);
-    } catch (err) {
-      // Store initialization and normal startup must remain available even when
-      // counter repair cannot obtain a reliable snapshot.
-      this.logger.warn(
-        `${TAG} Checkpoint counter reconciliation skipped: ` +
-        `${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -47,7 +47,10 @@ import {
   createL3Runner,
 } from "../utils/pipeline-factory.js";
 import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
-import { CheckpointManager } from "../utils/checkpoint.js";
+import {
+  CheckpointManager,
+  reconcileCheckpointFromStore,
+} from "../utils/checkpoint.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
 
@@ -409,10 +412,30 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      await this.reconcileCheckpointCounters();
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(
         `${TAG} Store init failed; recall/dedup degraded: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Best-effort startup repair for aggregate counters drifted by cleanup. */
+  private async reconcileCheckpointCounters(): Promise<void> {
+    const store = this.vectorStore;
+    if (!store || store.isDegraded()) return;
+
+    try {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await reconcileCheckpointFromStore(checkpoint, store);
+      this.logger.debug?.(`${TAG} Checkpoint aggregate counters reconciled from Store`);
+    } catch (err) {
+      // Store initialization and normal startup must remain available even when
+      // counter repair cannot obtain a reliable snapshot.
+      this.logger.warn(
+        `${TAG} Checkpoint counter reconciliation skipped: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -409,6 +409,16 @@ export class TdaiCore {
       const stores = await initStores(this.cfg, this.dataDir, this.logger);
       this.vectorStore = stores.vectorStore;
       this.embeddingService = stores.embeddingService;
+      if (this.vectorStore) {
+        try {
+          await new CheckpointManager(this.dataDir, this.logger)
+            .reconcileCountersFromStore(this.vectorStore);
+        } catch (err) {
+          this.logger.warn(
+            `${TAG} Checkpoint counter reconciliation failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
       this.logger.debug?.(`${TAG} Stores initialized: backend=${this.cfg.storeBackend}, embedding=${this.cfg.embedding.provider}`);
     } catch (err) {
       this.logger.warn(

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   CheckpointManager,
-  reconcileCheckpointFromStore,
 } from "./checkpoint.js";
 import { LocalMemoryCleaner } from "./memory-cleaner.js";
 import type { IMemoryStore } from "../core/store/types.js";
@@ -57,7 +56,7 @@ describe("Checkpoint counter reconciliation", () => {
       ],
     };
 
-    await reconcileCheckpointFromStore(manager, store);
+    await manager.reconcileCountersFromStore(store);
 
     expect(await manager.read()).toMatchObject({
       total_processed: 100,
@@ -78,8 +77,30 @@ describe("Checkpoint counter reconciliation", () => {
       queryL1Records: () => [],
     };
 
-    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow("database unavailable");
+    await expect(manager.reconcileCountersFromStore(store)).rejects.toThrow("database unavailable");
     expect(await manager.read()).toEqual(before);
+  });
+
+  it("does not double-count concurrent reconciliation and L1 completion", async () => {
+    const manager = await createCheckpointManager();
+    const initial = await manager.read();
+    await manager.write({ ...initial, total_memories_extracted: 20 });
+    const store = {
+      countL0: () => 8,
+      countL1: () => 21,
+      queryL1Records: () => [{ updated_time: "2026-07-22T00:00:00.000Z" }],
+    };
+
+    await Promise.all([
+      manager.reconcileCountersFromStore(store),
+      manager.markL1ExtractionComplete("session-a", 1, 1000, undefined, store),
+    ]);
+
+    expect(await manager.read()).toMatchObject({
+      l0_conversations_count: 8,
+      total_memories_extracted: 21,
+      memories_since_last_persona: 21,
+    });
   });
 
   it("reconciles counters after Cleaner deletes Store records", async () => {
@@ -123,13 +144,12 @@ describe("Checkpoint counter reconciliation", () => {
     });
   });
 
-  it("does not change counters when Cleaner deletes no records", async () => {
+  it("repairs existing drift even when Cleaner deletes no records", async () => {
     const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
     tempDirs.push(dataDir);
     const manager = new CheckpointManager(dataDir);
     const initial = await manager.read();
-    await manager.write({ ...initial, l0_conversations_count: 50, total_memories_extracted: 20 });
-    const before = await manager.read();
+    await manager.write({ ...initial, l0_conversations_count: 90, total_memories_extracted: 70 });
     const store = {
       isDegraded: () => false,
       countL0: () => 50,
@@ -147,6 +167,10 @@ describe("Checkpoint counter reconciliation", () => {
 
     await cleaner.runOnce(new Date("2026-07-24T12:00:00.000Z").getTime());
 
-    expect(await manager.read()).toEqual(before);
+    expect(await manager.read()).toMatchObject({
+      l0_conversations_count: 50,
+      total_memories_extracted: 20,
+      memories_since_last_persona: 20,
+    });
   });
 });

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,394 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CheckpointManager,
+  reconcileCheckpointFromStore,
+} from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const tempDirs: string[] = [];
+
+async function createCheckpointManager(): Promise<CheckpointManager> {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dataDir);
+  return new CheckpointManager(dataDir);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager counter reconciliation", () => {
+  it("uses the cold-start timestamp once, then reuses the saved cursor", async () => {
+    const manager = await createCheckpointManager();
+
+    let firstCursor: number | undefined;
+    await manager.captureAtomically("practice-session", 100, async (cursor) => {
+      firstCursor = cursor;
+      return { maxTimestamp: 250, messageCount: 1 };
+    });
+
+    let secondCursor: number | undefined;
+    await manager.captureAtomically("practice-session", 100, async (cursor) => {
+      secondCursor = cursor;
+      return null;
+    });
+
+    expect(firstCursor).toBe(100);
+    expect(secondCursor).toBe(250);
+  });
+
+  it("increments L1 counters and saves the L1 cursor", async () => {
+    const manager = await createCheckpointManager();
+
+    await manager.markL1ExtractionComplete("practice-session", 3, 250);
+
+    expect(await manager.read()).toMatchObject({
+      total_memories_extracted: 3,
+      memories_since_last_persona: 3,
+      runner_states: {
+        "practice-session": { last_l1_cursor: 250 },
+      },
+    });
+  });
+
+
+  it("counts every message in a captured L0 batch", async () => {
+    const manager = await createCheckpointManager();
+
+    await manager.captureAtomically("session-a", undefined, async () => ({
+      maxTimestamp: 1000,
+      messageCount: 2,
+    }));
+
+    expect(await manager.read()).toMatchObject({
+      total_processed: 2,
+      l0_conversations_count: 2,
+      runner_states: {
+        "session-a": { last_captured_timestamp: 1000 },
+      },
+    });
+  });
+
+  it("repairs drifted aggregates without rewriting processing cursors", async () => {
+    const manager = await createCheckpointManager();
+    const initial = await manager.read();
+
+    await manager.write({
+      ...initial,
+      total_processed: 100,
+      l0_conversations_count: 40,
+      total_memories_extracted: 80,
+      memories_since_last_persona: 30,
+      runner_states: {
+        "session-a": {
+          last_captured_timestamp: 1000,
+          last_l1_cursor: 900,
+          last_scene_name: "project",
+        },
+      },
+      pipeline_states: {
+        "session-a": {
+          conversation_count: 3,
+          last_extraction_time: "2026-07-24T00:00:00.000Z",
+          last_extraction_updated_time: "2026-07-24T00:00:00.000Z",
+          last_active_time: 1000,
+          l2_pending_l1_count: 2,
+          warmup_threshold: 4,
+          l2_last_extraction_time: "2026-07-24T00:00:00.000Z",
+        },
+      },
+    });
+
+    await manager.reconcileCounters({
+      l0Conversations: 3,
+      totalMemoriesExtracted: 4,
+      memoriesSinceLastPersona: 1,
+    });
+
+    const repaired = await manager.read();
+    expect(repaired).toMatchObject({
+      total_processed: 100,
+      l0_conversations_count: 3,
+      total_memories_extracted: 4,
+      memories_since_last_persona: 1,
+      runner_states: {
+        "session-a": {
+          last_captured_timestamp: 1000,
+          last_l1_cursor: 900,
+          last_scene_name: "project",
+        },
+      },
+      pipeline_states: {
+        "session-a": {
+          conversation_count: 3,
+          warmup_threshold: 4,
+        },
+      },
+    });
+  });
+
+  it("rebuilds aggregate counters from durable store records", async () => {
+    const manager = await createCheckpointManager();
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      total_processed: 100,
+      l0_conversations_count: 40,
+      total_memories_extracted: 80,
+      memories_since_last_persona: 30,
+      last_persona_time: "2026-07-20T00:00:00.000Z",
+    });
+    const requestedFilters: Array<{ updatedAfter?: string } | undefined> = [];
+    const store = {
+      countL0: () => 6,
+      countL1: () => 4,
+      queryL1Records: (filter?: { updatedAfter?: string }) => {
+        requestedFilters.push(filter);
+        return [
+          { updated_time: "2026-07-21T00:00:00.000Z" },
+          { updated_time: "2026-07-22T00:00:00.000Z" },
+        ];
+      },
+    };
+
+    await reconcileCheckpointFromStore(manager, store);
+
+    expect(requestedFilters).toEqual([
+      { updatedAfter: "2026-07-20T00:00:00.000Z" },
+    ]);
+    expect(await manager.read()).toMatchObject({
+      total_processed: 100,
+      l0_conversations_count: 6,
+      total_memories_extracted: 4,
+      memories_since_last_persona: 2,
+    });
+  });
+
+  it("uses all active L1 records as the Persona baseline when none exists", async () => {
+    const manager = await createCheckpointManager();
+    let queriedL1Records = false;
+    const store = {
+      countL0: () => 3,
+      countL1: () => 2,
+      queryL1Records: () => {
+        queriedL1Records = true;
+        return [];
+      },
+    };
+
+    await reconcileCheckpointFromStore(manager, store);
+
+    expect(queriedL1Records).toBe(false);
+    expect(await manager.read()).toMatchObject({
+      total_processed: 0,
+      l0_conversations_count: 3,
+      total_memories_extracted: 2,
+      memories_since_last_persona: 2,
+    });
+  });
+
+  it("leaves the checkpoint unchanged when the Store cannot provide a count", async () => {
+    const manager = await createCheckpointManager();
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      total_processed: 9,
+      l0_conversations_count: 9,
+      total_memories_extracted: 5,
+      memories_since_last_persona: 3,
+    });
+    const before = await manager.read();
+    const store = {
+      countL0: () => {
+        throw new Error("database unavailable");
+      },
+      countL1: () => 2,
+      queryL1Records: () => [],
+    };
+
+    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow(
+      "Checkpoint reconciliation countL0() failed: database unavailable",
+    );
+    expect(await manager.read()).toEqual(before);
+  });
+
+  it("skips a degraded Store without clearing counters", async () => {
+    const manager = await createCheckpointManager();
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      l0_conversations_count: 9,
+      total_memories_extracted: 5,
+      memories_since_last_persona: 3,
+    });
+    const before = await manager.read();
+    const store = {
+      isDegraded: () => true,
+      countL0: () => 0,
+      countL1: () => 0,
+      queryL1Records: () => [],
+    };
+
+    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow(
+      "Checkpoint reconciliation skipped: Store is degraded",
+    );
+    expect(await manager.read()).toEqual(before);
+  });
+
+  it("reports the failing Store operation without changing the checkpoint", async () => {
+    const manager = await createCheckpointManager();
+    const store = {
+      countL0: () => 1,
+      countL1: () => 1,
+      queryL1Records: () => {
+        throw new Error("query unavailable");
+      },
+    };
+
+    await manager.markPersonaGenerated(0);
+    const before = await manager.read();
+
+    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow(
+      "Checkpoint reconciliation queryL1Records(updatedAfter=",
+    );
+    expect(await manager.read()).toEqual(before);
+  });
+
+  it("does not overwrite a capture that starts while reconciliation is counting", async () => {
+    const manager = await createCheckpointManager();
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      total_processed: 6,
+      l0_conversations_count: 6,
+      total_memories_extracted: 2,
+      memories_since_last_persona: 2,
+    });
+
+    let signalCountStarted!: () => void;
+    let releaseCount!: () => void;
+    const countStarted = new Promise<void>((resolve) => {
+      signalCountStarted = resolve;
+    });
+    const countReleased = new Promise<void>((resolve) => {
+      releaseCount = resolve;
+    });
+    const store = {
+      countL0: async () => {
+        signalCountStarted();
+        await countReleased;
+        return 6;
+      },
+      countL1: () => 2,
+      queryL1Records: () => [],
+    };
+
+    const reconciliation = reconcileCheckpointFromStore(manager, store);
+    await countStarted;
+
+    let captureCallbackRan = false;
+    const capture = manager.captureAtomically("session-a", undefined, async () => {
+      captureCallbackRan = true;
+      return { maxTimestamp: 1000, messageCount: 1 };
+    });
+
+    await Promise.resolve();
+    expect(captureCallbackRan).toBe(false);
+
+    releaseCount();
+    await Promise.all([reconciliation, capture]);
+
+    expect(await manager.read()).toMatchObject({
+      total_processed: 7,
+      l0_conversations_count: 7,
+      total_memories_extracted: 2,
+    });
+  });
+
+  it("reconciles counters immediately after Cleaner deletes Store records", async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+    tempDirs.push(dataDir);
+    const manager = new CheckpointManager(dataDir);
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      total_processed: 100,
+      l0_conversations_count: 100,
+      total_memories_extracted: 40,
+      memories_since_last_persona: 20,
+      last_persona_time: "2026-07-20T00:00:00.000Z",
+    });
+
+    let l0Count = 52;
+    let l1Count = 22;
+    const store = {
+      isDegraded: () => false,
+      countL0: () => l0Count,
+      countL1: () => l1Count,
+      deleteL0Expired: () => {
+        l0Count -= 2;
+        return 2;
+      },
+      deleteL1Expired: () => {
+        l1Count -= 2;
+        return 2;
+      },
+      queryL1Records: () => [
+        { updated_time: "2026-07-21T00:00:00.000Z" },
+      ],
+    } as unknown as IMemoryStore;
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: store,
+    });
+
+    await cleaner.runOnce(new Date("2026-07-24T12:00:00.000Z").getTime());
+
+    expect(await manager.read()).toMatchObject({
+      total_processed: 100,
+      l0_conversations_count: 50,
+      total_memories_extracted: 20,
+      memories_since_last_persona: 1,
+    });
+  });
+
+  it("does not change counters when Cleaner retains every Store record", async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+    tempDirs.push(dataDir);
+    const manager = new CheckpointManager(dataDir);
+    const initial = await manager.read();
+    await manager.write({
+      ...initial,
+      total_processed: 50,
+      l0_conversations_count: 50,
+      total_memories_extracted: 20,
+      memories_since_last_persona: 7,
+    });
+    const before = await manager.read();
+    const store = {
+      isDegraded: () => false,
+      countL0: () => 50,
+      countL1: () => 20,
+      deleteL0Expired: () => 0,
+      deleteL1Expired: () => 0,
+      queryL1Records: () => [],
+    } as unknown as IMemoryStore;
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      vectorStore: store,
+    });
+
+    await cleaner.runOnce(new Date("2026-07-24T12:00:00.000Z").getTime());
+
+    expect(await manager.read()).toEqual(before);
+  });
+});

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -22,41 +22,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
-describe("CheckpointManager counter reconciliation", () => {
-  it("uses the cold-start timestamp once, then reuses the saved cursor", async () => {
-    const manager = await createCheckpointManager();
-
-    let firstCursor: number | undefined;
-    await manager.captureAtomically("practice-session", 100, async (cursor) => {
-      firstCursor = cursor;
-      return { maxTimestamp: 250, messageCount: 1 };
-    });
-
-    let secondCursor: number | undefined;
-    await manager.captureAtomically("practice-session", 100, async (cursor) => {
-      secondCursor = cursor;
-      return null;
-    });
-
-    expect(firstCursor).toBe(100);
-    expect(secondCursor).toBe(250);
-  });
-
-  it("increments L1 counters and saves the L1 cursor", async () => {
-    const manager = await createCheckpointManager();
-
-    await manager.markL1ExtractionComplete("practice-session", 3, 250);
-
-    expect(await manager.read()).toMatchObject({
-      total_memories_extracted: 3,
-      memories_since_last_persona: 3,
-      runner_states: {
-        "practice-session": { last_l1_cursor: 250 },
-      },
-    });
-  });
-
-
+describe("Checkpoint counter reconciliation", () => {
   it("counts every message in a captured L0 batch", async () => {
     const manager = await createCheckpointManager();
 
@@ -68,71 +34,10 @@ describe("CheckpointManager counter reconciliation", () => {
     expect(await manager.read()).toMatchObject({
       total_processed: 2,
       l0_conversations_count: 2,
-      runner_states: {
-        "session-a": { last_captured_timestamp: 1000 },
-      },
     });
   });
 
-  it("repairs drifted aggregates without rewriting processing cursors", async () => {
-    const manager = await createCheckpointManager();
-    const initial = await manager.read();
-
-    await manager.write({
-      ...initial,
-      total_processed: 100,
-      l0_conversations_count: 40,
-      total_memories_extracted: 80,
-      memories_since_last_persona: 30,
-      runner_states: {
-        "session-a": {
-          last_captured_timestamp: 1000,
-          last_l1_cursor: 900,
-          last_scene_name: "project",
-        },
-      },
-      pipeline_states: {
-        "session-a": {
-          conversation_count: 3,
-          last_extraction_time: "2026-07-24T00:00:00.000Z",
-          last_extraction_updated_time: "2026-07-24T00:00:00.000Z",
-          last_active_time: 1000,
-          l2_pending_l1_count: 2,
-          warmup_threshold: 4,
-          l2_last_extraction_time: "2026-07-24T00:00:00.000Z",
-        },
-      },
-    });
-
-    await manager.reconcileCounters({
-      l0Conversations: 3,
-      totalMemoriesExtracted: 4,
-      memoriesSinceLastPersona: 1,
-    });
-
-    const repaired = await manager.read();
-    expect(repaired).toMatchObject({
-      total_processed: 100,
-      l0_conversations_count: 3,
-      total_memories_extracted: 4,
-      memories_since_last_persona: 1,
-      runner_states: {
-        "session-a": {
-          last_captured_timestamp: 1000,
-          last_l1_cursor: 900,
-          last_scene_name: "project",
-        },
-      },
-      pipeline_states: {
-        "session-a": {
-          conversation_count: 3,
-          warmup_threshold: 4,
-        },
-      },
-    });
-  });
-
-  it("rebuilds aggregate counters from durable store records", async () => {
+  it("rebuilds current counters without decreasing the historical total", async () => {
     const manager = await createCheckpointManager();
     const initial = await manager.read();
     await manager.write({
@@ -143,24 +48,17 @@ describe("CheckpointManager counter reconciliation", () => {
       memories_since_last_persona: 30,
       last_persona_time: "2026-07-20T00:00:00.000Z",
     });
-    const requestedFilters: Array<{ updatedAfter?: string } | undefined> = [];
     const store = {
       countL0: () => 6,
       countL1: () => 4,
-      queryL1Records: (filter?: { updatedAfter?: string }) => {
-        requestedFilters.push(filter);
-        return [
-          { updated_time: "2026-07-21T00:00:00.000Z" },
-          { updated_time: "2026-07-22T00:00:00.000Z" },
-        ];
-      },
+      queryL1Records: () => [
+        { updated_time: "2026-07-21T00:00:00.000Z" },
+        { updated_time: "2026-07-22T00:00:00.000Z" },
+      ],
     };
 
     await reconcileCheckpointFromStore(manager, store);
 
-    expect(requestedFilters).toEqual([
-      { updatedAfter: "2026-07-20T00:00:00.000Z" },
-    ]);
     expect(await manager.read()).toMatchObject({
       total_processed: 100,
       l0_conversations_count: 6,
@@ -169,148 +67,22 @@ describe("CheckpointManager counter reconciliation", () => {
     });
   });
 
-  it("uses all active L1 records as the Persona baseline when none exists", async () => {
-    const manager = await createCheckpointManager();
-    let queriedL1Records = false;
-    const store = {
-      countL0: () => 3,
-      countL1: () => 2,
-      queryL1Records: () => {
-        queriedL1Records = true;
-        return [];
-      },
-    };
-
-    await reconcileCheckpointFromStore(manager, store);
-
-    expect(queriedL1Records).toBe(false);
-    expect(await manager.read()).toMatchObject({
-      total_processed: 0,
-      l0_conversations_count: 3,
-      total_memories_extracted: 2,
-      memories_since_last_persona: 2,
-    });
-  });
-
-  it("leaves the checkpoint unchanged when the Store cannot provide a count", async () => {
+  it("does not overwrite checkpoint counters when Store counting fails", async () => {
     const manager = await createCheckpointManager();
     const initial = await manager.read();
-    await manager.write({
-      ...initial,
-      total_processed: 9,
-      l0_conversations_count: 9,
-      total_memories_extracted: 5,
-      memories_since_last_persona: 3,
-    });
+    await manager.write({ ...initial, l0_conversations_count: 9 });
     const before = await manager.read();
     const store = {
-      countL0: () => {
-        throw new Error("database unavailable");
-      },
+      countL0: () => { throw new Error("database unavailable"); },
       countL1: () => 2,
       queryL1Records: () => [],
     };
 
-    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow(
-      "Checkpoint reconciliation countL0() failed: database unavailable",
-    );
+    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow("database unavailable");
     expect(await manager.read()).toEqual(before);
   });
 
-  it("skips a degraded Store without clearing counters", async () => {
-    const manager = await createCheckpointManager();
-    const initial = await manager.read();
-    await manager.write({
-      ...initial,
-      l0_conversations_count: 9,
-      total_memories_extracted: 5,
-      memories_since_last_persona: 3,
-    });
-    const before = await manager.read();
-    const store = {
-      isDegraded: () => true,
-      countL0: () => 0,
-      countL1: () => 0,
-      queryL1Records: () => [],
-    };
-
-    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow(
-      "Checkpoint reconciliation skipped: Store is degraded",
-    );
-    expect(await manager.read()).toEqual(before);
-  });
-
-  it("reports the failing Store operation without changing the checkpoint", async () => {
-    const manager = await createCheckpointManager();
-    const store = {
-      countL0: () => 1,
-      countL1: () => 1,
-      queryL1Records: () => {
-        throw new Error("query unavailable");
-      },
-    };
-
-    await manager.markPersonaGenerated(0);
-    const before = await manager.read();
-
-    await expect(reconcileCheckpointFromStore(manager, store)).rejects.toThrow(
-      "Checkpoint reconciliation queryL1Records(updatedAfter=",
-    );
-    expect(await manager.read()).toEqual(before);
-  });
-
-  it("does not overwrite a capture that starts while reconciliation is counting", async () => {
-    const manager = await createCheckpointManager();
-    const initial = await manager.read();
-    await manager.write({
-      ...initial,
-      total_processed: 6,
-      l0_conversations_count: 6,
-      total_memories_extracted: 2,
-      memories_since_last_persona: 2,
-    });
-
-    let signalCountStarted!: () => void;
-    let releaseCount!: () => void;
-    const countStarted = new Promise<void>((resolve) => {
-      signalCountStarted = resolve;
-    });
-    const countReleased = new Promise<void>((resolve) => {
-      releaseCount = resolve;
-    });
-    const store = {
-      countL0: async () => {
-        signalCountStarted();
-        await countReleased;
-        return 6;
-      },
-      countL1: () => 2,
-      queryL1Records: () => [],
-    };
-
-    const reconciliation = reconcileCheckpointFromStore(manager, store);
-    await countStarted;
-
-    let captureCallbackRan = false;
-    const capture = manager.captureAtomically("session-a", undefined, async () => {
-      captureCallbackRan = true;
-      return { maxTimestamp: 1000, messageCount: 1 };
-    });
-
-    await Promise.resolve();
-    expect(captureCallbackRan).toBe(false);
-
-    releaseCount();
-    await Promise.all([reconciliation, capture]);
-
-    expect(await manager.read()).toMatchObject({
-      total_processed: 7,
-      l0_conversations_count: 7,
-      total_memories_extracted: 2,
-    });
-  });
-
-  it("reconciles counters immediately after Cleaner deletes Store records", async () => {
+  it("reconciles counters after Cleaner deletes Store records", async () => {
     const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
     tempDirs.push(dataDir);
     const manager = new CheckpointManager(dataDir);
@@ -330,17 +102,9 @@ describe("CheckpointManager counter reconciliation", () => {
       isDegraded: () => false,
       countL0: () => l0Count,
       countL1: () => l1Count,
-      deleteL0Expired: () => {
-        l0Count -= 2;
-        return 2;
-      },
-      deleteL1Expired: () => {
-        l1Count -= 2;
-        return 2;
-      },
-      queryL1Records: () => [
-        { updated_time: "2026-07-21T00:00:00.000Z" },
-      ],
+      deleteL0Expired: () => { l0Count -= 2; return 2; },
+      deleteL1Expired: () => { l1Count -= 2; return 2; },
+      queryL1Records: () => [{ updated_time: "2026-07-21T00:00:00.000Z" }],
     } as unknown as IMemoryStore;
     const cleaner = new LocalMemoryCleaner({
       baseDir: dataDir,
@@ -359,18 +123,12 @@ describe("CheckpointManager counter reconciliation", () => {
     });
   });
 
-  it("does not change counters when Cleaner retains every Store record", async () => {
+  it("does not change counters when Cleaner deletes no records", async () => {
     const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
     tempDirs.push(dataDir);
     const manager = new CheckpointManager(dataDir);
     const initial = await manager.read();
-    await manager.write({
-      ...initial,
-      total_processed: 50,
-      l0_conversations_count: 50,
-      total_memories_extracted: 20,
-      memories_since_last_persona: 7,
-    });
+    await manager.write({ ...initial, l0_conversations_count: 50, total_memories_extracted: 20 });
     const before = await manager.read();
     const store = {
       isDegraded: () => false,

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -122,10 +122,8 @@ export interface CheckpointCounters {
   memoriesSinceLastPersona: number;
 }
 
-/** Minimal Store surface required for startup checkpoint reconciliation. */
+/** Minimal Store surface required to recalculate aggregate counters after cleanup. */
 export interface CheckpointCounterStore {
-  /** When true, count methods may return fault-tolerant empty values. */
-  isDegraded?(): boolean;
   countL0(): number | Promise<number>;
   countL1(): number | Promise<number>;
   /** `updatedAfter` must use a strict `updated_time >` comparison. */
@@ -147,19 +145,6 @@ function applyCounters(checkpoint: Checkpoint, actual: CheckpointCounters): void
   checkpoint.total_memories_extracted = actual.totalMemoriesExtracted;
   checkpoint.memories_since_last_persona = actual.memoriesSinceLastPersona;
 }
-
-async function readStoreValue<T>(operation: string, read: () => T | Promise<T>): Promise<T> {
-  try {
-    return await read();
-  } catch (err) {
-    throw new Error(
-      `Checkpoint reconciliation ${operation} failed: ` +
-      `${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-const RECONCILIATION_LOCK_WARN_MS = 1_000;
 
 const DEFAULT_RUNNER_STATE: RunnerSessionState = {
   last_captured_timestamp: 0,
@@ -348,7 +333,7 @@ export class CheckpointManager {
 
   /**
    * @internal Replace aggregate counters with values already validated against
-   * durable data. Production callers should prefer reconcileCountersFromStore.
+   * durable data. Production callers should prefer reconcileCheckpointFromStore.
    * Per-session timestamps and state remain unchanged because those cursors
    * govern incremental processing rather than status.
    */
@@ -361,45 +346,26 @@ export class CheckpointManager {
   }
 
   /**
-   * Recount aggregate values while holding the checkpoint lock. Store reads are
-   * intentionally inside the critical section: an L0/L1 write that starts
-   * after the count must run after the replacement values are written, rather
-   * than being overwritten by an old snapshot.
+   * Recalculate aggregate counters while holding the checkpoint lock, so a
+   * capture that starts during cleanup cannot be overwritten by a stale count.
    */
   async reconcileCountersFromStore(store: CheckpointCounterStore): Promise<void> {
-    if (store.isDegraded?.()) {
-      throw new Error("Checkpoint reconciliation skipped: Store is degraded");
-    }
+    await this.mutate(async (checkpoint) => {
+      const [l0Conversations, totalMemoriesExtracted] = await Promise.all([
+        store.countL0(),
+        store.countL1(),
+      ]);
+      const memoriesSinceLastPersona = checkpoint.last_persona_time
+        ? (await store.queryL1Records({ updatedAfter: checkpoint.last_persona_time })).length
+        : totalMemoriesExtracted;
 
-    await this.mutate(async (cp) => {
-      const startedAt = Date.now();
-      try {
-        const [l0Conversations, totalMemoriesExtracted] = await Promise.all([
-          readStoreValue("countL0()", () => store.countL0()),
-          readStoreValue("countL1()", () => store.countL1()),
-        ]);
-        const memoriesSinceLastPersona = cp.last_persona_time
-          ? (await readStoreValue(
-            `queryL1Records(updatedAfter=${cp.last_persona_time})`,
-            () => store.queryL1Records({ updatedAfter: cp.last_persona_time }),
-          )).length
-          : totalMemoriesExtracted;
-        const actual = {
-          l0Conversations,
-          totalMemoriesExtracted,
-          memoriesSinceLastPersona,
-        };
-
-        assertValidCounters(actual);
-        applyCounters(cp, actual);
-      } finally {
-        const elapsedMs = Date.now() - startedAt;
-        if (elapsedMs >= RECONCILIATION_LOCK_WARN_MS) {
-          this.logger.warn?.(
-            `[checkpoint] Counter reconciliation held the checkpoint lock for ${elapsedMs}ms`,
-          );
-        }
-      }
+      const actual = {
+        l0Conversations,
+        totalMemoriesExtracted,
+        memoriesSinceLastPersona,
+      };
+      assertValidCounters(actual);
+      applyCounters(checkpoint, actual);
     });
   }
 

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -107,7 +107,7 @@ export interface Checkpoint {
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /** Current active/searchable L1 records (legacy field name). */
   total_memories_extracted: number;
 }
 
@@ -116,13 +116,13 @@ export interface Checkpoint {
  * Per-session cursors are intentionally absent: reconciliation must never
  * rewind incremental L0/L1 processing state.
  */
-export interface CheckpointCounters {
+interface CheckpointCounters {
   l0Conversations: number;
   totalMemoriesExtracted: number;
   memoriesSinceLastPersona: number;
 }
 
-/** Minimal Store surface required to recalculate aggregate counters after cleanup. */
+/** Minimal Store surface required to recalculate active aggregate counters. */
 export interface CheckpointCounterStore {
   countL0(): number | Promise<number>;
   countL1(): number | Promise<number>;
@@ -332,38 +332,13 @@ export class CheckpointManager {
   }
 
   /**
-   * @internal Replace aggregate counters with values already validated against
-   * durable data. Production callers should prefer reconcileCheckpointFromStore.
-   * Per-session timestamps and state remain unchanged because those cursors
-   * govern incremental processing rather than status.
-   */
-  async reconcileCounters(actual: CheckpointCounters): Promise<void> {
-    assertValidCounters(actual);
-
-    await this.mutate((cp) => {
-      applyCounters(cp, actual);
-    });
-  }
-
-  /**
-   * Recalculate aggregate counters while holding the checkpoint lock, so a
-   * capture that starts during cleanup cannot be overwritten by a stale count.
+   * Recalculate active aggregate counters while holding the checkpoint lock.
+   * Store counts are authoritative because update/merge removes superseded
+   * records there while the recovery JSONL remains append-only.
    */
   async reconcileCountersFromStore(store: CheckpointCounterStore): Promise<void> {
     await this.mutate(async (checkpoint) => {
-      const [l0Conversations, totalMemoriesExtracted] = await Promise.all([
-        store.countL0(),
-        store.countL1(),
-      ]);
-      const memoriesSinceLastPersona = checkpoint.last_persona_time
-        ? (await store.queryL1Records({ updatedAfter: checkpoint.last_persona_time })).length
-        : totalMemoriesExtracted;
-
-      const actual = {
-        l0Conversations,
-        totalMemoriesExtracted,
-        memoriesSinceLastPersona,
-      };
+      const actual = await this.readStoreCounters(store, checkpoint.last_persona_time);
       assertValidCounters(actual);
       applyCounters(checkpoint, actual);
     });
@@ -488,8 +463,9 @@ export class CheckpointManager {
     memoriesExtracted: number,
     cursorRecordedAtMs?: number,
     lastSceneName?: string,
+    store?: CheckpointCounterStore,
   ): Promise<void> {
-    await this.mutate((cp) => {
+    await this.mutate(async (cp) => {
       const state = this.getRunnerState(cp, sessionKey);
       if (cursorRecordedAtMs) {
         state.last_l1_cursor = cursorRecordedAtMs;
@@ -497,14 +473,34 @@ export class CheckpointManager {
       if (lastSceneName !== undefined) {
         state.last_scene_name = lastSceneName;
       }
-      cp.total_memories_extracted += memoriesExtracted;
-      cp.memories_since_last_persona += memoriesExtracted;
+      if (store) {
+        const actual = await this.readStoreCounters(store, cp.last_persona_time);
+        assertValidCounters(actual);
+        applyCounters(cp, actual);
+      } else {
+        cp.total_memories_extracted += memoriesExtracted;
+        cp.memories_since_last_persona += memoriesExtracted;
+      }
     });
     this.logger.info(
       `[checkpoint] markL1ExtractionComplete session=${sessionKey}: ` +
       `extracted=${memoriesExtracted}, cursor=${cursorRecordedAtMs ?? "(unchanged)"}, ` +
       `lastScene="${lastSceneName ?? "(unchanged)"}"`,
     );
+  }
+
+  private async readStoreCounters(
+    store: CheckpointCounterStore,
+    lastPersonaTime: string,
+  ): Promise<CheckpointCounters> {
+    const [l0Conversations, totalMemoriesExtracted] = await Promise.all([
+      store.countL0(),
+      store.countL1(),
+    ]);
+    const memoriesSinceLastPersona = lastPersonaTime
+      ? (await store.queryL1Records({ updatedAfter: lastPersonaTime })).length
+      : totalMemoriesExtracted;
+    return { l0Conversations, totalMemoriesExtracted, memoriesSinceLastPersona };
   }
 
   // ============================
@@ -561,16 +557,4 @@ export class CheckpointManager {
     });
   }
 
-}
-
-/**
- * Rebuild aggregate counters from the durable Store without touching any
- * per-session cursor. `l0_conversations_count` is normalized to persisted L0
- * message records so it has the same cross-backend meaning as `countL0()`.
- */
-export async function reconcileCheckpointFromStore(
-  manager: CheckpointManager,
-  store: CheckpointCounterStore,
-): Promise<void> {
-  await manager.reconcileCountersFromStore(store);
 }

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -100,13 +100,66 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /**
+   * Legacy field name kept for on-disk checkpoint compatibility.
+   * Counts persisted L0 message records (the same unit as Store.countL0()).
+   */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
   /** Total L1 memories extracted across all time */
   total_memories_extracted: number;
 }
+
+/**
+ * Authoritative aggregate values used to repair checkpoint counter drift.
+ * Per-session cursors are intentionally absent: reconciliation must never
+ * rewind incremental L0/L1 processing state.
+ */
+export interface CheckpointCounters {
+  l0Conversations: number;
+  totalMemoriesExtracted: number;
+  memoriesSinceLastPersona: number;
+}
+
+/** Minimal Store surface required for startup checkpoint reconciliation. */
+export interface CheckpointCounterStore {
+  /** When true, count methods may return fault-tolerant empty values. */
+  isDegraded?(): boolean;
+  countL0(): number | Promise<number>;
+  countL1(): number | Promise<number>;
+  /** `updatedAfter` must use a strict `updated_time >` comparison. */
+  queryL1Records(filter?: { updatedAfter?: string }):
+    | Array<{ updated_time: string }>
+    | Promise<Array<{ updated_time: string }>>;
+}
+
+function assertValidCounters(actual: CheckpointCounters): void {
+  for (const [name, value] of Object.entries(actual)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`Checkpoint counter ${name} must be a non-negative safe integer`);
+    }
+  }
+}
+
+function applyCounters(checkpoint: Checkpoint, actual: CheckpointCounters): void {
+  checkpoint.l0_conversations_count = actual.l0Conversations;
+  checkpoint.total_memories_extracted = actual.totalMemoriesExtracted;
+  checkpoint.memories_since_last_persona = actual.memoriesSinceLastPersona;
+}
+
+async function readStoreValue<T>(operation: string, read: () => T | Promise<T>): Promise<T> {
+  try {
+    return await read();
+  } catch (err) {
+    throw new Error(
+      `Checkpoint reconciliation ${operation} failed: ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+const RECONCILIATION_LOCK_WARN_MS = 1_000;
 
 const DEFAULT_RUNNER_STATE: RunnerSessionState = {
   last_captured_timestamp: 0,
@@ -293,6 +346,63 @@ export class CheckpointManager {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
   }
 
+  /**
+   * @internal Replace aggregate counters with values already validated against
+   * durable data. Production callers should prefer reconcileCountersFromStore.
+   * Per-session timestamps and state remain unchanged because those cursors
+   * govern incremental processing rather than status.
+   */
+  async reconcileCounters(actual: CheckpointCounters): Promise<void> {
+    assertValidCounters(actual);
+
+    await this.mutate((cp) => {
+      applyCounters(cp, actual);
+    });
+  }
+
+  /**
+   * Recount aggregate values while holding the checkpoint lock. Store reads are
+   * intentionally inside the critical section: an L0/L1 write that starts
+   * after the count must run after the replacement values are written, rather
+   * than being overwritten by an old snapshot.
+   */
+  async reconcileCountersFromStore(store: CheckpointCounterStore): Promise<void> {
+    if (store.isDegraded?.()) {
+      throw new Error("Checkpoint reconciliation skipped: Store is degraded");
+    }
+
+    await this.mutate(async (cp) => {
+      const startedAt = Date.now();
+      try {
+        const [l0Conversations, totalMemoriesExtracted] = await Promise.all([
+          readStoreValue("countL0()", () => store.countL0()),
+          readStoreValue("countL1()", () => store.countL1()),
+        ]);
+        const memoriesSinceLastPersona = cp.last_persona_time
+          ? (await readStoreValue(
+            `queryL1Records(updatedAfter=${cp.last_persona_time})`,
+            () => store.queryL1Records({ updatedAfter: cp.last_persona_time }),
+          )).length
+          : totalMemoriesExtracted;
+        const actual = {
+          l0Conversations,
+          totalMemoriesExtracted,
+          memoriesSinceLastPersona,
+        };
+
+        assertValidCounters(actual);
+        applyCounters(cp, actual);
+      } finally {
+        const elapsedMs = Date.now() - startedAt;
+        if (elapsedMs >= RECONCILIATION_LOCK_WARN_MS) {
+          this.logger.warn?.(
+            `[checkpoint] Counter reconciliation held the checkpoint lock for ${elapsedMs}ms`,
+          );
+        }
+      }
+    });
+  }
+
   // ============================
   // Public API — mutating (all serialized via file lock)
   // ============================
@@ -449,8 +559,8 @@ export class CheckpointManager {
    *   - `{ maxTimestamp, messageCount }` to advance the cursor, or
    *   - `null` to leave the cursor unchanged (nothing captured).
    *
-   * L0 conversation count is also incremented inside the lock when messages
-   * are captured, removing the need for a separate `incrementL0ConversationCount()` call.
+   * L0 message count is also incremented inside the lock when messages are
+   * captured, removing the need for a separate counter update.
    *
    * @param sessionKey   Per-session identifier
    * @param pluginStartTimestamp  Cold-start floor (used when no cursor exists yet)
@@ -479,10 +589,22 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        // Keep this aggregate aligned with persisted L0 message records.
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }
 
+}
+
+/**
+ * Rebuild aggregate counters from the durable Store without touching any
+ * per-session cursor. `l0_conversations_count` is normalized to persisted L0
+ * message records so it has the same cross-backend meaning as `countL0()`.
+ */
+export async function reconcileCheckpointFromStore(
+  manager: CheckpointManager,
+  store: CheckpointCounterStore,
+): Promise<void> {
+  await manager.reconcileCountersFromStore(store);
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
+import {
+  CheckpointManager,
+  reconcileCheckpointFromStore,
+} from "./checkpoint.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
@@ -163,6 +167,7 @@ export class LocalMemoryCleaner {
 
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
+        await this.reconcileCheckpointCounters(vectorStore);
       }
 
       // ── Post-delete: audit summary ──
@@ -184,6 +189,27 @@ export class LocalMemoryCleaner {
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+  }
+
+  /** Keep checkpoint aggregates aligned with Store rows immediately after TTL deletion. */
+  private async reconcileCheckpointCounters(vectorStore: IMemoryStore): Promise<void> {
+    if (vectorStore.isDegraded()) {
+      this.opts.logger?.debug?.(`${TAG} Skip checkpoint reconciliation: Store is degraded`);
+      return;
+    }
+
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await reconcileCheckpointFromStore(checkpoint, vectorStore);
+      this.opts.logger?.debug?.(`${TAG} Reconciled checkpoint aggregate counters after cleanup`);
+    } catch (err) {
+      // Cleanup has already completed successfully. A later startup reconciliation
+      // can retry, so checkpoint repair must not turn this into a failed cleanup.
+      this.opts.logger?.warn?.(
+        `${TAG} Checkpoint reconciliation after cleanup failed (non-fatal): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private scheduleNext(): void {

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -203,8 +203,8 @@ export class LocalMemoryCleaner {
       await reconcileCheckpointFromStore(checkpoint, vectorStore);
       this.opts.logger?.debug?.(`${TAG} Reconciled checkpoint aggregate counters after cleanup`);
     } catch (err) {
-      // Cleanup has already completed successfully. A later startup reconciliation
-      // can retry, so checkpoint repair must not turn this into a failed cleanup.
+      // Cleanup has already completed successfully, so checkpoint repair must
+      // not turn this into a failed cleanup.
       this.opts.logger?.warn?.(
         `${TAG} Checkpoint reconciliation after cleanup failed (non-fatal): ` +
         `${err instanceof Error ? err.message : String(err)}`,

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -2,10 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
-import {
-  CheckpointManager,
-  reconcileCheckpointFromStore,
-} from "./checkpoint.js";
+import { CheckpointManager } from "./checkpoint.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
@@ -165,10 +162,8 @@ export class LocalMemoryCleaner {
         }
       }
 
-      if (removedL1 > 0 || removedL0 > 0) {
-        total.changedFiles += 1;
-        await this.reconcileCheckpointCounters(vectorStore);
-      }
+      if (removedL1 > 0 || removedL0 > 0) total.changedFiles += 1;
+      await this.reconcileCheckpointCounters(vectorStore);
 
       // ── Post-delete: audit summary ──
       const durationMs = Date.now() - startMs;
@@ -200,7 +195,7 @@ export class LocalMemoryCleaner {
 
     try {
       const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
-      await reconcileCheckpointFromStore(checkpoint, vectorStore);
+      await checkpoint.reconcileCountersFromStore(vectorStore);
       this.opts.logger?.debug?.(`${TAG} Reconciled checkpoint aggregate counters after cleanup`);
     } catch (err) {
       // Cleanup has already completed successfully, so checkpoint repair must

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -379,7 +379,13 @@ export function createL1Runner(opts: {
       }
 
       // Use maxRecordedAtMs (write time) as cursor — always positive, TCVDB-safe
-      await checkpoint.markL1ExtractionComplete(sessionKey, totalStored, maxRecordedAtMs || undefined, lastSceneName);
+      await checkpoint.markL1ExtractionComplete(
+        sessionKey,
+        totalStored,
+        maxRecordedAtMs || undefined,
+        lastSceneName,
+        vectorStore && !vectorStore.isDegraded() ? vectorStore : undefined,
+      );
       logger.info(
         `${TAG} [l1] L1 complete: extracted=${totalExtracted}, stored=${totalStored} (${groups.length} group(s))`,
       );


### PR DESCRIPTION
## Description | 描述

修复 Checkpoint 聚合计数与当前 Store 数据漂移的问题，并消除 Cleaner 绝对校准与 L1 增量更新并发时的重复计数窗口。

Store 是当前可检索记录的权威源；恢复 JSONL 是 append-only 日志，可能保留已被更新或合并取代的旧记录。因此在 Store 健康时，下列聚合值统一按 Store 绝对计数写入：

- `l0_conversations_count`
- `total_memories_extracted`
- `memories_since_last_persona`

校准发生在 Store 初始化、L1 完成以及每次 Cleaner 运行后，不再依赖“本轮必须删到记录”。L1 完成和 Cleaner 都在 Checkpoint 文件锁内应用绝对值，避免增量与校准交错导致 double count。Store 降级时保留原有增量路径，不影响 JSONL-only 运行。

`total_processed` 继续保持历史累计语义；校准不会回退 session cursor 或 pipeline state。

## Related Issue | 关联 Issue

Fixes #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Validation | 验证

- [x] `npm test -- src/utils/checkpoint.test.ts` — 6 passed
- [x] `npm test` — 73 passed
- [x] `npm run build:plugin`
- [x] 覆盖校准失败不改写、Cleaner 无删除仍修复漂移、L1 完成与校准并发不重复计数

## Additional Notes | 其他说明

实现未引入跨模块共享锁或额外状态缓存；一致性边界仍由现有 Checkpoint 原子写与文件锁承担。
