### PR TITLE
fix(proxy): clear pending-write deadline timer

### DIFF
--- a/MemoryProxy/src/tdai/__tests__/pending-writes.test.ts
+++ b/MemoryProxy/src/tdai/__tests__/pending-writes.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  flushPendingWrites,
+  pendingWriteCount,
+  trackWrite,
+} from "../pending-writes.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("flushPendingWrites", () => {
+  it("clears the deadline timer when writes drain early", async () => {
+    vi.useFakeTimers();
+    let resolveWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    trackWrite(write);
+
+    const flushing = flushPendingWrites(10_000);
+    expect(vi.getTimerCount()).toBe(1);
+
+    resolveWrite();
+    await expect(flushing).resolves.toEqual({ drained: true, remaining: 0 });
+
+    expect(pendingWriteCount()).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("reports pending writes and clears the fired deadline timer", async () => {
+    vi.useFakeTimers();
+    let resolveWrite!: () => void;
+    const write = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    trackWrite(write);
+
+    const flushing = flushPendingWrites(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(flushing).resolves.toEqual({ drained: false, remaining: 1 });
+    expect(vi.getTimerCount()).toBe(0);
+
+    resolveWrite();
+    await write;
+    await Promise.resolve();
+    expect(pendingWriteCount()).toBe(0);
+  });
+});

--- a/MemoryProxy/src/tdai/pending-writes.ts
+++ b/MemoryProxy/src/tdai/pending-writes.ts
@@ -57,9 +57,16 @@ export async function flushPendingWrites(deadlineMs: number = 10_000): Promise<{
   if (pendingWrites.size === 0) return { drained: true, remaining: 0 };
   const snapshot = [...pendingWrites];
   const settled = Promise.allSettled(snapshot);
-  const timeout = new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), deadlineMs));
-  const outcome = await Promise.race([settled.then(() => "ok" as const), timeout]);
-  return { drained: outcome === "ok", remaining: pendingWrites.size };
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<"timeout">((resolve) => {
+    timeoutHandle = setTimeout(() => resolve("timeout"), deadlineMs);
+  });
+  try {
+    const outcome = await Promise.race([settled.then(() => "ok" as const), timeout]);
+    return { drained: outcome === "ok", remaining: pendingWrites.size };
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
 }
 
 /**


### PR DESCRIPTION
## Description | 描述

`flushPendingWrites()` is used by the MemoryProxy SIGTERM handler to wait for
fire-and-forget L0 writes. It races the writes against a deadline timeout, but
the timeout remains scheduled when the writes settle first.

Because the timer is referenced, a fully drained shutdown can still keep the
Node process alive until the complete deadline (10 seconds in the production
caller). This change clears that timer as soon as the race finishes.

## Related Issue | 关联 Issue

No linked issue. Found during the default-branch MemoryProxy shutdown and
resource-lifecycle audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Added regression coverage | 已添加回归测试

## What & Why

- Keep the deadline handle and clear it from a `finally` block after
  `Promise.race()` settles.
- Preserve the timeout behavior when writes do not drain before the deadline.
- Add fake-timer tests for both early drain and deadline expiry.

The change does not alter write tracking, retry behavior, the default deadline,
or the reported `{ drained, remaining }` contract.

## Verification | 验证

- `pnpm vitest run src/tdai/__tests__/pending-writes.test.ts`
  - 1 file, 2 tests passed
- `pnpm test`
  - 1 file, 2 tests passed
- Strict changed-file TypeScript check
- `git diff --check`

The early-drain regression verifies that the active timer count returns to
zero immediately. The deadline case verifies the existing non-drained result
and cleanup after timeout.

## Additional Notes | 其他说明

- Scope is limited to one shutdown helper and its focused tests.
- The target branch's existing `pnpm-lock.yaml` disagrees with
  `package.json` on `cos-nodejs-sdk-v5`; validation used the current manifest
  with lockfile writes disabled, and this PR contains no dependency changes.
- AI assistance: TRAE was used to audit the lifecycle, reproduce the lingering
  timer, implement the cleanup, and run validation. I reviewed and take
  responsibility for the final change.
