### PR TITLE
fix(proxy): avoid re-recording stale user turns

### DIFF
--- a/MemoryProxy/src/__tests__/tdai-recorder.test.ts
+++ b/MemoryProxy/src/__tests__/tdai-recorder.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { extractLatestUserMessage } from "../tdai/recorder.js";
+
+describe("extractLatestUserMessage", () => {
+  it("does not fall back to an older turn when the latest user message is harness noise", () => {
+    const result = extractLatestUserMessage([
+      { role: "user", content: "earlier real question" },
+      { role: "assistant", content: "earlier answer" },
+      {
+        role: "user",
+        content: "<system-reminder>metadata only</system-reminder>",
+      },
+    ]);
+
+    expect(result).toBeNull();
+  });
+
+  it("still extracts the newest real user message past trailing assistant messages", () => {
+    const result = extractLatestUserMessage([
+      { role: "user", content: "older question" },
+      { role: "user", content: "<user_query>new question</user_query>" },
+      { role: "assistant", content: "pending answer" },
+    ]);
+
+    expect(result).toEqual({ role: "user", content: "new question" });
+  });
+});

--- a/MemoryProxy/src/tdai/recorder.ts
+++ b/MemoryProxy/src/tdai/recorder.ts
@@ -24,7 +24,7 @@ export function extractLatestUserMessage(messages: unknown[]): TdaiMessage | nul
     if (msg?.role !== "user") continue;
     // 只取真实 user_query，避免把 harness 上下文写进 L0
     const content = extractUserQueryText(extractContentText(msg.content));
-    if (content.trim()) return { role: "user", content };
+    return content.trim() ? { role: "user", content } : null;
   }
   return null;
 }


### PR DESCRIPTION
## Description | 描述

TDAI L0 recording should consider the newest user-role message in the current
request. When that message contains only coding-agent harness metadata,
`extractLatestUserMessage()` currently continues scanning backward and returns
an older real question. The current turn then records that previous question a
second time.

This change:

- stops after evaluating the newest user-role message;
- returns `null` when that message contains no human input;
- preserves extraction of the newest real user message when assistant messages
  follow it;
- adds focused regression tests for both cases.

The shared user-query cleanup rules and TDAI write path are unchanged.

## Related Issue | 关联 Issue

L3 MemoryProxy TDAI data-correctness audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npm test -- --run src/__tests__/tdai-recorder.test.ts` (2/2)
- `npm test` (2/2 collected Proxy tests)
- strict changed-file TypeScript check
- `git diff --check`

## Additional Notes | 其他说明

The default-branch full Proxy typecheck errors are repaired separately by
#741. This PR changes only TDAI user-turn selection and its regression test; it
does not change configuration, dependencies, or lockfiles.
