### PR TITLE
feat(memory-core): reproducible memory evaluation harness (eval-memory)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ coverage/
 
 # Local project docs (generated, not for VCS)
 .local-docs/
+
+# eval-memory run artifacts (reports, per-run gateway data/config)
+MemoryCore/scripts/eval-memory/results/

--- a/MemoryCore/__tests__/eval-memory.test.ts
+++ b/MemoryCore/__tests__/eval-memory.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Unit tests for scripts/eval-memory — pure logic only (dataset adapters,
+ * orchestration over DI fakes, judge parsing, aggregation, report render).
+ * No Gateway process, no network, no LLM.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSyntheticDataset,
+  conversationTranscript,
+  pairLocomoTurns,
+  parseLocomoSample,
+} from "../scripts/eval-memory/datasets.js";
+import { parseJudgeVerdict } from "../scripts/eval-memory/llm.js";
+import { renderMarkdown, summaryLine } from "../scripts/eval-memory/report.js";
+import {
+  aggregateScores,
+  runConversation,
+  sliceDataset,
+  waitForPipeline,
+  type RunnerOptions,
+} from "../scripts/eval-memory/runner.js";
+import type {
+  EvalGateway,
+  EvalLlm,
+  PipelineStatus,
+  QuestionResult,
+  RunReport,
+} from "../scripts/eval-memory/types.js";
+
+// ============================
+// Fakes (DI, no module mocks)
+// ============================
+
+function idleStatus(): PipelineStatus {
+  const layer = { queued: 0, running: 0, idle: true };
+  return { l1: { ...layer }, l2: { ...layer }, l3: { ...layer } };
+}
+
+class FakeGateway implements EvalGateway {
+  captures: Array<{ sessionKey: string; user: string; assistant: string }> = [];
+  sessionEnds: string[] = [];
+  recallQueries: string[] = [];
+  closed = false;
+  statusSequence: Array<PipelineStatus | null>;
+  recallContext: string;
+
+  constructor(opts?: { statusSequence?: Array<PipelineStatus | null>; recallContext?: string }) {
+    this.statusSequence = opts?.statusSequence ?? [];
+    this.recallContext = opts?.recallContext ?? "Dana adopted a corgi named Biscuit.";
+  }
+
+  async capture(sessionKey: string, user: string, assistant: string): Promise<void> {
+    this.captures.push({ sessionKey, user, assistant });
+  }
+  async sessionEnd(sessionKey: string): Promise<void> {
+    this.sessionEnds.push(sessionKey);
+  }
+  async pipelineStatus(): Promise<PipelineStatus | null> {
+    return this.statusSequence.length > 0 ? this.statusSequence.shift()! : idleStatus();
+  }
+  async recall(query: string): Promise<import("../scripts/eval-memory/types.js").RecallResult> {
+    this.recallQueries.push(query);
+    return { context: this.recallContext, strategy: "fts", memoryCount: 1, code: 0 };
+  }
+  async countL1(): Promise<number | null> {
+    return 3;
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+/** Answers with the recalled context verbatim; judges by substring. */
+const fakeLlm: EvalLlm = {
+  async answer(_question, context) {
+    return context || "The information is not mentioned in the conversation";
+  },
+  async judge(_question, goldAnswer, generated) {
+    const correct = generated.toLowerCase().includes(goldAnswer.toLowerCase());
+    return { correct, reason: correct ? "match" : "mismatch" };
+  },
+};
+
+function testRunnerOpts(overrides?: Partial<RunnerOptions>): RunnerOptions {
+  return {
+    baseline: "none",
+    baselineMaxChars: 60_000,
+    settleTimeoutMs: 2_000,
+    settleStablePolls: 2,
+    settlePollIntervalMs: 1,
+    settleFallbackMs: 5,
+    countTokens: (text) => Math.ceil(text.length / 4),
+    log: () => {},
+    ...overrides,
+  };
+}
+
+// ============================
+// LoCoMo adapter
+// ============================
+
+describe("pairLocomoTurns", () => {
+  it("maps speaker_a to user, merges consecutive same-speaker lines, keeps names", () => {
+    const rounds = pairLocomoTurns(
+      [
+        { speaker: "Melanie", text: "Hi Caroline!" },
+        { speaker: "Melanie", text: "How was your week?" },
+        { speaker: "Caroline", text: "Great, I went hiking." },
+        { speaker: "Melanie", text: "Nice!" },
+        { speaker: "Caroline", text: "You should join next time." },
+      ],
+      "Melanie",
+      undefined,
+    );
+    expect(rounds).toHaveLength(2);
+    expect(rounds[0].user).toBe("Melanie: Hi Caroline!\nMelanie: How was your week?");
+    expect(rounds[0].assistant).toBe("Caroline: Great, I went hiking.");
+    expect(rounds[1].user).toBe("Melanie: Nice!");
+    expect(rounds[1].assistant).toBe("Caroline: You should join next time.");
+  });
+
+  it("anchors the session date on the first round and fills structural gaps", () => {
+    const rounds = pairLocomoTurns(
+      [{ speaker: "Caroline", text: "Guess what happened!" }],
+      "Melanie",
+      "1:56 pm on 8 May, 2023",
+    );
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].user).toContain("1:56 pm on 8 May, 2023");
+    expect(rounds[0].user).toContain("(listens)");
+    expect(rounds[0].assistant).toBe("Caroline: Guess what happened!");
+  });
+
+  it("includes image captions so visual turns are not silently dropped", () => {
+    const rounds = pairLocomoTurns(
+      [
+        { speaker: "Melanie", text: "Look at this!", blip_caption: "a dog on a beach" },
+        { speaker: "Caroline", text: "Cute!" },
+      ],
+      "Melanie",
+      undefined,
+    );
+    expect(rounds[0].user).toContain("[shares an image: a dog on a beach]");
+  });
+});
+
+describe("parseLocomoSample", () => {
+  const sample = {
+    sample_id: "conv-26",
+    conversation: {
+      speaker_a: "Melanie",
+      speaker_b: "Caroline",
+      session_2_date_time: "2:14 pm on 20 June, 2023",
+      session_2: [
+        { speaker: "Melanie", text: "I started pottery classes." },
+        { speaker: "Caroline", text: "That sounds relaxing." },
+      ],
+      session_1_date_time: "1:56 pm on 8 May, 2023",
+      session_1: [
+        { speaker: "Melanie", text: "Hi!" },
+        { speaker: "Caroline", text: "Hello!" },
+      ],
+    },
+    qa: [
+      { question: "What hobby did Melanie start?", answer: "Pottery", category: 4, evidence: ["D2:1"] },
+      { question: "How long between sessions?", answer: "About six weeks", category: 2 },
+      { question: "What is Melanie's cat called?", adversarial_answer: "Whiskers", category: 5 },
+    ],
+  };
+
+  it("orders sessions numerically and maps categories to names", () => {
+    const convo = parseLocomoSample(sample, 0, false);
+    expect(convo.conversationId).toBe("conv-26");
+    expect(convo.sessions.map((s) => s.sessionKey)).toEqual([
+      "conv-26:session_1",
+      "conv-26:session_2",
+    ]);
+    expect(convo.sessions[0].dateTime).toBe("1:56 pm on 8 May, 2023");
+    expect(convo.questions.map((q) => q.category)).toEqual(["single-hop", "temporal"]);
+  });
+
+  it("keeps adversarial questions only when asked, with an abstention gold answer", () => {
+    const convo = parseLocomoSample(sample, 0, true);
+    expect(convo.questions).toHaveLength(3);
+    const adversarial = convo.questions.find((q) => q.category === "adversarial");
+    expect(adversarial?.goldAnswer).toMatch(/not mentioned/i);
+  });
+});
+
+// ============================
+// Runner
+// ============================
+
+describe("runConversation", () => {
+  it("captures every round, flushes each session, and judges answers", async () => {
+    const dataset = buildSyntheticDataset();
+    const convo = dataset.conversations[0];
+    const gateway = new FakeGateway({ recallContext: "Biscuit" });
+    const outcome = await runConversation(convo, async () => gateway, fakeLlm, testRunnerOpts());
+
+    const expectedRounds = convo.sessions.reduce((a, s) => a + s.rounds.length, 0);
+    expect(gateway.captures).toHaveLength(expectedRounds);
+    expect(gateway.sessionEnds).toEqual(convo.sessions.map((s) => s.sessionKey));
+    expect(gateway.closed).toBe(true);
+    expect(outcome.stats.rounds).toBe(expectedRounds);
+    expect(outcome.stats.l1Records).toBe(3);
+    expect(outcome.results).toHaveLength(convo.questions.length);
+
+    // The fake recall context only contains "Biscuit", so exactly the
+    // questions whose gold answer is "Biscuit" should be judged correct.
+    const byId = new Map(outcome.results.map((r) => [r.questionId, r]));
+    expect(byId.get("syn-q4")?.memory.correct).toBe(true);
+    expect(byId.get("syn-q1")?.memory.correct).toBe(false);
+  });
+
+  it("adds a baseline outcome when requested", async () => {
+    const dataset = buildSyntheticDataset();
+    const convo = dataset.conversations[0];
+    const gateway = new FakeGateway({ recallContext: "" });
+    const outcome = await runConversation(
+      convo,
+      async () => gateway,
+      fakeLlm,
+      testRunnerOpts({ baseline: "full-context" }),
+    );
+    // Baseline answers from the raw transcript, which contains Biscuit.
+    const q4 = outcome.results.find((r) => r.questionId === "syn-q4");
+    expect(q4?.baseline?.correct).toBe(true);
+    expect(q4?.memory.correct).toBe(false);
+    expect(q4?.baseline?.contextTokens).toBeGreaterThan(0);
+  });
+
+  it("closes the gateway even when a question throws", async () => {
+    const gateway = new FakeGateway();
+    gateway.recall = async () => {
+      throw new Error("boom");
+    };
+    const dataset = buildSyntheticDataset();
+    await expect(
+      runConversation(dataset.conversations[0], async () => gateway, fakeLlm, testRunnerOpts()),
+    ).rejects.toThrow("boom");
+    expect(gateway.closed).toBe(true);
+  });
+});
+
+describe("waitForPipeline", () => {
+  it("requires consecutive idle polls before declaring the pipeline drained", async () => {
+    const busy: PipelineStatus = {
+      ...idleStatus(),
+      l1: { queued: 1, running: 0, idle: false },
+    };
+    // idle → busy (L2 timer fired) → idle → idle: must not settle on poll 1.
+    const gateway = new FakeGateway({
+      statusSequence: [idleStatus(), idleStatus(), busy, idleStatus(), idleStatus()],
+    });
+    const settled = await waitForPipeline(gateway, testRunnerOpts());
+    expect(settled).toBe(true);
+    // The busy snapshot reset the stability counter, so 5 polls were needed.
+    expect(gateway.statusSequence).toHaveLength(0);
+  });
+
+  it("falls back to a fixed wait when the status endpoint is unavailable", async () => {
+    const gateway = new FakeGateway({ statusSequence: [null] });
+    const settled = await waitForPipeline(gateway, testRunnerOpts());
+    expect(settled).toBe(false);
+  });
+
+  it("gives up after the timeout when the pipeline never drains", async () => {
+    const busy: PipelineStatus = {
+      ...idleStatus(),
+      l1: { queued: 1, running: 1, idle: false },
+    };
+    const gateway = new FakeGateway({ statusSequence: [] });
+    gateway.pipelineStatus = async () => busy;
+    const settled = await waitForPipeline(gateway, testRunnerOpts({ settleTimeoutMs: 30 }));
+    expect(settled).toBe(false);
+  });
+});
+
+// ============================
+// Judge parsing & aggregation
+// ============================
+
+describe("parseJudgeVerdict", () => {
+  it("parses a clean verdict", () => {
+    expect(parseJudgeVerdict('{"correct": true, "reason": "matches"}')).toEqual({
+      correct: true,
+      reason: "matches",
+    });
+  });
+
+  it("extracts JSON wrapped in prose or fences", () => {
+    const verdict = parseJudgeVerdict('Sure!\n```json\n{"correct": false, "reason": "wrong date"}\n```');
+    expect(verdict.correct).toBe(false);
+    expect(verdict.reason).toBe("wrong date");
+  });
+
+  it("counts unparseable judge output as wrong, never correct", () => {
+    const verdict = parseJudgeVerdict("The answer seems fine to me");
+    expect(verdict.correct).toBe(false);
+    expect(verdict.reason).toContain("unparseable");
+  });
+});
+
+describe("aggregateScores", () => {
+  function result(
+    category: QuestionResult["category"],
+    memoryCorrect: boolean,
+    baselineCorrect?: boolean,
+  ): QuestionResult {
+    return {
+      conversationId: "c1",
+      questionId: `${category}-${Math.random()}`,
+      category,
+      question: "q",
+      goldAnswer: "a",
+      memory: {
+        answer: "a",
+        correct: memoryCorrect,
+        judgeReason: "",
+        contextChars: 100,
+        contextTokens: 25,
+        latencyMs: 1,
+      },
+      baseline:
+        baselineCorrect === undefined
+          ? undefined
+          : {
+              answer: "a",
+              correct: baselineCorrect,
+              judgeReason: "",
+              contextChars: 4000,
+              contextTokens: 1000,
+              latencyMs: 1,
+            },
+    };
+  }
+
+  it("computes overall and per-category accuracy", () => {
+    const scores = aggregateScores([
+      result("single-hop", true),
+      result("single-hop", false),
+      result("temporal", true),
+    ]);
+    const overall = scores.find((s) => s.category === "overall");
+    expect(overall).toMatchObject({ total: 3, memoryCorrect: 2 });
+    expect(overall?.memoryAccuracy).toBeCloseTo(2 / 3, 3);
+    const singleHop = scores.find((s) => s.category === "single-hop");
+    expect(singleHop).toMatchObject({ total: 2, memoryCorrect: 1, memoryAccuracy: 0.5 });
+    // Categories with no questions are omitted rather than reported as 0/0.
+    expect(scores.find((s) => s.category === "adversarial")).toBeUndefined();
+  });
+
+  it("tracks baseline accuracy and context tokens separately", () => {
+    const scores = aggregateScores([
+      result("temporal", false, true),
+      result("temporal", true, true),
+    ]);
+    const overall = scores.find((s) => s.category === "overall");
+    expect(overall?.baselineAccuracy).toBe(1);
+    expect(overall?.memoryAccuracy).toBe(0.5);
+    expect(overall?.avgBaselineContextTokens).toBe(1000);
+    expect(overall?.avgMemoryContextTokens).toBe(25);
+  });
+});
+
+// ============================
+// Dataset utilities & report
+// ============================
+
+describe("sliceDataset / conversationTranscript", () => {
+  it("limits conversations and questions when caps are positive", () => {
+    const dataset = buildSyntheticDataset();
+    const sliced = sliceDataset(dataset, 1, 2);
+    expect(sliced.conversations).toHaveLength(1);
+    expect(sliced.conversations[0].questions).toHaveLength(2);
+    // 0 = unlimited
+    const unsliced = sliceDataset(dataset, 0, 0);
+    expect(unsliced.conversations[0].questions).toHaveLength(
+      dataset.conversations[0].questions.length,
+    );
+  });
+
+  it("keeps the transcript tail when truncating (later facts win)", () => {
+    const convo = buildSyntheticDataset().conversations[0];
+    const truncated = conversationTranscript(convo, 200);
+    expect(truncated.length).toBeLessThanOrEqual(200);
+    expect(truncated).toContain("Biscuit");
+  });
+});
+
+describe("report rendering", () => {
+  it("renders metadata, accuracy rows, and methodology credits", () => {
+    const results: QuestionResult[] = [
+      {
+        conversationId: "c1",
+        questionId: "q1",
+        category: "single-hop",
+        question: "What is the pet's name?",
+        goldAnswer: "Biscuit",
+        memory: {
+          answer: "Rex",
+          correct: false,
+          judgeReason: "wrong pet",
+          contextChars: 10,
+          contextTokens: 3,
+          latencyMs: 5,
+        },
+      },
+    ];
+    const report: RunReport = {
+      metadata: {
+        harnessVersion: "0.1.0",
+        startedAt: "2026-08-05T00:00:00Z",
+        finishedAt: "2026-08-05T00:10:00Z",
+        repoCommit: "abc1234",
+        nodeVersion: "v22.16.0",
+        platform: "linux-x64",
+        dataset: { name: "synthetic-smoke", source: "built-in", conversations: 1, sessions: 2, questions: 1 },
+        models: { extraction: "gpt-4o", answer: "gpt-4o", judge: "gpt-4o" },
+        gateway: { mode: "spawned", url: "http://127.0.0.1:8437" },
+        flags: { dataset: "synthetic" },
+      },
+      scores: aggregateScores(results),
+      conversations: [
+        {
+          conversationId: "c1",
+          sessions: 2,
+          rounds: 5,
+          l1Records: 4,
+          ingestMs: 100,
+          settleMs: 2000,
+          settled: true,
+        },
+      ],
+      results,
+    };
+    const md = renderMarkdown(report);
+    expect(md).toContain("synthetic-smoke");
+    expect(md).toContain("abc1234");
+    expect(md).toContain("| overall | 1 | 0.0% (0/1) |");
+    expect(md).toContain("mem0ai/memory-benchmarks");
+    expect(md).toContain("wrong pet");
+    expect(summaryLine(report.scores)).toContain("0.0%");
+  });
+});

--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -45,6 +45,7 @@
     "smoke:skill:all": "tsx scripts/smoke-skill/smoke-skill-all.ts",
     "e2e:memory-prompt:vdb-cos": "tsx scripts/e2e-memory-prompt-vdb-cos.ts",
     "import:opik": "tsx scripts/import-opik-to-memory-core/index.ts",
+    "eval:memory": "tsx scripts/eval-memory/cli-entry.ts",
     "postinstall": "bash scripts/openclaw-after-tool-call-messages.patch.sh 2>/dev/null || true"
   },
   "files": [

--- a/MemoryCore/scripts/eval-memory/README.md
+++ b/MemoryCore/scripts/eval-memory/README.md
@@ -1,0 +1,97 @@
+# eval-memory — reproducible memory evaluation
+
+A self-contained, opt-in harness that measures memory quality of the **standalone Gateway** end to end, so benchmark results can be reproduced and compared outside the team (issues [#106](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/106), [#73](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/73)).
+
+[中文文档](./README_CN.md)
+
+## What it does
+
+For each conversation in a benchmark dataset:
+
+1. **Ingest** — replays every round through `POST /capture`, flushing each session with `POST /session/end`.
+2. **Settle** — waits for the L1/L2/L3 pipeline to drain by polling `POST /v2/pipeline/status` (queue-based, with a stability window so short L2/L3 cascade timers are not mistaken for completion).
+3. **Answer** — for each benchmark question, calls `POST /recall` and has an answerer LLM answer **from the recalled context only**. Optionally a no-memory baseline answers from the raw transcript.
+4. **Judge** — an LLM judge grades each answer against the gold answer (lenient on wording, strict on facts). Unparseable verdicts count as wrong, so a flaky judge can only under-report accuracy.
+5. **Report** — writes `report.json` + `report.md` with per-category accuracy, context-token costs, pipeline stats, and the full run-metadata block (commit, models, dataset, resolved Gateway config) needed to compare independent runs.
+
+By default each conversation gets its **own spawned Gateway process with a fresh data directory**, so memories can never leak between conversations. The generated per-conversation Gateway config is kept in the output directory as part of the run record.
+
+The pipeline design (ingest → search → judge) follows [mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks) (Apache-2.0).
+
+## Requirements
+
+- Node.js ≥ 22.16.0, `npm install` done in `MemoryCore/`
+- An OpenAI-compatible LLM endpoint (used for the Gateway's L1/L2/L3 extraction **and** for the answerer/judge)
+
+No new dependencies: the harness reuses `ai`, `@ai-sdk/openai`, `js-tiktoken`, and `tsx`, which MemoryCore already declares. Nothing here is included in the published npm package, and nothing runs in CI.
+
+## Quick start
+
+```bash
+cd MemoryCore
+
+export TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+export TDAI_LLM_API_KEY="sk-..."
+export TDAI_LLM_MODEL="gpt-4o-mini"
+
+# 1. Wiring check with the tiny built-in dataset (~1 minute, a few LLM calls)
+npm run eval:memory -- --dataset synthetic
+
+# 2. Inspect what a LoCoMo run would do — no Gateway, no LLM calls
+npm run eval:memory -- --dataset locomo --dry-run
+
+# 3. Small LoCoMo slice (2 conversations × 20 questions)
+npm run eval:memory -- --dataset locomo --max-conversations 2 --max-questions 20
+
+# 4. Full LoCoMo with a full-context baseline comparison
+npm run eval:memory -- --dataset locomo --baseline full-context
+```
+
+Results land in `scripts/eval-memory/results/<timestamp>/` (git-ignored).
+
+## Datasets
+
+| Adapter | Contents | Source |
+| --- | --- | --- |
+| `synthetic` | 1 conversation, 2 sessions, 4 questions — a deterministic wiring check, **not** a quality benchmark | built in |
+| `locomo` | [LoCoMo](https://github.com/snap-research/locomo) (Maharana et al., ACL 2024): 10 multi-session conversations, ~1,500 judged questions (single-hop / multi-hop / temporal / open-domain) | downloaded from the official repo at run time |
+
+The LoCoMo dataset is **CC BY-NC 4.0** and is deliberately **not vendored** into this repository — the harness fetches it from the official source (or `--locomo-path` for an existing local copy). Use it for non-commercial evaluation in line with its license. Adversarial questions (category 5) are excluded by default, matching common practice ([mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks)); include them with `--include-adversarial`.
+
+LoCoMo dialogs are between two named humans; the adapter maps `speaker_a` → user and `speaker_b` → assistant, keeps every line prefixed with the real speaker name, and anchors each session's in-universe date into the first round (L0 capture timestamps are "now", so temporal questions must be answerable from content).
+
+Adding a benchmark (e.g. PersonaMem, or corpus-driven test databases) means adding one adapter in `datasets.ts` that emits the normalized `EvalDataset` shape — the runner is dataset-agnostic.
+
+## Options
+
+Run `npm run eval:memory -- --help` for the full list. The important ones:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--dataset` | `synthetic` | `synthetic` or `locomo` |
+| `--max-conversations` / `--max-questions` | 0 (all) | slice for cheap runs |
+| `--baseline` | `none` | `full-context` adds a no-memory comparison answering from the (tail-truncated) transcript |
+| `--gateway-url` | — | reuse an already-running Gateway instead of spawning; the caller owns data isolation |
+| `--port` | 8437 | port for spawned Gateways |
+| `--settle-timeout-s` | 600 | max pipeline-drain wait per conversation |
+| `--dry-run` | — | parse the dataset, print the plan, exit |
+
+Answerer / judge models default to `TDAI_LLM_MODEL`; override with `TDAI_EVAL_ANSWER_MODEL` / `TDAI_EVAL_JUDGE_MODEL`. Judging with a stronger model than the answerer is a common and cheap accuracy upgrade.
+
+## Reading the report
+
+`report.md` contains:
+
+- **Run metadata** — commit, node/platform, dataset + source, all three model roles, gateway mode, flags. Two reports are comparable iff these match (or the difference is the thing you are measuring).
+- **Accuracy** — per category and overall; with `--baseline full-context`, side-by-side memory vs. baseline accuracy and average context tokens (the memory-vs-raw-context token cost is usually the headline trade-off).
+- **Pipeline stats** — rounds ingested, L1 records extracted, settle time, and whether the pipeline fully drained (`settled=no` runs are still reported but should be treated as suspect).
+- **Sample failures** — the first 20 wrong answers with judge reasons, for quick error analysis.
+
+`report.json` has the full per-question detail (recall strategy, memory counts, recall error codes, latencies) for downstream analysis.
+
+## Caveats
+
+- Scores depend on the extraction/answer/judge models; only compare runs with matching metadata blocks.
+- The evaluation-tuned Gateway config shortens pipeline timers (`l2DelayAfterL1Seconds: 3` etc.) so runs settle in seconds; production defaults would behave identically given enough idle time, but timing-sensitive behaviours are not what this harness measures.
+- `--gateway-url` mode shares one memory store across all conversations in the dataset; recall can cross-contaminate. Prefer the default spawned mode for scoring.
+- LLM-as-judge is imperfect; spot-check `report.json` before quoting numbers.

--- a/MemoryCore/scripts/eval-memory/README_CN.md
+++ b/MemoryCore/scripts/eval-memory/README_CN.md
@@ -1,0 +1,86 @@
+# eval-memory — 可复现的记忆评测工具
+
+一个自包含、按需运行的评测工具，端到端度量 **standalone Gateway** 的记忆质量，让社区可以在团队之外复现和对比 Benchmark 结果（见 issue [#106](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/106)、[#73](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/73)）。
+
+[English](./README.md)
+
+## 工作流程
+
+对数据集中的每个对话：
+
+1. **导入** — 逐轮通过 `POST /capture` 回放对话，每个 session 结束时调用 `POST /session/end` 强制刷新。
+2. **等待管线** — 轮询 `POST /v2/pipeline/status` 等待 L1/L2/L3 队列排空（基于队列状态并带稳定窗口，避免把 L2/L3 级联定时器的间隙误判为完成）。
+3. **回答** — 对每个评测问题调用 `POST /recall`，回答模型**只依据召回的上下文**作答；可选的 no-memory 基线直接用原始对话全文作答。
+4. **评分** — 由 LLM 裁判对照标准答案打分（措辞宽松、事实严格）。裁判输出无法解析时按错误计，保证裁判不稳定只会低报、不会虚高。
+5. **报告** — 输出 `report.json` + `report.md`：分类准确率、上下文 token 开销、管线统计，以及完整的运行元数据（commit、模型、数据集、生效的 Gateway 配置），使独立运行可逐项对比。
+
+默认情况下，每个对话都会**独立拉起一个 Gateway 进程 + 全新数据目录**，不同对话的记忆绝不互相泄漏。每个对话生成的 Gateway 配置文件会保留在输出目录中，作为运行记录的一部分。
+
+评测管线设计（ingest → search → judge）参考 [mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks)（Apache-2.0）。
+
+## 前置条件
+
+- Node.js ≥ 22.16.0，且已在 `MemoryCore/` 执行过 `npm install`
+- 一个 OpenAI 兼容的 LLM 端点（Gateway 的 L1/L2/L3 提取和回答/裁判模型共用）
+
+不引入任何新依赖：工具复用 MemoryCore 已声明的 `ai`、`@ai-sdk/openai`、`js-tiktoken`、`tsx`。不进入 npm 发布包，不参与 CI。
+
+## 快速开始
+
+```bash
+cd MemoryCore
+
+export TDAI_LLM_BASE_URL="https://api.openai.com/v1"
+export TDAI_LLM_API_KEY="sk-..."
+export TDAI_LLM_MODEL="gpt-4o-mini"
+
+# 1. 内置小数据集连通性检查（约 1 分钟，少量 LLM 调用）
+npm run eval:memory -- --dataset synthetic
+
+# 2. 查看 LoCoMo 运行计划 — 不启动 Gateway、不调用 LLM
+npm run eval:memory -- --dataset locomo --dry-run
+
+# 3. LoCoMo 小切片（2 个对话 × 每对话 20 题）
+npm run eval:memory -- --dataset locomo --max-conversations 2 --max-questions 20
+
+# 4. 完整 LoCoMo + 全文基线对比
+npm run eval:memory -- --dataset locomo --baseline full-context
+```
+
+结果输出到 `scripts/eval-memory/results/<时间戳>/`（已 git-ignore）。
+
+## 数据集
+
+| 适配器 | 内容 | 来源 |
+| --- | --- | --- |
+| `synthetic` | 1 个对话、2 个 session、4 个问题 — 确定性的连通性检查，**不是**质量基准 | 内置 |
+| `locomo` | [LoCoMo](https://github.com/snap-research/locomo)（Maharana et al., ACL 2024）：10 个多 session 对话、约 1500 个评测问题（single-hop / multi-hop / temporal / open-domain） | 运行时从官方仓库下载 |
+
+LoCoMo 数据集许可为 **CC BY-NC 4.0**，因此**不随仓库分发** — 工具在运行时从官方源下载（或用 `--locomo-path` 指定本地副本），请在其许可允许的非商业评测范围内使用。对抗性问题（category 5）默认排除，与 [mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks) 的常见做法一致；`--include-adversarial` 可包含。
+
+LoCoMo 对话发生在两个具名真人之间；适配器将 `speaker_a` → user、`speaker_b` → assistant，每行保留真实说话人前缀，并把每个 session 的日期锚定到首轮内容中（L0 捕获时间戳是"现在"，时间类问题必须能从内容中回答）。
+
+新增基准（如 PersonaMem 或语料驱动的测试库）只需在 `datasets.ts` 中增加一个输出标准 `EvalDataset` 结构的适配器 — runner 与数据集无关。
+
+## 参数
+
+完整列表见 `npm run eval:memory -- --help`。常用参数：
+
+| 参数 | 默认值 | 含义 |
+| --- | --- | --- |
+| `--dataset` | `synthetic` | `synthetic` 或 `locomo` |
+| `--max-conversations` / `--max-questions` | 0（全部） | 低成本切片 |
+| `--baseline` | `none` | `full-context` 增加一个以（尾部截断的）全文作答的 no-memory 对照 |
+| `--gateway-url` | — | 复用已运行的 Gateway 而非自行拉起；数据隔离由调用方负责 |
+| `--port` | 8437 | 自行拉起 Gateway 的端口 |
+| `--settle-timeout-s` | 600 | 每个对话等待管线排空的上限 |
+| `--dry-run` | — | 只解析数据集并打印计划 |
+
+回答/裁判模型默认取 `TDAI_LLM_MODEL`，可用 `TDAI_EVAL_ANSWER_MODEL` / `TDAI_EVAL_JUDGE_MODEL` 分别覆盖。用比回答模型更强的裁判模型是常见且低成本的准确率改进。
+
+## 注意事项
+
+- 分数依赖提取/回答/裁判模型；只应对比元数据块一致的运行（或差异正是你要测的变量）。
+- 评测用 Gateway 配置缩短了管线定时器（如 `l2DelayAfterL1Seconds: 3`）使运行在秒级完成；生产默认值给足空闲时间行为一致，但本工具不度量时序敏感行为。
+- `--gateway-url` 模式下所有对话共享同一记忆库，召回可能互相污染；正式评分请用默认的独立拉起模式。
+- LLM 裁判并不完美；引用数字前请抽查 `report.json`。

--- a/MemoryCore/scripts/eval-memory/cli-entry.ts
+++ b/MemoryCore/scripts/eval-memory/cli-entry.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env npx tsx
+/**
+ * eval-memory — reproducible memory-quality evaluation for the standalone
+ * Gateway. See scripts/eval-memory/README.md for usage; issues #106 / #73
+ * for motivation.
+ *
+ *   npm run eval:memory -- --dataset synthetic
+ *   npm run eval:memory -- --dataset locomo --max-conversations 2
+ */
+
+import { mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import { getEncoding } from "js-tiktoken";
+
+import { buildSyntheticDataset, loadLocomoDataset, LOCOMO_DEFAULT_URL } from "./datasets.js";
+import { HttpEvalGateway, spawnEvalGateway } from "./gateway.js";
+import { createAiSdkEvalLlm } from "./llm.js";
+import { detectRepoCommit, summaryLine, writeReport } from "./report.js";
+import { aggregateScores, runConversation, sliceDataset, type RunnerOptions } from "./runner.js";
+import type { ConversationRunStats, EvalGatewayFactory, QuestionResult, RunReport } from "./types.js";
+
+const HARNESS_VERSION = "0.1.0";
+const TAG = "[eval-memory]";
+
+const HELP = `eval-memory — reproducible memory evaluation for the standalone Gateway
+
+USAGE
+  npm run eval:memory -- [options]
+
+DATASET
+  --dataset <synthetic|locomo>   dataset adapter (default: synthetic)
+  --locomo-path <file>           read locomo10.json from disk instead of downloading
+  --locomo-url <url>             download URL (default: official snap-research/locomo raw file)
+  --include-adversarial          include LoCoMo category-5 questions (excluded by default,
+                                 matching mem0ai/memory-benchmarks practice)
+  --max-conversations <n>        evaluate only the first n conversations (0 = all)
+  --max-questions <n>            evaluate only the first n questions per conversation (0 = all)
+
+GATEWAY
+  --gateway-url <url>            reuse an already-running Gateway instead of spawning one.
+                                 The caller owns data isolation between conversations.
+  --gateway-api-key <key>        API key for --gateway-url mode (or TDAI_GATEWAY_API_KEY)
+  --port <n>                     port for spawned Gateways (default: 8437)
+  --verbose-gateway              inherit spawned Gateway stdout/stderr
+
+EVALUATION
+  --baseline <none|full-context> also answer from the raw transcript for comparison (default: none)
+  --baseline-max-chars <n>       transcript truncation for the baseline (default: 60000)
+  --settle-timeout-s <n>         max wait for the pipeline to drain per conversation (default: 600)
+  --out <dir>                    output directory (default: scripts/eval-memory/results/<timestamp>)
+  --dry-run                      parse the dataset and print the plan; no Gateway, no LLM calls
+
+LLM (answerer + judge; extraction uses the Gateway's own config)
+  TDAI_LLM_BASE_URL / TDAI_LLM_API_KEY / TDAI_LLM_MODEL     required unless --dry-run
+  TDAI_EVAL_ANSWER_MODEL / TDAI_EVAL_JUDGE_MODEL            optional per-role overrides
+`;
+
+async function main(): Promise<number> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      dataset: { type: "string", default: "synthetic" },
+      "locomo-path": { type: "string" },
+      "locomo-url": { type: "string" },
+      "include-adversarial": { type: "boolean", default: false },
+      "max-conversations": { type: "string", default: "0" },
+      "max-questions": { type: "string", default: "0" },
+      "gateway-url": { type: "string" },
+      "gateway-api-key": { type: "string" },
+      port: { type: "string", default: "8437" },
+      "verbose-gateway": { type: "boolean", default: false },
+      baseline: { type: "string", default: "none" },
+      "baseline-max-chars": { type: "string", default: "60000" },
+      "settle-timeout-s": { type: "string", default: "600" },
+      out: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+  });
+
+  if (values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  // ── Dataset ──
+  let dataset;
+  if (values.dataset === "synthetic") {
+    dataset = buildSyntheticDataset();
+  } else if (values.dataset === "locomo") {
+    dataset = await loadLocomoDataset({
+      path: values["locomo-path"],
+      url: values["locomo-url"] ?? LOCOMO_DEFAULT_URL,
+      includeAdversarial: values["include-adversarial"],
+    });
+  } else {
+    process.stderr.write(`${TAG} unknown dataset "${values.dataset}" (expected synthetic|locomo)\n`);
+    return 1;
+  }
+  dataset = sliceDataset(
+    dataset,
+    Number(values["max-conversations"]),
+    Number(values["max-questions"]),
+  );
+
+  const totalSessions = dataset.conversations.reduce((a, c) => a + c.sessions.length, 0);
+  const totalQuestions = dataset.conversations.reduce((a, c) => a + c.questions.length, 0);
+  process.stdout.write(
+    `${TAG} dataset=${dataset.name} conversations=${dataset.conversations.length} ` +
+      `sessions=${totalSessions} questions=${totalQuestions}\n`,
+  );
+
+  if (values["dry-run"]) {
+    for (const c of dataset.conversations) {
+      const rounds = c.sessions.reduce((a, s) => a + s.rounds.length, 0);
+      process.stdout.write(
+        `${TAG}   ${c.conversationId}: ${c.sessions.length} sessions, ${rounds} rounds, ${c.questions.length} questions\n`,
+      );
+    }
+    process.stdout.write(`${TAG} dry run complete — no Gateway or LLM calls were made\n`);
+    return 0;
+  }
+
+  // ── LLM config ──
+  const llmBaseUrl = process.env.TDAI_LLM_BASE_URL ?? "https://api.openai.com/v1";
+  const llmApiKey = process.env.TDAI_LLM_API_KEY ?? "";
+  const llmModel = process.env.TDAI_LLM_MODEL ?? "gpt-4o";
+  if (!llmApiKey) {
+    process.stderr.write(`${TAG} TDAI_LLM_API_KEY is required (or use --dry-run)\n`);
+    return 1;
+  }
+  const answerModel = process.env.TDAI_EVAL_ANSWER_MODEL ?? llmModel;
+  const judgeModel = process.env.TDAI_EVAL_JUDGE_MODEL ?? llmModel;
+  const llm = createAiSdkEvalLlm({
+    baseUrl: llmBaseUrl,
+    apiKey: llmApiKey,
+    answerModel,
+    judgeModel,
+    timeoutMs: 120_000,
+  });
+
+  // ── Gateway factory ──
+  const memoryCoreDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const startedAt = new Date();
+  const runStamp = startedAt.toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outDir = values.out
+    ? resolve(values.out)
+    : join(memoryCoreDir, "scripts", "eval-memory", "results", runStamp);
+  mkdirSync(outDir, { recursive: true });
+
+  const externalUrl = values["gateway-url"];
+  const gatewayFactory: EvalGatewayFactory = async (conversationId) => {
+    if (externalUrl) {
+      return new HttpEvalGateway({
+        baseUrl: externalUrl,
+        apiKey: values["gateway-api-key"] ?? process.env.TDAI_GATEWAY_API_KEY,
+      });
+    }
+    return spawnEvalGateway({
+      memoryCoreDir,
+      runDir: outDir,
+      conversationId,
+      port: Number(values.port),
+      llm: { baseUrl: llmBaseUrl, apiKey: llmApiKey, model: llmModel },
+      verbose: values["verbose-gateway"],
+    });
+  };
+  if (externalUrl && dataset.conversations.length > 1) {
+    process.stdout.write(
+      `${TAG} WARNING: --gateway-url with ${dataset.conversations.length} conversations shares one ` +
+        `memory store across all of them; recall may cross-contaminate. Prefer spawned mode for scoring.\n`,
+    );
+  }
+
+  // ── Run ──
+  const encoding = getEncoding("cl100k_base");
+  const runnerOpts: RunnerOptions = {
+    baseline: values.baseline === "full-context" ? "full-context" : "none",
+    baselineMaxChars: Number(values["baseline-max-chars"]),
+    settleTimeoutMs: Number(values["settle-timeout-s"]) * 1000,
+    settleStablePolls: 5,
+    settlePollIntervalMs: 1000,
+    settleFallbackMs: 30_000,
+    countTokens: (text) => (text ? encoding.encode(text).length : 0),
+    log: (line) => process.stdout.write(`${TAG} ${line}\n`),
+  };
+
+  const allResults: QuestionResult[] = [];
+  const allStats: ConversationRunStats[] = [];
+  for (const convo of dataset.conversations) {
+    const outcome = await runConversation(convo, gatewayFactory, llm, runnerOpts);
+    allResults.push(...outcome.results);
+    allStats.push(outcome.stats);
+  }
+
+  // ── Report ──
+  const scores = aggregateScores(allResults);
+  const report: RunReport = {
+    metadata: {
+      harnessVersion: HARNESS_VERSION,
+      startedAt: startedAt.toISOString(),
+      finishedAt: new Date().toISOString(),
+      repoCommit: detectRepoCommit(memoryCoreDir),
+      nodeVersion: process.version,
+      platform: `${process.platform}-${process.arch}`,
+      dataset: {
+        name: dataset.name,
+        source: dataset.source,
+        conversations: dataset.conversations.length,
+        sessions: totalSessions,
+        questions: totalQuestions,
+      },
+      models: { extraction: llmModel, answer: answerModel, judge: judgeModel },
+      gateway: {
+        mode: externalUrl ? "external" : "spawned",
+        url: externalUrl ?? `http://127.0.0.1:${values.port}`,
+      },
+      flags: {
+        dataset: values.dataset,
+        baseline: runnerOpts.baseline,
+        includeAdversarial: values["include-adversarial"],
+        maxConversations: Number(values["max-conversations"]),
+        maxQuestions: Number(values["max-questions"]),
+      },
+    },
+    scores,
+    conversations: allStats,
+    results: allResults,
+  };
+  const { jsonPath, mdPath } = writeReport(outDir, report);
+
+  process.stdout.write(`${TAG} ${summaryLine(scores)}\n`);
+  process.stdout.write(`${TAG} report: ${mdPath}\n`);
+  process.stdout.write(`${TAG} detail: ${jsonPath}\n`);
+  return 0;
+}
+
+try {
+  process.exitCode = await main();
+} catch (err) {
+  const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  process.stderr.write(`${TAG} ${message}\n`);
+  process.exitCode = 1;
+}

--- a/MemoryCore/scripts/eval-memory/datasets.ts
+++ b/MemoryCore/scripts/eval-memory/datasets.ts
@@ -1,0 +1,295 @@
+/**
+ * eval-memory — dataset adapters.
+ *
+ * Every dataset is normalized to EvalDataset (conversations → sessions →
+ * strictly-alternating rounds + judged questions), so the runner never
+ * knows which benchmark it is executing. Adding a benchmark = adding an
+ * adapter here.
+ *
+ * Built-in adapters:
+ *  - synthetic: a tiny offline smoke set (no download, deterministic).
+ *  - locomo:    LoCoMo (Maharana et al., ACL 2024), 10 multi-session
+ *               conversations, ~300 judged questions. The dataset is
+ *               CC BY-NC 4.0 and is therefore NEVER vendored into this
+ *               repo — it is fetched from the official source at run
+ *               time (or read from --locomo-path).
+ *               https://github.com/snap-research/locomo
+ */
+
+import { readFileSync } from "node:fs";
+
+import type {
+  EvalConversation,
+  EvalDataset,
+  EvalQuestion,
+  EvalSession,
+  QuestionCategory,
+} from "./types.js";
+
+export const LOCOMO_DEFAULT_URL =
+  "https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json";
+
+/**
+ * LoCoMo qa `category` labels, matching task_eval/evaluation.py in the
+ * official repo (multi-hop=1 is scored with sub-answer partial F1 there;
+ * 2/3/4 are scored whole; 5 is the adversarial option-selection set).
+ */
+const LOCOMO_CATEGORY: Record<number, QuestionCategory> = {
+  1: "multi-hop",
+  2: "temporal",
+  3: "open-domain",
+  4: "single-hop",
+  5: "adversarial",
+};
+
+// ============================
+// Synthetic smoke set
+// ============================
+
+/**
+ * Small enough to run end-to-end in minutes on any OpenAI-compatible
+ * endpoint, with unambiguous gold answers. Useful as a wiring check
+ * before paying for a full LoCoMo run — not as a quality benchmark.
+ */
+export function buildSyntheticDataset(): EvalDataset {
+  const sessions: EvalSession[] = [
+    {
+      sessionKey: "synthetic-1:s1",
+      dateTime: "10:00 am on 3 March, 2026",
+      rounds: [
+        {
+          user: "Hi! I'm Dana Whitfield, I just joined the platform team as a database engineer.",
+          assistant: "Welcome Dana! Great to have a database engineer on the platform team.",
+        },
+        {
+          user: "My main project this quarter is migrating our metrics store from InfluxDB to ClickHouse. The deadline is June 15th.",
+          assistant: "Noted — an InfluxDB to ClickHouse migration for the metrics store, due June 15th.",
+        },
+        {
+          user: "By the way, I'm allergic to peanuts, so please keep that in mind if you ever suggest snacks for team events.",
+          assistant: "Understood, I'll remember your peanut allergy for any food suggestions.",
+        },
+      ],
+    },
+    {
+      sessionKey: "synthetic-1:s2",
+      dateTime: "4:30 pm on 21 April, 2026",
+      rounds: [
+        {
+          user: "Update: the ClickHouse migration deadline moved from June 15th to July 1st because the security review slipped.",
+          assistant: "Got it — the migration deadline is now July 1st, pushed back by the security review.",
+        },
+        {
+          user: "Also, I adopted a corgi last weekend! Her name is Biscuit.",
+          assistant: "Congratulations on adopting Biscuit the corgi!",
+        },
+      ],
+    },
+  ];
+
+  const questions: EvalQuestion[] = [
+    {
+      id: "syn-q1",
+      question: "What is Dana's role and which team did she join?",
+      goldAnswer: "Database engineer on the platform team",
+      category: "single-hop",
+    },
+    {
+      id: "syn-q2",
+      question: "What is the current deadline of Dana's metrics store migration?",
+      goldAnswer: "July 1st (moved from June 15th)",
+      category: "temporal",
+    },
+    {
+      id: "syn-q3",
+      question: "Why should the assistant avoid suggesting peanut snacks to Dana, and what pet did she adopt?",
+      goldAnswer: "She is allergic to peanuts, and she adopted a corgi named Biscuit",
+      category: "multi-hop",
+    },
+    {
+      id: "syn-q4",
+      question: "What is the name of Dana's pet?",
+      goldAnswer: "Biscuit",
+      category: "single-hop",
+    },
+  ];
+
+  return {
+    name: "synthetic-smoke",
+    source: "built-in",
+    conversations: [{ conversationId: "synthetic-1", sessions, questions }],
+  };
+}
+
+// ============================
+// LoCoMo adapter
+// ============================
+
+interface LocomoTurn {
+  speaker: string;
+  dia_id?: string;
+  text?: string;
+  blip_caption?: string;
+}
+
+interface LocomoQa {
+  question: string;
+  answer?: unknown;
+  adversarial_answer?: unknown;
+  category: number;
+  evidence?: string[];
+}
+
+interface LocomoSample {
+  sample_id?: string;
+  qa: LocomoQa[];
+  conversation: Record<string, unknown> & { speaker_a?: string; speaker_b?: string };
+}
+
+export async function loadLocomoDataset(opts: {
+  path?: string;
+  url?: string;
+  includeAdversarial?: boolean;
+}): Promise<EvalDataset> {
+  let raw: string;
+  let source: string;
+  if (opts.path) {
+    raw = readFileSync(opts.path, "utf8");
+    source = opts.path;
+  } else {
+    source = opts.url ?? LOCOMO_DEFAULT_URL;
+    const res = await fetch(source);
+    if (!res.ok) {
+      throw new Error(`Failed to download LoCoMo dataset from ${source}: HTTP ${res.status}`);
+    }
+    raw = await res.text();
+  }
+  const samples = JSON.parse(raw) as LocomoSample[];
+  if (!Array.isArray(samples)) {
+    throw new Error("Unexpected LoCoMo format: top-level JSON array expected");
+  }
+  return {
+    name: "locomo10",
+    source,
+    conversations: samples.map((s, i) => parseLocomoSample(s, i, opts.includeAdversarial ?? false)),
+  };
+}
+
+export function parseLocomoSample(
+  sample: LocomoSample,
+  index: number,
+  includeAdversarial: boolean,
+): EvalConversation {
+  const conversationId = String(sample.sample_id ?? `locomo-${index}`);
+  const conv = sample.conversation ?? {};
+  const speakerA = typeof conv.speaker_a === "string" ? conv.speaker_a : "SpeakerA";
+
+  // Collect session_<n> keys in numeric order; each has a sibling
+  // session_<n>_date_time carrying the in-universe date used by the
+  // temporal questions.
+  const sessionNums = Object.keys(conv)
+    .map((k) => /^session_(\d+)$/.exec(k))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map((m) => Number(m[1]))
+    .sort((a, b) => a - b);
+
+  const sessions: EvalSession[] = [];
+  for (const n of sessionNums) {
+    const turns = conv[`session_${n}`];
+    if (!Array.isArray(turns) || turns.length === 0) continue;
+    const dateTime = typeof conv[`session_${n}_date_time`] === "string"
+      ? (conv[`session_${n}_date_time`] as string)
+      : undefined;
+    sessions.push({
+      sessionKey: `${conversationId}:session_${n}`,
+      dateTime,
+      rounds: pairLocomoTurns(turns as LocomoTurn[], speakerA, dateTime),
+    });
+  }
+
+  const questions: EvalQuestion[] = (sample.qa ?? [])
+    .filter((qa) => includeAdversarial || qa.category !== 5)
+    .map((qa, qi) => ({
+      id: `${conversationId}:q${qi}`,
+      question: qa.question,
+      // Adversarial items carry the trap in `adversarial_answer`; the correct
+      // behaviour is to say the information is not present.
+      goldAnswer:
+        qa.category === 5
+          ? "The information is not mentioned in the conversation"
+          : String(qa.answer ?? ""),
+      category: LOCOMO_CATEGORY[qa.category] ?? "open-domain",
+      evidence: qa.evidence,
+    }));
+
+  return { conversationId, sessions, questions };
+}
+
+/**
+ * LoCoMo dialogs are two named humans, not user/assistant. We map
+ * speaker_a → user and speaker_b → assistant, keep each line prefixed
+ * with the real speaker name so extraction can attribute facts, merge
+ * consecutive same-speaker lines, and anchor the session date on the
+ * first round (the L0 capture timestamp is "now", so temporal questions
+ * must be answerable from content alone).
+ */
+export function pairLocomoTurns(
+  turns: LocomoTurn[],
+  speakerA: string,
+  dateTime: string | undefined,
+): Array<{ user: string; assistant: string }> {
+  const rounds: Array<{ user: string; assistant: string }> = [];
+  let current: { user: string; assistant: string } | null = null;
+
+  for (const t of turns) {
+    const text = (t.text ?? "").trim();
+    if (!text && !t.blip_caption) continue;
+    const caption = t.blip_caption ? ` [shares an image: ${t.blip_caption}]` : "";
+    const line = `${t.speaker}: ${text}${caption}`;
+    const isUser = t.speaker === speakerA;
+
+    if (isUser) {
+      // A user line after the assistant already spoke closes the round.
+      if (current && current.assistant) {
+        rounds.push(current);
+        current = null;
+      }
+      if (!current) current = { user: "", assistant: "" };
+      current.user = current.user ? `${current.user}\n${line}` : line;
+    } else {
+      if (!current) current = { user: "", assistant: "" };
+      current.assistant = current.assistant ? `${current.assistant}\n${line}` : line;
+    }
+  }
+  if (current && (current.user || current.assistant)) rounds.push(current);
+
+  // /capture requires both sides non-empty; fill structural gaps without
+  // inventing content.
+  for (const r of rounds) {
+    if (!r.user) r.user = "(listens)";
+    if (!r.assistant) r.assistant = "(listens)";
+  }
+  if (rounds.length > 0 && dateTime) {
+    rounds[0].user = `[This conversation session takes place at ${dateTime}]\n${rounds[0].user}`;
+  }
+  return rounds;
+}
+
+// ============================
+// Shared helpers
+// ============================
+
+/** Full raw transcript of a conversation — the no-memory baseline context. */
+export function conversationTranscript(convo: EvalConversation, maxChars: number): string {
+  const parts: string[] = [];
+  for (const s of convo.sessions) {
+    parts.push(`--- Session${s.dateTime ? ` (${s.dateTime})` : ""} ---`);
+    for (const r of s.rounds) {
+      parts.push(r.user, r.assistant);
+    }
+  }
+  const full = parts.join("\n");
+  // Keep the tail: later sessions override earlier facts more often than
+  // the reverse, so truncating the head loses less.
+  return full.length > maxChars ? full.slice(full.length - maxChars) : full;
+}

--- a/MemoryCore/scripts/eval-memory/gateway.ts
+++ b/MemoryCore/scripts/eval-memory/gateway.ts
@@ -1,0 +1,291 @@
+/**
+ * eval-memory — Gateway access.
+ *
+ * Two modes:
+ *  - spawned (default): each conversation gets its own short-lived Gateway
+ *    process with a fresh TDAI_DATA_DIR, so recall for conversation A can
+ *    never surface memories from conversation B. This mirrors the
+ *    one-instance-per-user deployment shape and is what makes runs
+ *    reproducible from a clean state.
+ *  - external (--gateway-url): reuse a Gateway the caller manages. Useful
+ *    against docker deployments, but the caller owns data isolation.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type {
+  EvalGateway,
+  PipelineStatus,
+  RecallResult,
+} from "./types.js";
+
+const TAG = "[eval-memory]";
+
+// Dummy v2 credentials: parseV2Auth requires non-empty Bearer + service id
+// even when the standalone Gateway has no API key configured.
+const EVAL_SERVICE_ID = "eval-memory";
+
+export interface HttpGatewayOptions {
+  baseUrl: string;
+  apiKey?: string;
+  fetchTimeoutMs?: number;
+}
+
+export class HttpEvalGateway implements EvalGateway {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+  private readonly child?: ChildProcess;
+
+  constructor(opts: HttpGatewayOptions, child?: ChildProcess) {
+    this.baseUrl = opts.baseUrl.replace(/\/$/, "");
+    this.apiKey = opts.apiKey || "eval";
+    this.timeoutMs = opts.fetchTimeoutMs ?? 120_000;
+    this.child = child;
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    // v1 routes ignore these headers when the Gateway has no API key;
+    // v2 routes require them to be non-empty regardless.
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      authorization: `Bearer ${this.apiKey}`,
+      "x-tdai-service-id": EVAL_SERVICE_ID,
+    };
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(`${path} → HTTP ${res.status}: ${text.slice(0, 300)}`);
+    }
+    return JSON.parse(text) as T;
+  }
+
+  async capture(sessionKey: string, user: string, assistant: string): Promise<void> {
+    await this.post("/capture", {
+      user_content: user,
+      assistant_content: assistant,
+      session_key: sessionKey,
+    });
+  }
+
+  async sessionEnd(sessionKey: string): Promise<void> {
+    await this.post("/session/end", { session_key: sessionKey });
+  }
+
+  async pipelineStatus(): Promise<PipelineStatus | null> {
+    try {
+      const envelope = await this.post<{ code: number; data?: PipelineStatus }>(
+        "/v2/pipeline/status",
+        {},
+      );
+      if (envelope.code !== 0 || !envelope.data) return null;
+      return envelope.data;
+    } catch {
+      // Legacy standalone (no state backend) has no status endpoint; the
+      // runner falls back to a fixed grace wait.
+      return null;
+    }
+  }
+
+  async recall(query: string, sessionKey: string): Promise<RecallResult> {
+    const res = await this.post<{
+      context: string;
+      strategy?: string;
+      memory_count?: number;
+      code?: number;
+      message?: string;
+    }>("/recall", { query, session_key: sessionKey });
+    return {
+      context: res.context ?? "",
+      strategy: res.strategy,
+      memoryCount: res.memory_count ?? 0,
+      code: res.code ?? 0,
+      message: res.message,
+    };
+  }
+
+  async countL1(): Promise<number | null> {
+    try {
+      const envelope = await this.post<{ code: number; data?: { total?: number } }>(
+        "/v3/atomic/count",
+        {},
+      );
+      if (envelope.code !== 0) return null;
+      return envelope.data?.total ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.child || this.child.exitCode !== null) return;
+    const exited = new Promise<void>((resolve) => {
+      this.child?.once("exit", () => resolve());
+    });
+    this.child.kill("SIGTERM");
+    // SIGTERM is best-effort on Windows; escalate if the process lingers.
+    const timeout = new Promise<void>((resolve) =>
+      setTimeout(() => {
+        if (this.child && this.child.exitCode === null) this.child.kill("SIGKILL");
+        resolve();
+      }, 5000),
+    );
+    await Promise.race([exited, timeout]);
+    await exited.catch(() => {});
+  }
+}
+
+// ============================
+// Spawning a fresh Gateway
+// ============================
+
+export interface SpawnOptions {
+  /** MemoryCore package root (cwd for the child process). */
+  memoryCoreDir: string;
+  /** Per-conversation run directory; data + config land here. */
+  runDir: string;
+  conversationId: string;
+  port: number;
+  llm: { baseUrl: string; apiKey: string; model: string };
+  /** Extra YAML appended verbatim (advanced overrides). */
+  verbose: boolean;
+}
+
+/**
+ * Pipeline timing tuned for evaluation: low L1 threshold and short L2/L3
+ * cascade delays so a run settles in seconds instead of the production
+ * defaults (10-minute idle timers). Every value is recorded in the report
+ * via the generated config file.
+ */
+export function buildEvalGatewayConfig(opts: {
+  port: number;
+  dataDir: string;
+  llm: { baseUrl: string; apiKey: string; model: string };
+}): string {
+  // YAML written explicitly (no yaml dep needed for emit) — keep it simple
+  // and greppable in the run directory.
+  return [
+    "# Generated by scripts/eval-memory — evaluation-tuned standalone Gateway config.",
+    "deployMode: standalone",
+    'stateBackend: "local"',
+    "",
+    "server:",
+    `  port: ${opts.port}`,
+    '  host: "127.0.0.1"',
+    "",
+    "data:",
+    `  baseDir: ${JSON.stringify(opts.dataDir)}`,
+    "",
+    "llm:",
+    `  baseUrl: ${JSON.stringify(opts.llm.baseUrl)}`,
+    `  apiKey: ${JSON.stringify(opts.llm.apiKey)}`,
+    `  model: ${JSON.stringify(opts.llm.model)}`,
+    "  maxTokens: 4096",
+    "  timeoutMs: 120000",
+    "",
+    "memory:",
+    "  capture:",
+    "    enabled: true",
+    "  extraction:",
+    "    enabled: true",
+    "    enableDedup: true",
+    "    maxMemoriesPerSession: 50",
+    "  persona:",
+    "    triggerEveryN: 10",
+    "  pipeline:",
+    "    everyNConversations: 3",
+    "    enableWarmup: true",
+    "    l1IdleTimeoutSeconds: 5",
+    "    l2DelayAfterL1Seconds: 3",
+    "    l2MinIntervalSeconds: 5",
+    "    l2MaxIntervalSeconds: 60",
+    "  recall:",
+    "    enabled: true",
+    "    maxResults: 10",
+    "    scoreThreshold: 0.3",
+    '    strategy: "keyword"',
+    "    timeoutMs: 10000",
+    '  storeBackend: "sqlite"',
+    "  embedding:",
+    '    provider: "none"',
+    "  bm25:",
+    "    enabled: true",
+    '    language: "en"',
+    "",
+  ].join("\n");
+}
+
+export async function spawnEvalGateway(opts: SpawnOptions): Promise<HttpEvalGateway> {
+  const dataDir = join(opts.runDir, "data", sanitize(opts.conversationId));
+  const configPath = join(opts.runDir, "config", `${sanitize(opts.conversationId)}.yaml`);
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(opts.runDir, "config"), { recursive: true });
+  writeFileSync(
+    configPath,
+    buildEvalGatewayConfig({ port: opts.port, dataDir, llm: opts.llm }),
+    "utf8",
+  );
+
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "src/gateway/server.ts"],
+    {
+      cwd: opts.memoryCoreDir,
+      env: {
+        ...process.env,
+        TDAI_GATEWAY_CONFIG: configPath,
+        TDAI_DATA_DIR: dataDir,
+        // Ensure a stray env key can't force service mode or remote stores.
+        TDAI_DEPLOY_MODE: "standalone",
+        STATE_BACKEND: "local",
+      },
+      stdio: opts.verbose ? "inherit" : ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  // Keep the last chunk of output around for startup failure diagnostics.
+  let recentOutput = "";
+  if (!opts.verbose) {
+    for (const stream of [child.stdout, child.stderr]) {
+      stream?.on("data", (chunk: Buffer) => {
+        recentOutput = (recentOutput + chunk.toString()).slice(-4000);
+      });
+    }
+  }
+
+  const baseUrl = `http://127.0.0.1:${opts.port}`;
+  const gateway = new HttpEvalGateway({ baseUrl }, child);
+
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `${TAG} Gateway exited during startup (code ${child.exitCode}).\n${recentOutput}`,
+      );
+    }
+    try {
+      const res = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(2000) });
+      if (res.ok) return gateway;
+    } catch {
+      // not up yet
+    }
+    await sleep(500);
+  }
+  await gateway.close();
+  throw new Error(`${TAG} Gateway did not become healthy within 90s.\n${recentOutput}`);
+}
+
+function sanitize(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/MemoryCore/scripts/eval-memory/llm.ts
+++ b/MemoryCore/scripts/eval-memory/llm.ts
@@ -1,0 +1,94 @@
+/**
+ * eval-memory — answerer + judge LLM.
+ *
+ * Uses the same `ai` + `@ai-sdk/openai` stack the standalone Gateway's own
+ * LLM runner is built on (src/adapters/standalone/llm-runner.ts), so the
+ * harness adds no new dependency and honours the same TDAI_LLM_* env vars.
+ *
+ * Prompt structure (answer from retrieved context only; lenient binary
+ * LLM-as-judge against the gold answer) follows mem0ai/memory-benchmarks
+ * (Apache-2.0): https://github.com/mem0ai/memory-benchmarks
+ */
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+import type { EvalLlm, JudgeVerdict } from "./types.js";
+
+export interface LlmEndpointConfig {
+  baseUrl: string;
+  apiKey: string;
+  answerModel: string;
+  judgeModel: string;
+  timeoutMs: number;
+}
+
+const ANSWER_SYSTEM = `You are answering questions about a past conversation.
+Use ONLY the information in the provided context. Be concise: answer in one
+short sentence or phrase, without preamble. If the context does not contain
+the information needed, reply exactly: "The information is not mentioned in
+the conversation".`;
+
+const JUDGE_SYSTEM = `You are grading whether a generated answer matches a
+gold answer for a question about a conversation. Reply with a single JSON
+object: {"correct": true|false, "reason": "<one sentence>"}.
+Grade leniently on wording: paraphrases, extra correct detail, or different
+date formats for the same date are all CORRECT. Grade strictly on facts:
+wrong entity, wrong value, wrong date, or a made-up answer is WRONG. An
+answer that says the information is unavailable is only CORRECT when the
+gold answer also says so.`;
+
+export function createAiSdkEvalLlm(cfg: LlmEndpointConfig): EvalLlm {
+  const provider = createOpenAI({ baseURL: cfg.baseUrl, apiKey: cfg.apiKey });
+
+  async function complete(model: string, system: string, prompt: string): Promise<string> {
+    const result = await generateText({
+      model: provider.chat(model),
+      system,
+      prompt,
+      abortSignal: AbortSignal.timeout(cfg.timeoutMs),
+    });
+    return result.text.trim();
+  }
+
+  return {
+    async answer(question, context, mode) {
+      const label = mode === "memory" ? "Retrieved memory context" : "Conversation transcript";
+      return complete(
+        cfg.answerModel,
+        ANSWER_SYSTEM,
+        `${label}:\n"""\n${context || "(empty)"}\n"""\n\nQuestion: ${question}\nAnswer:`,
+      );
+    },
+
+    async judge(question, goldAnswer, generated): Promise<JudgeVerdict> {
+      const text = await complete(
+        cfg.judgeModel,
+        JUDGE_SYSTEM,
+        `Question: ${question}\nGold answer: ${goldAnswer}\nGenerated answer: ${generated}\n\nJSON verdict:`,
+      );
+      return parseJudgeVerdict(text);
+    },
+  };
+}
+
+/**
+ * Judges occasionally wrap the JSON in prose or code fences; extract the
+ * first JSON object rather than failing the whole question. An unparseable
+ * verdict counts as WRONG so a flaky judge can only under-report accuracy,
+ * never inflate it.
+ */
+export function parseJudgeVerdict(text: string): JudgeVerdict {
+  const match = /\{[\s\S]*?\}/.exec(text);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[0]) as { correct?: unknown; reason?: unknown };
+      if (typeof parsed.correct === "boolean") {
+        return { correct: parsed.correct, reason: String(parsed.reason ?? "") };
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return { correct: false, reason: `unparseable judge output: ${text.slice(0, 200)}` };
+}

--- a/MemoryCore/scripts/eval-memory/report.ts
+++ b/MemoryCore/scripts/eval-memory/report.ts
@@ -1,0 +1,132 @@
+/**
+ * eval-memory — report emission.
+ *
+ * Writes report.json (machine-readable, full per-question detail) and
+ * report.md (human-readable summary). The metadata block carries what
+ * docs/reproducible-memory-evaluation.md (PR #204) asks reproductions to
+ * record, so two runs can be compared line by line.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { CategoryScore, RunReport } from "./types.js";
+
+export function detectRepoCommit(cwd: string): string {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+export function writeReport(outDir: string, report: RunReport): { jsonPath: string; mdPath: string } {
+  mkdirSync(outDir, { recursive: true });
+  const jsonPath = join(outDir, "report.json");
+  const mdPath = join(outDir, "report.md");
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  writeFileSync(mdPath, renderMarkdown(report), "utf8");
+  return { jsonPath, mdPath };
+}
+
+export function renderMarkdown(report: RunReport): string {
+  const m = report.metadata;
+  const hasBaseline = report.scores.some((s) => s.baselineAccuracy !== undefined);
+
+  const lines: string[] = [
+    "# Memory evaluation report",
+    "",
+    "## Run metadata",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    `| Harness | eval-memory ${m.harnessVersion} |`,
+    `| Repo commit | \`${m.repoCommit}\` |`,
+    `| Started / finished | ${m.startedAt} → ${m.finishedAt} |`,
+    `| Node / platform | ${m.nodeVersion} / ${m.platform} |`,
+    `| Dataset | ${m.dataset.name} (${m.dataset.conversations} conversations, ${m.dataset.sessions} sessions, ${m.dataset.questions} questions) |`,
+    `| Dataset source | ${m.dataset.source} |`,
+    `| Extraction model | ${m.models.extraction} |`,
+    `| Answer model | ${m.models.answer} |`,
+    `| Judge model | ${m.models.judge} |`,
+    `| Gateway | ${m.gateway.mode} (${m.gateway.url}) |`,
+    `| Flags | ${Object.entries(m.flags).map(([k, v]) => `${k}=${v}`).join(", ") || "(defaults)"} |`,
+    "",
+    "## Accuracy",
+    "",
+  ];
+
+  if (hasBaseline) {
+    lines.push(
+      "| Category | Questions | Memory accuracy | Baseline (full context) | Memory ctx tokens (avg) | Baseline ctx tokens (avg) |",
+      "| --- | ---: | ---: | ---: | ---: | ---: |",
+    );
+    for (const s of report.scores) {
+      lines.push(
+        `| ${s.category} | ${s.total} | ${pct(s.memoryAccuracy)} (${s.memoryCorrect}/${s.total}) | ` +
+          `${s.baselineAccuracy !== undefined ? `${pct(s.baselineAccuracy)} (${s.baselineCorrect}/${s.total})` : "—"} | ` +
+          `${s.avgMemoryContextTokens} | ${s.avgBaselineContextTokens ?? "—"} |`,
+      );
+    }
+  } else {
+    lines.push(
+      "| Category | Questions | Memory accuracy | Memory ctx tokens (avg) |",
+      "| --- | ---: | ---: | ---: |",
+    );
+    for (const s of report.scores) {
+      lines.push(
+        `| ${s.category} | ${s.total} | ${pct(s.memoryAccuracy)} (${s.memoryCorrect}/${s.total}) | ${s.avgMemoryContextTokens} |`,
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    "## Pipeline stats per conversation",
+    "",
+    "| Conversation | Sessions | Rounds | L1 records | Ingest (ms) | Settle (ms) | Fully drained |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | :---: |",
+  );
+  for (const c of report.conversations) {
+    lines.push(
+      `| ${c.conversationId} | ${c.sessions} | ${c.rounds} | ${c.l1Records ?? "n/a"} | ${c.ingestMs} | ${c.settleMs} | ${c.settled ? "yes" : "no"} |`,
+    );
+  }
+
+  const failures = report.results.filter((r) => !r.memory.correct).slice(0, 20);
+  if (failures.length > 0) {
+    lines.push("", `## Sample failures (first ${failures.length})`, "");
+    for (const f of failures) {
+      lines.push(
+        `- **${f.questionId}** (${f.category}): "${f.question}"`,
+        `  - gold: ${f.goldAnswer}`,
+        `  - got: ${f.memory.answer}`,
+        `  - judge: ${f.memory.judgeReason}`,
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    "---",
+    "",
+    "Methodology: ingest → settle → answer-from-recall-only → LLM-as-judge, after",
+    "[mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks) (Apache-2.0).",
+    "LoCoMo dataset: [snap-research/locomo](https://github.com/snap-research/locomo) (CC BY-NC 4.0, fetched at run time, not redistributed).",
+    "",
+  );
+  return lines.join("\n");
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+export function summaryLine(scores: CategoryScore[]): string {
+  const overall = scores.find((s) => s.category === "overall");
+  if (!overall) return "no questions were evaluated";
+  const baseline =
+    overall.baselineAccuracy !== undefined ? ` (baseline ${pct(overall.baselineAccuracy)})` : "";
+  return `overall memory accuracy ${pct(overall.memoryAccuracy)} on ${overall.total} questions${baseline}`;
+}

--- a/MemoryCore/scripts/eval-memory/runner.ts
+++ b/MemoryCore/scripts/eval-memory/runner.ts
@@ -1,0 +1,272 @@
+/**
+ * eval-memory — orchestration.
+ *
+ * Pure logic over the EvalGateway / EvalLlm seams so the whole flow is
+ * unit-testable without a Gateway process or network:
+ *
+ *   per conversation:  ingest (capture rounds) → flush (/session/end)
+ *                      → settle (pipeline drains) → answer (recall-only
+ *                      context) → judge
+ *   then:              aggregate per-category scores
+ */
+
+import { conversationTranscript } from "./datasets.js";
+import { sleep } from "./gateway.js";
+import type {
+  AnswerOutcome,
+  CategoryScore,
+  ConversationRunStats,
+  EvalConversation,
+  EvalDataset,
+  EvalGateway,
+  EvalGatewayFactory,
+  EvalLlm,
+  PipelineStatus,
+  QuestionCategory,
+  QuestionResult,
+} from "./types.js";
+
+export interface RunnerOptions {
+  /** "none" (default) or "full-context" — adds a no-memory comparison run. */
+  baseline: "none" | "full-context";
+  baselineMaxChars: number;
+  /** Hard cap on waiting for the pipeline to drain, per conversation. */
+  settleTimeoutMs: number;
+  /** Pipeline must report all layers idle this many consecutive polls. */
+  settleStablePolls: number;
+  settlePollIntervalMs: number;
+  /** Fallback wait when /v2/pipeline/status is unavailable. */
+  settleFallbackMs: number;
+  /** Rough token count for context-size reporting. */
+  countTokens: (text: string) => number;
+  log: (line: string) => void;
+}
+
+export interface ConversationOutcome {
+  stats: ConversationRunStats;
+  results: QuestionResult[];
+}
+
+export async function runConversation(
+  convo: EvalConversation,
+  gatewayFactory: EvalGatewayFactory,
+  llm: EvalLlm,
+  opts: RunnerOptions,
+): Promise<ConversationOutcome> {
+  const gateway = await gatewayFactory(convo.conversationId);
+  try {
+    // ── Ingest ──
+    const ingestStart = Date.now();
+    let rounds = 0;
+    for (const session of convo.sessions) {
+      for (const round of session.rounds) {
+        await gateway.capture(session.sessionKey, round.user, round.assistant);
+        rounds++;
+      }
+      // Flush per session so buffered L1 work is extracted even when the
+      // round count never crosses the everyN threshold.
+      await gateway.sessionEnd(session.sessionKey);
+    }
+    const ingestMs = Date.now() - ingestStart;
+
+    // ── Settle ──
+    const settleStart = Date.now();
+    const settled = await waitForPipeline(gateway, opts);
+    const settleMs = Date.now() - settleStart;
+    const l1Records = await gateway.countL1();
+    opts.log(
+      `[${convo.conversationId}] ingested ${rounds} rounds in ${ingestMs}ms; ` +
+        `settled=${settled} in ${settleMs}ms; l1_records=${l1Records ?? "n/a"}`,
+    );
+
+    // ── Answer + judge ──
+    const recallSessionKey = `${convo.conversationId}:eval`;
+    const results: QuestionResult[] = [];
+    for (const q of convo.questions) {
+      const memory = await answerFromMemory(gateway, llm, q.question, q.goldAnswer, recallSessionKey, opts);
+      let baseline: AnswerOutcome | undefined;
+      if (opts.baseline === "full-context") {
+        baseline = await answerFromTranscript(llm, convo, q.question, q.goldAnswer, opts);
+      }
+      results.push({
+        conversationId: convo.conversationId,
+        questionId: q.id,
+        category: q.category,
+        question: q.question,
+        goldAnswer: q.goldAnswer,
+        memory,
+        baseline,
+      });
+      opts.log(
+        `[${convo.conversationId}] ${q.id} (${q.category}) memory=${memory.correct ? "✓" : "✗"}` +
+          (baseline ? ` baseline=${baseline.correct ? "✓" : "✗"}` : ""),
+      );
+    }
+
+    return {
+      stats: {
+        conversationId: convo.conversationId,
+        sessions: convo.sessions.length,
+        rounds,
+        l1Records,
+        ingestMs,
+        settleMs,
+        settled,
+      },
+      results,
+    };
+  } finally {
+    await gateway.close();
+  }
+}
+
+async function answerFromMemory(
+  gateway: EvalGateway,
+  llm: EvalLlm,
+  question: string,
+  goldAnswer: string,
+  sessionKey: string,
+  opts: RunnerOptions,
+): Promise<AnswerOutcome> {
+  const start = Date.now();
+  const recall = await gateway.recall(question, sessionKey);
+  const answer = await llm.answer(question, recall.context, "memory");
+  const verdict = await llm.judge(question, goldAnswer, answer);
+  return {
+    answer,
+    correct: verdict.correct,
+    judgeReason: verdict.reason,
+    contextChars: recall.context.length,
+    contextTokens: opts.countTokens(recall.context),
+    recallStrategy: recall.strategy,
+    recallMemoryCount: recall.memoryCount,
+    recallCode: recall.code,
+    latencyMs: Date.now() - start,
+  };
+}
+
+async function answerFromTranscript(
+  llm: EvalLlm,
+  convo: EvalConversation,
+  question: string,
+  goldAnswer: string,
+  opts: RunnerOptions,
+): Promise<AnswerOutcome> {
+  const start = Date.now();
+  const transcript = conversationTranscript(convo, opts.baselineMaxChars);
+  const answer = await llm.answer(question, transcript, "baseline");
+  const verdict = await llm.judge(question, goldAnswer, answer);
+  return {
+    answer,
+    correct: verdict.correct,
+    judgeReason: verdict.reason,
+    contextChars: transcript.length,
+    contextTokens: opts.countTokens(transcript),
+    latencyMs: Date.now() - start,
+  };
+}
+
+/**
+ * Wait until L1/L2/L3 all report idle for `settleStablePolls` consecutive
+ * polls. The stability window matters because the L2/L3 cascade is armed
+ * by short timers — a single idle snapshot between L1 finishing and the
+ * L2 timer firing would otherwise end the wait early. Queue-based status
+ * (not conversation-count heuristics) deliberately avoids the failure
+ * mode reported for /seed's waitL1 in issue #505.
+ */
+export async function waitForPipeline(
+  gateway: { pipelineStatus: () => Promise<PipelineStatus | null> },
+  opts: Pick<RunnerOptions, "settleTimeoutMs" | "settleStablePolls" | "settlePollIntervalMs" | "settleFallbackMs" | "log">,
+): Promise<boolean> {
+  const first = await gateway.pipelineStatus();
+  if (first === null) {
+    opts.log(`pipeline status unavailable — falling back to a fixed ${opts.settleFallbackMs}ms wait`);
+    await sleep(opts.settleFallbackMs);
+    return false;
+  }
+
+  const deadline = Date.now() + opts.settleTimeoutMs;
+  let stable = 0;
+  while (Date.now() < deadline) {
+    const status = await gateway.pipelineStatus();
+    const idle = status !== null && status.l1.idle && status.l2.idle && status.l3.idle;
+    stable = idle ? stable + 1 : 0;
+    if (stable >= opts.settleStablePolls) return true;
+    await sleep(opts.settlePollIntervalMs);
+  }
+  opts.log(`pipeline did not fully drain within ${opts.settleTimeoutMs}ms — continuing anyway`);
+  return false;
+}
+
+// ============================
+// Aggregation
+// ============================
+
+const CATEGORY_ORDER: Array<QuestionCategory | "overall"> = [
+  "overall",
+  "single-hop",
+  "multi-hop",
+  "temporal",
+  "open-domain",
+  "adversarial",
+];
+
+export function aggregateScores(results: QuestionResult[]): CategoryScore[] {
+  const hasBaseline = results.some((r) => r.baseline !== undefined);
+
+  function scoreFor(category: QuestionCategory | "overall"): CategoryScore | null {
+    const subset = category === "overall" ? results : results.filter((r) => r.category === category);
+    if (subset.length === 0) return null;
+    const memoryCorrect = subset.filter((r) => r.memory.correct).length;
+    const score: CategoryScore = {
+      category,
+      total: subset.length,
+      memoryCorrect,
+      memoryAccuracy: round4(memoryCorrect / subset.length),
+      avgMemoryContextTokens: Math.round(avg(subset.map((r) => r.memory.contextTokens))),
+    };
+    if (hasBaseline) {
+      const withBaseline = subset.filter((r) => r.baseline !== undefined);
+      if (withBaseline.length > 0) {
+        const baselineCorrect = withBaseline.filter((r) => r.baseline?.correct).length;
+        score.baselineCorrect = baselineCorrect;
+        score.baselineAccuracy = round4(baselineCorrect / withBaseline.length);
+        score.avgBaselineContextTokens = Math.round(
+          avg(withBaseline.map((r) => r.baseline?.contextTokens ?? 0)),
+        );
+      }
+    }
+    return score;
+  }
+
+  return CATEGORY_ORDER.map(scoreFor).filter((s): s is CategoryScore => s !== null);
+}
+
+function avg(nums: number[]): number {
+  return nums.length === 0 ? 0 : nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+// ============================
+// Dataset slicing (cheap runs)
+// ============================
+
+export function sliceDataset(
+  dataset: EvalDataset,
+  maxConversations: number,
+  maxQuestionsPerConversation: number,
+): EvalDataset {
+  const conversations = dataset.conversations
+    .slice(0, maxConversations > 0 ? maxConversations : dataset.conversations.length)
+    .map((c) => ({
+      ...c,
+      questions: c.questions.slice(
+        0,
+        maxQuestionsPerConversation > 0 ? maxQuestionsPerConversation : c.questions.length,
+      ),
+    }));
+  return { ...dataset, conversations };
+}

--- a/MemoryCore/scripts/eval-memory/types.ts
+++ b/MemoryCore/scripts/eval-memory/types.ts
@@ -1,0 +1,183 @@
+/**
+ * eval-memory — shared types.
+ *
+ * The harness replays a benchmark dataset through a standalone Gateway
+ * (ingest → settle → answer → judge) and reports judged accuracy with the
+ * run metadata needed to make independent reproductions comparable
+ * (see docs/reproducible-memory-evaluation.md once merged, and issue #106).
+ *
+ * Pipeline design follows mem0ai/memory-benchmarks (Apache-2.0):
+ * https://github.com/mem0ai/memory-benchmarks
+ */
+
+export type QuestionCategory =
+  | "single-hop"
+  | "multi-hop"
+  | "temporal"
+  | "open-domain"
+  | "adversarial";
+
+export interface EvalTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/** One multi-turn session inside a conversation (one /capture per round). */
+export interface EvalSession {
+  sessionKey: string;
+  /** Human-readable date the session took place ("1:56 pm on 8 May, 2023"). */
+  dateTime?: string;
+  /** Strictly alternating user/assistant rounds, normalized by the adapter. */
+  rounds: Array<{ user: string; assistant: string }>;
+}
+
+export interface EvalQuestion {
+  id: string;
+  question: string;
+  goldAnswer: string;
+  category: QuestionCategory;
+  /** Dialog ids that contain the answer, when the dataset provides them. */
+  evidence?: string[];
+}
+
+/**
+ * One independent memory scope. Each conversation is evaluated against a
+ * fresh Gateway data directory so memories from other conversations cannot
+ * leak into recall (mirrors the one-agent-per-user deployment shape).
+ */
+export interface EvalConversation {
+  conversationId: string;
+  sessions: EvalSession[];
+  questions: EvalQuestion[];
+}
+
+export interface EvalDataset {
+  name: string;
+  /** Where the data came from (URL or path) — recorded in the report. */
+  source: string;
+  conversations: EvalConversation[];
+}
+
+// ============================
+// Gateway seam (DI for tests)
+// ============================
+
+export interface RecallResult {
+  context: string;
+  strategy?: string;
+  memoryCount: number;
+  /** Non-zero recall failure code (H-15 taxonomy) — recorded, not fatal. */
+  code: number;
+  message?: string;
+}
+
+export interface PipelineLayerStatus {
+  queued: number;
+  running: number;
+  idle: boolean;
+}
+
+export interface PipelineStatus {
+  l1: PipelineLayerStatus;
+  l2: PipelineLayerStatus;
+  l3: PipelineLayerStatus;
+}
+
+/** Minimal Gateway surface the runner needs. Real impl is HTTP; tests fake it. */
+export interface EvalGateway {
+  capture(sessionKey: string, user: string, assistant: string): Promise<void>;
+  sessionEnd(sessionKey: string): Promise<void>;
+  /** null = endpoint unavailable (legacy standalone) — settle falls back to a fixed grace wait. */
+  pipelineStatus(): Promise<PipelineStatus | null>;
+  recall(query: string, sessionKey: string): Promise<RecallResult>;
+  /** Total L1 records extracted, when countable; null when not supported. */
+  countL1(): Promise<number | null>;
+  close(): Promise<void>;
+}
+
+/** Creates a fresh, isolated gateway scope per conversation. */
+export type EvalGatewayFactory = (conversationId: string) => Promise<EvalGateway>;
+
+// ============================
+// LLM seam (DI for tests)
+// ============================
+
+export interface JudgeVerdict {
+  correct: boolean;
+  reason: string;
+}
+
+export interface EvalLlm {
+  /** Answer a question given only the provided context. */
+  answer(question: string, context: string, mode: "memory" | "baseline"): Promise<string>;
+  /** Grade a generated answer against the gold answer. */
+  judge(question: string, goldAnswer: string, generated: string): Promise<JudgeVerdict>;
+}
+
+// ============================
+// Results
+// ============================
+
+export interface QuestionResult {
+  conversationId: string;
+  questionId: string;
+  category: QuestionCategory;
+  question: string;
+  goldAnswer: string;
+  memory: AnswerOutcome;
+  /** Present only when --baseline full-context was requested. */
+  baseline?: AnswerOutcome;
+}
+
+export interface AnswerOutcome {
+  answer: string;
+  correct: boolean;
+  judgeReason: string;
+  contextChars: number;
+  contextTokens: number;
+  recallStrategy?: string;
+  recallMemoryCount?: number;
+  recallCode?: number;
+  latencyMs: number;
+}
+
+export interface CategoryScore {
+  category: QuestionCategory | "overall";
+  total: number;
+  memoryCorrect: number;
+  memoryAccuracy: number;
+  baselineCorrect?: number;
+  baselineAccuracy?: number;
+  avgMemoryContextTokens: number;
+  avgBaselineContextTokens?: number;
+}
+
+export interface ConversationRunStats {
+  conversationId: string;
+  sessions: number;
+  rounds: number;
+  l1Records: number | null;
+  ingestMs: number;
+  settleMs: number;
+  settled: boolean;
+}
+
+export interface RunReport {
+  metadata: RunMetadata;
+  scores: CategoryScore[];
+  conversations: ConversationRunStats[];
+  results: QuestionResult[];
+}
+
+export interface RunMetadata {
+  harnessVersion: string;
+  startedAt: string;
+  finishedAt: string;
+  repoCommit: string;
+  nodeVersion: string;
+  platform: string;
+  dataset: { name: string; source: string; conversations: number; sessions: number; questions: number };
+  models: { extraction: string; answer: string; judge: string };
+  gateway: { mode: "spawned" | "external"; url: string; configPath?: string };
+  flags: Record<string, string | number | boolean>;
+}


### PR DESCRIPTION
## Description | 描述

Adds `MemoryCore/scripts/eval-memory/` — a self-contained, opt-in harness that measures standalone Gateway memory quality end to end, so benchmark results can be reproduced and compared outside the team. This implements the runnable-harness half of the evaluation story proposed in https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/106#issuecomment-5197106540 (the docs half is #204, whose run-metadata template this report follows).

Per conversation: **ingest** (replay rounds via `POST /capture`, flush each session via `POST /session/end`) → **settle** (poll `POST /v2/pipeline/status` until L1/L2/L3 drain, queue-based with a stability window — deliberately avoiding the conversation-count heuristic failure mode reported in #505) → **answer** (answerer LLM answers from `POST /recall` context only; optional `--baseline full-context` comparison from the raw transcript) → **judge** (lenient-wording/strict-facts LLM judge; unparseable verdicts count as wrong so a flaky judge can only under-report) → **report** (`report.json` + `report.md` with per-category accuracy, context-token costs, pipeline stats, and full run metadata: commit, models, dataset, resolved Gateway config).

Datasets are pluggable adapters:
- `synthetic` — built-in deterministic smoke set (wiring check);
- `locomo` — [LoCoMo](https://github.com/snap-research/locomo) (Maharana et al., ACL 2024), 10 multi-session conversations / ~1,500 judged questions. **CC BY-NC 4.0, so it is fetched from the official source at run time and never vendored into this repo.** Adversarial questions excluded by default, matching [mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks) practice.
- PersonaMem (the benchmark the README cites) can land later as one more adapter — the runner is dataset-agnostic.

Isolation: each conversation runs against its own spawned Gateway process with a fresh `TDAI_DATA_DIR`, so recall can never cross-contaminate between conversations. `--gateway-url` reuses an existing Gateway instead (documented caveat).

Scope guardrails:
- **No new dependencies** — reuses `ai`, `@ai-sdk/openai`, `js-tiktoken`, `tsx` already declared by MemoryCore.
- **Nothing added to the published npm package** (the `files` whitelist is untouched) and **nothing runs in CI** (opt-in `npm run eval:memory`).
- No Gateway runtime code changes; only `package.json` gains one script line and `.gitignore` gains the results dir.

Methodology (ingest → search → judge, LLM-as-judge) follows [mem0ai/memory-benchmarks](https://github.com/mem0ai/memory-benchmarks) (Apache-2.0), credited in the README and report footer.

## Related Issue | 关联 Issue

Refs #106, #73 (proposed in https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/106#issuecomment-5197106540 before implementation; complements docs PR #204)

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verification performed (Node v24, Windows 11; harness targets Node ≥ 22.16):
- `npm test` — 19/19 unit tests pass (`__tests__/eval-memory.test.ts`: dataset adapters, runner orchestration over DI fakes, settle stability window, judge parsing, aggregation, report rendering — no network, no Gateway process, no module mocks).
- `npm run eval:memory -- --dataset synthetic --dry-run` and `--dataset locomo --dry-run` — LoCoMo adapter parses the official dataset (10 conversations, 272 sessions, 1,540 questions).
- Full end-to-end run against a local OpenAI-compatible endpoint: Gateway spawned per conversation, 5 rounds ingested, pipeline settled via `/v2/pipeline/status` in ~4s, recall + judging + report generation all exercised.
- `bash scripts/ci/check-skill-queue-isolation.sh` — PASS.

## Additional Notes | 其他说明

- `npm pack` / `npm run build` currently fail on this branch **before** this PR due to the missing `scripts/seed-v2/` build target (#716 / #759, fixes in flight in #729 / #763 / #775). This PR intentionally does not hook into the build chain, so it neither fixes nor worsens that.
- Report accuracy depends on the extraction/answer/judge models; the metadata block exists precisely so that two runs are only compared when their setups match. Happy to adjust scope, location (e.g. a top-level `eval/`), or dataset policy per maintainer preference.
