### PR TITLE
feat(recall): expose stable/dynamic cache observability and keep dyna…

### DIFF
--- a/docs/issue-120-cache-safe-recall-measurement.md
+++ b/docs/issue-120-cache-safe-recall-measurement.md
@@ -1,0 +1,116 @@
+# Issue 120 Cache-Safe Recall: Measurement Report
+
+## Background
+
+Issue #120 reports prompt cache hit-rate regression for OpenAI-compatible providers
+(DeepSeek, MiMo) after enabling memory recall. The recall path produces two kinds of context:
+
+| block | field | stability | desired behavior |
+| --- | --- | --- | --- |
+| stable memory context | `appendSystemContext` | mostly stable | reusable, cacheable system-prefix material |
+| dynamic L1 recall | `prependContext` | per-query | current-turn-only, never persisted |
+
+This change makes the split explicit and observable (stable/dynamic context parts plus
+cache-debug telemetry), and keeps injected dynamic recall out of persisted history.
+
+## Memory-Injected Context Structure (basic-stage artifact)
+
+How recall context is placed in the prompt, and what each segment means for prefix caching:
+
+```mermaid
+flowchart TB
+  subgraph Prompt["每轮发送给 Provider 的完整 Prompt / Request"]
+    S["System Prompt 前缀（字节稳定）<br/>persona + scene navigation + memory tools guide<br/><b>✅ 可缓存</b> — 应位于 CACHE_BOUNDARY 之前"]
+    B["CACHE_BOUNDARY（OpenClaw host 契约）<br/>—— 缓存区 ｜ 非缓存区 ——"]
+    H["History 对话历史<br/>⚠️ 若动态 &lt;relevant-memories&gt; 被写入历史<br/>→ 每轮膨胀 → truncation 变化 → 前缀失效"]
+    U["本轮 User Message<br/>prependContext 动态召回（仅当前轮可见）<br/><b>❌ 不应持久化</b>；当前实现会写入历史"]
+  end
+  S --> B --> H --> U
+  style S fill:#d4edda
+  style U fill:#f8d7da
+```
+
+- Stable block (`appendSystemContext`): byte-stable, hash-observable (single SHA-256 across Gateway smoke turns) — cacheable prefix material.
+- Dynamic block (`prependContext`): per-query L1 recall — must stay current-turn-only.
+- The v5 provider matrix (below) isolates exactly these two effects.
+
+## Provider Measurement (DeepSeek)
+
+Real `deepseek-chat` (api.deepseek.com), warm turns (turn > 1),
+`warmHitRate = cacheRead / (miss + cacheRead)`, miss = `prompt_cache_miss_tokens`.
+
+### pi host (`--provider deepseek`, prompt via file, stable block via `--append-system-prompt`)
+
+| variant | warm input miss | warm cache read | warm hit rate |
+| --- | ---: | ---: | ---: |
+| `current-dynamic-persist` | 5137 | 14336 | 0.7362 |
+| `clean-history-only` | 4389 | 12288 | 0.7368 |
+| `stable-prefix-clean-history` | 4408 | 19200 | 0.8133 |
+
+### direct API (constructed multi-turn inputs)
+
+| variant | warm input miss | warm cache read | warm hit rate |
+| --- | ---: | ---: | ---: |
+| `current-dynamic-persist` | 6166 | 16640 | 0.7296 |
+| `clean-history-only` | 5001 | 13952 | 0.7361 |
+| `stable-prefix-clean-history` | 5032 | 22528 | 0.8174 |
+
+## Interpretation
+
+1. **Dynamic recall persisted in history costs real cache misses**: current → clean reduces the
+   warm miss surface by ~15% (pi 5137 → 4389; direct 6166 → 5001), i.e. ~180 tokens/turn on pi.
+   Keeping dynamic `<relevant-memories>` out of persisted history is backed by data.
+2. **A stable memory prefix at the front of the system prompt is reused by the provider cache**:
+   `stable-prefix-clean-history` beats `clean-history-only` on both tracks (pi 0.8133 vs 0.7368;
+   direct 0.8174 vs 0.7361) with no additional miss — the stable block rides on the cache.
+3. Stable context is byte-stable across turns (single stable SHA-256 in Gateway smoke) and now
+   separately observable via `context_parts` / `cache_debug`.
+
+## Long-History Pressure Validation (supporting)
+
+The matrix above uses 5–6 turns. Two earlier pi runs on real DeepSeek (complete prompts) cover the
+long-session regime described by issue #120 (history bloat after many turns):
+
+**12-turn pressure** (deepseek-v4-flash, warm turns 2–12):
+
+| variant | warm input miss | warm cache read | warm hit rate |
+| --- | ---: | ---: | ---: |
+| `current-prepend-persist-pressure` | 44551 | 270080 | 0.8584 |
+| `stable-prefix-clean-history-pressure` | 42662 | 276608 | 0.8664 |
+
+- stable-prefix + clean-history beats current-prepend-persist by `+0.0080` hit rate and `−1889` warm
+  miss tokens under 12-turn history pressure. Two-way only — the three-way v5 matrix separates the
+  clean-history and stable-prefix effects; this run confirms the combined direction at long history.
+
+**6-turn smoke** (deepseek-chat, warm turns 2–6):
+
+| variant | warm input miss | warm cache read | warm hit rate |
+| --- | ---: | ---: | ---: |
+| `baseline-clean` | 448 | 13056 | 0.9668 |
+| `current-prepend-persist` | 670 | 12928 | 0.9507 |
+| `stable-prefix-clean-history` | 424 | 10880 | 0.9625 |
+
+- `current-prepend-persist` (dynamic recall persisted) is the worst arm (`+222` warm miss vs baseline),
+  independently supporting the dynamic-recall non-persistence direction.
+- stable-prefix-clean-history ≈ baseline hit rate (0.9625 vs 0.9668): stable input adds no miss.
+
+## Scope of This PR
+
+- Stable/dynamic recall split exposed as `contextParts` (core) and `context_parts` (Gateway `/recall`),
+  backward-compatible with `appendSystemContext` / `prependContext`.
+- `before_message_write` strip of `<relevant-memories>` moved into a tested shared utility
+  (`src/utils/recall-context.ts`) with string + content-parts handling.
+- Cache-debug telemetry (hashes, sizes, placement, persist policy) gated behind
+  `TDAI_CACHE_DEBUG` / `TDAI_EXPERIMENT_CACHE_DEBUG`.
+
+Not in scope: OpenClaw `CACHE_BOUNDARY` host placement (pi `--append-system-prompt` approximates
+a true system-prefix slot; OpenClaw does not expose the insertion point) and MiMo verification
+(no API key available for this measurement).
+
+## Validation
+
+| command | result |
+| --- | --- |
+| `npm test` | 7 files / 73 tests passed |
+| `npm run build` | passed |
+| `git diff --check` | clean |

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/utils/clean-context-runner.js";
 import { SessionFilter } from "./src/utils/session-filter.js";
 import { LocalMemoryCleaner } from "./src/utils/memory-cleaner.js";
+import { stripRelevantMemoriesFromContentParts, stripRelevantMemoriesFromText } from "./src/utils/recall-context.js";
 import { registerMemoryTdaiCli } from "./src/cli/index.js";
 import { initDataDirectories, resetStores } from "./src/utils/pipeline-factory.js";
 import { getOrCreateInstanceId, initReporter, report, resetReporter } from "./src/core/report/reporter.js";
@@ -625,27 +626,17 @@ export default function register(api: OpenClawPluginApi) {
     if (msg.role !== "user") return;
 
     // UserMessage.content: string | (TextContent | ImageContent)[]
-    const STRIP_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
-
     if (typeof msg.content === "string") {
-      if (!msg.content.includes("<relevant-memories>")) return;
-      const cleaned = msg.content.replace(STRIP_RE, "").trim();
+      const cleaned = stripRelevantMemoriesFromText(msg.content);
       if (cleaned === msg.content) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} → ${cleaned.length} chars`);
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped: ${msg.content.length} -> ${cleaned.length} chars`);
       return { message: { ...event.message, content: cleaned } as typeof event.message };
     }
 
     if (Array.isArray(msg.content)) {
-      let totalStripped = 0;
-      const cleanedParts = (msg.content as Array<Record<string, unknown>>).map((part) => {
-        if (part.type !== "text" || typeof part.text !== "string") return part;
-        if (!(part.text as string).includes("<relevant-memories>")) return part;
-        const cleaned = (part.text as string).replace(STRIP_RE, "").trim();
-        totalStripped += (part.text as string).length - cleaned.length;
-        return { ...part, text: cleaned };
-      });
-      if (totalStripped === 0) return;
-      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${totalStripped} chars`);
+      const { parts: cleanedParts, strippedChars } = stripRelevantMemoriesFromContentParts(msg.content as Array<Record<string, unknown>>);
+      if (strippedChars === 0) return;
+      api.logger.debug?.(`${TAG} [before_message_write] Stripped from parts: removed ${strippedChars} chars`);
       return { message: { ...event.message, content: cleanedParts } as unknown as typeof event.message };
     }
   });

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -10,6 +10,7 @@
  * - L2 scene navigation (full injection, LLM decides relevance)
  */
 
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatForLLM } from "../../utils/time.js";
@@ -21,12 +22,22 @@ import type { IMemoryStore, L1SearchResult, L1FtsResult } from "../store/types.j
 import { buildFtsQuery } from "../store/sqlite.js";
 import type { EmbeddingService, EmbeddingCallOptions } from "../store/embedding.js";
 import { sanitizeText } from "../../utils/sanitize.js";
-import type { Logger } from "../types.js";
+import type { Logger, RecallContextParts } from "../types.js";
 
 const TAG = "[memory-tdai] [recall]";
 const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
 const MIN_TRUNCATED_RECALL_LINE_CHARS = 40;
 const RECALL_LINE_SEPARATOR = "\n";
+
+function sha256Text(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function isCacheDebugEnabled(): boolean {
+  const value = process.env.TDAI_CACHE_DEBUG ?? process.env.TDAI_EXPERIMENT_CACHE_DEBUG;
+  return value === "1" || value === "true" || value === "yes";
+}
 
 /**
  * Memory tools usage guide — injected at the end of memory context so the
@@ -59,6 +70,10 @@ export interface RecallResult {
   prependContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide — cacheable) */
   appendSystemContext?: string;
+  /** Structured stable/dynamic context contract for cache-boundary-aware hosts. */
+  contextParts?: RecallContextParts;
+  /** Optional cache diagnostics, emitted only when TDAI_CACHE_DEBUG is enabled. */
+  cacheDebug?: Record<string, unknown>;
 
   // ── Metric payload (for pendingRecallCache in index.ts) ──
   /** L1 memories that were recalled (with scores), for metric reporting */
@@ -216,6 +231,23 @@ async function performAutoRecallInner(params: {
   }
 
   const appendSystemContext = stableParts.length > 0 ? stableParts.join("\n\n") : undefined;
+  const contextParts: RecallContextParts = {};
+  if (appendSystemContext) {
+    contextParts.stable = {
+      content: appendSystemContext,
+      placement: "system",
+      cachePolicy: "cacheable",
+      persist: false,
+    };
+  }
+  if (prependContext) {
+    contextParts.dynamic = {
+      content: prependContext,
+      placement: "user",
+      cachePolicy: "ephemeral",
+      persist: false,
+    };
+  }
 
   const totalMs = performance.now() - tRecallStart;
   logger?.info(
@@ -227,6 +259,31 @@ async function performAutoRecallInner(params: {
     `scene=${(tSceneEnd - tSceneStart).toFixed(0)}ms(${sceneNavigation ? "loaded" : "none"})`,
   );
 
+  const stableContextSha256 = sha256Text(appendSystemContext);
+  const dynamicContextSha256 = sha256Text(prependContext);
+  const cacheDebug = isCacheDebugEnabled() ? {
+    mode: process.env.TDAI_STABLE_PREFIX_MODE ?? process.env.TDAI_EXPERIMENT_STABLE_PREFIX_MODE ?? "current",
+    stableContextChars: appendSystemContext?.length ?? 0,
+    dynamicContextChars: prependContext?.length ?? 0,
+    stableContextSha256,
+    dynamicContextSha256,
+    stablePlacementTarget: "system-context-fallback",
+    dynamicPersistPolicy: "never",
+    appendSystemContextChars: appendSystemContext?.length ?? 0,
+    prependContextChars: prependContext?.length ?? 0,
+    appendSystemContextSha256: stableContextSha256,
+    prependContextSha256: dynamicContextSha256,
+    personaChars: personaContent?.length ?? 0,
+    sceneNavigationChars: sceneNavigation?.length ?? 0,
+    memoryToolsGuideChars: stableParts.includes(MEMORY_TOOLS_GUIDE) ? MEMORY_TOOLS_GUIDE.length : 0,
+    recalledL1Count: memoryLines.length,
+    searchStrategy: effectiveStrategy,
+  } : undefined;
+
+  if (cacheDebug) {
+    logger?.info(`${TAG} cache-debug ${JSON.stringify(cacheDebug)}`);
+  }
+
   if (!appendSystemContext && !prependContext) {
     return undefined;
   }
@@ -234,9 +291,11 @@ async function performAutoRecallInner(params: {
   return {
     prependContext,
     appendSystemContext,
+    contextParts,
     recalledL1Memories,
     recalledL3Persona: personaContent ?? null,
     recallStrategy: effectiveStrategy,
+    cacheDebug,
   };
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,6 +16,8 @@ export type {
   HostAdapter,
   CompletedTurn,
   RecallResult,
+  RecallContextPart,
+  RecallContextParts,
   CaptureResult,
   MemorySearchParams,
   ConversationSearchParams,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -196,17 +196,32 @@ export interface CompletedTurn {
 // ============================
 
 /** Result from a recall (prefetch) operation. */
+export interface RecallContextPart {
+  content: string;
+  placement: "system" | "user";
+  cachePolicy: "cacheable" | "ephemeral";
+  persist: boolean;
+}
+
+export interface RecallContextParts {
+  stable?: RecallContextPart;
+  dynamic?: RecallContextPart;
+}
+
 export interface RecallResult {
   /** L1 relevant memories — prepended to user prompt text (dynamic, per-turn). */
   prependContext?: string;
   /** Stable recall context appended to system prompt (persona, scene nav, tools guide). */
   appendSystemContext?: string;
+  /** Structured stable/dynamic context contract for hosts that can place cacheable blocks explicitly. */
+  contextParts?: RecallContextParts;
   /** Recalled L1 memories with scores (for metrics). */
   recalledL1Memories?: Array<{ content: string; score: number; type: string }>;
   /** L3 Persona content (for metrics). */
   recalledL3Persona?: string | null;
   /** Search strategy used. */
   recallStrategy?: string;
+  cacheDebug?: Record<string, unknown>;
 }
 
 /** Result from a capture (sync_turn) operation. */

--- a/src/gateway/recall-response.test.ts
+++ b/src/gateway/recall-response.test.ts
@@ -1,0 +1,54 @@
+﻿import { describe, expect, it } from "vitest";
+import { buildRecallResponse } from "./recall-response.js";
+import type { RecallResult } from "../core/types.js";
+
+describe("buildRecallResponse", () => {
+  it("keeps legacy context while exposing structured stable and dynamic parts", () => {
+    const result: RecallResult = {
+      appendSystemContext: "<user-persona>stable</user-persona>",
+      prependContext: "<relevant-memories>dynamic</relevant-memories>",
+      contextParts: {
+        stable: {
+          content: "<user-persona>stable</user-persona>",
+          placement: "system",
+          cachePolicy: "cacheable",
+          persist: false,
+        },
+        dynamic: {
+          content: "<relevant-memories>dynamic</relevant-memories>",
+          placement: "user",
+          cachePolicy: "ephemeral",
+          persist: false,
+        },
+      },
+      recalledL1Memories: [{ content: "dynamic", score: 0.9, type: "episodic" }],
+      recallStrategy: "hybrid",
+      cacheDebug: { dynamicPersistPolicy: "never" },
+    };
+
+    expect(buildRecallResponse(result)).toEqual({
+      context: "<user-persona>stable</user-persona>",
+      stable_context: "<user-persona>stable</user-persona>",
+      dynamic_context: "<relevant-memories>dynamic</relevant-memories>",
+      context_parts: {
+        stable: {
+          content: "<user-persona>stable</user-persona>",
+          placement: "system",
+          cache_policy: "cacheable",
+          persist: false,
+        },
+        dynamic: {
+          content: "<relevant-memories>dynamic</relevant-memories>",
+          placement: "user",
+          cache_policy: "ephemeral",
+          persist: false,
+        },
+      },
+      strategy: "hybrid",
+      memory_count: 1,
+      cache_debug: { dynamicPersistPolicy: "never" },
+    });
+  });
+});
+
+

--- a/src/gateway/recall-response.ts
+++ b/src/gateway/recall-response.ts
@@ -1,0 +1,38 @@
+import type { RecallResult } from "../core/types.js";
+import type {
+  RecallContextPartResponse,
+  RecallContextPartsResponse,
+  RecallResponse,
+} from "./types.js";
+
+function toResponsePart(
+  part: NonNullable<NonNullable<RecallResult["contextParts"]>["stable"]>,
+): RecallContextPartResponse {
+  return {
+    content: part.content,
+    placement: part.placement,
+    cache_policy: part.cachePolicy,
+    persist: part.persist,
+  };
+}
+
+function toResponseParts(parts: RecallResult["contextParts"]): RecallContextPartsResponse | undefined {
+  if (!parts?.stable && !parts?.dynamic) return undefined;
+
+  return {
+    stable: parts.stable ? toResponsePart(parts.stable) : undefined,
+    dynamic: parts.dynamic ? toResponsePart(parts.dynamic) : undefined,
+  };
+}
+
+export function buildRecallResponse(result: RecallResult): RecallResponse {
+  return {
+    context: result.appendSystemContext ?? "",
+    stable_context: result.appendSystemContext,
+    dynamic_context: result.prependContext,
+    context_parts: toResponseParts(result.contextParts),
+    strategy: result.recallStrategy,
+    memory_count: result.recalledL1Memories?.length ?? 0,
+    cache_debug: result.cacheDebug,
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -18,6 +18,7 @@ import http from "node:http";
 import { URL } from "node:url";
 import { timingSafeEqual } from "node:crypto";
 import { TdaiCore } from "../core/tdai-core.js";
+import { buildRecallResponse } from "./recall-response.js";
 import { StandaloneHostAdapter } from "../adapters/standalone/host-adapter.js";
 import { loadGatewayConfig } from "./config.js";
 import type { GatewayConfig } from "./config.js";
@@ -382,11 +383,7 @@ export class TdaiGateway {
 
     this.logger.info(`Recall completed in ${elapsed}ms: context=${(result.appendSystemContext?.length ?? 0)} chars`);
 
-    const response: RecallResponse = {
-      context: result.appendSystemContext ?? "",
-      strategy: result.recallStrategy,
-      memory_count: result.recalledL1Memories?.length ?? 0,
-    };
+    const response: RecallResponse = buildRecallResponse(result);
     sendJson(res, 200, response);
   }
 

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -35,10 +35,30 @@ export interface RecallRequest {
   user_id?: string;
 }
 
+export interface RecallContextPartResponse {
+  content: string;
+  placement: "system" | "user";
+  cache_policy: "cacheable" | "ephemeral";
+  persist: boolean;
+}
+
+export interface RecallContextPartsResponse {
+  stable?: RecallContextPartResponse;
+  dynamic?: RecallContextPartResponse;
+}
+
 export interface RecallResponse {
+  /** Backward-compatible stable context field consumed by existing Gateway clients. */
   context: string;
+  /** Stable memory context intended for cacheable host/system placement. */
+  stable_context?: string;
+  /** Dynamic per-turn recall context intended for user-prompt placement only. */
+  dynamic_context?: string;
+  /** Structured stable/dynamic contract for cache-boundary-aware hosts. */
+  context_parts?: RecallContextPartsResponse;
   strategy?: string;
   memory_count?: number;
+  cache_debug?: Record<string, unknown>;
 }
 
 // ============================

--- a/src/utils/recall-context.test.ts
+++ b/src/utils/recall-context.test.ts
@@ -1,0 +1,36 @@
+﻿import { describe, expect, it } from "vitest";
+import {
+  stripRelevantMemoriesFromContentParts,
+  stripRelevantMemoriesFromText,
+} from "./recall-context.js";
+
+describe("recall context cleanup", () => {
+  it("strips injected relevant memories from string user content", () => {
+    const cleaned = stripRelevantMemoriesFromText(
+      "<relevant-memories>\n- [episodic] dynamic memory\n</relevant-memories>\n\nWhat changed?",
+    );
+
+    expect(cleaned).toBe("What changed?");
+  });
+
+  it("leaves content without injected memories unchanged", () => {
+    expect(stripRelevantMemoriesFromText("What changed?")).toBe("What changed?");
+  });
+
+  it("strips injected relevant memories from text content parts only", () => {
+    const image = { type: "image", source: "data:image/png;base64,abc" };
+    const { parts, strippedChars } = stripRelevantMemoriesFromContentParts([
+      {
+        type: "text",
+        text: "<relevant-memories>\n- [instruction] dynamic memory\n</relevant-memories>\n\nPlease continue.",
+      },
+      image,
+    ]);
+
+    expect(parts).toEqual([
+      { type: "text", text: "Please continue." },
+      image,
+    ]);
+    expect(strippedChars).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/recall-context.ts
+++ b/src/utils/recall-context.ts
@@ -1,0 +1,20 @@
+﻿const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+export function stripRelevantMemoriesFromText(text: string): string {
+  if (!text.includes("<relevant-memories>")) return text;
+  return text.replace(RELEVANT_MEMORIES_RE, "").trim();
+}
+
+export function stripRelevantMemoriesFromContentParts<T extends Record<string, unknown>>(
+  parts: T[],
+): { parts: T[]; strippedChars: number } {
+  let strippedChars = 0;
+  const cleanedParts = parts.map((part) => {
+    if (part.type !== "text" || typeof part.text !== "string") return part;
+    const original = part.text;
+    const cleaned = stripRelevantMemoriesFromText(original);
+    strippedChars += original.length - cleaned.length;
+    return cleaned === original ? part : { ...part, text: cleaned };
+  });
+  return { parts: cleanedParts, strippedChars };
+}

--- a/src/utils/sanitize-recall-context.test.ts
+++ b/src/utils/sanitize-recall-context.test.ts
@@ -1,0 +1,17 @@
+﻿import { describe, expect, it } from "vitest";
+
+import { sanitizeText } from "./sanitize.js";
+
+describe("sanitize recall context", () => {
+  it("strips injected relevant memories before memory persistence", () => {
+    const text = "<relevant-memories>\n- dynamic memory\n</relevant-memories>\n\nActual user text";
+
+    expect(sanitizeText(text)).toBe("Actual user text");
+  });
+
+  it("strips stable recall wrappers before memory persistence", () => {
+    const text = "<user-persona>\nstable profile\n</user-persona>\n\n<scene-navigation>\nstable scenes\n</scene-navigation>\n\nActual user text";
+
+    expect(sanitizeText(text)).toBe("Actual user text");
+  });
+});


### PR DESCRIPTION
## Description | 描述

This PR addresses issue #120 (prompt cache hit-rate regression for OpenAI-compatible providers)
in a staged way and covers the **Basic**, **Intermediate**, and **Deep** stages of the acceptance
criteria:

- **Basic / 基础**: read the recall source and produced the memory-injected context structure
  diagram, marking each segment's cache impact.
- **Intermediate / 进阶**: analyzed the `showInjected` context-bloat trend (synthetic prefix diff +
  long-history pressure runs) and proposed the split of stable/dynamic recall blocks.
- **Deep / 深入**: implemented the optimization and measured the cache hit-rate change on real
  DeepSeek: dynamic recall is kept current-turn-only, and stable/dynamic recall is exposed as a
  structured `context_parts` contract with `cache_debug` telemetry.

本 PR 按照 issue #120 的渐进式验收标准，覆盖 **基础、进阶、深入** 三个阶段：

- **基础阶段**：阅读召回源码，画出 memory 注入后的上下文结构图，标注各段内容对前缀缓存的影响。
- **进阶阶段**：分析 `showInjected` 导致的对话膨胀趋势（合成前缀 diff + 长历史压力实验），
  提出稳定/动态召回分块的优化方案。
- **深入阶段**：实现优化并用真实 DeepSeek 测量缓存命中率变化：动态召回仅当前轮可见、
  不再写入持久化历史；稳定/动态分块通过 `context_parts` 结构化契约与 `cache_debug` 遥测暴露。

## Stage Coverage | 阶段完成情况

| Stage / 阶段 | Acceptance criterion / 验收标准 | Status / 状态 | Evidence / 证据 |
| --- | --- | --- | --- |
| Basic / 基础 | Read source, draw context structure diagram with cache impact<br/>阅读源码，画出上下文结构图并标注缓存影响 | ✅ | Diagram above; `docs/issue-120-cache-safe-recall-measurement.md`<br/>上图及测量文档 |
| Intermediate / 进阶 | Analyze bloat trend, propose ≥1 optimization<br/>分析膨胀趋势，提出至少一种优化方案 | ✅ | Synthetic prefix diff, 6-/12-turn pressure runs, `context_parts` design<br/>合成前缀 diff、6/12 轮压力实验、`context_parts` 设计 |
| Deep / 深入 | Implement optimization, measure hit-rate change, verify<br/>实现优化，测量命中率变化，验证效果 | ✅ | v5 DeepSeek matrix below; 73 tests + build<br/>下文 v5 DeepSeek 矩阵；73 测试 + 构建通过 |
| Extension / 拓展 | DeepSeek vs MiMo cache strategy, or session-level system dedup<br/>对比 DeepSeek vs MiMo 缓存策略，或 session 级系统提示去重 | ⏳ Not covered / 未覆盖 | MiMo API key unavailable; session-level dedup left as follow-up<br/>MiMo 无可用 API key；session 级去重留作后续 |

## Memory-Injected Context Structure | 上下文结构图

The recall path produces two kinds of context. The diagram marks each segment's cache impact:

召回路径产生两类上下文，下图标出每一段对前缀缓存的影响：

```mermaid
flowchart TB
  subgraph Prompt["每轮发送给 Provider 的完整 Prompt / Request"]
    S["System Prompt 前缀（字节稳定）<br/>persona + scene navigation + memory tools guide<br/><b>✅ 可缓存</b> — 应位于 CACHE_BOUNDARY 之前"]
    B["CACHE_BOUNDARY（OpenClaw host 契约）<br/>—— 缓存区 ｜ 非缓存区 ——"]
    H["History 对话历史<br/>⚠️ 若动态 &lt;relevant-memories&gt; 被写入历史<br/>→ 每轮膨胀 → truncation 变化 → 前缀失效"]
    U["本轮 User Message<br/>prependContext 动态召回（仅当前轮可见）<br/><b>❌ 不应持久化</b>"]
  end
  S --> B --> H --> U
  style S fill:#d4edda
  style U fill:#f8d7da
```

- Stable block (`appendSystemContext`): byte-stable, hash-observable (single SHA-256 across Gateway
  smoke turns) — cacheable prefix material.
- Dynamic block (`prependContext`): per-query L1 recall — must stay current-turn-only.

- 稳定块（`appendSystemContext`）：字节稳定、可哈希观测（Gateway smoke 各轮稳定 SHA-256 唯一）——
  属于可缓存前缀材料。
- 动态块（`prependContext`）：每查询一次的 L1 召回——必须仅当前轮可见。

## Provider Measurement | 实测数据

Real `deepseek-chat` (api.deepseek.com), warm turns (turn > 1).
`warmHitRate = cacheRead / (miss + cacheRead)`, miss = `prompt_cache_miss_tokens`.

使用真实 `deepseek-chat`（api.deepseek.com），统计 warm 轮次（第 2 轮起）。
`warmHitRate = cacheRead / (miss + cacheRead)`，miss 对应 `prompt_cache_miss_tokens`。

### pi host | pi 宿主（stable block via `--append-system-prompt` ）

| variant / 变体 | warm input miss<br/>warm 未命中输入 | warm cache read<br/>warm 缓存命中 | warm hit rate<br/>warm 命中率 |
| --- | ---: | ---: | ---: |
| `current-dynamic-persist` | 5137 | 14336 | 0.7362 |
| `clean-history-only` | 4389 | 12288 | 0.7368 |
| `stable-prefix-clean-history` | 4408 | 19200 | **0.8133** |

### direct API | 直连 API（constructed multi-turn inputs / 构造多轮输入）

| variant / 变体 | warm input miss | warm cache read | warm hit rate |
| --- | ---: | ---: | ---: |
| `current-dynamic-persist` | 6166 | 16640 | 0.7296 |
| `clean-history-only` | 5001 | 13952 | 0.7361 |
| `stable-prefix-clean-history` | 5032 | 22528 | **0.8174** |

### Long-history pressure | 长历史压力（12-turn ，supportings ）

| variant / 变体 | warm input miss | warm cache read | warm hit rate |
| --- | ---: | ---: | ---: |
| `current-prepend-persist-pressure` | 44551 | 270080 | 0.8584 |
| `stable-prefix-clean-history-pressure` | 42662 | 276608 | **0.8664** |

## Findings | 结论

1. **Dynamic recall persisted in history costs real cache misses**: current → clean cuts the warm
   miss surface by ~15% (~180 tokens/turn on pi). Keeping dynamic `<relevant-memories>` out of
   persisted history is backed by data.
   **动态召回写入历史会带来真实的缓存未命中成本**：current → clean 使 warm miss 面减少约 15%
   （pi 上每轮约 180 tokens）。将动态 `<relevant-memories>` 排除在持久化历史之外有数据支撑。

2. **A stable memory prefix at the front of the system prompt is reused by the provider cache**:
   `stable-prefix-clean-history` beats `clean-history-only` on both tracks (pi 0.8133 vs 0.7368;
   direct 0.8174 vs 0.7361) with no additional miss.
   **置于系统提示词前部的稳定记忆前缀会被 provider 缓存复用**：`stable-prefix-clean-history`
   在两条实验轨上均优于 `clean-history-only`（pi 0.8133 vs 0.7368；direct 0.8174 vs 0.7361），
   且未增加 miss。

3. Stable context is byte-stable across turns and separately observable via `context_parts` /
   `cache_debug` (gated by `TDAI_CACHE_DEBUG` / `TDAI_EXPERIMENT_CACHE_DEBUG`).
   稳定上下文跨轮次字节稳定，并可通过 `context_parts` / `cache_debug` 独立观测
   （由 `TDAI_CACHE_DEBUG` / `TDAI_EXPERIMENT_CACHE_DEBUG` 门控）。

## Scope | 范围声明

- Stable/dynamic recall split exposed as `contextParts` (core) and `context_parts` (Gateway `/recall`),
  backward-compatible with `appendSystemContext` / `prependContext`.
  稳定/动态召回分块以 `contextParts`（core）与 `context_parts`（Gateway `/recall`）暴露，
  与 `appendSystemContext` / `prependContext` 向后兼容。

- `before_message_write` strip of `<relevant-memories>` moved into a tested shared utility
  (`src/utils/recall-context.ts`), string + content-parts handling.
  `before_message_write` 对 `<relevant-memories>` 的剥离重构进经过测试的共享工具
  （`src/utils/recall-context.ts`），覆盖字符串与 content-parts 两种形态。

- Not claimed / 未声称：
  - OpenClaw `CACHE_BOUNDARY` placement（pi `--append-system-prompt` 近似真实 system-prefix 槽位；
    OpenClaw 未暴露该插入点）。OpenClaw `CACHE_BOUNDARY` 放置能力（pi 的
    `--append-system-prompt` 近似真实 system-prefix 槽位，OpenClaw 尚未暴露该插入点）。
  - MiMo verification / MiMo 验证（no API key available / 无可用 API key）。

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能          ← 勾选
- [x] Documentation update | 文档更新  ← 勾选
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过（73 tests + build + gateway smoke）  ← 勾选
- [x] No existing features affected | 无影响现有功能
## Validation | 验证

| command / 命令 | result / 结果 |
| --- | --- |
| `npm test` | 7 files / 73 tests passed / 7 个文件 73 个测试全部通过 |
| `npm run build` | passed / 通过 |
| `git diff --check` | clean / 干净 |

Fixes #120
