### PR TITLE
fix(deploy): restrict generated gateway config to 0600 (contains the LLM API key)

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -119,6 +119,8 @@ skill:
   resources:
     maxResourceSizeBytes: 5000000
 YAML
+# 配置里含 apiKey 明文，收紧文件权限
+chmod 600 "$CORE_CONFIG_FILE"
 
 info "启动 memory-core (image=$MEMORY_CORE_IMAGE, port=$MEMORY_CORE_PORT)"
 $DOCKER run -d --name "$CONTAINER" \


### PR DESCRIPTION
### Description
`start-memory-core.sh` writes `MEMORY_LLM_API_KEY` in plaintext into `.memory-core-config/tdai-gateway.yaml` with default 0644 permissions — readable by any local process. This PR tightens the generated file to owner-only right after generation.

### Change Type
- [x] Bug fix (security hygiene)

### Self-test Checklist
- [x] Boot unchanged; generated file mode is 0600
