### PR TITLE
feat(l1): add auditable replay for historical L0 rows (#541)

### DIFF
--- a/src/core/record/l1-replay.test.ts
+++ b/src/core/record/l1-replay.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../../config.js";
+import { CheckpointManager } from "../../utils/checkpoint.js";
+import type { MemoryRecord } from "./l1-writer.js";
+import type { IMemoryStore, L0QueryRow, L0ReplayQuery } from "../store/types.js";
+import type { LLMRunner, Logger } from "../types.js";
+import {
+  L1_REPLAY_RECEIPT_PATH,
+  L1ReplayExecutionError,
+  replayL1,
+} from "./l1-replay.js";
+
+const logger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const rows: L0QueryRow[] = [
+  {
+    record_id: "m1",
+    session_key: "session-retry",
+    session_id: "conversation-a",
+    role: "user",
+    message_text: "Project Atlas has a deployment freeze until Friday.",
+    recorded_at: new Date(1_000).toISOString(),
+    timestamp: 1_000,
+  },
+  {
+    record_id: "m2",
+    session_key: "session-retry",
+    session_id: "conversation-a",
+    role: "assistant",
+    message_text: "I will remember the deployment freeze and its deadline.",
+    recorded_at: new Date(2_000).toISOString(),
+    timestamp: 2_000,
+  },
+];
+
+function makeStore(stored: MemoryRecord[]): IMemoryStore {
+  return {
+    isDegraded: () => false,
+    queryL0ForReplay: vi.fn(async (query: L0ReplayQuery) =>
+      rows.filter((row) => {
+        const recordedAt = Date.parse(row.recorded_at);
+        return row.session_key === query.sessionKey &&
+          (query.fromRecordedAtMs == null || recordedAt >= query.fromRecordedAtMs) &&
+          (query.toRecordedAtMs == null || recordedAt <= query.toRecordedAtMs);
+      }).slice(0, query.limit)),
+    countL1: () => 0,
+    isFtsAvailable: () => false,
+    upsertL1: (record: MemoryRecord) => {
+      stored.push(record);
+      return true;
+    },
+  } as unknown as IMemoryStore;
+}
+
+function makeRunner(run: LLMRunner["run"]): LLMRunner {
+  return { run };
+}
+
+function makeDeps(baseDir: string, store: IMemoryStore, llmRunner: LLMRunner) {
+  return {
+    baseDir,
+    cfg: parseConfig({
+      extraction: {
+        enabled: true,
+        enableDedup: true,
+        maxMemoriesPerSession: 10,
+      },
+      embedding: { provider: "none" },
+    }),
+    vectorStore: store,
+    llmRunner,
+    logger,
+  };
+}
+
+async function seedCheckpoint(baseDir: string, cursor: number): Promise<void> {
+  const checkpoint = new CheckpointManager(baseDir, logger);
+  const data = await checkpoint.read();
+  checkpoint.getRunnerState(data, "session-retry").last_l1_cursor = cursor;
+  await checkpoint.write(data);
+}
+
+describe("replayL1", () => {
+  it("dry-runs a bounded historical range without invoking the LLM or writing a receipt", async () => {
+    const baseDir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-l1-replay-dry-"));
+    const run = vi.fn<LLMRunner["run"]>();
+    try {
+      await seedCheckpoint(baseDir, 9_000);
+      const store = makeStore([]);
+      const receipt = await replayL1({
+        sessionKey: "session-retry",
+        fromRecordedAtMs: 1_500,
+        toRecordedAtMs: 2_500,
+        limit: 10,
+        dryRun: true,
+      }, makeDeps(baseDir, store, makeRunner(run)));
+
+      expect(receipt.status).toBe("dry-run");
+      expect(receipt.l0RecordIds).toEqual(["m2"]);
+      expect(receipt.attemptedCount).toBe(1);
+      expect(receipt.checkpointCursorBefore).toBe(9_000);
+      expect(receipt.checkpointCursorAfter).toBe(9_000);
+      expect(run).not.toHaveBeenCalled();
+      await expect(fs.stat(path.join(baseDir, L1_REPLAY_RECEIPT_PATH))).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves L0 lineage, audits success, and skips an exact completed replay", async () => {
+    const baseDir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-l1-replay-success-"));
+    const stored: MemoryRecord[] = [];
+    const run = vi.fn<LLMRunner["run"]>().mockResolvedValue(JSON.stringify([{
+      scene_name: "Project Atlas deployment",
+      message_ids: ["m1", "m2"],
+      memories: [{
+        content: "Project Atlas has a deployment freeze until Friday.",
+        type: "episodic",
+        priority: 80,
+        source_message_ids: ["m1", "m2"],
+        metadata: {},
+      }],
+    }]));
+
+    try {
+      await seedCheckpoint(baseDir, 9_000);
+      const store = makeStore(stored);
+      const deps = makeDeps(baseDir, store, makeRunner(run));
+      const first = await replayL1({
+        sessionKey: "session-retry",
+        fromRecordedAtMs: 1_000,
+        toRecordedAtMs: 2_000,
+      }, deps);
+
+      expect(first.status).toBe("completed");
+      expect(first.l0RecordIds).toEqual(["m1", "m2"]);
+      expect(first.extractedCount).toBe(1);
+      expect(first.storedCount).toBe(1);
+      expect(first.checkpointCursorAfter).toBe(9_000);
+      expect(stored[0]?.source_message_ids).toEqual(["m1", "m2"]);
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls[0]?.[0].prompt).toContain("[m1]");
+      expect(run.mock.calls[0]?.[0].prompt).toContain("[m2]");
+
+      const second = await replayL1({
+        sessionKey: "session-retry",
+        fromRecordedAtMs: 1_000,
+        toRecordedAtMs: 2_000,
+      }, deps);
+      expect(second.status).toBe("skipped");
+      expect(second.reusedReceiptId).toBe(first.replayId);
+      expect(run).toHaveBeenCalledTimes(1);
+
+      const receipts = (await fs.readFile(path.join(baseDir, L1_REPLAY_RECEIPT_PATH), "utf-8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(receipts.map((receipt) => receipt.status)).toEqual(["completed", "skipped"]);
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records failed extraction without advancing the live checkpoint", async () => {
+    const baseDir = await fs.mkdtemp(path.join(process.cwd(), ".tmp-l1-replay-failure-"));
+    const run = vi.fn<LLMRunner["run"]>().mockRejectedValue(new Error("provider unavailable"));
+    try {
+      await seedCheckpoint(baseDir, 9_000);
+      const store = makeStore([]);
+
+      await expect(replayL1({
+        sessionKey: "session-retry",
+      }, makeDeps(baseDir, store, makeRunner(run)))).rejects.toBeInstanceOf(L1ReplayExecutionError);
+
+      const checkpoint = new CheckpointManager(baseDir, logger);
+      const data = await checkpoint.read();
+      expect(checkpoint.getRunnerState(data, "session-retry").last_l1_cursor).toBe(9_000);
+
+      const receipt = JSON.parse(
+        (await fs.readFile(path.join(baseDir, L1_REPLAY_RECEIPT_PATH), "utf-8")).trim(),
+      );
+      expect(receipt.status).toBe("failed");
+      expect(receipt.error).toContain("L1 extraction failed");
+      expect(receipt.checkpointCursorBefore).toBe(9_000);
+      expect(receipt.checkpointCursorAfter).toBe(9_000);
+    } finally {
+      await fs.rm(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/record/l1-replay.ts
+++ b/src/core/record/l1-replay.ts
@@ -1,0 +1,324 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { MemoryTdaiConfig } from "../../config.js";
+import { CheckpointManager } from "../../utils/checkpoint.js";
+import { readConversationMessagesGroupedBySessionId } from "../conversation/l0-recorder.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore, L0QueryRow } from "../store/types.js";
+import type { LLMRunner, Logger } from "../types.js";
+import { extractL1Memories } from "./l1-extractor.js";
+
+const TAG = "[memory-tdai][l1-replay]";
+const DEFAULT_REPLAY_LIMIT = 100;
+const MAX_REPLAY_LIMIT = 500;
+export const L1_REPLAY_RECEIPT_PATH = ".metadata/l1-replay-receipts.jsonl";
+
+export interface L1ReplayRequest {
+  sessionKey: string;
+  fromRecordedAtMs?: number;
+  toRecordedAtMs?: number;
+  limit?: number;
+  dryRun?: boolean;
+}
+
+export type L1ReplayStatus = "dry-run" | "completed" | "failed" | "skipped";
+
+export interface L1ReplayReceipt {
+  replayId: string;
+  fingerprint: string;
+  sessionKey: string;
+  status: L1ReplayStatus;
+  dryRun: boolean;
+  fromRecordedAtMs?: number;
+  toRecordedAtMs?: number;
+  limit: number;
+  l0RecordIds: string[];
+  attemptedCount: number;
+  groupCount: number;
+  successfulGroups: number;
+  extractedCount: number;
+  storedCount: number;
+  checkpointCursorBefore: number;
+  checkpointCursorAfter: number;
+  startedAt: string;
+  completedAt: string;
+  reusedReceiptId?: string;
+  error?: string;
+}
+
+export class L1ReplayValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "L1ReplayValidationError";
+  }
+}
+
+export class L1ReplayExecutionError extends Error {
+  readonly receipt: L1ReplayReceipt;
+
+  constructor(message: string, receipt: L1ReplayReceipt) {
+    super(message);
+    this.name = "L1ReplayExecutionError";
+    this.receipt = receipt;
+  }
+}
+
+export interface L1ReplayDependencies {
+  baseDir: string;
+  cfg: MemoryTdaiConfig;
+  config?: unknown;
+  vectorStore?: IMemoryStore;
+  embeddingService?: EmbeddingService;
+  llmRunner: LLMRunner;
+  logger: Logger;
+  instanceId?: string;
+}
+
+export async function replayL1(
+  request: L1ReplayRequest,
+  deps: L1ReplayDependencies,
+): Promise<L1ReplayReceipt> {
+  const normalized = normalizeRequest(request);
+  const startedAt = new Date().toISOString();
+  const checkpoint = new CheckpointManager(deps.baseDir, deps.logger);
+  const checkpointBefore = await checkpoint.read();
+  const cursorBefore = checkpoint.getRunnerState(checkpointBefore, normalized.sessionKey).last_l1_cursor;
+  const rows = await readReplayRows(normalized, deps);
+  const l0RecordIds = rows.map((row) => row.record_id);
+  const fingerprint = replayFingerprint(normalized, l0RecordIds);
+  const baseReceipt = {
+    replayId: randomUUID(),
+    fingerprint,
+    sessionKey: normalized.sessionKey,
+    dryRun: normalized.dryRun,
+    fromRecordedAtMs: normalized.fromRecordedAtMs,
+    toRecordedAtMs: normalized.toRecordedAtMs,
+    limit: normalized.limit,
+    l0RecordIds,
+    attemptedCount: rows.length,
+    groupCount: 0,
+    successfulGroups: 0,
+    extractedCount: 0,
+    storedCount: 0,
+    checkpointCursorBefore: cursorBefore,
+    checkpointCursorAfter: cursorBefore,
+    startedAt,
+  };
+
+  if (normalized.dryRun) {
+    const groups = groupRows(rows);
+    return {
+      ...baseReceipt,
+      status: "dry-run",
+      groupCount: groups.length,
+      completedAt: new Date().toISOString(),
+    };
+  }
+
+  const previous = await findCompletedReceipt(deps.baseDir, fingerprint);
+  if (previous) {
+    const skipped: L1ReplayReceipt = {
+      ...baseReceipt,
+      status: "skipped",
+      groupCount: previous.groupCount,
+      successfulGroups: previous.successfulGroups,
+      extractedCount: previous.extractedCount,
+      storedCount: previous.storedCount,
+      reusedReceiptId: previous.replayId,
+      completedAt: new Date().toISOString(),
+    };
+    await appendReceipt(deps.baseDir, skipped);
+    deps.logger.info(
+      `${TAG} Exact replay already completed; skipped session=${normalized.sessionKey} ` +
+      `receipt=${previous.replayId}`,
+    );
+    return skipped;
+  }
+
+  const groups = groupRows(rows);
+  const receipt: L1ReplayReceipt = {
+    ...baseReceipt,
+    status: "completed",
+    groupCount: groups.length,
+    completedAt: startedAt,
+  };
+
+  try {
+    for (const group of groups) {
+      const result = await extractL1Memories({
+        messages: group.messages,
+        sessionKey: normalized.sessionKey,
+        sessionId: group.sessionId,
+        baseDir: deps.baseDir,
+        config: deps.config,
+        options: {
+          enableDedup: true,
+          maxMemoriesPerSession: deps.cfg.extraction.maxMemoriesPerSession,
+          model: deps.cfg.extraction.model,
+          vectorStore: deps.vectorStore,
+          embeddingService: deps.embeddingService,
+          conflictRecallTopK: deps.cfg.embedding.conflictRecallTopK,
+          embeddingTimeoutMs: deps.cfg.embedding.captureTimeoutMs ?? deps.cfg.embedding.timeoutMs,
+          llmRunner: deps.llmRunner,
+        },
+        logger: deps.logger,
+        instanceId: deps.instanceId,
+      });
+      if (!result.success) {
+        throw new Error(`L1 extraction failed for sessionId=${group.sessionId || "(empty)"}`);
+      }
+      receipt.successfulGroups++;
+      receipt.extractedCount += result.extractedCount;
+      receipt.storedCount += result.storedCount;
+    }
+
+    const checkpointAfter = await checkpoint.read();
+    receipt.checkpointCursorAfter =
+      checkpoint.getRunnerState(checkpointAfter, normalized.sessionKey).last_l1_cursor;
+    receipt.completedAt = new Date().toISOString();
+    await appendReceipt(deps.baseDir, receipt);
+    deps.logger.info(
+      `${TAG} Replay completed session=${normalized.sessionKey}: ` +
+      `attempted=${receipt.attemptedCount}, extracted=${receipt.extractedCount}, stored=${receipt.storedCount}`,
+    );
+    return receipt;
+  } catch (err) {
+    const checkpointAfter = await checkpoint.read();
+    receipt.status = "failed";
+    receipt.checkpointCursorAfter =
+      checkpoint.getRunnerState(checkpointAfter, normalized.sessionKey).last_l1_cursor;
+    receipt.error = err instanceof Error ? err.message : String(err);
+    receipt.completedAt = new Date().toISOString();
+    await appendReceipt(deps.baseDir, receipt);
+    throw new L1ReplayExecutionError(receipt.error, receipt);
+  }
+}
+
+function normalizeRequest(request: L1ReplayRequest): Required<Pick<L1ReplayRequest, "sessionKey" | "limit" | "dryRun">> &
+  Pick<L1ReplayRequest, "fromRecordedAtMs" | "toRecordedAtMs"> {
+  const sessionKey = request.sessionKey?.trim();
+  if (!sessionKey) {
+    throw new L1ReplayValidationError("sessionKey is required");
+  }
+  for (const [name, value] of [
+    ["fromRecordedAtMs", request.fromRecordedAtMs],
+    ["toRecordedAtMs", request.toRecordedAtMs],
+  ] as const) {
+    if (value != null && (!Number.isFinite(value) || value < 0)) {
+      throw new L1ReplayValidationError(`${name} must be a non-negative epoch millisecond value`);
+    }
+  }
+  if (
+    request.fromRecordedAtMs != null &&
+    request.toRecordedAtMs != null &&
+    request.fromRecordedAtMs > request.toRecordedAtMs
+  ) {
+    throw new L1ReplayValidationError("fromRecordedAtMs must be <= toRecordedAtMs");
+  }
+
+  const limit = request.limit ?? DEFAULT_REPLAY_LIMIT;
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_REPLAY_LIMIT) {
+    throw new L1ReplayValidationError(`limit must be an integer between 1 and ${MAX_REPLAY_LIMIT}`);
+  }
+
+  return {
+    sessionKey,
+    fromRecordedAtMs: request.fromRecordedAtMs,
+    toRecordedAtMs: request.toRecordedAtMs,
+    limit,
+    dryRun: request.dryRun ?? false,
+  };
+}
+
+async function readReplayRows(
+  request: ReturnType<typeof normalizeRequest>,
+  deps: L1ReplayDependencies,
+): Promise<L0QueryRow[]> {
+  if (deps.vectorStore && !deps.vectorStore.isDegraded()) {
+    return await deps.vectorStore.queryL0ForReplay({
+      sessionKey: request.sessionKey,
+      fromRecordedAtMs: request.fromRecordedAtMs,
+      toRecordedAtMs: request.toRecordedAtMs,
+      limit: request.limit,
+    });
+  }
+
+  const groups = await readConversationMessagesGroupedBySessionId(
+    request.sessionKey,
+    deps.baseDir,
+    undefined,
+    deps.logger,
+  );
+  const rows: L0QueryRow[] = [];
+  for (const group of groups) {
+    for (const message of group.messages) {
+      if (request.fromRecordedAtMs != null && message.recordedAtMs < request.fromRecordedAtMs) continue;
+      if (request.toRecordedAtMs != null && message.recordedAtMs > request.toRecordedAtMs) continue;
+      rows.push({
+        record_id: message.id,
+        session_key: request.sessionKey,
+        session_id: group.sessionId,
+        role: message.role,
+        message_text: message.content,
+        recorded_at: new Date(message.recordedAtMs).toISOString(),
+        timestamp: message.timestamp,
+      });
+    }
+  }
+  rows.sort((a, b) => Date.parse(a.recorded_at) - Date.parse(b.recorded_at));
+  return rows.slice(0, request.limit);
+}
+
+function groupRows(rows: L0QueryRow[]): Array<{
+  sessionId: string;
+  messages: Array<{ id: string; role: "user" | "assistant"; content: string; timestamp: number }>;
+}> {
+  const groups = new Map<string, Array<{ id: string; role: "user" | "assistant"; content: string; timestamp: number }>>();
+  for (const row of rows) {
+    if (row.role !== "user" && row.role !== "assistant") continue;
+    const messages = groups.get(row.session_id) ?? [];
+    messages.push({
+      id: row.record_id,
+      role: row.role,
+      content: row.message_text,
+      timestamp: row.timestamp,
+    });
+    groups.set(row.session_id, messages);
+  }
+  return [...groups.entries()].map(([sessionId, messages]) => ({ sessionId, messages }));
+}
+
+function replayFingerprint(request: ReturnType<typeof normalizeRequest>, recordIds: string[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify({
+      sessionKey: request.sessionKey,
+      fromRecordedAtMs: request.fromRecordedAtMs ?? null,
+      toRecordedAtMs: request.toRecordedAtMs ?? null,
+      recordIds,
+    }))
+    .digest("hex");
+}
+
+async function findCompletedReceipt(baseDir: string, fingerprint: string): Promise<L1ReplayReceipt | undefined> {
+  try {
+    const raw = await fs.readFile(path.join(baseDir, L1_REPLAY_RECEIPT_PATH), "utf-8");
+    for (const line of raw.trim().split("\n").reverse()) {
+      if (!line.trim()) continue;
+      const receipt = JSON.parse(line) as L1ReplayReceipt;
+      if (receipt.fingerprint === fingerprint && receipt.status === "completed") {
+        return receipt;
+      }
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") throw err;
+  }
+  return undefined;
+}
+
+async function appendReceipt(baseDir: string, receipt: L1ReplayReceipt): Promise<void> {
+  const receiptPath = path.join(baseDir, L1_REPLAY_RECEIPT_PATH);
+  await fs.mkdir(path.dirname(receiptPath), { recursive: true });
+  await fs.appendFile(receiptPath, `${JSON.stringify(receipt)}\n`, "utf-8");
+}

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -32,6 +32,8 @@ import type {
   L1FtsResult,
   L0SearchResult,
   L0FtsResult,
+  L0QueryRow,
+  L0ReplayQuery,
 } from "./types.js";
 import type { Logger } from "../types.js";
 
@@ -1934,6 +1936,57 @@ export class VectorStore implements IMemoryStore {
     } catch (err) {
       this.logger?.warn(
         `${TAG} [L0-query] FAILED (non-fatal, returning empty): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return [];
+    }
+  }
+
+  queryL0ForReplay(params: L0ReplayQuery): L0QueryRow[] {
+    if (this.degraded) {
+      this.logger?.warn(`${TAG} [L0-replay-query] SKIPPED (degraded mode)`);
+      return [];
+    }
+
+    try {
+      const conditions = ["session_key = ?"];
+      const values: Array<string | number> = [params.sessionKey];
+      if (params.fromRecordedAtMs != null) {
+        conditions.push("recorded_at >= ?");
+        values.push(new Date(params.fromRecordedAtMs).toISOString());
+      }
+      if (params.toRecordedAtMs != null) {
+        conditions.push("recorded_at <= ?");
+        values.push(new Date(params.toRecordedAtMs).toISOString());
+      }
+      values.push(params.limit);
+
+      const stmt = this.db.prepare(`
+        SELECT record_id, session_key, session_id, role, message_text, recorded_at, timestamp
+        FROM l0_conversations
+        WHERE ${conditions.join(" AND ")}
+        ORDER BY recorded_at ASC
+        LIMIT ?
+      `);
+      const rows = stmt.all(...values) as Array<Record<string, unknown>>;
+
+      this.logger?.info(
+        `${TAG} [L0-replay-query] session=${params.sessionKey}, ` +
+        `from=${params.fromRecordedAtMs ?? "(start)"}, to=${params.toRecordedAtMs ?? "(end)"}, ` +
+        `limit=${params.limit}, returned=${rows.length}`,
+      );
+
+      return rows.map((row) => ({
+        record_id: String(row.record_id ?? ""),
+        session_key: String(row.session_key ?? ""),
+        session_id: String(row.session_id ?? ""),
+        role: String(row.role ?? ""),
+        message_text: String(row.message_text ?? ""),
+        recorded_at: String(row.recorded_at ?? ""),
+        timestamp: Number(row.timestamp ?? 0),
+      }));
+    } catch (err) {
+      this.logger?.warn(
+        `${TAG} [L0-replay-query] FAILED: ${err instanceof Error ? err.message : String(err)}`,
       );
       return [];
     }

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -24,6 +24,7 @@ import type {
   L0SearchResult,
   L0FtsResult,
   L0QueryRow,
+  L0ReplayQuery,
   L0SessionGroup,
   ProfileRecord,
   ProfileSyncRecord,
@@ -901,6 +902,42 @@ export class TcvdbMemoryStore implements IMemoryStore {
       return rows.reverse();
     } catch (err) {
       this.logger?.warn(`${TAG} [L0-queryForL1] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
+  async queryL0ForReplay(params: L0ReplayQuery): Promise<L0QueryRow[]> {
+    try {
+      await this._ensureInit();
+      if (this.degraded) return [];
+
+      const conditions = [`session_key = ${JSON.stringify(params.sessionKey)}`];
+      if (params.fromRecordedAtMs != null) {
+        conditions.push(`recorded_at_ms >= ${params.fromRecordedAtMs}`);
+      }
+      if (params.toRecordedAtMs != null) {
+        conditions.push(`recorded_at_ms <= ${params.toRecordedAtMs}`);
+      }
+
+      const docs = await this._queryAllDocs(
+        this.l0Collection,
+        conditions.join(" and "),
+        L0_OUTPUT_FIELDS,
+        params.limit,
+        [{ fieldName: "recorded_at_ms", direction: "asc" }],
+      );
+
+      return docs.map((doc) => ({
+        record_id: String(doc.id ?? ""),
+        session_key: String(doc.session_key ?? ""),
+        session_id: String(doc.session_id ?? ""),
+        role: String(doc.role ?? ""),
+        message_text: String(doc.message_text ?? ""),
+        recorded_at: epochMsToIso(Number(doc.recorded_at_ms ?? 0)),
+        timestamp: Number(doc.timestamp ?? 0),
+      }));
+    } catch (err) {
+      this.logger?.warn(`${TAG} [L0-replay-query] FAILED: ${err instanceof Error ? err.message : String(err)}`);
       return [];
     }
   }

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -145,6 +145,17 @@ export interface L0QueryRow {
   timestamp: number;
 }
 
+/** Bounded range query used by the operator-facing L1 replay path. */
+export interface L0ReplayQuery {
+  sessionKey: string;
+  /** Inclusive lower recorded_at bound (epoch ms). */
+  fromRecordedAtMs?: number;
+  /** Inclusive upper recorded_at bound (epoch ms). */
+  toRecordedAtMs?: number;
+  /** Maximum rows returned in chronological order. */
+  limit: number;
+}
+
 /** L0 messages grouped by session ID (for L1 runner). */
 export interface L0SessionGroup {
   sessionId: string;
@@ -288,6 +299,7 @@ export interface IMemoryStore {
   countL0(): MaybePromise<number>;
   queryL0ForL1(sessionKey: string, afterRecordedAtMs?: number, limit?: number): MaybePromise<L0QueryRow[]>;
   queryL0GroupedBySessionId(sessionKey: string, afterRecordedAtMs?: number, limit?: number): MaybePromise<L0SessionGroup[]>;
+  queryL0ForReplay(params: L0ReplayQuery): MaybePromise<L0QueryRow[]>;
   getAllL0Texts(): MaybePromise<Array<{ record_id: string; message_text: string; recorded_at: string }>>;
 
   // ── L0 Search ────────────────────────────────────────────

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -37,6 +37,11 @@ import { performAutoCapture } from "./hooks/auto-capture.js";
 import { executeMemorySearch, formatSearchResponse } from "./tools/memory-search.js";
 import { executeConversationSearch, formatConversationSearchResponse } from "./tools/conversation-search.js";
 import {
+  replayL1 as runL1Replay,
+  type L1ReplayReceipt,
+  type L1ReplayRequest,
+} from "./record/l1-replay.js";
+import {
   initDataDirectories,
   initStores,
   resetStores,
@@ -323,6 +328,34 @@ export class TdaiCore {
       text: formatConversationSearchResponse(result),
       total: result.total,
     };
+  }
+
+  /**
+   * Replay existing L0 rows through L1 extraction without moving the live
+   * scheduler cursor. Exact completed batches are skipped using the persisted
+   * replay receipt fingerprint.
+   */
+  async replayL1(params: L1ReplayRequest): Promise<L1ReplayReceipt> {
+    await this.storeReady?.catch(() => {});
+
+    const llmRunner = this.runnerFactory.createRunner({
+      modelRef: this.cfg.extraction.model,
+      enableTools: false,
+    });
+    const openclawConfig = this.hostAdapter.hostType === "openclaw"
+      ? (this.hostAdapter as { getOpenClawConfig?(): unknown }).getOpenClawConfig?.()
+      : undefined;
+
+    return runL1Replay(params, {
+      baseDir: this.dataDir,
+      cfg: this.cfg,
+      config: openclawConfig,
+      vectorStore: this.vectorStore,
+      embeddingService: this.embeddingService,
+      llmRunner,
+      logger: this.logger,
+      instanceId: this.instanceId,
+    });
   }
 
   /**

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -8,6 +8,7 @@
  *   POST /search/memories     — L1 memory search
  *   POST /search/conversations — L0 conversation search
  *   POST /session/end         — Session end + flush
+ *   POST /admin/replay-l1     — Replay historical L0 rows through L1
  *   POST /seed               — Batch seed historical conversations (L0 → L1)
  *
  * Built with Node.js native `http` module — no Express/Fastify dependency.
@@ -35,10 +36,16 @@ import type {
   ConversationSearchResponse,
   SessionEndRequest,
   SessionEndResponse,
+  L1ReplayRequest,
+  L1ReplayResponse,
   SeedRequest,
   SeedResponse,
   GatewayErrorResponse,
 } from "./types.js";
+import {
+  L1ReplayValidationError,
+  L1_REPLAY_RECEIPT_PATH,
+} from "../core/record/l1-replay.js";
 import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
@@ -105,6 +112,20 @@ function safeEqual(a: string, b: string): boolean {
   const bb = Buffer.from(b, "utf-8");
   if (ab.length !== bb.length) return false;
   return timingSafeEqual(ab, bb);
+}
+
+function parseReplayTimestamp(value: string | number | undefined, field: "from" | "to"): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number") {
+    if (Number.isFinite(value) && value >= 0) return value;
+    throw new L1ReplayValidationError(`${field} must be a non-negative epoch millisecond value`);
+  }
+  const trimmed = value.trim();
+  const parsed = trimmed ? Date.parse(trimmed) : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    throw new L1ReplayValidationError(`${field} must be a valid ISO 8601 timestamp or epoch milliseconds`);
+  }
+  return parsed;
 }
 
 // ============================
@@ -254,6 +275,13 @@ export class TdaiGateway {
         return this.handleHealth(res);
       }
 
+      // Replay performs LLM calls and persistent writes. Unlike the legacy
+      // public routes, it is never exposed when gateway auth is disabled.
+      if (pathname.startsWith("/admin/") && !this.config.server.apiKey) {
+        sendError(res, 503, "Admin endpoints require TDAI_GATEWAY_API_KEY");
+        return;
+      }
+
       // All other routes go through the optional auth gate. When apiKey is
       // unset the gate is a no-op (preserves legacy open behaviour) — the
       // startup WARN in `logSecurityPosture` covers that case.
@@ -270,6 +298,8 @@ export class TdaiGateway {
           return await this.handleSearchConversations(req, res);
         case "POST /session/end":
           return await this.handleSessionEnd(req, res);
+        case "POST /admin/replay-l1":
+          return await this.handleReplayL1(req, res);
         case "POST /seed":
           return await this.handleSeed(req, res);
         default:
@@ -476,6 +506,52 @@ export class TdaiGateway {
 
     const response: SessionEndResponse = { flushed: true };
     sendJson(res, 200, response);
+  }
+
+  private async handleReplayL1(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const body = await parseJsonBody<L1ReplayRequest>(req);
+    if (!body.session_key?.trim()) {
+      sendError(res, 400, "Missing required field: session_key");
+      return;
+    }
+
+    try {
+      const receipt = await this.core.replayL1({
+        sessionKey: body.session_key,
+        fromRecordedAtMs: parseReplayTimestamp(body.from, "from"),
+        toRecordedAtMs: parseReplayTimestamp(body.to, "to"),
+        limit: body.limit,
+        dryRun: body.dry_run,
+      });
+      const response: L1ReplayResponse = {
+        replay_id: receipt.replayId,
+        status: receipt.status,
+        session_key: receipt.sessionKey,
+        dry_run: receipt.dryRun,
+        from_recorded_at_ms: receipt.fromRecordedAtMs,
+        to_recorded_at_ms: receipt.toRecordedAtMs,
+        limit: receipt.limit,
+        l0_record_ids: receipt.l0RecordIds,
+        attempted_count: receipt.attemptedCount,
+        group_count: receipt.groupCount,
+        successful_groups: receipt.successfulGroups,
+        extracted_count: receipt.extractedCount,
+        stored_count: receipt.storedCount,
+        checkpoint_cursor_before: receipt.checkpointCursorBefore,
+        checkpoint_cursor_after: receipt.checkpointCursorAfter,
+        started_at: receipt.startedAt,
+        completed_at: receipt.completedAt,
+        reused_receipt_id: receipt.reusedReceiptId,
+        receipt_path: L1_REPLAY_RECEIPT_PATH,
+      };
+      sendJson(res, 200, response);
+    } catch (err) {
+      if (err instanceof L1ReplayValidationError) {
+        sendError(res, 400, err.message);
+        return;
+      }
+      throw err;
+    }
   }
 
   private async handleSeed(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -105,6 +105,42 @@ export interface SessionEndResponse {
 }
 
 // ============================
+// /admin/replay-l1
+// ============================
+
+export interface L1ReplayRequest {
+  session_key: string;
+  /** Inclusive ISO 8601 or epoch-ms recorded_at lower bound. */
+  from?: string | number;
+  /** Inclusive ISO 8601 or epoch-ms recorded_at upper bound. */
+  to?: string | number;
+  limit?: number;
+  dry_run?: boolean;
+}
+
+export interface L1ReplayResponse {
+  replay_id: string;
+  status: "dry-run" | "completed" | "failed" | "skipped";
+  session_key: string;
+  dry_run: boolean;
+  from_recorded_at_ms?: number;
+  to_recorded_at_ms?: number;
+  limit: number;
+  l0_record_ids: string[];
+  attempted_count: number;
+  group_count: number;
+  successful_groups: number;
+  extracted_count: number;
+  stored_count: number;
+  checkpoint_cursor_before: number;
+  checkpoint_cursor_after: number;
+  started_at: string;
+  completed_at: string;
+  reused_receipt_id?: string;
+  receipt_path: string;
+}
+
+// ============================
 // /seed
 // ============================
 


### PR DESCRIPTION
## Summary

Closes #541.

Adds a supported Gateway admin API for replaying historical L0 rows that were skipped after an earlier L1 extraction failure and are now behind `last_l1_cursor`.

## What changed

- Add `POST /admin/replay-l1` with required `session_key` and optional inclusive `from`, `to`, `limit`, and `dry_run` controls.
- Query existing L0 rows directly from SQLite or Tencent Cloud VectorDB; no duplicate L0 seed/import writes are created.
- Preserve original L0 message IDs in the extraction prompt and resulting `source_message_ids` lineage.
- Reuse the existing L1 extraction and dedup pipeline.
- Persist audit receipts to `.metadata/l1-replay-receipts.jsonl` for completed, failed, and idempotently skipped replay attempts.
- Fingerprint exact completed batches so repeating the same replay does not invoke the LLM or write L1 again.
- Keep the live `last_l1_cursor` unchanged. Historical replay uses an independent receipt ledger rather than moving the online scheduler cursor backward and accidentally reprocessing unrelated rows.

## API example

```bash
curl -X POST http://127.0.0.1:8420/admin/replay-l1 \
  -H "Authorization: Bearer $TDAI_GATEWAY_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "session_key": "session-retry",
    "from": "2026-07-01T00:00:00Z",
    "to": "2026-07-02T00:00:00Z",
    "limit": 100,
    "dry_run": true
  }'
```

The admin route is unavailable when `TDAI_GATEWAY_API_KEY` is not configured; this prevents an unauthenticated caller from triggering LLM calls and persistent memory writes.

## Design decisions

- **No checkpoint rewind:** replaying rows behind the cursor must not reset the live scheduler cursor. The response and receipt include `checkpoint_cursor_before` and `checkpoint_cursor_after` so operators can verify this invariant.
- **Bounded execution:** `limit` defaults to 100 and is capped at 500.
- **Range correctness:** both storage backends apply session and recorded-at bounds before the limit.
- **Fail visibly:** unsuccessful L1 extraction records a failed receipt and returns an error instead of being treated as a successful zero-memory replay.

## Verification

- [x] `npm test` — 70/70 tests passed
- [x] `npm run build:plugin`
- [x] `git diff --check`

Focused replay tests cover:
- dry-run range planning with no LLM call or receipt write;
- successful extraction with original L0 IDs and unchanged checkpoint;
- exact replay idempotency;
- failed extraction receipt with unchanged checkpoint.

## Impact

- Breaking change: no
- Existing capture, extraction, seed, and scheduler behavior: unchanged
- New persistent data: append-only replay receipt JSONL under `.metadata/`
