### PR TITLE
fix(embedding): unlock local provider and trigger startWarmup (#678)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -389,13 +389,10 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     embeddingProvider = "none";
     embeddingEnabled = false;
   } else if (embeddingProviderRaw === "local") {
-    // Local embedding is not exposed to users; treat as disabled at entry level.
-    // Internal LocalEmbeddingService code is preserved but not reachable from config.
-    embeddingProvider = "none";
-    embeddingEnabled = false;
-    embeddingConfigError =
-      "Local embedding provider is not available in user config. " +
-      "Please configure a remote embedding provider (e.g. openai, deepseek). Embedding has been disabled.";
+    // Local embedding provider (node-llama-cpp): enabled, no API key required
+    // startWarmup() will be called during core/gateway initialization
+    embeddingProvider = "local";
+    embeddingEnabled = true;
   } else if (embeddingProviderRaw === "qclaw") {
     // qclaw provider: requires proxyUrl for local proxy forwarding
     const missingFields: string[] = [];

--- a/src/core/store/factory.test.ts
+++ b/src/core/store/factory.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the modules that have side effects or require runtime dependencies
+vi.mock("../../../utils/manifest.js", () => ({
+  writeStoreConfigManifest: vi.fn(),
+}));
+
+vi.mock("../../../utils/bm25-local.js", () => ({
+  createBM25Encoder: vi.fn().mockReturnValue({
+    encodeText: vi.fn(),
+    loadCorpus: vi.fn(),
+    search: vi.fn(),
+    scores: vi.fn(),
+    setMode: vi.fn(),
+    save: vi.fn(),
+    getStats: vi.fn(),
+  }),
+}));
+
+// We need to mock the embedding.ts module because it tries to load llama-cpp
+// We will also mock VectorStore to avoid real file I/O
+vi.mock("./embedding.js", () => {
+  const LocalMockEmbedding = vi.fn().mockImplementation(() => ({
+    provider: "local",
+    startWarmup: vi.fn().mockResolvedValue(undefined),
+    embed: vi.fn().mockResolvedValue(new Float32Array(768)),
+    embedBatch: vi.fn().mockResolvedValue([new Float32Array(768)]),
+  }));
+  const RemoteMockEmbedding = vi.fn().mockImplementation(() => ({
+    provider: "remote",
+    startWarmup: vi.fn(),
+    embed: vi.fn().mockResolvedValue(new Float32Array(768)),
+    embedBatch: vi.fn().mockResolvedValue([new Float32Array(768)]),
+  }));
+  const NoopMockEmbedding = vi.fn();
+
+  return {
+    createEmbeddingService: vi.fn((config: any) => {
+      if (config?.provider === "local") return new LocalMockEmbedding();
+      if (config?.provider !== "local" && config?.apiKey) return new RemoteMockEmbedding();
+      return new LocalMockEmbedding(); // Fallback
+    }),
+    NoopEmbeddingService: NoopMockEmbedding,
+  };
+});
+
+vi.mock("./sqlite.js", () => ({
+  VectorStore: vi.fn().mockImplementation(() => ({
+    insert: vi.fn(),
+    insertBatch: vi.fn(),
+    search: vi.fn().mockResolvedValue([]),
+    getById: vi.fn().mockResolvedValue(null),
+    delete: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+    addFtsIndex: vi.fn(),
+    searchFts: vi.fn().mockResolvedValue([]),
+    getL0Records: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+import { createStoreBundle } from "./factory.js";
+
+describe("StoreFactory - Local Embedding Provider (Issue #678)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create a local embedding service and call startWarmup() when provider is 'local'", async () => {
+    const config = {
+      storeBackend: "sqlite",
+      embedding: {
+        enabled: true,
+        provider: "local",
+        apiKey: undefined,
+        baseUrl: "",
+        model: "",
+        dimensions: 768,
+      },
+    } as any;
+
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const result = createStoreBundle(config, { dataDir: "/tmp/test-data", logger });
+
+    // Should have created an embedding service
+    expect(result.embedding).toBeDefined();
+    expect(result.embedding.provider).toBe("local");
+
+    // startWarmup should have been called (fire-and-forget, so we wait a tick)
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(result.embedding.startWarmup).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("Triggering local embedding warmup")
+    );
+  });
+
+  it("should create a remote embedding service without calling startWarmup when provider is not 'local'", async () => {
+    const config = {
+      storeBackend: "sqlite",
+      embedding: {
+        enabled: true,
+        provider: "deepseek",
+        apiKey: "test-api-key",
+        baseUrl: "https://api.deepseek.com/v1",
+        model: "deepseek-chat",
+        dimensions: 768,
+      },
+    } as any;
+
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const result = createStoreBundle(config, { dataDir: "/tmp/test-data", logger });
+
+    // Should have created an embedding service
+    expect(result.embedding).toBeDefined();
+    expect(result.embedding.provider).toBe("remote");
+
+    // startWarmup should NOT have been called for remote provider
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(result.embedding.startWarmup).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("Triggering local embedding warmup")
+    );
+  });
+});

--- a/src/core/store/factory.ts
+++ b/src/core/store/factory.ts
@@ -91,7 +91,8 @@ export function createStoreBundle(
     default: {
       // ── Embedding service (only when enabled) ──
       let embeddingService: EmbeddingService | undefined;
-      if (config.embedding.enabled && config.embedding.provider !== "local" && config.embedding.apiKey) {
+      // Allow local provider without API key, but require API key for remote providers
+      if (config.embedding.enabled && (config.embedding.provider === "local" || config.embedding.apiKey)) {
         embeddingService = createEmbeddingService({
           provider: config.embedding.provider,
           baseUrl: config.embedding.baseUrl,
@@ -101,6 +102,15 @@ export function createStoreBundle(
           sendDimensions: config.embedding.sendDimensions,
           maxInputChars: config.embedding.maxInputChars,
         }, logger);
+
+        // Trigger warmup for local embedding to ensure the GGUF model is loaded
+        if (config.embedding.provider === "local") {
+          logger?.info?.(`${TAG} Triggering local embedding warmup...`);
+          // Fire-and-forget; warmup is safe to call multiple times
+          void embeddingService.startWarmup().catch((err) => {
+            logger?.warn?.(`${TAG} Local embedding warmup failed: ${err instanceof Error ? err.message : String(err)}`);
+          });
+        }
       }
 
       // dimensions from config (0 when provider="none" → vec0 deferred)


### PR DESCRIPTION
## 背景 (Background)

Closes #678

`createEmbeddingService()` supports `LocalEmbeddingService` (node-llama-cpp), but two layers blocked it:
1. `config.ts` rewrites `provider=local` to `provider=none`, disabling local embedding.
2. `factory.ts` only creates an embedding service when `config.embedding.provider !== "local"`.

Additionally, after a local service was created, `startWarmup()` was never called, so the GGUF model was never downloaded and `embed()` would fail with `EmbeddingNotReadyError`.

## 改动内容 (What & Why)

1. **`src/config.ts`**:
   - Changed logic for `provider="local"`: Now sets `embeddingEnabled = true` and `embeddingProvider = "local"` instead of disabling it.

2. **`src/core/store/factory.ts`**:
   - Modified condition in `createSqliteBackend`: Now creates the embedding service for `provider="local"` even without an API key.
   - After creating the service, triggers `embeddingService.startWarmup()` as a fire-and-forget promise for local providers, ensuring the GGUF model is downloaded and ready.

3. **`src/core/store/factory.test.ts`**:
   - Added vitest cases to verify that `startWarmup()` is called for `provider="local"` and is NOT called for remote providers.

## 验证方式 (Verification)

- [x] Added unit tests in `src/core/store/factory.test.ts` covering both local and remote provider behaviors.
- [x] Verified logic manually via code review.

## 影响范围 (Impact)

- Users who want fully-offline embedding (no external API key) can now enable it via config.
- The model will be loaded automatically on startup.
- No breaking changes for remote embedding providers.