### PR TITLE
fix(proxy): make logger initialization idempotent

### DIFF
--- a/MemoryProxy/src/__tests__/logger-lifecycle.test.ts
+++ b/MemoryProxy/src/__tests__/logger-lifecycle.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ILogBackend, LogConfig } from "../report/types.js";
+
+function createBackend(type: string): ILogBackend {
+  return {
+    type,
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const debugConfig: LogConfig = {
+  level: "debug",
+  filePath: "",
+  rotate: {
+    maxSizeBytes: 1024,
+    backupLimit: 1,
+  },
+  backend: "noop",
+};
+
+describe("logger lifecycle", () => {
+  it("ignores repeated initialization and shuts down the original backend", async () => {
+    const { getLogLevel, initLogger, log, shutdownLogger } = await import("../report/log.js");
+    const originalBackend = createBackend("original");
+    const replacementBackend = createBackend("replacement");
+
+    initLogger(debugConfig, originalBackend);
+    initLogger({ ...debugConfig, level: "error" }, replacementBackend);
+    log.info("still_original");
+
+    expect(getLogLevel()).toBe("debug");
+    expect(originalBackend.info).toHaveBeenCalledWith("still_original", {});
+    expect(replacementBackend.info).not.toHaveBeenCalled();
+
+    await shutdownLogger();
+
+    expect(originalBackend.shutdown).toHaveBeenCalledOnce();
+    expect(replacementBackend.shutdown).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryProxy/src/report/log.ts
+++ b/MemoryProxy/src/report/log.ts
@@ -29,6 +29,7 @@ import { LOG_LEVEL_PRIORITY } from "./types.js";
 let fileLogger: FileLogger | null = null;
 let backend: ILogBackend = new NoopLogBackend();
 let minLevel: LogLevel = "info";
+let initialized = false;
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
@@ -41,6 +42,9 @@ let minLevel: LogLevel = "info";
  * @param customBackend Optional custom ILogBackend (for testing/extension)
  */
 export function initLogger(config: LogConfig, customBackend?: ILogBackend): void {
+  if (initialized) return;
+  initialized = true;
+
   minLevel = config.level;
 
   // Initialize file logger


### PR DESCRIPTION
## Description | 描述

`initLogger()` documents that initialization is idempotent, but repeated calls
currently replace the active backend and FileLogger references. Any previous
backend resources, file stream, and flush timer then become unreachable and
are omitted from the later shutdown.

This change:

- ignores initialization attempts after the first successful lifecycle entry;
- preserves the original log level, backend, and FileLogger ownership;
- adds a deterministic lifecycle test proving that logs and shutdown remain
  attached to the original backend.

Log formatting, filtering, backend behavior, and normal single-call startup
are unchanged.

## Related Issue | 关联 Issue

L3 MemoryProxy logging lifecycle audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test -- --run src/__tests__/logger-lifecycle.test.ts` (1/1)
- `npm test` (1/1 collected Proxy test)
- strict changed-file TypeScript check
- `git diff --check`

## Additional Notes | 其他说明

The repository-wide Proxy typecheck retains unchanged default-branch errors in
`RawYamlConfig.memCommand`, two session `isDefault` fields, and the absent
optional `@context-proxy/cost-guard` package. This PR does not change those
modules, dependencies, or lockfiles.
