### PR TITLE
fix(proxy): authenticate session management routes

### DIFF
--- a/MemoryProxy/src/routes/__tests__/session-admin-auth.test.ts
+++ b/MemoryProxy/src/routes/__tests__/session-admin-auth.test.ts
@@ -1,0 +1,97 @@
+import { Hono, type Context } from "hono";
+import { describe, expect, it } from "vitest";
+
+import type { ProxyConfig } from "../../types.js";
+import { createSessionForceArchiveHandler } from "../session-force-archive.js";
+import { createSessionRefreshHandler } from "../session-refresh.js";
+
+const routes = [
+  {
+    path: "/v3/session/refresh-cache",
+    createHandler: createSessionRefreshHandler,
+  },
+  {
+    path: "/v3/session/force-archive-skill",
+    createHandler: createSessionForceArchiveHandler,
+  },
+] as const;
+
+type HandlerFactory = (config: ProxyConfig) => (c: Context) => Promise<Response>;
+
+function appFor(
+  path: string,
+  createHandler: HandlerFactory,
+  apiKey: string,
+): Hono {
+  const app = new Hono();
+  const handler = createHandler({
+    admin: { apiKey },
+  } as ProxyConfig);
+  app.post(path, handler);
+  return app;
+}
+
+describe.each(routes)("$path admin auth", ({ path, createHandler }) => {
+  it("rejects a missing token before parsing the request", async () => {
+    const response = await appFor(path, createHandler, "admin-secret").request(
+      path,
+      {
+        method: "POST",
+        body: "{not-json",
+      },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      code: 401,
+      message: "Unauthorized: missing Bearer token",
+    });
+  });
+
+  it("rejects an invalid token", async () => {
+    const response = await appFor(path, createHandler, "admin-secret").request(
+      path,
+      {
+        method: "POST",
+        headers: { authorization: "Bearer wrong-secret" },
+        body: "{not-json",
+      },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      code: 401,
+      message: "Unauthorized: invalid token",
+    });
+  });
+
+  it("allows the configured token to reach request validation", async () => {
+    const response = await appFor(path, createHandler, "admin-secret").request(
+      path,
+      {
+        method: "POST",
+        headers: { authorization: "Bearer admin-secret" },
+        body: "{not-json",
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: 40001,
+      message: "Invalid JSON body",
+    });
+  });
+
+  it("preserves the existing open behavior when no key is configured", async () => {
+    const response = await appFor(path, createHandler, "").request(path, {
+      method: "POST",
+      body: "{not-json",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      code: 40001,
+      message: "Invalid JSON body",
+    });
+  });
+});

--- a/MemoryProxy/src/routes/session-force-archive.ts
+++ b/MemoryProxy/src/routes/session-force-archive.ts
@@ -13,6 +13,7 @@ import type { ProxyConfig } from "../types.js";
 import { getSessionStore } from "../session/store.js";
 import { getCoreSkillClient } from "../skill/core-client.js";
 import type { SessionInitState } from "../session/types.js";
+import { adminAuthError, checkAdminAuth } from "./admin-auth.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -112,6 +113,11 @@ export async function forceArchiveSkill(input: ForceArchiveInput): Promise<Force
  */
 export function createSessionForceArchiveHandler(config: ProxyConfig) {
   return async (c: Context): Promise<Response> => {
+    const authResult = checkAdminAuth(c, config.admin.apiKey);
+    if (authResult !== "ok") {
+      return adminAuthError(c, authResult);
+    }
+
     let body: Record<string, unknown>;
     try {
       body = await c.req.json<Record<string, unknown>>();

--- a/MemoryProxy/src/routes/session-refresh.ts
+++ b/MemoryProxy/src/routes/session-refresh.ts
@@ -16,6 +16,7 @@ import { getSessionStore } from "../session/store.js";
 import { prewarmFromConfig } from "../injection/index.js";
 import type { SessionInitState, AgentDetail, TaskDetail } from "../session/types.js";
 import { getMetadataClient } from "../meta/client.js";
+import { adminAuthError, checkAdminAuth } from "./admin-auth.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -232,6 +233,11 @@ export async function refreshSessionCache(input: RefreshInput): Promise<RefreshR
  */
 export function createSessionRefreshHandler(config: ProxyConfig) {
   return async (c: Context): Promise<Response> => {
+    const authResult = checkAdminAuth(c, config.admin.apiKey);
+    if (authResult !== "ok") {
+      return adminAuthError(c, authResult);
+    }
+
     let body: Record<string, unknown>;
     try {
       body = await c.req.json<Record<string, unknown>>();


### PR DESCRIPTION
## Description | 描述

The v2.0.0 release adds two Proxy session-management endpoints:

- `POST /v3/session/refresh-cache`
- `POST /v3/session/force-archive-skill`

The refresh handler explicitly documents that it uses the existing admin authentication contract, but neither handler currently calls `checkAdminAuth()`. As a result, configuring `admin.apiKey` protects the existing instance-destroy endpoint while unauthenticated callers can still reach session lookup, cache refresh, and force-archive logic.

This PR applies the shared constant-time Bearer-token guard at the start of both handlers, before JSON parsing or session operations. Focused tests cover missing, invalid, and valid tokens for both routes, plus the existing empty-key compatibility behavior.

## Related Issue | 关联 Issue

No dedicated issue. Discovered during the v2.0.0 default-branch Proxy route audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm vitest run src/routes/__tests__/session-admin-auth.test.ts` - 1 file, 8 tests passed
- `pnpm test` - 1 file, 8 tests passed
- `git diff --check` - passed

The repository-wide Proxy typecheck reaches existing v2.0.0 baseline errors in the raw config model, session task-detail types, and private `@context-proxy/cost-guard` package resolution. None reference the changed files.

## Additional Notes | 其他说明

- No session payload, response envelope, archive, or refresh behavior changes after authentication succeeds.
- An empty `admin.apiKey` retains the current shared-helper behavior (authentication disabled). This PR intentionally does not change the fail-open/fail-closed policy under discussion in #673 and #685.
- #673/#685 modify the shared helper and rate-limit routes; full changed-file scans found no active PR touching either v2.0.0 session route.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
