### PR TITLE
fix(embedding): enable provider=local and warm up the local model

### DIFF
--- a/MemoryCore/src/config.test.ts
+++ b/MemoryCore/src/config.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests for #678 — parseConfig must accept provider="local" for fully-offline
+ * embedding (node-llama-cpp), instead of coercing it to "none" + disabled.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig embedding provider (#678)", () => {
+  it("defaults to provider=none (embedding disabled)", () => {
+    const cfg = parseConfig({});
+    expect(cfg.embedding.provider).toBe("none");
+    expect(cfg.embedding.enabled).toBe(false);
+  });
+
+  it("keeps provider=none disabled when explicitly set", () => {
+    const cfg = parseConfig({ embedding: { provider: "none" } });
+    expect(cfg.embedding.provider).toBe("none");
+    expect(cfg.embedding.enabled).toBe(false);
+  });
+
+  it("enables embedding when provider=local (offline, no apiKey)", () => {
+    const cfg = parseConfig({ embedding: { provider: "local" } });
+    expect(cfg.embedding.provider).toBe("local");
+    expect(cfg.embedding.enabled).toBe(true);
+  });
+});

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -412,13 +412,11 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     embeddingProvider = "none";
     embeddingEnabled = false;
   } else if (embeddingProviderRaw === "local") {
-    // Local embedding is not exposed to users; treat as disabled at entry level.
-    // Internal LocalEmbeddingService code is preserved but not reachable from config.
-    embeddingProvider = "none";
-    embeddingEnabled = false;
-    embeddingConfigError =
-      "Local embedding provider is not available in user config. " +
-      "Please configure a remote embedding provider (e.g. openai, deepseek). Embedding has been disabled.";
+    // Local embedding via node-llama-cpp (offline, no API key needed).
+    // The GGUF model downloads lazily on startWarmup(); until ready, embed()
+    // throws EmbeddingNotReadyError and recall falls back to keyword-only.
+    embeddingProvider = "local";
+    embeddingEnabled = true;
   } else if (embeddingProviderRaw === "qclaw") {
     // qclaw provider: requires proxyUrl for local proxy forwarding
     const missingFields: string[] = [];

--- a/MemoryCore/src/core/store/factory.test.ts
+++ b/MemoryCore/src/core/store/factory.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for #678 — createStoreBundle must create an embedding service for
+ * provider="local" (offline node-llama-cpp), not only for remote providers
+ * with an apiKey.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { createEmbeddingService } = vi.hoisted(() => ({
+  createEmbeddingService: vi.fn(() => ({ getDimensions: () => 768, startWarmup: vi.fn() })),
+}));
+
+vi.mock("./embedding.js", () => ({
+  createEmbeddingService,
+  NoopEmbeddingService: class {
+    getDimensions() {
+      return 0;
+    }
+  },
+}));
+
+import { createStoreBundle } from "./factory.js";
+
+function makeConfig(provider: string, enabled: boolean) {
+  return {
+    storeBackend: "sqlite",
+    embedding: {
+      enabled,
+      provider,
+      baseUrl: "",
+      apiKey: "",
+      model: "",
+      dimensions: 768,
+      sendDimensions: false,
+      maxInputChars: 512,
+    },
+    bm25: { enabled: true, language: "zh" },
+  } as never;
+}
+
+describe("createStoreBundle embedding provider (#678)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-factory-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("creates an embedding service when provider=local (no apiKey needed)", () => {
+    createStoreBundle(makeConfig("local", true), { dataDir });
+
+    expect(createEmbeddingService).toHaveBeenCalledTimes(1);
+    expect(createEmbeddingService).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "local" }),
+      undefined,
+    );
+  });
+
+  it("skips the embedding service when provider=none", () => {
+    createStoreBundle(makeConfig("none", false), { dataDir });
+
+    expect(createEmbeddingService).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryCore/src/core/store/factory.ts
+++ b/MemoryCore/src/core/store/factory.ts
@@ -97,8 +97,14 @@ export function createStoreBundle(
     case "sqlite":
     default: {
       // ── Embedding service (only when enabled) ──
+      // provider="local" uses node-llama-cpp (offline, no apiKey needed);
+      // remote providers require an apiKey.
       let embeddingService: EmbeddingService | undefined;
-      if (config.embedding.enabled && config.embedding.provider !== "local" && config.embedding.apiKey) {
+      if (
+        config.embedding.enabled &&
+        config.embedding.provider !== "none" &&
+        (config.embedding.provider === "local" || config.embedding.apiKey)
+      ) {
         embeddingService = createEmbeddingService({
           provider: config.embedding.provider,
           baseUrl: config.embedding.baseUrl,

--- a/MemoryCore/src/core/store/store-pool.ts
+++ b/MemoryCore/src/core/store/store-pool.ts
@@ -370,10 +370,16 @@ export class StorePool {
   // ════════════════════════════════════════════════════════
 
   private createSqliteStore(instanceId: string): PooledStore {
-    // Embedding service (远端 API, 如 OpenAI text-embedding)
+    // Embedding service: remote API (e.g. OpenAI) or local (node-llama-cpp,
+    // offline, no apiKey). provider="local" falls back to keyword-only until
+    // the GGUF model finishes warming up.
     let embeddingService: EmbeddingService | undefined;
     const embCfg = this.memoryCfg.embedding;
-    if (embCfg.enabled && embCfg.provider !== "local" && embCfg.provider !== "none" && embCfg.apiKey) {
+    if (
+      embCfg.enabled &&
+      embCfg.provider !== "none" &&
+      (embCfg.provider === "local" || embCfg.apiKey)
+    ) {
       embeddingService = createEmbeddingService({
         provider: embCfg.provider,
         baseUrl: embCfg.baseUrl,
@@ -382,6 +388,9 @@ export class StorePool {
         dimensions: embCfg.dimensions,
         maxInputChars: embCfg.maxInputChars,
       }, this.logger as StoreLogger);
+      // Kick off model download/load in the background. No-op for remote
+      // providers; idempotent for local.
+      embeddingService.startWarmup?.();
     }
 
     const dims = embCfg.dimensions ?? 0;

--- a/MemoryCore/src/utils/pipeline-factory.ts
+++ b/MemoryCore/src/utils/pipeline-factory.ts
@@ -290,6 +290,10 @@ async function _doInitStores(
     });
     vectorStore = bundle.store;
     embeddingService = bundle.embedding ?? undefined;
+    // Kick off model download/load for local embedding providers (no-op for
+    // remote providers, idempotent). Without this the GGUF model is never
+    // loaded and embed() throws EmbeddingNotReadyError (issue #678).
+    embeddingService?.startWarmup?.();
 
     const providerInfo = embeddingService?.getProviderInfo();
     const initResult = await vectorStore.init(providerInfo);


### PR DESCRIPTION
Fixes #678.

## Problem

`LocalEmbeddingService` (node-llama-cpp, embeddinggemma-300m, offline, 768-dim) was fully implemented but unreachable:

1. `config.ts` coerced `provider=local` to `provider=none` + `embeddingEnabled=false` ("Local embedding provider is not available in user config")
2. the sqlite store factories created an embedding service only when `enabled && provider !== "local" && apiKey`
3. nothing ever called `startWarmup()` — the GGUF model was never downloaded, and `embed()` threw `EmbeddingNotReadyError`, silently degrading recall to keyword-only

## Change

- **`config.ts`**: `provider=local` now keeps `embeddingEnabled=true` (offline, no apiKey needed). Model downloads lazily on `startWarmup()`; until ready, `embed()` throws `EmbeddingNotReadyError` and recall falls back to keyword-only.
- **`store/factory.ts` + `store-pool.ts`** (sqlite branches): create the embedding service for `provider=local` (remote providers still require apiKey; `none` stays disabled).
- **`pipeline-factory.ts` (`initStores`) + `store-pool.ts` (`createSqliteStore`)**: call `startWarmup()` at startup — triggers background model download/load, a safe no-op for remote providers.

## Tests

- `src/config.test.ts` (3): `provider=local` enables embedding; `none`/default stays disabled
- `src/core/store/factory.test.ts` (2): `createStoreBundle` builds an embedding service for `local`, skips `none`

`npm test`: 2 files, 5 tests, all passing. `npm run build:plugin` passes.

## Notes

- `node-llama-cpp` is an optional peerDependency; if absent, `startWarmup()` fails to load and recall degrades to keyword-only (existing behaviour).
- The deploy yaml (`start-memory-core.sh`) still emits `embedding.provider: none`; users can switch to offline embedding by setting `provider: local` in their gateway config.