### PR TITLE
fix(offload): reject empty/relative offload.dataDir in parseConfig

### DIFF
--- a/MemoryCore/src/config.test.ts
+++ b/MemoryCore/src/config.test.ts
@@ -1,0 +1,21 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "./config.js";
+
+describe("parseConfig offload.dataDir", () => {
+  it("treats an empty offload.dataDir as omitted", () => {
+    expect(parseConfig({ offload: { dataDir: "" } }).offload.dataDir).toBeUndefined();
+  });
+
+  it("treats a relative offload.dataDir as omitted", () => {
+    expect(parseConfig({ offload: { dataDir: "relative-root" } }).offload.dataDir).toBeUndefined();
+  });
+
+  it("preserves an explicit absolute offload.dataDir", () => {
+    const absoluteRoot = join(tmpdir(), "memory-tdai-offload");
+
+    expect(parseConfig({ offload: { dataDir: absoluteRoot } }).offload.dataDir).toBe(absoluteRoot);
+  });
+});

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -7,6 +7,8 @@
  * Minimal config (zero config): {} — all fields have sensible defaults.
  */
 
+import { isAbsolute } from "node:path";
+
 // ============================
 // Type definitions
 // ============================
@@ -513,7 +515,9 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     model: optStr(offloadGroup, "model"),
     temperature: num(offloadGroup, "temperature") ?? 0.2,
     forceTriggerThreshold: num(offloadGroup, "forceTriggerThreshold") ?? 4,
-    dataDir: optStr(offloadGroup, "dataDir"),
+    // offload.dataDir 契约为绝对路径（见 openclaw.plugin.json）。
+    // 空串与相对路径会被静默接受并随后作为存储根目录使用，导致数据落到进程 cwd —— 这里在解析期直接判为未设置。
+    dataDir: optAbsStr(offloadGroup, "dataDir"),
     defaultContextWindow: num(offloadGroup, "defaultContextWindow") ?? 200000,
     maxPairsPerBatch: num(offloadGroup, "maxPairsPerBatch") ?? 20,
     l2NullThreshold: num(offloadGroup, "l2NullThreshold") ?? 4,
@@ -668,6 +672,12 @@ function normalizePromptMode(value: string | undefined, fallback: MemoryPromptMo
 function optStr(src: Record<string, unknown>, key: string): string | undefined {
   const v = src[key];
   return typeof v === "string" ? v : undefined;
+}
+
+/** optStr, but only accepts a non-empty absolute path; anything else degrades to undefined. */
+function optAbsStr(src: Record<string, unknown>, key: string): string | undefined {
+  const v = optStr(src, key);
+  return v && isAbsolute(v) ? v : undefined;
 }
 
 function num(src: Record<string, unknown>, key: string): number | undefined {


### PR DESCRIPTION
Fixes #521.

`openclaw.plugin.json` declares `offload.dataDir` as an absolute path (`【local 模式】自定义数据目录（绝对路径）`), but `optStr()` returned any string verbatim — including `""` and relative values — which then served as the context-offload storage root (`offload.jsonl`, `refs/`, `mmds/`, `state.json`). Depending on the process working directory this silently scatters runtime data in unintended places.

## What changed
`MemoryCore/src/config.ts` introduces an `optAbsStr()` helper and uses it for `offload.dataDir`: empty or non-absolute values are now treated as unset and fall back to the default root (`DEFAULT_DATA_ROOT`).

## Test evidence
| Check | Result |
|---|---|
| `npx vitest run src/config.test.ts` | 3/3 **PASS** (empty→unset, relative→unset, absolute→preserved) |
| `npx vitest run` (full pkg) | **PASS** |
| `npm run build:plugin` (tsdown, typechecks) | **OK** |

Adds `MemoryCore/src/config.test.ts` as a regression test covering exactly the contract from the issue.

Signed-off-by: iroiro147 <sarthak.singh@juspay.in>