### PR TITLE
fix(panel): reject failed metadata HTTP responses

### DIFF
--- a/MemoryPanel/src/panel/kernel/transport-fetch.ts
+++ b/MemoryPanel/src/panel/kernel/transport-fetch.ts
@@ -167,6 +167,19 @@ export async function executeMetaFetch<T>(
       });
       throw err;
     }
+    if (!resp.ok && env.code === 0) {
+      const code = resp.status >= 400 && resp.status < 600 ? resp.status : 502;
+      const err = new KernelFetchError(code, `remote metadata HTTP ${resp.status} at ${path}`);
+      logRemoteMeta(log, 'error', env.request_id ?? reqId, {
+        path,
+        request_id: env.request_id ?? reqId,
+        durationMs: Date.now() - startedAt,
+        httpStatus: resp.status,
+        envelopeCode: env.code,
+        error: err.message,
+      });
+      throw err;
+    }
     const envelope: MetaEnvelope<unknown> = {
       code: env.code,
       message: env.message ?? (env.code === 0 ? 'ok' : `error ${env.code}`),

--- a/MemoryPanel/tests/kernel/transport-fetch.test.ts
+++ b/MemoryPanel/tests/kernel/transport-fetch.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  executeMetaFetch,
+  type MetaFetchConfig,
+} from '../../src/panel/kernel/transport-fetch.js';
+
+const config: MetaFetchConfig = {
+  endpoint: 'https://kernel.example.com',
+  apiKey: 'api-key',
+  serviceId: 'service-1',
+  requestId: 'request-1',
+};
+
+function mockResponse(status: number, body: unknown): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('executeMetaFetch HTTP status handling', () => {
+  it.each(['data', 'envelope'] as const)(
+    'rejects HTTP failures carrying a success envelope in %s mode',
+    async (mode) => {
+      mockResponse(500, {
+        code: 0,
+        message: 'ok',
+        request_id: 'upstream-1',
+        data: { accepted: true },
+      });
+
+      await expect(
+        executeMetaFetch(config, '/v3/meta/test', {}, mode),
+      ).rejects.toMatchObject({
+        name: 'KernelFetchError',
+        code: 500,
+        httpStatus: 500,
+        message: 'remote metadata HTTP 500 at /v3/meta/test',
+      });
+    },
+  );
+
+  it('keeps business error envelopes transparent in envelope mode', async () => {
+    mockResponse(400, {
+      code: 400,
+      message: 'invalid input',
+      request_id: 'upstream-2',
+      data: null,
+    });
+
+    await expect(
+      executeMetaFetch(config, '/v3/meta/test', {}, 'envelope'),
+    ).resolves.toEqual({
+      code: 400,
+      message: 'invalid input',
+      request_id: 'upstream-2',
+      data: {},
+    });
+  });
+
+  it('returns data from a successful HTTP response', async () => {
+    mockResponse(200, {
+      code: 0,
+      message: 'ok',
+      request_id: 'upstream-3',
+      data: { accepted: true },
+    });
+
+    await expect(
+      executeMetaFetch(config, '/v3/meta/test', {}, 'data'),
+    ).resolves.toEqual({ accepted: true });
+  });
+});


### PR DESCRIPTION
## Description | 描述

The shared Panel metadata transport currently validates only the response envelope. A non-success HTTP response such as `HTTP 500` is therefore accepted when its JSON body contains `{ "code": 0 }`, and callers receive successful data even though the transport failed.

This PR treats a non-2xx response carrying a code-zero envelope as a `KernelFetchError`. It preserves the existing distinction between transport and business errors:

- `HTTP 200 + code:0` continues to return successful data;
- `HTTP 400 + code:400` remains a transparent business-error envelope in `envelope` mode;
- `HTTP 500 + code:0` is rejected in both `data` and `envelope` modes.

Focused tests cover both transport modes and the two compatibility paths.

## Related Issue | 关联 Issue

No existing issue. Discovered during a default-branch Panel kernel transport audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm vitest run tests/kernel/transport-fetch.test.ts` - 1 file, 4 tests passed
- `pnpm test` - 1 file, 4 tests passed
- `pnpm typecheck` - passed
- strict changed-file TypeScript check - passed
- `pnpm build` - passed
- `git diff --check` - passed

## Additional Notes | 其他说明

- No route, envelope schema, authentication header, retry policy, or public API changes.
- The original 4xx/5xx status is preserved as the `KernelFetchError` code when possible.
- PR #703 changes the separate Knowledge adapter; PR #721 changes only the startup binding client. Full Open PR changed-file scans found no active implementation touching this shared metadata transport.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
