### PR TITLE
fix(pipeline): preserve tenant scope on periodic L2 timers

### DIFF
--- a/MemoryCore/src/utils/stateful-pipeline-manager.test.ts
+++ b/MemoryCore/src/utils/stateful-pipeline-manager.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IStateBackend } from "../core/state/types.js";
+import {
+  StatefulPipelineManager,
+  type PipelineConfig,
+} from "./stateful-pipeline-manager.js";
+
+const config: PipelineConfig = {
+  everyNConversations: 5,
+  enableWarmup: false,
+  l1: {
+    idleTimeoutSeconds: 60,
+  },
+  l2: {
+    delayAfterL1Seconds: 90,
+    minIntervalSeconds: 900,
+    maxIntervalSeconds: 3_600,
+    sessionActiveWindowHours: 24,
+  },
+};
+
+function createManager() {
+  const setTimer = vi.fn().mockResolvedValue(undefined);
+  const backend = { setTimer } as unknown as IStateBackend;
+  return {
+    manager: new StatefulPipelineManager(config, backend, "default"),
+    setTimer,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("StatefulPipelineManager.armL2MaxInterval", () => {
+  it("preserves team and agent scope in the periodic L2 timer member", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const { manager, setTimer } = createManager();
+
+    await manager.armL2MaxInterval(
+      "session one",
+      "instance-1",
+      "team:a",
+      "agent/b",
+    );
+
+    expect(setTimer).toHaveBeenCalledWith(
+      "instance-1",
+      "scope:team:team%3Aa|agent:agent%2Fb|session:session%20one:L2_schedule",
+      3_601_000,
+    );
+  });
+
+  it("keeps the legacy timer member when tenant scope is unavailable", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    const { manager, setTimer } = createManager();
+
+    await manager.armL2MaxInterval("session-legacy", "instance-2");
+
+    expect(setTimer).toHaveBeenCalledWith(
+      "instance-2",
+      "session-legacy:L2_schedule",
+      3_602_000,
+    );
+  });
+});

--- a/MemoryCore/src/utils/stateful-pipeline-manager.ts
+++ b/MemoryCore/src/utils/stateful-pipeline-manager.ts
@@ -340,7 +340,7 @@ export class StatefulPipelineManager {
     }
     await this.stateBackend.setTimer(
       effectiveId,
-      `${sessionKey}:L2_schedule`,
+      buildPipelineTimerMember(sessionKey, "L2_schedule", { teamId, agentId }),
       Date.now() + this.l2MaxIntervalMs,
     );
   }


### PR DESCRIPTION
## Description | 描述

Preserve tenant routing information when the stateful v2 pipeline schedules periodic L2 work.

`advanceL2TimerAfterL1()` already builds a scoped timer member containing `teamId`, `agentId`, and `sessionId`. However, `armL2MaxInterval()` used the legacy raw `${sessionKey}:L2_schedule` member even when team and agent were available.

When TimerScanner claimed that max-interval timer, it could no longer reconstruct the tenant fields. The resulting periodic L2 task therefore lost `teamId`/`agentId` and fell back to the shared instance lock bucket instead of the intended per-team/agent routing.

Changes:

- Build max-interval timer members through `buildPipelineTimerMember()`, matching the delay-after-L1 path.
- Preserve the legacy `${session}:L2_schedule` format when tenant scope is unavailable.
- Add tests for encoded scoped identifiers and legacy compatibility.

Scope boundary: timer deadlines, Redis ZSET keys, Lua single-key behavior, L2 cadence, and task execution logic are unchanged.

## Related Issue | 关联 Issue

No existing issue. Discovered from the explicit team/agent timer-member contract while reviewing `StatefulPipelineManager` on the default v2 branch.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation in `MemoryCore`:

```text
npm test -- src/utils/stateful-pipeline-manager.test.ts
# 1 file, 2 tests passed

npm run build:plugin
npm run build:migrate-sqlite-to-vdb
npm run build:export-tencent-vdb
npm run build:read-local-memory
# all passed

git diff --check
# passed
```

The branch-wide `npm run build` still includes the unrelated missing `scripts/seed-v2/tsconfig.json` target. PR #652 removes that incomplete target; this PR remains a one-line runtime fix plus focused regression coverage.
