### PR TITLE
fix(mcp): send x-tdai-service-id header + log to stderr

### DIFF
--- a/MemoryKnowledge/.env.example
+++ b/MemoryKnowledge/.env.example
@@ -32,6 +32,9 @@ LLM_BASE_URL=
 # MCP server 通过 HTTP 调用本服务 API，这里配置转发目标
 KNOWLEDGE_API_URL=http://localhost:8421
 # KNOWLEDGE_API_TOKEN=optional-bearer-token
+# service_id 租户身份：随 x-tdai-service-id header 发送，每个 /v3 端点必传。
+# 未设置时 MCP 工具的 HTTP 调用会被服务端以 400 拒绝。
+KNOWLEDGE_SERVICE_ID=
 
 # ═══ 与管控（team-memory-control）对接 ═══
 # TMC + KS 部署时以下两项必须显式配置。代码中的默认值均为空：

--- a/MemoryKnowledge/README.md
+++ b/MemoryKnowledge/README.md
@@ -96,6 +96,19 @@ pnpm test
 pnpm build        # tsdown → dist/
 ```
 
+## MCP stdio
+
+MCP server 通过 HTTP 转发工具调用到本服务，启动时需把租户身份 `service_id` 一并注入：
+
+```bash
+KNOWLEDGE_API_URL=http://localhost:8421 \
+KNOWLEDGE_SERVICE_ID=<tenant-id> \
+pnpm dev:mcp
+```
+
+`KNOWLEDGE_SERVICE_ID` 会以 `x-tdai-service-id` 请求头发送（每个 `/v3` 端点必传，缺失返回 400）。  
+MCP 是 stdio 协议，诊断日志统一走 stderr，stdout 仅承载 JSON-RPC。
+
 ## 可选：Langfuse
 
 配置 `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`（及可选 `LANGFUSE_BASE_URL`）即可上报 Wiki LLM 调用。  

--- a/MemoryKnowledge/src/logger.test.ts
+++ b/MemoryKnowledge/src/logger.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for #766 — all diagnostic log levels must go to stderr so the MCP
+ * stdio transport (which reads JSON-RPC from stdout) is never corrupted by
+ * log lines.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "./logger.js";
+
+describe("createLogger (#766)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes info to stderr, never stdout", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    createLogger("test").info("hello");
+
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("hello"));
+    expect(stdout).not.toHaveBeenCalled();
+  });
+
+  it("writes debug to stderr, never stdout", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    createLogger("test").debug("trace");
+
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("trace"));
+    expect(stdout).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryKnowledge/src/logger.ts
+++ b/MemoryKnowledge/src/logger.ts
@@ -25,11 +25,14 @@ function format(level: Level, tag: string, msg: string, data?: unknown) {
 
 export function createLogger(tag: string) {
   return {
+    // All log levels go to stderr: the MCP stdio transport reads the protocol
+    // from stdout, so any diagnostic line written there would corrupt the
+    // JSON-RPC stream (see issue #766).
     debug(msg: string, data?: unknown) {
-      if (shouldLog("debug")) console.log(format("debug", tag, msg, data));
+      if (shouldLog("debug")) process.stderr.write(format("debug", tag, msg, data) + "\n");
     },
     info(msg: string, data?: unknown) {
-      if (shouldLog("info")) console.log(format("info", tag, msg, data));
+      if (shouldLog("info")) process.stderr.write(format("info", tag, msg, data) + "\n");
     },
     warn(msg: string, data?: unknown) {
       if (shouldLog("warn")) console.warn(format("warn", tag, msg, data));

--- a/MemoryKnowledge/src/mcp/http-client.test.ts
+++ b/MemoryKnowledge/src/mcp/http-client.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for #766 — the MCP HTTP client must send the `x-tdai-service-id`
+ * header (tenant identity) that every /v3 endpoint requires, otherwise every
+ * MCP `tools/call` fails with 400.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { callApi } from "./http-client.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const OK = { code: 0, message: "ok", data: { id: 1 } };
+
+describe("callApi (#766)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends x-tdai-service-id header when serviceId is provided", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, OK));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const data = await callApi(
+      { baseUrl: "http://localhost:8421", serviceId: "my-tenant" },
+      "/wiki/search",
+      { q: "x" },
+    );
+    expect(data).toEqual({ id: 1 });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8421/v3/wiki/search");
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "x-tdai-service-id": "my-tenant",
+    });
+  });
+
+  it("omits x-tdai-service-id when serviceId is absent (backward compatible)", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, OK));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await callApi({ baseUrl: "http://localhost:8421" }, "/wiki/search", {});
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).not.toHaveProperty("x-tdai-service-id");
+  });
+
+  it("sends bearer token when provided", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, OK));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await callApi({ baseUrl: "http://localhost:8421", token: "abc" }, "/wiki/search", {});
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toMatchObject({ Authorization: "Bearer abc" });
+  });
+
+  it("normalizes a trailing slash in baseUrl", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, OK));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await callApi({ baseUrl: "http://localhost:8421/" }, "/wiki/search", {});
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8421/v3/wiki/search");
+  });
+
+  it("throws the server message on HTTP error status (e.g. missing service_id)", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(400, { code: 400, message: "x-tdai-service-id header is required", data: null }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      callApi({ baseUrl: "http://localhost:8421" }, "/wiki/search", {}),
+    ).rejects.toThrow("x-tdai-service-id header is required");
+  });
+
+  it("throws on a non-zero business code", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, { code: 1, message: "boom", data: null }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(callApi({ baseUrl: "http://localhost:8421" }, "/wiki/search", {})).rejects.toThrow(
+      "boom",
+    );
+  });
+
+  it("throws a descriptive error on invalid JSON response", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response("not json", { status: 200, headers: { "Content-Type": "text/plain" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(callApi({ baseUrl: "http://localhost:8421" }, "/wiki/search", {})).rejects.toThrow(
+      /invalid JSON/,
+    );
+  });
+});

--- a/MemoryKnowledge/src/mcp/http-client.ts
+++ b/MemoryKnowledge/src/mcp/http-client.ts
@@ -14,6 +14,12 @@ export interface HttpClientOptions {
   baseUrl: string;
   /** Optional bearer token for auth. */
   token?: string;
+  /**
+   * Tenant identity (`service_id`). Every /v3 endpoint requires the
+   * `x-tdai-service-id` header (missing/malformed → 400), so the MCP server
+   * must send it to be able to call its own knowledge API.
+   */
+  serviceId?: string;
 }
 
 export interface ApiResponse {
@@ -36,6 +42,7 @@ export async function callApi(
   const url = `${opts.baseUrl.replace(/\/$/, "")}/v3${endpoint}`;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (opts.token) headers["Authorization"] = `Bearer ${opts.token}`;
+  if (opts.serviceId) headers["x-tdai-service-id"] = opts.serviceId;
 
   log.debug(`POST ${url}`);
 

--- a/MemoryKnowledge/src/mcp/server.ts
+++ b/MemoryKnowledge/src/mcp/server.ts
@@ -5,10 +5,13 @@
  * the server forwards the request to the Hono HTTP API via callApi().
  *
  * Usage:
- *   KNOWLEDGE_API_URL=http://localhost:8421 node dist/mcp/server.js
+ *   KNOWLEDGE_API_URL=http://localhost:8421 \
+ *   KNOWLEDGE_SERVICE_ID=<tenant-id> \
+ *   node dist/mcp/server.js
  *
  * The agent connects via stdio; the server translates tool calls to HTTP
- * requests against the knowledge service.
+ * requests against the knowledge service. `KNOWLEDGE_SERVICE_ID` is sent as
+ * the `x-tdai-service-id` header, which every /v3 endpoint requires.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -93,10 +96,11 @@ export function createMcpServer(httpOpts: HttpClientOptions): Server {
 if (import.meta.url === `file://${process.argv[1]}`) {
   const baseUrl = process.env.KNOWLEDGE_API_URL || "http://localhost:8421";
   const token = process.env.KNOWLEDGE_API_TOKEN;
+  const serviceId = process.env.KNOWLEDGE_SERVICE_ID;
 
   log.info(`MCP server starting, API URL: ${baseUrl}`);
 
-  const server = createMcpServer({ baseUrl, token });
+  const server = createMcpServer({ baseUrl, token, serviceId });
   const transport = new StdioServerTransport();
 
   server.connect(transport).then(() => {


### PR DESCRIPTION
## Problem

The bundled MCP server can never call the knowledge API that ships in the same package: `MemoryKnowledge/src/mcp/http-client.ts` sends only `Content-Type` and an optional bearer token, while every `/v3` endpoint requires the `x-tdai-service-id` header (`api-helpers.ts` → `extractIdFields` returns null → 400). As a result **every MCP `tools/call` fails**.

A second, equally fatal issue surfaced while fixing the first: the logger writes `info`/`debug` to **stdout**, which is exactly the channel the MCP stdio transport reads JSON-RPC from — clients fail to parse the handshake unless `LOG_LEVEL=error`.

Fixes #766.

## Change

**Commit 1 — `fix(mcp): send x-tdai-service-id header from KNOWLEDGE_SERVICE_ID`**
- `HttpClientOptions` gains an optional `serviceId`, sent as `x-tdai-service-id` when present (absent keeps previous behaviour — backward compatible)
- MCP server startup reads `KNOWLEDGE_SERVICE_ID` from the environment
- documented in `.env.example` and `README.md`

**Commit 2 — `fix(mcp): write diagnostic logs to stderr for stdio safety`**
- `logger.ts`: `debug`/`info` now write to stderr; stdout carries only the MCP protocol. (HTTP-server logging is unaffected functionally — stderr is the standard diagnostic channel.)

## Tests

New vitest files (first tests for this package):

- `src/mcp/http-client.test.ts` — 7 tests: header sent when `serviceId` present, omitted when absent, bearer token forwarding, trailing-slash normalization, HTTP-error / non-zero-code / invalid-JSON handling.
- `src/logger.test.ts` — 2 tests: `info`/`debug` go to stderr, never stdout.

`npm test`: 2 files, 9 tests, all passing.

## Note

`npm run typecheck` reports one **pre-existing** error in `src/middleware/response-envelope.ts(47,9)` (`Promise<string>` not assignable to `string`) — unrelated to this change and present on `feat/server_team`. Happy to follow up separately if useful.