### PR TITLE
feat(export): support the skill asset in export bundles (#779)

### DIFF
--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -248,6 +248,10 @@ npm run seed-v2
 # Export memory assets (chat-memory) to a portable ZIP bundle (issue #779, step 1)
 npm run build:export-memory
 npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
+
+# Validate an export bundle before applying — dry-run, nothing is written (issue #779, step 2)
+npm run build:import-memory
+npm run import-memory -- --file ./memory-backup.zip --dry-run
 ```
 
 ## Security recommendations

--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -245,9 +245,9 @@ MemoryCore/
 npm run read-local-memory
 npm run seed-v2
 
-# Export memory assets (chat-memory) to a portable ZIP bundle (issue #779, step 1)
+# Export memory assets to a portable ZIP bundle (issue #779). --asset: chat-memory | skill | all (default all)
 npm run build:export-memory
-npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
+npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip --asset all
 
 # Validate an export bundle before applying — dry-run, nothing is written (issue #779, step 2)
 npm run build:import-memory

--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -244,6 +244,10 @@ MemoryCore/
 ```bash
 npm run read-local-memory
 npm run seed-v2
+
+# Export memory assets (chat-memory) to a portable ZIP bundle (issue #779, step 1)
+npm run build:export-memory
+npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
 ```
 
 ## Security recommendations

--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -252,6 +252,10 @@ npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out 
 # Validate an export bundle before applying — dry-run, nothing is written (issue #779, step 2)
 npm run build:import-memory
 npm run import-memory -- --file ./memory-backup.zip --dry-run
+
+# Apply an export bundle into a data directory (issue #779, step 3).
+# --on-conflict: skip (default) | rename | replace
+npm run import-memory -- --file ./memory-backup.zip --data-dir "$HOME/.memory-tencentdb/memory-tdai" --apply --on-conflict skip
 ```
 
 ## Security recommendations

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -248,9 +248,9 @@ MemoryCore/
 npm run read-local-memory
 npm run seed-v2
 
-# 导出记忆资产（chat-memory）为可移植 ZIP（issue #779 第一步）
+# 导出记忆资产为可移植 ZIP（issue #779）。--asset: chat-memory | skill | all（默认 all）
 npm run build:export-memory
-npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
+npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip --asset all
 
 # 导入前校验导出包（dry-run，不写入；issue #779 第二步）
 npm run build:import-memory

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -251,6 +251,10 @@ npm run seed-v2
 # 导出记忆资产（chat-memory）为可移植 ZIP（issue #779 第一步）
 npm run build:export-memory
 npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
+
+# 导入前校验导出包（dry-run，不写入；issue #779 第二步）
+npm run build:import-memory
+npm run import-memory -- --file ./memory-backup.zip --dry-run
 ```
 
 ## 安全建议

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -255,6 +255,10 @@ npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out 
 # 导入前校验导出包（dry-run，不写入；issue #779 第二步）
 npm run build:import-memory
 npm run import-memory -- --file ./memory-backup.zip --dry-run
+
+# 应用导出包到数据目录（issue #779 第三步）。
+# --on-conflict: skip（默认）| rename | replace
+npm run import-memory -- --file ./memory-backup.zip --data-dir "$HOME/.memory-tencentdb/memory-tdai" --apply --on-conflict skip
 ```
 
 ## 安全建议

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -247,6 +247,10 @@ MemoryCore/
 ```bash
 npm run read-local-memory
 npm run seed-v2
+
+# 导出记忆资产（chat-memory）为可移植 ZIP（issue #779 第一步）
+npm run build:export-memory
+npm run export-memory -- --data-dir "$HOME/.memory-tencentdb/memory-tdai" --out ./memory-backup.zip
 ```
 
 ## 安全建议

--- a/MemoryCore/__tests__/export-memory/export-memory.test.ts
+++ b/MemoryCore/__tests__/export-memory/export-memory.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for #779 (step 1) — read-only export of chat-memory to a ZIP bundle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import JSZip from "jszip";
+
+import { buildExportBundle } from "../../scripts/export-memory/export-memory.js";
+
+describe("buildExportBundle (#779)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-export-"));
+    mkdirSync(join(dataDir, "conversations"), { recursive: true });
+    mkdirSync(join(dataDir, "records"), { recursive: true });
+    writeFileSync(
+      join(dataDir, "conversations", "2026-08-01.jsonl"),
+      '{"role":"user","content":"hi"}\n{"role":"assistant","content":"yo"}\n',
+    );
+    writeFileSync(join(dataDir, "records", "2026-08-01.jsonl"), '{"type":"episodic","content":"x"}\n');
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("produces a ZIP with manifest + conversations + records", async () => {
+    const { manifest, zip } = await buildExportBundle({ dataDir, instanceId: "inst-1" });
+
+    expect(manifest.schema_version).toBe("1.0.0");
+    expect(manifest.assets[0].type).toBe("chat-memory");
+    expect(manifest.assets[0].id).toBe("inst-1");
+    expect(manifest.assets[0].files).toHaveLength(2);
+
+    const z = await JSZip.loadAsync(zip);
+    expect(z.file("manifest.json")).toBeTruthy();
+    expect(z.file("conversations/2026-08-01.jsonl")).toBeTruthy();
+    expect(z.file("records/2026-08-01.jsonl")).toBeTruthy();
+
+    const conv = manifest.assets[0].files.find((f) => f.path === "conversations/2026-08-01.jsonl")!;
+    expect(conv.checksum).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(conv.size).toBeGreaterThan(0);
+  });
+
+  it("skips records when includeRecords=false", async () => {
+    const { manifest } = await buildExportBundle({ dataDir, includeRecords: false });
+    const paths = manifest.assets[0].files.map((f) => f.path);
+    expect(paths).toEqual(["conversations/2026-08-01.jsonl"]);
+  });
+
+  it("throws when there is nothing to export", async () => {
+    const empty = mkdtempSync(join(tmpdir(), "tdai-export-empty-"));
+    try {
+      await expect(buildExportBundle({ dataDir: empty })).rejects.toThrow(/未找到可导出/);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/__tests__/export-memory/export-skill.test.ts
+++ b/MemoryCore/__tests__/export-memory/export-skill.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for #779 — exporting the "skill" asset: head rows from the skills
+ * table in vectors.db plus per-skill resource files.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import JSZip from "jszip";
+
+import { buildExportBundle } from "../../scripts/export-memory/export-memory.js";
+
+describe("buildExportBundle skill asset (#779)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-skill-"));
+    mkdirSync(join(dataDir, "conversations"), { recursive: true });
+    writeFileSync(join(dataDir, "conversations", "2026-08-01.jsonl"), '{"role":"user","content":"hi"}\n');
+
+    // Build a vectors.db with a `skills` table (mirrors SKILLS_DDL head fields).
+    const db = new DatabaseSync(join(dataDir, "vectors.db"));
+    db.exec(`
+      CREATE TABLE skills (
+        row_id TEXT PRIMARY KEY,
+        skill_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        is_head INTEGER NOT NULL DEFAULT 1,
+        user_id TEXT NOT NULL,
+        owner_agent_id TEXT NOT NULL,
+        team_id TEXT NOT NULL,
+        task_id TEXT NOT NULL DEFAULT '',
+        name TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        content TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        manifest_json TEXT NOT NULL DEFAULT '[]',
+        storage_dir TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at_ms INTEGER NOT NULL,
+        updated_at_ms INTEGER NOT NULL
+      )
+    `);
+    db.prepare(`
+      INSERT INTO skills (row_id, skill_id, version, is_head, user_id, owner_agent_id,
+        team_id, task_id, name, description, content, content_hash, manifest_json,
+        storage_dir, status, metadata_json, created_at_ms, updated_at_ms)
+      VALUES (?, ?, ?, 1, 'u', 'a', 't', '', 'review-skill', 'desc',
+        'do a code review', 'hash1', '[]', ?, 'active', '{}', 1, 1)
+    `).run("r1", "skill-1", 1, join(dataDir, "skill-res"));
+
+    // Resource file for the skill.
+    mkdirSync(join(dataDir, "skill-res"), { recursive: true });
+    writeFileSync(join(dataDir, "skill-res", "prompt.md"), "# review skill prompt");
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("exports the skill asset with skills.jsonl + resources + manifest", async () => {
+    const { manifest, zip } = await buildExportBundle({ dataDir, assets: ["skill"] });
+
+    const skillAsset = manifest.assets.find((a) => a.type === "skill");
+    expect(skillAsset).toBeDefined();
+    expect(skillAsset!.files.some((f) => f.path === "skills.jsonl")).toBe(true);
+    expect(skillAsset!.files.some((f) => f.path.startsWith("skills/resources/"))).toBe(true);
+
+    const z = await JSZip.loadAsync(zip);
+    expect(z.file("skills.jsonl")).toBeTruthy();
+    expect(z.file("manifest.json")).toBeTruthy();
+    const skillsText = await z.file("skills.jsonl")!.async("string");
+    const row = JSON.parse(skillsText.split("\n")[0]);
+    expect(row.name).toBe("review-skill");
+  });
+
+  it("exports chat-memory and skill together when assets default to all", async () => {
+    const { manifest } = await buildExportBundle({ dataDir });
+    const types = manifest.assets.map((a) => a.type);
+    expect(types).toContain("chat-memory");
+    expect(types).toContain("skill");
+  });
+});

--- a/MemoryCore/__tests__/export-memory/manifest.test.ts
+++ b/MemoryCore/__tests__/export-memory/manifest.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for #779 (step 1) — export manifest schema validation.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MANIFEST_SCHEMA_VERSION,
+  validateManifest,
+  type ExportManifest,
+} from "../../scripts/export-memory/manifest.js";
+
+const validManifest: ExportManifest = {
+  schema_version: MANIFEST_SCHEMA_VERSION,
+  created_at: "2026-08-05T00:00:00.000Z",
+  source_instance_id: "inst-1",
+  assets: [
+    {
+      type: "chat-memory",
+      id: "default",
+      files: [
+        {
+          path: "conversations/2026-08-01.jsonl",
+          checksum: `sha256:${"a".repeat(64)}`,
+          size: 10,
+        },
+      ],
+    },
+  ],
+};
+
+describe("validateManifest (#779)", () => {
+  it("accepts a valid manifest", () => {
+    expect(() => validateManifest(validManifest)).not.toThrow();
+  });
+
+  it("rejects an unknown schema_version", () => {
+    expect(() => validateManifest({ ...validManifest, schema_version: "9.9.9" })).toThrow();
+  });
+
+  it("rejects a malformed checksum", () => {
+    const bad = {
+      ...validManifest,
+      assets: [
+        {
+          ...validManifest.assets[0],
+          files: [{ path: "a.jsonl", checksum: "md5:xyz", size: 1 }],
+        },
+      ],
+    };
+    expect(() => validateManifest(bad)).toThrow(/checksum/);
+  });
+
+  it("rejects an empty files list", () => {
+    const bad = {
+      ...validManifest,
+      assets: [{ ...validManifest.assets[0], files: [] }],
+    };
+    expect(() => validateManifest(bad)).toThrow();
+  });
+
+  it("rejects an unsupported asset type", () => {
+    const bad = {
+      ...validManifest,
+      assets: [{ ...validManifest.assets[0], type: "brain" }],
+    };
+    expect(() => validateManifest(bad)).toThrow();
+  });
+});

--- a/MemoryCore/__tests__/import-memory/import-apply.test.ts
+++ b/MemoryCore/__tests__/import-memory/import-apply.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for #779 (step 3) — apply import: write files into a data directory
+ * with conflict handling (skip / rename / replace).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildExportBundle } from "../../scripts/export-memory/export-memory.js";
+import { applyImport } from "../../scripts/import-memory/import-memory.js";
+
+describe("applyImport (#779 step 3)", () => {
+  let srcDir: string;
+  let bundle: Buffer;
+
+  beforeEach(async () => {
+    srcDir = mkdtempSync(join(tmpdir(), "tdai-apply-src-"));
+    mkdirSync(join(srcDir, "conversations"), { recursive: true });
+    writeFileSync(
+      join(srcDir, "conversations", "2026-08-01.jsonl"),
+      '{"role":"user","content":"hi"}\n',
+    );
+    bundle = (await buildExportBundle({ dataDir: srcDir, instanceId: "inst" })).zip;
+  });
+
+  afterEach(() => {
+    rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  function makeTargetDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "tdai-apply-dst-"));
+    afterEach(() => rmSync(dir, { recursive: true, force: true }));
+    return dir;
+  }
+
+  it("writes files into an empty data directory", async () => {
+    const dst = makeTargetDir();
+    const result = await applyImport(bundle, dst, { conflict: "skip" });
+
+    expect(result.applied).toContain(join(dst, "conversations", "2026-08-01.jsonl"));
+    expect(result.skipped).toHaveLength(0);
+    const written = readFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "utf8");
+    expect(written).toContain("hi");
+  });
+
+  it("skips existing files with conflict=skip", async () => {
+    const dst = makeTargetDir();
+    mkdirSync(join(dst, "conversations"), { recursive: true });
+    writeFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "ORIGINAL");
+
+    const result = await applyImport(bundle, dst, { conflict: "skip" });
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].path).toBe("conversations/2026-08-01.jsonl");
+    // Original untouched.
+    expect(readFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "utf8")).toBe("ORIGINAL");
+  });
+
+  it("overwrites existing files with conflict=replace", async () => {
+    const dst = makeTargetDir();
+    mkdirSync(join(dst, "conversations"), { recursive: true });
+    writeFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "ORIGINAL");
+
+    const result = await applyImport(bundle, dst, { conflict: "replace" });
+    expect(result.applied).toHaveLength(1);
+    expect(readFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "utf8")).toContain("hi");
+  });
+
+  it("writes a renamed copy with conflict=rename and keeps the original", async () => {
+    const dst = makeTargetDir();
+    mkdirSync(join(dst, "conversations"), { recursive: true });
+    writeFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "ORIGINAL");
+
+    const result = await applyImport(bundle, dst, { conflict: "rename" });
+    expect(result.applied).toHaveLength(1);
+    expect(result.applied[0]).toMatch(/\.import\.\d+$/);
+    // Original preserved.
+    expect(readFileSync(join(dst, "conversations", "2026-08-01.jsonl"), "utf8")).toBe("ORIGINAL");
+    // Renamed copy has the bundle content.
+    expect(readFileSync(result.applied[0], "utf8")).toContain("hi");
+  });
+
+  it("refuses to write when the bundle fails validation", async () => {
+    const { default: JSZip } = await import("jszip");
+    const z = await JSZip.loadAsync(bundle);
+    z.file("conversations/2026-08-01.jsonl", "TAMPERED");
+    const bad = await z.generateAsync({ type: "nodebuffer" });
+
+    const dst = makeTargetDir();
+    await expect(applyImport(bad, dst, { conflict: "skip" })).rejects.toThrow(/校验失败/);
+    expect(existsSync(join(dst, "conversations"))).toBe(false);
+  });
+});

--- a/MemoryCore/__tests__/import-memory/import-memory.test.ts
+++ b/MemoryCore/__tests__/import-memory/import-memory.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for #779 (step 2) — import dry-run: validate the bundle and report
+ * conflicts/errors without writing anything.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import JSZip from "jszip";
+
+import { buildExportBundle } from "../../scripts/export-memory/export-memory.js";
+import { dryRunImport } from "../../scripts/import-memory/import-memory.js";
+
+describe("dryRunImport (#779 step 2)", () => {
+  let dataDir: string;
+  let bundle: Buffer;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-import-"));
+    mkdirSync(join(dataDir, "conversations"), { recursive: true });
+    writeFileSync(
+      join(dataDir, "conversations", "2026-08-01.jsonl"),
+      '{"role":"user","content":"hi"}\n',
+    );
+    bundle = (await buildExportBundle({ dataDir, instanceId: "inst" })).zip;
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("accepts a valid bundle (dry-run ok)", async () => {
+    const result = await dryRunImport(bundle);
+
+    expect(result.ok).toBe(true);
+    expect(result.missingFiles).toHaveLength(0);
+    expect(result.checksumFailures).toHaveLength(0);
+    expect(result.manifest.assets[0].type).toBe("chat-memory");
+    expect(result.files).toHaveLength(1);
+  });
+
+  it("reports files declared in the manifest but missing from the bundle", async () => {
+    const z = await JSZip.loadAsync(bundle);
+    z.remove("conversations/2026-08-01.jsonl");
+    const tampered = await z.generateAsync({ type: "nodebuffer" });
+
+    const result = await dryRunImport(tampered);
+    expect(result.ok).toBe(false);
+    expect(result.missingFiles).toContain("conversations/2026-08-01.jsonl");
+  });
+
+  it("reports checksum mismatches after content tampering", async () => {
+    const z = await JSZip.loadAsync(bundle);
+    z.file("conversations/2026-08-01.jsonl", '{"role":"user","content":"TAMPERED"}\n');
+    const tampered = await z.generateAsync({ type: "nodebuffer" });
+
+    const result = await dryRunImport(tampered);
+    expect(result.ok).toBe(false);
+    expect(result.checksumFailures).toContain("conversations/2026-08-01.jsonl");
+  });
+
+  it("throws on a malformed manifest", async () => {
+    const z = await JSZip.loadAsync(bundle);
+    z.file("manifest.json", JSON.stringify({ schema_version: "9.9.9", assets: [] }));
+    const bad = await z.generateAsync({ type: "nodebuffer" });
+
+    await expect(dryRunImport(bad)).rejects.toThrow(/manifest 校验失败/);
+  });
+
+  it("throws when manifest.json is absent", async () => {
+    const z = await JSZip.loadAsync(bundle);
+    z.remove("manifest.json");
+    const noManifest = await z.generateAsync({ type: "nodebuffer" });
+
+    await expect(dryRunImport(noManifest)).rejects.toThrow(/缺少 manifest.json/);
+  });
+});

--- a/MemoryCore/bin/export-memory.mjs
+++ b/MemoryCore/bin/export-memory.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// 薄启动器：加载预编译好的 memory export 脚本。
+// 构建：npm run build:export-memory
+// 使用：npm run export-memory -- --data-dir <dir> --out <file.zip> [--instance-id <id>] [--skip-records]
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const entryScript = path.resolve(thisDir, "../scripts/export-memory/dist/export-memory.js");
+
+if (!fs.existsSync(entryScript)) {
+  console.error("❌  预编译产物不存在: " + entryScript);
+  console.error("   请先执行: npm run build:export-memory");
+  process.exit(1);
+}
+
+import(entryScript);

--- a/MemoryCore/bin/import-memory.mjs
+++ b/MemoryCore/bin/import-memory.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// 薄启动器：加载预编译好的 memory import (dry-run) 脚本。
+// 构建：npm run build:import-memory
+// 使用：npm run import-memory -- --file <bundle.zip> --dry-run
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const entryScript = path.resolve(thisDir, "../scripts/import-memory/dist/import-memory/import-memory.js");
+
+if (!fs.existsSync(entryScript)) {
+  console.error("❌  预编译产物不存在: " + entryScript);
+  console.error("   请先执行: npm run build:import-memory");
+  process.exit(1);
+}
+
+import(entryScript);

--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -8,7 +8,8 @@
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
     "read-local-memory": "./bin/read-local-memory.mjs",
-    "export-memory": "./bin/export-memory.mjs"
+    "export-memory": "./bin/export-memory.mjs",
+    "import-memory": "./bin/import-memory.mjs"
   },
   "exports": {
     ".": {
@@ -29,6 +30,8 @@
     "read-local-memory": "node ./bin/read-local-memory.mjs",
     "build:export-memory": "tsc --project scripts/export-memory/tsconfig.json",
     "export-memory": "node ./bin/export-memory.mjs",
+    "build:import-memory": "tsc --project scripts/import-memory/tsconfig.json",
+    "import-memory": "node ./bin/import-memory.mjs",
     "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
     "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
@@ -55,11 +58,13 @@
     "bin/export-tencent-vdb.mjs",
     "bin/read-local-memory.mjs",
     "bin/export-memory.mjs",
+    "bin/import-memory.mjs",
     "index.ts",
     "scripts/migrate-sqlite-to-tcvdb/dist/",
     "scripts/export-tencent-vdb/dist/",
     "scripts/read-local-memory/dist/",
     "scripts/export-memory/dist/",
+    "scripts/import-memory/dist/",
     "scripts/import-opik-to-memory-core/",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",

--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "export-memory": "./bin/export-memory.mjs"
   },
   "exports": {
     ".": {
@@ -26,6 +27,8 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
+    "build:export-memory": "tsc --project scripts/export-memory/tsconfig.json",
+    "export-memory": "node ./bin/export-memory.mjs",
     "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
     "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
@@ -51,10 +54,12 @@
     "bin/migrate-sqlite-to-tcvdb.mjs",
     "bin/export-tencent-vdb.mjs",
     "bin/read-local-memory.mjs",
+    "bin/export-memory.mjs",
     "index.ts",
     "scripts/migrate-sqlite-to-tcvdb/dist/",
     "scripts/export-tencent-vdb/dist/",
     "scripts/read-local-memory/dist/",
+    "scripts/export-memory/dist/",
     "scripts/import-opik-to-memory-core/",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",

--- a/MemoryCore/scripts/export-memory/export-memory.ts
+++ b/MemoryCore/scripts/export-memory/export-memory.ts
@@ -33,6 +33,7 @@ import JSZip from "jszip";
 import {
   MANIFEST_SCHEMA_VERSION,
   validateManifest,
+  type ExportAsset,
   type ExportManifest,
 } from "./manifest.js";
 
@@ -75,13 +76,65 @@ async function collectDir(
   return out;
 }
 
+export type ExportAssetKind = "chat-memory" | "skill";
+
 export interface ExportOptions {
-  /** Root data directory (contains conversations/ and records/). */
+  /** Root data directory (contains conversations/, records/, vectors.db). */
   dataDir: string;
   /** Instance id recorded in the manifest (default "default"). */
   instanceId?: string;
-  /** Whether to include L1 records/ (default true). */
+  /** Whether to include L1 records/ for chat-memory (default true). */
   includeRecords?: boolean;
+  /** Which assets to export. Default: all supported. */
+  assets?: ExportAssetKind[];
+}
+
+/**
+ * Collect the "skill" asset: head skill rows from the `skills` table in
+ * vectors.db, plus each skill's resource files from its storage_dir.
+ * Returns [] when vectors.db is absent or has no skills.
+ */
+async function collectSkillAsset(zip: JSZip, dataDir: string): Promise<CollectedFile[]> {
+  const dbPath = path.join(dataDir, "vectors.db");
+
+  let DatabaseSync: typeof import("node:sqlite").DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import("node:sqlite"));
+  } catch {
+    return [];
+  }
+
+  let db: InstanceType<typeof DatabaseSync>;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return []; // no vectors.db → no skill data
+  }
+
+  try {
+    const rows = db.prepare("SELECT * FROM skills WHERE is_head = 1").all() as Record<string, unknown>[];
+    if (rows.length === 0) return [];
+
+    const jsonl = rows.map((r) => JSON.stringify(r)).join("\n");
+    zip.file("skills.jsonl", jsonl);
+    const files: CollectedFile[] = [{
+      path: "skills.jsonl",
+      checksum: `sha256:${await sha256(Buffer.from(jsonl))}`,
+      size: Buffer.byteLength(jsonl),
+    }];
+
+    // Pack each skill's resource directory as skills/resources/<n>/<file>.
+    const storageDirs = [...new Set(
+      rows.map((r) => (typeof r.storage_dir === "string" ? r.storage_dir : "")).filter(Boolean),
+    )];
+    for (let i = 0; i < storageDirs.length; i++) {
+      const res = await collectDir(zip, storageDirs[i], `skills/resources/${i}`);
+      files.push(...res);
+    }
+    return files;
+  } finally {
+    db.close();
+  }
 }
 
 export interface ExportResult {
@@ -91,29 +144,43 @@ export interface ExportResult {
 }
 
 /**
- * Build a portable chat-memory export bundle from a data directory.
+ * Build a portable export bundle from a data directory.
  * Returns the validated manifest + the ZIP buffer (not yet written to disk).
  */
 export async function buildExportBundle(opts: ExportOptions): Promise<ExportResult> {
   const zip = new JSZip();
+  const assetId = opts.instanceId ?? "default";
+  const kinds: ExportAssetKind[] = opts.assets ?? ["chat-memory", "skill"];
+  const assets: ExportAsset[] = [];
 
-  const convFiles = await collectDir(zip, path.join(opts.dataDir, "conversations"), "conversations");
-  const recordFiles =
-    opts.includeRecords === false
-      ? []
-      : await collectDir(zip, path.join(opts.dataDir, "records"), "records");
-
-  const files = [...convFiles, ...recordFiles];
-  if (files.length === 0) {
-    throw new Error("未找到可导出的记忆文件（conversations/ 或 records/ 为空）");
+  if (kinds.includes("chat-memory")) {
+    const convFiles = await collectDir(zip, path.join(opts.dataDir, "conversations"), "conversations");
+    const recordFiles =
+      opts.includeRecords === false
+        ? []
+        : await collectDir(zip, path.join(opts.dataDir, "records"), "records");
+    const files = [...convFiles, ...recordFiles];
+    if (files.length > 0) {
+      assets.push({ type: "chat-memory", id: assetId, files });
+    }
   }
 
-  const assetId = opts.instanceId ?? "default";
+  if (kinds.includes("skill")) {
+    const skillFiles = await collectSkillAsset(zip, opts.dataDir);
+    if (skillFiles.length > 0) {
+      assets.push({ type: "skill", id: assetId, files: skillFiles });
+    }
+  }
+
+  if (assets.length === 0) {
+    throw new Error("未找到可导出的记忆资产（conversations/、records/ 或 skills 为空）");
+  }
+
   const manifest: ExportManifest = {
     schema_version: MANIFEST_SCHEMA_VERSION,
     created_at: new Date().toISOString(),
     ...(opts.instanceId ? { source_instance_id: opts.instanceId } : {}),
-    assets: [{ type: "chat-memory", id: assetId, files }],
+    assets,
   };
 
   // Self-check: the manifest must round-trip through the schema.
@@ -131,6 +198,7 @@ async function main(): Promise<void> {
       "out": { type: "string", short: "o", required: true },
       "instance-id": { type: "string" },
       "skip-records": { type: "boolean", default: false },
+      asset: { type: "string", default: "all" },
     },
   });
 
@@ -140,21 +208,31 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  const rawAssets = (values["asset"] ?? "all") as string;
+  const assetKinds: ExportAssetKind[] | undefined =
+    rawAssets === "all" ? undefined : [rawAssets as ExportAssetKind];
+
   const { manifest, zip } = await buildExportBundle({
     dataDir,
     instanceId: values["instance-id"],
     includeRecords: values["skip-records"] ? false : true,
+    assets: assetKinds,
   });
 
   const outPath = values["out"] as string;
   await fs.mkdir(path.dirname(path.resolve(outPath)), { recursive: true });
   await fs.writeFile(outPath, zip);
 
-  const files = manifest.assets[0].files;
-  const totalBytes = files.reduce((s, f) => s + f.size, 0);
+  const totalBytes = manifest.assets.reduce(
+    (sum, a) => sum + a.files.reduce((s, f) => s + f.size, 0),
+    0,
+  );
+  const totalFiles = manifest.assets.reduce((sum, a) => sum + a.files.length, 0);
   console.log(`✅ 导出完成 → ${outPath}`);
-  console.log(`   资产: chat-memory (id=${manifest.assets[0].id})`);
-  console.log(`   文件: ${files.length} 个 (${totalBytes} bytes)`);
+  for (const asset of manifest.assets) {
+    console.log(`   资产: ${asset.type} (id=${asset.id}, files=${asset.files.length})`);
+  }
+  console.log(`   文件: ${totalFiles} 个 (${totalBytes} bytes)`);
   console.log(`   schema_version: ${manifest.schema_version}`);
 }
 

--- a/MemoryCore/scripts/export-memory/export-memory.ts
+++ b/MemoryCore/scripts/export-memory/export-memory.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * memory export — export memory assets to a portable ZIP bundle.
+ *
+ * Step 1 of issue #779: manifest/schema + read-only export of chat-memory
+ * (L0 conversations + L1 memory records). Import / restore lands in a later
+ * step.
+ *
+ * Usage:
+ *   node ./bin/export-memory.mjs --data-dir <dir> --out ./backup.zip
+ *   node ./bin/export-memory.mjs --data-dir <dir> --out ./backup.zip \
+ *       --instance-id <id> --skip-records
+ *
+ * Data layout read from the data directory:
+ *   conversations/YYYY-MM-DD.jsonl   (L0)
+ *   records/YYYY-MM-DD.jsonl         (L1)
+ *
+ * Output ZIP:
+ *   manifest.json
+ *   conversations/…  records/…
+ *
+ * manifest.json is validated against exportManifestSchema before writing
+ * (see manifest.ts).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { parseArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+import JSZip from "jszip";
+
+import {
+  MANIFEST_SCHEMA_VERSION,
+  validateManifest,
+  type ExportManifest,
+} from "./manifest.js";
+
+async function sha256(content: Buffer): Promise<string> {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+interface CollectedFile {
+  path: string;
+  checksum: string;
+  size: number;
+}
+
+/**
+ * Add every non-directory file under `dirPath` to the ZIP under `prefix`,
+ * returning file entries (path + checksum + size). Missing dir → empty list.
+ */
+async function collectDir(
+  zip: JSZip,
+  dirPath: string,
+  prefix: string,
+): Promise<CollectedFile[]> {
+  const out: CollectedFile[] = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dirPath);
+  } catch {
+    return out; // directory absent → no files for this namespace
+  }
+  entries.sort();
+  for (const entry of entries) {
+    const full = path.join(dirPath, entry);
+    const stat = await fs.stat(full);
+    if (stat.isDirectory()) continue;
+    const rel = `${prefix}/${entry}`;
+    const content = await fs.readFile(full);
+    zip.file(rel, content);
+    out.push({ path: rel, checksum: `sha256:${await sha256(content)}`, size: content.length });
+  }
+  return out;
+}
+
+export interface ExportOptions {
+  /** Root data directory (contains conversations/ and records/). */
+  dataDir: string;
+  /** Instance id recorded in the manifest (default "default"). */
+  instanceId?: string;
+  /** Whether to include L1 records/ (default true). */
+  includeRecords?: boolean;
+}
+
+export interface ExportResult {
+  manifest: ExportManifest;
+  /** ZIP archive as a Buffer. */
+  zip: Buffer;
+}
+
+/**
+ * Build a portable chat-memory export bundle from a data directory.
+ * Returns the validated manifest + the ZIP buffer (not yet written to disk).
+ */
+export async function buildExportBundle(opts: ExportOptions): Promise<ExportResult> {
+  const zip = new JSZip();
+
+  const convFiles = await collectDir(zip, path.join(opts.dataDir, "conversations"), "conversations");
+  const recordFiles =
+    opts.includeRecords === false
+      ? []
+      : await collectDir(zip, path.join(opts.dataDir, "records"), "records");
+
+  const files = [...convFiles, ...recordFiles];
+  if (files.length === 0) {
+    throw new Error("未找到可导出的记忆文件（conversations/ 或 records/ 为空）");
+  }
+
+  const assetId = opts.instanceId ?? "default";
+  const manifest: ExportManifest = {
+    schema_version: MANIFEST_SCHEMA_VERSION,
+    created_at: new Date().toISOString(),
+    ...(opts.instanceId ? { source_instance_id: opts.instanceId } : {}),
+    assets: [{ type: "chat-memory", id: assetId, files }],
+  };
+
+  // Self-check: the manifest must round-trip through the schema.
+  validateManifest(manifest);
+  zip.file("manifest.json", JSON.stringify(manifest, null, 2));
+
+  const buf = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+  return { manifest, zip: buf };
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      "data-dir": { type: "string", short: "d" },
+      "out": { type: "string", short: "o", required: true },
+      "instance-id": { type: "string" },
+      "skip-records": { type: "boolean", default: false },
+    },
+  });
+
+  const dataDir = values["data-dir"] ?? process.env.TDAI_DATA_DIR;
+  if (!dataDir) {
+    console.error("❌ 缺少数据目录：请用 --data-dir 或设置 TDAI_DATA_DIR");
+    process.exit(1);
+  }
+
+  const { manifest, zip } = await buildExportBundle({
+    dataDir,
+    instanceId: values["instance-id"],
+    includeRecords: values["skip-records"] ? false : true,
+  });
+
+  const outPath = values["out"] as string;
+  await fs.mkdir(path.dirname(path.resolve(outPath)), { recursive: true });
+  await fs.writeFile(outPath, zip);
+
+  const files = manifest.assets[0].files;
+  const totalBytes = files.reduce((s, f) => s + f.size, 0);
+  console.log(`✅ 导出完成 → ${outPath}`);
+  console.log(`   资产: chat-memory (id=${manifest.assets[0].id})`);
+  console.log(`   文件: ${files.length} 个 (${totalBytes} bytes)`);
+  console.log(`   schema_version: ${manifest.schema_version}`);
+}
+
+// Run the CLI only when invoked directly (node dist/export-memory.js) or via
+// the thin bin launcher (bin/export-memory.mjs imports this module). Tests and
+// other importers get the pure buildExportBundle without side effects.
+const isCliEntry = process.argv[1] !== undefined && (
+  import.meta.url === pathToFileURL(process.argv[1]).href
+  || process.argv[1].endsWith("bin/export-memory.mjs")
+);
+if (isCliEntry) {
+  main().catch((err) => {
+    console.error(`❌ 导出失败: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/MemoryCore/scripts/export-memory/manifest.ts
+++ b/MemoryCore/scripts/export-memory/manifest.ts
@@ -1,0 +1,63 @@
+/**
+ * Export bundle manifest — schema + validation for the portable memory
+ * export format (issue #779, step 1: manifest/schema + read-only export).
+ *
+ * A manifest describes the assets inside a bundle (e.g. a ZIP archive):
+ *   manifest.json
+ *   conversations/YYYY-MM-DD.jsonl   (L0 chat memory)
+ *   records/YYYY-MM-DD.jsonl         (L1 memory records)
+ *
+ * schema_version is fixed so importers can detect incompatible bundles.
+ */
+
+import { z } from "zod";
+
+export const MANIFEST_SCHEMA_VERSION = "1.0.0";
+
+/** Asset types covered by the memory system (step 1 exports chat-memory). */
+export const memoryAssetTypeSchema = z.enum([
+  "chat-memory",
+  "skill",
+  "llm-wiki",
+  "code-graph",
+]);
+export type MemoryAssetType = z.infer<typeof memoryAssetTypeSchema>;
+
+/** A single file inside the bundle with its integrity checksum. */
+export const exportFileSchema = z.object({
+  /** Path inside the bundle (e.g. "conversations/2026-08-01.jsonl"). */
+  path: z.string().min(1),
+  /** sha256 of the file content ("sha256:<64 hex>"). */
+  checksum: z.string().regex(/^sha256:[0-9a-f]{64}$/, "checksum must be sha256:<64 hex>"),
+  /** Size in bytes. */
+  size: z.number().int().nonnegative(),
+});
+export type ExportFile = z.infer<typeof exportFileSchema>;
+
+/** One exported memory asset (e.g. a chat-memory bundle). */
+export const exportAssetSchema = z.object({
+  type: memoryAssetTypeSchema,
+  /** Stable asset id (instance / scope the memory belongs to). */
+  id: z.string().min(1),
+  files: z.array(exportFileSchema).min(1),
+});
+export type ExportAsset = z.infer<typeof exportAssetSchema>;
+
+/** Top-level export manifest. */
+export const exportManifestSchema = z.object({
+  schema_version: z.literal(MANIFEST_SCHEMA_VERSION),
+  /** ISO-8601 export timestamp. */
+  created_at: z.string(),
+  /** Source instance id (optional). */
+  source_instance_id: z.string().optional(),
+  assets: z.array(exportAssetSchema),
+});
+export type ExportManifest = z.infer<typeof exportManifestSchema>;
+
+/**
+ * Validate a raw manifest object. Throws a ZodError with a precise path when
+ * the manifest is malformed (unknown version, bad checksum format, ...).
+ */
+export function validateManifest(raw: unknown): ExportManifest {
+  return exportManifestSchema.parse(raw);
+}

--- a/MemoryCore/scripts/export-memory/tsconfig.json
+++ b/MemoryCore/scripts/export-memory/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["export-memory.ts", "manifest.ts"],
+  "exclude": ["dist", "node_modules", "docs"]
+}

--- a/MemoryCore/scripts/import-memory/import-memory.ts
+++ b/MemoryCore/scripts/import-memory/import-memory.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * memory import — validate and dry-run an export bundle before applying it.
+ *
+ * Issue #779, step 2: import dry-run only (validation + conflict report). The
+ * real write path (step 3) is intentionally out of scope here.
+ *
+ * Usage:
+ *   node ./bin/import-memory.mjs --file ./memory-backup.zip --dry-run
+ *
+ * What it checks (without writing anything):
+ *   - manifest.json exists and passes exportManifestSchema (schema_version,
+ *     asset types, per-file sha256 checksums)
+ *   - every file declared in the manifest exists inside the bundle
+ *   - every file's content hash matches its declared checksum
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import { parseArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+import JSZip from "jszip";
+
+import {
+  validateManifest,
+  type ExportManifest,
+} from "../export-memory/manifest.js";
+
+export interface DryRunFile {
+  path: string;
+  size: number;
+  checksumValid: boolean;
+}
+
+export interface DryRunResult {
+  manifest: ExportManifest;
+  files: DryRunFile[];
+  totalBytes: number;
+  /** Files declared in the manifest but absent from the bundle. */
+  missingFiles: string[];
+  /** Files whose content hash does not match the manifest checksum. */
+  checksumFailures: string[];
+  /** True when every declared file exists and its checksum matches. */
+  ok: boolean;
+  /** Human-readable one-line summary. */
+  summary: string;
+}
+
+/**
+ * Validate an export bundle without writing anything to storage.
+ * Throws on a malformed manifest; returns a DryRunResult otherwise.
+ */
+export async function dryRunImport(bundle: Buffer): Promise<DryRunResult> {
+  const zip = await JSZip.loadAsync(bundle);
+  const manifestEntry = zip.file("manifest.json");
+  if (!manifestEntry) {
+    throw new Error("bundle 缺少 manifest.json，不是有效的导出文件");
+  }
+
+  let manifest: ExportManifest;
+  try {
+    manifest = validateManifest(JSON.parse(await manifestEntry.async("string")));
+  } catch (err) {
+    throw new Error(
+      `manifest 校验失败: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const files: DryRunFile[] = [];
+  const missingFiles: string[] = [];
+  const checksumFailures: string[] = [];
+  let totalBytes = 0;
+
+  for (const asset of manifest.assets) {
+    for (const f of asset.files) {
+      const entry = zip.file(f.path);
+      if (!entry) {
+        missingFiles.push(f.path);
+        continue;
+      }
+      const content = await entry.async("nodebuffer");
+      const actual = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+      const valid = actual === f.checksum;
+      if (!valid) checksumFailures.push(f.path);
+      files.push({ path: f.path, size: content.length, checksumValid: valid });
+      totalBytes += content.length;
+    }
+  }
+
+  const ok = missingFiles.length === 0 && checksumFailures.length === 0;
+  const summary = ok
+    ? `dry-run OK: ${manifest.assets.length} 个资产, ${files.length} 个文件, ${totalBytes} bytes`
+    : `dry-run 发现问题: 缺失 ${missingFiles.length} 个, checksum 失败 ${checksumFailures.length} 个`;
+
+  return { manifest, files, totalBytes, missingFiles, checksumFailures, ok, summary };
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      file: { type: "string", short: "f", required: true },
+      "dry-run": { type: "boolean", default: true },
+    },
+  });
+
+  const bundle = await fs.readFile(values.file as string);
+  const result = await dryRunImport(bundle);
+
+  console.log(`📦 bundle: schema_version=${result.manifest.schema_version}`);
+  for (const asset of result.manifest.assets) {
+    console.log(`   资产: ${asset.type} (id=${asset.id}, files=${asset.files.length})`);
+  }
+  console.log(`   文件: ${result.files.length} 个 (${result.totalBytes} bytes)`);
+
+  if (result.missingFiles.length > 0) {
+    console.error(`❌ 缺失文件 (${result.missingFiles.length}): ${result.missingFiles.join(", ")}`);
+  }
+  if (result.checksumFailures.length > 0) {
+    console.error(`❌ checksum 不匹配 (${result.checksumFailures.length}): ${result.checksumFailures.join(", ")}`);
+  }
+
+  if (result.ok) {
+    console.log(`✅ ${result.summary} (dry-run，未写入)`);
+  } else {
+    console.error(`❌ ${result.summary}`);
+    process.exit(1);
+  }
+}
+
+// Run the CLI only when invoked directly or via the thin bin launcher
+// (bin/import-memory.mjs imports this module); importers/tests get the pure
+// dryRunImport without side effects.
+const isCliEntry = process.argv[1] !== undefined && (
+  import.meta.url === pathToFileURL(process.argv[1]).href
+  || process.argv[1].endsWith("bin/import-memory.mjs")
+);
+if (isCliEntry) {
+  main().catch((err) => {
+    console.error(`❌ import dry-run 失败: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/MemoryCore/scripts/import-memory/import-memory.ts
+++ b/MemoryCore/scripts/import-memory/import-memory.ts
@@ -1,22 +1,32 @@
 #!/usr/bin/env node
 /**
- * memory import — validate and dry-run an export bundle before applying it.
+ * memory import — validate and apply an export bundle.
  *
- * Issue #779, step 2: import dry-run only (validation + conflict report). The
- * real write path (step 3) is intentionally out of scope here.
+ * Issue #779, step 2 (dry-run) + step 3 (apply with conflict handling).
  *
  * Usage:
+ *   # Validate only — nothing is written
  *   node ./bin/import-memory.mjs --file ./memory-backup.zip --dry-run
  *
- * What it checks (without writing anything):
+ *   # Apply into a data directory (writes conversations/ + records/)
+ *   node ./bin/import-memory.mjs --file ./memory-backup.zip --data-dir <dir> --apply \
+ *       --on-conflict skip|rename|replace
+ *
+ * Validation (always runs first):
  *   - manifest.json exists and passes exportManifestSchema (schema_version,
  *     asset types, per-file sha256 checksums)
  *   - every file declared in the manifest exists inside the bundle
  *   - every file's content hash matches its declared checksum
+ *
+ * Conflict policy (--apply only, key = same target path already on disk):
+ *   - skip    (default): leave the existing file untouched
+ *   - rename : write the bundle copy as "<path>.import.<timestamp>"
+ *   - replace: overwrite the existing file
  */
 
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { parseArgs } from "node:util";
 import { pathToFileURL } from "node:url";
 import JSZip from "jszip";
@@ -95,36 +105,138 @@ export async function dryRunImport(bundle: Buffer): Promise<DryRunResult> {
   return { manifest, files, totalBytes, missingFiles, checksumFailures, ok, summary };
 }
 
+export type ConflictPolicy = "skip" | "rename" | "replace";
+
+export interface ApplyResult {
+  /** Files written (target paths on disk). */
+  applied: string[];
+  /** Files not written, with the reason. */
+  skipped: { path: string; reason: string }[];
+  totalFiles: number;
+}
+
+/**
+ * Write a file, creating parent directories as needed.
+ */
+async function writeFileDir(filePath: string, content: Buffer): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+/**
+ * Apply an export bundle into a data directory, honouring a conflict policy.
+ *
+ * Runs the full dry-run validation first and refuses to write anything when
+ * the bundle has missing files or checksum failures.
+ */
+export async function applyImport(
+  bundle: Buffer,
+  dataDir: string,
+  opts: { conflict: ConflictPolicy },
+): Promise<ApplyResult> {
+  const check = await dryRunImport(bundle);
+  if (!check.ok) {
+    throw new Error(`bundle 校验失败，未写入任何文件: ${check.summary}`);
+  }
+
+  const root = path.resolve(dataDir);
+  const zip = await JSZip.loadAsync(bundle);
+  const applied: string[] = [];
+  const skipped: { path: string; reason: string }[] = [];
+
+  for (const f of check.files) {
+    const target = path.resolve(root, f.path);
+    // Safety: the resolved target must stay inside the data directory.
+    if (target !== root && !target.startsWith(root + path.sep)) {
+      skipped.push({ path: f.path, reason: "path escapes data directory" });
+      continue;
+    }
+
+    const exists = await fs.access(target).then(() => true).catch(() => false);
+    if (exists) {
+      if (opts.conflict === "skip") {
+        skipped.push({ path: f.path, reason: `conflict=skip (exists: ${target})` });
+        continue;
+      }
+      if (opts.conflict === "rename") {
+        const alt = `${target}.import.${Date.now()}`;
+        const entry = zip.file(f.path);
+        if (entry) await writeFileDir(alt, await entry.async("nodebuffer"));
+        applied.push(alt);
+        continue;
+      }
+      // conflict=replace → overwrite below
+    }
+
+    const entry = zip.file(f.path);
+    if (entry) await writeFileDir(target, await entry.async("nodebuffer"));
+    applied.push(target);
+  }
+
+  return { applied, skipped, totalFiles: check.files.length };
+}
+
 async function main(): Promise<void> {
   const { values } = parseArgs({
     options: {
       file: { type: "string", short: "f", required: true },
-      "dry-run": { type: "boolean", default: true },
+      "data-dir": { type: "string", short: "d" },
+      "on-conflict": { type: "string", default: "skip" },
+      apply: { type: "boolean", default: false },
+      "dry-run": { type: "boolean", default: false },
     },
   });
 
   const bundle = await fs.readFile(values.file as string);
-  const result = await dryRunImport(bundle);
 
-  console.log(`📦 bundle: schema_version=${result.manifest.schema_version}`);
-  for (const asset of result.manifest.assets) {
-    console.log(`   资产: ${asset.type} (id=${asset.id}, files=${asset.files.length})`);
-  }
-  console.log(`   文件: ${result.files.length} 个 (${result.totalBytes} bytes)`);
+  if (!values["apply"]) {
+    // Default: dry-run only.
+    const result = await dryRunImport(bundle);
+    console.log(`📦 bundle: schema_version=${result.manifest.schema_version}`);
+    for (const asset of result.manifest.assets) {
+      console.log(`   资产: ${asset.type} (id=${asset.id}, files=${asset.files.length})`);
+    }
+    console.log(`   文件: ${result.files.length} 个 (${result.totalBytes} bytes)`);
 
-  if (result.missingFiles.length > 0) {
-    console.error(`❌ 缺失文件 (${result.missingFiles.length}): ${result.missingFiles.join(", ")}`);
-  }
-  if (result.checksumFailures.length > 0) {
-    console.error(`❌ checksum 不匹配 (${result.checksumFailures.length}): ${result.checksumFailures.join(", ")}`);
+    if (result.missingFiles.length > 0) {
+      console.error(`❌ 缺失文件 (${result.missingFiles.length}): ${result.missingFiles.join(", ")}`);
+    }
+    if (result.checksumFailures.length > 0) {
+      console.error(`❌ checksum 不匹配 (${result.checksumFailures.length}): ${result.checksumFailures.join(", ")}`);
+    }
+
+    if (result.ok) {
+      console.log(`✅ ${result.summary} (dry-run，未写入)`);
+    } else {
+      console.error(`❌ ${result.summary}`);
+      process.exit(1);
+    }
+    return;
   }
 
-  if (result.ok) {
-    console.log(`✅ ${result.summary} (dry-run，未写入)`);
-  } else {
-    console.error(`❌ ${result.summary}`);
+  // Apply mode.
+  const dataDir = values["data-dir"] ?? process.env.TDAI_DATA_DIR;
+  if (!dataDir) {
+    console.error("❌ --apply 需要数据目录：请用 --data-dir 或设置 TDAI_DATA_DIR");
     process.exit(1);
   }
+  const conflict = (values["on-conflict"] ?? "skip") as ConflictPolicy;
+  if (conflict !== "skip" && conflict !== "rename" && conflict !== "replace") {
+    console.error(`❌ --on-conflict 仅支持 skip|rename|replace（实际: ${conflict}）`);
+    process.exit(1);
+  }
+
+  const result = await applyImport(bundle, dataDir, { conflict });
+  for (const p of result.applied) {
+    console.log(`   ✅ 写入 ${p}`);
+  }
+  for (const s of result.skipped) {
+    console.log(`   ⏭  跳过 ${s.path} (${s.reason})`);
+  }
+  console.log(
+    `✅ import 完成: 写入 ${result.applied.length} 个, 跳过 ${result.skipped.length} 个 ` +
+    `(共 ${result.totalFiles} 个, conflict=${conflict})`,
+  );
 }
 
 // Run the CLI only when invoked directly or via the thin bin launcher
@@ -136,7 +248,7 @@ const isCliEntry = process.argv[1] !== undefined && (
 );
 if (isCliEntry) {
   main().catch((err) => {
-    console.error(`❌ import dry-run 失败: ${err instanceof Error ? err.message : String(err)}`);
+    console.error(`❌ import 失败: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   });
 }

--- a/MemoryCore/scripts/import-memory/tsconfig.json
+++ b/MemoryCore/scripts/import-memory/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "..",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["import-memory.ts", "../export-memory/manifest.ts"],
+  "exclude": ["dist", "node_modules", "docs"]
+}


### PR DESCRIPTION
Extends #779's export workflow to the **skill** asset (in addition to chat-memory from #793/#795/#796).

> This head branch contains steps 1–3 + this change; **the incremental diff of this PR is the skill-asset support.**

## What

`npm run export-memory -- --asset skill` (or `all`, the default) now includes the skill asset:

- `--asset chat-memory|skill|all` (default `all`)
- `buildExportBundle` collects head skill rows from the `skills` table in `vectors.db` into `skills.jsonl`
- each skill's resource files are packed from its `storage_dir` under `skills/resources/<n>/`
- the manifest carries a second asset entry `type: "skill"` alongside `chat-memory`

No changes to the manifest schema — `skill` was already in the `memoryAssetTypeSchema` enum.

## Verification

- `tsc -p scripts/export-memory/tsconfig.json` passes
- 2 new tests in `__tests__/export-memory/export-skill.test.ts` (skill-only export with `skills.jsonl` + resources + manifest; combined chat-memory+skill) — export/import suite now **20 tests**, all passing

## Out of scope

`llm-wiki` / `code-graph` live in the **separate `MemoryKnowledge`** module (`knowledge.db` + wiki assets + git repos), not in MemoryCore's data dir — their export belongs in a MemoryKnowledge-side tool, out of scope here.