### PR TITLE
fix(panel): normalize knowledge transport failures

### DIFF
--- a/MemoryPanel/src/panel/kernel/adapters/http-knowledge-client.ts
+++ b/MemoryPanel/src/panel/kernel/adapters/http-knowledge-client.ts
@@ -62,8 +62,27 @@ export class HttpKnowledgeClient implements KnowledgeClientPort {
         body: JSON.stringify(body),
         signal: ctrl.signal,
       });
-      const json = (await resp.json()) as CoreEnvelope<T>;
-      if (json.code !== undefined && json.code !== 0) {
+      let raw: unknown;
+      try {
+        raw = await resp.json();
+      } catch {
+        throw new CoreUpstreamError(
+          'CORE_UPSTREAM_ERROR',
+          resp.status >= 400 ? resp.status : 502,
+          `invalid JSON from knowledge service at ${path} (HTTP ${resp.status})`,
+          0,
+        );
+      }
+      if (!raw || typeof raw !== 'object' || typeof (raw as { code?: unknown }).code !== 'number') {
+        throw new CoreUpstreamError(
+          'CORE_UPSTREAM_ERROR',
+          resp.status >= 400 ? resp.status : 502,
+          `invalid envelope from knowledge service at ${path} (HTTP ${resp.status})`,
+          0,
+        );
+      }
+      const json = raw as CoreEnvelope<T>;
+      if (json.code !== 0) {
         throw new CoreUpstreamError(
           'CORE_UPSTREAM_ERROR',
           resp.status >= 400 ? resp.status : 502,
@@ -75,6 +94,19 @@ export class HttpKnowledgeClient implements KnowledgeClientPort {
         throw new CoreUpstreamError('CORE_UPSTREAM_ERROR', resp.status, json.message || `HTTP ${resp.status}`, 0);
       }
       return json.data as T;
+    } catch (err) {
+      if (err instanceof CoreUpstreamError) throw err;
+      const isTimeout =
+        ctrl.signal.aborted ||
+        (err as { name?: string }).name === 'AbortError' ||
+        (err as { name?: string }).name === 'TimeoutError';
+      throw new CoreUpstreamError(
+        'CORE_UPSTREAM_ERROR',
+        isTimeout ? 504 : 502,
+        isTimeout
+          ? `knowledge service timeout at ${path}`
+          : `knowledge service request failed at ${path}`,
+      );
     } finally {
       clearTimeout(timer);
     }

--- a/MemoryPanel/tests/kernel/http-knowledge-client.test.ts
+++ b/MemoryPanel/tests/kernel/http-knowledge-client.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CoreUpstreamError } from '../../src/panel/domain/errors.js';
+import { HttpKnowledgeClient } from '../../src/panel/kernel/adapters/http-knowledge-client.js';
+
+function client(timeoutMs = 15_000): HttpKnowledgeClient {
+  return new HttpKnowledgeClient({
+    baseUrl: 'https://knowledge.example',
+    authToken: 'secret-token',
+    serviceId: 'memory-1',
+    timeoutMs,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('HttpKnowledgeClient transport errors', () => {
+  it('maps request timeouts to CoreUpstreamError 504', async () => {
+    const fetchMock: typeof fetch = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('aborted', 'AbortError')),
+          { once: true },
+        );
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(client(5).wikiGet('wiki-1')).rejects.toMatchObject({
+      name: 'CoreUpstreamError',
+      code: 'CORE_UPSTREAM_ERROR',
+      httpStatus: 504,
+      message: 'knowledge service timeout at /v3/wiki/get',
+    } satisfies Partial<CoreUpstreamError>);
+  });
+
+  it('maps non-JSON upstream responses without exposing their body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response('sensitive gateway failure', {
+          status: 502,
+          headers: { 'content-type': 'text/plain' },
+        }),
+      ),
+    );
+
+    let error: unknown;
+    try {
+      await client().wikiGet('wiki-1');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(CoreUpstreamError);
+    expect(error).toMatchObject({
+      httpStatus: 502,
+      message:
+        'invalid JSON from knowledge service at /v3/wiki/get (HTTP 502)',
+    });
+    expect((error as Error).message).not.toContain('sensitive gateway failure');
+  });
+
+  it('maps network failures to CoreUpstreamError 502', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('socket disconnected');
+      }),
+    );
+
+    await expect(client().wikiGet('wiki-1')).rejects.toMatchObject({
+      name: 'CoreUpstreamError',
+      code: 'CORE_UPSTREAM_ERROR',
+      httpStatus: 502,
+      message: 'knowledge service request failed at /v3/wiki/get',
+    } satisfies Partial<CoreUpstreamError>);
+  });
+
+  it('preserves valid envelopes and request credentials', async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        code: 0,
+        message: 'ok',
+        data: { wiki_id: 'wiki-1', name: 'Example' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(client().wikiGet('wiki-1')).resolves.toMatchObject({
+      wiki_id: 'wiki-1',
+      name: 'Example',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://knowledge.example/v3/wiki/get',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer secret-token',
+          'x-tdai-service-id': 'memory-1',
+        },
+        body: JSON.stringify({ wiki_id: 'wiki-1' }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Description | 描述

`HttpKnowledgeClient` is the MemoryPanel boundary for Knowledge Service
requests, but transport failures currently escape as implementation-specific
errors:

- timeout aborts leak a raw `AbortError` with no HTTP status;
- network failures leak `TypeError`;
- non-JSON upstream responses leak `SyntaxError`.

Routes currently compensate with a generic fallback, but direct adapter
callers cannot distinguish a timeout from an upstream availability failure and
the adapter no longer satisfies its `CoreUpstreamError` contract.

This change normalizes those failures while preserving existing Knowledge
Service business-envelope errors.

## Related Issue | 关联 Issue

No linked issue. Found during the default-branch MemoryPanel upstream-adapter
audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Added regression coverage | 已添加回归测试

## What & Why

- Map abort/timeout failures to `CoreUpstreamError` with HTTP 504.
- Map network failures to `CoreUpstreamError` with HTTP 502.
- Validate JSON and the numeric envelope `code` before consuming `data`.
- Preserve a non-2xx upstream status when the response body is invalid.
- Avoid including an upstream response body or low-level socket message in
  client-facing errors.
- Keep existing non-zero business envelope codes and successful request
  headers/body unchanged.

This remains an adapter-only change. Route schemas, Knowledge Service
envelopes, authentication headers, and retry policy are unchanged.

## Verification | 验证

- `pnpm vitest run tests/kernel/http-knowledge-client.test.ts`
  - 1 file, 4 tests passed
- `pnpm test`
  - 1 file, 4 tests passed
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

The focused suite covers a real abort signal, a text/plain HTTP 502 response,
a network exception, and the successful envelope/request-credentials path.

## Additional Notes | 其他说明

- Scope is limited to one adapter and its focused tests.
- Error text intentionally omits upstream response content.
- AI assistance: TRAE was used to audit the boundary, reproduce each raw error
  shape, implement normalization, and run validation. I reviewed and take
  responsibility for the final change.
