### PR TITLE
fix(telemetry): coordinate OTel SDK lifecycle

### DIFF
--- a/MemoryCore/src/core/report/otel-sdk-init.test.ts
+++ b/MemoryCore/src/core/report/otel-sdk-init.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  let releaseSdkImport = () => {};
+  let sdkImportGate = Promise.resolve();
+  let releaseSdkShutdown = () => {};
+  let sdkShutdownGate = Promise.resolve();
+  let constructionError: Error | undefined;
+
+  const nodeSDKConstructed = vi.fn();
+  const sdkStart = vi.fn();
+  const sdkShutdown = vi.fn(() => sdkShutdownGate);
+  const loggerShutdown = vi.fn().mockResolvedValue(undefined);
+  const diagWarn = vi.fn();
+
+  return {
+    nodeSDKConstructed,
+    sdkStart,
+    sdkShutdown,
+    loggerShutdown,
+    diagWarn,
+    waitForSdkImport: () => sdkImportGate,
+    deferSdkImport: () => {
+      sdkImportGate = new Promise<void>((resolve) => {
+        releaseSdkImport = resolve;
+      });
+    },
+    releaseSdkImport: () => releaseSdkImport(),
+    deferSdkShutdown: () => {
+      sdkShutdownGate = new Promise<void>((resolve) => {
+        releaseSdkShutdown = resolve;
+      });
+    },
+    releaseSdkShutdown: () => releaseSdkShutdown(),
+    failNextConstruction: (error: Error) => {
+      constructionError = error;
+    },
+    takeConstructionError: () => {
+      const error = constructionError;
+      constructionError = undefined;
+      return error;
+    },
+    reset: () => {
+      releaseSdkImport();
+      releaseSdkShutdown();
+      releaseSdkImport = () => {};
+      sdkImportGate = Promise.resolve();
+      releaseSdkShutdown = () => {};
+      sdkShutdownGate = Promise.resolve();
+      constructionError = undefined;
+      nodeSDKConstructed.mockClear();
+      sdkStart.mockClear();
+      sdkShutdown.mockClear();
+      loggerShutdown.mockClear();
+      diagWarn.mockClear();
+    },
+  };
+});
+
+vi.mock("@opentelemetry/api", () => ({
+  diag: {
+    setLogger: vi.fn(),
+    warn: mocks.diagWarn,
+  },
+  DiagConsoleLogger: class {},
+  DiagLogLevel: { DEBUG: 1 },
+  trace: {},
+}));
+
+vi.mock("@opentelemetry/sdk-node", async () => {
+  await mocks.waitForSdkImport();
+  return {
+    NodeSDK: class {
+      constructor() {
+        mocks.nodeSDKConstructed();
+        const error = mocks.takeConstructionError();
+        if (error) throw error;
+      }
+
+      start() {
+        mocks.sdkStart();
+      }
+
+      shutdown() {
+        return mocks.sdkShutdown();
+      }
+    },
+  };
+});
+
+vi.mock("@opentelemetry/resources", () => ({
+  resourceFromAttributes: vi.fn((attributes) => ({ attributes })),
+}));
+
+vi.mock("@opentelemetry/semantic-conventions", () => ({
+  ATTR_SERVICE_NAME: "service.name",
+  ATTR_SERVICE_VERSION: "service.version",
+  ATTR_SERVICE_INSTANCE_ID: "service.instance.id",
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-grpc", () => ({
+  OTLPTraceExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-http", () => ({
+  OTLPTraceExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-grpc", () => ({
+  OTLPLogExporter: class {},
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-http", () => ({
+  OTLPLogExporter: class {},
+}));
+
+vi.mock("@opentelemetry/sdk-logs", () => ({
+  LoggerProvider: class {
+    shutdown() {
+      return mocks.loggerShutdown();
+    }
+  },
+  BatchLogRecordProcessor: class {},
+}));
+
+vi.mock("@opentelemetry/context-async-hooks", () => ({
+  AsyncLocalStorageContextManager: class {},
+}));
+
+vi.mock("@opentelemetry/api-logs", () => ({
+  logs: {
+    setGlobalLoggerProvider: vi.fn(),
+  },
+}));
+
+vi.mock("@opentelemetry/sdk-trace-base", () => ({
+  BatchSpanProcessor: class {},
+  SimpleSpanProcessor: class {},
+}));
+
+vi.mock("./langfuse-span-processor.js", () => ({
+  LangfuseFilteringProcessor: class {
+    shutdown() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+async function loadModule() {
+  return import("./otel-sdk-init.js");
+}
+
+describe("OTel SDK lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.reset();
+    vi.stubEnv("CLICKHOUSE_ENABLED", "false");
+    vi.stubEnv("LANGFUSE_ENABLED", "false");
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mocks.releaseSdkImport();
+    mocks.releaseSdkShutdown();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("shares one in-flight initialization", async () => {
+    mocks.deferSdkImport();
+    const { initOTelSDK, shutdownOTelSDK } = await loadModule();
+
+    const first = initOTelSDK({ endpoint: "http://otel.test:4317" });
+    const second = initOTelSDK({ endpoint: "http://otel.test:4317" });
+
+    expect(second).toBe(first);
+    expect(mocks.nodeSDKConstructed).not.toHaveBeenCalled();
+
+    mocks.releaseSdkImport();
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+
+    expect(mocks.nodeSDKConstructed).toHaveBeenCalledTimes(1);
+    expect(mocks.sdkStart).toHaveBeenCalledTimes(1);
+    await shutdownOTelSDK();
+  });
+
+  it("waits for initialization before shared shutdown", async () => {
+    mocks.deferSdkImport();
+    const {
+      initOTelSDK,
+      isOTelSDKInitialized,
+      shutdownOTelSDK,
+    } = await loadModule();
+
+    const initialization = initOTelSDK({
+      endpoint: "http://otel.test:4317",
+    });
+    const firstShutdown = shutdownOTelSDK();
+    const secondShutdown = shutdownOTelSDK();
+
+    expect(secondShutdown).toBe(firstShutdown);
+    expect(mocks.sdkShutdown).not.toHaveBeenCalled();
+
+    mocks.releaseSdkImport();
+    await initialization;
+    await firstShutdown;
+
+    expect(mocks.sdkShutdown).toHaveBeenCalledTimes(1);
+    expect(mocks.loggerShutdown).toHaveBeenCalledTimes(1);
+    expect(isOTelSDKInitialized()).toBe(false);
+  });
+
+  it("defers reinitialization until shutdown completes", async () => {
+    const {
+      initOTelSDK,
+      isOTelSDKInitialized,
+      shutdownOTelSDK,
+    } = await loadModule();
+    await initOTelSDK({ endpoint: "http://otel.test:4317" });
+    mocks.deferSdkShutdown();
+
+    const shutdown = shutdownOTelSDK();
+    const reinitialization = initOTelSDK({
+      endpoint: "http://otel.test:4317",
+    });
+    await Promise.resolve();
+
+    expect(mocks.nodeSDKConstructed).toHaveBeenCalledTimes(1);
+
+    mocks.releaseSdkShutdown();
+    await shutdown;
+    await expect(reinitialization).resolves.toBe(true);
+
+    expect(mocks.nodeSDKConstructed).toHaveBeenCalledTimes(2);
+    expect(mocks.sdkStart).toHaveBeenCalledTimes(2);
+    expect(isOTelSDKInitialized()).toBe(true);
+    await shutdownOTelSDK();
+  });
+
+  it("allows retry after initialization fails", async () => {
+    const { initOTelSDK, shutdownOTelSDK } = await loadModule();
+    mocks.failNextConstruction(new Error("SDK unavailable"));
+
+    await expect(
+      initOTelSDK({ endpoint: "http://otel.test:4317" }),
+    ).resolves.toBe(false);
+    await expect(
+      initOTelSDK({ endpoint: "http://otel.test:4317" }),
+    ).resolves.toBe(true);
+
+    expect(mocks.nodeSDKConstructed).toHaveBeenCalledTimes(2);
+    expect(mocks.sdkStart).toHaveBeenCalledTimes(1);
+    expect(mocks.diagWarn).toHaveBeenCalledWith(
+      expect.stringContaining("SDK unavailable"),
+    );
+    await shutdownOTelSDK();
+  });
+});

--- a/MemoryCore/src/core/report/otel-sdk-init.ts
+++ b/MemoryCore/src/core/report/otel-sdk-init.ts
@@ -68,14 +68,20 @@ export interface OTelSDKInitOptions {
 
 let _sdkInstance: { shutdown: () => Promise<void> } | undefined;
 let _initialized = false;
+let _initPromise: Promise<boolean> | undefined;
+let _shutdownPromise: Promise<void> | undefined;
 
 /**
  * 初始化 OpenTelemetry SDK。
  * 安全地多次调用 — 后续调用为 no-op。
  * 如果 SDK 包未安装，记录警告并返回 false。
  */
-export async function initOTelSDK(options: OTelSDKInitOptions = {}): Promise<boolean> {
-  if (_initialized) return true;
+export function initOTelSDK(options: OTelSDKInitOptions = {}): Promise<boolean> {
+  if (_shutdownPromise) {
+    return _shutdownPromise.then(() => initOTelSDK(options));
+  }
+  if (_initialized) return Promise.resolve(true);
+  if (_initPromise) return _initPromise;
 
   // 当配置了 endpoint 或 Langfuse 时启用 SDK
   const hasLangfuse = typeof options.langfuse === "object" && options.langfuse && options.langfuse.host;
@@ -84,14 +90,28 @@ export async function initOTelSDK(options: OTelSDKInitOptions = {}): Promise<boo
     : hasLangfuse
       ? true
       : process.env.TDAI_OTEL_ENABLED === "true";
-  if (!enabled) return false;
+  if (!enabled) return Promise.resolve(false);
 
   // @opentelemetry/api 不可用时直接返回
   if (!_otelApiAvailable) {
     console.warn("[core][otel] @opentelemetry/api not available, skipping SDK init.");
-    return false;
+    return Promise.resolve(false);
   }
 
+  const pending = Promise.resolve().then(() => performOTelSDKInit(options));
+  _initPromise = pending;
+  void pending.then(
+    () => {
+      if (_initPromise === pending) _initPromise = undefined;
+    },
+    () => {
+      if (_initPromise === pending) _initPromise = undefined;
+    },
+  );
+  return pending;
+}
+
+async function performOTelSDKInit(options: OTelSDKInitOptions): Promise<boolean> {
   if (options.debug || process.env.OTEL_LOG_LEVEL === "DEBUG") {
     diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
   }
@@ -363,14 +383,40 @@ export async function initOTelSDK(options: OTelSDKInitOptions = {}): Promise<boo
 /**
  * 优雅关闭 OTel SDK。
  */
-export async function shutdownOTelSDK(): Promise<void> {
-  if (!_sdkInstance) return;
+export function shutdownOTelSDK(): Promise<void> {
+  if (_shutdownPromise) return _shutdownPromise;
+
+  const pending = Promise.resolve().then(performOTelSDKShutdown);
+  _shutdownPromise = pending;
+  void pending.then(
+    () => {
+      if (_shutdownPromise === pending) _shutdownPromise = undefined;
+    },
+    () => {
+      if (_shutdownPromise === pending) _shutdownPromise = undefined;
+    },
+  );
+  return pending;
+}
+
+async function performOTelSDKShutdown(): Promise<void> {
   try {
-    await _sdkInstance.shutdown();
+    await _initPromise;
+  } catch {
+    // Failed initialization leaves no SDK to shut down.
+  }
+
+  const instance = _sdkInstance;
+  if (!instance) {
+    _initialized = false;
+    return;
+  }
+  try {
+    await instance.shutdown();
   } catch {
     // Best-effort shutdown
   } finally {
-    _sdkInstance = undefined;
+    if (_sdkInstance === instance) _sdkInstance = undefined;
     _initialized = false;
   }
 }


### PR DESCRIPTION
## Description | 描述

`initOTelSDK()` set `_initialized` only after all dynamic imports, exporters, and
the `NodeSDK` were ready. Concurrent cold callers could therefore each pass the
initial guard and create duplicate SDKs and global providers. At the same time,
`shutdownOTelSDK()` returned immediately when initialization was still in
flight because `_sdkInstance` had not been published yet.

This change:

- shares one in-flight initialization Promise across concurrent callers;
- shares one shutdown Promise across concurrent shutdown callers;
- waits for initialization before shutting down the published SDK;
- defers initialization requested during shutdown until shutdown completes;
- clears settled initialization state so failed attempts remain retryable;
- adds deterministic tests for all lifecycle orderings above.

Exporter selection, resource attributes, environment handling, and public
return values are unchanged.

## Related Issue | 关联 Issue

L3 MemoryCore telemetry lifecycle audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `pnpm test` (1 file, 4 tests)
- `pnpm run build:plugin`
- `pnpm run lint:skill-isolation`
- `git diff --check`

## Additional Notes | 其他说明

The standalone strict changed-file TypeScript command still reaches existing
default-branch errors in the missing `integrations/observability` module, OTel
gRPC exporter `headers` types, and the OTel Resource API. The production plugin
build passes, and this PR does not change those exporter configurations or
dependencies.
