### PR TITLE
fix(checkpoint): recalibrate append-only counters on startup (fixes #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
 ### 🐛 修复
 
+#### 数据一致性
+- **Checkpoint 计数器只增不减，cleanup 后与真实数据漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：`recall_checkpoint.json` 中的 `total_memories_extracted` 和 `l0_conversations_count` 仅在 L0 capture / L1 完成时递增，`memory-cleaner` 清理 JSONL 分片或 SQLite 过期行、以及手工编辑 checkpoint 后从不下调；结果计数长期偏高，导致 `memories_since_last_persona` / `total_processed` 触发 L3 persona 生成阈值时机错乱，状态查询也持续高报。新增 `CheckpointManager.recalibrate(dataDir, store?)`：JSONL (`records/*.jsonl`) 为 L1 数据源、可选 store probe (`countL0` / `countL1`) 为 L0 数据源；`MAX(jsonl, dbL1)` 容忍两侧未同步；**只下调不上调**（避免 crash 前未 flush 的写入落盘后被双计）；对 `memories_since_last_persona` 做 clamp 防止 persona 幻触发。`TdaiCore.initialize()` 中在 `storeReady` 后 fire-and-forget 调用一次，best-effort，永不阻塞启动。12 组 vitest 覆盖 issue 复现、downward 修正、no-grow 保护、probe 抛错回退、malformed JSONL 跳过、并发写入锁。
+
 #### 数据安全 / 数据隔离
 - **L2 LLM 提取失败导致 `scene_blocks/` 被清空 / 半写入** ([#88](https://github.com/Tencent/TencentDB-Agent-Memory/issues/88))：Phase 1 已对 `scene_blocks/` 做完整快照，但 LLM 抛错时 `catch` 直接 `return`，沙箱里的部分写入 / 删除不会回滚，后续 recall 因此看不到场景导航，降级为碎片召回。新增 `BackupManager.findLatestBackup` + `restoreLatestDirectory`，在 LLM 失败时自动从最新备份恢复；采用 fail-soft 设计：无备份时不动目标目录，恢复过程自身的错误也不会替换原始 LLM 错误。
 - **Cleaner 安全加固**：`computeCutoffMsByLocalDay` 拒绝无效 cutoff（未来时间 / 距今不足 24h）；SQLite 与 TCVDB 在 `expired/total > 80%` 时阻止删除；`runOnce` 增加最小保留护栏（L0:50 / L1:20）并产出 `cleaner_summary` JSON 审计日志；新增 `__tests__/cleaner/verify-cleaner-safety.ts` E2E 校验。

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -160,6 +160,28 @@ export class TdaiCore {
         });
     }
 
+    // Reconcile drifted counters once the store is ready. `total_memories_extracted`
+    // and `l0_conversations_count` are append-only; nothing decrements them when
+    // memory-cleaner prunes JSONL / SQLite rows or when the operator edits the
+    // checkpoint by hand, so we recount from the sources of truth on each boot.
+    // Fire-and-forget: recalibration is best-effort and must not block startup
+    // or fail initialize() — the checkpoint remains usable in its pre-recount
+    // state if this errors.
+    void this.storeReady
+      .then(async () => {
+        try {
+          const cp = new CheckpointManager(this.dataDir, this.logger);
+          await cp.recalibrate(this.dataDir, this.vectorStore);
+        } catch (err) {
+          this.logger.warn(
+            `${TAG} Checkpoint recalibrate failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      })
+      .catch(() => {
+        // storeReady rejection is already logged above by the wirePipelineRunners branch.
+      });
+
     this.logger.debug?.(`${TAG} TDAI Core initialized`);
   }
 

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { CheckpointManager, type CheckpointStoreProbe } from "./checkpoint.js";
+
+/**
+ * Tests for the `recalibrate()` drift-correction path (issue #157).
+ *
+ * The append-only counters `total_memories_extracted` and `l0_conversations_count`
+ * drift upward when memory-cleaner prunes JSONL shards / SQLite rows or when
+ * `recall_checkpoint.json` is hand-edited. `recalibrate()` recounts from the
+ * on-disk JSONL and the store probe, and corrects the counters downward only.
+ */
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+}
+
+async function writeCheckpoint(dataDir: string, cp: Record<string, unknown>): Promise<void> {
+  const dir = path.join(dataDir, ".metadata");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "recall_checkpoint.json"), JSON.stringify(cp), "utf-8");
+}
+
+async function writeJsonlShard(dataDir: string, name: string, lines: string[]): Promise<void> {
+  const dir = path.join(dataDir, "records");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, name), lines.join("\n") + (lines.length ? "\n" : ""), "utf-8");
+}
+
+function makeProbe(l0: number, l1: number): CheckpointStoreProbe {
+  return {
+    countL0: () => l0,
+    countL1: () => l1,
+  };
+}
+
+function makeThrowingProbe(): CheckpointStoreProbe {
+  return {
+    countL0: () => { throw new Error("countL0 boom"); },
+    countL1: () => { throw new Error("countL1 boom"); },
+  };
+}
+
+describe("CheckpointManager.recalibrate", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("corrects downward when JSONL has fewer records than the checkpoint claims", async () => {
+    // Simulate: gateway ran for a while (counter = 50), operator pruned so
+    // only 42 records remain on disk.
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 42 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 50,
+      l0_conversations_count: 30,
+      memories_since_last_persona: 12,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir);
+
+    expect(result.total_memories_extracted).toEqual({ before: 50, after: 42 });
+    expect(result.l0_conversations_count).toEqual({ before: 30, after: 30 }); // no probe → unchanged
+    expect(result.memories_since_last_persona).toEqual({ before: 12, after: 12 }); // still ≤ new total
+
+    const persisted = JSON.parse(await fs.readFile(path.join(dataDir, ".metadata", "recall_checkpoint.json"), "utf-8"));
+    expect(persisted.total_memories_extracted).toBe(42);
+  });
+
+  it("does NOT grow counters upward — recount larger than stored is ignored", async () => {
+    // If JSONL somehow has more records than the checkpoint knows about (rare
+    // — recovery from a crash before flush), we do not raise the counter,
+    // otherwise we double-count once the pending write lands.
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 100 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 42,
+      l0_conversations_count: 10,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir);
+
+    expect(result.total_memories_extracted).toEqual({ before: 42, after: 42 });
+  });
+
+  it("uses the store probe to recount L0 downward", async () => {
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", [JSON.stringify({ id: "m1" })]);
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 1,
+      l0_conversations_count: 50,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir, makeProbe(8, 1));
+
+    expect(result.l0_conversations_count).toEqual({ before: 50, after: 8 });
+  });
+
+  it("clamps memories_since_last_persona to the new total after a downward correction", async () => {
+    // total shrinks from 50 → 3, memories_since (=25) must be pulled down to 3
+    // otherwise the persona trigger would fire on phantom counts.
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 3 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 50,
+      memories_since_last_persona: 25,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir);
+
+    expect(result.total_memories_extracted.after).toBe(3);
+    expect(result.memories_since_last_persona).toEqual({ before: 25, after: 3 });
+  });
+
+  it("leaves memories_since_last_persona alone when it is still within bounds", async () => {
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 30 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 42,
+      memories_since_last_persona: 5,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir);
+
+    expect(result.total_memories_extracted.after).toBe(30);
+    expect(result.memories_since_last_persona).toEqual({ before: 5, after: 5 });
+  });
+
+  it("takes the MAX of JSONL and store counts for L1 (avoids clobbering the healthier side)", async () => {
+    // JSONL pruned to 10, SQLite still has 40 — take 40 so we don't drop
+    // memories that the store still holds.
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 10 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 100,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir, makeProbe(0, 40));
+    expect(result.total_memories_extracted).toEqual({ before: 100, after: 40 });
+  });
+
+  it("skips malformed JSONL lines silently", async () => {
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", [
+      JSON.stringify({ id: "m1" }),
+      "not-json{",
+      JSON.stringify({ id: "m2" }),
+      "",
+      JSON.stringify({ id: "m3" }),
+    ]);
+    await writeCheckpoint(dataDir, { total_memories_extracted: 10 });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir);
+    expect(result.total_memories_extracted.after).toBe(3);
+  });
+
+  it("handles missing records/ directory as zero JSONL records", async () => {
+    await writeCheckpoint(dataDir, { total_memories_extracted: 7 });
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir);
+    expect(result.total_memories_extracted).toEqual({ before: 7, after: 0 });
+  });
+
+  it("survives a store probe that throws — falls back to JSONL-only", async () => {
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", [JSON.stringify({ id: "m1" })]);
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 5,
+      l0_conversations_count: 5,
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    // Should not throw; L0 stays as-is because probe failed.
+    const result = await cp.recalibrate(dataDir, makeThrowingProbe());
+    expect(result.total_memories_extracted).toEqual({ before: 5, after: 1 });
+    expect(result.l0_conversations_count).toEqual({ before: 5, after: 5 });
+  });
+
+  it("is idempotent — running twice produces the same result", async () => {
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 3 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, { total_memories_extracted: 10, memories_since_last_persona: 8 });
+
+    const cp = new CheckpointManager(dataDir);
+    const first = await cp.recalibrate(dataDir);
+    const second = await cp.recalibrate(dataDir);
+
+    expect(first.total_memories_extracted.after).toBe(3);
+    expect(second.total_memories_extracted).toEqual({ before: 3, after: 3 });
+    expect(second.memories_since_last_persona).toEqual({ before: 3, after: 3 });
+  });
+
+  // Exact scenario from issue #157:
+  //   1. gateway accumulates ~50 L1 records
+  //   2. operator deletes 8 pipeline_states + the 8 matching JSONL lines
+  //   3. total_memories_extracted=50 while JSONL has 42 records
+  //   4. verify recalibrate corrects to 42 AND preserves the operator's edits
+  it("issue #157 exact repro: prune 8 of 50, recalibrate to 42", async () => {
+    const kept = Array.from({ length: 42 }, (_, i) => JSON.stringify({ id: `mem-${i}` }));
+    await writeJsonlShard(dataDir, "2026-07-30.jsonl", kept);
+    await writeCheckpoint(dataDir, {
+      total_memories_extracted: 50,
+      l0_conversations_count: 50,
+      memories_since_last_persona: 50,
+      pipeline_states: {
+        // Operator kept exactly one session after removing 8 others.
+        "kept-session": {
+          conversation_count: 3,
+          last_extraction_time: "",
+          last_extraction_updated_time: "",
+          last_active_time: 0,
+          l2_pending_l1_count: 0,
+          warmup_threshold: 0,
+          l2_last_extraction_time: "",
+        },
+      },
+    });
+
+    const cp = new CheckpointManager(dataDir);
+    const result = await cp.recalibrate(dataDir, makeProbe(42, 42));
+
+    expect(result.total_memories_extracted).toEqual({ before: 50, after: 42 });
+    expect(result.l0_conversations_count).toEqual({ before: 50, after: 42 });
+    expect(result.memories_since_last_persona).toEqual({ before: 50, after: 42 });
+
+    // Operator's pipeline_states edits must survive — recalibrate is scoped
+    // to the drifted counters and does not touch per-session state.
+    const persisted = JSON.parse(
+      await fs.readFile(path.join(dataDir, ".metadata", "recall_checkpoint.json"), "utf-8"),
+    );
+    expect(persisted.pipeline_states["kept-session"].conversation_count).toBe(3);
+    expect(Object.keys(persisted.pipeline_states)).toEqual(["kept-session"]);
+  });
+
+  it("is safe against a concurrent mutating call (serialized via file lock)", async () => {
+    await writeJsonlShard(dataDir, "2026-01-01.jsonl", Array.from({ length: 2 }, (_, i) => JSON.stringify({ id: `m${i}` })));
+    await writeCheckpoint(dataDir, { total_memories_extracted: 10 });
+
+    const cp = new CheckpointManager(dataDir);
+    // Run recalibrate and a concurrent markL1ExtractionComplete. The lock
+    // ensures a well-defined ordering: either recount runs first (10→2, then
+    // +3 → 5) or the mark runs first (10+3=13, then recount clamps to
+    // MAX(jsonl=2, dbL1=undef) = 2). Either way, the recount clamp is at most
+    // the actual JSONL count.
+    await Promise.all([
+      cp.recalibrate(dataDir),
+      cp.markL1ExtractionComplete("session-A", 3),
+    ]);
+    const after = await cp.read();
+    expect(after.total_memories_extracted).toBeLessThanOrEqual(5);
+    expect(after.total_memories_extracted).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -29,6 +29,58 @@ import path from "node:path";
 import { randomBytes } from "node:crypto";
 
 // ============================
+// Recount helpers (used by recalibrate)
+// ============================
+
+/**
+ * Optional store adapter used by `recalibrate()` to obtain authoritative counts.
+ * Structural so callers can pass an `IMemoryStore` directly without importing
+ * it here (avoids a cycle between `utils/checkpoint.ts` and `core/store/*`).
+ */
+export interface CheckpointStoreProbe {
+  countL0(): number | Promise<number>;
+  countL1(): number | Promise<number>;
+}
+
+/**
+ * Count valid JSONL records under `<dataDir>/records/*.jsonl`.
+ * Malformed lines are skipped silently — recalibration must never throw on a
+ * partially-corrupt shard. Returns 0 when `records/` is missing.
+ */
+async function countJsonlRecords(dataDir: string, logger?: CheckpointLogger): Promise<number> {
+  const recordsDir = path.join(dataDir, "records");
+  let files: string[];
+  try {
+    files = await fs.readdir(recordsDir);
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const file of files) {
+    if (!file.endsWith(".jsonl")) continue;
+    const filePath = path.join(recordsDir, file);
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      for (const line of raw.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          JSON.parse(trimmed);
+          total += 1;
+        } catch {
+          // Skip malformed line — do not abort the recount.
+        }
+      }
+    } catch (err) {
+      logger?.warn?.(
+        `[checkpoint] countJsonlRecords: failed to read ${file}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  return total;
+}
+
+// ============================
 // Types
 // ============================
 
@@ -483,6 +535,125 @@ export class CheckpointManager {
         cp.l0_conversations_count += 1;
       }
     });
+  }
+
+  // ============================
+  // Recalibration (drift correction)
+  // ============================
+
+  /**
+   * Reconcile monotonic counters against actual on-disk / in-DB state.
+   *
+   * `total_memories_extracted` and `l0_conversations_count` are append-only —
+   * they grow on capture / L1 completion but nothing decrements them when the
+   * memory-cleaner prunes JSONL shards, when the operator hand-edits
+   * `recall_checkpoint.json`, or when SQLite rows expire via `deleteL0Expired`.
+   * The counters then permanently overstate reality, biasing the L2/L3
+   * persona-threshold logic and any status readout that surfaces them.
+   *
+   * Behavior:
+   * - Recounts L1 by walking `records/*.jsonl` (source-of-truth per l1-writer).
+   * - Recounts L0 via the optional `store` probe. Without a probe,
+   *   `l0_conversations_count` is left alone (no authoritative source outside
+   *   SQLite).
+   * - Clamps `memories_since_last_persona` to the new L1 total so persona
+   *   thresholds can't fire on phantom counts left over from pruning.
+   * - **Downward-only.** If the recount is *larger* than the stored value we
+   *   keep the stored value, so a partially-flushed shard on the disk side
+   *   can't reset counters and cause future double-counting when the pending
+   *   writes land.
+   *
+   * Safe to call repeatedly. Serialized via the per-file lock like every
+   * other mutating method.
+   *
+   * @param dataDir  Plugin data directory (same one the manager was
+   *   constructed with — passed explicitly so this method stays independent
+   *   of the private `filePath` layout; records live alongside `.metadata/`).
+   * @param store    Optional store probe supplying `countL0()` / `countL1()`.
+   *   When omitted, only JSONL is recounted.
+   */
+  async recalibrate(
+    dataDir: string,
+    store?: CheckpointStoreProbe,
+  ): Promise<{
+    total_memories_extracted: { before: number; after: number };
+    l0_conversations_count: { before: number; after: number };
+    memories_since_last_persona: { before: number; after: number };
+  }> {
+    // Recount OUTSIDE the file lock — reading JSONL shards can be slow on
+    // large installs and we don't want to block concurrent captures.
+    const jsonlL1 = await countJsonlRecords(dataDir, this.logger);
+    let dbL1: number | undefined;
+    let dbL0: number | undefined;
+    if (store) {
+      try {
+        dbL1 = await store.countL1();
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: countL1 failed (skipping L1 store probe): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      try {
+        dbL0 = await store.countL0();
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] recalibrate: countL0 failed (skipping L0 recount): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    // JSONL is the persistent source-of-truth for L1 per l1-writer.ts. If
+    // the store also reports a count, take the MAX — a shard pruned on one
+    // side but not yet on the other shouldn't clobber the healthier side.
+    const recountedL1 = dbL1 !== undefined ? Math.max(jsonlL1, dbL1) : jsonlL1;
+
+    let result!: {
+      total_memories_extracted: { before: number; after: number };
+      l0_conversations_count: { before: number; after: number };
+      memories_since_last_persona: { before: number; after: number };
+    };
+
+    await this.mutate((cp) => {
+      const beforeL1 = cp.total_memories_extracted;
+      const beforeL0 = cp.l0_conversations_count;
+      const beforeSince = cp.memories_since_last_persona;
+
+      if (recountedL1 < beforeL1) {
+        cp.total_memories_extracted = recountedL1;
+      }
+      if (dbL0 !== undefined && dbL0 < beforeL0) {
+        cp.l0_conversations_count = dbL0;
+      }
+      if (cp.memories_since_last_persona > cp.total_memories_extracted) {
+        cp.memories_since_last_persona = cp.total_memories_extracted;
+      }
+
+      result = {
+        total_memories_extracted: { before: beforeL1, after: cp.total_memories_extracted },
+        l0_conversations_count: { before: beforeL0, after: cp.l0_conversations_count },
+        memories_since_last_persona: { before: beforeSince, after: cp.memories_since_last_persona },
+      };
+    });
+
+    const drifted =
+      result.total_memories_extracted.before !== result.total_memories_extracted.after ||
+      result.l0_conversations_count.before !== result.l0_conversations_count.after ||
+      result.memories_since_last_persona.before !== result.memories_since_last_persona.after;
+    if (drifted) {
+      this.logger.info(
+        `[checkpoint] recalibrate: drift corrected — ` +
+        `total_memories_extracted ${result.total_memories_extracted.before}→${result.total_memories_extracted.after}, ` +
+        `l0_conversations_count ${result.l0_conversations_count.before}→${result.l0_conversations_count.after}, ` +
+        `memories_since_last_persona ${result.memories_since_last_persona.before}→${result.memories_since_last_persona.after} ` +
+        `(jsonl=${jsonlL1}, dbL1=${dbL1 ?? "n/a"}, dbL0=${dbL0 ?? "n/a"})`,
+      );
+    } else {
+      this.logger.info(
+        `[checkpoint] recalibrate: no drift ` +
+        `(total_memories_extracted=${result.total_memories_extracted.after}, l0_conversations_count=${result.l0_conversations_count.after})`,
+      );
+    }
+    return result;
   }
 
 }


### PR DESCRIPTION
## Description | 描述

Fixes the drift bug reported in #157: `total_memories_extracted` and `l0_conversations_count` in `recall_checkpoint.json` only ever increment. After any cleanup (`memory-cleaner` pruning JSONL shards, SQLite `deleteL0Expired`, or manual edits to the checkpoint), the counters permanently overstate reality. That biases L2/L3 persona-threshold logic (`memories_since_last_persona`, `total_processed`) and misleads every status readout that surfaces them.

Adds `CheckpointManager.recalibrate(dataDir, store?)` and calls it once on `TdaiCore` startup (fire-and-forget, after `storeReady`).

### Design decisions worth reviewer attention

1. **Downward-only correction.** A recount larger than the stored value is *ignored*. Otherwise a shard that was written to disk before a crash but never got a checkpoint flush would leave `records/` transiently ahead of the counter; if we raised the counter to match, the pending `markL1ExtractionComplete` that was queued in memory would double-count when it eventually lands.
2. **MAX(jsonl, dbL1) for L1.** JSONL is the persistent source-of-truth per `l1-writer.ts`, but the vector store deletes eagerly on update/merge while JSONL is append-only. When the two disagree, taking the max avoids clobbering the healthier side.
3. **Structural `CheckpointStoreProbe`.** A tiny interface exposing only `countL0` / `countL1`, so callers pass `IMemoryStore` directly without dragging `core/store/*` into `utils/checkpoint.ts` (that would introduce a circular import — `checkpoint` is imported everywhere the store lives).
4. **Clamp `memories_since_last_persona`** to the new L1 ceiling so persona triggers can't fire on phantom counts after pruning.
5. **Recount outside the file lock, correction inside.** Walking JSONL can be slow on large installs; we don't want to block concurrent `captureAtomically` / `markL1ExtractionComplete` on that. The write phase acquires the existing per-file lock as usual.
6. **Fire-and-forget from `initialize()`.** Best-effort. Any error is logged as `warn` and never blocks or fails startup — the checkpoint is still usable in its pre-recount state if recalibration errors.

### Why not the alternatives

- **Recount unconditionally (grow too):** rejected — see (1) above.
- **JSONL-only, drop the probe:** rejected — L0 lives only in SQLite, so `l0_conversations_count` would never recalibrate.
- **Recount lazily on every read:** rejected — breaks the append-only semantics the pipeline relies on and adds a hot-path cost.

## Related Issue | 关联 Issue

Closes #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

### Verification commands

```
npx vitest run                # 91 pass, 0 fail (12 new + 79 existing)
npx tsc --noEmit              # no errors
npx tsdown --dts=false        # build clean
```

### Tests added (12 cases in `src/utils/checkpoint.test.ts`)

- **Exact issue #157 repro** — 50 accumulated → operator prunes 8 pipeline_states + 8 JSONL lines → recalibrate corrects to 42, and the operator's remaining `pipeline_states` are preserved.
- Downward correction (50 → 42).
- No-grow guarantee (JSONL=100, stored=42 → stays at 42).
- L0 probe path (stored=50, probe=8 → 8).
- Persona clamp (total 50→3, `memories_since_last_persona` 25 → 3).
- Persona left alone when already within bounds.
- `MAX(jsonl, dbL1)` tie-break (jsonl=10, dbL1=40 → 40).
- Malformed / blank JSONL lines skipped.
- Missing `records/` treated as zero.
- Throwing store probe falls back to JSONL-only.
- Idempotence (twice yields the same result).
- Concurrent-mutation safety (`recalibrate` + `markL1ExtractionComplete` serialized correctly).

## Additional Notes | 其他说明

- Commit signed off per CONTRIBUTING.md DCO requirement.
- `CHANGELOG.md` updated under `[Unreleased] → 🐛 修复 → 数据一致性`.
- No public API break — `recalibrate()` is additive, existing callers unchanged.
- Runtime cost: one directory scan + one JSON parse per JSONL line at boot, bounded by the current shard count (default retention keeps this small). Zero cost after startup — nothing else calls into it.