### PR TITLE
fix(seed): wait for L2/L3 before closing v2 pipeline

### DIFF
--- a/MemoryCore/src/core/seed/seed-runtime.ts
+++ b/MemoryCore/src/core/seed/seed-runtime.ts
@@ -5,15 +5,9 @@
  * L1 runner, L2 runner, L3 runner, and persister wiring — keeping this
  * module focused on seed-specific concerns:
  * - Synchronous per-round L0 capture with progress reporting
- * - waitForL1Idle polling (L1 only — see FIXME below)
+ * - Per-batch L1 idle polling to preserve extraction boundaries
+ * - Final L1→L2→L3 drain before storage resources are closed
  * - Ctrl+C graceful shutdown
- *
- * FIXME: Currently we only wait for L1 to become idle before destroying the
- * pipeline.  L2 (scene extraction) and L3 (persona generation) may still be
- * in-flight when `pipeline.destroy()` is called.  This is intentional for now
- * to avoid excessively long seed runs, but means seed output may not include
- * the latest L2/L3 artifacts.  Re-evaluate adding a full L1+L2+L3 idle wait
- * once pipeline-manager exposes reliable L2/L3 idle signals.
  */
 
 import path from "node:path";
@@ -200,11 +194,8 @@ async function waitForL1Idle(
 // ============================
 
 /**
- * Execute the seed pipeline: feed normalized input through L0 → L1.
- *
- * L2/L3 runners are wired but their completion is **not** awaited — see the
- * module-level FIXME.  The pipeline is destroyed after L1 idle, so L2/L3 may
- * be interrupted mid-run.
+ * Execute the seed pipeline: feed normalized input through L0 → L1, then
+ * drain downstream L2/L3 work before closing the seed output store.
  *
  * This is the core runtime called by `src/cli/commands/seed.ts` after
  * all input validation and user confirmation are complete.
@@ -353,16 +344,13 @@ export async function executeSeed(
       }
     }
 
-    // Final wait for all sessions
+    // Final barrier for all sessions. Unlike the per-batch L1 waits above,
+    // this explicitly flushes scheduled L2 work and waits for the resulting
+    // L3 persona generation before the finally block closes storage.
     if (!interrupted) {
-      const allKeys = input.sessions.map((s) => s.sessionKey);
-      logger.info(`${TAG} Final L1 idle wait for all sessions...`);
-      await waitForL1Idle(
-        pipeline.scheduler,
-        allKeys,
-        logger,
-        { pollIntervalMs: 1_000, stableRounds: 3, maxWaitMs: 300_000 },
-      );
+      logger.info(`${TAG} Final L1→L2→L3 pipeline flush...`);
+      await pipeline.scheduler.flushAll();
+      logger.info(`${TAG} Final pipeline flush complete`);
     }
   } finally {
     process.removeListener("SIGINT", onSigint);

--- a/MemoryCore/src/utils/pipeline-manager.test.ts
+++ b/MemoryCore/src/utils/pipeline-manager.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MemoryPipelineManager,
+  type CapturedMessage,
+  type PipelineConfig,
+} from "./pipeline-manager.js";
+
+const config: PipelineConfig = {
+  everyNConversations: 1,
+  enableWarmup: false,
+  l1: {
+    idleTimeoutSeconds: 60,
+  },
+  l2: {
+    delayAfterL1Seconds: 3_600,
+    minIntervalSeconds: 3_600,
+    maxIntervalSeconds: 3_600,
+    sessionActiveWindowHours: 24,
+  },
+};
+
+const message: CapturedMessage = {
+  role: "user",
+  content: "Project Atlas has a deployment freeze until Friday.",
+  timestamp: "2026-07-31T00:00:00.000Z",
+};
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("MemoryPipelineManager.flushAll", () => {
+  it("waits for L2 and the L3 work enqueued by L2 before returning", async () => {
+    const manager = new MemoryPipelineManager(config);
+    const l2Gate = deferred();
+    const l3Gate = deferred();
+
+    manager.setL1Runner(vi.fn().mockResolvedValue({ processedCount: 1 }));
+    const l2Runner = vi.fn(async () => {
+      await l2Gate.promise;
+      return { latestCursor: "2026-07-31T00:00:01.000Z" };
+    });
+    const l3Runner = vi.fn(async () => {
+      await l3Gate.promise;
+    });
+    manager.setL2Runner(l2Runner);
+    manager.setL3Runner(l3Runner);
+
+    await manager.notifyConversation("seed-session", [message]);
+
+    let flushCompleted = false;
+    const flushPromise = manager.flushAll().then(() => {
+      flushCompleted = true;
+    });
+
+    await vi.waitFor(() => expect(l2Runner).toHaveBeenCalledTimes(1));
+    expect(flushCompleted).toBe(false);
+
+    l2Gate.resolve();
+    await vi.waitFor(() => expect(l3Runner).toHaveBeenCalledTimes(1));
+    expect(flushCompleted).toBe(false);
+
+    l3Gate.resolve();
+    await flushPromise;
+
+    expect(flushCompleted).toBe(true);
+    expect(manager.getQueueSizes()).toMatchObject({
+      l1Idle: true,
+      l2Idle: true,
+      l3Idle: true,
+    });
+
+    await manager.destroy();
+    expect(l2Runner).toHaveBeenCalledTimes(1);
+    expect(l3Runner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/MemoryCore/src/utils/pipeline-manager.ts
+++ b/MemoryCore/src/utils/pipeline-manager.ts
@@ -515,6 +515,31 @@ export class MemoryPipelineManager {
   }
 
   /**
+   * Flush all pending L1 -> L2 -> L3 work without destroying the manager.
+   *
+   * Long-running batch callers such as `seed` need a completion barrier
+   * before closing storage resources. `destroy()` cannot provide that
+   * barrier because its short gateway-shutdown timeout is intentionally
+   * bounded and it marks the manager destroyed before flushing, which
+   * suppresses the L2 -> L3 cascade.
+   *
+   * After the current work is drained, cancel the recurring L2 timers that
+   * successful L2 runs arm for the live gateway. A finite batch has no future
+   * activity to poll, and leaving those timers pending would make the
+   * subsequent `destroy()` execute an unnecessary second L2 pass.
+   */
+  async flushAll(): Promise<void> {
+    if (this.destroyed) return;
+
+    await this._doFlush();
+
+    for (const timers of this.sessionTimers.values()) {
+      timers.l1Idle.cancel();
+      timers.l2Schedule.cancel();
+    }
+  }
+
+  /**
    * Maximum time (ms) to wait for pipeline flush during destroy.
    * Must be shorter than the gateway_stop hook timeout (3 s) to leave
    * headroom for VectorStore / EmbeddingService cleanup that runs after.
@@ -597,12 +622,12 @@ export class MemoryPipelineManager {
       }
     }
 
-    // Step 4: Wait for all remaining queues to drain
+    // Step 4: Wait for L2 before observing L3. L2 enqueues L3 near the end
+    // of its task, so waiting for both queues concurrently can observe L3 as
+    // idle too early and return while the newly-enqueued L3 task is running.
     this.logger?.debug?.(`${TAG} Waiting for queues to drain (l2=${this.l2Queue.size}, l3=${this.l3Queue.size})`);
-    await Promise.all([
-      this.l2Queue.onIdle(),
-      this.l3Queue.onIdle(),
-    ]);
+    await this.l2Queue.onIdle();
+    await this.l3Queue.onIdle();
   }
 
   // ============================


### PR DESCRIPTION
## Description | 描述

Port the seed completion fix from the legacy `main` line (#645) to the repository's current default `feat/server_team` / `MemoryCore` line. These branches have unrelated histories, and both contain the same L1-only seed FIXME, so the v2 package needs its own equivalent change.

Before this PR, `MemoryCore/src/core/seed/seed-runtime.ts` waited only for L1 idle and then called the gateway-oriented `destroy()` path. That path has an intentional 2-second shutdown budget and marks the scheduler destroyed before flushing, so scheduled/running L2 scene extraction or the L3 persona task triggered by L2 could be skipped or interrupted before artifacts reached disk.

Changes:

- Add `MemoryPipelineManager.flushAll()` to drain pending L1 work, flush scheduled L2 work, then wait for L3.
- Wait for L2 and L3 **sequentially**. A concurrent wait can observe an initially-idle L3 queue before L2 enqueues its L3 task and return too early.
- Cancel recurring L2 timers after a finite batch drain so the following `destroy()` does not execute an unnecessary second L2 pass.
- Replace seed's final L1-only barrier with `flushAll()` before storage teardown.
- Add a regression test with independently blocked L2 and L3 runners, proving the barrier waits for both and destroy does not trigger a duplicate extraction.

Scope boundary: no Gateway request behavior, store schema, stateful worker scheduling, or LLM extraction logic changes.

## Related Issue | 关联 Issue

Refs #115

Related implementation for the legacy `main` line: #645

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation in `MemoryCore` (Node v26.5.0, npm v11.17.0):

```text
npm test -- src/utils/pipeline-manager.test.ts
# 1 file, 1 test passed

npm test
# 1 file, 1 test passed (the branch currently contains this test file)

npm run build:plugin
npm run build:migrate-sqlite-to-vdb
npm run build:export-tencent-vdb
npm run build:read-local-memory
# all passed

git diff --check
# passed
```

Full `npm run build` reaches and passes the plugin plus the three existing script builds, then fails at the upstream baseline command `build:seed-v2` because `MemoryCore/scripts/seed-v2/tsconfig.json` is absent on `feat/server_team`. This PR does not add that unrelated missing build file.
