### PR TITLE
feat(knowledge): export llm-wiki / code-graph assets (#779)

### DIFF
--- a/MemoryKnowledge/README.md
+++ b/MemoryKnowledge/README.md
@@ -94,6 +94,10 @@ pnpm dev:mcp      # MCP stdio（另开终端；需 HTTP 已起）
 pnpm typecheck
 pnpm test
 pnpm build        # tsdown → dist/
+
+# 导出 llm-wiki / code-graph 资产为可移植 ZIP（issue #779，MemoryKnowledge 侧）
+pnpm build:export-knowledge
+pnpm export-knowledge -- --data-dir ./data --out ./knowledge-backup.zip --asset all
 ```
 
 ## 可选：Langfuse

--- a/MemoryKnowledge/__tests__/export-knowledge/export-knowledge.test.ts
+++ b/MemoryKnowledge/__tests__/export-knowledge/export-knowledge.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for #779 — MemoryKnowledge-side export of llm-wiki / code-graph
+ * assets into a portable ZIP bundle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import JSZip from "jszip";
+
+import { buildKnowledgeBundle } from "../../scripts/export-knowledge/export-knowledge.js";
+
+describe("buildKnowledgeBundle (#779)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "tdai-kb-"));
+    const db = new DatabaseSync(join(dataDir, "knowledge.db"));
+
+    db.exec(`
+      CREATE TABLE knowledge_wiki (
+        wiki_id TEXT PRIMARY KEY, service_id TEXT NOT NULL, team_id TEXT NOT NULL,
+        name TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'draft', version INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL, deleted_at TEXT
+      );
+      CREATE TABLE knowledge_code_graph (
+        code_graph_id TEXT PRIMARY KEY, service_id TEXT NOT NULL, team_id TEXT NOT NULL,
+        repo_url TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', version INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL, deleted_at TEXT
+      );
+    `);
+    db.prepare(
+      "INSERT INTO knowledge_wiki (wiki_id, service_id, team_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, 't', 't')",
+    ).run("wiki-1", "svc", "team-x", "onboarding");
+
+    // wiki material dir: dataDir/<service_id>/<team_id>/<wiki_id>/
+    const wikiDir = join(dataDir, "svc", "team-x", "wiki-1");
+    mkdirSync(wikiDir, { recursive: true });
+    writeFileSync(join(wikiDir, "index.db"), "fake-index");
+    writeFileSync(join(wikiDir, "onboarding.md"), "# Onboarding guide");
+
+    // code-graph row + dir
+    db.prepare(
+      "INSERT INTO knowledge_code_graph (code_graph_id, service_id, team_id, repo_url, created_at, updated_at) VALUES (?, ?, ?, ?, 't', 't')",
+    ).run("cg-1", "svc", "team-x", "https://example.com/repo");
+    const cgDir = join(dataDir, "svc", "team-x", "cg-1");
+    mkdirSync(join(cgDir, "symbols"), { recursive: true });
+    writeFileSync(join(cgDir, "symbols", "a.json"), "{}");
+
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("exports llm-wiki + code-graph with metadata and material", async () => {
+    const { manifest, zip } = await buildKnowledgeBundle({ dataDir, instanceId: "inst" });
+
+    const types = manifest.assets.map((a) => a.type);
+    expect(types).toContain("llm-wiki");
+    expect(types).toContain("code-graph");
+
+    const wiki = manifest.assets.find((a) => a.type === "llm-wiki")!;
+    expect(wiki.files.some((f) => f.path === "knowledge_wiki.jsonl")).toBe(true);
+    expect(wiki.files.some((f) => f.path.endsWith("wiki/svc/team-x/wiki-1/onboarding.md"))).toBe(true);
+    expect(wiki.files.some((f) => f.path.endsWith("wiki/svc/team-x/wiki-1/index.db"))).toBe(true);
+
+    const cg = manifest.assets.find((a) => a.type === "code-graph")!;
+    expect(cg.files.some((f) => f.path.endsWith("code-graph/svc/team-x/cg-1/symbols/a.json"))).toBe(true);
+
+    const z = await JSZip.loadAsync(zip);
+    expect(z.file("manifest.json")).toBeTruthy();
+    const jsonl = await z.file("knowledge_wiki.jsonl")!.async("string");
+    expect(JSON.parse(jsonl.split("\n")[0]).name).toBe("onboarding");
+  });
+
+  it("exports only the requested asset kind", async () => {
+    const { manifest } = await buildKnowledgeBundle({ dataDir, assets: ["llm-wiki"] });
+    expect(manifest.assets.map((a) => a.type)).toEqual(["llm-wiki"]);
+  });
+});

--- a/MemoryKnowledge/bin/export-knowledge.mjs
+++ b/MemoryKnowledge/bin/export-knowledge.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// 薄启动器：加载预编译好的 knowledge export 脚本。
+// 构建：npm run build:export-knowledge
+// 使用：npm run export-knowledge -- --data-dir <dir> --out <bundle.zip> [--asset llm-wiki|code-graph|all]
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const entryScript = path.resolve(thisDir, "../scripts/export-knowledge/dist/export-knowledge.js");
+
+if (!fs.existsSync(entryScript)) {
+  console.error("❌  预编译产物不存在: " + entryScript);
+  console.error("   请先执行: npm run build:export-knowledge");
+  process.exit(1);
+}
+
+import(entryScript);

--- a/MemoryKnowledge/package.json
+++ b/MemoryKnowledge/package.json
@@ -6,12 +6,15 @@
   "main": "./dist/server.js",
   "bin": {
     "knowledge-server": "./bin/server.mjs",
-    "knowledge-mcp": "./bin/mcp.mjs"
+    "knowledge-mcp": "./bin/mcp.mjs",
+    "export-knowledge": "./bin/export-knowledge.mjs"
   },
   "scripts": {
     "dev": "tsx src/server.ts",
     "dev:mcp": "tsx src/mcp/server.ts",
     "build": "tsdown",
+    "build:export-knowledge": "tsc --project scripts/export-knowledge/tsconfig.json",
+    "export-knowledge": "node ./bin/export-knowledge.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -46,6 +49,7 @@
     "js-tiktoken": "^1.0.18",
     "js-yaml": "^4.2.0",
     "json5": "^2.2.3",
+    "jszip": "^3.10.1",
     "lru-cache": "^11.0.0",
     "minisearch": "^7.2.0",
     "simple-git": "^3.36.0",

--- a/MemoryKnowledge/scripts/export-knowledge/export-knowledge.ts
+++ b/MemoryKnowledge/scripts/export-knowledge/export-knowledge.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * memory knowledge export — export llm-wiki / code-graph assets to a
+ * portable ZIP bundle (issue #779, MemoryKnowledge side).
+ *
+ * Chat-memory + skill export live in MemoryCore (scripts/export-memory); the
+ * wiki / code-graph assets live in this module's data dir, so they get their
+ * own exporter. The bundle format is identical to MemoryCore's export
+ * (manifest.json with schema_version + assets[].type + per-file sha256).
+ *
+ * Usage:
+ *   node ./bin/export-knowledge.mjs --data-dir ./data --out ./knowledge-backup.zip
+ *   node ./bin/export-knowledge.mjs --data-dir ./data --out ./kb.zip --asset llm-wiki
+ *
+ * Data layout read from the data directory:
+ *   knowledge.db                                        (SQLite metadata)
+ *   <service_id>/<team_id>/<wiki_id>/                   (wiki material + index.db)
+ *   <service_id>/<team_id>/<code_graph_id>/             (code-graph index)
+ */
+
+import fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import { parseArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+import JSZip from "jszip";
+
+const MANIFEST_SCHEMA_VERSION = "1.0.0";
+
+interface FileEntry {
+  path: string;
+  checksum: string;
+  size: number;
+}
+
+export interface KnowledgeExportOptions {
+  /** Root data directory (contains knowledge.db + per-tenant dirs). */
+  dataDir: string;
+  /** knowledge.db path (default <dataDir>/knowledge.db). */
+  dbPath?: string;
+  /** Instance id recorded in the manifest (default "default"). */
+  instanceId?: string;
+  /** Which assets to export: "llm-wiki" | "code-graph" | "all" (default all). */
+  assets?: ("llm-wiki" | "code-graph")[];
+}
+
+export interface KnowledgeExportResult {
+  manifest: {
+    schema_version: string;
+    created_at: string;
+    source_instance_id?: string;
+    assets: {
+      type: string;
+      id: string;
+      files: FileEntry[];
+    }[];
+  };
+  zip: Buffer;
+}
+
+async function sha256(content: Buffer): Promise<string> {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/** Recursively add every file under dirPath to the ZIP under prefix. */
+async function collectDir(
+  zip: JSZip,
+  dirPath: string,
+  prefix: string,
+  out: FileEntry[],
+): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return; // directory absent → nothing to collect
+  }
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const e of entries) {
+    const full = path.join(dirPath, e.name);
+    const rel = `${prefix}/${e.name}`;
+    if (e.isDirectory()) {
+      await collectDir(zip, full, rel, out);
+    } else {
+      const content = await fs.readFile(full);
+      zip.file(rel, content);
+      out.push({ path: rel, checksum: `sha256:${await sha256(content)}`, size: content.length });
+    }
+  }
+}
+
+/** Read all rows of a knowledge_* table as plain objects. */
+function readTableRows(
+  dbPath: string,
+  table: "knowledge_wiki" | "knowledge_code_graph",
+): Record<string, unknown>[] {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return db.prepare(`SELECT * FROM ${table}`).all() as Record<string, unknown>[];
+  } finally {
+    db.close();
+  }
+}
+
+export async function buildKnowledgeBundle(
+  opts: KnowledgeExportOptions,
+): Promise<KnowledgeExportResult> {
+  const zip = new JSZip();
+  const dataDir = path.resolve(opts.dataDir);
+  const dbPath = opts.dbPath ?? path.join(dataDir, "knowledge.db");
+  const assetId = opts.instanceId ?? "default";
+  const kinds = opts.assets ?? ["llm-wiki", "code-graph"];
+  const manifestAssets: { type: string; id: string; files: FileEntry[] }[] = [];
+
+  if (kinds.includes("llm-wiki")) {
+    const rows = readTableRows(dbPath, "knowledge_wiki");
+    if (rows.length > 0) {
+      const jsonl = rows.map((r) => JSON.stringify(r)).join("\n");
+      zip.file("knowledge_wiki.jsonl", jsonl);
+      const files: FileEntry[] = [{
+        path: "knowledge_wiki.jsonl",
+        checksum: `sha256:${await sha256(Buffer.from(jsonl))}`,
+        size: Buffer.byteLength(jsonl),
+      }];
+      for (const row of rows) {
+        if (typeof row.service_id !== "string" || typeof row.team_id !== "string"
+          || typeof row.wiki_id !== "string") continue;
+        await collectDir(
+          zip,
+          path.join(dataDir, row.service_id, row.team_id, row.wiki_id),
+          `wiki/${row.service_id}/${row.team_id}/${row.wiki_id}`,
+          files,
+        );
+      }
+      manifestAssets.push({ type: "llm-wiki", id: assetId, files });
+    }
+  }
+
+  if (kinds.includes("code-graph")) {
+    const rows = readTableRows(dbPath, "knowledge_code_graph");
+    if (rows.length > 0) {
+      const jsonl = rows.map((r) => JSON.stringify(r)).join("\n");
+      zip.file("knowledge_code_graph.jsonl", jsonl);
+      const files: FileEntry[] = [{
+        path: "knowledge_code_graph.jsonl",
+        checksum: `sha256:${await sha256(Buffer.from(jsonl))}`,
+        size: Buffer.byteLength(jsonl),
+      }];
+      for (const row of rows) {
+        if (typeof row.service_id !== "string" || typeof row.team_id !== "string"
+          || typeof row.code_graph_id !== "string") continue;
+        await collectDir(
+          zip,
+          path.join(dataDir, row.service_id, row.team_id, row.code_graph_id),
+          `code-graph/${row.service_id}/${row.team_id}/${row.code_graph_id}`,
+          files,
+        );
+      }
+      manifestAssets.push({ type: "code-graph", id: assetId, files });
+    }
+  }
+
+  if (manifestAssets.length === 0) {
+    throw new Error("未找到可导出的知识资产（knowledge_wiki / knowledge_code_graph 为空）");
+  }
+
+  const manifest = {
+    schema_version: MANIFEST_SCHEMA_VERSION,
+    created_at: new Date().toISOString(),
+    ...(opts.instanceId ? { source_instance_id: opts.instanceId } : {}),
+    assets: manifestAssets,
+  };
+  zip.file("manifest.json", JSON.stringify(manifest, null, 2));
+
+  const buf = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+  return { manifest, zip: buf };
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      "data-dir": { type: "string", short: "d" },
+      "db-path": { type: "string" },
+      "out": { type: "string", short: "o", required: true },
+      "instance-id": { type: "string" },
+      asset: { type: "string", default: "all" },
+    },
+  });
+
+  const dataDir = values["data-dir"] ?? process.env.KNOWLEDGE_DATA_DIR ?? "./data";
+  const raw = (values["asset"] ?? "all") as string;
+  const kinds = raw === "all"
+    ? undefined
+    : [raw as "llm-wiki" | "code-graph"];
+
+  const { manifest, zip } = await buildKnowledgeBundle({
+    dataDir,
+    dbPath: values["db-path"],
+    instanceId: values["instance-id"],
+    assets: kinds,
+  });
+
+  const outPath = values["out"] as string;
+  await fs.mkdir(path.dirname(path.resolve(outPath)), { recursive: true });
+  await fs.writeFile(outPath, zip);
+
+  const totalBytes = manifest.assets.reduce(
+    (sum, a) => sum + a.files.reduce((s, f) => s + f.size, 0),
+    0,
+  );
+  const totalFiles = manifest.assets.reduce((sum, a) => sum + a.files.length, 0);
+  console.log(`✅ 导出完成 → ${outPath}`);
+  for (const asset of manifest.assets) {
+    console.log(`   资产: ${asset.type} (id=${asset.id}, files=${asset.files.length})`);
+  }
+  console.log(`   文件: ${totalFiles} 个 (${totalBytes} bytes)`);
+  console.log(`   schema_version: ${manifest.schema_version}`);
+}
+
+// Run the CLI only when invoked directly or via the thin bin launcher.
+const isCliEntry = process.argv[1] !== undefined && (
+  import.meta.url === pathToFileURL(process.argv[1]).href
+  || process.argv[1].endsWith("bin/export-knowledge.mjs")
+);
+if (isCliEntry) {
+  main().catch((err) => {
+    console.error(`❌ 导出失败: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/MemoryKnowledge/scripts/export-knowledge/tsconfig.json
+++ b/MemoryKnowledge/scripts/export-knowledge/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["export-knowledge.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Extends #779's export/import workflow to the **llm-wiki** and **code-graph** assets. These live in the **MemoryKnowledge** module (chat-memory + skill are covered by MemoryCore's `export-memory`, PRs #793/#795/#796/#797).

## What

`npm run export-knowledge` (MemoryKnowledge) exports wiki + code-graph into a portable ZIP bundle **in the same format as MemoryCore's export** (so a future shared import can consume all four asset types):

- `buildKnowledgeBundle()` reads `knowledge_wiki` / `knowledge_code_graph` from `knowledge.db` into JSONL
- packs each row's material dir (`<service_id>/<team_id>/<wiki_id|code_graph_id>/`, e.g. `index.db`, wiki markdown, code-graph index) recursively
- writes `manifest.json` with `schema_version` + `assets[].type: llm-wiki | code-graph` + per-file sha256 checksums
- CLI: `--asset llm-wiki|code-graph|all`, `--data-dir` (or `KNOWLEDGE_DATA_DIR`)

### Wiring
`scripts/export-knowledge/` (independent `tsc` script), `bin/export-knowledge.mjs` thin launcher, `package.json` (`build:export-knowledge` / `export-knowledge` bin + script, `jszip` dep), README.

## Verification

- `tsc -p scripts/export-knowledge/tsconfig.json` passes
- 2 tests in `__tests__/export-knowledge/` (both assets with metadata + material; `--asset` filtering) pass
- CLI end-to-end: exports `knowledge_wiki.jsonl` + `wiki/…` + `knowledge_code_graph.jsonl` + `code-graph/…` + `manifest.json`

## Scope

Export only, on the MemoryKnowledge side. A shared cross-module import tool (all four asset types) could be a follow-up — the bundle format is already aligned via `manifest.json`.