### PR TITLE
fix(knowledge): align package entrypoints with mjs build

### DIFF
--- a/MemoryKnowledge/bin/mcp.mjs
+++ b/MemoryKnowledge/bin/mcp.mjs
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import "../dist/mcp/server.js";
+import "../dist/mcp/server.mjs";

--- a/MemoryKnowledge/bin/server.mjs
+++ b/MemoryKnowledge/bin/server.mjs
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import "../dist/server.js";
+import "../dist/server.mjs";

--- a/MemoryKnowledge/package.json
+++ b/MemoryKnowledge/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Standalone knowledge service — Code-Graph + LLM-Wiki engine for user-side deployment",
   "type": "module",
-  "main": "./dist/server.js",
+  "main": "./dist/server.mjs",
   "bin": {
     "knowledge-server": "./bin/server.mjs",
     "knowledge-mcp": "./bin/mcp.mjs"


### PR DESCRIPTION
## Summary

- update `MemoryKnowledge` package `main` to the actual `dist/server.mjs` output emitted by tsdown
- update the tracked `knowledge-server` and `knowledge-mcp` CLI wrappers to import the emitted `.mjs` files

Fixes #783.

## Verification

- `cd MemoryKnowledge && ./node_modules/.bin/tsdown --config tsdown.config.ts`
- `node -e 'const p=require("./MemoryKnowledge/package.json"); const fs=require("fs"); for (const f of [p.main, p.bin["knowledge-server"], p.bin["knowledge-mcp"]]) { if (!fs.existsSync("MemoryKnowledge/"+f.replace(/^\\.\\//,""))) throw new Error(f+" missing before build"); } console.log("package entry files exist")'`
- `git diff --check`

Note: `cd MemoryKnowledge && ./node_modules/.bin/tsc --noEmit` still fails on existing `src/middleware/response-envelope.ts(47,9): Type 'Promise<string>' is not assignable to type 'string'`, which appears tracked separately in #784.
