### PR TITLE
fix(deploy): resolve curl from PATH in Git Bash

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -16,6 +16,11 @@ source "$SCRIPT_DIR/_lib.sh"
 load_env
 require_vars MEMORY_CORE_IMAGE MEMORY_CORE_PORT MEMORY_CORE_VOLUME
 
+CURL="${CURL:-curl}"
+if ! command -v "$CURL" >/dev/null 2>&1; then
+  die "curl not found; install curl or set CURL=/path/to/curl"
+fi
+
 # ── Gateway 内部管理凭据 ─────────────────────────────────────────
 # 用 ${VAR-default}（不是 :-default）：允许 .env 里显式设为空字符串来关闭 Bearer gate。
 #
@@ -161,13 +166,20 @@ generate_user_key() {
 
 verify_user_key() {
   local key="$1"
-  local code
-  code=$(/usr/bin/curl -sS -o /dev/null -w "%{http_code}" --max-time 5 \
+  local code curl_rc=0
+  local curl_error_file="/tmp/auth-verify.$$.err"
+  code=$("$CURL" -sS -o /dev/null -w "%{http_code}" --max-time 5 \
     -X POST -H "Content-Type: application/json" \
     -H "x-tdai-service-id: default" \
     ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
     "http://localhost:${MEMORY_CORE_PORT}/v3/meta/auth/verify" \
-    -d "$(printf '{"user_key":"%s"}' "$key")" 2>/dev/null || echo "000")
+    -d "$(printf '{"user_key":"%s"}' "$key")" 2>"$curl_error_file") || curl_rc=$?
+  if (( curl_rc != 0 )); then
+    warn "auth/verify curl failed (exit=${curl_rc}): $(head -c 200 "$curl_error_file" 2>/dev/null)"
+    rm -f "$curl_error_file"
+    return 1
+  fi
+  rm -f "$curl_error_file"
   [[ "$code" == "200" ]]
 }
 
@@ -183,12 +195,20 @@ fi
 
 init_body=$(printf '{"username":"%s","user_key":"%s"}' \
   "$MEMORY_CORE_ADMIN_USERNAME" "$ADMIN_KEY")
-init_resp=$(/usr/bin/curl -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
+init_curl_error_file="/tmp/init-admin.$$.err"
+init_curl_rc=0
+init_resp=$("$CURL" -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
   -X POST -H "Content-Type: application/json" \
   ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
   -H "x-tdai-service-id: default" \
   "http://localhost:${MEMORY_CORE_PORT}/v3/internal/meta/user/init-admin" \
-  -d "$init_body" 2>/dev/null || echo "000")
+  -d "$init_body" 2>"$init_curl_error_file") || init_curl_rc=$?
+
+if (( init_curl_rc != 0 )); then
+  warn "init-admin curl failed (exit=${init_curl_rc}): $(head -c 200 "$init_curl_error_file" 2>/dev/null)"
+  init_resp="000"
+fi
+rm -f "$init_curl_error_file"
 
 case "$init_resp" in
   200)

--- a/deploy/global-images/verify.sh
+++ b/deploy/global-images/verify.sh
@@ -37,7 +37,10 @@ done
 
 ERRORS=0
 WARNS=0
-CURL=/usr/bin/curl
+CURL="${CURL:-curl}"
+if ! command -v "$CURL" >/dev/null 2>&1; then
+  die "curl not found; install curl or set CURL=/path/to/curl"
+fi
 
 # ─── LLM 通路检查函数 ───────────────────────────────────────────────
 # check_llm_openai <label> <base_url> <api_key> <model>
@@ -50,10 +53,17 @@ check_llm_openai() {
   base="${base%/messages}"
   base="${base%/chat/completions}"
   local url="${base}/models"
-  local code body_file=/tmp/llm-check.$$
+  local code body_file=/tmp/llm-check.$$ curl_error_file=/tmp/llm-check.$$.err
+  local curl_rc=0
   code=$("$CURL" -sS --max-time 10 -o "$body_file" -w "%{http_code}" \
     -H "Authorization: Bearer $key" \
-    "$url" 2>/dev/null || echo "000")
+    "$url" 2>"$curl_error_file") || curl_rc=$?
+  if (( curl_rc != 0 )); then
+    warn "$label curl failed (exit=${curl_rc}): $(head -c 200 "$curl_error_file" 2>/dev/null)"
+    rm -f "$body_file" "$curl_error_file"
+    return 1
+  fi
+  rm -f "$curl_error_file"
   if [[ "$code" == "200" ]]; then
     # 尝试解析 model 是否在列表里（宽松匹配，不匹配也只 warn）
     if grep -q "\"$model\"" "$body_file" 2>/dev/null; then
@@ -95,14 +105,21 @@ check_llm_anthropic() {
   else
     url="${base}/v1/messages"
   fi
-  local code body_file=/tmp/llm-check.$$
+  local code body_file=/tmp/llm-check.$$ curl_error_file=/tmp/llm-check.$$.err
+  local curl_rc=0
   code=$("$CURL" -sS --max-time 15 -o "$body_file" -w "%{http_code}" \
     -X POST -H "Content-Type: application/json" \
     -H "x-api-key: $key" \
     -H "Authorization: Bearer $key" \
     -H "anthropic-version: 2023-06-01" \
     -d "{\"model\":\"$model\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
-    "$url" 2>/dev/null || echo "000")
+    "$url" 2>"$curl_error_file") || curl_rc=$?
+  if (( curl_rc != 0 )); then
+    warn "$label curl failed (exit=${curl_rc}): $(head -c 200 "$curl_error_file" 2>/dev/null)"
+    rm -f "$body_file" "$curl_error_file"
+    return 1
+  fi
+  rm -f "$curl_error_file"
   case "$code" in
     200)
       ok "$label Anthropic 协议通路 OK（模型 $model 已应答）"

--- a/deploy/global-images/verify.sh
+++ b/deploy/global-images/verify.sh
@@ -38,9 +38,6 @@ done
 ERRORS=0
 WARNS=0
 CURL="${CURL:-curl}"
-if ! command -v "$CURL" >/dev/null 2>&1; then
-  die "curl not found; install curl or set CURL=/path/to/curl"
-fi
 
 # ─── LLM 通路检查函数 ───────────────────────────────────────────────
 # check_llm_openai <label> <base_url> <api_key> <model>
@@ -256,6 +253,9 @@ else
     info "跳过 LLM 通路检查（--skip-llm）"
   elif (( ${#MISSING[@]} > 0 )); then
     warn "跳过 LLM 通路检查（必填参数未填齐）"
+  elif ! command -v "$CURL" >/dev/null 2>&1; then
+    ERRORS=$((ERRORS+1))
+    echo "${C_RED}[error]${C_RST} curl not found; install curl or set CURL=/path/to/curl" >&2
   else
     echo ""
     info "═══ LLM 通路检查 ═══════════════════════════════════════"


### PR DESCRIPTION
## Summary

- Resolve curl from `PATH` in the deployment scripts.
- Support an explicit `CURL=/path/to/curl` override.
- Check curl only when host-side LLM verification runs.
- Report curl exit codes and preserve short error details.

## Root cause

`start-memory-core.sh` and `verify.sh` assumed that curl exists at `/usr/bin/curl`.
Git Bash can provide curl at a different path.
The scripts also converted command failures to HTTP `000` and discarded stderr.

## User impact

Windows Git Bash can now use curl from `PATH`.
Linux and macOS keep their existing PATH behavior.
Operators can set an explicit curl executable through `CURL`.
Offline verification with `--skip-llm` does not require curl.

## Validation

- `bash -n deploy/global-images/start-memory-core.sh deploy/global-images/verify.sh`
- `shellcheck -x deploy/global-images/_lib.sh deploy/global-images/start-memory-core.sh deploy/global-images/verify.sh`
- Verified that `--skip-llm` ignores `CURL=/definitely/missing`.
- Verified a clear missing-curl error when LLM verification runs.
- Verified exit-code output with `CURL=/bin/false`.
- Verified that `.env` can override an inherited `CURL` value.
- Verified default `CURL=curl` resolution on Linux.

Windows Git Bash validation remains pending.

The shell changes and failure paths have been validated on Linux.
An end-to-end Windows Git Bash test is still requested from the original reporter.

Fixes #655
