### PR TITLE
fix(checkpoint): recalculate counters from retained data

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -144,6 +144,19 @@ export class TdaiCore {
     this.logger.debug?.(`${TAG} Initializing TDAI Core: dataDir=${this.dataDir}`);
     initDataDirectories(this.dataDir);
 
+    // Repair checkpoint counters before any capture or extraction work starts.
+    // This also picks up manual JSONL pruning performed while the service was
+    // stopped. Recalibration is best-effort and must not block startup.
+    try {
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.recalibrateFromDisk();
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint counter recalibration failed at startup (non-fatal): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
     // Initialize stores (async)
     this.storeReady = this.initStores();
 

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,328 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(
+  dataDir: string,
+  subdir: "conversations" | "records",
+  fileName: string,
+  lines: Array<Record<string, unknown> | string>,
+): Promise<void> {
+  const dir = path.join(dataDir, subdir);
+  await fs.mkdir(dir, { recursive: true });
+  const content = lines
+    .map((line) => (typeof line === "string" ? line : JSON.stringify(line)))
+    .join("\n");
+  await fs.writeFile(path.join(dir, fileName), `${content}\n`, "utf-8");
+}
+
+function l0Message(
+  id: string,
+  recordedAt: string,
+  sessionKey = "agent:test",
+  sessionId = "session-1",
+): Record<string, unknown> {
+  return {
+    sessionKey,
+    sessionId,
+    recordedAt,
+    id,
+    role: "user",
+    content: `message ${id}`,
+    timestamp: Date.parse(recordedAt),
+  };
+}
+
+function l1Memory(
+  id: string,
+  sessionKey = "agent:test",
+  sessionId = "session-1",
+): Record<string, unknown> {
+  return {
+    id,
+    content: `memory ${id}`,
+    type: "episodic",
+    priority: 50,
+    sessionKey,
+    sessionId,
+  };
+}
+
+async function seedCheckpoint(
+  manager: CheckpointManager,
+  l0Count: number,
+  l1Count: number,
+): Promise<void> {
+  const checkpoint = await manager.read();
+  checkpoint.l0_conversations_count = l0Count;
+  checkpoint.total_memories_extracted = l1Count;
+  checkpoint.total_processed = 123;
+  checkpoint.memories_since_last_persona = 7;
+  await manager.write(checkpoint);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("CheckpointManager.recalibrateFromDisk", () => {
+  it("recounts retained L0 capture batches and L1 memory records", async () => {
+    const dataDir = await makeTempDir();
+    const manager = new CheckpointManager(dataDir);
+    await seedCheckpoint(manager, 99, 88);
+
+    const firstCaptureAt = "2026-07-30T08:00:00.000Z";
+    await writeJsonl(dataDir, "conversations", "2026-07-30.jsonl", [
+      l0Message("m1", firstCaptureAt),
+      // Same capture timestamp and session: this is still one L0 batch.
+      { ...l0Message("m2", firstCaptureAt), role: "assistant" },
+      l0Message("m3", "2026-07-30T09:00:00.000Z"),
+      {
+        sessionKey: "agent:test",
+        sessionId: "legacy-session",
+        recordedAt: "2026-07-30T10:00:00.000Z",
+        messageCount: 2,
+        messages: [
+          { role: "user", content: "legacy", timestamp: 1 },
+          { role: "assistant", content: "legacy reply", timestamp: 2 },
+        ],
+      },
+      "{not-json",
+      {},
+      "",
+    ]);
+    await writeJsonl(dataDir, "records", "2026-07-30.jsonl", [
+      l1Memory("r1"),
+      l1Memory("r2"),
+      { record_id: "r3", content: "legacy memory" },
+      "{not-json",
+      {},
+      "",
+    ]);
+
+    const result = await manager.recalibrateFromDisk();
+    const checkpoint = await manager.read();
+
+    expect(result.changed).toBe(true);
+    expect(result.before).toEqual({
+      l0ConversationsCount: 99,
+      totalMemoriesExtracted: 88,
+    });
+    expect(result.after).toEqual({
+      l0ConversationsCount: 3,
+      totalMemoriesExtracted: 3,
+    });
+    expect(result.sources.l0).toEqual({
+      ok: true,
+      count: 3,
+      skippedLines: 2,
+    });
+    expect(result.sources.l1).toEqual({
+      ok: true,
+      count: 3,
+      skippedLines: 2,
+    });
+    expect(checkpoint.total_processed).toBe(123);
+    expect(checkpoint.memories_since_last_persona).toBe(7);
+  });
+
+  it("repairs counters after manual JSONL pruning", async () => {
+    const dataDir = await makeTempDir();
+    const manager = new CheckpointManager(dataDir);
+    const l0File = "2026-07-30.jsonl";
+    const l1File = "2026-07-30.jsonl";
+
+    await writeJsonl(dataDir, "conversations", l0File, [
+      l0Message("m1", "2026-07-30T08:00:00.000Z"),
+      l0Message("m2", "2026-07-30T09:00:00.000Z"),
+    ]);
+    await writeJsonl(dataDir, "records", l1File, [
+      l1Memory("r1"),
+      l1Memory("r2"),
+    ]);
+    await seedCheckpoint(manager, 2, 2);
+
+    await writeJsonl(dataDir, "conversations", l0File, [
+      l0Message("m2", "2026-07-30T09:00:00.000Z"),
+    ]);
+    await writeJsonl(dataDir, "records", l1File, [l1Memory("r2")]);
+
+    const result = await manager.recalibrateFromDisk();
+
+    expect(result.after).toEqual({
+      l0ConversationsCount: 1,
+      totalMemoriesExtracted: 1,
+    });
+    expect((await manager.read()).l0_conversations_count).toBe(1);
+    expect((await manager.read()).total_memories_extracted).toBe(1);
+  });
+
+  it("repairs counters after one session's JSONL data is reset", async () => {
+    const dataDir = await makeTempDir();
+    const manager = new CheckpointManager(dataDir);
+    const l0File = "2026-07-30.jsonl";
+    const l1File = "2026-07-30.jsonl";
+
+    const retainedL0 = l0Message(
+      "b1",
+      "2026-07-30T10:00:00.000Z",
+      "agent:b",
+      "session-b",
+    );
+    const retainedL1 = l1Memory("b1", "agent:b", "session-b");
+
+    await writeJsonl(dataDir, "conversations", l0File, [
+      l0Message(
+        "a1",
+        "2026-07-30T08:00:00.000Z",
+        "agent:a",
+        "session-a",
+      ),
+      l0Message(
+        "a2",
+        "2026-07-30T09:00:00.000Z",
+        "agent:a",
+        "session-a",
+      ),
+      retainedL0,
+    ]);
+    await writeJsonl(dataDir, "records", l1File, [
+      l1Memory("a1", "agent:a", "session-a"),
+      l1Memory("a2", "agent:a", "session-a"),
+      retainedL1,
+    ]);
+
+    const checkpoint = await manager.read();
+    checkpoint.l0_conversations_count = 3;
+    checkpoint.total_memories_extracted = 3;
+    checkpoint.runner_states = {
+      "agent:a": {
+        last_captured_timestamp: 100,
+        last_l1_cursor: 200,
+        last_scene_name: "scene-a",
+      },
+      "agent:b": {
+        last_captured_timestamp: 300,
+        last_l1_cursor: 400,
+        last_scene_name: "scene-b",
+      },
+    };
+    checkpoint.pipeline_states = {
+      "agent:a": {
+        conversation_count: 2,
+        last_extraction_time: "2026-07-30T09:00:00.000Z",
+        last_extraction_updated_time: "2026-07-30T09:00:00.000Z",
+        last_active_time: 100,
+        l2_pending_l1_count: 1,
+        warmup_threshold: 2,
+        l2_last_extraction_time: "2026-07-30T09:00:00.000Z",
+      },
+      "agent:b": {
+        conversation_count: 1,
+        last_extraction_time: "2026-07-30T10:00:00.000Z",
+        last_extraction_updated_time: "2026-07-30T10:00:00.000Z",
+        last_active_time: 300,
+        l2_pending_l1_count: 0,
+        warmup_threshold: 4,
+        l2_last_extraction_time: "2026-07-30T10:00:00.000Z",
+      },
+    };
+    await manager.write(checkpoint);
+
+    // Simulate an external reset of agent:a while preserving agent:b's data.
+    await writeJsonl(dataDir, "conversations", l0File, [retainedL0]);
+    await writeJsonl(dataDir, "records", l1File, [retainedL1]);
+
+    const result = await manager.recalibrateFromDisk();
+    const repaired = await manager.read();
+
+    expect(result.after).toEqual({
+      l0ConversationsCount: 1,
+      totalMemoriesExtracted: 1,
+    });
+    expect(repaired.runner_states).toEqual(checkpoint.runner_states);
+    expect(repaired.pipeline_states).toEqual(checkpoint.pipeline_states);
+  });
+
+  it("treats missing L0/L1 directories as empty data", async () => {
+    const dataDir = await makeTempDir();
+    const manager = new CheckpointManager(dataDir);
+    await seedCheckpoint(manager, 4, 5);
+
+    const result = await manager.recalibrateFromDisk();
+
+    expect(result.sources.l0.ok).toBe(true);
+    expect(result.sources.l1.ok).toBe(true);
+    expect(result.after).toEqual({
+      l0ConversationsCount: 0,
+      totalMemoriesExtracted: 0,
+    });
+  });
+
+  it("preserves one layer when that data source cannot be read", async () => {
+    const dataDir = await makeTempDir();
+    const manager = new CheckpointManager(dataDir);
+    const warnings: string[] = [];
+    const loggingManager = new CheckpointManager(dataDir, {
+      info() {},
+      warn(message) {
+        warnings.push(message);
+      },
+    });
+    await seedCheckpoint(manager, 9, 9);
+
+    // A regular file where a directory is expected makes only the L0 scan fail.
+    await fs.writeFile(
+      path.join(dataDir, "conversations"),
+      "not a directory",
+      "utf-8",
+    );
+    await writeJsonl(dataDir, "records", "2026-07-30.jsonl", [
+      l1Memory("r1"),
+    ]);
+
+    const result = await loggingManager.recalibrateFromDisk();
+    const checkpoint = await manager.read();
+
+    expect(result.sources.l0.ok).toBe(false);
+    expect(result.sources.l1.ok).toBe(true);
+    expect(checkpoint.l0_conversations_count).toBe(9);
+    expect(checkpoint.total_memories_extracted).toBe(1);
+    expect(warnings.some((message) => message.includes("L0 recount failed"))).toBe(
+      true,
+    );
+  });
+
+  it("does not rewrite counters when disk and checkpoint already agree", async () => {
+    const dataDir = await makeTempDir();
+    const manager = new CheckpointManager(dataDir);
+    await writeJsonl(dataDir, "conversations", "2026-07-30.jsonl", [
+      l0Message("m1", "2026-07-30T08:00:00.000Z"),
+    ]);
+    await writeJsonl(dataDir, "records", "2026-07-30.jsonl", [
+      l1Memory("r1"),
+    ]);
+    await seedCheckpoint(manager, 1, 1);
+
+    const result = await manager.recalibrateFromDisk();
+
+    expect(result.changed).toBe(false);
+    expect(result.before).toEqual(result.after);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -24,9 +24,11 @@
  * Writes use atomic tmp+rename to prevent corruption on crash.
  */
 
+import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
+import { createInterface } from "node:readline";
 
 // ============================
 // Types
@@ -100,11 +102,11 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /** Number of L0 capture batches currently retained in local JSONL shards */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /** Number of L1 memory records currently retained in local JSONL shards */
   total_memories_extracted: number;
 }
 
@@ -146,6 +148,145 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+export interface CheckpointCounterValues {
+  l0ConversationsCount: number;
+  totalMemoriesExtracted: number;
+}
+
+export interface CheckpointCounterSourceResult {
+  ok: boolean;
+  count?: number;
+  skippedLines: number;
+}
+
+export interface CheckpointRecalibrationResult {
+  before: CheckpointCounterValues;
+  after: CheckpointCounterValues;
+  changed: boolean;
+  sources: {
+    l0: CheckpointCounterSourceResult;
+    l1: CheckpointCounterSourceResult;
+  };
+}
+
+interface JsonlScanResult {
+  count: number;
+  skippedLines: number;
+}
+
+type JsonlRecordCollector = (value: unknown) => boolean;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function scanJsonlDirectory(
+  dirPath: string,
+  collect: JsonlRecordCollector,
+): Promise<JsonlScanResult> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return { count: 0, skippedLines: 0 };
+    }
+    throw error;
+  }
+
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => path.join(dirPath, entry.name))
+    .sort();
+
+  let count = 0;
+  let skippedLines = 0;
+
+  for (const filePath of files) {
+    const input = createReadStream(filePath, { encoding: "utf-8" });
+    const lines = createInterface({ input, crlfDelay: Infinity });
+
+    try {
+      for await (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        try {
+          const value = JSON.parse(trimmed) as unknown;
+          if (collect(value)) {
+            count += 1;
+          } else {
+            skippedLines += 1;
+          }
+        } catch {
+          skippedLines += 1;
+        }
+      }
+    } finally {
+      lines.close();
+      input.destroy();
+    }
+  }
+
+  return { count, skippedLines };
+}
+
+async function countL0CaptureBatches(dataDir: string): Promise<JsonlScanResult> {
+  const batchKeys = new Set<string>();
+
+  const scan = await scanJsonlDirectory(
+    path.join(dataDir, "conversations"),
+    (value) => {
+      if (!isRecord(value)) return false;
+
+      const isFlatMessage =
+        (value.role === "user" || value.role === "assistant") &&
+        typeof value.content === "string";
+      const isLegacyBatch = Array.isArray(value.messages);
+      if (!isFlatMessage && !isLegacyBatch) return false;
+
+      if (
+        typeof value.sessionKey !== "string" ||
+        typeof value.recordedAt !== "string"
+      ) {
+        return false;
+      }
+
+      const sessionId =
+        typeof value.sessionId === "string" ? value.sessionId : "";
+      const batchKey = JSON.stringify([
+        value.sessionKey,
+        sessionId,
+        value.recordedAt,
+      ]);
+
+      batchKeys.add(batchKey);
+      return true;
+    },
+  );
+
+  // scan.count is the number of valid L0 lines. The checkpoint counter tracks
+  // capture batches, so collapse lines written by the same capture event.
+  return { count: batchKeys.size, skippedLines: scan.skippedLines };
+}
+
+async function countL1MemoryRecords(dataDir: string): Promise<JsonlScanResult> {
+  return scanJsonlDirectory(path.join(dataDir, "records"), (value) => {
+    if (!isRecord(value)) return false;
+    const hasId =
+      typeof value.id === "string" || typeof value.record_id === "string";
+    return hasId && typeof value.content === "string";
+  });
+}
+
 // ============================
 // Per-file async lock
 // ============================
@@ -179,10 +320,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -291,6 +434,107 @@ export class CheckpointManager {
   /** Write a full checkpoint (acquires lock + atomic write). */
   async write(checkpoint: Checkpoint): Promise<void> {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
+  }
+
+  /**
+   * Recount the L0/L1 records that are currently present in local JSONL
+   * storage and repair drifted aggregate counters.
+   *
+   * L0 files contain one line per message, while the checkpoint increments
+   * once per capture event. All messages from one capture share
+   * sessionKey/sessionId/recordedAt, so they are collapsed into one batch.
+   *
+   * A missing data directory is treated as an empty layer. Other read errors
+   * leave that layer's previous checkpoint value untouched.
+   */
+  async recalibrateFromDisk(): Promise<CheckpointRecalibrationResult> {
+    const warnings: string[] = [];
+
+    const result = await withFileLock(this.filePath, async () => {
+      const cp = await this.readRaw();
+      const before: CheckpointCounterValues = {
+        l0ConversationsCount: cp.l0_conversations_count,
+        totalMemoriesExtracted: cp.total_memories_extracted,
+      };
+
+      const [l0Scan, l1Scan] = await Promise.allSettled([
+        countL0CaptureBatches(this.dataDir),
+        countL1MemoryRecords(this.dataDir),
+      ]);
+
+      const l0Source: CheckpointCounterSourceResult =
+        l0Scan.status === "fulfilled"
+          ? {
+              ok: true,
+              count: l0Scan.value.count,
+              skippedLines: l0Scan.value.skippedLines,
+            }
+          : { ok: false, skippedLines: 0 };
+      const l1Source: CheckpointCounterSourceResult =
+        l1Scan.status === "fulfilled"
+          ? {
+              ok: true,
+              count: l1Scan.value.count,
+              skippedLines: l1Scan.value.skippedLines,
+            }
+          : { ok: false, skippedLines: 0 };
+
+      if (l0Scan.status === "fulfilled") {
+        cp.l0_conversations_count = l0Scan.value.count;
+        if (l0Scan.value.skippedLines > 0) {
+          warnings.push(
+            `L0 recount skipped ${l0Scan.value.skippedLines} malformed or unrecognized JSONL line(s)`,
+          );
+        }
+      } else {
+        warnings.push(`L0 recount failed: ${errorMessage(l0Scan.reason)}`);
+      }
+
+      if (l1Scan.status === "fulfilled") {
+        cp.total_memories_extracted = l1Scan.value.count;
+        if (l1Scan.value.skippedLines > 0) {
+          warnings.push(
+            `L1 recount skipped ${l1Scan.value.skippedLines} malformed or unrecognized JSONL line(s)`,
+          );
+        }
+      } else {
+        warnings.push(`L1 recount failed: ${errorMessage(l1Scan.reason)}`);
+      }
+
+      const after: CheckpointCounterValues = {
+        l0ConversationsCount: cp.l0_conversations_count,
+        totalMemoriesExtracted: cp.total_memories_extracted,
+      };
+      const changed =
+        before.l0ConversationsCount !== after.l0ConversationsCount ||
+        before.totalMemoriesExtracted !== after.totalMemoriesExtracted;
+
+      if (changed) {
+        await this.writeRaw(cp);
+      }
+
+      return {
+        before,
+        after,
+        changed,
+        sources: {
+          l0: l0Source,
+          l1: l1Source,
+        },
+      };
+    });
+
+    for (const warning of warnings) {
+      this.logger.warn?.(`[checkpoint] ${warning}`);
+    }
+    this.logger.info(
+      `[checkpoint] recalibrateFromDisk: ` +
+      `L0 ${result.before.l0ConversationsCount} -> ${result.after.l0ConversationsCount}, ` +
+      `L1 ${result.before.totalMemoriesExtracted} -> ${result.after.totalMemoriesExtracted}, ` +
+      `changed=${result.changed}`,
+    );
+
+    return result;
   }
 
   // ============================

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-cleaner-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(
+  dataDir: string,
+  subdir: "conversations" | "records",
+  fileName: string,
+  records: Array<Record<string, unknown>>,
+): Promise<string> {
+  const dir = path.join(dataDir, subdir);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, fileName);
+  await fs.writeFile(
+    filePath,
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    "utf-8",
+  );
+  return filePath;
+}
+
+function l0Message(id: string, recordedAt: string): Record<string, unknown> {
+  return {
+    sessionKey: "agent:test",
+    sessionId: "session-1",
+    recordedAt,
+    id,
+    role: "user",
+    content: `message ${id}`,
+    timestamp: Date.parse(recordedAt),
+  };
+}
+
+function l1Memory(id: string): Record<string, unknown> {
+  return { id, content: `memory ${id}` };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("LocalMemoryCleaner checkpoint reconciliation", () => {
+  it("recalibrates L0/L1 counters after expired shards are removed", async () => {
+    const dataDir = await makeTempDir();
+    const oldL0 = await writeJsonl(
+      dataDir,
+      "conversations",
+      "2026-07-20.jsonl",
+      [
+        l0Message("old-1", "2026-07-20T08:00:00.000Z"),
+        l0Message("old-2", "2026-07-20T09:00:00.000Z"),
+      ],
+    );
+    const retainedL0 = await writeJsonl(
+      dataDir,
+      "conversations",
+      "2026-07-31.jsonl",
+      [l0Message("new-1", "2026-07-31T08:00:00.000Z")],
+    );
+    const oldL1 = await writeJsonl(dataDir, "records", "2026-07-20.jsonl", [
+      l1Memory("old-1"),
+      l1Memory("old-2"),
+    ]);
+    const retainedL1 = await writeJsonl(
+      dataDir,
+      "records",
+      "2026-07-31.jsonl",
+      [l1Memory("new-1")],
+    );
+
+    const checkpoint = new CheckpointManager(dataDir);
+    const state = await checkpoint.read();
+    state.l0_conversations_count = 3;
+    state.total_memories_extracted = 3;
+    await checkpoint.write(state);
+
+    const cleaner = new LocalMemoryCleaner({
+      baseDir: dataDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+    });
+    const nowMs = new Date(2026, 6, 31, 12, 0, 0, 0).getTime();
+
+    await cleaner.runOnce(nowMs);
+
+    const repaired = await checkpoint.read();
+    expect(repaired.l0_conversations_count).toBe(1);
+    expect(repaired.total_memories_extracted).toBe(1);
+    await expect(fs.stat(oldL0)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(oldL1)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(retainedL0)).resolves.toBeDefined();
+    await expect(fs.stat(retainedL1)).resolves.toBeDefined();
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "./checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -178,6 +179,19 @@ export class LocalMemoryCleaner {
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
+    }
+
+    try {
+      const checkpoint = new CheckpointManager(
+        this.opts.baseDir,
+        this.opts.logger,
+      );
+      await checkpoint.recalibrateFromDisk();
+    } catch (err) {
+      this.opts.logger?.warn(
+        `${TAG} Checkpoint counter recalibration failed after cleanup (non-fatal): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     this.opts.logger?.info(


### PR DESCRIPTION
## Description | 描述

根据本地实际保留的 JSONL 数据重新计算 Checkpoint 聚合计数器，避免清理或修剪数据后 `l0_conversations_count` 和 `total_memories_extracted` 永久高估。

Main changes | 主要改动：

- Recount L0 capture batches using `sessionKey + sessionId + recordedAt`.
- Recount valid L1 memory records from local JSONL shards.
- Run recalculation during startup before capture or extraction begins.
- Run recalculation after `memory-cleaner` completes.
- Handle missing directories, malformed records, and independent L0/L1 read failures.
- Preserve progress cursors, `runner_states`, `pipeline_states`, and unrelated counters.
- Add tests for manual pruning, automatic cleanup, and resetting one session's data.

## Related Issue | 关联 Issue

Fixes #157

## Change Type | 修改类型

- [✅] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [✅] Verified locally | 本地验证通过
- [✅] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Checkpoint data flow:

`conversation capture → conversations/*.jsonl → l0_conversations_count`

`L1 extraction → records/*.jsonl → total_memories_extracted`

`startup / memory-cleaner → recount retained JSONL → repair aggregate counters`

Verification:

- `npm test` — 6 test files, 74 tests passed
- `npm run build` — passed
- `git diff --check` — clean
- Commit includes DCO `Signed-off-by`