### PR TITLE
fix(deploy): 修复 global-images 脚本在 Windows / Git Bash 下无法部署

### DIFF
--- a/deploy/global-images/.env.example
+++ b/deploy/global-images/.env.example
@@ -45,6 +45,17 @@ PROXY_UPSTREAM_API_KEY=REPLACE_ME           # 例：sk-xxxxxxxx（可与 memory 
 PROXY_UPSTREAM_MODEL=REPLACE_ME             # 例：deepseek-chat
 
 # ── 端口（默认可直接用；有本地冲突时改这里） ───────────────────────────────
+#
+# Windows 注意：Hyper-V / WSL2 / Docker Desktop 会预留成片的 TCP 端口区段
+# （常见的 8345-8444 就覆盖了下面的 8420 和 8424）。落在保留段里的端口，
+# docker run -p 不会报错，容器也照样 healthy，但端口实际发布不了——
+# `docker inspect` 里 NetworkSettings.Ports 是空的，宿主机连不上。
+# 表现很像内核挂了（脚本里的 init-admin 会连不上而失败）。
+#
+# 先查一下再改：
+#   netsh interface ipv4 show excludedportrange protocol=tcp
+# 撞上了就换到区段外，例如 18420 / 18424（容器内部端口不变，
+# 只是宿主机映射换了；记得同步下面的 KNOWLEDGE_PUBLIC_BASE_URL）。
 MEMORY_CORE_PORT=8420
 PANEL_PORT=8125
 KNOWLEDGE_PORT=8424

--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -14,6 +14,29 @@ else
   C_RED=""; C_GRN=""; C_YLW=""; C_BLU=""; C_RST=""
 fi
 
+# ── Windows / Git Bash 兼容 ─────────────────────────────────────
+# MSYS(Git Bash) 会把"看起来像路径"的参数自动转成 Windows 路径再传给原生
+# docker.exe，导致：
+#   -e TDAI_DATA_DIR=/data/tdai-memory  → C:/Program Files/Git/data/tdai-memory
+#   -v src:/data/config/x.yaml:ro       → 目标端被改写成 \Program Files\Git\...
+# 关掉转换即可，但**只针对 docker 调用**（见下面的 docker_cmd 包装）。
+# 不要全局 export：curl.exe 同样是原生程序，全局关掉之后 `-o /tmp/xxx` 会被
+# 原样传过去而写不进文件，curl 于是以非 0 退出——看着像请求失败，其实成过了。
+IS_MSYS=0
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW*|MSYS*|CYGWIN*) IS_MSYS=1 ;;
+esac
+
+# 宿主机路径 → docker 能识别的形式。
+# Git Bash 下 /f/foo 对 docker.exe 无意义，用 cygpath -m 转成 F:/foo。
+to_host_path() {
+  if (( IS_MSYS )) && command -v cygpath >/dev/null 2>&1; then
+    cygpath -m "$1"
+  else
+    echo "$1"
+  fi
+}
+
 info() { echo "${C_BLU}[$(date +%H:%M:%S)]${C_RST} $*"; }
 ok()   { echo "${C_GRN}[ok]${C_RST} $*"; }
 warn() { echo "${C_YLW}[warn]${C_RST} $*" >&2; }
@@ -75,7 +98,44 @@ find_docker() {
   die "找不到 docker 命令。请先安装 Docker Desktop / OrbStack / colima + docker CLI。"
 }
 
-DOCKER="$(find_docker)"
+DOCKER_BIN="$(find_docker)"
+
+# 所有 docker 调用都走这里：只在这一层关掉 MSYS 路径转换，
+# 保证 -e /data/... 和 -v src:/dest:ro 的容器侧路径原样传进去。
+docker_cmd() {
+  if (( IS_MSYS )); then
+    MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' "$DOCKER_BIN" "$@"
+  else
+    "$DOCKER_BIN" "$@"
+  fi
+}
+
+# 各脚本统一用 $DOCKER 调用（这里指向上面的函数，不是可执行文件路径）
+DOCKER=docker_cmd
+
+# 找到可用 curl。
+# 优先 /usr/bin/curl（macOS/Linux 系统自带，避开 brew 版本差异）；
+# Git Bash for Windows 没有 /usr/bin/curl（在 /mingw64/bin），退回 PATH。
+find_curl() {
+  if [[ -x /usr/bin/curl ]]; then
+    echo "/usr/bin/curl"
+    return
+  fi
+  if command -v curl >/dev/null 2>&1; then
+    command -v curl
+    return
+  fi
+  die "找不到 curl 命令。"
+}
+
+CURL="$(find_curl)"
+
+# 打本机容器端口用这个：绕过 HTTP_PROXY/HTTPS_PROXY。
+# 否则宿主机上设了全局代理时，localhost 请求也会被送去代理，
+# 代理连不上就回 502 —— 看起来像 gateway 挂了，其实没有。
+curl_local() {
+  "$CURL" --noproxy '*' "$@"
+}
 
 # PULL=1 时拉取镜像最新版本。
 # 默认关闭：docker run 在本地没有镜像时会自动拉，但本地已有同名 :latest 时会直接复用，

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -127,7 +127,7 @@ $DOCKER run -d --name "$CONTAINER" \
   --network-alias memory-core \
   -p "${MEMORY_CORE_PORT}:8420" \
   -v "${MEMORY_CORE_VOLUME}:/data/tdai-memory" \
-  -v "$CORE_CONFIG_FILE:/data/config/tdai-gateway.yaml:ro" \
+  -v "$(to_host_path "$CORE_CONFIG_FILE"):/data/config/tdai-gateway.yaml:ro" \
   -e TDAI_GATEWAY_PORT=8420 \
   -e TDAI_GATEWAY_HOST=0.0.0.0 \
   -e TDAI_GATEWAY_API_KEY="$MEMORY_CORE_GATEWAY_API_KEY" \
@@ -163,7 +163,7 @@ generate_user_key() {
 verify_user_key() {
   local key="$1"
   local code
-  code=$(/usr/bin/curl -sS -o /dev/null -w "%{http_code}" --max-time 5 \
+  code=$(curl_local -sS -o /dev/null -w "%{http_code}" --max-time 5 \
     -X POST -H "Content-Type: application/json" \
     -H "x-tdai-service-id: default" \
     ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
@@ -184,7 +184,7 @@ fi
 
 init_body=$(printf '{"username":"%s","user_key":"%s"}' \
   "$MEMORY_CORE_ADMIN_USERNAME" "$ADMIN_KEY")
-init_resp=$(/usr/bin/curl -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
+init_resp=$(curl_local -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
   -X POST -H "Content-Type: application/json" \
   ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
   -H "x-tdai-service-id: default" \
@@ -227,3 +227,8 @@ if [[ -s "$ADMIN_KEY_FILE" ]]; then
     warn "admin user_key 校验失败（auth/verify 非 200）。检查 $ADMIN_KEY_FILE 与 volume 是否匹配。"
   fi
 fi
+
+# 上面 admin 相关的问题一律只 warn（真正的致命错误已经 die 了）。
+# 显式 exit 0，避免脚本退出码取自最后一个 if 判断 —— .admin-key 不存在时
+# 那个 if 为假会让脚本以 1 退出，把 start-all.sh 的 set -e 连带打断。
+exit 0

--- a/deploy/global-images/start-memory-hub.sh
+++ b/deploy/global-images/start-memory-hub.sh
@@ -36,24 +36,37 @@ MEMORY_CORE_GATEWAY_API_KEY="${MEMORY_CORE_GATEWAY_API_KEY:-local}"
 # 显式设了 MEMORY_HUB_PROXY_PUBLIC_URL 环境变量则完全按你给的值来。
 # 显式设为空字符串则 Panel 前端回落到 gateway_endpoint（老行为）。
 # Panel 后端 → Kernel 的转发地址始终走 REMOTE_INSTANCE_URL，不受此变量影响。
+is_ipv4() { [[ "$1" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; }
+
 detect_host_ip() {
   local ip=""
+  # Windows / Git Bash：系统自带的 hostname.exe 不认 -I，ipconfig.exe 也不是
+  # macOS 那套子命令语法（`ipconfig getifaddr en0` 会把整篇帮助打到 stdout）。
+  # 单独走 PowerShell 取第一个非回环 IPv4。
+  if (( IS_MSYS )); then
+    ip=$(powershell.exe -NoProfile -Command \
+      "(Get-NetIPAddress -AddressFamily IPv4 | Where-Object { \$_.IPAddress -notmatch '^(127\.|169\.254\.)' } | Select-Object -First 1 -ExpandProperty IPAddress)" \
+      2>/dev/null | tr -d '\r\n')
+    is_ipv4 "$ip" && { echo "$ip"; return; }
+    echo "localhost"
+    return
+  fi
   # Linux
   if command -v hostname >/dev/null 2>&1; then
     ip=$(hostname -I 2>/dev/null | tr ' ' '\n' | awk '/^[0-9]+\./ && $0 !~ /^127\./ && $0 !~ /^169\.254\./' | head -n1)
-    [[ -n "$ip" ]] && { echo "$ip"; return; }
+    is_ipv4 "$ip" && { echo "$ip"; return; }
   fi
   # macOS
   if command -v ipconfig >/dev/null 2>&1; then
     for iface in en0 en1 en2; do
       ip=$(ipconfig getifaddr "$iface" 2>/dev/null)
-      [[ -n "$ip" ]] && { echo "$ip"; return; }
+      is_ipv4 "$ip" && { echo "$ip"; return; }
     done
   fi
   # 兜底：ip route（Linux 无 hostname -I 时）
   if command -v ip >/dev/null 2>&1; then
     ip=$(ip -4 route get 1 2>/dev/null | awk '/src/ {for (i=1;i<=NF;i++) if ($i=="src") print $(i+1); exit}')
-    [[ -n "$ip" ]] && { echo "$ip"; return; }
+    is_ipv4 "$ip" && { echo "$ip"; return; }
   fi
   echo "localhost"
 }

--- a/deploy/global-images/start-proxy.sh
+++ b/deploy/global-images/start-proxy.sh
@@ -146,7 +146,7 @@ $DOCKER run -d --name "$CONTAINER" \
   --network-alias proxy \
   --add-host=host.docker.internal:host-gateway \
   -p "${PROXY_PORT}:8096" \
-  -v "$CONFIG_FILE:/data/config.yaml:ro" \
+  -v "$(to_host_path "$CONFIG_FILE"):/data/config.yaml:ro" \
   "$PROXY_IMAGE" >/dev/null
 
 wait_healthy "$CONTAINER" 90

--- a/deploy/global-images/verify.sh
+++ b/deploy/global-images/verify.sh
@@ -37,7 +37,7 @@ done
 
 ERRORS=0
 WARNS=0
-CURL=/usr/bin/curl
+# CURL 由 _lib.sh 的 find_curl() 解析（兼容 Git Bash 无 /usr/bin/curl 的情况）
 
 # ─── LLM 通路检查函数 ───────────────────────────────────────────────
 # check_llm_openai <label> <base_url> <api_key> <model>
@@ -174,8 +174,8 @@ check_llm_from_container() {
 }
 
 # 1. docker
-if command -v "$DOCKER" >/dev/null 2>&1 || [[ -x "$DOCKER" ]]; then
-  ok "docker 可用: $DOCKER"
+if command -v "$DOCKER_BIN" >/dev/null 2>&1 || [[ -x "$DOCKER_BIN" ]]; then
+  ok "docker 可用: $DOCKER_BIN"
 else
   ERRORS=$((ERRORS+1))
   echo "${C_RED}[error]${C_RST} docker 不可用" >&2


### PR DESCRIPTION
## 背景

在 Windows 11 + Docker Desktop + Git Bash 环境下执行 `deploy/global-images/start-all.sh` 无法完成部署。逐个定位后发现 4 个独立问题，本 PR 一并修复。**所有改动都做了平台分支或保持原有优先级，不影响 macOS / Linux 现有行为。**

这几个问题的共同特点是**失败得很安静**：容器照样 `healthy`，脚本也不一定报错，但服务实际不可用，排查成本很高。

## 修复内容

### 1. MSYS 路径转换污染 docker 参数

Git Bash 会把"看起来像路径"的参数自动转成 Windows 路径，再传给原生 `docker.exe`：

| 传入 | 实际到达 docker | 后果 |
|---|---|---|
| `-e TDAI_DATA_DIR=/data/tdai-memory` | `C:/Program Files/Git/data/tdai-memory` | 数据写到挂载卷外面，重启即丢 |
| `-v src:/data/config/tdai-gateway.yaml:ro` | 目标端 `\Program Files\Git\data\config\...;ro` | **网关配置根本没挂上**，静默回落到镜像内置默认值 |

两处都不报错，容器仍然 `healthy`——第二条尤其隐蔽：`.env` 里配好的 LLM 参数完全没生效，但表面看不出来。

**修法**：新增 `docker_cmd()` 包装，**只在调用 docker 这一层**设 `MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL='*'`；宿主机侧路径改用 `to_host_path()`（`cygpath -m`）显式转换。

> 这里踩过一个坑：一开始是全局 `export MSYS_NO_PATHCONV=1`，结果 `curl.exe` 同样是原生程序，`-o /tmp/xxx` 被原样传过去写不进文件，curl 以非 0 退出——HTTP 明明返回 200 却被判定成失败。所以必须限定作用域。

### 2. `detect_host_ip()` 在 Windows 上返回帮助文本

`hostname -I` 不被 Windows 自带的 `hostname.exe` 支持；紧接着 `command -v ipconfig` 命中的是 Windows 的 `ipconfig.exe`，而 `ipconfig getifaddr en0` 会把**整篇帮助文本**打到 stdout。这段输出被当成 IP 拼进 `MEMORY_HUB_PROXY_PUBLIC_URL`，最终撑坏 `docker run` 的参数：

```
docker: 'docker run' requires at least 1 argument
```

**修法**：新增 Windows 分支走 PowerShell `Get-NetIPAddress`；同时给**所有**分支套一层 `is_ipv4()` 校验。

> 原来的 `[[ -n "$ip" ]]` 只判非空，任何命令的噪音输出都会被当成 IP 用。这一点在 Linux / macOS 上同样是隐患，所以校验是统一加的，不只是 Windows 分支。

### 3. `/usr/bin/curl` 硬编码

Git Bash 没有 `/usr/bin/curl`（在 `/mingw64/bin`）。`init-admin` 那次调用直接失败，**admin user_key 永远存不下来**，后续 proxy 鉴权全断。

**修法**：新增 `find_curl()`，优先 `/usr/bin/curl`（保持 macOS / Linux 原行为，避开 brew 版本差异），拿不到再退回 PATH。

### 4. `start-memory-core.sh` 可能以 1 退出

脚本最后一句是 `if [[ -s "$ADMIN_KEY_FILE" ]]`，`.admin-key` 不存在时退出码取自这个判断 = 1，把 `start-all.sh` 的 `set -e` 连带打断。而 admin 相关问题脚本本身只 `warn`（真正致命的错误都已 `die`），显然不该中止整条流水线。补一个显式 `exit 0`。

### 附带：`.env.example` 端口段加说明

Hyper-V / WSL2 会预留成片的 TCP 端口区段，常见的 `8345-8444` 正好覆盖默认的 **8420 和 8424**。落在保留段里的端口，`docker run -p` 不报错、容器也 `healthy`，但 `docker inspect` 里 `NetworkSettings.Ports` 是空的，宿主机连不上——表现非常像内核挂了。

补了一段注释说明现象，附上查询命令和换端口建议：

```
netsh interface ipv4 show excludedportrange protocol=tcp
```

（只改注释，默认端口值未动。）

## 测试

Windows 11 + Docker Desktop 29.3.0 (linux engine) + Git Bash：

- `./verify.sh` 全项通过
- `./start-all.sh` 退出码 0，三个容器均 `healthy`
- `docker inspect` 确认 `TDAI_DATA_DIR=/data/tdai-memory`、配置挂载点为 `/data/config/tdai-gateway.yaml`
- 容器日志确认网关加载的是 `.env` 里配置的模型（修复前是镜像默认值）
- 经 proxy 请求上游 LLM 返回 HTTP 200，`connectivity.check: all_ok`

未在 macOS / Linux 上回归测试，但改动均为平台分支或保持原有优先级；`is_ipv4()` 是唯一对非 Windows 路径有行为影响的改动（收紧了校验）。
