### PR TITLE
fix(sdk): preserve metadata list request scope

### DIFF
--- a/sdk/memory-core/typescript/src/v3/metadata-client.ts
+++ b/sdk/memory-core/typescript/src/v3/metadata-client.ts
@@ -84,6 +84,13 @@ function body(o: object): Record<string, unknown> {
   return stripUndefined(o as Record<string, unknown>);
 }
 
+function paginationFields(pagination?: PaginationInput): PaginationInput {
+  return {
+    limit: pagination?.limit,
+    offset: pagination?.offset,
+  };
+}
+
 function requireAnyString(
   payload: Record<string, unknown>,
   fields: string[],
@@ -146,7 +153,7 @@ export class MetadataClient {
     pagination?: PaginationInput,
   ): Promise<PaginatedResult<UserPublic>> {
     if (typeof teamIdOrRequest === "string") {
-      return this.http.post(`${V3}/user/list`, body({ team_id: teamIdOrRequest, ...pagination }));
+      return this.http.post(`${V3}/user/list`, body({ ...paginationFields(pagination), team_id: teamIdOrRequest }));
     }
     return this.http.post(`${V3}/user/list`, body(teamIdOrRequest));
   }
@@ -160,7 +167,7 @@ export class MetadataClient {
     pagination?: PaginationInput,
   ): Promise<PaginatedResult<UserKeyPublic>> {
     if (typeof userIdOrRequest === "string") {
-      return this.http.post(`${V3}/user-key/list`, body({ user_id: userIdOrRequest, ...pagination }));
+      return this.http.post(`${V3}/user-key/list`, body({ ...paginationFields(pagination), user_id: userIdOrRequest }));
     }
     return this.http.post(`${V3}/user-key/list`, body(userIdOrRequest));
   }
@@ -181,7 +188,7 @@ export class MetadataClient {
   ): Promise<PaginatedResult<TeamEntity>> {
     const payload = body(
       typeof userIdOrRequest === "string"
-        ? { user_id: userIdOrRequest, ...pagination }
+        ? { ...paginationFields(pagination), user_id: userIdOrRequest }
         : userIdOrRequest,
     );
     requireAnyString(payload, ["user_id", "user_key"], "listTeams");
@@ -192,7 +199,7 @@ export class MetadataClient {
   addTeamMember(p: AddTeamMemberRequest): Promise<TeamMemberEntity> { return this.http.post(`${V3}/team-member/add`, body(p)); }
   removeTeamMember(teamId: string, userId: string): Promise<{ ok: true }> { return this.http.post(`${V3}/team-member/remove`, { team_id: teamId, user_id: userId }); }
   listTeamMembers(teamId: string, pagination?: PaginationInput): Promise<PaginatedResult<TeamMemberEntity>> {
-    return this.http.post(`${V3}/team-member/list`, body({ team_id: teamId, ...pagination }));
+    return this.http.post(`${V3}/team-member/list`, body({ ...paginationFields(pagination), team_id: teamId }));
   }
   getTeamMember(teamId: string, userId: string): Promise<TeamMemberEntity> { return this.http.post(`${V3}/team-member/get`, { team_id: teamId, user_id: userId }); }
 
@@ -218,7 +225,7 @@ export class MetadataClient {
   ): Promise<PaginatedResult<TaskEntity>> {
     const payload = body(
       typeof teamIdOrRequest === "string"
-        ? { team_id: teamIdOrRequest, status, ...pagination }
+        ? { ...paginationFields(pagination), team_id: teamIdOrRequest, status }
         : teamIdOrRequest,
     );
     requireAnyString(payload, ["team_id", "creator_user_id", "creator_user_key"], "listTasks");
@@ -230,7 +237,7 @@ export class MetadataClient {
   linkTaskAgent(taskId: string, agentId: string, roleInTask?: string): Promise<TaskAgentEntity> { return this.http.post(`${V3}/task-agent/link`, body({ task_id: taskId, agent_id: agentId, role_in_task: roleInTask })); }
   unlinkTaskAgent(taskId: string, agentId: string): Promise<{ ok: true }> { return this.http.post(`${V3}/task-agent/unlink`, { task_id: taskId, agent_id: agentId }); }
   listTaskAgents(taskId: string, pagination?: PaginationInput): Promise<PaginatedResult<TaskAgentEntity>> {
-    return this.http.post(`${V3}/task-agent/list`, body({ task_id: taskId, ...pagination }));
+    return this.http.post(`${V3}/task-agent/list`, body({ ...paginationFields(pagination), task_id: taskId }));
   }
 
   // ── ParticipationLog ──
@@ -255,7 +262,7 @@ export class MetadataClient {
   // ── AgentFixedAsset ──
   setAgentFixedAssets(agentId: string, bindings: FixedAssetBindingInput[]): Promise<{ ok: true }> { return this.http.post(`${V3}/agent-fixed-asset/set`, { agent_id: agentId, bindings }); }
   listAgentFixedAssets(agentId: string, pagination?: PaginationInput): Promise<PaginatedResult<FixedAssetBindingEntity>> {
-    return this.http.post(`${V3}/agent-fixed-asset/list`, body({ agent_id: agentId, ...pagination }));
+    return this.http.post(`${V3}/agent-fixed-asset/list`, body({ ...paginationFields(pagination), agent_id: agentId }));
   }
   listAgentFixedAssetsWithDetail(p: ListWithDetailRequest): Promise<AgentFixedAssetDetailResult> { return this.http.post(`${V3}/agent-fixed-asset/list-with-detail`, body(p)); }
   summarizeAgentFixedAssetsByAgents(p: SummarizeAgentFixedAssetsRequest): Promise<AgentFixedAssetSummaryResult> {
@@ -266,7 +273,7 @@ export class MetadataClient {
   grantAcl(p: GrantAclRequest): Promise<AclEntity> { return this.http.post(`${V3}/acl/grant`, body(p)); }
   revokeAcl(id: string): Promise<{ ok: true }> { return this.http.post(`${V3}/acl/revoke`, { id }); }
   listAcl(assetId: string, pagination?: PaginationInput): Promise<PaginatedResult<AclEntity>> {
-    return this.http.post(`${V3}/acl/list`, body({ asset_id: assetId, ...pagination }));
+    return this.http.post(`${V3}/acl/list`, body({ ...paginationFields(pagination), asset_id: assetId }));
   }
   checkAcl(p: CheckAclRequest): Promise<PermCheckResult> { return this.http.post(`${V3}/acl/check`, body(p)); }
 

--- a/sdk/memory-core/typescript/tests/v3-metadata-pagination-scope.test.ts
+++ b/sdk/memory-core/typescript/tests/v3-metadata-pagination-scope.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Transport } from "../src/client.js";
+import { MetadataClient } from "../src/v3/metadata-client.js";
+import type { PaginationInput } from "../src/v3/metadata-types.js";
+
+const post = vi.fn().mockResolvedValue({
+  items: [],
+  total: 0,
+  limit: 25,
+  offset: 5,
+});
+const client = new MetadataClient({ post } as Transport);
+
+const paginationWithExtras = {
+  limit: 25,
+  offset: 5,
+  team_id: "wrong-team",
+  user_id: "wrong-user",
+  task_id: "wrong-task",
+  agent_id: "wrong-agent",
+  asset_id: "wrong-asset",
+  status: "completed",
+} as PaginationInput;
+
+beforeEach(() => {
+  post.mockClear();
+});
+
+describe("MetadataClient positional list scopes", () => {
+  it.each([
+    {
+      name: "users",
+      path: "/v3/meta/user/list",
+      invoke: () => client.listUsers("team-1", paginationWithExtras),
+      expected: { team_id: "team-1" },
+    },
+    {
+      name: "user keys",
+      path: "/v3/meta/user-key/list",
+      invoke: () => client.listUserKeys("user-1", paginationWithExtras),
+      expected: { user_id: "user-1" },
+    },
+    {
+      name: "teams",
+      path: "/v3/meta/team/list",
+      invoke: () => client.listTeams("user-1", paginationWithExtras),
+      expected: { user_id: "user-1" },
+    },
+    {
+      name: "team members",
+      path: "/v3/meta/team-member/list",
+      invoke: () => client.listTeamMembers("team-1", paginationWithExtras),
+      expected: { team_id: "team-1" },
+    },
+    {
+      name: "tasks",
+      path: "/v3/meta/task/list",
+      invoke: () => client.listTasks("team-1", "running", paginationWithExtras),
+      expected: { team_id: "team-1", status: "running" },
+    },
+    {
+      name: "task agents",
+      path: "/v3/meta/task-agent/list",
+      invoke: () => client.listTaskAgents("task-1", paginationWithExtras),
+      expected: { task_id: "task-1" },
+    },
+    {
+      name: "agent fixed assets",
+      path: "/v3/meta/agent-fixed-asset/list",
+      invoke: () => client.listAgentFixedAssets("agent-1", paginationWithExtras),
+      expected: { agent_id: "agent-1" },
+    },
+    {
+      name: "ACL entries",
+      path: "/v3/meta/acl/list",
+      invoke: () => client.listAcl("asset-1", paginationWithExtras),
+      expected: { asset_id: "asset-1" },
+    },
+  ])("keeps $name scope authoritative", async ({ path, invoke, expected }) => {
+    await invoke();
+
+    expect(post).toHaveBeenCalledWith(path, {
+      limit: 25,
+      offset: 5,
+      ...expected,
+    });
+  });
+});


### PR DESCRIPTION
## Description | 描述

The TypeScript metadata SDK's positional list overloads previously spread the
pagination object after authoritative identity fields. JavaScript callers, or
TypeScript callers using a cast, could therefore supply runtime extras such as
`team_id`, `user_id`, or `asset_id` and redirect a request away from the scope
specified by the positional argument.

This change narrows positional pagination serialization to the declared
`limit` and `offset` fields, then writes identity and status arguments last.
Regression coverage verifies all eight affected list methods at the transport
boundary.

Scope is limited to positional convenience overloads. Request-object overloads,
public types, endpoint paths, and valid pagination behavior are unchanged.

## Related Issue | 关联 Issue

No linked issue. This defect was found during an SDK request-serialization
audit.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation:

- `npm test -- tests/v3-metadata-pagination-scope.test.ts` (8 passed)
- `npm test` (8 passed)
- `npm run build`
- `npm pack --dry-run --json` (44 files)
- `git diff --check`
