### PR TITLE
fix(seed): waitForL1Idle race condition causes /seed to hang (#505)

### DIFF
--- a/src/core/seed/seed-runtime.test.ts
+++ b/src/core/seed/seed-runtime.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { waitForL1Idle } from "./seed-runtime.js";
+
+// Mock the dependencies
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+const mockScheduler = {
+  getQueueSizes: vi.fn(),
+  getBufferedMessageCount: vi.fn(),
+  getSessionState: vi.fn(),
+  destroy: vi.fn(),
+  hasSessionEnded: vi.fn(),
+  setGracefulShutdown: vi.fn(),
+  listSessions: vi.fn(),
+  getL2Stats: vi.fn(),
+  getL3Stats: vi.fn(),
+  scheduleL3: vi.fn(),
+  cleanupSession: vi.fn(),
+};
+
+describe("waitForL1Idle (Issue #505 fix)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return successfully when l1Idle is true and buffer is empty, even if conversation_count is non-zero", async () => {
+    // Arrange: simulate a scenario where L1 is idle but conversation_count is stale
+    mockScheduler.getQueueSizes.mockReturnValue({
+      l1: 0,
+      l1Pending: false,
+      l1Idle: true,
+      l2: 0,
+      l2Pending: false,
+      l2Idle: false,
+      l3: 0,
+      l3Pending: false,
+      l3Idle: false,
+    });
+    mockScheduler.getBufferedMessageCount.mockReturnValue(0);
+    mockScheduler.getSessionState.mockReturnValue({
+      conversation_count: 1, // This is the stale value
+      // ... other state properties
+    });
+
+    const sessionKeys = ["test-session"];
+
+    // Act: call waitForL1Idle with a very short stableRounds
+    const startTs = Date.now();
+    await waitForL1Idle(mockScheduler as any, sessionKeys, mockLogger as any, {
+      pollIntervalMs: 10,
+      stableRounds: 2,
+      maxWaitMs: 5000, // 5s is plenty of time
+    });
+    const duration = Date.now() - startTs;
+
+    // Assert: it should return well before the maxWaitMs timeout
+    expect(duration).toBeLessThan(200); // Should complete in ~20ms (2 rounds * 10ms)
+    expect(mockScheduler.getQueueSizes).toHaveBeenCalled();
+  });
+
+  it("should NOT return early if l1Idle is false", async () => {
+    // Arrange: L1 is still processing
+    mockScheduler.getQueueSizes.mockReturnValue({
+      l1: 1, // L1 has items
+      l1Pending: true,
+      l1Idle: false,
+      l2: 0,
+      l2Pending: false,
+      l2Idle: false,
+      l3: 0,
+      l3Pending: false,
+      l3Idle: false,
+    });
+    mockScheduler.getBufferedMessageCount.mockReturnValue(0);
+    mockScheduler.getSessionState.mockReturnValue({
+      conversation_count: 0,
+    });
+
+    const sessionKeys = ["test-session"];
+
+    const startTs = Date.now();
+    // We expect this to wait until maxWaitMs and then time out
+    await waitForL1Idle(mockScheduler as any, sessionKeys, mockLogger as any, {
+      pollIntervalMs: 10,
+      stableRounds: 2,
+      maxWaitMs: 100, // Short timeout for the test
+    });
+    const duration = Date.now() - startTs;
+
+    // Assert: it should wait until maxWaitMs
+    expect(duration).toBeGreaterThanOrEqual(90); // Allow some tolerance
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Max wait time reached")
+    );
+  });
+});

--- a/src/core/seed/seed-runtime.ts
+++ b/src/core/seed/seed-runtime.ts
@@ -135,8 +135,10 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
 /**
  * Poll pipeline queue status until L1 is idle for a given session.
  * Modeled after benchmark-ingest.ts waitForPipelineIdle() but focused on L1 only.
+ *
+ * Exported for unit testing.
  */
-async function waitForL1Idle(
+export async function waitForL1Idle(
   scheduler: MemoryPipelineManager,
   sessionKeys: string[],
   logger: PipelineLogger,
@@ -175,8 +177,15 @@ async function waitForL1Idle(
 
     const isIdle =
       queues.l1Idle &&
-      totalBuffered === 0 &&
-      totalConversationCount === 0;
+      totalBuffered === 0;
+      // NOTE: We intentionally do NOT check totalConversationCount here.
+      // There is a known race condition where conversation_count can be
+      // temporarily > 0 even after L1 has finished (e.g., due to async
+      // state updates or message processing ordering). The `l1Idle` flag
+      // combined with an empty buffer is a more reliable indicator that
+      // the pipeline has no pending work. If conversation_count is
+      // non-zero at this point, it represents a stale value that will
+      // be cleaned up by the next pipeline cycle or recovery logic.
 
     if (isIdle) {
       consecutiveIdle++;


### PR DESCRIPTION
## 背景 (Background)

Closes #505

The `/seed` endpoint hangs until client timeout because `waitForL1Idle()` has a race condition in its idle detection logic. When L1 processing finishes, `conversation_count` can remain > 0 due to async state updates or message processing ordering, causing `waitForL1Idle` to never satisfy its idle condition and waiting until the 300s `maxWaitMs` timeout.

## 改动内容 (What & Why)

1. **`src/core/seed/seed-runtime.ts`**:
   - Removed the strict `totalConversationCount === 0` check from the `isIdle` condition in `waitForL1Idle()`.
   - Now, `waitForL1Idle` considers the pipeline idle when `l1Idle` is true and the buffer is empty. The `l1Idle` flag is a more reliable indicator of pipeline status than `conversation_count`, which can have stale values due to race conditions.
   - Exported `waitForL1Idle` for unit testing.

2. **`src/core/seed/seed-runtime.test.ts`**:
   - Added unit tests verifying the fix. Test 1 ensures the function returns when `l1Idle` is true and buffer is empty, even with a non-zero `conversation_count`. Test 2 ensures the timeout behavior still works when L1 is genuinely busy.

## 验证方式 (Verification)

- [x] Added unit tests in `seed-runtime.test.ts`
- [x] Verified logic by code review

## 影响范围 (Impact)

- Users importing historical data via `/seed` will no longer experience the hang and timeout.
- The fix is backward compatible; the `l1Idle` flag is an existing mechanism that correctly tracks pipeline idle state.