### PR TITLE
fix(knowledge): validate LLM binding inputs

### DIFF
--- a/MemoryKnowledge/src/routes/llm-binding.test.ts
+++ b/MemoryKnowledge/src/routes/llm-binding.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ILlmBindingStore,
+  LlmBindingInput,
+  LlmBindingRow,
+} from "../store/llm-binding-store.js";
+import { createLlmBindingRoutes } from "./llm-binding.js";
+
+const SERVICE_ID = "service-1";
+
+function binding(overrides: Partial<LlmBindingRow> = {}): LlmBindingRow {
+  return {
+    service_id: SERVICE_ID,
+    mode: "proxy",
+    proxy_base_url: "https://proxy.example.com",
+    api_key: "existing-key",
+    base_url: null,
+    enabled: true,
+    updated_at: "2026-08-03T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createStore(initial: LlmBindingRow | null = null) {
+  let current = initial;
+  const upsert = vi.fn(
+    (serviceId: string, input: LlmBindingInput): LlmBindingRow => {
+      const previous = current;
+      current = binding({
+        service_id: serviceId,
+        mode: input.mode,
+        proxy_base_url: input.proxy_base_url ?? null,
+        api_key:
+          input.api_key === undefined
+            ? (previous?.api_key ?? null)
+            : input.api_key,
+        base_url: input.base_url ?? null,
+        enabled: input.enabled !== false,
+      });
+      return current;
+    },
+  );
+  const store: ILlmBindingStore = {
+    get: vi.fn(() => current),
+    listAll: vi.fn(() => (current ? [current] : [])),
+    upsert,
+    status: vi.fn(() => ({
+      bound: current !== null,
+      mode: current?.mode ?? null,
+      enabled: current?.enabled ?? false,
+    })),
+  };
+  return { store, upsert };
+}
+
+async function setBinding(
+  store: ILlmBindingStore,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return await createLlmBindingRoutes({ llmBindingStore: store }).request("/set", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-tdai-service-id": SERVICE_ID,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /set", () => {
+  it.each(["", "   ", "\t\n"])(
+    "rejects an explicitly blank API key %#",
+    async (apiKey) => {
+      const { store, upsert } = createStore(binding());
+      const response = await setBinding(store, {
+        mode: "proxy",
+        proxy_base_url: "https://proxy.example.com",
+        api_key: apiKey,
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        code: 400,
+        message: "api_key must be a non-blank string",
+      });
+      expect(upsert).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["proxy", "proxy_base_url", "   "],
+    ["proxy", "proxy_base_url", "not a URL"],
+    ["proxy", "proxy_base_url", "ftp://proxy.example.com"],
+    ["byo", "base_url", "\n\t"],
+    ["byo", "base_url", "/relative/v1"],
+    ["byo", "base_url", "file:///tmp/llm.sock"],
+  ] as const)(
+    "rejects an invalid %s endpoint %#",
+    async (mode, field, endpoint) => {
+      const { store, upsert } = createStore();
+      const response = await setBinding(store, {
+        mode,
+        [field]: endpoint,
+        api_key: "secret",
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        code: 400,
+        message: `${field} must be a valid HTTP(S) URL`,
+      });
+      expect(upsert).not.toHaveBeenCalled();
+    },
+  );
+
+  it("normalizes the endpoint without modifying a non-blank API key", async () => {
+    const { store, upsert } = createStore();
+    const response = await setBinding(store, {
+      mode: "proxy",
+      proxy_base_url: "  https://proxy.example.com/v1/  ",
+      api_key: "  exact secret  ",
+    });
+
+    expect(response.status).toBe(200);
+    expect(upsert).toHaveBeenCalledWith(
+      SERVICE_ID,
+      expect.objectContaining({
+        proxy_base_url: "https://proxy.example.com/v1/",
+        api_key: "  exact secret  ",
+      }),
+    );
+  });
+
+  it("preserves the existing API key when the field is omitted", async () => {
+    const { store, upsert } = createStore(binding());
+    const response = await setBinding(store, {
+      mode: "byo",
+      base_url: "http://llm.example.com/v1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(upsert).toHaveBeenCalledWith(
+      SERVICE_ID,
+      expect.objectContaining({
+        base_url: "http://llm.example.com/v1",
+        api_key: undefined,
+      }),
+    );
+  });
+});

--- a/MemoryKnowledge/src/routes/llm-binding.ts
+++ b/MemoryKnowledge/src/routes/llm-binding.ts
@@ -29,8 +29,22 @@ function isMode(v: unknown): v is LlmBindingMode {
   return v === "proxy" || v === "byo";
 }
 
-function asOptString(v: unknown): string | undefined {
-  return typeof v === "string" && v.length > 0 ? v : undefined;
+function asNonBlankString(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim().length > 0 ? v : undefined;
+}
+
+function asHttpUrl(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const value = v.trim();
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:") && url.hostname
+      ? value
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function createLlmBindingRoutes(deps: LlmBindingRouteDeps): Hono {
@@ -51,10 +65,20 @@ export function createLlmBindingRoutes(deps: LlmBindingRouteDeps): Hono {
       return c.json(wrapError(400, "mode must be 'proxy' or 'byo'"), 400);
     }
 
-    const apiKey = asOptString(body.api_key);
-    const proxyBaseUrl = asOptString(body.proxy_base_url);
-    const baseUrl = asOptString(body.base_url);
+    const apiKey = asNonBlankString(body.api_key);
+    const proxyBaseUrl = asHttpUrl(body.proxy_base_url);
+    const baseUrl = asHttpUrl(body.base_url);
     const enabled = body.enabled === undefined ? undefined : body.enabled !== false;
+
+    if (body.api_key !== undefined && !apiKey) {
+      return c.json(wrapError(400, "api_key must be a non-blank string"), 400);
+    }
+    if (body.proxy_base_url !== undefined && !proxyBaseUrl) {
+      return c.json(wrapError(400, "proxy_base_url must be a valid HTTP(S) URL"), 400);
+    }
+    if (body.base_url !== undefined && !baseUrl) {
+      return c.json(wrapError(400, "base_url must be a valid HTTP(S) URL"), 400);
+    }
 
     // proxy_base_url / base_url 始终必填（KS 调 LLM 需要地址）
     if (mode === "proxy" && !proxyBaseUrl) {
@@ -75,7 +99,7 @@ export function createLlmBindingRoutes(deps: LlmBindingRouteDeps): Hono {
     const row = llmBindingStore.upsert(serviceId, {
       mode,
       proxy_base_url: proxyBaseUrl ?? null,
-      // asOptString 返回 string | undefined；upsert 层把 undefined 解释为"保留原值"
+      // undefined means "preserve the existing value" in the upsert layer.
       api_key: apiKey,
       base_url: baseUrl ?? null,
       enabled,


### PR DESCRIPTION
## Description | 描述

`POST /v3/internal/llm-binding/set` currently accepts whitespace-only API keys and endpoint strings that are blank, malformed, or use non-HTTP schemes. Those values are persisted successfully and fail only when a later wiki ingest constructs the LLM client, separating the configuration error from its source.

This PR validates binding inputs before persistence:

- explicitly provided `api_key` values must contain at least one non-whitespace character;
- `proxy_base_url` and `base_url`, when provided, must parse as HTTP(S) URLs with a hostname;
- endpoint strings are trimmed before storage;
- non-blank API key text is preserved exactly;
- omitting `api_key` for an existing binding retains the current key, preserving the update contract.

Focused route tests cover blank credentials, blank/malformed/non-HTTP endpoints, valid HTTP(S) endpoints, exact key preservation, and existing-binding updates.

## Related Issue | 关联 Issue

No existing issue. Discovered during a default-branch Knowledge control-plane audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm vitest run src/routes/llm-binding.test.ts` - 1 file, 11 tests passed
- `pnpm test` - 1 file, 11 tests passed
- strict changed-file TypeScript check - passed
- `pnpm build` - 11 output files built
- `git diff --check` - passed

The repository-wide `pnpm typecheck` still reaches the existing base-branch error in `src/middleware/response-envelope.ts:47` (`Promise<string>` is not assignable to `string`). The changed files pass an isolated strict TypeScript check.

## Additional Notes | 其他说明

- Invalid binding requests now return the existing HTTP 400 error envelope and do not call the store.
- No database schema, resolver, Panel startup, or response-envelope changes.
- This intentionally validates URL syntax and scheme only. It does not add SSRF or reachability checks because private/custom LLM endpoints remain valid deployment targets.
- Full Open PR title/body and changed-file checks found no active implementation touching the Knowledge binding route; PR #721 changes only the Panel startup client.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
