### PR TITLE
fix(skill): release recovered transient failure state

### DIFF
--- a/MemoryCore/src/core/skill/conversation-add/extract-worker-transient-state.test.ts
+++ b/MemoryCore/src/core/skill/conversation-add/extract-worker-transient-state.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../report/otel-context.js", () => ({
+  runInRootContext: <T>(fn: () => T): T => fn(),
+}));
+vi.mock("../../report/obs-logger.js", () => ({
+  obsLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock("../../report/trace.js", () => ({
+  trace: { report: vi.fn() },
+}));
+
+import type {
+  AgentTuple,
+  ISkillAgentTaskQueue,
+} from "./agent-task-queue.js";
+import type {
+  SkillBufferStorage,
+  SkillTaskEntry,
+} from "./buffer-storage.js";
+import { SkillConversationExtractWorker } from "./extract-worker.js";
+
+describe("SkillConversationExtractWorker transient state", () => {
+  it("starts a fresh failure streak after a task recovers", async () => {
+    const agent: AgentTuple = {
+      space_id: "space-1",
+      user_id: "user-1",
+      team_id: "team-1",
+      agent_id: "agent-1",
+    };
+    const task: SkillTaskEntry = {
+      task_id: "task-reused",
+      session_id: "session-1",
+      user_id: agent.user_id,
+      team_id: agent.team_id,
+      agent_id: agent.agent_id,
+      space_id: agent.space_id,
+      archive_key: "archive-1",
+      archived_at_ms: 1,
+      enqueued_at_ms: 1,
+    };
+
+    const queue = {
+      dequeueAgent: vi.fn().mockResolvedValue(agent),
+      acquireExtractLock: vi.fn().mockResolvedValue({
+        key: "agent-lock",
+        token: "token",
+      }),
+      renewExtractLock: vi.fn().mockResolvedValue(true),
+      releaseExtractLock: vi.fn().mockResolvedValue(undefined),
+      requeueAgent: vi.fn().mockResolvedValue(undefined),
+      removeAgent: vi.fn().mockResolvedValue(undefined),
+      enqueueAgent: vi.fn().mockResolvedValue(true),
+      withTasksMutex: vi.fn(
+        async (
+          _tuple: AgentTuple,
+          _opts: { lockTtlMs: number; waitDeadlineMs: number },
+          fn: () => Promise<unknown>,
+        ) => fn(),
+      ),
+    } as unknown as ISkillAgentTaskQueue;
+
+    const buffer = {
+      readTasks: vi.fn().mockImplementation(async () => ({
+        team_id: agent.team_id,
+        agent_id: agent.agent_id,
+        updated_at_ms: 1,
+        tasks: [{ ...task }],
+      })),
+      writeTasks: vi.fn().mockResolvedValue(undefined),
+      readArchive: vi.fn().mockResolvedValue({
+        messages: [{ role: "user", content: "remember this" }],
+      }),
+    } as unknown as SkillBufferStorage;
+
+    const extractor = {
+      extract: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("fetch failed"))
+        .mockResolvedValueOnce({ candidates: [] })
+        .mockRejectedValueOnce(new Error("fetch failed")),
+    };
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const worker = new SkillConversationExtractWorker({
+      workerId: "worker-1",
+      buffer,
+      queue,
+      extractor,
+      sink: { applyCandidates: vi.fn().mockResolvedValue(undefined) },
+      logger,
+      brpopBlockMs: 0,
+      extractLockRenewIntervalMs: 0,
+      failureRequeueSleepMs: 0,
+    });
+
+    await worker.runOnce(); // transient failure: streak = 1
+    await worker.runOnce(); // success: terminal state should clear the streak
+    await worker.runOnce(); // reused id must log as a first failure again
+
+    expect(logger.error).toHaveBeenCalledTimes(2);
+    expect(logger.error.mock.calls[0]?.[0]).toContain("task=task-reused");
+    expect(logger.error.mock.calls[1]?.[0]).toContain("task=task-reused");
+  });
+});

--- a/MemoryCore/src/core/skill/conversation-add/extract-worker.ts
+++ b/MemoryCore/src/core/skill/conversation-add/extract-worker.ts
@@ -452,6 +452,10 @@ export class SkillConversationExtractWorker {
           dur_ms: Date.now() - t0Del,
           remaining: remainingTasks,
         });
+        // Success and ghost handling are terminal for this task. Retaining the
+        // sampling streak would leak one map entry per recovered task and make
+        // a reused task id inherit stale logging state.
+        this.transientFailStreak.delete(head.task_id);
 
         // trace.report 后端 span：跟 skill.extract / skill.conversation_add 对齐，
         // 按 task_id 就能在 clickhouse / langfuse 里拉到 handler + worker 双段。


### PR DESCRIPTION
## Description | 描述

`SkillConversationExtractWorker` keeps a per-task transient failure counter so
repeated network/timeout failures can be log-sampled. The counter was removed
when a later failure became permanent, but not when the task recovered
successfully or was terminally discarded as a ghost.

As a result, a long-lived worker retained one map entry for every recovered
task that had ever failed transiently. A reused task id also inherited the old
sampling count and no longer emitted the expected first-failure error.

This change:

- clears the transient streak only after success/ghost handling has removed the
  task under the existing tasks mutex;
- preserves the streak when extraction or terminal task removal fails and the
  task may still be retried;
- adds a regression test covering `transient failure -> success -> reused id
  transient failure`, proving that the final failure starts a fresh streak.

The retry classification, retry delay, permanent retry count, DLQ policy, and
queue locking behavior are unchanged.

## Related Issue | 关联 Issue

No linked issue. This was found while auditing the v2.0.0 long-lived skill
worker lifecycle on `feat/server_team`.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification

- `pnpm exec vitest run src/core/skill/conversation-add/extract-worker-transient-state.test.ts`
  - 1 test passed
- `pnpm test`
  - 1 test passed
- `pnpm run build:plugin`
  - plugin bundle completed successfully
- `pnpm run lint:skill-isolation`
  - passed
- `git diff --check`
  - passed

The focused test was also run before the implementation change and failed with
one error log instead of two, directly reproducing the stale streak.

## Additional Notes | 其他说明

- Breaking change: none.
- A strict standalone `tsc` invocation still reaches existing default-branch
  errors for the excluded observability integration, the OpenTelemetry v2
  `Resource` API, and an optional worker log field. The production plugin build
  succeeds and none of those diagnostics are introduced or modified here.
- Scope is limited to two files: the worker state cleanup and its regression
  test.
