### PR TITLE
fix(knowledge): restore middleware typecheck

### DIFF
--- a/MemoryKnowledge/src/middleware/response-envelope.test.ts
+++ b/MemoryKnowledge/src/middleware/response-envelope.test.ts
@@ -1,0 +1,59 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => logger,
+}));
+
+import { accessLog } from "./response-envelope.js";
+
+describe("accessLog", () => {
+  it("keeps a JSON request body readable by downstream handlers", async () => {
+    const app = new Hono();
+    app.use("*", accessLog());
+    app.post("/echo", async (c) => {
+      return c.json({ received: await c.req.json() });
+    });
+
+    const response = await app.request("/echo", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ wiki_id: "wiki-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      received: { wiki_id: "wiki-1" },
+    });
+  });
+
+  it("preserves an error response after logging its body", async () => {
+    const app = new Hono();
+    app.use("*", accessLog());
+    app.post("/fail", async (c) => {
+      const body = await c.req.json();
+      return c.json({ code: 400, data: body }, 400);
+    });
+
+    const response = await app.request("/fail", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ wiki_id: "wiki-2" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      code: 400,
+      data: { wiki_id: "wiki-2" },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "POST /fail error",
+      expect.objectContaining({ status: 400, wiki_id: "wiki-2" }),
+    );
+  });
+});

--- a/MemoryKnowledge/src/middleware/response-envelope.ts
+++ b/MemoryKnowledge/src/middleware/response-envelope.ts
@@ -37,15 +37,13 @@ export function accessLog(): MiddlewareHandler {
     const requestId = c.req.header("x-request-id") || crypto.randomUUID();
     c.set("requestId", requestId);
 
-    // 缓存 request body（body 只能读一次，失败时用于日志）
-    // Hono 的 bodyCache 期望 Promise（c.req.json()/text() 会对缓存值调 .then()）
+    // c.req.text() caches the body internally, so downstream handlers can
+    // still read it through c.req.json() or c.req.text().
     let reqBody: unknown = undefined;
     if (c.req.method === 'POST' || c.req.method === 'PUT') {
       try {
         const raw = await c.req.text();
         reqBody = raw ? JSON.parse(raw) : undefined;
-        c.req.bodyCache.text = Promise.resolve(raw);
-        if (reqBody) c.req.bodyCache.json = Promise.resolve(reqBody);
       } catch {
         // 非 JSON body，忽略
       }


### PR DESCRIPTION
## Description | 描述

`MemoryKnowledge` currently fails its own `pnpm typecheck` because the access-log middleware assigns `Promise<string>` and `Promise<unknown>` values directly to Hono's publicly typed `bodyCache` fields. Those writes are also unnecessary: `c.req.text()` already populates Hono's internal cache, and later `c.req.json()`/`c.req.text()` reads derive from that cached body.

This PR removes the direct internal-cache mutation and relies on Hono's request reader to own the cache lifecycle. Focused middleware tests prove that:

- a JSON request body remains readable by the downstream route after access logging inspects it;
- reading an error response for logging does not consume the response returned to the client.

## Related Issue | 关联 Issue

No existing issue. Discovered during a default-branch Knowledge build/typecheck audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm vitest run src/middleware/response-envelope.test.ts` - 1 file, 2 tests passed
- `pnpm test` - 1 file, 2 tests passed
- `pnpm typecheck` - passed
- strict changed-file TypeScript check - passed
- `pnpm build` - 11 output files built
- `git diff --check` - passed

## Additional Notes | 其他说明

- No route, envelope, logging format, dependency, or public API changes.
- The request body is still inspected once for error-log fields; Hono retains ownership of the cached representation.
- Full Open PR title/body and changed-file scans found no active implementation touching this middleware.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
