### PR TITLE
fix(knowledge): bound MCP API requests

### DIFF
--- a/MemoryKnowledge/src/mcp/http-client.test.ts
+++ b/MemoryKnowledge/src/mcp/http-client.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { callApi } from "./http-client.js";
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("callApi", () => {
+  it("aborts a stalled request after the configured timeout", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        if (!init?.signal) {
+          reject(new Error("missing abort signal"));
+          return;
+        }
+        init.signal.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        }, { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    const request = callApi(
+      { baseUrl: "http://knowledge.test", timeoutMs: 25 },
+      "/wiki/search",
+      { query: "memory" },
+    );
+    const rejection = expect(request).rejects.toThrow(
+      "API request timed out after 25ms: /wiki/search",
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the deadline after a successful response", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      code: 0,
+      message: "ok",
+      data: { items: [] },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+
+    await expect(
+      callApi(
+        { baseUrl: "http://knowledge.test", timeoutMs: 25 },
+        "/wiki/search",
+        { query: "memory" },
+      ),
+    ).resolves.toEqual({ items: [] });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/MemoryKnowledge/src/mcp/http-client.ts
+++ b/MemoryKnowledge/src/mcp/http-client.ts
@@ -14,6 +14,8 @@ export interface HttpClientOptions {
   baseUrl: string;
   /** Optional bearer token for auth. */
   token?: string;
+  /** Request timeout in milliseconds. Defaults to 15 seconds. */
+  timeoutMs?: number;
 }
 
 export interface ApiResponse {
@@ -36,35 +38,53 @@ export async function callApi(
   const url = `${opts.baseUrl.replace(/\/$/, "")}/v3${endpoint}`;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (opts.token) headers["Authorization"] = `Bearer ${opts.token}`;
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   log.debug(`POST ${url}`);
 
-  let resp: Response;
   try {
-    resp = await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error(`fetch failed for ${endpoint}: ${msg}`);
-    throw err;
-  }
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (controller.signal.aborted) {
+        const timeoutError = new Error(`API request timed out after ${timeoutMs}ms: ${endpoint}`);
+        log.error(timeoutError.message);
+        throw timeoutError;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`fetch failed for ${endpoint}: ${msg}`);
+      throw err;
+    }
 
-  let json: ApiResponse;
-  try {
-    json = (await resp.json()) as ApiResponse;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error(`JSON parse failed for ${endpoint} (status=${resp.status}): ${msg}`);
-    throw new Error(`API error: ${resp.status} (invalid JSON)`);
-  }
+    let json: ApiResponse;
+    try {
+      json = (await resp.json()) as ApiResponse;
+    } catch (err) {
+      if (controller.signal.aborted) {
+        const timeoutError = new Error(`API request timed out after ${timeoutMs}ms: ${endpoint}`);
+        log.error(timeoutError.message);
+        throw timeoutError;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`JSON parse failed for ${endpoint} (status=${resp.status}): ${msg}`);
+      throw new Error(`API error: ${resp.status} (invalid JSON)`);
+    }
 
-  if (resp.status >= 400 || json.code !== 0) {
-    log.warn(`API error on ${endpoint}: status=${resp.status} code=${json.code} message="${json.message}"`);
-    throw new Error(json.message || `API error: ${resp.status}`);
-  }
+    if (resp.status >= 400 || json.code !== 0) {
+      log.warn(`API error on ${endpoint}: status=${resp.status} code=${json.code} message="${json.message}"`);
+      throw new Error(json.message || `API error: ${resp.status}`);
+    }
 
-  return json.data;
+    return json.data;
+  } finally {
+    clearTimeout(timer);
+  }
 }


### PR DESCRIPTION
## Description | 描述

The Knowledge MCP HTTP client previously called the Knowledge API without an abort signal or deadline. If the backend accepted a connection but never responded, the MCP tool call remained pending indefinitely.

This change adds a 15-second default request timeout with an optional `timeoutMs` override. The abort signal covers both the initial fetch and response-body read, timeout failures use a clear endpoint-specific error, and the deadline timer is cleared on every exit path.

## Related Issue | 关联 Issue

Maintenance fix found during default-branch MCP transport audit; no linked issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- `npx vitest run src/mcp/http-client.test.ts` (2/2)
- `npm test` (2/2)
- strict changed-file TypeScript check
- `npm run build` (11 files)
- `git diff --check`

## Impact | 影响范围

Only the Knowledge MCP stdio client transport changes. Normal responses and existing API/envelope errors are unchanged. Stalled requests now fail after a bounded deadline. No breaking API change; `timeoutMs` is optional.

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The repository-wide Knowledge typecheck still fails on the unchanged default-branch error in `src/middleware/response-envelope.ts:47` (`Promise<string>` is not assignable to `string`). The changed source and test pass strict TypeScript checking independently.