### PR TITLE
fix: L1 drain chain silently breaks on lock conflict; flush never runs L1 (#549)

### DIFF
--- a/MemoryCore/openclaw-plugin/__tests__/fix-549-l1-drain.test.ts
+++ b/MemoryCore/openclaw-plugin/__tests__/fix-549-l1-drain.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Fix #549 Regression-Tests: L1-Drain-Resilience
+ *
+ * Defect 1: L1-drain-Task darf bei Lock-Conflict-Timeout NICHT gedroppt
+ *           werden (Kette bricht still) — stattdessen re-enqueue mit Grenze.
+ * Defect 2: flush muss L1 tatsächlich ausführen (nicht nur handleSessionEnd).
+ */
+import { describe, expect, it } from "vitest";
+import { isL1DrainTask } from "../../src/services/pipeline-worker.js";
+
+describe("Fix #549 Defect 1: L1-drain-Task-Erkennung", () => {
+  it("erkennt L1-drain-Task am ID-Präfix (L1-drain-)", () => {
+    expect(isL1DrainTask({ type: "L1", id: "L1-drain-sess-123" })).toBe(true);
+  });
+
+  it("verwirft normale L1-Tasks (threshold) — nur Drain wird re-enqueued", () => {
+    expect(isL1DrainTask({ type: "L1", id: "L1-threshold-sess-1" })).toBe(false);
+  });
+
+  it("verwirft flush-Tasks", () => {
+    expect(isL1DrainTask({ type: "flush", id: "flush-sess-1" })).toBe(false);
+  });
+});

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -2520,7 +2520,17 @@ export class TdaiGateway {
         }
       },
       async executeFlush(task: TaskPayload) {
+        // Fix #549 Defect 2: flush muss L1 tatsächlich ausführen.
+        // Vorher: nur core.handleSessionEnd — kein Code-Pfad im flush-Flow
+        // rief jemals runL1WithStore auf, und flushSession hatte den
+        // L1_idle-Sicherheitstimer bereits gecancelt. Ergebnis: "Idle-time
+        // catch-up extraction" wurde zu "idle-time extraction cancellation".
+        // Delegation an executeL1 nutzt denselben idempotenten L1-Pfad
+        // (upsert-by-record_id), der auch von Timer/Drain-Trigger läuft.
         await core.handleSessionEnd(task.sessionId);
+        // `this` ist das rawExecutor-Objekt-Literal (inner des Decorators);
+        // `this.executeL1` ist die Methode im selben Literal weiter unten.
+        await this.executeL1(task);
       },
 
       // ── Offload executors (L1 summary, L1.5 task judgment, L2 MMD update) ──

--- a/MemoryCore/src/services/pipeline-worker.ts
+++ b/MemoryCore/src/services/pipeline-worker.ts
@@ -116,6 +116,15 @@ const TAG = "[pipeline-worker]";
 // PipelineWorker
 // ============================
 
+/**
+ * Fix #549: Identifiziert L1-Drain-Tasks (Selbst-Re-Enqueue-Kette).
+ * Drain-Tasks werden von enqueueL1Drain() mit id=`L1-drain-...` erzeugt.
+ * Exportiert für Regressionstests.
+ */
+export function isL1DrainTask(task: { type: string; id: string }): boolean {
+  return task.type === "L1" && task.id.startsWith("L1-drain-");
+}
+
 export class PipelineWorker {
   private backend: IStateBackend;
   private executor: TaskExecutor;
@@ -366,6 +375,32 @@ export class PipelineWorker {
         delay = Math.min(delay * 3, 5000);
       }
       if (!acquired) {
+        // Fix #549: L1-Drain-Tasks NICHT droppen — die Drain-Kette lebt nur
+        // über die Selbst-Re-Enqueue der vorherigen Batch (kein Supervisor,
+        // kein L1_idle-Timer im hasFullBacklog-Branch). Ein Drop hier beendet
+        // den gesamten Backlog-Abbau still für Tage.
+        // Stattdessen: mit Backoff-Grenze re-enqueuen (idempotent, da
+        // L1-Extraktion upsert-by-record_id ist).
+        const isL1Drain = isL1DrainTask(task);
+        if (isL1Drain) {
+          this.logger?.warn?.(
+            `${TAG} Lock conflict timeout [${task.type}] (task=${task.id}): ${lockKey}, ` +
+            `re-enqueuing to preserve drain chain (attempt=${(task.data as any)?.retryCount ?? 0})`,
+          );
+          const msgId = (task as any)._msgId;
+          if (msgId) {
+            try { await this.backend.ackTask(msgId); } catch { /* best effort */ }
+          }
+          const nextRetry = ((task.data as any)?.retryCount ?? 0) + 1;
+          if (nextRetry <= this.config.maxRetries + 5) {
+            await this.reEnqueue(task, nextRetry);
+            this.metrics.tasksRetried++;
+          } else {
+            await this.moveToDeadLetter(task, `lock conflict timeout after ${nextRetry} retries`, nextRetry);
+          }
+          releasePermitOnce();
+          return;
+        }
         this.logger?.warn?.(`${TAG} Lock conflict timeout [${task.type}] (task=${task.id}): ${lockKey}, dropping task`);
         // CR-1 fix: ACK to prevent stale recovery from re-claiming this message in an
         // infinite loop. Without it, XPENDING keeps returning this msgId every


### PR DESCRIPTION
Fixes #549

**Defect 1:** An L1-drain task is dropped after a lock-conflict timeout, permanently breaking the drain chain — there is no supervisor and no `L1_idle` timer in the `hasFullBacklog` branch, so a single drop silently stalls backlog draining for days while L0 capture keeps working.
**Fix:** L1-drain tasks are now re-enqueued with bounded retries (maxRetries + 5), then dead-lettered. Re-enqueue is safe: L1 extraction is idempotent (upsert-by-record_id).

**Defect 2:** The `/session/end` flush path only called `core.handleSessionEnd` — no code path in the flush flow ever ran `runL1WithStore`, and `flushSession` had already cancelled the `L1_idle` safety timer. Net effect: "idle-time catch-up extraction" became "idle-time extraction cancellation".
**Fix:** `executeFlush` now delegates to `executeL1`, the same idempotent L1 path used by timer/drain triggers.

**Verification:** `isL1DrainTask` regression test added (openclaw-plugin/__tests__/fix-549-l1-drain.test.ts).

This matches the root cause confirmed by @Wilson-G in the issue (self-recursive flush chain, ~200ms cadence, 63 GiB log growth in 4 days) and aligns with the Fix 2 direction of #553 — offered as an independent reference implementation.