### PR TITLE
fix(proxy): reject malformed ACL response envelopes

### DIFF
--- a/MemoryProxy/src/__tests__/tdai-acl-envelope.test.ts
+++ b/MemoryProxy/src/__tests__/tdai-acl-envelope.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TdaiClient, checkAclOrDeny } from "../tdai/client.js";
+import type { TdaiMemoryConfig } from "../tdai/types.js";
+
+const config: TdaiMemoryConfig = {
+  enabled: true,
+  endpoint: "https://memory.example.test",
+  apiKey: "service-token",
+  serviceId: "instance-1",
+  writeL0: true,
+  recallL1: true,
+  injectL2L3: true,
+  l1Limit: 5,
+  l2Limit: 5,
+  timeoutMs: 5_000,
+};
+
+const params = {
+  user_key: "sk-mem-user",
+  asset_id: "asset-1",
+  action: "read",
+} as const;
+
+function stubEnvelope(envelope: unknown): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(envelope), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TdaiClient ACL response envelopes", () => {
+  it.each([
+    { data: { allowed: true } },
+    { code: "0", data: { allowed: true } },
+    { code: null, data: { allowed: true } },
+  ])("rejects a malformed business code: %#", async (envelope) => {
+    stubEnvelope(envelope);
+
+    await expect(new TdaiClient(config).checkAcl(params)).rejects.toThrow(
+      "acl/check envelope code=",
+    );
+  });
+
+  it("keeps the injection helper fail-closed for malformed envelopes", async () => {
+    stubEnvelope({ data: { allowed: true } });
+
+    await expect(
+      checkAclOrDeny(new TdaiClient(config), params),
+    ).resolves.toEqual({
+      allowed: false,
+      reason: "acl_check_error",
+    });
+  });
+
+  it("preserves valid allow responses", async () => {
+    stubEnvelope({ code: 0, data: { allowed: true, reason: "owner" } });
+
+    await expect(new TdaiClient(config).checkAcl(params)).resolves.toEqual({
+      allowed: true,
+      reason: "owner",
+    });
+  });
+});

--- a/MemoryProxy/src/tdai/client.ts
+++ b/MemoryProxy/src/tdai/client.ts
@@ -350,7 +350,7 @@ export class TdaiClient {
         throw new Error(`acl/check http ${res.status}: ${body.slice(0, 200)}`);
       }
       const envelope = (await res.json()) as TdaiEnvelope<AclCheckResult>;
-      if (typeof envelope.code === "number" && envelope.code !== 0) {
+      if (envelope.code !== 0) {
         throw new Error(`acl/check envelope code=${envelope.code} msg=${envelope.message ?? ""}`);
       }
       const data = envelope.data;


### PR DESCRIPTION
## Description | 描述

`TdaiClient.checkAcl()` previously rejected only numeric non-zero business
codes. A successful HTTP response with a missing, string, or null `code` could
therefore return `allowed: true`, despite this authorization path's
fail-closed contract.

This change requires the response business code to be exactly numeric zero
before ACL data is trusted. It also adds regression coverage for malformed
codes, the fail-closed helper result, and a valid allow response.

Scope is limited to Proxy ACL response validation. Other TDAI data-plane
graceful-degradation behavior and valid allow/deny responses are unchanged.

## Related Issue | 关联 Issue

No linked issue. This defect was found during an authorization-boundary audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation:

- `npm test -- src/__tests__/tdai-acl-envelope.test.ts` (5 passed)
- `npm test` (5 passed)
- strict TypeScript compilation of the changed dependency graph
- `npm pack --dry-run --json` (148 files)
- `git diff --check`

The repository-wide Proxy typecheck remains blocked by unrelated baseline
errors in `src/config.ts`, the Claude/CodeBuddy session initializers, and the
optional `@context-proxy/cost-guard` import. The changed client and regression
test compile cleanly under strict TypeScript settings.
