### PR TITLE
fix(knowledge): wake stopped auto-sync workers

### DIFF
--- a/MemoryKnowledge/src/store/auto-sync-scheduler.test.ts
+++ b/MemoryKnowledge/src/store/auto-sync-scheduler.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CodeGraphService } from "./code-graph-service.js";
+import type { IKnowledgeStore } from "./types.js";
+
+const logger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => logger,
+}));
+
+import { AutoSyncScheduler } from "./auto-sync-scheduler.js";
+
+function createScheduler(maxConcurrentSyncs = 2): AutoSyncScheduler {
+  const store = {
+    listSyncedCodeGraphs: vi.fn(() => []),
+  } as unknown as IKnowledgeStore;
+  const cgService = {
+    sync: vi.fn(),
+  } as unknown as CodeGraphService;
+  return new AutoSyncScheduler({
+    store,
+    cgService,
+    config: {
+      enabled: true,
+      scanIntervalMs: 60_000,
+      maxConcurrentSyncs,
+    },
+  });
+}
+
+function workerCount(scheduler: AutoSyncScheduler): number {
+  return (scheduler as unknown as { workerCount: number }).workerCount;
+}
+
+async function settleWorkers(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("AutoSyncScheduler worker lifecycle", () => {
+  it("wakes sleeping workers on stop", async () => {
+    vi.useFakeTimers();
+    const scheduler = createScheduler();
+
+    scheduler.start();
+    expect(workerCount(scheduler)).toBe(2);
+
+    scheduler.stop();
+    await settleWorkers();
+
+    expect(workerCount(scheduler)).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not revive stopped workers during an immediate restart", async () => {
+    vi.useFakeTimers();
+    const scheduler = createScheduler();
+
+    scheduler.start();
+    scheduler.stop();
+    scheduler.start();
+    await settleWorkers();
+
+    expect(workerCount(scheduler)).toBe(2);
+
+    scheduler.stop();
+    await settleWorkers();
+    expect(workerCount(scheduler)).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/MemoryKnowledge/src/store/auto-sync-scheduler.ts
+++ b/MemoryKnowledge/src/store/auto-sync-scheduler.ts
@@ -87,8 +87,8 @@ export class AutoSyncScheduler {
   /** 启动延迟 + 周期 scan 的 timer。 */
   private startupTimer: ReturnType<typeof setTimeout> | null = null;
   private scanTimer: ReturnType<typeof setInterval> | null = null;
-  /** worker 空转 sleep 的 timer 集合（stop 时统一清理）。 */
-  private readonly workerSleepTimers = new Set<ReturnType<typeof setTimeout>>();
+  /** worker 空转 sleep 的 timer + 唤醒回调（stop 时统一清理并 resolve）。 */
+  private readonly workerSleeps = new Map<ReturnType<typeof setTimeout>, () => void>();
 
   /** FIFO 待处理队列 + 去重 Set（队列内 + 处理中的 id）。 */
   private readonly queue: CodeGraphRow[] = [];
@@ -98,6 +98,8 @@ export class AutoSyncScheduler {
   private activeSyncs = 0;
   /** worker 数（常驻）。 */
   private workerCount = 0;
+  /** 每次 start/stop 都递增，防止旧 worker 在快速重启后加入新一轮。 */
+  private runGeneration = 0;
   /** 停止标记。stop 后 workers 循环退出。 */
   private stopped = true;
   /** 上一轮 scan 是否仍在进行。 */
@@ -125,6 +127,7 @@ export class AutoSyncScheduler {
       return;
     }
     this.stopped = false;
+    const generation = ++this.runGeneration;
     log.info("[auto-sync] starting scheduler", {
       scanIntervalMs: this.config.scanIntervalMs,
       maxConcurrentSyncs: this.config.maxConcurrentSyncs,
@@ -133,7 +136,7 @@ export class AutoSyncScheduler {
     // 启动常驻 worker pool
     for (let i = 0; i < this.config.maxConcurrentSyncs; i++) {
       this.workerCount++;
-      void this.runWorker(i).finally(() => { this.workerCount--; });
+      void this.runWorker(i, generation).finally(() => { this.workerCount--; });
     }
 
     // 延迟首扫 30s
@@ -153,6 +156,7 @@ export class AutoSyncScheduler {
   /** 停止调度器：取消 timer、通知 worker 退出（已在跑的 sync 自然完成）。 */
   stop(): void {
     this.stopped = true;
+    this.runGeneration++;
     if (this.startupTimer !== null) {
       clearTimeout(this.startupTimer);
       this.startupTimer = null;
@@ -161,8 +165,11 @@ export class AutoSyncScheduler {
       clearInterval(this.scanTimer);
       this.scanTimer = null;
     }
-    for (const t of this.workerSleepTimers) clearTimeout(t);
-    this.workerSleepTimers.clear();
+    for (const [timer, wake] of this.workerSleeps) {
+      clearTimeout(timer);
+      wake();
+    }
+    this.workerSleeps.clear();
     log.info("[auto-sync] stopped");
   }
 
@@ -254,9 +261,9 @@ export class AutoSyncScheduler {
    * 一个常驻 worker：循环 shift 队列执行 sync；空则短睡后重试。
    * stop() 后 loop 自然退出。异常一律吞掉（记录日志），保证 worker 不死。
    */
-  private async runWorker(workerIdx: number): Promise<void> {
+  private async runWorker(workerIdx: number, generation: number): Promise<void> {
     log.debug(`[auto-sync] worker#${workerIdx} started`);
-    while (!this.stopped) {
+    while (!this.stopped && generation === this.runGeneration) {
       const row = this.queue.shift();
       if (!row) {
         await this.sleep(WORKER_IDLE_POLL_MS);
@@ -306,11 +313,18 @@ export class AutoSyncScheduler {
   /** setTimeout 版 sleep，stop 时统一清理避免测试环境 timer 泄漏。 */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => {
-      const t = setTimeout(() => {
-        this.workerSleepTimers.delete(t);
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout>;
+      const wake = () => {
+        if (settled) return;
+        settled = true;
+        this.workerSleeps.delete(timer);
         resolve();
+      };
+      timer = setTimeout(() => {
+        wake();
       }, ms);
-      this.workerSleepTimers.add(t);
+      this.workerSleeps.set(timer, wake);
     });
   }
 }


### PR DESCRIPTION
## Description | 描述

The v2.0.0 auto-sync scheduler keeps its idle workers alive by awaiting short `setTimeout` sleeps. `stop()` clears those timers, but the associated Promises are never resolved. The worker loops therefore never exit or decrement `workerCount`, and repeated stop/start cycles accumulate suspended workers.

This PR stores a wake callback with each idle timer and resolves cancelled sleeps during shutdown. Each scheduler run also receives a generation token, preventing an old worker from joining a new pool when callers execute `stop(); start()` before the old continuation resumes.

Fake-timer tests cover:

- a normal stop waking all idle workers and clearing every timer;
- an immediate stop/start retaining exactly the configured worker count, followed by a clean final stop.

## Related Issue | 关联 Issue

No existing issue. Discovered during a v2.0.0 default-branch Knowledge scheduler lifecycle audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证

- `pnpm vitest run src/store/auto-sync-scheduler.test.ts` - 1 file, 2 tests passed
- `pnpm test` - 1 file, 2 tests passed
- strict changed-file TypeScript check - passed
- `pnpm build` - 11 output files built
- `git diff --check` - passed

The full-package typecheck still reaches the unchanged `src/middleware/response-envelope.ts:47` base-branch error, which is fixed separately by #730. The changed scheduler and test pass an isolated strict TypeScript check.

## Additional Notes | 其他说明

- In-progress sync operations still finish naturally after stop, matching the existing contract.
- Queue contents, `inFlight` deduplication, scan cadence, and max concurrency are unchanged.
- Full Open PR title/body and changed-file scans found no active implementation touching the auto-sync scheduler.

Signed-off-by: RerankerGuo <121015044+RerankerGuo@users.noreply.github.com>
