### PR TITLE
fix(persona): back up COS persona before regeneration

### DIFF
--- a/MemoryCore/src/core/persona/persona-generator.ts
+++ b/MemoryCore/src/core/persona/persona-generator.ts
@@ -178,15 +178,16 @@ export class PersonaGenerator {
       checkpointPath,
     });
 
-    // 7. Backup before LLM run (LLM writes persona.md via tools)
-    const bm = new BackupManager(this.storage
-      ? undefined  // COS mode: BackupManager not used (TODO: adapt BackupManager for StorageAdapter)
-      : await (async () => { const path = await import("node:path"); return path.default.join(this.dataDir, ".backup"); })()
-    );
-    if (!this.storage) {
-      const path = await import("node:path");
-      await bm.backupFile(path.default.join(this.dataDir, targetFile), "persona", `offset${cp.total_processed}`, this.backupCount);
-    }
+    // 7. Backup before LLM run (LLM writes persona.md via tools).
+    // StorageAdapter mode uses object-key prefixes; fs mode uses absolute paths.
+    const backupRoot = this.storage
+      ? StoragePaths.backupDir
+      : await (async () => { const path = await import("node:path"); return path.default.join(this.dataDir, ".backup"); })();
+    const personaSource = this.storage
+      ? targetFile
+      : await (async () => { const path = await import("node:path"); return path.default.join(this.dataDir, targetFile); })();
+    const bm = new BackupManager(backupRoot, this.storage);
+    await bm.backupFile(personaSource, "persona", `offset${cp.total_processed}`, this.backupCount);
 
     // 8. Run LLM agent (sandboxed to dataDir, tools enabled — LLM writes target L3 file directly)
     try {

--- a/MemoryCore/src/utils/backup.test.ts
+++ b/MemoryCore/src/utils/backup.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { StorageAdapter } from "../core/storage/adapter.js";
+import { LocalStorageBackend } from "../core/storage/local-backend.js";
+import { StoragePaths } from "../core/storage/types.js";
+import { BackupManager } from "./backup.js";
+
+const tempDirs: string[] = [];
+
+async function createStorage(): Promise<StorageAdapter> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-backup-"));
+  tempDirs.push(dir);
+  return new StorageAdapter(new LocalStorageBackend(dir));
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("BackupManager StorageAdapter mode", () => {
+  it("backs up persona objects and prunes the oldest entries", async () => {
+    const storage = await createStorage();
+    const manager = new BackupManager(StoragePaths.backupDir, storage);
+
+    for (let version = 1; version <= 3; version++) {
+      await storage.writeFile(StoragePaths.persona, `persona-v${version}`);
+      await manager.backupFile(
+        StoragePaths.persona,
+        "persona",
+        `offset${version}`,
+        2,
+      );
+    }
+
+    const entries = (await storage.readdir(".backup/persona/"))
+      .filter((entry) => !entry.isDirectory)
+      .sort((a, b) => a.key.localeCompare(b.key));
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.key)).toEqual([
+      expect.stringContaining("offset2.md"),
+      expect.stringContaining("offset3.md"),
+    ]);
+    await expect(storage.readFile(entries[0].key)).resolves.toBe("persona-v2");
+    await expect(storage.readFile(entries[1].key)).resolves.toBe("persona-v3");
+  });
+
+  it("does nothing when the source object does not exist", async () => {
+    const storage = await createStorage();
+    const manager = new BackupManager(StoragePaths.backupDir, storage);
+
+    await manager.backupFile(StoragePaths.persona, "persona", "offset0", 3);
+
+    await expect(storage.readdir(".backup/persona/")).resolves.toEqual([]);
+  });
+});

--- a/MemoryCore/src/utils/backup.ts
+++ b/MemoryCore/src/utils/backup.ts
@@ -12,16 +12,20 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { StorageAdapter } from "../core/storage/adapter.js";
 
 export class BackupManager {
   private backupRoot: string;
+  private storage: StorageAdapter | undefined;
 
   /**
-   * @param backupRoot - Absolute path to the root backup directory
-   *                     (e.g. `<dataDir>/.backup`).
+   * @param backupRoot - Filesystem: absolute backup directory.
+   *                     StorageAdapter: relative object-key prefix.
+   * @param storage    - Optional object-storage adapter. When omitted, use fs.
    */
-  constructor(backupRoot: string) {
+  constructor(backupRoot: string, storage?: StorageAdapter) {
     this.backupRoot = backupRoot;
+    this.storage = storage;
   }
 
   /**
@@ -40,6 +44,23 @@ export class BackupManager {
     tag: string,
     maxKeep: number,
   ): Promise<void> {
+    if (this.storage) {
+      if (!(await this.storage.exists(srcFile))) {
+        return;
+      }
+
+      const destDir = path.posix.join(this.backupRoot, category);
+      const ext = path.posix.extname(srcFile);
+      const timestamp = formatTimestamp(new Date());
+      const destName = `${category}_${timestamp}_${tag}${ext}`;
+      await this.storage.copyFile(srcFile, path.posix.join(destDir, destName));
+
+      if (maxKeep > 0) {
+        await pruneOldStorageFiles(this.storage, destDir, maxKeep);
+      }
+      return;
+    }
+
     try {
       await fs.access(srcFile);
     } catch {
@@ -211,6 +232,33 @@ async function pruneOldEntries(
       } else {
         await fs.rm(path.join(dir, name), { recursive: true, force: true });
       }
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+async function pruneOldStorageFiles(
+  storage: StorageAdapter,
+  dir: string,
+  maxKeep: number,
+): Promise<void> {
+  let files: string[];
+  try {
+    const prefix = `${dir.replace(/\/+$/, "")}/`;
+    const entries = await storage.readdir(prefix);
+    files = entries
+      .filter((entry) => !entry.isDirectory && entry.key.startsWith(prefix))
+      .map((entry) => entry.key)
+      .sort();
+  } catch {
+    return;
+  }
+
+  const toRemove = files.slice(0, Math.max(0, files.length - maxKeep));
+  for (const key of toRemove) {
+    try {
+      await storage.unlink(key);
     } catch {
       // best-effort
     }


### PR DESCRIPTION
## Description | 描述

Restore the L3 persona backup guarantee in service/COS mode.

`PersonaGenerator` backs up the current `persona.md` before allowing the LLM tool runner to overwrite it. The filesystem path retained the configured backups, but the `StorageAdapter` path explicitly skipped `BackupManager`, leaving COS-backed instances with no prior persona copy when regeneration failed or produced bad content.

Changes:

- Extend `BackupManager.backupFile()` with an optional `StorageAdapter` mode.
- Use object-key-safe POSIX paths for backup destinations.
- Preserve object content type and metadata through `StorageAdapter.copyFile()`.
- Apply the existing timestamp/tag naming and `maxKeep` retention semantics by listing and pruning old backup objects best-effort.
- Route `PersonaGenerator` through the same backup call in both filesystem and StorageAdapter modes.
- Add focused tests for retaining the newest two persona backups and treating a missing source object as a no-op.

Scope boundary:

- Directory backup/restore for scene blocks is unchanged.
- This PR creates rollback material but does not introduce automatic persona restore policy.
- No storage schema, LLM prompt, checkpoint, or API changes.

## Related Issue | 关联 Issue

No existing issue. Implements the explicit StorageAdapter backup TODO in `MemoryCore/src/core/persona/persona-generator.ts` discovered during default-branch maintenance.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation in `MemoryCore` (Node v26.5.0, npm v11.17.0):

```text
npm test -- src/utils/backup.test.ts
# 1 file, 2 tests passed

npm run build:plugin
npm run build:migrate-sqlite-to-vdb
npm run build:export-tencent-vdb
npm run build:read-local-memory
# all passed

git diff --check
# passed
```

The branch-wide `npm run build` still reaches the unrelated missing `scripts/seed-v2/tsconfig.json` baseline target. PR #652 removes that incomplete target; this PR is otherwise independent and can be reviewed separately.
