### PR TITLE
fix(panel): repair E2E package script entries

### DIFF
--- a/MemoryPanel/.env.example
+++ b/MemoryPanel/.env.example
@@ -47,4 +47,4 @@ KNOWLEDGE_LLM_PROXY_BASE_URL=http://127.0.0.1:8096
 
 # ── 联调 ──
 # Gateway：http://127.0.0.1:8420
-# Panel E2E：./tests/panel/e2e-panel-meta.sh
+# Panel E2E：pnpm test:panel:e2e

--- a/MemoryPanel/README.md
+++ b/MemoryPanel/README.md
@@ -97,8 +97,9 @@ npm run dev
 | `pnpm typecheck` | 执行 TypeScript 类型检查 |
 | `pnpm test` | 运行单元测试 |
 | `pnpm generate:meta-openapi` | 生成 Meta OpenAPI 文档 |
-| `pnpm test:panel:e2e` | 运行 Panel Meta E2E |
-| `pnpm test:knowledge:e2e` | 运行 Knowledge E2E |
+| `pnpm test:panel:e2e` | 依次运行 Knowledge 与 Skill 授权 E2E |
+| `pnpm test:knowledge:e2e` | 运行 Knowledge 资产授权 E2E |
+| `pnpm test:skill:e2e` | 运行 Skill 资产与 ACL E2E |
 | `cd web && npm run dev` | 启动前端开发服务器 |
 | `cd web && npm run build` | 构建前端到 `web/dist/` |
 | `bash scripts/secret-scan.sh` | 扫描敏感信息 |

--- a/MemoryPanel/package.json
+++ b/MemoryPanel/package.json
@@ -14,9 +14,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "generate:meta-openapi": "tsx scripts/generate-meta-openapi.ts",
-    "test:panel:e2e": "tests/panel/e2e-panel-meta.sh",
-    "test:knowledge:e2e": "tsx tests/knowledge/e2e-knowledge-chain.ts",
-    "test:knowledge:e2e:full": "E2E_MODE=full tsx tests/knowledge/e2e-knowledge-chain.ts",
+    "test:panel:e2e": "npm run test:knowledge:e2e && npm run test:skill:e2e",
+    "test:knowledge:e2e": "bash scripts/e2e-knowledge-authz.sh",
+    "test:skill:e2e": "bash scripts/e2e-skill-authz.sh",
     "mock-kernel": "tsx scripts/mock-memory-server.ts"
   },
   "dependencies": {

--- a/MemoryPanel/tests/config/package-scripts.test.ts
+++ b/MemoryPanel/tests/config/package-scripts.test.ts
@@ -1,0 +1,41 @@
+import { accessSync, constants, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const panelRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const packageJson = JSON.parse(
+  readFileSync(resolve(panelRoot, "package.json"), "utf8"),
+) as { scripts: Record<string, string> };
+const envExample = readFileSync(resolve(panelRoot, ".env.example"), "utf8");
+
+describe("MemoryPanel E2E package scripts", () => {
+  it("maps public E2E commands to the checked-in authz scripts", () => {
+    expect(packageJson.scripts["test:knowledge:e2e"]).toBe(
+      "bash scripts/e2e-knowledge-authz.sh",
+    );
+    expect(packageJson.scripts["test:skill:e2e"]).toBe(
+      "bash scripts/e2e-skill-authz.sh",
+    );
+    expect(packageJson.scripts["test:panel:e2e"]).toBe(
+      "npm run test:knowledge:e2e && npm run test:skill:e2e",
+    );
+    expect(packageJson.scripts["test:knowledge:e2e:full"]).toBeUndefined();
+  });
+
+  it("keeps both E2E shell entrypoints executable", () => {
+    for (const relativePath of [
+      "scripts/e2e-knowledge-authz.sh",
+      "scripts/e2e-skill-authz.sh",
+    ]) {
+      expect(() =>
+        accessSync(resolve(panelRoot, relativePath), constants.X_OK),
+      ).not.toThrow();
+    }
+  });
+
+  it("documents the public aggregate command instead of a removed script", () => {
+    expect(envExample).toContain("Panel E2E：pnpm test:panel:e2e");
+    expect(envExample).not.toContain("tests/panel/e2e-panel-meta.sh");
+  });
+});


### PR DESCRIPTION
## Description | 描述

MemoryPanel's public E2E package commands referenced test files that no longer exist:

- `test:panel:e2e` pointed to `tests/panel/e2e-panel-meta.sh`;
- `test:knowledge:e2e` pointed to `tests/knowledge/e2e-knowledge-chain.ts`;
- `test:knowledge:e2e:full` pointed to the same removed TypeScript entrypoint.

The repository already contains executable Knowledge and Skill authorization E2E scripts under `MemoryPanel/scripts/`. This PR maps the public commands to those maintained entrypoints, makes `test:panel:e2e` run both suites, updates the documented commands, and adds a regression test for script existence, executable permissions, and package mappings.

## Related Issue | 关联 Issue

L4 build/package audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `pnpm test` (3/3)
- `pnpm typecheck`
- `pnpm build`
- `bash -n scripts/e2e-knowledge-authz.sh`
- `bash -n scripts/e2e-skill-authz.sh`
- `git diff --check`

The live authorization E2E requests were not executed because they require running Gateway and Knowledge service instances with test credentials.

## Additional Notes | 其他说明

This changes package entrypoints and documentation only. It does not alter either authorization E2E implementation or production Panel behavior.
