### PR TITLE
fix(proxy): coordinate ClickHouse lifecycle

### DIFF
--- a/MemoryProxy/src/__tests__/clickhouse-lifecycle.test.ts
+++ b/MemoryProxy/src/__tests__/clickhouse-lifecycle.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@clickhouse/client", () => ({
+  createClient: mocks.createClient,
+}));
+
+import {
+  __resetClickHouseForTests,
+  initClickHouse,
+  shutdownClickHouse,
+  type ClickHouseConfig,
+} from "../clickhouse.js";
+
+const config: ClickHouseConfig = {
+  enabled: true,
+  url: "http://clickhouse.test:8123",
+  database: "memory",
+  table: "usage_logs",
+  rawTable: "",
+  user: "default",
+  password: "",
+  flushIntervalMs: 5_000,
+  flushThreshold: 50,
+  ttlDays: 0,
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function client(command = vi.fn().mockResolvedValue(undefined)) {
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    command,
+    insert: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("ClickHouse writer lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await __resetClickHouseForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("deduplicates repeated initialization", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const bootstrap = client();
+    const target = client();
+    mocks.createClient
+      .mockReturnValueOnce(bootstrap)
+      .mockReturnValueOnce(target);
+
+    initClickHouse(config);
+    initClickHouse(config);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    await shutdownClickHouse();
+
+    expect(mocks.createClient).toHaveBeenCalledTimes(2);
+    expect(bootstrap.close).toHaveBeenCalledTimes(1);
+    expect(target.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for in-flight initialization before closing", async () => {
+    const targetDdl = deferred();
+    const bootstrap = client();
+    const target = client(
+      vi.fn()
+        .mockReturnValueOnce(targetDdl.promise)
+        .mockResolvedValue(undefined),
+    );
+    mocks.createClient
+      .mockReturnValueOnce(bootstrap)
+      .mockReturnValueOnce(target);
+
+    initClickHouse(config);
+    try {
+      await vi.waitFor(() => {
+        expect(target.command).toHaveBeenCalledTimes(1);
+      });
+
+      let shutdownComplete = false;
+      const shutdown = shutdownClickHouse().then(() => {
+        shutdownComplete = true;
+      });
+      await Promise.resolve();
+
+      expect(shutdownComplete).toBe(false);
+      expect(target.close).not.toHaveBeenCalled();
+
+      targetDdl.resolve();
+      await shutdown;
+
+      expect(target.close).toHaveBeenCalledTimes(1);
+    } finally {
+      targetDdl.resolve();
+    }
+  });
+
+  it("allows retry after initialization fails", async () => {
+    const firstBootstrap = client();
+    const firstTarget = client(
+      vi.fn().mockRejectedValueOnce(new Error("DDL unavailable")),
+    );
+    const secondBootstrap = client();
+    const secondTarget = client();
+    mocks.createClient
+      .mockReturnValueOnce(firstBootstrap)
+      .mockReturnValueOnce(firstTarget)
+      .mockReturnValueOnce(secondBootstrap)
+      .mockReturnValueOnce(secondTarget);
+
+    initClickHouse(config);
+    await vi.waitFor(() => {
+      expect(firstTarget.close).toHaveBeenCalledTimes(1);
+    });
+    await Promise.resolve();
+
+    initClickHouse(config);
+    await shutdownClickHouse();
+
+    expect(mocks.createClient).toHaveBeenCalledTimes(4);
+    expect(secondTarget.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/MemoryProxy/src/clickhouse.ts
+++ b/MemoryProxy/src/clickhouse.ts
@@ -118,12 +118,17 @@ let buffer: ClickHouseRow[] = [];
 let rawBuffer: ClickHouseRawUsageRow[] = [];
 let flushTimer: ReturnType<typeof setInterval> | null = null;
 let disabled = false;
+let initPromise: Promise<void> | null = null;
+let shutdownPromise: Promise<void> | null = null;
 
 /**
  * Initialize the ClickHouse writer.
  * Must be called once at startup. Idempotent.
  */
 export function initClickHouse(cfg: ClickHouseConfig): void {
+  if (client || initPromise || shutdownPromise) {
+    return;
+  }
   if (!cfg.enabled) {
     disabled = true;
     return;
@@ -138,11 +143,13 @@ export function initClickHouse(cfg: ClickHouseConfig): void {
   disabled = false;
 
   // Periodic flush (both main and raw buffers)
-  flushTimer = setInterval(() => {
-    void flush();
-    void flushRaw();
-  }, cfg.flushIntervalMs);
-  flushTimer.unref(); // Don't prevent process exit
+  if (!flushTimer) {
+    flushTimer = setInterval(() => {
+      void flush();
+      void flushRaw();
+    }, cfg.flushIntervalMs);
+    flushTimer.unref(); // Don't prevent process exit
+  }
 
   log.info("clickhouse.init", {
     url: cfg.url,
@@ -154,11 +161,17 @@ export function initClickHouse(cfg: ClickHouseConfig): void {
   });
 
   // Fire-and-forget: create client + database + table (idempotent)
-  ensureClickHouse(cfg).catch((err: unknown) => {
-    log.warn("clickhouse.init.ensureFailed", {
-      error: err instanceof Error ? err.message : String(err),
+  const pending = ensureClickHouse(cfg);
+  initPromise = pending;
+  void pending
+    .catch((err: unknown) => {
+      log.warn("clickhouse.init.ensureFailed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    })
+    .finally(() => {
+      if (initPromise === pending) initPromise = null;
     });
-  });
 }
 
 /**
@@ -186,7 +199,7 @@ async function ensureClickHouse(cfg: ClickHouseConfig): Promise<void> {
   }
 
   // Target client bound to the database, reused for all inserts.
-  client = createClient({
+  const targetClient = createClient({
     url: cfg.url,
     username: cfg.user,
     password: cfg.password,
@@ -231,49 +244,55 @@ async function ensureClickHouse(cfg: ClickHouseConfig): Promise<void> {
     .filter(Boolean)
     .join("\n");
 
-  await client.command({
-    query: ddl,
-    clickhouse_settings: { wait_end_of_query: 1 },
-  });
-
-  // Raw usage table (traceability for non-TokenHub / unrecognized format).
-  if (cfg.rawTable) {
-    // 新表默认排序键用 user_id（与主表对齐）；老表继续用 key_id（在 migrate 里补齐 user_id 列即可）
-    const rawDdl = [
-      `CREATE TABLE IF NOT EXISTS ${cfg.rawTable} (`,
-      "  timestamp DateTime64(3, 'Asia/Shanghai'),",
-      "  model_id String,",
-      "  model_name String DEFAULT '',",
-      "  key_id LowCardinality(String),",
-      "  user_id String DEFAULT '',",
-      "  session_key String,",
-      "  turn_seq UInt32 DEFAULT 0,",
-      "  user_input String DEFAULT '',",
-      "  upstream_url String,",
-      "  stream UInt8,",
-      "  usage String,",
-      "  reason LowCardinality(String),",
-      "  routed_from String DEFAULT '',",
-      "  space_id String DEFAULT '',",
-      "  source_tag LowCardinality(String) DEFAULT 'proxy',",
-      "  host LowCardinality(String),",
-      "  upstream_request_id String DEFAULT ''",
-      ") ENGINE = MergeTree()",
-      "ORDER BY (user_id, timestamp)",
-      ttlClause,
-    ]
-      .filter(Boolean)
-      .join("\n");
-
-    await client.command({
-      query: rawDdl,
+  try {
+    await targetClient.command({
+      query: ddl,
       clickhouse_settings: { wait_end_of_query: 1 },
     });
-  }
 
-  // 补齐历史 schema 漂移：对存量表执行 ALTER TABLE ADD COLUMN IF NOT EXISTS。
-  // 幂等且失败不阻断（缺 DDL 权限时降级为 warn，业务继续用可写字段）。
-  await migrateSchema(client, cfg);
+    // Raw usage table (traceability for non-TokenHub / unrecognized format).
+    if (cfg.rawTable) {
+      // 新表默认排序键用 user_id（与主表对齐）；老表继续用 key_id（在 migrate 里补齐 user_id 列即可）
+      const rawDdl = [
+        `CREATE TABLE IF NOT EXISTS ${cfg.rawTable} (`,
+        "  timestamp DateTime64(3, 'Asia/Shanghai'),",
+        "  model_id String,",
+        "  model_name String DEFAULT '',",
+        "  key_id LowCardinality(String),",
+        "  user_id String DEFAULT '',",
+        "  session_key String,",
+        "  turn_seq UInt32 DEFAULT 0,",
+        "  user_input String DEFAULT '',",
+        "  upstream_url String,",
+        "  stream UInt8,",
+        "  usage String,",
+        "  reason LowCardinality(String),",
+        "  routed_from String DEFAULT '',",
+        "  space_id String DEFAULT '',",
+        "  source_tag LowCardinality(String) DEFAULT 'proxy',",
+        "  host LowCardinality(String),",
+        "  upstream_request_id String DEFAULT ''",
+        ") ENGINE = MergeTree()",
+        "ORDER BY (user_id, timestamp)",
+        ttlClause,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      await targetClient.command({
+        query: rawDdl,
+        clickhouse_settings: { wait_end_of_query: 1 },
+      });
+    }
+
+    // 补齐历史 schema 漂移：对存量表执行 ALTER TABLE ADD COLUMN IF NOT EXISTS。
+    // 幂等且失败不阻断（缺 DDL 权限时降级为 warn，业务继续用可写字段）。
+    await migrateSchema(targetClient, cfg);
+    client = targetClient;
+  } catch (err) {
+    await targetClient.close().catch(() => {});
+    throw err;
+  }
 
   log.info("clickhouse.init.tableReady", {
     table: `${cfg.database}.${cfg.table}`,
@@ -810,15 +829,43 @@ export async function flushRaw(): Promise<void> {
 /**
  * Graceful shutdown: stop timer, flush remaining buffer, close client.
  */
-export async function shutdownClickHouse(): Promise<void> {
+export function shutdownClickHouse(): Promise<void> {
+  if (shutdownPromise) return shutdownPromise;
+  const pending = performShutdown();
+  shutdownPromise = pending;
+  void pending.then(
+    () => {
+      if (shutdownPromise === pending) shutdownPromise = null;
+    },
+    () => {
+      if (shutdownPromise === pending) shutdownPromise = null;
+    },
+  );
+  return pending;
+}
+
+async function performShutdown(): Promise<void> {
   if (flushTimer) {
     clearInterval(flushTimer);
     flushTimer = null;
   }
+  await initPromise?.catch(() => {});
   await flush();
   await flushRaw();
   if (client) {
     await client.close().catch(() => {});
     client = null;
   }
+}
+
+/** Reset module state between unit tests. */
+export async function __resetClickHouseForTests(): Promise<void> {
+  await shutdownClickHouse();
+  config = null;
+  client = null;
+  buffer = [];
+  rawBuffer = [];
+  disabled = false;
+  initPromise = null;
+  shutdownPromise = null;
 }


### PR DESCRIPTION
## Description | 描述

`initClickHouse()` started asynchronous database/table setup without retaining the
initialization task. Repeated startup calls could create multiple timers and
bootstrap/target client pairs, while `shutdownClickHouse()` could flush and
return before an in-flight target client was published. A failed target DDL
also left lifecycle state ambiguous.

This change:

- shares one in-flight initialization and creates only one periodic flush timer;
- publishes the target client only after DDL and schema migration complete;
- closes a partially initialized target client on failure and permits retry;
- makes shutdown idempotent and waits for in-flight initialization before
  flushing and closing;
- adds deterministic regression tests for repeated initialization, shutdown
  ordering, and retry after failed DDL.

Normal buffering, schemas, flush thresholds, and ClickHouse configuration are
unchanged.

## Related Issue | 关联 Issue

L3 MemoryProxy lifecycle audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `pnpm test -- --run src/__tests__/clickhouse-lifecycle.test.ts` (3/3)
- `pnpm test` (3/3 collected Proxy tests)
- `git diff --check`

## Additional Notes | 其他说明

After rebasing onto release commit `0aff21a`, the repository-wide Proxy
typecheck reaches unchanged default-branch errors in `config.ts` (`memCommand`),
the Claude Code/CodeBuddy session initializers (`isDefault`), and the
`@context-proxy/cost-guard` declarations. This PR does not change those paths,
dependencies, or lockfiles.
