### PR TITLE
fix(panel): reject failed knowledge binding responses

### DIFF
--- a/MemoryPanel/src/panel/startup/ensure-knowledge-llm-binding.ts
+++ b/MemoryPanel/src/panel/startup/ensure-knowledge-llm-binding.ts
@@ -74,7 +74,7 @@ async function ksPost<T>(
       signal: ctrl.signal,
     });
     const json = (await resp.json().catch(() => null)) as KsEnvelope<T> | null;
-    if (!json || (json.code !== undefined && json.code !== 0)) {
+    if (!resp.ok || !json || (json.code !== undefined && json.code !== 0)) {
       throw new Error(`KS ${path} failed (http ${resp.status}, code ${json?.code}): ${json?.message ?? ''}`);
     }
     return (json.data ?? {}) as T;

--- a/MemoryPanel/tests/startup/ensure-knowledge-llm-binding.test.ts
+++ b/MemoryPanel/tests/startup/ensure-knowledge-llm-binding.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { InstanceEntry } from '../../src/panel/config/instance-registry.js';
+import type { Logger } from '../../src/panel/infra/logger.js';
+import {
+  ensureKnowledgeLlmBinding,
+  type KnowledgeLlmBindingOptions,
+} from '../../src/panel/startup/ensure-knowledge-llm-binding.js';
+
+const instance: InstanceEntry = {
+  instance_id: 'instance-1',
+  name: 'Instance 1',
+  gateway_endpoint: 'http://gateway.test',
+  api_key: 'gateway-key',
+};
+
+const options: KnowledgeLlmBindingOptions = {
+  knowledgeBaseUrl: 'http://knowledge.test',
+  knowledgeAuthToken: 'knowledge-token',
+  proxyBaseUrl: 'http://proxy.test',
+  timeoutMs: 1_000,
+};
+
+function logger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+}
+
+function existingBindings() {
+  return new Map([
+    ['instance-1', {
+      service_id: 'instance-1',
+      mode: 'proxy',
+      proxy_base_url: 'http://old-proxy.test',
+      base_url: null,
+      has_api_key: true,
+      enabled: true,
+    }],
+  ]);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ensureKnowledgeLlmBinding', () => {
+  it('rejects non-success HTTP responses without an envelope code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })));
+
+    await expect(
+      ensureKnowledgeLlmBinding(instance, options, logger(), existingBindings()),
+    ).rejects.toThrow('http 500');
+  });
+
+  it('accepts successful legacy responses without an envelope code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })));
+
+    await expect(
+      ensureKnowledgeLlmBinding(instance, options, logger(), existingBindings()),
+    ).resolves.toBe('bound');
+  });
+});


### PR DESCRIPTION
## Description | 描述

The Panel startup binding client previously accepted any parseable JSON response unless it contained an explicit non-zero envelope code. An HTTP 500 response such as `{}` was therefore treated as success, and startup logged that the Knowledge Service binding had been refreshed even though the request failed.

This change also requires a successful HTTP status before accepting the response. Legacy 2xx responses without an envelope code remain supported. Focused tests cover both paths.

## Related Issue | 关联 Issue

Maintenance fix found during default-branch startup transport audit; no linked issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- `npx vitest run tests/startup/ensure-knowledge-llm-binding.test.ts` (2/2)
- `npm test` (2/2)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Impact | 影响范围

Only Panel startup calls to the Knowledge Service LLM-binding endpoints change. HTTP failures now enter the existing best-effort warning/recovery path. Successful legacy responses remain compatible. No API or configuration changes.

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The startup flow remains best-effort and does not block Panel startup.