### PR TITLE
fix(offload): resolve after_tool_call messages from fallback sources on OpenClaw 5.27+

### DIFF
--- a/src/offload/hooks/after-tool-call.ts
+++ b/src/offload/hooks/after-tool-call.ts
@@ -39,6 +39,7 @@ import {
   recordToolCall,
   REPORT_TYPE_L3,
   L3_FIXED_PATCH_COST_TOKENS,
+  resolveMessagesFromEvent,
 } from "../state-reporter.js";
 
 function isHeartbeatToolCall(event: any, cachedParams: any): boolean {
@@ -108,21 +109,39 @@ export function createAfterToolCallHandler(
     // rate, not just the cases where L3 actually runs.
     recordToolCall();
 
+    // ── OpenClaw 5.27+ compatibility layer ──
+    // After the channel/session identity hardening in 5.27, `event.messages`
+    // is no longer populated by the upstream patch without explicit opt-in.
+    // We resolve the conversation array from a chain of alternative sources
+    // (event.historyMessages / event.state.messages / event.session.messages
+    // / ctx.session.messages / ctx.messages / ctx.historyMessages) and
+    // transparently re-attach it to event.messages so the rest of the
+    // handler (MMD injection, L3 compression, snapshots, tracing) continues
+    // to work without refactoring every call site.
     const eventKeys = event ? Object.keys(event) : [];
+    const _originalMessages = event?.messages;
+    const _fallbackMessages = resolveMessagesFromEvent(event, ctx);
+    if ((!_originalMessages || !Array.isArray(_originalMessages)) && _fallbackMessages && Array.isArray(_fallbackMessages)) {
+      event.messages = _fallbackMessages;
+    }
+    const messages: any[] | undefined =
+      (event?.messages && Array.isArray(event.messages)) ? event.messages : undefined;
+
     const hasMsgsKey = "messages" in (event ?? {});
-    const msgsValue = event?.messages;
-    const hasMsgs = msgsValue && Array.isArray(msgsValue);
-    logger.debug?.(`[context-offload] after_tool_call event keys=[${eventKeys.join(",")}], hasMsgsKey=${hasMsgsKey}, msgsType=${typeof msgsValue}, isArray=${Array.isArray(msgsValue)}, len=${hasMsgs ? msgsValue.length : "N/A"}`);
+    const hasMsgs = messages && Array.isArray(messages) && messages.length > 0;
+    const msgsValue = messages;
+    const _usedFallback = _originalMessages !== event.messages;
+    logger.debug?.(`[context-offload] after_tool_call event keys=[${eventKeys.join(",")}], hasMsgsKey=${hasMsgsKey}, fallback=${_usedFallback}, isArray=${Array.isArray(messages)}, len=${hasMsgs ? messages!.length : "N/A"}`);
 
     // ── Patch-effectiveness detection ──
     // The upstream runtime patch is expected to populate event.messages with
     // the current conversation. If it is missing/empty the patch is NOT in
     // effect and L3 compression cannot run from this hook. Report that
     // explicitly so operators can detect misconfigurations.
-    const _patchStatus = classifyPatchEffectiveness(event, "after_tool_call");
+    const _patchStatus = classifyPatchEffectiveness(event, "after_tool_call", ctx);
     if (_patchStatus.status !== "effective") {
       logger.warn(
-        `[context-offload] after_tool_call patch check: NOT EFFECTIVE (status=${_patchStatus.status}). ` +
+        `[context-offload] after_tool_call patch check: NOT EFFECTIVE (status=${_patchStatus.status}, resolvedFrom=${_patchStatus.resolvedFrom}). ` +
         `event.messages is ${Array.isArray(msgsValue) ? "empty array" : typeof msgsValue}. ` +
         `L3 compression will be skipped this turn.`,
       );

--- a/src/offload/state-reporter.ts
+++ b/src/offload/state-reporter.ts
@@ -61,20 +61,60 @@ export type L3TriggerStage = "after_tool_call" | "llm_input" | "assemble";
  */
 export type PatchEffective = "effective" | "missing_field" | "empty_messages" | "n/a";
 
-/** Inspects `event.messages` to classify patch health for after_tool_call. */
+export function resolveMessagesFromEvent(event: unknown, ctx?: unknown): any[] | undefined {
+  if (event && typeof event === "object") {
+    const ev = event as Record<string, unknown>;
+    if (Array.isArray(ev.messages)) return ev.messages as any[];
+    if (Array.isArray(ev.historyMessages)) return ev.historyMessages as any[];
+    const state = ev.state;
+    if (state && typeof state === "object" && Array.isArray((state as Record<string, unknown>).messages)) {
+      return (state as Record<string, unknown>).messages as any[];
+    }
+    const session = ev.session;
+    if (session && typeof session === "object" && Array.isArray((session as Record<string, unknown>).messages)) {
+      return (session as Record<string, unknown>).messages as any[];
+    }
+  }
+  if (ctx && typeof ctx === "object") {
+    const c = ctx as Record<string, unknown>;
+    const s = c.session;
+    if (s && typeof s === "object" && Array.isArray((s as Record<string, unknown>).messages)) {
+      return (s as Record<string, unknown>).messages as any[];
+    }
+    if (Array.isArray(c.messages)) return c.messages as any[];
+    if (Array.isArray(c.historyMessages)) return c.historyMessages as any[];
+  }
+  return undefined;
+}
+
 export function classifyPatchEffectiveness(
   event: unknown,
   stage: L3TriggerStage,
-): { status: PatchEffective; messagesLen: number } {
-  // Only after_tool_call depends on the runtime patch for event.messages.
-  if (stage !== "after_tool_call") return { status: "n/a", messagesLen: 0 };
+  ctx?: unknown,
+): { status: PatchEffective; messagesLen: number; resolvedFrom: string } {
+  if (stage !== "after_tool_call") return { status: "n/a", messagesLen: 0, resolvedFrom: "n/a" };
   if (!event || typeof event !== "object") {
-    return { status: "missing_field", messagesLen: 0 };
+    return { status: "missing_field", messagesLen: 0, resolvedFrom: "none" };
   }
-  const msgs = (event as { messages?: unknown }).messages;
-  if (!Array.isArray(msgs)) return { status: "missing_field", messagesLen: 0 };
-  if (msgs.length === 0) return { status: "empty_messages", messagesLen: 0 };
-  return { status: "effective", messagesLen: msgs.length };
+  const ev = event as Record<string, unknown>;
+  if (Array.isArray(ev.messages)) {
+    const len = (ev.messages as any[]).length;
+    return {
+      status: len === 0 ? "empty_messages" : "effective",
+      messagesLen: len,
+      resolvedFrom: "event.messages",
+    };
+  }
+  const resolved = resolveMessagesFromEvent(event, ctx);
+  if (resolved && Array.isArray(resolved)) {
+    const len = resolved.length;
+    return {
+      status: len === 0 ? "empty_messages" : "effective",
+      messagesLen: len,
+      resolvedFrom: "fallback",
+    };
+  }
+  return { status: "missing_field", messagesLen: 0, resolvedFrom: "none" };
 }
 
 // ─── Global cumulative counters ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

修复 OpenClaw 5.27+ 场景下 after_tool_call hook 无法读取会话消息导致 L3 压缩被每轮跳过的问题 (Closes #118)。

OpenClaw 5.27 对 channel/session identity 做了安全加固，导致 without-explicit-patch 时 event.messages 字段为空，从而触发 NOT EFFECTIVE (status=missing_field) 告警，L3 压缩无法运行。本 PR 增加多源回退链路并在 handler 内部透明回填。

## 设计决策

1. 多源回退链路 (resolveMessagesFromEvent)
   - 优先使用 event.messages（保持既有 patch 生效场景行为完全不变）
   - 否则依次尝试：event.historyMessages / event.state.messages / event.session.messages / ctx.session.messages / ctx.messages / ctx.historyMessages
   - 与 before_prompt_build / llm_input_l3 等已有 hook 对 historyMessages 的使用模式保持一致

2. 透明回填而非每处改造
   - 在 after_tool_call 入口将解析到的 messages 回写 event.messages，使 MMD 注入、L3 压缩、token snapshot、opik tracing 等 10+ 下游消费点零改动运行
   - 保持 checkAndCompressAfterToolCall 签名不变，避免连锁改动

3. 状态遥测增强
   - classifyPatchEffectiveness 新增 ctx 参数与 resolvedFrom 字段（event.messages / fallback / none），后台 /store 报表直接体现兼容层是否启用
   - debug log 新增 fallback=yes/no 字段便于排障

## 变更列表

- src/offload/state-reporter.ts
  - 新增 resolveMessagesFromEvent(event, ctx) 回退解析函数
  - 扩展 classifyPatchEffectiveness(event, stage, ctx?) 返回新增 resolvedFrom 字段
- src/offload/hooks/after-tool-call.ts
  - 入口增加 OpenClaw 5.27+ compatibility layer：回退解析 + 透明回填
  - patch check / debug log 增加 fallback 信息

## 风险评估

- 兼容性：低风险。当上游 patch 生效（event.messages 已有有效数组）本逻辑完全跳过，仅在缺失时兜底；historyMessages 等字段与其他 hook 早已使用的字段同词语义一致
- 性能：O(1) 字段探察，无序列化开销
- 正确性：回写后所有下游消费点按原契约执行，MMD 注入与 L3 的 mutate-in-place 行为保持不变

## 测试清单

- [x] node --check 语法检查通过
- [ ] Manifest 检查 (等待 CI)
- [x] 变更集中无 event.messages 消费点遗漏（MMD 注入块、L3 调用、traceMessagesSnapshot 均走 event.messages）
