### PR TITLE
fix(sdk): allow clearing Python skill client defaults

### DIFF
--- a/sdk/memory-core/python/tencentdb_agent_memory/v3/skill_client.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/v3/skill_client.py
@@ -33,6 +33,7 @@ from .._v3_http import AsyncHttpStub, HttpStub
 from ..errors import ParamError
 
 _V3 = "/v3/skill"
+_UNSET = object()
 
 # ── Numeric error codes returned in envelope.code for /v3/skill/*. ──
 SKILL_ERROR_CODE: Dict[str, int] = {
@@ -178,19 +179,23 @@ class SkillClient:
     def with_defaults(
         self,
         *,
-        team_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        task_id: Optional[str] = None,
+        team_id: Any = _UNSET,
+        agent_id: Any = _UNSET,
+        user_id: Any = _UNSET,
+        task_id: Any = _UNSET,
     ) -> "SkillClient":
-        """Return a clone sharing the transport but with overridden defaults."""
+        """Clone this client with selected defaults overridden.
+
+        Pass ``None`` to clear a default; omitted arguments retain their
+        current values.
+        """
         clone = object.__new__(SkillClient)
         clone._stub = self._stub
         clone._defaults = _SkillDefaults(
-            team_id if team_id is not None else self._defaults.team_id,
-            agent_id if agent_id is not None else self._defaults.agent_id,
-            user_id if user_id is not None else self._defaults.user_id,
-            task_id if task_id is not None else self._defaults.task_id,
+            self._defaults.team_id if team_id is _UNSET else team_id,
+            self._defaults.agent_id if agent_id is _UNSET else agent_id,
+            self._defaults.user_id if user_id is _UNSET else user_id,
+            self._defaults.task_id if task_id is _UNSET else task_id,
         )
         return clone
 
@@ -617,18 +622,23 @@ class AsyncSkillClient:
     def with_defaults(
         self,
         *,
-        team_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        task_id: Optional[str] = None,
+        team_id: Any = _UNSET,
+        agent_id: Any = _UNSET,
+        user_id: Any = _UNSET,
+        task_id: Any = _UNSET,
     ) -> "AsyncSkillClient":
+        """Clone this client with selected defaults overridden.
+
+        Pass ``None`` to clear a default; omitted arguments retain their
+        current values.
+        """
         clone = object.__new__(AsyncSkillClient)
         clone._stub = self._stub
         clone._defaults = _SkillDefaults(
-            team_id if team_id is not None else self._defaults.team_id,
-            agent_id if agent_id is not None else self._defaults.agent_id,
-            user_id if user_id is not None else self._defaults.user_id,
-            task_id if task_id is not None else self._defaults.task_id,
+            self._defaults.team_id if team_id is _UNSET else team_id,
+            self._defaults.agent_id if agent_id is _UNSET else agent_id,
+            self._defaults.user_id if user_id is _UNSET else user_id,
+            self._defaults.task_id if task_id is _UNSET else task_id,
         )
         return clone
 

--- a/sdk/memory-core/python/tests/test_v3_skill_defaults.py
+++ b/sdk/memory-core/python/tests/test_v3_skill_defaults.py
@@ -1,0 +1,106 @@
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+from tencentdb_agent_memory.v3.skill_client import (
+    AsyncSkillClient,
+    SkillClient,
+)
+
+
+class RecordingStub:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    def post(
+        self,
+        path: str,
+        body: Dict[str, Any],
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append((path, body))
+        return {}
+
+    def close(self) -> None:
+        return None
+
+
+class AsyncRecordingStub:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def post(
+        self,
+        path: str,
+        body: Dict[str, Any],
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append((path, body))
+        return {}
+
+    async def close(self) -> None:
+        return None
+
+
+def test_sync_with_defaults_distinguishes_omitted_from_none() -> None:
+    stub = RecordingStub()
+    client = SkillClient(
+        stub=stub,
+        team_id="team-1",
+        agent_id="agent-1",
+        user_id="user-1",
+        task_id="task-1",
+    )
+
+    client.with_defaults().list()
+    client.with_defaults(team_id=None, task_id=None).list()
+
+    assert stub.calls[0] == (
+        "/v3/skill/list",
+        {
+            "team_id": "team-1",
+            "agent_id": "agent-1",
+            "user_id": "user-1",
+            "task_id": "task-1",
+        },
+    )
+    assert stub.calls[1] == (
+        "/v3/skill/list",
+        {
+            "agent_id": "agent-1",
+            "user_id": "user-1",
+        },
+    )
+
+
+def test_async_with_defaults_distinguishes_omitted_from_none() -> None:
+    stub = AsyncRecordingStub()
+    client = AsyncSkillClient(
+        stub=stub,
+        team_id="team-1",
+        agent_id="agent-1",
+        user_id="user-1",
+        task_id="task-1",
+    )
+
+    async def run() -> None:
+        await client.with_defaults().list()
+        await client.with_defaults(agent_id=None, task_id=None).list()
+
+    asyncio.run(run())
+
+    assert stub.calls[0] == (
+        "/v3/skill/list",
+        {
+            "team_id": "team-1",
+            "agent_id": "agent-1",
+            "user_id": "user-1",
+            "task_id": "task-1",
+        },
+    )
+    assert stub.calls[1] == (
+        "/v3/skill/list",
+        {
+            "team_id": "team-1",
+            "user_id": "user-1",
+        },
+    )


### PR DESCRIPTION
## Description | 描述

`SkillClient.with_defaults()` and `AsyncSkillClient.with_defaults()` currently
use `None` as the default value for every keyword argument. As a result, the
clone operation cannot distinguish an omitted argument from an explicit
request to clear an optional default:

```python
client.with_defaults(task_id=None)
```

retains the existing `task_id` instead of removing it from subsequent request
bodies. This can keep stale optional isolation fields attached when an
application reuses a client for a broader scope.

This change:

- introduces an internal sentinel for omitted `with_defaults()` arguments;
- preserves existing defaults only when the corresponding argument is omitted;
- treats explicit `None` as a request to clear that default;
- applies the same behavior to synchronous and asynchronous skill clients;
- documents the distinction on both public clone methods.

The approach matches the sentinel pattern already used by the Python v3 data
client for clearable isolation fields.

## Related Issue | 关联 Issue

L3/L4 Python SDK behavior audit finding; no existing issue or active PR modifies
the affected v3 Skill client files.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `PYTHONPATH=. /usr/bin/python3 -m pytest -q tests/test_v3_skill_defaults.py`
  (2/2)
- `PYTHONPATH=. /usr/bin/python3 -m pytest -q` (2/2 collected tests)
- `/usr/bin/python3 -m compileall -q tencentdb_agent_memory tests`
- `/usr/bin/python3 -m pip check`
- `/usr/bin/python3 -m pip wheel --no-deps .` (wheel built and inspected)
- `git diff --check`

The regression tests exercise both sync and async clients. They verify that an
argument omitted from `with_defaults()` is inherited, while an explicitly
cleared value is absent from the next serialized `/v3/skill/list` request.

## Additional Notes | 其他说明

This PR changes only clone-time handling of optional Skill client defaults.
Constructor behavior, per-request override behavior, transport sharing,
dependencies, and package metadata are unchanged. Existing calls that omit
arguments retain their current behavior; explicit `None` now performs the
clear operation that the public optional-value API could not previously
express.
