### PR TITLE
fix(panel): scope task request deduplication by team

### DIFF
--- a/MemoryPanel/tests/web/task-request-key.test.ts
+++ b/MemoryPanel/tests/web/task-request-key.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { taskRequestKey } from '../../web/src/stores/task-request-key';
+
+describe('taskRequestKey', () => {
+  it('deduplicates identical requests within one team', () => {
+    expect(taskRequestKey('team-a', 20, 10)).toBe(
+      taskRequestKey('team-a', 20, 10),
+    );
+  });
+
+  it('keeps the same page independent across teams', () => {
+    expect(taskRequestKey('team-a', 0, 20)).not.toBe(
+      taskRequestKey('team-b', 0, 20),
+    );
+  });
+});

--- a/MemoryPanel/web/src/stores/backend.ts
+++ b/MemoryPanel/web/src/stores/backend.ts
@@ -23,6 +23,7 @@ import {
 import { tea } from '@/lib/tea-bridge';
 import i18n from '@/i18n';
 import { seedDisplayNameCache } from '@/services/user-profile-store';
+import { taskRequestKey } from './task-request-key';
 
 // 从 backendStore.ts re-import 纯函数（adapters / types），避免循环依赖
 import {
@@ -183,12 +184,16 @@ export const useBackendStore = create<BackendState>((set, get) => ({
     const offset = params?.offset ?? 0;
     // 缓存 key：按 (offset, limit) 粒度（teamId 已在 tasksPagesByTeam[teamId] 这层隔离）
     const cacheKey = `${offset}:${limit}`;
+    const inflightKey = taskRequestKey(teamId, offset, limit);
     // 已缓存且非强制刷新 → 直接返回
     if (!params?.force && state.tasksPagesByTeam[teamId]?.[cacheKey]) {
       return state.tasksPagesByTeam[teamId][cacheKey];
     }
     // in-flight 去重
-    if (state.inflightTasks[cacheKey]) { await state.inflightTasks[cacheKey]; return get().tasksPagesByTeam[teamId]?.[cacheKey] ?? []; }
+    if (state.inflightTasks[inflightKey]) {
+      await state.inflightTasks[inflightKey];
+      return get().tasksPagesByTeam[teamId]?.[cacheKey] ?? [];
+    }
 
     const promise = (async () => {
       try {
@@ -202,7 +207,7 @@ export const useBackendStore = create<BackendState>((set, get) => ({
             tasksPagesByTeam: { ...s.tasksPagesByTeam, [teamId]: { ...teamPages, [cacheKey]: adapted } },
             tasksTotalByTeam: { ...s.tasksTotalByTeam, [teamId]: total },
             inflightTasks: Object.fromEntries(
-              Object.entries(s.inflightTasks).filter(([k]) => k !== cacheKey)
+              Object.entries(s.inflightTasks).filter(([k]) => k !== inflightKey)
             ),
           };
         });
@@ -211,7 +216,7 @@ export const useBackendStore = create<BackendState>((set, get) => ({
         console.error('[backend store] fetchTasks failed:', err);
         set((s) => ({
           inflightTasks: Object.fromEntries(
-            Object.entries(s.inflightTasks).filter(([k]) => k !== cacheKey)
+            Object.entries(s.inflightTasks).filter(([k]) => k !== inflightKey)
           ),
         }));
         tea.notify.error(i18n.t('backend.loadTasksFailed'));
@@ -219,7 +224,7 @@ export const useBackendStore = create<BackendState>((set, get) => ({
       }
     })();
 
-    set((s) => ({ inflightTasks: { ...s.inflightTasks, [cacheKey]: promise } }));
+    set((s) => ({ inflightTasks: { ...s.inflightTasks, [inflightKey]: promise } }));
     return promise;
   },
 

--- a/MemoryPanel/web/src/stores/task-request-key.ts
+++ b/MemoryPanel/web/src/stores/task-request-key.ts
@@ -1,0 +1,3 @@
+export function taskRequestKey(teamId: string, offset: number, limit: number): string {
+  return JSON.stringify([teamId, offset, limit]);
+}


### PR DESCRIPTION
## Description | 描述

The Panel Web task store caches pages by team, but its in-flight request map
uses only `offset:limit`. When two teams request the same page concurrently,
the second caller reuses the first team's Promise, never requests its own team,
and returns an empty team-local cache.

This change:

- scopes task in-flight keys by `(teamId, offset, limit)`;
- uses the scoped key consistently for lookup, insertion, and cleanup;
- adds focused tests proving same-team requests deduplicate while equal pages
  from different teams remain independent.

Task page caching, API requests, response adaptation, and invalidation behavior
are unchanged.

## Related Issue | 关联 Issue

L3 MemoryPanel Web cache-isolation audit finding; no existing issue.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npx vitest run tests/web/task-request-key.test.ts` (2/2)
- `npm test` (2/2 collected Panel tests)
- `npm run typecheck`
- `npm run build`
- `npm run build` in `MemoryPanel/web`
- ESLint on both changed Web source files
- `git diff --check`

## Additional Notes | 其他说明

The default branch's full `backend.ts` Prettier check already reports existing
formatting differences. The new helper passes its standalone Prettier check;
this PR intentionally avoids unrelated whole-file formatting churn.
