### PR TITLE
fix(hermes): register and wire pre_llm_call hook for v0.18.0

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -1079,6 +1079,83 @@ class MemoryTencentdbProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("memory-tencentdb on_session_end failed: %s", e)
 
+    def pre_llm_call(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        session_id: str = "",
+        **kwargs: Any,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Hermes v0.18.0+ hook: last chance to touch messages before the LLM runs.
+
+        Mirrors OpenClaw's ``before_prompt_build`` which runs the 3-stage
+        pipeline (offload-delete re-apply → L3 token-guard compression →
+        MMD canvas injection) against the Gateway's
+        ``POST /before_prompt_build`` endpoint.
+
+        Fail-open semantics: *any* problem (Gateway down, timeout, non-JSON
+        payload, missing ``messages`` field, breaker open, ...) returns the
+        input messages unchanged so the LLM call never stalls.
+        """
+        # 1. Fast-path: no input → nothing to do.  Return None means
+        #    "no change, keep original" — identical to a missing hook.
+        if not messages:
+            return None
+
+        # 2. Ensure the sidecar + client are ready (spawns Gateway process
+        #    lazily and refreshes the client handle).  If this fails we
+        #    silently skip — never block the hot path.
+        if not self._ensure_alive_for_request() or not self._client:
+            return None
+
+        effective_session = session_id or self._session_id
+
+        # 3. Call the Gateway.  We cap the timeout inside the client wrapper
+        #    at 8s (see client.before_prompt_build) so a slow Gateway never
+        #    stalls the user's LLM turn.
+        try:
+            result = self._client.before_prompt_build(
+                messages,
+                session_key=effective_session,
+                user_id=self._user_id,
+            )
+        except Exception as e:
+            # Circuit-breaker pattern: record the failure so we skip the
+            # next N requests, then attempt a non-blocking recovery.
+            self._record_failure()
+            self._try_recover_gateway()
+            logger.debug(
+                "memory-tencentdb pre_llm_call failed (fail-open): %s",
+                e,
+            )
+            return None
+
+        # 4. Validate the response shape.  The Gateway always returns
+        #    ``{messages, stats}`` but a proxy or partial payload shouldn't
+        #    take down the conversation.
+        if not isinstance(result, dict):
+            logger.debug(
+                "memory-tencentdb pre_llm_call: non-dict result, keeping original messages",
+            )
+            return None
+
+        returned_messages = result.get("messages")
+        if returned_messages is None:
+            logger.debug(
+                "memory-tencentdb pre_llm_call: response missing 'messages', keeping original",
+            )
+            return None
+
+        if not isinstance(returned_messages, list):
+            logger.debug(
+                "memory-tencentdb pre_llm_call: 'messages' not a list, keeping original",
+            )
+            return None
+
+        # 5. Success: hand the (possibly compressed / MMD-injected) message
+        #    list back to Hermes.
+        return returned_messages
+
     # -- Config ---------------------------------------------------------------
 
     def get_config_schema(self) -> List[Dict[str, Any]]:

--- a/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/hermes-plugin/memory/memory_tencentdb/client.py
@@ -10,7 +10,7 @@ import json
 import logging
 import urllib.request
 import urllib.error
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/hermes-plugin/memory/memory_tencentdb/plugin.yaml
+++ b/hermes-plugin/memory/memory_tencentdb/plugin.yaml
@@ -5,6 +5,7 @@ description: "memory-tencentdb four-layer memory — L0 conversation recording, 
 hooks:
   - on_memory_write
   - on_session_end
+  - pre_llm_call
 # Legacy provider name — kept so that users whose config still says
 # `memory.provider: tdai` continue to resolve to this provider.
 aliases:

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_pre_llm_call.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_pre_llm_call.py
@@ -1,0 +1,352 @@
+"""Tests for the Hermes v0.18.0+ ``pre_llm_call`` hook.
+
+Covers the full chain introduced by the fix for #550:
+
+  * Plugin contract (provider  ××××:
+  1. ``MemoryTencentdbProvider`` exposes a ``pre_llm_call`` method whose
+     whose (shape matches the Hermes hook signature and that Hermes will dispatch by
+     after plugin.yaml registers the hook.
+  2. Fail-open semantics: Gateway unreachable / timeout / malformed response all
+     return ``None`` (keep original messages unchanged) so the LLM hot path never
+     stalls.
+  3. Success path: Gateway returns ``{messages, stats}`` → provider forwards the
+     returned message list.
+  4. Response-shape guards: non-dict / missing-``messages`` / non-list
+     ``messages`` all fall back to fail-open.
+  5. Empty input list short-circuits and does not touch the client at all.
+  6. ``_ensure_alive_for_request`` returning False → silent skip.
+
+  * Client (``MemoryTencentdbSdkClient.before_prompt_build``:
+  7. Issues ``POST /before_prompt_build`` with the correct URL.
+  8. Body contains ``messages``, ``session_key`` and optional ``user_id``.
+  9. Effective timeout is capped at 8 seconds (the hot-path safety bound, clamped to
+     the provider timeout or the caller value, whichever is smaller.
+ 10. 4xx / 5xx / network errors propagate as exceptions (so the provider's
+     fail-open catches them).
+
+All tests mock all tests use mocks; no real Node process or real socket.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Inject plugin roots so we match the layout pattern used by
+# ``test_memory_tencentdb_recovery.py`` next door.
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_HERE = _THIS_FILE.parent
+for candidate in (
+    _HERE.parents[3] if len(_HERE.parents) >= 4 else None,
+    _HERE.parents[4] if len(_HERE.parents) >= 5 else None,
+    _HERE.parents[2] if len(_HERE.parents) >= 3 else None,
+):
+    if candidate is not None and (candidate / "plugins").is_dir():
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+try:
+    from plugins.memory.memory_tencentdb import MemoryTencentdbProvider
+    from plugins.memory.memory_tencentdb.client import MemoryTencentdbSdkClient
+except ImportError as e:  # pragma: no cover
+    pytest.skip(
+        f"memory_tencentdb provider not importable ({e})",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeSupervisor:
+    """Minimal supervisor stand-in (mirrors the one in test_memory_tencentdb_recovery.py).
+
+    We only expose what ``pre_llm_call`` actually inspects: ``client`` + ensure_running()
+    + is_running().
+    """
+
+    def __init__(self) -> None:
+        self.alive = True
+        self.client = MagicMock(name="MemoryTencentdbSdkClient")
+
+    def is_running(self) -> bool:
+        return self.alive
+
+    def is_process_alive(self) -> bool:
+        return self.alive
+
+    def ensure_running(self) -> bool:
+        self.alive = True
+        return True
+
+    def shutdown(self) -> None:
+        self.alive = False
+
+
+def _make_provider(monkeypatch, supervisor: FakeSupervisor) -> MemoryTencentdbProvider:
+    """Build a provider wired to the given FakeSupervisor.
+
+    Replicates the wiring from the recovery tests, stripped down to the hooks
+    actually exercised in this file.
+    """
+    import plugins.memory.memory_tencentdb as mod
+
+    # Collapse recovery)  cooldowns and disable the watchdog (not under test here.
+    monkeypatch.setattr(mod, "_WATCHDOG_INTERVAL_SECS", 9999)
+    monkeypatch.setattr(mod, "_RECOVER_COOLDOWN_SECS", 0)
+    monkeypatch.setattr(
+        mod, "GatewaySupervisor", lambda *a, **kw: supervisor)
+
+    provider = MemoryTencentdbProvider()
+    provider._user_id = "u-test"
+    provider._session_id = "sess-123"
+
+    # Mark the gateway up so _ensure_alive_for_request does not early-return
+    # unless a test explicitly flips it.
+    provider._gateway_available = True
+    provider._supervisor = supervisor
+    provider._client = supervisor.client
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Provider tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreLlmCallProvider:
+    """Contract + fail-open tests for MemoryTencentdbProvider.pre_llm_call."""
+
+    # -- contract ------------------------------------------------------------
+
+    def test_method_exists_and_signature(self) -> None:
+        """The provider exposes a ``pre_llm_call`` attribute (plugin.yaml
+        registration matches the implementation)."""
+        assert hasattr(MemoryTencentdbProvider, "pre_llm_call")
+        import inspect
+        sig = inspect.signature(MemoryTencentdbProvider.pre_llm_call)
+        assert "messages" in sig.parameters
+        assert "session_id" in sig.parameters
+
+    def test_empty_messages_short_circuits(self, monkeypatch) -> None:
+        """Empty message lists must not touch the network (no client call at all)."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+
+        result = provider.pre_llm_call([], session_id="sess-x")
+        assert result is None
+        # client.before_prompt_build must never be called for empty input
+        supervisor.client.before_prompt_build.assert_not_called()
+
+    def test_ensure_alive_returns_false_skips(self, monkeypatch) -> None:
+        """When _ensure_alive_for_request False → fail-open silently skip."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+        provider._gateway_available = False
+        # Force _ensure_alive_for_request short-circuits False when the
+        # gateway is down and the supervisor cannot respawn.
+        supervisor.alive = False
+        supervisor.ensure_running = MagicMock(return_value=False)
+
+        msgs = [{"role": "user", "content": "hi"}]
+        result = provider.pre_llm_call(msgs)
+
+        assert result is None
+        supervisor.client.before_prompt_build.assert_not_called()
+
+    # -- Fail-open: every error modes -----------------------------------------
+
+    def test_client_raises_returns_none(self, monkeypatch) -> None:
+        """Client call raises (Gateway down, timeout, DNS) → fail-open."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+
+        def boom(*a, **kw):
+            raise ConnectionError("refused")
+
+        supervisor.client.before_prompt_build.side_effect = boom
+
+        msgs = [{"role": "user", "content": "hello"}]
+        # Must not raise.
+        result = provider.pre_llm_call(msgs, session_id="s1")
+        assert result is None  # fail-open: keep original
+        # Failure was recorded + recovery attempted.
+        assert provider._breaker_failures >= 1
+
+    def test_non_dict_response_returns_none(self, monkeypatch) -> None:
+        """Non-dict response → fail-open."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+        supervisor.client.before_prompt_build.return_value = ["not", "a", "dict"]
+
+        msgs = [{"role": "user", "content": "ping"}]
+        assert provider.pre_llm_call(msgs) is None
+
+    def test_missing_messages_key_returns_none(self, monkeypatch) -> None:
+        """Response dict without 'messages' key → fail-open."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+        supervisor.client.before_prompt_build.return_value = {"stats": {}}
+
+        msgs = [{"role": "user", "content": "ping"}]
+        assert provider.pre_llm_call(msgs) is None
+
+    def test_messages_not_a_list_returns_none(self, monkeypatch) -> None:
+        """Response 'messages' not a list → fail-open."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+        supervisor.client.before_prompt_build.return_value = {"messages": "oops"}
+
+        msgs = [{"role": "user", "content": "ping"}]
+        assert provider.pre_llm_call(msgs) is None
+
+    # -- Success path ---------------------------------------------------
+
+    def test_success_returns_modified_messages(self, monkeypatch) -> None:
+        """Valid response → returned list is forwarded verbatim."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+
+        modified = [
+            {"role": "system", "content": "L3 compressed"},
+            {"role": "user", "content": "actual"},
+        ]
+        supervisor.client.before_prompt_build.return_value = {
+            "messages": modified,
+            "stats": {"compression_rounds": 1},
+        }
+
+        msgs = [{"role": "user", "content": "original"}]
+        out = provider.pre_llm_call(msgs, session_id="s42")
+
+        assert out is modified
+        # Arguments forwarded with the right session + user.
+        args, kwargs = supervisor.client.before_prompt_build.call_args
+        assert args[0] is msgs
+        assert kwargs["session_key"] == "s42"
+        assert kwargs["user_id"] == "u-test"
+
+    def test_session_id_falls_back_to_provider_session(self, monkeypatch) -> None:
+        """Hook-level ``session_id`` kwarg is missing → use provider._session_id."""
+        supervisor = FakeSupervisor()
+        provider = _make_provider(monkeypatch, supervisor)
+        supervisor.client.before_prompt_build.return_value = {"messages": []}
+
+        provider.pre_llm_call([{"role": "user", "content": "x"}])
+
+        _args, kwargs = supervisor.client.before_prompt_build.call_args
+        assert kwargs["session_key"] == "sess-123"
+
+
+# ---------------------------------------------------------------------------
+# Client tests
+# ---------------------------------------------------------------------------
+
+
+class TestClientBeforePromptBuild:
+    """HTTP-shape tests for MemoryTencentdbSdkClient.before_prompt_build."""
+
+    def _make_client(self, timeout: float = 30.0) -> MemoryTencentdbSdkClient:
+        return MemoryTencentdbSdkClient(
+            host="127.0.0.1",
+            port=18420,
+            timeout=timeout,
+        )
+
+    def test_url_and_body(self) -> None:
+        """Correct URL path + body fields match the contract."""
+        client = self._make_client()
+        captured: Dict[str, Any] = {}
+
+        def fake_request(method, url, *, json=None, timeout=None, headers=None):
+            captured["method"] = method
+            captured["url"] = url
+            captured["json"] = json
+            captured["timeout"] = timeout
+            captured["headers"] = headers
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.text = json.dumps({"messages": [1, 2, 3], "stats": {}})
+            resp.json.return_value = {"messages": [1, 2, 3], "stats": {}}
+            return resp
+
+        with patch("plugins.memory.memory_tencentdb.client.requests.Session") as mock_session_cls:
+            mock_sess = MagicMock()
+            mock_sess.request.side_effect = fake_request
+            mock_session_cls.return_value = mock_sess
+
+            msgs = [{"role": "user", "content": "q"}]
+            result = client.before_prompt_build(msgs, session_key="sk-9", user_id="u")
+
+            assert captured["method"] == "POST"
+            assert captured["url"].endswith("/before_prompt_build")
+            assert captured["json"]["messages"] == msgs
+            assert captured["json"]["session_key"] == "sk-9"
+            assert captured["json"]["user_id"] == "u"
+            # messages field is present in the response.
+            assert result["messages"] == [1, 2, 3]
+
+    def test_timeout_capped_at_8_seconds(self) -> None:
+        """Regardless of client default/configured timeout >8s → 8s hot-path cap."""
+        client = self._make_client(timeout=120.0)
+        captured_timeout = {"t": None}
+
+        def fake_request(method, url, *, timeout=None, **_):
+            captured_timeout["t"] = timeout
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"messages": [], "stats": {}}
+            return resp
+
+        with patch("plugins.memory.memory_tencentdb.client.requests.Session") as mock_session_cls:
+            mock_sess = MagicMock()
+            mock_sess.request.side_effect = fake_request
+            mock_session_cls.return_value = mock_sess
+
+            client.before_prompt_build([], session_key="s")
+            assert captured_timeout["t"] == 8.0
+
+    def test_timeout_below_cap_preserved(self) -> None:
+        """Client timeout already <8s → caller value preserved (no expansion)."""
+        client = self._make_client(timeout=3.5)
+        captured_timeout = {"t": None}
+
+        def fake_request(method, url, *, timeout=None, **_):
+            captured_timeout["t"] = timeout
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"messages": [], "stats": {}}
+            return resp
+
+        with patch("plugins.memory.memory_tencentdb.client.requests.Session") as mock_session_cls:
+            mock_sess = MagicMock()
+            mock_sess.request.side_effect = fake_request
+            mock_session_cls.return_value = mock_sess
+
+            client.before_prompt_build([], session_key="s")
+            assert captured_timeout["t"] == 3.5
+
+    def test_http_errors_propagate(self) -> None:
+        """5xx / 4xx / non-2xx → raise (so provider fail-open catches it)."""
+        client = self._make_client()
+
+        def fake_request(*a, **kw):
+            resp = MagicMock()
+            resp.status_code = 502
+            resp.raise_for_status.side_effect = RuntimeError("bad gateway")
+            return resp
+
+        with patch("plugins.memory.memory_tencentdb.client.requests.Session") as mock_session_cls:
+            mock_sess = MagicMock()
+            mock_sess.request.side_effect = fake_request
+            mock_session_cls.return_value = mock_sess
+
+            with pytest.raises(RuntimeError):
+                client.before_prompt_build([], session_key="s")

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -28,6 +28,7 @@ import type {
   CompletedTurn,
   MemorySearchParams,
   ConversationSearchParams,
+  BeforePromptBuildResult,
 } from "./types.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import type { IMemoryStore } from "./store/types.js";
@@ -361,6 +362,83 @@ export class TdaiCore {
     await this.storeReady?.catch(() => {});
     if (!this.scheduler) return;
     await this.scheduler.flushSession(sessionKey);
+  }
+
+  /**
+   * Handle before_prompt_build / pre_llm_call — last hook before the LLM is invoked.
+   *
+   * In OpenClaw this runs the full 3-stage pipeline:
+   *   1. Fast-path re-apply of offloaded messages (L3 cleanup)
+   *   2. Token-guard → aggressive + mild L3 compression
+   *   3. MMD (Mermaid L2 canvas) injection
+   *
+   * In the standalone Gateway this currently returns the messages unchanged
+   * with a diagnostic stats block.  The method exists so that Hermes
+   * `pre_llm_call` (v0.18.0+) has a stable HTTP endpoint to hit; the full
+   * compression + MMD pipeline will be wired in via a follow-up PR that
+   * shares the offload hook state between the in-process plugin and the
+   * Gateway server.
+   *
+   * Maps to: OpenClaw `before_prompt_build` / Hermes `pre_llm_call`.
+   *
+   * @param messages    Input message list (the conversation that will be sent
+   *                    to the LLM).  Treated as opaque here — no mutations
+   *                    are performed on the caller's array.
+   * @param sessionKey  Session key for scoping (matches capture/recall).
+   */
+  async handleBeforePromptBuild(
+    messages: unknown[],
+    sessionKey: string,
+  ): Promise<BeforePromptBuildResult> {
+    const started = Date.now();
+
+    if (!messages || !Array.isArray(messages) || messages.length === 0) {
+      return {
+        messages: [],
+        stats: {
+          messagesInput: 0,
+          messagesOutput: 0,
+          mmdBlocksInjected: 0,
+          offloadMessagesDeleted: 0,
+          compressionRounds: 0,
+          durationMs: Date.now() - started,
+          skipped: true,
+          skipReason: "no_messages",
+        },
+      };
+    }
+
+    if (this.sessionFilter && !this.sessionFilter.accept(sessionKey)) {
+      return {
+        messages: [...messages],
+        stats: {
+          messagesInput: messages.length,
+          messagesOutput: messages.length,
+          mmdBlocksInjected: 0,
+          offloadMessagesDeleted: 0,
+          compressionRounds: 0,
+          durationMs: Date.now() - started,
+          skipped: true,
+          skipReason: "session_filtered",
+        },
+      };
+    }
+
+    this.logger.debug?.(
+      `${TAG} handleBeforePromptBuild: session=${sessionKey}, messages=${messages.length}`,
+    );
+
+    return {
+      messages: [...messages],
+      stats: {
+        messagesInput: messages.length,
+        messagesOutput: messages.length,
+        mmdBlocksInjected: 0,
+        offloadMessagesDeleted: 0,
+        compressionRounds: 0,
+        durationMs: Date.now() - started,
+      },
+    };
   }
 
   // ============================

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -225,6 +225,24 @@ export interface CaptureResult {
   }>;
 }
 
+/** Result from before_prompt_build / pre_llm_call (L1.5 extraction + L3 cleanup + MMD injection). */
+export interface BeforePromptBuildResult {
+  /** The (possibly modified) message list to forward to the LLM. */
+  messages: unknown[];
+  /** Opaque diagnostic counters — reported to logs/metrics but not part of the contract. */
+  stats: {
+    messagesInput: number;
+    messagesOutput: number;
+    mmdBlocksInjected: number;
+    offloadMessagesDeleted: number;
+    compressionRounds: number;
+    durationMs?: number;
+    skipped?: boolean;
+    skipReason?: "no_messages" | "session_filtered" | "gateway_disabled";
+    [key: string]: unknown;
+  };
+}
+
 /** Search parameters for L1 memory search. */
 export interface MemorySearchParams {
   query: string;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -8,7 +8,8 @@
  *   POST /search/memories     — L1 memory search
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
- *   POST /seed               — Batch seed historical conversations (L0 → L1)
+ *   POST /seed                — Batch seed historical conversations (L0 → L1)
+ *   POST /before_prompt_build — L1.5 + L3 cleanup + MMD injection (Hermes `pre_llm_call` hook)
  *
  * Built with Node.js native `http` module — no Express/Fastify dependency.
  * Designed to run as a managed sidecar alongside Hermes.
@@ -38,6 +39,8 @@ import type {
   SeedRequest,
   SeedResponse,
   GatewayErrorResponse,
+  BeforePromptBuildRequest,
+  BeforePromptBuildResponse,
 } from "./types.js";
 import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
@@ -272,6 +275,8 @@ export class TdaiGateway {
           return await this.handleSessionEnd(req, res);
         case "POST /seed":
           return await this.handleSeed(req, res);
+        case "POST /before_prompt_build":
+          return await this.handleBeforePromptBuild(req, res);
         default:
           sendError(res, 404, `Not found: ${method} ${pathname}`);
       }
@@ -475,6 +480,44 @@ export class TdaiGateway {
     await this.core.handleSessionEnd(body.session_key);
 
     const response: SessionEndResponse = { flushed: true };
+    sendJson(res, 200, response);
+  }
+
+  private async handleBeforePromptBuild(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<BeforePromptBuildRequest>(req);
+
+    if (!body.session_key) {
+      sendError(res, 400, "Missing required field: session_key");
+      return;
+    }
+    if (!body.messages || !Array.isArray(body.messages)) {
+      sendError(res, 400, "Missing or invalid required field: messages (must be an array)");
+      return;
+    }
+
+    const startMs = Date.now();
+    const result = await this.core.handleBeforePromptBuild(body.messages, body.session_key);
+    const elapsed = Date.now() - startMs;
+
+    this.logger.info(
+      `BeforePromptBuild completed in ${elapsed}ms: ` +
+      `in=${result.stats.messagesInput} out=${result.stats.messagesOutput} ` +
+      `deleted=${result.stats.offloadMessagesDeleted} mmd=${result.stats.mmdBlocksInjected}`,
+    );
+
+    const response: BeforePromptBuildResponse = {
+      messages: result.messages,
+      stats: {
+        messages_input: result.stats.messagesInput,
+        messages_output: result.stats.messagesOutput,
+        mmd_blocks_injected: result.stats.mmdBlocksInjected,
+        offload_messages_deleted: result.stats.offloadMessagesDeleted,
+        compression_rounds: result.stats.compressionRounds,
+        duration_ms: elapsed,
+        ...(result.stats.skipped !== undefined ? { skipped: result.stats.skipped } : {}),
+        ...(result.stats.skipReason !== undefined ? { skip_reason: result.stats.skipReason } : {}),
+      },
+    };
     sendJson(res, 200, response);
   }
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -141,3 +141,52 @@ export interface SeedResponse {
   duration_ms: number;
   output_dir: string;
 }
+
+// ============================
+// /before_prompt_build (pre_llm_call hook endpoint)
+// ============================
+
+/**
+ * Request body for `POST /before_prompt_build`.
+ *
+ * Called by the Hermes `pre_llm_call` hook (v0.18.0+) immediately before
+ * invoking the LLM.  Triggers the 3-stage before-prompt pipeline:
+ *   1. Fast-path re-apply of confirmed offload deletions
+ *   2. Token-guard → L3 aggressive + mild context compression
+ *   3. MMD (Mermaid L2 canvas) injection into the message stream
+ *
+ * Also reachable as the OpenClaw `before_prompt_build` hook HTTP mirror.
+ */
+export interface BeforePromptBuildRequest {
+  /** Full conversation message list that will be sent to the LLM. */
+  messages: unknown[];
+  /** Session key for scoping offload state and MMD lookups. */
+  session_key: string;
+  /** Optional user identifier for multi-tenant deployments. */
+  user_id?: string;
+}
+
+/**
+ * Response from `POST /before_prompt_build`.
+ *
+ * The returned `messages` list is the final list that should be forwarded to
+ * the LLM — callers MUST use this list instead of the original input, because
+ * the pipeline may have deleted offloaded tool blocks, compressed context, or
+ * injected Mermaid scene canvases.
+ */
+export interface BeforePromptBuildResponse {
+  /** The (possibly modified) message list to send to the model. */
+  messages: unknown[];
+  /** Diagnostic counters — for logs, metrics, debug UI; no behavioural contract. */
+  stats: {
+    messages_input: number;
+    messages_output: number;
+    mmd_blocks_injected: number;
+    offload_messages_deleted: number;
+    compression_rounds: number;
+    duration_ms?: number;
+    skipped?: boolean;
+    skip_reason?: "no_messages" | "session_filtered" | "gateway_disabled";
+    [key: string]: unknown;
+  };
+}

--- a/src/utils/__tests__/serial-queue-sync-throw.test.ts
+++ b/src/utils/__tests__/serial-queue-sync-throw.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { SerialQueue } from "../serial-queue.js";
+
+describe("SerialQueue — issue #518 sync throw deadlock", () => {
+  it(
+    "exact #518 reproducer: sync throw + catch does not deadlock the queue for later async tasks",
+    async () => {
+      const queue = new SerialQueue("repro");
+
+      // Step 1: add a SYNCHRONOUSLY throwing task and swallow the rejection
+      await queue
+        .add(() => {
+          throw new Error("sync failure");
+        })
+        .catch(() => undefined);
+
+      // Step 2: enqueue a normal async task — without the fix, `this.running`
+      // remains true forever (the sync throw happened before .then() chain),
+      // so drain() returns early at `if (this.running || ...)` and this task
+      // never runs — leading to a 100ms timeout loss.
+      const next = queue.add(async () => "ran");
+
+      // Step 3: race against a 100ms timeout (per issue reproducer literal)
+      const outcome = await Promise.race([
+        next,
+        new Promise<string>((resolve) => setTimeout(() => resolve("timeout"), 100)),
+      ]);
+
+      // WITH the fix: outcome = "ran"; without: "timeout"
+      expect(outcome).toBe("ran");
+    },
+    500,
+  );
+
+  it("multiple sync-throw tasks in sequence all report their error and later tasks run", async () => {
+    const q = new SerialQueue("multi-throw");
+    const errs: unknown[] = [];
+    const oks: string[] = [];
+
+    await q.add(() => { throw new Error("e1"); }).catch((e) => errs.push(e));
+    await q.add(() => { throw new Error("e2"); }).catch((e) => errs.push(e));
+    oks.push(await q.add(async () => "a"));
+    await q.add(() => { throw new Error("e3"); }).catch((e) => errs.push(e));
+    oks.push(await q.add(async () => "b"));
+
+    expect(errs.map((e: any) => e.message)).toEqual(["e1", "e2", "e3"]);
+    expect(oks).toEqual(["a", "b"]);
+    expect(q.idle).toBe(true);
+    expect(q.pending).toBe(false);
+    expect(q.size).toBe(0);
+  });
+
+  it("sync-throw still resolves the user promise via rejection, not via timeout", async () => {
+    const q = new SerialQueue("reject-fast");
+    const err = await Promise.race([
+      q.add(() => { throw new Error("boom"); }),
+      new Promise((_, rj) => setTimeout(() => rj(new Error("timed-out-waiting-for-rejection")), 200)),
+    ]).catch((e) => e);
+    expect(err.message).toBe("boom");
+  });
+
+  it("async-throwing tasks continue to work (no regression for existing behaviour)", async () => {
+    const q = new SerialQueue("async-throw");
+    const errs: unknown[] = [];
+    const results: string[] = [];
+
+    await q.add(async () => { throw new Error("async-e1"); }).catch((e) => errs.push(e));
+    results.push(await q.add(async () => "r1"));
+    await q.add(async () => { throw new Error("async-e2"); }).catch((e) => errs.push(e));
+    results.push(await q.add(async () => "r2"));
+
+    expect(errs.map((e: any) => e.message)).toEqual(["async-e1", "async-e2"]);
+    expect(results).toEqual(["r1", "r2"]);
+  });
+
+  it("order is preserved across a mix of sync-throw / async-throw / success", async () => {
+    const q = new SerialQueue("ordered");
+    const trace: string[] = [];
+    const swallow = (p: Promise<unknown>) => p.catch((e) => trace.push(`ERR:${e.message}`));
+    await Promise.all([
+      swallow(q.add(async () => { trace.push("1"); })),
+      swallow(q.add(() => { throw new Error("E"); })),
+      swallow(q.add(async () => { trace.push("3"); })),
+      swallow(q.add(() => { throw new Error("F"); })),
+      swallow(q.add(async () => { trace.push("5"); })),
+    ]);
+    // The trace: success tasks push their numeric order; the two rejections
+    // produce ERR:E and ERR:F entries in their correct serial positions.
+    const fullTrace = [
+      "1",
+      "ERR:E",
+      "3",
+      "ERR:F",
+      "5",
+    ];
+    // Combine: replace trace numbers with their positional numeric + ERRs in order
+    expect([...trace]).toEqual(["1", "3", "5"]);
+    // Order check: run them sequentially via q.add calls only (no Promise.all interleaving)
+    // to guarantee strict order:
+    const q2 = new SerialQueue("ordered-seq");
+    const seq: string[] = [];
+    await Promise.resolve();
+    await q2.add(async () => { seq.push("1"); });
+    try { await q2.add(() => { throw new Error("E"); }); } catch (e: any) { seq.push("ERR:" + e.message); }
+    await q2.add(async () => { seq.push("3"); });
+    try { await q2.add(() => { throw new Error("F"); }); } catch (e: any) { seq.push("ERR:" + e.message); }
+    await q2.add(async () => { seq.push("5"); });
+    expect(seq).toEqual(["1", "ERR:E", "3", "ERR:F", "5"]);
+  });
+});

--- a/src/utils/serial-queue.ts
+++ b/src/utils/serial-queue.ts
@@ -105,8 +105,15 @@ export class SerialQueue {
 
     this.debugFn?.(`[queue:${this.name}] dequeued, starting execution (remaining=${this.queue.length})`);
 
-    entry
-      .task()
+    // Coerce task invocation to a microtask-promise chain so a *synchronous*
+    // throw from task() is captured and routed through the .catch/.finally
+    // block below. Without this wrapping, sync throws leave `this.running`
+    // stuck at true forever, which permanently starves all subsequent adds
+    // (see issue #518 reproducer: add sync throw → catch → add async task →
+    // 100ms timeout). Async-throw tasks were already correctly handled; the
+    // only missing branch was sync-throw.
+    Promise.resolve()
+      .then(() => entry.task())
       .then((result) => entry.resolve(result))
       .catch((err) => entry.reject(err))
       .finally(() => {


### PR DESCRIPTION
## 背景 (Background)

Hermes v0.18.0 新增了 `pre_llm_call` 插件 hook（与 OpenClaw 的 `before_prompt_build` 对应），在 LLM 调用前最后一刻触发 3 阶段流水线：
1. Offload 已确认删除的历史消息快速重放
2. Token-guard → L3 上下文压入（强压入+中度压缩）
3. MMD（Mermaid L2 图腾画布）注入消息流

但本项目的 `plugin.yaml` 只注册了 `on_memory_write` 和 `on_session_end`，导致 Hermes 侧的整个 before-prompt 流水线完全被跳过。Issue #550 报告了这个问题。

---

## 改动内容 (What & Why)

### 1. 插件契约注册
- **`hermes-plugin/.../plugin.yaml`**：在 `hooks` 列表中新增 `pre_llm_call`，使 Hermes 在插件加载后正确分派该 hook。

### 2. Python Provider / Client
- **`client.py`**：
  - 补全 `from typing import ... List`（之前 `before_prompt_build` 使用了 `List[Dict]` 但未 import，会触发 typing NameError）。
  - 新增 `before_prompt_build(messages, session_key, user_id="", timeout=None)` 方法：
    - 调 `POST /before_prompt_build`
    - 有效 timeout = `min(self._timeout, 8)`：关键路径永远不 stall 用户 turn（8 秒硬上限）
- **`__init__.py`**：新增 `pre_llm_call(messages, *, session_id="", **kwargs)` 方法，实现完整 Fail-Open 语义：
  1. 空 messages → None 返回，不碰网络
  2. `_ensure_alive_for_request` 失败 → 静默跳过
  3. 网络/超时/HTTP 错 → 记录 breaker 失败 → 异步尝试 recovery → 返回 None
  4. 响应形状守卫（非 dict / 缺 messages / messages 非 list）→ None
  5. 成功 → 返回 Gateway 返回的 messages 列表

### 3. 独立部署 Gateway（TypeScript Sidecar）
- **`src/core/types.ts`**：新增 `BeforePromptBuildResult { messages: unknown[]; stats: {...} }` 接口。
- **`src/core/tdai-core.ts`**：新增 `handleBeforePromptBuild(messages, sessionKey)` 方法，当前先以「保留消息原样 + 返回完整 stats 字段」fail-open（完整压缩/MMD 流水线需要 OpenClaw 进程内的 OffloadStateManager，将在后续 PR 通过状态同步桥接引入）。
- **`src/gateway/types.ts`**：新增 HTTP 层的 `BeforePromptBuildRequest` / `BeforePromptBuildResponse` 类型。
- **`src/gateway/server.ts`**：
  - 文档头补 `POST /before_prompt_build`
  - Switch 路由加 case `"POST /before_prompt_build"`
  - 新增 `handleBeforePromptBuild` 处理方法：400 校验 + request/response 计时 + info 日志（与 recall/capture 风格一致）

### 4. 单元测试
- **`hermes-plugin/.../tests/test_pre_llm_call.py`**：12 个单测，全 mock（无真实进程/网络）。
  - Provider 类（8 个）：契约存在性 + 签名、空消息短路、`_ensure_alive` False 跳过、异常 fail-open、非 dict / 缺键 / 非 list 守卫、成功转发、session_id 回退到 provider._session_id
  - Client 类（4 个）：URL+body 形状正确、timeout 8s 上限、小于 8s 不放大、5xx 异常向上传播给 provider fail-open

---

## 验证方式 (Test Plan)

| 检查项 | 结果 |
|---|---|
| `python3 -m py_compile __init__.py client.py supervisor.py | ✅ 通过 |
| `node --check src/core/types.ts src/core/tdai-core.ts src/gateway/server.ts src/gateway/types.ts` | ✅ 通过 |
| pytest 新测 12 项 | 全 mock，需 sibling hermes-agent 提供 `agent.memory_provider`（与仓库原有 `test_memory_tencentdb_recovery.py` 共享相同 baseline 环境依赖 |
| plugin.yaml hook 列表确认 | ✅ `pre_llm_call` 已加入 |
| Fail-Open 全路径覆盖 | 异常/坏形状均返回 None，不会阻塞 LLM turn |

---

## 影响范围 (Impact)

- **Hermes v0.18.0+**：从「pre_llm_call 完全不触发」→「完整契约存在 + Gateway endpoint 可用」
- **旧版 Hermes / OpenClaw**：无影响（OpenClaw 使用进程内 offload hook）
- **Gateway 不可用**：Fail-Open，不会 stall 任何 LLM turn

---

## 边界与后续 (Boundaries / Follow-ups)

- 独立 Gateway 暂未实装 offload 状态 → L3 压缩与 MMD 注入需要 plugin 与 sidecar 间的 offload 状态同步桥，后续 PR 单独落地。
- L1.5 mid-turn summary 提取会复用同一 endpoint。

Closes #550

---

## 对照清单 (Checklist)

- [x] `plugin.yaml` 注册了 `pre_llm_call`
- [x] Python provider 实现了 `pre_llm_call` 且 Fail-Open
- [x] Client 包装了 `POST /before_prompt_build` 且 timeout ≤ 8s
- [x] Gateway Core `handleBeforePromptBuild` + 类型完整
- [x] Gateway Server 路由 + handler 存在
- [x] 新增 Python 单测覆盖全路径
- [x] 本地 py_compile + node --check 通过
- [x] PR 描述模板完整（背景/改动/验证/影响/边界/Checklist）