### PR TITLE
fix(config): prevent stale VDB cache resurrection

### DIFF
--- a/MemoryCore/src/core/instance-config-provider.test.ts
+++ b/MemoryCore/src/core/instance-config-provider.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { IConfigSource } from "./abstractions/index.js";
+import {
+  InstanceConfigProvider,
+  type VdbConfig,
+} from "./instance-config-provider.js";
+
+const vdbConfig: VdbConfig = {
+  url: "https://vdb.example.test",
+  user: "test-user",
+  apiKey: "test-key",
+  database: "test-db",
+};
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("InstanceConfigProvider cache invalidation", () => {
+  it("does not repopulate an evicted entry from an older in-flight fetch", async () => {
+    const request = deferred<VdbConfig>();
+    const source: IConfigSource = {
+      fetchVdb: vi.fn(() => request.promise),
+      fetchCos: vi.fn(async () => null),
+    };
+    const provider = new InstanceConfigProvider({ source, logger });
+
+    const pending = provider.resolveVdb("deleted-instance");
+    provider.evictVdb("deleted-instance");
+    request.resolve(vdbConfig);
+
+    await expect(pending).resolves.toEqual(vdbConfig);
+    expect(provider.poolSize).toBe(0);
+  });
+
+  it("keeps a fresh request after eviction separate from the stale request", async () => {
+    const stale = deferred<VdbConfig>();
+    const fresh = deferred<VdbConfig>();
+    const fetchVdb = vi
+      .fn<() => Promise<VdbConfig>>()
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise);
+    const source: IConfigSource = {
+      fetchVdb,
+      fetchCos: vi.fn(async () => null),
+    };
+    const provider = new InstanceConfigProvider({ source, logger });
+
+    const stalePending = provider.resolveVdb("instance-1");
+    provider.evictVdb("instance-1");
+    const freshPending = provider.resolveVdb("instance-1");
+
+    stale.resolve({ ...vdbConfig, database: "stale-db" });
+    fresh.resolve({ ...vdbConfig, database: "fresh-db" });
+
+    await expect(stalePending).resolves.toMatchObject({ database: "stale-db" });
+    await expect(freshPending).resolves.toMatchObject({ database: "fresh-db" });
+    await expect(provider.resolveVdb("instance-1")).resolves.toMatchObject({
+      database: "fresh-db",
+    });
+    expect(fetchVdb).toHaveBeenCalledTimes(2);
+    expect(provider.poolSize).toBe(1);
+  });
+
+  it("does not let an in-flight fetch repopulate the cache after clear", async () => {
+    const request = deferred<VdbConfig>();
+    const source: IConfigSource = {
+      fetchVdb: vi.fn(() => request.promise),
+      fetchCos: vi.fn(async () => null),
+    };
+    const provider = new InstanceConfigProvider({ source, logger });
+
+    const pending = provider.resolveVdb("instance-to-clear");
+    provider.clear();
+    request.resolve(vdbConfig);
+
+    await expect(pending).resolves.toEqual(vdbConfig);
+    expect(provider.poolSize).toBe(0);
+  });
+});

--- a/MemoryCore/src/core/instance-config-provider.ts
+++ b/MemoryCore/src/core/instance-config-provider.ts
@@ -106,6 +106,11 @@ interface VdbCacheEntry {
   lastAccessedAt: number;
 }
 
+interface VdbFetchEntry {
+  promise: Promise<VdbConfig>;
+  invalidation: { invalidated: boolean };
+}
+
 // ════════════════════════════════════════════════════════
 // InstanceConfigProvider
 // ════════════════════════════════════════════════════════
@@ -137,7 +142,7 @@ export class InstanceConfigProvider {
    * 并发首次访问同一 instanceId 时，复用同一个 fetch Promise，
    * 避免向 source 同时发出 N 次请求触发限流。
    */
-  private vdbFetchPromises = new Map<string, Promise<VdbConfig>>();
+  private vdbFetchPromises = new Map<string, VdbFetchEntry>();
 
   // ── COS: 全局单例缓存 (一份凭证，按 PathPrefix 隔离) ──
   private cosCache: CosConfig | null = null;
@@ -193,18 +198,22 @@ export class InstanceConfigProvider {
     const inflight = this.vdbFetchPromises.get(instanceId);
     if (inflight) {
       this.logger.debug?.(`[instance-config] VDB fetch in-flight for ${instanceId}, awaiting...`);
-      return inflight;
+      return inflight.promise;
     }
 
     this.logger.debug?.(`[instance-config] VDB cache ${cached ? "expired" : "miss"} for ${instanceId}, fetching...`);
-    const fetchPromise = this.fetchAndStoreVdb(instanceId);
-    this.vdbFetchPromises.set(instanceId, fetchPromise);
+    const invalidation = { invalidated: false };
+    const fetchPromise = this.fetchAndStoreVdb(instanceId, invalidation);
+    const fetchEntry = { promise: fetchPromise, invalidation };
+    this.vdbFetchPromises.set(instanceId, fetchEntry);
     try {
       return await fetchPromise;
     } finally {
-      // 清理 in-flight 标记。注意要在 await 之后清理 (即使 fetch 抛错也清), 
-      // 否则一次失败会让该 instanceId 永久卡住。
-      this.vdbFetchPromises.delete(instanceId);
+      // Only remove our own request. evictVdb() may have invalidated this
+      // request and allowed a newer fetch to occupy the same map key.
+      if (this.vdbFetchPromises.get(instanceId) === fetchEntry) {
+        this.vdbFetchPromises.delete(instanceId);
+      }
     }
   }
 
@@ -212,7 +221,10 @@ export class InstanceConfigProvider {
    * 实际执行 source fetch + 写入 vdbPool。
    * 仅由 resolveVdb 内部调用 (并发去重保证只跑一次)。
    */
-  private async fetchAndStoreVdb(instanceId: string): Promise<VdbConfig> {
+  private async fetchAndStoreVdb(
+    instanceId: string,
+    invalidation: { invalidated: boolean },
+  ): Promise<VdbConfig> {
     const config = await this.source.fetchVdb(instanceId);
 
     // source 返回空 → 直接报错记录日志
@@ -220,6 +232,16 @@ export class InstanceConfigProvider {
       const msg = `[instance-config] Config source returned empty VDB config for instanceId="${instanceId}" (url=${config?.url})`;
       this.logger.error(msg);
       throw new Error(msg);
+    }
+
+    // An explicit eviction happened while the request was in flight. The
+    // original caller still receives the fetched value, but stale data must
+    // not resurrect the cache entry.
+    if (invalidation.invalidated) {
+      this.logger.debug?.(
+        `[instance-config] Ignoring stale VDB fetch result for ${instanceId}`,
+      );
+      return config;
     }
 
     // LRU 淘汰
@@ -264,7 +286,10 @@ export class InstanceConfigProvider {
    * 清除指定实例的 VDB 缓存 (实例下线时调用)
    */
   evictVdb(instanceId: string): void {
+    const inflight = this.vdbFetchPromises.get(instanceId);
+    if (inflight) inflight.invalidation.invalidated = true;
     this.vdbPool.delete(instanceId);
+    this.vdbFetchPromises.delete(instanceId);
     this.logger.debug?.(`[instance-config] Evicted VDB cache for ${instanceId}`);
   }
 
@@ -279,6 +304,10 @@ export class InstanceConfigProvider {
    * 清除所有缓存
    */
   clear(): void {
+    for (const inflight of this.vdbFetchPromises.values()) {
+      inflight.invalidation.invalidated = true;
+    }
+    this.vdbFetchPromises.clear();
     this.vdbPool.clear();
     this.cosCache = null;
     this.cosExpiresAt = 0;


### PR DESCRIPTION
## Description | 描述

`InstanceConfigProvider.evictVdb()` and `clear()` removed cached VDB configs but did not invalidate requests already awaiting the remote config source. When an older request completed, `fetchAndStoreVdb()` inserted the explicitly evicted instance back into the cache. Its unconditional `finally` cleanup could also delete a newer in-flight request registered for the same instance.

This PR binds a small invalidation token to each in-flight fetch:

- eviction and full cache clearing invalidate and detach the current request;
- stale requests still resolve for their original callers, but cannot repopulate the cache;
- completion only removes its own in-flight entry, so a newer request remains deduplicated;
- no per-instance generation registry is retained after requests settle.

Regression tests cover eviction during a fetch, a fresh fetch racing the stale request, and full-cache clearing.

## Related Issue | 关联 Issue

No existing issue. Discovered by the default-branch concurrency audit after all open Issue candidates were deduplicated.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `vitest run` - 1 file, 3 tests passed
- `npm run build:plugin` - 6 output files built
- `git diff --check` - passed
- remote author identity checked after PR creation

## Additional Notes | 其他说明

- No API, configuration schema, storage schema, or dependency changes.
- Eviction does not cancel the source request; it only prevents stale cache resurrection.
- Full changed-file and PR-body deduplication found no active implementation for `instance-config-provider.ts`.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>