### PR TITLE
fix(telemetry): drain ClickHouse inserts on shutdown

### DIFF
--- a/MemoryCore/src/core/report/clickhouse-exporter.test.ts
+++ b/MemoryCore/src/core/report/clickhouse-exporter.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  createClient: vi.fn(),
+  insert: vi.fn(),
+}));
+
+vi.mock("@clickhouse/client", () => ({
+  createClient: mocks.createClient,
+}));
+
+import { ClickHouseDirectExporter } from "./clickhouse-exporter.js";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("ClickHouseDirectExporter shutdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.createClient.mockReturnValue({
+      close: mocks.close,
+      insert: mocks.insert,
+    });
+    mocks.close.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for threshold-triggered inserts before closing once", async () => {
+    const insert = deferred();
+    mocks.insert.mockReturnValueOnce(insert.promise);
+    const exporter = new ClickHouseDirectExporter({
+      batchSize: 1,
+      flushIntervalMs: 60_000,
+    });
+
+    exporter.exportLog({ body: "pending log" });
+    const firstShutdown = exporter.shutdown();
+    const secondShutdown = exporter.shutdown();
+
+    expect(secondShutdown).toBe(firstShutdown);
+    expect(mocks.insert).toHaveBeenCalledTimes(1);
+    expect(mocks.close).not.toHaveBeenCalled();
+
+    insert.resolve();
+    await firstShutdown;
+
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("flushes rows requeued by a failed in-flight insert before closing", async () => {
+    const insert = deferred();
+    mocks.insert
+      .mockReturnValueOnce(insert.promise)
+      .mockResolvedValueOnce(undefined);
+    const exporter = new ClickHouseDirectExporter({
+      batchSize: 1,
+      flushIntervalMs: 60_000,
+    });
+
+    exporter.exportLog({ body: "retry on shutdown" });
+    const shutdown = exporter.shutdown();
+
+    insert.reject(new Error("temporary failure"));
+    await shutdown;
+
+    expect(mocks.insert).toHaveBeenCalledTimes(2);
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/MemoryCore/src/core/report/clickhouse-exporter.ts
+++ b/MemoryCore/src/core/report/clickhouse-exporter.ts
@@ -172,9 +172,11 @@ export class ClickHouseDirectExporter {
 
   // 并发控制
   private activeInserts = 0;
+  private readonly pendingInserts = new Set<Promise<void>>();
 
   private flushTimer: ReturnType<typeof setInterval> | undefined;
   private _shutdown = false;
+  private shutdownPromise: Promise<void> | undefined;
 
   constructor(options: ClickHouseExporterOptions = {}) {
     const endpoint = options.endpoint
@@ -497,12 +499,24 @@ export class ClickHouseDirectExporter {
   /**
    * 优雅关闭：flush 剩余数据，关闭连接池.
    */
-  async shutdown(): Promise<void> {
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownPromise = this.performShutdown();
+    return this.shutdownPromise;
+  }
+
+  private async performShutdown(): Promise<void> {
     this._shutdown = true;
     if (this.flushTimer) {
       clearInterval(this.flushTimer);
       this.flushTimer = undefined;
     }
+
+    // Drain rows still buffered, then wait for threshold-triggered inserts that
+    // were already running in the background. A failed in-flight insert may
+    // requeue its rows, so flush once more before closing the shared client.
+    await this.flush();
+    await Promise.allSettled([...this.pendingInserts]);
     await this.flush();
     await this.client.close();
     if (this.debug) {
@@ -566,26 +580,35 @@ export class ClickHouseDirectExporter {
     }
 
     this.activeInserts++;
-    try {
-      await this.client.insert({
-        table,
-        values: rows,
-        format: "JSONEachRow",
-      });
+    const pending = (async () => {
+      try {
+        await this.client.insert({
+          table,
+          values: rows,
+          format: "JSONEachRow",
+        });
 
-      if (this.debug) {
-        console.debug(`[clickhouse-exporter] INSERT ${table}: ${rows.length} rows OK`);
+        if (this.debug) {
+          console.debug(`[clickhouse-exporter] INSERT ${table}: ${rows.length} rows OK`);
+        }
+      } catch (err) {
+        if (this.debug) {
+          console.warn(
+            `[clickhouse-exporter] INSERT ${table} error: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        // 失败的数据放回缓冲区
+        this.requeue(table, rows);
+      } finally {
+        this.activeInserts--;
       }
-    } catch (err) {
-      if (this.debug) {
-        console.warn(
-          `[clickhouse-exporter] INSERT ${table} error: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-      // 失败的数据放回缓冲区
-      this.requeue(table, rows);
+    })();
+
+    this.pendingInserts.add(pending);
+    try {
+      await pending;
     } finally {
-      this.activeInserts--;
+      this.pendingInserts.delete(pending);
     }
   }
 


### PR DESCRIPTION
## Description | 描述

`ClickHouseDirectExporter` starts inserts in the background when a buffer reaches `batchSize`. `shutdown()` flushed only the rows still in memory and then closed the shared client immediately, without waiting for those threshold-triggered inserts. A delayed request could therefore finish after client close, and a failed request could requeue rows after the final flush.

This PR:
- tracks every in-flight insert promise;
- waits for existing inserts during shutdown;
- performs a second flush for rows requeued by failed inserts before closing;
- makes shutdown idempotent because the OTel span and log adapters share one exporter;
- adds deterministic tests for delayed and failed in-flight inserts.

Batch sizing, buffer limits, ClickHouse schema, and normal runtime export behavior are unchanged.

## Related Issue | 关联 Issue

L3 telemetry lifecycle audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test` (2/2)
- `npm run build:plugin`
- `npm run lint:skill-isolation`
- `git diff --check`

## Additional Notes | 其他说明

The tests hold an insert promise pending and verify that client close cannot run early. They also reject an in-flight insert and verify its requeued row is flushed before the single client close.
