### PR TITLE
fix(data): reconcile checkpoint counters with persisted memory

### DIFF
--- a/src/core/record/l1-reader.test.ts
+++ b/src/core/record/l1-reader.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { countL1JsonlRecords } from "./l1-reader.js";
+import { StorageAdapter } from "../storage/adapter.js";
+import { LocalStorageBackend } from "../storage/local-backend.js";
+
+describe("countL1JsonlRecords", () => {
+  const tempDirs: string[] = [];
+
+  async function createDataDir(): Promise<string> {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "l1-jsonl-count-test-"));
+    tempDirs.push(dataDir);
+    return dataDir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("counts valid records across JSONL shards", async () => {
+    const dataDir = await createDataDir();
+    const recordsDir = path.join(dataDir, "records");
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-30.jsonl"),
+      '{"id":"1"}\n{"id":"2"}\n\n',
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-31.jsonl"),
+      '{"id":"3"}\r\n{"id":"4"}\r\n',
+      "utf-8",
+    );
+    await fs.writeFile(path.join(recordsDir, "ignore.txt"), '{"id":"5"}\n', "utf-8");
+
+    await expect(countL1JsonlRecords(dataDir)).resolves.toBe(4);
+  });
+
+  it("ignores blank and malformed lines", async () => {
+    const dataDir = await createDataDir();
+    const recordsDir = path.join(dataDir, "records");
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recordsDir, "2026-07-31.jsonl"),
+      '{"id":"1"}\nnot-json\n  \n{"id":"2"}\n',
+      "utf-8",
+    );
+    const warn = vi.fn();
+
+    await expect(countL1JsonlRecords(dataDir, {
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    })).resolves.toBe(2);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("reflects records removed by manual JSONL pruning", async () => {
+    const dataDir = await createDataDir();
+    const recordsDir = path.join(dataDir, "records");
+    const shardPath = path.join(recordsDir, "2026-07-31.jsonl");
+    await fs.mkdir(recordsDir, { recursive: true });
+    await fs.writeFile(
+      shardPath,
+      '{"id":"1"}\n{"id":"2"}\n{"id":"3"}\n',
+      "utf-8",
+    );
+
+    await expect(countL1JsonlRecords(dataDir)).resolves.toBe(3);
+
+    await fs.writeFile(shardPath, '{"id":"1"}\n', "utf-8");
+
+    await expect(countL1JsonlRecords(dataDir)).resolves.toBe(1);
+  });
+
+  it("returns zero when the records directory does not exist", async () => {
+    const dataDir = await createDataDir();
+
+    await expect(countL1JsonlRecords(dataDir)).resolves.toBe(0);
+  });
+
+  it("counts records through the configured storage adapter", async () => {
+    const dataDir = await createDataDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+
+    await storage.writeFile(
+      "records/2026-07-31.jsonl",
+      '{"id":"1"}\n{"id":"2"}\n',
+    );
+
+    // Deliberately pass an unrelated baseDir: when storage is configured it
+    // must be the source of truth for both local-adapter and COS deployments.
+    await expect(
+      countL1JsonlRecords(path.join(dataDir, "unused"), undefined, storage),
+    ).resolves.toBe(2);
+  });
+});

--- a/src/core/record/l1-reader.ts
+++ b/src/core/record/l1-reader.ts
@@ -92,6 +92,68 @@ function rowToMemoryRecord(row: L1RecordRow): MemoryRecord {
 // ============================
 
 /**
+ * Count valid L1 records across all daily JSONL shards.
+ *
+ * The JSONL files are the source of truth for the checkpoint's
+ * `total_memories_extracted` counter. Empty and malformed lines are ignored.
+ * A missing records directory means no memories have been extracted yet;
+ * other I/O failures are propagated so startup recalibration cannot replace a
+ * valid checkpoint counter with a partial count.
+ */
+export async function countL1JsonlRecords(
+  baseDir: string,
+  logger?: Logger,
+  storage?: StorageAdapter,
+): Promise<number> {
+  let files: string[];
+
+  if (storage) {
+    files = await storage.readdirNames(StoragePaths.recordsDir, ".jsonl");
+  } else {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const recordsDir = path.default.join(baseDir, "records");
+
+    try {
+      files = (await fs.default.readdir(recordsDir)).filter((file) => file.endsWith(".jsonl"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+      throw err;
+    }
+  }
+
+  let count = 0;
+
+  for (const file of files) {
+    let raw: string | null;
+    if (storage) {
+      raw = await storage.readFile(`${StoragePaths.recordsDir}${file}`);
+    } else {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      raw = await fs.default.readFile(path.default.join(baseDir, "records", file), "utf-8");
+    }
+
+    if (!raw) continue;
+
+    const lines = raw.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+
+      try {
+        JSON.parse(line);
+        count += 1;
+      } catch {
+        logger?.warn?.(`${TAG} Skipping malformed JSONL line in ${file}:${i + 1}`);
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
  * Read all memory records for a session from JSONL files.
  *
  * Current naming mode:

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -50,6 +50,7 @@ import { MemoryPipelineManager } from "../utils/pipeline-manager.js";
 import { CheckpointManager } from "../utils/checkpoint.js";
 import { SessionFilter } from "../utils/session-filter.js";
 import { StandaloneLLMRunnerFactory } from "../adapters/standalone/llm-runner.js";
+import { countL1JsonlRecords } from "./record/l1-reader.js";
 
 const TAG = "[memory-tdai] [core]";
 
@@ -144,8 +145,10 @@ export class TdaiCore {
     this.logger.debug?.(`${TAG} Initializing TDAI Core: dataDir=${this.dataDir}`);
     initDataDirectories(this.dataDir);
 
-    // Initialize stores (async)
-    this.storeReady = this.initStores();
+    // Initialize stores, then reconcile checkpoint counters with actual data.
+    this.storeReady = this.initStores().then(async () => {
+      await this.recalibrateCheckpointCounters();
+    });
 
     // Create pipeline manager (sync — does not need store)
     if (this.cfg.extraction.enabled) {
@@ -161,6 +164,45 @@ export class TdaiCore {
     }
 
     this.logger.debug?.(`${TAG} TDAI Core initialized`);
+  }
+
+  /**
+   * Reconcile checkpoint counters with the actual persisted records.
+   *
+   * L0 is counted from the memory store and L1 from the JSONL shards. This
+   * repairs counters that drifted after cleanup or manual record pruning.
+   * Recalibration is best-effort and must not prevent core startup.
+   */
+  private async recalibrateCheckpointCounters(): Promise<void> {
+    const store = this.vectorStore;
+
+    if (!store) {
+      this.logger.debug?.(
+        `${TAG} Checkpoint counter recalibration skipped: memory store unavailable`,
+      );
+      return;
+    }
+
+    try {
+      const [actualL0Count, actualL1Count] = await Promise.all([
+        Promise.resolve(store.countL0()),
+        countL1JsonlRecords(this.dataDir, this.logger),
+      ]);
+
+      const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+      await checkpoint.recalibrateCounters(actualL0Count, actualL1Count);
+
+      this.logger.debug?.(
+        `${TAG} Checkpoint counters recalibrated: ` +
+          `l0=${actualL0Count}, l1=${actualL1Count}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} Checkpoint counter recalibration failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   /**

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CheckpointManager } from "./checkpoint.js";
+import { StorageAdapter } from "../core/storage/adapter.js";
+import { LocalStorageBackend } from "../core/storage/local-backend.js";
+
+describe("CheckpointManager.recalibrateCounters", () => {
+  const tempDirs: string[] = [];
+
+  async function createManager(): Promise<{
+    dataDir: string;
+    manager: CheckpointManager;
+  }> {
+    const dataDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "checkpoint-test-"),
+    );
+
+    tempDirs.push(dataDir);
+
+    return {
+      dataDir,
+      manager: new CheckpointManager(dataDir),
+    };
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) =>
+        fs.rm(dir, { recursive: true, force: true }),
+      ),
+    );
+  });
+
+  it("recalibrates counters downward without changing other fields", async () => {
+    const { manager } = await createManager();
+
+    const checkpoint = await manager.read();
+
+    await manager.write({
+      ...checkpoint,
+      total_processed: 100,
+      memories_since_last_persona: 7,
+      l0_conversations_count: 50,
+      total_memories_extracted: 42,
+      runner_states: {
+        "session-1": {
+          last_captured_timestamp: 123,
+          last_l1_cursor: 456,
+          last_scene_name: "test scene",
+        },
+      },
+    });
+
+    await manager.recalibrateCounters(40, 34);
+
+    const result = await manager.read();
+
+    expect(result.l0_conversations_count).toBe(40);
+    expect(result.total_memories_extracted).toBe(34);
+
+    expect(result.total_processed).toBe(100);
+    expect(result.memories_since_last_persona).toBe(7);
+    expect(result.runner_states["session-1"]).toEqual({
+      last_captured_timestamp: 123,
+      last_l1_cursor: 456,
+      last_scene_name: "test scene",
+    });
+  });
+
+  it("recalibrates counters upward", async () => {
+    const { manager } = await createManager();
+
+    await manager.recalibrateCounters(10, 8);
+    await manager.recalibrateCounters(15, 12);
+
+    const result = await manager.read();
+
+    expect(result.l0_conversations_count).toBe(15);
+    expect(result.total_memories_extracted).toBe(12);
+  });
+
+  it("allows counters to be recalibrated to zero", async () => {
+    const { manager } = await createManager();
+
+    await manager.recalibrateCounters(10, 8);
+    await manager.recalibrateCounters(0, 0);
+
+    const result = await manager.read();
+
+    expect(result.l0_conversations_count).toBe(0);
+    expect(result.total_memories_extracted).toBe(0);
+  });
+
+  it("rejects invalid counter values", async () => {
+    const { manager } = await createManager();
+
+    await expect(
+      manager.recalibrateCounters(-1, 10),
+    ).rejects.toThrow("Invalid checkpoint counters");
+
+    await expect(
+      manager.recalibrateCounters(10, Number.NaN),
+    ).rejects.toThrow("Invalid checkpoint counters");
+  });
+
+  it("recalibrates the checkpoint selected by a storage adapter", async () => {
+    const dataDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "checkpoint-storage-test-"),
+    );
+    tempDirs.push(dataDir);
+
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    const manager = new CheckpointManager(
+      path.join(dataDir, "unused-local-path"),
+      undefined,
+      storage,
+    );
+
+    await manager.recalibrateCounters(6, 4);
+
+    const result = await manager.read();
+    expect(result.l0_conversations_count).toBe(6);
+    expect(result.total_memories_extracted).toBe(4);
+    await expect(
+      fs.readFile(path.join(dataDir, ".metadata", "checkpoint.json"), "utf-8"),
+    ).resolves.toContain('"total_memories_extracted": 4');
+  });
+});

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -293,6 +293,48 @@ export class CheckpointManager {
     return withFileLock(this.filePath, () => this.writeRaw(checkpoint));
   }
 
+  /**
+   * Recalibrate aggregate counters from the current persisted data.
+   *
+   * Used during startup to repair counters that may have drifted after
+   * memory cleanup or manual data removal.
+   */
+  async recalibrateCounters(
+    actualL0Count: number,
+    actualL1Count: number,
+  ): Promise<void> {
+    if (
+      !Number.isFinite(actualL0Count) ||
+      !Number.isFinite(actualL1Count) ||
+      actualL0Count < 0 ||
+      actualL1Count < 0
+    ) {
+      throw new Error(
+        `Invalid checkpoint counters: l0=${actualL0Count}, l1=${actualL1Count}`,
+      );
+    }
+
+    const l0Count = Math.floor(actualL0Count);
+    const l1Count = Math.floor(actualL1Count);
+
+    let previousL0Count = 0;
+    let previousL1Count = 0;
+
+    await this.mutate((cp) => {
+      previousL0Count = cp.l0_conversations_count;
+      previousL1Count = cp.total_memories_extracted;
+
+      cp.l0_conversations_count = l0Count;
+      cp.total_memories_extracted = l1Count;
+    });
+
+    this.logger.info(
+      `[checkpoint] Counters recalibrated: ` +
+        `l0_conversations_count=${previousL0Count}->${l0Count}, ` +
+        `total_memories_extracted=${previousL1Count}->${l1Count}`,
+    );
+  }
+
   // ============================
   // Public API — mutating (all serialized via file lock)
   // ============================


### PR DESCRIPTION
<h2>♻️ Summary</h2>

<p>
Fixes checkpoint counter drift after persisted L0/L1 memory data is cleaned up
or manually removed.
</p>

<p>
The key principle of this change is:
</p>

<blockquote>
  <p>
    <strong>
      Checkpoint counters are derived state; persisted memory data remains the
      source of truth.
    </strong>
  </p>
</blockquote>

<p>
Previously, <code>l0_conversations_count</code> and
<code>total_memories_extracted</code> only increased. After deleting persisted
records, the checkpoint could permanently report stale values.
</p>

<pre><code class="language-text">Checkpoint count: 50
Persisted records: 42
Before:            50  ❌
After startup:     42  ✅
</code></pre>

<hr>

<h2>🛠️ Changes</h2>

<h3>1. Recount persisted L1 records</h3>

<p>
Added <code>countL1JsonlRecords()</code> to count valid records across
<code>records/*.jsonl</code>.
</p>

<ul>
  <li>Supports multiple JSONL shards.</li>
  <li>Supports LF and CRLF line endings.</li>
  <li>Ignores blank lines.</li>
  <li>Skips malformed JSON with a warning.</li>
  <li>Returns zero when the records directory does not exist.</li>
  <li>Supports local and <code>StorageAdapter</code>-backed storage.</li>
  <li>Propagates unexpected I/O failures to avoid writing a partial count.</li>
</ul>

<h3>2. Recalibrate checkpoint counters</h3>

<p>
Added <code>CheckpointManager.recalibrateCounters()</code> to atomically replace
the two drifted counters:
</p>

<pre><code class="language-typescript">cp.l0_conversations_count = actualL0Count;
cp.total_memories_extracted = actualL1Count;
</code></pre>

<p>
The method supports downward, upward, and zero-value corrections while
preserving all unrelated checkpoint and pipeline state.
</p>

<h3>3. Reconcile during startup</h3>

<p>
After the memory store is initialized, <code>TdaiCore</code> now:
</p>

<ol>
  <li>counts persisted L0 conversations with <code>store.countL0()</code>;</li>
  <li>counts persisted L1 JSONL records;</li>
  <li>atomically updates the checkpoint counters.</li>
</ol>

<p>
Recalibration is best-effort: failures are logged, while core startup continues
with the existing checkpoint unchanged.
</p>

<hr>

<h2>🛡️ Safety</h2>

<p>
Only these fields are modified:
</p>

<ul>
  <li><code>l0_conversations_count</code></li>
  <li><code>total_memories_extracted</code></li>
</ul>

<p>
Runner states, cursors, processing progress, scene state, and persona state are
preserved.
</p>

<hr>

<h2>🧪 Test Coverage</h2>

<ul>
  <li>multiple JSONL shards;</li>
  <li>blank and malformed lines;</li>
  <li>LF and CRLF line endings;</li>
  <li>manual JSONL pruning;</li>
  <li>missing records directory;</li>
  <li>local and <code>StorageAdapter</code>-backed storage;</li>
  <li>downward, upward, and zero-value recalibration;</li>
  <li>invalid counter values;</li>
  <li>preservation of unrelated checkpoint fields.</li>
</ul>

<details>
  <summary><strong>ℹ️ Local validation note</strong></summary>

  <p>
    The current upstream <code>package.json</code> and
    <code>package-lock.json</code> are not synchronized, so
    <code>npm ci</code> stops before test execution with missing lockfile
    entries.
  </p>

  <p>
    This PR intentionally does not modify dependency files because that issue is
    unrelated to checkpoint recalibration.
  </p>
</details>

<hr>

<p><strong>Fixes #157</strong></p>
Fixes TencentCloud/TencentDB-Agent-Memory#157