### PR TITLE
fix(panel): reject duplicate instance ids

### DIFF
--- a/MemoryPanel/src/panel/config/instance-registry.ts
+++ b/MemoryPanel/src/panel/config/instance-registry.ts
@@ -46,7 +46,16 @@ export class InstanceRegistry {
   private readonly byId: Map<string, InstanceEntry>;
 
   constructor(entries: InstanceEntry[]) {
-    this.byId = new Map(entries.map((e) => [e.instance_id, e]));
+    this.byId = new Map();
+    for (const entry of entries) {
+      if (this.byId.has(entry.instance_id)) {
+        throw new InstanceRegistryError(
+          500,
+          `duplicate metadata instance id: ${entry.instance_id}`,
+        );
+      }
+      this.byId.set(entry.instance_id, entry);
+    }
   }
 
   static load(configPath: string): InstanceRegistry {

--- a/MemoryPanel/tests/config/instance-registry.test.ts
+++ b/MemoryPanel/tests/config/instance-registry.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  InstanceRegistry,
+  InstanceRegistryError,
+  type InstanceEntry,
+} from '../../src/panel/config/instance-registry.js';
+
+function instance(
+  instanceId: string,
+  endpoint = `https://${instanceId}.example`,
+): InstanceEntry {
+  return {
+    instance_id: instanceId,
+    name: instanceId,
+    gateway_endpoint: endpoint,
+    api_key: `secret-${instanceId}`,
+  };
+}
+
+describe('InstanceRegistry', () => {
+  it('rejects duplicate instance IDs when loading configuration', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'panel-instance-registry-'));
+    const configPath = join(dir, 'metadata-instances.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        instances: [
+          {
+            id: 'duplicate',
+            name: 'first',
+            gateway_endpoint: 'https://first.example',
+            api_key: 'first-secret',
+          },
+          {
+            id: 'duplicate',
+            name: 'second',
+            gateway_endpoint: 'https://second.example',
+            api_key: 'second-secret',
+          },
+        ],
+      }),
+    );
+
+    try {
+      expect(() => InstanceRegistry.load(configPath)).toThrowError(
+        new InstanceRegistryError(
+          500,
+          'duplicate metadata instance id: duplicate',
+        ),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps distinct instances and omits credentials from public listings', () => {
+    const registry = new InstanceRegistry([
+      instance('first'),
+      instance('second'),
+    ]);
+
+    expect(registry.listPublic()).toEqual([
+      {
+        instance_id: 'first',
+        name: 'first',
+        gateway_endpoint: 'https://first.example',
+      },
+      {
+        instance_id: 'second',
+        name: 'second',
+        gateway_endpoint: 'https://second.example',
+      },
+    ]);
+    expect(registry.resolve('second').api_key).toBe('secret-second');
+  });
+});


### PR DESCRIPTION
## Description | 描述

`MemoryPanel` currently builds its instance lookup with `new Map(entries)`.
When `metadata-instances.json` repeats an `id`, the later row silently replaces
the earlier endpoint and API key. Startup succeeds, but requests for that
instance can be routed with unintended credentials.

This change makes duplicate IDs a startup configuration error. The error names
only the duplicated ID and does not expose either credential.

## Related Issue | 关联 Issue

No linked issue. Found during the default-branch MemoryPanel configuration
boundary audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Added regression coverage | 已添加回归测试

## What & Why

- Build the registry incrementally and reject an ID that is already present.
- Apply the check in the public constructor so both JSON loading and
  programmatic construction follow the same invariant.
- Preserve insertion order and the existing `listPublic()` credential
  redaction for valid configurations.

The implementation deliberately does not choose first-wins or last-wins:
either policy would keep startup alive with an ambiguous tenant-to-credential
mapping.

## Verification | 验证

- `pnpm vitest run tests/config/instance-registry.test.ts`
  - 1 file, 2 tests passed
- `pnpm test`
  - 1 file, 2 tests passed
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

The regression test loads a real temporary JSON config with duplicate IDs and
asserts fail-fast behavior. A second case verifies distinct instances and
confirms public listings still omit API keys.

## Additional Notes | 其他说明

- Scope is limited to one configuration class and its focused tests.
- No configuration schema or valid runtime behavior changes.
- AI assistance: TRAE was used to audit the boundary, reproduce the silent
  overwrite, implement the guard, and run validation. I reviewed and take
  responsibility for the final change.
