### PR TITLE
fix(recall): degrade hybrid strategy to keyword when EmbeddingService is absent

### DIFF
--- a/MemoryCore/src/core/hooks/auto-recall.test.ts
+++ b/MemoryCore/src/core/hooks/auto-recall.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Tests for #579 — hybrid recall must degrade to keyword-only when the
+ * EmbeddingService is unavailable, instead of erroring every turn.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveStrategy } from "./auto-recall.js";
+
+describe("resolveEffectiveStrategy (#579)", () => {
+  it("keeps keyword unchanged (with or without embeddings)", () => {
+    expect(resolveEffectiveStrategy("keyword", false)).toBe("keyword");
+    expect(resolveEffectiveStrategy("keyword", true)).toBe("keyword");
+  });
+
+  it("keeps hybrid when embeddings are available", () => {
+    expect(resolveEffectiveStrategy("hybrid", true)).toBe("hybrid");
+  });
+
+  it("degrades hybrid to keyword when the EmbeddingService is unavailable", () => {
+    expect(resolveEffectiveStrategy("hybrid", false)).toBe("keyword");
+  });
+
+  it("keeps embedding when embeddings are available", () => {
+    expect(resolveEffectiveStrategy("embedding", true)).toBe("embedding");
+  });
+
+  it("throws for embedding when the EmbeddingService is unavailable", () => {
+    expect(() => resolveEffectiveStrategy("embedding", false)).toThrow(/EmbeddingService/);
+  });
+});

--- a/MemoryCore/src/core/hooks/auto-recall.ts
+++ b/MemoryCore/src/core/hooks/auto-recall.ts
@@ -430,6 +430,34 @@ async function searchMemoriesWithDetails(
  *
  * Falls back to keyword if embedding resources are unavailable.
  */
+/**
+ * Resolve the effective recall strategy given whether an EmbeddingService is
+ * available.
+ *   - "embedding" + unavailable → throws RecallErrors.configMissingEmbedding
+ *   - "hybrid"   + unavailable → degrades to "keyword" (issue #579)
+ *   - otherwise                → unchanged
+ */
+export function resolveEffectiveStrategy(
+  strategy: "keyword" | "embedding" | "hybrid",
+  embeddingAvailable: boolean,
+  logger?: Logger,
+): "keyword" | "embedding" | "hybrid" {
+  if (strategy === "embedding" && !embeddingAvailable) {
+    // H-15: throw structured RecallFailure so the top-level catch in
+    // performAutoRecallInner can translate it into RecallResult.error
+    // (preserves fast-fail semantics + observability while keeping the
+    // hook contract "always resolves, never rejects").
+    throw RecallErrors.configMissingEmbedding(strategy);
+  }
+  if (strategy === "hybrid" && !embeddingAvailable) {
+    logger?.warn?.(
+      `${TAG} [recall] strategy=hybrid but EmbeddingService unavailable — degrading to keyword-only`,
+    );
+    return "keyword";
+  }
+  return strategy;
+}
+
 async function searchMemories(
   userText: string,
   pluginDataDir: string,
@@ -467,15 +495,9 @@ async function searchMemories(
     `maxResults=${maxResults}, threshold=${threshold}`,
   );
 
-  // Determine effective strategy — no degradation: if embedding is configured but unavailable, fail
-  let effectiveStrategy = strategy;
-  if ((strategy === "embedding" || strategy === "hybrid") && !embeddingAvailable) {
-    // H-15: throw structured RecallFailure so the top-level catch in
-    // performAutoRecallInner can translate it into RecallResult.error
-    // (preserves fast-fail semantics + observability while keeping the
-    // hook contract "always resolves, never rejects").
-    throw RecallErrors.configMissingEmbedding(strategy);
-  }
+  // Determine effective strategy (hybrid degrades to keyword-only without an
+  // EmbeddingService; embedding stays a hard failure) — issue #579.
+  const effectiveStrategy = resolveEffectiveStrategy(strategy, embeddingAvailable, logger);
 
   logger?.debug?.(`${TAG} Search strategy: ${effectiveStrategy} (configured: ${strategy})`);
 


### PR DESCRIPTION
Fixes #579.

## Problem

After an OpenClaw update, the default recall strategy became `"hybrid"`. For installs without an embedding provider, `searchMemories` threw `Recall strategy "hybrid" requires EmbeddingService but it is not available` on **every turn** — recall was completely broken (`code=10001` config error).

## Change

`hybrid` is keyword + embedding; without embeddings the keyword side still works. It now **gracefully degrades to keyword-only** with a warn log instead of erroring every recall.

- `"embedding"` stays a hard failure (explicit choice cannot be satisfied)
- `"hybrid"` + unavailable EmbeddingService → keyword-only
- Extracted `resolveEffectiveStrategy()` for testability

## Tests

`src/core/hooks/auto-recall.test.ts` (5): hybrid→keyword fallback, embedding hard-fails, keyword/hybrid/embedding unchanged when embeddings are available.

`npm test` passes, `npm run build:plugin` passes.