### PR TITLE
fix(proxy): restore v2 typecheck

### DIFF
--- a/MemoryProxy/src/__tests__/config-mem-command.test.ts
+++ b/MemoryProxy/src/__tests__/config-mem-command.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildConfig } from "../config.js";
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("memCommand config", () => {
+  it("loads the optional YAML section and filters invalid commands", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "proxy-config-"));
+    const configPath = join(tempDir, "config.yaml");
+    writeFileSync(
+      configPath,
+      [
+        "memCommand:",
+        "  enabled: true",
+        "  allowedCommands:",
+        "    - sync",
+        "    - 42",
+        "    - help",
+        "",
+      ].join("\n"),
+    );
+
+    const config = buildConfig({ configFile: configPath });
+
+    expect(config.memCommand).toEqual({
+      enabled: true,
+      allowedCommands: ["sync", "help"],
+    });
+  });
+});

--- a/MemoryProxy/src/optional-modules.d.ts
+++ b/MemoryProxy/src/optional-modules.d.ts
@@ -1,0 +1,3 @@
+declare module "@context-proxy/cost-guard" {
+  export const openKernelStsCosBackend: unknown;
+}

--- a/MemoryProxy/src/session/claude-code/init.ts
+++ b/MemoryProxy/src/session/claude-code/init.ts
@@ -119,7 +119,7 @@ async function fetchTeamsAndAgents(
         metadataClient.listAgents(t.team_id, userId),
         metadataClient.listTasks(t.team_id),
       ]);
-      const tasks = tasksRaw.map((tk) => ({
+      const tasks: TeamOption["tasks"] = tasksRaw.map((tk) => ({
         task_id: tk.task_id,
         task_name: tk.title,
       }));

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -96,7 +96,7 @@ async function fetchTeamsAndAgents(
         metadataClient.listAgents(t.team_id, userId),
         metadataClient.listTasks(t.team_id),
       ]);
-      const tasks = tasksRaw.map((tk) => ({
+      const tasks: TeamOption["tasks"] = tasksRaw.map((tk) => ({
         task_id: tk.task_id,
         task_name: tk.title,
       }));

--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -796,6 +796,10 @@ export interface RawYamlConfig {
   admin?: {
     apiKey?: string;
   };
+  memCommand?: {
+    enabled?: boolean;
+    allowedCommands?: string[];
+  };
 }
 
 /** request event — written when a request is intercepted (metadata only, no messages). */


### PR DESCRIPTION
## Description | 描述

The v2.0.0 Proxy package does not pass its own TypeScript check. The release
runtime already supports `memCommand` configuration and virtual default task
entries, but the corresponding raw-config and inferred task-list types were
not updated. Open-source checkouts also lack a declaration for the optional
private cost-guard submodule.

This change:

- adds the existing `memCommand` YAML shape to `RawYamlConfig`;
- types both session-init task arrays with the shared `TeamOption` contract so
  the existing `isDefault` marker remains valid;
- declares the optional cost-guard export without requiring the submodule in
  an open-source checkout;
- adds focused coverage for loading and filtering `memCommand` configuration.

Runtime configuration, session selection, and optional-module loading behavior
are unchanged.

## Related Issue | 关联 Issue

L4 v2.0.0 Proxy build/typecheck audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test -- --run src/__tests__/config-mem-command.test.ts` (1/1)
- `npm test` (1/1 collected Proxy test)
- `npx tsc --noEmit`
- `npm pack --dry-run --json` (149 files)
- `git diff --check`

## Additional Notes | 其他说明

The default branch reported six errors across these boundaries before this
change. The full package typecheck now passes. No dependency or lockfile is
changed.
