### PR TITLE
feat(memory-core): support native Anthropic protocol (#709)

### DIFF
--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -96,6 +96,7 @@
     "node": ">=22.16.0"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.95",
     "@ai-sdk/openai": "^3.0.53",
     "@node-rs/jieba": "^2.0.1",
     "@opentelemetry/api": "^1.9.0",

--- a/MemoryCore/src/adapters/standalone/llm-runner-protocol.test.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner-protocol.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const anthropicModel = { provider: "anthropic" };
+  const openaiModel = { provider: "openai" };
+  return {
+    anthropicModel,
+    openaiModel,
+    anthropicChat: vi.fn(() => anthropicModel),
+    openaiChat: vi.fn(() => openaiModel),
+    createAnthropic: vi.fn(),
+    createOpenAI: vi.fn(),
+    generateText: vi.fn(),
+  };
+});
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: mocks.createAnthropic,
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: mocks.createOpenAI,
+}));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: mocks.generateText,
+  };
+});
+
+import { StandaloneLLMRunner } from "./llm-runner.js";
+
+describe("StandaloneLLMRunner wire protocol", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createAnthropic.mockReturnValue({
+      chat: mocks.anthropicChat,
+    });
+    mocks.createOpenAI.mockReturnValue({
+      chat: mocks.openaiChat,
+    });
+    mocks.generateText.mockResolvedValue({
+      text: "ok",
+      steps: [],
+      usage: undefined,
+      finishReason: "stop",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the native Anthropic provider for protocol=anthropic", async () => {
+    const runner = new StandaloneLLMRunner({
+      config: {
+        protocol: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "anthropic-key",
+        model: "claude-haiku",
+      },
+    });
+
+    await runner.run({
+      taskId: "anthropic-test",
+      systemPrompt: "system",
+      prompt: "hello",
+    });
+
+    expect(mocks.createAnthropic).toHaveBeenCalledWith({
+      baseURL: "https://api.anthropic.com",
+      apiKey: "anthropic-key",
+    });
+    expect(mocks.anthropicChat).toHaveBeenCalledWith("claude-haiku");
+    expect(mocks.createOpenAI).not.toHaveBeenCalled();
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({ model: mocks.anthropicModel }),
+    );
+  });
+
+  it("keeps the OpenAI-compatible provider as the default", async () => {
+    const runner = new StandaloneLLMRunner({
+      config: {
+        baseUrl: "https://api.example.com/v1",
+        apiKey: "openai-key",
+        model: "memory-model",
+      },
+    });
+
+    await runner.run({
+      taskId: "openai-test",
+      systemPrompt: "system",
+      prompt: "hello",
+    });
+
+    expect(mocks.createOpenAI).toHaveBeenCalledWith({
+      baseURL: "https://api.example.com/v1",
+      apiKey: "openai-key",
+      compatibility: "compatible",
+    });
+    expect(mocks.openaiChat).toHaveBeenCalledWith("memory-model");
+    expect(mocks.createAnthropic).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryCore/src/adapters/standalone/llm-runner.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.ts
@@ -19,6 +19,7 @@
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { generateText, tool, stepCountIs, jsonSchema } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
 import { report } from "../../core/report/reporter.js";
 import type {
@@ -78,7 +79,9 @@ function buildTelemetryMetadata(params: LLMRunParams): Record<string, unknown> {
 // ============================
 
 export interface StandaloneLLMConfig {
-  /** OpenAI-compatible API base URL (e.g. "https://api.openai.com/v1"). */
+  /** Wire protocol used by the configured endpoint (default: "openai"). */
+  protocol?: "openai" | "anthropic";
+  /** Provider API base URL. */
   baseUrl: string;
   /** API key for authentication. */
   apiKey: string;
@@ -280,14 +283,19 @@ export class StandaloneLLMRunner implements LLMRunner {
       `tools=${effectiveEnableTools}${callerProvidedTools ? "(caller)" : ""}, timeout=${timeoutMs}ms`,
     );
 
-    // Create OpenAI-compatible provider via AI SDK
-    // Use "compatible" mode to call /chat/completions (not Responses API),
-    // which works with all OpenAI-compatible backends (DeepSeek, Qwen, etc.)
-    const provider = createOpenAI({
-      baseURL: this.config.baseUrl,
-      apiKey: this.config.apiKey,
-      compatibility: "compatible",
-    });
+    // Select the AI SDK provider from the explicit wire protocol. Access mode
+    // (`provider=openai|proxy`) is resolved by the Gateway before this runner
+    // is created and remains independent from the HTTP wire shape.
+    const provider = this.config.protocol === "anthropic"
+      ? createAnthropic({
+          baseURL: this.config.baseUrl,
+          apiKey: this.config.apiKey,
+        })
+      : createOpenAI({
+          baseURL: this.config.baseUrl,
+          apiKey: this.config.apiKey,
+          compatibility: "compatible",
+        });
 
     // Select tools based on mode + storage
     // Service mode (COS): use storage-backed tools → LLM reads/writes via StorageAdapter

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -202,7 +202,9 @@ export interface ReportConfig {
 export interface StandaloneLLMOverrideConfig {
   /** Enable standalone LLM mode (default: false). When false, uses host LLM. */
   enabled: boolean;
-  /** OpenAI-compatible API base URL (e.g. "https://api.openai.com/v1"). */
+  /** Wire protocol used by the endpoint (default: "openai"). */
+  protocol: "openai" | "anthropic";
+  /** Provider API base URL. */
   baseUrl: string;
   /** API key for authentication. */
   apiKey: string;
@@ -620,9 +622,13 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       const rawProvider = str(llmGroup, "provider");
       const provider: "openai" | "proxy" =
         rawProvider === "proxy" ? "proxy" : "openai";
+      const protocol = str(llmGroup, "protocol") === "anthropic"
+        ? "anthropic"
+        : "openai";
       const proxyGroup = obj(llmGroup, "proxy");
       return {
         enabled: bool(llmGroup, "enabled") ?? false,
+        protocol,
         baseUrl: str(llmGroup, "baseUrl") ?? "https://api.openai.com/v1",
         apiKey: str(llmGroup, "apiKey") ?? "",
         model: str(llmGroup, "model") ?? "gpt-4o",

--- a/MemoryCore/src/core/seed/seed-runtime.ts
+++ b/MemoryCore/src/core/seed/seed-runtime.ts
@@ -82,6 +82,7 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
   if (cfg.llm.enabled && cfg.llm.apiKey) {
     const runnerFactory = new StandaloneLLMRunnerFactory({
       config: {
+        protocol: cfg.llm.protocol,
         baseUrl: cfg.llm.baseUrl,
         apiKey: cfg.llm.apiKey,
         model: cfg.llm.model,

--- a/MemoryCore/src/core/tdai-core.ts
+++ b/MemoryCore/src/core/tdai-core.ts
@@ -626,6 +626,7 @@ export class TdaiCore {
    * apiKey 用 env.TDAI_MEMORY_SYSTEM_USER_KEY。四个 runner factory 构造点共用。
    */
   private resolveRuntimeLlm(): {
+    protocol: "openai" | "anthropic";
     baseUrl: string;
     apiKey: string;
     model: string;
@@ -634,6 +635,7 @@ export class TdaiCore {
   } {
     const resolved = resolveStandaloneLlmForRuntime(this.cfg.llm, this.instanceId);
     return {
+      protocol: resolved.protocol ?? "openai",
       baseUrl: resolved.baseUrl,
       apiKey: resolved.apiKey,
       model: resolved.model,
@@ -999,6 +1001,7 @@ export class TdaiCore {
     const runtimeLlm = this.resolveRuntimeLlm();
     const runner = new StandaloneLLMRunner({
       config: {
+        protocol: runtimeLlm.protocol,
         baseUrl: runtimeLlm.baseUrl,
         apiKey: runtimeLlm.apiKey,
         model: runtimeLlm.model,

--- a/MemoryCore/src/gateway/config.ts
+++ b/MemoryCore/src/gateway/config.ts
@@ -445,7 +445,13 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   const rawLlmProvider = env("TDAI_LLM_PROVIDER") ?? str(llmConfig, "provider");
   const llmProvider: "openai" | "proxy" =
     rawLlmProvider === "proxy" ? "proxy" : "openai";
+  const llmProtocol = (
+    env("TDAI_LLM_PROTOCOL") ?? str(llmConfig, "protocol")
+  ) === "anthropic"
+    ? "anthropic"
+    : "openai";
   const llm: StandaloneLLMConfig = {
+    protocol: llmProtocol,
     baseUrl: env("TDAI_LLM_BASE_URL") ?? str(llmConfig, "baseUrl") ?? "https://api.openai.com/v1",
     apiKey: env("TDAI_LLM_API_KEY") ?? str(llmConfig, "apiKey") ?? "",
     model: env("TDAI_LLM_MODEL") ?? str(llmConfig, "model") ?? "gpt-4o",

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -1509,6 +1509,7 @@ export class TdaiGateway {
       ...baseConfig,
       llm: {
         enabled: true,
+        protocol: this.config.llm.protocol,
         baseUrl: this.config.llm.baseUrl,
         apiKey: this.config.llm.apiKey,
         model: this.config.llm.model,
@@ -1940,6 +1941,7 @@ export class TdaiGateway {
 
     const llmRunner = new StandaloneLLMRunner({
       config: {
+        protocol: effective.protocol,
         baseUrl: effective.baseUrl,
         apiKey: effective.apiKey,
         model: effective.model ?? "default",

--- a/MemoryCore/src/llm-protocol-config.test.ts
+++ b/MemoryCore/src/llm-protocol-config.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "./config.js";
+import { resolveStandaloneLlmForRuntime } from "./adapters/standalone/llm-provider-resolver.js";
+import { loadGatewayConfig } from "./gateway/config.js";
+
+describe("standalone LLM protocol configuration", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("parses anthropic and defaults unknown values to openai", () => {
+    expect(parseConfig({ llm: { protocol: "anthropic" } }).llm.protocol).toBe(
+      "anthropic",
+    );
+    expect(parseConfig({ llm: { protocol: "invalid" } }).llm.protocol).toBe(
+      "openai",
+    );
+  });
+
+  it("accepts TDAI_LLM_PROTOCOL for Gateway deployments", () => {
+    vi.stubEnv("TDAI_LLM_PROTOCOL", "anthropic");
+    expect(loadGatewayConfig().llm.protocol).toBe("anthropic");
+
+    vi.stubEnv("TDAI_LLM_PROTOCOL", "invalid");
+    expect(loadGatewayConfig().llm.protocol).toBe("openai");
+  });
+
+  it("preserves the wire protocol when proxy access rewrites credentials", () => {
+    vi.stubEnv("TDAI_MEMORY_SYSTEM_USER_KEY", `sk-mem-${"a".repeat(32)}`);
+    const llm = parseConfig({
+      llm: {
+        enabled: true,
+        provider: "proxy",
+        protocol: "anthropic",
+        baseUrl: "https://proxy.example.com",
+      },
+    }).llm;
+
+    expect(resolveStandaloneLlmForRuntime(llm, "tenant/a")).toMatchObject({
+      protocol: "anthropic",
+      baseUrl: "https://proxy.example.com/proxy/tenant%2Fa/v1",
+      apiKey: `sk-mem-${"a".repeat(32)}`,
+    });
+  });
+
+  it("writes MEMORY_LLM_PROTOCOL into the generated Gateway yaml", () => {
+    const script = readFileSync(
+      new URL("../../deploy/global-images/start-memory-core.sh", import.meta.url),
+      "utf8",
+    );
+    expect(script).toContain(
+      'protocol: "${MEMORY_LLM_PROTOCOL:-openai}"',
+    );
+  });
+});

--- a/MemoryCore/tdai-gateway.standalone.yaml
+++ b/MemoryCore/tdai-gateway.standalone.yaml
@@ -17,6 +17,7 @@ data:
 
 # ── LLM (必填) ──
 llm:
+  protocol: "openai"                # "openai" (/chat/completions) or "anthropic" (/messages)
   baseUrl: "https://api.openai.com/v1"
   apiKey: "${TDAI_LLM_API_KEY}"    # 通过环境变量注入
   model: "gpt-4o"

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -64,6 +64,7 @@ data:
   baseDir: /data/tdai-memory
 
 llm:
+  protocol: "${MEMORY_LLM_PROTOCOL:-openai}"
   baseUrl: "${MEMORY_LLM_BASE_URL:-}"
   apiKey: "${MEMORY_LLM_API_KEY:-}"
   model: "${MEMORY_LLM_MODEL:-}"


### PR DESCRIPTION
## Description | 描述

`MEMORY_LLM_PROTOCOL=anthropic` passed deployment verification but was dropped before MemoryCore runtime calls, so the standalone runner still sent OpenAI-compatible `/chat/completions` requests and L1 extraction failed with 404.

This PR:
- adds an explicit `openai | anthropic` wire-protocol setting while keeping `openai` as the backward-compatible default;
- selects `@ai-sdk/anthropic` for native `/v1/messages` requests;
- propagates the protocol through Gateway env/YAML loading, pipeline, seed, and per-instance skill runners;
- adds regression tests for config parsing, proxy resolution, deployment generation, provider selection, and the OpenAI default.

Access routing (`llm.provider=openai|proxy`) remains independent from the HTTP wire protocol. This change does not modify MemoryProxy or the separate offload HTTP client.

## Related Issue | 关联 Issue

Closes #709

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test` (6/6)
- `npm run build:plugin`
- `npm run lint:skill-isolation`
- `bash -n deploy/global-images/start-memory-core.sh`
- `git diff --check`

## Additional Notes | 其他说明

The Anthropic AI SDK normalizes the issue's `https://api.anthropic.com` base URL to `https://api.anthropic.com/v1`, so the original deployment configuration reaches the native `/v1/messages` endpoint without requiring a URL workaround.
