### PR TITLE
fix(knowledge): remove redundant bodyCache writes to fix typecheck (#…

### DIFF
--- a/MemoryKnowledge/src/middleware/response-envelope.ts
+++ b/MemoryKnowledge/src/middleware/response-envelope.ts
@@ -38,14 +38,14 @@ export function accessLog(): MiddlewareHandler {
     c.set("requestId", requestId);
 
     // 缓存 request body（body 只能读一次，失败时用于日志）
-    // Hono 的 bodyCache 期望 Promise（c.req.json()/text() 会对缓存值调 .then()）
+    // 注意：c.req.text() 内部已把 body 缓存为 Promise（bodyCache），后续 handler 的
+    // c.req.json()/text() 会复用该缓存，手动写入本就是多余的；且 Hono 发布类型中
+    // text 为 string，赋 Promise 会报 TS2322，故不要手动写 bodyCache。
     let reqBody: unknown = undefined;
     if (c.req.method === 'POST' || c.req.method === 'PUT') {
       try {
         const raw = await c.req.text();
         reqBody = raw ? JSON.parse(raw) : undefined;
-        c.req.bodyCache.text = Promise.resolve(raw);
-        if (reqBody) c.req.bodyCache.json = Promise.resolve(reqBody);
       } catch {
         // 非 JSON body，忽略
       }


### PR DESCRIPTION
## Description
 
Fixes the `MemoryKnowledge` typecheck failure reported in #784. Before this change, `npm run typecheck` (`tsc --noEmit`) always failed with a pre-existing error:
 
```
src/middleware/response-envelope.ts(47,9): error TS2322: Type 'Promise<string>' is not assignable to type 'string'.
```
 
### Root cause — Hono type/runtime mismatch
 
Line 47 was `c.req.bodyCache.text = Promise.resolve(raw);` in the `accessLog()` middleware.
 
- **Runtime**: Hono caches request bodies as **Promises** in `c.req.bodyCache`. `c.req.text()` stores `bodyCache.text = raw.text()` (a `Promise<string>`), and `#cachedBody()` calls `.then()` on cached values — e.g. `json()` does `#cachedBody("text").then(JSON.parse)`.
- **Types**: Hono's published `.d.ts` declares `BodyCache = Partial<Body>` with `text: string`, so assigning a `Promise<string>` triggers TS2322. This mismatch exists across the project's whole Hono range (4.7.0 → 4.13.0).
- The manual cache writes were **redundant**: `await c.req.text()` in the middleware already populates the cache, so the subsequent writes were a no-op. The `json` write was additionally dead in current Hono (`json()` re-parses from the cached text; when the key is absent it falls back to the same re-parse).
- ⚠️ The naive fix (assigning the raw string `bodyCache.text = raw`) would pass typecheck but **break at runtime**: downstream `c.req.json()` calls `.then()` on the cached value and would throw `TypeError: ...then is not a function`. That is why we remove the writes instead of "awaiting" them.
 
### Fix
 
Remove the two redundant manual `bodyCache` writes and update the stale comment:
 
```diff
       const raw = await c.req.text();
       reqBody = raw ? JSON.parse(raw) : undefined;
-      c.req.bodyCache.text = Promise.resolve(raw);
-      if (reqBody) c.req.bodyCache.json = Promise.resolve(reqBody);
```
 
## Related Issue
 
Fixes #784
 
## Change Type
 
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code optimization
 
## Self-test Checklist
 
- [x] Verified locally — `cd MemoryKnowledge && npm run typecheck` now exits 0 (failed with exactly one error before)
- [x] No existing features affected — runtime smoke-tested on Hono 4.7.0 and 4.13.0
 
## Additional Notes
 
**Validation performed:**
 
1. **Reproduced the failure** on `feat/server_team` (v2.0.0) before the fix: full-project `npm run typecheck` reported exactly one error at `response-envelope.ts(47,9)` — confirming the issue's claim that this error masked new type errors.
2. **After the fix**: full-project `npm run typecheck` passes (exit 0).
3. **Runtime behavior preserved**: a Hono smoke test (middleware consumes `c.req.text()`, downstream handler calls `c.req.json()`) returns the correctly parsed body on both Hono **4.7.0** (minimum of the `^4.7.0` range) and **4.13.0** (latest resolved). Edge cases (non-JSON body, falsy body, form body) behave identically before/after.
 
**Notes:**
 
- No lockfile changes; verification dependencies were installed with `--ignore-scripts --no-package-lock` (`node_modules` is gitignored).
- A full `npm install` with native builds requires a working node-gyp toolchain for `better-sqlite3`.