### PR TITLE
fix(skill): strengthen archive task identifiers

### DIFF
--- a/MemoryCore/src/core/skill/conversation-add/trigger-service-task-id.test.ts
+++ b/MemoryCore/src/core/skill/conversation-add/trigger-service-task-id.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+const cryptoMocks = vi.hoisted(() => ({
+  randomUUID: vi.fn(),
+  randomBytes: vi.fn(),
+}));
+
+vi.mock("node:crypto", () => ({
+  randomUUID: cryptoMocks.randomUUID,
+  randomBytes: cryptoMocks.randomBytes,
+}));
+vi.mock("../../report/obs-logger.js", () => ({
+  obsLogger: { info: vi.fn() },
+}));
+
+import type { ISkillAgentTaskQueue } from "./agent-task-queue.js";
+import type {
+  AgentTasksDoc,
+  SessionKey,
+  SkillBufferStorage,
+} from "./buffer-storage.js";
+import { SkillTriggerService } from "./trigger-service.js";
+
+describe("SkillTriggerService task ids", () => {
+  it("does not collapse UUIDs that share their first eight hex digits", async () => {
+    cryptoMocks.randomUUID
+      .mockReturnValueOnce("deadbeef-0000-4000-8000-000000000001")
+      .mockReturnValueOnce("deadbeef-0000-4000-8000-000000000002");
+    let byte = 0;
+    cryptoMocks.randomBytes.mockImplementation((size: number) =>
+      Buffer.alloc(size, byte++),
+    );
+
+    const session: SessionKey = {
+      space_id: "space-1",
+      user_id: "user-1",
+      team_id: "team-1",
+      agent_id: "agent-1",
+      session_id: "session-1",
+    };
+    let tasks: AgentTasksDoc = {
+      team_id: session.team_id,
+      agent_id: session.agent_id,
+      updated_at_ms: 0,
+      tasks: [],
+    };
+
+    const buffer = {
+      archiveKey: vi.fn(
+        (_session: SessionKey, archivedAtMs: number) =>
+          `archive-${archivedAtMs}`,
+      ),
+      writeArchive: vi.fn().mockResolvedValue(undefined),
+      readTasks: vi.fn().mockImplementation(async () => ({
+        ...tasks,
+        tasks: [...tasks.tasks],
+      })),
+      writeTasks: vi.fn().mockImplementation(async (_agent, next) => {
+        tasks = { ...next, tasks: [...next.tasks] };
+      }),
+    } as unknown as SkillBufferStorage;
+    const queue = {
+      withTasksMutex: vi.fn(
+        async (_agent, _opts, fn: () => Promise<unknown>) => fn(),
+      ),
+      enqueueAgent: vi.fn().mockResolvedValue(true),
+    } as unknown as ISkillAgentTaskQueue;
+
+    let now = 1_000;
+    const service = new SkillTriggerService({
+      buffer,
+      queue,
+      now: () => now++,
+    });
+    const input = {
+      session,
+      bufferAtTrigger: {
+        messages: [{ role: "user", content: "remember this" }],
+      },
+    };
+
+    const first = await service.archive(input);
+    const second = await service.archive(input);
+
+    expect(first.taskId).toMatch(/^skill-extract-task-[0-9A-Za-z]{12}$/);
+    expect(second.taskId).toMatch(/^skill-extract-task-[0-9A-Za-z]{12}$/);
+    expect(second.taskId).not.toBe(first.taskId);
+    expect(tasks.tasks.map((task) => task.task_id)).toEqual([
+      first.taskId,
+      second.taskId,
+    ]);
+  });
+});

--- a/MemoryCore/src/core/skill/conversation-add/trigger-service.ts
+++ b/MemoryCore/src/core/skill/conversation-add/trigger-service.ts
@@ -22,8 +22,6 @@
  *     或后续 GC 清）。这比现状好得多：不再有丢任务风险。
  */
 
-import { randomUUID } from "node:crypto";
-
 import type {
   AgentTuple,
   ISkillAgentTaskQueue,
@@ -35,6 +33,7 @@ import type {
   SkillTaskEntry,
 } from "./buffer-storage.js";
 import { obsLogger } from "../../report/obs-logger.js";
+import { randomBase62 } from "../../../utils/short-id.js";
 
 export interface TriggerArchiveInput {
   session: SessionKey;
@@ -113,7 +112,7 @@ export class SkillTriggerService {
     // task_id=…` 与 worker 侧 `[skill-perf] kind=worker phase=consume.*` 共用同一
     // 值，grep 一次拉全 handler + worker 双段耗时。老数据前缀 `task-` 会被
     // worker 自然消费掉，无迁移风险（filter 按 task_id 值等价比较，不解析前缀）。
-    const taskId = `skill-extract-task-${randomUUID().slice(0, 8)}`;
+    const taskId = `skill-extract-task-${randomBase62(12)}`;
     const agent: AgentTuple = {
       space_id: session.space_id,
       user_id: session.user_id,


### PR DESCRIPTION
## Description | 描述

`SkillTriggerService.archive()` generated internal task IDs from only the
first eight hexadecimal characters of `randomUUID()`. That leaves a 32-bit
identity space:

- collision probability reaches roughly 1% around 9,300 generated IDs;
- it reaches roughly 50% around 77,000 generated IDs.

This is not only an observability concern. The worker completes a task by
filtering `_tasks.json` on `task_id`, so two same-agent tasks with a colliding
ID can be removed together even though only one was processed.

This change replaces the truncated UUID suffix with the existing
`randomBase62(12)` helper:

- approximately 71 bits of unbiased CSPRNG entropy;
- URL, storage-key, and log friendly alphanumeric output;
- the existing `skill-extract-task-` prefix is preserved.

A deterministic service-level test supplies two legacy UUIDs with the same
first eight characters and verifies that the queued task IDs remain distinct
and match the 12-character base62 format.

Queue ordering, archive keys, task payload fields, retry behavior, and worker
processing are unchanged.

## Related Issue | 关联 Issue

No linked issue. This was found during a v2.0.0 skill queue identity audit.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification

- `pnpm exec vitest run src/core/skill/conversation-add/trigger-service-task-id.test.ts`
  - 1 test passed
- `pnpm test`
  - 1 test passed
- `pnpm run build:plugin`
  - plugin bundle completed successfully
- `pnpm run lint:skill-isolation`
  - passed
- `npm pack --dry-run --json --ignore-scripts`
  - 293 files verified
- `git diff --check`
  - passed

The focused regression test was first run against the unchanged
implementation and failed with
`skill-extract-task-deadbeef`, directly reproducing the prefix collision.

## Additional Notes | 其他说明

- Breaking change: none. Task IDs are opaque strings; their documented prefix
  remains unchanged.
- Callers that incorrectly validate the old eight-hex-character suffix will
  need to stop parsing this internal identifier.
- Scope is limited to the task ID generator call and its regression test.
