### PR TITLE
fix(knowledge): validate list pagination

### DIFF
--- a/MemoryKnowledge/openapi.yaml
+++ b/MemoryKnowledge/openapi.yaml
@@ -833,9 +833,11 @@ components:
               enum: [draft, pending, processing, ready, failed]
             limit:
               type: integer
+              minimum: 1
               default: 20
             offset:
               type: integer
+              minimum: 0
               default: 0
 
     WikiListData:
@@ -1072,9 +1074,11 @@ components:
               enum: [pending, processing, ready, failed]
             limit:
               type: integer
+              minimum: 1
               default: 20
             offset:
               type: integer
+              minimum: 0
               default: 0
 
     CodeGraphListData:

--- a/MemoryKnowledge/src/api-helpers.ts
+++ b/MemoryKnowledge/src/api-helpers.ts
@@ -68,6 +68,37 @@ export function extractIdFields(
   return fields;
 }
 
+// ───────────────────────── Pagination ─────────────────────────
+
+export type ListPaginationResult =
+  | { ok: true; limit: number; offset: number }
+  | { ok: false; message: string };
+
+/** Validate shared offset pagination for Knowledge list endpoints. */
+export function parseListPagination(body: Record<string, unknown>): ListPaginationResult {
+  const limit = body.limit === undefined ? 20 : body.limit;
+  if (
+    typeof limit !== "number"
+    || !Number.isFinite(limit)
+    || !Number.isInteger(limit)
+    || limit < 1
+  ) {
+    return { ok: false, message: "limit must be a positive integer" };
+  }
+
+  const offset = body.offset === undefined ? 0 : body.offset;
+  if (
+    typeof offset !== "number"
+    || !Number.isFinite(offset)
+    || !Number.isInteger(offset)
+    || offset < 0
+  ) {
+    return { ok: false, message: "offset must be a non-negative integer" };
+  }
+
+  return { ok: true, limit, offset };
+}
+
 // ───────────────────────── ApiResponseEnvelope ─────────────────────────
 
 export interface ApiResponseEnvelope<T = unknown> {

--- a/MemoryKnowledge/src/routes/code-graph.ts
+++ b/MemoryKnowledge/src/routes/code-graph.ts
@@ -21,6 +21,7 @@ import { toCodeGraphToolName, CODEGRAPH_QUERY_TOOL_NAMES } from "./tools.js";
 import {
   extractIdFields,
   isValidIdSegment,
+  parseListPagination,
   wrapOk,
   wrapError,
   toCodeGraphDetail,
@@ -221,10 +222,14 @@ export function createCodeGraphRoutes(deps: CodeGraphRouteDeps): Hono {
     if (!idFields) return c.json(wrapError(400, "x-tdai-service-id header and team_id are required"), 400);
 
     const status = typeof body.status === "string" ? (body.status as SyncStatus) : undefined;
-    const limit = typeof body.limit === "number" ? body.limit : 20;
-    const offset = typeof body.offset === "number" ? body.offset : 0;
+    const pagination = parseListPagination(body);
+    if (!pagination.ok) return c.json(wrapError(400, pagination.message), 400);
 
-    const items = cgService.list(idFields.service_id, idFields.team_id, { syncStatus: status, limit, offset });
+    const items = cgService.list(idFields.service_id, idFields.team_id, {
+      syncStatus: status,
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
     const total = cgService.count(idFields.service_id, idFields.team_id, status ? { syncStatus: status } : undefined);
     return c.json(wrapOk({ items: items.map(toCodeGraphDetail), total }));
   });

--- a/MemoryKnowledge/src/routes/list-pagination.test.ts
+++ b/MemoryKnowledge/src/routes/list-pagination.test.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+
+import type { WikiSourceManager } from "../engines/wiki/index.js";
+import type { CodeGraphInstancePool } from "../module.js";
+import type { CodeGraphService, WikiService } from "../store/index.js";
+import { createCodeGraphRoutes } from "./code-graph.js";
+import { createWikiRoutes } from "./wiki.js";
+
+const wikiList = vi.fn(() => []);
+const wikiCount = vi.fn(() => 0);
+const codeGraphList = vi.fn(() => []);
+const codeGraphCount = vi.fn(() => 0);
+
+const app = new Hono();
+app.route(
+  "/v3/wiki",
+  createWikiRoutes({
+    wikiService: {
+      list: wikiList,
+      count: wikiCount,
+    } as unknown as WikiService,
+    wikiMgr: {} as WikiSourceManager,
+    publicBaseUrl: "",
+  }),
+);
+app.route(
+  "/v3/code-graph",
+  createCodeGraphRoutes({
+    cgService: {
+      list: codeGraphList,
+      count: codeGraphCount,
+    } as unknown as CodeGraphService,
+    instancePool: {} as CodeGraphInstancePool,
+    publicBaseUrl: "",
+  }),
+);
+
+async function post(path: string, body: Record<string, unknown>): Promise<Response> {
+  return app.request(path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-tdai-service-id": "instance-1",
+    },
+    body: JSON.stringify({ team_id: "team-1", ...body }),
+  });
+}
+
+describe.each([
+  ["wiki", "/v3/wiki/list", wikiList],
+  ["code graph", "/v3/code-graph/list", codeGraphList],
+] as const)("%s list pagination", (_resource, path, list) => {
+  it.each([
+    [{ limit: 0 }, "limit must be a positive integer"],
+    [{ limit: -1 }, "limit must be a positive integer"],
+    [{ limit: 1.5 }, "limit must be a positive integer"],
+    [{ limit: "10" }, "limit must be a positive integer"],
+    [{ offset: -1 }, "offset must be a non-negative integer"],
+    [{ offset: 1.5 }, "offset must be a non-negative integer"],
+    [{ offset: "0" }, "offset must be a non-negative integer"],
+  ])("rejects invalid pagination %#", async (pagination, message) => {
+    vi.clearAllMocks();
+
+    const response = await post(path, pagination);
+    const envelope = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(envelope).toMatchObject({ code: 400, message, data: null });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("passes validated pagination to the store", async () => {
+    vi.clearAllMocks();
+
+    const response = await post(path, { limit: 25, offset: 50 });
+
+    expect(response.status).toBe(200);
+    expect(list).toHaveBeenCalledWith(
+      "instance-1",
+      "team-1",
+      expect.objectContaining({ limit: 25, offset: 50 }),
+    );
+  });
+});

--- a/MemoryKnowledge/src/routes/wiki.ts
+++ b/MemoryKnowledge/src/routes/wiki.ts
@@ -22,6 +22,7 @@ import type { WikiStatus } from "../store/index.js";
 import {
   extractIdFields,
   isValidIdSegment,
+  parseListPagination,
   wrapOk,
   wrapError,
   toWikiDetail,
@@ -187,10 +188,14 @@ export function createWikiRoutes(deps: WikiRouteDeps): Hono {
     if (!ids) return c.json(wrapError(400, "x-tdai-service-id header and team_id are required"), 400);
 
     const status = typeof body.status === "string" ? (body.status as WikiStatus) : undefined;
-    const limit = typeof body.limit === "number" ? body.limit : 20;
-    const offset = typeof body.offset === "number" ? body.offset : 0;
+    const pagination = parseListPagination(body);
+    if (!pagination.ok) return c.json(wrapError(400, pagination.message), 400);
 
-    const items = wikiService.list(ids.service_id, ids.team_id, { syncStatus: status, limit, offset });
+    const items = wikiService.list(ids.service_id, ids.team_id, {
+      syncStatus: status,
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
     const total = wikiService.count(ids.service_id, ids.team_id, status ? { syncStatus: status } : undefined);
     return c.json(wrapOk({ items: items.map(toWikiDetail), total }));
   });


### PR DESCRIPTION
## Background

`POST /v3/wiki/list` and `POST /v3/code-graph/list` previously accepted any JavaScript number for `limit` and `offset`. Fractional, negative, or non-finite values could therefore reach Drizzle/SQLite instead of producing a deterministic client error.

## Changes

- Add one shared parser for Knowledge list pagination.
- Require `limit` to be a positive integer and `offset` to be a non-negative integer.
- Reject malformed pagination with an HTTP 400 envelope before calling either store.
- Document the same bounds in the Wiki and Code-Graph OpenAPI schemas.
- Add route-level coverage for both resource types and valid/invalid values.

The change is limited to pagination validation. Filtering, ordering, defaults, store queries, and response shapes remain unchanged.

## Verification

- [x] `npm test -- src/routes/list-pagination.test.ts` (16 tests passed)
- [x] `npm test` (16 tests passed)
- [x] Strict changed-file TypeScript compilation
- [x] `npm run build`
- [x] OpenAPI YAML parse
- [x] `npm pack --dry-run --ignore-scripts` (80 files)
- [x] `git diff --check`

Full-package `npm run typecheck` still reaches the default-branch error at `src/middleware/response-envelope.ts:47`, which is independently fixed by open PR #730. The strict compilation covering every file changed by this PR passes.

## Impact

- Breaking change: No for contract-valid requests
- Affected module: `MemoryKnowledge`
- Performance impact: None

## Checklist

- [x] The change follows the existing route validation style.
- [x] Regression tests cover both affected endpoints.
- [x] Focused and package-level validation passes locally.
- [x] The PR contains one isolated fix.
