### PR TITLE
fix(deploy): brace-wrap variables followed by full-width CJK characters

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -171,7 +171,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then

--- a/deploy/panel-knowledge-combined/build.sh
+++ b/deploy/panel-knowledge-combined/build.sh
@@ -36,9 +36,9 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 err() { echo "[build-combined] error: $*" >&2; exit 1; }
 
 [[ -d "$TMC_DIR/package.json" || -f "$TMC_DIR/package.json" ]] \
-  || err "MemoryPanel 不在 $TMC_DIR（设 TMC_DIR=<path> 指定）"
+  || err "MemoryPanel 不在 ${TMC_DIR}（设 TMC_DIR=<path> 指定）"
 [[ -f "$KNOWLEDGE_DIR/package.json" ]] \
-  || err "MemoryKnowledge 不在 $KNOWLEDGE_DIR（设 KNOWLEDGE_DIR=<path> 指定）"
+  || err "MemoryKnowledge 不在 ${KNOWLEDGE_DIR}（设 KNOWLEDGE_DIR=<path> 指定）"
 [[ -f "$SCRIPT_DIR/Dockerfile" ]] || err "Dockerfile 不在 $SCRIPT_DIR"
 [[ -f "$SCRIPT_DIR/start-combined.sh" ]] || err "start-combined.sh 不在 $SCRIPT_DIR"
 
@@ -133,4 +133,4 @@ docker build --platform "$PLATFORM" -t "$IMAGE_NAME:$IMAGE_TAG" "$CTX_DIR"
 
 echo ""
 echo "[build-combined] ✅ done: $IMAGE_NAME:$IMAGE_TAG"
-echo "[build-combined] context 保留在 $CTX_DIR（KEEP_CTX=0 时下次会清掉）"
+echo "[build-combined] context 保留在 ${CTX_DIR}（KEEP_CTX=0 时下次会清掉）"


### PR DESCRIPTION
### Description
Under a non-UTF-8 locale (bash launched without `LC_ALL`/`LANG`, common in CI shells and automation on macOS), bash includes the bytes of a full-width CJK character that immediately follows a bare `$VAR` into the variable name. With `set -u` this aborts the script with `unbound variable`.

Reproduced with `start-memory-core.sh:174` — `$ADMIN_KEY_FILE）` fails the whole first boot (admin key never created, hub/proxy never start).

The repo already uses the `${VAR}` style before CJK punctuation in 22 places; this PR fixes the four remaining bare references (1 in `start-memory-core.sh`, 3 in `deploy/panel-knowledge-combined/build.sh`).

### Change Type
- [x] Bug fix

### Self-test Checklist
- [x] `bash -n` clean on both files
- [x] Full `./start-all.sh` boot verified on macOS under C locale

### Additional Notes
If you'd like a regression gate, a tiny shell-lint check over `deploy/**/*.sh` could be added to CI — happy to follow up; kept out of this diff to stay minimal.
