### PR TITLE
fix(deploy): gate init-admin on HTTP readiness; fix macOS bash unbound variable

### DIFF
--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -77,6 +77,11 @@ find_docker() {
 
 DOCKER="$(find_docker)"
 
+# curl 优先走 PATH（Windows Git Bash 没有 /usr/bin/curl，见 issue #655），
+# 兜底 /usr/bin/curl 与 Homebrew/系统默认布局保持兼容。所有脚本里发 HTTP
+# 请求都应该用 $CURL，不要再各自硬编码 /usr/bin/curl。
+CURL="$(command -v curl 2>/dev/null || echo /usr/bin/curl)"
+
 # PULL=1 时拉取镜像最新版本。
 # 默认关闭：docker run 在本地没有镜像时会自动拉，但本地已有同名 :latest 时会直接复用，
 # 不会感知远端更新——想升级到最新 latest 就带 PULL=1。
@@ -148,15 +153,11 @@ wait_http_ready() {
   local url="$1"
   local timeout="${2:-45}"
   local label="${3:-$1}"
-  # curl 优先走 PATH（Windows Git Bash 没有 /usr/bin/curl，见 issue #655），
-  # 兜底 /usr/bin/curl 与本目录其它脚本保持一致。
-  local curl_bin
-  curl_bin="$(command -v curl 2>/dev/null || echo /usr/bin/curl)"
   local waited=0 code="000"
   while (( waited < timeout )); do
     # curl 失败时 -w 已经输出 "000"，|| true 只兜 set -e，不再追加字符
     # （否则会出现 "000000" 这类叠加状态码，见 issue #761 的报错样例）。
-    code="$("$curl_bin" -sS -o /dev/null -w "%{http_code}" --max-time 2 "$url" 2>/dev/null || true)"
+    code="$("$CURL" -sS -o /dev/null -w "%{http_code}" --max-time 2 "$url" 2>/dev/null || true)"
     code="${code:-000}"
     if [[ "$code" == "200" ]]; then
       ok "$label HTTP 就绪（$url → 200）"

--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -134,6 +134,41 @@ wait_healthy() {
   die "${name} 在 ${timeout}s 内未就绪。"
 }
 
+# 等待一个 HTTP 端点真正就绪（返回 200）。
+#
+# wait_healthy 对没有 healthcheck 的镜像只等容器 running 就返回，而容器
+# running 只代表 entrypoint 已启动 —— 内部服务真正监听端口还需要几秒
+# （podman libkrun 下窗口更大，Docker Desktop 偶发）。在这个窗口内发请求，
+# 连接会被拒绝或在服务半启动时中断，表现为 HTTP=000 或请求体不完整
+# （见 issue #761）。需要在 wait_healthy 之后紧接着调接口的脚本，先用本
+# 函数确认 HTTP 已就绪。
+#
+# 用法：wait_http_ready <url> [timeout_s=45] [label=<url>]
+wait_http_ready() {
+  local url="$1"
+  local timeout="${2:-45}"
+  local label="${3:-$1}"
+  # curl 优先走 PATH（Windows Git Bash 没有 /usr/bin/curl，见 issue #655），
+  # 兜底 /usr/bin/curl 与本目录其它脚本保持一致。
+  local curl_bin
+  curl_bin="$(command -v curl 2>/dev/null || echo /usr/bin/curl)"
+  local waited=0 code="000"
+  while (( waited < timeout )); do
+    # curl 失败时 -w 已经输出 "000"，|| true 只兜 set -e，不再追加字符
+    # （否则会出现 "000000" 这类叠加状态码，见 issue #761 的报错样例）。
+    code="$("$curl_bin" -sS -o /dev/null -w "%{http_code}" --max-time 2 "$url" 2>/dev/null || true)"
+    code="${code:-000}"
+    if [[ "$code" == "200" ]]; then
+      ok "$label HTTP 就绪（$url → 200）"
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  warn "$label 在 ${timeout}s 内未就绪（最后状态码 $code，url=$url）"
+  return 1
+}
+
 # 打印统一的服务地址表
 print_endpoints() {
   echo ""

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -135,6 +135,16 @@ $DOCKER run -d --name "$CONTAINER" \
   "$MEMORY_CORE_IMAGE" >/dev/null
 
 wait_healthy "$CONTAINER" 90
+
+# memory-core 镜像没有 healthcheck，wait_healthy 看到容器 running 就返回，
+# 但内部 Node 服务监听 8420 还需要几秒。下面的 init-admin 紧接着就发请求，
+# 必须先等 /health 真正返回 200，否则会拿到 HTTP=000（连接拒绝）或请求在
+# 半启动的服务上中断（issue #761，podman 下几乎必现，Docker Desktop 偶发）。
+if ! wait_http_ready "http://localhost:${MEMORY_CORE_PORT}/health" 45 "memory-core"; then
+  warn "memory-core 容器日志："
+  $DOCKER logs --tail 30 "$CONTAINER" 2>&1 || true
+  die "memory-core HTTP 未就绪，init-admin 无法继续。"
+fi
 ok "memory-core 已启动 → http://localhost:${MEMORY_CORE_PORT}/"
 
 # ── Admin user 生命周期 ─────────────────────────────────────────
@@ -167,12 +177,14 @@ verify_user_key() {
     -X POST -H "Content-Type: application/json" \
     -H "x-tdai-service-id: default" \
     ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
-    "http://localhost:${MEMORY_CORE_PORT}/v3/meta/auth/verify" \
-    -d "$(printf '{"user_key":"%s"}' "$key")" 2>/dev/null || echo "000")
+    -d "$(printf '{"user_key":"%s"}' "$key")" \
+    "http://localhost:${MEMORY_CORE_PORT}/v3/meta/auth/verify" 2>/dev/null || echo "000")
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+# ${ADMIN_KEY_FILE} 必须带花括号：macOS 自带 bash 3.2 会把紧邻的全角"）"
+# 字节并入变量名，在 set -u 下报 "ADMIN_KEY_FILE）: unbound variable"。
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then
@@ -188,8 +200,8 @@ init_resp=$(/usr/bin/curl -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
   -X POST -H "Content-Type: application/json" \
   ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
   -H "x-tdai-service-id: default" \
-  "http://localhost:${MEMORY_CORE_PORT}/v3/internal/meta/user/init-admin" \
-  -d "$init_body" 2>/dev/null || echo "000")
+  -d "$init_body" \
+  "http://localhost:${MEMORY_CORE_PORT}/v3/internal/meta/user/init-admin" 2>/dev/null || echo "000")
 
 case "$init_resp" in
   200)

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -173,7 +173,7 @@ generate_user_key() {
 verify_user_key() {
   local key="$1"
   local code
-  code=$(/usr/bin/curl -sS -o /dev/null -w "%{http_code}" --max-time 5 \
+  code=$("$CURL" -sS -o /dev/null -w "%{http_code}" --max-time 5 \
     -X POST -H "Content-Type: application/json" \
     -H "x-tdai-service-id: default" \
     ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
@@ -196,7 +196,7 @@ fi
 
 init_body=$(printf '{"username":"%s","user_key":"%s"}' \
   "$MEMORY_CORE_ADMIN_USERNAME" "$ADMIN_KEY")
-init_resp=$(/usr/bin/curl -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
+init_resp=$("$CURL" -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
   -X POST -H "Content-Type: application/json" \
   ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
   -H "x-tdai-service-id: default" \


### PR DESCRIPTION
## Description | 描述

Fixes the `start-all.sh` / `start-memory-core.sh` init-admin failures reported in #761 (v2.0.0, macOS + podman; the race also hits Docker Desktop intermittently). Credit to @liShuangQ for the detailed forensic report.

**1. Startup race (the reported "HTTP=000000" and the 500 "Invalid JSON body") — real fix.**
The three published images have no Docker healthcheck, so `wait_healthy`'s `none` branch returns as soon as the container is `running` — but the Node service inside takes a few more seconds to listen on 8420. `start-memory-core.sh` fires the `init-admin` curl immediately after, hitting a port that isn't listening yet (HTTP `000`) or a barely-up server (aborted/truncated request → `Invalid JSON body` 500). This PR adds a reusable `wait_http_ready <url> [timeout] [label]` helper to `_lib.sh` and gates `init-admin` on `GET /health` → 200, dumping container logs and failing fast if readiness never arrives.
The helper resolves curl via `command -v curl` first (falling back to `/usr/bin/curl`), so the *new* code also works in Git Bash on Windows without expanding the scope of #655 / #669. It also avoids the `000000` stacked-status artifact from `-w "%{http_code}" ... || echo "000"` (visible in the issue's logs) by using `|| true` instead of appending a second code.

**2. `unbound variable` on macOS (Bug 1 in the issue) — one-line fix.**
`$ADMIN_KEY_FILE` is immediately followed by a full-width `）` (U+FF09); macOS's stock bash 3.2 folds those bytes into the variable name and aborts under `set -u`. Brace-wrapped to `${ADMIN_KEY_FILE}`. Note #710 proposes the same brace-wrap repo-wide for this whole class; this PR only touches the one occurrence that breaks deployment, and merges cleanly with #710 in either order.

**3. `-d` position (Bug 2 in the issue) — style only, with a corrected diagnosis.**
The issue attributed the 500 to `-d "$init_body"` appearing after the URL. Empirically that is not a bug: curl applies options position-independently, and the exact command shape from the script sends the body fine (verified against an echo server, curl 8.x; see my comment on #761). The observed 500 is explained by the startup race above. The `-d`-before-URL reorder (here applied to both `init-admin` and `verify_user_key`) is kept as convention/readability, not as a behavioural fix.

## Related Issue | 关联 Issue

Fix #761

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verification:
- `bash -n` clean on both scripts.
- `wait_http_ready` exercised standalone: (a) dead endpoint → returns 1 after timeout with a clean `000` last-status; (b) endpoint that starts listening 3s late → helper waits through the window and returns 0.
- curl `-d`-after-URL behaviour tested against an echo server with the exact header/arg shape used by the script (body present in all orderings, with and without the optional Bearer header).
- Full container e2e on Docker Desktop pending on my side (daemon unavailable in this session); the readiness helper was validated against a live slow-starting HTTP server instead, which exercises the same race window. Will follow up with a full `start-memory-core.sh` run if useful.

## Additional Notes | 其他说明

- `memory-hub` / `proxy` start scripts don't fire requests immediately after `wait_healthy`, so they are left untouched; if that changes, the same `wait_http_ready` helper is now available. Adding image healthchecks upstream would be the deeper fix.
- Interplays: #710 (repo-wide brace-wrap, one overlapping line), #669 (PATH-resolved curl for existing call sites — no overlap with the new helper).
