### PR TITLE
docs(knowledge): restore OpenAPI runtime contract

### DIFF
--- a/MemoryKnowledge/docs/api/openapi.yaml
+++ b/MemoryKnowledge/docs/api/openapi.yaml
@@ -1,0 +1,494 @@
+openapi: 3.1.0
+info:
+  title: TencentDB Agent Memory Knowledge API
+  version: 0.1.0
+  description: |
+    HTTP contract for the standalone Wiki and CodeGraph knowledge service.
+    All `/v3` data-plane requests are tenant-scoped by
+    `x-tdai-service-id`.
+servers:
+  - url: http://localhost:8421
+tags:
+  - name: Health
+  - name: Wiki
+  - name: CodeGraph
+  - name: Tools
+  - name: LLMBinding
+
+paths:
+  /health:
+    get:
+      tags: [Health]
+      operationId: getHealth
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /v3/wiki/create:
+    post:
+      tags: [Wiki]
+      operationId: createWiki
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "201":
+          $ref: "#/components/responses/Success"
+        "400":
+          $ref: "#/components/responses/Error"
+  /v3/wiki/list:
+    post:
+      tags: [Wiki]
+      operationId: listWikis
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/get:
+    post:
+      tags: [Wiki]
+      operationId: getWiki
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "404":
+          $ref: "#/components/responses/Error"
+  /v3/wiki/update-meta:
+    post:
+      tags: [Wiki]
+      operationId: updateWikiMetadata
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/ingest:
+    post:
+      tags: [Wiki]
+      operationId: ingestWiki
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "202":
+          $ref: "#/components/responses/Success"
+        "409":
+          $ref: "#/components/responses/Error"
+  /v3/wiki/delete:
+    post:
+      tags: [Wiki]
+      operationId: deleteWikis
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/raw/ls:
+    post:
+      tags: [Wiki]
+      operationId: listWikiRawFiles
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/raw/read:
+    post:
+      tags: [Wiki]
+      operationId: readWikiRawFiles
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/raw/write:
+    post:
+      tags: [Wiki]
+      operationId: writeWikiRawFiles
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "413":
+          $ref: "#/components/responses/Error"
+  /v3/wiki/raw/rm:
+    post:
+      tags: [Wiki]
+      operationId: removeWikiRawFiles
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/page/ls:
+    post:
+      tags: [Wiki]
+      operationId: listWikiPages
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/page/read:
+    post:
+      tags: [Wiki]
+      operationId: readWikiPages
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/page/write:
+    post:
+      tags: [Wiki]
+      operationId: writeWikiPages
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/page/rm:
+    post:
+      tags: [Wiki]
+      operationId: removeWikiPages
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/graph:
+    post:
+      tags: [Wiki]
+      operationId: getWikiGraph
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/wiki/search:
+    post:
+      tags: [Wiki]
+      operationId: searchWiki
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+
+  /v3/code-graph/create:
+    post:
+      tags: [CodeGraph]
+      operationId: createCodeGraph
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "201":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/list:
+    post:
+      tags: [CodeGraph]
+      operationId: listCodeGraphs
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/get:
+    post:
+      tags: [CodeGraph]
+      operationId: getCodeGraph
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/update-meta:
+    post:
+      tags: [CodeGraph]
+      operationId: updateCodeGraphMetadata
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/sync:
+    post:
+      tags: [CodeGraph]
+      operationId: syncCodeGraph
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "202":
+          $ref: "#/components/responses/Success"
+        "409":
+          $ref: "#/components/responses/Error"
+  /v3/code-graph/delete:
+    post:
+      tags: [CodeGraph]
+      operationId: deleteCodeGraphs
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/search:
+    post:
+      tags: [CodeGraph]
+      operationId: searchCodeGraph
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/explore:
+    post:
+      tags: [CodeGraph]
+      operationId: exploreCodeGraph
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/callers:
+    post:
+      tags: [CodeGraph]
+      operationId: findCodeGraphCallers
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/callees:
+    post:
+      tags: [CodeGraph]
+      operationId: findCodeGraphCallees
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/impact:
+    post:
+      tags: [CodeGraph]
+      operationId: analyzeCodeGraphImpact
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/node:
+    post:
+      tags: [CodeGraph]
+      operationId: getCodeGraphNode
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/status:
+    post:
+      tags: [CodeGraph]
+      operationId: getCodeGraphStatus
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/code-graph/files:
+    post:
+      tags: [CodeGraph]
+      operationId: listCodeGraphFiles
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/CodeGraphQuery"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+
+  /v3/tools/list:
+    post:
+      tags: [Tools]
+      operationId: listKnowledgeTools
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/tools/call:
+    post:
+      tags: [Tools]
+      operationId: callKnowledgeTool
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "403":
+          $ref: "#/components/responses/Error"
+
+  /v3/internal/llm-binding/set:
+    post:
+      tags: [LLMBinding]
+      operationId: setLlmBinding
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/internal/llm-binding/status:
+    post:
+      tags: [LLMBinding]
+      operationId: getLlmBindingStatus
+      parameters:
+        - $ref: "#/components/parameters/ServiceId"
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+  /v3/internal/llm-binding/list:
+    post:
+      tags: [LLMBinding]
+      operationId: listLlmBindings
+      requestBody:
+        $ref: "#/components/requestBodies/JsonObject"
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+
+components:
+  parameters:
+    ServiceId:
+      name: x-tdai-service-id
+      in: header
+      required: true
+      description: Tenant/service identifier.
+      schema:
+        type: string
+        minLength: 1
+  requestBodies:
+    JsonObject:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: true
+    CodeGraphQuery:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [code_graph_id]
+            properties:
+              code_graph_id:
+                type: string
+            additionalProperties: true
+  responses:
+    Success:
+      description: Successful response.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiEnvelope"
+    Error:
+      description: Error response.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiEnvelope"
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, timestamp]
+      properties:
+        status:
+          type: string
+          const: ok
+        timestamp:
+          type: string
+          format: date-time
+    ApiEnvelope:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+        request_id:
+          type: string
+        data: {}
+      additionalProperties: false

--- a/MemoryKnowledge/src/__tests__/openapi-contract.test.ts
+++ b/MemoryKnowledge/src/__tests__/openapi-contract.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const specPath = new URL("../../docs/api/openapi.yaml", import.meta.url);
+
+const mountedPaths = [
+  "/health",
+  "/v3/wiki/create",
+  "/v3/wiki/list",
+  "/v3/wiki/get",
+  "/v3/wiki/update-meta",
+  "/v3/wiki/ingest",
+  "/v3/wiki/delete",
+  "/v3/wiki/raw/ls",
+  "/v3/wiki/raw/read",
+  "/v3/wiki/raw/write",
+  "/v3/wiki/raw/rm",
+  "/v3/wiki/page/ls",
+  "/v3/wiki/page/read",
+  "/v3/wiki/page/write",
+  "/v3/wiki/page/rm",
+  "/v3/wiki/graph",
+  "/v3/wiki/search",
+  "/v3/code-graph/create",
+  "/v3/code-graph/list",
+  "/v3/code-graph/get",
+  "/v3/code-graph/update-meta",
+  "/v3/code-graph/sync",
+  "/v3/code-graph/delete",
+  "/v3/code-graph/search",
+  "/v3/code-graph/explore",
+  "/v3/code-graph/callers",
+  "/v3/code-graph/callees",
+  "/v3/code-graph/impact",
+  "/v3/code-graph/node",
+  "/v3/code-graph/status",
+  "/v3/code-graph/files",
+  "/v3/tools/list",
+  "/v3/tools/call",
+  "/v3/internal/llm-binding/set",
+  "/v3/internal/llm-binding/status",
+  "/v3/internal/llm-binding/list",
+] as const;
+
+describe("Knowledge OpenAPI contract", () => {
+  it("is valid YAML and documents every mounted HTTP path", () => {
+    const document = parse(readFileSync(specPath, "utf8")) as {
+      openapi?: string;
+      paths?: Record<string, unknown>;
+    };
+
+    expect(document.openapi).toMatch(/^3\./);
+    expect(Object.keys(document.paths ?? {}).sort()).toEqual([...mountedPaths].sort());
+  });
+
+  it("matches the Docker and repository documentation runtime path", () => {
+    const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+    const readme = readFileSync(new URL("../../../README.md", import.meta.url), "utf8");
+    const readmeCn = readFileSync(new URL("../../../README_CN.md", import.meta.url), "utf8");
+
+    expect(dockerfile).toContain("COPY docs/api/openapi.yaml ./docs/api/openapi.yaml");
+    expect(readme).toContain("./MemoryKnowledge/docs/api/openapi.yaml");
+    expect(readmeCn).toContain("./MemoryKnowledge/docs/api/openapi.yaml");
+  });
+});


### PR DESCRIPTION
## Description | 描述

Restore the OpenAPI runtime asset that the Knowledge service already treats as
required:

- add `MemoryKnowledge/docs/api/openapi.yaml` with all 36 mounted HTTP paths;
- document tenant scoping through `x-tdai-service-id`;
- add a regression test that parses the YAML, checks every mounted route, and
  locks the Docker/README path contract.

The default branch currently has three references to this file but no file:

- `MemoryKnowledge/Dockerfile` unconditionally copies it, so image builds fail
  at the `COPY docs/api/openapi.yaml` step;
- `MemoryKnowledge/src/server.ts` skips Swagger UI when it is absent;
- both root READMEs link to a missing document.

The change is contract/documentation-only. It does not alter route behavior,
authentication, persistence, or dependencies.

## Related Issue | 关联 Issue

No linked issue. Found by the default-branch build and documentation audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `npm test` - 2/2 passed.
- `npm run build` - 11 output files built.
- `npm pack --dry-run --ignore-scripts --json` - spec included in 78 files.
- YAML contract check - 36 paths, 36 unique operation IDs.
- `git diff --check` - clean.

The repository-wide `npm run typecheck` still reports the pre-existing
`src/middleware/response-envelope.ts:47` `Promise<string>`/`string` mismatch;
this PR does not change that file.

## Additional Notes | 其他说明

The schemas intentionally describe the stable envelope and routing contract
while allowing endpoint-specific request fields to evolve. The regression test
requires the path inventory to stay synchronized when routes are added or
removed.
