### PR TITLE
fix(memory-core): recover SerialQueue after synchronous task throw

### DIFF
--- a/MemoryCore/src/utils/serial-queue.test.ts
+++ b/MemoryCore/src/utils/serial-queue.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { SerialQueue } from "./serial-queue.js";
+
+describe("SerialQueue", () => {
+  it("runs tasks serially in FIFO order", async () => {
+    const queue = new SerialQueue("fifo");
+    const order: number[] = [];
+    await Promise.all([
+      queue.add(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        order.push(1);
+      }),
+      queue.add(async () => {
+        order.push(2);
+      }),
+      queue.add(async () => {
+        order.push(3);
+      }),
+    ]);
+    expect(order).toEqual([1, 2, 3]);
+    // running=false is flipped in the drain chain's .finally, one microtask
+    // after the last caller promise resolves — wait for idle, don't poll it.
+    await queue.onIdle();
+    expect(queue.idle).toBe(true);
+  });
+
+  it("rejects the caller on async task failure and keeps draining", async () => {
+    const queue = new SerialQueue("async-fail");
+    await expect(queue.add(async () => {
+      throw new Error("async failure");
+    })).rejects.toThrow("async failure");
+    await expect(queue.add(async () => "recovered")).resolves.toBe("recovered");
+    await queue.onIdle();
+    expect(queue.idle).toBe(true);
+  });
+
+  // Regression for #518: a task that throws before returning its promise used
+  // to escape drain() ahead of the .finally() bookkeeping, leaving the queue
+  // permanently stuck with running=true.
+  it("recovers from a synchronously-throwing task (#518)", async () => {
+    const queue = new SerialQueue("sync-throw");
+
+    await expect(
+      queue.add((() => {
+        throw new Error("sync failure");
+      }) as () => Promise<never>),
+    ).rejects.toThrow("sync failure");
+
+    // onIdle() must resolve rather than wait forever (hung before the fix)...
+    await queue.onIdle();
+
+    // ...queue bookkeeping must be finalized...
+    expect(queue.pending).toBe(false);
+    expect(queue.size).toBe(0);
+
+    // ...and the next task must actually run (also hung before the fix).
+    await expect(queue.add(async () => "ran")).resolves.toBe("ran");
+    await queue.onIdle();
+    expect(queue.idle).toBe(true);
+  });
+
+  it("resolves onIdle() waiters after a sync throw with queued followers", async () => {
+    const queue = new SerialQueue("sync-throw-idle");
+    const results: string[] = [];
+
+    const first = queue
+      .add((() => {
+        throw new Error("boom");
+      }) as () => Promise<never>)
+      .catch(() => results.push("first-rejected"));
+    const second = queue.add(async () => {
+      results.push("second-ran");
+    });
+
+    await queue.onIdle();
+    await Promise.all([first, second]);
+    expect(results).toEqual(["first-rejected", "second-ran"]);
+  });
+});

--- a/MemoryCore/src/utils/serial-queue.ts
+++ b/MemoryCore/src/utils/serial-queue.ts
@@ -105,8 +105,13 @@ export class SerialQueue {
 
     this.debugFn?.(`[queue:${this.name}] dequeued, starting execution (remaining=${this.queue.length})`);
 
-    entry
-      .task()
+    // Invoke the task from a resolved promise: a synchronously-throwing task
+    // must reject through the same chain as an async failure. Calling
+    // entry.task() bare would let the throw escape before .finally() is
+    // attached, leaving running=true forever — every later task stalls and
+    // onIdle() never resolves (#518).
+    Promise.resolve()
+      .then(() => entry.task())
       .then((result) => entry.resolve(result))
       .catch((err) => entry.reject(err))
       .finally(() => {


### PR DESCRIPTION
## Description | 描述

Ports the #518 fix to the current default branch. `SerialQueue.drain()` in `MemoryCore/src/utils/serial-queue.ts` invokes `entry.task()` bare, so a task that throws **synchronously** (before returning its promise) escapes ahead of the `.finally()` bookkeeping: the caller's promise rejects, but the queue is left with `running = true` forever. All three pipeline queues (`l1Queue`/`l2Queue`/`l3Queue`) share this class, so one bad task silently stalls every later task, and `flushSession()` / `onIdle()` waiters hang until `destroy()`'s timeout fallback.

Fix: start task invocation from `Promise.resolve().then(() => entry.task())`, so synchronous throws and async rejections share the existing rejection + cleanup path. FIFO ordering, error propagation to the caller, and idle notification semantics are unchanged.

Credit where due: this is the same fix shape as @yangjj-iso's #519, which targets `main`'s pre-v2 layout (`src/utils/serial-queue.ts` at the repo root) and does not apply to `feat/server_team`'s `MemoryCore/` tree. The identical bug in MemoryKnowledge's separate `SerialQueue` was already addressed by #694 — this PR closes the remaining copy.

Regression tests (`MemoryCore/src/utils/serial-queue.test.ts`, vitest, no mocks):
- FIFO ordering and async-failure recovery (baseline behaviour lock);
- a synchronously-throwing task rejects its caller, the queue finishes bookkeeping, the **next task actually runs**, and `onIdle()` resolves — before the fix these hang (verified: with the fix stashed, the new tests time out at 120s);
- `onIdle()` waiters resolve when a sync throw is followed by queued tasks.

## Related Issue | 关联 Issue

Fix #518 (port of #519 to feat/server_team; MemoryKnowledge twin fixed in #694)

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

`npm test` passes (Node v24, Windows 11). Negative check: with the fix stashed and only the tests applied, the regression tests hang and fail on timeout, confirming they capture #518 exactly.

## Additional Notes | 其他说明

None — two-file change, no dependency or API surface changes.
