### PR TITLE
feat(seed): support explicit checkpoint resume

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -26,6 +26,7 @@ openclaw memory-tdai seed --input <file> [options]
 | `--config <file>` | — | 配置覆盖文件（JSON，与 openclaw.json 插件配置深度合并） |
 | `--strict-round-role` | — | 严格校验每轮对话必须包含 user 和 assistant 消息 |
 | `--yes` | — | 跳过交互确认（如时间戳自动填充确认） |
+| `--resume` | — | 从指定输出目录的 checkpoint 恢复；必须同时提供 `--output-dir`，且输入消息必须有稳定时间戳 |
 
 ### 示例
 
@@ -44,7 +45,24 @@ openclaw memory-tdai seed --input data.json --yes
 
 # 严格模式 + 自定义配置
 openclaw memory-tdai seed --input data.json --config seed-config.json --strict-round-role --yes
+
+# 从中断的导入恢复（输入需保留原始时间戳）
+openclaw memory-tdai seed --input data.json --output-dir ./seed-output --resume
 ```
+
+### 从 checkpoint 恢复
+
+`--resume` 会复用输出目录中的 `.metadata/checkpoint.json`。命令仍读取完整输入文件，
+但已有 per-session capture cursor 会跳过已经落入 L0 的消息，并继续处理时间戳更晚的追加轮次。
+
+为避免重复导入，恢复模式采用 fail-fast 约束：
+
+- 必须显式传入 `--output-dir`，不能使用自动生成目录；
+- 输出目录必须已经存在，且包含 `.metadata/checkpoint.json`；
+- 输入中每条消息都必须保留稳定的原始 `timestamp`；恢复模式不会自动补时间戳；
+- 建议使用上一次运行的同一输入文件，或仅在末尾追加新轮次，不要重写已导入消息的时间戳。
+
+不带 `--resume` 时，已有 checkpoint 的目录仍会被拒绝，避免意外覆盖。
 
 ### 输入文件格式
 

--- a/src/cli/commands/seed.test.ts
+++ b/src/cli/commands/seed.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { validateSeedOutputPlan } from "./seed.js";
+
+const validResume = {
+  resume: true,
+  hasExplicitOutputDir: true,
+  inputHasTimestamps: true,
+  outputDirExists: true,
+  checkpointExists: true,
+  outputDirEmpty: false,
+  outputDir: "/tmp/seed-output",
+};
+
+describe("validateSeedOutputPlan", () => {
+  it("accepts an explicit checkpoint resume with stable input timestamps", () => {
+    expect(validateSeedOutputPlan(validResume)).toBeUndefined();
+  });
+
+  it("requires an explicit output directory for resume", () => {
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        hasExplicitOutputDir: false,
+      }),
+    ).toContain("--resume requires an explicit --output-dir");
+  });
+
+  it("rejects resume when timestamps would be regenerated", () => {
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        inputHasTimestamps: false,
+      }),
+    ).toContain("stable timestamps");
+  });
+
+  it("requires an existing directory and checkpoint for resume", () => {
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        outputDirExists: false,
+        checkpointExists: false,
+      }),
+    ).toContain("does not exist");
+
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        checkpointExists: false,
+      }),
+    ).toContain("checkpoint not found");
+  });
+
+  it("preserves the existing fail-safe behavior without --resume", () => {
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        resume: false,
+      }),
+    ).toContain("already contains a checkpoint");
+
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        resume: false,
+        checkpointExists: false,
+      }),
+    ).toContain("already exists and is not empty");
+  });
+
+  it("allows a new or empty output directory without --resume", () => {
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        resume: false,
+        outputDirExists: false,
+        checkpointExists: false,
+        outputDirEmpty: true,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      validateSeedOutputPlan({
+        ...validResume,
+        resume: false,
+        checkpointExists: false,
+        outputDirEmpty: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/cli/commands/seed.ts
+++ b/src/cli/commands/seed.ts
@@ -32,12 +32,14 @@ export function registerSeedCommand(parent: Command, ctx: SeedCliContext): void 
     .option("--config <file>", "Path to memory-tdai config override file (JSON, deep-merged on top of current plugin config)")
     .option("--strict-round-role", "Require each round to have both user and assistant messages", false)
     .option("--yes", "Skip interactive confirmations (e.g. timestamp auto-fill)", false)
+    .option("--resume", "Resume an existing output directory from its checkpoint", false)
     .addHelpText("after", `
 Examples:
   openclaw memory-tdai seed --input conversations.json
   openclaw memory-tdai seed --input data.json --output-dir ./seed-output --strict-round-role
   openclaw memory-tdai seed --input data.json --config ./seed-config.json
   openclaw memory-tdai seed --input data.json --yes
+  openclaw memory-tdai seed --input data.json --output-dir ./seed-output --resume
 `)
     .action(async (rawOpts: Record<string, unknown>) => {
       const opts: SeedCommandOptions = {
@@ -46,6 +48,7 @@ Examples:
         sessionKey: rawOpts.sessionKey as string | undefined,
         strictRoundRole: rawOpts.strictRoundRole === true,
         yes: rawOpts.yes === true,
+        resume: rawOpts.resume === true,
         configFile: rawOpts.config as string | undefined,
       };
 
@@ -67,6 +70,7 @@ async function runSeedCommand(opts: SeedCommandOptions, ctx: SeedCliContext): Pr
   logger.info(`${TAG}   config:     ${opts.configFile ?? "(default)"}`);
   logger.info(`${TAG}   strict:     ${opts.strictRoundRole}`);
   logger.info(`${TAG}   yes:        ${opts.yes}`);
+  logger.info(`${TAG}   resume:     ${opts.resume}`);
 
   // 0. Load config override file and deep-merge with base plugin config
   const mergedPluginConfig = loadAndMergePluginConfig(
@@ -95,7 +99,31 @@ async function runSeedCommand(opts: SeedCommandOptions, ctx: SeedCliContext): Pr
     `${input.hasTimestamps ? "" : " (no timestamps)"}`,
   );
 
-  // 2. Timestamp confirmation (if all messages lack timestamps)
+  // 2. Resolve and validate the output plan before prompting for timestamps.
+  const outputDir = resolveOutputDir(opts.outputDir, ctx.stateDir);
+  const outputDirExists = fs.existsSync(outputDir);
+  const checkpointPath = path.join(outputDir, ".metadata", "checkpoint.json");
+  const checkpointExists = outputDirExists && fs.existsSync(checkpointPath);
+  const outputDirEmpty = !outputDirExists || fs.readdirSync(outputDir).length === 0;
+  const outputError = validateSeedOutputPlan({
+    resume: opts.resume,
+    hasExplicitOutputDir: Boolean(opts.outputDir),
+    inputHasTimestamps: input.hasTimestamps,
+    outputDirExists,
+    checkpointExists,
+    outputDirEmpty,
+    outputDir,
+  });
+  if (outputError) {
+    console.error(`\n❌ ${outputError}\n`);
+    process.exit(1);
+  }
+  logger.info(`${TAG} Output directory: ${outputDir}`);
+  if (opts.resume) {
+    console.log(`\n↻ Resuming from checkpoint: ${checkpointPath}`);
+  }
+
+  // 3. Timestamp confirmation (if all messages lack timestamps)
   if (needsTimestampConfirmation) {
     if (opts.yes) {
       console.log("   Timestamps missing — auto-filling with current time (--yes)");
@@ -112,35 +140,7 @@ async function runSeedCommand(opts: SeedCommandOptions, ctx: SeedCliContext): Pr
     }
   }
 
-  // 3. Resolve output directory
-  const outputDir = resolveOutputDir(opts.outputDir, ctx.stateDir);
-  logger.info(`${TAG} Output directory: ${outputDir}`);
-
-  // 4. Check for existing directory / checkpoint (resume detection)
-  if (fs.existsSync(outputDir)) {
-    const checkpointPath = path.join(outputDir, ".metadata", "checkpoint.json");
-    if (fs.existsSync(checkpointPath)) {
-      // Checkpoint exists → resume scenario → P0 not implemented
-      console.error(
-        "\n❌ Resume from checkpoint is not implemented in P0 yet. " +
-        "Please use a new output directory.\n" +
-        `   Existing: ${outputDir}\n`,
-      );
-      process.exit(1);
-    }
-
-    // Directory exists but no checkpoint → might have stale data
-    const entries = fs.readdirSync(outputDir);
-    if (entries.length > 0) {
-      console.error(
-        `\n❌ Output directory already exists and is not empty: ${outputDir}\n` +
-        "   Please use a new directory or clean the existing one.\n",
-      );
-      process.exit(1);
-    }
-  }
-
-  // 5. Execute seed pipeline
+  // 4. Execute seed pipeline
   console.log(`\n🔧 Output: ${outputDir}`);
   console.log(`▶️  Starting seed pipeline...\n`);
 
@@ -159,7 +159,7 @@ async function runSeedCommand(opts: SeedCommandOptions, ctx: SeedCliContext): Pr
     },
   });
 
-  // 6. Print summary
+  // 5. Print summary
   console.log("\n");
   console.log("╔══════════════════════════════════════════╗");
   console.log("║               Seed Summary               ║");
@@ -176,6 +176,60 @@ async function runSeedCommand(opts: SeedCommandOptions, ctx: SeedCliContext): Pr
 // ============================
 // Helpers
 // ============================
+
+export function validateSeedOutputPlan(params: {
+  resume: boolean;
+  hasExplicitOutputDir: boolean;
+  inputHasTimestamps: boolean;
+  outputDirExists: boolean;
+  checkpointExists: boolean;
+  outputDirEmpty: boolean;
+  outputDir: string;
+}): string | undefined {
+  const {
+    resume,
+    hasExplicitOutputDir,
+    inputHasTimestamps,
+    outputDirExists,
+    checkpointExists,
+    outputDirEmpty,
+    outputDir,
+  } = params;
+
+  if (resume) {
+    if (!hasExplicitOutputDir) {
+      return "--resume requires an explicit --output-dir.";
+    }
+    if (!inputHasTimestamps) {
+      return (
+        "--resume requires input messages with stable timestamps. " +
+        "Auto-filled timestamps change between runs and could duplicate imported data."
+      );
+    }
+    if (!outputDirExists) {
+      return `Resume output directory does not exist: ${outputDir}`;
+    }
+    if (!checkpointExists) {
+      return `Resume checkpoint not found: ${path.join(outputDir, ".metadata", "checkpoint.json")}`;
+    }
+    return undefined;
+  }
+
+  if (checkpointExists) {
+    return (
+      "Output directory already contains a checkpoint. " +
+      "Use --resume with the same timestamped input, or choose a new output directory.\n" +
+      `   Existing: ${outputDir}`
+    );
+  }
+  if (outputDirExists && !outputDirEmpty) {
+    return (
+      `Output directory already exists and is not empty: ${outputDir}\n` +
+      "   Please use a new directory or clean the existing one."
+    );
+  }
+  return undefined;
+}
 
 /**
  * Load an optional config override file and deep-merge it on top of the

--- a/src/core/seed/types.ts
+++ b/src/core/seed/types.ts
@@ -109,6 +109,8 @@ export interface SeedCommandOptions {
   strictRoundRole: boolean;
   /** Skip interactive confirmations. */
   yes: boolean;
+  /** Resume an existing output directory from its checkpoint. */
+  resume: boolean;
   /** Path to memory-tdai config override file (JSON, deep-merged on top of current plugin config). */
   configFile?: string;
 }


### PR DESCRIPTION
## Background

The seed command already persists per-session capture and L1 cursors in
`.metadata/checkpoint.json`, but it unconditionally rejects every output
directory containing a checkpoint. An interrupted historical import therefore
cannot reuse its durable progress and must start from an empty directory.

This PR adds a conservative, explicit resume mode. It replays the full input
through the existing cursor-based capture path, which skips already captured
timestamps and continues with appended rounds.

Refs #115.

## Changes

- Add `--resume` to `openclaw memory-tdai seed`.
- Require all resume preconditions before starting:
  - an explicit `--output-dir`;
  - an existing output directory;
  - an existing `.metadata/checkpoint.json`;
  - stable timestamps already present on every input message.
- Preserve the existing fail-safe behavior without `--resume`: checkpointed and
  non-empty directories remain rejected.
- Move output-plan validation before timestamp confirmation so an invalid resume
  fails without prompting or mutating normalized input.
- Add six focused tests for valid resume and every rejection branch.
- Document the append-only resume contract and example command.

### Why stable timestamps are mandatory

Auto-filled timestamps use the current time. Generating them again on a resumed
run would make old messages appear new and duplicate the import. Requiring
source timestamps makes the existing per-session cursor idempotent without a
new checkpoint schema or input-side index.

### Out of scope

- No checkpoint format or storage migration.
- No arbitrary mid-file rewrite detection.
- No change to L1/L2/L3 scheduling.
- No automatic resume; users must opt in with `--resume`.

## Verification

- `npm test -- src/cli/commands/seed.test.ts` — 6 passed
- `npm test` — 73 passed
- `npm run build` — passed
- `npm pack --dry-run` — passed, package size 716.4 kB
- `git diff --check` — clean

## Impact

- **Breaking change:** No.
- **Default behavior:** Unchanged.
- **Persistence:** Reuses existing checkpoint fields; no schema changes.
- **Safety:** Resume is rejected unless the input can be replayed
  deterministically.

## Checklist

- [x] Resume requires explicit user intent.
- [x] Missing/unstable inputs fail before pipeline startup.
- [x] Existing overwrite protections remain intact.
- [x] Focused and full test suites pass.
- [x] Full build and package dry-run pass.
- [x] Documentation includes constraints and example usage.
