### PR TITLE
fix(storage): prevent path traversal in writeRefMd/readRefMd (CWE-22)

### DIFF
--- a/src/offload/storage.security.test.ts
+++ b/src/offload/storage.security.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { createStorageContext, isoToFilename, writeRefMd, readRefMd } from "./storage.js";
+
+describe("storage security (CWE-22)", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "offload-sec-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("isoToFilename strips path separators and dotdot", () => {
+    expect(isoToFilename("../../../etc/passwd")).not.toMatch(/[/\\]|\.\./);
+    expect(isoToFilename("../../../etc/passwd")).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("isoToFilename returns non-empty fallback", () => {
+    expect(isoToFilename("")).toBe("ref");
+    expect(isoToFilename("///")).toBe("ref");
+  });
+
+  it("isoToFilename caps length", () => {
+    expect(isoToFilename("a".repeat(500)).length).toBeLessThanOrEqual(128);
+  });
+
+  it("writeRefMd writes inside refsDir with normal timestamp", async () => {
+    const ctx = createStorageContext(root, "agent1", "sess1");
+    mkdirSync(ctx.refsDir, { recursive: true });
+    const rel = await writeRefMd(ctx, "2024-01-02T03:04:05.678Z", "tool", "hello");
+    expect(rel.startsWith("refs/")).toBe(true);
+    expect(existsSync(join(ctx.refsDir, rel.slice("refs/".length)))).toBe(true);
+  });
+
+  it("writeRefMd cannot escape refsDir even with malicious timestamp", async () => {
+    const ctx = createStorageContext(root, "agent1", "sess1");
+    mkdirSync(ctx.refsDir, { recursive: true });
+    const rel = await writeRefMd(ctx, "../../evil", "tool", "x");
+    // filename must be inside refs/, no escape
+    expect(rel).toMatch(/^refs\/[A-Za-z0-9_-]+\.md$/);
+    expect(existsSync(join(root, "evil.md"))).toBe(false);
+  });
+
+  it("readRefMd returns null on traversal attempts", async () => {
+    const ctx = createStorageContext(root, "agent1", "sess1");
+    mkdirSync(ctx.dataDir, { recursive: true });
+    // Plant a secret outside dataDir
+    const secret = join(root, "secret.txt");
+    writeFileSync(secret, "TOPSECRET");
+    const res = await readRefMd(ctx, "../secret.txt");
+    expect(res).toBeNull();
+  });
+
+  it("readRefMd reads legitimate ref", async () => {
+    const ctx = createStorageContext(root, "agent1", "sess1");
+    mkdirSync(ctx.refsDir, { recursive: true });
+    const rel = await writeRefMd(ctx, "2024-01-02T03:04:05.678Z", "tool", "payload");
+    const content = await readRefMd(ctx, rel);
+    expect(content).toContain("payload");
+  });
+
+  it("prefix-confusion (sibling dir with same prefix) is blocked", async () => {
+    // dataDir is <root>/agent1; a sibling <root>/agent1evil must not be accepted.
+    const ctx = createStorageContext(root, "agent1", "sess1");
+    mkdirSync(ctx.dataDir, { recursive: true });
+    const sibling = join(root, "agent1evil");
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(join(sibling, "x.md"), "nope");
+    const res = await readRefMd(ctx, `..${sep}agent1evil${sep}x.md`);
+    expect(res).toBeNull();
+  });
+});

--- a/src/offload/storage.ts
+++ b/src/offload/storage.ts
@@ -10,7 +10,7 @@
  */
 import { readFile, writeFile, appendFile, mkdir, readdir, unlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, resolve, sep } from "node:path";
 import { homedir } from "node:os";
 import type { OffloadEntry, PluginLogger } from "./types.js";
 
@@ -523,9 +523,42 @@ export async function updateOffloadNodeIds(
 
 // ─── MD (Tool Result Refs) Operations ────────────────────────────────────────
 
-/** Convert ISO 8601 timestamp to a safe filename (replace special chars) */
+/**
+ * Convert ISO 8601 timestamp to a safe filename component.
+ *
+ * Security: this is a filename-component sanitizer, not just a display helper.
+ * Any character outside the strict allowlist `[A-Za-z0-9_-]` is replaced with
+ * `-`, so path separators (`/`, `\\`), parent-dir tokens (`..`), NUL bytes,
+ * and other filesystem-metacharacters cannot survive into a filename passed to
+ * `join(ctx.refsDir, ...)`. See writeRefMd for the defence-in-depth containment
+ * check that also enforces the resolved path stays inside `ctx.refsDir`.
+ */
 export function isoToFilename(iso: string): string {
-  return iso.replace(/:/g, "-").replace(/\./g, "-").replace(/\+/g, "p");
+  const replaced = String(iso ?? "")
+    .replace(/:/g, "-")
+    .replace(/\./g, "-")
+    .replace(/\+/g, "p")
+    .replace(/[^A-Za-z0-9_-]/g, "-");
+  // Collapse to a non-empty, bounded token to guarantee a valid filename.
+  const trimmed = replaced.replace(/^-+|-+$/g, "").slice(0, 128);
+  return trimmed.length > 0 ? trimmed : "ref";
+}
+
+/**
+ * Assert that `candidate` resolves inside `root`. Throws on escape attempts.
+ * Prevents path traversal via crafted filename components (CWE-22).
+ */
+function assertWithin(root: string, candidate: string): void {
+  const resolvedRoot = resolve(root);
+  const resolvedCandidate = resolve(candidate);
+  if (
+    resolvedCandidate !== resolvedRoot &&
+    !resolvedCandidate.startsWith(resolvedRoot + sep)
+  ) {
+    throw new Error(
+      `[context-offload] path traversal blocked: ${resolvedCandidate} escapes ${resolvedRoot}`,
+    );
+  }
 }
 
 /** Write tool result content to a ref MD file, return relative path */
@@ -537,6 +570,8 @@ export async function writeRefMd(
 ): Promise<string> {
   const filename = `${isoToFilename(timestamp)}.md`;
   const filePath = join(ctx.refsDir, filename);
+  // Defence-in-depth: even if isoToFilename regressed, refuse to write outside refsDir.
+  assertWithin(ctx.refsDir, filePath);
   const safeContent = (content ?? "").replace(UNSAFE_CHAR_RE, "");
   const header = `# Tool Result: ${toolName}\n\n**Timestamp:** ${timestamp}\n\n---\n\n`;
   await writeFile(filePath, header + safeContent, "utf-8");
@@ -549,6 +584,12 @@ export async function readRefMd(
   refPath: string,
 ): Promise<string | null> {
   const filePath = join(ctx.dataDir, refPath);
+  // Containment check: refPath comes from stored state and must stay inside dataDir.
+  try {
+    assertWithin(ctx.dataDir, filePath);
+  } catch {
+    return null;
+  }
   if (!existsSync(filePath)) return null;
   return readFile(filePath, "utf-8");
 }


### PR DESCRIPTION
## Description | 描述

Hardens `src/offload/storage.ts` against path traversal (CWE-22) in the tool-result "ref MD" storage layer. The three affected functions are `isoToFilename`, `writeRefMd`, and `readRefMd`, all exported from the `@tencentdb-agent-memory/memory-tencentdb` package.

### Why this matters

This package is published as an npm library with `writeRefMd(ctx, timestamp, …)` and `readRefMd(ctx, refPath)` in its public storage module. Inside this repo the `timestamp` argument is always sourced from `nowChinaISO()` and `refPath` values are produced internally, so the in-tree call graph is safe today. However, `isoToFilename` and both ref functions are exported symbols consumed by downstream integrations, and there is no guarantee those consumers only pass server-generated values. The current `isoToFilename` is a display-oriented replacer — it only rewrites `:`, `.`, `+`. Any other character (including `/`, `\`, `..`, NUL) passes through untouched, and the resulting string is fed directly into `join(ctx.refsDir, …)`. A downstream consumer that ever forwards a user-supplied timestamp or ref path would get an arbitrary-file-write / arbitrary-file-read primitive scoped to the Node process's FS permissions.

Treating these exported functions as a library boundary and adding defence-in-depth containment is the right call regardless of the in-repo threat model.

### Fix

1. `isoToFilename` now applies a strict allowlist: anything outside `[A-Za-z0-9_-]` is replaced with `-`, the result is trimmed of leading/trailing dashes, capped at 128 chars, and falls back to `"ref"` if empty. This makes it impossible for the filename component to contain path separators, `..`, NUL bytes, or other filesystem metacharacters.
2. A new internal `assertWithin(root, candidate)` helper resolves both paths with `path.resolve` and requires the candidate to equal `root` or start with `root + path.sep`. The `+ sep` guard is important — a naive `startsWith(root)` would accept a sibling like `<root>evil` (prefix-confusion). This is covered by a regression test.
3. `writeRefMd` calls `assertWithin(ctx.refsDir, filePath)` before writing, so even if `isoToFilename` ever regressed the write is refused.
4. `readRefMd` calls `assertWithin(ctx.dataDir, filePath)` and returns `null` on containment failure, matching the existing "missing file" behaviour so callers don't need to change error handling.

The changes are localized (one file, ~44 lines) and preserve all existing behaviour on valid inputs — filenames like `2024-01-02T03:04:05.678Z` still round-trip correctly, and legitimate ref reads still succeed.

## Related Issue | 关联 Issue

None — reporting via PR.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复 (security hardening)

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Added `src/offload/storage.security.test.ts` with 8 regression tests, all passing under `npx vitest run`:

- `isoToFilename` strips path separators and `..` from `"../../../etc/passwd"`
- `isoToFilename` returns the `"ref"` fallback for empty / all-separator input
- `isoToFilename` caps output at 128 chars
- `writeRefMd` writes inside `refsDir` for a normal ISO timestamp
- `writeRefMd` with a malicious `"../../evil"` timestamp still produces a safe filename inside `refs/` and does not create `<root>/evil.md`
- `readRefMd` returns `null` for a `"../secret.txt"` traversal attempt while a real secret exists outside `dataDir`
- `readRefMd` still reads legitimate refs written by `writeRefMd`
- Prefix-confusion check: a sibling directory `<root>/agent1evil` next to `dataDir=<root>/agent1` is rejected, proving the `+ sep` guard works

## Additional Notes | 其他说明

### Proof of concept (library-consumer scenario)

```ts
import { createStorageContext, writeRefMd, readRefMd } from "@tencentdb-agent-memory/memory-tencentdb/dist/offload/storage.js";

const ctx = createStorageContext("/tmp/store", "agent1", "sess1");
// Before the fix: attacker-controlled timestamp escapes refsDir.
await writeRefMd(ctx, "../../evil", "tool", "pwned");
// Result on unpatched build: /tmp/evil.md created outside refsDir.

// Before the fix: attacker-controlled refPath reads outside dataDir.
await readRefMd(ctx, "../../../etc/hostname");
// Result on unpatched build: returns contents of /etc/hostname.
```

After the fix, the write lands at a sanitized filename inside `refs/` and the read returns `null`. The regression tests in `storage.security.test.ts` encode exactly these two cases.

### Adversarial review

Before submitting we tried to disprove this. In the current repo the `timestamp` passed to `writeRefMd` is `nowChinaISO()` and `readRefMd` has no non-test caller with untrusted `refPath`, so an in-repo-only threat model would classify this as non-exploitable. We still think the fix is worth merging because (a) `isoToFilename`, `writeRefMd` and `readRefMd` are exported from a published npm package and any downstream integration that forwards user input reintroduces the primitive, (b) the current `isoToFilename` reads like a security sanitizer but is actually a display helper — that mismatch is a footgun for future contributors, and (c) the change is small, has no behavioural impact on valid inputs, and comes with tests. We also checked that `assertWithin` uses `resolve` + `startsWith(root + sep)` rather than a naive prefix match, so sibling-directory confusion (`agent1` vs `agent1evil`) is correctly blocked — the test suite pins that behaviour.

No other call sites in the repo build filesystem paths from the same values, so no parallel sinks need patching.