### PR TITLE
fix(panel): scope user-key request deduplication

### DIFF
--- a/MemoryPanel/tests/web-user-key-dedupe.test.ts
+++ b/MemoryPanel/tests/web-user-key-dedupe.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../web/src/lib/error-message.ts", () => ({
+  formatApiErrorMessage: ({ message }: { message?: string }) =>
+    message ?? "API error",
+}));
+
+import { userKeysApi } from "../web/src/lib/api/users.js";
+import {
+  clearPanelSession,
+  setPanelSession,
+  type PanelSession,
+} from "../web/src/lib/panelSession.js";
+
+interface PendingRequest {
+  userKey: string;
+  resolve: (response: Response) => void;
+}
+
+function session(userId: string, userKey: string): PanelSession {
+  return {
+    instanceId: "instance-1",
+    userKey,
+    user: {
+      user_id: userId,
+      auth_provider: "local",
+      external_id: userId,
+      username: userId,
+      status: "active",
+      created_at: "2026-08-03T00:00:00.000Z",
+      updated_at: "2026-08-03T00:00:00.000Z",
+    },
+  };
+}
+
+function responseFor(userKey: string): Response {
+  return new Response(
+    JSON.stringify({
+      code: 0,
+      message: "ok",
+      request_id: `request-${userKey}`,
+      data: {
+        items: [{ key_id: `key-for-${userKey}` }],
+        total: 1,
+        limit: 100,
+        offset: 0,
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+describe("user key request deduplication", () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    });
+  });
+
+  afterEach(() => {
+    clearPanelSession();
+    storage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  function stubPendingFetch(): {
+    pending: PendingRequest[];
+    fetchMock: ReturnType<typeof vi.fn>;
+  } {
+    const pending: PendingRequest[] = [];
+    const fetchMock = vi.fn(
+      async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> =>
+        new Promise((resolve) => {
+          const headers = init?.headers as Record<string, string>;
+          pending.push({
+            userKey: headers["X-Tdai-User-Key"],
+            resolve,
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return { pending, fetchMock };
+  }
+
+  it("does not reuse a pending list across authenticated users", async () => {
+    const { pending, fetchMock } = stubPendingFetch();
+    setPanelSession(session("user-a", "secret-a"));
+    const first = userKeysApi.list();
+
+    setPanelSession(session("user-b", "secret-b"));
+    const second = userKeysApi.list();
+
+    for (const request of pending) {
+      request.resolve(responseFor(request.userKey));
+    }
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(firstResult).toEqual([{ key_id: "key-for-secret-a" }]);
+    expect(secondResult).toEqual([{ key_id: "key-for-secret-b" }]);
+  });
+
+  it("still reuses a pending list within one authenticated user", async () => {
+    const { pending, fetchMock } = stubPendingFetch();
+    setPanelSession(session("user-a", "secret-a"));
+    const first = userKeysApi.list();
+    const second = userKeysApi.list();
+
+    pending[0]?.resolve(responseFor("secret-a"));
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(firstResult).toEqual([{ key_id: "key-for-secret-a" }]);
+    expect(secondResult).toEqual(firstResult);
+  });
+});

--- a/MemoryPanel/web/src/lib/api/users.ts
+++ b/MemoryPanel/web/src/lib/api/users.ts
@@ -2,6 +2,7 @@
  * api/users.ts — User + UserKey + UserConfig（链路 A：meta/user/* + meta/user-key/* + meta/config/user/*）。
  */
 import { metaPost, metaListAll, getCurrentUser, dedupeInFlight } from './base';
+import { getPanelSession } from '../panelSession';
 import type { PublicUser } from './types';
 
 /** 内核 user/create 响应（CreateUserResult） — 不含 username，含一次性密钥 */
@@ -60,9 +61,16 @@ export interface UserKey {
   last_used_at?: string;
 }
 
+function userKeyListDedupeKey(): string {
+  const session = getPanelSession();
+  if (!session) return 'user-key/list:anonymous';
+  const principal = session.user?.user_id ?? session.userKey;
+  return `user-key/list:${JSON.stringify([session.instanceId, principal])}`;
+}
+
 export const userKeysApi = {
   /** 列出当前登录用户的全部 API Key（按内核分页拉全量） */
-  list: () => dedupeInFlight('user-key/list', () => metaListAll<UserKey>('user-key/list', {})),
+  list: () => dedupeInFlight(userKeyListDedupeKey(), () => metaListAll<UserKey>('user-key/list', {})),
 
   /** 创建一把新 Key；返回值里的 key_value 明文只展示这一次，调用方需立即展示给用户 */
   create: (data: { name?: string; expires_at?: string; user_id?: string }) => metaPost<UserKey>('user-key/create', data),


### PR DESCRIPTION
## Description | 描述

The Panel deduplicates concurrent read requests to avoid duplicate network
calls from React StrictMode and concurrent component mounts. The user-key list
used one global in-flight key, `user-key/list`, independent of the active
Panel session.

If user A's request was still pending while the local session switched to user
B, B's call reused A's Promise instead of issuing a request with B's
credentials. This could render user A's key metadata in user B's session until
the view refreshed.

This change scopes only the user-key list dedupe key to:

- the selected memory instance; and
- the authenticated `user_id` (falling back to the current user key only for
  legacy/incomplete cached sessions without a user object).

Concurrent reads within one authenticated session still share one Promise.
Different users or instances now use independent pending requests. The
response format, backend API, authentication headers, and create/revoke paths
are unchanged.

## Related Issue | 关联 Issue

No linked issue. This was found during a v2.0.0 Panel authentication and
session-boundary audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification

- `pnpm exec vitest run tests/web-user-key-dedupe.test.ts`
  - 2 tests passed
- `pnpm test`
  - 2 tests passed
- `pnpm run typecheck`
  - passed
- `pnpm run build`
  - Panel backend build passed
- `npm run build` in `MemoryPanel/web`
  - TypeScript and Vite production build passed
- `npx eslint src/lib/api/users.ts`
  - passed
- `npm pack --dry-run --json --ignore-scripts`
  - 197 files verified
- `git diff --check`
  - passed

The cross-user regression test was first run against the unchanged
implementation and failed because two authenticated users produced only one
fetch. A second test locks the intended same-user coalescing behavior.

## Additional Notes | 其他说明

- Breaking change: none.
- A full Web lint run still reports the existing `AgentGrid.tsx` empty-block
  error and 97 unrelated warnings. The changed production file passes ESLint.
- The source change is limited to the user-key list request key. The generic
  dedupe helper and public instance-list deduplication remain unchanged.
