### PR TITLE
fix: one-time warning for hybrid recall fallback when embedding unavailable

### DIFF
--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -28,6 +28,8 @@ const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search �
 const MIN_TRUNCATED_RECALL_LINE_CHARS = 40;
 const RECALL_LINE_SEPARATOR = "\n";
 
+let warnedEmbeddingFallback = false;
+
 /**
  * Memory tools usage guide — injected at the end of memory context so the
  * main agent knows how to actively retrieve deeper information.
@@ -345,9 +347,13 @@ async function searchMemories(
   // Determine effective strategy (fall back to keyword if embedding not available)
   let effectiveStrategy = strategy;
   if ((strategy === "embedding" || strategy === "hybrid") && !embeddingAvailable) {
-    logger?.warn?.(
-      `${TAG} Strategy "${strategy}" requested but EmbeddingService not available, falling back to keyword`,
-    );
+    if (!warnedEmbeddingFallback) {
+      warnedEmbeddingFallback = true;
+      logger?.warn?.(
+        `${TAG} Strategy "${strategy}" requested but EmbeddingService not available, falling back to keyword. ` +
+        `This message appears only once. To suppress permanently, set recall.strategy: "keyword" in config.`,
+      );
+    }
     effectiveStrategy = "keyword";
   }
 


### PR DESCRIPTION
## Background

This PR fixes the noisy warning log described in #579: when `recall.strategy` is set to `hybrid` (the default) but `EmbeddingService` is not configured, the fallback to `keyword` strategy fires a WARN log on **every single recall call**, causing log spam.

Closes #579

## Changes

### `src/core/hooks/auto-recall.ts`
- Added module-level `warnedEmbeddingFallback` flag to track whether the fallback warning has already been emitted
- Changed the `hybrid`/ `embedding` → `keyword` fallback warning from per-call to one-time
- Enhanced the warning message to guide users: `To suppress permanently, set recall.strategy: "keyword" in config.`

### Design Rationale
- One-time warning preserves discoverability (users learn about the fallback once) while eliminating log spam
- The warning still appears early (on the first recall) so users are aware their configured strategy was overridden
- The guidance in the message tells users exactly how to configure their plugin if they want to silence it

### What this does NOT change
- The fallback logic itself remains identical: hybrid→keyword when embedding is unavailable
- The effective strategy computation is unchanged
- No behavior change — only log verbosity change

## Verification
- [x] TypeScript diagnostics pass
- [x] Backward compatible: all existing search behavior preserved
- [x] First recall with hybrid+no-embedding: WARN fires with guidance
- [x] Subsequent recalls: silent fallback to keyword, no WARN

## Impact
- **Breaking Change?** → No
- **Files changed**: 1 (`src/core/hooks/auto-recall.ts`)
- **Risk**: Minimal — log-only change, no logic modification