### PR TITLE
fix(python-sdk): validate v2 response envelopes

### DIFF
--- a/sdk/memory-core/python/tencentdb_agent_memory/_http.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/_http.py
@@ -34,6 +34,45 @@ class Stub(ABC):
         ...
 
 
+def _decode_success_response(resp: httpx.Response) -> dict:
+    request_id = (
+        resp.headers.get("x-qcloud-transaction-id")
+        or resp.headers.get("x-trace-id")
+        or ""
+    )
+    try:
+        envelope = resp.json()
+    except ValueError as exc:
+        raise TDAMError(-1, "API response must be valid JSON", request_id) from exc
+
+    if not isinstance(envelope, dict):
+        raise TDAMError(-1, "API response must be a JSON object", request_id)
+
+    code = envelope.get("code")
+    if isinstance(code, bool) or not isinstance(code, int):
+        raise TDAMError(-1, "API response code must be an integer", request_id)
+    if code != 0:
+        payload = envelope.get("data")
+        details = payload if isinstance(payload, dict) else None
+        raise TDAMError(
+            code=code,
+            message=envelope.get("message", "unknown error"),
+            request_id=request_id or envelope.get("request_id", ""),
+            details=details,
+        )
+
+    result = envelope.get("data")
+    if result is None:
+        result = {}
+    if not isinstance(result, dict):
+        raise TDAMError(-1, "API response data must be a JSON object", request_id)
+
+    trace_id = resp.headers.get("x-trace-id")
+    if trace_id:
+        result["trace_id"] = trace_id
+    return result
+
+
 class HttpStub(Stub):
     """Synchronous HTTP transport backed by :mod:`httpx`.
 
@@ -84,22 +123,7 @@ class HttpStub(Stub):
         )
         logger.debug("Response %s %s", path, resp.text)
         resp.raise_for_status()
-        data = resp.json()
-        if data.get("code") != 0:
-            req_id = resp.headers.get("x-qcloud-transaction-id", data.get("request_id", ""))
-            payload = data.get("data")
-            details = payload if isinstance(payload, dict) else None
-            raise TDAMError(
-                code=data.get("code", -1),
-                message=data.get("message", "unknown error"),
-                request_id=req_id,
-                details=details,
-            )
-        result: dict = data.get("data", {})
-        trace_id = resp.headers.get("x-trace-id")
-        if trace_id:
-            result["trace_id"] = trace_id
-        return result
+        return _decode_success_response(resp)
 
     def close(self) -> None:
         if isinstance(self.client, httpx.Client):
@@ -144,22 +168,7 @@ class AsyncHttpStub:
         )
         logger.debug("Response %s %s", path, resp.text)
         resp.raise_for_status()
-        data = resp.json()
-        if data.get("code") != 0:
-            req_id = resp.headers.get("x-qcloud-transaction-id", data.get("request_id", ""))
-            payload = data.get("data")
-            details = payload if isinstance(payload, dict) else None
-            raise TDAMError(
-                code=data.get("code", -1),
-                message=data.get("message", "unknown error"),
-                request_id=req_id,
-                details=details,
-            )
-        result: dict = data.get("data", {})
-        trace_id = resp.headers.get("x-trace-id")
-        if trace_id:
-            result["trace_id"] = trace_id
-        return result
+        return _decode_success_response(resp)
 
     async def close(self) -> None:
         if isinstance(self.client, httpx.AsyncClient):

--- a/sdk/memory-core/python/tests/test_v2_http.py
+++ b/sdk/memory-core/python/tests/test_v2_http.py
@@ -1,0 +1,138 @@
+import httpx
+import pytest
+
+from tencentdb_agent_memory._http import (
+    AsyncHttpStub,
+    HttpStub,
+    _decode_success_response,
+)
+from tencentdb_agent_memory.errors import TDAMError
+
+
+@pytest.mark.parametrize("payload", [[], "ok"])
+def test_success_requires_object_envelope(payload):
+    response = httpx.Response(200, json=payload)
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_success_response(response)
+
+    assert exc_info.value.code == -1
+    assert exc_info.value.message == "API response must be a JSON object"
+
+
+def test_success_rejects_json_null_envelope():
+    response = httpx.Response(
+        200,
+        content=b"null",
+        headers={"content-type": "application/json"},
+    )
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_success_response(response)
+
+    assert exc_info.value.code == -1
+    assert exc_info.value.message == "API response must be a JSON object"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": "ok", "data": {}},
+        {"code": True, "message": "ok", "data": {}},
+    ],
+)
+def test_success_requires_integer_code(payload):
+    response = httpx.Response(200, json=payload)
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_success_response(response)
+
+    assert exc_info.value.code == -1
+    assert exc_info.value.message == "API response code must be an integer"
+
+
+@pytest.mark.parametrize("data", [[], "", False])
+def test_success_requires_object_data(data):
+    response = httpx.Response(200, json={"code": 0, "message": "ok", "data": data})
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_success_response(response)
+
+    assert exc_info.value.code == -1
+    assert exc_info.value.message == "API response data must be a JSON object"
+
+
+def test_success_allows_null_data():
+    response = httpx.Response(200, json={"code": 0, "message": "ok", "data": None})
+
+    assert _decode_success_response(response) == {}
+
+
+def test_success_preserves_object_data_and_trace_id():
+    response = httpx.Response(
+        200,
+        json={"code": 0, "message": "ok", "data": {"memory_id": "memory-1"}},
+        headers={"x-trace-id": "trace-1"},
+    )
+
+    assert _decode_success_response(response) == {
+        "memory_id": "memory-1",
+        "trace_id": "trace-1",
+    }
+
+
+def test_business_error_preserves_code_details_and_request_id():
+    response = httpx.Response(
+        200,
+        json={
+            "code": 40901,
+            "message": "stale version",
+            "request_id": "body-request",
+            "data": {"current_version": 3},
+        },
+        headers={"x-qcloud-transaction-id": "header-request"},
+    )
+
+    with pytest.raises(TDAMError) as exc_info:
+        _decode_success_response(response)
+
+    assert exc_info.value.code == 40901
+    assert exc_info.value.message == "stale version"
+    assert exc_info.value.request_id == "header-request"
+    assert exc_info.value.details == {"current_version": 3}
+
+
+def test_sync_transport_rejects_non_object_success_data():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"code": 0, "message": "ok", "data": []},
+            request=request,
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        stub = HttpStub("https://memory.example.test", "key", "service", client=client)
+
+        with pytest.raises(TDAMError, match="data must be a JSON object"):
+            stub.post("/v2/test", {})
+
+
+@pytest.mark.asyncio
+async def test_async_transport_rejects_non_object_success_data():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"code": 0, "message": "ok", "data": []},
+            request=request,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        stub = AsyncHttpStub(
+            "https://memory.example.test",
+            "key",
+            "service",
+            client=client,
+        )
+
+        with pytest.raises(TDAMError, match="data must be a JSON object"):
+            await stub.post("/v2/test", {})


### PR DESCRIPTION
## Description | 描述

The Python v2 sync and async transports duplicate response-envelope decoding
and assume both the top-level response and successful `data` value are
mappings. A successful response such as `{"code": 0, "data": []}` therefore
returns a list even though both transport methods declare an object result.

This change:

- shares successful-response decoding across the sync and async transports;
- requires an object envelope, an integer business code, and object success
  data while retaining `null` data as an empty object;
- preserves trace IDs, business error details, and request IDs;
- adds focused helper, sync transport, and async transport regression tests.

Non-2xx responses continue to use the existing `raise_for_status()` behavior.
Request serialization and public APIs are unchanged.

## Related Issue | 关联 Issue

N/A - found while auditing the default branch's Python v2 transport.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verification:

- `python3 -m pytest -q` (13 passed)
- `python3 -m compileall -q tencentdb_agent_memory tests`
- `python -m build --wheel` (wheel built successfully)
- `git diff --check`
