### PR TITLE
fix(gateway): preserve dynamic recall context

### DIFF
--- a/src/gateway/recall-response.test.ts
+++ b/src/gateway/recall-response.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildRecallResponse } from "./recall-response.js";
+
+describe("buildRecallResponse", () => {
+  it("preserves stable and dynamic recall context for gateway clients", () => {
+    expect(
+      buildRecallResponse({
+        appendSystemContext: "<user-persona>stable</user-persona>",
+        prependContext: "<relevant-memories>dynamic</relevant-memories>",
+        recallStrategy: "hybrid",
+        recalledL1Memories: [
+          { content: "dynamic", score: 0.9, type: "episodic" },
+        ],
+      }),
+    ).toEqual({
+      context:
+        "<user-persona>stable</user-persona>\n\n" +
+        "<relevant-memories>dynamic</relevant-memories>",
+      strategy: "hybrid",
+      memory_count: 1,
+    });
+  });
+
+  it("returns dynamic recall when no stable context exists", () => {
+    expect(
+      buildRecallResponse({
+        prependContext: "<relevant-memories>dynamic</relevant-memories>",
+        recalledL1Memories: [],
+      }),
+    ).toEqual({
+      context: "<relevant-memories>dynamic</relevant-memories>",
+      strategy: undefined,
+      memory_count: 0,
+    });
+  });
+});

--- a/src/gateway/recall-response.ts
+++ b/src/gateway/recall-response.ts
@@ -1,0 +1,21 @@
+import type { RecallResult } from "../core/types.js";
+import type { RecallResponse } from "./types.js";
+
+/**
+ * Flatten host-neutral recall regions into the Gateway's single context field.
+ *
+ * OpenClaw can place stable and dynamic regions independently, while Gateway
+ * clients consume one string. Keep the existing stable region first and append
+ * dynamic L1 recall so the cache-aware split does not drop recalled memories.
+ */
+export function buildRecallResponse(result: RecallResult): RecallResponse {
+  const context = [result.appendSystemContext, result.prependContext]
+    .filter((part): part is string => Boolean(part))
+    .join("\n\n");
+
+  return {
+    context,
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -26,7 +26,6 @@ import { SessionFilter } from "../utils/session-filter.js";
 import type {
   HealthResponse,
   RecallRequest,
-  RecallResponse,
   CaptureRequest,
   CaptureResponse,
   MemorySearchRequest,
@@ -43,6 +42,7 @@ import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
+import { buildRecallResponse } from "./recall-response.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
@@ -379,14 +379,10 @@ export class TdaiGateway {
     const startMs = Date.now();
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
+    const response = buildRecallResponse(result);
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    this.logger.info(`Recall completed in ${elapsed}ms: context=${response.context.length} chars`);
 
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
     sendJson(res, 200, response);
   }
 


### PR DESCRIPTION
## Description

The cache-aware recall split returns stable persona/scene/tool guidance in `appendSystemContext` and dynamic L1 matches in `prependContext`. The Gateway `/recall` endpoint currently serializes only `appendSystemContext`, so Hermes receives the stable guidance but silently loses the actual query-specific memories.

This PR adds a small Gateway adapter function that flattens both regions into the existing single `context` response field:

1. stable context first, preserving the existing response prefix;
2. dynamic L1 recall second;
3. the HTTP response schema remains unchanged.

The change is intentionally limited to Gateway/Hermes compatibility. It does not alter OpenClaw prompt placement, recall ranking, persistence, or configuration.

## Impact

- Gateway clients receive dynamic L1 memories again when recall returns them.
- Stable-only and empty recall responses retain their existing behavior.
- Existing clients require no changes because `RecallResponse.context` remains a string.

## Verification

- `npm test` — 5 test files, 69 tests passed
- `npm run build` — passed
- `git diff --check upstream/main...HEAD` — passed

Refs #120.

Related broader proposal: #575.
