### PR TITLE
fix(build): remove reference to missing scripts/seed-v2 from build chain

### DIFF
--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "npm run build:plugin && npm run build:scripts",
     "build:plugin": "tsdown",
-    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory && npm run build:seed-v2",
+    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
     "prepack": "npm run build",
     "build:migrate-sqlite-to-vdb": "tsc -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false",
     "migrate-sqlite-to-tcvdb": "node ./bin/migrate-sqlite-to-tcvdb.mjs",
@@ -26,7 +26,6 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
-    "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
     "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
     "test:oss": "vitest run -c vitest.oss.config.ts",


### PR DESCRIPTION
## Description | 描述

`npm run build` fails out of the box because the `build:scripts` chain calls `build:seed-v2`, which compiles `scripts/seed-v2/tsconfig.json` — a path that does not exist in the repository.

```
> build:seed-v2
> tsc --project scripts/seed-v2/tsconfig.json
error TS5058: The specified path does not exist: 'scripts/seed-v2/tsconfig.json'.
```

This PR removes the `build:seed-v2` entry from the build chain. The runtime entry point (`bin/seed-v2.mjs`) already handles a missing compiled artifact gracefully — it falls back to running the source via `tsx` when no dist output exists, so the seeding workflow remains usable once the source directory is added back.

## Related Issue | 关联 Issue

Fixes #716

## Change Type | 修改类型
- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- Only `build:seed-v2` (the TypeScript compilation step) is removed
- The `seed-v2` runtime script (`node ./bin/seed-v2.mjs`) is intentionally kept — it has its own existence check and graceful fallback
- `build:plugin` and all other `build:scripts` sub-tasks are unaffected

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.