### PR TITLE
fix: address upstream CI/build issues (#782 #783 #784)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # The repo's default / release branch (feat/server_team) is where every
+    # PR lands — main is a legacy branch. Trigger CI on both (issue #782).
+    branches: [main, feat/server_team]
 
 # Cancel previous runs for the same PR / branch
 concurrency:

--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "npm run build:plugin && npm run build:scripts",
     "build:plugin": "tsdown",
-    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory && npm run build:seed-v2",
+    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
     "prepack": "npm run build",
     "build:migrate-sqlite-to-vdb": "tsc -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false",
     "migrate-sqlite-to-tcvdb": "node ./bin/migrate-sqlite-to-tcvdb.mjs",
@@ -26,8 +26,6 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
-    "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
-    "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
     "test:oss": "vitest run -c vitest.oss.config.ts",
     "test:watch": "vitest",

--- a/MemoryKnowledge/bin/mcp.mjs
+++ b/MemoryKnowledge/bin/mcp.mjs
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import "../dist/mcp/server.js";
+import "../dist/mcp/server.mjs";

--- a/MemoryKnowledge/bin/server.mjs
+++ b/MemoryKnowledge/bin/server.mjs
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import "../dist/server.js";
+import "../dist/server.mjs";

--- a/MemoryKnowledge/package.json
+++ b/MemoryKnowledge/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Standalone knowledge service — Code-Graph + LLM-Wiki engine for user-side deployment",
   "type": "module",
-  "main": "./dist/server.js",
+  "main": "./dist/server.mjs",
   "bin": {
     "knowledge-server": "./bin/server.mjs",
     "knowledge-mcp": "./bin/mcp.mjs"

--- a/MemoryKnowledge/src/middleware/response-envelope.ts
+++ b/MemoryKnowledge/src/middleware/response-envelope.ts
@@ -44,7 +44,9 @@ export function accessLog(): MiddlewareHandler {
       try {
         const raw = await c.req.text();
         reqBody = raw ? JSON.parse(raw) : undefined;
-        c.req.bodyCache.text = Promise.resolve(raw);
+        // Hono's Body.text is typed `string`, but bodyCache holds Promises at
+        // runtime (c.req.text()/json() call .then() on the cached value).
+        c.req.bodyCache.text = Promise.resolve(raw) as unknown as string;
         if (reqBody) c.req.bodyCache.json = Promise.resolve(reqBody);
       } catch {
         // 非 JSON body，忽略


### PR DESCRIPTION
Fixes #782, #783, #784 — three upstream issues, plus the dead `build:seed-v2` that blocks CI on the release branch.

## #782 — CI never runs on PRs to `feat/server_team`

`pr-ci.yml` only triggered on PRs to `main`, but the default/release branch is `feat/server_team`. Trigger on both branches so pack validation, manifest checks, size guard, and skill-isolation guard actually run on PRs.

## #783 — `main` / bin launchers point at `dist/server.js` (tsdown emits `.mjs`)

- `package.json` `main` → `./dist/server.mjs`
- `bin/server.mjs` → `import "../dist/server.mjs"`
- `bin/mcp.mjs` → `import "../dist/mcp/server.mjs"`

npm consumers and `knowledge-server` / `knowledge-mcp` bins now resolve the real build output.

## #784 — `typecheck` fails in `response-envelope.ts`

`bodyCache.text` is typed `string` in Hono but holds a `Promise` at runtime. Cast the cached value (`as unknown as string`) to keep runtime behaviour and fix the TS error.

## (extra) — dead `build:seed-v2` breaks CI Pack

With CI now enabled (#782), the Pack job surfaced a pre-existing build break: `build:scripts` still runs `build:seed-v2`, which references the removed `scripts/seed-v2/` (`TS5058`). Dropped the dead script so this branch's CI is green (same change as #775, needed here because #782 now triggers CI on `feat/server_team`).

## Verification

- `MemoryKnowledge`: `npm run build` → emits `dist/server.mjs`; `npm run typecheck` → exit 0
- `node --check` on both bin launchers
- `pr-ci.yml` parses with `branches: ["main", "feat/server_team"]`
- `MemoryCore`: `npm run build:scripts` passes (seed-v2 removed)