### PR TITLE
docs(sdk): clarify v3 session isolation

### DIFF
--- a/sdk/memory-core/python/AGENT_GUIDE.python.zh-CN.md
+++ b/sdk/memory-core/python/AGENT_GUIDE.python.zh-CN.md
@@ -222,7 +222,7 @@ except TDAMError as e:
 
 ## 7. 管理面：Knowledge / 元数据
 
-上面讲的都是 `MemoryClient`（数据面：读写记忆）。如果你还需要**管理** Knowledge 知识源（wiki / code-graph）的元数据，用 `MetadataClient`（v3 管理面，不需要 isolation 四元组）：
+上面讲的都是 `MemoryClient`（数据面：读写记忆）。如果你还需要**管理** Knowledge 知识源（wiki / code-graph）的元数据，用 `MetadataClient`（v3 管理面，不需要数据面 isolation 字段）：
 
 ```python
 from tencentdb_agent_memory.v3 import MetadataClient

--- a/sdk/memory-core/python/README.md
+++ b/sdk/memory-core/python/README.md
@@ -126,7 +126,7 @@ asyncio.run(main())
 
 ## MetadataClient (v3 management plane)
 
-`MetadataClient` / `AsyncMetadataClient` wrap the gateway's v3 management-plane endpoints. Unlike `MemoryClient` they do **not** require the isolation quad (team/agent/user/session); auth is Bearer + `x-tdai-service-id`, with business fields like `team_id` in the request body.
+`MetadataClient` / `AsyncMetadataClient` wrap the gateway's v3 management-plane endpoints. Unlike the v3 data-plane `MemoryClient`, they do **not** require data-plane isolation fields; auth is Bearer + `x-tdai-service-id`, with business fields like `team_id` in the request body.
 
 Covers all **54 public `/v3/meta/*` routes** (aligned with Panel Control `META_ACTIONS`, including `user-key/*`), plus **5 `/v3/knowledge/*` Knowledge CRUD** routes.
 

--- a/sdk/memory-core/python/README_CN.md
+++ b/sdk/memory-core/python/README_CN.md
@@ -106,7 +106,10 @@ asyncio.run(main())
 
 ### v3（推荐）
 
-> v3 与 v2 的主要差异：L0/L1 强制要求 `session_id`（strict session isolation），请求路径从 `/v2/*` 升级为 `/v3/*`，响应包络结构一致。
+> v3 与 v2 的主要差异：构造时显式绑定 `team_id` / `agent_id` /
+> `user_id`。L0 写入必须提供 `session_id`；L0/L1 读取可选，缺省时按
+> `(team_id, agent_id, user_id)` 跨 session 聚合。请求路径从 `/v2/*`
+> 升级为 `/v3/*`，响应包络结构一致。
 
 | 层级 | 方法 | 接口 |
 |------|------|------|
@@ -157,14 +160,14 @@ asyncio.run(main())
 | 维度 | v2 | v3 |
 |------|----|----|
 | 路径前缀 | `/v2/*` | `/v3/*` |
-| L0/L1 隔离 | `(team_id, user_id, agent_id)` 三元组 | 三元组 + `session_id`（strict session isolation） |
-| `session_id` | 可选 | L0/L1 必填，缺失返回 422 |
+| L0/L1 隔离 | `(team_id, user_id, agent_id)` 三元组 | 三元组 + 可选的 `session_id` 读取范围 |
+| `session_id` | 可选 | `add_conversation` 必填；查询/搜索/计数可选 |
 | L2/L3 | 仅三元组隔离 | 仅三元组隔离（无变化） |
 | 响应包络 | `{ code, message, data, request_id }` | 同 v2，结构不变 |
 
 ### MetadataClient（v3 管理面）
 
-`MetadataClient` / `AsyncMetadataClient` 封装网关 v3 管理面接口。与 `MemoryClient` 不同，**不需要** isolation 四元组（team/agent/user/session）；鉴权用 Bearer + `x-tdai-service-id`，`team_id` 等业务字段放在请求 body 里。
+`MetadataClient` / `AsyncMetadataClient` 封装网关 v3 管理面接口。与 `MemoryClient` 不同，**不需要**数据面 isolation 字段；鉴权用 Bearer + `x-tdai-service-id`，`team_id` 等业务字段放在请求 body 里。
 
 当前先落地 **Knowledge 实体管理** 5 个端点（`/v3/knowledge/*`，类型 `wiki` | `code-graph`）。其余 v3/meta 实体（user/team/agent/task/asset/acl/config）后续再补。
 

--- a/sdk/memory-core/python/tencentdb_agent_memory/__init__.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/__init__.py
@@ -4,7 +4,8 @@
 
 - 默认导出 `MemoryClient` / `AsyncMemoryClient` 指向 v2 — 老代码升级 SDK 后零修改即可继续工作。
 - 显式 import `from tencentdb_agent_memory.v3 import MemoryClient` 切到 v3
-  严格 isolation 版本（team/agent/user/session 构造时全部必填，路径走 /v3）。
+  isolation 版本（team/agent/user 构造时必填；session 对 L0 对话写入必填、
+  读取可选，路径走 /v3）。
 
 >>> # 老代码
 >>> from tencentdb_agent_memory import MemoryClient

--- a/sdk/memory-core/python/tencentdb_agent_memory/v3/__init__.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/v3/__init__.py
@@ -1,10 +1,11 @@
 """TencentDB Agent Memory v3 Python SDK — 严格 isolation 数据面客户端。
 
-构造时必须提供 team_id / agent_id / user_id / session_id 四元组；
+构造时必须提供 team_id / agent_id / user_id；session_id 对
+``add_conversation`` 写入必填，对查询/搜索/计数可选（缺省时跨 session 聚合）。
 路径走 ``/v3/...``。详见 ``v3.client.MemoryClient`` docstring。
 
 管理面客户端 :class:`MetadataClient` / :class:`AsyncMetadataClient` 不需要 isolation
-四元组，封装 ``/v3/meta/*`` 公开接口（54 条，与 Panel ``META_ACTIONS`` 对齐）及
+字段，封装 ``/v3/meta/*`` 公开接口（54 条，与 Panel ``META_ACTIONS`` 对齐）及
 ``/v3/knowledge/*`` Knowledge CRUD，详见 ``v3.metadata_client``。
 
 Skill 客户端 :class:`SkillClient` / :class:`AsyncSkillClient` 封装 14 条

--- a/sdk/memory-core/python/tencentdb_agent_memory/v3/metadata_client.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/v3/metadata_client.py
@@ -3,8 +3,8 @@
 与 ``v3.client.MemoryClient``（数据面，严格 isolation L0–L3）的区别
 ------------------------------------------------------------------
 
-- 数据面客户端构造时必须提供 ``team_id`` / ``agent_id`` / ``user_id`` 四元组。
-- 管理面客户端**不需要** isolation 四元组；鉴权用 Bearer + ``x-tdai-service-id``，
+- 数据面客户端构造时必须提供 ``team_id`` / ``agent_id`` / ``user_id`` 三元组。
+- 管理面客户端**不需要** isolation 字段；鉴权用 Bearer + ``x-tdai-service-id``，
   ``team_id`` 等业务字段放在请求 body 里。可选 ``user_key`` 走 ``x-tdai-user-key``
   头（``user/create``、``user/delete`` 等 system_admin 接口需要）。
 


### PR DESCRIPTION
## Background

The Python SDK implementation requires `team_id`, `agent_id`, and `user_id` when constructing a v3 `MemoryClient`. `session_id` is required only for `add_conversation`; query, search, count, and delete operations may omit it to aggregate across sessions.

Several package docstrings and documentation pages instead said that all four values were constructor requirements or that every L0/L1 call required a session. That guidance contradicted the implemented and documented client behavior.

## Changes

- Clarify the v3 constructor requirements in package and module docstrings.
- Document that L0 conversation writes require a session while reads may omit it.
- Correct the Chinese v2/v3 comparison table.
- Replace misleading "isolation quad" wording in MetadataClient documentation.

This PR changes documentation and docstrings only. It does not alter SDK behavior, request bodies, validation, or public signatures.

## Verification

- [x] Runtime contract check: construct v3 `MemoryClient` without a session and query across sessions
- [x] Runtime contract check: `add_conversation` without a session still fails
- [x] `python3 -m compileall -q sdk/memory-core/python/tencentdb_agent_memory`
- [x] `python3 -m pip wheel sdk/memory-core/python --no-deps`
- [x] `git diff --check`

## Impact

- Breaking change: No
- Affected module: Python SDK documentation
- Runtime impact: None

## Checklist

- [x] The text matches the current synchronous and asynchronous client contract.
- [x] English and Chinese management-plane wording is consistent.
- [x] The Python package compiles and builds as a wheel.
- [x] The PR contains one isolated documentation correction.
