### PR TITLE
feat(examples): Claude Code hooks for subscription-auth users

### DIFF
--- a/examples/claude-code-hooks/README.md
+++ b/examples/claude-code-hooks/README.md
@@ -1,0 +1,78 @@
+# Claude Code hooks — TencentDB Agent Memory for subscription-auth users
+
+> **适用人群**：Claude Code 会话通过 **订阅（OAuth）** 认证的用户。
+
+官方集成通过把 `ANTHROPIC_BASE_URL` 重定向到 memory-proxy 工作，但这会**破坏订阅鉴权**——OAuth 会话无法被指向代理。本示例用两个轻量 shell hooks 直连 Memory Gateway 的 v2 API，**对话仍然走订阅，记忆照常沉淀**。
+
+工作原理与 API-key 代理路径一致（已验证 L0→L1 抽取正常）：
+
+| Hook | 时机 | 作用 |
+|------|------|------|
+| `stop-hook.sh` | 每轮对话结束（`Stop`） | 从 session transcript 提取最后 user/assistant 一轮，`POST /v2/conversation/add` 写入 L0 |
+| `session-start-hook.sh` | 会话开始（`SessionStart`） | `POST /v2/core/read` + `/v2/scenario/ls`，把 L3 画像与场景索引以 `<user-profile>` / `<known-scenes>` 注入会话上下文 |
+
+两个脚本都 **fail-silent**：写失败、网关不可达、`curl --max-time 4` 超时都不会阻塞或报错 Claude Code。
+
+## 1. 配置环境变量
+
+在 `~/.zshrc` / `~/.bashrc`（或 Claude Code 的 env 配置）里设置：
+
+```bash
+export TD_MEMORY_URL="http://127.0.0.1:8420"   # Memory Gateway 地址
+export TD_MEMORY_KEY="sk-mem-xxxxxxxx..."       # 业务用户 key（Bearer）
+# 可选 v2 isolation（默认本地部署可不设）：
+# export TD_MEMORY_TEAM_ID="default"
+# export TD_MEMORY_AGENT_ID="default"
+# export TD_MEMORY_USER_ID="default"
+```
+
+## 2. 注册 hooks
+
+把两个 hook 写入 Claude Code 的 `settings.json`（用户级 `~/.claude/settings.json` 或项目级 `.claude/settings.json`）：
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /absolute/path/to/examples/claude-code-hooks/stop-hook.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /absolute/path/to/examples/claude-code-hooks/session-start-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> `command` 用**绝对路径**。hook 脚本默认可执行，也可以不加 `bash` 前缀直接写路径。
+
+## 3. 验证
+
+- **写记忆**：跑一轮对话后，检查 Gateway 是否收到 L0 写入：
+  ```bash
+  # 应返回刚写入的会话消息数
+  curl -sS -X POST "$TD_MEMORY_URL/v2/conversation/query" \
+    -H "Authorization: Bearer $TD_MEMORY_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"session_id":"<session>","limit":5}'
+  ```
+- **注入画像**：开一个新会话，SessionStart hook 会把 `<user-profile>` 和 `<known-scenes>` 块注入上下文；若无画像/场景则不输出。
+- 想临时看 hook 是否触发，可在脚本里加 `echo "[tdai] stop-hook fired" >> /tmp/tdai-hooks.log`。
+
+## 参考
+
+- v2 API 文档：`MemoryCore` 仓库根 README 的 API surface 一节（`/v2/conversation/*`、`/v2/core/*`、`/v2/scenario/*`）
+- 相关 issue：[#715](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/715)

--- a/examples/claude-code-hooks/session-start-hook.sh
+++ b/examples/claude-code-hooks/session-start-hook.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Claude Code "SessionStart" hook — inject a compact L3 profile + scene index
+# into the session context, for subscription-authenticated (OAuth) users who
+# cannot route through ANTHROPIC_BASE_URL.
+#
+# Reads from the Gateway's /v2/core/read (L3 persona) and /v2/scenario/ls
+# (L2 scene index) and prints a small labelled block to stdout, which Claude
+# Code adds to the session context.
+#
+# Env:
+#   TD_MEMORY_URL   Gateway base URL        (default http://127.0.0.1:8420)
+#   TD_MEMORY_KEY   Business user key       (required; without it, no output)
+#   TD_MEMORY_TEAM_ID / TD_MEMORY_AGENT_ID / TD_MEMORY_USER_ID  (optional)
+#
+set +e
+
+export TD_MEMORY_URL="${TD_MEMORY_URL:-http://127.0.0.1:8420}"
+export TD_MEMORY_KEY="${TD_MEMORY_KEY:-}"
+
+[[ -n "$TD_MEMORY_KEY" ]] || exit 0
+
+core_json="$(
+  curl -sS --max-time 4 \
+    -X POST "${TD_MEMORY_URL%/}/v2/core/read" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TD_MEMORY_KEY}" \
+    -d '{}' 2>/dev/null || true
+)"
+scenes_json="$(
+  curl -sS --max-time 4 \
+    -X POST "${TD_MEMORY_URL%/}/v2/scenario/ls" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TD_MEMORY_KEY}" \
+    -d '{}' 2>/dev/null || true
+)"
+
+python3 - "$core_json" "$scenes_json" <<'PY'
+import json, sys
+
+lines = []
+
+core_raw, scenes_raw = sys.argv[1], sys.argv[2]
+
+try:
+    core = json.loads(core_raw)
+    content = (core.get("data") or {}).get("content")
+    if content:
+        lines.append("<user-profile>")
+        lines.append(content.strip())
+        lines.append("</user-profile>")
+except Exception:
+    pass
+
+try:
+    scenes = json.loads(scenes_raw)
+    entries = (scenes.get("data") or {}).get("entries") or []
+    paths = [e.get("path") for e in entries if isinstance(e, dict) and e.get("path")]
+    if paths:
+        lines.append("<known-scenes>")
+        lines.extend(f"- {p}" for p in paths)
+        lines.append("</known-scenes>")
+except Exception:
+    pass
+
+if lines:
+    print("\n".join(lines))
+PY
+
+exit 0

--- a/examples/claude-code-hooks/stop-hook.sh
+++ b/examples/claude-code-hooks/stop-hook.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Claude Code "Stop" hook — feed the last user/assistant exchange into
+# TencentDB Agent Memory for subscription-authenticated (OAuth) users.
+#
+# Why this exists: the documented integration reroutes ANTHROPIC_BASE_URL
+# through memory-proxy, which works for API-key users but breaks
+# subscription (OAuth) auth entirely. This hook talks straight to the
+# Gateway's /v2/conversation/add API instead, so the conversation still
+# flows through the subscription and memory capture still happens.
+#
+# Behaviour:
+#   - Reads the hook JSON (with `transcript`) from stdin
+#   - Extracts the last user message and its nearest following assistant reply
+#   - POSTs them to {TD_MEMORY_URL}/v2/conversation/add
+#   - Fail-silent: never blocks, errors, or slows down Claude Code
+#
+# Env (all optional except the key for a running Gateway):
+#   TD_MEMORY_URL        Gateway base URL          (default http://127.0.0.1:8420)
+#   TD_MEMORY_KEY        Business user key (Bearer) (required to write)
+#   TD_MEMORY_TEAM_ID    v2 isolation team_id       (optional)
+#   TD_MEMORY_AGENT_ID   v2 isolation agent_id      (optional)
+#   TD_MEMORY_USER_ID    v2 isolation user_id       (optional)
+#   TD_MEMORY_SESSION_ID Force a session_id         (default: from hook or "default")
+#
+set +e
+
+export TD_MEMORY_URL="${TD_MEMORY_URL:-http://127.0.0.1:8420}"
+export TD_MEMORY_KEY="${TD_MEMORY_KEY:-}"
+export TD_MEMORY_TEAM_ID="${TD_MEMORY_TEAM_ID:-}"
+export TD_MEMORY_AGENT_ID="${TD_MEMORY_AGENT_ID:-}"
+export TD_MEMORY_USER_ID="${TD_MEMORY_USER_ID:-}"
+export TD_MEMORY_SESSION_ID="${TD_MEMORY_SESSION_ID:-}"
+
+# Without a key there is nothing we can do — stay silent.
+[[ -n "$TD_MEMORY_KEY" ]] || exit 0
+
+# Claude Code feeds the hook payload (JSON with `transcript`) via stdin.
+input="$(cat 2>/dev/null || true)"
+[[ -n "$input" ]] || exit 0
+
+# Build the /v2/conversation/add payload with python3 (present on macOS,
+# avoids a jq dependency).
+payload="$(
+  python3 - "$input" <<'PY'
+import json, os, sys
+
+try:
+    data = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+
+transcript = data.get("transcript") or []
+if not isinstance(transcript, list) or len(transcript) == 0:
+    sys.exit(0)
+
+# Last user message + its nearest following assistant reply.
+user_msg = None
+assistant_msg = None
+for m in transcript:
+    if not isinstance(m, dict):
+        continue
+    role = m.get("role")
+    if role == "user":
+        user_msg = m
+        assistant_msg = None
+    elif role == "assistant" and user_msg is not None:
+        assistant_msg = m
+
+if not user_msg:
+    sys.exit(0)
+
+session = os.environ.get("TD_MEMORY_SESSION_ID") or data.get("session_id") or "default"
+body = {"session_id": session, "messages": []}
+for key, env in (("team_id", "TD_MEMORY_TEAM_ID"), ("agent_id", "TD_MEMORY_AGENT_ID"),
+                 ("user_id", "TD_MEMORY_USER_ID")):
+    val = os.environ.get(env)
+    if val:
+        body[key] = val
+
+msgs = [user_msg] + ([assistant_msg] if assistant_msg else [])
+for m in msgs:
+    item = {"role": m.get("role"), "content": m.get("content") or ""}
+    if m.get("timestamp"):
+        item["timestamp"] = m["timestamp"]
+    body["messages"].append(item)
+
+print(json.dumps(body))
+PY
+)"
+
+[[ -n "$payload" && "$payload" != "null" ]] || exit 0
+
+curl -sS -o /dev/null --max-time 4 \
+  -X POST "${TD_MEMORY_URL%/}/v2/conversation/add" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TD_MEMORY_KEY}" \
+  -d "$payload" >/dev/null 2>&1 || true
+
+exit 0


### PR DESCRIPTION
Closes #715.

## Problem

The documented Claude Code integration reroutes `ANTHROPIC_BASE_URL` through memory-proxy — that works for API-key users but **breaks subscription (OAuth) auth** entirely. Subscription-authenticated users had no supported way to feed conversations into TencentDB Agent Memory.

## Change

A documented hook example at `examples/claude-code-hooks/`:

- **`stop-hook.sh`** (`Stop` hook): reads the hook payload from stdin, extracts the last user/assistant exchange, `POST /v2/conversation/add` (Bearer = business user key). Verified extraction keeps the final user turn + its nearest assistant reply, honours optional team/agent/user isolation, and falls back to `session_id` → `default`.
- **`session-start-hook.sh`** (`SessionStart` hook): `POST /v2/core/read` + `/v2/scenario/ls`, prints a compact `<user-profile>` / `<known-scenes>` block that Claude Code injects into session context.
- **`README.md`**: env vars (`TD_MEMORY_URL` / `TD_MEMORY_KEY` / optional isolation), `settings.json` registration, verification steps.

Both hooks are **fail-silent** (`set +e`, `curl --max-time 4`) — never block, error, or slow down Claude Code.

## Verification

- `sh -n` passes for both scripts
- The JSON extraction (stop) and response parsing (session-start) logic verified against sample payloads (last-exchange extraction, isolation passthrough, empty-scene handling)

Related wish from the issue (a `memory-core` Dockerfile) is not part of this PR.