### PR TITLE
feat(hermes): add working offload ContextEngine (#102)

### DIFF
--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -154,7 +154,28 @@ TDAI_MEMORY_INSTANCE_ID=default
 
 ### Hermes
 
-`hermes-plugin/` provides the Hermes Memory Provider. It follows the same adapter model and uses the Gateway for conversation capture and memory recall.
+`hermes-plugin/` provides both the Hermes Memory Provider and a short-term
+ContextEngine backed by the Gateway's Offload V2 API:
+
+```bash
+bash scripts/install-hermes-plugin.sh
+```
+
+The installer links both plugins, writes their shared Gateway connection
+settings, and configures:
+
+```yaml
+memory:
+  provider: memory_tencentdb
+context:
+  engine: tencentdb_offload
+```
+
+The provider handles conversation capture and long-term recall. The
+ContextEngine delegates threshold-based compaction and MMD injection to
+`POST /v2/offload/compact`. See
+[`hermes-plugin/context_engine/tencentdb_offload/README.md`](hermes-plugin/context_engine/tencentdb_offload/README.md)
+for its environment variables and failure behavior.
 
 ### Custom Agents
 
@@ -177,6 +198,7 @@ An adapter generally has three responsibilities:
 | `/v2/conversation/*` | L0 write, query, search, delete, and count | Stable |
 | `/v2/atomic/*` | L1 query, search, update, delete, and count | Stable |
 | `/v2/scenario/*`, `/v2/core/*` | L2/L3 read and write | Stable |
+| `/v2/offload/ingest`, `/v2/offload/compact`, `/v2/offload/query-mmd` | Short-term context offload | Stable |
 | `/v3/conversation/*`, `/v3/atomic/*`, `/v3/scenario/*`, `/v3/core/*` | Strongly isolated L0–L3 data plane | Recommended for new integrations |
 | `/v3/skill/*` | Skill management, search, versions, resources, and extraction | Stable |
 | `/v3/meta/*` | User, Team, Agent, Task, Asset, and access relationships | Management plane |
@@ -232,7 +254,7 @@ MemoryCore/
 ├── src/gateway/           HTTP Gateway and v2/v3 routers
 ├── src/services/          Pipeline scanner, workers, and scheduling services
 ├── openclaw-plugin/       Lightweight OpenClaw client adapter
-├── hermes-plugin/         Hermes Memory Provider
+├── hermes-plugin/         Hermes Memory Provider and ContextEngine
 ├── scripts/               Installation, build, migration, and operations tools
 ├── Dockerfile             MemoryCore Gateway image
 ├── tdai-gateway*.yaml     Gateway configuration templates

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -154,7 +154,26 @@ TDAI_MEMORY_INSTANCE_ID=default
 
 ### Hermes
 
-`hermes-plugin/` 提供 Hermes Memory Provider。它遵循同样的 Adapter 模式，通过 Gateway 完成对话写入与记忆召回。
+`hermes-plugin/` 同时提供 Hermes Memory Provider 和由 Offload V2 API
+驱动的短期 ContextEngine：
+
+```bash
+bash scripts/install-hermes-plugin.sh
+```
+
+安装脚本会链接两个插件、写入共享的 Gateway 连接参数，并配置：
+
+```yaml
+memory:
+  provider: memory_tencentdb
+context:
+  engine: tencentdb_offload
+```
+
+Memory Provider 负责对话写入与长期记忆召回；ContextEngine 将阈值触发的
+上下文压缩和 MMD 注入委托给 `POST /v2/offload/compact`。环境变量和降级
+行为见
+[`hermes-plugin/context_engine/tencentdb_offload/README.md`](hermes-plugin/context_engine/tencentdb_offload/README.md)。
 
 ### 自定义 Agent
 
@@ -177,6 +196,7 @@ TDAI_MEMORY_INSTANCE_ID=default
 | `/v2/conversation/*` | L0 写入、查询、搜索、删除和计数 | 稳定 |
 | `/v2/atomic/*` | L1 查询、搜索、更新、删除和计数 | 稳定 |
 | `/v2/scenario/*`、`/v2/core/*` | L2/L3 读写 | 稳定 |
+| `/v2/offload/ingest`、`/v2/offload/compact`、`/v2/offload/query-mmd` | 短期上下文卸载 | 稳定 |
 | `/v3/conversation/*`、`/v3/atomic/*`、`/v3/scenario/*`、`/v3/core/*` | 强隔离的 L0–L3 数据面 | 推荐新接入使用 |
 | `/v3/skill/*` | Skill 管理、检索、版本、资源和抽取 | 稳定 |
 | `/v3/meta/*` | User、Team、Agent、Task、Asset 和权限关系 | 管理面 |
@@ -232,10 +252,10 @@ MemoryCore/
 ├── src/gateway/           HTTP Gateway 与 v2/v3 Router
 ├── src/services/          Pipeline Scanner、Worker 和调度服务
 ├── openclaw-plugin/       OpenClaw 轻量客户端 Adapter
-├── hermes-plugin/         Hermes Memory Provider
+├── hermes-plugin/         Hermes Memory Provider 与 ContextEngine
 ├── scripts/               安装、构建、迁移和运维工具
-│   ├── install-hermes-plugin.sh         Hermes provider 安装脚本
-│   ├── install-openclaw-plugin-v2.sh    OpenClaw 插件安装脚本
+│   ├── install-hermes-plugin.sh         Hermes Provider/ContextEngine 安装脚本
+│   ├── install-openclaw-plugin.sh       OpenClaw 插件安装脚本
 │   └── migrate-v2-to-v3/                数据迁移工具（v2 → v3）
 ├── Dockerfile             MemoryCore Gateway 镜像
 ├── tdai-gateway*.yaml     Gateway 配置模板

--- a/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/README.md
+++ b/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/README.md
@@ -1,0 +1,46 @@
+# TencentDB Offload ContextEngine
+
+This Hermes plugin delegates short-term context compaction to MemoryCore's
+`POST /v2/offload/compact` API. It complements the `memory_tencentdb` provider;
+the provider owns long-term recall and capture, while this engine owns
+context-window compaction.
+
+## Installation
+
+From the `MemoryCore` directory:
+
+```bash
+bash scripts/install-hermes-plugin.sh
+```
+
+The installer links this directory to
+`<hermes-agent>/plugins/context_engine/tencentdb_offload` and configures:
+
+```yaml
+memory:
+  provider: memory_tencentdb
+context:
+  engine: tencentdb_offload
+```
+
+## Configuration
+
+The engine reuses the v2 provider connection variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TDAI_MEMORY_ENDPOINT` | `http://127.0.0.1:8420` | MemoryCore Gateway URL |
+| `TDAI_MEMORY_API_KEY` | `local` | Bearer token |
+| `TDAI_MEMORY_SERVICE_ID` | `default` | `X-TDAI-Service-Id` value |
+| `TDAI_OFFLOAD_CONTEXT_LENGTH` | `128000` | Initial context window |
+| `TDAI_OFFLOAD_COMPACTION_RATIO` | `0.5` | Automatic compaction threshold |
+| `TDAI_OFFLOAD_COMPACTION_TIMEOUT_SECONDS` | `30` | HTTP timeout |
+
+Hermes updates the context length when the active model changes. The engine
+uses Hermes's prompt-token count when available and sends the exact Offload V2
+request fields: `session_id`, `messages`, `ratio`, `context_window`, and
+`total_tokens`.
+
+Gateway failures and malformed responses are fail-open: the original message
+list is preserved so an unavailable memory service cannot corrupt the active
+conversation.

--- a/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/__init__.py
+++ b/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/__init__.py
@@ -1,0 +1,249 @@
+"""Hermes ContextEngine backed by MemoryCore's Offload V2 API."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+try:
+    from agent.context_engine import ContextEngine
+except ModuleNotFoundError as exc:
+    if exc.name not in {"agent", "agent.context_engine"}:
+        raise
+    # Keep the module self-testable outside a Hermes checkout. Hermes itself
+    # always provides the real ABC before loading user plugins.
+    class ContextEngine:  # type: ignore[no-redef]
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+ENGINE_NAME = "tencentdb_offload"
+_SAFE_SESSION_CHARS = re.compile(r"[^a-zA-Z0-9_.:-]+")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_session_id(value: str) -> str:
+    normalized = _SAFE_SESSION_CHARS.sub("_", (value or "").strip()).strip("_")
+    return (normalized or "hermes")[:500]
+
+
+def _estimate_tokens(messages: List[Dict[str, Any]]) -> int:
+    """Return a conservative fallback when Hermes has no usage count yet."""
+    try:
+        serialized = json.dumps(messages, ensure_ascii=False, default=str)
+    except Exception:
+        serialized = str(messages)
+    return max(1, (len(serialized) + 3) // 4)
+
+
+class OffloadV2Client:
+    """Minimal stdlib client for ``POST /v2/offload/compact``."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key: str = "local",
+        service_id: str = "default",
+        timeout: float = 30.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key or "local"
+        self.service_id = service_id or "default"
+        self.timeout = timeout
+
+    @classmethod
+    def from_env(cls) -> "OffloadV2Client":
+        return cls(
+            os.environ.get("TDAI_MEMORY_ENDPOINT", "http://127.0.0.1:8420"),
+            api_key=os.environ.get("TDAI_MEMORY_API_KEY", "local"),
+            service_id=os.environ.get("TDAI_MEMORY_SERVICE_ID", "default"),
+            timeout=_env_float("TDAI_OFFLOAD_COMPACTION_TIMEOUT_SECONDS", 30.0),
+        )
+
+    def compact(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        request = urllib.request.Request(
+            f"{self.base_url}/v2/offload/compact",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+                "X-TDAI-Service-Id": self.service_id,
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                raw = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Offload compact returned HTTP {exc.code}: {detail[:300]}"
+            ) from exc
+
+        if not isinstance(raw, dict) or raw.get("code") != 0:
+            raise RuntimeError(
+                f"Offload compact returned an error envelope: {raw!r}"
+            )
+        data = raw.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("Offload compact response is missing data")
+        return data
+
+
+class TencentdbOffloadContextEngine(ContextEngine):
+    """Hermes context engine that delegates compaction to MemoryCore."""
+
+    emit_automatic_compaction_status = False
+
+    def __init__(
+        self,
+        *,
+        client: Optional[OffloadV2Client] = None,
+        context_length: Optional[int] = None,
+        threshold_percent: Optional[float] = None,
+    ) -> None:
+        self.client = client or OffloadV2Client.from_env()
+        self.context_length = max(
+            1_000,
+            context_length
+            if context_length is not None
+            else _env_int("TDAI_OFFLOAD_CONTEXT_LENGTH", 128_000),
+        )
+        configured_threshold = (
+            threshold_percent
+            if threshold_percent is not None
+            else _env_float("TDAI_OFFLOAD_COMPACTION_RATIO", 0.5)
+        )
+        self.threshold_percent = min(0.99, max(0.05, configured_threshold))
+        self.threshold_tokens = int(
+            self.context_length * self.threshold_percent
+        )
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.compression_count = 0
+        self._session_id = "hermes"
+
+    @property
+    def name(self) -> str:
+        return ENGINE_NAME
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        usage = usage or {}
+        self.last_prompt_tokens = int(
+            usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+        )
+        self.last_completion_tokens = int(
+            usage.get("completion_tokens") or usage.get("output_tokens") or 0
+        )
+        self.last_total_tokens = int(
+            usage.get("total_tokens")
+            or self.last_prompt_tokens + self.last_completion_tokens
+        )
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        tokens = (
+            self.last_prompt_tokens
+            if prompt_tokens is None
+            else max(0, int(prompt_tokens))
+        )
+        return tokens >= self.threshold_tokens
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        memory_context: str = "",
+    ) -> List[Dict[str, Any]]:
+        del focus_topic, force, memory_context
+        if not messages:
+            return messages
+
+        total_tokens = int(
+            current_tokens
+            or self.last_prompt_tokens
+            or _estimate_tokens(messages)
+        )
+        ratio = min(
+            2.0,
+            max(0.0, total_tokens / max(1, self.context_length)),
+        )
+        payload = {
+            "session_id": self._session_id,
+            "messages": messages,
+            "ratio": ratio,
+            "context_window": self.context_length,
+            "total_tokens": max(0, total_tokens),
+        }
+
+        try:
+            data = self.client.compact(payload)
+        except Exception as exc:
+            logger.warning(
+                "TencentDB offload compaction failed; preserving original "
+                "messages: %s",
+                exc,
+            )
+            return messages
+
+        compacted = data.get("messages")
+        if not isinstance(compacted, list) or not all(
+            isinstance(message, dict) for message in compacted
+        ):
+            logger.warning(
+                "TencentDB offload compaction returned invalid messages; "
+                "preserving original messages"
+            )
+            return messages
+
+        self.compression_count += 1
+        self.last_prompt_tokens = 0
+        self.last_total_tokens = 0
+        return compacted
+
+    def on_session_start(self, session_id: str, **kwargs: Any) -> None:
+        del kwargs
+        self._session_id = _normalize_session_id(session_id)
+
+    def on_session_end(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        del session_id, messages
+        self._session_id = "hermes"
+
+
+def register(ctx: Any) -> None:
+    """Register the engine through Hermes's ordinary user-plugin loader."""
+    ctx.register_context_engine(TencentdbOffloadContextEngine())
+
+
+__all__ = [
+    "ENGINE_NAME",
+    "OffloadV2Client",
+    "TencentdbOffloadContextEngine",
+    "register",
+]

--- a/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/plugin.yaml
+++ b/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/plugin.yaml
@@ -1,0 +1,4 @@
+name: tencentdb_offload
+display_name: TencentDB Offload ContextEngine
+version: 1.0.0
+description: "Hermes ContextEngine backed by MemoryCore's Offload V2 compaction API."

--- a/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/tests/test_context_engine.py
+++ b/MemoryCore/hermes-plugin/context_engine/tencentdb_offload/tests/test_context_engine.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+THIS_FILE = pathlib.Path(__file__).resolve()
+PLUGIN_DIR = THIS_FILE.parents[1]
+CONTEXT_ENGINE_ROOT = PLUGIN_DIR.parent
+MEMORY_CORE_ROOT = THIS_FILE.parents[4]
+
+hermes_root = os.environ.get("HERMES_AGENT_ROOT")
+if hermes_root:
+    sys.path.insert(0, hermes_root)
+sys.path.insert(0, str(CONTEXT_ENGINE_ROOT))
+
+from tencentdb_offload import (  # noqa: E402
+    ENGINE_NAME,
+    OffloadV2Client,
+    TencentdbOffloadContextEngine,
+    register,
+)
+
+
+class FakeClient:
+    def __init__(self, response=None, error: Exception | None = None):
+        self.response = response or {"messages": []}
+        self.error = error
+        self.payloads = []
+
+    def compact(self, payload):
+        self.payloads.append(payload)
+        if self.error:
+            raise self.error
+        return self.response
+
+
+class ContextEngineTests(unittest.TestCase):
+    def test_registers_real_context_engine_contract(self):
+        captured = []
+
+        class Ctx:
+            def register_context_engine(self, engine):
+                captured.append(engine)
+
+        register(Ctx())
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0].name, ENGINE_NAME)
+
+        if hermes_root:
+            from agent.context_engine import ContextEngine
+
+            self.assertIsInstance(captured[0], ContextEngine)
+
+    def test_usage_updates_threshold_decision(self):
+        engine = TencentdbOffloadContextEngine(
+            client=FakeClient(),
+            context_length=1_000,
+            threshold_percent=0.5,
+        )
+        engine.update_from_response(
+            {
+                "prompt_tokens": 499,
+                "completion_tokens": 20,
+                "total_tokens": 519,
+            }
+        )
+        self.assertFalse(engine.should_compress())
+        self.assertTrue(engine.should_compress(500))
+        self.assertEqual(engine.last_completion_tokens, 20)
+        self.assertEqual(engine.last_total_tokens, 519)
+
+    def test_compact_uses_exact_v2_contract_and_envelope_data(self):
+        compacted = [{"role": "user", "content": "compact"}]
+        client = FakeClient({"messages": compacted, "report": {"resolvedLevel": "mild"}})
+        engine = TencentdbOffloadContextEngine(
+            client=client,
+            context_length=2_000,
+            threshold_percent=0.5,
+        )
+        engine.on_session_start("team/a session")
+
+        messages = [{"role": "user", "content": "x" * 100}]
+        result = engine.compress(messages, current_tokens=1_200)
+
+        self.assertIs(result, compacted)
+        self.assertEqual(
+            client.payloads,
+            [
+                {
+                    "session_id": "team_a_session",
+                    "messages": messages,
+                    "ratio": 0.6,
+                    "context_window": 2_000,
+                    "total_tokens": 1_200,
+                }
+            ],
+        )
+        self.assertEqual(engine.compression_count, 1)
+
+    def test_compact_is_fail_open_on_transport_error(self):
+        messages = [{"role": "user", "content": "keep me"}]
+        engine = TencentdbOffloadContextEngine(
+            client=FakeClient(error=ConnectionError("down"))
+        )
+        self.assertIs(engine.compress(messages, current_tokens=90_000), messages)
+        self.assertEqual(engine.compression_count, 0)
+
+    def test_compact_is_fail_open_on_bad_message_shape(self):
+        messages = [{"role": "user", "content": "keep me"}]
+        engine = TencentdbOffloadContextEngine(
+            client=FakeClient({"messages": ["not-a-message"]})
+        )
+        self.assertIs(engine.compress(messages, current_tokens=90_000), messages)
+
+    def test_engine_can_be_deep_copied_for_hermes_agent_isolation(self):
+        engine = TencentdbOffloadContextEngine(client=FakeClient())
+        cloned = copy.deepcopy(engine)
+        self.assertIsNot(cloned, engine)
+        self.assertEqual(cloned.name, engine.name)
+
+
+class ClientTests(unittest.TestCase):
+    def test_client_sends_auth_service_and_v2_payload(self):
+        captured = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {"code": 0, "message": "ok", "data": {"messages": []}}
+                ).encode()
+
+        def fake_urlopen(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+        client = OffloadV2Client(
+            "http://memory.example/",
+            api_key="secret",
+            service_id="tenant-a",
+            timeout=7,
+        )
+        payload = {
+            "session_id": "s",
+            "messages": [],
+            "ratio": 0.5,
+            "context_window": 1_000,
+            "total_tokens": 500,
+        }
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            data = client.compact(payload)
+
+        request = captured["request"]
+        self.assertEqual(request.full_url, "http://memory.example/v2/offload/compact")
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret")
+        self.assertEqual(request.get_header("X-tdai-service-id"), "tenant-a")
+        self.assertEqual(json.loads(request.data.decode()), payload)
+        self.assertEqual(captured["timeout"], 7)
+        self.assertEqual(data, {"messages": []})
+
+
+class InstallerTests(unittest.TestCase):
+    def test_installer_links_both_plugins_and_updates_config(self):
+        script = MEMORY_CORE_ROOT / "scripts" / "install-hermes-plugin.sh"
+        provider_source = (
+            MEMORY_CORE_ROOT / "hermes-plugin" / "memory" / "memory_tencentdb"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            hermes_home = root / ".hermes"
+            agent_dir = hermes_home / "hermes-agent"
+            (agent_dir / "plugins" / "memory").mkdir(parents=True)
+            hermes_home.mkdir(exist_ok=True)
+            config = hermes_home / "config.yaml"
+            config.write_text("model: test-model\n", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HERMES_HOME": str(hermes_home),
+                    "HERMES_AGENT_DIR": str(agent_dir),
+                    "HERMES_CONFIG": str(config),
+                    "HERMES_ENV": str(hermes_home / ".env"),
+                    "HERMES_PROVIDER_SRC": str(provider_source),
+                    "HERMES_CONTEXT_ENGINE_SRC": str(PLUGIN_DIR),
+                    "WRITE_HERMES_ENV": "0",
+                    "WRITE_HERMES_CONFIG": "1",
+                    "FORCE": "1",
+                }
+            )
+
+            subprocess.run(
+                ["bash", str(script)],
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            provider_target = (
+                agent_dir / "plugins" / "memory" / "memory_tencentdb"
+            )
+            engine_target = (
+                agent_dir / "plugins" / "context_engine" / ENGINE_NAME
+            )
+            self.assertTrue(provider_target.is_symlink())
+            self.assertEqual(provider_target.resolve(), provider_source.resolve())
+            self.assertTrue(engine_target.is_symlink())
+            self.assertEqual(engine_target.resolve(), PLUGIN_DIR.resolve())
+
+            rendered = config.read_text(encoding="utf-8")
+            self.assertIn("provider: memory_tencentdb", rendered)
+            self.assertIn(f"engine: {ENGINE_NAME}", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -59,6 +59,7 @@
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",
     "scripts/install-hermes-plugin-v2.sh",
+    "scripts/install-hermes-plugin.sh",
     "scripts/install-openclaw-plugin.sh",
     "scripts/README.memory-tencentdb-ctl.md",
     "src",

--- a/MemoryCore/scripts/install-hermes-plugin.sh
+++ b/MemoryCore/scripts/install-hermes-plugin.sh
@@ -16,13 +16,16 @@ ALLOW_SYSTEM_PYTHON="${ALLOW_SYSTEM_PYTHON:-0}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROVIDER_SRC="${HERMES_PROVIDER_SRC:-$REPO_ROOT/hermes-plugin/memory/memory_tencentdb}"
+CONTEXT_ENGINE_SRC="${HERMES_CONTEXT_ENGINE_SRC:-$REPO_ROOT/hermes-plugin/context_engine/tencentdb_offload}"
 
 HERMES_HOME="${HERMES_HOME:-$USER_HOME/.hermes}"
 HERMES_AGENT_DIR="${HERMES_AGENT_DIR:-$HERMES_HOME/hermes-agent}"
 HERMES_CONFIG="${HERMES_CONFIG:-$HERMES_HOME/config.yaml}"
 HERMES_ENV="${HERMES_ENV:-$HERMES_HOME/.env}"
 HERMES_MEMORY_PLUGIN_DIR="${HERMES_MEMORY_PLUGIN_DIR:-$HERMES_AGENT_DIR/plugins/memory}"
+HERMES_CONTEXT_ENGINE_PLUGIN_DIR="${HERMES_CONTEXT_ENGINE_PLUGIN_DIR:-$HERMES_AGENT_DIR/plugins/context_engine}"
 PROVIDER_TARGET="$HERMES_MEMORY_PLUGIN_DIR/memory_tencentdb"
+CONTEXT_ENGINE_TARGET="$HERMES_CONTEXT_ENGINE_PLUGIN_DIR/tencentdb_offload"
 
 TDAI_MEMORY_ENDPOINT="${TDAI_MEMORY_ENDPOINT:-http://127.0.0.1:8420}"
 TDAI_MEMORY_API_KEY="${TDAI_MEMORY_API_KEY:-local}"
@@ -33,27 +36,36 @@ WRITE_HERMES_CONFIG="${WRITE_HERMES_CONFIG:-1}"
 if [[ ! -d "$PROVIDER_SRC" ]]; then
   fail "Hermes provider directory not found: $PROVIDER_SRC"
 fi
+if [[ ! -d "$CONTEXT_ENGINE_SRC" ]]; then
+  fail "Hermes context engine directory not found: $CONTEXT_ENGINE_SRC"
+fi
 
 if [[ ! -d "$HERMES_AGENT_DIR" ]]; then
   log "WARN: Hermes agent dir not found: $HERMES_AGENT_DIR"
   log "      Set HERMES_AGENT_DIR if Hermes is installed elsewhere."
 fi
 
-log "Installing Hermes provider"
+log "Installing Hermes provider and ContextEngine"
 mkdir -p "$HERMES_MEMORY_PLUGIN_DIR"
-if [[ -e "$PROVIDER_TARGET" || -L "$PROVIDER_TARGET" ]]; then
-  if [[ "$FORCE" == "1" ]]; then
-    rm -rf "$PROVIDER_TARGET"
-  else
-    fail "target already exists: $PROVIDER_TARGET (set FORCE=1 to overwrite)"
+mkdir -p "$HERMES_CONTEXT_ENGINE_PLUGIN_DIR"
+for target in "$PROVIDER_TARGET" "$CONTEXT_ENGINE_TARGET"; do
+  if [[ -e "$target" || -L "$target" ]]; then
+    if [[ "$FORCE" != "1" ]]; then
+      fail "target already exists: $target (set FORCE=1 to overwrite)"
+    fi
   fi
+done
+if [[ "$FORCE" == "1" ]]; then
+  rm -rf "$PROVIDER_TARGET" "$CONTEXT_ENGINE_TARGET"
 fi
 ln -s "$PROVIDER_SRC" "$PROVIDER_TARGET"
+ln -s "$CONTEXT_ENGINE_SRC" "$CONTEXT_ENGINE_TARGET"
 log "Provider linked: $PROVIDER_TARGET -> $PROVIDER_SRC"
+log "ContextEngine linked: $CONTEXT_ENGINE_TARGET -> $CONTEXT_ENGINE_SRC"
 
 log "Checking Hermes config"
 if [[ "$WRITE_HERMES_CONFIG" == "1" ]]; then
-  log "Enabling memory.provider=memory_tencentdb in $HERMES_CONFIG"
+  log "Enabling memory.provider=memory_tencentdb and context.engine=tencentdb_offload in $HERMES_CONFIG"
   mkdir -p "$(dirname "$HERMES_CONFIG")"
   if [[ -f "$HERMES_CONFIG" ]]; then
     cp "$HERMES_CONFIG" "$HERMES_CONFIG.bak.$(date +%Y%m%d%H%M%S)"
@@ -65,7 +77,6 @@ import re
 from pathlib import Path
 
 path = Path(os.environ["HERMES_CONFIG"])
-provider_line = "  provider: memory_tencentdb"
 
 
 def update_with_pyyaml(text: str) -> str:
@@ -78,37 +89,57 @@ def update_with_pyyaml(text: str) -> str:
         memory = {}
     data["memory"] = memory
     memory["provider"] = "memory_tencentdb"
+    context = data.get("context")
+    if not isinstance(context, dict):
+        context = {}
+    data["context"] = context
+    context["engine"] = "tencentdb_offload"
     return yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+
+
+def upsert_section_value(
+    lines: list[str],
+    section: str,
+    key: str,
+    value: str,
+) -> list[str]:
+    section_start = None
+    section_end = None
+    for i, line in enumerate(lines):
+        if re.match(rf"^{re.escape(section)}\s*:\s*(#.*)?$", line):
+            section_start = i
+            section_end = len(lines)
+            for j in range(i + 1, len(lines)):
+                if lines[j] and not lines[j].startswith((" ", "\t")):
+                    section_end = j
+                    break
+            break
+
+    rendered = f"  {key}: {value}"
+    if section_start is None:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.extend([f"{section}:", rendered])
+        return lines
+
+    for i in range(section_start + 1, section_end):
+        if re.match(rf"^\s*{re.escape(key)}\s*:", lines[i]):
+            indent = re.match(r"^(\s*)", lines[i]).group(1) or "  "
+            lines[i] = f"{indent}{key}: {value}"
+            return lines
+
+    lines.insert(section_start + 1, rendered)
+    return lines
 
 
 def update_minimal(text: str) -> str:
     lines = text.splitlines()
-    memory_start = None
-    memory_end = None
-    for i, line in enumerate(lines):
-        if re.match(r"^memory\s*:\s*(#.*)?$", line):
-            memory_start = i
-            memory_end = len(lines)
-            for j in range(i + 1, len(lines)):
-                if lines[j] and not lines[j].startswith((" ", "\t")):
-                    memory_end = j
-                    break
-            break
-
-    if memory_start is None:
-        if lines and lines[-1].strip():
-            lines.append("")
-        lines.extend(["memory:", provider_line])
-        return "\n".join(lines) + "\n"
-
-    for i in range(memory_start + 1, memory_end):
-        if re.match(r"^\s*provider\s*:", lines[i]):
-            indent = re.match(r"^(\s*)", lines[i]).group(1) or "  "
-            lines[i] = f"{indent}provider: memory_tencentdb"
-            return "\n".join(lines) + "\n"
-
-    insert_at = memory_start + 1
-    lines.insert(insert_at, provider_line)
+    lines = upsert_section_value(
+        lines, "memory", "provider", "memory_tencentdb"
+    )
+    lines = upsert_section_value(
+        lines, "context", "engine", "tencentdb_offload"
+    )
     return "\n".join(lines) + "\n"
 
 
@@ -120,14 +151,18 @@ except Exception:
 path.write_text(updated)
 PY
 else
-  if [[ -f "$HERMES_CONFIG" ]] && sed -n '/^memory:/,/^[[:alpha:]_][[:alnum:]_]*:/p' "$HERMES_CONFIG" | grep -q 'provider: memory_tencentdb'; then
-    log "memory.provider already set to memory_tencentdb"
+  if [[ -f "$HERMES_CONFIG" ]] \
+    && sed -n '/^memory:/,/^[[:alpha:]_][[:alnum:]_]*:/p' "$HERMES_CONFIG" | grep -q 'provider: memory_tencentdb' \
+    && sed -n '/^context:/,/^[[:alpha:]_][[:alnum:]_]*:/p' "$HERMES_CONFIG" | grep -q 'engine: tencentdb_offload'; then
+    log "memory.provider and context.engine are already configured"
   else
-    log "Provider installed but NOT enabled because WRITE_HERMES_CONFIG=$WRITE_HERMES_CONFIG. Add/edit in $HERMES_CONFIG:"
+    log "Plugins installed but NOT enabled because WRITE_HERMES_CONFIG=$WRITE_HERMES_CONFIG. Add/edit in $HERMES_CONFIG:"
     cat >&2 <<'EOF'
 
 memory:
   provider: memory_tencentdb
+context:
+  engine: tencentdb_offload
 EOF
   fi
 fi
@@ -160,10 +195,13 @@ cat >&2 <<EOF
 [install-hermes-plugin-v2] Done.
 Provider installed at:
   $PROVIDER_TARGET
+ContextEngine installed at:
+  $CONTEXT_ENGINE_TARGET
 
 Hermes config:
   $HERMES_CONFIG
   memory.provider = memory_tencentdb
+  context.engine = tencentdb_offload
 
 Gateway env (written to $HERMES_ENV):
   TDAI_MEMORY_ENDPOINT="$TDAI_MEMORY_ENDPOINT"


### PR DESCRIPTION
## Description | 描述

This PR adds a loadable Hermes `ContextEngine` for MemoryCore's existing
Offload V2 API.

The previous implementations for #102 were not executable by Hermes:

- #376 did not subclass `agent.context_engine.ContextEngine`.
- #624 placed a duck-typed class inside a memory-provider directory, where
  Hermes never discovers or registers context engines.

This replacement targets the repository's default `feat/server_team` line,
where `/v2/offload/compact` is implemented.

### Changes

- Add `TencentdbOffloadContextEngine`, a real `ContextEngine` subclass with:
  - prompt-usage tracking and threshold decisions;
  - normalized per-session routing;
  - the exact Offload V2 request and response-envelope contract;
  - Bearer and `X-TDAI-Service-Id` authentication;
  - fail-open behavior for transport errors and malformed responses.
- Register the engine through Hermes's dedicated
  `plugins/context_engine/<name>` loader.
- Extend `install-hermes-plugin.sh` to:
  - link both the memory provider and ContextEngine;
  - configure `memory.provider` and `context.engine`;
  - preserve the existing backup and `FORCE` behavior.
- Fix the npm package allowlist to include the real
  `scripts/install-hermes-plugin.sh` path instead of the missing
  `install-hermes-plugin-v2.sh`.
- Document the integration in English and Chinese.
- Add self-contained contract, HTTP, fail-open, deep-copy, and installer
  regression tests.

### Boundaries

- No MemoryCore TypeScript runtime behavior is changed.
- Tool-pair ingest remains owned by the existing adapters. This ContextEngine
  only owns host-triggered compaction.
- Gateway failures preserve the original messages rather than applying an
  unsafe local truncation.

## Related Issue | 关联 Issue

Closes #102

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] Existing installations are unchanged until the installer is rerun

## Verification | 验证

- `python3 -m unittest MemoryCore/hermes-plugin/context_engine/tencentdb_offload/tests/test_context_engine.py`
  - 8/8 passed with the self-contained test contract.
- `HERMES_AGENT_ROOT=<current-hermes> python3.12 -m unittest ...`
  - 8/8 passed against the current real Hermes ABC.
- Hermes `_load_engine_from_dir()` integration check
  - returned `TencentdbOffloadContextEngine tencentdb_offload`.
- `bash -n MemoryCore/scripts/install-hermes-plugin.sh`
- `npm run build:plugin`
- `npm run build:migrate-sqlite-to-vdb`
- `npm run build:export-tencent-vdb`
- `npm run build:read-local-memory`
- `npm pack --dry-run --ignore-scripts --json`
  - 331 files; all ContextEngine and installer artifacts present.
- `git diff --check`

### Existing base-branch limitations

- `npm test` reports `No test files found` because `feat/server_team` contains
  no files matching its configured Vitest patterns.
- The final `npm run build:seed-v2` stage fails because
  `scripts/seed-v2/tsconfig.json` does not exist on the base branch. The
  independent baseline fix is #652. All preceding build stages pass.

## Additional Notes | 其他说明

The installer keeps its existing config backup behavior before writing:

```yaml
memory:
  provider: memory_tencentdb
context:
  engine: tencentdb_offload
```

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
