### PR TITLE
fix(panel): retry failed knowledge callbacks

### DIFF
--- a/MemoryPanel/src/panel/http/routes/knowledge/callback-routes.ts
+++ b/MemoryPanel/src/panel/http/routes/knowledge/callback-routes.ts
@@ -135,13 +135,13 @@ export function registerKnowledgeCallbackRoutes(api: Hono, deps: PanelDeps): voi
         if (body.type === 'wiki') {
           const detail = await kc.wikiGet(body.knowledge_id);
           if (!detail?.service_url) {
-            log.error(`[knowledge-callback] wiki ${body.knowledge_id}: null service_url; skip kernel detail sync`);
+            throw new Error(`wiki ${body.knowledge_id}: null service_url`);
           } else {
             log.info('[knowledge-callback] wiki → writing kernel entity', {
               knowledge_id: detail.wiki_id, team_id: detail.team_id, owner: detail.owner_user_id,
               has_summary: !!body.summary,
             });
-            await deps.kernelHttp.postEnvelope('/v3/knowledge/create', {
+            const env = await deps.kernelHttp.postEnvelope('/v3/knowledge/create', {
               knowledge_id: detail.wiki_id,
               type: 'wiki',
               service_url: detail.service_url,
@@ -150,6 +150,9 @@ export function registerKnowledgeCallbackRoutes(api: Hono, deps: PanelDeps): voi
               team_id: detail.team_id,
               user_id: detail.owner_user_id,
             }, cred);
+            if (env.code !== 0) {
+              throw new Error(`kernel knowledge/create rejected: code=${env.code} message=${env.message}`);
+            }
             log.info('[knowledge-callback] wiki → kernel entity written', { knowledge_id: detail.wiki_id });
             // wiki 的 meta 资产在创建时已注册，callback 不再重复注册。
           }
@@ -160,13 +163,13 @@ export function registerKnowledgeCallbackRoutes(api: Hono, deps: PanelDeps): voi
             has_service_url: !!detail?.service_url, owner: detail?.owner_user_id,
           });
           if (!detail?.service_url) {
-            log.error(`[knowledge-callback] code-graph ${body.knowledge_id}: null service_url; skip kernel detail sync`);
+            throw new Error(`code-graph ${body.knowledge_id}: null service_url`);
           } else {
             log.info('[knowledge-callback] code-graph → writing kernel entity', {
               knowledge_id: detail.code_graph_id, team_id: detail.team_id, owner: detail.owner_user_id,
               has_summary: !!body.summary,
             });
-            await deps.kernelHttp.postEnvelope('/v3/knowledge/create', {
+            const env = await deps.kernelHttp.postEnvelope('/v3/knowledge/create', {
               knowledge_id: detail.code_graph_id,
               type: 'code-graph',
               service_url: detail.service_url,
@@ -177,6 +180,9 @@ export function registerKnowledgeCallbackRoutes(api: Hono, deps: PanelDeps): voi
               repo_url: detail.repo_url,
               branch: detail.branch,
             }, cred);
+            if (env.code !== 0) {
+              throw new Error(`kernel knowledge/create rejected: code=${env.code} message=${env.message}`);
+            }
             log.info('[knowledge-callback] code-graph → kernel entity written', { knowledge_id: detail.code_graph_id });
             // 注册 meta asset（主力路径）：用 create 时 stash 的 owner key 以 owner 身份
             // 打 /v3/meta/asset/create。callback 本身是 S2S 无 user_key，靠内存任务表补。
@@ -186,6 +192,12 @@ export function registerKnowledgeCallbackRoutes(api: Hono, deps: PanelDeps): voi
         }
       } catch (err) {
         log.error(`[knowledge-callback] kernel detail sync error for ${body.knowledge_id}: ${(err as Error).message}`);
+        return c.json({
+          code: 502,
+          message: 'knowledge detail sync failed',
+          request_id: '',
+          data: null,
+        }, 502);
       }
     } else if (body.status === 'failed') {
       log.info('[knowledge-callback] failed; not writing entity/meta (UI reads KS status)', { knowledge_id: body.knowledge_id, sync_error: body.sync_error });

--- a/MemoryPanel/tests/knowledge/callback-retry.test.ts
+++ b/MemoryPanel/tests/knowledge/callback-retry.test.ts
@@ -1,0 +1,100 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PanelDeps } from '../../src/panel/panel-deps.js';
+import { registerKnowledgeCallbackRoutes } from '../../src/panel/http/routes/knowledge/callback-routes.js';
+
+function wikiDetail() {
+  return {
+    wiki_id: 'wiki-1',
+    team_id: 'team-1',
+    name: 'Wiki 1',
+    service_url: 'http://knowledge.test/v3/wiki/wiki-1',
+    owner_user_id: 'user-1',
+  };
+}
+
+function createDeps(overrides: {
+  wikiGet?: () => Promise<ReturnType<typeof wikiDetail>>;
+  postEnvelope?: () => Promise<{ code: number; message: string; data: unknown }>;
+} = {}): PanelDeps {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  return {
+    config: { metadataRemoteTimeoutMs: 1_000 },
+    logger,
+    instanceRegistry: {
+      resolve: vi.fn(() => ({
+        instance_id: 'instance-1',
+        name: 'Instance 1',
+        gateway_endpoint: 'http://gateway.test',
+        api_key: 'gateway-key',
+      })),
+    },
+    knowledgeClientFactory: vi.fn(() => ({
+      wikiGet: overrides.wikiGet ?? vi.fn(async () => wikiDetail()),
+    })),
+    kernelHttp: {
+      postEnvelope: overrides.postEnvelope ?? vi.fn(async () => ({
+        code: 0,
+        message: 'ok',
+        data: {},
+      })),
+    },
+    knowledgeTaskRegistry: {
+      peek: vi.fn(),
+      take: vi.fn(),
+    },
+  } as unknown as PanelDeps;
+}
+
+async function sendReadyCallback(deps: PanelDeps): Promise<Response> {
+  const app = new Hono();
+  registerKnowledgeCallbackRoutes(app, deps);
+  return app.request('/knowledge/status-callback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      knowledge_id: 'wiki-1',
+      service_id: 'instance-1',
+      type: 'wiki',
+      status: 'ready',
+      summary: 'summary',
+    }),
+  });
+}
+
+describe('knowledge status callback retry semantics', () => {
+  it('returns a retryable status when the Knowledge detail fetch fails', async () => {
+    const response = await sendReadyCallback(createDeps({
+      wikiGet: vi.fn(async () => {
+        throw new Error('Knowledge unavailable');
+      }),
+    }));
+
+    expect(response.status).toBe(502);
+  });
+
+  it('returns a retryable status when the kernel rejects detail persistence', async () => {
+    const response = await sendReadyCallback(createDeps({
+      postEnvelope: vi.fn(async () => ({
+        code: 503,
+        message: 'kernel unavailable',
+        data: null,
+      })),
+    }));
+
+    expect(response.status).toBe(502);
+  });
+
+  it('acknowledges a fully persisted ready callback', async () => {
+    const response = await sendReadyCallback(createDeps());
+
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Description | 描述

Knowledge Service retries status callbacks only when Panel returns a non-success HTTP status. Panel previously caught ready-callback failures while fetching Knowledge detail or persisting the kernel detail entity, then still returned HTTP 200. That permanently acknowledged a callback even though the kernel entity used as the injection gate was missing.

This change returns HTTP 502 for critical ready-callback synchronization failures, validates the kernel envelope, and treats a missing `service_url` as incomplete synchronization. Successful callbacks remain HTTP 200. Code-graph meta-asset registration remains best-effort as designed.

## Related Issue | 关联 Issue

Maintenance fix found during default-branch callback reliability audit; no linked issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- `npx vitest run tests/knowledge/callback-retry.test.ts` (3/3)
- `npm test` (3/3)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Impact | 影响范围

Only ready status callbacks whose critical detail synchronization fails change from HTTP 200 to 502. Knowledge Service already retries non-success callbacks once. Successful and failed-status callbacks are unchanged. No API payload or configuration changes.

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Meta-asset registration still logs and degrades to the existing frontend fallback instead of failing the callback.