### PR TITLE
fix(knowledge): release idle per-asset build queues

### DIFF
--- a/MemoryKnowledge/src/store/build-queue.test.ts
+++ b/MemoryKnowledge/src/store/build-queue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BuildQueue } from "./build-queue.js";
+
+function activeQueueCount(queue: BuildQueue): number {
+  return (
+    queue as unknown as {
+      queues: Map<string, unknown>;
+    }
+  ).queues.size;
+}
+
+async function expectQueuesReleased(queue: BuildQueue): Promise<void> {
+  await vi.waitFor(() => {
+    expect(activeQueueCount(queue)).toBe(0);
+  });
+}
+
+describe("BuildQueue", () => {
+  it("releases queues after many distinct asset jobs become idle", async () => {
+    const queue = new BuildQueue();
+
+    for (let i = 0; i < 100; i++) {
+      queue.enqueue(`asset-${i}`, async () => {});
+    }
+
+    await queue.onIdle();
+    await expectQueuesReleased(queue);
+  });
+
+  it("releases a queue after a rejected job", async () => {
+    const queue = new BuildQueue();
+
+    queue.enqueue("failed-asset", async () => {
+      throw new Error("build failed");
+    });
+
+    await queue.onIdle("failed-asset");
+    await expectQueuesReleased(queue);
+  });
+
+  it("keeps a reused queue until every job for the key finishes", async () => {
+    const queue = new BuildQueue();
+    const events: string[] = [];
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    queue.enqueue("shared-asset", async () => {
+      events.push("first");
+    });
+    queue.enqueue("shared-asset", async () => {
+      events.push("second-start");
+      await secondGate;
+      events.push("second-end");
+    });
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(["first", "second-start"]);
+    });
+    expect(activeQueueCount(queue)).toBe(1);
+
+    releaseSecond();
+    await queue.onIdle("shared-asset");
+    await expectQueuesReleased(queue);
+    expect(events).toEqual(["first", "second-start", "second-end"]);
+  });
+});

--- a/MemoryKnowledge/src/store/build-queue.ts
+++ b/MemoryKnowledge/src/store/build-queue.ts
@@ -10,6 +10,7 @@ import { SerialQueue } from "./serial-queue.js";
 
 export class BuildQueue {
   private readonly queues = new Map<string, SerialQueue>();
+  private readonly cleanupScheduled = new WeakSet<SerialQueue>();
 
   /** Enqueue job to this key's serial queue; fire-and-forget. */
   enqueue(key: string, job: () => Promise<void>): void {
@@ -18,9 +19,11 @@ export class BuildQueue {
       q = new SerialQueue(key);
       this.queues.set(key, q);
     }
-    void q.add(job).catch(() => {
-      /* job already set failed status; swallow unhandled rejection */
-    });
+    const queue = q;
+    const cleanup = () => {
+      this.scheduleRemoval(key, queue);
+    };
+    void queue.add(job).then(cleanup, cleanup);
   }
 
   /** Wait for a key (or all) queue to be idle. Mainly for tests / shutdown. */
@@ -30,5 +33,22 @@ export class BuildQueue {
       return;
     }
     await Promise.all([...this.queues.values()].map((q) => q.onIdle()));
+  }
+
+  private scheduleRemoval(key: string, queue: SerialQueue): void {
+    if (this.cleanupScheduled.has(queue)) return;
+    this.cleanupScheduled.add(queue);
+    void this.removeWhenIdle(key, queue);
+  }
+
+  private async removeWhenIdle(key: string, queue: SerialQueue): Promise<void> {
+    try {
+      await queue.onIdle();
+      if (queue.idle && this.queues.get(key) === queue) {
+        this.queues.delete(key);
+      }
+    } finally {
+      this.cleanupScheduled.delete(queue);
+    }
   }
 }


### PR DESCRIPTION
## Description | 描述

`MemoryKnowledge` keeps one `SerialQueue` in `BuildQueue.queues` for every
wiki or code-graph asset key ever observed. Completed and failed jobs leave
their empty queue in the map permanently, so a long-lived service processing
new asset IDs grows this registry without a bound.

This PR releases a per-asset queue after its jobs settle and the queue reaches
a true idle state.

- Cleanup is scheduled for both fulfilled and rejected jobs.
- A queue-identity check prevents an old cleanup from deleting a replacement
  queue for the same key.
- A `WeakSet` coalesces cleanup scheduling to one idle waiter per queue
  instance, even when many same-key jobs are pending.
- Same-key jobs remain serialized; no public API or job error semantics change.

Regression tests cover 100 distinct asset keys, a rejected build job, and
same-key reuse while a second job is still running.

## Related Issue | 关联 Issue

Related to #694. That PR recovers a `SerialQueue` after synchronous task
throws; this PR addresses the independent retention of already-idle queues by
the owning `BuildQueue`.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `vitest run src/store/build-queue.test.ts` - 3 tests passed
- `vitest run` - 3 tests passed
- strict changed-file TypeScript check - passed
- `tsdown` - 11 output files built
- `git diff --check` - passed

## Additional Notes | 其他说明

- No API, configuration, storage schema, or dependency changes.
- Validation reused the existing workspace dependencies without modifying any
  package manifest or lockfile.
