### PR TITLE
feat(l1): validate LLM memories against source evidence (#82)

### DIFF
--- a/src/core/record/l1-confidence.test.ts
+++ b/src/core/record/l1-confidence.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { LLMRunner, Logger } from "../types.js";
+import type { ExtractedMemory } from "./l1-writer.js";
+import { validateLlmMemory } from "./l1-confidence.js";
+import { extractL1Memories } from "./l1-extractor.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("validateLlmMemory", () => {
+  const source = [
+    message("m1", "user", "我是后端工程师，主要使用 TypeScript 和 PostgreSQL。"),
+    message("m2", "user", "Please always answer release questions in concise English."),
+  ];
+
+  it("accepts traceable persona and instruction memories", () => {
+    expect(validateLlmMemory(
+      memory("用户是后端工程师，主要使用 TypeScript 和 PostgreSQL", "persona", ["m1"]),
+      source,
+    )).toEqual({ accepted: true });
+
+    expect(validateLlmMemory(
+      memory("The user requires the AI to always answer release questions in concise English.", "instruction", ["m2"]),
+      source,
+    )).toEqual({ accepted: true });
+  });
+
+  it("falls back to the new-message window when source ids are omitted", () => {
+    expect(validateLlmMemory(
+      memory("用户主要使用 TypeScript 开发后端服务", "persona", []),
+      source,
+    )).toEqual({ accepted: true });
+  });
+
+  it("accepts concise paraphrases instead of requiring verbatim copying", () => {
+    expect(validateLlmMemory(
+      memory(
+        "The user requires the AI to always answer release questions concisely in English.",
+        "instruction",
+        ["m2"],
+      ),
+      source,
+    )).toEqual({ accepted: true });
+  });
+
+  it("rejects unknown source ids and zero-overlap hallucinations", () => {
+    expect(validateLlmMemory(
+      memory("用户是后端工程师", "persona", ["not-in-prompt"]),
+      source,
+    )).toEqual({ accepted: false, reason: "unknown-source-message-id" });
+    expect(validateLlmMemory(
+      memory("用户是后端工程师", "persona", ["m1", "m2"]),
+      [
+        source[0],
+        message("m2", "assistant", "用户是后端工程师"),
+      ],
+    )).toEqual({ accepted: false, reason: "unknown-source-message-id" });
+
+    expect(validateLlmMemory(
+      memory("用户是后端工程师，长期居住在柏林并经营一家咖啡馆", "persona", ["m1"]),
+      source,
+    )).toEqual({ accepted: false, reason: "no-evidence-overlap" });
+  });
+
+  it("rejects clearly short or type-inconsistent outputs", () => {
+    expect(validateLlmMemory(memory("好的", "episodic", ["m1"]), source))
+      .toEqual({ accepted: false, reason: "content-too-short" });
+    expect(validateLlmMemory(memory("后端工程师，熟悉 TypeScript", "persona", ["m1"]), source))
+      .toEqual({ accepted: false, reason: "persona-missing-user-anchor" });
+    expect(validateLlmMemory(memory("中文回复", "instruction", ["m2"]), source))
+      .toEqual({ accepted: false, reason: "instruction-missing-directive-shape" });
+  });
+
+  it("rejects trivial episodic boilerplate", () => {
+    expect(validateLlmMemory(
+      memory("用户询问了关于 PostgreSQL 的问题", "episodic", ["m1"]),
+      source,
+    )).toEqual({ accepted: false, reason: "episodic-trivial-boilerplate" });
+  });
+});
+
+describe("extractL1Memories confidence integration", () => {
+  it("stores traceable memories and drops hallucinated LLM output with a reason", async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-confidence-"));
+    tempDirs.push(dataDir);
+    const debug = vi.fn();
+    const logger: Logger = {
+      debug,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const runner: LLMRunner = {
+      async run() {
+        return JSON.stringify([{
+          scene_name: "开发偏好",
+          message_ids: ["m1"],
+          memories: [
+            {
+              content: "用户主要使用 TypeScript 开发后端服务",
+              type: "persona",
+              priority: 80,
+              source_message_ids: ["m1"],
+              metadata: {},
+            },
+            {
+              content: "用户是后端工程师，长期居住在柏林并经营一家咖啡馆",
+              type: "persona",
+              priority: 90,
+              source_message_ids: ["m1"],
+              metadata: {},
+            },
+          ],
+        }]);
+      },
+    };
+
+    const result = await extractL1Memories({
+      messages: [message("m1", "user", "我主要使用 TypeScript 开发后端服务，请记录这个技术偏好。")],
+      sessionKey: "confidence-test",
+      baseDir: dataDir,
+      config: {},
+      options: { enableDedup: false, llmRunner: runner },
+      logger,
+    });
+
+    expect(result.records.map((record) => record.content)).toEqual([
+      "用户主要使用 TypeScript 开发后端服务",
+    ]);
+    expect(debug).toHaveBeenCalledWith(
+      expect.stringContaining("reason=no-evidence-overlap"),
+    );
+  });
+});
+
+function message(
+  id: string,
+  role: ConversationMessage["role"],
+  content: string,
+): ConversationMessage {
+  return { id, role, content, timestamp: Date.now() };
+}
+
+function memory(
+  content: string,
+  type: ExtractedMemory["type"],
+  sourceMessageIds: string[],
+): ExtractedMemory {
+  return {
+    content,
+    type,
+    priority: 80,
+    source_message_ids: sourceMessageIds,
+    metadata: {},
+    scene_name: "test",
+  };
+}

--- a/src/core/record/l1-confidence.ts
+++ b/src/core/record/l1-confidence.ts
@@ -1,0 +1,145 @@
+/**
+ * Conservative post-LLM validation for extracted L1 memories.
+ *
+ * The validator only rejects outputs with clear evidence problems. It does not
+ * score or rewrite memories, and it does not apply to deterministic
+ * pre-extraction results.
+ */
+
+import type { ConversationMessage } from "../conversation/l0-recorder.js";
+import type { ExtractedMemory } from "./l1-writer.js";
+
+export interface L1ConfidenceResult {
+  accepted: boolean;
+  reason?: string;
+}
+
+const ENGLISH_STOP_WORDS = new Set([
+  "about", "after", "again", "also", "always", "assistant", "before",
+  "from", "have", "into", "should", "that", "their", "there", "they",
+  "this", "user", "want", "with", "would",
+]);
+
+const CJK_STRUCTURAL_BIGRAMS = new Set([
+  "用户", "要求", "希望", "以后", "回答", "回复", "助手", "记忆",
+]);
+
+/**
+ * Validate one LLM-produced memory against the new-message evidence window.
+ */
+export function validateLlmMemory(
+  memory: ExtractedMemory,
+  newMessages: ConversationMessage[],
+): L1ConfidenceResult {
+  const content = memory.content.trim();
+  if (!hasMinimumContent(content)) {
+    return { accepted: false, reason: "content-too-short" };
+  }
+
+  const typeResult = validateTypeShape(memory);
+  if (!typeResult.accepted) return typeResult;
+
+  const messageById = new Map(
+    newMessages
+      .filter((message) => message.role === "user")
+      .map((message) => [message.id, message]),
+  );
+  const declaredIds = [...new Set(memory.source_message_ids.filter(Boolean))];
+  const evidenceMessages = declaredIds.length > 0
+    ? declaredIds.map((id) => messageById.get(id)).filter((message): message is ConversationMessage => !!message)
+    : newMessages.filter((message) => message.role === "user");
+
+  if (declaredIds.length > 0 && evidenceMessages.length !== declaredIds.length) {
+    return { accepted: false, reason: "unknown-source-message-id" };
+  }
+  if (evidenceMessages.length === 0) {
+    return { accepted: false, reason: "no-source-evidence" };
+  }
+
+  const evidence = evidenceMessages.map((message) => message.content).join("\n");
+  if (!hasEvidenceOverlap(content, evidence)) {
+    return { accepted: false, reason: "no-evidence-overlap" };
+  }
+
+  return { accepted: true };
+}
+
+function hasMinimumContent(content: string): boolean {
+  const cjkCount = content.match(/[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/gu)?.length ?? 0;
+  if (cjkCount > 0) return cjkCount >= 4;
+
+  const latinOrDigitCount = content.match(/[a-z0-9]/giu)?.length ?? 0;
+  return latinOrDigitCount >= 12;
+}
+
+function validateTypeShape(memory: ExtractedMemory): L1ConfidenceResult {
+  const content = memory.content.trim();
+
+  if (memory.type === "persona") {
+    if (!/(?:用户|本人|\bthe user\b|\buser\b)/iu.test(content)) {
+      return { accepted: false, reason: "persona-missing-user-anchor" };
+    }
+  }
+
+  if (memory.type === "instruction") {
+    const hasActor = /(?:用户|本人|\bthe user\b|\buser\b)/iu.test(content);
+    const hasTarget = /(?:\bAI\b|助手|\bassistant\b)/iu.test(content);
+    const hasDirective = /(?:要求|希望|必须|以后|始终|禁止|\brequires?\b|\basks?\b|\bwants?\b|\bmust\b|\balways\b|\bnever\b)/iu.test(content);
+    if (!hasActor || !hasTarget || !hasDirective) {
+      return { accepted: false, reason: "instruction-missing-directive-shape" };
+    }
+  }
+
+  if (
+    memory.type === "episodic" &&
+    /^(?:用户)?(?:询问|讨论|咨询|聊)(?:了)?(?:关于)?|^(?:the )?user (?:asked|talked|discussed) about/iu.test(content)
+  ) {
+    return { accepted: false, reason: "episodic-trivial-boilerplate" };
+  }
+
+  return { accepted: true };
+}
+
+function hasEvidenceOverlap(content: string, evidence: string): boolean {
+  const contentEnglish = englishTokens(content);
+  const evidenceEnglish = englishTokens(evidence);
+  if (contentEnglish.size > 0) {
+    let matches = 0;
+    for (const token of contentEnglish) {
+      if (evidenceEnglish.has(token)) matches++;
+    }
+    if (matches >= Math.max(1, Math.ceil(contentEnglish.size * 0.4))) return true;
+  }
+
+  const contentCjk = cjkBigrams(content);
+  const evidenceCjk = cjkBigrams(evidence);
+  if (contentCjk.size > 0) {
+    let matches = 0;
+    for (const bigram of contentCjk) {
+      if (evidenceCjk.has(bigram)) matches++;
+    }
+    if (matches >= Math.max(1, Math.ceil(contentCjk.size * 0.4))) return true;
+  }
+
+  return false;
+}
+
+function englishTokens(text: string): Set<string> {
+  const tokens = text.toLowerCase().match(/[a-z0-9][a-z0-9_-]{2,}/gu) ?? [];
+  return new Set(tokens.filter((token) => !ENGLISH_STOP_WORDS.has(token)));
+}
+
+function cjkBigrams(text: string): Set<string> {
+  const result = new Set<string>();
+  const runs = text.match(/[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]+/gu) ?? [];
+
+  for (const run of runs) {
+    const chars = Array.from(run);
+    for (let i = 0; i < chars.length - 1; i++) {
+      const bigram = chars[i] + chars[i + 1];
+      if (!CJK_STRUCTURAL_BIGRAMS.has(bigram)) result.add(bigram);
+    }
+  }
+
+  return result;
+}

--- a/src/core/record/l1-extractor.ts
+++ b/src/core/record/l1-extractor.ts
@@ -23,6 +23,7 @@ import type { IMemoryStore } from "../store/types.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import { report } from "../report/reporter.js";
 import type { LLMRunner, Logger } from "../types.js";
+import { validateLlmMemory } from "./l1-confidence.js";
 
 const TAG = "[memory-tdai][l1-extractor]";
 
@@ -178,14 +179,23 @@ export async function extractL1Memories(params: {
         logger?.warn?.(`${TAG} Skipping memory with invalid type "${mem.type}"`);
         continue;
       }
-      allExtracted.push({
+      const extractedMemory: ExtractedMemory = {
         content: mem.content,
         type: memType,
         priority: typeof mem.priority === "number" ? mem.priority : 50,
         source_message_ids: Array.isArray(mem.source_message_ids) ? mem.source_message_ids : [],
         metadata: mem.metadata ?? {},
         scene_name: scene.scene_name,
-      });
+      };
+      const confidence = validateLlmMemory(extractedMemory, newMessages);
+      if (!confidence.accepted) {
+        logger?.debug?.(
+          `${TAG} Skipping low-confidence LLM memory: reason=${confidence.reason}, ` +
+          `type=${extractedMemory.type}, content=${JSON.stringify(extractedMemory.content.slice(0, 120))}`,
+        );
+        continue;
+      }
+      allExtracted.push(extractedMemory);
     }
   }
 


### PR DESCRIPTION
## Background

Issue #82 Problem 4 notes that LLM-extracted memories currently reach dedup/storage without a source-evidence or type-consistency check. The maintainer triage asked that this remaining work be split from the already-canonical quality-gate (#336), parsing (#181), and retry (#190) changes.

This PR implements **Problem 4 only** as a conservative post-LLM filter.

Refs #82

## What changed

Added a pure `validateLlmMemory()` step between LLM parsing and dedup/storage:

- rejects clearly undersized content;
- rejects `source_message_ids` that do not reference this batch's **new user messages**;
- when source ids are omitted, falls back only to the new-user evidence window (never assistant/background text);
- requires at least 40% coverage of significant English tokens or CJK bigrams;
- removes structural words such as “user/用户/要求/回复” from evidence matching so boilerplate alone cannot satisfy the check;
- validates persona/user anchors and instruction actor + AI target + directive shape;
- rejects trivial episodic boilerplate such as “the user asked about...”;
- logs a structured debug rejection reason without logging the full memory.

### Why this design

The filter rejects only clear evidence failures. It does not rewrite, rescore, or persist extra metadata. A concise same-language paraphrase still passes; mixed memories containing one real fact plus multiple unsupported claims fail the 40% coverage threshold.

Restricting evidence to new user messages preserves the extraction prompt contract: background is context-only and assistant acknowledgements cannot become evidence for user facts.

### Explicitly out of scope

- rule-based pre-extraction (separate #82 follow-up)
- prompt changes
- malformed JSON retry (#190)
- schema/status/storage changes
- embedding or dedup behavior
- LLM-based validator/doctor calls

## Verification

- `COREPACK_ENABLE_AUTO_PIN=0 npm test -- --run src/core/record/l1-confidence.test.ts` — 7/7 passed
- `COREPACK_ENABLE_AUTO_PIN=0 npm test` — 74/74 passed
- `COREPACK_ENABLE_AUTO_PIN=0 npm run build` — passed
- `git diff --check` — passed

Focused coverage includes:

1. valid persona and instruction memories;
2. same-language concise paraphrasing;
3. fallback when source IDs are omitted;
4. unknown, mixed-valid/invalid, and assistant source IDs;
5. unsupported/hallucinated facts mixed with a real claim;
6. short and type-inconsistent outputs;
7. trivial episodic boilerplate;
8. end-to-end L1 extraction storing the traceable memory and dropping the hallucinated one with a debug reason.

## Impact

- Breaking change: No API/schema changes
- Performance: local linear token/bigram set comparison; no extra LLM or embedding call
- Affected module: L1 LLM output only
- Failure behavior: rejected memories are debug-logged and omitted before dedup/write

## Checklist

- [x] One #82 subproblem only
- [x] Deterministic pure validator
- [x] New-user evidence boundary enforced
- [x] Focused and integration tests added
- [x] Full test suite and build pass
- [x] No overlap with #336/#181/#190
