### PR TITLE
fix(capture): skip pipeline scheduling for empty L0 batches

### DIFF
--- a/src/core/hooks/auto-capture.test.ts
+++ b/src/core/hooks/auto-capture.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../../config.js";
+import { CheckpointManager } from "../../utils/checkpoint.js";
+import type { MemoryPipelineManager } from "../../utils/pipeline-manager.js";
+import type { Logger } from "../types.js";
+import { performAutoCapture } from "./auto-capture.js";
+
+const logger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+describe("performAutoCapture", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("does not notify the pipeline when the checkpoint filters an empty duplicate batch", async () => {
+    const pluginDataDir = await mkdtemp(path.join(tmpdir(), "tdai-empty-capture-"));
+    tempDirs.push(pluginDataDir);
+
+    const notifyConversation = vi.fn(async () => undefined);
+    const scheduler = { notifyConversation } as unknown as MemoryPipelineManager;
+    const params = {
+      messages: [
+        {
+          role: "user",
+          content: "Remember that Project Atlas is frozen until Friday.",
+          timestamp: 1_785_427_200_000,
+        },
+        {
+          role: "assistant",
+          content: "Recorded.",
+          timestamp: 1_785_427_200_100,
+        },
+      ],
+      sessionKey: "agent:main:atlas",
+      sessionId: "thread-atlas",
+      cfg: parseConfig({}),
+      pluginDataDir,
+      logger,
+      scheduler,
+      pluginStartTimestamp: 0,
+    };
+
+    const first = await performAutoCapture(params);
+    const duplicate = await performAutoCapture(params);
+
+    expect(first).toMatchObject({
+      schedulerNotified: true,
+      l0RecordedCount: 2,
+    });
+    expect(duplicate).toMatchObject({
+      schedulerNotified: false,
+      l0RecordedCount: 0,
+    });
+    expect(notifyConversation).toHaveBeenCalledTimes(1);
+    expect(notifyConversation).toHaveBeenCalledWith("agent:main:atlas", []);
+
+    const checkpoint = await new CheckpointManager(pluginDataDir, logger).read();
+    expect(checkpoint.l0_conversations_count).toBe(1);
+    expect(checkpoint.total_processed).toBe(2);
+  });
+});

--- a/src/core/hooks/auto-capture.ts
+++ b/src/core/hooks/auto-capture.ts
@@ -299,7 +299,11 @@ export async function performAutoCapture(params: {
   // ============================
   const tNotifyStart = performance.now();
   // Pass empty array: L1 Runner reads from VectorStore DB (or L0 JSONL fallback), not from in-memory buffers.
-  if (scheduler) {
+  // Only count a conversation when this invocation actually captured new L0
+  // messages. Duplicate hook delivery and seed replay can legitimately produce
+  // an empty filtered batch; notifying in that case advances L1 thresholds for
+  // work that does not exist.
+  if (scheduler && filteredMessages.length > 0) {
     await scheduler.notifyConversation(sessionKey, []);
     logger?.debug?.(`${TAG} Scheduler notified of conversation round (sessionKey=${sessionKey})`);
 
@@ -333,7 +337,11 @@ export async function performAutoCapture(params: {
     `notify=${(performance.now() - tNotifyStart).toFixed(0)}ms`,
   );
 
-  logger?.debug?.(`${TAG} No scheduler provided, skipping notification`);
+  if (!scheduler) {
+    logger?.debug?.(`${TAG} No scheduler provided, skipping notification`);
+  } else {
+    logger?.debug?.(`${TAG} No new L0 messages captured, skipping scheduler notification`);
+  }
   return {
     schedulerNotified: false,
     l0RecordedCount: filteredMessages.length,


### PR DESCRIPTION
## Background

`performAutoCapture()` currently notifies `MemoryPipelineManager` whenever a
scheduler is present, even when checkpoint filtering recorded zero new L0
messages.

This happens for duplicate hook delivery and is also the expected shape of a
checkpoint-based seed replay. The extra notification increments
`conversation_count`, advances L1 thresholds, and schedules extraction for work
that does not exist.

Refs #115.

## Changes

- Require `filteredMessages.length > 0` before calling
  `scheduler.notifyConversation()`.
- Keep the existing no-scheduler behavior unchanged.
- Return `schedulerNotified: false` and emit a debug-level reason for an empty
  filtered batch.
- Add a regression test that captures the same timestamped round twice and
  verifies:
  - the first call records two messages and notifies once;
  - the duplicate call records zero messages and does not notify;
  - checkpoint `l0_conversations_count` and `total_processed` remain stable.

### Why this approach

The checkpoint already decides whether the invocation produced new durable L0
data. Reusing that result at the scheduler boundary is narrower and safer than
adding duplicate detection inside `MemoryPipelineManager`.

### Out of scope

- No change to L0 filtering or cursor semantics.
- No change to L1/L2 thresholds for real captured conversations.
- No seed CLI resume option in this PR.

## Verification

- `npm test -- src/core/hooks/auto-capture.test.ts` — 1 passed
- `npm test` — 68 passed
- `npm run build` — passed
- `git diff --check` — clean

## Impact

- **Breaking change:** No.
- **Affected path:** L0 capture to pipeline scheduling boundary.
- **Performance:** Avoids unnecessary no-op L1 scheduling.
- **Persistence:** No schema or file-format changes.

## Checklist

- [x] Change is limited to one behavioral guard.
- [x] Regression test covers duplicate checkpoint filtering.
- [x] Existing tests pass.
- [x] Full build passes.
- [x] No unrelated changes included.
