### PR TITLE
docs: fix clone URL org in CONTRIBUTING.md (Tencent -> TencentCloud)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ The simplest inner loop: run the full stack in Docker, then patch the target
 module locally.
 
 ```bash
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory/deploy/global-images
 cp .env.example .env && $EDITOR .env
 ./start-all.sh


### PR DESCRIPTION
### Description
`CONTRIBUTING.md` still points the clone command at `github.com/Tencent/...`; the repository lives under `TencentCloud` and the documented command 404s. Same fix as a7d7d85 applied to INSTALL.md.

### Change Type
- [x] Documentation update
