### PR TITLE
Fix variable interpolation in info messages

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -121,7 +121,7 @@ skill:
     maxResourceSizeBytes: 5000000
 YAML
 
-info "启动 memory-core (image=$MEMORY_CORE_IMAGE, port=$MEMORY_CORE_PORT)"
+info "启动 memory-core (image=${MEMORY_CORE_IMAGE}, port=${MEMORY_CORE_PORT})"
 $DOCKER run -d --name "$CONTAINER" \
   --network "$NETWORK" \
   --network-alias memory-core \
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then


### PR DESCRIPTION
## Description | 描述

fix(scripts): wrap ADMIN_KEY_FILE variable in braces for bash 3.2 compatibility

Fix an "unbound variable" error when running under bash 3.2.57 (default on macOS).

In bash 3.2, variable parsing is not multibyte-safe. Placing a full-width  closing parenthesis '）' (UTF-8: `EF BC 89`) immediately after a unbraced variable  causes the parser to consume the leading byte (`0xEF`) as part of the variable  identifier (e.g., `ADMIN_KEY_FILE\xEF`). Under `set -u`, this triggers an unbound  variable fatal error.

Explicitly scoping the identifier as `${ADMIN_KEY_FILE}` resolves the parsing ambiguousness.

Fixes: #175 in start-memory-core.sh

## Related Issue | 关联 Issue


## Change Type | 修改类型
- [✅] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ] Verified locally | 本地验证通过
- [ ] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
<!-- Optional | 可选 -->