### PR TITLE
fix(metadata): dedupe concurrent store initialization

### DIFF
--- a/MemoryCore/src/metadata/store/factory.test.ts
+++ b/MemoryCore/src/metadata/store/factory.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MetadataStorePool } from "./factory.js";
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.allSettled(cleanup.splice(0).map((fn) => fn()));
+});
+
+describe("MetadataStorePool", () => {
+  it("deduplicates concurrent initialization for the same instance", async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), "metadata-store-pool-"));
+    const pool = new MetadataStorePool({
+      backend: "sqlite",
+      sqliteBaseDir: baseDir,
+    });
+    cleanup.push(async () => {
+      await pool.closeAll();
+      await rm(baseDir, { recursive: true, force: true });
+    });
+
+    const stores = await Promise.all([
+      pool.getStore("instance-1"),
+      pool.getStore("instance-1"),
+      pool.getStore("instance-1"),
+    ]);
+
+    expect(stores[1]).toBe(stores[0]);
+    expect(stores[2]).toBe(stores[0]);
+  });
+});

--- a/MemoryCore/src/metadata/store/factory.ts
+++ b/MemoryCore/src/metadata/store/factory.ts
@@ -180,6 +180,8 @@ interface CachedStore {
  */
 export class MetadataStorePool {
   private readonly cache = new Map<string, CachedStore>();
+  /** Deduplicates concurrent cold starts for the same instance database. */
+  private readonly pendingStores = new Map<string, Promise<IMetadataStore>>();
   private readonly config: MetadataStoreConfig;
   private sharedMongoClient: import("mongodb").MongoClient | null = null;
   private sharedMongoClientPromise: Promise<import("mongodb").MongoClient> | null = null;
@@ -237,6 +239,23 @@ export class MetadataStorePool {
       return existing.store;
     }
 
+    const pending = this.pendingStores.get(instanceId);
+    if (pending) return pending;
+
+    const creation = this.createAndCacheStore(instanceId);
+    this.pendingStores.set(instanceId, creation);
+    try {
+      return await creation;
+    } finally {
+      if (this.pendingStores.get(instanceId) === creation) {
+        this.pendingStores.delete(instanceId);
+      }
+    }
+  }
+
+  private async createAndCacheStore(
+    instanceId: string,
+  ): Promise<IMetadataStore> {
     if (this.config.backend === "mongodb") {
       const client = await this.getSharedMongoClient();
       const { MongoMetadataStore } = await import("./mongodb-adapter.js");
@@ -261,6 +280,10 @@ export class MetadataStorePool {
 
   async purgeInstance(instanceId: string): Promise<PurgeMetadataResult> {
     const dbName = resolveMetadataDbName(instanceId, this.dbPrefix);
+    // A cold getStore() may still be initializing this instance. Wait for it
+    // before closing/dropping so the completed request cannot repopulate the
+    // cache after purge.
+    await this.pendingStores.get(instanceId)?.catch(() => {});
     const cached = this.cache.get(instanceId);
     if (cached) {
       await Promise.resolve(cached.store.close()).catch(() => {});
@@ -280,6 +303,10 @@ export class MetadataStorePool {
   }
 
   async closeAll(): Promise<void> {
+    // Ensure stores already being initialized are visible in the cache before
+    // the shutdown sweep. Otherwise they can complete after closeAll() and
+    // leave a live connection behind.
+    await Promise.allSettled([...this.pendingStores.values()]);
     for (const [key, entry] of this.cache) {
       await Promise.resolve(entry.store.close()).catch(() => {});
       this.cache.delete(key);


### PR DESCRIPTION
## Description | 描述

Concurrent cold calls to `MetadataStorePool.getStore(instanceId)` all observed an empty cache because the store was cached only after asynchronous initialization. Each request therefore created and initialized a separate SQLite/MongoDB store; the last result replaced the cache entry while the other connections were leaked to callers.

This PR adds per-instance in-flight initialization deduplication:

- concurrent cold requests share one store creation Promise and receive the same store;
- failed initialization removes only its own pending entry and remains retryable;
- `purgeInstance()` waits for an already-started initialization before closing and dropping the database;
- `closeAll()` waits for pending stores before sweeping the cache, preventing post-shutdown connection resurrection.

A SQLite regression test proves that three concurrent cold calls now return the exact same store object.

## Related Issue | 关联 Issue

No existing issue. Discovered by the default-branch metadata lifecycle audit after all open Issue candidates were deduplicated.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `vitest run` - 1 file, 1 test passed
- `npm run build:plugin` - 6 output files built
- `git diff --check` - passed
- remote author identity checked after PR creation

## Additional Notes | 其他说明

- No public API, metadata schema, configuration, or dependency changes.
- Deduplication is scoped per instance; different instance databases still initialize concurrently.
- Full changed-file and PR-body deduplication found no active implementation for `metadata/store/factory.ts`.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>