### PR TITLE
security: fix auth bypass and SSRF in MemoryProxy & MemoryKnowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@
 
 ---
 
+## [Unreleased]
+
+### 🔒 安全修复
+
+- **修复 MemoryProxy 管理端点未授权访问** ([#672](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/672))：
+  - `rate-limits.ts`：`GET/PUT/DELETE /v3/admin/rate-limits` 现在强制 `checkAdminAuth`（之前无需认证即可查询/修改/删除租户限流）。
+  - `admin-auth.ts`：未配置 `admin.apiKey` 时 fail-closed（之前返回 `"ok"` = 无认证绕过，可触发 `POST /v3/instance/proxy-destroy` 远程清空数据）。
+- **修复 MemoryKnowledge Git 源抓取 SSRF + 参数注入** ([#672](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/672))：
+  - `git-fetcher.ts`：SSRF 校验增加 DNS 解析（hostname 正则可被 DNS-rebinding / 云元数据地址绕过）；`repo_url` 含 Git 选项分隔符（`--`）或 shell 元字符时拒绝。
+  - 新增回归测试：`MemoryProxy/src/routes/__tests__/security-672-auth.test.ts`（4 个）、`MemoryKnowledge/src/source-fetcher/__tests__/security-672-ssrf.test.ts`（6 个）。
+
+---
+
 ## [2.0.0-beta.1] — 2026-07-21
 
 首次公开发布。SemVer 从 `2.0.0-beta.1` 起步（npm 包名迁移到 `-v2` 后缀：

--- a/MemoryKnowledge/src/source-fetcher/__tests__/security-672-ssrf.test.ts
+++ b/MemoryKnowledge/src/source-fetcher/__tests__/security-672-ssrf.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Security #672 Regression-Tests: SSRF + Argument Injection (MemoryKnowledge)
+ *
+ * Verifiziert die Schwachstellen 3+4 aus dem Advisory:
+ * 3. SSRF: Hostname-Regex allein reicht nicht — DNS-Auflösung wird mitgeprüft
+ * 4. Argument Injection: Git-Options-/Shell-Metazeichen in repo_url → abgelehnt
+ */
+import { describe, expect, it } from "vitest";
+import { GitSourceFetcher } from "../git-fetcher.js";
+
+describe("Security #672: Argument Injection", () => {
+  it("Git-Options-Separator (--) in repo_url → Error", async () => {
+    const fetcher = new GitSourceFetcher({ ssrfCheck: false });
+    await expect(
+      fetcher.validate("https://github.com/x/y --upload-pack=touch /tmp/pwn"),
+    ).rejects.toThrow(/forbidden characters/);
+  });
+
+  it("Shell-Metazeichen (;&) in repo_url → Error", async () => {
+    const fetcher = new GitSourceFetcher({ ssrfCheck: false });
+    await expect(
+      fetcher.validate("https://github.com/x/y;rm -rf /"),
+    ).rejects.toThrow(/forbidden characters/);
+  });
+
+  it("normale HTTPS-URL ohne SSRF-Check → kein Error", async () => {
+    const fetcher = new GitSourceFetcher({ ssrfCheck: false });
+    await expect(
+      fetcher.validate("https://github.com/TencentCloud/TencentDB-Agent-Memory"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("Security #672: SSRF via DNS-Auflösung", () => {
+  it("localhost → Error", async () => {
+    const fetcher = new GitSourceFetcher({ ssrfCheck: true });
+    await expect(fetcher.validate("https://localhost/repo")).rejects.toThrow(/private/);
+  });
+
+  it("öffentliche IP 8.8.8.8 → kein SSRF-Error (öffentlich)", async () => {
+    const fetcher = new GitSourceFetcher({ ssrfCheck: true });
+    // 8.8.8.8 ist öffentlich (Google DNS), kein privates Netz
+    await expect(fetcher.validate("https://8.8.8.8/repo")).resolves.toBeUndefined();
+  });
+
+  it("privater Host, der auf RFC1918 auflöst → Error", async () => {
+    const fetcher = new GitSourceFetcher({ ssrfCheck: true });
+    // "localtest.me" ist eine Wildcard-Domain, die auf 127.0.0.1 auflöst
+    await expect(fetcher.validate("https://localtest.me/repo")).rejects.toThrow(/private/);
+  });
+});

--- a/MemoryKnowledge/src/source-fetcher/git-fetcher.ts
+++ b/MemoryKnowledge/src/source-fetcher/git-fetcher.ts
@@ -25,6 +25,23 @@ import type { ISourceFetcher, FetchResult, SourceType } from "./types.js";
 const PRIVATE_ADDR_RE =
   /^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.|127\.|0\.|localhost$|::1$|fe80:)/i;
 
+/** IPv4 / IPv6 私有-IP-Prüfung (zusätzlich zur Hostname-Regex). */
+const PRIVATE_IP_RE =
+  /^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.|127\.|0\.|::1$|fe80:|fc|fd)/i;
+
+/** Security #672: DNS-Auflösung für SSRF-Prüfung (async). */
+async function resolvePrivate(host: string): Promise<boolean> {
+  try {
+    const { lookup } = await import("node:dns/promises");
+    const { address } = await lookup(host, { all: false });
+    return PRIVATE_IP_RE.test(address);
+  } catch {
+    // Auflösung fehlgeschlagen → Host nicht erreichbar → als privat behandeln
+    // (fail-closed statt fail-open gegen DNS-Rebinding).
+    return true;
+  }
+}
+
 /**
  * 读取 SSRF 私网黑名单开关。默认开启；
  * 当 KNOWLEDGE_SSRF_CHECK 为 off/false/0/no（大小写不敏感）时关闭。
@@ -54,25 +71,40 @@ export class GitSourceFetcher implements ISourceFetcher {
     this.ssrfCheck = opts?.ssrfCheck ?? ssrfCheckEnabledFromEnv();
   }
 
-  validate(sourceUrl: string): void {
+  async validate(sourceUrl: string): Promise<void> {
     // 第一版：仅支持 public HTTPS 仓库（SSH / 私有仓库鉴权见文档 005）。
     if (!sourceUrl.startsWith("https://")) {
       throw new Error(
         "first version only supports public HTTPS repos; SSH/private repo support coming soon",
       );
     }
+    // Security #672 (Argument Injection): URL darf keine Git-Options-Separatoren
+    // oder Shell-Metazeichen enthalten, die in simpleGit().clone() als eigene
+    // Argumente interpretiert werden könnten (z.B. "--upload-pack=...").
+    if (/[\s"'`;|&<>]|--/.test(sourceUrl)) {
+      throw new Error(`invalid repo_url: contains forbidden characters: ${sourceUrl}`);
+    }
     const host = this.extractHost(sourceUrl);
     if (!host) {
       throw new Error(`invalid repo_url: cannot parse host from ${sourceUrl}`);
     }
     // R2: SSRF 防护 —— 禁止指向内网 / 环回地址（可经 KNOWLEDGE_SSRF_CHECK=off 关闭）。
-    if (this.ssrfCheck && this.isPrivateAddress(host)) {
-      throw new Error(`repo_url must not point to private/loopback address: ${host}`);
+    // Security #672: zusätzlich DNS-Auflösung (Hostname-Regex allein kann durch
+    // DNS-Rebinding / Cloud-Metadata-Hosts umgangen werden).
+    if (this.ssrfCheck) {
+      const hostPrivate = this.isPrivateAddress(host);
+      const resolvedPrivate = hostPrivate ? true : await resolvePrivate(host);
+      if (hostPrivate || resolvedPrivate) {
+        throw new Error(
+          `repo_url must not point to private/loopback address: ${host}` +
+          (resolvedPrivate && !hostPrivate ? " (via DNS resolution)" : ""),
+        );
+      }
     }
   }
 
   async fetch(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
-    this.validate(sourceUrl);
+    await this.validate(sourceUrl);
     // 浅克隆单分支。注：git clone/fetch 不会拉取远端的 .git/hooks（hooks 是本地态），
     // 所以正常仓库 clone 出来不带可执行钩子；此处不再配置 core.hooksPath
     // （加固版 git 会拒绝该配置：需 allowUnsafeHooksPath）。
@@ -85,7 +117,7 @@ export class GitSourceFetcher implements ISourceFetcher {
   }
 
   async sync(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
-    this.validate(sourceUrl);
+    await this.validate(sourceUrl);
     const git = simpleGit(localPath);
     await git.fetch("origin", branch, { "--depth": 1 });
     await git.reset(ResetMode.HARD, [`origin/${branch}`]);

--- a/MemoryProxy/src/routes/__tests__/security-672-auth.test.ts
+++ b/MemoryProxy/src/routes/__tests__/security-672-auth.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Security #672 Regression-Tests: Auth-Bypass (MemoryProxy)
+ *
+ * Verifiziert die Schwachstellen 1+2 aus dem Advisory:
+ * 1. rate-limits: GET/PUT/DELETE OHNE Admin-Token → 401 (vorher: offen)
+ * 2. admin-auth: ohne konfigurierten admin.apiKey → fail-closed "missing"
+ */
+import { describe, expect, it } from "vitest";
+import { checkAdminAuth } from "../admin-auth.js";
+
+// Hono-Context-Mock: nur header() wird gebraucht
+function mockCtx(authHeader?: string): any {
+  return {
+    req: {
+      header: (name: string) => {
+        if (name.toLowerCase() === "authorization") return authHeader ?? "";
+        return undefined;
+      },
+    },
+  };
+}
+
+describe("Security #672: admin-auth fail-closed", () => {
+  it("ohne konfigurierten admin.apiKey → 'missing' (vorher 'ok' = Bypass)", () => {
+    const ctx = mockCtx(undefined);
+    expect(checkAdminAuth(ctx, "")).toBe("missing");
+  });
+
+  it("korrekter Bearer-Token → 'ok'", () => {
+    const ctx = mockCtx("Bearer sekret123");
+    expect(checkAdminAuth(ctx, "sekret123")).toBe("ok");
+  });
+
+  it("fehlender Header → 'missing'", () => {
+    const ctx = mockCtx(undefined);
+    expect(checkAdminAuth(ctx, "sekret123")).toBe("missing");
+  });
+
+  it("falscher Token → 'invalid'", () => {
+    const ctx = mockCtx("Bearer falsch");
+    expect(checkAdminAuth(ctx, "sekret123")).toBe("invalid");
+  });
+});

--- a/MemoryProxy/src/routes/admin-auth.ts
+++ b/MemoryProxy/src/routes/admin-auth.ts
@@ -5,7 +5,10 @@ export type AdminAuthResult = "ok" | "missing" | "invalid";
 
 /** Shared Bearer authentication for proxy administration endpoints. */
 export function checkAdminAuth(c: Context, expected: string): AdminAuthResult {
-  if (!expected) return "ok";
+  // Security #672: fail-closed. Wenn kein admin.apiKey konfiguriert ist,
+  // sind Admin-Endpoints gesperrt (vorher: "ok" = voller Zugang ohne Auth).
+  // Wer Admin-Funktionen nutzen will, muss explizit einen Key setzen.
+  if (!expected) return "missing";
 
   const header = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
   if (!header.startsWith("Bearer ")) return "missing";

--- a/MemoryProxy/src/routes/rate-limits.ts
+++ b/MemoryProxy/src/routes/rate-limits.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ProxyConfig } from "../types.js";
 import { assertKeySegment } from "../storage/key-utils.js";
 import { getRateLimitStore } from "../rate-limit/guard.js";
+import { adminAuthError, checkAdminAuth } from "./admin-auth.js";
 
 interface RateLimitBody {
   instance_id?: unknown;
@@ -10,11 +11,20 @@ interface RateLimitBody {
   qpm?: unknown;
 }
 
+/** Security #672: Admin-Auth-Guard für alle Rate-Limit-Verwaltungs-Endpoints. */
+function enforceAdminAuth(c: Context, config: ProxyConfig): Response | null {
+  const authResult = checkAdminAuth(c, config.admin.apiKey);
+  if (authResult !== "ok") {
+    return adminAuthError(c, authResult);
+  }
+  return null;
+}
+
 export function createRateLimitHandlers(config: ProxyConfig) {
   return {
-    get: (c: Context) => handleGet(c, config),
-    put: (c: Context) => handlePut(c, config),
-    delete: (c: Context) => handleDelete(c, config),
+    get: (c: Context) => enforceAdminAuth(c, config) ?? handleGet(c, config),
+    put: (c: Context) => enforceAdminAuth(c, config) ?? handlePut(c, config),
+    delete: (c: Context) => enforceAdminAuth(c, config) ?? handleDelete(c, config),
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #672 — all 4 vulnerabilities from the security advisory:

### CRITICAL: MemoryProxy Auth Bypass
1. **rate-limits.ts** — `GET/PUT/DELETE /v3/admin/rate-limits` had no auth check; unauthenticated callers could query/modify/delete tenant rate limits (DoS via qpm=1). Now wrapped with `checkAdminAuth`.
2. **admin-auth.ts** — `if (!expected) return "ok"` meant an unconfigured `admin.apiKey` granted full admin access (including `POST /v3/instance/proxy-destroy` = remote data purge). Now fail-closed: unconfigured key → "missing" (401).

### HIGH: MemoryKnowledge SSRF + Argument Injection
3. **SSRF (git-fetcher.ts)** — `isPrivateAddress()` only regex-matched the hostname string; DNS-rebinding / cloud-metadata hosts (e.g. resolving to 169.254.169.254) bypassed it. Now also resolves DNS via `node:dns/promises` and checks the resolved address; unresolvable hosts fail closed.
4. **Argument Injection (git-fetcher.ts)** — `sourceUrl` was passed unsanitized to `simpleGit().clone()`; git option separators (`--upload-pack=...`) or shell metacharacters could inject options. Now rejected with a clear error.

## Changes

- `MemoryProxy/src/routes/rate-limits.ts` — auth guard on get/put/delete
- `MemoryProxy/src/routes/admin-auth.ts` — fail-closed on empty apiKey
- `MemoryKnowledge/src/source-fetcher/git-fetcher.ts` — DNS-resolved SSRF check + injection-safe URL validation
- Regression tests: `security-672-auth.test.ts` (4), `security-672-ssrf.test.ts` (6)
- CHANGELOG entry (Unreleased)

## Test Plan

- `npx vitest run src/routes/__tests__/security-672-auth.test.ts` — 4/4 passed
- `npx vitest run src/source-fetcher/__tests__/security-672-ssrf.test.ts` — 6/6 passed
- `npx tsc --noEmit` — only pre-existing errors (unrelated to this PR)

Note: advisory paths referenced the old monorepo layout (`MemoryProxy/src/...`); verified and fixed against current `feat/server_team`.