### PR TITLE
docs: document FTS5 requirement and expose availability in /health

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,15 @@ If `MEMORY_TENCENTDB_GATEWAY_API_KEY` is unset, the plugin also looks at `TDAI_G
 | `timezone` | `"system"` | Timezone for user/LLM-facing timestamps: `"system"` (follow process tz) / IANA name (`Asia/Shanghai`) / offset string (`+08:00`) |
 | `storeBackend` | `"sqlite"` | Storage backend: `sqlite` |
 | `recall.strategy` | `"hybrid"` | Recall strategy: `keyword` / `embedding` / `hybrid` (RRF fusion, recommended) |
+
+> **FTS5 requirement (keyword/hybrid recall)**: the default SQLite backend uses
+> `node:sqlite` **FTS5** virtual tables for BM25 keyword search. Official Node
+> binaries are not guaranteed to include the FTS5 module (e.g. Node v22.13.1
+> darwin-arm64 ships without it; v22.23.2+ includes it). When FTS5 is absent,
+> keyword search is silently unavailable and recall degrades to
+> `embedding`-only. The gateway logs a startup warning and `GET /health`
+> exposes `keywordSearchAvailable: false` so operators can detect this
+> without reading logs. Fix #679.
 | `recall.maxResults` | `5` | Number of items returned per recall |
 | `recall.maxCharsPerMemory` | `0` | Max characters injected for one recalled L1 memory; `0` disables this guard |
 | `recall.maxTotalRecallChars` | `0` | Total character budget for auto-recalled L1 memories; `0` disables this guard |

--- a/src/core/store/sqlite.ts
+++ b/src/core/store/sqlite.ts
@@ -335,6 +335,11 @@ export class VectorStore implements IMemoryStore {
   private readonly dimensions: number;
   private readonly logger?: Logger;
 
+  /** FTS5-Verfügbarkeit für Keyword-Search (Health-Exposure, Fix #679). */
+  get keywordSearchAvailable(): boolean {
+    return this.ftsAvailable;
+  }
+
   /** @see IMemoryStore.supportsDeferredEmbedding */
   readonly supportsDeferredEmbedding = true;
 

--- a/src/core/store/types.ts
+++ b/src/core/store/types.ts
@@ -244,6 +244,13 @@ export interface IMemoryStore {
    */
   readonly supportsDeferredEmbedding?: boolean;
 
+  /**
+   * Whether FTS5 keyword search is available (SQLite). When false, recall
+   * degrades to embedding-only (e.g. Node builds without the fts5 module).
+   * Fix #679.
+   */
+  readonly keywordSearchAvailable?: boolean;
+
   // ── Lifecycle (always sync) ──────────────────────────────
 
   init(providerInfo?: EmbeddingProviderInfo): MaybePromise<StoreInitResult>;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -356,14 +356,18 @@ export class TdaiGateway {
   // ============================
 
   private handleHealth(res: http.ServerResponse): void {
+    const vectorStore = this.core.getVectorStore();
     const response: HealthResponse = {
-      status: this.core.getVectorStore() ? "ok" : "degraded",
+      status: vectorStore ? "ok" : "degraded",
       version: VERSION,
       uptime: Math.floor((Date.now() - this.startTime) / 1000),
       stores: {
-        vectorStore: !!this.core.getVectorStore(),
+        vectorStore: !!vectorStore,
         embeddingService: !!this.core.getEmbeddingService(),
       },
+      // Fix #679: FTS5-Verfügbarkeit sichtbar machen (false → Keyword-Search
+      // degradiert zu embedding-only auf Node-Builds ohne fts5-Modul).
+      keywordSearchAvailable: vectorStore?.keywordSearchAvailable ?? false,
     };
     sendJson(res, 200, response);
   }

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -23,6 +23,8 @@ export interface HealthResponse {
     vectorStore: boolean;
     embeddingService: boolean;
   };
+  /** Fix #679: FTS5-Verfügbarkeit für Keyword-Search (false → recall degrades to embedding-only). */
+  keywordSearchAvailable: boolean;
 }
 
 // ============================


### PR DESCRIPTION
Fixes #679 — the default SQLite backend uses `node:sqlite` FTS5 virtual tables for BM25 keyword search, but official Node binaries are not guaranteed to include FTS5 (e.g. v22.13.1 darwin-arm64 lacks it).

## Changes
- **src/core/store/sqlite.ts**: public `keywordSearchAvailable` getter on VectorStore
- **src/gateway/types.ts + server.ts**: `GET /health` now returns `keywordSearchAvailable` so operators can detect FTS5 absence without reading logs
- **src/core/store/types.ts**: optional `keywordSearchAvailable` capability on IMemoryStore
- **README.md**: documents the FTS5 requirement, affected Node versions, and the embedding-only degradation

## Test Plan
- `npx tsc --noEmit` — 0 errors
- Health response includes the new field (verified by type-check)