### PR TITLE
fix(knowledge): recover queue after synchronous task throws

### DIFF
--- a/MemoryKnowledge/src/store/serial-queue.test.ts
+++ b/MemoryKnowledge/src/store/serial-queue.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { SerialQueue } from "./serial-queue.js";
+
+describe("SerialQueue", () => {
+  it("continues processing and reaches idle after a task throws synchronously", async () => {
+    const queue = new SerialQueue("sync-throw");
+    const executionOrder: string[] = [];
+
+    const failedTask = queue.add(() => {
+      executionOrder.push("first");
+      throw new Error("sync failure");
+    });
+    const nextTask = queue.add(async () => {
+      executionOrder.push("second");
+      return "completed";
+    });
+
+    await expect(failedTask).rejects.toThrow("sync failure");
+    await expect(
+      Promise.race([
+        nextTask,
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error("next task timed out")), 100);
+        }),
+      ]),
+    ).resolves.toBe("completed");
+    await expect(queue.onIdle()).resolves.toBeUndefined();
+
+    expect(executionOrder).toEqual(["first", "second"]);
+    expect(queue.size).toBe(0);
+    expect(queue.pending).toBe(false);
+    expect(queue.idle).toBe(true);
+  });
+});

--- a/MemoryKnowledge/src/store/serial-queue.ts
+++ b/MemoryKnowledge/src/store/serial-queue.ts
@@ -84,8 +84,8 @@ export class SerialQueue {
     const entry = this.queue.shift()!;
     this.running = true;
 
-    entry
-      .task()
+    Promise.resolve()
+      .then(() => entry.task())
       .then((result) => entry.resolve(result))
       .catch((err) => entry.reject(err))
       .finally(() => {


### PR DESCRIPTION
## Description | 描述

`MemoryKnowledge` invokes each `SerialQueue` task before the promise cleanup
chain is attached. If a task throws before returning its promise, the exception
rejects the task's caller but bypasses the queue's `.finally()` cleanup. The
queue then keeps `running = true`, so later Wiki or CodeGraph builds for that
asset key never start and `onIdle()` never resolves.

This PR starts task invocation from a resolved promise. Synchronous throws and
asynchronous rejections now share the existing rejection and cleanup path.

It also adds a regression test that verifies:

- the original task promise rejects with the synchronous error;
- the next queued task still runs in FIFO order;
- the queue reaches its final idle state.

This is the separate `MemoryKnowledge` queue on `feat/server_team`. PR #519
addresses the analogous `MemoryCore` implementation on the unrelated `main`
history and does not modify these files.

## Related Issue | 关联 Issue

Related to #518 and #519 (same failure mode in a separate queue implementation).

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm exec vitest run src/store/serial-queue.test.ts` - 1 test passed
- `pnpm test` - 1 test passed
- changed-file strict TypeScript check - passed
- `pnpm run build` - 11 output files built
- `git diff --check` - passed

## Additional Notes | 其他说明

- No public API, configuration, storage schema, or dependency changes.
- The repository-wide `pnpm run typecheck` still reports the existing
  `src/middleware/response-envelope.ts:47` `Promise<string>`/`string` mismatch.
  That file is byte-for-byte unchanged from `origin/feat/server_team`.
- Native `better-sqlite3@11.10.0` installation is incompatible with the local
  Node 26 runtime, so validation linked dependencies with install scripts
  disabled. The focused queue test and bundle do not load the SQLite binding.
