### PR TITLE
fix(checkpoint): fail closed on corrupt checkpoint instead of silent reset

### DIFF
--- a/MemoryCore/src/utils/checkpoint.test.ts
+++ b/MemoryCore/src/utils/checkpoint.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for #770 — checkpoint read failures must never be silently
+ * treated as a first run (which allowed the next mutation to overwrite the only
+ * recoverable checkpoint evidence).
+ *
+ * Failure semantics under test:
+ *   - missing checkpoint (ENOENT / storage null)            → DEFAULT_CHECKPOINT
+ *   - malformed/truncated JSON + no backup                  → throw (fail closed)
+ *   - malformed/truncated JSON + last-known-good `.bak`     → recover from backup
+ *   - a mutation after a failed read must NOT overwrite the corrupted file
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CheckpointManager, type Checkpoint } from "./checkpoint.js";
+import { StoragePaths } from "../core/storage/types.js";
+import { StorageAdapter } from "../core/storage/adapter.js";
+
+/** Build a valid, non-default checkpoint payload (mirrors the #770 reproduction). */
+function validCheckpoint(overrides: Record<string, unknown> = {}): Checkpoint {
+  return {
+    last_captured_timestamp: 0,
+    total_processed: 99,
+    last_persona_at: 0,
+    last_persona_time: "",
+    request_persona_update: false,
+    persona_update_reason: "",
+    memories_since_last_persona: 0,
+    scenes_processed: 0,
+    runner_states: {
+      sessionA: { last_captured_timestamp: 1234, last_l1_cursor: 1200, last_scene_name: "checkout" },
+    },
+    pipeline_states: {
+      sessionA: {
+        conversation_count: 7,
+        last_extraction_time: "2026-08-01T00:00:00Z",
+        last_extraction_updated_time: "",
+        last_active_time: 1,
+        l2_pending_l1_count: 2,
+        warmup_threshold: 4,
+        l2_last_extraction_time: "",
+      },
+    },
+    l0_conversations_count: 0,
+    total_memories_extracted: 12,
+    ...overrides,
+  } as Checkpoint;
+}
+
+/** In-memory StorageAdapter stand-in for the COS/storage mode tests. */
+function mockStorage(initial: Record<string, string | null>): StorageAdapter {
+  const files = new Map<string, string | null>(Object.entries(initial));
+  return {
+    readFile: vi.fn(async (key: string) => files.get(key) ?? null),
+    writeFile: vi.fn(async (key: string, content: string) => {
+      files.set(key, content);
+    }),
+  } as unknown as StorageAdapter;
+}
+
+const CORRUPTED = '{"runner_states":{"sessionA":';
+
+describe("CheckpointManager read failure semantics (#770)", () => {
+  let dataDir: string;
+  let cpPath: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-cp-test-"));
+    cpPath = join(dataDir, ".metadata", "recall_checkpoint.json");
+    mkdirSync(join(dataDir, ".metadata"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("missing checkpoint initializes defaults (first run)", async () => {
+    const manager = new CheckpointManager(dataDir);
+    const cp = await manager.read();
+    expect(cp.total_processed).toBe(0);
+    expect(cp.runner_states).toEqual({});
+    expect(cp.pipeline_states).toEqual({});
+  });
+
+  it("valid checkpoint is parsed and merged with defaults", async () => {
+    writeFileSync(cpPath, JSON.stringify(validCheckpoint()));
+    const manager = new CheckpointManager(dataDir);
+    const cp = await manager.read();
+    expect(cp.total_processed).toBe(99);
+    expect(cp.total_memories_extracted).toBe(12);
+    expect(cp.runner_states.sessionA?.last_captured_timestamp).toBe(1234);
+    expect(cp.pipeline_states.sessionA?.conversation_count).toBe(7);
+  });
+
+  it("malformed JSON is NOT treated as first run and surfaces an error", async () => {
+    writeFileSync(cpPath, CORRUPTED);
+    const manager = new CheckpointManager(dataDir);
+    await expect(manager.read()).rejects.toThrow(/corrupt checkpoint/);
+  });
+
+  it("a mutation after a failed read cannot overwrite the corrupted checkpoint", async () => {
+    writeFileSync(cpPath, CORRUPTED);
+    const manager = new CheckpointManager(dataDir);
+    await expect(manager.setPersonaUpdateRequest("manual")).rejects.toThrow(/corrupt checkpoint/);
+    // The corrupted file must remain byte-for-byte intact — never reset to defaults.
+    expect(readFileSync(cpPath, "utf8")).toBe(CORRUPTED);
+    // A file that never wrote successfully has no backup.
+    expect(existsSync(`${cpPath}.bak`)).toBe(false);
+  });
+
+  it("recovers from last-known-good backup when primary is truncated", async () => {
+    const manager = new CheckpointManager(dataDir);
+    // First successful mutation writes primary + backup.
+    await manager.setPersonaUpdateRequest("manual");
+    expect(existsSync(`${cpPath}.bak`)).toBe(true);
+
+    // Now simulate a truncated write on the primary only.
+    writeFileSync(cpPath, CORRUPTED);
+
+    // read() must recover the previously persisted state from the backup.
+    const cp = await manager.read();
+    expect(cp.request_persona_update).toBe(true);
+    expect(cp.runner_states).toBeDefined();
+  });
+
+  it("successful write keeps a backup equal to the primary", async () => {
+    const manager = new CheckpointManager(dataDir);
+    await manager.setPersonaUpdateRequest("manual");
+    const primary = JSON.parse(readFileSync(cpPath, "utf8")) as Checkpoint;
+    const backup = JSON.parse(readFileSync(`${cpPath}.bak`, "utf8")) as Checkpoint;
+    expect(backup).toEqual(primary);
+    expect(backup.request_persona_update).toBe(true);
+  });
+
+  it("writes remain atomic and produce a valid checkpoint", async () => {
+    const manager = new CheckpointManager(dataDir);
+    await manager.incrementScenesProcessed();
+    const cp = JSON.parse(readFileSync(cpPath, "utf8")) as Checkpoint;
+    expect(cp.scenes_processed).toBe(1);
+  });
+
+  it("storage mode: missing checkpoint initializes defaults", async () => {
+    const storage = mockStorage({});
+    const manager = new CheckpointManager("", undefined, storage);
+    const cp = await manager.read();
+    expect(cp.total_processed).toBe(0);
+    expect(cp.runner_states).toEqual({});
+  });
+
+  it("storage mode: corrupt checkpoint fails closed (no backup fallback)", async () => {
+    const storage = mockStorage({ [StoragePaths.checkpoint]: CORRUPTED });
+    const manager = new CheckpointManager("", undefined, storage);
+    await expect(manager.read()).rejects.toThrow(/corrupt checkpoint/);
+  });
+});

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -146,6 +146,20 @@ export interface CheckpointLogger {
 
 const noopLogger: CheckpointLogger = { info() {} };
 
+/** True when the error is a missing-file (ENOENT) condition. */
+function isEnoentError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+/** Stable one-line error description for logs / exception messages. */
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 // ============================
 // Per-file async lock
 // ============================
@@ -199,61 +213,116 @@ export class CheckpointManager {
   // ============================
 
   private async readRaw(): Promise<Checkpoint> {
+    let raw: string | null;
     try {
-      let raw: string | null;
-      if (this.storage) {
-        raw = await this.storage.readFile(this.filePath);
-      } else {
-        const fs = await import("node:fs/promises");
-        raw = await fs.default.readFile(this.filePath, "utf-8");
+      raw = await this.readFileContent();
+    } catch (err) {
+      if (isEnoentError(err)) {
+        // First run — no checkpoint written yet.
+        return structuredClone(DEFAULT_CHECKPOINT);
       }
-      if (!raw) return structuredClone(DEFAULT_CHECKPOINT);
+      // Present but unreadable (permissions, storage failure, ...). Fail closed
+      // instead of silently resetting every processing cursor to defaults.
+      throw new Error(
+        `[checkpoint] failed to read checkpoint at ${this.filePath}: ${describeError(err)}`,
+      );
+    }
+    if (!raw) return structuredClone(DEFAULT_CHECKPOINT);
 
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      // Merge with defaults for backward compat (old checkpoints lack new fields).
-      // structuredClone avoids shallow-copy pitfall: without it, the nested
-      // runner_states/pipeline_states objects in DEFAULT_CHECKPOINT would be
-      // shared across all callers and mutated in place — corrupting the default.
-      const cp = { ...structuredClone(DEFAULT_CHECKPOINT), ...parsed } as Checkpoint;
+    try {
+      return this.parseCheckpoint(raw);
+    } catch (err) {
+      // Corrupt/truncated JSON. Never treat this as a first run: recover from
+      // the last-known-good backup when one exists, otherwise fail closed.
+      const recovered = await this.tryRecoverFromBackup();
+      if (recovered) {
+        this.logger.warn?.(
+          `[checkpoint] corrupt checkpoint at ${this.filePath}; ` +
+          `recovered from last-known-good backup ${this.backupPath()}`,
+        );
+        return recovered;
+      }
+      throw new Error(
+        `[checkpoint] corrupt checkpoint at ${this.filePath}: ${describeError(err)}` +
+        (this.storage ? "" : ` (no recoverable backup at ${this.backupPath()})`),
+      );
+    }
+  }
 
-      // Migrate from old session_states format (pre-split)
-      const oldStates = parsed.session_states as Record<string, Record<string, unknown>> | undefined;
-      if (oldStates && !parsed.runner_states && !parsed.pipeline_states) {
-        cp.runner_states = {};
-        cp.pipeline_states = {};
-        for (const [key, state] of Object.entries(oldStates)) {
-          cp.runner_states[key] = {
-            ...DEFAULT_RUNNER_STATE,
-            last_captured_timestamp: (state.last_captured_timestamp as number) ?? 0,
-            last_l1_cursor: (state.last_l1_cursor as number) ?? 0,
-            last_scene_name: (state.last_scene_name as string) ?? "",
-          };
-          cp.pipeline_states[key] = {
-            ...DEFAULT_PIPELINE_STATE,
-            conversation_count: (state.conversation_count as number) ?? 0,
-            last_extraction_time: (state.last_extraction_time as string) ?? "",
-            last_extraction_updated_time: (state.last_extraction_updated_time as string) ?? "",
-            last_active_time: (state.last_active_time as number) ?? 0,
-            l2_pending_l1_count: (state.l2_pending_l1_count as number) ?? 0,
-            l2_last_extraction_time: (state.l2_last_extraction_time as string) ?? "",
-          };
-        }
-      } else {
-        // Ensure per-session states have all fields with defaults
-        if (cp.runner_states) {
-          for (const [key, state] of Object.entries(cp.runner_states)) {
-            cp.runner_states[key] = { ...DEFAULT_RUNNER_STATE, ...state };
-          }
-        }
-        if (cp.pipeline_states) {
-          for (const [key, state] of Object.entries(cp.pipeline_states)) {
-            cp.pipeline_states[key] = { ...DEFAULT_PIPELINE_STATE, ...state };
-          }
+  /** Read the raw checkpoint text. Storage mode: null when missing; fs mode: throws ENOENT when missing. */
+  private async readFileContent(): Promise<string | null> {
+    if (this.storage) {
+      return this.storage.readFile(this.filePath);
+    }
+    const fs = await import("node:fs/promises");
+    return fs.default.readFile(this.filePath, "utf-8");
+  }
+
+  /** Parse + normalize a raw checkpoint JSON payload into a {@link Checkpoint}. Throws on malformed JSON. */
+  private parseCheckpoint(raw: string): Checkpoint {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    // Merge with defaults for backward compat (old checkpoints lack new fields).
+    // structuredClone avoids shallow-copy pitfall: without it, the nested
+    // runner_states/pipeline_states objects in DEFAULT_CHECKPOINT would be
+    // shared across all callers and mutated in place — corrupting the default.
+    const cp = { ...structuredClone(DEFAULT_CHECKPOINT), ...parsed } as Checkpoint;
+
+    // Migrate from old session_states format (pre-split)
+    const oldStates = parsed.session_states as Record<string, Record<string, unknown>> | undefined;
+    if (oldStates && !parsed.runner_states && !parsed.pipeline_states) {
+      cp.runner_states = {};
+      cp.pipeline_states = {};
+      for (const [key, state] of Object.entries(oldStates)) {
+        cp.runner_states[key] = {
+          ...DEFAULT_RUNNER_STATE,
+          last_captured_timestamp: (state.last_captured_timestamp as number) ?? 0,
+          last_l1_cursor: (state.last_l1_cursor as number) ?? 0,
+          last_scene_name: (state.last_scene_name as string) ?? "",
+        };
+        cp.pipeline_states[key] = {
+          ...DEFAULT_PIPELINE_STATE,
+          conversation_count: (state.conversation_count as number) ?? 0,
+          last_extraction_time: (state.last_extraction_time as string) ?? "",
+          last_extraction_updated_time: (state.last_extraction_updated_time as string) ?? "",
+          last_active_time: (state.last_active_time as number) ?? 0,
+          l2_pending_l1_count: (state.l2_pending_l1_count as number) ?? 0,
+          l2_last_extraction_time: (state.l2_last_extraction_time as string) ?? "",
+        };
+      }
+    } else {
+      // Ensure per-session states have all fields with defaults
+      if (cp.runner_states) {
+        for (const [key, state] of Object.entries(cp.runner_states)) {
+          cp.runner_states[key] = { ...DEFAULT_RUNNER_STATE, ...state };
         }
       }
-      return cp;
+      if (cp.pipeline_states) {
+        for (const [key, state] of Object.entries(cp.pipeline_states)) {
+          cp.pipeline_states[key] = { ...DEFAULT_PIPELINE_STATE, ...state };
+        }
+      }
+    }
+    return cp;
+  }
+
+  /** Last-known-good backup path (fs mode only). */
+  private backupPath(): string {
+    return `${this.filePath}.bak`;
+  }
+
+  /**
+   * Attempt recovery from the last-known-good backup written by {@link writeRaw}.
+   * Returns null when no backup exists, it is empty, or it is itself corrupt.
+   */
+  private async tryRecoverFromBackup(): Promise<Checkpoint | null> {
+    if (this.storage) return null; // no backup capability in storage (COS) mode
+    try {
+      const fs = await import("node:fs/promises");
+      const raw = await fs.default.readFile(this.backupPath(), "utf-8");
+      if (!raw) return null;
+      return this.parseCheckpoint(raw);
     } catch {
-      return structuredClone(DEFAULT_CHECKPOINT);
+      return null;
     }
   }
 
@@ -262,14 +331,23 @@ export class CheckpointManager {
     const content = JSON.stringify(checkpoint, null, 2);
     if (this.storage) {
       await this.storage.writeFile(this.filePath, content);
-    } else {
-      const fs = await import("node:fs/promises");
-      const path = await import("node:path");
-      const dir = path.default.dirname(this.filePath);
-      await fs.default.mkdir(dir, { recursive: true });
-      const tmp = `${this.filePath}.tmp.${randomBytes(4).toString("hex")}`;
-      await fs.default.writeFile(tmp, content, "utf-8");
-      await fs.default.rename(tmp, this.filePath);
+      return;
+    }
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const dir = path.default.dirname(this.filePath);
+    await fs.default.mkdir(dir, { recursive: true });
+    const tmp = `${this.filePath}.tmp.${randomBytes(4).toString("hex")}`;
+    await fs.default.writeFile(tmp, content, "utf-8");
+    await fs.default.rename(tmp, this.filePath);
+    // Keep a last-known-good backup so a later corrupt write can be recovered
+    // from. Best-effort: a backup failure must never fail the primary write.
+    try {
+      await fs.default.copyFile(this.filePath, this.backupPath());
+    } catch (err) {
+      this.logger.warn?.(
+        `[checkpoint] failed to update backup at ${this.backupPath()}: ${describeError(err)}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Problem

`CheckpointManager` treats **every** checkpoint read failure as a first-run condition and returns `DEFAULT_CHECKPOINT` — including malformed/truncated JSON and other I/O errors, not just a missing file. The next ordinary checkpoint mutation then rewrites `.metadata/recall_checkpoint.json` from the empty default state, permanently replacing the corrupted file and losing all persisted processing cursors (per-session capture/L1 cursors, pipeline progress, scene/persona state, counters).

Fixes #770.

## Change

`MemoryCore/src/utils/checkpoint.ts` — `readRaw()` now distinguishes failure classes:

- **ENOENT** (file missing) → `DEFAULT_CHECKPOINT`, i.e. genuine first run (unchanged behavior).
- **Other read errors** (permissions, storage failure) → throw a clear error. No silent reset.
- **Malformed/truncated JSON** → recover from the last-known-good backup (`.bak`) when one exists; otherwise throw. Never treated as first run.
- `writeRaw()` (fs mode) now maintains a `.bak` backup after each successful atomic write (best-effort — a backup failure never fails the primary write).
- A mutation whose read fails aborts before writing, so a corrupted checkpoint is **never overwritten**.

Storage (COS) mode has no backup capability and fails closed on corruption.

## Tests

New `MemoryCore/src/utils/checkpoint.test.ts` — 9 regression tests covering the issue's suggested cases in both fs and storage modes:

- missing checkpoint initializes defaults
- valid checkpoint parsed + merged with defaults
- malformed JSON is not treated as first run (throws)
- a mutation after a failed read cannot overwrite the corrupted checkpoint (file stays byte-for-byte intact)
- recovery from last-known-good backup when the primary is truncated
- successful writes keep a backup equal to the primary
- writes remain atomic
- storage mode: missing → defaults; corrupt → fail closed

`npm test` (vitest): 1 file, 9 tests, all passing.