### PR TITLE
fix(core): serialize and drain timer scanner runs

### DIFF
--- a/MemoryCore/src/services/timer-scanner.test.ts
+++ b/MemoryCore/src/services/timer-scanner.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IStateBackend, TimerEntry } from "../core/state/types.js";
+import { TimerScanner } from "./timer-scanner.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function createBackend(
+  claimExpiredFromShard: () => Promise<TimerEntry[]>,
+): IStateBackend {
+  return {
+    timerShardCount: 1,
+    claimExpiredFromShard,
+    enqueueTask: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IStateBackend;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TimerScanner lifecycle", () => {
+  it("does not overlap interval scans while a shard claim is pending", async () => {
+    vi.useFakeTimers();
+    const firstClaim = deferred<TimerEntry[]>();
+    const claimExpiredFromShard = vi
+      .fn<() => Promise<TimerEntry[]>>()
+      .mockReturnValueOnce(firstClaim.promise)
+      .mockResolvedValue([]);
+    const scanner = new TimerScanner(
+      createBackend(claimExpiredFromShard),
+      { scanIntervalMs: 10 },
+    );
+
+    await scanner.start();
+    try {
+      await vi.advanceTimersByTimeAsync(30);
+      expect(claimExpiredFromShard).toHaveBeenCalledTimes(1);
+    } finally {
+      firstClaim.resolve([]);
+      await scanner.stop();
+    }
+  });
+
+  it("waits for an active scan to drain before stop resolves", async () => {
+    vi.useFakeTimers();
+    const firstClaim = deferred<TimerEntry[]>();
+    const backend = createBackend(() => firstClaim.promise);
+    const scanner = new TimerScanner(backend, { scanIntervalMs: 10 });
+
+    await scanner.start();
+    await vi.advanceTimersByTimeAsync(10);
+
+    let stopped = false;
+    const stopPromise = scanner.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+
+    try {
+      expect(stopped).toBe(false);
+      firstClaim.resolve([
+        {
+          member: "instance-1\u0000session-1:L1_idle",
+          fireAtMs: Date.now(),
+        },
+      ]);
+      await stopPromise;
+
+      expect(backend.enqueueTask).toHaveBeenCalledTimes(1);
+      expect(stopped).toBe(true);
+    } finally {
+      firstClaim.resolve([]);
+      await scanner.stop();
+    }
+  });
+});

--- a/MemoryCore/src/services/timer-scanner.ts
+++ b/MemoryCore/src/services/timer-scanner.ts
@@ -58,6 +58,7 @@ export class TimerScanner {
   private logger: Logger;
 
   private scanTimer: ReturnType<typeof setInterval> | null = null;
+  private scanInFlight: Promise<void> | null = null;
   private destroyed = false;
 
   // Metrics
@@ -92,9 +93,13 @@ export class TimerScanner {
   }
 
   async stop(): Promise<void> {
-    if (this.destroyed) return;
+    if (this.destroyed) {
+      await this.scanInFlight;
+      return;
+    }
     this.destroyed = true;
     this.stopScanLoop();
+    await this.scanInFlight;
     this.logger.info(`${TAG} Stopped (scans=${this.metrics.scansCompleted}, enqueued=${this.metrics.tasksEnqueued})`);
   }
 
@@ -108,7 +113,14 @@ export class TimerScanner {
 
   private startScanLoop(): void {
     if (this.scanTimer) return;
-    this.scanTimer = setInterval(() => this.scan(), this.config.scanIntervalMs);
+    this.scanTimer = setInterval(() => {
+      if (this.scanInFlight) return;
+      const scan = this.scan();
+      this.scanInFlight = scan;
+      void scan.finally(() => {
+        if (this.scanInFlight === scan) this.scanInFlight = null;
+      });
+    }, this.config.scanIntervalMs);
   }
 
   private stopScanLoop(): void {


### PR DESCRIPTION
## Description | 描述

`TimerScanner` currently starts its asynchronous `scan()` method directly from
`setInterval`. If one shard claim takes longer than the configured interval,
later ticks start additional scans against the same backend. Although the
Redis claim itself is atomic, overlapping scans multiply backend pressure and
make lifecycle accounting non-deterministic.

The same ownership gap affects shutdown: `stop()` clears the interval but does
not wait for a scan that has already started. It can therefore report that the
scanner stopped while the owned scan is still claiming timers and enqueueing
tasks.

This change:

- tracks the scanner's single owned in-flight scan;
- coalesces interval ticks while that scan is still running;
- makes `stop()` wait for the active scan after disabling new ticks;
- preserves completion of already-claimed timers before shutdown returns.

Completing the owned scan is intentional. Returning early or abandoning its
results after an atomic Redis claim would remove timers without enqueueing
their tasks.

## Related Issue | 关联 Issue

L3 MemoryCore service-lifecycle audit finding; no existing issue or active PR
modifies the TimerScanner implementation or tests.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `npx vitest run src/services/timer-scanner.test.ts` (2/2)
- `npm test` (2/2 collected tests)
- `npm run build:plugin`
- `npm run lint:skill-isolation`
- `npm pack --dry-run --ignore-scripts` (293 files)
- `git diff --check`

The regression tests use a deferred shard claim to prove that:

1. multiple interval ticks issue only one claim while a scan is pending; and
2. `stop()` remains pending until the active scan enqueues an already-claimed
   timer.

## Additional Notes | 其他说明

This PR changes only TimerScanner scheduling and shutdown ownership. Timer
shard formats, claim batch size, task payload construction, backend APIs, and
the local-state fallback are unchanged.
