### PR TITLE
fix(proxy): bound Opik telemetry requests

### DIFF
--- a/MemoryProxy/src/__tests__/opik-timeout.test.ts
+++ b/MemoryProxy/src/__tests__/opik-timeout.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  opikCreateLlmSpan,
+  opikCreateTrace,
+  opikUpdateTrace,
+} from "../opik.js";
+import type { ProxyConfig } from "../types.js";
+
+const config = {
+  opik: {
+    enabled: true,
+    url: "https://opik.example.test",
+    apiKey: "",
+    stripRequestLogContent: false,
+  },
+} as ProxyConfig;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Opik request deadlines", () => {
+  it("bounds every fire-and-forget request", () => {
+    const signals: AbortSignal[] = [];
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
+      const signal = new AbortController().signal;
+      signals.push(signal);
+      return signal;
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    opikCreateTrace(config, {
+      traceId: "trace-1",
+      projectName: "project",
+      name: "request",
+      startTime: "2026-08-03T00:00:00.000Z",
+      input: {},
+    });
+    opikUpdateTrace(config, {
+      traceId: "trace-1",
+      projectName: "project",
+      endTime: "2026-08-03T00:00:01.000Z",
+      output: {},
+      usage: {},
+    });
+    opikCreateLlmSpan(config, {
+      traceId: "trace-1",
+      projectName: "project",
+      name: "completion",
+      startTime: "2026-08-03T00:00:00.000Z",
+      endTime: "2026-08-03T00:00:01.000Z",
+      inputMessages: [],
+      outputMessage: null,
+      model: "test-model",
+      usage: {},
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledTimes(3);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(1, 10_000);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(2, 10_000);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(3, 10_000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    for (const [index, call] of fetchMock.mock.calls.entries()) {
+      expect(call[1]?.signal).toBe(signals[index]);
+    }
+  });
+});

--- a/MemoryProxy/src/opik.ts
+++ b/MemoryProxy/src/opik.ts
@@ -11,6 +11,8 @@ import { createHash, randomBytes } from "node:crypto";
 import type { ProxyConfig } from "./types.js";
 import { log } from "./report/log.js";
 
+const OPIK_REQUEST_TIMEOUT_MS = 10_000;
+
 /**
  * Generate a UUID v7 (time-ordered), required by Opik API.
  * Layout: 48-bit unix_ts_ms | 4-bit ver(0x7) | 12-bit rand_a | 2-bit var(0b10) | 62-bit rand_b
@@ -99,6 +101,7 @@ function fireCreateTrace(
     method: "POST",
     headers,
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(OPIK_REQUEST_TIMEOUT_MS),
   }).then(async (res) => {
     if (!res.ok) {
       const body = await res.text().catch(() => "");
@@ -184,6 +187,7 @@ export function opikUpdateTrace(
       output: update.output,
       usage: update.usage, // raw, unmodified
     }),
+    signal: AbortSignal.timeout(OPIK_REQUEST_TIMEOUT_MS),
   }).then(async (res) => {
     if (!res.ok) {
       const body = await res.text().catch(() => "");
@@ -206,6 +210,7 @@ function fireCreateLlmSpan(
     method: "POST",
     headers,
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(OPIK_REQUEST_TIMEOUT_MS),
   }).then(async (res) => {
     if (!res.ok) {
       const body = await res.text().catch(() => "");


### PR DESCRIPTION
## Description | 描述

Opik tracing is deliberately fire-and-forget so telemetry never delays the
proxy request path. The three request paths did not set a deadline, however, so
a stalled Opik endpoint could retain pending fetches indefinitely while new
requests continued to create more.

This change:

- applies a 10-second `AbortSignal.timeout()` to trace creation, trace updates,
  and LLM span creation;
- keeps timeout failures on the existing warning-only error path;
- adds a deterministic test that verifies every Opik request carries its own
  deadline signal.

Payloads, response handling, retries, and proxy hot-path behavior are
unchanged.

## Related Issue | 关联 Issue

L3 MemoryProxy telemetry resource audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test -- --run src/__tests__/opik-timeout.test.ts` (1/1)
- `npm test` (1/1 collected Proxy test)
- strict changed-file TypeScript check
- `git diff --check`

## Additional Notes | 其他说明

The repository-wide Proxy typecheck retains unchanged default-branch errors in
`RawYamlConfig.memCommand`, two session `isDefault` fields, and the absent
optional `@context-proxy/cost-guard` package. This PR does not change those
modules, dependencies, or lockfiles.
