### PR TITLE
fix(sdk): validate Python v3 response envelopes

### DIFF
--- a/sdk/memory-core/python/tencentdb_agent_memory/_v3_http.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/_v3_http.py
@@ -51,8 +51,12 @@ def _decode_response(resp: httpx.Response) -> dict:
         raise TDAMError(-1, "API response must be a JSON object", header_request_id)
 
     code = envelope.get("code")
-    if resp.is_error or code != 0:
-        effective_code = code if isinstance(code, int) and code != 0 else resp.status_code
+    if resp.is_error:
+        effective_code = (
+            code
+            if isinstance(code, int) and not isinstance(code, bool) and code != 0
+            else resp.status_code
+        )
         payload = envelope.get("data")
         details = payload if isinstance(payload, dict) else None
         raise TDAMError(
@@ -62,7 +66,21 @@ def _decode_response(resp: httpx.Response) -> dict:
             details=details,
         )
 
-    result = envelope.get("data") or {}
+    if isinstance(code, bool) or not isinstance(code, int):
+        raise TDAMError(-1, "API response code must be an integer", header_request_id)
+    if code != 0:
+        payload = envelope.get("data")
+        details = payload if isinstance(payload, dict) else None
+        raise TDAMError(
+            code=code,
+            message=str(envelope.get("message") or f"HTTP {resp.status_code}"),
+            request_id=str(envelope.get("request_id") or header_request_id),
+            details=details,
+        )
+
+    result = envelope.get("data")
+    if result is None:
+        result = {}
     if not isinstance(result, dict):
         raise TDAMError(-1, "API response data must be a JSON object", header_request_id)
     trace_id = resp.headers.get("x-trace-id")

--- a/sdk/memory-core/python/tests/test_v3_http.py
+++ b/sdk/memory-core/python/tests/test_v3_http.py
@@ -1,0 +1,60 @@
+import httpx
+import pytest
+
+from tencentdb_agent_memory._v3_http import _decode_response
+from tencentdb_agent_memory.errors import TDAMError
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": "ok", "data": {}},
+        {"code": True, "message": "ok", "data": {}},
+    ],
+)
+def test_success_requires_integer_code(payload):
+    response = httpx.Response(200, json=payload)
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_response(response)
+
+    assert exc_info.value.code == -1
+    assert exc_info.value.message == "API response code must be an integer"
+
+
+@pytest.mark.parametrize("data", [[], "", False])
+def test_success_requires_object_data(data):
+    response = httpx.Response(200, json={"code": 0, "message": "ok", "data": data})
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_response(response)
+
+    assert exc_info.value.code == -1
+    assert exc_info.value.message == "API response data must be a JSON object"
+
+
+def test_success_allows_null_data():
+    response = httpx.Response(200, json={"code": 0, "message": "ok", "data": None})
+
+    assert _decode_response(response) == {}
+
+
+def test_http_error_without_code_preserves_status():
+    response = httpx.Response(503, json={"message": "unavailable"})
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_response(response)
+
+    assert exc_info.value.code == 503
+    assert exc_info.value.message == "unavailable"
+
+
+def test_business_error_preserves_code_and_details():
+    response = httpx.Response(200, json={"code": 40901, "data": {"current_version": 3}})
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_response(response)
+
+    assert exc_info.value.code == 40901
+    assert exc_info.value.message == "HTTP 200"
+    assert exc_info.value.details == {"current_version": 3}


### PR DESCRIPTION
## Description | 描述

The Python v3 transport does not fully enforce its strict response-envelope
contract. A successful response without a numeric `code` currently raises
`TDAMError(code=200)`, while falsy primitive data such as `[]`, `""`, or
`false` is converted to `{}` and accepted.

This change:

- requires successful responses to carry an integer, non-boolean `code`;
- reports malformed successful codes as protocol error `-1`;
- treats only `null` data as the existing empty-object fallback;
- rejects all other non-object success data;
- preserves HTTP-error status precedence, business codes, details, request IDs,
  and valid response behavior.

Focused tests cover malformed codes, primitive data, null data, HTTP errors,
and business-error details.

## Related Issue | 关联 Issue

L3/L4 Python v3 SDK protocol audit finding; no existing issue. PR #740 fixes
the equivalent TypeScript SDK boundary but does not modify Python files.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `PYTHONPATH=. python3 -m pytest -q tests/test_v3_http.py` (8/8)
- `PYTHONPATH=. python3 -m pytest -q` (8/8 collected tests)
- `python3 -m compileall -q tencentdb_agent_memory tests`
- `python3 -m pip wheel . --no-deps` (wheel built)
- `git diff --check`

## Additional Notes | 其他说明

This PR changes only Python v3 response decoding and its focused tests. Public
method signatures, request serialization, dependencies, and package metadata
are unchanged.
