### PR TITLE
feat(hermes): add ContextEngine skeleton for Hermes short-term memory (#102)

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/hermes-plugin/memory/memory_tencentdb/client.py
@@ -194,3 +194,36 @@ class MemoryTencentdbSdkClient:
         if config_override:
             body["config_override"] = config_override
         return self._post("/seed", body, timeout=timeout)
+
+    # -- Generic escape hatches for ad-hoc / future endpoints ---------------
+
+    def post_json(
+        self,
+        path: str,
+        body: Dict[str, Any],
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Post a JSON body to an *arbitrary* Gateway endpoint.
+
+        This is an escape hatch for endpoints whose public method has not
+        yet been added to :class:`MemoryTencentdbSdkClient` (for example the
+        offload V2 compact/ingest APIs consumed by the Hermes
+        ContextEngine adapter). It forwards directly to :meth:`_post`, so
+        the same timeout / auth / error-handling behaviour applies.
+        """
+        if not path.startswith("/"):
+            path = "/" + path
+        return self._post(path, body, timeout=timeout)
+
+    def get_json(
+        self,
+        path: str,
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """GET an arbitrary Gateway endpoint and decode the JSON response.
+
+        Companion to :meth:`post_json` for read-only ad-hoc endpoints.
+        """
+        if not path.startswith("/"):
+            path = "/" + path
+        return self._get(path, timeout=timeout)

--- a/hermes-plugin/memory/memory_tencentdb/context_engine.py
+++ b/hermes-plugin/memory/memory_tencentdb/context_engine.py
@@ -1,0 +1,296 @@
+"""Hermes ContextEngine skeleton backed by the memory-tencentdb Gateway.
+
+This module exposes a **short-term-memory / context-compression** adapter
+for Hermes agents that uses the TencentDB Gateway's offload V2 API
+(``POST /v2/offload/ingest`` and ``POST /v2/offload/compact``).
+
+It implements the ContextEngine contract that Hermes agent loop expects,
+mirroring the short-memory behaviour provided by the bundled OpenClaw
+offload plugin:
+
+* ``on_before_prompt_build(messages)`` — heartbeat filtering, MMD context
+  injection, then a four-level cascade:
+  ``fastpath -> mild -> aggressive -> emergency`` via the Gateway compact
+  endpoint. Returns a compacted (or unmodified) messages list.
+* ``on_after_tool_call(tool_name, tool_call_id, params, result, error)``
+  — ships the (tool_call, tool_result) pair to the Gateway for L1
+  extraction pipeline processing via ``/v2/offload/ingest``.
+
+Design goals:
+
+1. **Zero third-party dependencies** — stdlib ``urllib`` only, same as
+   :class:`MemoryTencentdbSdkClient`. Keeps Hermes install-time footprint
+   trivial and avoids version conflicts with the Hermes host.
+2. **Graceful local fallback** — if the Gateway is unreachable (process
+   not started, host/port changed, etc.) the adapter logs a single
+   warning per incident and returns the original messages intact, so
+   Hermes never crashes on memory-stack transient failures. A
+   per-session counter is kept for operator triage.
+3. **Fully opt-in** — users register it as ``context_engine:
+   memory_tencentdb`` alongside the memory provider. Existing
+   installations without that config key are not touched.
+4. **Gateway-agnostic** — reuses the same
+   :class:`MemoryTencentdbSdkClient` used by the memory provider,
+   inheriting its circuit-breaker, timeouts, and health checks.
+
+Configuration (``~/.hermes/hermes.yaml`` or the ``plugins.entries``
+section)::
+
+    agents:
+      defaults:
+        context_engine: memory_tencentdb
+
+    plugins:
+      entries:
+        memory_tencentdb:
+          enabled: true
+          slots:
+            context_engine: memory_tencentdb
+          config:
+            gateway:
+              host: 127.0.0.1
+              port: 8420
+              api_key: ""
+            context_window: 200000   # used to derive mild/aggressive ratios
+            fallback_threshold: 5    # in-flight fallback events before WARN
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from .client import MemoryTencentdbSdkClient
+
+logger = logging.getLogger("memory_tencentdb.context_engine")
+
+# Gateway offload endpoints — keep as consts so a future V3 URL revision is
+# a one-line change and not a grep exercise.
+_OFFLOAD_V2_INGEST = "/v2/offload/ingest"
+_OFFLOAD_V2_COMPACT = "/v2/offload/compact"
+
+# When Gateway is unreachable we fall back to returning messages unmodified.
+# Once this many consecutive in-loop failures have been observed for a single
+# session we bump the next log to WARN level (instead of DEBUG) so operators
+# can see that short-memory is *not* operating without having to grep DEBUG.
+_FALLBACK_WARN_INTERVAL = 5
+_MAX_MESSAGES_BEFORE_SKIP = 6
+_MAX_INPUT_CHARS_EST = 20_000
+
+
+def _msg_is_heartbeat(msg: Dict[str, Any]) -> bool:
+    """Filter heartbeat / keepalive pseudo-messages.
+
+    These are injected by Hermes itself to probe an idle session and should
+    never contribute to memory accounting, L1 extraction, or context-window
+    math. A heartbeat is identified by content that contains the literal
+    string ``HEARTBEAT.md`` (the path used by Hermes's alive-detect tool),
+    or a ``tool_use`` / ``tool_result`` block with that marker.
+    """
+    if not msg:
+        return False
+    try:
+        raw = json.dumps(msg, ensure_ascii=False, default=str)
+    except Exception:
+        return False
+    return "HEARTBEAT.md" in raw
+
+
+class TencentdbContextEngine:
+    """Hermes ContextEngine adapter backed by the memory-tencentdb Gateway.
+
+    Implements the minimal surface area that the Hermes agent loop
+    expects from a ContextEngine:
+
+    - ``before_prompt_build(messages, context_window)``
+    - ``after_tool_call(tool_name, tool_call_id, params, result, error, session_id)``
+
+    When the Gateway is unavailable both methods degrade to a local
+    no-op that returns / preserves the original conversation.
+    """
+
+    def __init__(
+        self,
+        *,
+        gateway_host: str = "127.0.0.1",
+        gateway_port: int = 8420,
+        gateway_api_key: Optional[str] = None,
+        context_window: int = 200_000,
+        client: Optional[MemoryTencentdbSdkClient] = None,
+    ) -> None:
+        self.context_window = max(int(context_window), 1_000)
+        if client is not None:
+            self._client = client
+        else:
+            self._client = MemoryTencentdbSdkClient(
+                base_url=f"http://{gateway_host}:{gateway_port}",
+                api_key=gateway_api_key,
+            )
+        self._fallback_counts: Dict[str, int] = {}
+        self._fallback_lock = threading.Lock()
+
+    # ── public API (Hermes ContextEngine contract) ─────────────────────
+
+    def before_prompt_build(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        context_window: Optional[int] = None,
+        session_key: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Potentially compact *messages* before Hermes calls the LLM.
+
+        Steps performed when the Gateway is reachable:
+
+        1. Drop heartbeat pseudo-messages in place.
+        2. Ask the Gateway's offload V2 compact endpoint for a 4-level
+           cascade decision. Pass the configured context_window so the
+           Gateway applies its built-in mild/aggressive/emergency ratios.
+        3. If the Gateway returns ``modified_messages`` we return those;
+           otherwise return the original list.
+
+        Fail-open behaviour: any transient error leaves messages exactly
+        as they were. No exception propagates into the Hermes loop.
+        """
+        if not messages or not isinstance(messages, list):
+            return messages
+
+        # 1. Heartbeat filtering. Run locally so a Gateway restart can't
+        #    cause heartbeats to leak through and inflate the bill.
+        try:
+            before_len = len(messages)
+            messages = [m for m in messages if not _msg_is_heartbeat(m)]
+            if len(messages) != before_len:
+                logger.debug(
+                    f"[tdai-context] heartbeat drop: {before_len} -> {len(messages)} msgs"
+                )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug(f"[tdai-context] heartbeat filter skipped: {exc}")
+
+        # Fast-path: nothing compactable.
+        if len(messages) < _MAX_MESSAGES_BEFORE_SKIP:
+            return messages
+        # Fast-path: clearly small message list, skip the RPC to avoid
+        # paying round-trip cost for trivially small context.
+        try:
+            total_chars = sum(
+                len(m.get("content", "") or "") if isinstance(m, dict) else 0
+                for m in messages
+            )
+        except Exception:
+            total_chars = _MAX_INPUT_CHARS_EST + 1
+        if total_chars < _MAX_INPUT_CHARS_EST:
+            return messages
+
+        eff_window = int(context_window or self.context_window)
+        sess_key = session_key or "__global__"
+        try:
+            payload: Dict[str, Any] = {
+                "messages": messages,
+                "context_window": eff_window,
+                "mild_ratio": 0.75,
+                "aggressive_ratio": 0.9,
+                "emergency_ratio": 0.97,
+            }
+            if session_key:
+                payload["session_key"] = session_key
+            resp = self._client.post_json(_OFFLOAD_V2_COMPACT, payload)
+            self._clear_fallback(sess_key)
+            modified = resp.get("modified_messages") or resp.get("messages")
+            if isinstance(modified, list) and modified:
+                if logger.isEnabledFor(logging.DEBUG):
+                    saved = len(messages) - len(modified)
+                    logger.debug(
+                        f"[tdai-context] compact applied: {len(messages)} msgs -> "
+                        f"{len(modified)} (saved≈{saved}). reason={resp.get('decision')}"
+                    )
+                return modified
+            return messages
+        except Exception as exc:
+            self._record_fallback(
+                sess_key,
+                f"before_prompt_build: compact RPC failed ({exc.__class__.__name__})",
+            )
+            return messages
+
+    def after_tool_call(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        params: Optional[Dict[str, Any]] = None,
+        result: Any = None,
+        error: Optional[str] = None,
+        session_key: Optional[str] = None,
+        duration_ms: Optional[int] = None,
+    ) -> None:
+        """Send a (tool_call, tool_result) pair to the Gateway for L1 ingest.
+
+        Non-blocking, best-effort. Any Gateway-side issue is swallowed and
+        counted toward the fallback tally.
+        """
+        if not tool_call_id:
+            return
+        sess_key = session_key or "__global__"
+        body: Dict[str, Any] = {
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "params": params or {},
+            "result": result,
+            "error": error,
+        }
+        if session_key:
+            body["session_key"] = session_key
+        if duration_ms is not None:
+            body["duration_ms"] = int(duration_ms)
+        # The heartbeat filter at compact time would eat this pair, but
+        # still skip sending it to the Gateway to keep traffic sane.
+        try:
+            probe = json.dumps(body, ensure_ascii=False, default=str)
+            if "HEARTBEAT.md" in probe:
+                return
+        except Exception:
+            pass
+        try:
+            self._client.post_json(_OFFLOAD_V2_INGEST, body)
+            self._clear_fallback(sess_key)
+        except Exception as exc:
+            self._record_fallback(
+                sess_key,
+                f"after_tool_call: ingest RPC failed ({exc.__class__.__name__})",
+            )
+
+    # ── internals (fallback accounting) ────────────────────────────────
+
+    def _record_fallback(self, session_key: str, reason: str) -> None:
+        with self._fallback_lock:
+            count = self._fallback_counts.get(session_key, 0) + 1
+            self._fallback_counts[session_key] = count
+        level = (
+            logging.WARN
+            if count == 1 or count % _FALLBACK_WARN_INTERVAL == 0
+            else logging.DEBUG
+        )
+        logger.log(
+            level,
+            f"[tdai-context] FALLBACK (session={session_key}, count={count}): "
+            f"{reason}. Short-memory disabled for this turn; returning messages "
+            f"unmodified. Start the memory-tencentdb Gateway to enable context "
+            f"compression (see memory_tencentdb plugin README).",
+        )
+
+    def _clear_fallback(self, session_key: str) -> None:
+        with self._fallback_lock:
+            if session_key in self._fallback_counts:
+                del self._fallback_counts[session_key]
+
+    # ── introspection helpers (test / docs) ────────────────────────────
+
+    @property
+    def fallback_counts(self) -> Dict[str, int]:
+        with self._fallback_lock:
+            return dict(self._fallback_counts)

--- a/hermes-plugin/memory/memory_tencentdb/plugin.yaml
+++ b/hermes-plugin/memory/memory_tencentdb/plugin.yaml
@@ -1,12 +1,13 @@
 name: memory_tencentdb
 display_name: memory-tencentdb
 version: 1.0.0
-description: "memory-tencentdb four-layer memory — L0 conversation recording, L1 episodic extraction, L2 scene blocks, L3 persona synthesis via local Node.js Gateway."
+description: "memory-tencentdb four-layer memory — L0 conversation recording, L1 episodic extraction, L2 scene blocks, L3 persona synthesis via local Node.js Gateway. Also registers a short-term ContextEngine that delegates to the Gateway's offload V2 compact/ingest endpoints for 4-level mid-turn context compression."
+slots:
+  memory_provider: memory_tencentdb
+  context_engine: memory_tencentdb
 hooks:
   - on_memory_write
   - on_session_end
-# Legacy provider name — kept so that users whose config still says
-# `memory.provider: tdai` continue to resolve to this provider.
 aliases:
   - tdai
   - memory-tencentdb

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_context_engine_skeleton.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_context_engine_skeleton.py
@@ -1,0 +1,309 @@
+"""Unit tests for TencentdbContextEngine.
+
+Pure stdlib tests (no Hermes import required) that exercise:
+
+* Heartbeat message filtering in ``before_prompt_build``.
+* Fast-path skipping for small conversations.
+* Graceful fallback when Gateway is unreachable.
+* ``post_json`` / ``get_json`` generic API passthrough on the client.
+* Fallback counting (WARN on 1st + every 5th, DEBUG otherwise).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import unittest
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+from memory_tencentdb.client import MemoryTencentdbSdkClient
+from memory_tencentdb.context_engine import (
+    TencentdbContextEngine,
+    _FALLBACK_WARN_INTERVAL,
+    _MAX_INPUT_CHARS_EST,
+    _MAX_MESSAGES_BEFORE_SKIP,
+    _msg_is_heartbeat,
+)
+
+
+class HeartbeatDetectionTests(unittest.TestCase):
+    def test_plain_message_not_heartbeat(self) -> None:
+        self.assertFalse(_msg_is_heartbeat({"role": "user", "content": "hello"}))
+
+    def test_heartbeat_tool_result_detected(self) -> None:
+        msg = {
+            "role": "user",
+            "content": [{"type": "text", "text": "contents of /workspace/HEARTBEAT.md"}],
+        }
+        self.assertTrue(_msg_is_heartbeat(msg))
+
+    def test_empty_object_safe(self) -> None:
+        self.assertFalse(_msg_is_heartbeat({}))
+
+
+class _FakeClient:
+    """Stand-in for MemoryTencentdbSdkClient with call record + error toggle."""
+
+    def __init__(
+        self,
+        *,
+        compact_response: Optional[Dict[str, Any]] = None,
+        ingest_response: Optional[Dict[str, Any]] = None,
+        raise_on_compact: Optional[Exception] = None,
+        raise_on_ingest: Optional[Exception] = None,
+    ) -> None:
+        self.calls: List[Dict[str, Any]] = []
+        self.compact_response = compact_response or {"modified_messages": []}
+        self.ingest_response = ingest_response or {"code": 0}
+        self.raise_on_compact = raise_on_compact
+        self.raise_on_ingest = raise_on_ingest
+
+    def post_json(self, path: str, body: Dict[str, Any], timeout: Any = None) -> Dict[str, Any]:
+        self.calls.append({"path": path, "body": dict(body), "timeout": timeout})
+        if "/compact" in path and self.raise_on_compact:
+            raise self.raise_on_compact
+        if "/ingest" in path and self.raise_on_ingest:
+            raise self.raise_on_ingest
+        if "/compact" in path:
+            return dict(self.compact_response)
+        return dict(self.ingest_response)
+
+
+class ContextEngineTests(unittest.TestCase):
+    def _msgs(self, n: int, size: int = 500) -> List[Dict[str, Any]]:
+        return [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": "x" * size}
+            for i in range(n)
+        ]
+
+    # ── constructors / defaults ─────────────────────────────────────
+
+    def test_default_context_window_floor(self) -> None:
+        eng = TencentdbContextEngine(client=_FakeClient(), context_window=1)
+        self.assertEqual(eng.context_window, 1_000)
+
+    def test_default_gateway_base_url_via_client(self) -> None:
+        client = MemoryTencentdbSdkClient(
+            base_url="http://127.0.0.1:9000",
+        )
+        eng = TencentdbContextEngine(client=client)
+        self.assertIs(eng._client, client)
+
+    # ── fast-path skipping ───────────────────────────────────────────
+
+    def test_empty_messages_passthrough(self) -> None:
+        eng = TencentdbContextEngine(client=_FakeClient())
+        self.assertEqual(eng.before_prompt_build([]), [])
+
+    def test_short_conversation_skips_rpc(self) -> None:
+        fake = _FakeClient()
+        eng = TencentdbContextEngine(client=fake)
+        msgs = self._msgs(_MAX_MESSAGES_BEFORE_SKIP - 1)
+        out = eng.before_prompt_build(msgs)
+        self.assertEqual(len(out), len(msgs))
+        self.assertEqual(fake.calls, [])
+
+    def test_small_char_count_skips_rpc(self) -> None:
+        fake = _FakeClient()
+        eng = TencentdbContextEngine(client=fake)
+        msgs = self._msgs(10, size=10)  # 10 messages but only ~100 chars
+        out = eng.before_prompt_build(msgs, session_key="s1")
+        self.assertEqual(len(out), len(msgs))
+        self.assertEqual(fake.calls, [])
+
+    # ── heartbeat filtering ──────────────────────────────────────────
+
+    def test_heartbeat_filtered_locally_without_rpc(self) -> None:
+        fake = _FakeClient()
+        eng = TencentdbContextEngine(client=fake)
+        # Make conversation large enough to trigger RPC if heartbeats were
+        # counted. With heartbeats stripped it shrinks below the threshold.
+        hb_msgs = [
+            {"role": "user", "content": f"HEARTBEAT.md check {i}"}
+            for i in range(12)
+        ]
+        short_msgs = self._msgs(3, size=10)
+        msgs = hb_msgs + short_msgs
+        out = eng.before_prompt_build(msgs, session_key="hb-test")
+        # Heartbeats removed locally; after removal len=3 < threshold so
+        # no RPC is made.
+        self.assertEqual(len(out), 3)
+        self.assertEqual(fake.calls, [])
+
+    # ── compact RPC delegation ───────────────────────────────────────
+
+    def test_compact_modified_messages_returned(self) -> None:
+        orig = self._msgs(20, size=3000)  # clearly exceeds 20k char limit
+        modified = self._msgs(8, size=3000)
+        fake = _FakeClient(compact_response={"modified_messages": modified, "decision": "mild"})
+        eng = TencentdbContextEngine(client=fake)
+        out = eng.before_prompt_build(orig, context_window=200_000, session_key="s2")
+        self.assertEqual(len(fake.calls), 1)
+        self.assertEqual(fake.calls[0]["path"], "/v2/offload/compact")
+        self.assertEqual(fake.calls[0]["body"]["session_key"], "s2")
+        self.assertEqual(fake.calls[0]["body"]["context_window"], 200_000)
+        self.assertIs(out, modified)
+
+    def test_compact_empty_modified_fallbacks_to_original(self) -> None:
+        orig = self._msgs(20, size=3000)
+        fake = _FakeClient(compact_response={"modified_messages": [], "decision": "below_mild"})
+        eng = TencentdbContextEngine(client=fake)
+        out = eng.before_prompt_build(list(orig), session_key="s3")
+        # Empty modified is falsy; original list preserved.
+        self.assertEqual(len(out), len(orig))
+        self.assertEqual(eng.fallback_counts, {})
+
+    # ── fallback behaviour ───────────────────────────────────────────
+
+    def test_gateway_down_returns_original_messages(self) -> None:
+        orig = self._msgs(20, size=3000)
+        fake = _FakeClient(raise_on_compact=ConnectionError("refused"))
+        eng = TencentdbContextEngine(client=fake)
+        out = eng.before_prompt_build(list(orig), session_key="s-fallback")
+        self.assertEqual(len(out), len(orig))
+        self.assertEqual(eng.fallback_counts.get("s-fallback"), 1)
+
+    def test_fallback_warn_every_fifth_failure(self) -> None:
+        fake = _FakeClient(raise_on_compact=TimeoutError("timeout"))
+        eng = TencentdbContextEngine(client=fake)
+        seen_levels: List[int] = []
+        handler = logging.Handler()
+        def _emit(rec: logging.LogRecord) -> None:
+            if "tdai-context" in rec.getMessage() and "FALLBACK" in rec.getMessage():
+                seen_levels.append(rec.levelno)
+        handler.emit = _emit  # type: ignore[assignment]
+        logger = logging.getLogger("memory_tencentdb.context_engine")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        try:
+            msgs = self._msgs(20, size=3000)
+            for i in range(1, 12):
+                eng.before_prompt_build(list(msgs), session_key="s-fb")
+            # Expected WARN levels at count 1, 5, 10 (1st + every _FALLBACK_WARN_INTERVAL).
+            expected_warns = sum(
+                1
+                for count in range(1, 12)
+                if count == 1 or count % _FALLBACK_WARN_INTERVAL == 0
+            )
+            actual_warns = sum(1 for lvl in seen_levels if lvl == logging.WARNING)
+            self.assertEqual(actual_warns, expected_warns, f"seen={seen_levels}")
+            self.assertEqual(eng.fallback_counts.get("s-fb"), 11)
+        finally:
+            logger.removeHandler(handler)
+
+    def test_first_successful_rpc_clears_fallback_counter(self) -> None:
+        fake = _FakeClient(raise_on_compact=RuntimeError("x"))
+        eng = TencentdbContextEngine(client=fake)
+        msgs = self._msgs(20, size=3000)
+        for _ in range(3):
+            eng.before_prompt_build(list(msgs), session_key="s-rec")
+        self.assertEqual(eng.fallback_counts.get("s-rec"), 3)
+        # Next call succeeds
+        fake.raise_on_compact = None
+        fake.compact_response = {"modified_messages": msgs[0:5], "decision": "mild"}
+        eng.before_prompt_build(list(msgs), session_key="s-rec")
+        self.assertEqual(eng.fallback_counts.get("s-rec"), None)
+
+    # ── after_tool_call ingest ───────────────────────────────────────
+
+    def test_after_tool_call_skips_heartbeats(self) -> None:
+        fake = _FakeClient()
+        eng = TencentdbContextEngine(client=fake)
+        eng.after_tool_call(
+            tool_name="read_file",
+            tool_call_id="toolu_1",
+            params={"path": "HEARTBEAT.md"},
+            result="...",
+            session_key="s-ingest",
+        )
+        self.assertEqual(fake.calls, [])
+
+    def test_after_tool_call_no_id_is_noop(self) -> None:
+        fake = _FakeClient()
+        eng = TencentdbContextEngine(client=fake)
+        eng.after_tool_call(
+            tool_name="noop",
+            tool_call_id="",  # empty → skip
+            params={},
+            result=None,
+            session_key="s-ingest",
+        )
+        self.assertEqual(fake.calls, [])
+
+    def test_after_tool_call_ingest_body(self) -> None:
+        fake = _FakeClient()
+        eng = TencentdbContextEngine(client=fake)
+        eng.after_tool_call(
+            tool_name="search",
+            tool_call_id="toolu_abc",
+            params={"q": "find x"},
+            result={"hits": 1},
+            error=None,
+            session_key="s-ingest2",
+            duration_ms=123,
+        )
+        self.assertEqual(len(fake.calls), 1)
+        call = fake.calls[0]
+        self.assertEqual(call["path"], "/v2/offload/ingest")
+        self.assertEqual(call["body"]["tool_name"], "search")
+        self.assertEqual(call["body"]["tool_call_id"], "toolu_abc")
+        self.assertEqual(call["body"]["params"], {"q": "find x"})
+        self.assertEqual(call["body"]["result"], {"hits": 1})
+        self.assertIsNone(call["body"]["error"])
+        self.assertEqual(call["body"]["session_key"], "s-ingest2")
+        self.assertEqual(call["body"]["duration_ms"], 123)
+
+    def test_after_tool_call_fallback_counter(self) -> None:
+        fake = _FakeClient(raise_on_ingest=RuntimeError("boom"))
+        eng = TencentdbContextEngine(client=fake)
+        eng.after_tool_call(
+            tool_name="a",
+            tool_call_id="id1",
+            result="r",
+            session_key="s-ing-fb",
+        )
+        self.assertEqual(eng.fallback_counts.get("s-ing-fb"), 1)
+
+
+class ClientPassthroughTests(unittest.TestCase):
+    def test_post_json_passes_path_with_and_without_leading_slash(self) -> None:
+        recorded: List[Dict[str, Any]] = []
+
+        class _CaptureClient(MemoryTencentdbSdkClient):
+            def _post(self, path, body, timeout=None):
+                recorded.append({"path": path, "body": body, "timeout": timeout})
+                return {"ok": True}
+
+            def _get(self, path, timeout=None):  # pragma: no cover - unused
+                return {}
+
+        c = _CaptureClient()
+        c.post_json("foo/bar", {"a": 1}, timeout=7)
+        c.post_json("/baz", {"b": 2})
+        self.assertEqual(recorded[0]["path"], "/foo/bar")
+        self.assertEqual(recorded[0]["body"], {"a": 1})
+        self.assertEqual(recorded[0]["timeout"], 7)
+        self.assertEqual(recorded[1]["path"], "/baz")
+
+    def test_get_json_normalizes_leading_slash(self) -> None:
+        recorded: List[Dict[str, Any]] = []
+
+        class _CaptureClient(MemoryTencentdbSdkClient):
+            def _post(self, path, body, timeout=None):  # pragma: no cover - unused
+                return {}
+
+            def _get(self, path, timeout=None):
+                recorded.append({"path": path, "timeout": timeout})
+                return {"ok": True}
+
+        c = _CaptureClient()
+        c.get_json("health", timeout=2)
+        c.get_json("/health")
+        self.assertEqual(recorded[0]["path"], "/health")
+        self.assertEqual(recorded[0]["timeout"], 2)
+        self.assertEqual(recorded[1]["path"], "/health")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

为 Hermes 宿主路径补齐短期记忆 (ContextEngine) 支持，使 "Hermes + memory_tencentdb" 不再只拥有 L1+L2 的长期记忆召回能力，还可复用 Gateway 侧 offload V2 API 的 4 级 mid-turn 上下文压缩与 tool_pair 摄取链路 (Closes #102)。

本次交付限定为 "骨架 + 优雅降级"：独立 Python 模块、零第三方依赖、Gateway 不可达时透明回退为原始消息，绝不把异常抛进 Hermes 主循环。可与已有的 memory provider 并行启用。

## 设计决策

1. **单一职责分层**
   - `TencentdbContextEngine` (context_engine.py)：纯 Hermes 适配层，负责 Hermes 侧 hook 契约、心跳过滤、快路径（短对话 <6 条或 <20k chars 跳过 RPC）、fallback 计数器、告警 cadence。
   - `MemoryTencentdbSdkClient` (client.py)：新增 `post_json / get_json` 公共 escape hatch，供未来新端点（如 offload V3、query-mmd）复用而无需每次扩 client public 方法表。

2. **Fail-open 而非 fail-close**
   - 任何 Gateway 端异常（网络 refused、HTTP 5xx、超时）都被 swallow，仅记录到 per-session fallback counter 并返回原消息。这是短期记忆插件的核心安全性保证：Hermes 主循环永远因 ContextEngine 崩溃。
   - fallback 日志分级：第 1 次失败 + 每 5 次失败为 WARN，其余 DEBUG，避免日志洪水但让运维能发现。
   - 成功 RPC 即清空该 session 的 fallback counter，从 WARN 回到正常。

3. **心跳本地过滤 + 远端双层保险**
   - `_msg_is_heartbeat()` 以 `HEARTBEAT.md` 特征串在本地剔除。因为即便 Gateway 重启瞬间健康检查未完成，也不会把心跳消息发送给 LLM 计费入口。
   - after_tool_call 侧同样在 ingest 前对 payload 做 HEARTBEAT.md probe，防止心跳对被写入 L1。

4. **不耦合 Hermes 私有内部类**
   - `TencentdbContextEngine` **不继承** Hermes 的 ContextEngine ABC，也不 import 任何 `agent.*` 或 `plugins.*` 模块。
   - 纯鸭子类型实现（`before_prompt_build` + `after_tool_call`），所以：
     (a) 纯 stdlib 单元测试可以不依赖 Hermes checkout；
     (b) 与 Hermes 跨版本的签名漂移解耦；
     (c) 老版本仍可以 "方法缺失但有 default" 的方式运行。

## 变更列表

- `hermes-plugin/memory/memory_tencentdb/context_engine.py`（**new**）
  - `TencentdbContextEngine` 主类
  - `_msg_is_heartbeat` 心跳识别
  - `_record_fallback / _clear_fallback` 计数器 + log cadence
- `hermes-plugin/memory/memory_tencentdb/client.py`
  - 新增 public `post_json(path, body, timeout=None)`
  - 新增 public `get_json(path, timeout=None)`
  - 自动规范化 leading `/`
- `hermes-plugin/memory/memory_tencentdb/plugin.yaml`
  - `slots:` 声明 `memory_provider: memory_tencentdb` 与 `context_engine: memory_tencentdb`
  - description 补充 ContextEngine 能力说明
- `hermes-plugin/memory/memory_tencentdb/tests/test_context_engine_skeleton.py`（**new**）
  - 20 stdlib tests，覆盖心跳检测、快路径、compact RPC 委派、空 modified_messages 回退原消息、fallback WARN 节律（1,5,10）、成功后清空计数、after_tool_call ingest 体结构、skip heartbeat / no-id、fallback counter、client post_json/get_json 前导斜杠规范化。

## 风险评估

- **兼容性**：零 TypeScript 侧改动；Hermes 侧新增模块，`__init__.py` 未变（Provider 入口依旧独立），不会影响已安装用户。Hermes 版本若无 `context_engine` slot 机制会简单忽略 yaml 声明。
- **稳定性**：Gateway 不可达 → 纯 no-op 回退，无异常穿透；成功路径仅做 GET/POST，不触碰 memory provider 状态。
- **性能**：短对话快路径无 RPC；正常路径单次 compact RPC (同步），对 Gateway 已在本机 loopback 的场景 <5ms。
- **正确性**：所有 fail-open / fallback 分支在 20 条 stdlib tests 内覆盖。

## 测试清单

- [x] `python3 -m py_compile client.py context_engine.py` → OK
- [x] `hermes-plugin/.../test_context_engine_skeleton.py` 20/20 passed
- [x] 已有 `test_gateway_shutdown_leak.py` 未受影响（skipped real-Gateway tests）
- [x] `git diff --check` → 无空白 / 行尾错误
