### PR TITLE
fix(deploy): delimit admin key variable for macOS Bash 3.2

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then


### PR DESCRIPTION
## Description | 描述

Fixes `start-memory-core.sh` failing on macOS Bash 3.2 with the following error:
<img width="1142" height="186" alt="image" src="https://github.com/user-attachments/assets/c66464e0-2123-45f7-baf7-317f278643e5" />

```text
ADMIN_KEY_FILE�: unbound variable
```

The failure occurred after `tdai-memory-core` became healthy, preventing `start-all.sh` from completing the admin initialization.

This PR changes:

```bash
$ADMIN_KEY_FILE）
```

to:

```bash
${ADMIN_KEY_FILE}）
```

The braces explicitly delimit the variable name before the Chinese full-width parenthesis. This does not change the expanded value or behavior on other Bash/Linux environments.

## Related Issue | 关联 Issue

N/A

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validated with:

- `bash -n deploy/global-images/start-memory-core.sh`
- macOS Bash 3.2.57 variable expansion test

`${ADMIN_KEY_FILE}` is standard shell syntax and produces the same value as `$ADMIN_KEY_FILE`; it only makes the variable boundary explicit.
