### PR TITLE
fix(proxy): release identities with session state

### DIFF
--- a/MemoryProxy/src/session/__tests__/store-identity-cleanup.test.ts
+++ b/MemoryProxy/src/session/__tests__/store-identity-cleanup.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { SessionStore, type SessionIdentity } from "../store.js";
+import type { SessionInitState } from "../types.js";
+
+const identity: SessionIdentity = {
+  userId: "user-1",
+  agentSource: "codebuddy",
+  sessionId: "session-1",
+};
+
+function pendingState(keyId: string, startedAt: number): SessionInitState {
+  return {
+    status: "pending_asset_confirm",
+    keyId,
+    startedAt,
+    attemptCount: 0,
+  };
+}
+
+describe("SessionStore identity lifecycle", () => {
+  it("releases the bound identity when a session is explicitly deleted", () => {
+    const store = new SessionStore();
+    store.bind("key-1", identity);
+
+    store.delete("key-1");
+
+    expect(store.getBoundIdentity("key-1")).toBeUndefined();
+  });
+
+  it("releases the bound identity when get evicts an expired pending state", async () => {
+    const store = new SessionStore(10);
+    store.bind("key-1", identity);
+    await store.set("key-1", pendingState("key-1", Date.now() - 100));
+
+    expect(store.get("key-1")).toBeUndefined();
+    expect(store.getBoundIdentity("key-1")).toBeUndefined();
+  });
+
+  it("cleanup releases only identities whose pending states expired", async () => {
+    const store = new SessionStore(10);
+    const now = Date.now();
+
+    store.bind("expired", { ...identity, sessionId: "expired" });
+    store.bind("fresh", { ...identity, sessionId: "fresh" });
+    store.bind("initialized", { ...identity, sessionId: "initialized" });
+    await store.set("expired", pendingState("expired", now - 100));
+    await store.set("fresh", pendingState("fresh", now));
+    await store.set("initialized", {
+      status: "initialized",
+      keyId: "initialized",
+      startedAt: now - 100,
+      attemptCount: 0,
+    });
+
+    store.cleanup();
+
+    expect(store.getBoundIdentity("expired")).toBeUndefined();
+    expect(store.getBoundIdentity("fresh")).toBeDefined();
+    expect(store.getBoundIdentity("initialized")).toBeDefined();
+  });
+});

--- a/MemoryProxy/src/session/store.ts
+++ b/MemoryProxy/src/session/store.ts
@@ -106,6 +106,7 @@ export class SessionStore {
     if (state.status !== "initialized" && Date.now() - state.startedAt > this.ttlMs) {
       this.states.delete(keyId);
       const id = this.identities.get(keyId);
+      this.identities.delete(keyId);
       if (id) this.repo?.deleteBySessionId(spaceOf(id), id.userId, id.agentSource, id.sessionId);
       return undefined;
     }
@@ -176,6 +177,7 @@ export class SessionStore {
   delete(keyId: string): void {
     this.states.delete(keyId);
     const id = this.identities.get(keyId);
+    this.identities.delete(keyId);
     if (!id) return;
     this.repo?.deleteBySessionId(spaceOf(id), id.userId, id.agentSource, id.sessionId);
     void this.bindingRepo
@@ -193,6 +195,7 @@ export class SessionStore {
       if (state.status !== "initialized" && now - state.startedAt > this.ttlMs) {
         this.states.delete(keyId);
         const id = this.identities.get(keyId);
+        this.identities.delete(keyId);
         if (id) this.repo?.deleteBySessionId(spaceOf(id), id.userId, id.agentSource, id.sessionId);
       }
     }


### PR DESCRIPTION
## Description | 描述

`SessionStore` keeps a `keyId` to `SessionIdentity` map for persistence calls.
Explicit deletion and both pending-state TTL eviction paths removed the state
but retained its identity for the lifetime of the proxy process.

This change releases the matching identity whenever the state is removed. The
identity is copied before deletion, so existing repository and binding cleanup
still receives the same tuple. Initialized and non-expired sessions are
unchanged.

Regression tests cover:

- explicit `delete()`
- lazy TTL eviction through `get()`
- batch TTL eviction through `cleanup()`, including retained live and
  initialized identities

## Related Issue | 关联 Issue

N/A. Found during a default-branch resource-lifecycle audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- [x] `npm test -- src/session/__tests__/store-identity-cleanup.test.ts`
  (3 tests passed)
- [x] `npm test` (3 tests passed)
- [x] Strict targeted typecheck for the changed files and dependency closure:
  `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --strict --esModuleInterop --skipLibCheck src/session/store.ts src/session/__tests__/store-identity-cleanup.test.ts`
- [x] `git diff --check`

The repository-wide `npx tsc --noEmit` cannot resolve
`@context-proxy/cost-guard` in a clean checkout because
`MemoryProxy/packages/cost-guard` is a gitlink without a `.gitmodules`
mapping. The changed-file typecheck above passes.

## Impact | 影响范围

- Breaking change: No
- Affected module: `MemoryProxy` session state lifecycle
- Persistence behavior: Unchanged; cleanup calls still use the captured
  identity

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The PR is limited to identity lifecycle cleanup and its regression tests.
