### PR TITLE
fix(knowledge): dedupe code-graph instance loads

### DIFF
--- a/MemoryKnowledge/src/code-graph-instance-pool.test.ts
+++ b/MemoryKnowledge/src/code-graph-instance-pool.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createCodeGraphInstancePool,
+  type CodeGraphInstancePoolOptions,
+} from "./code-graph-instance-pool.js";
+import type { CodeGraphInstance } from "./engines/code/index.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function instance(name: string): CodeGraphInstance {
+  return { name } as unknown as CodeGraphInstance;
+}
+
+function createPool(
+  loadIndex: CodeGraphInstancePoolOptions["loadIndex"],
+  closeIndex = vi.fn<CodeGraphInstancePoolOptions["closeIndex"]>(),
+) {
+  return {
+    closeIndex,
+    pool: createCodeGraphInstancePool({ loadIndex, closeIndex }),
+  };
+}
+
+describe("createCodeGraphInstancePool", () => {
+  it("shares one lazy load across concurrent callers", async () => {
+    const loading = deferred<CodeGraphInstance>();
+    const loadIndex = vi.fn(() => loading.promise);
+    const { pool } = createPool(loadIndex);
+
+    const first = pool.loadIfMissing("graph-1", "/data/graph-1");
+    const second = pool.loadIfMissing("graph-1", "/data/graph-1");
+
+    await Promise.resolve();
+    expect(loadIndex).toHaveBeenCalledTimes(1);
+    const loaded = instance("shared");
+    loading.resolve(loaded);
+
+    await expect(first).resolves.toBe(loaded);
+    await expect(second).resolves.toBe(loaded);
+    expect(pool.get("graph-1")).toBe(loaded);
+  });
+
+  it("does not repopulate the pool when an in-flight load is deleted", async () => {
+    const staleLoading = deferred<CodeGraphInstance>();
+    const freshLoading = deferred<CodeGraphInstance>();
+    const loadIndex = vi
+      .fn<CodeGraphInstancePoolOptions["loadIndex"]>()
+      .mockImplementationOnce(() => staleLoading.promise)
+      .mockImplementationOnce(() => freshLoading.promise);
+    const { pool, closeIndex } = createPool(loadIndex);
+
+    const staleRequest = pool.loadIfMissing("graph-1", "/data/graph-1");
+    pool.delete("graph-1");
+    const freshRequest = pool.loadIfMissing("graph-1", "/data/graph-1");
+
+    const stale = instance("stale");
+    staleLoading.resolve(stale);
+    await expect(staleRequest).resolves.toBeUndefined();
+    expect(closeIndex).toHaveBeenCalledWith(stale);
+    expect(pool.get("graph-1")).toBeUndefined();
+
+    const fresh = instance("fresh");
+    freshLoading.resolve(fresh);
+    await expect(freshRequest).resolves.toBe(fresh);
+    expect(pool.get("graph-1")).toBe(fresh);
+    expect(loadIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a failed load so a later request can retry", async () => {
+    const loaded = instance("retry");
+    const loadIndex = vi
+      .fn<CodeGraphInstancePoolOptions["loadIndex"]>()
+      .mockRejectedValueOnce(new Error("index unavailable"))
+      .mockResolvedValueOnce(loaded);
+    const { pool } = createPool(loadIndex);
+
+    await expect(
+      pool.loadIfMissing("graph-1", "/data/graph-1"),
+    ).resolves.toBeUndefined();
+    await expect(
+      pool.loadIfMissing("graph-1", "/data/graph-1"),
+    ).resolves.toBe(loaded);
+    expect(loadIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a synchronous load failure so a later request can retry", async () => {
+    const loaded = instance("retry");
+    const loadIndex = vi
+      .fn<CodeGraphInstancePoolOptions["loadIndex"]>()
+      .mockImplementationOnce(() => {
+        throw new Error("invalid index path");
+      })
+      .mockResolvedValueOnce(loaded);
+    const { pool } = createPool(loadIndex);
+
+    await expect(
+      pool.loadIfMissing("graph-1", "/data/graph-1"),
+    ).resolves.toBeUndefined();
+    await expect(
+      pool.loadIfMissing("graph-1", "/data/graph-1"),
+    ).resolves.toBe(loaded);
+    expect(loadIndex).toHaveBeenCalledTimes(2);
+  });
+});

--- a/MemoryKnowledge/src/code-graph-instance-pool.ts
+++ b/MemoryKnowledge/src/code-graph-instance-pool.ts
@@ -1,0 +1,108 @@
+import type { CodeGraphInstance } from "./engines/code/index.js";
+
+export interface CodeGraphInstancePool {
+  get(codeGraphId: string): CodeGraphInstance | undefined;
+  set(codeGraphId: string, instance: CodeGraphInstance): void;
+  delete(codeGraphId: string): void;
+  loadIfMissing?(
+    codeGraphId: string,
+    dir: string,
+  ): Promise<CodeGraphInstance | undefined>;
+}
+
+export interface CodeGraphInstancePoolOptions {
+  loadIndex: (dir: string) => Promise<CodeGraphInstance>;
+  closeIndex: (instance: CodeGraphInstance) => void;
+  logger?: {
+    info?: (message: string) => void;
+    warn?: (message: string) => void;
+  };
+}
+
+interface PendingLoad {
+  token: { invalidated: boolean };
+  promise: Promise<CodeGraphInstance | undefined>;
+}
+
+export function createCodeGraphInstancePool(
+  options: CodeGraphInstancePoolOptions,
+): CodeGraphInstancePool & {
+  loadIfMissing(
+    codeGraphId: string,
+    dir: string,
+  ): Promise<CodeGraphInstance | undefined>;
+} {
+  const instances = new Map<string, CodeGraphInstance>();
+  const pendingLoads = new Map<string, PendingLoad>();
+
+  const invalidatePending = (codeGraphId: string): void => {
+    const pending = pendingLoads.get(codeGraphId);
+    if (!pending) return;
+    pending.token.invalidated = true;
+    pendingLoads.delete(codeGraphId);
+  };
+
+  return {
+    get(codeGraphId) {
+      return instances.get(codeGraphId);
+    },
+
+    set(codeGraphId, instance) {
+      invalidatePending(codeGraphId);
+      instances.set(codeGraphId, instance);
+    },
+
+    delete(codeGraphId) {
+      invalidatePending(codeGraphId);
+      instances.delete(codeGraphId);
+    },
+
+    loadIfMissing(codeGraphId, dir) {
+      const cached = instances.get(codeGraphId);
+      if (cached) return Promise.resolve(cached);
+
+      const existing = pendingLoads.get(codeGraphId);
+      if (existing) return existing.promise;
+
+      const token = { invalidated: false };
+      const promise: Promise<CodeGraphInstance | undefined> = Promise.resolve()
+        .then(() => options.loadIndex(dir))
+        .then((instance) => {
+          if (token.invalidated) {
+            try {
+              options.closeIndex(instance);
+            } catch (err) {
+              options.logger?.warn?.(
+                `[code-graph] close invalidated lazy-load failed ${codeGraphId}: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              );
+            }
+            return instances.get(codeGraphId);
+          }
+          instances.set(codeGraphId, instance);
+          options.logger?.info?.(
+            `[code-graph] lazy-loaded instance ${codeGraphId}`,
+          );
+          return instance;
+        })
+        .catch((err: unknown) => {
+          options.logger?.warn?.(
+            `[code-graph] lazy-load failed ${codeGraphId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          return undefined;
+        })
+        .finally(() => {
+          const current = pendingLoads.get(codeGraphId);
+          if (current?.token === token) {
+            pendingLoads.delete(codeGraphId);
+          }
+        });
+
+      pendingLoads.set(codeGraphId, { token, promise });
+      return promise;
+    },
+  };
+}

--- a/MemoryKnowledge/src/module.ts
+++ b/MemoryKnowledge/src/module.ts
@@ -20,11 +20,17 @@ import {
   type ILlmBindingStore,
 } from "./store/llm-binding-store.js";
 import { createWikiSourceManager, type WikiSourceManager } from "./engines/wiki/index.js";
-import { indexProject, openIndex, syncIndex, getStats, closeIndex, type CodeGraphInstance } from "./engines/code/index.js";
+import { indexProject, openIndex, syncIndex, getStats, closeIndex } from "./engines/code/index.js";
 import { SourceFetcherRegistry } from "./source-fetcher/index.js";
 import { createLogger } from "./logger.js";
 import type { LlmConfig } from "./config.js";
 import { AutoSyncScheduler, resolveAutoSyncConfig, type AutoSyncConfig } from "./store/auto-sync-scheduler.js";
+import {
+  createCodeGraphInstancePool,
+  type CodeGraphInstancePool,
+} from "./code-graph-instance-pool.js";
+
+export type { CodeGraphInstancePool } from "./code-graph-instance-pool.js";
 
 const log = createLogger("knowledge-module");
 
@@ -41,13 +47,6 @@ export interface KnowledgeModuleConfig {
   wikiWorker?: WikiWorker;
   /** Optional: externally injected code worker (for testing). */
   codeWorker?: CodeGraphWorker;
-}
-
-export interface CodeGraphInstancePool {
-  get(codeGraphId: string): CodeGraphInstance | undefined;
-  set(codeGraphId: string, instance: CodeGraphInstance): void;
-  delete(codeGraphId: string): void;
-  loadIfMissing?(codeGraphId: string, dir: string): Promise<CodeGraphInstance | undefined>;
 }
 
 export interface KnowledgeModule {
@@ -84,24 +83,11 @@ export function createKnowledgeModule(config: KnowledgeModuleConfig): KnowledgeM
     resolveLlmConfig(serviceId, llmBindingStore.get(serviceId), llmConfig);
 
   // Instance pool (code-graph) — lazy loading
-  const _poolMap = new Map<string, CodeGraphInstance>();
-  const instancePool: CodeGraphInstancePool = {
-    get(id: string) { return _poolMap.get(id); },
-    set(id: string, inst: CodeGraphInstance) { _poolMap.set(id, inst); },
-    delete(id: string) { _poolMap.delete(id); },
-    async loadIfMissing(id: string, dir: string) {
-      if (_poolMap.has(id)) return _poolMap.get(id);
-      try {
-        const instance = await openIndex(dir);
-        _poolMap.set(id, instance);
-        log.info(`[code-graph] lazy-loaded instance ${id}`);
-        return instance;
-      } catch (err) {
-        log.warn(`[code-graph] lazy-load failed ${id}: ${err instanceof Error ? err.message : String(err)}`);
-        return undefined;
-      }
-    },
-  };
+  const instancePool: CodeGraphInstancePool = createCodeGraphInstancePool({
+    loadIndex: openIndex,
+    closeIndex,
+    logger: log,
+  });
 
   // Wiki engine manager
   const wikiMgr = createWikiSourceManager(join(dataDir, "_wiki_engines"));


### PR DESCRIPTION
## Description | 描述

Code-graph query routes lazily reopen a persisted index through
`instancePool.loadIfMissing()`. The current pool only checks the completed
instance map, so concurrent cache misses each call `openIndex(dir)`.

That creates multiple handles for the same index: callers can receive different
instances, the last map write wins, and the other handle is never closed. A
delete during a lazy load can also let the stale completion repopulate the
pool after cleanup.

This change gives the pool explicit in-flight and invalidation lifecycle
management.

## Related Issue | 关联 Issue

No linked issue. Found during the default-branch MemoryKnowledge concurrency
and resource-lifecycle audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能
- [x] Added regression coverage | 已添加回归测试

## What & Why

- Extract instance-pool lifecycle logic into a small injected helper.
- Share one in-flight load for concurrent callers of the same code-graph ID.
- Invalidate pending loads when an instance is deleted or explicitly replaced.
- Close a handle that completes after invalidation and prevent it from
  repopulating the pool.
- Remove failed loads from the in-flight map so a later query can retry.
- Preserve the original optional `loadIfMissing` interface contract for route
  mocks and external callers.

The change does not alter query endpoints, index format, startup restoration,
or the existing synchronous close behavior for completed instances.

## Verification | 验证

- `pnpm vitest run src/code-graph-instance-pool.test.ts`
  - 1 file, 4 tests passed
- `pnpm test`
  - 1 file, 4 tests passed
- Changed-file strict TypeScript check
- `pnpm build`
  - 11 output files built
- `git diff --check`

The tests deterministically cover concurrent deduplication, delete-during-load
invalidation/close, and retry after rejected or synchronously thrown loads.

## Additional Notes | 其他说明

- Full-package `pnpm typecheck` reaches an existing default-branch error at
  `src/middleware/response-envelope.ts:47` (`Promise<string>` assigned to
  `string`). The changed files pass an isolated strict TypeScript check and
  the production build succeeds.
- Node 26 cannot compile the target branch's `better-sqlite3@11.10.0`; tooling
  installation used `--ignore-scripts`. These tests are pure TypeScript and do
  not load SQLite.
- AI assistance: TRAE was used to audit the concurrency path, design the
  invalidation ownership, implement tests, and run validation. I reviewed and
  take responsibility for the final change.