### PR TITLE
fix(memory-core): sqlite queryL1Records ignores recordIds filter

### DIFF
--- a/MemoryCore/src/core/store/sqlite.recordids.test.ts
+++ b/MemoryCore/src/core/store/sqlite.recordids.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { MemoryRecord } from "../record/l1-writer";
+import { VectorStore } from "./sqlite";
+
+function makeRecord(id: string, overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id,
+    content: `content-${id}`,
+    type: "episodic",
+    priority: 50,
+    scene_name: "",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: ["2026-01-01T00:00:00.000Z"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    version: 1,
+    sessionKey: "session-key",
+    sessionId: "session-id",
+    ...overrides,
+  };
+}
+
+describe("VectorStore.queryL1Records with recordIds", () => {
+  let dir: string;
+  let store: VectorStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "l1-recordids-test-"));
+    store = new VectorStore(path.join(dir, "vectors.db"), 0);
+    store.init();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns only the record matching the requested primary key, not the oldest record in the table", () => {
+    // Insert an older record first, then the one we'll actually query for.
+    store.upsertL1(makeRecord("older-record", { updatedAt: "2026-01-01T00:00:00.000Z" }), undefined);
+    store.upsertL1(makeRecord("target-record", { updatedAt: "2026-02-01T00:00:00.000Z" }), undefined);
+
+    const results = store.queryL1Records({ recordIds: ["target-record"] });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].record_id).toBe("target-record");
+  });
+
+  it("returns an empty array for a recordId that does not exist, even when other records are present", () => {
+    store.upsertL1(makeRecord("existing-record"), undefined);
+
+    const results = store.queryL1Records({ recordIds: ["does-not-exist"] });
+
+    expect(results).toEqual([]);
+  });
+
+  it("looks up multiple recordIds and preserves isolation filtering afterward", () => {
+    store.upsertL1(makeRecord("rec-a", { teamId: "team-1" }), undefined);
+    store.upsertL1(makeRecord("rec-b", { teamId: "team-2" }), undefined);
+
+    const results = store.queryL1Records({ recordIds: ["rec-a", "rec-b"], teamId: "team-1" });
+
+    expect(results.map((r) => r.record_id)).toEqual(["rec-a"]);
+  });
+});

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -386,6 +386,7 @@ export class VectorStore implements IMemoryStore {
   private stmtQueryBySessionKeySince!: StatementSync;
   private stmtQueryAll!: StatementSync;
   private stmtQueryAllSince!: StatementSync;
+  private stmtQueryByRecordId!: StatementSync;
 
   // Prepared statements — L0 (initialized in init())
   private stmtL0UpsertMeta!: StatementSync;
@@ -1149,6 +1150,11 @@ export class VectorStore implements IMemoryStore {
       ORDER BY updated_time ASC
     `);
 
+    this.stmtQueryByRecordId = this.db.prepare(`
+      SELECT ${l1QueryCols} FROM l1_records
+      WHERE record_id = ?
+    `);
+
     this.stmtL1QueryMigrationCursor = this.db.prepare(`
       SELECT ${l1QueryCols} FROM l1_records
       WHERE record_id > ?
@@ -1703,12 +1709,16 @@ export class VectorStore implements IMemoryStore {
       return [];
     }
     try {
-      const { sessionKey, sessionId, taskId, updatedAfter } = filter ?? {};
+      const { sessionKey, sessionId, taskId, updatedAfter, recordIds } = filter ?? {};
 
       let raw: Record<string, unknown>[];
 
-      // Priority: sessionId > sessionKey (sessionId is more specific)
-      if (sessionId && updatedAfter) {
+      // Priority: recordIds (primary-key lookup) > sessionId > sessionKey
+      if (recordIds && recordIds.length > 0) {
+        raw = recordIds
+          .map((id) => this.stmtQueryByRecordId.get(id) as Record<string, unknown> | undefined)
+          .filter((row): row is Record<string, unknown> => row !== undefined);
+      } else if (sessionId && updatedAfter) {
         raw = this.stmtQueryBySessionIdSince.all(sessionId, updatedAfter) as Record<string, unknown>[];
       } else if (sessionId) {
         raw = this.stmtQueryBySessionId.all(sessionId) as Record<string, unknown>[];


### PR DESCRIPTION
## Description | 描述
`VectorStore.queryL1Records()` in `MemoryCore/src/core/store/sqlite.ts` never reads `filter.recordIds`, even though the `L1QueryFilter` interface documents it ("Query by document primary keys") and the TCVDB backend (`tcvdb.ts`) handles it correctly. With no other filter field set, it falls through to a full-table scan ordered by `updated_time ASC` and returns everything.

This matters because `handleAtomicUpdate()` in `gateway/v2-router.ts` does `store.queryL1Records({ recordIds: [id] })` to read a record by primary key before updating it, with a comment saying exactly that. On the SQLite backend, `existing[0]` is actually the oldest record in the entire store, not the one matching `id`:
- a lookup for a nonexistent `id` never returns 404,
- an update can silently copy `type`/`priority`/`scene_name`/timestamps/`team_id`/`user_id`/`agent_id` from an unrelated record before upserting under the caller-supplied `id`.

Fix adds a dedicated primary-key lookup branch (same approach as `tcvdb.ts`'s `documentIds` handling), given priority over the session-based branches, so SQLite and TCVDB behave the same way for this filter.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Added `MemoryCore/src/core/store/sqlite.recordids.test.ts`. Confirmed all 3 new tests fail against the pre-fix code (`git stash`) with exactly the described wrong-record/no-404 behavior, and pass after the fix. `npx vitest run` and `npx tsdown` (the `build:plugin` step) both clean.

## Additional Notes | 其他说明
`npm run build:seed-v2` fails on this branch even without my change (`scripts/seed-v2/tsconfig.json` doesn't exist) — confirmed pre-existing on `feat/server_team` HEAD via `git stash`, unrelated to this PR.