### PR TITLE
fix(sdk): validate v3 response envelopes

### DIFF
--- a/sdk/memory-core/typescript/src/v3/http.ts
+++ b/sdk/memory-core/typescript/src/v3/http.ts
@@ -62,9 +62,9 @@ export class V3HttpTransport {
         response.headers.get("x-trace-id") ??
         "";
 
-      let envelope: ApiResponseEnvelope<T>;
+      let parsed: unknown;
       try {
-        envelope = JSON.parse(responseText) as ApiResponseEnvelope<T>;
+        parsed = JSON.parse(responseText) as unknown;
       } catch {
         throw new TDAMError(
           response.ok ? -1 : response.status,
@@ -72,12 +72,23 @@ export class V3HttpTransport {
           headerRequestId,
         );
       }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new TDAMError(-1, "API response must be a JSON object", headerRequestId);
+      }
+      const envelope = parsed as ApiResponseEnvelope<T>;
 
       const businessCode = typeof envelope.code === "number" ? envelope.code : undefined;
       if (!response.ok || businessCode !== 0) {
-        const code = businessCode && businessCode !== 0 ? businessCode : response.status;
+        const code =
+          businessCode !== undefined && businessCode !== 0
+            ? businessCode
+            : response.ok
+              ? -1
+              : response.status;
         const details =
-          envelope.data && typeof envelope.data === "object"
+          envelope.data &&
+          typeof envelope.data === "object" &&
+          !Array.isArray(envelope.data)
             ? (envelope.data as Record<string, unknown>)
             : undefined;
         throw new TDAMError(
@@ -88,7 +99,11 @@ export class V3HttpTransport {
         );
       }
 
-      const result = (envelope.data ?? {}) as T & { trace_id?: string };
+      const data = envelope.data ?? {};
+      if (typeof data !== "object" || Array.isArray(data)) {
+        throw new TDAMError(-1, "API response data must be a JSON object", headerRequestId);
+      }
+      const result = data as T & { trace_id?: string };
       const traceId = response.headers.get("x-trace-id");
       if (traceId && result && typeof result === "object") {
         (result as Record<string, unknown>).trace_id = traceId;

--- a/sdk/memory-core/typescript/tests/v3-http-envelope.test.ts
+++ b/sdk/memory-core/typescript/tests/v3-http-envelope.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TDAMError } from "../src/errors.js";
+import { V3HttpTransport } from "../src/v3/http.js";
+
+const transport = new V3HttpTransport({
+  endpoint: "https://memory.example.test",
+  apiKey: "api-key",
+  serviceId: "default",
+});
+
+function response(body: unknown, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("V3HttpTransport response envelopes", () => {
+  it("rejects a non-object response envelope as a protocol error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response([])));
+
+    await expect(transport.post("/v3/test")).rejects.toMatchObject<TDAMError>({
+      code: -1,
+      message: expect.stringContaining("API response must be a JSON object"),
+    });
+  });
+
+  it("uses a protocol error code when a successful envelope omits code", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(response({ message: "ok", data: {} })),
+    );
+
+    await expect(transport.post("/v3/test")).rejects.toMatchObject<TDAMError>({
+      code: -1,
+    });
+  });
+
+  it("rejects primitive success data", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        response({
+          code: 0,
+          message: "ok",
+          request_id: "request-1",
+          data: "not-an-object",
+        }),
+      ),
+    );
+
+    await expect(transport.post("/v3/test")).rejects.toMatchObject<TDAMError>({
+      code: -1,
+      message: expect.stringContaining("API response data must be a JSON object"),
+    });
+  });
+
+  it("preserves object data and response trace ids", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        response(
+          {
+            code: 0,
+            message: "ok",
+            request_id: "request-1",
+            data: { value: 1 },
+          },
+          { "x-trace-id": "trace-1" },
+        ),
+      ),
+    );
+
+    await expect(transport.post("/v3/test")).resolves.toEqual({
+      value: 1,
+      trace_id: "trace-1",
+    });
+  });
+});


### PR DESCRIPTION
## Background

The TypeScript v3 HTTP transport treated malformed successful responses inconsistently. A success envelope without a numeric `code` could surface as `TDAMError(code=200)`, while a primitive `data` value could be returned as though it were a valid SDK result. The Python v3 transport already rejects these protocol-invalid shapes.

## Changes

- Parse response JSON as `unknown` and require the top-level envelope to be an object.
- Treat a missing or invalid business code on a successful HTTP response as protocol error `-1`.
- Require successful `data` to be an object before returning it.
- Preserve the current behavior for valid object data, business errors, request IDs, and trace IDs.
- Add focused tests for invalid envelopes, missing codes, primitive data, and valid trace propagation.

The change is limited to v3 HTTP response validation. It does not alter request serialization or public SDK method signatures.

## Verification

- [x] `npm test -- --run tests/v3-http-envelope.test.ts` (4 tests passed)
- [x] `npm test` (4 tests passed)
- [x] `npm run build`
- [x] `git diff --check`

## Impact

- Breaking change: No for protocol-valid server responses
- Affected module: `sdk/memory-core/typescript`
- Performance impact: None

## Checklist

- [x] The change follows the existing transport and test style.
- [x] Regression tests cover malformed and valid envelopes.
- [x] Focused and package-level validation passes locally.
- [x] The PR contains one isolated fix.
