### PR TITLE
fix(core): conversation/delete 按 id 删除时静默删 0 条（返回成功但数据还在）

### DIFF
--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -967,8 +967,21 @@ async function handleConversationDelete(body: unknown, auth: V2AuthContext, requ
   let deletedCount = 0;
 
   if (message_ids && message_ids.length > 0) {
+    // 按 id 删除时，只使用显式传入的 isolation 维度作为 filter。
+    // resolveIsolation() 在调用方没传 session_id 时会把 sessionId 填成占位值
+    // ("default")，而 rowMatchesIsolation() 会拿它和真实 session 比对 —— 结果
+    // 是任何不带 session_id 的按 id 删除都匹配不上、静默删 0 条。
+    // 与 handleAtomicDelete 的处理保持一致。
+    const iso = deps.requestIsolation;
+    const deleteFilter = iso ? {
+      ...(iso.teamId ? { teamId: iso.teamId } : {}),
+      ...(iso.userId ? { userId: iso.userId } : {}),
+      ...(iso.agentId ? { agentId: iso.agentId } : {}),
+      ...(iso.taskId ? { taskId: iso.taskId } : {}),
+      // 不传 sessionId：按 id 删除不应被默认 sessionId 限制
+    } : undefined;
     for (const id of message_ids) {
-      const ok = await store.deleteL0(id, deps.requestIsolation);
+      const ok = await store.deleteL0(id, deleteFilter);
       if (ok) deletedCount++;
     }
   } else if (session_id) {


### PR DESCRIPTION
## 问题

`POST /v3/conversation/delete` 传 `message_ids` 删除 L0 对话时，如果没有**同时**传 `session_id`，接口返回：

```json
{"code": 0, "message": "ok", "data": {"deleted_count": 0}}
```

HTTP 200、业务码 0、message 是 `ok` —— 但**一条都没删掉**。

最危险的不是删不掉，而是**它看起来成功了**。调用方拿到 `code: 0 / "ok"` 会认为删除已完成，实际数据仍在库里。想删除自己数据的用户不会察觉删除没生效。

## 复现

在 `agentmemory/memory-core:latest`（standalone + sqlite）上实测：

```bash
# 1. 写入两条
POST /v3/conversation/add
{"team_id":T,"agent_id":A,"user_id":U,"session_id":"probe",
 "messages":[{"role":"user","content":"x"},{"role":"user","content":"y"}]}

# 2. 按 id 删除，不带 session_id
POST /v3/conversation/delete
{"team_id":T,"agent_id":A,"user_id":U,"message_ids":[id1,id2]}
→ {"code":0,"message":"ok","data":{"deleted_count":0}}    # 没删，但报成功
# 查询确认：仍然是 2 条

# 3. 同样的调用，加上 session_id
POST /v3/conversation/delete
{"team_id":T,"agent_id":A,"user_id":U,"session_id":"probe","message_ids":[id1,id2]}
→ {"code":0,"message":"ok","data":{"deleted_count":2}}    # 这次才真的删了
```

不带 isolation、改用 `x-tdai-*` header 传，结果都是 `deleted_count: 0`。

## 成因

四步凑出来的静默失败：

1. **`resolveIsolation()`**（`v2-schemas.ts:339-353`）在 body 和 header 都没有 `session_id` 时，把 `sessionId` 填成占位值：

   ```ts
   const sessionId = (body?.session_id as string|undefined) ?? headerStr("x-tdai-session-id") ?? "";
   const ctx = { ..., sessionId: sessionId || ph, ... };   // ph = DEFAULT_ISOLATION_ID
   ```

2. **`handleConversationDelete`**（`v2-router.ts:971`）把整个 `deps.requestIsolation` 原样当 filter 传下去：

   ```ts
   const ok = await store.deleteL0(id, deps.requestIsolation);
   ```

3. **`rowMatchesIsolation()`**（`isolation.ts:167`）拿占位 sessionId 去比对真实行：

   ```ts
   if (filter.sessionId !== undefined && row.session_id !== filter.sessionId) return false;
   ```

   真实 session 的行永远匹配不上 `"default"`，`deleteL0` 每条都返回 `false`。

4. 处理函数只累加成功计数，最后仍走 `successEnvelope` —— 于是 0 条删除被包装成 `ok` 返回。

## 修复

改法不是新发明的：**同文件里的 `handleAtomicDelete`（L1 按 id 删除）早就处理过这个坑**，还留了注释说明原因：

```ts
// 按 id 删除时，只使用显式传入的 isolation 维度作为 filter。
// 避免默认 sessionId="default" 导致真实 session 下的 L1 记录无法删除。
```

这个防御模式在本文件里已经用了三处：

| 位置 | 场景 |
|---|---|
| `v2-router.ts:901` | 搜索 |
| `v2-router.ts:1173` | L1 召回 |
| `v2-router.ts:1264` | `atomic/delete` |

**L0 的按 id 删除是唯一漏掉的一处**，本 PR 补齐，写法与 `handleAtomicDelete` 保持一致：按 id 删除时只用显式传入的 isolation 维度构造 filter，不带 `sessionId`。

按 `session_id` 整段删除的分支没有动 —— 那条路径本来就有明确的 session 语义。

## 两点补充（未在本 PR 处理，供维护者判断）

**1. schema 契约缺 IdFields。** `conversationDeleteRequestSchema` 只声明了 `message_ids`：

```ts
export const conversationDeleteRequestSchema = z.object({
    "message_ids": z.array(z.string()).min(1).max(100)
})
```

而 `conversationAdd` / `conversationQuery` 等都是 `z.lazy(() => idFieldsSchema).and(...)`。也就是说按接口契约，调用方**根本无从得知**可以传 `session_id` 来绕过这个 bug（`resolveIsolation` 读的是原始 body，所以传了会生效，只是 schema 会把它 strip 掉、handler 里的 `session_id` 形同虚设）。

`generated/schemas.ts` 由 Kubb 从 spec 生成、且该 spec 不在本仓库内，所以这里没有改。如果认为契约也该修，需要在源 spec 侧补 `IdFields`。

**2. 删除数少于请求数时是否该报错。** 即使修好匹配逻辑，`deleted_count < message_ids.length` 仍然会返回 `ok`。要不要在部分失败时给出可区分的响应，涉及接口语义，留给维护者定。`atomic/delete` 也是同样的行为，改的话建议两边一起。

## 测试

- 本地未安装依赖，**没有跑构建和类型检查**。改动是照抄同文件 `handleAtomicDelete` 的写法；`deps.requestIsolation` 的类型声明（`v2-router.ts:309`）与 `IsolationFilter` 字段一致。
- 上面的复现步骤是在预编译镜像上验证的 —— 也就是说复现确凿，但**修复后的代码我没能实际运行验证**（需要重新构建镜像）。这一点请 reviewer 留意。
