### PR TITLE
feat: add sessionKey/sessionId filtering to memory search

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -293,6 +293,8 @@ export class TdaiCore {
       limit: params.limit ?? 5,
       type: params.type,
       scene: params.scene,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
       logger: this.logger,

--- a/src/core/tools/memory-search.ts
+++ b/src/core/tools/memory-search.ts
@@ -28,6 +28,8 @@ export interface MemorySearchResultItem {
   score: number;
   created_at: string;
   updated_at: string;
+  session_key?: string;
+  session_id?: string;
 }
 
 export interface MemorySearchResult {
@@ -84,6 +86,8 @@ export async function executeMemorySearch(params: {
   limit: number;
   type?: string;
   scene?: string;
+  sessionKey?: string;
+  sessionId?: string;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
   logger?: Logger;
@@ -93,6 +97,8 @@ export async function executeMemorySearch(params: {
     limit,
     type: typeFilter,
     scene: sceneFilter,
+    sessionKey: sessionKeyFilter,
+    sessionId: sessionIdFilter,
     vectorStore,
     embeddingService,
     logger,
@@ -158,6 +164,8 @@ export async function executeMemorySearch(params: {
           score: r.score,
           created_at: r.timestamp_start,
           updated_at: r.timestamp_end,
+          session_key: r.session_key,
+          session_id: r.session_id,
         }));
       } catch (err) {
         logger?.warn?.(
@@ -187,6 +195,8 @@ export async function executeMemorySearch(params: {
           score: r.score,
           created_at: r.timestamp_start,
           updated_at: r.timestamp_end,
+          session_key: r.session_key,
+          session_id: r.session_id,
         }));
       } catch (err) {
         logger?.warn?.(
@@ -225,7 +235,7 @@ export async function executeMemorySearch(params: {
     results = ftsOk ? ftsItems : vecItems;
   }
 
-  // ── Apply secondary filters (type, scene) ──
+  // ── Apply secondary filters (type, scene, session) ──
   const preFilterCount = results.length;
   if (typeFilter) {
     results = results.filter((r) => r.type === typeFilter);
@@ -237,6 +247,14 @@ export async function executeMemorySearch(params: {
       r.scene_name.toLowerCase().includes(normalizedScene),
     );
     logger?.debug?.(`${TAG} After scene filter "${sceneFilter}": ${results.length}/${preFilterCount}`);
+  }
+  if (sessionIdFilter) {
+    results = results.filter((r) => r.session_id === sessionIdFilter);
+    logger?.debug?.(`${TAG} After sessionId filter "${sessionIdFilter}": ${results.length}/${preFilterCount}`);
+  }
+  if (sessionKeyFilter) {
+    results = results.filter((r) => r.session_key === sessionKeyFilter);
+    logger?.debug?.(`${TAG} After sessionKey filter "${sessionKeyFilter}": ${results.length}/${preFilterCount}`);
   }
 
   // ── Trim to requested limit ──

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -231,6 +231,8 @@ export interface MemorySearchParams {
   limit?: number;
   type?: string;
   scene?: string;
+  sessionKey?: string;
+  sessionId?: string;
 }
 
 /** Search parameters for L0 conversation search. */


### PR DESCRIPTION
## Description

This PR adds optional `sessionKey` and `sessionId` filtering to the `tdai_memory_search` tool, preventing cross-agent memory contamination in multi-agent scenarios.

## Related Issue

Fixes #111

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code optimization

## Changes

### `src/core/tools/memory-search.ts`
- Extended `MemorySearchResultItem` with optional `session_key` and `session_id` fields
- Extended `executeMemorySearch()` params with optional `sessionKey` / `sessionId` filters
- Both FTS5 and vector search result mappings now include session metadata
- Post-retrieval filtering applied after type/scene filters

### `src/core/types.ts`
- Extended `MemorySearchParams` with `sessionKey` and `sessionId`

### `src/core/tdai-core.ts`
- Thread `sessionKey` / `sessionId` params from `searchMemories()` to `executeMemorySearch()`

## Design Note

Filtering is applied post-retrieval (not in SQL) because sqlite-vec does not support WHERE clauses on KNN queries. The system over-retrieves by 3× (`candidateK = limit * 3`) before trimming, so session filtering has minimal impact on recall quality for the typical case.

## Self-test Checklist

- [x] TypeScript diagnostics pass for all modified files
- [x] Backward compatible: when no session filters are provided, behavior is unchanged
- [x] No existing features affected