### PR TITLE
fix: make local embedding provider (provider=local) reachable from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## [Unreleased]
 
+### 🐛 修复
+
+- **本地嵌入提供方 (`provider=local`) 现在可从配置启用** ([#678](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/678))：`config.ts` 之前将 `provider=local` 改写为 `none`，导致完全离线的嵌入（node-llama-cpp + embeddinggemma-300m, 768-dim）不可用。
+  - `config.ts`：`provider=local` 现在直接通过，`embeddingEnabled=true`（无需 API key）。
+  - `core/store/factory.ts`（sqlite 分支）：为 `provider=local` 创建嵌入服务，无需 `apiKey`，并在启动时调用 `startWarmup()`（对远程提供方是安全的 no-op）。
+  - 新增回归测试：`src/core/store/__tests__/fix-678-local-embedding.test.ts`（4 个测试覆盖配置解析、工厂创建、warmup 可用性和远程无 apiKey 守卫）。
+
 ### ✨ 新功能
 
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。

--- a/src/config.ts
+++ b/src/config.ts
@@ -378,7 +378,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
   const embeddingProxyUrl = str(embeddingGroup, "proxyUrl");
 
   // provider="none" → embedding disabled (default for zero-config users)
-  // provider="local" → no longer exposed to users; treated as disabled at entry level
+  // provider="local" → fully-offline embedding via node-llama-cpp (no API key)
   // provider="qclaw" → requires proxyUrl for local proxy forwarding
   // Any other value → remote mode (requires apiKey, baseUrl, model, dimensions)
   let embeddingProvider: string;
@@ -389,13 +389,11 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     embeddingProvider = "none";
     embeddingEnabled = false;
   } else if (embeddingProviderRaw === "local") {
-    // Local embedding is not exposed to users; treat as disabled at entry level.
-    // Internal LocalEmbeddingService code is preserved but not reachable from config.
-    embeddingProvider = "none";
-    embeddingEnabled = false;
-    embeddingConfigError =
-      "Local embedding provider is not available in user config. " +
-      "Please configure a remote embedding provider (e.g. openai, deepseek). Embedding has been disabled.";
+    // Fully-offline embedding (node-llama-cpp + embeddinggemma-300m, 768-dim).
+    // No API key, baseUrl or model required — defaults are applied by
+    // LocalEmbeddingService. Fix #678: was previously rewritten to "none".
+    embeddingProvider = "local";
+    embeddingEnabled = true;
   } else if (embeddingProviderRaw === "qclaw") {
     // qclaw provider: requires proxyUrl for local proxy forwarding
     const missingFields: string[] = [];

--- a/src/core/store/__tests__/fix-678-local-embedding.test.ts
+++ b/src/core/store/__tests__/fix-678-local-embedding.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Fix #678 Regression-Test: Local Embedding Provider
+ *
+ * Verifiziert die drei Blockaden aus Issue #678:
+ * 1. parseConfig akzeptiert provider="local" (statt es zu "none" umzuschreiben)
+ * 2. createStoreBundle (sqlite) erstellt einen Embedding-Service für local
+ *    OHNE apiKey
+ * 3. startWarmup() wird beim Erstellen aufgerufen (Modell lädt im Hintergrund)
+ */
+import { describe, expect, it } from "vitest";
+import { mkdirSync } from "node:fs";
+import { parseConfig } from "../../../config.js";
+
+function tmpDataDir(): string {
+  const dir = "/tmp/tdam-test-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("Fix #678: local embedding provider", () => {
+  it("1) parseConfig lässt provider=local durch (enabled, nicht none)", () => {
+    const cfg = parseConfig({
+      embedding: { enabled: true, provider: "local" },
+    });
+    expect(cfg.embedding.provider).toBe("local");
+    expect(cfg.embedding.enabled).toBe(true);
+    // keine Config-Fehler-Meldung
+    expect(cfg.embedding.configError ?? "").toBe("");
+  });
+
+  it("1b) provider=none bleibt disabled", () => {
+    const cfg = parseConfig({
+      embedding: { provider: "none" },
+    });
+    expect(cfg.embedding.enabled).toBe(false);
+    expect(cfg.embedding.provider).toBe("none");
+  });
+
+  it("2) factory erstellt Service für local ohne apiKey + startWarmup existiert", async () => {
+    const { createStoreBundle } = await import("../factory.js");
+
+    const cfg = parseConfig({
+      storeBackend: "sqlite",
+      embedding: { enabled: true, provider: "local" },
+    });
+
+    const bundle = createStoreBundle(cfg, {
+      dataDir: tmpDataDir(),
+    });
+
+    expect(bundle.embedding).toBeDefined();
+    expect(bundle.embedding.getProviderInfo().provider).toBe("local");
+    expect(typeof (bundle.embedding as { startWarmup?: () => void }).startWarmup)
+      .toBe("function");
+  });
+
+  it("3) remote provider ohne apiKey erstellt KEINEN Service (Regression)", async () => {
+    const { createStoreBundle } = await import("../factory.js");
+
+    const cfg = parseConfig({
+      storeBackend: "sqlite",
+      embedding: { enabled: true, provider: "openai" }, // kein apiKey
+    });
+
+    const bundle = createStoreBundle(cfg, {
+      dataDir: tmpDataDir(),
+    });
+
+    // Ohne apiKey → kein Embedding-Service erstellt (embedding undefined)
+    expect(bundle.embedding).toBeUndefined();
+  });
+});

--- a/src/core/store/factory.ts
+++ b/src/core/store/factory.ts
@@ -13,7 +13,7 @@ import type { IMemoryStore, IEmbeddingService, StoreLogger } from "./types.js";
 import { VectorStore } from "./sqlite.js";
 import { TcvdbMemoryStore } from "./tcvdb.js";
 import { createEmbeddingService, NoopEmbeddingService } from "./embedding.js";
-import type { EmbeddingService } from "./embedding.js";
+import type { EmbeddingService, EmbeddingConfig } from "./embedding.js";
 import { createBM25Encoder } from "./bm25-local.js";
 import type { BM25LocalEncoder } from "./bm25-local.js";
 
@@ -91,16 +91,28 @@ export function createStoreBundle(
     default: {
       // ── Embedding service (only when enabled) ──
       let embeddingService: EmbeddingService | undefined;
-      if (config.embedding.enabled && config.embedding.provider !== "local" && config.embedding.apiKey) {
+      // Fix #678: provider="local" (offline) benötigt keinen apiKey.
+      // Remote-Provider (alle außer "none"/"local") erfordern weiterhin apiKey.
+      const emb = config.embedding;
+      if (emb.enabled && emb.provider !== "none" &&
+          (emb.provider === "local" || emb.apiKey)) {
         embeddingService = createEmbeddingService({
-          provider: config.embedding.provider,
-          baseUrl: config.embedding.baseUrl,
-          apiKey: config.embedding.apiKey,
-          model: config.embedding.model,
-          dimensions: config.embedding.dimensions,
-          sendDimensions: config.embedding.sendDimensions,
-          maxInputChars: config.embedding.maxInputChars,
-        }, logger);
+          provider: emb.provider,
+          baseUrl: emb.baseUrl,
+          apiKey: emb.apiKey,
+          model: emb.model,
+          // modelPath ist nicht im Config-Interface — LocalEmbeddingService
+          // nutzt sein Default-Modell (embeddinggemma-300m), wenn unset.
+          modelCacheDir: emb.modelCacheDir,
+          dimensions: emb.dimensions,
+          sendDimensions: emb.sendDimensions,
+          maxInputChars: emb.maxInputChars,
+        } as EmbeddingConfig, logger);
+        // Fix #678: Warmup starten, damit das lokale Modell (GGUF) im
+        // Hintergrund geladen wird. No-op für Remote-Provider.
+        if (embeddingService && typeof embeddingService.startWarmup === "function") {
+          embeddingService.startWarmup();
+        }
       }
 
       // dimensions from config (0 when provider="none" → vec0 deferred)


### PR DESCRIPTION
## Summary

Fixes #678 — `provider=local` (fully-offline embedding via node-llama-cpp + embeddinggemma-300m, 768-dim) was unreachable from config:

1. **config.ts** rewrote `provider=local` to `provider=none` with `embeddingEnabled=false` ("Local embedding provider is not available in user config").
2. **core/store/factory.ts** (sqlite branch) only created an embedding service when `provider !== "local" && apiKey` was set.
3. After creation, **nothing called `startWarmup()`** — the GGUF model was never downloaded, so `embed()` threw `EmbeddingNotReadyError`.

## Changes

- **config.ts**: `provider=local` now passes through with `embeddingEnabled=true` (no API key required).
- **core/store/factory.ts**: creates the embedding service for `provider=local` without requiring `apiKey`, and calls `startWarmup()` once at startup (safe no-op for remote providers).
- **Regression tests**: `src/core/store/__tests__/fix-678-local-embedding.test.ts` — 4 tests covering config parsing, factory creation, warmup availability, and the remote-without-apiKey guard.

## Test Plan

- `npx tsc --noEmit` — 0 errors
- `npx vitest run src/core/store/__tests__/fix-678-local-embedding.test.ts` — 4/4 passed

Verified on main @ 0.3.6 with Standalone Gateway (src/gateway/server.ts), as reported in the issue.