### PR TITLE
fix: resolve issue #2

### DIFF
--- a/src/utils/checkpoint-snapshot.ts
+++ b/src/utils/checkpoint-snapshot.ts
@@ -1,0 +1,105 @@
+/**
+ * Build a `CheckpointRecalculateSnapshot` from ground-truth storage.
+ *
+ * Primary use cases (see the checkpoint drift issue):
+ *   - Manual JSONL / DB trimming  → run after the trim, cursors clamp back.
+ *   - Historical rollback         → snapshot max < cursor → cursor rewinds.
+ *   - Ad-hoc "recalculate" CLI    → open the DB read-only, build, recalculate.
+ *
+ * The builder talks to the SQLite file directly (`node:sqlite`, read-only) —
+ * no VectorStore / embedding machinery is needed, so it also works while the
+ * plugin is degraded or offline.
+ */
+
+import path from "node:path";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import type { DatabaseSync } from "node:sqlite";
+
+import type { CheckpointRecalculateSnapshot } from "./checkpoint.js";
+
+const require = createRequire(import.meta.url);
+
+/** Same loading strategy as sqlite.ts (node:sqlite is experimental on Node 22). */
+function requireNodeSqlite(): typeof import("node:sqlite") {
+  return require("node:sqlite") as typeof import("node:sqlite");
+}
+
+/** Default DB file name used by the SQLite VectorStore (`<dataDir>/vectors.db`). */
+export const SQLITE_DB_FILENAME = "vectors.db";
+
+/**
+ * Build a recalculate snapshot from the SQLite memory store.
+ *
+ * Returns `undefined` when the DB file does not exist or cannot be read —
+ * callers should treat that as "no ground truth available" and skip the
+ * recalculation (never recalculate against an empty guess).
+ *
+ * The snapshot is always exhaustive (full-table GROUP BY), so sessions that
+ * disappeared from the DB entirely will have their checkpoint cursors reset.
+ */
+export function buildSnapshotFromSqlite(
+  dataDir: string,
+  logger?: { warn?(msg: string): void },
+): CheckpointRecalculateSnapshot | undefined {
+  const dbPath = path.join(dataDir, SQLITE_DB_FILENAME);
+  if (!fs.existsSync(dbPath)) {
+    logger?.warn?.(`[checkpoint-snapshot] DB not found, snapshot skipped: ${dbPath}`);
+    return undefined;
+  }
+
+  let db: DatabaseSync | undefined;
+  try {
+    const { DatabaseSync: DbSync } = requireNodeSqlite();
+    db = new DbSync(dbPath, { readOnly: true });
+
+    const l0MessageCount = (
+      db.prepare("SELECT COUNT(*) AS cnt FROM l0_conversations").get() as { cnt: number }
+    ).cnt;
+    const l1RecordCount = (
+      db.prepare("SELECT COUNT(*) AS cnt FROM l1_records").get() as { cnt: number }
+    ).cnt;
+
+    // Per-session watermarks. recorded_at / updated_time are ISO 8601 UTC
+    // strings, so MAX() over them is chronologically correct.
+    const sessions: NonNullable<CheckpointRecalculateSnapshot["sessions"]> = {};
+
+    const l0Rows = db
+      .prepare("SELECT session_key AS k, MAX(recorded_at) AS maxRecordedAt FROM l0_conversations GROUP BY session_key")
+      .all() as Array<{ k: string; maxRecordedAt: string | null }>;
+    for (const row of l0Rows) {
+      if (!row.k) continue;
+      const ms = row.maxRecordedAt ? Date.parse(row.maxRecordedAt) : NaN;
+      sessions[row.k] = {
+        ...sessions[row.k],
+        ...(Number.isFinite(ms) ? { l0MaxRecordedAtMs: ms } : {}),
+      };
+    }
+
+    const l1Rows = db
+      .prepare("SELECT session_key AS k, MAX(updated_time) AS maxUpdatedAt FROM l1_records GROUP BY session_key")
+      .all() as Array<{ k: string; maxUpdatedAt: string | null }>;
+    for (const row of l1Rows) {
+      if (!row.k || !row.maxUpdatedAt) continue;
+      sessions[row.k] = { ...sessions[row.k], l1MaxUpdatedAtIso: row.maxUpdatedAt };
+    }
+
+    return {
+      l0MessageCount,
+      l1RecordCount,
+      sessions,
+      exhaustiveSessions: true,
+    };
+  } catch (err) {
+    logger?.warn?.(
+      `[checkpoint-snapshot] Failed to build snapshot (skipped): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* non-fatal */
+    }
+  }
+}

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,659 @@
+/**
+ * Checkpoint drift fix — test suite.
+ *
+ * Maps to the issue's acceptance levels:
+ * - [基础] checkpoint read/write basics incl. stats_revision migration
+ * - [进阶] decrement* / recalculate / resetSession implementations
+ * - [深入] multi-scenario coverage: automatic cleanup (memory-cleaner),
+ *   manual trimming (real SQLite + JSONL), historical rollback, session reset,
+ *   concurrency serialization
+ * - [拓展] executable proof that timestamp-based cursors self-heal after
+ *   rollback: records skipped before recalculate become processable after
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+import { CheckpointManager, type Checkpoint } from "./checkpoint.js";
+import { buildSnapshotFromSqlite, SQLITE_DB_FILENAME } from "./checkpoint-snapshot.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { MemoryPipelineManager } from "./pipeline-manager.js";
+import type { Logger } from "../core/types.js";
+
+const require = createRequire(import.meta.url);
+
+const noopLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// ============================
+// Helpers
+// ============================
+
+let tmpDirs: string[] = [];
+
+async function makeTmpDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "checkpoint-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function seedCheckpoint(dir: string, patch: Partial<Checkpoint>): Promise<Checkpoint> {
+  const manager = new CheckpointManager(dir, noopLogger);
+  const cp = await manager.read();
+  const next: Checkpoint = {
+    ...cp,
+    ...patch,
+    runner_states: { ...cp.runner_states, ...(patch.runner_states ?? {}) },
+    pipeline_states: { ...cp.pipeline_states, ...(patch.pipeline_states ?? {}) },
+  };
+  await manager.write(next);
+  return next;
+}
+
+function requireNodeSqlite(): typeof import("node:sqlite") {
+  return require("node:sqlite") as typeof import("node:sqlite");
+}
+
+/** Create a minimal vectors.db with just the columns the snapshot builder reads. */
+async function createMiniDb(dir: string): Promise<import("node:sqlite").DatabaseSync> {
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(path.join(dir, SQLITE_DB_FILENAME));
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS l0_conversations (
+      record_id TEXT PRIMARY KEY,
+      session_key TEXT NOT NULL,
+      session_id TEXT DEFAULT '',
+      role TEXT NOT NULL DEFAULT '',
+      message_text TEXT NOT NULL,
+      recorded_at TEXT DEFAULT '',
+      timestamp INTEGER DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS l1_records (
+      record_id TEXT PRIMARY KEY,
+      session_key TEXT DEFAULT '',
+      content TEXT NOT NULL DEFAULT '',
+      updated_time TEXT DEFAULT ''
+    );
+  `);
+  return db;
+}
+
+function insertL0(db: import("node:sqlite").DatabaseSync, id: string, sessionKey: string, recordedAt: string): void {
+  db.prepare(
+    "INSERT INTO l0_conversations (record_id, session_key, role, message_text, recorded_at, timestamp) VALUES (?, ?, 'user', ?, ?, 0)",
+  ).run(id, sessionKey, `msg-${id}`, recordedAt);
+}
+
+function insertL1(db: import("node:sqlite").DatabaseSync, id: string, sessionKey: string, updatedAt: string): void {
+  db.prepare(
+    "INSERT INTO l1_records (record_id, session_key, content, updated_time) VALUES (?, ?, ?, ?)",
+  ).run(id, sessionKey, `mem-${id}`, updatedAt);
+}
+
+function isoDaysAgo(days: number, hour = 12): string {
+  const d = new Date(Date.now() - days * 86_400_000);
+  d.setHours(hour, 0, 0, 0);
+  return d.toISOString();
+}
+
+function shardNameDaysAgo(days: number): string {
+  const d = new Date(Date.now() - days * 86_400_000);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}.jsonl`;
+}
+
+afterEach(async () => {
+  for (const dir of tmpDirs) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+  tmpDirs = [];
+});
+
+// ============================
+// [基础] read/write + migration
+// ============================
+
+describe("[基础] checkpoint 基础读写", () => {
+  it("returns defaults (incl. stats_revision=0) for a missing checkpoint file", async () => {
+    const dir = await makeTmpDir();
+    const cp = await new CheckpointManager(dir, noopLogger).read();
+    expect(cp.total_processed).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.stats_revision).toBe(0);
+    expect(cp.runner_states).toEqual({});
+    expect(cp.pipeline_states).toEqual({});
+  });
+
+  it("migrates old checkpoints that lack stats_revision", async () => {
+    const dir = await makeTmpDir();
+    const metaDir = path.join(dir, ".metadata");
+    await fs.mkdir(metaDir, { recursive: true });
+    // Legacy format: no stats_revision field at all.
+    await fs.writeFile(
+      path.join(metaDir, "recall_checkpoint.json"),
+      JSON.stringify({ total_processed: 42, scenes_processed: 3 }),
+      "utf-8",
+    );
+    const cp = await new CheckpointManager(dir, noopLogger).read();
+    expect(cp.total_processed).toBe(42);
+    expect(cp.stats_revision).toBe(0);
+  });
+});
+
+// ============================
+// [进阶] decrement* methods
+// ============================
+
+describe("[进阶] decrement 系列", () => {
+  it("decrementTotalProcessed subtracts and floors at 0", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_processed: 10 });
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    const revBefore = (await manager.read()).stats_revision;
+    await manager.decrementTotalProcessed(4);
+    let cp = await manager.read();
+    expect(cp.total_processed).toBe(6);
+    expect(cp.stats_revision).toBe(revBefore + 1);
+
+    await manager.decrementTotalProcessed(100);
+    cp = await manager.read();
+    expect(cp.total_processed).toBe(0);
+  });
+
+  it("decrementMemoriesExtracted also clamps memories_since_last_persona", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_memories_extracted: 20, memories_since_last_persona: 15 });
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    await manager.decrementMemoriesExtracted(8);
+    let cp = await manager.read();
+    expect(cp.total_memories_extracted).toBe(12);
+    expect(cp.memories_since_last_persona).toBe(12); // clamped: cannot exceed total
+
+    await manager.decrementMemoriesExtracted(0); // no-op amount
+    cp = await manager.read();
+    expect(cp.total_memories_extracted).toBe(12);
+  });
+
+  it("decrementL0Conversations works with floor protection", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { l0_conversations_count: 3 });
+    const manager = new CheckpointManager(dir, noopLogger);
+    await manager.decrementL0Conversations(5);
+    expect((await manager.read()).l0_conversations_count).toBe(0);
+  });
+
+  it("serializes concurrent decrements through the file lock (no lost updates)", async () => {
+    const dir = await makeTmpDir();
+    const N = 25;
+    await seedCheckpoint(dir, { total_processed: N });
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    await Promise.all(Array.from({ length: N }, () => manager.decrementTotalProcessed(1)));
+    expect((await manager.read()).total_processed).toBe(0);
+  });
+});
+
+// ============================
+// [进阶] resetSession
+// ============================
+
+describe("[进阶] resetSession", () => {
+  it("removes runner + pipeline state for the target session only", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, {
+      runner_states: {
+        s1: { last_captured_timestamp: 100, last_l1_cursor: 90, last_scene_name: "travel" },
+        s2: { last_captured_timestamp: 200, last_l1_cursor: 190, last_scene_name: "work" },
+      },
+      pipeline_states: {
+        s1: {
+          conversation_count: 3,
+          last_extraction_time: "2026-07-01T00:00:00.000Z",
+          last_extraction_updated_time: "2026-07-01T00:00:00.000Z",
+          last_active_time: 1,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+    });
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    const removed = await manager.resetSession("s1");
+    expect(removed).toBe(true);
+
+    const cp = await manager.read();
+    expect(cp.runner_states.s1).toBeUndefined();
+    expect(cp.pipeline_states.s1).toBeUndefined();
+    // Other sessions untouched:
+    expect(cp.runner_states.s2.last_l1_cursor).toBe(190);
+  });
+
+  it("is a no-op (no revision bump) for unknown sessions", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, {});
+    const manager = new CheckpointManager(dir, noopLogger);
+    const revBefore = (await manager.read()).stats_revision;
+
+    expect(await manager.resetSession("ghost")).toBe(false);
+    expect((await manager.read()).stats_revision).toBe(revBefore);
+  });
+});
+
+// ============================
+// [进阶] recalculate — counter reconciliation
+// ============================
+
+describe("[进阶] recalculate 计数器重算", () => {
+  it("assigns exact counts and clamps derived counters", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, {
+      total_processed: 999,
+      l0_conversations_count: 999, // batches can never exceed messages
+      total_memories_extracted: 888,
+      memories_since_last_persona: 50,
+    });
+    const manager = new CheckpointManager(dir, noopLogger);
+    const revBefore = (await manager.read()).stats_revision;
+
+    const result = await manager.recalculate({ l0MessageCount: 120, l1RecordCount: 30 });
+    const cp = await manager.read();
+
+    expect(cp.total_processed).toBe(120);
+    expect(cp.l0_conversations_count).toBe(120); // clamped (min), not exact
+    expect(cp.total_memories_extracted).toBe(30);
+    expect(cp.memories_since_last_persona).toBe(30); // clamped to new total
+    expect(cp.stats_revision).toBe(revBefore + 1);
+    expect(result.adjustments.length).toBeGreaterThan(0);
+  });
+
+  it("does not bump stats_revision when nothing changed", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_processed: 10, total_memories_extracted: 5 });
+    const manager = new CheckpointManager(dir, noopLogger);
+    const revBefore = (await manager.read()).stats_revision;
+
+    const result = await manager.recalculate({ l0MessageCount: 10, l1RecordCount: 5 });
+    expect(result.adjustments).toEqual([]);
+    expect((await manager.read()).stats_revision).toBe(revBefore);
+  });
+
+  it("rejects invalid snapshot numbers gracefully", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_processed: 10 });
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    const result = await manager.recalculate({ l0MessageCount: Number.NaN, l1RecordCount: -5 });
+    expect(result.adjustments).toEqual([]);
+    expect((await manager.read()).total_processed).toBe(10);
+  });
+});
+
+// ============================
+// [深入] 场景一：自动清理（memory-cleaner 集成）
+// ============================
+
+describe("[深入] 自动清理场景（memory-cleaner → checkpoint 校准）", () => {
+  it("JSONL shard deletion decrements counters by exact line counts", async () => {
+    const dir = await makeTmpDir();
+    const convDir = path.join(dir, "conversations");
+    const recDir = path.join(dir, "records");
+    await fs.mkdir(convDir, { recursive: true });
+    await fs.mkdir(recDir, { recursive: true });
+
+    // Expired shards (3 days old): 3 L0 lines + 2 L1 lines.
+    await fs.writeFile(path.join(convDir, shardNameDaysAgo(3)), '{"a":1}\n{"a":2}\n{"a":3}\n', "utf-8");
+    await fs.writeFile(path.join(recDir, shardNameDaysAgo(3)), '{"b":1}\n{"b":2}\n', "utf-8");
+    // Fresh shards (today): must be kept.
+    await fs.writeFile(path.join(convDir, shardNameDaysAgo(0)), '{"a":4}\n', "utf-8");
+
+    await seedCheckpoint(dir, {
+      total_processed: 100,
+      total_memories_extracted: 50,
+      memories_since_last_persona: 50,
+    });
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger: noopLogger,
+    });
+    await cleaner.runOnce();
+
+    const cp = await new CheckpointManager(dir, noopLogger).read();
+    expect(cp.total_processed).toBe(97); // 100 - 3 L0 lines
+    expect(cp.total_memories_extracted).toBe(48); // 50 - 2 L1 lines
+    expect(cp.memories_since_last_persona).toBe(48); // clamped
+    expect(cp.stats_revision).toBeGreaterThan(0);
+
+    // Fresh shard preserved on disk:
+    expect(fsSync.existsSync(path.join(convDir, shardNameDaysAgo(0)))).toBe(true);
+  });
+
+  it("VectorStore deletion decrements counters by the store-reported amounts", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_processed: 200, total_memories_extracted: 80 });
+
+    const fakeStore = {
+      countL0: async () => 100, // > MIN_RETAIN_L0 (50)
+      countL1: async () => 40, //  > MIN_RETAIN_L1 (20)
+      deleteL0Expired: async () => 30,
+      deleteL1Expired: async () => 10,
+    };
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger: noopLogger,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vectorStore: fakeStore as any,
+    });
+    await cleaner.runOnce();
+
+    const cp = await new CheckpointManager(dir, noopLogger).read();
+    expect(cp.total_processed).toBe(170); // 200 - 30
+    expect(cp.total_memories_extracted).toBe(70); // 80 - 10
+  });
+
+  it("skips calibration gracefully when nothing was deleted", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_processed: 5 });
+    const revBefore = (await new CheckpointManager(dir, noopLogger).read()).stats_revision;
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dir, // no conversations/records dirs at all
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger: noopLogger,
+    });
+    await cleaner.runOnce();
+
+    const cp = await new CheckpointManager(dir, noopLogger).read();
+    expect(cp.total_processed).toBe(5);
+    expect(cp.stats_revision).toBe(revBefore);
+  });
+});
+
+// ============================
+// [深入] 场景二：手动修剪（real SQLite + recalculate）
+// ============================
+
+describe("[深入] 手动修剪场景（真实 SQLite 快照 + recalculate）", () => {
+  it("clamps cursors to actual data and resets fully-deleted sessions", async () => {
+    const dir = await makeTmpDir();
+    const db = await createMiniDb(dir);
+
+    const t1 = isoDaysAgo(10);
+    const t2 = isoDaysAgo(5);
+    const u1 = isoDaysAgo(9);
+    const u2 = isoDaysAgo(4);
+    // Session A: L0 t1,t2 + L1 u1,u2. Session B: one L0 row + one L1 row.
+    insertL0(db, "a1", "sessA", t1);
+    insertL0(db, "a2", "sessA", t2);
+    insertL1(db, "m1", "sessA", u1);
+    insertL1(db, "m2", "sessA", u2);
+    insertL0(db, "b1", "sessB", isoDaysAgo(8));
+    insertL1(db, "m3", "sessB", isoDaysAgo(7));
+    db.close();
+
+    // Checkpoint is AHEAD of reality (counters inflated, cursors too far).
+    await seedCheckpoint(dir, {
+      total_processed: 999,
+      total_memories_extracted: 888,
+      memories_since_last_persona: 100,
+      runner_states: {
+        sessA: {
+          last_captured_timestamp: 777_000, // message-clock: must survive recalculate
+          last_l1_cursor: Date.parse(t2) + 86_400_000, // ahead of any data
+          last_scene_name: "x",
+        },
+        sessB: { last_captured_timestamp: 555, last_l1_cursor: 444, last_scene_name: "" },
+      },
+      pipeline_states: {
+        sessA: {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: isoDaysAgo(1), // ahead of u2
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+        sessB: {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: isoDaysAgo(1),
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+    });
+
+    // ── Manual trim: delete newest A L0 row + ALL of session B ──
+    const trim = requireNodeSqlite();
+    const trimDb = new trim.DatabaseSync(path.join(dir, SQLITE_DB_FILENAME));
+    trimDb.prepare("DELETE FROM l0_conversations WHERE record_id = 'a2'").run();
+    trimDb.prepare("DELETE FROM l0_conversations WHERE session_key = 'sessB'").run();
+    trimDb.prepare("DELETE FROM l1_records WHERE session_key = 'sessB'").run();
+    trimDb.close();
+
+    const snapshot = buildSnapshotFromSqlite(dir, noopLogger);
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.l0MessageCount).toBe(1); // a2 trimmed, b1 wiped with sessB → only a1 left
+    expect(snapshot!.l1RecordCount).toBe(2); // m1, m2
+    expect(snapshot!.exhaustiveSessions).toBe(true);
+    expect(snapshot!.sessions!.sessA.l0MaxRecordedAtMs).toBe(Date.parse(t1));
+    expect(snapshot!.sessions!.sessA.l1MaxUpdatedAtIso).toBe(u2);
+    expect(snapshot!.sessions!.sessB).toBeUndefined();
+
+    const manager = new CheckpointManager(dir, noopLogger);
+    const result = await manager.recalculate(snapshot!);
+    const cp = await manager.read();
+
+    // Counters exact:
+    expect(cp.total_processed).toBe(1);
+    expect(cp.total_memories_extracted).toBe(2);
+    expect(cp.memories_since_last_persona).toBe(2);
+
+    // Session A cursors clamped to actual watermarks:
+    expect(cp.runner_states.sessA.last_l1_cursor).toBe(Date.parse(t1));
+    expect(cp.pipeline_states.sessA.last_extraction_updated_time).toBe(u2);
+    // L0 capture cursor uses the message clock — NOT clamped/reset while the
+    // session still has data:
+    expect(cp.runner_states.sessA.last_captured_timestamp).toBe(777_000);
+
+    // Session B fully deleted → all cursors reset for future re-import:
+    expect(cp.runner_states.sessB.last_captured_timestamp).toBe(0);
+    expect(cp.runner_states.sessB.last_l1_cursor).toBe(0);
+    expect(cp.pipeline_states.sessB.last_extraction_updated_time).toBe("");
+
+    expect(result.adjustments.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("buildSnapshotFromSqlite returns undefined for a missing DB", async () => {
+    const dir = await makeTmpDir();
+    expect(buildSnapshotFromSqlite(dir, noopLogger)).toBeUndefined();
+  });
+});
+
+// ============================
+// [深入] 场景三：历史数据回滚
+// ============================
+
+describe("[深入] 历史回滚场景", () => {
+  it("rewinds cursors past the rollback point so records are reprocessed", async () => {
+    const dir = await makeTmpDir();
+    const db = await createMiniDb(dir);
+    const t1 = isoDaysAgo(20);
+    const t2 = isoDaysAgo(10);
+    const t3 = isoDaysAgo(2);
+    insertL0(db, "r1", "sessR", t1);
+    insertL0(db, "r2", "sessR", t2);
+    insertL0(db, "r3", "sessR", t3);
+    insertL1(db, "rm1", "sessR", isoDaysAgo(2));
+    db.close();
+
+    // Simulate "checkpoint captured up to t3" before rollback:
+    await seedCheckpoint(dir, {
+      runner_states: {
+        sessR: { last_captured_timestamp: 1, last_l1_cursor: Date.parse(t3), last_scene_name: "" },
+      },
+      pipeline_states: {
+        sessR: {
+          conversation_count: 0,
+          last_extraction_time: "",
+          last_extraction_updated_time: isoDaysAgo(2),
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+    });
+
+    // ── Rollback: DB restored to a backup from before t3 ──
+    const rb = requireNodeSqlite();
+    const rbDb = new rb.DatabaseSync(path.join(dir, SQLITE_DB_FILENAME));
+    rbDb.prepare("DELETE FROM l0_conversations WHERE recorded_at > ?").run(t2);
+    rbDb.prepare("DELETE FROM l1_records").run();
+    rbDb.close();
+
+    const manager = new CheckpointManager(dir, noopLogger);
+    const snapshot = buildSnapshotFromSqlite(dir, noopLogger);
+    await manager.recalculate(snapshot!);
+    const cp = await manager.read();
+
+    // L1 cursor rewound to the surviving max (t2):
+    expect(cp.runner_states.sessR.last_l1_cursor).toBe(Date.parse(t2));
+    // L1 layer is now empty → L2 cursor reset for a full (empty) rescan:
+    expect(cp.pipeline_states.sessR.last_extraction_updated_time).toBe("");
+
+    // [拓展] Executable proof of self-healing: with the rewound cursor, the
+    // L1 incremental filter (recorded_at > cursor) now picks r3 up again —
+    // before recalculate it was skipped as "already processed".
+    const check = requireNodeSqlite();
+    const checkDb = new check.DatabaseSync(path.join(dir, SQLITE_DB_FILENAME));
+    // Re-import the rolled-back row (data returns):
+    checkDb.prepare(
+      "INSERT INTO l0_conversations (record_id, session_key, role, message_text, recorded_at, timestamp) VALUES ('r3', 'sessR', 'user', 're-imported', ?, 0)",
+    ).run(t3);
+    const rows = checkDb
+      .prepare("SELECT record_id FROM l0_conversations WHERE session_key = 'sessR' AND recorded_at > ?")
+      .all(new Date(cp.runner_states.sessR.last_l1_cursor).toISOString()) as Array<{ record_id: string }>;
+    checkDb.close();
+    expect(rows.map((r) => r.record_id)).toEqual(["r3"]);
+  });
+});
+
+// ============================
+// [深入] 场景四：session 重置（checkpoint + pipeline 内存态）
+// ============================
+
+describe("[深入] session 重置场景", () => {
+  it("resetSession + evictSession restarts the session cold", async () => {
+    const dir = await makeTmpDir();
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    const pm = new MemoryPipelineManager(
+      {
+        everyNConversations: 5,
+        enableWarmup: false,
+        l1: { idleTimeoutSeconds: 60 },
+        l2: {
+          delayAfterL1Seconds: 90,
+          minIntervalSeconds: 900,
+          maxIntervalSeconds: 3600,
+          sessionActiveWindowHours: 24,
+        },
+      },
+      noopLogger,
+    );
+
+    // Live session: buffered messages + persisted pipeline state.
+    await pm.notifyConversation("s1", [{ role: "user", content: "hello", timestamp: new Date().toISOString() }]);
+    pm.setPersister(async (states) => {
+      await manager.mergePipelineStates(states);
+    });
+    await pm.notifyConversation("s1", [{ role: "user", content: "again", timestamp: new Date().toISOString() }]);
+    expect(pm.getBufferedMessageCount("s1")).toBe(2);
+    expect(pm.getSessionState("s1")).toBeDefined();
+
+    // Reset: persisted state wiped, runtime state evicted.
+    await manager.resetSession("s1");
+    pm.evictSession("s1");
+
+    expect(pm.getSessionState("s1")).toBeUndefined();
+    expect(pm.getBufferedMessageCount("s1")).toBe(0);
+    const cp = await manager.read();
+    expect(cp.pipeline_states.s1).toBeUndefined();
+
+    // Unknown-key eviction is a safe no-op:
+    expect(() => pm.evictSession("ghost")).not.toThrow();
+
+    // Session can restart cold:
+    await pm.notifyConversation("s1", [{ role: "user", content: "fresh", timestamp: new Date().toISOString() }]);
+    expect(pm.getSessionState("s1")?.conversation_count).toBe(1);
+
+    await pm.destroy();
+  });
+});
+
+// ============================
+// [深入] 并发安全
+// ============================
+
+describe("[深入] 并发安全", () => {
+  it("captureAtomically and recalculate serialize without lost updates", async () => {
+    const dir = await makeTmpDir();
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    // Two concurrent captures on the same session: the second MUST observe
+    // the first one's cursor (proves the read-modify-write is atomic).
+    const seen: number[] = [];
+    const capture = (maxTs: number) =>
+      manager.captureAtomically("s1", undefined, async (after) => {
+        seen.push(after);
+        return { maxTimestamp: maxTs, messageCount: 1 };
+      });
+
+    await Promise.all([capture(1000), capture(2000)]);
+    seen.sort((a, b) => a - b);
+    expect(seen).toEqual([0, 1000]); // serialized: 0 → 1000
+
+    const cp = await manager.read();
+    expect(cp.total_processed).toBe(2);
+    expect(cp.runner_states.s1.last_captured_timestamp).toBe(2000);
+  });
+
+  it("concurrent recalculate calls are serialized and idempotent", async () => {
+    const dir = await makeTmpDir();
+    await seedCheckpoint(dir, { total_processed: 500 });
+    const manager = new CheckpointManager(dir, noopLogger);
+
+    const results = await Promise.all([
+      manager.recalculate({ l0MessageCount: 100 }),
+      manager.recalculate({ l0MessageCount: 100 }),
+      manager.recalculate({ l0MessageCount: 100 }),
+    ]);
+    // Exactly one of them did the adjustment; the rest were no-ops.
+    const adjusted = results.filter((r) => r.adjustments.length > 0);
+    expect(adjusted.length).toBe(1);
+    expect((await manager.read()).total_processed).toBe(100);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -90,6 +90,14 @@ export interface Checkpoint {
   persona_update_reason: string;
   memories_since_last_persona: number;
   scenes_processed: number;
+  /**
+   * Monotonic revision bumped by every intentional downward calibration
+   * (`decrement*`, `recalculate`, `resetSession`). Concurrent writers that
+   * defensively restore "only-ever-increasing" counters (e.g. the L2 runner's
+   * corruption guard in pipeline-factory.ts) compare this revision to tell a
+   * legitimate calibration apart from an accidental clobber.
+   */
+  stats_revision: number;
 
   // ═══ Per-session split state ═══
   /** Runner-managed per-session state (L0 capture cursor, L1 cursor, scene name).
@@ -137,11 +145,68 @@ const DEFAULT_CHECKPOINT: Checkpoint = {
   pipeline_states: {},
   l0_conversations_count: 0,
   total_memories_extracted: 0,
+  stats_revision: 0,
 };
 
 export interface CheckpointLogger {
   info(msg: string): void;
   warn?(msg: string): void;
+}
+
+// ============================
+// Recalculate types
+// ============================
+
+/**
+ * Actual-data snapshot used by `recalculate()`.
+ *
+ * CheckpointManager is deliberately storage-agnostic: the caller builds this
+ * snapshot from the real store (e.g. `countL0()`/`countL1()` plus per-session
+ * MAX(recorded_at)/MAX(updated_at) queries, or a JSONL file scan) and hands it
+ * over. The recalculate logic then reconciles counters and cursors with
+ * ground truth.
+ */
+export interface CheckpointRecalculateSnapshot {
+  /**
+   * Actual number of L0 messages currently in the store.
+   * Same unit as `total_processed` (messages, not conversation batches).
+   */
+  l0MessageCount?: number;
+  /**
+   * Actual number of L1 records currently in the store.
+   * Same unit as `total_memories_extracted`.
+   */
+  l1RecordCount?: number;
+  /**
+   * Per-session actual data watermarks, keyed by sessionKey.
+   *
+   * When `exhaustiveSessions` is true, this map MUST list every session that
+   * still has data: any session present in the checkpoint but absent here is
+   * treated as fully deleted, and its cursors are reset to zero so a later
+   * re-import is processed from scratch instead of being skipped.
+   */
+  sessions?: Record<
+    string,
+    {
+      /** Max L0 `recorded_at` (epoch ms) still present for this session. */
+      l0MaxRecordedAtMs?: number;
+      /** Max L1 `updated_at` (ISO 8601 string) still present for this session. */
+      l1MaxUpdatedAtIso?: string;
+    }
+  >;
+  /** See `sessions`. Cursor resets for absent sessions only happen when true. */
+  exhaustiveSessions?: boolean;
+}
+
+/** A single field adjustment performed by `recalculate()` (for logging/tests). */
+export interface RecalculateAdjustment {
+  field: string;
+  before: number | string;
+  after: number | string;
+}
+
+export interface RecalculateResult {
+  adjustments: RecalculateAdjustment[];
 }
 
 const noopLogger: CheckpointLogger = { info() {} };
@@ -483,6 +548,250 @@ export class CheckpointManager {
         cp.l0_conversations_count += 1;
       }
     });
+  }
+
+  // ============================
+  // Calibration (decrement / recalculate / reset)
+  // ============================
+  //
+  // Counters and cursors are write-only-increment by design, so any operation
+  // that REMOVES underlying data (memory-cleaner expiry, manual JSONL pruning,
+  // session reset, historical rollback) leaves the checkpoint permanently
+  // overestimated — incremental processing then skips records that should have
+  // been processed. The methods below are the downward write paths.
+  //
+  // Every calibration bumps `stats_revision` so defensive readers can tell an
+  // intentional decrease from accidental corruption.
+
+  private static floorSub(current: number, amount: number): number {
+    if (!Number.isFinite(amount) || amount <= 0) return current;
+    return Math.max(0, current - Math.floor(amount));
+  }
+
+  /**
+   * Decrement `total_processed` by `amount` (message units), floored at 0.
+   * Used by memory-cleaner after deleting expired L0 messages.
+   */
+  async decrementTotalProcessed(amount: number): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      cp.total_processed = CheckpointManager.floorSub(cp.total_processed, amount);
+      cp.stats_revision += 1;
+    });
+    this.logger.info(`[checkpoint] decrementTotalProcessed(${amount}): total_processed=${cp.total_processed}`);
+  }
+
+  /**
+   * Decrement `l0_conversations_count` by `amount` (capture-batch units),
+   * floored at 0. Note: store-level deletions are counted in messages, so
+   * callers usually want `decrementTotalProcessed` or `recalculate` instead.
+   */
+  async decrementL0Conversations(amount: number): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      cp.l0_conversations_count = CheckpointManager.floorSub(cp.l0_conversations_count, amount);
+      cp.stats_revision += 1;
+    });
+    this.logger.info(`[checkpoint] decrementL0Conversations(${amount}): l0_conversations_count=${cp.l0_conversations_count}`);
+  }
+
+  /**
+   * Decrement `total_memories_extracted` by `amount` (L1 record units),
+   * floored at 0. `memories_since_last_persona` is clamped to the new total
+   * (it can never exceed the number of memories actually present).
+   * Used by memory-cleaner after deleting expired L1 records.
+   */
+  async decrementMemoriesExtracted(amount: number): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      cp.total_memories_extracted = CheckpointManager.floorSub(cp.total_memories_extracted, amount);
+      cp.memories_since_last_persona = Math.min(cp.memories_since_last_persona, cp.total_memories_extracted);
+      cp.stats_revision += 1;
+    });
+    this.logger.info(
+      `[checkpoint] decrementMemoriesExtracted(${amount}): total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+  }
+
+  /**
+   * Fully reset a session's persisted state (runner + pipeline namespaces).
+   *
+   * Pairs with data-level session deletion: after the session's L0/L1 data is
+   * wiped, its cursors would otherwise stay ahead of the (now empty) data and
+   * every later re-import would be skipped as "already processed".
+   *
+   * Runtime callers should also evict the session from MemoryPipelineManager's
+   * in-memory maps (`evictSession`) so timers/buffers restart cold.
+   *
+   * @returns true if any state entry was actually removed.
+   */
+  async resetSession(sessionKey: string): Promise<boolean> {
+    let removed = false;
+    await this.mutate((cp) => {
+      if (cp.runner_states && sessionKey in cp.runner_states) {
+        delete cp.runner_states[sessionKey];
+        removed = true;
+      }
+      if (cp.pipeline_states && sessionKey in cp.pipeline_states) {
+        delete cp.pipeline_states[sessionKey];
+        removed = true;
+      }
+      if (removed) {
+        cp.stats_revision += 1;
+      }
+    });
+    this.logger.info(`[checkpoint] resetSession session=${sessionKey}: removed=${removed}`);
+    return removed;
+  }
+
+  /**
+   * Reconcile counters and cursors with an actual-data snapshot.
+   *
+   * Counter reconciliation (exact, same-unit assignments):
+   *   - `total_processed`           := l0MessageCount (messages)
+   *   - `total_memories_extracted`  := l1RecordCount (records)
+   *   - `l0_conversations_count`    := min(current, l0MessageCount)  — batches
+   *     can never exceed messages; the exact batch count is not derivable from
+   *     the store, so this is a clamp, not an assignment.
+   *   - `memories_since_last_persona` := min(current, l1RecordCount)
+   *
+   * Cursor reconciliation:
+   *   - `runner_states[s].last_l1_cursor` uses recorded_at semantics — clamped
+   *     to the session's actual max recorded_at when it runs ahead (rollback).
+   *   - `pipeline_states[s].last_extraction_updated_time` is an ISO cursor —
+   *     clamped lexicographically to the session's actual max updated_at.
+   *   - `runner_states[s].last_captured_timestamp` uses the message-timestamp
+   *     clock, NOT recorded_at, so it is never clamped against recorded_at
+   *     data (mixing clocks could re-capture history). It is only reset when
+   *     the session has no data left at all.
+   *   - With `exhaustiveSessions`, sessions absent from the snapshot have all
+   *     cursors reset (full deletion / re-import scenario).
+   *
+   * Bumps `stats_revision` when (and only when) at least one field changed.
+   */
+  async recalculate(snapshot: CheckpointRecalculateSnapshot): Promise<RecalculateResult> {
+    const adjustments: RecalculateAdjustment[] = [];
+
+    const setExact = (field: string, obj: Record<string, number>, key: string, next: number): void => {
+      const prev = obj[key];
+      if (prev !== next) {
+        adjustments.push({ field, before: prev, after: next });
+        obj[key] = next;
+      }
+    };
+    const clampMax = (field: string, obj: Record<string, number>, key: string, max: number): void => {
+      const prev = obj[key];
+      if (prev > max) {
+        adjustments.push({ field, before: prev, after: max });
+        obj[key] = max;
+      }
+    };
+
+    await this.mutate((cp) => {
+      // ── Global counters ──
+      if (typeof snapshot.l0MessageCount === "number" && Number.isFinite(snapshot.l0MessageCount)) {
+        const n = Math.max(0, Math.floor(snapshot.l0MessageCount));
+        setExact("total_processed", cp as unknown as Record<string, number>, "total_processed", n);
+        clampMax("l0_conversations_count", cp as unknown as Record<string, number>, "l0_conversations_count", n);
+      }
+      if (typeof snapshot.l1RecordCount === "number" && Number.isFinite(snapshot.l1RecordCount)) {
+        const n = Math.max(0, Math.floor(snapshot.l1RecordCount));
+        setExact("total_memories_extracted", cp as unknown as Record<string, number>, "total_memories_extracted", n);
+        clampMax("memories_since_last_persona", cp as unknown as Record<string, number>, "memories_since_last_persona", n);
+      }
+
+      // ── Per-session cursors ──
+      if (snapshot.sessions) {
+        const exhaustive = snapshot.exhaustiveSessions === true;
+
+        for (const [sessionKey, rState] of Object.entries(cp.runner_states ?? {})) {
+          const s = snapshot.sessions[sessionKey];
+          if (!s) {
+            if (exhaustive) {
+              // No L0/L1 rows left for this session at all. Reset both
+              // cursors so a later re-import is processed instead of skipped.
+              // Note: captureAtomically treats cursor 0 as cold-start and
+              // falls back to pluginStartTimestamp, bounding re-capture.
+              if (rState.last_captured_timestamp !== 0 || rState.last_l1_cursor !== 0) {
+                adjustments.push({
+                  field: `runner_states.${sessionKey}`,
+                  before: `captured=${rState.last_captured_timestamp},l1=${rState.last_l1_cursor}`,
+                  after: "captured=0,l1=0",
+                });
+                rState.last_captured_timestamp = 0;
+                rState.last_l1_cursor = 0;
+              }
+            }
+            continue;
+          }
+          if (typeof s.l0MaxRecordedAtMs === "number" && Number.isFinite(s.l0MaxRecordedAtMs)) {
+            // L1 cursor shares the recorded_at clock → clamp when ahead of data.
+            if (rState.last_l1_cursor > s.l0MaxRecordedAtMs) {
+              adjustments.push({
+                field: `runner_states.${sessionKey}.last_l1_cursor`,
+                before: rState.last_l1_cursor,
+                after: s.l0MaxRecordedAtMs,
+              });
+              rState.last_l1_cursor = s.l0MaxRecordedAtMs;
+            }
+          } else if (exhaustive && rState.last_l1_cursor !== 0) {
+            // Session exists (has L1 rows) but its L0 rows are all gone:
+            // rewind the L1 cursor so re-imported L0 data is not skipped.
+            // last_captured_timestamp is deliberately NOT touched — its data
+            // source is the host conversation history, not the L0 store.
+            adjustments.push({
+              field: `runner_states.${sessionKey}.last_l1_cursor`,
+              before: rState.last_l1_cursor,
+              after: 0,
+            });
+            rState.last_l1_cursor = 0;
+          }
+        }
+
+        for (const [sessionKey, pState] of Object.entries(cp.pipeline_states ?? {})) {
+          const s = snapshot.sessions[sessionKey];
+          if (!s) {
+            if (exhaustive && pState.last_extraction_updated_time !== "") {
+              adjustments.push({
+                field: `pipeline_states.${sessionKey}.last_extraction_updated_time`,
+                before: pState.last_extraction_updated_time,
+                after: "",
+              });
+              pState.last_extraction_updated_time = "";
+            }
+            continue;
+          }
+          if (typeof s.l1MaxUpdatedAtIso === "string") {
+            // ISO 8601 UTC strings compare correctly lexicographically — the
+            // same semantics the L2 runner already uses (`updatedAt > cursor`).
+            if (pState.last_extraction_updated_time > s.l1MaxUpdatedAtIso) {
+              adjustments.push({
+                field: `pipeline_states.${sessionKey}.last_extraction_updated_time`,
+                before: pState.last_extraction_updated_time,
+                after: s.l1MaxUpdatedAtIso,
+              });
+              pState.last_extraction_updated_time = s.l1MaxUpdatedAtIso;
+            }
+          } else if (exhaustive && pState.last_extraction_updated_time !== "") {
+            // Session has L0 rows but zero L1 records → full rescan next L2.
+            adjustments.push({
+              field: `pipeline_states.${sessionKey}.last_extraction_updated_time`,
+              before: pState.last_extraction_updated_time,
+              after: "",
+            });
+            pState.last_extraction_updated_time = "";
+          }
+        }
+      }
+
+      if (adjustments.length > 0) {
+        cp.stats_revision += 1;
+      }
+    });
+
+    this.logger.info(
+      `[checkpoint] recalculate: ${adjustments.length} adjustment(s)` +
+      (adjustments.length > 0 ? ` — ${adjustments.map((a) => `${a.field}: ${a.before} → ${a.after}`).join("; ")}` : ""),
+    );
+    return { adjustments };
   }
 
 }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
+import { CheckpointManager } from "./checkpoint.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
 
@@ -12,6 +13,8 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  /** Optional injection for tests; defaults to a CheckpointManager on baseDir. */
+  checkpoint?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -19,6 +22,9 @@ interface CleanupStats {
   changedFiles: number;
   skippedNonShardFiles: number;
   deleteFailedFiles: number;
+  /** Data entries (JSONL lines / DB rows) actually removed, used to
+   *  calibrate checkpoint counters after the run. */
+  removedEntries: number;
 }
 
 const TAG = "[memory-tdai][cleaner]";
@@ -33,14 +39,24 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpoint?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpoint = opts.checkpoint;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  /** Lazy checkpoint accessor (cleaner and checkpoint share the same data dir). */
+  private getCheckpoint(): CheckpointManager {
+    if (!this.checkpoint) {
+      this.checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+    }
+    return this.checkpoint;
   }
 
   start(): void {
@@ -85,9 +101,9 @@ export class LocalMemoryCleaner {
       this.opts.logger?.error(`${TAG} ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
-    const targetDirs = [
-      path.join(this.opts.baseDir, L0_DIR_NAME),
-      path.join(this.opts.baseDir, L1_DIR_NAME),
+    const targetDirs: Array<{ kind: "L0" | "L1"; dirPath: string }> = [
+      { kind: "L0", dirPath: path.join(this.opts.baseDir, L0_DIR_NAME) },
+      { kind: "L1", dirPath: path.join(this.opts.baseDir, L1_DIR_NAME) },
     ];
 
     const total: CleanupStats = {
@@ -95,14 +111,23 @@ export class LocalMemoryCleaner {
       changedFiles: 0,
       skippedNonShardFiles: 0,
       deleteFailedFiles: 0,
+      removedEntries: 0,
     };
 
-    for (const dirPath of targetDirs) {
+    // Track removed entries per layer so checkpoint counters can be
+    // decremented by the exact amount afterwards.
+    let removedL0Entries = 0;
+    let removedL1Entries = 0;
+
+    for (const { kind, dirPath } of targetDirs) {
       const stats = await this.cleanDirectory(dirPath, cutoffMs);
       total.scannedFiles += stats.scannedFiles;
       total.changedFiles += stats.changedFiles;
       total.skippedNonShardFiles += stats.skippedNonShardFiles;
       total.deleteFailedFiles += stats.deleteFailedFiles;
+      total.removedEntries += stats.removedEntries;
+      if (kind === "L0") removedL0Entries += stats.removedEntries;
+      else removedL1Entries += stats.removedEntries;
     }
 
     if (this.vectorStore) {
@@ -164,6 +189,9 @@ export class LocalMemoryCleaner {
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
       }
+      removedL0Entries += removedL0;
+      removedL1Entries += removedL1;
+      total.removedEntries += removedL0 + removedL1;
 
       // ── Post-delete: audit summary ──
       const durationMs = Date.now() - startMs;
@@ -178,6 +206,32 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    // ── Checkpoint calibration ──
+    // Counters only ever increase, so without this step every cleanup would
+    // leave the checkpoint permanently overestimated. Decrement by the exact
+    // number of removed entries (floored at 0 inside the checkpoint); the
+    // decrement also bumps stats_revision so concurrent defensive readers
+    // accept the lower counters instead of "repairing" them back up.
+    if (removedL0Entries > 0 || removedL1Entries > 0) {
+      try {
+        const checkpoint = this.getCheckpoint();
+        if (removedL0Entries > 0) {
+          await checkpoint.decrementTotalProcessed(removedL0Entries);
+        }
+        if (removedL1Entries > 0) {
+          await checkpoint.decrementMemoriesExtracted(removedL1Entries);
+        }
+        this.opts.logger?.info(
+          `${TAG} Checkpoint calibrated: total_processed -= ${removedL0Entries}, total_memories_extracted -= ${removedL1Entries}`,
+        );
+      } catch (err) {
+        // Non-fatal: counters can also be rebuilt later via recalculate().
+        this.opts.logger?.warn(
+          `${TAG} Checkpoint calibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     this.opts.logger?.info(
@@ -231,6 +285,7 @@ export class LocalMemoryCleaner {
       changedFiles: 0,
       skippedNonShardFiles: 0,
       deleteFailedFiles: 0,
+      removedEntries: 0,
     };
 
     let entries;
@@ -259,9 +314,13 @@ export class LocalMemoryCleaner {
 
       const dayEndMs = localDayEndMs(shard.year, shard.month, shard.day);
       if (dayEndMs < cutoffMs) {
+        // Count entries before deletion so checkpoint counters can be
+        // calibrated by the exact amount (one JSONL line = one entry).
+        const entries = await countJsonlEntries(filePath);
         try {
           await fs.unlink(filePath);
           stats.changedFiles += 1;
+          stats.removedEntries += entries;
           this.opts.logger?.info(`${TAG} Removed expired file by name: ${filePath}`);
         } catch (err) {
           stats.deleteFailedFiles += 1;
@@ -280,6 +339,23 @@ export class LocalMemoryCleaner {
 
 function isJsonLikeFile(name: string): boolean {
   return name.endsWith(".jsonl") || name.endsWith(".json");
+}
+
+/**
+ * Count data entries in a JSONL-like file (one non-empty line = one entry).
+ * Returns 0 on unreadable files — deletion proceeds regardless.
+ */
+async function countJsonlEntries(filePath: string): Promise<number> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    let count = 0;
+    for (const line of content.split("\n")) {
+      if (line.trim().length > 0) count += 1;
+    }
+    return count;
+  } catch {
+    return 0;
+  }
 }
 
 function extractShardDateFromFileName(

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -527,6 +527,7 @@ export function createL2Runner(opts: {
     const preScenesProcessed = preState.scenes_processed;
     const preMemoriesSince = preState.memories_since_last_persona;
     const preTotalProcessed = preState.total_processed;
+    const preStatsRevision = preState.stats_revision;
 
     const extractResult = await extractor.extract(memories);
     if (extractResult.success && extractResult.memoriesProcessed > 0) {
@@ -536,20 +537,35 @@ export function createL2Runner(opts: {
         postState.scenes_processed < preScenesProcessed ||
         postState.total_processed < preTotalProcessed
       ) {
-        logger.warn(
-          `${TAG} [L2] ⚠️ Checkpoint corruption detected! ` +
-          `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
-          `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
-          `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
-          `Repairing...`,
-        );
-        await checkpoint.write({
-          ...postState,
-          scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
-          total_processed: Math.max(postState.total_processed, preTotalProcessed),
-          memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
-        });
-        logger.info(`${TAG} [L2] Checkpoint repaired`);
+        // A decrease is only "corruption" when no intentional calibration
+        // happened in between. decrement*/recalculate/resetSession all bump
+        // stats_revision — if it changed, the lower counters are ground truth
+        // (e.g. memory-cleaner just deleted expired data) and must NOT be
+        // restored, otherwise every cleanup would be immediately undone.
+        if (postState.stats_revision !== preStatsRevision) {
+          logger.info(
+            `${TAG} [L2] Checkpoint calibration detected (stats_revision ${preStatsRevision} → ` +
+            `${postState.stats_revision}), accepting lower counters: ` +
+            `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
+            `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
+            `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}.`,
+          );
+        } else {
+          logger.warn(
+            `${TAG} [L2] ⚠️ Checkpoint corruption detected! ` +
+            `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
+            `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
+            `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
+            `Repairing...`,
+          );
+          await checkpoint.write({
+            ...postState,
+            scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
+            total_processed: Math.max(postState.total_processed, preTotalProcessed),
+            memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
+          });
+          logger.info(`${TAG} [L2] Checkpoint repaired`);
+        }
       }
 
       if (vectorStore && supportsProfileSyncWrite(vectorStore)) {

--- a/src/utils/pipeline-manager.ts
+++ b/src/utils/pipeline-manager.ts
@@ -499,6 +499,32 @@ export class MemoryPipelineManager {
   }
 
   /**
+   * Evict a single session from ALL in-memory maps (state, timers, buffer,
+   * L2 last-run time). Pending timers are cancelled first.
+   *
+   * Pairs with `CheckpointManager.resetSession()` for the "session data
+   * reset" scenario: after the persisted runner/pipeline states are wiped,
+   * the runtime copies must go too — otherwise the pipeline would persist the
+   * stale counters right back on the next notifyConversation().
+   *
+   * Unlike `gcStaleSessions()` this is unconditional and immediate: callers
+   * are expected to have flushed (or deliberately discarded) pending work.
+   * Unknown session keys are a no-op.
+   */
+  evictSession(sessionKey: string): void {
+    const timers = this.sessionTimers.get(sessionKey);
+    if (timers) {
+      timers.l1Idle.cancel();
+      timers.l2Schedule.cancel();
+    }
+    this.sessionStates.delete(sessionKey);
+    this.sessionTimers.delete(sessionKey);
+    this.messageBuffers.delete(sessionKey);
+    this.l2LastRunTime.delete(sessionKey);
+    this.logger?.debug?.(`${TAG} [${sessionKey}] Session evicted from pipeline memory`);
+  }
+
+  /**
    * Maximum time (ms) to wait for pipeline flush during destroy.
    * Must be shorter than the gateway_stop hook timeout (3 s) to leave
    * headroom for VectorStore / EmbeddingService cleanup that runs after.


### PR DESCRIPTION
# Fix checkpoint counter/cursor drift after data deletion

## Description | 描述

A close read of every consumer showed the fields fall into three classes, and
the drift symptom in the issue ("incremental processing skips records") is
specifically caused by the first one:

1. **Cursors** (drive incremental filtering): `last_captured_timestamp`,
   `last_l1_cursor` (runner states), `last_extraction_updated_time` (pipeline
   states). A cursor ahead of the actual data makes L0/L1/L2 skip real records.
2. **Trigger counters** (persona scheduling): `scenes_processed`,
   `memories_since_last_persona`. Inflation breaks the cold-start conditions
   (`scenes_processed === 1` can never hold again after a reset).
3. **Pure stats** (write-only, no consumers): `total_processed`,
   `l0_conversations_count`, `total_memories_extracted` — drift here is
   cosmetic but still worth correcting.

The fix introduces explicit **downward write paths**, all serialized through
the existing per-file async lock (`mutate()`):

- **`decrementTotalProcessed(n)` / `decrementL0Conversations(n)` /
  `decrementMemoriesExtracted(n)`** — floored at 0; the L1 variant also clamps
  `memories_since_last_persona` to the new total (it can never exceed the
  number of memories actually present).
- **`recalculate(snapshot)`** — reconciles the checkpoint with a ground-truth
  snapshot: counters are re-assigned exactly (`total_processed` ← actual L0
  messages, `total_memories_extracted` ← actual L1 records), derived counters
  are clamped (`l0_conversations_count`, `memories_since_last_persona`), and
  per-session cursors are **clamped to the actual data watermark** when they
  run ahead (rollback), or **reset to zero** when a session's data is fully
  gone (re-import protection). `last_captured_timestamp` is deliberately
  *never* clamped against `recorded_at` data — it runs on the message clock,
  and mixing clocks could re-capture history; it resets only when a session
  has no data left at all (bounded by the existing `pluginStartTimestamp`
  cold-start floor).
- **`resetSession(sessionKey)`** — wipes a session's runner + pipeline state
  so a data-level session reset restarts processing from scratch, paired with
  the new **`MemoryPipelineManager.evictSession()`** that clears the runtime
  copies (timers, buffers, counters) so they are not persisted back.
- **`stats_revision`** — a monotonic field bumped by every intentional
  downward calibration. The pre-existing L2 "checkpoint corruption" guard in
  `pipeline-factory.ts` assumed counters only ever increase and would
  `Math.max`-restore any decrease — silently undoing every cleanup. It now
  compares `stats_revision` and **accepts** legitimate calibrations while
  still repairing genuine clobbers.
- **`buildSnapshotFromSqlite(dataDir)`** (new `checkpoint-snapshot.ts`) —
  builds an exhaustive ground-truth snapshot straight from `vectors.db`
  (`node:sqlite`, read-only): exact counts plus per-session
  `MAX(recorded_at)` / `MAX(updated_time)` watermarks. No VectorStore /
  embedding machinery needed, so it also works while degraded.

`LocalMemoryCleaner.runOnce()` now calibrates automatically: JSONL shards are
line-counted before `unlink`, DB deletions report exact row counts, and the
checkpoint is decremented by the precise amounts at the end of each run.

## Related Issue | 关联 Issue

Fixes the checkpoint drift issue described in  [[#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157)](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157 "issue2") (counters
only implement `increment*`; cleanup/reset/rollback leaves them permanently
overestimated, so incremental processing skips records that should be
processed).

## Change Type | 修改类型

- Bug fix | Bug 修复
- New feature | 新功能 (`decrement*` / `recalculate` / `resetSession` /
  `evictSession` / `buildSnapshotFromSqlite`)
- Code optimization | 代码优化 (memory-cleaner now calibrates the checkpoint
  after each run)

## Acceptance Criteria Coverage | 验收标准对应

### 基础：阅读源码，画出 checkpoint 数据流图，确认漂移问题和影响范围
![[Checkpoint_数据流与漂移路径图.png]]

Confirmed drift paths and blast radius:

- **memory-cleaner**: deletes expired rows/shards; counters inflate (cursors
  stay correct — expired data precedes them — but any later *reprocessing*
  intent is blocked).
- **Session reset / test-state deletion** (primary failure path):
  `runner_states[key].last_l1_cursor` survives the data wipe, so re-imported
  data is filtered out as "already processed".
- **Historical rollback**: all cursors run ahead of the restored data → every
  incremental stage idles.
- **Persona triggers**: `scenes_processed === 1` (P3) can never hold again
  after a reset; `memories_since_last_persona` inflates the P4 threshold
  input.
- **Hidden conflict found**: the L2 runner's corruption guard
  (`pipeline-factory.ts`) `Math.max`-restores counter decreases — any
  decrement/recalculate would be reverted unless the guard is taught about
  legitimate calibration (fixed via `stats_revision`).

### 进阶：实现至少一种修复方案并提交 PR（增加 decrement 或引入 recalculate 逻辑）

 **both** mechanisms implemented, plus the reset path:

- `decrementTotalProcessed` / `decrementL0Conversations` /
  `decrementMemoriesExtracted` (floored at 0, revision-bumped), wired into
  `LocalMemoryCleaner` so the automatic-cleanup scenario self-calibrates with
  exact amounts (JSONL line counts + store-reported row counts).
- `recalculate(snapshot)` with exact counter re-assignment, derived-counter
  clamps, per-session cursor clamps (rollback) and cursor resets
  (fully-deleted sessions, gated by `exhaustiveSessions`).
- `resetSession(sessionKey)` + `MemoryPipelineManager.evictSession()` for the
  session-reset scenario (persisted state + runtime state).
- `buildSnapshotFromSqlite()` for ground truth without VectorStore machinery.

Test file: `src/utils/checkpoint.test.ts` → `[进阶]` (10 tests).

### 深入：覆盖多种清理场景（手动 / 自动 / 重置）的测试用例

 — 20 tests over the four scenario families:

- **自动清理 (memory-cleaner integration)**: expired JSONL shards are
  line-counted and counters decremented exactly (`100 → 97`, `50 → 48`);
  store-backed deletion decrements by the store-reported amounts
  (`200 → 170`, `80 → 70`); a no-deletion run leaves the checkpoint untouched
  (no revision bump).
- **手动修剪 (real SQLite)**: rows are inserted into a real `vectors.db`,
  manually `DELETE`d (newest rows of one session + all rows of another), then
  `buildSnapshotFromSqlite` + `recalculate` clamps the survivors' cursors to
  the actual `MAX(recorded_at)` / `MAX(updated_time)` and resets the wiped
  session's cursors to zero — while the message-clock
  `last_captured_timestamp` is provably preserved.
- **历史回滚**: after deleting everything newer than a point in time, the L1
  cursor rewinds to the surviving max and the emptied L1 layer resets its L2
  cursor; a following re-import is picked up by the incremental filter
  (`recorded_at > cursor`) — executed against real SQLite queries.
- **重置**: `resetSession` + `evictSession` clear persisted and runtime state;
  the session restarts cold (`conversation_count` rebuilds from 1) and other
  sessions are untouched.
- **并发安全**: N concurrent decrements lose no updates; concurrent
  `captureAtomically` calls observe each other's cursor (`[0, 1000]`);
  concurrent identical `recalculate` calls adjust exactly once.

Test file: `src/utils/checkpoint.test.ts` → `[深入]` (7 tests) + concurrency
coverage inside `[进阶]`.

### 拓展：分析是否有更好的 Checkpoint 设计模式（如基于时间戳而非计数器）

— analysis, with an executable proof:

- **Derived counters (query-on-read)**: `total_processed` /
  `total_memories_extracted` are pure stats with no consumers; they could be
  computed from `countL0()`/`countL1()` on demand and dropped from the
  checkpoint entirely, deleting a whole drift class. Kept persistent for now
  (zero-cost writes, used in logs/backup naming), but `recalculate` makes
  them reconcilable — the first step toward deriving them.
- **Timestamp-based cursors**: the design already half-uses them
  (`last_l1_cursor` is recorded_at-ms, `last_extraction_updated_time` is ISO).
  Timestamps survive *expiry* deletion gracefully (deleted data precedes the
  cursor) but not *rollback/re-import* — which is why `recalculate` adds the
  missing clamp/reset path instead of replacing the scheme.
- **Generation/epoch tagging** (evaluated alternative): tag every cursor with
  a `data_generation` bumped on reset/rollback; consumers discard cursors from
  older generations. More explicit than heuristic clamping, but requires every
  writer/reader to carry the generation and a migration of the on-disk format.
  Chosen trade-off: clamp + reset + `stats_revision` fixes the drift with a
  strictly smaller blast radius; generation tagging remains a documented
  follow-up if reset storms ever become common.
- **Executable proof** (`[深入]` rollback test): with the pre-recalculate
  cursor the re-imported row is invisible to `recorded_at > cursor`; after
  `recalculate` the same query returns exactly the re-imported row —
  demonstrating that timestamp cursors + reconciliation self-heal.

Test file: `src/utils/checkpoint.test.ts` → proof embedded in the rollback
scenario (1 assertion chain).

## Files Changed | 修改文件

- `src/utils/checkpoint.ts`
  - Added `stats_revision` field (default `0`, backward-compatible merge for
    old checkpoint files).
  - Added `decrementTotalProcessed` / `decrementL0Conversations` /
    `decrementMemoriesExtracted` (floored, revision-bumped).
  - Added `resetSession(sessionKey)` — removes runner + pipeline state.
  - Added `recalculate(snapshot)` — counter re-assignment/clamps, per-session
    cursor clamp (rollback) and reset (fully-deleted sessions).
  - Added `CheckpointRecalculateSnapshot` / `RecalculateAdjustment` /
    `RecalculateResult` types.
- `src/utils/checkpoint-snapshot.ts` (new) — `buildSnapshotFromSqlite()`:
  exhaustive ground-truth snapshot from `vectors.db` via `node:sqlite`
  (read-only), incl. per-session `MAX(recorded_at)` / `MAX(updated_time)`.
- `src/utils/memory-cleaner.ts`
  - Counts JSONL entries before `unlink` (`countJsonlEntries`), tracks
    removed entries per layer (files + store deletions).
  - Calibrates the checkpoint (`decrementTotalProcessed` /
    `decrementMemoriesExtracted`) after each run; failure is logged and
    non-fatal.
  - Optional `checkpoint` injection for tests.
- `src/utils/pipeline-factory.ts`
  - The L2 corruption guard now compares `stats_revision`: legitimate
    calibrations are accepted (logged), genuine clobbers are still repaired.
- `src/utils/pipeline-manager.ts`
  - Added public `evictSession(sessionKey)` — cancels timers, clears
    state/buffer/L2-runtime maps; pairs with `resetSession()`.
- `src/utils/checkpoint.test.ts` (new) — 4-level test suite (20 tests).

No call-site migration needed: old checkpoint files load unchanged
(`stats_revision` merges from defaults), and all new APIs are additive.

## Self-test Checklist | 自测清单

  ✅ Verified locally | 本地验证通过
  ✅ No existing features affected | 无影响现有功能
  - Old checkpoints without `stats_revision` load with default `0`.
  - `recalculate` with a no-change snapshot performs zero writes and does not
    bump `stats_revision`.
  - memory-cleaner skips calibration gracefully when nothing was deleted.
  ✅ decrement methods floor at 0 and clamp derived counters
  - `total_processed`, `l0_conversations_count`, `total_memories_extracted`
    never go negative.
  - `memories_since_last_persona` is clamped to the new total after
    `decrementMemoriesExtracted`.
  ✅ Automatic cleanup calibrates the checkpoint
  - JSONL shard deletion: `100 → 97` (3 L0 lines), `50 → 48` (2 L1 lines).
  - Store deletion: `200 → 170` (30 rows), `80 → 70` (10 rows).
  ✅ Manual trim reconciled against real SQLite ground truth
  - Cursors clamp to actual `MAX(recorded_at)` / `MAX(updated_time)`.
  - Fully-deleted session cursors reset to `0` / `""`.
  - Message-clock `last_captured_timestamp` preserved while data remains.
  ✅ Historical rollback rewinds cursors and reprocessing heals
  - L1 cursor rewinds to the surviving max; emptied layer resets its cursor.
  - Re-imported row is visible to the incremental filter after recalculate.
  ✅ Session reset clears persisted + runtime state
  - `resetSession` removes only the target session, bumps `stats_revision`.
  - `evictSession` clears pipeline memory; session restarts cold.
  ✅ L2 corruption guard no longer reverts legitimate calibrations
  - Guard skips the `Math.max` restore when `stats_revision` changed.
  ✅ Concurrency safety
  - 25 concurrent decrements lose no updates.
  - Concurrent `captureAtomically` observes serialized cursors `[0, 1000]`.
  - Concurrent identical `recalculate` calls adjust exactly once.
  ✅ Full test suite passes

```plain
$ npx vitest run src/utils/checkpoint.test.ts
 Test Files  1 passed (1)
      Tests  20 passed | 0 failed
```

```plain
$ npm test
 Test Files  5 passed (5)
      Tests  87 passed | 0 failed
```

```plain
$ npm run build:plugin
✔ Build complete
```

> **Note:** Some content was generated with AI assistance.