### PR TITLE
fix(panel): preserve kernel task pagination

### DIFF
--- a/MemoryPanel/src/panel/http/routes/task.ts
+++ b/MemoryPanel/src/panel/http/routes/task.ts
@@ -153,8 +153,8 @@ export function registerTaskRoutes(api: Hono, deps: PanelDeps): void {
         okEnvelope(c, {
           items,
           total,
-          limit: (listPayload.limit as number) ?? 50,
-          offset: (listPayload.offset as number) ?? 0,
+          limit: taskData?.limit ?? (listPayload.limit as number) ?? 50,
+          offset: taskData?.offset ?? (listPayload.offset as number) ?? 0,
         }),
       );
     },

--- a/MemoryPanel/tests/http/task-pagination.test.ts
+++ b/MemoryPanel/tests/http/task-pagination.test.ts
@@ -1,0 +1,84 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { InstanceRegistry } from "../../src/panel/config/instance-registry.js";
+import { registerTaskRoutes } from "../../src/panel/http/routes/task.js";
+import type { PanelDeps } from "../../src/panel/panel-deps.js";
+
+describe("task list aggregation pagination", () => {
+  it("returns pagination metadata normalized by the kernel", async () => {
+    const invoke = vi.fn(async (action: string) => {
+      if (action === "task/list") {
+        return {
+          code: 0,
+          message: "ok",
+          request_id: "kernel-list",
+          data: {
+            items: [
+              {
+                task_id: "task-1",
+                team_id: "team-1",
+                title: "Task",
+                status: "active",
+                created_at: "2026-08-03T00:00:00.000Z",
+                updated_at: "2026-08-03T00:00:00.000Z",
+              },
+            ],
+            total: 42,
+            limit: 20,
+            offset: 40,
+          },
+        };
+      }
+      return {
+        code: 0,
+        message: "ok",
+        request_id: "kernel-agents",
+        data: { items: [] },
+      };
+    });
+    const deps = {
+      instanceRegistry: new InstanceRegistry([
+        {
+          instance_id: "default",
+          name: "Default",
+          gateway_endpoint: "http://gateway.test",
+          api_key: "gateway-key",
+        },
+      ]),
+      metaKernel: { invoke },
+    } as unknown as PanelDeps;
+    const app = new Hono();
+    registerTaskRoutes(app, deps);
+
+    const response = await app.request("/task/list-with-agents", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-tdai-service-id": "default",
+        "x-tdai-user-key": "user-key",
+      },
+      body: JSON.stringify({
+        team_id: "team-1",
+        limit: 500,
+        offset: 10,
+      }),
+    });
+    const envelope = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(envelope.data).toMatchObject({
+      total: 42,
+      limit: 20,
+      offset: 40,
+    });
+    expect(invoke).toHaveBeenNthCalledWith(
+      1,
+      "task/list",
+      { team_id: "team-1", limit: 200, offset: 10 },
+      expect.objectContaining({
+        instanceId: "default",
+        userKey: "user-key",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Background

`POST /task/list-with-agents` aggregates task and agent data from the metadata kernel. The route previously rebuilt `limit` and `offset` from the request, even though the kernel may normalize or clamp those values. This could make the response metadata disagree with the returned task page.

## Changes

- Return the pagination metadata supplied by `task/list`.
- Keep the existing request-derived values only as a compatibility fallback when older kernel responses omit pagination metadata.
- Add a route-level regression test covering a clamped limit and kernel-provided offset.

The change is limited to the Panel task aggregation response. It does not modify kernel pagination behavior or other task routes.

## Verification

- [x] `npm test -- --run tests/http/task-pagination.test.ts` (1 test passed)
- [x] `npm test` (1 test passed)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check`

## Impact

- Breaking change: No
- Affected module: `MemoryPanel`
- Performance impact: None

## Checklist

- [x] The change follows the existing route and test style.
- [x] A regression test proves the corrected behavior.
- [x] Focused and package-level validation passes locally.
- [x] The PR contains one isolated fix.
