### PR TITLE
fix(ts-sdk): avoid process-wide TLS disablement

### DIFF
--- a/sdk/memory-core/typescript/src/http.ts
+++ b/sdk/memory-core/typescript/src/http.ts
@@ -4,10 +4,11 @@
  * - Auth: `Authorization: Bearer {apiKey}` + `x-tdai-service-id` + optional `x-tdai-user-key`
  * - Envelope unwrap: `code === 0` → return `data`; else throw `TDAMError`
  * - trace_id: extracted from `x-trace-id` response header
- * - Zero runtime dependencies — uses native `fetch`.
+ * - Uses native `fetch` with an undici dispatcher for TLS configuration.
  * - TLS: `rejectUnauthorized` defaults to `false` (self-signed cert friendly).
  */
 
+import { Agent } from "undici";
 import { TDAMError } from "./errors.js";
 import type { ApiResponseEnvelope } from "./types.js";
 
@@ -28,7 +29,7 @@ export class HttpTransport {
   private readonly endpoint: string;
   private readonly headers: Record<string, string>;
   private readonly timeout: number;
-  private dispatcher: unknown;
+  private readonly dispatcher?: Agent;
 
   constructor(opts: HttpTransportOptions) {
     this.endpoint = opts.endpoint.replace(/\/+$/, "");
@@ -46,19 +47,9 @@ export class HttpTransport {
     // skips TLS certificate validation. This mirrors the Python SDK's
     // `verify=False` default for self-signed cert environments.
     if (opts.rejectUnauthorized !== true) {
-      try {
-        // Node 18+ bundles undici; dynamic import to keep zero-dep for bundlers
-        const { Agent } = require("undici");
-        this.dispatcher = new Agent({
-          connect: { rejectUnauthorized: false },
-        });
-      } catch {
-        // If undici is not available (browser/edge runtime), fall back to
-        // process.env which only works in Node.js.
-        if (typeof process !== "undefined") {
-          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-        }
-      }
+      this.dispatcher = new Agent({
+        connect: { rejectUnauthorized: false },
+      });
     }
   }
 

--- a/sdk/memory-core/typescript/tests/http-tls.test.ts
+++ b/sdk/memory-core/typescript/tests/http-tls.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpTransport } from "../src/http.js";
+
+const originalTlsSetting = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+
+afterEach(() => {
+  if (originalTlsSetting === undefined) {
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  } else {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = originalTlsSetting;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("HttpTransport TLS scope", () => {
+  it("uses a request-local dispatcher without mutating process TLS settings", async () => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: 0, message: "ok", data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = new HttpTransport({
+      endpoint: "https://memory.example.test",
+      apiKey: "key",
+      serviceId: "service",
+    });
+
+    await transport.post("/v2/test");
+
+    expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe("1");
+    const request = fetchMock.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: { close(): Promise<void> } })
+      | undefined;
+    expect(request?.dispatcher).toBeDefined();
+    await request?.dispatcher?.close();
+  });
+
+  it("omits the custom dispatcher when certificate verification is enabled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: 0, message: "ok", data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = new HttpTransport({
+      endpoint: "https://memory.example.test",
+      apiKey: "key",
+      serviceId: "service",
+      rejectUnauthorized: true,
+    });
+
+    await transport.post("/v2/test");
+
+    const request = fetchMock.mock.calls[0]?.[1] as
+      | (RequestInit & { dispatcher?: unknown })
+      | undefined;
+    expect(request?.dispatcher).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description | 描述

The TypeScript v2 transport currently calls `require("undici")` from an ESM
package. Because `require` is unavailable in ESM, construction falls into the
catch path and sets `NODE_TLS_REJECT_UNAUTHORIZED=0`, disabling TLS certificate
verification for every HTTPS request in the process.

This change:

- imports `Agent` from the SDK's existing `undici` runtime dependency;
- keeps the self-signed-certificate behavior scoped to this transport's
  dispatcher;
- adds regression tests for the default and `rejectUnauthorized: true` paths.

The public API and the existing v2 default (`rejectUnauthorized: false`) remain
unchanged.

## Related Issue | 关联 Issue

N/A - found while auditing the default branch's TypeScript v2 transport.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verification:

- `npx vitest run tests/http-tls.test.ts` (2 passed)
- `npm test` (2 passed)
- `npm run build`
- `npm pack --dry-run` (44 files)
- `git diff --check`

No process environment variables are changed by the transport after this fix.
