### PR TITLE
feat(llm): support Anthropic wire protocol (MEMORY_LLM_PROTOCOL=anthropic)

### DIFF
--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -98,6 +98,7 @@
     "node": ">=22.16.0"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^4.0.29",
     "@ai-sdk/openai": "^3.0.53",
     "@node-rs/jieba": "^2.0.1",
     "@opentelemetry/api": "^1.9.0",

--- a/MemoryCore/src/adapters/standalone/llm-runner.test.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for #709 — StandaloneLLMRunner must pick the wire protocol provider
+ * from `config.protocol`: Anthropic native when "anthropic", OpenAI-compatible
+ * otherwise (backward compatible).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createOpenAI } = vi.hoisted(() => ({
+  createOpenAI: vi.fn(() => ({ chat: vi.fn() })),
+}));
+const { createAnthropic } = vi.hoisted(() => ({
+  createAnthropic: vi.fn(() => ({ chat: vi.fn() })),
+}));
+const { generateText } = vi.hoisted(() => ({
+  generateText: vi.fn(async () => ({ text: "done", steps: [] })),
+}));
+
+vi.mock("@ai-sdk/openai", () => ({ createOpenAI }));
+vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic }));
+vi.mock("ai", () => ({
+  generateText,
+  tool: vi.fn(),
+  stepCountIs: vi.fn(),
+  jsonSchema: vi.fn(),
+}));
+
+import { StandaloneLLMRunner, type StandaloneLLMConfig } from "./llm-runner.js";
+
+const BASE: StandaloneLLMConfig = {
+  baseUrl: "https://api.test/v1",
+  apiKey: "test-key",
+  model: "some-model",
+};
+
+async function runWith(overrides: Partial<StandaloneLLMConfig>): Promise<void> {
+  const runner = new StandaloneLLMRunner({
+    config: { ...BASE, ...overrides },
+  });
+  await runner.run({
+    prompt: "hi",
+    systemPrompt: "sys",
+    taskId: "t-1",
+  } as never);
+}
+
+describe("StandaloneLLMRunner protocol selection (#709)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses createAnthropic when protocol=anthropic", async () => {
+    await runWith({ protocol: "anthropic" });
+
+    expect(createAnthropic).toHaveBeenCalledWith({
+      baseURL: BASE.baseUrl,
+      apiKey: BASE.apiKey,
+    });
+    expect(createOpenAI).not.toHaveBeenCalled();
+  });
+
+  it("uses createOpenAI by default (protocol unset, backward compatible)", async () => {
+    await runWith({});
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      baseURL: BASE.baseUrl,
+      apiKey: BASE.apiKey,
+      compatibility: "compatible",
+    });
+    expect(createAnthropic).not.toHaveBeenCalled();
+  });
+
+  it("uses createOpenAI when protocol=openai", async () => {
+    await runWith({ protocol: "openai" });
+
+    expect(createOpenAI).toHaveBeenCalled();
+    expect(createAnthropic).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryCore/src/adapters/standalone/llm-runner.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.ts
@@ -20,6 +20,7 @@ import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { generateText, tool, stepCountIs, jsonSchema } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { report } from "../../core/report/reporter.js";
 import type {
   LLMRunner,
@@ -88,6 +89,13 @@ export interface StandaloneLLMConfig {
   maxTokens?: number;
   /** Request timeout in milliseconds (default: 120_000). */
   timeoutMs?: number;
+  /**
+   * LLM 线协议（wire protocol）：
+   *   - "openai"（默认）：OpenAI 兼容协议（POST /chat/completions）
+   *   - "anthropic"：Anthropic 原生协议（POST /v1/messages，x-api-key + anthropic-version）
+   * 未设置或未知值按 "openai" 处理，向后兼容。
+   */
+  protocol?: "openai" | "anthropic";
   /**
    * LLM 访问模式（gateway 层解释；runner 拿到的是已解析后的 baseUrl/apiKey）：
    *   - "openai": 直连通用 OpenAI 兼容服务（默认，向后兼容）
@@ -280,14 +288,20 @@ export class StandaloneLLMRunner implements LLMRunner {
       `tools=${effectiveEnableTools}${callerProvidedTools ? "(caller)" : ""}, timeout=${timeoutMs}ms`,
     );
 
-    // Create OpenAI-compatible provider via AI SDK
-    // Use "compatible" mode to call /chat/completions (not Responses API),
-    // which works with all OpenAI-compatible backends (DeepSeek, Qwen, etc.)
-    const provider = createOpenAI({
-      baseURL: this.config.baseUrl,
-      apiKey: this.config.apiKey,
-      compatibility: "compatible",
-    });
+    // Create the provider via AI SDK. Two wire protocols are supported:
+    //   - openai (default): OpenAI-compatible /chat/completions — works with
+    //     DeepSeek, Qwen, etc.
+    //   - anthropic: native Anthropic /v1/messages (x-api-key header)
+    const provider = this.config.protocol === "anthropic"
+      ? createAnthropic({
+          baseURL: this.config.baseUrl,
+          apiKey: this.config.apiKey,
+        })
+      : createOpenAI({
+          baseURL: this.config.baseUrl,
+          apiKey: this.config.apiKey,
+          compatibility: "compatible",
+        });
 
     // Select tools based on mode + storage
     // Service mode (COS): use storage-backed tools → LLM reads/writes via StorageAdapter

--- a/MemoryCore/src/config.test.ts
+++ b/MemoryCore/src/config.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Tests for #709 — parseConfig must read the LLM wire protocol
+ * (`llm.protocol`): "anthropic" → native Anthropic, anything else → "openai".
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig llm.protocol (#709)", () => {
+  it("defaults to openai when llm block is absent", () => {
+    const cfg = parseConfig({});
+    expect(cfg.llm.protocol).toBe("openai");
+  });
+
+  it("parses protocol=anthropic", () => {
+    const cfg = parseConfig({ llm: { protocol: "anthropic" } });
+    expect(cfg.llm.protocol).toBe("anthropic");
+  });
+
+  it("coerces unknown protocol values to openai (backward compatible)", () => {
+    const cfg = parseConfig({ llm: { protocol: "not-a-protocol" } });
+    expect(cfg.llm.protocol).toBe("openai");
+  });
+});

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -213,6 +213,13 @@ export interface StandaloneLLMOverrideConfig {
   /** Request timeout in milliseconds (default: 120000). */
   timeoutMs: number;
   /**
+   * LLM 线协议（wire protocol）：
+   *   - "openai"（默认）：OpenAI 兼容协议（POST /chat/completions）
+   *   - "anthropic"：Anthropic 原生协议（POST /v1/messages，x-api-key + anthropic-version）
+   * 未设置或未知值按 "openai" 处理，向后兼容。
+   */
+  protocol?: "openai" | "anthropic";
+  /**
    * LLM 访问模式：
    *   - "openai": 直连 OpenAI 兼容服务（默认）
    *   - "proxy":  走 context_proxy，运行时把 baseUrl 拼成
@@ -620,6 +627,9 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       const rawProvider = str(llmGroup, "provider");
       const provider: "openai" | "proxy" =
         rawProvider === "proxy" ? "proxy" : "openai";
+      const rawProtocol = str(llmGroup, "protocol");
+      const protocol: "openai" | "anthropic" =
+        rawProtocol === "anthropic" ? "anthropic" : "openai";
       const proxyGroup = obj(llmGroup, "proxy");
       return {
         enabled: bool(llmGroup, "enabled") ?? false,
@@ -628,6 +638,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
         model: str(llmGroup, "model") ?? "gpt-4o",
         maxTokens: num(llmGroup, "maxTokens") ?? 4096,
         timeoutMs: num(llmGroup, "timeoutMs") ?? 120_000,
+        protocol,
         provider,
         proxy: {
           // 默认 true：走 proxy 时用 memory 系统用户 key 作为 Authorization。

--- a/MemoryCore/src/gateway/config.ts
+++ b/MemoryCore/src/gateway/config.ts
@@ -435,22 +435,25 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
 
   // LLM config
   //
-  // provider 支持两种模式：
-  //   - "openai"（默认）：直连 OpenAI 兼容服务
-  //   - "proxy"：走 context_proxy，运行期把 baseUrl 拼成 `${baseUrl}/proxy/<iid>/v1`，
-  //             Authorization 用 memory 系统用户 key。gateway 层负责最终解析，
-  //             见 src/gateway/llm-resolver.ts 的 resolveEffectiveLlmConfig。
+  // protocol（线协议）："openai"（默认，/chat/completions）| "anthropic"（/v1/messages）。
+  // provider（访问模式）："openai"（默认）| "proxy"（走 context_proxy，运行期把
+  //   baseUrl 拼成 `${baseUrl}/proxy/<iid>/v1`，Authorization 用 memory 系统用户 key；
+  //   gateway 层负责最终解析，见 src/gateway/llm-resolver.ts 的 resolveEffectiveLlmConfig）。
   const llmConfig = obj(fileConfig, "llm");
   const llmProxyConfig = obj(llmConfig, "proxy");
   const rawLlmProvider = env("TDAI_LLM_PROVIDER") ?? str(llmConfig, "provider");
   const llmProvider: "openai" | "proxy" =
     rawLlmProvider === "proxy" ? "proxy" : "openai";
+  const rawLlmProtocol = env("TDAI_LLM_PROTOCOL") ?? str(llmConfig, "protocol");
+  const llmProtocol: "openai" | "anthropic" =
+    rawLlmProtocol === "anthropic" ? "anthropic" : "openai";
   const llm: StandaloneLLMConfig = {
     baseUrl: env("TDAI_LLM_BASE_URL") ?? str(llmConfig, "baseUrl") ?? "https://api.openai.com/v1",
     apiKey: env("TDAI_LLM_API_KEY") ?? str(llmConfig, "apiKey") ?? "",
     model: env("TDAI_LLM_MODEL") ?? str(llmConfig, "model") ?? "gpt-4o",
     maxTokens: envInt("TDAI_LLM_MAX_TOKENS") ?? num(llmConfig, "maxTokens") ?? 4096,
     timeoutMs: envInt("TDAI_LLM_TIMEOUT_MS") ?? num(llmConfig, "timeoutMs") ?? 120_000,
+    protocol: llmProtocol,
     provider: llmProvider,
     proxy: {
       useMemorySystemUserKey: bool(llmProxyConfig, "useMemorySystemUserKey") ?? true,
@@ -485,6 +488,7 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
       model: llm.model,
       maxTokens: llm.maxTokens ?? 4096,
       timeoutMs: llm.timeoutMs ?? 120_000,
+      protocol: llm.protocol,
       provider: llm.provider,
       proxy: {
         useMemorySystemUserKey: llm.proxy?.useMemorySystemUserKey ?? true,

--- a/deploy/global-images/README.md
+++ b/deploy/global-images/README.md
@@ -82,7 +82,7 @@ $EDITOR .env
 | `MEMORY_LLM_BASE_URL` | OpenAI 兼容 base URL | `https://api.deepseek.com/v1` |
 | `MEMORY_LLM_API_KEY` | 上述端点的 API Key | `sk-xxxxxxxx` |
 | `MEMORY_LLM_MODEL` | 模型 ID | `deepseek-chat` |
-| `MEMORY_LLM_PROTOCOL` | `openai` 或 `anthropic`，默认 `openai` | `openai` |
+| `MEMORY_LLM_PROTOCOL` | 线协议：`openai`（/chat/completions）或 `anthropic`（原生 /v1/messages），默认 `openai`；`anthropic` 时 base URL 指向 Anthropic API 根 | `openai` |
 
 ### proxy 组（proxy 使用）
 

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -68,6 +68,8 @@ llm:
   baseUrl: "${MEMORY_LLM_BASE_URL:-}"
   apiKey: "${MEMORY_LLM_API_KEY:-}"
   model: "${MEMORY_LLM_MODEL:-}"
+  # 线协议：openai（默认，/chat/completions）| anthropic（/v1/messages，x-api-key）
+  protocol: "${MEMORY_LLM_PROTOCOL:-openai}"
   maxTokens: 32000
   timeoutMs: 300000
 


### PR DESCRIPTION
Fixes #709.

## Problem

`MEMORY_LLM_PROTOCOL=anthropic` passed `verify.sh` but was **silently ignored by memory-core**: the generated gateway yaml carried no protocol field, the loader didn't parse it, and `StandaloneLLMRunner` always created an OpenAI-compatible provider (`createOpenAI` → `POST /chat/completions`). Pointing `MEMORY_LLM_BASE_URL` at the Anthropic API made every L1 extraction fail with 404 (`/chat/completions` does not exist).

## Change

The wire protocol now flows end to end:

**Commit 1 — `feat(llm): support anthropic wire protocol in standalone runner`**
- `StandaloneLLMConfig` gains `protocol?: "openai" | "anthropic"`
- `run()` picks `createAnthropic` (native `/v1/messages`, `x-api-key` header) when `protocol=anthropic`; otherwise keeps the existing OpenAI-compatible path (backward compatible)
- add `@ai-sdk/anthropic` dependency

**Commit 2 — `feat(config): thread llm.protocol through gateway config and deploy`**
- `gateway/config.ts`: reads `llm.protocol` (yaml or `TDAI_LLM_PROTOCOL`), splices it onto `memory.llm`
- `config.ts`: `parseConfig` reads `llm.protocol` into `StandaloneLLMOverrideConfig` (unknown → `openai`)
- `start-memory-core.sh`: emits `protocol: ${MEMORY_LLM_PROTOCOL:-openai}` into the generated gateway yaml
- deploy README documents the protocol semantics

## Tests

- `src/adapters/standalone/llm-runner.test.ts` (3): provider selection for `protocol=anthropic` / unset / `openai`, with the two SDK providers mocked
- `src/config.test.ts` (3): `parseConfig` reads `protocol`, defaults to `openai`, coerces unknown values

`npm test`: 2 files, 6 tests, all passing. `npm run build:plugin` passes.

## Note

`verify.sh` already probed the Anthropic endpoint (`POST /v1/messages` + `x-api-key` + `anthropic-version`) — this PR makes the runtime use the same wire protocol, so `MEMORY_LLM_PROTOCOL=anthropic` now works end to end without the OpenAI-compatible `https://api.anthropic.com/v1` workaround.