### PR TITLE
security: fix auth bypass, unauthenticated admin endpoints, SSRF, git injection (#672)

### DIFF
--- a/MemoryKnowledge/__tests__/source-fetcher/git-fetcher.test.ts
+++ b/MemoryKnowledge/__tests__/source-fetcher/git-fetcher.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Security tests for #672 — GitSourceFetcher:
+ *   - CWE-88 argument injection: sourceUrl must be a plain https URL
+ *   - CWE-918 SSRF: private / loopback / link-local hosts rejected
+ */
+
+import { describe, expect, it } from "vitest";
+import { GitSourceFetcher } from "../../src/source-fetcher/git-fetcher.js";
+
+describe("GitSourceFetcher security (#672)", () => {
+  it("rejects non-https URLs", async () => {
+    const f = new GitSourceFetcher({ ssrfCheck: false });
+    await expect(f.validate("ssh://git@github.com/x/y.git")).rejects.toThrow(/HTTPS/);
+    await expect(f.validate("http://github.com/x/y.git")).rejects.toThrow(/HTTPS/);
+  });
+
+  it("rejects URLs carrying CLI args (argument injection, CWE-88)", async () => {
+    const f = new GitSourceFetcher({ ssrfCheck: false });
+    // Spaces / git options appended to the URL would be parsed by git.
+    await expect(f.validate("https://github.com/x/y.git --upload-pack=echo")).rejects.toThrow(/plain https URL/);
+    await expect(f.validate("https://github.com/x/y.git -c core.pager=cat")).rejects.toThrow(/plain https URL/);
+    await expect(f.validate("https://github.com/x/y.git --depth 1")).rejects.toThrow(/plain https URL/);
+  });
+
+  it("rejects literal private / loopback IP hosts (SSRF, CWE-918)", async () => {
+    const f = new GitSourceFetcher({ ssrfCheck: true });
+    await expect(f.validate("https://169.254.169.254/latest/meta-data/")).rejects.toThrow(/private\/loopback/);
+    await expect(f.validate("https://10.0.0.1/repo.git")).rejects.toThrow(/private\/loopback/);
+    await expect(f.validate("https://127.0.0.1/repo.git")).rejects.toThrow(/private\/loopback/);
+  });
+
+  it("accepts a plain public https URL", async () => {
+    const f = new GitSourceFetcher({ ssrfCheck: false });
+    await expect(f.validate("https://github.com/user/repo.git")).resolves.toBeUndefined();
+  });
+});

--- a/MemoryKnowledge/src/source-fetcher/git-fetcher.ts
+++ b/MemoryKnowledge/src/source-fetcher/git-fetcher.ts
@@ -54,11 +54,19 @@ export class GitSourceFetcher implements ISourceFetcher {
     this.ssrfCheck = opts?.ssrfCheck ?? ssrfCheckEnabledFromEnv();
   }
 
-  validate(sourceUrl: string): void {
+  async validate(sourceUrl: string): Promise<void> {
     // 第一版：仅支持 public HTTPS 仓库（SSH / 私有仓库鉴权见文档 005）。
     if (!sourceUrl.startsWith("https://")) {
       throw new Error(
         "first version only supports public HTTPS repos; SSH/private repo support coming soon",
+      );
+    }
+    // 防 git 参数注入：sourceUrl 必须是纯 https URL，不允许空白/控制字符/CLI 参数
+    // （如 "--upload-pack=..."、"-c ..." 会被 simple-git 当作 git 选项，issue #672 CWE-88）。
+    const PLAIN_URL_RE = /^https:\/\/[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$/;
+    if (!PLAIN_URL_RE.test(sourceUrl)) {
+      throw new Error(
+        `invalid repo_url: must be a plain https URL without spaces or CLI args: ${sourceUrl}`,
       );
     }
     const host = this.extractHost(sourceUrl);
@@ -66,13 +74,20 @@ export class GitSourceFetcher implements ISourceFetcher {
       throw new Error(`invalid repo_url: cannot parse host from ${sourceUrl}`);
     }
     // R2: SSRF 防护 —— 禁止指向内网 / 环回地址（可经 KNOWLEDGE_SSRF_CHECK=off 关闭）。
-    if (this.ssrfCheck && this.isPrivateAddress(host)) {
-      throw new Error(`repo_url must not point to private/loopback address: ${host}`);
+    // 同时把 hostname 解析成实际 IP 再校验，防止 DNS rebinding / 通配符 DNS 绕过
+    // 字面量正则（issue #672 CWE-918）。
+    if (this.ssrfCheck) {
+      const privateIps = await this.resolvePrivateIps(host);
+      if (privateIps.length > 0) {
+        throw new Error(
+          `repo_url must not point to private/loopback address: ${host} (resolved to ${privateIps.join(", ")})`,
+        );
+      }
     }
   }
 
   async fetch(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
-    this.validate(sourceUrl);
+    await this.validate(sourceUrl);
     // 浅克隆单分支。注：git clone/fetch 不会拉取远端的 .git/hooks（hooks 是本地态），
     // 所以正常仓库 clone 出来不带可执行钩子；此处不再配置 core.hooksPath
     // （加固版 git 会拒绝该配置：需 allowUnsafeHooksPath）。
@@ -85,7 +100,7 @@ export class GitSourceFetcher implements ISourceFetcher {
   }
 
   async sync(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
-    this.validate(sourceUrl);
+    await this.validate(sourceUrl);
     const git = simpleGit(localPath);
     await git.fetch("origin", branch, { "--depth": 1 });
     await git.reset(ResetMode.HARD, [`origin/${branch}`]);
@@ -116,5 +131,26 @@ export class GitSourceFetcher implements ISourceFetcher {
 
   private isPrivateAddress(host: string): boolean {
     return PRIVATE_ADDR_RE.test(host);
+  }
+
+  /**
+   * Resolve a hostname to its IPs and return any that fall in private /
+   * loopback / link-local ranges. Guards against DNS rebinding where a domain
+   * resolves to internal or cloud-metadata addresses (169.254.169.254 etc.)
+   * that the literal-hostname regex would miss (issue #672, CWE-918).
+   */
+  private async resolvePrivateIps(host: string): Promise<string[]> {
+    const { lookup } = await import("node:dns/promises");
+    const privateIps: string[] = [];
+    try {
+      const entries = await lookup(host, { all: true });
+      for (const entry of entries) {
+        if (this.isPrivateAddress(entry.address)) privateIps.push(entry.address);
+      }
+    } catch {
+      // DNS resolution failure — the URL-level checks already passed; let git
+      // attempt the fetch and surface its own error.
+    }
+    return privateIps;
   }
 }

--- a/MemoryProxy/src/__tests__/admin-auth.test.ts
+++ b/MemoryProxy/src/__tests__/admin-auth.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Security tests for #672 (CWE-287) — checkAdminAuth must deny by default when
+ * admin.apiKey is unconfigured.
+ */
+
+import { describe, expect, it } from "vitest";
+import { checkAdminAuth } from "../routes/admin-auth.js";
+
+function ctx(header?: string): any {
+  return {
+    req: {
+      header: (name: string) =>
+        name.toLowerCase() === "authorization" ? header : undefined,
+    },
+  };
+}
+
+describe("checkAdminAuth (#672)", () => {
+  it("denies when admin.apiKey is unconfigured (default deny)", () => {
+    expect(checkAdminAuth(ctx("Bearer whatever"), "")).toBe("missing");
+  });
+
+  it("accepts a matching Bearer token", () => {
+    expect(checkAdminAuth(ctx("Bearer secret"), "secret")).toBe("ok");
+  });
+
+  it("rejects a wrong token", () => {
+    expect(checkAdminAuth(ctx("Bearer wrong"), "secret")).toBe("invalid");
+  });
+
+  it("rejects a missing Authorization header", () => {
+    expect(checkAdminAuth(ctx(), "secret")).toBe("missing");
+  });
+});

--- a/MemoryProxy/src/__tests__/rate-limits.test.ts
+++ b/MemoryProxy/src/__tests__/rate-limits.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Security tests for #672 (CWE-306) — /v3/admin/rate-limits must require the
+ * admin.apiKey bearer token.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { createRateLimitHandlers } from "../routes/rate-limits.js";
+
+const cfg = {
+  admin: { apiKey: "adminkey" },
+  rateLimit: { tpm: 1000, qpm: 100 },
+} as any;
+
+describe("rate-limit admin endpoints require auth (#672)", () => {
+  it("rejects an unauthenticated GET", async () => {
+    const app = new Hono();
+    app.get("/v3/admin/rate-limits", createRateLimitHandlers(cfg).get);
+    const res = await app.request("/v3/admin/rate-limits");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects unauthenticated PUT / DELETE", async () => {
+    const app = new Hono();
+    const handlers = createRateLimitHandlers(cfg);
+    app.put("/v3/admin/rate-limits", handlers.put);
+    app.delete("/v3/admin/rate-limits", handlers.delete);
+
+    expect((await app.request("/v3/admin/rate-limits", { method: "PUT" })).status).toBe(401);
+    expect((await app.request("/v3/admin/rate-limits", { method: "DELETE" })).status).toBe(401);
+  });
+
+  it("passes auth through with a valid admin key", async () => {
+    const app = new Hono();
+    app.get("/v3/admin/rate-limits", createRateLimitHandlers(cfg).get);
+    const res = await app.request("/v3/admin/rate-limits", {
+      headers: { Authorization: "Bearer adminkey" },
+    });
+    // With a valid key the request reaches the handler — it must NOT be 401.
+    expect(res.status).not.toBe(401);
+  });
+});

--- a/MemoryProxy/src/routes/admin-auth.ts
+++ b/MemoryProxy/src/routes/admin-auth.ts
@@ -5,7 +5,10 @@ export type AdminAuthResult = "ok" | "missing" | "invalid";
 
 /** Shared Bearer authentication for proxy administration endpoints. */
 export function checkAdminAuth(c: Context, expected: string): AdminAuthResult {
-  if (!expected) return "ok";
+  // Deny by default when admin.apiKey is not configured — operational admin
+  // routes (proxy-destroy, rate-limit overrides, ...) must never be reachable
+  // without an explicitly configured key (issue #672, CWE-287).
+  if (!expected) return "missing";
 
   const header = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
   if (!header.startsWith("Bearer ")) return "missing";

--- a/MemoryProxy/src/routes/rate-limits.ts
+++ b/MemoryProxy/src/routes/rate-limits.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ProxyConfig } from "../types.js";
 import { assertKeySegment } from "../storage/key-utils.js";
 import { getRateLimitStore } from "../rate-limit/guard.js";
+import { adminAuthError, checkAdminAuth } from "./admin-auth.js";
 
 interface RateLimitBody {
   instance_id?: unknown;
@@ -11,10 +12,18 @@ interface RateLimitBody {
 }
 
 export function createRateLimitHandlers(config: ProxyConfig) {
+  // Admin endpoints must require the admin.apiKey bearer token — otherwise any
+  // network caller can tamper with tenant rate limits (issue #672, CWE-306).
+  const enforceAuth = (c: Context): Response | null => {
+    const result = checkAdminAuth(c, config.admin.apiKey);
+    if (result !== "ok") return adminAuthError(c, result);
+    return null;
+  };
+
   return {
-    get: (c: Context) => handleGet(c, config),
-    put: (c: Context) => handlePut(c, config),
-    delete: (c: Context) => handleDelete(c, config),
+    get: (c: Context) => enforceAuth(c) || handleGet(c, config),
+    put: (c: Context) => enforceAuth(c) || handlePut(c, config),
+    delete: (c: Context) => enforceAuth(c) || handleDelete(c, config),
   };
 }
 


### PR DESCRIPTION
Fixes #672 — CRITICAL security advisory (4 vulnerabilities, 2 modules).

## 1. [CRITICAL] Unauthenticated `/v3/admin/rate-limits` (CWE-306) — `MemoryProxy`

`GET/PUT/DELETE /v3/admin/rate-limits` ran without any auth; any network caller could tamper with tenant rate limits. Wrapped the handlers with `checkAdminAuth`.

## 2. [CRITICAL] Auth bypass when `admin.apiKey` unconfigured (CWE-287) — `MemoryProxy`

`checkAdminAuth` returned `"ok"` when `admin.apiKey` was empty, leaving `POST /v3/instance/proxy-destroy` publicly reachable. **Deny by default** when no key is configured.

## 3. [HIGH] DNS-rebinding SSRF (CWE-918) — `MemoryKnowledge`

`GitSourceFetcher` matched only literal IP strings, so hostnames resolving to private / link-local / `169.254.169.254` (via wildcard DNS) bypassed the check. Now resolves the hostname with `node:dns/promises` and rejects any resolved IP in private ranges.

## 4. [HIGH] Git argument injection (CWE-88) — `MemoryKnowledge`

`sourceUrl` was passed straight to `simpleGit().clone()`; a trailing `--upload-pack=…` / `-c …` was parsed as git options. Reject URLs that are not plain `https` URLs without whitespace / CLI args.

## Tests

- `MemoryProxy/src/__tests__/admin-auth.test.ts` (4): default-deny without key, matching / wrong / missing token
- `MemoryProxy/src/__tests__/rate-limits.test.ts` (3): 401 without a key (GET/PUT/DELETE), auth passes through with a valid key
- `MemoryKnowledge/__tests__/source-fetcher/git-fetcher.test.ts` (4): non-https + CLI-arg URLs rejected, literal private IPs rejected, plain public https accepted

All passing. Verified `tsc` on both modules — only pre-existing errors remain (none in the touched files).