### PR TITLE
 enforce end-to-end recall delivery correctness`

### DIFF
--- a/src/gateway/recall-conformance.test.ts
+++ b/src/gateway/recall-conformance.test.ts
@@ -1,0 +1,286 @@
+import http from "node:http";
+import path from "node:path";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../config.js";
+import type { MemoryTdaiConfig } from "../config.js";
+import type { MemoryRecord } from "../core/record/l1-writer.js";
+import { VectorStore } from "../core/store/sqlite.js";
+import { TdaiGateway } from "./server.js";
+import type { RecallResponse } from "./types.js";
+
+const HOST = "127.0.0.1";
+const API_KEY = "gateway-api-key-do-not-log";
+const EMBEDDING_API_KEY = "embedding-api-key-do-not-log";
+const USER_ID = "gateway-user-id-do-not-log";
+const PERSONA_MARKER = "PERSONA_CONFORMANCE_MARKER";
+const SCENE_MARKER = "SCENE_CONFORMANCE_MARKER";
+const L1_MARKER = "L1_CONFORMANCE_MARKER gatewayconformance";
+
+const gateways: TdaiGateway[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const gateway of gateways.splice(0).reverse()) {
+    await gateway.stop();
+  }
+  for (const dir of tempDirs.splice(0).reverse()) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeDataDir(): Promise<string> {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "tdai-gateway-recall-"));
+  tempDirs.push(dataDir);
+  await mkdir(path.join(dataDir, ".metadata"), { recursive: true });
+  await mkdir(path.join(dataDir, "scene_blocks"), { recursive: true });
+  return dataDir;
+}
+
+async function writeStableContext(dataDir: string): Promise<void> {
+  await writeFile(path.join(dataDir, "persona.md"), PERSONA_MARKER, "utf8");
+  await writeFile(
+    path.join(dataDir, ".metadata", "scene_index.json"),
+    JSON.stringify([
+      {
+        filename: "gateway-conformance.md",
+        summary: SCENE_MARKER,
+        heat: 10,
+        created: "2026-01-01T00:00:00.000Z",
+        updated: "2026-01-01T00:00:00.000Z",
+      },
+    ]),
+    "utf8",
+  );
+}
+
+function l1Record(id: string, content: string): MemoryRecord {
+  return {
+    id,
+    content,
+    type: "episodic",
+    priority: 80,
+    scene_name: "gateway-conformance",
+    source_message_ids: ["source-1"],
+    metadata: {},
+    timestamps: ["2026-01-01T00:00:00.000Z"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    sessionKey: "fixture-session",
+    sessionId: "fixture-session-id",
+  };
+}
+
+function seedL1(dataDir: string, records: MemoryRecord[]): void {
+  const store = new VectorStore(path.join(dataDir, "vectors.db"), 0);
+  store.init();
+  expect(store.isFtsAvailable()).toBe(true);
+  for (const record of records) {
+    expect(store.upsertL1(record, undefined)).toBe(true);
+  }
+  store.close();
+}
+
+async function unusedPort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, HOST, resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected an ephemeral TCP address");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+  return address.port;
+}
+
+function keywordMemoryConfig(): MemoryTdaiConfig {
+  return parseConfig({
+    extraction: { enabled: false },
+    embedding: { provider: "none" },
+    recall: {
+      strategy: "keyword",
+      maxResults: 5,
+      scoreThreshold: 0,
+      timeoutMs: 2_000,
+    },
+  });
+}
+
+async function startGateway(
+  dataDir: string,
+  memory: MemoryTdaiConfig = keywordMemoryConfig(),
+): Promise<string> {
+  const port = await unusedPort();
+  const gateway = new TdaiGateway({
+    server: { host: HOST, port, apiKey: API_KEY, corsOrigins: [] },
+    data: { baseDir: dataDir },
+    memory,
+  });
+  gateways.push(gateway);
+  await gateway.start();
+  return `http://${HOST}:${port}`;
+}
+
+async function recall(baseUrl: string): Promise<RecallResponse> {
+  const response = await fetch(`${baseUrl}/recall`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+      Connection: "close",
+    },
+    body: JSON.stringify({
+      query: "gatewayconformance",
+      session_key: "gateway-conformance-session",
+      user_id: USER_ID,
+    }),
+  });
+  expect(response.status).toBe(200);
+  return await response.json() as RecallResponse;
+}
+
+function occurrences(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+describe.sequential("POST /recall conformance", () => {
+  it("delivers stable and dynamic L1 context once in stable-first order", async () => {
+    const dataDir = await makeDataDir();
+    await writeStableContext(dataDir);
+    seedL1(dataDir, [l1Record("l1-matching", L1_MARKER)]);
+
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const baseUrl = await startGateway(dataDir);
+
+    const first = await recall(baseUrl);
+    const second = await recall(baseUrl);
+
+    expect(first.memory_count).toBe(1);
+    expect(first.strategy).toBe("keyword");
+    expect(first.stable_context).toContain(PERSONA_MARKER);
+    expect(first.stable_context).toContain(SCENE_MARKER);
+    expect(first.dynamic_context).toContain(L1_MARKER);
+    expect(occurrences(first.context, PERSONA_MARKER)).toBe(1);
+    expect(occurrences(first.context, SCENE_MARKER)).toBe(1);
+    expect(occurrences(first.context, L1_MARKER)).toBe(1);
+    expect(first.context.indexOf(PERSONA_MARKER)).toBeLessThan(first.context.indexOf(L1_MARKER));
+    expect(first.context).toBe(`${first.stable_context}\n\n${first.dynamic_context}`);
+    expect(second).toEqual(first);
+
+    const logs = [debug, info, warn, error]
+      .flatMap((spy) => spy.mock.calls.flat())
+      .map(String)
+      .join("\n");
+    for (const secret of [PERSONA_MARKER, SCENE_MARKER, L1_MARKER, USER_ID, API_KEY]) {
+      expect(logs).not.toContain(secret);
+    }
+  });
+
+  it("does not count stable-only Persona and Scene content as L1 hits", async () => {
+    const dataDir = await makeDataDir();
+    await writeStableContext(dataDir);
+    const baseUrl = await startGateway(dataDir);
+
+    const response = await recall(baseUrl);
+
+    expect(response.memory_count).toBe(0);
+    expect(response.stable_context).toContain(PERSONA_MARKER);
+    expect(response.stable_context).toContain(SCENE_MARKER);
+    expect(response).not.toHaveProperty("dynamic_context");
+    expect(response.context).toBe(response.stable_context);
+  });
+
+  it("keeps an L1 hit in the dynamic partition without Persona or Scene data", async () => {
+    const dataDir = await makeDataDir();
+    seedL1(dataDir, [l1Record("l1-without-profile", L1_MARKER)]);
+    const baseUrl = await startGateway(dataDir);
+
+    const response = await recall(baseUrl);
+
+    expect(response.memory_count).toBe(1);
+    expect(response.dynamic_context).toContain(L1_MARKER);
+    expect(response.stable_context ?? "").not.toContain(PERSONA_MARKER);
+    expect(response.stable_context ?? "").not.toContain(SCENE_MARKER);
+    expect(response.context).toBe(
+      [response.stable_context, response.dynamic_context].filter(Boolean).join("\n\n"),
+    );
+  });
+
+  it("returns an explicit empty legacy context when recall finds nothing", async () => {
+    const dataDir = await makeDataDir();
+    const baseUrl = await startGateway(dataDir);
+
+    const response = await recall(baseUrl);
+
+    expect(response).toEqual({
+      context: "",
+      memory_count: 0,
+    });
+  });
+
+  it("degrades to an empty response when the real recall path times out", async () => {
+    const embeddingServer = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ data: [{ index: 0, embedding: [1, 0] }] }));
+      }, 75);
+    });
+    await new Promise<void>((resolve, reject) => {
+      embeddingServer.once("error", reject);
+      embeddingServer.listen(0, HOST, resolve);
+    });
+    const embeddingAddress = embeddingServer.address();
+    if (!embeddingAddress || typeof embeddingAddress === "string") {
+      throw new Error("Expected an embedding server TCP address");
+    }
+
+    try {
+      const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+      const info = vi.spyOn(console, "info").mockImplementation(() => {});
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const dataDir = await makeDataDir();
+      await writeStableContext(dataDir);
+      const memory = parseConfig({
+        extraction: { enabled: false },
+        recall: { strategy: "embedding", timeoutMs: 10 },
+        embedding: {
+          provider: "openai",
+          baseUrl: `http://${HOST}:${embeddingAddress.port}/v1`,
+          apiKey: EMBEDDING_API_KEY,
+          model: "conformance-embedding",
+          dimensions: 2,
+          timeoutMs: 1_000,
+        },
+      });
+      const baseUrl = await startGateway(dataDir, memory);
+
+      const response = await recall(baseUrl);
+
+      expect(response).toEqual({ context: "", memory_count: 0 });
+      expect(warn.mock.calls.flat().map(String).join("\n")).toContain("Recall timed out");
+
+      // The timed-out work is not cancellable yet; let its local HTTP request
+      // settle before closing the real SQLite store in afterEach.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const logs = [debug, info, warn, error]
+        .flatMap((spy) => spy.mock.calls.flat())
+        .map(String)
+        .join("\n");
+      for (const secret of [PERSONA_MARKER, USER_ID, API_KEY, EMBEDDING_API_KEY]) {
+        expect(logs).not.toContain(secret);
+      }
+    } finally {
+      embeddingServer.closeAllConnections();
+      await new Promise<void>((resolve) => embeddingServer.close(() => resolve()));
+    }
+  });
+});

--- a/src/gateway/recall-response.ts
+++ b/src/gateway/recall-response.ts
@@ -1,0 +1,24 @@
+import type { RecallResult } from "../core/types.js";
+import type { RecallResponse } from "./types.js";
+
+/**
+ * Adapt host-neutral recall regions to the Gateway response contract.
+ *
+ * Legacy clients receive both regions through `context`. New clients can keep
+ * stable and per-turn context separate without depending on host-specific
+ * `appendSystemContext` / `prependContext` terminology.
+ */
+export function buildRecallResponse(result: RecallResult): RecallResponse {
+  const stableContext = result.appendSystemContext;
+  const dynamicContext = result.prependContext;
+
+  return {
+    context: [stableContext, dynamicContext]
+      .filter((part): part is string => Boolean(part))
+      .join("\n\n"),
+    ...(stableContext ? { stable_context: stableContext } : {}),
+    ...(dynamicContext ? { dynamic_context: dynamicContext } : {}),
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -26,7 +26,6 @@ import { SessionFilter } from "../utils/session-filter.js";
 import type {
   HealthResponse,
   RecallRequest,
-  RecallResponse,
   CaptureRequest,
   CaptureResponse,
   MemorySearchRequest,
@@ -43,6 +42,7 @@ import type { Logger } from "../core/types.js";
 import { validateAndNormalizeRaw, fillTimestamps, SeedValidationError } from "../core/seed/input.js";
 import { executeSeed } from "../core/seed/seed-runtime.js";
 import type { SeedProgress } from "../core/seed/types.js";
+import { buildRecallResponse } from "./recall-response.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
@@ -379,14 +379,9 @@ export class TdaiGateway {
     const startMs = Date.now();
     const result = await this.core.handleBeforeRecall(body.query, body.session_key);
     const elapsed = Date.now() - startMs;
+    const response = buildRecallResponse(result);
 
-    this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
-
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
+    this.logger.info(`Recall completed in ${elapsed}ms: context=${response.context.length} chars`);
     sendJson(res, 200, response);
   }
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -36,7 +36,12 @@ export interface RecallRequest {
 }
 
 export interface RecallResponse {
+  /** Legacy flattened context, with stable context before dynamic L1 recall. */
   context: string;
+  /** Cacheable Persona, Scene Navigation, and memory tool guidance. */
+  stable_context?: string;
+  /** Per-turn L1 recall that changes with the query. */
+  dynamic_context?: string;
   strategy?: string;
   memory_count?: number;
 }


### PR DESCRIPTION
## 背景

缓存优化后，Core 将 Persona、Scene Navigation 和工具指引放在 `appendSystemContext`，将随查询变化的 L1 召回放在 `prependContext`。当前 Gateway 的 `/recall` 只序列化前者，因此可能出现 `memory_count: 1`，但 Hermes 实际拿不到该条 L1 正文的情况。

#626 已定位并修复这个序列化问题，但测试直接调用内部转换函数，没有覆盖真实交付链路。本 PR 在其基础上补齐公共 HTTP 接口的黑盒契约，并为后续缓存位置调整建立正确性守卫。

## 修改内容

- legacy `context` 按“稳定区在前、动态 L1 在后”的顺序返回完整召回结果；
- 新增可选字段 `stable_context` 和 `dynamic_context`，供新客户端保留上下文分区语义；
- 新增 `POST /recall` 黑盒测试，使用临时 SQLite/FTS、真实 `TdaiCore` 和实际监听端口的 `TdaiGateway`；
- 检查 Gateway 调试日志，确保其中不包含 Persona、Scene、L1 正文、`user_id`、Gateway Bearer Token 或 embedding 凭据。

本 PR 不修改召回排序、默认注入方式、`showInjected`、缓存位置、持久化逻辑或 session 级去重。

## 契约覆盖

| 场景 | 对外行为 |
| --- | --- |
| 稳定区与 L1 同时存在 | 两类内容各出现一次，稳定区位于动态区之前，`memory_count` 为 1 |
| 只有稳定区 | Persona 与 Scene 正常返回，不产生 `dynamic_context`，`memory_count` 为 0 |
| 无 Persona/Scene，但命中 L1 | L1 保留在 `dynamic_context`；测试允许 Core 继续附带现有的静态工具指引 |
| 空召回 | 保持明确的 legacy 降级结果 `{ "context": "", "memory_count": 0 }` |
| 召回超时 | 通过本地延迟 embedding 端点稳定触发超时，并返回同样的空降级结果 |
| 相同数据与请求重复执行 | 完整 JSON 序列化结果保持一致 |

这里没有强行构造“纯 dynamic-only”状态。现有 Core 在 L1 命中时会同时加入静态工具指引，因此真实路径不会产生该状态。测试只约束 L1 必须进入动态分区，不借机改变默认注入策略。

现有 Hermes 客户端仍通过 `result.get("context", "")` 读取结果，无需修改即可获得完整内容。两个分区字段均为向后兼容的增量字段。

## 验证

- `npm test`：5 个测试文件，72 个测试全部通过
- `npm run build`：通过
- conformance test 连续运行 3 次，共 15 个用例全部通过
- `git diff --check upstream/main...HEAD`：通过

Refs #120。
本 PR 以真实端到端契约覆盖取代 #626 的内部函数测试方案。
