### PR TITLE
fix(deploy): warn when MEMORY_LLM_PROTOCOL=anthropic reaches memory-core; document the limitation

### DIFF
--- a/deploy/global-images/.env.example
+++ b/deploy/global-images/.env.example
@@ -34,7 +34,7 @@ PROXY_IMAGE=agentmemory/memory-proxy:latest
 MEMORY_LLM_BASE_URL=REPLACE_ME              # 例：https://api.deepseek.com/v1
 MEMORY_LLM_API_KEY=REPLACE_ME               # 例：sk-xxxxxxxx
 MEMORY_LLM_MODEL=REPLACE_ME                 # 例：deepseek-chat
-MEMORY_LLM_PROTOCOL=openai                  # openai | anthropic
+MEMORY_LLM_PROTOCOL=openai                  # openai | anthropic（anthropic 仅对 hub/knowledge 生效；memory-core 需 OpenAI 兼容端点）
 
 # ── proxy 组：proxy 把用户请求转发到的上游 LLM ──────────────────────────────
 # 用途：coding agent / 客户端调 proxy:8096，proxy 再转发到这里

--- a/deploy/global-images/README.md
+++ b/deploy/global-images/README.md
@@ -82,7 +82,7 @@ $EDITOR .env
 | `MEMORY_LLM_BASE_URL` | OpenAI 兼容 base URL | `https://api.deepseek.com/v1` |
 | `MEMORY_LLM_API_KEY` | 上述端点的 API Key | `sk-xxxxxxxx` |
 | `MEMORY_LLM_MODEL` | 模型 ID | `deepseek-chat` |
-| `MEMORY_LLM_PROTOCOL` | `openai` 或 `anthropic`，默认 `openai` | `openai` |
+| `MEMORY_LLM_PROTOCOL` | `openai` 或 `anthropic`，默认 `openai`。注意：`anthropic` 仅对 hub/knowledge 生效，memory-core 需 OpenAI 兼容端点（Anthropic 用 `https://api.anthropic.com/v1` + `openai`） | `openai` |
 
 ### proxy 组（proxy 使用）
 

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -16,6 +16,13 @@ source "$SCRIPT_DIR/_lib.sh"
 load_env
 require_vars MEMORY_CORE_IMAGE MEMORY_CORE_PORT MEMORY_CORE_VOLUME
 
+# MEMORY_LLM_PROTOCOL 对 hub/knowledge 生效，但 memory-core 的 standalone
+# runner 目前只支持 OpenAI 兼容协议（POST {base}/chat/completions）。
+if [[ "${MEMORY_LLM_PROTOCOL:-openai}" == "anthropic" ]]; then
+  warn "MEMORY_LLM_PROTOCOL=anthropic：memory-core 运行时只走 OpenAI 兼容 /chat/completions，该设置对 memory-core 不生效。"
+  warn "Anthropic 请改用其 OpenAI 兼容端点：MEMORY_LLM_BASE_URL=https://api.anthropic.com/v1 + MEMORY_LLM_PROTOCOL=openai，否则 L1 抽取会一直 404（Not Found）。"
+fi
+
 # ── Gateway 内部管理凭据 ─────────────────────────────────────────
 # 用 ${VAR-default}（不是 :-default）：允许 .env 里显式设为空字符串来关闭 Bearer gate。
 #


### PR DESCRIPTION
### Description
`MEMORY_LLM_PROTOCOL` is honored by verify.sh and memory-hub, but memory-core's standalone runner always speaks OpenAI-compatible `/chat/completions` (see #709 for the full chain). With `anthropic` configured, verify.sh is green while every L1 extraction fails with 404 — a silent contradiction.

This PR makes the failure loud and documented, without breaking hub-only setups where the value is legitimate:
- `start-memory-core.sh`: prints a prominent `warn` when `MEMORY_LLM_PROTOCOL=anthropic`, pointing to the working configuration (`MEMORY_LLM_BASE_URL=https://api.anthropic.com/v1` + `MEMORY_LLM_PROTOCOL=openai`);
- `.env.example` and `deploy/global-images/README.md`: annotate that `anthropic` applies to hub/knowledge only; memory-core requires an OpenAI-compatible endpoint.

Real Anthropic support is proposed separately in #709.

### Related Issue
#709

### Change Type
- [x] Bug fix

### Self-test Checklist
- [x] `bash -n` clean
- [x] Boot with `protocol=anthropic` shows the warning and continues; boot with `openai` unchanged
