### PR TITLE
fix(offload): clear client request deadlines

### DIFF
--- a/MemoryCore/src/offload-client/offload-api-client.test.ts
+++ b/MemoryCore/src/offload-client/offload-api-client.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OffloadApiClient } from "./offload-api-client.js";
+import type { Logger, OffloadClientConfig } from "./types.js";
+
+const config: OffloadClientConfig = {
+  enabled: true,
+  serverUrl: "http://127.0.0.1:9100",
+  apiKey: "test-key",
+  serviceId: "test-service",
+  compactionRatio: 0.5,
+  ingestTimeoutMs: 5_000,
+  compactionTimeoutMs: 30_000,
+};
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("OffloadApiClient timeout cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["health", (client: OffloadApiClient) => client.checkHealth()],
+    ["ingest", (client: OffloadApiClient) => client.ingest("session-1", [])],
+    ["L1.5 ingest", (client: OffloadApiClient) => client.ingestL15("session-1", "prompt")],
+    ["compaction", (client: OffloadApiClient) => client.compaction({
+      sessionId: "session-1",
+      messages: [],
+      ratio: 0.8,
+      contextWindow: 128_000,
+      totalTokens: 100_000,
+    })],
+  ])("clears the %s deadline after fetch rejects", async (_name, run) => {
+    await run(new OffloadApiClient(config, logger));
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/MemoryCore/src/offload-client/offload-api-client.ts
+++ b/MemoryCore/src/offload-client/offload-api-client.ts
@@ -12,14 +12,10 @@ export class OffloadApiClient {
   /** Health check: GET /v2/offload/health. Returns true if server is reachable (any HTTP response = reachable). */
   async checkHealth(): Promise<boolean> {
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-      const res = await fetch(`${this.config.serverUrl}/v2/offload/health`, {
+      const res = await this.fetchWithTimeout(`${this.config.serverUrl}/v2/offload/health`, {
         method: "GET",
         headers: { Authorization: `Bearer ${this.config.apiKey}` },
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
+      }, 5000);
       // Any HTTP response (including 401/403) means server is reachable
       return res.status < 500;
     } catch {
@@ -63,17 +59,11 @@ export class OffloadApiClient {
     const body = JSON.stringify(payload);
 
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), this.config.ingestTimeoutMs);
-
-      await fetch(url, {
+      await this.fetchWithTimeout(url, {
         method: "POST",
         headers: this.buildHeaders(),
         body,
-        signal: controller.signal,
-      });
-
-      clearTimeout(timer);
+      }, this.config.ingestTimeoutMs);
     } catch (err) {
       this.logger.warn(`[offload-client] ingest failed: ${err}`);
     }
@@ -94,17 +84,11 @@ export class OffloadApiClient {
     const body = JSON.stringify(payload);
 
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), this.config.ingestTimeoutMs);
-
-      const response = await fetch(url, {
+      const response = await this.fetchWithTimeout(url, {
         method: "POST",
         headers: this.buildHeaders(),
         body,
-        signal: controller.signal,
-      });
-
-      clearTimeout(timer);
+      }, this.config.ingestTimeoutMs);
 
       if (!response.ok) {
         this.logger.warn(`[offload-client] ingestL15 returned ${response.status}`);
@@ -137,17 +121,11 @@ export class OffloadApiClient {
     });
 
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), this.config.compactionTimeoutMs);
-
-      const response = await fetch(url, {
+      const response = await this.fetchWithTimeout(url, {
         method: "POST",
         headers: this.buildHeaders(),
         body,
-        signal: controller.signal,
-      });
-
-      clearTimeout(timer);
+      }, this.config.compactionTimeoutMs);
 
       if (!response.ok) {
         this.logger.warn(`[offload-client] compaction returned ${response.status}`);
@@ -164,6 +142,20 @@ export class OffloadApiClient {
     } catch (err) {
       this.logger.warn(`[offload-client] compaction failed: ${err}`);
       return null;
+    }
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
     }
   }
 


### PR DESCRIPTION
## Description | 描述

`OffloadApiClient` created an abort deadline for each health, ingest, L1.5, and compaction request, but cleared it only after `fetch()` resolved. An immediate connection or transport rejection returned through `catch` while leaving the timer active for another 5-30 seconds.

This PR:
- centralizes the repeated timeout setup in a private request helper;
- clears every deadline in `finally`, covering both resolve and reject paths;
- adds fake-timer regression coverage for all four public request paths.

Timeout values, response handling, logging, and Offload Server API contracts are unchanged.

## Related Issue | 关联 Issue

L3 resource-lifecycle audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test` (4/4)
- `npm run build:plugin`
- `npm run lint:skill-isolation`
- `git diff --check`

## Additional Notes | 其他说明

The test rejects `fetch()` immediately and verifies that no pending timer remains after each API method returns.
