### PR TITLE
fix: remove stale build:seed-v2 script and bump version to 2.0.0

### DIFF
--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tencentdb-agent-memory/memory-tencentdb-v2",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "description": "Four-layer local memory system plugin for OpenClaw — auto-captures, structures, and profiles conversational knowledge using local LLM + SQLite vector search (L0→L1→L2→L3 pipeline)",
   "type": "module",
   "main": "./dist/index.mjs",
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "npm run build:plugin && npm run build:scripts",
     "build:plugin": "tsdown",
-    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory && npm run build:seed-v2",
+    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
     "prepack": "npm run build",
     "build:migrate-sqlite-to-vdb": "tsc -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false",
     "migrate-sqlite-to-tcvdb": "node ./bin/migrate-sqlite-to-tcvdb.mjs",
@@ -26,7 +26,6 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
-    "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
     "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
     "test:oss": "vitest run -c vitest.oss.config.ts",


### PR DESCRIPTION
## Summary

Fixes two post-release oversights in the v2.0.0 tag.

### Fix 1 — Remove stale `build:seed-v2` reference (closes #759, closes #716)

The `scripts/seed-v2/` directory was removed during the v2.0.0 refactor, but `build:seed-v2` was left in the `build:scripts` chain. Running `npm run build` fails immediately with:

```
error TS5058: The specified path does not exist: 'scripts/seed-v2/tsconfig.json'
```

Changes:
- Remove `&& npm run build:seed-v2` from the `build:scripts` script
- Remove the dangling `build:seed-v2` script entry
- Keep the `seed-v2` run script (`bin/seed-v2.mjs` is prebuilt and the entry is valid for manual use)

### Fix 2 — Bump version to `2.0.0` (closes #760)

The v2.0.0 release tag was cut without updating `MemoryCore/package.json` from `2.0.0-beta.1`. Any npm publish from this tag would ship a stable release under a beta SemVer string.

Change: `"version": "2.0.0-beta.1"` to `"version": "2.0.0"`

## Testing

Verified `scripts/seed-v2/` does not exist in the repository. `bin/seed-v2.mjs` is present and unaffected. The `build:scripts` chain now only references directories that exist.