### PR TITLE
fix:在#177的recalibrateCount基础上增加recalibrateCursor的功能

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { CheckpointManager } from "./src/utils/checkpoint.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -305,6 +306,7 @@ export default function register(api: OpenClawPluginApi) {
         retentionDays: cfg.memoryCleanup.retentionDays,
         cleanTime: cfg.memoryCleanup.cleanTime,
         logger: api.logger,
+        checkpoint: new CheckpointManager(pluginDataDir, api.logger),
       });
       sharedMemoryCleaner.start();
       api.logger.debug?.(`${TAG} Memory cleaner started (singleton)`);

--- a/src/core/hooks/auto-capture.ts
+++ b/src/core/hooks/auto-capture.ts
@@ -262,6 +262,8 @@ export async function performAutoCapture(params: {
             try {
               const ok = await bgVectorStore.updateL0Embedding!(bgSnapshot[i].recordId, embeddings[i]);
               if (ok) bgUpdated++;
+              // Clear sqlite dirty tier 
+              await checkpoint.clearDirtyTier("l0", sessionKey, "sqlite");
             } catch (err) {
               bgLogger?.warn?.(
                 `${TAG} [L0-vec-index-bg] Failed to update embedding for ${bgSnapshot[i].recordId}: ` +

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -380,6 +380,10 @@ export class VectorStore implements IMemoryStore {
   private stmtL0QueryAll!: StatementSync;
   /** L0 query for L1 runner: messages after a timestamp cursor */
   private stmtL0QueryAfter!: StatementSync;
+  /** L0 max timestamp by session */
+  private stmtL0MaxTsBySession!: StatementSync;
+  /** L1 stats by session (max updated_time + scene_name) */
+  private stmtL1StatsBySession!: StatementSync;
   /** L1 cursor-based pagination for migration (by PK) */
   private stmtL1QueryMigrationCursor!: StatementSync;
   /** L0 cursor-based pagination for migration (by PK) */
@@ -893,6 +897,17 @@ export class VectorStore implements IMemoryStore {
       WHERE record_id > ?
       ORDER BY record_id ASC
       LIMIT ?
+    `);
+
+    // Recovery helper prepared statements
+    this.stmtL0MaxTsBySession = this.db.prepare(
+      "SELECT MAX(timestamp) AS max_ts FROM l0_conversations WHERE session_key = ?",
+    );
+    this.stmtL1StatsBySession = this.db.prepare(`
+      SELECT updated_time, scene_name FROM l1_records
+      WHERE session_key = ?
+      ORDER BY updated_time DESC
+      LIMIT 1
     `);
 
     this.logger?.debug?.(`${TAG} Initialized (dimensions=${this.dimensions})`);
@@ -2296,6 +2311,37 @@ export class VectorStore implements IMemoryStore {
       this.logger?.warn(
         `${TAG} FTS5 rebuild failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
       );
+    }
+  }
+
+  // ── Recovery helpers ───────────────────────────────────────
+
+  /** Get max timestamp for L0 records by session. */
+  getL0MaxTimestampBySession(sessionKey: string): number {
+    if (this.degraded) return 0;
+    try {
+      const row = this.stmtL0MaxTsBySession.get(sessionKey) as { max_ts: number | null } | undefined;
+      return row?.max_ts ?? 0;
+    } catch (err) {
+      this.logger?.warn(`${TAG} getL0MaxTimestampBySession FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      return 0;
+    }
+  }
+
+  /** Get max timestamp and last scene name for L1 records by session. */
+  getL1StatsBySession(sessionKey: string): { maxTimestamp: number; lastSceneName?: string } {
+    if (this.degraded) return { maxTimestamp: 0 };
+    try {
+      const row = this.stmtL1StatsBySession.get(sessionKey) as { updated_time: string; scene_name: string } | undefined;
+      if (!row?.updated_time) return { maxTimestamp: 0 };
+      const ts = Date.parse(row.updated_time);
+      return {
+        maxTimestamp: Number.isFinite(ts) ? ts : 0,
+        lastSceneName: row.scene_name || undefined,
+      };
+    } catch (err) {
+      this.logger?.warn(`${TAG} getL1StatsBySession FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      return { maxTimestamp: 0 };
     }
   }
 

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -1157,6 +1157,50 @@ export class TcvdbMemoryStore implements IMemoryStore {
     }
   }
 
+  // ── Recovery helpers (stubs — TCVDB may not expose MAX queries) ──
+
+  async getL0MaxTimestampBySession(sessionKey: string): Promise<number> {
+    try {
+      await this._ensureInit();
+      if (this.degraded) return 0;
+
+      const docs = await this._queryAllDocs(
+        this.l0Collection,
+        `session_key = "${sessionKey}"`,
+        ["timestamp"],
+        1,
+        [{ fieldName: "timestamp", direction: "desc" }],
+      );
+      return docs.length > 0 ? Number(docs[0].timestamp ?? 0) : 0;
+    } catch (err) {
+      this.logger?.warn(`${TAG} [L0-maxTimestamp] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      return 0;
+    }
+  }
+
+  async getL1StatsBySession(sessionKey: string): Promise<{ maxTimestamp: number; lastSceneName?: string }> {
+    try {
+      await this._ensureInit();
+      if (this.degraded) return { maxTimestamp: 0 };
+
+      const docs = await this._queryAllDocs(
+        this.l1Collection,
+        `session_key = "${sessionKey}"`,
+        ["updated_time_ms", "scene_name"],
+        1,
+        [{ fieldName: "updated_time_ms", direction: "desc" }],
+      );
+      if (docs.length === 0) return { maxTimestamp: 0 };
+      return {
+        maxTimestamp: Number(docs[0].updated_time_ms ?? 0),
+        lastSceneName: docs[0].scene_name ? String(docs[0].scene_name) : undefined,
+      };
+    } catch (err) {
+      this.logger?.warn(`${TAG} [L1-statsBySession] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      return { maxTimestamp: 0 };
+    }
+  }
+
   // ── Re-index ─────────────────────────────────────────────
 
   async reindexAll(

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -306,6 +306,13 @@ export interface IMemoryStore {
     onProgress?: (done: number, total: number, layer: "L1" | "L0") => void,
   ): Promise<{ l1Count: number; l0Count: number }>;
 
+  // ── Recovery helpers (optional) ─────────────────────────
+
+  /** Get max timestamp for L0 records by session. */
+  getL0MaxTimestampBySession?(sessionKey: string): MaybePromise<number>;
+  /** Get max timestamp and last scene name for L1 records by session. */
+  getL1StatsBySession?(sessionKey: string): MaybePromise<{ maxTimestamp: number; lastSceneName?: string }>;
+
   // ── FTS (always sync — cached flag) ──────────────────────
 
   isFtsAvailable(): boolean;

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -514,6 +514,23 @@ export class TdaiCore {
     this.schedulerStartPromise = (async () => {
       try {
         const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        if (this.vectorStore && !this.vectorStore.isDegraded()) {
+          try {
+            const [actualL0, actualL1] = await Promise.all([
+              this.vectorStore.countL0(),
+              this.vectorStore.countL1(),
+            ]);
+            await checkpoint.recalibrateCounts({
+              l0ConversationsCount: actualL0,
+              totalMemoriesExtracted: actualL1,
+            });
+          } catch (err) {
+            this.logger.warn(
+              `${TAG} Checkpoint recalibration failed on scheduler start (non-fatal): ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
         const cp = await checkpoint.read();
         scheduler.start(checkpoint.getAllPipelineStates(cp));
         this.logger.debug?.(`${TAG} Scheduler started`);

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -50,6 +50,13 @@ import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
 import { CheckpointManager } from "../utils/checkpoint.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
+import { readConversationRecords } from "./conversation/l0-recorder.js";
+import { readMemoryRecords, queryMemoryRecords } from "./record/l1-reader.js";
+import { formatLocalDate } from "../utils/time.js";
+import type { DirtyTier } from "../utils/checkpoint.js";
+import type { L0Record } from "./store/types.js";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 const TAG = "[memory-tdai] [core]";
 
@@ -153,7 +160,11 @@ export class TdaiCore {
       // Wire runners after store is ready (or after store init fails — runners
       // still work in degraded mode with JSONL fallback and no embedding)
       this.storeReady
-        .then(() => this.wirePipelineRunners())
+        .then(async () => {
+          // Recovery check: after store init, before wiring pipeline runners
+          await this.runRecoveryIfNeeded();
+          this.wirePipelineRunners();
+        })
         .catch((err) => {
           this.logger.error(`${TAG} Store init failed; wiring pipeline runners in degraded mode: ${err instanceof Error ? err.message : String(err)}`);
           this.wirePipelineRunners();
@@ -230,6 +241,15 @@ export class TdaiCore {
     }
 
     resetStores(this.dataDir);
+
+    // Mark shutdown clean only if all cleanup steps succeeded
+    try {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.markShutdownClean();
+    } catch (err) {
+      this.logger.warn(`${TAG} Failed to mark shutdown clean: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
     this.logger.debug?.(`${TAG} TDAI Core destroyed`);
   }
 
@@ -498,6 +518,245 @@ export class TdaiCore {
     });
 
     this.logger.debug?.(`${TAG} Pipeline runners wired`);
+  }
+
+  // ============================
+  // Recovery from dirty state
+  // ============================
+
+  /**
+   * Run recovery if last shutdown was not clean.
+   * Called after store init, before wiring pipeline runners.
+   */
+  private async runRecoveryIfNeeded(): Promise<void> {
+    const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+    const cp = await checkpoint.read();
+    if (cp.last_shutdown_clean) {
+      // Zero-cost fast path: skip recovery, but immediately reset to false
+      // so a crash in this run won't falsely skip recovery next time.
+      await checkpoint.markShutdownDirty();
+      return;
+    }
+    await this.recoverFromDirtyState(checkpoint);
+  }
+
+  /**
+   * Main recovery orchestrator: process all dirty sessions, recalibrate counters.
+   */
+  private async recoverFromDirtyState(checkpoint: CheckpointManager): Promise<void> {
+    const cp = await checkpoint.read();
+
+    const dirtyL0Sessions = checkpoint.getDirtySessions(cp, "l0");
+    const dirtyL1Sessions = checkpoint.getDirtySessions(cp, "l1");
+
+    if (dirtyL0Sessions.length === 0 && dirtyL1Sessions.length === 0) {
+      this.logger.debug?.(`${TAG} Recovery: no dirty sessions found, skipping`);
+      await this.recalibrateCount(checkpoint);
+      return;
+    }
+
+    this.logger.info(
+      `${TAG} Recovery: dirty_l0=[${dirtyL0Sessions.join(",")}], dirty_l1=[${dirtyL1Sessions.join(",")}]`,
+    );
+
+    for (const sessionKey of dirtyL0Sessions) {
+      const tiers = checkpoint.getDirtyTiers(cp, "l0", sessionKey);
+      await this.recoverSession(checkpoint, "l0", sessionKey, tiers);
+    }
+
+    for (const sessionKey of dirtyL1Sessions) {
+      const tiers = checkpoint.getDirtyTiers(cp, "l1", sessionKey);
+      await this.recoverSession(checkpoint, "l1", sessionKey, tiers);
+    }
+
+    // Recalibrate global counters unconditionally
+    await this.recalibrateCount(checkpoint);
+
+    this.logger.info(`${TAG} Recovery complete`);
+  }
+
+  /**
+   * Three-rule decision tree for recovery of a single session+layer.
+   *
+   * Rule 1 (j ∧ s ∧ c): all tiers dirty → clear markers, self-heal
+   * Rule 2: at least one data tier clean → repair dirty tier(s), fix cursor if needed
+   * Rule 3 (j ∧ s ∧ ¬c): both data tiers dirty, checkpoint clean → cursor repair only
+   */
+  private async recoverSession(
+    checkpoint: CheckpointManager,
+    layer: "l0" | "l1",
+    sessionKey: string,
+    dirtyTiers: DirtyTier[],
+  ): Promise<void> {
+    const j = dirtyTiers.includes("jsonl");
+    const s = dirtyTiers.includes("sqlite");
+    const c = dirtyTiers.includes("checkpoint");
+
+    this.logger.info(
+      `${TAG} Recovery ${layer}: session=${sessionKey}, dirty=[${dirtyTiers.join(",")}]`,
+    );
+
+    // Rule 1: all three dirty → clear markers, normal flow self-heals
+    if (j && s && c) {
+      await checkpoint.clearAllDirtyTiers(layer, sessionKey);
+      return;
+    }
+
+    // Rule 3: both data tiers dirty, checkpoint clean → cursor repair only
+    if (j && s && !c) {
+      await this.recalibrateCursorFromStore(checkpoint, layer, sessionKey);
+      return;
+    }
+
+    // Rule 2: at least one data tier clean → repair the dirty tier(s)
+    if (j && !s) {
+      // jsonl dirty, sqlite clean → restore jsonl from sqlite
+      await this.repairJsonlFromSqlite(layer, sessionKey);
+    }
+    if (s && !j) {
+      // sqlite dirty, jsonl clean → restore sqlite from jsonl
+      await this.repairSqliteFromJsonl(layer, sessionKey);
+    }
+    if (c) {
+      // checkpoint dirty → recalibrate cursor from store (clears markers internally)
+      await this.recalibrateCursorFromStore(checkpoint, layer, sessionKey);
+    } else {
+      // No cursor fix needed → just clear remaining markers
+      await checkpoint.clearAllDirtyTiers(layer, sessionKey);
+    }
+  }
+
+  /**
+   * Repair sqlite store from jsonl files (jsonl is clean source, sqlite is dirty).
+   * L0: readConversationRecords → expand messages[] → upsertL0 (deferred embedding, no embeddingService)
+   * L1: readMemoryRecords → upsertL1 (embeddingService degraded if undefined)
+   */
+  private async repairSqliteFromJsonl(layer: "l0" | "l1", sessionKey: string): Promise<void> {
+    if (!this.vectorStore) return;
+
+    let synced = 0;
+    if (layer === "l0") {
+      const conversationRecords = await readConversationRecords(sessionKey, this.dataDir, this.logger);
+      for (const conv of conversationRecords) {
+        for (const msg of conv.messages) {
+          const l0Record: L0Record = {
+            id: msg.id,
+            sessionKey: conv.sessionKey,
+            sessionId: conv.sessionId || "",
+            role: msg.role,
+            messageText: msg.content,
+            recordedAt: conv.recordedAt,
+            timestamp: msg.timestamp,
+          };
+          await this.vectorStore.upsertL0(l0Record);
+          synced++;
+        }
+      }
+    } else {
+      const records = await readMemoryRecords(sessionKey, this.dataDir, this.logger);
+      for (const r of records) {
+        const embedding = this.embeddingService
+          ? await this.embeddingService.embed(r.content)
+          : undefined;
+        await this.vectorStore.upsertL1(r, embedding);
+        synced++;
+      }
+    }
+    this.logger.info(`${TAG} repairSqliteFromJsonl ${layer}: session=${sessionKey}, synced=${synced}`);
+  }
+
+  /**
+   * Repair jsonl files from sqlite store (sqlite is clean source, jsonl is dirty).
+   * L0: queryL0ForL1 (snake_case) → convert to camelCase jsonl records → append to shard file
+   * L1: queryMemoryRecords (already camelCase) → directly append to shard file
+   */
+  private async repairJsonlFromSqlite(layer: "l0" | "l1", sessionKey: string): Promise<void> {
+    if (!this.vectorStore) return;
+
+    const dir = layer === "l0" ? "conversations" : "records";
+    let appended = 0;
+
+    if (layer === "l0") {
+      const rows = await this.vectorStore.queryL0ForL1(sessionKey);
+      for (const row of rows) {
+        const jsonlLine = {
+          id: row.record_id,
+          sessionKey: row.session_key,
+          sessionId: row.session_id || "",
+          role: row.role,
+          content: row.message_text,
+          recordedAt: row.recorded_at,
+          timestamp: row.timestamp,
+        };
+        const date = formatLocalDate(new Date(row.recorded_at));
+        const filePath = path.join(this.dataDir, dir, `${date}.jsonl`);
+        await fs.appendFile(filePath, JSON.stringify(jsonlLine) + "\n", "utf-8");
+        appended++;
+      }
+    } else {
+      const records = await queryMemoryRecords(this.vectorStore, { sessionKey });
+      for (const r of records) {
+        const date = formatLocalDate(new Date(r.createdAt));
+        const filePath = path.join(this.dataDir, dir, `${date}.jsonl`);
+        await fs.appendFile(filePath, JSON.stringify(r) + "\n", "utf-8");
+        appended++;
+      }
+    }
+    this.logger.info(`${TAG} repairJsonlFromSqlite ${layer}: session=${sessionKey}, appended=${appended}`);
+  }
+
+  /**
+   * Recalibrate cursor from store MAX queries (no full scan).
+   * Falls back to clearAllDirtyTiers if store methods unavailable or no data.
+   */
+  private async recalibrateCursorFromStore(
+    checkpoint: CheckpointManager,
+    layer: "l0" | "l1",
+    sessionKey: string,
+  ): Promise<void> {
+    if (!this.vectorStore) {
+      await checkpoint.clearAllDirtyTiers(layer, sessionKey);
+      return;
+    }
+
+    let maxTs = 0;
+    let lastScene: string | undefined;
+
+    if (layer === "l0") {
+      maxTs = await this.vectorStore.getL0MaxTimestampBySession!(sessionKey);
+    } else {
+      const stats = await this.vectorStore.getL1StatsBySession!(sessionKey);
+      maxTs = stats.maxTimestamp;
+      lastScene = stats.lastSceneName;
+    }
+
+    if (maxTs > 0) {
+      await checkpoint.recalibrateCursor(sessionKey, layer, maxTs, lastScene);
+    } else {
+      await checkpoint.clearAllDirtyTiers(layer, sessionKey);
+    }
+  }
+
+  /**
+   * Recalibrate global L0/L1 counters from actual store counts.
+   */
+  private async recalibrateCount(checkpoint: CheckpointManager): Promise<void> {
+    if (!this.vectorStore) return;
+
+    try {
+      const [actualL0, actualL1] = await Promise.all([
+        this.vectorStore.countL0(),
+        this.vectorStore.countL1(),
+      ]);
+      await checkpoint.recalibrateCounts({
+        l0ConversationsCount: actualL0,
+        totalMemoriesExtracted: actualL1,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Recovery: recalibrateCounts failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private ensureSchedulerStarted(): Promise<void> {

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("CheckpointManager.recalibrateCounts", () => {
+  it("reconciles L0 and L1 counters with actual storage counts", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 12,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 8,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 12,
+      total_memories_extracted: 10,
+    });
+
+    await checkpoint.recalibrateCounts({
+      l0ConversationsCount: 4,
+      totalMemoriesExtracted: 6,
+    });
+
+    const cp = await checkpoint.read();
+    expect(cp.l0_conversations_count).toBe(4);
+    expect(cp.total_memories_extracted).toBe(6);
+    expect(cp.memories_since_last_persona).toBe(4);
+  });
+
+  it("does not let memories_since_last_persona go below zero", async () => {
+    const dataDir = await makeTempDir();
+    const checkpoint = new CheckpointManager(dataDir);
+
+    await checkpoint.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 2,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 0,
+      total_memories_extracted: 10,
+    });
+
+    await checkpoint.recalibrateCounts({ totalMemoriesExtracted: 1 });
+
+    const cp = await checkpoint.read();
+    expect(cp.total_memories_extracted).toBe(1);
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+});

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CheckpointManager } from "./checkpoint.js";
+import type { DirtyTier } from "./checkpoint.js";
 
 const tempDirs: string[] = [];
 
@@ -35,6 +36,10 @@ describe("CheckpointManager.recalibrateCounts", () => {
       pipeline_states: {},
       l0_conversations_count: 12,
       total_memories_extracted: 10,
+      dirty_l0: {},
+      dirty_l1: {},
+      last_shutdown_clean: false,
+      last_shutdown_ts: 0,
     });
 
     await checkpoint.recalibrateCounts({
@@ -65,6 +70,10 @@ describe("CheckpointManager.recalibrateCounts", () => {
       pipeline_states: {},
       l0_conversations_count: 0,
       total_memories_extracted: 10,
+      dirty_l0: {},
+      dirty_l1: {},
+      last_shutdown_clean: false,
+      last_shutdown_ts: 0,
     });
 
     await checkpoint.recalibrateCounts({ totalMemoriesExtracted: 1 });
@@ -72,5 +81,239 @@ describe("CheckpointManager.recalibrateCounts", () => {
     const cp = await checkpoint.read();
     expect(cp.total_memories_extracted).toBe(1);
     expect(cp.memories_since_last_persona).toBe(0);
+  });
+});
+
+// ============================
+// Dirty Tracker tests
+// ============================
+
+describe("CheckpointManager.dirtyTracker", () => {
+  it("setDirtyTiers marks tiers as dirty with dedup", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.setDirtyTiers("l0", "session-1", ["jsonl", "sqlite", "checkpoint"]);
+
+    const state = await cp.read();
+    expect(state.dirty_l0["session-1"]).toEqual(["jsonl", "sqlite", "checkpoint"]);
+
+    // Repeat with overlapping set — should not duplicate
+    await cp.setDirtyTiers("l0", "session-1", ["jsonl", "sqlite"]);
+    const state2 = await cp.read();
+    expect(state2.dirty_l0["session-1"]).toEqual(["jsonl", "sqlite", "checkpoint"]);
+  });
+
+  it("clearDirtyTier removes a single tier and cleans up empty session entries", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.setDirtyTiers("l0", "session-1", ["jsonl", "sqlite"]);
+    await cp.clearDirtyTier("l0", "session-1", "jsonl");
+
+    const state = await cp.read();
+    expect(state.dirty_l0["session-1"]).toEqual(["sqlite"]);
+
+    // Clear last tier — session entry should be removed
+    await cp.clearDirtyTier("l0", "session-1", "sqlite");
+    const state2 = await cp.read();
+    expect(state2.dirty_l0["session-1"]).toBeUndefined();
+  });
+
+  it("setDirtyTiers and clearDirtyTier work independently for L0 and L1", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.setDirtyTiers("l0", "session-1", ["jsonl"]);
+    await cp.setDirtyTiers("l1", "session-1", ["sqlite"]);
+
+    const state = await cp.read();
+    expect(state.dirty_l0["session-1"]).toEqual(["jsonl"]);
+    expect(state.dirty_l1["session-1"]).toEqual(["sqlite"]);
+
+    await cp.clearDirtyTier("l0", "session-1", "jsonl");
+    const state2 = await cp.read();
+    expect(state2.dirty_l0["session-1"]).toBeUndefined();
+    expect(state2.dirty_l1["session-1"]).toEqual(["sqlite"]);
+  });
+
+  it("clearAllDirtyTiers removes all tiers for a session", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.setDirtyTiers("l1", "session-1", ["jsonl", "sqlite", "checkpoint"]);
+    await cp.clearAllDirtyTiers("l1", "session-1");
+
+    const state = await cp.read();
+    expect(state.dirty_l1["session-1"]).toBeUndefined();
+  });
+
+  it("getDirtyTiers returns empty array for clean sessions", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    const state = await cp.read();
+    expect(cp.getDirtyTiers(state, "l0", "nonexistent")).toEqual([]);
+  });
+
+  it("getDirtySessions returns all sessions with dirty tiers", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.setDirtyTiers("l0", "session-a", ["jsonl"]);
+    await cp.setDirtyTiers("l0", "session-b", ["sqlite"]);
+
+    const state = await cp.read();
+    const sessions = cp.getDirtySessions(state, "l0");
+    expect(sessions).toEqual(expect.arrayContaining(["session-a", "session-b"]));
+    expect(sessions.length).toBe(2);
+  });
+});
+
+// ============================
+// Clean Shutdown Flag tests
+// ============================
+
+describe("CheckpointManager.shutdownFlag", () => {
+  it("markShutdownClean sets last_shutdown_clean and last_shutdown_ts", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.markShutdownClean();
+
+    const state = await cp.read();
+    expect(state.last_shutdown_clean).toBe(true);
+    expect(state.last_shutdown_ts).toBeGreaterThan(0);
+  });
+
+  it("markShutdownDirty sets last_shutdown_clean to false", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.markShutdownClean(); // true
+    await cp.markShutdownDirty(); // back to false
+
+    const state = await cp.read();
+    expect(state.last_shutdown_clean).toBe(false);
+  });
+});
+
+// ============================
+// Cursor recalibration tests
+// ============================
+
+describe("CheckpointManager.recalibrateCursor", () => {
+  it("advances L0 cursor with Math.max and clears dirty markers atomically", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    // Set initial state
+    await cp.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 0,
+      scenes_processed: 0,
+      runner_states: { "session-1": { last_captured_timestamp: 100, last_l1_cursor: 0, last_scene_name: "" } },
+      pipeline_states: {},
+      l0_conversations_count: 0,
+      total_memories_extracted: 0,
+      dirty_l0: { "session-1": ["jsonl", "sqlite", "checkpoint"] },
+      dirty_l1: {},
+      last_shutdown_clean: false,
+      last_shutdown_ts: 0,
+    });
+
+    // Recalibrate to a later timestamp
+    await cp.recalibrateCursor("session-1", "l0", 500);
+
+    const state = await cp.read();
+    expect(state.runner_states["session-1"].last_captured_timestamp).toBe(500);
+    expect(state.dirty_l0["session-1"]).toBeUndefined();
+  });
+
+  it("never retreats L0 cursor (Math.max with earlier timestamp)", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.setDirtyTiers("l0", "session-1", ["sqlite"]);
+    // Set runner state directly
+    await cp.write({
+      ...(await cp.read()),
+      runner_states: { "session-1": { last_captured_timestamp: 1000, last_l1_cursor: 0, last_scene_name: "" } },
+    });
+
+    // Try to recalibrate with an earlier timestamp
+    await cp.recalibrateCursor("session-1", "l0", 100);
+
+    const state = await cp.read();
+    expect(state.runner_states["session-1"].last_captured_timestamp).toBe(1000); // unchanged
+  });
+
+  it("recalibrateCursor advances L1 cursor and clears dirty markers", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    await cp.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 0,
+      scenes_processed: 0,
+      runner_states: { "session-1": { last_captured_timestamp: 0, last_l1_cursor: 100, last_scene_name: "" } },
+      pipeline_states: {},
+      l0_conversations_count: 0,
+      total_memories_extracted: 0,
+      dirty_l1: { "session-1": ["checkpoint"] },
+      dirty_l0: {},
+      last_shutdown_clean: false,
+      last_shutdown_ts: 0,
+    });
+
+    await cp.recalibrateCursor("session-1", "l1", 500, "scene-2");
+
+    const state = await cp.read();
+    expect(state.runner_states["session-1"].last_l1_cursor).toBe(500);
+    expect(state.runner_states["session-1"].last_scene_name).toBe("scene-2");
+    expect(state.dirty_l1["session-1"]).toBeUndefined();
+  });
+});
+
+// ============================
+// Backward compatibility tests
+// ============================
+
+describe("CheckpointManager.backwardCompat", () => {
+  it("old checkpoint without dirty/shutdown fields gets defaults", async () => {
+    const dataDir = await makeTempDir();
+    const cp = new CheckpointManager(dataDir);
+
+    // Write an old-style checkpoint (no new fields)
+    await cp.write({
+      last_captured_timestamp: 0,
+      total_processed: 0,
+      last_persona_at: 0,
+      last_persona_time: "",
+      request_persona_update: false,
+      persona_update_reason: "",
+      memories_since_last_persona: 0,
+      scenes_processed: 0,
+      runner_states: {},
+      pipeline_states: {},
+      l0_conversations_count: 0,
+      total_memories_extracted: 0,
+    } as any);
+
+    const state = await cp.read();
+    expect(state.dirty_l0).toEqual({});
+    expect(state.dirty_l1).toEqual({});
+    expect(state.last_shutdown_clean).toBe(false);
+    expect(state.last_shutdown_ts).toBe(0);
   });
 });

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -332,6 +332,41 @@ export class CheckpointManager {
     this.logger.info(`[checkpoint] incrementScenesProcessed: scenes_processed=${cp.scenes_processed}`);
   }
 
+  /**
+   * Reconcile aggregate counters with the current storage backend.
+   *
+   * L0/L1 records can be removed outside the normal append path (TTL cleanup,
+   * manual JSONL pruning, SQLite maintenance). The checkpoint counters are
+   * increment-only during capture/extraction, so they otherwise drift upward
+   * forever after deletes.
+   */
+  async recalibrateCounts(actual: {
+    l0ConversationsCount?: number;
+    totalMemoriesExtracted?: number;
+  }): Promise<void> {
+    const cp = await this.mutate((cp) => {
+      if (actual.l0ConversationsCount !== undefined) {
+        cp.l0_conversations_count = Math.max(0, actual.l0ConversationsCount);
+      }
+
+      if (actual.totalMemoriesExtracted !== undefined) {
+        const nextTotal = Math.max(0, actual.totalMemoriesExtracted);
+        const removedMemories = Math.max(0, cp.total_memories_extracted - nextTotal);
+        cp.total_memories_extracted = nextTotal;
+        if (removedMemories > 0) {
+          cp.memories_since_last_persona = Math.max(0, cp.memories_since_last_persona - removedMemories);
+        }
+      }
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrateCounts: ` +
+      `l0_conversations_count=${cp.l0_conversations_count}, ` +
+      `total_memories_extracted=${cp.total_memories_extracted}, ` +
+      `memories_since_last_persona=${cp.memories_since_last_persona}`,
+    );
+  }
+
   // ============================
   // Per-session helpers — runner state (L0/L1 owned)
   // ============================

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -32,6 +32,9 @@ import { randomBytes } from "node:crypto";
 // Types
 // ============================
 
+/** Storage tier identifiers for dirty tracking. */
+export type DirtyTier = "jsonl" | "sqlite" | "checkpoint";
+
 /**
  * Per-session state managed by L0/L1 runners (written directly to checkpoint).
  * These fields are ONLY written by CheckpointManager methods (markL1*, advanceSession*, etc.)
@@ -106,6 +109,18 @@ export interface Checkpoint {
   // ═══ L1 ═══
   /** Total L1 memories extracted across all time */
   total_memories_extracted: number;
+
+  // ═══ Dirty Tracker (per-session × per-layer × per-tier) ═══
+  /** Per-session L0 dirty markers. Key=sessionKey, value=array of dirty tier names. */
+  dirty_l0: Record<string, DirtyTier[]>;
+  /** Per-session L1 dirty markers. Same structure as dirty_l0. */
+  dirty_l1: Record<string, DirtyTier[]>;
+
+  // ═══ Clean Shutdown Flag ═══
+  /** Whether the last shutdown completed all pending writes successfully. */
+  last_shutdown_clean: boolean;
+  /** Epoch ms of the last shutdown. */
+  last_shutdown_ts: number;
 }
 
 const DEFAULT_RUNNER_STATE: RunnerSessionState = {
@@ -137,6 +152,10 @@ const DEFAULT_CHECKPOINT: Checkpoint = {
   pipeline_states: {},
   l0_conversations_count: 0,
   total_memories_extracted: 0,
+  dirty_l0: {},
+  dirty_l1: {},
+  last_shutdown_clean: false,
+  last_shutdown_ts: 0,
 };
 
 export interface CheckpointLogger {
@@ -368,6 +387,108 @@ export class CheckpointManager {
   }
 
   // ============================
+  // Dirty Tracker methods
+  // ============================
+
+  /** Mark specific tiers as dirty for a session+layer. Idempotent (deduplicates). */
+  async setDirtyTiers(layer: "l0" | "l1", sessionKey: string, tiers: DirtyTier[]): Promise<void> {
+    await this.mutate((cp) => {
+      const key = layer === "l0" ? "dirty_l0" : "dirty_l1";
+      if (!cp[key]) cp[key] = {};
+      const existing = cp[key][sessionKey] ?? [];
+      for (const tier of tiers) {
+        if (!existing.includes(tier)) existing.push(tier);
+      }
+      cp[key][sessionKey] = existing;
+    });
+  }
+
+  /** Clear a single tier for a session+layer. Removes empty session entries. */
+  async clearDirtyTier(layer: "l0" | "l1", sessionKey: string, tier: DirtyTier): Promise<void> {
+    await this.mutate((cp) => {
+      const key = layer === "l0" ? "dirty_l0" : "dirty_l1";
+      if (cp[key]?.[sessionKey]) {
+        cp[key][sessionKey] = cp[key][sessionKey].filter(t => t !== tier);
+        if (cp[key][sessionKey].length === 0) {
+          delete cp[key][sessionKey];
+        }
+      }
+    });
+  }
+
+  /** Clear ALL dirty tiers for a session in one mutate (recovery cleanup). */
+  async clearAllDirtyTiers(layer: "l0" | "l1", sessionKey: string): Promise<void> {
+    await this.mutate((cp) => {
+      const key = layer === "l0" ? "dirty_l0" : "dirty_l1";
+      if (cp[key]) {
+        delete cp[key][sessionKey];
+      }
+    });
+  }
+
+  /** Get dirty tiers for a session. Returns empty array if clean. */
+  getDirtyTiers(cp: Checkpoint, layer: "l0" | "l1", sessionKey: string): DirtyTier[] {
+    const key = layer === "l0" ? "dirty_l0" : "dirty_l1";
+    return cp[key]?.[sessionKey] ?? [];
+  }
+
+  /** Get all sessions that have any dirty tiers for a layer. */
+  getDirtySessions(cp: Checkpoint, layer: "l0" | "l1"): string[] {
+    const key = layer === "l0" ? "dirty_l0" : "dirty_l1";
+    return Object.keys(cp[key] ?? {});
+  }
+
+  // ============================
+  // Clean Shutdown Flag methods
+  // ============================
+
+  /** Mark shutdown as clean. Called at the end of destroy(). */
+  async markShutdownClean(): Promise<void> {
+    await this.mutate((cp) => {
+      cp.last_shutdown_clean = true;
+      cp.last_shutdown_ts = Date.now();
+    });
+  }
+
+  /** Mark shutdown as dirty. Called at initialize() after reading last_shutdown_clean=true. */
+  async markShutdownDirty(): Promise<void> {
+    await this.mutate((cp) => {
+      cp.last_shutdown_clean = false;
+    });
+  }
+
+  // ============================
+  // Cursor recalibration (recovery)
+  // ============================
+
+  /**
+   * Recalibrate cursor for a session+layer using actual data, and clear dirty markers
+   * in the same mutate (atomic). Uses Math.max to only advance, never retreat.
+   */
+  async recalibrateCursor(
+    sessionKey: string,
+    layer: "l0" | "l1",
+    actualMaxTimestamp: number,
+    actualLastSceneName?: string,
+  ): Promise<void> {
+    await this.mutate((cp) => {
+      const state = this.getRunnerState(cp, sessionKey);
+      if (layer === "l0") {
+        state.last_captured_timestamp = Math.max(state.last_captured_timestamp, actualMaxTimestamp);
+      } else {
+        if (actualMaxTimestamp > 0) {
+          state.last_l1_cursor = Math.max(state.last_l1_cursor, actualMaxTimestamp);
+        }
+        if (actualLastSceneName !== undefined) {
+          state.last_scene_name = actualLastSceneName;
+        }
+      }
+      const key = layer === "l0" ? "dirty_l0" : "dirty_l1";
+      if (cp[key]) delete cp[key][sessionKey];
+    });
+  }
+
+  // ============================
   // Per-session helpers — runner state (L0/L1 owned)
   // ============================
 
@@ -458,6 +579,13 @@ export class CheckpointManager {
       }
       cp.total_memories_extracted += memoriesExtracted;
       cp.memories_since_last_persona += memoriesExtracted;
+      // checkpoint are written - clear dirty flag
+      if (cp.dirty_l1?.[sessionKey]){
+        cp.dirty_l1[sessionKey]= cp.dirty_l1[sessionKey].filter(t => t !=="checkpoint");
+        if (cp.dirty_l1[sessionKey].length === 0) {
+          delete cp.dirty_l1[sessionKey];
+        }
+      }
     });
     this.logger.info(
       `[checkpoint] markL1ExtractionComplete session=${sessionKey}: ` +
@@ -499,6 +627,10 @@ export class CheckpointManager {
     await this.mutate(async (cp) => {
       // Read the per-session cursor inside the lock
       const state = this.getRunnerState(cp, sessionKey);
+      
+      // Mark all three tiers dirty before starting L0 capture.
+      if (!cp.dirty_l0) cp.dirty_l0 = {};
+      cp.dirty_l0[sessionKey] =["jsonl", "sqlite", "checkpoint"] as DirtyTier[];
       let afterTimestamp = state.last_captured_timestamp || 0;
 
       // Cold-start guard (same logic that was previously in auto-capture.ts)
@@ -507,6 +639,13 @@ export class CheckpointManager {
       }
 
       const result = await fn(afterTimestamp);
+      // JSONL are done — clear those tiers
+      if (cp.dirty_l0?.[sessionKey]){
+        cp.dirty_l0[sessionKey]= cp.dirty_l0[sessionKey].filter(t => t !=="jsonl");
+        if (cp.dirty_l0[sessionKey].length === 0) {
+          delete cp.dirty_l0[sessionKey];
+        }
+      }
 
       if (result) {
         // Advance per-session cursor (runner-owned)
@@ -516,6 +655,13 @@ export class CheckpointManager {
         cp.total_processed += result.messageCount;
         // Increment L0 conversation count (was a separate mutate() call before)
         cp.l0_conversations_count += 1;
+        // checkpoint are done — clear those tiers
+      if (cp.dirty_l0?.[sessionKey]){
+        cp.dirty_l0[sessionKey]= cp.dirty_l0[sessionKey].filter(t => t !=="checkpoint");
+        if (cp.dirty_l0[sessionKey].length === 0) {
+          delete cp.dirty_l0[sessionKey];
+        }
+      }
       }
     });
   }

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -12,6 +13,7 @@ export interface MemoryCleanerOptions {
   cleanTime: string;
   logger?: Logger;
   vectorStore?: IMemoryStore;
+  checkpoint?: CheckpointManager;
 }
 
 interface CleanupStats {
@@ -33,14 +35,20 @@ export class LocalMemoryCleaner {
   private readonly timer: ManagedTimer;
   private destroyed = false;
   private vectorStore?: IMemoryStore;
+  private checkpoint?: CheckpointManager;
 
   constructor(private readonly opts: MemoryCleanerOptions) {
     this.timer = new ManagedTimer("memory-tdai-cleaner", () => this.destroyed);
     this.vectorStore = opts.vectorStore;
+    this.checkpoint = opts.checkpoint;
   }
 
   setVectorStore(vectorStore: IMemoryStore | undefined): void {
     this.vectorStore = vectorStore;
+  }
+
+  setCheckpoint(checkpoint: CheckpointManager | undefined): void {
+    this.checkpoint = checkpoint;
   }
 
   start(): void {
@@ -163,6 +171,24 @@ export class LocalMemoryCleaner {
 
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
+      }
+
+      if ((removedL1 > 0 || removedL0 > 0) && this.checkpoint) {
+        try {
+          const [actualL0, actualL1] = await Promise.all([
+            vectorStore.countL0(),
+            vectorStore.countL1(),
+          ]);
+          await this.checkpoint.recalibrateCounts({
+            l0ConversationsCount: actualL0,
+            totalMemoriesExtracted: actualL1,
+          });
+        } catch (err) {
+          this.opts.logger?.warn(
+            `${TAG} Checkpoint recalibration failed after cleanup (non-fatal): ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
 
       // ── Post-delete: audit summary ──


### PR DESCRIPTION
## Description | 描述
在#177的recalibrateCount基础上增加recalibrateCursor的功能

## Related Issue | 关联 Issue
Fix #157

## Change Type | 修改类型
- [ ✅] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ✅] Verified locally | 本地验证通过
 ✓ src/utils/checkpoint.test.ts (14 tests) 96ms
 ✓ src/utils/time.test.ts (38 tests) 105ms
 ✓ src/utils/sanitize.test.ts (4 tests) 6ms
 ✓ src/utils/no-think-fetch.test.ts (20 tests) 63ms
 ✓ src/offload/auth-profile-key.test.ts (5 tests) 3ms

 Test Files  5 passed (5)
      Tests  81 passed (81)
   Start at  08:14:10
   Duration  842ms (transform 296ms, setup 0ms, import 447ms, tests 274ms, environment 1ms)
- [ ✅] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

由于计数器漂移的本质是JSONL / Checkpoint / SQLite三层存储的写入和更新并非原子化，在最小改动原则下进行以下变更，以确保三者存储的一致性。
（PS：由于L1的checkpoint变更是在多次JSONL和SQLite变更后统一更新，故为了保持原有结构，未增加L1相关的recalibrateCursor功能）
1.在 Checkpoint 中增加 per-session per-layer per-tier 的脏标记，记录「哪个 session 的哪个层级的哪个存储层尚未完成写入」。
2.在 Checkpoint 中增加全局关闭标记，根据上次是否正常关闭选择是否进行recovery
3.在 `TdaiCore.initialize()` 中，当检测到非干净关闭时，对每个 dirty session 按三规则决策树执行针对性修复。

## 新增接口/类型

| 位置 | 变更 |
|------|------|
| `Checkpoint` interface | 新增 `dirty_l0`, `dirty_l1`（`Record<string, DirtyTier[]>`）, `last_shutdown_clean`, `last_shutdown_ts`；新增 `DirtyTier` 类型 |
| `DEFAULT_CHECKPOINT` | 新增对应默认值 |
| `CheckpointManager` | 新增 `setDirtyTiers()`, `clearDirtyTier()`（单个清除）, `clearAllDirtyTiers()`（recovery 收尾）, `getDirtyTiers()`, `getDirtySessions()`, `markShutdownClean()`, `markShutdownDirty()`（initialize 读取后重置）, `recalibrateCursor()` |
| `IMemoryStore` | 新增可选方法（`?` 标记，与 `updateL0Embedding?` 模式一致）：`getL0MaxTimestampBySession?`, `getL1StatsBySession?` |


## 场景分析
（PS：只解决了场景1.1、1.2和2.1，1.3和1.4是L1变更，3.x需要另外增加全量修复逻辑）

### 一、写入中断场景分析

#### 场景 1.1：L0 performAutoCapture 中断 → 「只写了 JSONL」

即 `recordConversation()` append 成功，但 `captureAtomically` 的 mutate()（写 Checkpoint）**还没执行完就 crash/OOM/kill**。

**接下来业务流程的连锁影响（按时间顺序）：**

|**时间点**|**会发生什么**|**用户感知/影响**|
|---|---|---|
|下一次 agent\_end 触发 capture|因为 Checkpoint 游标没推进，`afterTimestamp` 仍然是旧值，`findNewMessages`/`recordConversation` 会把**刚刚那批消息重新当作「新消息」再采一遍** → JSONL 出现**完全重复行**|JSONL 文件重复记录；|


**后续影响：**

**若JSONL只作为备份，在memory-cleaner删除重复的JSONL前，工作流全部使用SQLite，则可以自修复**（memory-cleaner会删除重复的JSONL）。

---

#### 场景 1.2：L0 performAutoCapture 中断 → 「JSONL + Checkpoint 写了，SQLite 没写」

即 `captureAtomically` 成功（JSONL 和 Checkpoint 都正确），但在 `for` 循环 `upsertL0()` 过程中（或 VDB 网络超时、进程被杀）中断。

|**层级**|**状态**|
|---|---|
|JSONL|✅ 正确|
|Checkpoint|✅ 正确（游标推进了，计数加了）|
|SQLite l0\_conversations + l0\_fts|❌ 部分/全部缺|
|SQLite l0\_vec|❌ 更缺（后台任务还没跑）|


**后续影响：**

**重新运行时启动\#177的recalibrateCounts机制，checkpoint中的`l0_conversations_count`回退，与SQLite保持一致；**

session中的**`last_captured_timestamp` 和`total_processed`未更新，导致重新运行performAutoCapture时JSONL中存储的数据未更新到SQLite中。**

---

#### 场景 1.3：L1 writeMemory 中断 → 「只写了 JSONL」

即 `fs.appendFile(records/xxx.jsonl)` 成功了，但 `embeddingService.embed()` 或 `upsertL1()` 失败/被杀。

|**层级**|**状态**|
|---|---|
|JSONL (records/)|✅ L1 记录正确存在（含 id/content/type/source 等）|
|Checkpoint|`total_memories_extracted` 和last\_l1\_cursor未更新❌|
|SQLite l1\_records + l1\_fts + l1\_vec|❌ 缺|


**后续影响：**

**JSONL文件出现重复记录，类似场景1.1**

---

#### 场景 1.4：L1 writeMemory  中断 —— 「写了 JSONL和SQLite

」

|**层级**|**状态**|
|---|---|
|JSONL (records/)|✅ L1 记录正确存在（含 id/content/type/source 等）|
|Checkpoint|`total_memories_extracted` 和last\_l1\_cursor未更新❌|
|SQLite l1\_records + l1\_fts + l1\_vec|✅ |


**后续影响：**

**重新运行时启动\#177的recalibrateCounts机制，checkpoint中的`total_memories_extracted` 和`memories_since_last_persona`向前与SQLite保持一致，但是`last_l1_cursor、last_scene_name`没有更新，再次运行L1runner时重复提取**

---

### 二、更新/清理场景分析

#### 场景 2.1：memory-cleaner 清理旧数据 → 「JSONL + SQLite 删了，Checkpoint 没更新」

**后续影响：**

**重新运行时启动\#177的recalibrateCounts机制，checkpoint中的`total_memories_extracted` 、`memories_since_last_persona`和`l0_conversations_count`与SQLite保持一致，无异常。**

### 三、手动破坏场景分析

#### 场景 3a：手动删除 `recall_checkpoint.json`

**后续影响：**

**重新运行时启动\#177的recalibrateCounts机制，checkpoint中的`total_memories_extracted` 、`memories_since_last_persona`和`l0_conversations_count`与SQLite保持一致，**session中的**`last_captured_timestamp` 和`total_processed`**以及**`last_l1_cursor、last_scene_name`**归零，JSONL和SQLite中出现数据重复

---

#### 场景 3b：手动 JSONL 文件修剪（删几行/改内容/删某个日期分片）

|**层级**|**状态**|
|---|---|
|JSONL|❌ 人为缺行/旧分片删了|
|Checkpoint|✅ 原封不动，游标/计数都在|
|SQLite|✅ 原封不动（热数据完整）|


**后续影响：JSONL数据缺失，在线 search不受影响（全走 SQLite，用户完全没感觉）**

---

#### 场景 3c：手动删除 SQLite 数据（删 .db 文件 / `DELETE FROM l1_records` / `DROP TABLE`）

|**层级**|**状态**|
|---|---|
|JSONL|✅ 完整
|Checkpoint|✅ 原封不动|
|SQLite|❌ 空/部分空|


**后续影响：**

可以使用JSONL文件callback，但缺乏检测机制
