### PR TITLE
fix(proxy): stop metadata pagination on empty pages

### DIFF
--- a/MemoryProxy/src/meta/__tests__/client.test.ts
+++ b/MemoryProxy/src/meta/__tests__/client.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MetadataClient } from "../client.js";
+
+describe("MetadataClient pagination", () => {
+  it("aggregates successive pages with the requested offsets", async () => {
+    const offsets: number[] = [];
+    const fetcher = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { limit: number; offset: number };
+      offsets.push(body.offset);
+      const items = body.offset === 0
+        ? Array.from({ length: 100 }, (_, i) => ({ team_id: `team-${i}`, name: `Team ${i}` }))
+        : [{ team_id: "team-100", name: "Team 100" }];
+      return new Response(JSON.stringify({
+        code: 0,
+        data: { items, total: 101, limit: body.limit, offset: body.offset },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = new MetadataClient(
+      {
+        endpoint: "http://metadata.test",
+        serviceToken: "token",
+        timeoutMs: 1_000,
+      },
+      "instance-1",
+      "user-key",
+      fetcher as typeof fetch,
+    );
+
+    await expect(client.listTeams("user-1")).resolves.toHaveLength(101);
+    expect(offsets).toEqual([0, 100]);
+  });
+
+  it("stops when a page is empty even if the reported total is stale", async () => {
+    const fetcher = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      if (fetcher.mock.calls.length > 1) {
+        throw new Error("unexpected request after empty page");
+      }
+      const body = JSON.parse(String(init?.body)) as { limit: number; offset: number };
+      return new Response(JSON.stringify({
+        code: 0,
+        data: {
+          items: [],
+          total: 250,
+          limit: body.limit,
+          offset: body.offset,
+        },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = new MetadataClient(
+      {
+        endpoint: "http://metadata.test",
+        serviceToken: "token",
+        timeoutMs: 1_000,
+      },
+      "instance-1",
+      "user-key",
+      fetcher as typeof fetch,
+    );
+
+    await expect(client.listTeams("user-1")).resolves.toEqual([]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/MemoryProxy/src/meta/client.ts
+++ b/MemoryProxy/src/meta/client.ts
@@ -433,6 +433,7 @@ export class MetadataClient {
       total = result.total;
       allItems.push(...result.items);
       if (allItems.length >= total) break;
+      if (result.items.length === 0) break;
       offset += pageSize;
     }
 


### PR DESCRIPTION
## Description | 描述

`MetadataClient.fetchAll()` previously kept requesting pages while the accumulated item count was below the server-reported total. When a filtered or stale count reported `total > 0` with an empty page, the count never advanced and the client could request pages indefinitely.

This change stops generic metadata pagination on an empty page, matching the existing termination rule in `getAgentFixedAssets()`. Focused tests cover normal multi-page aggregation and the stale-total empty-page boundary.

## Related Issue | 关联 Issue

Maintenance fix found during default-branch pagination audit; no linked issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- `npm test` (2/2 tests)
- strict changed-file TypeScript check for `src/meta/client.ts` and its test
- `git diff --check`

## Impact | 影响范围

Only generic `/v3/meta/*` list pagination is affected. Normal multi-page aggregation remains unchanged. No API or configuration changes.

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The repository-wide Proxy typecheck remains blocked on the default branch because `packages/cost-guard/src/index.ts` is absent; the changed files pass strict TypeScript checking independently.