### PR TITLE
feat(gateway): session-level recall dedup with change detection (fixes #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   - **L0 JSONL 分片日**和 **cleaner 清理边界**跟随配置时区（默认仍为系统时区）。
   - 存储层（SQLite / TCVDB）时间戳始终为 UTC instant，**无需数据迁移**。
   - 统一收敛原有 4 处分散的时间格式化 helper 到 `src/utils/time.ts`，减少代码重复。
+
+- **Gateway `/recall` 会话级去重（变更检测）**（[#120](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/120)）：Hermes 侧每轮 prefetch 都会得到与上一轮逐字相同的 `appendSystemContext`（稳定 persona / scene / tools 块），同 session 内重复注入浪费 tokens。新增 Gateway 配置 `recallDedup`（`enabled` / `ttlMs` / `maxEntries`，**默认关闭**，开启后行为才改变）：同一 `session_key` 的 `/recall` 若返回内容与最近一次响应逐字相同，则以 `context: ""` + `deduplicated: true` 跳过重复注入；内容一旦变化（如场景切换）自动恢复注入。
+  - 语义为**变更检测**而非"出现过即跳过"：仅当与最近一次响应相同才跳过，避免消费方每轮重建 prompt 时丢失稳定上下文。
+  - 条目按 `session_key` 隔离；`ttlMs`（默认 1h）惰性过期；`maxEntries`（默认 1000）LRU 淘汰；`POST /session/end` 时清除对应会话。
+  - 环境变量：`TDAI_GATEWAY_RECALL_DEDUP_ENABLED` / `TDAI_GATEWAY_RECALL_DEDUP_TTL_MS` / `TDAI_GATEWAY_RECALL_DEDUP_MAX_ENTRIES`；yaml：`recallDedup: { enabled, ttlMs, maxEntries }`。
+  - 新增 `src/gateway/recall-dedup.ts` 及 13 个单测；`/recall` 响应新增可选字段 `deduplicated`（向后兼容）。
 - **关闭推理模型 thinking（`disableThinking`）**：新增 `llm.disableThinking` 与 `offload.disableThinking` 两项配置（均默认 `false`，不改变现有行为），支持多种推理引擎/模型提供商的关闭方式。
   - 可选策略：`"vllm"` (vLLM/SGLang, `chat_template_kwargs.enable_thinking=false`)、`"deepseek"` (DeepSeek API, 顶层 `enable_thinking=false`)、`"dashscope"` (阿里云 DashScope/Qwen, 顶层 `enable_thinking=false`)、`"openai"` (OpenAI o系列, `reasoning_effort="low"`)、`"anthropic"` (Anthropic Claude, `thinking.type="disabled"`)、`"kimi"` (Kimi/Moonshot, `thinking.type="disabled"`)、`"gemini"` (Google Gemini, `thinking_config.thinking_budget=0`)。
   - 环境变量 `TDAI_LLM_DISABLE_THINKING` 支持策略名（如 `deepseek`）和布尔值。

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -16,6 +16,7 @@ import { parseConfig as parseMemoryConfig } from "../config.js";
 import type { MemoryTdaiConfig } from "../config.js";
 import { normalizeDisableThinking } from "../utils/no-think-fetch.js";
 import type { StandaloneLLMConfig } from "../adapters/standalone/llm-runner.js";
+import { RECALL_DEDUP_DEFAULTS } from "./recall-dedup.js";
 
 // ============================
 // Gateway config types
@@ -66,6 +67,28 @@ export interface GatewayConfig {
   llm: StandaloneLLMConfig;
   /** Parsed memory-tdai plugin config (recall, capture, extraction, pipeline, etc.). */
   memory: MemoryTdaiConfig;
+  /**
+   * Session-level recall deduplication for `POST /recall`.
+   *
+   * When enabled, a session whose recalled `appendSystemContext` is
+   * byte-identical to its most recent /recall response gets an empty context
+   * plus `deduplicated: true`, so the consumer does not re-send the same stable
+   * context every turn (see issue #120 / #523).
+   *
+   * **Default: disabled** — dedup only activates when explicitly opted in, so
+   * existing deployments behave exactly as before.
+   *
+   * env: `TDAI_GATEWAY_RECALL_DEDUP_ENABLED` / `TDAI_GATEWAY_RECALL_DEDUP_TTL_MS`
+   *      / `TDAI_GATEWAY_RECALL_DEDUP_MAX_ENTRIES`
+   * yaml: `recallDedup: { enabled, ttlMs, maxEntries }`
+   */
+  recallDedup: {
+    enabled: boolean;
+    /** Entry lifetime without access, in ms. Default 1 hour. */
+    ttlMs: number;
+    /** Max tracked sessions. Oldest entry is evicted on overflow. Default 1000. */
+    maxEntries: number;
+  };
 }
 
 // ============================
@@ -142,11 +165,30 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   const memoryRaw = obj(fileConfig, "memory");
   const memory = parseMemoryConfig(memoryRaw as Record<string, unknown> | undefined);
 
+  // Recall dedup config — disabled by default so existing deployments are
+  // unaffected until they explicitly opt in.
+  const recallDedupRaw = obj(fileConfig, "recallDedup");
+  const recallDedup = {
+    enabled:
+      envBool("TDAI_GATEWAY_RECALL_DEDUP_ENABLED")
+        ?? bool(recallDedupRaw, "enabled")
+        ?? RECALL_DEDUP_DEFAULTS.enabled,
+    ttlMs:
+      envInt("TDAI_GATEWAY_RECALL_DEDUP_TTL_MS")
+        ?? num(recallDedupRaw, "ttlMs")
+        ?? RECALL_DEDUP_DEFAULTS.ttlMs,
+    maxEntries:
+      envInt("TDAI_GATEWAY_RECALL_DEDUP_MAX_ENTRIES")
+        ?? num(recallDedupRaw, "maxEntries")
+        ?? RECALL_DEDUP_DEFAULTS.maxEntries,
+  };
+
   const base: GatewayConfig = {
     server: { port, host, apiKey, corsOrigins },
     data: { baseDir },
     llm,
     memory,
+    recallDedup,
   };
 
   // Merge overrides one level deep so partial `server`/`data`/`llm` patches
@@ -159,6 +201,7 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
     server: { ...base.server, ...(overrides.server ?? {}) },
     data: { ...base.data, ...(overrides.data ?? {}) },
     llm: { ...base.llm, ...(overrides.llm ?? {}) },
+    recallDedup: { ...base.recallDedup, ...(overrides.recallDedup ?? {}) },
   };
 }
 
@@ -237,11 +280,7 @@ function envInt(key: string): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
-/**
- * Read an env var that may be a boolean ("true"/"false"/"1"/"0")
- * or a plain string (strategy name like "deepseek", "anthropic").
- * Returns the lowercase string for strategy names.
- */
+/** Read an env var that may be a boolean ("true"/"false"/"1"/"0") or a plain string (strategy name like "deepseek", "anthropic"). Returns the lowercase string for strategy names. */
 function envBoolOrStr(key: string): boolean | string | undefined {
   const raw = env(key);
   if (raw === undefined) return undefined;
@@ -251,12 +290,24 @@ function envBoolOrStr(key: string): boolean | string | undefined {
   return v; // lowercase strategy name
 }
 
+/** Read an env var strictly as a boolean; any other value is ignored. */
+function envBool(key: string): boolean | undefined {
+  const v = envBoolOrStr(key);
+  return typeof v === "boolean" ? v : undefined;
+}
+
 /** Read a field that may be boolean or string from a config object. */
 function boolOrStr(src: Record<string, unknown>, key: string): boolean | string | undefined {
   const v = src[key];
   if (typeof v === "boolean") return v;
   if (typeof v === "string" && v.trim()) return v.trim();
   return undefined;
+}
+
+/** Read a field strictly as a boolean from a config object. */
+function bool(src: Record<string, unknown>, key: string): boolean | undefined {
+  const v = src[key];
+  return typeof v === "boolean" ? v : undefined;
 }
 
 function obj(c: Record<string, unknown>, key: string): Record<string, unknown> {

--- a/src/gateway/recall-dedup.test.ts
+++ b/src/gateway/recall-dedup.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for SessionRecallDedup — session-level change detection for the
+ * Gateway `/recall` endpoint (issue #120 / #523).
+ *
+ * Core semantic under test: dedup compares against the session's *most recent*
+ * response (change detection), NOT "seen-before, never again". A context that
+ * changed and then changed back must be served again.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { SessionRecallDedup, fingerprintOf, RECALL_DEDUP_DEFAULTS } from "./recall-dedup.js";
+
+const CONTEXT_A = "<user-persona>Alice</user-persona>\n\n<memory-tools-guide>tools</memory-tools-guide>";
+const CONTEXT_B = "<user-persona>Bob</user-persona>\n\n<memory-tools-guide>tools</memory-tools-guide>";
+
+describe("SessionRecallDedup", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is a plain passthrough when disabled (default)", () => {
+    const dedup = new SessionRecallDedup();
+    const first = dedup.evaluate("s1", CONTEXT_A);
+    const second = dedup.evaluate("s1", CONTEXT_A);
+
+    expect(first).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(second).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(dedup.size).toBe(0); // nothing cached while disabled
+    expect(dedup.hits).toBe(0);
+  });
+
+  it("serves the first occurrence in full, skips the byte-identical repeat", () => {
+    const dedup = new SessionRecallDedup({ enabled: true });
+
+    const first = dedup.evaluate("s1", CONTEXT_A);
+    const second = dedup.evaluate("s1", CONTEXT_A);
+
+    expect(first).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(second).toEqual({ deduplicated: true, context: "" });
+    expect(dedup.hits).toBe(1);
+    expect(dedup.misses).toBe(1);
+  });
+
+  it("keeps different sessions independent", () => {
+    const dedup = new SessionRecallDedup({ enabled: true });
+
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(dedup.evaluate("s2", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: true, context: "" });
+    expect(dedup.evaluate("s2", CONTEXT_A)).toEqual({ deduplicated: true, context: "" });
+    expect(dedup.size).toBe(2);
+  });
+
+  it("re-serves after a change, and re-deduplicates only once the latest baseline repeats (change detection, not seen-before)", () => {
+    const dedup = new SessionRecallDedup({ enabled: true });
+
+    // A → serve
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    // A → skip
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: true, context: "" });
+    // scene/persona changes to B → serve again
+    expect(dedup.evaluate("s1", CONTEXT_B)).toEqual({ deduplicated: false, context: CONTEXT_B });
+    // B → skip
+    expect(dedup.evaluate("s1", CONTEXT_B)).toEqual({ deduplicated: true, context: "" });
+    // back to A: differs from the most recent response (B) → must be served,
+    // even though A was seen earlier in the session
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+  });
+
+  it("never caches or deduplicates an empty context", () => {
+    const dedup = new SessionRecallDedup({ enabled: true });
+
+    const first = dedup.evaluate("s1", "");
+    const second = dedup.evaluate("s1", "");
+
+    expect(first).toEqual({ deduplicated: false, context: "" });
+    expect(second).toEqual({ deduplicated: false, context: "" });
+    expect(dedup.size).toBe(0);
+  });
+
+  it("re-serves after TTL expiry without access", () => {
+    vi.useFakeTimers();
+    const dedup = new SessionRecallDedup({ enabled: true, ttlMs: 60_000 });
+
+    vi.setSystemTime(1_000);
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+
+    // Same session, same content, still within TTL → deduplicated
+    vi.setSystemTime(61_000);
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: true, context: "" });
+
+    // Last access was 61s ago, TTL is 60s → entry expired, serve again
+    vi.setSystemTime(121_001);
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+  });
+
+  it("evicts the least-recently-used session when maxEntries overflows", () => {
+    const dedup = new SessionRecallDedup({ enabled: true, maxEntries: 2 });
+
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(dedup.evaluate("s2", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    // s1 becomes the most-recently-used entry
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: true, context: "" });
+
+    // Overflow evicts s2 (the LRU entry), not s1
+    expect(dedup.evaluate("s3", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(dedup.size).toBe(2);
+
+    // s2 was evicted → served in full again
+    expect(dedup.evaluate("s2", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+  });
+
+  it("forgets a session on clearSession (session/end)", () => {
+    const dedup = new SessionRecallDedup({ enabled: true });
+
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: true, context: "" });
+
+    dedup.clearSession("s1");
+    expect(dedup.size).toBe(0);
+
+    expect(dedup.evaluate("s1", CONTEXT_A)).toEqual({ deduplicated: false, context: CONTEXT_A });
+  });
+
+  it("evictExpired reports and removes only stale entries", () => {
+    vi.useFakeTimers();
+    const dedup = new SessionRecallDedup({ enabled: true, ttlMs: 60_000 });
+
+    vi.setSystemTime(1_000);
+    dedup.evaluate("s1", CONTEXT_A);
+    dedup.evaluate("s2", CONTEXT_B);
+
+    // Both entries last accessed at t=1s; now 70s later → both stale.
+    vi.setSystemTime(70_001);
+    const removed = dedup.evictExpired(Date.now());
+
+    expect(removed).toBe(2);
+    expect(dedup.size).toBe(0);
+  });
+
+  it("counts hits and misses separately", () => {
+    const dedup = new SessionRecallDedup({ enabled: true });
+
+    dedup.evaluate("s1", CONTEXT_A); // miss
+    dedup.evaluate("s1", CONTEXT_A); // hit
+    dedup.evaluate("s2", CONTEXT_B); // miss
+    dedup.evaluate("s2", CONTEXT_B); // hit
+
+    expect(dedup.hits).toBe(2);
+    expect(dedup.misses).toBe(2);
+  });
+});
+
+describe("fingerprintOf", () => {
+  it("is stable for identical input and distinct for different input", () => {
+    expect(fingerprintOf(CONTEXT_A)).toBe(fingerprintOf(CONTEXT_A));
+    expect(fingerprintOf(CONTEXT_A)).not.toBe(fingerprintOf(CONTEXT_B));
+    expect(fingerprintOf(CONTEXT_A)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("distinguishes byte-level differences (trailing newline)", () => {
+    expect(fingerprintOf("abc")).not.toBe(fingerprintOf("abc\n"));
+  });
+});
+
+describe("RECALL_DEDUP_DEFAULTS", () => {
+  it("defaults to disabled with a 1h TTL and 1000-entry cap", () => {
+    expect(RECALL_DEDUP_DEFAULTS).toEqual({ enabled: false, ttlMs: 3_600_000, maxEntries: 1000 });
+  });
+});

--- a/src/gateway/recall-dedup.ts
+++ b/src/gateway/recall-dedup.ts
@@ -1,0 +1,150 @@
+/**
+ * Session-level recall deduplication for the Gateway `/recall` endpoint.
+ *
+ * Problem (see issue #120 / #523): Hermes calls `POST /recall` before every
+ * turn (prefetch). Within the same session and topic, the returned
+ * `appendSystemContext` (stable persona / scene / tools blocks) is byte-for-byte
+ * identical turn after turn, so the identical context text gets re-sent to the
+ * LLM every turn — redundant tokens, and (for providers with prefix-matching
+ * prompt caches) a prompt that drifts apart from the cached prefix as dynamic
+ * parts change around it.
+ *
+ * This component applies **change detection**, not "seen-before, never again":
+ * a session's context is skipped only when it is identical to the *most recent*
+ * /recall response for that session. If the context ever changes (e.g. the
+ * scene navigation block switches), the new context is served again and becomes
+ * the new baseline. This keeps the dedup safe even when the consumer (Hermes)
+ * rebuilds its prompt from scratch every turn: the LLM only ever misses a block
+ * it has just seen unchanged.
+ *
+ * Semantics:
+ * - Dedup is keyed by `session_key` only (different sessions never interfere).
+ * - Empty contexts are never cached and never deduplicated.
+ * - Entries expire after `ttlMs` without access (lazy, on next evaluate).
+ * - The map is bounded by `maxEntries` (oldest entry evicted on overflow).
+ * - `/session/end` clears the session entry so a new session starts fresh.
+ */
+
+import { createHash } from "node:crypto";
+
+export interface RecallDedupOptions {
+  /** Master switch. When false (default), every call is served in full. */
+  enabled: boolean;
+  /** Entry lifetime without access, in ms. Default 60 minutes. */
+  ttlMs: number;
+  /** Max tracked sessions. Oldest entry is evicted when the map overflows. */
+  maxEntries: number;
+}
+
+export interface RecallDedupDecision {
+  /** True when the context was identical to the session's previous response. */
+  deduplicated: boolean;
+  /** The context to serve. Empty string when `deduplicated` is true. */
+  context: string;
+}
+
+export const RECALL_DEDUP_DEFAULTS: RecallDedupOptions = {
+  enabled: false,
+  ttlMs: 60 * 60 * 1000, // 1 hour
+  maxEntries: 1000,
+};
+
+interface DedupEntry {
+  fingerprint: string;
+  lastAccess: number;
+}
+
+export class SessionRecallDedup {
+  private readonly entries = new Map<string, DedupEntry>();
+  private readonly options: RecallDedupOptions;
+  private hitCount = 0;
+  private missCount = 0;
+
+  constructor(options?: Partial<RecallDedupOptions>) {
+    this.options = { ...RECALL_DEDUP_DEFAULTS, ...options };
+  }
+
+  /**
+   * Decide whether `context` for `sessionKey` should be served or skipped.
+   *
+   * When dedup is disabled, or the context is empty, this is a plain passthrough
+   * (never deduplicated, never cached). Otherwise the context is fingerprinted
+   * and compared against the session's most recent response.
+   */
+  evaluate(sessionKey: string, context: string): RecallDedupDecision {
+    if (!this.options.enabled || !context) {
+      return { deduplicated: false, context };
+    }
+
+    this.evictExpired();
+
+    const fingerprint = fingerprintOf(context);
+    const entry = this.entries.get(sessionKey);
+
+    if (entry && entry.fingerprint === fingerprint) {
+      // Touch — move to the tail so it becomes the most-recently-used entry;
+      // an active session must never be evicted just because it was inserted
+      // early (FIFO would defeat the purpose of the dedup).
+      this.entries.delete(sessionKey);
+      this.entries.set(sessionKey, entry);
+      entry.lastAccess = Date.now();
+      this.hitCount++;
+      return { deduplicated: true, context: "" };
+    }
+
+    // Miss — a new (or changed) baseline is about to be stored. Bound the map
+    // here, only when inserting, so a hit never evicts another session.
+    this.evictOverflow();
+    this.entries.set(sessionKey, { fingerprint, lastAccess: Date.now() });
+    this.missCount++;
+    return { deduplicated: false, context };
+  }
+
+  /** Forget a session (called on `/session/end`). */
+  clearSession(sessionKey: string): void {
+    this.entries.delete(sessionKey);
+  }
+
+  /** Remove expired entries; returns how many were removed. */
+  evictExpired(now: number = Date.now()): number {
+    let removed = 0;
+    for (const [key, entry] of this.entries) {
+      if (now - entry.lastAccess > this.options.ttlMs) {
+        this.entries.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /** Number of dedup hits (identical repeats served as empty). */
+  get hits(): number {
+    return this.hitCount;
+  }
+
+  /** Number of non-dedup evaluations (full contexts served). */
+  get misses(): number {
+    return this.missCount;
+  }
+
+  /** Total tracked sessions. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  private evictOverflow(): void {
+    while (this.entries.size >= this.options.maxEntries) {
+      const oldest = this.entries.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+}
+
+/**
+ * Content fingerprint (SHA-256 hex) used for byte-exact change detection.
+ * Collisions are negligible for this use case; SHA-256 is Node built-in.
+ */
+export function fingerprintOf(context: string): string {
+  return createHash("sha256").update(context, "utf-8").digest("hex");
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -23,6 +23,7 @@ import { loadGatewayConfig } from "./config.js";
 import type { GatewayConfig } from "./config.js";
 import { initDataDirectories } from "../utils/pipeline-factory.js";
 import { SessionFilter } from "../utils/session-filter.js";
+import { SessionRecallDedup } from "./recall-dedup.js";
 import type {
   HealthResponse,
   RecallRequest,
@@ -117,6 +118,7 @@ export class TdaiGateway {
   private core: TdaiCore;
   private server: http.Server | null = null;
   private startTime = Date.now();
+  private recallDedup: SessionRecallDedup;
 
   constructor(configOverrides?: Partial<GatewayConfig>) {
     this.config = loadGatewayConfig(configOverrides);
@@ -136,6 +138,14 @@ export class TdaiGateway {
       config: this.config.memory,
       sessionFilter: new SessionFilter(this.config.memory.capture.excludeAgents),
     });
+
+    // Session-level recall dedup (opt-in, disabled by default)
+    this.recallDedup = new SessionRecallDedup(this.config.recallDedup);
+    if (this.config.recallDedup.enabled) {
+      this.logger.info(
+        `Recall dedup enabled: ttlMs=${this.config.recallDedup.ttlMs} maxEntries=${this.config.recallDedup.maxEntries}`
+      );
+    }
   }
 
   /**
@@ -380,13 +390,23 @@ export class TdaiGateway {
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
+    const fullContext = result.appendSystemContext ?? "";
+    const decision = this.recallDedup.evaluate(body.session_key, fullContext);
+
+    this.logger.info(
+      `Recall completed in ${elapsed}ms: context=${fullContext.length} chars` +
+      (decision.deduplicated ? " (deduplicated, skipped)" : "") +
+      ` [dedup hits=${this.recallDedup.hits} misses=${this.recallDedup.misses}]`
+    );
 
     const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
+      context: decision.context,
       strategy: result.recallStrategy,
       memory_count: result.recalledL1Memories?.length ?? 0,
     };
+    if (decision.deduplicated) {
+      response.deduplicated = true;
+    }
     sendJson(res, 200, response);
   }
 
@@ -473,6 +493,7 @@ export class TdaiGateway {
     }
 
     await this.core.handleSessionEnd(body.session_key);
+    this.recallDedup.clearSession(body.session_key);
 
     const response: SessionEndResponse = { flushed: true };
     sendJson(res, 200, response);

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -39,6 +39,13 @@ export interface RecallResponse {
   context: string;
   strategy?: string;
   memory_count?: number;
+  /**
+   * True when session-level recall dedup (recallDedup.enabled) skipped this
+   * response because the context was byte-identical to the session's most
+   * recent /recall response. `context` is then an empty string. Optional —
+   * only present (and only ever `true`) when dedup is active.
+   */
+  deduplicated?: boolean;
 }
 
 // ============================


### PR DESCRIPTION
## Background

Issue #120 and #523 observed that on the **Gateway/Hermes path**, every turn calls `POST /recall` (prefetch) and receives a byte-identical `appendSystemContext` (stable persona / scene / tools blocks) ??87.5% of injections within a session were exact duplicates. The redundant text is re-sent to the LLM every turn, wasting tokens.

The OpenClaw path is already covered by #188 / #335 / #375 / #514 (`showInjected`, `injectionMode`, `prependSystemContext`), but those PRs explicitly kept the Gateway `/recall` response compatible. This PR fills that gap.

## Approach

Adds opt-in session-level dedup to the Gateway via a new `SessionRecallDedup` component (src/gateway/recall-dedup.ts):

- **Change detection, not "seen-before"**: a context is skipped only when it is byte-identical to the session's *most recent* /recall response. If the context changes (e.g. scene switch), it is served again ??safe even when the consumer rebuilds its prompt from scratch each turn.
- When deduped, `/recall` returns `context: ""` + `deduplicated: true` (new optional field, fully backward compatible).
- Keyed by `session_key`; entries expire after `ttlMs` (default 1h), capped at `maxEntries` (default 1000, LRU eviction), and cleared on `/session/end`.
- **Disabled by default** ??existing deployments are unaffected until they explicitly opt in.

## Configuration

```yaml
recallDedup:
  enabled: false   # default; set true to activate
  ttlMs: 3600000
  maxEntries: 1000
```

Env vars: `TDAI_GATEWAY_RECALL_DEDUP_ENABLED`, `TDAI_GATEWAY_RECALL_DEDUP_TTL_MS`, `TDAI_GATEWAY_RECALL_DEDUP_MAX_ENTRIES`.

## Changes

- `src/gateway/recall-dedup.ts` ??new `SessionRecallDedup` + `fingerprintOf`
- `src/gateway/recall-dedup.test.ts` ??13 unit tests
- `src/gateway/types.ts` ??`RecallResponse.deduplicated?: boolean`
- `src/gateway/config.ts` ??`recallDedup` config section (env + yaml)
- `src/gateway/server.ts` ??wire dedup into `/recall` and `/session/end`
- `CHANGELOG.md` ??entry under Unreleased

## Testing

`npx vitest run` ??80/80 passing (5 files), including 13 new dedup tests covering: disabled passthrough, identical-repeat skip, session isolation, change-detection re-serve, empty-context passthrough, TTL expiry, LRU eviction, clearSession, and hit/miss counters.

Closes #120