### PR TITLE
fix(checkpoint): reconcile counters after cleanup

### DIFF
--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { CheckpointManager } from "./checkpoint.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+describe("CheckpointManager adjustCounters", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = path.join("/tmp", `test-checkpoint-${Date.now()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("decreases counters by confirmed deletions without going negative", async () => {
+    const cp = new CheckpointManager(testDir);
+    const cpData = {
+      total_processed: 100,
+      l0_conversations_count: 50,
+      total_memories_extracted: 30,
+      memories_since_last_persona: 15,
+    };
+    await cp.write(cpData);
+
+    await cp.adjustCounters(20, 10);
+
+    const after = await cp.read();
+    expect(after.total_processed).toBe(80);
+    expect(after.l0_conversations_count).toBe(30);
+    expect(after.total_memories_extracted).toBe(20);
+    expect(after.memories_since_last_persona).toBe(5);
+  });
+
+  it("clamps at zero on over-deletion", async () => {
+    const cp = new CheckpointManager(testDir);
+    const cpData = {
+      total_processed: 5,
+      l0_conversations_count: 3,
+      total_memories_extracted: 2,
+      memories_since_last_persona: 0,
+    };
+    await cp.write(cpData);
+
+    await cp.adjustCounters(10, 5);
+
+    const after = await cp.read();
+    expect(after.total_processed).toBe(0);
+    expect(after.l0_conversations_count).toBe(0);
+    expect(after.total_memories_extracted).toBe(0);
+    expect(after.memories_since_last_persona).toBe(0);
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -431,6 +431,27 @@ export class CheckpointManager {
     );
   }
 
+  /**
+   * Adjust aggregate counters after confirmed deletions (L0/L1 cleanup).
+   *
+   * Applied under the file lock via mutate() to ensure atomicity and prevent
+   * race with concurrent capture/extraction.
+   *
+   * @param removedL0 number of L0 files/conversations removed
+   * @param removedL1 number of L1 memories removed
+   *
+   * Counters are clamped at 0; never negative. This fixes drift where
+   * checkpoint totals exceed actual persisted L0/L1 data after cleanup.
+   */
+  async adjustCounters(removedL0: number, removedL1: number): Promise<void> {
+    await this.mutate((cp) => {
+      cp.total_processed = Math.max(0, cp.total_processed - removedL0);
+      cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count - removedL0);
+      cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted - removedL1);
+      cp.memories_since_last_persona = Math.max(0, cp.memories_since_last_persona - removedL1);
+    });
+  }
+
   // ============================
   // Atomic capture (race-condition fix)
   // ============================

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -5,6 +5,7 @@ import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
+import { CheckpointManager } from "../utils/checkpoint.js";
 
 export interface MemoryCleanerOptions {
   baseDir: string;
@@ -163,6 +164,18 @@ export class LocalMemoryCleaner {
 
       if (removedL1 > 0 || removedL0 > 0) {
         total.changedFiles += 1;
+      }
+
+      // Adjust checkpoint counters after confirmed deletions to prevent
+      // drift where checkpoint totals exceed actual L0/L1 data.
+      // Done under checkpoint lock for safety.
+      if (removedL0 > 0 || removedL1 > 0) {
+        const cpManager = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+        await cpManager.adjustCounters(removedL0, removedL1);
+        this.opts.logger?.info(
+          `${TAG} [cleaner] Adjusted checkpoint counters after deletion: ` +
+          `removedL0=${removedL0}, removedL1=${removedL1}`,
+        );
       }
 
       // ── Post-delete: audit summary ──


### PR DESCRIPTION
## Description | 描述

Apply confirmed L0 and L1 deletion deltas to checkpoint aggregate counters after successful memory cleanup. The mutation uses the existing locked read-modify-write path, clamps counters at zero, and preserves processing cursors and per-session state.

## Related Issue | 关联 Issue

Refs #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Overlap Check | 重叠检查

PR #504 also addresses Issue #157 with broader startup reconciliation and storage fallback behavior. This patch is limited to the live memory-cleaner deletion path and adds the corresponding locked checkpoint delta API and focused counter regression tests.

## Verification | 验证

- `./node_modules/.bin/vitest run` — 5 files, 69 tests passed
- `npm run build` — plugin and all three scripts passed
- `git diff upstream/main...HEAD --check` — passed

## Additional Notes | 其他说明

The patch does not reset runner or pipeline states, processing cursors, timestamps, or extraction state.