### PR TITLE
test(panel): lock chat-memory governance rules

### DIFF
--- a/MemoryPanel/tests/domain/chat-memory-governance.test.ts
+++ b/MemoryPanel/tests/domain/chat-memory-governance.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_CHAT_MEMORY_REL,
+  MAX_IMPORTED_AGENTS,
+  readChatMemoryRel,
+  validateImportedAgents,
+  writeChatMemoryRel,
+} from '../../src/panel/domain/chat-memory-governance.js';
+
+const teamAgents = [
+  { agent_id: 'a1' },
+  { agent_id: 'a2' },
+  { agent_id: 'a3' },
+];
+
+describe('validateImportedAgents', () => {
+  it('accepts up to MAX_IMPORTED_AGENTS distinct same-team peers', () => {
+    const first = MAX_IMPORTED_AGENTS >= 1 ? ['a2'] : [];
+    expect(validateImportedAgents('a1', first, teamAgents)).toEqual({ ok: true });
+
+    const full = teamAgents
+      .filter((agent) => agent.agent_id !== 'a1')
+      .slice(0, MAX_IMPORTED_AGENTS)
+      .map((agent) => agent.agent_id);
+    expect(validateImportedAgents('a1', full, teamAgents)).toEqual({ ok: true });
+  });
+
+  it('rejects arrays exceeding the borrow limit', () => {
+    const oversize = ['a2', 'a3', 'a1-clone'];
+    expect(validateImportedAgents('a1', oversize, teamAgents)).toEqual({
+      ok: false,
+      reason: `最多只能借入 ${MAX_IMPORTED_AGENTS} 个 agent`,
+    });
+  });
+
+  it('rejects non-array or malformed inputs', () => {
+    expect(
+      validateImportedAgents('a1', 'not-an-array' as unknown as string[], teamAgents),
+    ).toEqual({ ok: false, reason: 'imported_agent_ids 必须是数组' });
+    expect(validateImportedAgents('a1', ['' as unknown as string], teamAgents)).toEqual({
+      ok: false,
+      reason: '存在无效的 agent_id',
+    });
+  });
+
+  it('rejects borrowing yourself, cross-team agents, or duplicates', () => {
+    expect(validateImportedAgents('a1', ['a1'], teamAgents)).toEqual({
+      ok: false,
+      reason: '不能借入自己的记忆',
+    });
+    expect(validateImportedAgents('a1', ['outsider'], teamAgents)).toEqual({
+      ok: false,
+      reason: 'agent_id "outsider" 不在当前 team 中',
+    });
+    expect(validateImportedAgents('a1', ['a2', 'a2'], teamAgents)).toEqual({
+      ok: false,
+      reason: '借入列表中存在重复 agent',
+    });
+  });
+});
+
+describe('readChatMemoryRel / writeChatMemoryRel', () => {
+  it('returns the default relation when metadata is absent or unparseable', () => {
+    expect(readChatMemoryRel({ agent_id: 'a1' })).toEqual(DEFAULT_CHAT_MEMORY_REL);
+    expect(readChatMemoryRel({ agent_id: 'a1', metadata_json: 'not-json' })).toEqual(
+      DEFAULT_CHAT_MEMORY_REL,
+    );
+  });
+
+  it('round-trips chat_memory relations while preserving foreign metadata', () => {
+    const rel = { memory_shared_with_team: false, imported_agent_ids: ['a2', 'a3'] };
+    const prev = JSON.stringify({ untouched: { keep: true } });
+    const next = writeChatMemoryRel(prev, rel);
+
+    const parsed = JSON.parse(next);
+    expect(parsed.untouched).toEqual({ keep: true });
+    expect(readChatMemoryRel({ agent_id: 'a1', metadata_json: next })).toEqual(rel);
+  });
+
+  it('normalizes malformed values on read and enforces the borrow cap on write', () => {
+    const rel = {
+      memory_shared_with_team: 'yes' as unknown as boolean,
+      imported_agent_ids: ['a1', 'a1', 'a2', 42 as unknown as string, 'a3', 'a4'],
+    };
+    const raw = writeChatMemoryRel(undefined, rel);
+    const normalized = readChatMemoryRel({ agent_id: 'self', metadata_json: raw });
+
+    expect(normalized.memory_shared_with_team).toBe(true);
+    expect(normalized.imported_agent_ids.length).toBeLessThanOrEqual(MAX_IMPORTED_AGENTS);
+    expect(new Set(normalized.imported_agent_ids).size).toBe(
+      normalized.imported_agent_ids.length,
+    );
+    for (const id of normalized.imported_agent_ids) {
+      expect(typeof id).toBe('string');
+    }
+  });
+});


### PR DESCRIPTION
## Description | 描述

Add vitest coverage for `MemoryPanel/src/panel/domain/chat-memory-governance.ts`, the chat-memory ownership / borrow-cap module that both frontend and backend rely on.

The module documents a strict validation contract (borrow cap, same-team peers, no self-borrow, no duplicates) and a `metadata_json` namespace round-trip, but has no test file today. Test coverage is critical because the shape is being migrated from `metadata_json` into a dedicated schema field later, so any silent regression would corrupt every agent's `chat_memory` relation.

## Related Issue | 关联 Issue

None; this is `MemoryPanel` module-audit test coverage found during a default-branch review.

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | Test coverage

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## What & Why

- **New test suite `MemoryPanel/tests/domain/chat-memory-governance.test.ts`**:
  - `validateImportedAgents` accepts up to `MAX_IMPORTED_AGENTS` distinct
    same-team peers.
  - Rejects arrays exceeding the borrow limit with the documented reason.
  - Rejects non-array inputs, empty-string ids, self-borrow, cross-team ids,
    and duplicates — each with the exact reason string exposed to the UI.
  - `readChatMemoryRel` returns `DEFAULT_CHAT_MEMORY_REL` when metadata is
    missing or unparseable.
  - `writeChatMemoryRel` preserves foreign `metadata_json` keys and
    round-trips the `chat_memory` namespace.
  - Malformed inputs to `writeChatMemoryRel` are normalized: booleans default
    to shared, ids are de-duplicated, non-string entries are dropped, and the
    borrow cap is enforced on write.

### Boundaries

- Does not change any source file — pure additive test coverage.
- Does not add any new runtime dependency; only uses existing vitest.

## Verification | 验证

- `npx vitest run tests/domain/chat-memory-governance.test.ts` — 7/7 passed.
- `npm test` — full suite, 7/7 passed.
- `npm run typecheck` — clean.
- `git diff --check origin/feat/server_team...HEAD` — clean.
