### PR TITLE
fix: add root pnpm-workspace.yaml to resolve missing packages field e…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "MemoryCore"
+  - "MemoryKnowledge"
+  - "MemoryPanel"
+  - "MemoryProxy"
+  - "sdk/memory-core/typescript"


### PR DESCRIPTION
…rror

### Description | 描述

Fixes an issue where running `pnpm install` at the root directory throws:
**Root Cause:**
- Missing `pnpm-workspace.yaml` file
- pnpm could not recognize monorepo package structure

**Solution:**
- Added `pnpm-workspace.yaml` at the root
- Declared workspace paths explicitly:
  - `MemoryCore`
  - `MemoryKnowledge`
  - `MemoryPanel`
  - `MemoryProxy`
  - `sdk/memory-core/typescript`


**Result:**
- pnpm now correctly resolves and links dependencies across all sub-projects

**中文说明：**

修复了在项目根目录执行 `pnpm install` 时出现：

**问题原因：**
- 缺少 `pnpm-workspace.yaml` 工作空间配置文件
- pnpm 无法识别子项目结构

**解决方案：**
- 在根目录新增 `pnpm-workspace.yaml`
- 明确声明所有工作空间路径

**结果：**
- pnpm 可以正确解析并安装所有子项目依赖


### Related Issue | 关联 Issue
- N/A

---

### Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

---

### Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过  
  (`pnpm install` runs successfully without errors)

- [x] No existing features affected | 无影响现有功能  
  (Only introduces configuration file)


### Additional Notes | 其他说明
- This fix is **critical for new contributors**
- Ensures smooth setup when cloning the repository using `pnpm`