### PR TITLE
fix(core): retry failed store initialization

### DIFF
--- a/MemoryCore/src/utils/pipeline-factory-init.test.ts
+++ b/MemoryCore/src/utils/pipeline-factory-init.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { MemoryTdaiConfig } from "../config.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const mocks = vi.hoisted(() => ({
+  createStoreBundle: vi.fn(),
+}));
+
+vi.mock("../core/store/factory.js", () => ({
+  createStoreBundle: mocks.createStoreBundle,
+}));
+
+import {
+  initStores,
+  resetStores,
+  type PipelineLogger,
+} from "./pipeline-factory.js";
+
+const cfg = {
+  storeBackend: "sqlite",
+  embedding: { provider: "none" },
+} as unknown as MemoryTdaiConfig;
+
+const logger: PipelineLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function store(
+  init: IMemoryStore["init"],
+  degraded = false,
+): IMemoryStore {
+  return {
+    init,
+    isDegraded: () => degraded,
+  } as unknown as IMemoryStore;
+}
+
+function bundle(vectorStore: IMemoryStore) {
+  return {
+    store: vectorStore,
+    embedding: undefined,
+    storeSnapshot: { type: "sqlite", sqlitePath: "vectors.db" },
+  };
+}
+
+afterEach(() => {
+  resetStores();
+  mocks.createStoreBundle.mockReset();
+  vi.clearAllMocks();
+});
+
+describe("initStores cache lifecycle", () => {
+  it("retries after a failed initialization result", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "store-init-retry-"));
+    const failedStore = store(vi.fn().mockRejectedValue(new Error("offline")));
+    const healthyStore = store(
+      vi.fn().mockResolvedValue({ needsReindex: false }),
+    );
+    mocks.createStoreBundle
+      .mockReturnValueOnce(bundle(failedStore))
+      .mockReturnValueOnce(bundle(healthyStore));
+
+    try {
+      const first = initStores(cfg, dataDir, logger);
+      const second = initStores(cfg, dataDir, logger);
+      expect(first).toBe(second);
+      await expect(first).resolves.toMatchObject({
+        vectorStore: undefined,
+        embeddingService: undefined,
+      });
+      await expect(second).resolves.toMatchObject({
+        vectorStore: undefined,
+        embeddingService: undefined,
+      });
+      expect(mocks.createStoreBundle).toHaveBeenCalledTimes(1);
+
+      await expect(initStores(cfg, dataDir, logger)).resolves.toMatchObject({
+        vectorStore: healthyStore,
+        needsReindex: false,
+      });
+      expect(mocks.createStoreBundle).toHaveBeenCalledTimes(2);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still shares one successful initialization across concurrent callers", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "store-init-dedupe-"));
+    let resolveInit!: (value: { needsReindex: boolean }) => void;
+    const initResult = new Promise<{ needsReindex: boolean }>((resolve) => {
+      resolveInit = resolve;
+    });
+    const healthyStore = store(vi.fn(() => initResult));
+    mocks.createStoreBundle.mockReturnValue(bundle(healthyStore));
+
+    try {
+      const first = initStores(cfg, dataDir, logger);
+      const second = initStores(cfg, dataDir, logger);
+      expect(first).toBe(second);
+      expect(mocks.createStoreBundle).toHaveBeenCalledTimes(1);
+
+      resolveInit({ needsReindex: false });
+      await expect(first).resolves.toMatchObject({
+        vectorStore: healthyStore,
+      });
+      await expect(second).resolves.toMatchObject({
+        vectorStore: healthyStore,
+      });
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/src/utils/pipeline-factory.ts
+++ b/MemoryCore/src/utils/pipeline-factory.ts
@@ -234,8 +234,10 @@ const _storeInitCache = new Map<string, Promise<StoreInitResult>>();
  * Initialize store backend and (optionally) EmbeddingService.
  *
  * **Once-async semantics per dataDir**: the first call for a given
- * `pluginDataDir` creates the store and caches the result; subsequent
- * calls with the same dir return the cached Promise immediately.
+ * `pluginDataDir` creates the store and caches the result; concurrent and
+ * subsequent calls with the same dir return the cached Promise immediately.
+ * Failed/degraded results are evicted after they settle so a later call can
+ * retry without requiring a full process restart.
  * Call `resetStores()` during shutdown to clear the cache.
  *
  * Supports both SQLite (sync init) and TCVDB (async init) backends.
@@ -246,10 +248,29 @@ export function initStores(
   logger: PipelineLogger,
 ): Promise<StoreInitResult> {
   const key = pluginDataDir;
-  if (!_storeInitCache.has(key)) {
-    _storeInitCache.set(key, _doInitStores(cfg, pluginDataDir, logger));
-  }
-  return _storeInitCache.get(key)!;
+  const cached = _storeInitCache.get(key);
+  if (cached) return cached;
+
+  let cacheEntry: Promise<StoreInitResult>;
+  cacheEntry = _doInitStores(cfg, pluginDataDir, logger).then(
+    (result) => {
+      if (
+        !result.vectorStore &&
+        _storeInitCache.get(key) === cacheEntry
+      ) {
+        _storeInitCache.delete(key);
+      }
+      return result;
+    },
+    (err) => {
+      if (_storeInitCache.get(key) === cacheEntry) {
+        _storeInitCache.delete(key);
+      }
+      throw err;
+    },
+  );
+  _storeInitCache.set(key, cacheEntry);
+  return cacheEntry;
 }
 
 /**


### PR DESCRIPTION
## Description | 描述

`initStores()` caches the first initialization Promise for each data directory. When a transient backend failure is converted into a degraded result (`vectorStore: undefined`), that resolved Promise currently remains cached indefinitely. Every later caller receives the same unusable result until shutdown explicitly calls `resetStores()`.

This PR keeps successful initialization cached, but evicts failed or degraded results after they settle so a later request can retry. Cache deletion is guarded by Promise identity, preventing an older completion from deleting a newer entry after an explicit reset. Concurrent callers still share one in-flight initialization.

Regression tests cover both lifecycle guarantees:

- concurrent callers share one failed initialization, followed by a successful retry;
- concurrent callers continue to share one successful initialization.

## Related Issue | 关联 Issue

No existing issue. Discovered during a default-branch MemoryCore lifecycle audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm vitest run src/utils/pipeline-factory-init.test.ts` - 1 file, 2 tests passed
- `pnpm test` - 1 file, 2 tests passed
- `npm run build:plugin` - 6 output files built
- `npm run build:migrate-sqlite-to-vdb` - passed
- `npm run build:export-tencent-vdb` - passed
- `npm run build:read-local-memory` - passed
- `git diff --check` - passed

The aggregate `pnpm build` reaches the existing `build:seed-v2` step and then fails because `scripts/seed-v2/tsconfig.json` is absent on the base branch. All preceding production and script build steps pass.

## Additional Notes | 其他说明

- No public API, configuration, storage schema, or dependency changes.
- Successful store initialization retains the existing once-per-data-directory behavior.
- Full Open PR title/body and changed-file checks found no active implementation of failed `initStores()` retry behavior on `feat/server_team`.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
