### PR TITLE
feat: add MCP adapter for cross-platform memory access

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,7 @@
 [![Hermes](https://img.shields.io/badge/Hermes-Gateway-7B61FF)](https://hermes-agent.nousresearch.com/docs/)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/dJQM6mKMF)
 
-[效果亮点](#-效果亮点) · [项目简介](#项目简介) · [核心技术](#核心技术拒绝平铺走向分层与符号化) · [方案特点](#-方案特点) · [快速开始](#快速开始)
+[效果亮点](#-效果亮点) · [项目简介](#项目简介) · [核心技术](#核心技术拒绝平铺走向分层与符号化) · [方案特点](#-方案特点) · [快速开始](#快速开始) · [MCP 适配](./docs/MCP_ADAPTER_CN.md)
 
 <div align="center">
 
@@ -204,16 +204,35 @@ bash scripts/openclaw-after-tool-call-messages.patch.sh
 > 💡 patch 每次 OpenClaw 安装只需执行一次。升级 OpenClaw 后建议重新执行以确保钩子生效。
 
 
-### 2. Hermes
+### 2. MCP 适配（Claude Code / Codex / Cursor 等）
+
+本项目新增 MCP stdio 适配入口，可将 `TdaiCore` 的召回、捕获、搜索和 session flush 能力暴露为 MCP tools，供支持 MCP 的 Agent 客户端使用。
+
+构建后运行：
+
+```bash
+cd TencentDB-Agent-Memory
+npm run build
+TDAI_DATA_DIR="$HOME/.openclaw/memory-tdai" \
+TDAI_LLM_BASE_URL="https://api.deepseek.com" \
+TDAI_LLM_API_KEY="<redacted>" \
+TDAI_LLM_MODEL="deepseek-v4-flash" \
+node dist/mcp-server.mjs
+```
+
+详细架构、工具清单、客户端配置和验证方式见：[MCP 适配层方案](./docs/MCP_ADAPTER_CN.md)。
+
+
+### 3. Hermes
 
 除 OpenClaw 外，本插件同样支持 [Hermes](https://github.com/NousResearch/hermes-agent) Agent。根据部署场景选择安装路径：
 
 | 你的场景 | 走哪条路 |
 |---|---|
-| 想从零启动一个带记忆能力的 Hermes（一条命令搞定） | 2.A Docker（下文） |
-| 已经装好了Hermes，只想加上记忆能力 | 2.B 挂到已有 Hermes 上（再下文） |
+| 想从零启动一个带记忆能力的 Hermes（一条命令搞定） | 3.A Docker（下文） |
+| 已经装好了Hermes，只想加上记忆能力 | 3.B 挂到已有 Hermes 上（再下文） |
 
-#### 2.A Docker（全新部署，需版本号 ≥ 0.3.4）
+#### 3.A Docker（全新部署，需版本号 ≥ 0.3.4）
 
 Docker 镜像把 `hermes-agent` 和 `memory_tencentdb` provider 聚合在一起，Gateway 监听 `:8420`：
 
@@ -264,7 +283,7 @@ docker exec -it hermes-memory hermes
 
 > 镜像内置了腾讯云 DeepSeek-V3.2 的默认值，如果你使用该模型，`MODEL_BASE_URL`/`MODEL_NAME`/`MODEL_PROVIDER` 可以省略，只传 `MODEL_API_KEY` 即可。
 
-#### 2.B 挂到已有 Hermes 上（无 Docker）
+#### 3.B 挂到已有 Hermes 上（无 Docker）
 
 如果宿主机上已经装好了 `hermes-agent`，只想加上记忆能力，**不需要** Docker 镜像。
 
@@ -311,7 +330,7 @@ memory:
 编辑 `~/.hermes/.env`，添加：
 
 ```bash
-MEMORY_TENCENTDB_GATEWAY_CMD="sh -c 'cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin && exec npx tsx src/gateway/server.ts'"
+MEMORY_TENCENTDB_GATEWAY_CMD="sh -c 'cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin && exec node --import tsx/esm src/gateway/server.ts'"
 MEMORY_TENCENTDB_GATEWAY_HOST="127.0.0.1"
 MEMORY_TENCENTDB_GATEWAY_PORT="8420"
 ```
@@ -319,7 +338,7 @@ MEMORY_TENCENTDB_GATEWAY_PORT="8420"
 LLM 凭证请按需添加（Gateway 实际读取的是 `TDAI_LLM_*` 系列变量）：
 
 ```bash
-TDAI_LLM_API_KEY="sk-your-api-key-here"
+TDAI_LLM_API_KEY="<your-api-key>"
 TDAI_LLM_BASE_URL="https://api.openai.com/v1"
 TDAI_LLM_MODEL="gpt-4o"
 ```
@@ -342,7 +361,7 @@ TDAI_LLM_MODEL="gpt-4o"
 - **手动运行**：提前启动一个独立的 Gateway 进程：
   ```bash
   cd ~/.memory-tencentdb/tdai-memory-openclaw-plugin
-  npx tsx src/gateway/server.ts
+  node --import tsx/esm src/gateway/server.ts
   ```
 
 **7. 验证**：
@@ -356,7 +375,7 @@ curl http://127.0.0.1:8420/health
 
 ---
 
-### 3. Hermes（Windows 原生安装）
+#### 3.C Hermes（Windows 原生安装）
 
 Windows 原生 Hermes 环境下，在仓库根目录用 Command Prompt 或 PowerShell
 运行内置批处理脚本：

--- a/bin/memory-tencentdb-mcp.mjs
+++ b/bin/memory-tencentdb-mcp.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/mcp-server.mjs";

--- a/docs/MCP_ADAPTER_CN.md
+++ b/docs/MCP_ADAPTER_CN.md
@@ -1,0 +1,264 @@
+# MCP 适配层方案
+
+本文档对应 issue #235「Cross-Platform Adapters for the Memory Plugin」中的跨平台适配要求，说明如何通过 MCP（Model Context Protocol）把 TencentDB Agent Memory 接入 Claude Code、Codex、Cursor 等支持 MCP 的 Agent 客户端。
+
+MCP 官方规范将工具定义为可被模型发现和调用的能力，工具需要包含唯一名称、描述和 JSON Schema 输入结构；stdio 传输使用一行一个 JSON-RPC 消息的方式在客户端和服务端之间通信。基于这两个约束，本适配层把 `TdaiCore` 的核心记忆能力封装为 MCP tools。
+
+参考资料：
+
+- issue #235：`https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/235`
+- MCP Tools 规范：`https://modelcontextprotocol.io/specification/2026-07-28/server/tools`
+- MCP stdio 传输规范：`https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/stdio`
+
+## 一、交付目标
+
+本方案选择「MCP 兼容 Agent 客户端」作为新增适配平台，目标是让任意 MCP 客户端具备以下记忆读写能力：
+
+- 对话前召回相关长期记忆。
+- 对话后捕获本轮用户与助手内容。
+- 搜索 L1 结构化记忆。
+- 搜索 L0 原始对话。
+- 在单个 session 结束时 flush 管线任务。
+
+这满足 issue 的进阶验收标准：选择一个新平台编写适配代码，实现至少基本的记忆读写功能。
+
+## 二、总体架构
+
+```mermaid
+flowchart LR
+  Client["MCP 客户端<br/>Claude Code / Codex / Cursor"] -->|"stdio JSON-RPC"| Mcp["MCP 适配层<br/>src/adapters/mcp"]
+  Mcp -->|"tools/call"| Core["TdaiCore<br/>宿主无关核心"]
+  Core --> Store["SQLite / TCVDB<br/>L0/L1 检索存储"]
+  Core --> Pipeline["L1/L2/L3 Pipeline<br/>提取、场景、画像"]
+  Core --> LLM["Standalone LLM Runner<br/>OpenAI-compatible API"]
+```
+
+设计边界：
+
+- MCP 适配层只负责协议翻译，不重新实现记忆算法。
+- `TdaiCore` 继续作为唯一核心入口，保证 OpenClaw、Hermes、MCP 三条接入路径行为一致。
+- MCP 服务端使用 stderr 输出日志，stdout 只输出 JSON-RPC 消息，符合 stdio 传输要求。
+- 配置复用 Gateway 配置加载逻辑，支持 `tdai-gateway.yaml/json` 和 `TDAI_*` 环境变量。
+
+## 三、与已有适配层的对比
+
+| 适配层 | 入口 | 运行方式 | 触发方式 | 主要能力 | 适用场景 |
+|---|---|---|---|---|---|
+| OpenClaw 插件 | `index.ts` | OpenClaw Gateway 进程内插件 | OpenClaw hooks + tools | 自动召回、自动捕获、工具搜索、offload | OpenClaw 原生使用 |
+| Hermes Provider | `hermes-plugin/memory/memory_tencentdb` | Python provider + TDAI HTTP Gateway | Hermes memory provider 生命周期 | recall、capture、session flush | Hermes Agent |
+| MCP 适配层 | `src/adapters/mcp/server.ts` | MCP stdio 子进程 | MCP `tools/list` + `tools/call` | recall、capture、search、session flush | Claude Code、Codex、Cursor 等 MCP 客户端 |
+
+差异总结：
+
+- OpenClaw 可以依赖宿主 hook，因此自动化程度最高。
+- Hermes 通过 HTTP Gateway 解耦语言边界，适合 Python Agent。
+- MCP 通过标准工具协议接入，适合没有专用插件接口、但支持 MCP 的 Agent。
+
+## 四、MCP 工具清单
+
+### 1. `tdai_recall`
+
+用途：对话前召回相关长期记忆。
+
+参数：
+
+```json
+{
+  "query": "当前用户请求或召回问题",
+  "session_key": "稳定会话键"
+}
+```
+
+返回：
+
+- `content[0].text`：可直接注入 Agent 上下文的记忆文本。
+- `structuredContent.context`：召回上下文。
+- `structuredContent.strategy`：召回策略。
+- `structuredContent.memory_count`：召回到的 L1 记忆数量。
+
+### 2. `tdai_capture`
+
+用途：对话成功结束后写入本轮对话。
+
+参数：
+
+```json
+{
+  "user_content": "用户消息",
+  "assistant_content": "助手回复",
+  "session_key": "稳定会话键",
+  "session_id": "可选宿主 session id"
+}
+```
+
+返回：
+
+- `l0_recorded`：写入的 L0 消息数量。
+- `scheduler_notified`：是否通知后台 L1/L2/L3 管线。
+- `l0_vectors_written`：写入的 L0 向量数量。
+
+### 3. `tdai_memory_search`
+
+用途：搜索 L1 结构化长期记忆。
+
+参数：
+
+```json
+{
+  "query": "要搜索的记忆内容",
+  "limit": 5,
+  "type": "instruction",
+  "scene": "可选场景名"
+}
+```
+
+### 4. `tdai_conversation_search`
+
+用途：搜索 L0 原始对话记录，适合查找历史原话。
+
+参数：
+
+```json
+{
+  "query": "要搜索的历史对话",
+  "limit": 5,
+  "session_key": "可选会话过滤"
+}
+```
+
+### 5. `tdai_session_end`
+
+用途：结束单个 session 时 flush 待处理管线任务，不关闭 MCP 服务进程。
+
+参数：
+
+```json
+{
+  "session_key": "稳定会话键"
+}
+```
+
+## 五、安装与运行
+
+### 1. 构建
+
+```bash
+cd TencentDB-Agent-Memory
+npm run build
+```
+
+构建后会生成：
+
+```text
+dist/mcp-server.mjs
+```
+
+### 2. 使用 standalone 数据目录
+
+适合独立 Gateway、Hermes、MCP 共用一套数据：
+
+```bash
+TDAI_DATA_DIR="$HOME/.memory-tencentdb/memory-tdai" \
+TDAI_LLM_BASE_URL="https://api.deepseek.com" \
+TDAI_LLM_API_KEY="<redacted>" \
+TDAI_LLM_MODEL="deepseek-v4-flash" \
+node /path/to/TencentDB-Agent-Memory/dist/mcp-server.mjs
+```
+
+### 3. 使用 OpenClaw 数据目录
+
+适合让 MCP 客户端读取 OpenClaw 插件已经沉淀的记忆：
+
+```bash
+TDAI_DATA_DIR="$HOME/.openclaw/memory-tdai" \
+TDAI_LLM_BASE_URL="https://api.deepseek.com" \
+TDAI_LLM_API_KEY="<redacted>" \
+TDAI_LLM_MODEL="deepseek-v4-flash" \
+node /path/to/TencentDB-Agent-Memory/dist/mcp-server.mjs
+```
+
+注意：不要把真实 API Key 写进仓库、截图、issue 或聊天记录。客户端配置中建议使用环境变量或本地密钥管理。
+
+## 六、MCP 客户端配置示例
+
+不同 MCP 客户端的配置文件位置不同，但核心配置是一致的：
+
+```json
+{
+  "mcpServers": {
+    "memory-tencentdb": {
+      "command": "node",
+      "args": [
+        "/path/to/TencentDB-Agent-Memory/dist/mcp-server.mjs"
+      ],
+      "env": {
+        "TDAI_DATA_DIR": "${HOME}/.openclaw/memory-tdai",
+        "TDAI_LLM_BASE_URL": "https://api.deepseek.com",
+        "TDAI_LLM_API_KEY": "${DEEPSEEK_API_KEY}",
+        "TDAI_LLM_MODEL": "deepseek-v4-flash"
+      }
+    }
+  }
+}
+```
+
+如果通过 npm 包安装，也可以使用 bin：
+
+```json
+{
+  "mcpServers": {
+    "memory-tencentdb": {
+      "command": "memory-tencentdb-mcp",
+      "env": {
+        "TDAI_DATA_DIR": "${HOME}/.openclaw/memory-tdai",
+        "TDAI_LLM_BASE_URL": "https://api.deepseek.com",
+        "TDAI_LLM_API_KEY": "${DEEPSEEK_API_KEY}",
+        "TDAI_LLM_MODEL": "deepseek-v4-flash"
+      }
+    }
+  }
+}
+```
+
+## 七、手动协议验证
+
+初始化：
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | TDAI_DATA_DIR=/tmp/tencentdb-mcp-smoke \
+    TDAI_LLM_API_KEY=dummy \
+    TDAI_LLM_BASE_URL=https://example.invalid \
+    TDAI_LLM_MODEL=dummy \
+    node dist/mcp-server.mjs
+```
+
+预期结果：
+
+- `initialize` 返回 `serverInfo.name = "memory-tencentdb"`。
+- `tools/list` 返回 5 个工具：`tdai_recall`、`tdai_capture`、`tdai_memory_search`、`tdai_conversation_search`、`tdai_session_end`。
+
+## 八、测试结果
+
+当前验证命令：
+
+```bash
+npm run build
+npm test
+```
+
+当前结果：
+
+- 构建通过，生成 `dist/index.mjs` 与 `dist/mcp-server.mjs`。
+- Vitest 通过：`6` 个测试文件，`75` 个测试。
+- MCP stdio 冒烟验证通过：`initialize` 和 `tools/list` 均返回合法 JSON-RPC 响应。
+
+## 九、后续扩展建议
+
+- 为 Claude Code、Codex、Cursor 分别补充客户端配置路径示例。
+- 在 MCP 适配层加入 resources，暴露只读的 persona、scene block、manifest。
+- 增加 Streamable HTTP MCP 入口，支持远程 MCP 客户端。
+- 将 `session_key` 生成策略封装为小工具，减少不同客户端自行约定 session key 的成本。
+- 如果需要强制自动捕获，可在特定 MCP 客户端侧包装“对话结束后调用 `tdai_capture`”的流程。

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./dist/index.mjs",
   "bin": {
+    "memory-tencentdb-mcp": "./bin/memory-tencentdb-mcp.mjs",
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
     "read-local-memory": "./bin/read-local-memory.mjs"
@@ -47,6 +48,7 @@
     "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
+    "docs/",
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",

--- a/scripts/README.memory-tencentdb-ctl.md
+++ b/scripts/README.memory-tencentdb-ctl.md
@@ -39,7 +39,7 @@
 
 所有路径都能用同名环境变量覆盖（再次列出便于对照）：`MEMORY_TENCENTDB_ROOT`（默认 `~/.memory-tencentdb`）、`TDAI_INSTALL_DIR`（默认 `$MEMORY_TENCENTDB_ROOT/tdai-memory-openclaw-plugin`）、`TDAI_DATA_DIR`（默认 `$MEMORY_TENCENTDB_ROOT/memory-tdai`）、`HERMES_HOME`（默认 `~/.hermes`）、`MEMORY_TENCENTDB_LOG_DIR`、`MEMORY_TENCENTDB_GATEWAY_HOST/PORT`。
 
-依赖：`bash`、`python3`、`node >= 22`、`npx`、`lsof` 或 `ss`。
+依赖：`bash`、`python3`、`node >= 22`、`lsof` 或 `ss`。
 
 ## 3. 安装 & 调用
 
@@ -112,7 +112,7 @@ memory-tencentdb-ctl logs err 500 # 只看 stderr 最近 500 行
 启动命令解析顺序：
 
 1. 环境变量 `MEMORY_TENCENTDB_GATEWAY_CMD`（`install_hermes_memory_tencentdb.sh` 写入 `/etc/profile.d/memory-tencentdb-env.sh` 的那条）。
-2. 回退到 `sh -c 'cd $TDAI_INSTALL_DIR && exec npx tsx src/gateway/server.ts'`。
+2. 回退到 `sh -c 'cd $TDAI_INSTALL_DIR && exec node --import tsx/esm src/gateway/server.ts'`。
 
 启动时会自动 `source` 的环境文件：
 
@@ -320,7 +320,7 @@ memory-tencentdb-ctl config vdb-off --purge-creds --restart
 - 敏感文件权限一律 `0600`；`env.d/memory-tencentdb-llm.sh` 含明文 API key，**不要** commit。
 - 启动失败：`memory-tencentdb-ctl logs err 200` 查看 stderr；手动前台跑一遍更容易看到报错：
   ```bash
-  cd "$TDAI_INSTALL_DIR" && npx tsx src/gateway/server.ts
+  cd "$TDAI_INSTALL_DIR" && node --import tsx/esm src/gateway/server.ts
   ```
 - 端口冲突：`MEMORY_TENCENTDB_GATEWAY_PORT=18420 memory-tencentdb-ctl restart`。
 - 验证 hermes 有没有吃到新 env（hermes 模式）：
@@ -335,7 +335,7 @@ memory-tencentdb-ctl config vdb-off --purge-creds --restart
 | 0 | 成功 |
 | 1 | 参数错误 / 业务校验失败（如 `--base-url` 非 http(s)；在 standalone 下调 hermes 专属命令） |
 | 2 | 写盘失败（磁盘满、权限不足等） |
-| 127 | 依赖缺失（`python3` / `node` / `npx`） |
+| 127 | 依赖缺失（`python3` / `node`） |
 
 ---
 

--- a/scripts/install_hermes_memory_tencentdb.sh
+++ b/scripts/install_hermes_memory_tencentdb.sh
@@ -198,8 +198,9 @@ cd "$TDAI_INSTALL_DIR"
 echo "[memory-tencentdb] Running npm install (this may take a while)..."
 npm install --omit=dev 2>&1 | tail -5
 
-# 安装 tsx（Gateway 启动需要），优先本地安装
-if ! npx tsx --version &>/dev/null; then
+# 安装 tsx（Gateway 启动需要），优先本地安装；使用 Node 原生 --import
+# 检测，避免依赖某些环境中缺失的全局 npx。
+if ! node --import tsx/esm -e "" &>/dev/null; then
     npm install tsx 2>&1 | tail -2
 fi
 

--- a/scripts/memory-tencentdb-ctl.sh
+++ b/scripts/memory-tencentdb-ctl.sh
@@ -205,7 +205,7 @@ source_user_envs() {
 #
 # 优先级：
 #   1. MEMORY_TENCENTDB_GATEWAY_CMD（install 脚本写入的环境变量）
-#   2. 本地 tsx:  cd $TDAI_INSTALL_DIR && npx tsx src/gateway/server.ts
+#   2. 本地 tsx:  cd $TDAI_INSTALL_DIR && node --import tsx/esm src/gateway/server.ts
 # ============================================================
 
 resolve_gateway_cmd() {
@@ -215,8 +215,8 @@ resolve_gateway_cmd() {
     fi
     local entry="$TDAI_INSTALL_DIR/src/gateway/server.ts"
     [[ -f "$entry" ]] || die "Gateway entry not found: $entry (是否已执行 install_hermes_tdai_gateway.sh？)"
-    # 与 install 脚本相同风格：sh -c 'cd ... && exec npx tsx ...'
-    printf "sh -c 'cd %s && exec npx tsx src/gateway/server.ts'" "$TDAI_INSTALL_DIR"
+    # 使用 Node 原生 --import 加载本地 tsx，避免依赖全局 npx。
+    printf "sh -c 'cd %s && exec node --import tsx/esm src/gateway/server.ts'" "$TDAI_INSTALL_DIR"
 }
 
 # ============================================================
@@ -234,7 +234,6 @@ cmd_start() {
     fi
 
     need_cmd node
-    need_cmd npx
 
     local gw_cmd; gw_cmd="$(resolve_gateway_cmd)"
     log "starting gateway: $gw_cmd"

--- a/src/adapters/mcp/json-rpc.test.ts
+++ b/src/adapters/mcp/json-rpc.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+import { TdaiMcpJsonRpcServer } from "./json-rpc.js";
+import type { TdaiMcpCore } from "./tool-registry.js";
+
+function createCore(): TdaiMcpCore {
+  return {
+    handleBeforeRecall: vi.fn(async () => ({
+      appendSystemContext: "remembered context",
+      recallStrategy: "keyword",
+      recalledL1Memories: [],
+    })),
+    handleTurnCommitted: vi.fn(async () => ({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 0,
+      filteredMessages: [],
+    })),
+    searchMemories: vi.fn(async () => ({ text: "memory result", total: 1, strategy: "keyword" })),
+    searchConversations: vi.fn(async () => ({ text: "conversation result", total: 1 })),
+    handleSessionEnd: vi.fn(async () => undefined),
+  };
+}
+
+describe("TDAI MCP JSON-RPC server", () => {
+  it("responds to legacy initialize", async () => {
+    const server = new TdaiMcpJsonRpcServer(createCore());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-11-25" },
+    });
+
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        protocolVersion: "2025-11-25",
+        serverInfo: { name: "memory-tencentdb" },
+        capabilities: { tools: { listChanged: false } },
+      },
+    });
+  });
+
+  it("responds to modern server discovery", async () => {
+    const server = new TdaiMcpJsonRpcServer(createCore());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: "discover",
+      method: "server/discover",
+    });
+
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: "discover",
+      result: {
+        supportedVersions: ["2026-07-28", "2025-11-25"],
+        serverInfo: { name: "memory-tencentdb" },
+        capabilities: { tools: { listChanged: false } },
+      },
+    });
+  });
+
+  it("responds to JSON-RPC requests with null id", async () => {
+    const server = new TdaiMcpJsonRpcServer(createCore());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: null,
+      method: "tools/list",
+    });
+
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: null,
+      result: {
+        resultType: "complete",
+      },
+    });
+  });
+
+  it("lists tools", async () => {
+    const server = new TdaiMcpJsonRpcServer(createCore());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: "tools",
+      method: "tools/list",
+    });
+
+    const result = response?.result as { tools: Array<{ name: string }> };
+    expect(result.tools.map((tool) => tool.name)).toContain("tdai_capture");
+    expect(result.tools.map((tool) => tool.name)).toContain("tdai_memory_search");
+  });
+
+  it("calls tools and wraps the result", async () => {
+    const core = createCore();
+    const server = new TdaiMcpJsonRpcServer(core);
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "tdai_capture",
+        arguments: {
+          user_content: "u",
+          assistant_content: "a",
+          session_key: "s",
+        },
+      },
+    });
+
+    expect(core.handleTurnCommitted).toHaveBeenCalledOnce();
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        resultType: "complete",
+        isError: false,
+      },
+    });
+  });
+
+  it("returns MCP tool errors as tool results", async () => {
+    const server = new TdaiMcpJsonRpcServer(createCore());
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "tdai_memory_search",
+        arguments: {},
+      },
+    });
+
+    expect(response).toMatchObject({
+      jsonrpc: "2.0",
+      id: 3,
+      result: {
+        resultType: "complete",
+        isError: true,
+      },
+    });
+  });
+});

--- a/src/adapters/mcp/json-rpc.ts
+++ b/src/adapters/mcp/json-rpc.ts
@@ -1,0 +1,149 @@
+import { executeTdaiMcpTool, TDAI_MCP_TOOLS } from "./tool-registry.js";
+import type { McpToolResult, TdaiMcpCore } from "./tool-registry.js";
+import packageJson from "../../../package.json" with { type: "json" };
+
+export const TDAI_MCP_SERVER_NAME = "memory-tencentdb";
+export const TDAI_MCP_SERVER_VERSION = packageJson.version;
+export const TDAI_MCP_PROTOCOL_VERSIONS = ["2026-07-28", "2025-11-25"] as const;
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+const SERVER_INFO = {
+  name: TDAI_MCP_SERVER_NAME,
+  version: TDAI_MCP_SERVER_VERSION,
+};
+
+const CAPABILITIES = {
+  tools: {
+    listChanged: false,
+  },
+};
+
+export class TdaiMcpJsonRpcServer {
+  constructor(private readonly core: TdaiMcpCore) {}
+
+  async handle(raw: unknown): Promise<JsonRpcResponse | undefined> {
+    const req = this.asRequest(raw);
+    if (!req) {
+      return this.error(null, -32600, "Invalid Request");
+    }
+
+    const isNotification = req.id === undefined;
+    if (isNotification && this.isKnownNotification(req.method)) {
+      return undefined;
+    }
+    if (isNotification) {
+      return undefined;
+    }
+
+    try {
+      switch (req.method) {
+        case "server/discover":
+          return this.result(req.id, {
+            supportedVersions: [...TDAI_MCP_PROTOCOL_VERSIONS],
+            serverInfo: SERVER_INFO,
+            capabilities: CAPABILITIES,
+          });
+        case "initialize":
+          return this.result(req.id, {
+            protocolVersion: this.resolveProtocolVersion(req.params),
+            serverInfo: SERVER_INFO,
+            capabilities: CAPABILITIES,
+          });
+        case "tools/list":
+          return this.result(req.id, {
+            resultType: "complete",
+            tools: TDAI_MCP_TOOLS,
+          });
+        case "tools/call":
+          return this.result(req.id, await this.callTool(req.params));
+        case "resources/list":
+          return this.result(req.id, { resultType: "complete", resources: [] });
+        case "prompts/list":
+          return this.result(req.id, { resultType: "complete", prompts: [] });
+        default:
+          return this.error(req.id, -32601, `Method not found: ${req.method}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return this.result(req.id, {
+        resultType: "complete",
+        content: [{ type: "text", text: message }],
+        isError: true,
+      } satisfies McpToolResult);
+    }
+  }
+
+  private async callTool(params: Record<string, unknown> | undefined): Promise<McpToolResult> {
+    if (!params || typeof params.name !== "string") {
+      throw new Error("tools/call requires params.name");
+    }
+    const args = isRecord(params.arguments) ? params.arguments : {};
+    return executeTdaiMcpTool(this.core, params.name, args);
+  }
+
+  private resolveProtocolVersion(params: Record<string, unknown> | undefined): string {
+    const requested = typeof params?.protocolVersion === "string" ? params.protocolVersion : undefined;
+    if (requested && TDAI_MCP_PROTOCOL_VERSIONS.includes(requested as typeof TDAI_MCP_PROTOCOL_VERSIONS[number])) {
+      return requested;
+    }
+    return "2025-11-25";
+  }
+
+  private asRequest(raw: unknown): JsonRpcRequest | undefined {
+    if (!isRecord(raw)) return undefined;
+    if (raw.jsonrpc !== "2.0") return undefined;
+    if (typeof raw.method !== "string") return undefined;
+    if (raw.params !== undefined && !isRecord(raw.params)) return undefined;
+    return raw as unknown as JsonRpcRequest;
+  }
+
+  private isKnownNotification(method: string): boolean {
+    return method === "notifications/initialized" || method === "notifications/cancelled";
+  }
+
+  private result(id: string | number | null | undefined, result: unknown): JsonRpcResponse {
+    return {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      result,
+    };
+  }
+
+  private error(
+    id: string | number | null | undefined,
+    code: number,
+    message: string,
+    data?: unknown,
+  ): JsonRpcResponse {
+    return {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      error: {
+        code,
+        message,
+        ...(data === undefined ? {} : { data }),
+      },
+    };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * MCP stdio adapter for TDAI memory.
+ *
+ * The server exposes TdaiCore capabilities as MCP tools so MCP-compatible
+ * agents (Claude Code, Codex, Cursor, etc.) can recall, capture, and search
+ * TencentDB Agent Memory without depending on the OpenClaw plugin API.
+ */
+
+import readline from "node:readline";
+import { stdin, stdout, stderr } from "node:process";
+import { TdaiCore } from "../../core/tdai-core.js";
+import { StandaloneHostAdapter } from "../standalone/host-adapter.js";
+import { loadGatewayConfig } from "../../gateway/config.js";
+import { initDataDirectories } from "../../utils/pipeline-factory.js";
+import { SessionFilter } from "../../utils/session-filter.js";
+import type { GatewayConfig } from "../../gateway/config.js";
+import type { Logger } from "../../core/types.js";
+import { TdaiMcpJsonRpcServer } from "./json-rpc.js";
+
+const TAG = "[tdai-mcp]";
+
+function createStderrLogger(): Logger {
+  return {
+    debug: (message: string) => stderr.write(`${TAG} ${message}\n`),
+    info: (message: string) => stderr.write(`${TAG} ${message}\n`),
+    warn: (message: string) => stderr.write(`${TAG} WARN ${message}\n`),
+    error: (message: string) => stderr.write(`${TAG} ERROR ${message}\n`),
+  };
+}
+
+async function createCore(config: GatewayConfig, logger: Logger): Promise<TdaiCore> {
+  initDataDirectories(config.data.baseDir);
+
+  const adapter = new StandaloneHostAdapter({
+    dataDir: config.data.baseDir,
+    llmConfig: config.llm,
+    logger,
+    platform: "mcp",
+  });
+
+  const core = new TdaiCore({
+    hostAdapter: adapter,
+    config: config.memory,
+    sessionFilter: new SessionFilter(config.memory.capture.excludeAgents),
+  });
+  await core.initialize();
+  return core;
+}
+
+async function main(): Promise<void> {
+  const logger = createStderrLogger();
+  const config = loadGatewayConfig();
+  const core = await createCore(config, logger);
+  const server = new TdaiMcpJsonRpcServer(core);
+  const rl = readline.createInterface({ input: stdin, crlfDelay: Infinity });
+
+  logger.info(`MCP stdio server started: dataDir=${config.data.baseDir}`);
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    try {
+      await core.destroy();
+    } catch (err) {
+      logger.warn(`Core destroy failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  rl.on("line", (line) => {
+    void (async () => {
+      if (!line.trim()) return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        stdout.write(JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: "Parse error" },
+        }) + "\n");
+        return;
+      }
+
+      const response = await server.handle(parsed);
+      if (response) {
+        stdout.write(`${JSON.stringify(response)}\n`);
+      }
+    })().catch((err) => {
+      logger.error(`Unhandled request error: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+    });
+  });
+
+  rl.on("close", () => {
+    void close().finally(() => process.exit(0));
+  });
+  process.on("SIGINT", () => {
+    void close().finally(() => process.exit(0));
+  });
+  process.on("SIGTERM", () => {
+    void close().finally(() => process.exit(0));
+  });
+}
+
+const isMain = process.argv[1]?.endsWith("server.ts") || process.argv[1]?.endsWith("server.mjs") || process.argv[1]?.endsWith("memory-tencentdb-mcp.mjs");
+if (isMain) {
+  main().catch((err) => {
+    stderr.write(`${TAG} startup failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/adapters/mcp/tool-registry.test.ts
+++ b/src/adapters/mcp/tool-registry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeTdaiMcpTool, TDAI_MCP_TOOLS } from "./tool-registry.js";
+import type { TdaiMcpCore } from "./tool-registry.js";
+
+function createCore(): TdaiMcpCore {
+  return {
+    handleBeforeRecall: vi.fn(async () => ({
+      appendSystemContext: "persona: prefers Chinese docs",
+      prependContext: "memory: issue 235",
+      recallStrategy: "keyword",
+      recalledL1Memories: [{ content: "prefers Chinese docs", score: 0.9, type: "instruction" }],
+      recalledL3Persona: null,
+    })),
+    handleTurnCommitted: vi.fn(async () => ({
+      l0RecordedCount: 2,
+      schedulerNotified: true,
+      l0VectorsWritten: 0,
+      filteredMessages: [],
+    })),
+    searchMemories: vi.fn(async () => ({
+      text: "memory result",
+      total: 1,
+      strategy: "keyword",
+    })),
+    searchConversations: vi.fn(async () => ({
+      text: "conversation result",
+      total: 1,
+    })),
+    handleSessionEnd: vi.fn(async () => undefined),
+  };
+}
+
+describe("TDAI MCP tool registry", () => {
+  it("exposes deterministic memory tools", () => {
+    expect(TDAI_MCP_TOOLS.map((tool) => tool.name)).toEqual([
+      "tdai_recall",
+      "tdai_capture",
+      "tdai_memory_search",
+      "tdai_conversation_search",
+      "tdai_session_end",
+    ]);
+  });
+
+  it("executes recall through TdaiCore", async () => {
+    const core = createCore();
+    const result = await executeTdaiMcpTool(core, "tdai_recall", {
+      query: "What should I remember?",
+      session_key: "session-1",
+    });
+
+    expect(core.handleBeforeRecall).toHaveBeenCalledWith("What should I remember?", "session-1");
+    expect(result.content[0].text).toContain("prefers Chinese docs");
+    expect(result.structuredContent).toMatchObject({
+      strategy: "keyword",
+      memory_count: 1,
+    });
+  });
+
+  it("executes capture through TdaiCore", async () => {
+    const core = createCore();
+    const result = await executeTdaiMcpTool(core, "tdai_capture", {
+      user_content: "remember this",
+      assistant_content: "stored",
+      session_key: "session-1",
+    });
+
+    expect(core.handleTurnCommitted).toHaveBeenCalledWith(expect.objectContaining({
+      userText: "remember this",
+      assistantText: "stored",
+      sessionKey: "session-1",
+    }));
+    expect(result.structuredContent).toMatchObject({
+      l0_recorded: 2,
+      scheduler_notified: true,
+    });
+  });
+
+  it("rejects missing required arguments", async () => {
+    const core = createCore();
+    await expect(executeTdaiMcpTool(core, "tdai_memory_search", {}))
+      .rejects.toThrow("Missing required string argument: query");
+  });
+});

--- a/src/adapters/mcp/tool-registry.ts
+++ b/src/adapters/mcp/tool-registry.ts
@@ -1,0 +1,278 @@
+import type { CaptureResult, CompletedTurn, ConversationSearchParams, MemorySearchParams, RecallResult } from "../../core/types.js";
+
+export interface McpToolDefinition {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpToolResult {
+  resultType: "complete";
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+export interface TdaiMcpCore {
+  handleBeforeRecall(userText: string, sessionKey: string): Promise<RecallResult>;
+  handleTurnCommitted(turn: CompletedTurn): Promise<CaptureResult>;
+  searchMemories(params: MemorySearchParams): Promise<{ text: string; total: number; strategy: string }>;
+  searchConversations(params: ConversationSearchParams): Promise<{ text: string; total: number }>;
+  handleSessionEnd(sessionKey: string): Promise<void>;
+}
+
+const objectSchema = (
+  properties: Record<string, unknown>,
+  required: string[] = [],
+): Record<string, unknown> => ({
+  type: "object",
+  additionalProperties: false,
+  properties,
+  ...(required.length > 0 ? { required } : {}),
+});
+
+export const TDAI_MCP_TOOLS: McpToolDefinition[] = [
+  {
+    name: "tdai_recall",
+    title: "TDAI Recall",
+    description:
+      "Recall relevant long-term memory context before answering a user. Use this at the start of a turn when past preferences, facts, or instructions may matter.",
+    inputSchema: objectSchema({
+      query: {
+        type: "string",
+        description: "Current user request or recall query.",
+      },
+      session_key: {
+        type: "string",
+        description: "Stable conversation/session key used to scope recall.",
+      },
+    }, ["query", "session_key"]),
+  },
+  {
+    name: "tdai_capture",
+    title: "TDAI Capture",
+    description:
+      "Capture a completed user/assistant turn into TDAI memory. Call this after a successful response so future turns can recall it.",
+    inputSchema: objectSchema({
+      user_content: {
+        type: "string",
+        description: "The user's message for the completed turn.",
+      },
+      assistant_content: {
+        type: "string",
+        description: "The assistant's answer for the completed turn.",
+      },
+      session_key: {
+        type: "string",
+        description: "Stable conversation/session key used to group memory.",
+      },
+      session_id: {
+        type: "string",
+        description: "Optional host-specific session identifier.",
+      },
+      messages: {
+        type: "array",
+        description: "Optional raw message list. When omitted, a two-message user/assistant turn is synthesized.",
+        items: { type: "object" },
+      },
+    }, ["user_content", "assistant_content", "session_key"]),
+  },
+  {
+    name: "tdai_memory_search",
+    title: "TDAI Memory Search",
+    description:
+      "Search structured L1 long-term memories. Prefer this for user preferences, instructions, persona facts, and summarized past events.",
+    inputSchema: objectSchema({
+      query: {
+        type: "string",
+        description: "Search query describing what memory to find.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of results, default 5 and max 20.",
+      },
+      type: {
+        type: "string",
+        enum: ["persona", "episodic", "instruction"],
+        description: "Optional memory type filter.",
+      },
+      scene: {
+        type: "string",
+        description: "Optional scene name filter.",
+      },
+    }, ["query"]),
+  },
+  {
+    name: "tdai_conversation_search",
+    title: "TDAI Conversation Search",
+    description:
+      "Search raw L0 conversation history. Use this when structured memories are insufficient or exact prior wording matters.",
+    inputSchema: objectSchema({
+      query: {
+        type: "string",
+        description: "Search query describing what conversation content to find.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of messages, default 5 and max 20.",
+      },
+      session_key: {
+        type: "string",
+        description: "Optional session filter.",
+      },
+    }, ["query"]),
+  },
+  {
+    name: "tdai_session_end",
+    title: "TDAI Session End",
+    description:
+      "Flush pending memory pipeline work for a single session without shutting down the MCP server.",
+    inputSchema: objectSchema({
+      session_key: {
+        type: "string",
+        description: "Session key whose pending memory work should be flushed.",
+      },
+    }, ["session_key"]),
+  },
+];
+
+export async function executeTdaiMcpTool(
+  core: TdaiMcpCore,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<McpToolResult> {
+  switch (name) {
+    case "tdai_recall":
+      return recall(core, args);
+    case "tdai_capture":
+      return capture(core, args);
+    case "tdai_memory_search":
+      return memorySearch(core, args);
+    case "tdai_conversation_search":
+      return conversationSearch(core, args);
+    case "tdai_session_end":
+      return sessionEnd(core, args);
+    default:
+      throw new Error(`Unknown TDAI MCP tool: ${name}`);
+  }
+}
+
+async function recall(core: TdaiMcpCore, args: Record<string, unknown>): Promise<McpToolResult> {
+  const query = requireString(args, "query");
+  const sessionKey = requireString(args, "session_key");
+  const result = await core.handleBeforeRecall(query, sessionKey);
+  const context = joinRecallContext(result);
+  const structuredContent = {
+    context,
+    appendSystemContext: result.appendSystemContext ?? "",
+    prependContext: result.prependContext ?? "",
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+    persona_present: !!result.recalledL3Persona,
+  };
+
+  return textResult(context || "No relevant memory found.", structuredContent);
+}
+
+async function capture(core: TdaiMcpCore, args: Record<string, unknown>): Promise<McpToolResult> {
+  const userText = requireString(args, "user_content");
+  const assistantText = requireString(args, "assistant_content");
+  const sessionKey = requireString(args, "session_key");
+  const sessionId = optionalString(args, "session_id");
+  const rawMessages = Array.isArray(args.messages) ? args.messages : undefined;
+  const messages = rawMessages ?? [
+    { role: "user", content: userText },
+    { role: "assistant", content: assistantText },
+  ];
+
+  const result = await core.handleTurnCommitted({
+    userText,
+    assistantText,
+    messages,
+    sessionKey,
+    sessionId,
+    startedAt: Date.now(),
+  });
+  const structuredContent = {
+    l0_recorded: result.l0RecordedCount,
+    scheduler_notified: result.schedulerNotified,
+    l0_vectors_written: result.l0VectorsWritten,
+  };
+
+  return textResult(
+    `Captured ${result.l0RecordedCount} L0 message(s); scheduler_notified=${result.schedulerNotified}.`,
+    structuredContent,
+  );
+}
+
+async function memorySearch(core: TdaiMcpCore, args: Record<string, unknown>): Promise<McpToolResult> {
+  const result = await core.searchMemories({
+    query: requireString(args, "query"),
+    limit: optionalPositiveInt(args, "limit", 5, 20),
+    type: optionalString(args, "type"),
+    scene: optionalString(args, "scene"),
+  });
+  return textResult(result.text, {
+    results: result.text,
+    total: result.total,
+    strategy: result.strategy,
+  });
+}
+
+async function conversationSearch(core: TdaiMcpCore, args: Record<string, unknown>): Promise<McpToolResult> {
+  const result = await core.searchConversations({
+    query: requireString(args, "query"),
+    limit: optionalPositiveInt(args, "limit", 5, 20),
+    sessionKey: optionalString(args, "session_key"),
+  });
+  return textResult(result.text, {
+    results: result.text,
+    total: result.total,
+  });
+}
+
+async function sessionEnd(core: TdaiMcpCore, args: Record<string, unknown>): Promise<McpToolResult> {
+  const sessionKey = requireString(args, "session_key");
+  await core.handleSessionEnd(sessionKey);
+  return textResult(`Flushed pending memory work for session ${sessionKey}.`, {
+    flushed: true,
+    session_key: sessionKey,
+  });
+}
+
+function joinRecallContext(result: RecallResult): string {
+  return [result.appendSystemContext, result.prependContext]
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join("\n\n");
+}
+
+function textResult(text: string, structuredContent?: unknown): McpToolResult {
+  return {
+    resultType: "complete",
+    content: [{ type: "text", text }],
+    structuredContent,
+    isError: false,
+  };
+}
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Missing required string argument: ${key}`);
+  }
+  return value;
+}
+
+function optionalString(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalPositiveInt(args: Record<string, unknown>, key: string, fallback: number, max: number): number {
+  const raw = args[key];
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.min(n, max);
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,10 @@ function collectExternalDependencies(): string[] {
 }
 
 export default defineConfig({
-  entry: ["./index.ts"],
+  entry: {
+    index: "./index.ts",
+    "mcp-server": "./src/adapters/mcp/server.ts",
+  },
   outDir: "./dist",
   format: "esm",
   platform: "node",


### PR DESCRIPTION
## Description | 描述
Add an MCP stdio adapter for TencentDB Agent Memory, enabling MCP-compatible agent clients to access TdaiCore memory capabilities through standard MCP tools.

This PR includes:
- MCP stdio server entrypoint.
- Tool registry for TdaiCore recall, capture, memory search, conversation search, and session flush.
- JSON-RPC handling for initialize, server discovery, tools/list, and tools/call.
- Chinese adapter documentation covering architecture, data flow, configuration, usage, comparison with OpenClaw/Hermes, and verification steps.
- Package bin entry and build configuration for the MCP server.

## Related Issue | 关联 Issue
Refs #235
## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
Local tests:
- `npm run build`
- `npm test`
- `./node_modules/.bin/vitest run src/adapters/mcp/*.test.ts`
- `git diff --check`
- `npm_config_cache=/tmp/tencentdb-npm-pack-cache npm pack --dry-run --json --ignore-scripts`

## Additional Notes | 其他说明
The adapter is implemented as an MCP stdio bridge, so MCP-compatible clients can invoke memory operations without requiring a platform-specific plugin implementation.

The implementation keeps OpenClaw and Hermes behavior unchanged, while exposing the same TdaiCore memory workflow to MCP clients.