### PR TITLE
docs(health): surface FTS5 availability and document the requirement

### DIFF
--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -52,6 +52,7 @@ MemoryCore is distributed as a standalone runtime for local development, single-
 - Node.js `>= 22.16.0`
 - npm
 - An OpenAI-compatible LLM API. Read-only queries may not invoke an LLM, but memory extraction and aggregation require valid credentials.
+- **SQLite FTS5 module** for BM25 keyword / hybrid recall. The official Node binaries are not guaranteed to include FTS5 (e.g. v22.13.1 lacks it; v22.23.2 has it). When FTS5 is absent, keyword search silently returns nothing and recall degrades to embedding-only — check `GET /health` → `stores.ftsAvailable`.
 
 ## Quick start
 

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -52,6 +52,7 @@ MemoryCore 以 Standalone Runtime 形式开源，适合本地开发、单机部�
 - Node.js `>= 22.16.0`
 - npm
 - 一个 OpenAI-compatible LLM API；只读查询可以不触发 LLM，但记忆抽取和归纳需要有效凭证
+- **SQLite FTS5 模块**（BM25 关键词 / 混合召回需要）。官方 Node 二进制不保证包含 FTS5（如 v22.13.1 缺失、v22.23.2 有）。FTS5 缺失时关键词搜索静默返回空，召回降级为仅 embedding——可通过 `GET /health` 的 `stores.ftsAvailable` 查看
 
 ## 快速开始
 

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -1327,6 +1327,10 @@ export class TdaiGateway {
       stores: {
         vectorStore: !!this.core.getVectorStore(),
         embeddingService: !!this.core.getEmbeddingService(),
+        // BM25 keyword search depends on the FTS5 module, which is not
+        // compiled into every official Node build (e.g. v22.13.1). When
+        // false, recall degrades to embedding-only (issue #679).
+        ftsAvailable: this.core.getVectorStore()?.isFtsAvailable() ?? false,
       },
       // Integrated services status
       services: {


### PR DESCRIPTION
Fixes #679.

## Problem

BM25 keyword / hybrid recall depends on SQLite's **FTS5** module, but the official Node binaries are not guaranteed to include it (e.g. v22.13.1 → `no such module: fts5`; v22.23.2 → works). When absent, keyword search silently returns nothing and recall degrades to embedding-only, which is hard to diagnose.

## Change

- **`GET /health`** now reports `stores.ftsAvailable`, sourced from the store's existing `isFtsAvailable()` (which already tracks whether FTS5 compiled in).
- **README / README_CN** document the FTS5 requirement, the Node build caveat, and the embedding-only fallback.

`npm run build:plugin` passes.