### PR TITLE
feat(export): chat-memory export bundle with manifest schema (#779 step 1)

### DIFF
--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -244,6 +244,10 @@ MemoryCore/
 ```bash
 npm run read-local-memory
 npm run seed-v2
+
+# Export memory assets (chat-memory) to a portable ZIP bundle (issue #779, step 1)
+npm run build:export-memory
+npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
 ```
 
 ## Security recommendations

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -247,6 +247,10 @@ MemoryCore/
 ```bash
 npm run read-local-memory
 npm run seed-v2
+
+# 导出记忆资产（chat-memory）为可移植 ZIP（issue #779 第一步）
+npm run build:export-memory
+npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
 ```
 
 ## 安全建议

--- a/MemoryCore/__tests__/export-memory/export-memory.test.ts
+++ b/MemoryCore/__tests__/export-memory/export-memory.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for #779 (step 1) — read-only export of chat-memory to a ZIP bundle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import JSZip from "jszip";
+
+import { buildExportBundle } from "../../scripts/export-memory/export-memory.js";
+
+describe("buildExportBundle (#779)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-export-"));
+    mkdirSync(join(dataDir, "conversations"), { recursive: true });
+    mkdirSync(join(dataDir, "records"), { recursive: true });
+    writeFileSync(
+      join(dataDir, "conversations", "2026-08-01.jsonl"),
+      '{"role":"user","content":"hi"}\n{"role":"assistant","content":"yo"}\n',
+    );
+    writeFileSync(join(dataDir, "records", "2026-08-01.jsonl"), '{"type":"episodic","content":"x"}\n');
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("produces a ZIP with manifest + conversations + records", async () => {
+    const { manifest, zip } = await buildExportBundle({ dataDir, instanceId: "inst-1" });
+
+    expect(manifest.schema_version).toBe("1.0.0");
+    expect(manifest.assets[0].type).toBe("chat-memory");
+    expect(manifest.assets[0].id).toBe("inst-1");
+    expect(manifest.assets[0].files).toHaveLength(2);
+
+    const z = await JSZip.loadAsync(zip);
+    expect(z.file("manifest.json")).toBeTruthy();
+    expect(z.file("conversations/2026-08-01.jsonl")).toBeTruthy();
+    expect(z.file("records/2026-08-01.jsonl")).toBeTruthy();
+
+    const conv = manifest.assets[0].files.find((f) => f.path === "conversations/2026-08-01.jsonl")!;
+    expect(conv.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(conv.size).toBeGreaterThan(0);
+  });
+
+  it("skips records when includeRecords=false", async () => {
+    const { manifest } = await buildExportBundle({ dataDir, includeRecords: false });
+    const paths = manifest.assets[0].files.map((f) => f.path);
+    expect(paths).toEqual(["conversations/2026-08-01.jsonl"]);
+  });
+
+  it("throws when there is nothing to export", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "tdai-export-empty-"));
+    try {
+      await expect(buildExportBundle({ dataDir: empty })).rejects.toThrow(/未找到可导出/);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/__tests__/export-memory/manifest.test.ts
+++ b/MemoryCore/__tests__/export-memory/manifest.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for #779 (step 1) — export manifest schema validation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MANIFEST_SCHEMA_VERSION,
+  validateManifest,
+  type ExportManifest,
+} from "../../scripts/export-memory/manifest.js";
+
+const validManifest: ExportManifest = {
+  schema_version: MANIFEST_SCHEMA_VERSION,
+  created_at: "2026-08-05T00:00:00.000Z",
+  source_instance_id: "inst-1",
+  assets: [
+    {
+      type: "chat-memory",
+      id: "default",
+      files: [
+        {
+          path: "conversations/2026-08-01.jsonl",
+          checksum: `sha256:${"a".repeat(64)}`,
+          size: 10,
+        },
+      ],
+    },
+  ],
+};
+
+describe("validateManifest (#779)", () => {
+  it("accepts a valid manifest", () => {
+    expect(() => validateManifest(validManifest)).not.toThrow();
+  });
+
+  it("rejects an unknown schema_version", () => {
+    expect(() => validateManifest({ ...validManifest, schema_version: "9.9.9" })).toThrow();
+  });
+
+  it("rejects a malformed checksum", () => {
+    const bad = {
+      ...validManifest,
+      assets: [
+        {
+          ...validManifest.assets[0],
+          files: [{ path: "a.jsonl", checksum: "md5:xyz", size: 1 }],
+        },
+      ],
+    };
+    expect(() => validateManifest(bad)).toThrow(/checksum/);
+  });
+
+  it("rejects an empty files list", () => {
+    const bad = {
+      ...validManifest,
+      assets: [{ ...validManifest.assets[0], files: [] }],
+    };
+    expect(() => validateManifest(bad)).toThrow();
+  });
+
+  it("rejects an unsupported asset type", () => {
+    const bad = {
+      ...validManifest,
+      assets: [{ ...validManifest.assets[0], type: "brain" }],
+    };
+    expect(() => validateManifest(bad)).toThrow();
+  });
+});

--- a/MemoryCore/bin/export-memory.mjs
+++ b/MemoryCore/bin/export-memory.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// 薄启动器：加载预编译好的 memory export 脚本。
+// 构建：npm run build:export-memory
+// 使用：npm run export-memory -- --data-dir <dir> --out <file.zip> [--instance-id <id>] [--skip-records]
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const entryScript = path.resolve(thisDir, "../scripts/export-memory/dist/export-memory.js");
+
+if (!fs.existsSync(entryScript)) {
+  console.error("❌  预编译产物不存在: " + entryScript);
+  console.error("   请先执行: npm run build:export-memory");
+  process.exit(1);
+}
+
+import(entryScript);

--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "export-memory": "./bin/export-memory.mjs"
   },
   "exports": {
     ".": {
@@ -26,6 +27,8 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
+    "build:export-memory": "tsc --project scripts/export-memory/tsconfig.json",
+    "export-memory": "node ./bin/export-memory.mjs",
     "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
     "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
@@ -51,10 +54,12 @@
     "bin/migrate-sqlite-to-tcvdb.mjs",
     "bin/export-tencent-vdb.mjs",
     "bin/read-local-memory.mjs",
+    "bin/export-memory.mjs",
     "index.ts",
     "scripts/migrate-sqlite-to-tcvdb/dist/",
     "scripts/export-tencent-vdb/dist/",
     "scripts/read-local-memory/dist/",
+    "scripts/export-memory/dist/",
     "scripts/import-opik-to-memory-core/",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",

--- a/MemoryCore/scripts/export-memory/export-memory.ts
+++ b/MemoryCore/scripts/export-memory/export-memory.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * memory export — export memory assets to a portable ZIP bundle.
+ *
+ * Step 1 of issue #779: manifest/schema + read-only export of chat-memory
+ * (L0 conversations + L1 memory records). Import / restore lands in a later
+ * step.
+ *
+ * Usage:
+ *   node ./bin/export-memory.mjs --data-dir <dir> --out ./backup.zip
+ *   node ./bin/export-memory.mjs --data-dir <dir> --out ./backup.zip \
+ *       --instance-id <id> --skip-records
+ *
+ * Data layout read from the data directory:
+ *   conversations/YYYY-MM-DD.jsonl   (L0)
+ *   records/YYYY-MM-DD.jsonl         (L1)
+ *
+ * Output ZIP:
+ *   manifest.json
+ *   conversations/…  records/…
+ *
+ * manifest.json is validated against exportManifestSchema before writing
+ * (see manifest.ts).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { parseArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+import JSZip from "jszip";
+
+import {
+  MANIFEST_SCHEMA_VERSION,
+  validateManifest,
+  type ExportManifest,
+} from "./manifest.js";
+
+async function sha256(content: Buffer): Promise<string> {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+interface CollectedFile {
+  path: string;
+  checksum: string;
+  size: number;
+}
+
+/**
+ * Add every non-directory file under `dirPath` to the ZIP under `prefix`,
+ * returning file entries (path + checksum + size). Missing dir → empty list.
+ */
+async function collectDir(
+  zip: JSZip,
+  dirPath: string,
+  prefix: string,
+): Promise<CollectedFile[]> {
+  const out: CollectedFile[] = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dirPath);
+  } catch {
+    return out; // directory absent → no files for this namespace
+  }
+  entries.sort();
+  for (const entry of entries) {
+    const full = path.join(dirPath, entry);
+    const stat = await fs.stat(full);
+    if (stat.isDirectory()) continue;
+    const rel = `${prefix}/${entry}`;
+    const content = await fs.readFile(full);
+    zip.file(rel, content);
+    out.push({ path: rel, checksum: `sha256:${await sha256(content)}`, size: content.length });
+  }
+  return out;
+}
+
+export interface ExportOptions {
+  /** Root data directory (contains conversations/ and records/). */
+  dataDir: string;
+  /** Instance id recorded in the manifest (default "default"). */
+  instanceId?: string;
+  /** Whether to include L1 records/ (default true). */
+  includeRecords?: boolean;
+}
+
+export interface ExportResult {
+  manifest: ExportManifest;
+  /** ZIP archive as a Buffer. */
+  zip: Buffer;
+}
+
+/**
+ * Build a portable chat-memory export bundle from a data directory.
+ * Returns the validated manifest + the ZIP buffer (not yet written to disk).
+ */
+export async function buildExportBundle(opts: ExportOptions): Promise<ExportResult> {
+  const zip = new JSZip();
+
+  const convFiles = await collectDir(zip, path.join(opts.dataDir, "conversations"), "conversations");
+  const recordFiles =
+    opts.includeRecords === false
+      ? []
+      : await collectDir(zip, path.join(opts.dataDir, "records"), "records");
+
+  const files = [...convFiles, ...recordFiles];
+  if (files.length === 0) {
+    throw new Error("未找到可导出的记忆文件（conversations/ 或 records/ 为空）");
+  }
+
+  const assetId = opts.instanceId ?? "default";
+  const manifest: ExportManifest = {
+    schema_version: MANIFEST_SCHEMA_VERSION,
+    created_at: new Date().toISOString(),
+    ...(opts.instanceId ? { source_instance_id: opts.instanceId } : {}),
+    assets: [{ type: "chat-memory", id: assetId, files }],
+  };
+
+  // Self-check: the manifest must round-trip through the schema.
+  validateManifest(manifest);
+  zip.file("manifest.json", JSON.stringify(manifest, null, 2));
+
+  const buf = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+  return { manifest, zip: buf };
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      "data-dir": { type: "string", short: "d" },
+      "out": { type: "string", short: "o", required: true },
+      "instance-id": { type: "string" },
+      "skip-records": { type: "boolean", default: false },
+    },
+  });
+
+  const dataDir = values["data-dir"] ?? process.env.TDAI_DATA_DIR;
+  if (!dataDir) {
+    console.error("❌ 缺少数据目录：请用 --data-dir 或设置 TDAI_DATA_DIR");
+    process.exit(1);
+  }
+
+  const { manifest, zip } = await buildExportBundle({
+    dataDir,
+    instanceId: values["instance-id"],
+    includeRecords: values["skip-records"] ? false : true,
+  });
+
+  const outPath = values["out"] as string;
+  await fs.mkdir(path.dirname(path.resolve(outPath)), { recursive: true });
+  await fs.writeFile(outPath, zip);
+
+  const files = manifest.assets[0].files;
+  const totalBytes = files.reduce((s, f) => s + f.size, 0);
+  console.log(`✅ 导出完成 → ${outPath}`);
+  console.log(`   资产: chat-memory (id=${manifest.assets[0].id})`);
+  console.log(`   文件: ${files.length} 个 (${totalBytes} bytes)`);
+  console.log(`   schema_version: ${manifest.schema_version}`);
+}
+
+// Run the CLI only when invoked directly (node dist/export-memory.js) or via
+// the thin bin launcher (bin/export-memory.mjs imports this module). Tests and
+// other importers get the pure buildExportBundle without side effects.
+const isCliEntry = process.argv[1] !== undefined && (
+  import.meta.url === pathToFileURL(process.argv[1]).href
+  || process.argv[1].endsWith("bin/export-memory.mjs")
+);
+if (isCliEntry) {
+  main().catch((err) => {
+    console.error(`❌ 导出失败: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/MemoryCore/scripts/export-memory/manifest.ts
+++ b/MemoryCore/scripts/export-memory/manifest.ts
@@ -1,0 +1,63 @@
+/**
+ * Export bundle manifest — schema + validation for the portable memory
+ * export format (issue #779, step 1: manifest/schema + read-only export).
+ *
+ * A manifest describes the assets inside a bundle (e.g. a ZIP archive):
+ *   manifest.json
+ *   conversations/YYYY-MM-DD.jsonl   (L0 chat memory)
+ *   records/YYYY-MM-DD.jsonl         (L1 memory records)
+ *
+ * schema_version is fixed so importers can detect incompatible bundles.
+ */
+
+import { z } from "zod";
+
+export const MANIFEST_SCHEMA_VERSION = "1.0.0";
+
+/** Asset types covered by the memory system (step 1 exports chat-memory). */
+export const memoryAssetTypeSchema = z.enum([
+  "chat-memory",
+  "skill",
+  "llm-wiki",
+  "code-graph",
+]);
+export type MemoryAssetType = z.infer<typeof memoryAssetTypeSchema>;
+
+/** A single file inside the bundle with its integrity checksum. */
+export const exportFileSchema = z.object({
+  /** Path inside the bundle (e.g. "conversations/2026-08-01.jsonl"). */
+  path: z.string().min(1),
+  /** sha256 of the file content ("sha256:<64 hex>"). */
+  checksum: z.string().regex(/^sha256:[0-9a-f]{64}$/, "checksum must be sha256:<64 hex>"),
+  /** Size in bytes. */
+  size: z.number().int().nonnegative(),
+});
+export type ExportFile = z.infer<typeof exportFileSchema>;
+
+/** One exported memory asset (e.g. a chat-memory bundle). */
+export const exportAssetSchema = z.object({
+  type: memoryAssetTypeSchema,
+  /** Stable asset id (instance / scope the memory belongs to). */
+  id: z.string().min(1),
+  files: z.array(exportFileSchema).min(1),
+});
+export type ExportAsset = z.infer<typeof exportAssetSchema>;
+
+/** Top-level export manifest. */
+export const exportManifestSchema = z.object({
+  schema_version: z.literal(MANIFEST_SCHEMA_VERSION),
+  /** ISO-8601 export timestamp. */
+  created_at: z.string(),
+  /** Source instance id (optional). */
+  source_instance_id: z.string().optional(),
+  assets: z.array(exportAssetSchema),
+});
+export type ExportManifest = z.infer<typeof exportManifestSchema>;
+
+/**
+ * Validate a raw manifest object. Throws a ZodError with a precise path when
+ * the manifest is malformed (unknown version, bad checksum format, ...).
+ */
+export function validateManifest(raw: unknown): ExportManifest {
+  return exportManifestSchema.parse(raw);
+}

--- a/MemoryCore/scripts/export-memory/tsconfig.json
+++ b/MemoryCore/scripts/export-memory/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["export-memory.ts", "manifest.ts"],
+  "exclude": ["dist", "node_modules", "docs"]
+}


### PR DESCRIPTION
Part of #779 — step 1 (manifest/schema + read-only export) of the export/import/backup workflow.

## What

`npm run export-memory` exports **chat-memory** (L0 conversations + L1 records) from a data directory into a portable, validated ZIP bundle:

```
manifest.json
conversations/YYYY-MM-DD.jsonl   (L0)
records/YYYY-MM-DD.jsonl         (L1)
```

### `scripts/export-memory/manifest.ts`
Zod schema for the export manifest (`schema_version`, `assets[].type`, per-file `sha256` checksums) + `validateManifest()`. Importers can reject incompatible bundles via `schema_version`.

### `scripts/export-memory/export-memory.ts`
`buildExportBundle({ dataDir, instanceId, includeRecords })` reads `conversations/*.jsonl` + `records/*.jsonl`, computes checksums, validates the manifest, and packs a DEFLATE ZIP. CLI entry guarded so importing the module (tests) has no side effects.

### Wiring
`bin/export-memory.mjs` thin launcher, `package.json` (`build:export-memory`, `export-memory`, bin, files), README usage.

## Verification

- `tsc -p scripts/export-memory/tsconfig.json` passes
- 8 tests in `__tests__/export-memory/` (manifest validation + bundle end-to-end) pass
- CLI end-to-end verified: produces a ZIP with `manifest.json` + `conversations/` + `records/`

## Scope

Read-only export only. Import / restore / conflict handling / skill-llm-wiki-codegraph land in later incremental steps (per the design discussion in #779).

Follows the `export-tencent-vdb` script pattern. `jszip` is already a dependency.