### PR TITLE
fix(proxy): clear failed connectivity probe timers

### DIFF
--- a/MemoryProxy/src/__tests__/connectivity.test.ts
+++ b/MemoryProxy/src/__tests__/connectivity.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../report/log.js", () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { DEFAULT_CONFIG } from "../config.js";
+import { checkConnectivity } from "../connectivity.js";
+
+describe("connectivity HTTP probe cleanup", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("clears the abort deadline when fetch fails before the timeout", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new Error("connection refused"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkConnectivity({
+      ...DEFAULT_CONFIG,
+      upstream: {
+        ...DEFAULT_CONFIG.upstream,
+        url: "http://upstream.invalid/health",
+      },
+      creditReport: {
+        ...DEFAULT_CONFIG.creditReport,
+        url: "",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/MemoryProxy/src/connectivity.ts
+++ b/MemoryProxy/src/connectivity.ts
@@ -67,15 +67,16 @@ export async function checkConnectivity(config: ProxyConfig): Promise<void> {
 /** Probe an HTTP endpoint. Returns "ok (Xms)" or "FAIL: reason". */
 async function probe(url: string, headers?: Record<string, string>): Promise<string> {
   const start = Date.now();
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT);
   try {
-    const ctrl = new AbortController();
-    const t = setTimeout(() => ctrl.abort(), TIMEOUT);
     const resp = await fetch(url, { method: "GET", signal: ctrl.signal, headers, redirect: "follow" });
-    clearTimeout(t);
     await resp.text().catch(() => {});
     return `ok (${Date.now() - start}ms)`;
   } catch (err: unknown) {
     return `FAIL: ${err instanceof Error ? err.message : String(err)}`;
+  } finally {
+    clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
## Description | 描述

Fix a startup resource leak in the MemoryProxy HTTP connectivity probe.

Each HTTP probe creates a five-second abort deadline. The success path cleared
that timer, but an immediate DNS or connection failure returned from `catch`
without cleanup. A startup check with several quickly failing dependencies
therefore retained live timers and `AbortController` closures until every
deadline expired, which can delay short-lived process exit and waste resources.

### Changes

- Create the probe deadline before entering the request `try` block.
- Clear it in `finally`, covering success, HTTP/body errors, and immediate
  transport failures.
- Add a fake-timer regression test proving that a rejected `fetch()` leaves
  zero pending timers after `checkConnectivity()` returns.

### Boundaries

- No timeout duration or connectivity result semantics change.
- Redis probing and dependency configuration are unchanged.
- This PR only fixes HTTP probe deadline ownership.

## Related Issue | 关联 Issue

Discovered during the required default-branch resource-lifecycle audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `npx vitest run src/__tests__/connectivity.test.ts`
  - 1/1 passed.
- `npm test`
  - 1/1 passed (the default branch currently contains this one collected
    MemoryProxy test).
- `git diff --check`
  - passed.
- `npx tsc --noEmit`
  - reaches the existing default-branch blocker:
    `Cannot find module '@context-proxy/cost-guard'`; the optional private
    package is not present in this checkout and this PR does not touch it.

## Additional Notes | 其他说明

Semantic deduplication was run before implementation and immediately before
PR creation. No open PR references this timer leak or changes
`MemoryProxy/src/connectivity.ts`.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
