### PR TITLE
fix(deploy): resolve curl from PATH on Windows Git Bash (#655)

### DIFF
--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -75,6 +75,21 @@ find_docker() {
   die "找不到 docker 命令。请先安装 Docker Desktop / OrbStack / colima + docker CLI。"
 }
 
+find_curl() {
+  local candidate="${CURL:-curl}"
+  local resolved
+  resolved="$(command -v "$candidate" 2>/dev/null || true)"
+  if [[ -n "$resolved" ]]; then
+    echo "$resolved"
+    return
+  fi
+  if [[ -x "$candidate" ]]; then
+    echo "$candidate"
+    return
+  fi
+  die "找不到 curl 命令（CURL=${candidate}）。请安装 curl 或通过 CURL 指定可执行文件。"
+}
+
 DOCKER="$(find_docker)"
 
 # 幂等移除同名容器

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -15,6 +15,7 @@ source "$SCRIPT_DIR/_lib.sh"
 
 load_env
 require_vars MEMORY_CORE_IMAGE MEMORY_CORE_PORT MEMORY_CORE_VOLUME
+CURL="$(find_curl)"
 
 # ── Gateway 内部管理凭据 ─────────────────────────────────────────
 # 用 ${VAR-default}（不是 :-default）：允许 .env 里显式设为空字符串来关闭 Bearer gate。
@@ -162,7 +163,7 @@ generate_user_key() {
 verify_user_key() {
   local key="$1"
   local code
-  code=$(/usr/bin/curl -sS -o /dev/null -w "%{http_code}" --max-time 5 \
+  code=$("$CURL" -sS -o /dev/null -w "%{http_code}" --max-time 5 \
     -X POST -H "Content-Type: application/json" \
     -H "x-tdai-service-id: default" \
     ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
@@ -183,7 +184,7 @@ fi
 
 init_body=$(printf '{"username":"%s","user_key":"%s"}' \
   "$MEMORY_CORE_ADMIN_USERNAME" "$ADMIN_KEY")
-init_resp=$(/usr/bin/curl -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
+init_resp=$("$CURL" -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
   -X POST -H "Content-Type: application/json" \
   ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
   -H "x-tdai-service-id: default" \

--- a/deploy/global-images/tests/curl-resolution.test.sh
+++ b/deploy/global-images/tests/curl-resolution.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(cd "$TEST_DIR/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+make_fake_command() {
+  local path="$1"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$path"
+  chmod +x "$path"
+}
+
+make_fake_command "$TMP_DIR/docker"
+make_fake_command "$TMP_DIR/curl"
+make_fake_command "$TMP_DIR/custom-curl"
+
+PATH="$TMP_DIR:/usr/bin:/bin"
+# shellcheck source=../_lib.sh
+source "$DEPLOY_DIR/_lib.sh"
+
+resolved="$(CURL= find_curl)"
+[[ "$resolved" == "$TMP_DIR/curl" ]] ||
+  fail "PATH curl was not selected: $resolved"
+
+resolved="$(CURL="$TMP_DIR/custom-curl" find_curl)"
+[[ "$resolved" == "$TMP_DIR/custom-curl" ]] ||
+  fail "explicit CURL override was not selected: $resolved"
+
+if (CURL="missing-curl-command" find_curl) >"$TMP_DIR/missing.out" 2>&1; then
+  fail "missing CURL override should fail before an HTTP request"
+fi
+grep -q "找不到 curl 命令" "$TMP_DIR/missing.out" ||
+  fail "missing curl failure did not explain how to configure CURL"
+
+if grep -n "/usr/bin/curl" \
+  "$DEPLOY_DIR/start-memory-core.sh" "$DEPLOY_DIR/verify.sh"; then
+  fail "deployment scripts must not hard-code /usr/bin/curl"
+fi
+
+grep -q 'CURL="$(find_curl)"' "$DEPLOY_DIR/start-memory-core.sh" ||
+  fail "start-memory-core.sh does not resolve curl through find_curl"
+grep -q 'CURL="$(find_curl)"' "$DEPLOY_DIR/verify.sh" ||
+  fail "verify.sh does not resolve curl through find_curl"
+
+[[ "$(grep -c '"$CURL"' "$DEPLOY_DIR/start-memory-core.sh")" -ge 2 ]] ||
+  fail "start-memory-core.sh does not use the resolved curl command"
+
+echo "PASS: curl resolution is portable and rejects missing commands"

--- a/deploy/global-images/verify.sh
+++ b/deploy/global-images/verify.sh
@@ -37,7 +37,7 @@ done
 
 ERRORS=0
 WARNS=0
-CURL=/usr/bin/curl
+CURL="$(find_curl)"
 
 # ─── LLM 通路检查函数 ───────────────────────────────────────────────
 # check_llm_openai <label> <base_url> <api_key> <model>


### PR DESCRIPTION
## Description | 描述

Fix Windows Git Bash deployment startup by removing the macOS-specific
`/usr/bin/curl` assumption from `deploy/global-images`.

`start-memory-core.sh` previously invoked `/usr/bin/curl` directly for both
`init-admin` and `auth/verify`, while `verify.sh` assigned the same absolute
path. Git for Windows does not provide that path, so the command failed with
exit code 127. Because stderr was redirected and the fallback emitted `000`,
the deployment reported a misleading network-style `HTTP=000` even though the
memory-core service was healthy.

Changes:

- Add `find_curl()` to `_lib.sh`.
  - Honors an explicit `CURL` override.
  - Otherwise resolves `curl` through `PATH`, which works with Git Bash's
    Windows or MinGW curl installations.
  - Fails before any HTTP request with an actionable error when curl is absent.
- Resolve curl once in `start-memory-core.sh` and `verify.sh`.
- Route both admin HTTP calls through the resolved executable.
- Add a shell regression test covering PATH lookup, explicit overrides,
  missing-command failure, and the absence of hard-coded `/usr/bin/curl`.

This keeps macOS and Linux behavior unchanged while allowing Windows Git Bash
to use whichever curl executable is available in its environment.

## Related Issue | 关联 Issue

Closes #655

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation:

```text
bash deploy/global-images/tests/curl-resolution.test.sh
PASS: curl resolution is portable and rejects missing commands

bash -n \
  deploy/global-images/_lib.sh \
  deploy/global-images/start-memory-core.sh \
  deploy/global-images/verify.sh \
  deploy/global-images/tests/curl-resolution.test.sh
# passed

git diff --check
# passed
```

`shellcheck` was not installed in the local environment, so that optional
validation was not run.

Scope boundaries:

- No container images, ports, environment schema, or API payloads change.
- Runtime HTTP failures continue to use the existing `HTTP=000` fallback; this
  PR only prevents a missing executable from being disguised as such by
  validating curl before requests begin.
- The PR targets `feat/server_team`, where `deploy/global-images` currently
  lives.
