### PR TITLE
feat(l1): add high-confidence rule pre-extraction (#82)

### DIFF
--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -23,6 +23,7 @@ import type { IMemoryStore } from "../store/types.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import { report } from "../report/reporter.js";
 import type { LLMRunner, Logger } from "../types.js";
+import { preExtractHighConfidence } from "./pre-extractor.js";
 
 const TAG = "[memory-tdai][l1-extractor]";
 
@@ -145,29 +146,44 @@ export async function extractL1Memories(params: {
   const backgroundMessages = bgEndIdx > 0
     ? qualifiedMessages.slice(Math.max(0, bgEndIdx - maxBgMessages), bgEndIdx)
     : [];
+  const preExtracted = preExtractHighConfidence(newMessages);
+  const needsLlmExtraction = preExtracted.remainingMessages.some((message) => message.role === "user");
 
-  logger?.debug?.(`${TAG} Extracting from ${newMessages.length} new messages (+ ${backgroundMessages.length} background) [${qualifiedMessages.length} qualified from ${messages.length} input]`);
+  logger?.debug?.(
+    `${TAG} Extracting from ${preExtracted.remainingMessages.length} LLM message(s) + ` +
+    `${preExtracted.direct.length} direct rule memory/memories ` +
+    `(+ ${backgroundMessages.length} background) ` +
+    `[${qualifiedMessages.length} qualified from ${messages.length} input]`,
+  );
 
   // Step 1: LLM extraction (scene segmentation + memory extraction)
-  let scenes: SceneSegment[];
-  try {
-    scenes = await callLlmExtraction({
-      newMessages,
-      backgroundMessages,
-      previousSceneName: options.previousSceneName,
-      config,
-      logger,
-      model: options.model,
-      llmRunner: options.llmRunner,
-    });
-    logger?.debug?.(`${TAG} LLM detected ${scenes.length} scene(s)`);
-  } catch (err) {
-    logger?.error(`${TAG} LLM extraction failed: ${err instanceof Error ? err.message : String(err)}`);
-    return { success: false, extractedCount: 0, storedCount: 0, records: [], sceneNames: [] };
+  let scenes: SceneSegment[] = [];
+  if (needsLlmExtraction) {
+    try {
+      scenes = await callLlmExtraction({
+        newMessages: preExtracted.remainingMessages,
+        backgroundMessages,
+        previousSceneName: options.previousSceneName,
+        config,
+        logger,
+        model: options.model,
+        llmRunner: options.llmRunner,
+      });
+      logger?.debug?.(`${TAG} LLM detected ${scenes.length} scene(s)`);
+    } catch (err) {
+      logger?.error(`${TAG} LLM extraction failed: ${err instanceof Error ? err.message : String(err)}`);
+      return { success: false, extractedCount: 0, storedCount: 0, records: [], sceneNames: [] };
+    }
+  } else {
+    logger?.debug?.(
+      `${TAG} All new user messages handled by high-confidence rules; skipping LLM extraction`,
+    );
   }
 
   // Flatten all memories across scenes
-  const allExtracted: ExtractedMemory[] = [];
+  // Deterministic memories go first so maxMemoriesPerSession retains them
+  // before lower-confidence LLM inferences when the combined result is capped.
+  const allExtracted: ExtractedMemory[] = [...preExtracted.direct];
   const sceneNames: string[] = [];
 
   for (const scene of scenes) {
@@ -188,7 +204,6 @@ export async function extractL1Memories(params: {
       });
     }
   }
-
   logger?.debug?.(`${TAG} Total extracted memories: ${allExtracted.length} across ${scenes.length} scene(s)`);
 
   if (allExtracted.length === 0) {

--- a/src/core/record/pre-extractor.test.ts
+++ b/src/core/record/pre-extractor.test.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { LLMRunner } from "../types.js";
+import { extractL1Memories } from "./l1-extractor.js";
+import { preExtractHighConfidence } from "./pre-extractor.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("preExtractHighConfidence", () => {
+  it("extracts explicit user facts but never assistant messages", () => {
+    const input = [
+      message("u1", "user", "我是后端工程师"),
+      message("a1", "assistant", "我是前端工程师"),
+      message("u2", "user", "请用中文回复我"),
+    ];
+
+    const result = preExtractHighConfidence(input);
+
+    expect(result.direct.map((memory) => [memory.type, memory.content])).toEqual([
+      ["persona", "用户是后端工程师"],
+      ["instruction", "用户要求 AI 使用中文回复"],
+    ]);
+    expect(result.remainingMessages).toEqual([input[1]]);
+  });
+
+  it("leaves ambiguous or contextual messages in the LLM path", () => {
+    const input = [
+      message("u1", "user", "我觉得这个方案可能不错，但还需要比较两个数据库"),
+      message("u2", "user", "下周部署 Atlas 项目"),
+    ];
+
+    expect(preExtractHighConfidence(input)).toEqual({
+      direct: [],
+      remainingMessages: input,
+    });
+  });
+});
+
+describe("extractL1Memories pre-extraction integration", () => {
+  it("never pre-extracts background messages", async () => {
+    const runner: LLMRunner = {
+      run: vi.fn(async () => "[]"),
+    };
+
+    await runExtraction(
+      [
+        message("old", "user", "我是机密背景身份"),
+        message("new", "user", "请分析这个方案并列出风险"),
+      ],
+      runner,
+      { maxMessagesPerExtraction: 1 },
+    );
+
+    expect(runner.run).toHaveBeenCalledOnce();
+    const prompt = vi.mocked(runner.run).mock.calls[0][0].prompt;
+    expect(prompt).toContain("我是机密背景身份");
+    expect(prompt).toContain("请分析这个方案并列出风险");
+  });
+
+  it("skips the LLM when all new user messages are deterministic", async () => {
+    const runner: LLMRunner = {
+      run: vi.fn(async () => {
+        throw new Error("LLM must not be called");
+      }),
+    };
+
+    const result = await runExtraction(
+      [
+        message("u1", "user", "以后都使用简洁的项目进度格式"),
+        message("a1", "assistant", "明白，我会保持简洁。"),
+      ],
+      runner,
+    );
+
+    expect(runner.run).not.toHaveBeenCalled();
+    expect(result.records.map((record) => record.content)).toEqual([
+      "用户要求 AI 以后使用简洁的项目进度格式",
+    ]);
+  });
+
+  it("merges direct memories with LLM results without sending matched text to the LLM", async () => {
+    const runner: LLMRunner = {
+      run: vi.fn(async () => JSON.stringify([
+        {
+          scene_name: "项目规划",
+          message_ids: ["u2"],
+          memories: [{
+            content: "用户计划下周部署 Atlas 项目",
+            type: "episodic",
+            priority: 80,
+            source_message_ids: ["u2"],
+            metadata: {},
+          }],
+        },
+      ])),
+    };
+
+    const result = await runExtraction(
+      [
+        message("u1", "user", "我是后端工程师"),
+        message("u2", "user", "请帮我规划下周部署 Atlas 项目的步骤和风险"),
+      ],
+      runner,
+    );
+
+    const prompt = vi.mocked(runner.run).mock.calls[0][0].prompt;
+    expect(prompt).not.toContain("我是后端工程师");
+    expect(prompt).toContain("请帮我规划下周部署 Atlas 项目的步骤和风险");
+    expect(result.records.map((record) => record.content)).toEqual([
+      "用户是后端工程师",
+      "用户计划下周部署 Atlas 项目",
+    ]);
+  });
+});
+
+function message(
+  id: string,
+  role: ConversationMessage["role"],
+  content: string,
+): ConversationMessage {
+  return { id, role, content, timestamp: Date.now() };
+}
+
+async function runExtraction(
+  messages: ConversationMessage[],
+  llmRunner: LLMRunner,
+  extraOptions: { maxMessagesPerExtraction?: number } = {},
+) {
+  const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-pre-extract-"));
+  tempDirs.push(dataDir);
+
+  return extractL1Memories({
+    messages,
+    sessionKey: "pre-extraction-test",
+    baseDir: dataDir,
+    config: {},
+    options: {
+      enableDedup: false,
+      llmRunner,
+      ...extraOptions,
+    },
+  });
+}

--- a/src/core/record/pre-extractor.ts
+++ b/src/core/record/pre-extractor.ts
@@ -1,0 +1,119 @@
+/**
+ * Conservative rule-based extraction for explicit, high-confidence L1 facts.
+ *
+ * This intentionally handles only full-message user statements whose meaning
+ * is stable without surrounding context. Ambiguous text stays in the normal
+ * LLM path; background and assistant messages are never passed here.
+ */
+
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { ExtractedMemory, MemoryType } from "./l1-writer.js";
+
+interface DirectRule {
+  type: MemoryType;
+  priority: number;
+  pattern: RegExp;
+  format: (value: string) => string;
+}
+
+const DIRECT_RULES: DirectRule[] = [
+  {
+    type: "persona",
+    priority: 80,
+    pattern: /^(?:我|本人)(?:是|的职业是|的工作是|的岗位是)\s*(.{2,60})[。.!！]?$/u,
+    format: (value) => `用户是${value}`,
+  },
+  {
+    type: "persona",
+    priority: 70,
+    pattern: /^(?:我|本人)(?:很|非常|比较|特别)?(?:喜欢|偏好)\s*(.{2,60})[。.!！]?$/u,
+    format: (value) => `用户喜欢${value}`,
+  },
+  {
+    type: "persona",
+    priority: 75,
+    pattern: /^(?:I am|I'm)\s+(?:an?\s+)?(.{3,80})[.!]?$/iu,
+    format: (value) => `The user is ${value}`,
+  },
+  {
+    type: "persona",
+    priority: 70,
+    pattern: /^I (?:really )?(?:like|prefer)\s+(.{3,80})[.!]?$/iu,
+    format: (value) => `The user prefers ${value}`,
+  },
+  {
+    type: "instruction",
+    priority: 90,
+    pattern: /^(?:以后|从现在开始)(?:都|请|要|务必)?\s*(.{3,80})[。.!！]?$/u,
+    format: (value) => `用户要求 AI 以后${value}`,
+  },
+  {
+    type: "instruction",
+    priority: 95,
+    pattern: /^(?:请)?(?:用|使用)(中文|英文|日文|法文)(?:来)?回复(?:我)?[。.!！]?$/u,
+    format: (value) => `用户要求 AI 使用${value}回复`,
+  },
+  {
+    type: "instruction",
+    priority: 90,
+    pattern: /^(?:Please\s+)?(?:always|from now on)\s+(.{4,100})[.!]?$/iu,
+    format: (value) => `The user requires the AI to always ${value}`,
+  },
+];
+
+const PUNCTUATION_ONLY = /^[\s，。、！？,.!?;；:："'“”‘’()[\]{}]+$/u;
+
+export interface PreExtractionResult {
+  direct: ExtractedMemory[];
+  remainingMessages: ConversationMessage[];
+}
+
+/**
+ * Extract only deterministic memories from new user messages.
+ *
+ * A matched message is removed from the LLM input so the same fact is not
+ * extracted twice. Non-matches preserve their original order.
+ */
+export function preExtractHighConfidence(
+  newMessages: ConversationMessage[],
+): PreExtractionResult {
+  const direct: ExtractedMemory[] = [];
+  const remainingMessages: ConversationMessage[] = [];
+
+  for (const message of newMessages) {
+    if (message.role !== "user") {
+      remainingMessages.push(message);
+      continue;
+    }
+
+    const match = matchDirectRule(message);
+    if (!match) {
+      remainingMessages.push(message);
+      continue;
+    }
+    direct.push(match);
+  }
+
+  return { direct, remainingMessages };
+}
+
+function matchDirectRule(message: ConversationMessage): ExtractedMemory | null {
+  const text = message.content.trim();
+
+  for (const rule of DIRECT_RULES) {
+    const match = rule.pattern.exec(text);
+    const captured = match?.[1]?.trim();
+    if (!captured || PUNCTUATION_ONLY.test(captured)) continue;
+
+    return {
+      content: rule.format(captured),
+      type: rule.type,
+      priority: rule.priority,
+      source_message_ids: [message.id],
+      metadata: {},
+      scene_name: "（规则预提取）",
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Background

Issue #82 proposes four independent L1 extraction improvements. The maintainer triage explicitly asked that the remaining work be split into narrow follow-ups after the canonical fixes for Problem 1 (#336), JSON retry (#190), and robust parsing (#181).

This PR implements **Problem 2 only**: conservative, HIGH-confidence rule-based extraction for explicit persona and long-term instruction statements.

Refs #82

## What changed

- Added `preExtractHighConfidence()` with anchored full-message rules for explicit persona/identity/preferences and long-term instructions in Chinese and English.
- Runs the pre-extractor **after** the background/new-message split and only on new user messages.
- Never pre-extracts assistant or background context.
- Removes deterministic matches from the LLM prompt; when every new user message is handled, the LLM call is skipped entirely.
- Keeps unmatched/ambiguous messages in their original order for the normal LLM path.
- Places deterministic results before LLM results so `maxMemoriesPerSession` does not discard the higher-confidence memory first.

### Why this scope

The earlier broad implementation review identified a semantics bug where background messages could be stored as new memories. This version makes that boundary explicit and directly tests it.

It also uses anchored, full-message patterns rather than substring matching. A sentence such as “I think this plan might work, but compare both databases” remains in the LLM path; only statements such as “I am a backend engineer” or “Please always use concise status updates” bypass it.

### Explicitly out of scope

- MEDIUM-confidence hints
- episodic/date rules
- malformed JSON retry (#190 already covers it)
- L1 quality gates (#336 already covers them)
- post-LLM confidence validation (separate follow-up)
- schema or persistence changes

## Verification

- `COREPACK_ENABLE_AUTO_PIN=0 npm test -- --run src/core/record/pre-extractor.test.ts` — 5/5 passed
- `COREPACK_ENABLE_AUTO_PIN=0 npm test` — 73/73 passed
- `COREPACK_ENABLE_AUTO_PIN=0 npm run build` — passed
- `git diff --check` — passed

Focused coverage proves:

1. explicit user persona/instruction statements are extracted deterministically;
2. assistant messages are never pre-extracted;
3. background messages remain context-only;
4. all-deterministic user input skips the LLM even when an assistant acknowledgement is present;
5. mixed input removes matched text from the prompt and merges deterministic + LLM results;
6. ambiguous messages remain on the LLM path.

## Impact

- Breaking change: No
- Storage/schema change: No
- Performance: Saves one LLM call when all new user inputs are deterministic; otherwise reduces prompt size for matched statements.
- Affected modules: L1 extraction only

## Checklist

- [x] Narrow scope: one #82 subproblem
- [x] Focused regression tests added
- [x] Full test suite passes
- [x] Full build passes
- [x] No background/assistant extraction
- [x] No overlap with canonical #336/#190/#181
