### PR TITLE
fix(sdk): support internal COS URLs in Python

### DIFF
--- a/sdk/memory-core/python/tencentdb_agent_memory/cos.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/cos.py
@@ -34,16 +34,24 @@ logger = logging.getLogger(__name__)
 # COS URL parser
 # ---------------------------------------------------------------------------
 
-def _parse_cos_url(cos_url: str) -> tuple[str, str]:
-    """Parse CosUrl like ``https://bucket.cos.region.myqcloud.com`` → (bucket, region)."""
+def _parse_cos_url(cos_url: str) -> tuple[str, str, str]:
+    """Parse a public or internal COS URL into ``(bucket, region, host)``."""
     host = urlparse(cos_url).hostname or ""
-    # Pattern: {bucket}.cos.{region}.myqcloud.com
-    m = re.match(r"^(.+?)\.cos\.(.+?)\.myqcloud\.com$", host)
-    if m:
-        return m.group(1), m.group(2)
+    public = re.match(r"^(.+?)\.cos\.(.+?)\.myqcloud\.com$", host)
+    if public:
+        return public.group(1), public.group(2), host
+    internal = re.match(
+        r"^(.+?)\.cos-internal\.(.+?)\.tencentcos\.cn$",
+        host,
+    )
+    if internal:
+        return internal.group(1), internal.group(2), host
     raise TDAMError(
         code=-1,
-        message=f"Cannot parse CosUrl: {cos_url!r} (expected {{bucket}}.cos.{{region}}.myqcloud.com)",
+        message=(
+            f"Cannot parse CosUrl: {cos_url!r} "
+            "(expected a public myqcloud.com or internal tencentcos.cn COS URL)"
+        ),
     )
 
 
@@ -68,7 +76,7 @@ class StsCredential:
 
     __slots__ = (
         "tmp_secret_id", "tmp_secret_key", "token",
-        "bucket", "region", "prefix", "expires_at_epoch",
+        "bucket", "region", "_cos_host", "prefix", "expires_at_epoch",
     )
 
     def __init__(self, data: Dict[str, Any]) -> None:
@@ -78,7 +86,8 @@ class StsCredential:
         # Parse bucket + region from CosUrl
         self.bucket: str
         self.region: str
-        self.bucket, self.region = _parse_cos_url(data["CosUrl"])
+        self._cos_host: str
+        self.bucket, self.region, self._cos_host = _parse_cos_url(data["CosUrl"])
         # PathPrefix — ensure trailing slash for key concatenation
         prefix = data.get("PathPrefix", "")
         self.prefix: str = prefix if prefix.endswith("/") else f"{prefix}/"
@@ -100,7 +109,7 @@ class StsCredential:
 
     @property
     def cos_host(self) -> str:
-        return f"{self.bucket}.cos.{self.region}.myqcloud.com"
+        return self._cos_host
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/memory-core/python/tests/test_cos_internal_url.py
+++ b/sdk/memory-core/python/tests/test_cos_internal_url.py
@@ -1,0 +1,114 @@
+import asyncio
+from typing import Any, Dict
+
+import httpx
+
+from tencentdb_agent_memory.cos import (
+    AsyncMemoryFileReader,
+    MemoryFileReader,
+    StsCredential,
+)
+
+
+def credential(cos_url: str) -> StsCredential:
+    return StsCredential(
+        {
+            "CosUrl": cos_url,
+            "TmpSecretId": "secret-id",
+            "TmpSecretKey": "secret-key",
+            "TmpToken": "token",
+            "ExpirationTime": "2099-01-01T00:00:00Z",
+            "PathPrefix": "memory_v2/cos_data/mem-1",
+        },
+    )
+
+
+class StaticCredentialManager:
+    def __init__(self, value: StsCredential) -> None:
+        self.value = value
+
+    def get_credential(self) -> StsCredential:
+        return self.value
+
+    def invalidate(self) -> None:
+        return None
+
+
+class AsyncStaticCredentialManager:
+    def __init__(self, value: StsCredential) -> None:
+        self.value = value
+
+    async def get_credential(self) -> StsCredential:
+        return self.value
+
+    def invalidate(self) -> None:
+        return None
+
+
+def test_public_cos_url_remains_supported() -> None:
+    value = credential("https://bucket-1.cos.ap-shanghai.myqcloud.com")
+
+    assert value.bucket == "bucket-1"
+    assert value.region == "ap-shanghai"
+    assert value.cos_host == "bucket-1.cos.ap-shanghai.myqcloud.com"
+    assert value.prefix == "memory_v2/cos_data/mem-1/"
+
+
+def test_sync_reader_preserves_internal_cos_host() -> None:
+    host = "bucket-1.cos-internal.ap-shanghai.tencentcos.cn"
+    value = credential(f"https://{host}")
+    seen: Dict[str, Any] = {}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["host"] = request.headers["host"]
+        return httpx.Response(200, text="memory")
+
+    client = httpx.Client(transport=httpx.MockTransport(handle))
+    reader = MemoryFileReader(
+        StaticCredentialManager(value),  # type: ignore[arg-type]
+        client=client,
+    )
+
+    try:
+        assert reader.read("persona.md") == "memory"
+    finally:
+        reader.close()
+
+    assert value.bucket == "bucket-1"
+    assert value.region == "ap-shanghai"
+    assert value.cos_host == host
+    assert seen == {
+        "url": f"https://{host}/memory_v2/cos_data/mem-1/persona.md",
+        "host": host,
+    }
+
+
+def test_async_reader_preserves_internal_cos_host() -> None:
+    host = "bucket-2.cos-internal.ap-guangzhou.tencentcos.cn"
+    value = credential(f"https://{host}")
+    seen: Dict[str, Any] = {}
+
+    async def handle(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["host"] = request.headers["host"]
+        return httpx.Response(200, text="scene")
+
+    async def run() -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+        reader = AsyncMemoryFileReader(
+            AsyncStaticCredentialManager(value),  # type: ignore[arg-type]
+            client=client,
+        )
+        try:
+            assert await reader.read("scene_blocks/project.md") == "scene"
+        finally:
+            await reader.close()
+
+    asyncio.run(run())
+
+    assert value.cos_host == host
+    assert seen == {
+        "url": f"https://{host}/memory_v2/cos_data/mem-1/scene_blocks/project.md",
+        "host": host,
+    }


### PR DESCRIPTION
## Description | 描述

The Python memory-file reader accepts only public COS URLs of the form:

```text
bucket.cos.<region>.myqcloud.com
```

However, STS can return the VPC/internal form used by MemoryCore and already
supported by the TypeScript SDK:

```text
bucket.cos-internal.<region>.tencentcos.cn
```

The Python `StsCredential` currently rejects that valid `CosUrl` before any
file request is attempted. It also reconstructs a public host from the parsed
bucket and region, which would be incorrect for signing an internal request.

This change:

- parses both public and internal COS hostname forms;
- preserves the exact normalized host returned by STS;
- uses that preserved host for the COS request URL and signed `Host` header;
- keeps existing bucket, region, prefix, expiry, and credential APIs intact.

## Related Issue | 关联 Issue

L3/L4 Python/TypeScript SDK compatibility audit finding; no existing issue or
active PR modifies the Python COS reader or its tests.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification | 验证方式

- `PYTHONPATH=. /usr/bin/python3 -m pytest -q tests/test_cos_internal_url.py`
  (3/3)
- `PYTHONPATH=. /usr/bin/python3 -m pytest -q` (3/3 collected tests)
- `/usr/bin/python3 -m compileall -q tencentdb_agent_memory tests`
- `/usr/bin/python3 -m pip check`
- `/usr/bin/python3 -m pip wheel --no-deps .` (wheel built and inspected)
- `git diff --check`

The regression tests verify:

1. public COS parsing remains unchanged;
2. the synchronous reader sends an internal URL and matching `Host` header;
3. the asynchronous reader preserves the same internal-host behavior.

## Additional Notes | 其他说明

This PR does not change credential refresh/coalescing, 403 retry behavior, COS
V5 signing, request timeouts, package dependencies, or server contracts. It
only brings the Python hostname boundary in line with the existing MemoryCore
and TypeScript SDK behavior.
