### PR TITLE
fix(checkpoint): recalibrate counters after cleanup (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   - 修复 offload local-llm 模式下每次 LLM 调用都重新创建 fetch wrapper 的性能问题（现在在 `LocalLlmClient` 构造函数中创建一次并缓存）。
   - 注入逻辑抽取到 `src/utils/no-think-fetch.ts` 共享，新增 vitest 单测覆盖全部策略 / 跳过 embedding / 非 JSON 容错。
 
+### 🐛 修复
+
+- **Checkpoint 清理后计数漂移** ([#157](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/157))：启动时从健康 Store 或降级 JSONL 重建 L0/L1 派生计数，Cleaner 运行时按实际删除量原子递减，避免覆盖并发捕获/提取；同时统一 L0 计数单位、精确维护 Persona 阈值并保留增量处理游标。
+
 ### ⚠️ 升级注意（仅在显式配置 `timezone` 时生效）
 
 如果你**显式**设置了 IANA 时区（如 `"Asia/Shanghai"`）：

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -32,6 +32,8 @@ import type {
   L1FtsResult,
   L0SearchResult,
   L0FtsResult,
+  CheckpointCountFilter,
+  CheckpointCounts,
 } from "./types.js";
 import type { Logger } from "../types.js";
 
@@ -1755,6 +1757,38 @@ export class VectorStore implements IMemoryStore {
         `${TAG} countL0 failed (non-fatal, returning 0): ${err instanceof Error ? err.message : String(err)}`,
       );
       return 0;
+    }
+  }
+
+  getCheckpointCounts(filter?: CheckpointCountFilter): CheckpointCounts {
+    if (this.degraded) throw new Error("SQLite store is degraded");
+    try {
+      const l0 = this.db.prepare("SELECT COUNT(*) AS cnt FROM l0_conversations").get() as { cnt: number };
+      const l1 = this.db.prepare("SELECT COUNT(*) AS cnt FROM l1_records").get() as { cnt: number };
+      const clauses: string[] = [];
+      const params: string[] = [];
+      if (filter?.l1UpdatedAfter) {
+        clauses.push("updated_time > ?");
+        params.push(filter.l1UpdatedAfter);
+      }
+      if (filter?.l1UpdatedBefore) {
+        clauses.push("updated_time < ?");
+        params.push(filter.l1UpdatedBefore);
+      }
+      const where = clauses.length > 0 ? ` WHERE ${clauses.join(" AND ")}` : "";
+      const filtered = this.db
+        .prepare(`SELECT COUNT(*) AS cnt FROM l1_records${where}`)
+        .get(...params) as { cnt: number };
+      return {
+        l0Records: l0.cnt,
+        l1Records: l1.cnt,
+        filteredL1Records: filtered.cnt,
+      };
+    } catch (err) {
+      throw new Error(
+        `SQLite checkpoint count failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     }
   }
 

--- a/src/core/store/tcvdb.ts
+++ b/src/core/store/tcvdb.ts
@@ -28,6 +28,8 @@ import type {
   ProfileRecord,
   ProfileSyncRecord,
   StoreLogger,
+  CheckpointCountFilter,
+  CheckpointCounts,
 } from "./types.js";
 import { TcvdbClient, TcvdbApiError } from "./tcvdb-client.js";
 import type { BM25LocalEncoder } from "./bm25-local.js";
@@ -865,6 +867,40 @@ export class TcvdbMemoryStore implements IMemoryStore {
     } catch (err) {
       this.logger?.warn(`${TAG} [L0-count] FAILED: ${err instanceof Error ? err.message : String(err)}`);
       return 0;
+    }
+  }
+
+  async getCheckpointCounts(filter?: CheckpointCountFilter): Promise<CheckpointCounts> {
+    await this._ensureInit();
+    if (this.degraded) throw new Error("TCVDB store is degraded");
+
+    const conditions: string[] = [];
+    if (filter?.l1UpdatedAfter) {
+      const timestamp = isoToEpochMs(filter.l1UpdatedAfter);
+      if (timestamp > 0) conditions.push(`updated_time_ms > ${timestamp}`);
+    }
+    if (filter?.l1UpdatedBefore) {
+      const timestamp = isoToEpochMs(filter.l1UpdatedBefore);
+      if (timestamp > 0) conditions.push(`updated_time_ms < ${timestamp}`);
+    }
+    const filtered = conditions.length > 0
+      ? await this.client.count(this.l1Collection, conditions.join(" and "))
+      : undefined;
+    try {
+      const [l0Records, l1Records] = await Promise.all([
+        this.client.count(this.l0Collection),
+        this.client.count(this.l1Collection),
+      ]);
+      return {
+        l0Records,
+        l1Records,
+        filteredL1Records: filtered ?? l1Records,
+      };
+    } catch (err) {
+      throw new Error(
+        `TCVDB checkpoint count failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     }
   }
 

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -75,6 +75,18 @@ export interface L1QueryFilter {
   updatedAfter?: string;
 }
 
+/** Filtered aggregate counts used by checkpoint reconciliation. */
+export interface CheckpointCountFilter {
+  l1UpdatedAfter?: string;
+  l1UpdatedBefore?: string;
+}
+
+export interface CheckpointCounts {
+  l0Records: number;
+  l1Records: number;
+  filteredL1Records: number;
+}
+
 /** Row shape returned by L1 query methods. */
 export interface L1RecordRow {
   record_id: string;
@@ -248,6 +260,12 @@ export interface IMemoryStore {
 
   init(providerInfo?: EmbeddingProviderInfo): MaybePromise<StoreInitResult>;
   isDegraded(): boolean;
+  /**
+   * Return authoritative aggregate counts. Unlike the normal fault-tolerant
+   * count/query methods, this method throws when the backend cannot answer so
+   * callers never mistake a failed read for an empty store.
+   */
+  getCheckpointCounts(filter?: CheckpointCountFilter): MaybePromise<CheckpointCounts>;
   getCapabilities(): StoreCapabilities;
   close(): void;
 

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -518,7 +518,7 @@ export class TdaiCore {
         // restoring pipeline state so persona thresholds resume from accurate
         // numbers even after manual pruning (non-fatal).
         try {
-          await checkpoint.recalibrate(this.vectorStore);
+          await checkpoint.recalibrateFromStorage(this.vectorStore, "scheduler-startup");
         } catch (err) {
           this.logger.warn(
             `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -514,6 +514,16 @@ export class TdaiCore {
     this.schedulerStartPromise = (async () => {
       try {
         const checkpoint = new CheckpointManager(this.dataDir, this.logger);
+        // Reconcile drift-prone counters with live store counts before
+        // restoring pipeline state so persona thresholds resume from accurate
+        // numbers even after manual pruning (non-fatal).
+        try {
+          await checkpoint.recalibrate(this.vectorStore);
+        } catch (err) {
+          this.logger.warn(
+            `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
         const cp = await checkpoint.read();
         scheduler.start(checkpoint.getAllPipelineStates(cp));
         this.logger.debug?.(`${TAG} Scheduler started`);

--- a/src/utils/checkpoint-data.ts
+++ b/src/utils/checkpoint-data.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type CheckpointDataKind = "l0" | "l1";
+
+export interface CheckpointDataLogger {
+  warn?(message: string): void;
+}
+
+export interface CheckpointDataCounts {
+  l0Records: number;
+  l1Records: number;
+  l1RecordsSincePersona: number;
+}
+
+export interface CheckpointFileCounts {
+  records: number;
+  recordsSincePersona: number;
+  malformedLines: number;
+}
+
+const SHARD_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}\.(?:jsonl|json)$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingPathError(err: unknown): boolean {
+  return isObject(err) && err.code === "ENOENT";
+}
+
+function validTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function countL0Record(value: unknown): number | undefined {
+  if (!isObject(value)) return undefined;
+
+  // Backward compatibility for the old one-line-per-capture format.
+  if (Array.isArray(value.messages)) {
+    return value.messages.filter((message) => isObject(message)).length;
+  }
+
+  if (
+    typeof value.id !== "string"
+    || typeof value.sessionKey !== "string"
+    || validTimestamp(value.recordedAt) === undefined
+  ) {
+    return undefined;
+  }
+
+  return 1;
+}
+
+function readL1Timestamp(value: Record<string, unknown>): number | undefined {
+  return validTimestamp(
+    value.updatedAt
+    ?? value.updated_at
+    ?? value.updated_time
+    ?? value.createdAt
+    ?? value.created_at,
+  );
+}
+
+/** Count valid persisted records in one L0/L1 shard. */
+export async function countCheckpointJsonlFile(
+  filePath: string,
+  kind: CheckpointDataKind,
+  lastPersonaTime = "",
+): Promise<CheckpointFileCounts> {
+  const raw = await fs.readFile(filePath, "utf-8");
+  const personaTimestamp = validTimestamp(lastPersonaTime);
+  const countAllAsRecent = personaTimestamp === undefined;
+  const result: CheckpointFileCounts = {
+    records: 0,
+    recordsSincePersona: 0,
+    malformedLines: 0,
+  };
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      result.malformedLines += 1;
+      continue;
+    }
+
+    if (kind === "l0") {
+      const recordCount = countL0Record(parsed);
+      if (recordCount === undefined) {
+        result.malformedLines += 1;
+        continue;
+      }
+      result.records += recordCount;
+      continue;
+    }
+
+    if (!isObject(parsed) || typeof parsed.id !== "string" || typeof parsed.sessionKey !== "string") {
+      result.malformedLines += 1;
+      continue;
+    }
+
+    const updatedTimestamp = readL1Timestamp(parsed);
+    if (updatedTimestamp === undefined) {
+      result.malformedLines += 1;
+      continue;
+    }
+
+    result.records += 1;
+    if (countAllAsRecent || updatedTimestamp > personaTimestamp) {
+      result.recordsSincePersona += 1;
+    }
+  }
+
+  return result;
+}
+
+async function countDirectory(
+  baseDir: string,
+  subdirectory: string,
+  kind: CheckpointDataKind,
+  lastPersonaTime: string,
+  logger?: CheckpointDataLogger,
+): Promise<CheckpointFileCounts> {
+  const directory = path.join(baseDir, subdirectory);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (err) {
+    if (isMissingPathError(err)) {
+      return { records: 0, recordsSincePersona: 0, malformedLines: 0 };
+    }
+    throw err;
+  }
+
+  const total: CheckpointFileCounts = {
+    records: 0,
+    recordsSincePersona: 0,
+    malformedLines: 0,
+  };
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !SHARD_FILE_PATTERN.test(entry.name)) continue;
+
+    const filePath = path.join(directory, entry.name);
+    try {
+      const counts = await countCheckpointJsonlFile(filePath, kind, lastPersonaTime);
+      total.records += counts.records;
+      total.recordsSincePersona += counts.recordsSincePersona;
+      total.malformedLines += counts.malformedLines;
+    } catch (err) {
+      logger?.warn?.(
+        `[checkpoint] Failed to count ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
+  }
+
+  return total;
+}
+
+/**
+ * Reconstruct a best-effort recovery count from local JSONL shards. L0 is
+ * record-based; L1 is append-only event data and may include superseded
+ * update/merge rows, so callers must only use it for downward correction.
+ */
+export async function countCheckpointJsonlData(
+  baseDir: string,
+  lastPersonaTime: string,
+  logger?: CheckpointDataLogger,
+): Promise<CheckpointDataCounts> {
+  const [l0, l1] = await Promise.all([
+    countDirectory(baseDir, "conversations", "l0", lastPersonaTime, logger),
+    countDirectory(baseDir, "records", "l1", lastPersonaTime, logger),
+  ]);
+
+  const malformedLines = l0.malformedLines + l1.malformedLines;
+  if (malformedLines > 0) {
+    logger?.warn?.(
+      `[checkpoint] Ignored ${malformedLines} malformed or incomplete JSONL record(s) during recalibration`,
+    );
+  }
+
+  return {
+    l0Records: l0.records,
+    l1Records: l1.records,
+    l1RecordsSincePersona: l1.recordsSincePersona,
+  };
+}

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { CheckpointManager, type CheckpointRecalibrateSource } from "./checkpoint.js";
+
+/** Seed a checkpoint with the given global counters (other fields get defaults). */
+async function seedCheckpoint(dataDir: string, overrides: Record<string, unknown>): Promise<void> {
+  const mgr = new CheckpointManager(dataDir);
+  await mgr.write({
+    last_captured_timestamp: 0,
+    total_processed: 100,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 3,
+    runner_states: { s1: { last_captured_timestamp: 1, last_l1_cursor: 2, last_scene_name: "x" } },
+    pipeline_states: { s1: { conversation_count: 5, last_extraction_time: "t", last_extraction_updated_time: "t", last_active_time: 3, l2_pending_l1_count: 2, warmup_threshold: 4, l2_last_extraction_time: "t" } },
+    l0_conversations_count: 0,
+    total_memories_extracted: 0,
+    ...overrides,
+  });
+}
+
+async function writeJsonl(baseDir: string, subDir: string, fileName: string, lines: string[]): Promise<void> {
+  const dir = path.join(baseDir, subDir);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, fileName), lines.length > 0 ? `${lines.join("\n")}\n` : "", "utf-8");
+}
+
+describe("CheckpointManager.recalibrate", () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), "ckpt-recalibrate-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("decreases drifted counters to live store counts", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 50,
+      total_memories_extracted: 45,
+      memories_since_last_persona: 10,
+    });
+
+    const source: CheckpointRecalibrateSource = { countL0: () => 42, countL1: () => 20 };
+    await new CheckpointManager(dataDir).recalibrate(source);
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.l0_conversations_count).toBe(42);
+    expect(cp.total_memories_extracted).toBe(20);
+    // 10 <= actual L1 (20) → unchanged
+    expect(cp.memories_since_last_persona).toBe(10);
+  });
+
+  it("increases counters to live store counts", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 5,
+      total_memories_extracted: 3,
+    });
+
+    const source: CheckpointRecalibrateSource = { countL0: () => 100, countL1: () => 80 };
+    await new CheckpointManager(dataDir).recalibrate(source);
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.l0_conversations_count).toBe(100);
+    expect(cp.total_memories_extracted).toBe(80);
+  });
+
+  it("clamps memories_since_last_persona down when L1 records were removed", async () => {
+    await seedCheckpoint(dataDir, {
+      total_memories_extracted: 45,
+      memories_since_last_persona: 30,
+    });
+
+    const source: CheckpointRecalibrateSource = { countL0: () => 42, countL1: () => 12 };
+    await new CheckpointManager(dataDir).recalibrate(source);
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.total_memories_extracted).toBe(12);
+    expect(cp.memories_since_last_persona).toBe(12);
+  });
+
+  it("preserves unrelated checkpoint fields", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 50,
+      total_memories_extracted: 45,
+      total_processed: 999,
+      scenes_processed: 7,
+    });
+
+    const source: CheckpointRecalibrateSource = { countL0: () => 10, countL1: () => 5 };
+    await new CheckpointManager(dataDir).recalibrate(source);
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.total_processed).toBe(999);
+    expect(cp.scenes_processed).toBe(7);
+    expect(cp.runner_states.s1.last_l1_cursor).toBe(2);
+    expect(cp.pipeline_states.s1.conversation_count).toBe(5);
+  });
+
+  it("is idempotent", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 50,
+      total_memories_extracted: 45,
+    });
+
+    const source: CheckpointRecalibrateSource = { countL0: () => 42, countL1: () => 20 };
+    const mgr = new CheckpointManager(dataDir);
+    await mgr.recalibrate(source);
+    await mgr.recalibrate(source);
+
+    const cp = await mgr.read();
+    expect(cp.l0_conversations_count).toBe(42);
+    expect(cp.total_memories_extracted).toBe(20);
+  });
+
+  it("counts JSONL shard lines as fallback when no source is given", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 99,
+      total_memories_extracted: 99,
+    });
+    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", ["{\"a\":1}", "{\"a\":2}", ""]);
+    await writeJsonl(dataDir, "conversations", "2026-07-02.jsonl", ["{\"a\":3}"]);
+    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", ["{\"r\":1}", "{\"r\":2}", "{\"r\":3}"]);
+    // Non-JSONL files must be ignored
+    await writeJsonl(dataDir, "records", "notes.txt", ["{\"r\":9}"]);
+
+    await new CheckpointManager(dataDir).recalibrate();
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.l0_conversations_count).toBe(3);
+    expect(cp.total_memories_extracted).toBe(3);
+  });
+
+  it("falls back to JSONL line counts when the store source throws", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 99,
+      total_memories_extracted: 99,
+    });
+    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", ["{\"a\":1}", "{\"a\":2}"]);
+    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", ["{\"r\":1}"]);
+
+    const source: CheckpointRecalibrateSource = {
+      countL0: () => { throw new Error("store down"); },
+      countL1: () => Promise.reject(new Error("store down")),
+    };
+    await new CheckpointManager(dataDir).recalibrate(source);
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.l0_conversations_count).toBe(2);
+    expect(cp.total_memories_extracted).toBe(1);
+  });
+
+  it("clamps NaN and negative counts to zero", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 50,
+      total_memories_extracted: 45,
+    });
+
+    const source: CheckpointRecalibrateSource = { countL0: () => Number.NaN, countL1: () => -7 };
+    await new CheckpointManager(dataDir).recalibrate(source);
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+    expect(cp.memories_since_last_persona).toBe(0);
+  });
+
+  it("treats a missing JSONL directory as zero records", async () => {
+    await seedCheckpoint(dataDir, {
+      l0_conversations_count: 50,
+      total_memories_extracted: 45,
+    });
+
+    await new CheckpointManager(dataDir).recalibrate();
+
+    const cp = await new CheckpointManager(dataDir).read();
+    expect(cp.l0_conversations_count).toBe(0);
+    expect(cp.total_memories_extracted).toBe(0);
+  });
+});

--- a/src/utils/checkpoint.test.ts
+++ b/src/utils/checkpoint.test.ts
@@ -1,37 +1,64 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { CheckpointManager, type CheckpointRecalibrateSource } from "./checkpoint.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-/** Seed a checkpoint with the given global counters (other fields get defaults). */
+import {
+  CheckpointManager,
+  type CheckpointCountStore,
+} from "./checkpoint.js";
+
 async function seedCheckpoint(dataDir: string, overrides: Record<string, unknown>): Promise<void> {
-  const mgr = new CheckpointManager(dataDir);
-  await mgr.write({
+  await new CheckpointManager(dataDir).write({
     last_captured_timestamp: 0,
     total_processed: 100,
     last_persona_at: 0,
-    last_persona_time: "",
+    last_persona_time: "2026-07-10T00:00:00.000Z",
     request_persona_update: false,
     persona_update_reason: "",
-    memories_since_last_persona: 0,
+    memories_since_last_persona: 10,
     scenes_processed: 3,
-    runner_states: { s1: { last_captured_timestamp: 1, last_l1_cursor: 2, last_scene_name: "x" } },
-    pipeline_states: { s1: { conversation_count: 5, last_extraction_time: "t", last_extraction_updated_time: "t", last_active_time: 3, l2_pending_l1_count: 2, warmup_threshold: 4, l2_last_extraction_time: "t" } },
-    l0_conversations_count: 0,
-    total_memories_extracted: 0,
+    runner_states: {
+      s1: { last_captured_timestamp: 1, last_l1_cursor: 2, last_scene_name: "scene" },
+    },
+    pipeline_states: {
+      s1: {
+        conversation_count: 5,
+        last_extraction_time: "time",
+        last_extraction_updated_time: "time",
+        last_active_time: 3,
+        l2_pending_l1_count: 2,
+        warmup_threshold: 4,
+        l2_last_extraction_time: "time",
+      },
+    },
+    l0_conversations_count: 100,
+    total_memories_extracted: 45,
     ...overrides,
   });
 }
 
-async function writeJsonl(baseDir: string, subDir: string, fileName: string, lines: string[]): Promise<void> {
-  const dir = path.join(baseDir, subDir);
-  await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(path.join(dir, fileName), lines.length > 0 ? `${lines.join("\n")}\n` : "", "utf-8");
+async function writeJsonl(
+  baseDir: string,
+  subdirectory: string,
+  fileName: string,
+  lines: string[],
+): Promise<void> {
+  const directory = path.join(baseDir, subdirectory);
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(path.join(directory, fileName), `${lines.join("\n")}\n`, "utf-8");
 }
 
-describe("CheckpointManager.recalibrate", () => {
+function store(overrides: Partial<CheckpointCountStore> = {}): CheckpointCountStore {
+  return {
+    isDegraded: () => false,
+    getCheckpointCounts: () => ({ l0Records: 42, l1Records: 20, filteredL1Records: 3 }),
+    ...overrides,
+  };
+}
+
+describe("CheckpointManager recalibration", () => {
   let dataDir: string;
 
   beforeEach(async () => {
@@ -42,147 +69,171 @@ describe("CheckpointManager.recalibrate", () => {
     await fs.rm(dataDir, { recursive: true, force: true });
   });
 
-  it("decreases drifted counters to live store counts", async () => {
-    await seedCheckpoint(dataDir, {
-      l0_conversations_count: 50,
-      total_memories_extracted: 45,
-      memories_since_last_persona: 10,
+  it("rebuilds all derived counters from a healthy store", async () => {
+    await seedCheckpoint(dataDir, {});
+
+    const result = await new CheckpointManager(dataDir).recalibrateFromStorage(store());
+    const checkpoint = await new CheckpointManager(dataDir).read();
+
+    expect(result.source).toBe("store");
+    expect(checkpoint).toMatchObject({
+      total_processed: 42,
+      l0_conversations_count: 42,
+      total_memories_extracted: 20,
+      memories_since_last_persona: 3,
     });
-
-    const source: CheckpointRecalibrateSource = { countL0: () => 42, countL1: () => 20 };
-    await new CheckpointManager(dataDir).recalibrate(source);
-
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.l0_conversations_count).toBe(42);
-    expect(cp.total_memories_extracted).toBe(20);
-    // 10 <= actual L1 (20) → unchanged
-    expect(cp.memories_since_last_persona).toBe(10);
   });
 
-  it("increases counters to live store counts", async () => {
-    await seedCheckpoint(dataDir, {
-      l0_conversations_count: 5,
-      total_memories_extracted: 3,
+  it("preserves session cursors and non-derived checkpoint fields", async () => {
+    await seedCheckpoint(dataDir, { scenes_processed: 7 });
+
+    await new CheckpointManager(dataDir).recalibrateFromStorage(store());
+    const checkpoint = await new CheckpointManager(dataDir).read();
+
+    expect(checkpoint.scenes_processed).toBe(7);
+    expect(checkpoint.runner_states.s1).toMatchObject({
+      last_captured_timestamp: 1,
+      last_l1_cursor: 2,
+      last_scene_name: "scene",
     });
-
-    const source: CheckpointRecalibrateSource = { countL0: () => 100, countL1: () => 80 };
-    await new CheckpointManager(dataDir).recalibrate(source);
-
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.l0_conversations_count).toBe(100);
-    expect(cp.total_memories_extracted).toBe(80);
+    expect(checkpoint.pipeline_states.s1.conversation_count).toBe(5);
   });
 
-  it("clamps memories_since_last_persona down when L1 records were removed", async () => {
-    await seedCheckpoint(dataDir, {
-      total_memories_extracted: 45,
-      memories_since_last_persona: 30,
+  it("falls back to valid JSONL records for a degraded store", async () => {
+    await seedCheckpoint(dataDir, {});
+    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", [
+      JSON.stringify({ id: "l0-1", sessionKey: "s1", recordedAt: "2026-07-01T00:00:00Z" }),
+      JSON.stringify({ messages: [{ role: "user" }, { role: "assistant" }] }),
+      "{bad-json",
+    ]);
+    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", [
+      JSON.stringify({ id: "old", sessionKey: "s1", updatedAt: "2026-07-01T00:00:00Z" }),
+      JSON.stringify({ id: "new", sessionKey: "s1", updated_time: "2026-07-11T00:00:00Z" }),
+      JSON.stringify({ id: "incomplete" }),
+    ]);
+    await writeJsonl(dataDir, "records", "notes.jsonl.bak", [
+      JSON.stringify({ id: "ignored", sessionKey: "s1", updatedAt: "2026-07-12T00:00:00Z" }),
+    ]);
+
+    const result = await new CheckpointManager(dataDir).recalibrateFromStorage(
+      store({ isDegraded: () => true }),
+    );
+    const checkpoint = await new CheckpointManager(dataDir).read();
+
+    expect(result.source).toBe("jsonl");
+    expect(checkpoint).toMatchObject({
+      total_processed: 3,
+      l0_conversations_count: 3,
+      total_memories_extracted: 2,
+      memories_since_last_persona: 1,
     });
-
-    const source: CheckpointRecalibrateSource = { countL0: () => 42, countL1: () => 12 };
-    await new CheckpointManager(dataDir).recalibrate(source);
-
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.total_memories_extracted).toBe(12);
-    expect(cp.memories_since_last_persona).toBe(12);
   });
 
-  it("preserves unrelated checkpoint fields", async () => {
-    await seedCheckpoint(dataDir, {
-      l0_conversations_count: 50,
-      total_memories_extracted: 45,
-      total_processed: 999,
-      scenes_processed: 7,
-    });
+  it("preserves counters when a healthy store count fails", async () => {
+    await seedCheckpoint(dataDir, {});
+    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", [
+      JSON.stringify({ id: "l0", sessionKey: "s1", recordedAt: "2026-07-01T00:00:00Z" }),
+    ]);
+    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", [
+      JSON.stringify({ id: "l1", sessionKey: "s1", updatedAt: "2026-07-11T00:00:00Z" }),
+    ]);
 
-    const source: CheckpointRecalibrateSource = { countL0: () => 10, countL1: () => 5 };
-    await new CheckpointManager(dataDir).recalibrate(source);
+    const result = await new CheckpointManager(dataDir).recalibrateFromStorage(
+      store({ getCheckpointCounts: () => ({ l0Records: Number.NaN, l1Records: 20, filteredL1Records: 3 }) }),
+    );
 
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.total_processed).toBe(999);
-    expect(cp.scenes_processed).toBe(7);
-    expect(cp.runner_states.s1.last_l1_cursor).toBe(2);
-    expect(cp.pipeline_states.s1.conversation_count).toBe(5);
+    expect(result.source).toBe("store");
+    expect((await new CheckpointManager(dataDir).read()).total_processed).toBe(100);
   });
 
-  it("is idempotent", async () => {
-    await seedCheckpoint(dataDir, {
-      l0_conversations_count: 50,
-      total_memories_extracted: 45,
+  it("rebuilds a fresh checkpoint upward from JSONL during store degradation", async () => {
+    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", [
+      JSON.stringify({ id: "l0", sessionKey: "s1", recordedAt: "2026-07-01T00:00:00Z" }),
+    ]);
+    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", [
+      JSON.stringify({ id: "l1", sessionKey: "s1", updatedAt: "2026-07-11T00:00:00Z" }),
+    ]);
+
+    await new CheckpointManager(dataDir).recalibrateFromStorage(
+      store({ isDegraded: () => true }),
+    );
+
+    expect(await new CheckpointManager(dataDir).read()).toMatchObject({
+      total_processed: 1,
+      l0_conversations_count: 1,
+      total_memories_extracted: 1,
+      memories_since_last_persona: 1,
     });
-
-    const source: CheckpointRecalibrateSource = { countL0: () => 42, countL1: () => 20 };
-    const mgr = new CheckpointManager(dataDir);
-    await mgr.recalibrate(source);
-    await mgr.recalibrate(source);
-
-    const cp = await mgr.read();
-    expect(cp.l0_conversations_count).toBe(42);
-    expect(cp.total_memories_extracted).toBe(20);
   });
 
-  it("counts JSONL shard lines as fallback when no source is given", async () => {
-    await seedCheckpoint(dataDir, {
-      l0_conversations_count: 99,
-      total_memories_extracted: 99,
+  it("treats missing JSONL directories as empty storage", async () => {
+    await seedCheckpoint(dataDir, {});
+
+    await new CheckpointManager(dataDir).recalibrateFromStorage();
+
+    expect(await new CheckpointManager(dataDir).read()).toMatchObject({
+      total_processed: 0,
+      l0_conversations_count: 0,
+      total_memories_extracted: 0,
+      memories_since_last_persona: 0,
     });
-    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", ["{\"a\":1}", "{\"a\":2}", ""]);
-    await writeJsonl(dataDir, "conversations", "2026-07-02.jsonl", ["{\"a\":3}"]);
-    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", ["{\"r\":1}", "{\"r\":2}", "{\"r\":3}"]);
-    // Non-JSONL files must be ignored
-    await writeJsonl(dataDir, "records", "notes.txt", ["{\"r\":9}"]);
-
-    await new CheckpointManager(dataDir).recalibrate();
-
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.l0_conversations_count).toBe(3);
-    expect(cp.total_memories_extracted).toBe(3);
   });
 
-  it("falls back to JSONL line counts when the store source throws", async () => {
+  it("subtracts only removed L1 records newer than the persona watermark", async () => {
     await seedCheckpoint(dataDir, {
-      l0_conversations_count: 99,
-      total_memories_extracted: 99,
+      total_processed: 20,
+      l0_conversations_count: 20,
+      total_memories_extracted: 10,
+      memories_since_last_persona: 4,
     });
-    await writeJsonl(dataDir, "conversations", "2026-07-01.jsonl", ["{\"a\":1}", "{\"a\":2}"]);
-    await writeJsonl(dataDir, "records", "2026-07-01.jsonl", ["{\"r\":1}"]);
 
-    const source: CheckpointRecalibrateSource = {
-      countL0: () => { throw new Error("store down"); },
-      countL1: () => Promise.reject(new Error("store down")),
-    };
-    await new CheckpointManager(dataDir).recalibrate(source);
+    await new CheckpointManager(dataDir).applyCleanupDelta({
+      l0Records: 3,
+      l1Records: 5,
+      l1RecordsSincePersona: 1,
+    });
 
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.l0_conversations_count).toBe(2);
-    expect(cp.total_memories_extracted).toBe(1);
+    expect(await new CheckpointManager(dataDir).read()).toMatchObject({
+      total_processed: 17,
+      l0_conversations_count: 17,
+      total_memories_extracted: 5,
+      memories_since_last_persona: 3,
+    });
   });
 
-  it("clamps NaN and negative counts to zero", async () => {
+  it("preserves concurrent L1 increments while applying cleanup deltas", async () => {
     await seedCheckpoint(dataDir, {
-      l0_conversations_count: 50,
-      total_memories_extracted: 45,
+      total_memories_extracted: 10,
+      memories_since_last_persona: 5,
     });
+    const checkpoint = new CheckpointManager(dataDir);
 
-    const source: CheckpointRecalibrateSource = { countL0: () => Number.NaN, countL1: () => -7 };
-    await new CheckpointManager(dataDir).recalibrate(source);
+    await Promise.all([
+      checkpoint.applyCleanupDelta({ l1Records: 3, l1RecordsSincePersona: 1 }),
+      checkpoint.markL1ExtractionComplete("s1", 2),
+    ]);
 
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.l0_conversations_count).toBe(0);
-    expect(cp.total_memories_extracted).toBe(0);
-    expect(cp.memories_since_last_persona).toBe(0);
+    expect(await checkpoint.read()).toMatchObject({
+      total_memories_extracted: 9,
+      memories_since_last_persona: 6,
+    });
   });
 
-  it("treats a missing JSONL directory as zero records", async () => {
+  it("uses L0 message-record units during capture", async () => {
     await seedCheckpoint(dataDir, {
-      l0_conversations_count: 50,
-      total_memories_extracted: 45,
+      total_processed: 0,
+      l0_conversations_count: 0,
     });
+    const checkpoint = new CheckpointManager(dataDir);
 
-    await new CheckpointManager(dataDir).recalibrate();
+    await checkpoint.captureAtomically("s1", undefined, async () => ({
+      maxTimestamp: 100,
+      messageCount: 3,
+    }));
 
-    const cp = await new CheckpointManager(dataDir).read();
-    expect(cp.l0_conversations_count).toBe(0);
-    expect(cp.total_memories_extracted).toBe(0);
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 3,
+      l0_conversations_count: 3,
+    });
   });
 });

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -28,6 +28,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
 
+import { countCheckpointJsonlData, type CheckpointDataCounts } from "./checkpoint-data.js";
+
 // ============================
 // Types
 // ============================
@@ -82,7 +84,7 @@ export interface Checkpoint {
   // ═══ Global counters ═══
   /** Epoch ms of the newest message successfully uploaded. Messages with ts > this are new. */
   last_captured_timestamp: number;
-  /** Total messages processed across all time */
+  /** Total persisted L0 message records */
   total_processed: number;
   last_persona_at: number;
   last_persona_time: string;
@@ -100,11 +102,11 @@ export interface Checkpoint {
   pipeline_states: Record<string, PipelineSessionState>;
 
   // ═══ L0 ═══
-  /** Total L0 conversation files recorded */
+  /** Total persisted L0 message records (legacy field name retained for compatibility) */
   l0_conversations_count: number;
 
   // ═══ L1 ═══
-  /** Total L1 memories extracted across all time */
+  /** Total persisted L1 memory records */
   total_memories_extracted: number;
 }
 
@@ -154,20 +156,54 @@ const noopLogger: CheckpointLogger = { info() {} };
  * fault-tolerant (store implementations return 0 rather than throw when
  * degraded); `recalibrate()` additionally falls back to JSONL line counts.
  */
-export interface CheckpointRecalibrateSource {
-  /** Live count of L0 conversation records. */
-  countL0(): number | Promise<number>;
-  /** Live count of L1 memory records. */
-  countL1(): number | Promise<number>;
+export interface CheckpointCountStore {
+  isDegraded(): boolean;
+  getCheckpointCounts(filter?: {
+    l1UpdatedAfter?: string;
+    l1UpdatedBefore?: string;
+  }): {
+    l0Records: number;
+    l1Records: number;
+    filteredL1Records: number;
+  } | Promise<{
+    l0Records: number;
+    l1Records: number;
+    filteredL1Records: number;
+  }>;
 }
 
-const L0_JSONL_DIR = "conversations";
-const L1_JSONL_DIR = "records";
+export interface CheckpointCounterSnapshot {
+  total_processed: number;
+  l0_conversations_count: number;
+  total_memories_extracted: number;
+  memories_since_last_persona: number;
+}
 
-/** Coerce an arbitrary count into a safe non-negative integer. */
-function clampNonNegativeCount(n: number): number {
-  if (!Number.isFinite(n)) return 0;
-  return Math.max(0, Math.floor(n));
+export interface CheckpointRecalibrationResult {
+  source: "store" | "jsonl";
+  reason: string;
+  before: CheckpointCounterSnapshot;
+  after: CheckpointCounterSnapshot;
+}
+
+function normalizeCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+function requireValidCount(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} returned invalid count: ${value}`);
+  }
+  return Math.trunc(value);
+}
+
+function counterSnapshot(cp: Checkpoint): CheckpointCounterSnapshot {
+  return {
+    total_processed: cp.total_processed,
+    l0_conversations_count: cp.l0_conversations_count,
+    total_memories_extracted: cp.total_memories_extracted,
+    memories_since_last_persona: cp.memories_since_last_persona,
+  };
 }
 
 // ============================
@@ -328,98 +364,144 @@ export class CheckpointManager {
   // ============================
 
   /**
-   * Reconcile drift-prone global counters with the actual stored data.
+   * Rebuild derived counters from the active persistence layer.
    *
-   * `total_memories_extracted` and `l0_conversations_count` are increment-only:
-   * nothing ever decrements them when records are removed (memory-cleaner runs,
-   * manual JSONL pruning), so after any cleanup they permanently overstate
-   * reality. Since `memories_since_last_persona` feeds L2/L3 persona thresholds,
-   * the drift can make persona generation trigger prematurely or never.
-   *
-   * This method recounts against the authoritative source and clamps:
-   * - live store counts (`countL0`/`countL1`) when a source is available;
-   * - JSONL shard line counts as a degraded-mode fallback when it is not.
-   *
-   * `memories_since_last_persona` is clamped down to the actual L1 total so a
-   * phantom high count cannot fire persona generation early. Non-fatal: if a
-   * level cannot be counted, its counter is left untouched.
-   *
-   * @param source Optional live-count source (any `IMemoryStore` satisfies it).
-   *               Omit to count JSONL shard lines only.
+   * A healthy store is authoritative because retrieval and cleanup operate on
+   * its deduplicated rows. JSONL shards are used when the store is unavailable
+   * or degraded. This absolute recount is intended for startup, before runners
+   * begin mutating the checkpoint; runtime cleanup uses atomic deltas instead.
    */
-  async recalibrate(source?: CheckpointRecalibrateSource): Promise<void> {
-    const l0 = await this.safeCount(source ? () => source.countL0() : undefined, L0_JSONL_DIR);
-    const l1 = await this.safeCount(source ? () => source.countL1() : undefined, L1_JSONL_DIR);
+  async recalibrateFromStorage(
+    store?: CheckpointCountStore,
+    reason = "startup",
+  ): Promise<CheckpointRecalibrationResult> {
+    const current = await this.read();
+    const lastPersonaTime = Number.isFinite(Date.parse(current.last_persona_time))
+      ? current.last_persona_time
+      : "";
 
-    if (l0 === undefined && l1 === undefined) {
-      this.logger.warn?.("[checkpoint] recalibrate: no counts available, counters left untouched");
-      return;
+    let source: "store" | "jsonl" = "jsonl";
+    let actual: CheckpointDataCounts | undefined;
+
+    if (store && !store.isDegraded()) {
+      try {
+        const counts = await Promise.resolve(store.getCheckpointCounts(
+          lastPersonaTime ? { l1UpdatedAfter: lastPersonaTime } : undefined,
+        ));
+        const l0Records = requireValidCount(counts.l0Records, "l0Records");
+        const l1Records = requireValidCount(counts.l1Records, "l1Records");
+        const l1RecordsSincePersona = requireValidCount(
+          counts.filteredL1Records,
+          "filteredL1Records",
+        );
+        actual = { l0Records, l1Records, l1RecordsSincePersona };
+        source = "store";
+      } catch (err) {
+        this.logger.warn?.(
+          `[checkpoint] Store count failed during ${reason}; preserving checkpoint ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+        const before = counterSnapshot(current);
+        return { source: "store", reason, before, after: before };
+      }
     }
 
-    await this.mutate((cp) => {
-      if (l0 !== undefined) {
-        cp.l0_conversations_count = clampNonNegativeCount(l0);
-      }
-      if (l1 !== undefined) {
-        const actualL1 = clampNonNegativeCount(l1);
-        cp.total_memories_extracted = actualL1;
-        if (cp.memories_since_last_persona > actualL1) {
-          cp.memories_since_last_persona = actualL1;
-        }
-      }
+    if (!actual) {
+      actual = await countCheckpointJsonlData(this.dataDir, lastPersonaTime, this.logger);
+    }
+
+    return this.recalibrateCounts(actual, source, reason);
+  }
+
+  /**
+   * Atomically overwrite derived counters with already-counted persistence
+   * truth. JSONL can rebuild a brand-new checkpoint, but for an existing
+   * checkpoint it is append-only recovery data: it may lower drifted counters
+   * but must not grow them from superseded L1 events.
+   */
+  async recalibrateCounts(
+    actual: CheckpointDataCounts,
+    source: "store" | "jsonl" = "store",
+    reason = "manual",
+  ): Promise<CheckpointRecalibrationResult> {
+    let before!: CheckpointCounterSnapshot;
+    const cp = await this.mutate((cp) => {
+      before = counterSnapshot(cp);
+      const countedL0 = normalizeCount(actual.l0Records);
+      const countedL1 = normalizeCount(actual.l1Records);
+      // A brand-new checkpoint has no prior truth to protect. In that case
+      // JSONL is the active persistence layer (typically during store
+      // degradation) and must be allowed to rebuild counters upward.
+      const jsonlCanRebuild = source === "jsonl" &&
+        cp.total_processed === 0 &&
+        cp.total_memories_extracted === 0 &&
+        cp.memories_since_last_persona === 0;
+      const l0Records = source === "jsonl" && !jsonlCanRebuild
+        ? Math.min(cp.total_processed, countedL0)
+        : countedL0;
+      const l1Records = source === "jsonl" && !jsonlCanRebuild
+        ? Math.min(cp.total_memories_extracted, countedL1)
+        : countedL1;
+      const l1RecordsSincePersona = Math.min(
+        l1Records,
+        source === "jsonl" && !jsonlCanRebuild
+          ? Math.min(cp.memories_since_last_persona, normalizeCount(actual.l1RecordsSincePersona))
+          : normalizeCount(actual.l1RecordsSincePersona),
+      );
+
+      cp.total_processed = l0Records;
+      cp.l0_conversations_count = l0Records;
+      cp.total_memories_extracted = l1Records;
+      cp.memories_since_last_persona = l1RecordsSincePersona;
+    });
+    const after = counterSnapshot(cp);
+
+    this.logger.info(
+      `[checkpoint] recalibrated (${source}, ${reason}): ` +
+      `l0=${before.total_processed}->${after.total_processed}, ` +
+      `l1=${before.total_memories_extracted}->${after.total_memories_extracted}, ` +
+      `sincePersona=${before.memories_since_last_persona}->${after.memories_since_last_persona}`,
+    );
+
+    return { source, reason, before, after };
+  }
+
+  /** Apply successful cleanup as deltas so concurrent updates are preserved. */
+  async applyCleanupDelta(removed: {
+    l0Records?: number;
+    l1Records?: number;
+    l1RecordsSincePersona?: number;
+  }): Promise<void> {
+    const removedL0 = normalizeCount(removed.l0Records ?? 0);
+    const removedL1 = normalizeCount(removed.l1Records ?? 0);
+    const removedSincePersona = Math.min(
+      removedL1,
+      normalizeCount(removed.l1RecordsSincePersona ?? removedL1),
+    );
+    if (removedL0 === 0 && removedL1 === 0) return;
+
+    const cp = await this.mutate((cp) => {
+      cp.total_processed = Math.max(0, cp.total_processed - removedL0);
+      cp.l0_conversations_count = Math.max(0, cp.l0_conversations_count - removedL0);
+      cp.total_memories_extracted = Math.max(0, cp.total_memories_extracted - removedL1);
+      cp.memories_since_last_persona = Math.min(
+        cp.total_memories_extracted,
+        Math.max(0, cp.memories_since_last_persona - removedSincePersona),
+      );
     });
 
     this.logger.info(
-      `[checkpoint] recalibrate: l0_conversations_count=${l0 ?? "(kept)"}, ` +
-      `total_memories_extracted=${l1 ?? "(kept)"}`,
+      `[checkpoint] cleanup delta: removedL0=${removedL0}, removedL1=${removedL1}, ` +
+      `removedSincePersona=${removedSincePersona}, l0=${cp.total_processed}, ` +
+      `l1=${cp.total_memories_extracted}, sincePersona=${cp.memories_since_last_persona}`,
     );
   }
 
-  /**
-   * Count records for a level, preferring the live store source and falling
-   * back to JSONL shard line counts. Returns `undefined` when neither works.
-   */
-  private async safeCount(
-    storeCount: (() => number | Promise<number>) | undefined,
-    dirName: string,
-  ): Promise<number | undefined> {
-    if (storeCount) {
-      try {
-        const n = await storeCount();
-        if (Number.isFinite(n)) return n;
-      } catch {
-        // store unavailable — fall through to JSONL line count
-      }
-    }
-    return this.countJsonlLines(dirName);
-  }
-
-  /**
-   * Count non-empty JSONL lines across all shard files under `<dataDir>/<dirName>`.
-   * Returns 0 when the directory does not exist (no records).
-   */
-  private async countJsonlLines(dirName: string): Promise<number | undefined> {
-    const dir = path.join(this.dataDir, dirName);
-    let entries;
-    try {
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return 0;
-    }
-
-    let total = 0;
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
-      try {
-        const raw = await fs.readFile(path.join(dir, entry.name), "utf-8");
-        for (const line of raw.split("\n")) {
-          if (line.trim().length > 0) total += 1;
-        }
-      } catch {
-        // skip unreadable shard
-      }
-    }
-    return total;
+  async ensureScenesProcessedAtLeast(minimum: number): Promise<void> {
+    const normalizedMinimum = normalizeCount(minimum);
+    await this.mutate((cp) => {
+      cp.scenes_processed = Math.max(cp.scenes_processed, normalizedMinimum);
+    });
   }
 
   // ============================
@@ -574,8 +656,8 @@ export class CheckpointManager {
    *   - `{ maxTimestamp, messageCount }` to advance the cursor, or
    *   - `null` to leave the cursor unchanged (nothing captured).
    *
-   * L0 conversation count is also incremented inside the lock when messages
-   * are captured, removing the need for a separate `incrementL0ConversationCount()` call.
+   * The persisted L0 record count is also incremented inside the lock when
+   * messages are captured.
    *
    * @param sessionKey   Per-session identifier
    * @param pluginStartTimestamp  Cold-start floor (used when no cursor exists yet)
@@ -604,8 +686,7 @@ export class CheckpointManager {
         // Global stats (aggregate only — not used for filtering)
         cp.last_captured_timestamp = Math.max(cp.last_captured_timestamp, result.maxTimestamp);
         cp.total_processed += result.messageCount;
-        // Increment L0 conversation count (was a separate mutate() call before)
-        cp.l0_conversations_count += 1;
+        cp.l0_conversations_count += result.messageCount;
       }
     });
   }

--- a/src/utils/checkpoint.ts
+++ b/src/utils/checkpoint.ts
@@ -146,6 +146,30 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+/**
+ * Live-count source for recalibrating drift-prone global counters.
+ *
+ * Shape-compatible with the L0/L1 count methods of `IMemoryStore`, so any
+ * store instance can be passed directly. Both methods are expected to be
+ * fault-tolerant (store implementations return 0 rather than throw when
+ * degraded); `recalibrate()` additionally falls back to JSONL line counts.
+ */
+export interface CheckpointRecalibrateSource {
+  /** Live count of L0 conversation records. */
+  countL0(): number | Promise<number>;
+  /** Live count of L1 memory records. */
+  countL1(): number | Promise<number>;
+}
+
+const L0_JSONL_DIR = "conversations";
+const L1_JSONL_DIR = "records";
+
+/** Coerce an arbitrary count into a safe non-negative integer. */
+function clampNonNegativeCount(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.floor(n));
+}
+
 // ============================
 // Per-file async lock
 // ============================
@@ -179,10 +203,12 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
 
   constructor(dataDir: string, logger?: CheckpointLogger) {
+    this.dataDir = dataDir;
     this.filePath = path.join(dataDir, ".metadata", "recall_checkpoint.json");
     this.logger = logger ?? noopLogger;
   }
@@ -296,6 +322,105 @@ export class CheckpointManager {
   // ============================
   // Public API — mutating (all serialized via file lock)
   // ============================
+
+  // ============================
+  // Counter recalibration
+  // ============================
+
+  /**
+   * Reconcile drift-prone global counters with the actual stored data.
+   *
+   * `total_memories_extracted` and `l0_conversations_count` are increment-only:
+   * nothing ever decrements them when records are removed (memory-cleaner runs,
+   * manual JSONL pruning), so after any cleanup they permanently overstate
+   * reality. Since `memories_since_last_persona` feeds L2/L3 persona thresholds,
+   * the drift can make persona generation trigger prematurely or never.
+   *
+   * This method recounts against the authoritative source and clamps:
+   * - live store counts (`countL0`/`countL1`) when a source is available;
+   * - JSONL shard line counts as a degraded-mode fallback when it is not.
+   *
+   * `memories_since_last_persona` is clamped down to the actual L1 total so a
+   * phantom high count cannot fire persona generation early. Non-fatal: if a
+   * level cannot be counted, its counter is left untouched.
+   *
+   * @param source Optional live-count source (any `IMemoryStore` satisfies it).
+   *               Omit to count JSONL shard lines only.
+   */
+  async recalibrate(source?: CheckpointRecalibrateSource): Promise<void> {
+    const l0 = await this.safeCount(source ? () => source.countL0() : undefined, L0_JSONL_DIR);
+    const l1 = await this.safeCount(source ? () => source.countL1() : undefined, L1_JSONL_DIR);
+
+    if (l0 === undefined && l1 === undefined) {
+      this.logger.warn?.("[checkpoint] recalibrate: no counts available, counters left untouched");
+      return;
+    }
+
+    await this.mutate((cp) => {
+      if (l0 !== undefined) {
+        cp.l0_conversations_count = clampNonNegativeCount(l0);
+      }
+      if (l1 !== undefined) {
+        const actualL1 = clampNonNegativeCount(l1);
+        cp.total_memories_extracted = actualL1;
+        if (cp.memories_since_last_persona > actualL1) {
+          cp.memories_since_last_persona = actualL1;
+        }
+      }
+    });
+
+    this.logger.info(
+      `[checkpoint] recalibrate: l0_conversations_count=${l0 ?? "(kept)"}, ` +
+      `total_memories_extracted=${l1 ?? "(kept)"}`,
+    );
+  }
+
+  /**
+   * Count records for a level, preferring the live store source and falling
+   * back to JSONL shard line counts. Returns `undefined` when neither works.
+   */
+  private async safeCount(
+    storeCount: (() => number | Promise<number>) | undefined,
+    dirName: string,
+  ): Promise<number | undefined> {
+    if (storeCount) {
+      try {
+        const n = await storeCount();
+        if (Number.isFinite(n)) return n;
+      } catch {
+        // store unavailable — fall through to JSONL line count
+      }
+    }
+    return this.countJsonlLines(dirName);
+  }
+
+  /**
+   * Count non-empty JSONL lines across all shard files under `<dataDir>/<dirName>`.
+   * Returns 0 when the directory does not exist (no records).
+   */
+  private async countJsonlLines(dirName: string): Promise<number | undefined> {
+    const dir = path.join(this.dataDir, dirName);
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    let total = 0;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      try {
+        const raw = await fs.readFile(path.join(dir, entry.name), "utf-8");
+        for (const line of raw.split("\n")) {
+          if (line.trim().length > 0) total += 1;
+        }
+      } catch {
+        // skip unreadable shard
+      }
+    }
+    return total;
+  }
 
   // ============================
   // Persona methods (L3)

--- a/src/utils/memory-cleaner.test.ts
+++ b/src/utils/memory-cleaner.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { IMemoryStore } from "../core/store/types.js";
+import type { Logger } from "../core/types.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { LocalMemoryCleaner } from "./memory-cleaner.js";
+import { _resetTimeModuleForTest, initTimeModule } from "./time.js";
+
+const tempDirectories: string[] = [];
+const logger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+async function makeTempDirectory(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-cleaner-"));
+  tempDirectories.push(directory);
+  return directory;
+}
+
+async function seedCheckpoint(
+  baseDir: string,
+  counts: { l0: number; l1: number; sincePersona: number },
+): Promise<CheckpointManager> {
+  const checkpoint = new CheckpointManager(baseDir);
+  await checkpoint.write({
+    last_captured_timestamp: 0,
+    total_processed: counts.l0,
+    last_persona_at: 0,
+    last_persona_time: "2026-07-10T00:00:00.000Z",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: counts.sincePersona,
+    scenes_processed: 0,
+    runner_states: {},
+    pipeline_states: {},
+    l0_conversations_count: counts.l0,
+    total_memories_extracted: counts.l1,
+  });
+  return checkpoint;
+}
+
+async function writeShard(
+  baseDir: string,
+  subdirectory: "conversations" | "records",
+  date: string,
+  lines: string[],
+): Promise<void> {
+  const directory = path.join(baseDir, subdirectory);
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(path.join(directory, `${date}.jsonl`), `${lines.join("\n")}\n`, "utf-8");
+}
+
+function l0Line(id: string, recordedAt: string): string {
+  return JSON.stringify({ id, sessionKey: "session", recordedAt });
+}
+
+function l1Line(id: string, updatedAt: string): string {
+  return JSON.stringify({ id, sessionKey: "session", updatedAt });
+}
+
+afterEach(async () => {
+  _resetTimeModuleForTest();
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("LocalMemoryCleaner checkpoint updates", () => {
+  it("uses store deletion deltas and keeps the Persona-relative count exact", async () => {
+    initTimeModule({ timezone: "UTC" });
+    const baseDir = await makeTempDirectory();
+    const checkpoint = await seedCheckpoint(baseDir, { l0: 60, l1: 25, sincePersona: 5 });
+
+    const store = {
+      isDegraded: () => false,
+      getCheckpointCounts: () => ({
+        l0Records: 60,
+        l1Records: 25,
+        filteredL1Records: 1,
+      }),
+      deleteL0Expired: () => 8,
+      deleteL1Expired: () => 3,
+    } as Partial<IMemoryStore> as IMemoryStore;
+
+    await new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+      vectorStore: store,
+    }).runOnce(Date.parse("2026-07-15T12:00:00.000Z"));
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 52,
+      l0_conversations_count: 52,
+      total_memories_extracted: 22,
+      memories_since_last_persona: 4,
+    });
+  });
+
+  it("uses valid deleted JSONL records when no store is available", async () => {
+    initTimeModule({ timezone: "UTC" });
+    const baseDir = await makeTempDirectory();
+    const checkpoint = await seedCheckpoint(baseDir, { l0: 3, l1: 3, sincePersona: 2 });
+
+    await writeShard(baseDir, "conversations", "2026-07-12", [
+      l0Line("old-l0-1", "2026-07-12T12:00:00.000Z"),
+      l0Line("old-l0-2", "2026-07-12T12:01:00.000Z"),
+      "{bad-json",
+    ]);
+    await writeShard(baseDir, "conversations", "2026-07-15", [
+      l0Line("new-l0", "2026-07-15T12:00:00.000Z"),
+    ]);
+    await writeShard(baseDir, "records", "2026-07-12", [
+      l1Line("old-before-persona", "2026-07-09T12:00:00.000Z"),
+      l1Line("old-after-persona", "2026-07-12T12:00:00.000Z"),
+      JSON.stringify({ id: "incomplete" }),
+    ]);
+    await writeShard(baseDir, "records", "2026-07-15", [
+      l1Line("new-l1", "2026-07-15T12:00:00.000Z"),
+    ]);
+
+    await new LocalMemoryCleaner({
+      baseDir,
+      retentionDays: 2,
+      cleanTime: "03:00",
+      logger,
+    }).runOnce(Date.parse("2026-07-15T12:00:00.000Z"));
+
+    expect(await checkpoint.read()).toMatchObject({
+      total_processed: 1,
+      l0_conversations_count: 1,
+      total_memories_extracted: 1,
+      memories_since_last_persona: 1,
+    });
+    await expect(fs.access(path.join(baseDir, "records", "2026-07-12.jsonl"))).rejects.toThrow();
+    await expect(fs.access(path.join(baseDir, "records", "2026-07-15.jsonl"))).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
+import { CheckpointManager } from "./checkpoint.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
 
@@ -184,6 +185,17 @@ export class LocalMemoryCleaner {
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
 
+    // Reconcile checkpoint aggregate counters with the post-cleanup reality so
+    // l0_conversations_count / total_memories_extracted don't drift upward
+    // after deletions (non-fatal).
+    try {
+      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+      await checkpoint.recalibrate(this.vectorStore);
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   private scheduleNext(): void {

--- a/src/utils/memory-cleaner.ts
+++ b/src/utils/memory-cleaner.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { IMemoryStore } from "../core/store/types.js";
 import { ManagedTimer } from "./managed-timer.js";
 import { CheckpointManager } from "./checkpoint.js";
+import { countCheckpointJsonlFile, type CheckpointDataKind } from "./checkpoint-data.js";
 import type { Logger } from "../core/types.js";
 import { formatLocalDateTime, startOfLocalDay } from "./time.js";
 
@@ -20,6 +21,8 @@ interface CleanupStats {
   changedFiles: number;
   skippedNonShardFiles: number;
   deleteFailedFiles: number;
+  removedRecords: number;
+  removedRecordsSincePersona: number;
 }
 
 const TAG = "[memory-tdai][cleaner]";
@@ -86,47 +89,89 @@ export class LocalMemoryCleaner {
       this.opts.logger?.error(`${TAG} ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
-    const targetDirs = [
-      path.join(this.opts.baseDir, L0_DIR_NAME),
-      path.join(this.opts.baseDir, L1_DIR_NAME),
-    ];
+    const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
+    const checkpointState = await checkpoint.read();
+    const lastPersonaTime = Number.isFinite(Date.parse(checkpointState.last_persona_time))
+      ? checkpointState.last_persona_time
+      : "";
 
     const total: CleanupStats = {
       scannedFiles: 0,
       changedFiles: 0,
       skippedNonShardFiles: 0,
       deleteFailedFiles: 0,
+      removedRecords: 0,
+      removedRecordsSincePersona: 0,
     };
 
-    for (const dirPath of targetDirs) {
-      const stats = await this.cleanDirectory(dirPath, cutoffMs);
+    const localCleanup = await Promise.all([
+      this.cleanDirectory(
+        path.join(this.opts.baseDir, L0_DIR_NAME),
+        cutoffMs,
+        "l0",
+        lastPersonaTime,
+      ),
+      this.cleanDirectory(
+        path.join(this.opts.baseDir, L1_DIR_NAME),
+        cutoffMs,
+        "l1",
+        lastPersonaTime,
+      ),
+    ]);
+
+    for (const stats of localCleanup) {
       total.scannedFiles += stats.scannedFiles;
       total.changedFiles += stats.changedFiles;
       total.skippedNonShardFiles += stats.skippedNonShardFiles;
       total.deleteFailedFiles += stats.deleteFailedFiles;
+      total.removedRecords += stats.removedRecords;
+      total.removedRecordsSincePersona += stats.removedRecordsSincePersona;
     }
 
-    if (this.vectorStore) {
-      const vectorStore = this.vectorStore;
+    let removedL0FromStore = 0;
+    let removedL1FromStore = 0;
+    let removedL1SincePersonaFromStore = 0;
+    let storeCounts: {
+      l0Records: number;
+      l1Records: number;
+      filteredL1Records: number;
+    } | undefined;
+    let useStoreAsSource = false;
+
+    if (this.vectorStore && !this.vectorStore.isDegraded()) {
+      try {
+        storeCounts = await this.vectorStore.getCheckpointCounts({
+          ...(lastPersonaTime ? { l1UpdatedAfter: lastPersonaTime } : {}),
+          l1UpdatedBefore: new Date(cutoffMs).toISOString(),
+        });
+        useStoreAsSource = true;
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} Store checkpoint count unavailable; skipping DB cleanup this run: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    if (useStoreAsSource) {
+      const vectorStore = this.vectorStore!;
       const cutoffIso = new Date(cutoffMs).toISOString();
       const startMs = Date.now();
 
       // ── Pre-delete: count totals and decide whether to proceed ──
-      let totalL0 = 0;
-      let totalL1 = 0;
-      try { totalL0 = await vectorStore.countL0(); } catch { /* non-fatal */ }
-      try { totalL1 = await vectorStore.countL1(); } catch { /* non-fatal */ }
+      const totalL0 = storeCounts!.l0Records;
+      const totalL1 = storeCounts!.l1Records;
 
       this.opts.logger?.info(
         `${TAG} [Pre-delete] cutoffIso=${cutoffIso}, retentionDays=${retentionDays}, totalL0=${totalL0}, totalL1=${totalL1}`,
       );
 
-      let removedL0 = 0;
-      let removedL1 = 0;
       let skippedL0 = false;
       let skippedL1 = false;
       let failedL0DbCleanup = 0;
       let failedL1DbCleanup = 0;
+
+      const expiredL1SincePersona = storeCounts!.filteredL1Records;
 
       // ── L0 cleanup with minimum-retention guard ──
       if (totalL0 <= MIN_RETAIN_L0) {
@@ -136,7 +181,7 @@ export class LocalMemoryCleaner {
         );
       } else {
         try {
-          removedL0 = await vectorStore.deleteL0Expired(cutoffIso);
+          removedL0FromStore = await vectorStore.deleteL0Expired(cutoffIso);
         } catch (err) {
           failedL0DbCleanup = 1;
           this.opts.logger?.warn(
@@ -153,7 +198,10 @@ export class LocalMemoryCleaner {
         );
       } else {
         try {
-          removedL1 = await vectorStore.deleteL1Expired(cutoffIso);
+          removedL1FromStore = await vectorStore.deleteL1Expired(cutoffIso);
+          removedL1SincePersonaFromStore = lastPersonaTime
+            ? Math.min(removedL1FromStore, expiredL1SincePersona)
+            : removedL1FromStore;
         } catch (err) {
           failedL1DbCleanup = 1;
           this.opts.logger?.warn(
@@ -162,40 +210,53 @@ export class LocalMemoryCleaner {
         }
       }
 
-      if (removedL1 > 0 || removedL0 > 0) {
+      if (removedL1FromStore > 0 || removedL0FromStore > 0) {
         total.changedFiles += 1;
       }
 
       // ── Post-delete: audit summary ──
       const durationMs = Date.now() - startMs;
-      const remainingL0 = totalL0 - removedL0;
-      const remainingL1 = totalL1 - removedL1;
+      const remainingL0 = totalL0 - removedL0FromStore;
+      const remainingL1 = totalL1 - removedL1FromStore;
       const summary = {
         event: "cleaner_summary",
         cutoffIso,
         retentionDays,
-        l0: { total: totalL0, expired: removedL0, remaining: remainingL0, skipped: skippedL0, failed: failedL0DbCleanup > 0 },
-        l1: { total: totalL1, expired: removedL1, remaining: remainingL1, skipped: skippedL1, failed: failedL1DbCleanup > 0 },
+        l0: { total: totalL0, expired: removedL0FromStore, remaining: remainingL0, skipped: skippedL0, failed: failedL0DbCleanup > 0 },
+        l1: { total: totalL1, expired: removedL1FromStore, remaining: remainingL1, skipped: skippedL1, failed: failedL1DbCleanup > 0 },
         durationMs,
       };
       this.opts.logger?.info(`${TAG} ${JSON.stringify(summary)}`);
     }
 
+    const hasStore = !!this.vectorStore;
+    const removedL0 = useStoreAsSource
+      ? removedL0FromStore
+      : hasStore ? 0 : localCleanup[0].removedRecords;
+    const removedL1 = useStoreAsSource
+      ? removedL1FromStore
+      : hasStore ? 0 : localCleanup[1].removedRecords;
+    const removedL1SincePersona = useStoreAsSource
+      ? removedL1SincePersonaFromStore
+      : hasStore ? 0 : localCleanup[1].removedRecordsSincePersona;
+    if (removedL0 > 0 || removedL1 > 0) {
+      try {
+        await checkpoint.applyCleanupDelta({
+          l0Records: removedL0,
+          l1Records: removedL1,
+          l1RecordsSincePersona: removedL1SincePersona,
+        });
+      } catch (err) {
+        this.opts.logger?.warn(
+          `${TAG} Checkpoint cleanup update failed (non-fatal): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     this.opts.logger?.info(
       `${TAG} Cleanup done: scannedFiles=${total.scannedFiles}, changedFiles=${total.changedFiles}, skippedNonShardFiles=${total.skippedNonShardFiles}, deleteFailedFiles=${total.deleteFailedFiles}`,
     );
-
-    // Reconcile checkpoint aggregate counters with the post-cleanup reality so
-    // l0_conversations_count / total_memories_extracted don't drift upward
-    // after deletions (non-fatal).
-    try {
-      const checkpoint = new CheckpointManager(this.opts.baseDir, this.opts.logger);
-      await checkpoint.recalibrate(this.vectorStore);
-    } catch (err) {
-      this.opts.logger?.warn?.(
-        `${TAG} Checkpoint recalibration failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
   }
 
   private scheduleNext(): void {
@@ -237,12 +298,19 @@ export class LocalMemoryCleaner {
     }
   }
 
-  private async cleanDirectory(dirPath: string, cutoffMs: number): Promise<CleanupStats> {
+  private async cleanDirectory(
+    dirPath: string,
+    cutoffMs: number,
+    kind: CheckpointDataKind,
+    lastPersonaTime: string,
+  ): Promise<CleanupStats> {
     const stats: CleanupStats = {
       scannedFiles: 0,
       changedFiles: 0,
       skippedNonShardFiles: 0,
       deleteFailedFiles: 0,
+      removedRecords: 0,
+      removedRecordsSincePersona: 0,
     };
 
     let entries;
@@ -272,8 +340,19 @@ export class LocalMemoryCleaner {
       const dayEndMs = localDayEndMs(shard.year, shard.month, shard.day);
       if (dayEndMs < cutoffMs) {
         try {
+          let removedRecords = 0;
+          let removedRecordsSincePersona = 0;
+          try {
+            const counts = await countCheckpointJsonlFile(filePath, kind, lastPersonaTime);
+            removedRecords = counts.records;
+            removedRecordsSincePersona = counts.recordsSincePersona;
+          } catch {
+            // File deletion is still useful if the shard cannot be counted.
+          }
           await fs.unlink(filePath);
           stats.changedFiles += 1;
+          stats.removedRecords += removedRecords;
+          stats.removedRecordsSincePersona += removedRecordsSincePersona;
           this.opts.logger?.info(`${TAG} Removed expired file by name: ${filePath}`);
         } catch (err) {
           stats.deleteFailedFiles += 1;

--- a/src/utils/pipeline-factory.ts
+++ b/src/utils/pipeline-factory.ts
@@ -525,30 +525,17 @@ export function createL2Runner(opts: {
     const preCheckpoint = new CheckpointManager(pluginDataDir, logger);
     const preState = await preCheckpoint.read();
     const preScenesProcessed = preState.scenes_processed;
-    const preMemoriesSince = preState.memories_since_last_persona;
-    const preTotalProcessed = preState.total_processed;
 
     const extractResult = await extractor.extract(memories);
     if (extractResult.success && extractResult.memoriesProcessed > 0) {
       const checkpoint = new CheckpointManager(pluginDataDir, logger);
       const postState = await checkpoint.read();
-      if (
-        postState.scenes_processed < preScenesProcessed ||
-        postState.total_processed < preTotalProcessed
-      ) {
+      if (postState.scenes_processed < preScenesProcessed) {
         logger.warn(
-          `${TAG} [L2] ⚠️ Checkpoint corruption detected! ` +
-          `scenes_processed: ${preScenesProcessed} → ${postState.scenes_processed}, ` +
-          `total_processed: ${preTotalProcessed} → ${postState.total_processed}, ` +
-          `memories_since: ${preMemoriesSince} → ${postState.memories_since_last_persona}. ` +
-          `Repairing...`,
+          `${TAG} [L2] Checkpoint scenes_processed regressed: ` +
+          `${preScenesProcessed} -> ${postState.scenes_processed}; repairing`,
         );
-        await checkpoint.write({
-          ...postState,
-          scenes_processed: Math.max(postState.scenes_processed, preScenesProcessed),
-          total_processed: Math.max(postState.total_processed, preTotalProcessed),
-          memories_since_last_persona: Math.max(postState.memories_since_last_persona, preMemoriesSince),
-        });
+        await checkpoint.ensureScenesProcessedAtLeast(preScenesProcessed);
         logger.info(`${TAG} [L2] Checkpoint repaired`);
       }
 


### PR DESCRIPTION
## Description | 描述
修复 Issue #157 的 checkpoint 计数漂移：基于健康存储聚合计数进行启动校准，清理时使用原子增量扣减，并在存储不可用时对 JSONL 做受限恢复。

## Related Issue | 关联 Issue
Fixes #157

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
- SQLite/TencentDB 提供显式、可失败的聚合计数接口；健康存储计数失败时保留现有 checkpoint，避免不完整 JSONL 覆盖有效值。
- 清理按实际删除的 L0/L1 记录原子扣减，并按 persona 时间水位精确扣减；L0 使用消息记录单位。
- JSONL 仅在存储降级/缺失时作为恢复源：新 checkpoint 可重建，已有 checkpoint 只允许向下校准，避免 append-only 事件重复计数。
- 保留 session cursor；pipeline 只修复 scenes_processed 的单调性。

## Verification
- `npm test`（78 tests）
- `npm run build`
- `npm pack --dry-run`