### PR TITLE
fix(knowledge): terminate after telemetry flush

### DIFF
--- a/MemoryKnowledge/src/telemetry.test.ts
+++ b/MemoryKnowledge/src/telemetry.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTelemetrySigtermHandler } from "./telemetry.js";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("createTelemetrySigtermHandler", () => {
+  it("flushes telemetry before terminating and ignores duplicate signals", async () => {
+    const pending = deferred();
+    const shutdown = vi.fn(() => pending.promise);
+    const terminate = vi.fn();
+    const handler = createTelemetrySigtermHandler({ shutdown }, terminate);
+
+    handler();
+    handler();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(terminate).not.toHaveBeenCalled();
+
+    pending.resolve();
+    await pending.promise;
+    await Promise.resolve();
+
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("still terminates when telemetry shutdown fails", async () => {
+    const terminate = vi.fn();
+    const handler = createTelemetrySigtermHandler({
+      shutdown: vi.fn(async () => {
+        throw new Error("flush failed");
+      }),
+    }, terminate);
+
+    handler();
+    await vi.waitFor(() => {
+      expect(terminate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/MemoryKnowledge/src/telemetry.ts
+++ b/MemoryKnowledge/src/telemetry.ts
@@ -21,6 +21,35 @@ const log = createLogger("telemetry");
 
 let sdk: NodeSDK | null = null;
 
+interface TelemetrySdk {
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Build a one-shot SIGTERM handler that flushes telemetry before restoring the
+ * signal's terminating behavior. The injected terminate hook keeps lifecycle
+ * behavior deterministic in tests.
+ */
+export function createTelemetrySigtermHandler(
+  telemetrySdk: TelemetrySdk,
+  terminate: () => void = () => {
+    process.kill(process.pid, "SIGTERM");
+  },
+): () => void {
+  let shuttingDown = false;
+  return () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    void telemetrySdk.shutdown()
+      .catch((err) => {
+        log.warn("Langfuse telemetry shutdown failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(terminate);
+  };
+}
+
 /** 初始化 OpenTelemetry + Langfuse。未配置 key 时静默跳过。 */
 export function initTelemetry(): void {
   if (sdk) return; // 防止重复初始化
@@ -51,9 +80,9 @@ export function initTelemetry(): void {
   }
 
   // 优雅退出时 flush 残留 span
-  process.on("SIGTERM", () => {
-    sdk?.shutdown().catch(() => {});
-  });
+  if (sdk) {
+    process.once("SIGTERM", createTelemetrySigtermHandler(sdk));
+  }
 }
 
 // ── Tracing helpers ──


### PR DESCRIPTION
## Description | 描述

When Langfuse telemetry is enabled, Knowledge Service installs a `SIGTERM` listener to flush pending spans. Installing that listener suppresses Node's default SIGTERM termination, but the existing handler only started `sdk.shutdown()` and never exited or restored the signal behavior. The HTTP service could therefore remain alive after telemetry flush.

This change installs a one-shot handler that flushes telemetry once, logs shutdown failures, and then re-sends SIGTERM after the listener has been removed so Node resumes its default termination behavior. Focused tests verify ordering, duplicate-signal suppression, and failure handling.

## Related Issue | 关联 Issue

Maintenance fix found during default-branch telemetry lifecycle audit; no linked issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Verification | 验证方式

- `npx vitest run src/telemetry.test.ts` (2/2)
- `npm test` (2/2)
- strict changed-file TypeScript check
- `npm run build` (11 files)
- `git diff --check`

## Impact | 影响范围

Only SIGTERM handling when Knowledge Langfuse telemetry is enabled changes. Telemetry still receives a graceful flush opportunity, and the process now terminates afterward even if flush fails. No API or configuration changes.

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The repository-wide Knowledge typecheck still fails on the unchanged default-branch error in `src/middleware/response-envelope.ts:47`; the changed files pass strict TypeScript checking independently.