### PR TITLE
fix(hermes): bound Gateway stdout/stderr logs with a runtime rotation guard

### DIFF
--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/supervisor.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/supervisor.py
@@ -40,6 +40,13 @@ HEALTH_CHECK_RETRIES = 3     # retries for is_running check
 
 # Log file rotation parameters
 LOG_TAIL_BYTES_ON_CRASH = 2048  # bytes of stderr log to surface on startup crash
+# Runtime disk bound for Gateway stdout/stderr logs (issue #583): when an
+# active stream exceeds LOG_ACTIVE_MAX_BYTES, keep the last
+# LOG_TAIL_KEEP_BYTES as a bounded diagnostic tail in "<path>.1" and truncate
+# the active file in place (keeps the child's inherited descriptor valid).
+LOG_ACTIVE_MAX_BYTES = 10 * 1024 * 1024  # 10 MiB per stream
+LOG_TAIL_KEEP_BYTES = 1 * 1024 * 1024    # 1 MiB diagnostic tail preserved in .1
+LOG_GUARD_INTERVAL_S = 0.25              # guard poll interval
 
 # Startup single-flight state. The thread lock prevents multiple supervisor
 # instances in the same Python process from spawning the same Gateway
@@ -119,7 +126,9 @@ class GatewaySupervisor:
         # Gateway's event loop would block on write() after ~64 KB of logs).
         self._stdout_log: Optional[IO[bytes]] = None
         self._stderr_log: Optional[IO[bytes]] = None
+        self._stdout_log_path: Optional[str] = None
         self._stderr_log_path: Optional[str] = None
+        self._log_guard_thread: Optional[threading.Thread] = None
         self._shutdown_requested = False
 
         # Resolve Gateway command
@@ -258,6 +267,7 @@ class GatewaySupervisor:
                     # Append mode: preserve previous runs for postmortem.
                     self._stdout_log = open(stdout_path, "ab", buffering=0)
                     self._stderr_log = open(stderr_path, "ab", buffering=0)
+                    self._stdout_log_path = stdout_path
                     self._stderr_log_path = stderr_path
                     stdout_target: object = self._stdout_log
                     stderr_target: object = self._stderr_log
@@ -280,6 +290,7 @@ class GatewaySupervisor:
             # Keep the lock until the spawned process becomes healthy; otherwise
             # a second waiter can observe the port as down during cold start and
             # launch a duplicate process that immediately hits EADDRINUSE.
+            self._start_log_guard()
             return self._wait_for_health()
 
     def _resolve_log_dir(self) -> str:
@@ -304,8 +315,64 @@ class GatewaySupervisor:
             return os.path.join(home, ".hermes", "logs", "memory_tencentdb")
         return os.path.join(os.getcwd(), ".memory-tencentdb-logs")
 
+    # ── Runtime log-size guard (issue #583) ─────────────────────────────
+    # Gateway stdout/stderr logs grow without bound in append mode; a runaway
+    # log can exhaust disk (observed ~63 GiB). A daemon thread polls each
+    # active stream and, when it exceeds LOG_ACTIVE_MAX_BYTES, preserves the
+    # last LOG_TAIL_KEEP_BYTES as "<path>.1" and truncates the active file in
+    # place — keeping the child's inherited descriptor valid.
+
+    def _start_log_guard(self) -> None:
+        if self._log_guard_thread and self._log_guard_thread.is_alive():
+            return
+        self._log_guard_thread = threading.Thread(
+            target=self._log_guard_loop,
+            name="tdai-gateway-log-guard",
+            daemon=True,
+        )
+        self._log_guard_thread.start()
+
+    def _log_guard_loop(self) -> None:
+        while not self._shutdown_requested:
+            self._rotate_if_oversized(self._stdout_log_path, self._stdout_log)
+            self._rotate_if_oversized(self._stderr_log_path, self._stderr_log)
+            time.sleep(LOG_GUARD_INTERVAL_S)
+
+    def _rotate_if_oversized(self, path: Optional[str], handle: Optional[IO[bytes]]) -> None:
+        if not path or handle is None:
+            return
+        try:
+            size = os.fstat(handle.fileno()).st_size
+            if size <= LOG_ACTIVE_MAX_BYTES:
+                return
+            # Preserve the final diagnostic bytes before truncating. The
+            # append-mode handle is not readable, so read through a separate
+            # handle.
+            with open(path, "rb") as reader:
+                reader.seek(max(0, size - LOG_TAIL_KEEP_BYTES))
+                tail = reader.read(LOG_TAIL_KEEP_BYTES)
+            with open(path + ".1", "wb") as f:
+                f.write(tail)
+            # Truncate in place so the child process keeps writing to the same
+            # descriptor (renaming the path would orphan the old inode).
+            handle.seek(0)
+            handle.truncate(0)
+            handle.seek(0, os.SEEK_END)
+            logger.warning(
+                "Rotated oversized Gateway log %s (%.1f MiB → tail preserved in %s.1)",
+                path, size / (1024 * 1024), path,
+            )
+        except Exception as e:
+            logger.warning("Failed to rotate Gateway log %s: %s", path, e)
+
+    def _stop_log_guard(self) -> None:
+        if self._log_guard_thread and self._log_guard_thread.is_alive():
+            self._log_guard_thread.join(timeout=2)
+            self._log_guard_thread = None
+
     def _close_log_handles(self) -> None:
         """Close log file handles; safe to call multiple times."""
+        self._stop_log_guard()
         for attr in ("_stdout_log", "_stderr_log"):
             handle: Optional[IO[bytes]] = getattr(self, attr, None)
             if handle is not None:
@@ -372,6 +439,7 @@ class GatewaySupervisor:
     def shutdown(self) -> None:
         """Shut down the managed Gateway process (if we started it)."""
         self._shutdown_requested = True
+        self._stop_log_guard()
         if self._process is None:
             return
 

--- a/MemoryCore/hermes-plugin/tests/test_log_rotation.py
+++ b/MemoryCore/hermes-plugin/tests/test_log_rotation.py
@@ -1,0 +1,85 @@
+"""Regression tests for #583 — Gateway stdout/stderr logs must be bounded.
+
+Run: python3 -m unittest tests.test_log_rotation
+  or python3 tests/test_log_rotation.py
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# The plugin package imports the Hermes `agent` module which is not present in
+# a standalone test environment — stub it so the supervisor can be imported.
+_agent = types.ModuleType("agent")
+_mp = types.ModuleType("agent.memory_provider")
+class _MemoryProvider:  # noqa: N801
+    def __init__(self, *args, **kwargs):
+        pass
+_mp.MemoryProvider = _MemoryProvider
+sys.modules.setdefault("agent", _agent)
+sys.modules.setdefault("agent.memory_provider", _mp)
+
+import memory.memory_tencentdb.supervisor as supervisor_mod
+from memory.memory_tencentdb.supervisor import GatewaySupervisor
+
+
+class LogRotationTest(unittest.TestCase):
+    def setUp(self):
+        self.sv = GatewaySupervisor(gateway_cmd="true")
+        # Small thresholds so the test doesn't write MiB of data.
+        self._orig_max = supervisor_mod.LOG_ACTIVE_MAX_BYTES
+        self._orig_tail = supervisor_mod.LOG_TAIL_KEEP_BYTES
+        supervisor_mod.LOG_ACTIVE_MAX_BYTES = 1024  # 1 KiB
+        supervisor_mod.LOG_TAIL_KEEP_BYTES = 64     # 64 B tail
+
+    def tearDown(self):
+        supervisor_mod.LOG_ACTIVE_MAX_BYTES = self._orig_max
+        supervisor_mod.LOG_TAIL_KEEP_BYTES = self._orig_tail
+
+    def test_rotate_preserves_tail_and_truncates_in_place(self):
+        tmp = tempfile.mkdtemp()
+        path = os.path.join(tmp, "gateway.stdout.log")
+        content = b"".join(
+            b"line %d: payload-payload-payload-payload\n" % i for i in range(200)
+        )
+        self.assertGreater(len(content), supervisor_mod.LOG_ACTIVE_MAX_BYTES)
+
+        with open(path, "ab") as handle:
+            handle.write(content)
+            handle.flush()
+            # Simulate the supervisor's long-lived descriptor.
+            self.sv._stdout_log_path = path
+            self.sv._stdout_log = handle
+
+            self.sv._rotate_if_oversized(path, handle)
+
+            # Active file truncated in place (child descriptor stays valid).
+            self.assertLessEqual(os.path.getsize(path), supervisor_mod.LOG_ACTIVE_MAX_BYTES)
+            # Diagnostic tail preserved in .1.
+            tail_path = path + ".1"
+            self.assertTrue(os.path.exists(tail_path))
+            with open(tail_path, "rb") as f:
+                tail = f.read()
+            self.assertEqual(len(tail), supervisor_mod.LOG_TAIL_KEEP_BYTES)
+            self.assertEqual(tail, content[-supervisor_mod.LOG_TAIL_KEEP_BYTES:])
+
+    def test_undersized_file_is_untouched(self):
+        tmp = tempfile.mkdtemp()
+        path = os.path.join(tmp, "gateway.stderr.log")
+        small = b"small log line\n"
+        with open(path, "ab") as handle:
+            handle.write(small)
+            handle.flush()
+            self.sv._stderr_log_path = path
+            self.sv._stderr_log = handle
+            self.sv._rotate_if_oversized(path, handle)
+            self.assertEqual(os.path.getsize(path), len(small))
+            self.assertFalse(os.path.exists(path + ".1"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #583.

## Problem

`GatewaySupervisor` opens `gateway.stdout.log` / `gateway.stderr.log` in append mode and keeps those descriptors for the child's lifetime, with **no size limit or rotation**. A high-frequency logging defect can grow the files without bound and exhaust disk — observed **~63 GiB** in one incident.

## Change

A runtime log-size guard (per the issue's suggested design):

- daemon thread polls each active stream every `250 ms`
- when a stream exceeds **`LOG_ACTIVE_MAX_BYTES` (10 MiB)**, the last **`LOG_TAIL_KEEP_BYTES` (1 MiB)** is preserved as `<path>.1` (bounded diagnostic tail) and the active file is **truncated in place** — keeping the child's inherited descriptor valid (renaming the path would orphan the old inode)
- guard is stopped/joined before log handles close (in both `shutdown()` and `_close_log_handles()`)

## Tests

`MemoryCore/hermes-plugin/tests/test_log_rotation.py` (unittest):
- oversized file → truncated in place, final bytes preserved in `.1`
- undersized file → untouched, no `.1` created

`python3 -m unittest tests.test_log_rotation` passes.