### PR TITLE
fix(memory-core): include status, url and response body in LLM failure logs

### DIFF
--- a/MemoryCore/src/adapters/standalone/llm-runner.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.ts
@@ -18,7 +18,7 @@
 
 import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { generateText, tool, stepCountIs, jsonSchema } from "ai";
+import { APICallError, generateText, tool, stepCountIs, jsonSchema } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 import { report } from "../../core/report/reporter.js";
 import type {
@@ -396,7 +396,20 @@ export class StandaloneLLMRunner implements LLMRunner {
       return text;
     } catch (err) {
       const totalMs = Date.now() - runStartMs;
-      const errMsg = err instanceof Error ? err.message : String(err);
+      let errMsg = err instanceof Error ? err.message : String(err);
+      if (APICallError.isInstance(err)) {
+        // err.message alone can be as terse as "Not Found"; the failing URL,
+        // status and response body only exist on APICallError, so surface them
+        // here (preview + remainder counter, same convention as l1-extractor).
+        const body = typeof err.responseBody === "string" ? err.responseBody : "";
+        const bodyPreview = body.slice(0, 2048);
+        errMsg =
+          `${errMsg} (status=${err.statusCode ?? "?"}, url=${err.url}` +
+          (bodyPreview
+            ? `, body=${bodyPreview}${body.length > 2048 ? `…(+${body.length - 2048})` : ""}`
+            : "") +
+          ")";
+      }
       this.logger?.error(`${TAG} run() failed after ${totalMs}ms: ${errMsg}`);
 
       if (params.instanceId) {


### PR DESCRIPTION
### Description
When an LLM call fails, `llm-runner.ts` logs only `err.message`. For AI SDK's `APICallError` that can be as terse as `Not Found` — the failing URL, HTTP status and response body exist on the error object but are dropped, making misconfiguration (e.g. a wrong base URL) undebuggable from logs. The same bare message goes into `report("llm_call")` telemetry, so the context is lost there too.

This PR enriches the single top-level catch in `run()` (through which all standalone LLM calls pass): when `APICallError.isInstance(err)`, the log line and telemetry now carry `status=`, `url=` and a 2048-char response body preview with a remainder counter — the same preview convention already used in `l1-extractor.ts` (NO_JSON diagnostics).

Before: `run() failed after 546ms: Not Found`
After: `run() failed after 546ms: Not Found (status=404, url=https://api.anthropic.com/chat/completions, body={...})`

### Related Issue
#709

### Change Type
- [x] Bug fix

### Self-test Checklist
- [x] `npm run build` — build:plugin green (note: build:scripts fails on a pre-existing missing `scripts/seed-v2/`, reported separately)
- [x] `scripts/ci/check-skill-queue-isolation.sh` PASS
