### PR TITLE
fix: reconcile checkpoint counters after cleanup prevents drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ test-offload-sessions.sh
 
 # log files
 *.log
+
+# PR tracker (tool artifact)
+.pr-tracker/

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -332,6 +332,49 @@ export class CheckpointManager {
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
   }
 
+  /**
+   * Adjust checkpoint counters after data cleanup (retention policy).
+   *
+   * When the memory cleaner removes expired records, the checkpoint counters
+   * must be decremented to stay consistent with actual data. Without this,
+   * counters like total_processed / total_memories_extracted would drift
+   * further and further from reality over time.
+   *
+   * @param l0MessagesRemoved  Number of L0 messages deleted
+   * @param l0ConversationsRemoved  Number of L0 conversation files deleted
+   * @param l1MemoriesRemoved  Number of L1 memories deleted
+   * @param scenesRemoved  Number of scene records deleted
+   */
+  async adjustCountersAfterCleanup(
+    l0MessagesRemoved: number,
+    l0ConversationsRemoved: number,
+    l1MemoriesRemoved: number,
+    scenesRemoved: number,
+  ): Promise<void> {
+    if (l0MessagesRemoved <= 0 && l0ConversationsRemoved <= 0 && l1MemoriesRemoved <= 0 && scenesRemoved <= 0) {
+      return;
+    }
+    await this.mutate((cp) => {
+      if (l0MessagesRemoved > 0) {
+        cp.total_processed = Math.max(0, cp.total_processed - l0MessagesRemoved);
+      }
+      if (l0ConversationsRemoved > 0) {
+        cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count - l0ConversationsRemoved);
+      }
+      if (l1MemoriesRemoved > 0) {
+        cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted - l1MemoriesRemoved);
+      }
+      if (scenesRemoved > 0) {
+        cp.scenes_processed = Math.max(0, cp.scenes_processed - scenesRemoved);
+      }
+    });
+    this.logger.info(
+      `[checkpoint] adjustCountersAfterCleanup: ` +
+      `l0Messages-${l0MessagesRemoved}, l0Conversations-${l0ConversationsRemoved}, ` +
+      `l1Memories-${l1MemoriesRemoved}, scenes-${scenesRemoved}`,
+    );
+  }
+
   // ============================
   // Per-session helpers — runner state (L0/L1 owned)
   // ============================

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import type { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -12,6 +13,7 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  checkpointManager?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -33,14 +35,28 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpointManager?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpointManager = opts.checkpointManager;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  setCheckpointManager(checkpointManager: CheckpointManager | undefined): void {
+    this.checkpointManager = checkpointManager;
+  }
+
+  private async getOrCreateCheckpointManager(): Promise<CheckpointManager | undefined> {
+    if (this.checkpointManager) return this.checkpointManager;
+    if (!this.opts.logger) return undefined;
+    const { CheckpointManager } = await import("./checkpoint.js");
+    this.checkpointManager = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+    return this.checkpointManager;
   }
 
   start(): void {
@@ -163,6 +179,25 @@ export class LocalMemoryCleaner {
 
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
+      }
+
+      // ── Post-delete: reconcile checkpoint counters ──
+      if (removedL0 > 0 || removedL1 > 0) {
+        const cpMgr = await this.getOrCreateCheckpointManager();
+        if (cpMgr) {
+          try {
+            await cpMgr.adjustCountersAfterCleanup(
+              removedL0,
+              total.changedFiles,
+              removedL1,
+              0,
+            );
+          } catch (err) {
+            this.opts.logger?.warn(
+              `${TAG} [checkpoint] Failed to adjust counters after cleanup: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
       }
 
       // ── Post-delete: audit summary ──


### PR DESCRIPTION
## Summary

This PR fixes #157 by adding checkpoint counter reconciliation after data retention cleanup.

## Changes
- **checkpoint.ts**: Added `adjustCountersAfterCleanup()` method to `CheckpointManager` that decrements `total_processed`, `l0_conversations_count`, `total_memories_extracted`, and `scenes_processed` counters when expired records are removed
- **memory-cleaner.ts**: Wired checkpoint reconciliation into `LocalMemoryCleaner.runOnce()` so that after successful database cleanup, checkpoint counters are adjusted to stay consistent with actual data
- Added lazy creation of `CheckpointManager` via dynamic import to avoid tight coupling and enable standalone cleaner usage

## Problem
Previously, checkpoint counters (`total_processed`, `total_memories_extracted`, etc.) only ever increased. When the memory cleaner removed expired records as part of retention policy enforcement, these counters were never decremented, causing them to drift further and further from the actual data over time.

## Solution
Added a dedicated `adjustCountersAfterCleanup()` method that safely decrements counters with a floor of 0, wrapped in the existing file-lock concurrency safety mechanism. The cleaner calls this after successful deletion to keep the checkpoint consistent.

## Testing
- [x] Logic reviewed: counter decrements are guarded by Math.max(0, ...) to prevent negative values
- [x] Error handling: checkpoint adjustment failures are logged as warnings, non-fatal to cleanup
- [x] Lazy initialization: CheckpointManager is created on-demand, no startup overhead
- [x] Concurrency safety: adjustment runs under existing file lock via mutate()

## Checklist
- [x] My code follows the project's style guidelines
- [x] The fix is minimal and focused on the issue
- [x] No new dependencies introduced