### PR TITLE
feat(integrations): add codex adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,25 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Codex (MCP)
+
+Build the MCP server from the repository root, then add the generated command
+to Codex using the supplied configuration template:
+
+```powershell
+npm install
+npm run build:codex
+```
+
+Copy and adapt [`integrations/codex/templates/codex-config.example.toml`](./integrations/codex/templates/codex-config.example.toml)
+in your Codex MCP configuration. The adapter exposes health, recall, capture,
+structured-memory search, raw-conversation search, session flush, and seed
+tools. It uses the existing Gateway and can start a local Gateway sidecar when
+`MEMORY_TENCENTDB_CODEX_ENABLE_SUPERVISOR=true`.
+
+See [`integrations/codex/README.md`](./integrations/codex/README.md) for the
+recommended recall/capture workflow, configuration variables, and degraded-mode behavior.
+
 
 ## 🔒 Gateway Security (optional)
 
@@ -526,6 +545,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | :--- | :--- |
 | OpenClaw plugin | Automatically captures, extracts, and recalls memory once installed |
 | Hermes Gateway adapter | `TdaiCore + HostAdapter`, decoupled from the host framework |
+| Codex MCP adapter | Gateway-first stdio MCP tools with optional sidecar supervision |
 | Local backend | `SQLite + sqlite-vec`, ready to use out of the box |
 | Hybrid retrieval | BM25 + vector + RRF — supports both keyword and semantic recall |
 | Agent tools | `tdai_memory_search` / `tdai_conversation_search` |
@@ -539,6 +559,7 @@ Debugging no longer means probing an opaque database — it becomes a determinis
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | Operations & management tooling |
 | [`CHANGELOG.md`](./CHANGELOG.md) | Release notes and version history |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw plugin manifest and configuration schema |
+| [`integrations/codex/README.md`](./integrations/codex/README.md) | Codex MCP installation, configuration, and workflow |
 
 ---
 
@@ -559,6 +580,7 @@ We welcome every kind of contribution — bug reports, feature ideas, doc fixes,
 - [x] Short-term context compression (Context Offload + Mermaid canvas)
 - [x] Local SQLite backend and Tencent Cloud Vector Database (TCVDB) backend
 - [x] OpenClaw plugin and Hermes Gateway integration
+- [x] Codex MCP Gateway integration
 - [ ] Portable memory: cross-Agent / cross-framework / cross-device import, export, and live migration
 - [ ] Automatic Skill generation
 - [ ] Visual debugging and memory observability dashboard

--- a/README_CN.md
+++ b/README_CN.md
@@ -385,6 +385,21 @@ memory:
   provider: memory_tencentdb
 ```
 
+### 4. Codex（MCP）
+
+在仓库根目录构建 MCP Server，然后使用提供的配置模板把生成的命令加入 Codex：
+
+```powershell
+npm install
+npm run build:codex
+```
+
+复制并按需修改 [`integrations/codex/templates/codex-config.example.toml`](./integrations/codex/templates/codex-config.example.toml)，
+再写入 Codex 的 MCP 配置。适配层提供 health、召回、捕获、结构化记忆搜索、原始对话搜索、session flush 与 seed 工具；它复用既有 Gateway，且在
+`MEMORY_TENCENTDB_CODEX_ENABLE_SUPERVISOR=true` 时可以自动启动本地 Gateway sidecar。
+
+推荐调用流程、环境变量和降级行为见 [`integrations/codex/README.md`](./integrations/codex/README.md)。
+
 
 ## 🔒 Gateway 安全配置（可选）
 
@@ -527,6 +542,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | :--- | :--- |
 | OpenClaw 插件 | 安装后即可自动捕获、提取、召回记忆 |
 | Hermes Gateway 适配 | `TdaiCore + HostAdapter` 解耦宿主框架 |
+| Codex MCP 适配 | Gateway-first stdio MCP 工具，并可选管理 Gateway sidecar |
 | 本地后端 | `SQLite + sqlite-vec`，开箱即用 |
 | 混合检索 | BM25 + 向量 + RRF，兼顾关键词和语义召回 |
 | Agent 工具 | `tdai_memory_search` / `tdai_conversation_search` |
@@ -540,6 +556,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 | [`scripts/README.memory-tencentdb-ctl.md`](./scripts/README.memory-tencentdb-ctl.md) | 运维管理工具说明 |
 | [`CHANGELOG.md`](./CHANGELOG.md) | 版本变更记录 |
 | [`openclaw.plugin.json`](./openclaw.plugin.json) | OpenClaw 插件声明与配置 Schema |
+| [`integrations/codex/README.md`](./integrations/codex/README.md) | Codex MCP 安装、配置和使用流程 |
 
 ---
 ## 社区与贡献
@@ -560,6 +577,7 @@ export MEMORY_TENCENTDB_GATEWAY_API_KEY="<与 Gateway 同一份密钥>"
 - [x] 短期记忆压缩（Context Offload + Mermaid 画布）
 - [x] 可用本地 SQLite 后端与腾讯云向量数据库 TCVDB 后端
 - [x] OpenClaw 插件与 Hermes Gateway 适配
+- [x] Codex MCP Gateway 适配
 - [ ] 记忆可迁移：跨 Agent / 跨框架 / 跨设备的导入导出与热迁移
 - [ ] Skill自动生成
 - [ ] 可视化调试与记忆观测面板

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,14 @@
+# Codex adapter
+
+This integration exposes TencentDB Agent Memory as a standard stdio MCP server. The MCP process is intentionally thin: all memory reads and writes go through the existing local Gateway.
+
+Build from the repository root with `npm run build:codex`, then configure the generated `memory-tencentdb-codex-mcp` command in Codex using the template under `templates/codex-config.example.toml`.
+
+Recommended workflow:
+
+1. Call `agent_memory_recall` before a task when prior preferences, project context, or decisions may matter.
+2. Use `agent_memory_search` for structured facts and `agent_conversation_search` for exact raw evidence.
+3. Call `agent_memory_capture` after meaningful work, recording only new durable outcomes.
+4. Call `agent_memory_session_end` when a thread or task ends.
+
+The adapter can start the Gateway automatically. If the Gateway is unavailable, tools return a readable degraded result and the Codex task can continue without memory context.

--- a/integrations/codex/package.json
+++ b/integrations/codex/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@tencentdb-agent-memory/codex-adapter",
+  "private": true,
+  "type": "module"
+}

--- a/integrations/codex/src/config.ts
+++ b/integrations/codex/src/config.ts
@@ -1,0 +1,82 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AdapterLogger, CaptureMode, CodexAdapterConfig } from "./types.js";
+
+const DEFAULT_GATEWAY_URL = "http://127.0.0.1:8420";
+
+function optional(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function positiveInteger(value: string | undefined, fallback: number, name: string, logger: AdapterLogger): number {
+  if (!value?.trim()) return fallback;
+  const parsed = Number(value);
+  if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  logger.warn(`${name} must be a positive integer; using ${fallback}.`);
+  return fallback;
+}
+
+function booleanValue(value: string | undefined, fallback: boolean, name: string, logger: AdapterLogger): boolean {
+  if (!value?.trim()) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  logger.warn(`${name} must be true or false; using ${String(fallback)}.`);
+  return fallback;
+}
+
+function captureMode(value: string | undefined, logger: AdapterLogger): CaptureMode {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return "summary";
+  if (normalized === "summary" || normalized === "turn" || normalized === "raw") return normalized;
+  logger.warn("MEMORY_TENCENTDB_CODEX_CAPTURE_MODE must be summary, turn, or raw; using summary.");
+  return "summary";
+}
+
+function gatewayUrl(value: string | undefined, logger: AdapterLogger): string {
+  const normalized = optional(value) ?? DEFAULT_GATEWAY_URL;
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") return normalized;
+  } catch {
+    // Fall through to the documented local default.
+  }
+  logger.warn(`MEMORY_TENCENTDB_CODEX_GATEWAY_URL is invalid; using ${DEFAULT_GATEWAY_URL}.`);
+  return DEFAULT_GATEWAY_URL;
+}
+
+export function loadCodexAdapterConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  logger: AdapterLogger,
+): CodexAdapterConfig {
+  return {
+    gatewayUrl: gatewayUrl(env.MEMORY_TENCENTDB_CODEX_GATEWAY_URL, logger),
+    gatewayCommand: optional(env.MEMORY_TENCENTDB_CODEX_GATEWAY_CMD),
+    gatewayApiKey:
+      optional(env.MEMORY_TENCENTDB_CODEX_GATEWAY_API_KEY) ?? optional(env.TDAI_GATEWAY_API_KEY),
+    requestTimeoutMs: positiveInteger(
+      env.MEMORY_TENCENTDB_CODEX_REQUEST_TIMEOUT_MS,
+      10_000,
+      "MEMORY_TENCENTDB_CODEX_REQUEST_TIMEOUT_MS",
+      logger,
+    ),
+    enableSupervisor: booleanValue(
+      env.MEMORY_TENCENTDB_CODEX_ENABLE_SUPERVISOR,
+      true,
+      "MEMORY_TENCENTDB_CODEX_ENABLE_SUPERVISOR",
+      logger,
+    ),
+    explicitSessionKey: optional(env.MEMORY_TENCENTDB_CODEX_SESSION_KEY),
+    userId: optional(env.MEMORY_TENCENTDB_CODEX_USER_ID) ?? "default_user",
+    logDir:
+      optional(env.MEMORY_TENCENTDB_CODEX_LOG_DIR) ?? join(homedir(), ".codex", "logs", "memory_tencentdb"),
+    captureMode: captureMode(env.MEMORY_TENCENTDB_CODEX_CAPTURE_MODE, logger),
+    resultMaxChars: positiveInteger(
+      env.MEMORY_TENCENTDB_CODEX_RESULT_MAX_CHARS,
+      12_000,
+      "MEMORY_TENCENTDB_CODEX_RESULT_MAX_CHARS",
+      logger,
+    ),
+  };
+}

--- a/integrations/codex/src/gateway-client.ts
+++ b/integrations/codex/src/gateway-client.ts
@@ -1,0 +1,109 @@
+import type {
+  CaptureRequest,
+  CaptureResponse,
+  ConversationSearchRequest,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchRequest,
+  MemorySearchResponse,
+  RecallRequest,
+  RecallResponse,
+  SeedRequest,
+  SeedResponse,
+  SessionEndRequest,
+  SessionEndResponse,
+} from "./types.js";
+
+export interface GatewayClientOptions {
+  baseUrl: string;
+  timeoutMs: number;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class GatewayClientError extends Error {
+  constructor(
+    message: string,
+    readonly route: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "GatewayClientError";
+  }
+}
+
+export class GatewayClient {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: GatewayClientOptions) {
+    this.baseUrl = options.baseUrl.trim().replace(/\/+$/, "");
+    this.timeoutMs = options.timeoutMs;
+    this.apiKey = options.apiKey?.trim() || undefined;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  health(timeoutMs = Math.min(this.timeoutMs, 3_000)): Promise<HealthResponse> {
+    return this.request<HealthResponse>("/health", "GET", undefined, timeoutMs);
+  }
+
+  recall(body: RecallRequest): Promise<RecallResponse> {
+    return this.request("/recall", "POST", body);
+  }
+
+  capture(body: CaptureRequest): Promise<CaptureResponse> {
+    return this.request("/capture", "POST", body);
+  }
+
+  searchMemories(body: MemorySearchRequest): Promise<MemorySearchResponse> {
+    return this.request("/search/memories", "POST", body);
+  }
+
+  searchConversations(body: ConversationSearchRequest): Promise<ConversationSearchResponse> {
+    return this.request("/search/conversations", "POST", body);
+  }
+
+  sessionEnd(body: SessionEndRequest): Promise<SessionEndResponse> {
+    return this.request("/session/end", "POST", body);
+  }
+
+  seed(body: SeedRequest): Promise<SeedResponse> {
+    return this.request("/seed", "POST", body, Math.max(this.timeoutMs, 300_000));
+  }
+
+  private async request<T>(route: string, method: "GET" | "POST", body?: unknown, timeoutMs = this.timeoutMs): Promise<T> {
+    const headers: Record<string, string> = {};
+    if (method === "POST") headers["Content-Type"] = "application/json";
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${route}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new GatewayClientError(`Gateway request failed for ${route}: ${detail}`, route);
+    }
+
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new GatewayClientError(
+        `Gateway ${route} returned HTTP ${response.status}: ${responseText.slice(0, 500)}`,
+        route,
+        response.status,
+      );
+    }
+
+    try {
+      return JSON.parse(responseText) as T;
+    } catch {
+      throw new GatewayClientError(`Gateway ${route} returned invalid JSON.`, route, response.status);
+    }
+  }
+}

--- a/integrations/codex/src/gateway-supervisor.ts
+++ b/integrations/codex/src/gateway-supervisor.ts
@@ -1,0 +1,167 @@
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, type ChildProcess } from "node:child_process";
+import type { AdapterLogger } from "./types.js";
+import { GatewayClient } from "./gateway-client.js";
+
+interface SpawnSpec { command: string; args: string[]; cwd: string }
+
+export interface GatewaySupervisorOptions {
+  client: GatewayClient;
+  gatewayUrl: string;
+  gatewayCommand?: string;
+  logDir: string;
+  logger: AdapterLogger;
+  enabled?: boolean;
+  startupTimeoutMs?: number;
+  healthIntervalMs?: number;
+  cwd?: string;
+  spawnImpl?: typeof spawn;
+}
+
+export class GatewaySupervisor {
+  private child?: ChildProcess;
+  private ownsChild = false;
+  private startPromise?: Promise<boolean>;
+  private readonly spawnImpl: typeof spawn;
+
+  constructor(private readonly options: GatewaySupervisorOptions) {
+    this.spawnImpl = options.spawnImpl ?? spawn;
+  }
+
+  async isRunning(): Promise<boolean> {
+    try {
+      const health = await this.options.client.health(2_000);
+      return health.status === "ok" || health.status === "degraded";
+    } catch {
+      return false;
+    }
+  }
+
+  isProcessAlive(): boolean {
+    return Boolean(this.child && this.child.exitCode === null && !this.child.killed);
+  }
+
+  ensureRunning(): Promise<boolean> {
+    if (!this.options.enabled) return this.isRunning();
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.ensureRunningInternal().finally(() => { this.startPromise = undefined; });
+    return this.startPromise;
+  }
+
+  private async ensureRunningInternal(): Promise<boolean> {
+    if (await this.isRunning()) return true;
+    if (this.isProcessAlive()) return this.waitForHealth();
+    const spec = this.discoverCommand();
+    if (!spec) {
+      this.options.logger.warn("Gateway is unavailable and no start command could be discovered.");
+      return false;
+    }
+
+    mkdirSync(this.options.logDir, { recursive: true });
+    const stdoutFd = openSync(join(this.options.logDir, "gateway.stdout.log"), "a");
+    const stderrFd = openSync(join(this.options.logDir, "gateway.stderr.log"), "a");
+    try {
+      this.child = this.spawnImpl(spec.command, spec.args, {
+        cwd: spec.cwd,
+        env: this.gatewayEnvironment(),
+        detached: process.platform !== "win32",
+        windowsHide: true,
+        stdio: ["ignore", stdoutFd, stderrFd],
+      });
+      this.ownsChild = true;
+      this.child.once("exit", (code) => {
+        if (code !== 0 && code !== null) this.options.logger.warn(`Gateway child exited with code ${code}.`);
+      });
+      this.child.once("error", (error) => this.options.logger.error(`Gateway child failed: ${error.message}`));
+    } catch (error) {
+      this.options.logger.error(`Failed to start Gateway: ${error instanceof Error ? error.message : String(error)}`);
+      this.child = undefined;
+      this.ownsChild = false;
+      return false;
+    } finally {
+      closeSync(stdoutFd);
+      closeSync(stderrFd);
+    }
+    return this.waitForHealth();
+  }
+
+  async shutdown(): Promise<void> {
+    const child = this.child;
+    this.child = undefined;
+    if (!child || !this.ownsChild) return;
+    this.ownsChild = false;
+    if (child.exitCode !== null || child.killed) return;
+    child.kill("SIGTERM");
+    const exited = await new Promise<boolean>((resolveExit) => {
+      const timer = setTimeout(() => resolveExit(false), 10_000);
+      child.once("exit", () => { clearTimeout(timer); resolveExit(true); });
+    });
+    if (exited) return;
+    if (process.platform === "win32") {
+      const killer = spawn("taskkill", ["/F", "/T", "/PID", String(child.pid)], { windowsHide: true, stdio: "ignore" });
+      await new Promise<void>((resolveExit) => killer.once("exit", () => resolveExit()));
+    } else {
+      child.kill("SIGKILL");
+    }
+  }
+
+  private async waitForHealth(): Promise<boolean> {
+    const deadline = Date.now() + (this.options.startupTimeoutMs ?? 30_000);
+    const interval = this.options.healthIntervalMs ?? 500;
+    while (Date.now() < deadline) {
+      if (this.child && this.child.exitCode !== null) return false;
+      if (await this.isRunning()) return true;
+      await new Promise((resolveWait) => setTimeout(resolveWait, interval));
+    }
+    this.options.logger.warn("Gateway did not become healthy before the startup timeout.");
+    return false;
+  }
+
+  private gatewayEnvironment(): NodeJS.ProcessEnv {
+    const env = { ...process.env };
+    try {
+      const url = new URL(this.options.gatewayUrl);
+      env.TDAI_GATEWAY_HOST ??= url.hostname;
+      env.TDAI_GATEWAY_PORT ??= url.port || "8420";
+    } catch {
+      // The client will report an invalid URL; do not invent child settings.
+    }
+    return env;
+  }
+
+  private discoverCommand(): SpawnSpec | undefined {
+    const cwd = resolve(this.options.cwd ?? process.cwd());
+    if (this.options.gatewayCommand) {
+      return process.platform === "win32"
+        ? { command: process.env.ComSpec ?? "cmd.exe", args: ["/d", "/s", "/c", this.options.gatewayCommand], cwd }
+        : { command: "/bin/sh", args: ["-lc", this.options.gatewayCommand], cwd };
+    }
+
+    const integrationDir = dirname(fileURLToPath(import.meta.url));
+    const packageRoot = resolve(integrationDir, "..", "..", "..");
+    const roots = [
+      packageRoot,
+      resolve(homedir(), ".memory-tencentdb", "tdai-memory-openclaw-plugin"),
+      cwd,
+      resolve(cwd, "TencentDB-Agent-Memory"),
+    ];
+    for (const root of roots) {
+      const serverPath = join(root, "src", "gateway", "server.ts");
+      try {
+        if (basename(serverPath) === "server.ts" && requireExists(serverPath)) {
+          return { command: process.execPath, args: ["--import", "tsx/esm", serverPath], cwd: root };
+        }
+      } catch {
+        // Continue to the next documented discovery location.
+      }
+    }
+    return undefined;
+  }
+}
+
+function requireExists(path: string): boolean {
+  return existsSync(path);
+}

--- a/integrations/codex/src/index.ts
+++ b/integrations/codex/src/index.ts
@@ -1,0 +1,30 @@
+import { loadCodexAdapterConfig } from "./config.js";
+import { pathToFileURL } from "node:url";
+import { stderrLogger } from "./logger.js";
+import { CodexMcpServer } from "./mcp-server.js";
+
+export { loadCodexAdapterConfig } from "./config.js";
+export { GatewayClient, GatewayClientError } from "./gateway-client.js";
+export { GatewaySupervisor } from "./gateway-supervisor.js";
+export { ResultFormatter } from "./result-formatter.js";
+export { SessionResolver, sanitizeSessionKey } from "./session-resolver.js";
+export { TOOL_DEFINITIONS } from "./tools.js";
+export { CodexMcpServer } from "./mcp-server.js";
+export type * from "./types.js";
+
+export async function main(): Promise<void> {
+  const server = new CodexMcpServer({
+    config: loadCodexAdapterConfig(process.env, stderrLogger),
+    logger: stderrLogger,
+  });
+  const shutdown = async () => {
+    await server.shutdown().catch((error) => stderrLogger.warn(`Shutdown failed: ${String(error)}`));
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+  await server.start();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/integrations/codex/src/logger.ts
+++ b/integrations/codex/src/logger.ts
@@ -1,0 +1,12 @@
+import type { AdapterLogger } from "./types.js";
+
+function write(level: string, message: string): void {
+  process.stderr.write(`[memory-tencentdb-codex] ${level} ${message}\n`);
+}
+
+export const stderrLogger: AdapterLogger = {
+  debug: (message) => write("DEBUG", message),
+  info: (message) => write("INFO", message),
+  warn: (message) => write("WARN", message),
+  error: (message) => write("ERROR", message),
+};

--- a/integrations/codex/src/mcp-server.ts
+++ b/integrations/codex/src/mcp-server.ts
@@ -1,0 +1,69 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { AdapterLogger, CodexAdapterConfig } from "./types.js";
+import { GatewayClient } from "./gateway-client.js";
+import { GatewaySupervisor } from "./gateway-supervisor.js";
+import { ResultFormatter } from "./result-formatter.js";
+import { SessionResolver } from "./session-resolver.js";
+import { TOOL_DEFINITIONS, type ToolName } from "./tools.js";
+import { ToolRouter } from "./tool-router.js";
+
+export interface CodexMcpServerOptions {
+  config: CodexAdapterConfig;
+  logger: AdapterLogger;
+}
+
+export class CodexMcpServer {
+  readonly server: Server;
+  readonly router: ToolRouter;
+  readonly supervisor: GatewaySupervisor;
+
+  constructor(options: CodexMcpServerOptions) {
+    const { config, logger } = options;
+    const client = new GatewayClient({
+      baseUrl: config.gatewayUrl,
+      timeoutMs: config.requestTimeoutMs,
+      apiKey: config.gatewayApiKey,
+    });
+    this.supervisor = new GatewaySupervisor({
+      client,
+      gatewayUrl: config.gatewayUrl,
+      gatewayCommand: config.gatewayCommand,
+      logDir: config.logDir,
+      logger,
+      enabled: config.enableSupervisor,
+    });
+    this.router = new ToolRouter(
+      config,
+      client,
+      this.supervisor,
+      new SessionResolver({ explicitSessionKey: config.explicitSessionKey }),
+      new ResultFormatter(config.resultMaxChars),
+      logger,
+    );
+    this.server = new Server(
+      { name: "memory-tencentdb-codex", version: "0.1.0" },
+      { capabilities: { tools: {} } },
+    );
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFINITIONS }));
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const name = request.params.name as ToolName;
+      const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+      if (!TOOL_DEFINITIONS.some((tool) => tool.name === name)) {
+        return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
+      }
+      return this.router.call(name, args);
+    });
+  }
+
+  async start(): Promise<void> {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+  }
+
+  async shutdown(): Promise<void> {
+    await this.supervisor.shutdown();
+    await this.server.close();
+  }
+}

--- a/integrations/codex/src/result-formatter.ts
+++ b/integrations/codex/src/result-formatter.ts
@@ -1,0 +1,91 @@
+import type {
+  CaptureResponse,
+  ConversationSearchResponse,
+  HealthResponse,
+  MemorySearchResponse,
+  RecallResponse,
+  SeedResponse,
+  SessionEndResponse,
+} from "./types.js";
+
+export class ResultFormatter {
+  constructor(private readonly maxChars = 12_000) {}
+
+  health(result: HealthResponse): string {
+    return this.limit([
+      "## Agent Memory Health",
+      "",
+      `Status: ${result.status}`,
+      `Version: ${result.version}`,
+      `Uptime: ${Math.round(result.uptime)}s`,
+      `Vector store: ${result.stores.vectorStore ? "available" : "unavailable"}`,
+      `Embedding service: ${result.stores.embeddingService ? "available" : "unavailable"}`,
+    ].join("\n"));
+  }
+
+  recall(result: RecallResponse): string {
+    return this.limit([
+      "## Agent Memory Recall",
+      "",
+      `Strategy: ${result.strategy ?? "unknown"}`,
+      `Memory count: ${result.memory_count ?? 0}`,
+      "",
+      "<context>",
+      result.context || "No relevant long-term memory was found.",
+      "</context>",
+      "",
+      "Use `agent_memory_search` for structured facts or `agent_conversation_search` for exact prior wording.",
+    ].join("\n"));
+  }
+
+  memorySearch(result: MemorySearchResponse): string {
+    return this.limit(`## Agent Memory Search Results\n\nTotal: ${result.total}\nStrategy: ${result.strategy}\n\n${result.results}`);
+  }
+
+  conversationSearch(result: ConversationSearchResponse): string {
+    return this.limit(`## Agent Conversation Search Results\n\nTotal: ${result.total}\n\n${result.results}`);
+  }
+
+  capture(result: CaptureResponse): string {
+    return this.limit([
+      "## Agent Memory Capture",
+      "",
+      `L0 recorded: ${result.l0_recorded}`,
+      `Scheduler notified: ${String(result.scheduler_notified)}`,
+      "",
+      "Capture accepted. L1/L2/L3 extraction may run asynchronously.",
+    ].join("\n"));
+  }
+
+  sessionEnd(result: SessionEndResponse): string {
+    return this.limit(`## Agent Memory Session End\n\nFlushed: ${String(result.flushed)}`);
+  }
+
+  seed(result: SeedResponse): string {
+    return this.limit([
+      "## Agent Memory Seed",
+      "",
+      `Sessions processed: ${result.sessions_processed}`,
+      `Rounds processed: ${result.rounds_processed}`,
+      `Messages processed: ${result.messages_processed}`,
+      `L0 recorded: ${result.l0_recorded}`,
+      `Duration: ${result.duration_ms}ms`,
+      `Output directory: ${result.output_dir}`,
+    ].join("\n"));
+  }
+
+  unavailable(action: string, reason: string): string {
+    return this.limit([
+      `Agent Memory ${action} is temporarily unavailable.`,
+      `Reason: ${reason}`,
+      "Impact: Continue the main Codex task with the context already available.",
+      "Recovery: The adapter will retry the Gateway on a later call.",
+    ].join("\n"));
+  }
+
+  private limit(value: string): string {
+    if (value.length <= this.maxChars) return value;
+    const suffix = "\n\n[Result truncated by the Codex adapter]";
+    return `${value.slice(0, Math.max(0, this.maxChars - suffix.length))}${suffix}`;
+  }
+}

--- a/integrations/codex/src/session-resolver.ts
+++ b/integrations/codex/src/session-resolver.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+import { basename, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const MAX_SESSION_KEY_LENGTH = 160;
+const THREAD_ENV_NAMES = ["CODEX_THREAD_ID", "CODEX_CONVERSATION_ID", "CODEX_SESSION_ID"] as const;
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+export function sanitizeSessionKey(value: string): string {
+  const sanitized = value.trim().replace(/[^a-zA-Z0-9._:-]+/g, "-").replace(/^-+|-+$/g, "");
+  return (sanitized || "codex-default").slice(0, MAX_SESSION_KEY_LENGTH);
+}
+
+function gitValue(cwd: string, args: string[]): string | undefined {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", windowsHide: true, timeout: 2_000 });
+  if (result.status !== 0) return undefined;
+  return result.stdout.trim() || undefined;
+}
+
+export interface SessionResolverOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  explicitSessionKey?: string;
+}
+
+export class SessionResolver {
+  private readonly cwd: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly explicitSessionKey?: string;
+
+  constructor(options: SessionResolverOptions = {}) {
+    this.cwd = resolve(options.cwd ?? process.cwd());
+    this.env = options.env ?? process.env;
+    this.explicitSessionKey = options.explicitSessionKey?.trim() || undefined;
+  }
+
+  resolve(toolSessionKey?: string): string {
+    if (toolSessionKey?.trim()) return sanitizeSessionKey(toolSessionKey);
+    if (this.explicitSessionKey) return sanitizeSessionKey(this.explicitSessionKey);
+
+    const threadId = THREAD_ENV_NAMES.map((name) => this.env[name]?.trim()).find(Boolean);
+    const repoRoot = gitValue(this.cwd, ["rev-parse", "--show-toplevel"]);
+    const remote = gitValue(this.cwd, ["config", "--get", "remote.origin.url"]);
+    const workspaceIdentity = repoRoot ? `${repoRoot}|${remote ?? ""}` : this.cwd;
+    const repoName = sanitizeSessionKey(basename(repoRoot ?? this.cwd));
+    const base = `codex:${repoName}:${hash(workspaceIdentity)}`;
+    return sanitizeSessionKey(threadId ? `${base}:${hash(threadId)}` : base);
+  }
+}

--- a/integrations/codex/src/tool-router.ts
+++ b/integrations/codex/src/tool-router.ts
@@ -1,0 +1,185 @@
+import type { AdapterLogger, CaptureRequest, McpTextResult } from "./types.js";
+import type { CodexAdapterConfig } from "./types.js";
+import { GatewayClient } from "./gateway-client.js";
+import { GatewaySupervisor } from "./gateway-supervisor.js";
+import { ResultFormatter } from "./result-formatter.js";
+import { SessionResolver } from "./session-resolver.js";
+import type { ToolName } from "./tools.js";
+
+const BREAKER_THRESHOLD = 5;
+const BREAKER_COOLDOWN_MS = 60_000;
+const RECOVER_COOLDOWN_MS = 15_000;
+
+type Args = Record<string, unknown>;
+
+function textResult(text: string, isError = false): McpTextResult {
+  return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
+}
+
+function requiredString(args: Args, name: string): string {
+  const value = args[name];
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Missing required parameter: ${name}`);
+  return value.trim();
+}
+
+function optionalString(args: Args, name: string): string | undefined {
+  const value = args[name];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function limit(args: Args): number {
+  const value = args.limit;
+  return typeof value === "number" && Number.isInteger(value) ? Math.min(50, Math.max(1, value)) : 5;
+}
+
+export class ToolRouter {
+  private consecutiveFailures = 0;
+  private openUntilMs = 0;
+  private lastRecoverAttemptMs = 0;
+
+  constructor(
+    private readonly config: CodexAdapterConfig,
+    private readonly client: GatewayClient,
+    private readonly supervisor: GatewaySupervisor,
+    private readonly sessions: SessionResolver,
+    private readonly formatter: ResultFormatter,
+    private readonly logger: AdapterLogger,
+  ) {}
+
+  async call(name: ToolName, args: Args = {}): Promise<McpTextResult> {
+    if (name === "agent_memory_health") return this.health();
+    if (this.breakerOpen()) return textResult(this.formatter.unavailable("request", "circuit breaker is open"), true);
+    if (!(await this.ensureAvailable())) return textResult(this.formatter.unavailable(this.actionName(name), "Gateway is not connected"), true);
+
+    try {
+      const result = await this.dispatch(name, args);
+      this.recordSuccess();
+      return textResult(result);
+    } catch (error) {
+      this.recordFailure();
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`${name} failed: ${reason}`);
+      return textResult(this.formatter.unavailable(this.actionName(name), reason), true);
+    }
+  }
+
+  private async health(): Promise<McpTextResult> {
+    try {
+      if (!(await this.ensureAvailable())) return textResult(this.formatter.unavailable("health check", "Gateway is not connected"), true);
+      const result = await this.client.health();
+      this.recordSuccess();
+      return textResult(this.formatter.health(result));
+    } catch (error) {
+      this.recordFailure();
+      return textResult(this.formatter.unavailable("health check", error instanceof Error ? error.message : String(error)), true);
+    }
+  }
+
+  private async dispatch(name: ToolName, args: Args): Promise<string> {
+    switch (name) {
+      case "agent_memory_recall":
+        return this.formatter.recall(await this.client.recall({
+          query: requiredString(args, "query"),
+          session_key: this.sessions.resolve(optionalString(args, "session_key")),
+          user_id: optionalString(args, "user_id") ?? this.config.userId,
+        }));
+      case "agent_memory_capture":
+        return this.formatter.capture(await this.client.capture(this.captureRequest(args)));
+      case "agent_memory_search":
+        return this.formatter.memorySearch(await this.client.searchMemories({
+          query: requiredString(args, "query"),
+          limit: limit(args),
+          type: optionalString(args, "type"),
+          scene: optionalString(args, "scene"),
+        }));
+      case "agent_conversation_search":
+        return this.formatter.conversationSearch(await this.client.searchConversations({
+          query: requiredString(args, "query"),
+          limit: limit(args),
+          session_key: optionalString(args, "session_key"),
+        }));
+      case "agent_memory_session_end":
+        return this.formatter.sessionEnd(await this.client.sessionEnd({
+          session_key: this.sessions.resolve(optionalString(args, "session_key")),
+          user_id: optionalString(args, "user_id") ?? this.config.userId,
+        }));
+      case "agent_memory_seed":
+        if (!("data" in args)) throw new Error("Missing required parameter: data");
+        return this.formatter.seed(await this.client.seed({
+          data: args.data,
+          session_key: optionalString(args, "session_key"),
+          strict_round_role: typeof args.strict_round_role === "boolean" ? args.strict_round_role : undefined,
+          auto_fill_timestamps: typeof args.auto_fill_timestamps === "boolean" ? args.auto_fill_timestamps : undefined,
+          config_override: typeof args.config_override === "object" && args.config_override !== null
+            ? args.config_override as Record<string, unknown>
+            : undefined,
+        }));
+      case "agent_memory_health":
+        throw new Error("Health is handled separately.");
+    }
+  }
+
+  private captureRequest(args: Args): CaptureRequest {
+    const userContent = requiredString(args, "user_content");
+    const assistantContent = requiredString(args, "assistant_content");
+    const rawMessages = Array.isArray(args.messages) ? stripMessageTimestamps(args.messages) : undefined;
+    const generatedMessages = [
+      { role: "user", content: userContent },
+      { role: "assistant", content: assistantContent },
+    ];
+    return {
+      user_content: userContent,
+      assistant_content: assistantContent,
+      session_key: this.sessions.resolve(optionalString(args, "session_key")),
+      session_id: optionalString(args, "session_id"),
+      user_id: optionalString(args, "user_id") ?? this.config.userId,
+      messages: this.config.captureMode === "raw" ? rawMessages ?? generatedMessages
+        : this.config.captureMode === "turn" ? rawMessages ?? generatedMessages
+          : generatedMessages,
+    };
+  }
+
+  private async ensureAvailable(): Promise<boolean> {
+    const now = Date.now();
+    if (now - this.lastRecoverAttemptMs < RECOVER_COOLDOWN_MS) return this.supervisor.isRunning();
+    this.lastRecoverAttemptMs = now;
+    return this.supervisor.ensureRunning();
+  }
+
+  private breakerOpen(): boolean {
+    if (Date.now() >= this.openUntilMs) {
+      this.openUntilMs = 0;
+      return false;
+    }
+    return true;
+  }
+
+  private recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.openUntilMs = 0;
+  }
+
+  private recordFailure(): void {
+    this.consecutiveFailures += 1;
+    if (this.consecutiveFailures >= BREAKER_THRESHOLD) this.openUntilMs = Date.now() + BREAKER_COOLDOWN_MS;
+  }
+
+  private actionName(name: ToolName): string {
+    return name.replace(/^agent_memory_/, "").replace(/^agent_/, "").replaceAll("_", " ");
+  }
+}
+
+/**
+ * Gateway capture uses the core's current time as the cursor floor. Codex
+ * messages exist before the HTTP request reaches that core, so forwarding
+ * their original timestamps can make a brand-new turn look already captured.
+ * Let the Gateway assign capture-time timestamps instead. Historical imports
+ * that require source timestamps must use `agent_memory_seed`.
+ */
+function stripMessageTimestamps(messages: unknown[]): unknown[] {
+  return messages.map((message) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) return message;
+    const { timestamp: _timestamp, ...withoutTimestamp } = message as Record<string, unknown>;
+    return withoutTimestamp;
+  });
+}

--- a/integrations/codex/src/tools.ts
+++ b/integrations/codex/src/tools.ts
@@ -1,0 +1,94 @@
+export const TOOL_DEFINITIONS = [
+  {
+    name: "agent_memory_health",
+    description: "Check whether the TencentDB Agent Memory Gateway and its stores are available.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "agent_memory_recall",
+    description: "Recall relevant long-term memory before a Codex task when prior preferences, context, or decisions may matter.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Current task or question used for recall." },
+        session_key: { type: "string" },
+        user_id: { type: "string" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "agent_memory_capture",
+    description: "Capture a meaningful completed Codex task, turn, decision, or milestone into Agent Memory.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        user_content: { type: "string", description: "User request or concise task description." },
+        assistant_content: { type: "string", description: "Outcome, decisions, files changed, and unresolved follow-ups. Do not repeat recalled context verbatim." },
+        session_key: { type: "string" },
+        session_id: { type: "string" },
+        user_id: { type: "string" },
+        messages: { type: "array", items: { type: "object" } },
+      },
+      required: ["user_content", "assistant_content"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "agent_memory_search",
+    description: "Search L1 structured long-term memories for specific historical facts or decisions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 50 },
+        type: { type: "string" },
+        scene: { type: "string" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "agent_conversation_search",
+    description: "Search L0 raw conversation evidence when exact previous wording or turn history is needed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "integer", minimum: 1, maximum: 50 },
+        session_key: { type: "string" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "agent_memory_session_end",
+    description: "Flush pending memory work when a Codex thread or task session ends.",
+    inputSchema: {
+      type: "object",
+      properties: { session_key: { type: "string" }, user_id: { type: "string" } },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "agent_memory_seed",
+    description: "Import historical Codex conversations or prepared session data through the Gateway seed pipeline.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        data: {},
+        session_key: { type: "string" },
+        strict_round_role: { type: "boolean" },
+        auto_fill_timestamps: { type: "boolean" },
+        config_override: { type: "object" },
+      },
+      required: ["data"],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+export type ToolName = (typeof TOOL_DEFINITIONS)[number]["name"];

--- a/integrations/codex/src/types.ts
+++ b/integrations/codex/src/types.ts
@@ -1,0 +1,63 @@
+export type CaptureMode = "summary" | "turn" | "raw";
+
+export interface AdapterLogger {
+  debug?(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+export interface CodexAdapterConfig {
+  gatewayUrl: string;
+  gatewayCommand?: string;
+  gatewayApiKey?: string;
+  requestTimeoutMs: number;
+  enableSupervisor: boolean;
+  explicitSessionKey?: string;
+  userId: string;
+  logDir: string;
+  captureMode: CaptureMode;
+  resultMaxChars: number;
+}
+
+export interface HealthResponse {
+  status: "ok" | "degraded";
+  version: string;
+  uptime: number;
+  stores: { vectorStore: boolean; embeddingService: boolean };
+}
+
+export interface RecallRequest { query: string; session_key: string; user_id?: string }
+export interface RecallResponse { context: string; strategy?: string; memory_count?: number }
+export interface CaptureRequest {
+  user_content: string;
+  assistant_content: string;
+  session_key: string;
+  session_id?: string;
+  user_id?: string;
+  messages?: unknown[];
+}
+export interface CaptureResponse { l0_recorded: number; scheduler_notified: boolean }
+export interface MemorySearchRequest { query: string; limit?: number; type?: string; scene?: string }
+export interface MemorySearchResponse { results: string; total: number; strategy: string }
+export interface ConversationSearchRequest { query: string; limit?: number; session_key?: string }
+export interface ConversationSearchResponse { results: string; total: number }
+export interface SessionEndRequest { session_key: string; user_id?: string }
+export interface SessionEndResponse { flushed: boolean }
+export interface SeedRequest {
+  data: unknown;
+  session_key?: string;
+  strict_round_role?: boolean;
+  auto_fill_timestamps?: boolean;
+  config_override?: Record<string, unknown>;
+}
+export interface SeedResponse {
+  sessions_processed: number;
+  rounds_processed: number;
+  messages_processed: number;
+  l0_recorded: number;
+  duration_ms: number;
+  output_dir: string;
+}
+
+export type { CallToolResult as McpTextResult } from "@modelcontextprotocol/sdk/types.js";

--- a/integrations/codex/templates/AGENTS.memory-tencentdb.md
+++ b/integrations/codex/templates/AGENTS.memory-tencentdb.md
@@ -1,0 +1,7 @@
+# TencentDB Agent Memory for Codex
+
+- Use `agent_memory_recall` before work when historical context may affect the answer.
+- Use `agent_memory_search` for structured memories and `agent_conversation_search` for exact prior wording.
+- After meaningful work, use `agent_memory_capture` with a concise summary of new outcomes, decisions, changed files, and follow-ups. Do not copy recalled context verbatim.
+- Use `agent_memory_session_end` when the Codex thread or task is complete.
+- Memory is advisory. If the Gateway is unavailable, continue the task with the context already available.

--- a/integrations/codex/templates/codex-config.example.toml
+++ b/integrations/codex/templates/codex-config.example.toml
@@ -1,0 +1,15 @@
+[mcp_servers.memory_tencentdb]
+command = "memory-tencentdb-codex-mcp"
+args = []
+
+[mcp_servers.memory_tencentdb.env]
+MEMORY_TENCENTDB_CODEX_GATEWAY_URL = "http://127.0.0.1:8420"
+MEMORY_TENCENTDB_CODEX_ENABLE_SUPERVISOR = "true"
+MEMORY_TENCENTDB_CODEX_USER_ID = "default_user"
+TDAI_DATA_DIR = "~/.memory-tencentdb/memory-tdai"
+# Set both sides when Gateway auth is enabled.
+TDAI_GATEWAY_API_KEY = "change-me"
+MEMORY_TENCENTDB_CODEX_GATEWAY_API_KEY = "change-me"
+TDAI_LLM_BASE_URL = "https://api.openai.com/v1"
+TDAI_LLM_API_KEY = "sk-..."
+TDAI_LLM_MODEL = "gpt-4o"

--- a/integrations/codex/templates/tdai-gateway.example.yaml
+++ b/integrations/codex/templates/tdai-gateway.example.yaml
@@ -1,0 +1,12 @@
+server:
+  host: 127.0.0.1
+  port: 8420
+  # apiKey: change-me
+
+data:
+  baseDir: ~/.memory-tencentdb/memory-tdai
+
+llm:
+  baseUrl: https://api.openai.com/v1
+  apiKey: ""
+  model: gpt-4o

--- a/integrations/codex/tests/config.test.ts
+++ b/integrations/codex/tests/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadCodexAdapterConfig } from "../src/config.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe("loadCodexAdapterConfig", () => {
+  it("uses documented defaults and Gateway auth fallback", () => {
+    const config = loadCodexAdapterConfig({ TDAI_GATEWAY_API_KEY: " gateway-key " }, logger);
+    expect(config.gatewayUrl).toBe("http://127.0.0.1:8420");
+    expect(config.gatewayApiKey).toBe("gateway-key");
+    expect(config.captureMode).toBe("summary");
+    expect(config.enableSupervisor).toBe(true);
+  });
+
+  it("falls back safely for invalid values", () => {
+    const config = loadCodexAdapterConfig({
+      MEMORY_TENCENTDB_CODEX_REQUEST_TIMEOUT_MS: "none",
+      MEMORY_TENCENTDB_CODEX_ENABLE_SUPERVISOR: "perhaps",
+      MEMORY_TENCENTDB_CODEX_CAPTURE_MODE: "full",
+      MEMORY_TENCENTDB_CODEX_GATEWAY_URL: "not a URL",
+    }, logger);
+    expect(config.requestTimeoutMs).toBe(10_000);
+    expect(config.enableSupervisor).toBe(true);
+    expect(config.captureMode).toBe("summary");
+    expect(config.gatewayUrl).toBe("http://127.0.0.1:8420");
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/integrations/codex/tests/gateway-client.test.ts
+++ b/integrations/codex/tests/gateway-client.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { GatewayClient, GatewayClientError } from "../src/gateway-client.js";
+
+describe("GatewayClient", () => {
+  it("adds Bearer auth and serializes Gateway requests", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({ context: "memory" }), { status: 200 }));
+    const client = new GatewayClient({ baseUrl: "http://gateway/", timeoutMs: 100, apiKey: " secret ", fetchImpl });
+    await expect(client.recall({ query: "q", session_key: "s" })).resolves.toEqual({ context: "memory" });
+    expect(fetchImpl).toHaveBeenCalledWith("http://gateway/recall", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({ Authorization: "Bearer secret", "Content-Type": "application/json" }),
+    }));
+  });
+
+  it("reports bounded HTTP failures without secrets", async () => {
+    const client = new GatewayClient({
+      baseUrl: "http://gateway",
+      timeoutMs: 100,
+      fetchImpl: vi.fn().mockResolvedValue(new Response("forbidden", { status: 403 })),
+    });
+    await expect(client.health()).rejects.toBeInstanceOf(GatewayClientError);
+  });
+});

--- a/integrations/codex/tests/gateway-supervisor.test.ts
+++ b/integrations/codex/tests/gateway-supervisor.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { GatewaySupervisor } from "../src/gateway-supervisor.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe("GatewaySupervisor", () => {
+  it("reuses an externally healthy Gateway without spawning a child", async () => {
+    const health = vi.fn().mockResolvedValue({ status: "ok" });
+    const spawnImpl = vi.fn();
+    const supervisor = new GatewaySupervisor({
+      client: { health } as never,
+      gatewayUrl: "http://127.0.0.1:8420",
+      logDir: "logs",
+      logger,
+      enabled: true,
+      spawnImpl: spawnImpl as never,
+    });
+    await expect(supervisor.ensureRunning()).resolves.toBe(true);
+    expect(spawnImpl).not.toHaveBeenCalled();
+    await supervisor.shutdown();
+  });
+
+  it("reports an absent Gateway when supervision is disabled", async () => {
+    const supervisor = new GatewaySupervisor({
+      client: { health: vi.fn().mockRejectedValue(new Error("offline")) } as never,
+      gatewayUrl: "http://127.0.0.1:8420",
+      logDir: "logs",
+      logger,
+      enabled: false,
+      cwd: "C:\\not-a-memory-workspace",
+    });
+    await expect(supervisor.ensureRunning()).resolves.toBe(false);
+  });
+});

--- a/integrations/codex/tests/gateway.e2e.test.ts
+++ b/integrations/codex/tests/gateway.e2e.test.ts
@@ -1,0 +1,122 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "node:net";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TdaiGateway } from "../../../src/gateway/server.js";
+import { CodexMcpServer } from "../src/mcp-server.js";
+import type { CodexAdapterConfig } from "../src/types.js";
+
+async function freePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => server.once("error", reject).listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Unable to allocate a TCP port.");
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+describe("Codex MCP to Gateway E2E", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("captures, finds, flushes, and seeds L0 through real MCP and Gateway routes", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "tdai-codex-e2e-"));
+    const port = await freePort();
+    const configPath = join(dataDir, "tdai-gateway.yaml");
+    await writeFile(configPath, [
+      "memory:",
+      "  extraction:",
+      "    enabled: false",
+      "  embedding:",
+      "    enabled: false",
+      "  bm25:",
+      "    enabled: false",
+    ].join("\n"));
+    process.env.TDAI_GATEWAY_CONFIG = configPath;
+    process.env.TDAI_DATA_DIR = dataDir;
+    process.env.TDAI_GATEWAY_HOST = "127.0.0.1";
+    process.env.TDAI_GATEWAY_PORT = String(port);
+
+    const gateway = new TdaiGateway();
+    const config: CodexAdapterConfig = {
+      gatewayUrl: `http://127.0.0.1:${port}`,
+      requestTimeoutMs: 5_000,
+      enableSupervisor: false,
+      userId: "e2e-user",
+      logDir: join(dataDir, "logs"),
+      captureMode: "summary",
+      resultMaxChars: 12_000,
+    };
+    const mcp = new CodexMcpServer({ config, logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } });
+    const client = new Client({ name: "codex-e2e", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await gateway.start();
+      await Promise.all([mcp.server.connect(serverTransport), client.connect(clientTransport)]);
+
+      const health = await client.callTool({ name: "agent_memory_health", arguments: {} });
+      expect(health.isError).not.toBe(true);
+      expect(health.content).toMatchObject([{ type: "text", text: expect.stringContaining("Agent Memory Health") }]);
+
+      const marker = "codex-e2e durable project decision";
+      const capture = await client.callTool({
+        name: "agent_memory_capture",
+        arguments: { user_content: marker, assistant_content: "The decision was implemented and verified." },
+      });
+      expect(capture.isError).not.toBe(true);
+      expect(capture.content).toMatchObject([{ type: "text", text: expect.stringContaining("L0 recorded: 2") }]);
+
+      const conversations = await client.callTool({
+        name: "agent_conversation_search",
+        arguments: { query: marker },
+      });
+      expect(conversations.isError).not.toBe(true);
+      expect(conversations.content).toMatchObject([{ type: "text", text: expect.stringContaining(marker) }]);
+
+      // Extraction is deliberately disabled for this hermetic test, so L1
+      // search/recall may be empty. The assertions verify both routes make a
+      // complete MCP -> Gateway -> TdaiCore round trip without a fatal error.
+      const recall = await client.callTool({ name: "agent_memory_recall", arguments: { query: marker } });
+      expect(recall.isError).not.toBe(true);
+      expect(recall.content).toMatchObject([{ type: "text", text: expect.stringContaining("Agent Memory Recall") }]);
+
+      const memories = await client.callTool({ name: "agent_memory_search", arguments: { query: marker } });
+      expect(memories.isError).not.toBe(true);
+      expect(memories.content).toMatchObject([{ type: "text", text: expect.stringContaining("Agent Memory Search Results") }]);
+
+      const flush = await client.callTool({ name: "agent_memory_session_end", arguments: {} });
+      expect(flush.isError).not.toBe(true);
+      expect(flush.content).toMatchObject([{ type: "text", text: expect.stringContaining("Flushed: true") }]);
+
+      const seed = await client.callTool({
+        name: "agent_memory_seed",
+        arguments: {
+          data: [{
+            sessionKey: "codex:e2e:seed",
+            conversations: [[
+              { role: "user", content: "seed user", timestamp: Date.now() - 1 },
+              { role: "assistant", content: "seed assistant", timestamp: Date.now() },
+            ]],
+          }],
+        },
+      });
+      expect(seed.isError).not.toBe(true);
+      expect(seed.content).toMatchObject([{ type: "text", text: expect.stringContaining("Sessions processed: 1") }]);
+    } finally {
+      await client.close().catch(() => {});
+      await mcp.shutdown().catch(() => {});
+      await gateway.stop().catch(() => {});
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/integrations/codex/tests/mcp-server.test.ts
+++ b/integrations/codex/tests/mcp-server.test.ts
@@ -1,0 +1,38 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it, vi } from "vitest";
+import { CodexMcpServer } from "../src/mcp-server.js";
+import type { CodexAdapterConfig } from "../src/types.js";
+
+const config: CodexAdapterConfig = {
+  gatewayUrl: "http://127.0.0.1:8420",
+  requestTimeoutMs: 1_000,
+  enableSupervisor: false,
+  userId: "default_user",
+  logDir: "logs",
+  captureMode: "summary",
+  resultMaxChars: 12_000,
+};
+
+describe("CodexMcpServer", () => {
+  it("publishes the complete Codex memory tool set over MCP", async () => {
+    const server = new CodexMcpServer({ config, logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } });
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const response = await client.listTools();
+    expect(response.tools.map((tool) => tool.name)).toEqual([
+      "agent_memory_health",
+      "agent_memory_recall",
+      "agent_memory_capture",
+      "agent_memory_search",
+      "agent_conversation_search",
+      "agent_memory_session_end",
+      "agent_memory_seed",
+    ]);
+
+    await client.close();
+    await server.shutdown();
+  });
+});

--- a/integrations/codex/tests/result-formatter.test.ts
+++ b/integrations/codex/tests/result-formatter.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { ResultFormatter } from "../src/result-formatter.js";
+
+describe("ResultFormatter", () => {
+  it("formats recall with strategy and bounded context", () => {
+    const formatter = new ResultFormatter(100);
+    const text = formatter.recall({ context: "x".repeat(500), strategy: "hybrid", memory_count: 3 });
+    expect(text).toContain("Strategy: hybrid");
+    expect(text).toContain("Memory count: 3");
+    expect(text).toContain("[Result truncated by the Codex adapter]");
+  });
+});

--- a/integrations/codex/tests/session-resolver.test.ts
+++ b/integrations/codex/tests/session-resolver.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeSessionKey, SessionResolver } from "../src/session-resolver.js";
+
+describe("SessionResolver", () => {
+  it("prioritizes a tool-provided session key", () => {
+    const resolver = new SessionResolver({ explicitSessionKey: "configured key" });
+    expect(resolver.resolve("tool/session key")).toBe("tool-session-key");
+  });
+
+  it("uses explicit configured values before workspace discovery", () => {
+    const resolver = new SessionResolver({ explicitSessionKey: "configured key" });
+    expect(resolver.resolve()).toBe("configured-key");
+  });
+
+  it("sanitizes and limits keys", () => {
+    expect(sanitizeSessionKey("  hello / 世界  ")).toBe("hello");
+    expect(sanitizeSessionKey("x".repeat(300))).toHaveLength(160);
+  });
+});

--- a/integrations/codex/tests/tool-router.test.ts
+++ b/integrations/codex/tests/tool-router.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { ToolRouter } from "../src/tool-router.js";
+import { ResultFormatter } from "../src/result-formatter.js";
+import { SessionResolver } from "../src/session-resolver.js";
+import type { CodexAdapterConfig } from "../src/types.js";
+
+const config: CodexAdapterConfig = {
+  gatewayUrl: "http://gateway", requestTimeoutMs: 1000, enableSupervisor: true,
+  userId: "user", logDir: "logs", captureMode: "summary", resultMaxChars: 12_000,
+};
+
+describe("ToolRouter", () => {
+  it("normalizes capture into a valid two-message turn", async () => {
+    const capture = vi.fn().mockResolvedValue({ l0_recorded: 2, scheduler_notified: true });
+    const client = { capture };
+    const supervisor = { ensureRunning: vi.fn().mockResolvedValue(true), isRunning: vi.fn().mockResolvedValue(true) };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const router = new ToolRouter(
+      config,
+      client as never,
+      supervisor as never,
+      new SessionResolver({ explicitSessionKey: "session" }),
+      new ResultFormatter(),
+      logger,
+    );
+    const result = await router.call("agent_memory_capture", { user_content: "request", assistant_content: "outcome" });
+    expect(result.isError).toBeUndefined();
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({
+      session_key: "session",
+      messages: expect.arrayContaining([expect.objectContaining({ role: "user" }), expect.objectContaining({ role: "assistant" })]),
+    }));
+  });
+
+  it("returns a non-fatal result when Gateway recovery fails", async () => {
+    const supervisor = { ensureRunning: vi.fn().mockResolvedValue(false), isRunning: vi.fn().mockResolvedValue(false) };
+    const router = new ToolRouter(
+      config,
+      {} as never,
+      supervisor as never,
+      new SessionResolver({ explicitSessionKey: "session" }),
+      new ResultFormatter(),
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    );
+    const result = await router.call("agent_memory_recall", { query: "history" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("temporarily unavailable") });
+  });
+});

--- a/integrations/codex/tsconfig.json
+++ b/integrations/codex/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["tests/**/*.e2e.test.ts"]
+}

--- a/integrations/codex/tsdown.config.ts
+++ b/integrations/codex/tsdown.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["./src/index.ts"],
+  outDir: "./dist",
+  format: "esm",
+  platform: "node",
+  clean: true,
+  fixedExtension: true,
+  dts: false,
+  sourcemap: false,
+  banner: { js: "#!/usr/bin/env node" },
+  deps: {
+    neverBundle: (id) =>
+      id.startsWith("node:") ||
+      id === "@modelcontextprotocol/sdk" ||
+      id.startsWith("@modelcontextprotocol/sdk/"),
+  },
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-codex-mcp": "./integrations/codex/dist/index.mjs"
   },
   "exports": {
     ".": {
@@ -16,7 +17,7 @@
     }
   },
   "scripts": {
-    "build": "npm run build:plugin && npm run build:scripts",
+    "build": "npm run build:plugin && npm run build:scripts && npm run build:codex",
     "build:plugin": "tsdown",
     "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
     "prepack": "npm run build",
@@ -26,6 +27,8 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
+    "build:codex": "tsdown --config integrations/codex/tsdown.config.ts",
+    "memory-tencentdb-codex-mcp": "node ./integrations/codex/dist/index.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -38,6 +41,7 @@
     "scripts/migrate-sqlite-to-tcvdb/dist/",
     "scripts/export-tencent-vdb/dist/",
     "scripts/read-local-memory/dist/",
+    "integrations/codex/",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",
     "scripts/setup-hermes-memory-tencentdb.bat",
@@ -53,7 +57,9 @@
     "LICENSE",
     "!src/**/*.test.ts",
     "!src/**/*.spec.ts",
-    "!src/**/__tests__/"
+    "!src/**/__tests__/",
+    "!integrations/codex/tests/",
+    "!integrations/codex/**/*.test.ts"
   ],
   "keywords": [
     "openclaw",
@@ -76,6 +82,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.53",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@node-rs/jieba": "^2.0.1",
     "@tencentdb-agent-memory/tcvdb-text": "^0.1.1",
     "ai": "^6.0.164",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     pool: "forks",
-    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "integrations/**/*.test.ts", "__tests__/**/*.test.ts"],
     exclude: ["dist/**", "node_modules/**", "**/*.e2e.test.ts"],
     testTimeout: 120_000,
     hookTimeout: 120_000,


### PR DESCRIPTION
## Description | 描述

新增 TencentDB Agent Memory 的 Codex 适配层，采用 Gateway-first + stdio MCP 架构，不直接访问或修改 L0/L1/L2/L3 核心存储与算法。

本次实现包括：

- 新增 `integrations/codex/` 独立 TypeScript ESM MCP 集成包。
- 基于 `@modelcontextprotocol/sdk` 提供标准 Codex MCP Server。
- 新增并注册以下 MCP 工具：
  - `agent_memory_health`
  - `agent_memory_recall`
  - `agent_memory_capture`
  - `agent_memory_search`
  - `agent_conversation_search`
  - `agent_memory_session_end`
  - `agent_memory_seed`
- 实现 Gateway HTTP Client：
  - 与现有 `src/gateway/types.ts` 的 Gateway 路由契约对齐。
  - 支持 timeout、Bearer Token、HTTP 错误与非法 JSON 响应处理。
- 实现 Gateway Supervisor：
  - 自动探测并复用已运行的 Gateway。
  - Gateway 不可用时自动启动本地 sidecar。
  - 支持 Windows/POSIX 启动逻辑、health polling、stdout/stderr 日志和受控 shutdown。
  - 仅关闭由适配层自行启动的 Gateway 子进程。
- 实现稳定 session key 解析、capture mode、结果格式化、Circuit Breaker 和 Gateway 不可用时的非阻塞降级。
- 修复 Codex capture 消息时间戳与 Gateway 捕获游标冲突的问题，避免新消息被错误过滤为 `L0 recorded: 0`。
- 增加 Codex MCP 配置模板、Gateway YAML 模板、AGENTS 使用模板及中英文 README 接入说明。
- 更新根 `package.json`，增加 MCP SDK、Codex 构建脚本、bin 命令和 npm 发布文件配置。

## Related Issue | 关联 Issue

N/A

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

已完成验证：

- `npx tsc --project integrations/codex/tsconfig.json`
- `npm test`
  - 11 个测试文件通过
  - 80 项测试通过
- `npm run build`
  - OpenClaw 插件构建通过
  - 现有脚本构建通过
  - Codex MCP 构建通过
- `npx vitest run --config vitest.e2e.config.ts`
  - 真实 Gateway + SQLite + MCP E2E 通过
  - 覆盖 health、capture、conversation search、recall、memory search、session end、seed 的 MCP → Gateway → TdaiCore 调用链
- `npm pack --dry-run --ignore-scripts`
  - 确认发布包包含 Codex MCP 构建产物和模板
  - 确认不发布 Codex 适配层测试文件

## Additional Notes | 其他说明

- Codex 适配层默认以 MCP 工具方式接入，不依赖未公开的 Codex 生命周期 hook。
- Gateway 不可用时，工具会返回可读的降级结果，不会阻塞 Codex 主任务。
- 当前无需额外配置即可使用 Gateway health、L0 capture、conversation search、session flush 和 seed。
- 若要启用 L1/L2/L3 结构化抽取、长期记忆搜索和有效 recall，需要额外配置 `TDAI_LLM_BASE_URL`、`TDAI_LLM_API_KEY` 与 `TDAI_LLM_MODEL`。
- Codex MCP 安装配置、使用流程和变量说明见：
  - `integrations/codex/README.md`
  - `integrations/codex/templates/codex-config.example.toml`
  - `integrations/codex/templates/AGENTS.memory-tencentdb.md`