### PR TITLE
fix(proxy): clear prewarm deadline timer

### DIFF
--- a/MemoryProxy/src/injection/__tests__/prewarm.test.ts
+++ b/MemoryProxy/src/injection/__tests__/prewarm.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { HookCacheRepo } from "../../db/hookCacheRepo.js";
+import { prewarmAll } from "../prewarm.js";
+import { HookRegistryImpl } from "../registry.js";
+import type { PrewarmInput } from "../types.js";
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("prewarmAll", () => {
+  it("clears the global deadline timer after hooks finish", async () => {
+    vi.useFakeTimers();
+    const registry = new HookRegistryImpl();
+    registry.register({
+      id: "fast-hook",
+      point: "system.prefix",
+      priority: 0,
+      description: "resolves immediately",
+      cacheStrategy: "session_init",
+      prewarm: async () => [{ type: "text", content: "cached" }],
+      execute: async () => [],
+    });
+    const repo: HookCacheRepo = {
+      put: vi.fn(),
+      putMany: vi.fn(),
+      get: vi.fn(async () => null),
+      getAllForSession: vi.fn(async () => []),
+      clearBySession: vi.fn(),
+    };
+    const input: PrewarmInput = {
+      keyId: "key-1",
+      userId: "user-1",
+      agentSource: "claude-code",
+      sessionInfo: { session_id: "session-1" } as PrewarmInput["sessionInfo"],
+      agentDetail: null,
+      taskDetail: null,
+    };
+
+    await expect(
+      prewarmAll(registry, repo, input, { totalTimeoutMs: 1_000 }),
+    ).resolves.toMatchObject({ cachedHookIds: ["fast-hook"], skipped: [] });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/MemoryProxy/src/injection/prewarm.ts
+++ b/MemoryProxy/src/injection/prewarm.ts
@@ -122,12 +122,18 @@ export async function prewarmAll(
 
   // Top-level total deadline: even if one hook hangs longer than per-hook,
   // we don't want session_init to block forever.
-  const settled = await Promise.race([
-    Promise.allSettled(runs),
-    new Promise<PromiseSettledResult<unknown>[]>((resolve) => {
-      setTimeout(() => resolve([]), totalBudget + 500);
-    }),
-  ]);
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  let settled: PromiseSettledResult<unknown>[];
+  try {
+    settled = await Promise.race([
+      Promise.allSettled(runs),
+      new Promise<PromiseSettledResult<unknown>[]>((resolve) => {
+        deadlineTimer = setTimeout(() => resolve([]), totalBudget + 500);
+      }),
+    ]);
+  } finally {
+    if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+  }
 
   if (settled.length === 0) {
     console.warn(


### PR DESCRIPTION
## Description | 描述

`prewarmAll()` races hook completion against a global deadline, but the deadline timer previously remained active after hooks completed successfully. Each successful session prewarm therefore retained a live timer until `totalBudget + 500ms` elapsed.

This change keeps the deadline handle and clears it after the race settles, regardless of which side wins. A focused fake-timer regression test verifies that successful prewarm leaves no active timers.

## Related Issue | 关联 Issue

Maintenance fix found during default-branch timer lifecycle audit; no linked issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- `npm test` (1/1 test)
- strict changed-file TypeScript check for `src/injection/prewarm.ts` and its test
- `git diff --check`

## Impact | 影响范围

Only the lifecycle of the top-level prewarm deadline timer changes. Hook execution, cache writes, timeout duration, and timeout fallback behavior are unchanged. No API or configuration changes.

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The repository-wide Proxy typecheck remains blocked on the default branch because `packages/cost-guard/src/index.ts` is absent; the changed files pass strict TypeScript checking independently.