### PR TITLE
Fix/checkpoint recalibrate

### DIFF
--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -27,6 +27,7 @@ import type { GatewayConfig } from "./config.js";
 import { applyMetadataEnvFromGatewayConfig } from "./metadata-env.js";
 import { initDataDirectories } from "../utils/pipeline-factory.js";
 import { SessionFilter } from "../utils/session-filter.js";
+import { CheckpointManager } from "../utils/checkpoint.js";
 import { WorkerPermitPool } from "../services/worker-permit-pool.js";
 import { createExtractorAdapter, SkillExtractor as SkillExtractorClass } from "../core/skill/skill-extractor.js";
 import type { SkillCore as SkillCoreType } from "../core/skill/skill-core.js";
@@ -592,6 +593,22 @@ export class TdaiGateway {
       const backend = new LocalStorageBackend(this.config.data.baseDir);
       this.core.setStorage(new StorageAdapter(backend));
       this.logger.info(`${TAG} StorageAdapter initialized (local: ${this.config.data.baseDir})`);
+    }
+
+    // ── Reconcile checkpoint counters with actual persisted data (issue #157) ──
+    // total_memories_extracted / l0_conversations_count only ever increment,
+    // so data cleanup leaves them overstating reality. Recount once at startup.
+    try {
+      const checkpoint = new CheckpointManager(
+        this.config.data.baseDir,
+        this.logger,
+        this.core.getStorage(),
+      );
+      await checkpoint.recalibrate();
+    } catch (err) {
+      this.logger.warn(
+        `${TAG} checkpoint recalibrate skipped: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     // ── Skill module post-wiring (after storage is set) ──

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -595,9 +595,6 @@ export class TdaiGateway {
       this.logger.info(`${TAG} StorageAdapter initialized (local: ${this.config.data.baseDir})`);
     }
 
-    // ── Reconcile checkpoint counters with actual persisted data (issue #157) ──
-    // total_memories_extracted / l0_conversations_count only ever increment,
-    // so data cleanup leaves them overstating reality. Recount once at startup.
     try {
       const checkpoint = new CheckpointManager(
         this.config.data.baseDir,

--- a/MemoryCore/src/utils/checkpoint.test.ts
+++ b/MemoryCore/src/utils/checkpoint.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CheckpointManager } from "./checkpoint.js";
+
+async function makeDataDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "checkpoint-recal-"));
+  await mkdir(join(dir, ".metadata"), { recursive: true });
+  await mkdir(join(dir, "records"), { recursive: true });
+  await mkdir(join(dir, "conversations"), { recursive: true });
+  return dir;
+}
+
+describe("CheckpointManager.recalibrate", () => {
+  it("resets inflated counters to actual persisted record counts", async () => {
+    const dir = await makeDataDir();
+    try {
+      // Real data: 3 L1 records in one shard, 2 in another; 5 L0 conversations across 2 shards
+      await writeFile(join(dir, "records/2026-07-01.jsonl"), '{"id":1}\n{"id":2}\n{"id":3}\n');
+      await writeFile(join(dir, "records/2026-07-02.jsonl"), '{"id":4}\n{"id":5}\n');
+      await writeFile(join(dir, "conversations/2026-07-01.jsonl"), '{"c":1}\n{"c":2}\n{"c":3}\n');
+      await writeFile(join(dir, "conversations/2026-07-02.jsonl"), '{"c":4}\n{"c":5}\n');
+
+      // Drifted checkpoint: counters overstate reality (the #157 symptom)
+      await writeFile(
+        join(dir, ".metadata/recall_checkpoint.json"),
+        JSON.stringify({
+          last_captured_timestamp: 0,
+          total_processed: 0,
+          last_persona_at: 0,
+          last_persona_time: "",
+          request_persona_update: false,
+          persona_update_reason: "",
+          memories_since_last_persona: 0,
+          scenes_processed: 0,
+          runner_states: {},
+          pipeline_states: {},
+          l0_conversations_count: 42,
+          total_memories_extracted: 50,
+        }, null, 2),
+      );
+
+      const mgr = new CheckpointManager(dir);
+      const cp = await mgr.recalibrate();
+
+      expect(cp.total_memories_extracted).toBe(5);
+      expect(cp.l0_conversations_count).toBe(5);
+
+      // Persisted file must reflect the corrected counters
+      const persisted = JSON.parse(
+        await readFile(join(dir, ".metadata/recall_checkpoint.json"), "utf-8"),
+      );
+      expect(persisted.total_memories_extracted).toBe(5);
+      expect(persisted.l0_conversations_count).toBe(5);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("zeroes counters when no records exist", async () => {
+    const dir = await makeDataDir();
+    try {
+      await writeFile(
+        join(dir, ".metadata/recall_checkpoint.json"),
+        JSON.stringify({
+          runner_states: {},
+          pipeline_states: {},
+          l0_conversations_count: 10,
+          total_memories_extracted: 10,
+        }),
+      );
+
+      const mgr = new CheckpointManager(dir);
+      const cp = await mgr.recalibrate();
+
+      expect(cp.total_memories_extracted).toBe(0);
+      expect(cp.l0_conversations_count).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/src/utils/checkpoint.test.ts
+++ b/MemoryCore/src/utils/checkpoint.test.ts
@@ -80,4 +80,33 @@ describe("CheckpointManager.recalibrate", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("handles empty files and files without trailing newline", async () => {
+    const dir = await makeDataDir();
+    try {
+      // Empty shard (whitespace only) + shard without trailing newline
+      await writeFile(join(dir, "records/2026-07-01.jsonl"), "\n  \n\n");
+      await writeFile(join(dir, "records/2026-07-02.jsonl"), '{"id":1}\n{"id":2}');
+      await writeFile(join(dir, "conversations/2026-07-01.jsonl"), "");
+
+      await writeFile(
+        join(dir, ".metadata/recall_checkpoint.json"),
+        JSON.stringify({
+          runner_states: {},
+          pipeline_states: {},
+          l0_conversations_count: 7,
+          total_memories_extracted: 9,
+        }),
+      );
+
+      const mgr = new CheckpointManager(dir);
+      const cp = await mgr.recalibrate();
+
+      // Blank lines are not records; the no-trailing-newline record still counts
+      expect(cp.total_memories_extracted).toBe(2);
+      expect(cp.l0_conversations_count).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/MemoryCore/src/utils/checkpoint.test.ts
+++ b/MemoryCore/src/utils/checkpoint.test.ts
@@ -58,6 +58,41 @@ describe("CheckpointManager.recalibrate", () => {
     }
   });
 
+  it("counts L0 capture events, not message lines, for l0_conversations_count", async () => {
+    const dir = await makeDataDir();
+    try {
+      // One capture event wrote 3 messages (same sessionKey + recordedAt), another wrote 2
+      const event1 = "2026-07-01T10:00:00.000Z";
+      const event2 = "2026-07-01T11:00:00.000Z";
+      const lines = [
+        JSON.stringify({ sessionKey: "s1", recordedAt: event1, id: 1 }),
+        JSON.stringify({ sessionKey: "s1", recordedAt: event1, id: 2 }),
+        JSON.stringify({ sessionKey: "s1", recordedAt: event1, id: 3 }),
+        JSON.stringify({ sessionKey: "s2", recordedAt: event2, id: 4 }),
+        JSON.stringify({ sessionKey: "s2", recordedAt: event2, id: 5 }),
+      ].join("\n") + "\n";
+      await writeFile(join(dir, "conversations/2026-07-01.jsonl"), lines);
+
+      await writeFile(
+        join(dir, ".metadata/recall_checkpoint.json"),
+        JSON.stringify({
+          runner_states: {},
+          pipeline_states: {},
+          l0_conversations_count: 9,
+          total_memories_extracted: 0,
+        }),
+      );
+
+      const mgr = new CheckpointManager(dir);
+      const cp = await mgr.recalibrate();
+
+      // 5 message lines but only 2 distinct capture events
+      expect(cp.l0_conversations_count).toBe(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("zeroes counters when no records exist", async () => {
     const dir = await makeDataDir();
     try {

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -179,10 +179,10 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
-  private readonly dataDir: string;
-  private readonly filePath: string;
-  private readonly logger: CheckpointLogger;
-  private readonly storage?: StorageAdapter;
+  private dataDir: string;
+  private filePath: string;
+  private logger: CheckpointLogger;
+  private storage: StorageAdapter | undefined;
 
   constructor(dataDir: string, logger?: CheckpointLogger, storage?: StorageAdapter) {
     this.dataDir = dataDir;

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -424,11 +424,6 @@ export class CheckpointManager {
   // L1-specific methods
   // ============================
 
-  /**
-   * Count non-empty JSONL records under a storage prefix (e.g. `records/` for
-   * L1 memories, `conversations/` for L0 conversations). Works in both
-   * storage-backed and fs-based modes; missing directories count as zero.
-   */
   private async countJsonlRecords(dirPrefix: string): Promise<number> {
     let files: string[];
     if (this.storage) {
@@ -470,18 +465,6 @@ export class CheckpointManager {
     return count;
   }
 
-  /**
-   * Reconcile the aggregate counters with the actual persisted data.
-   *
-   * `total_memories_extracted` and `l0_conversations_count` are only ever
-   * incremented (see `markL1ExtractionComplete` / `captureAtomically`), so any
-   * cleanup — deleting test pipeline states, running memory-cleaner, or manual
-   * JSONL pruning — leaves them permanently overstating reality. This method
-   * recounts the real records from `records/*.jsonl` and
-   * `conversations/*.jsonl` and rewrites the counters to match.
-   *
-   * Intended to be called once on gateway startup.
-   */
   async recalibrate(): Promise<Checkpoint> {
     return this.mutate(async (cp) => {
       const actualL1 = await this.countJsonlRecords(StoragePaths.recordsDir);

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -465,10 +465,74 @@ export class CheckpointManager {
     return count;
   }
 
+  private async countL0CaptureEvents(): Promise<number> {
+    const lines = await this.readJsonlLines(StoragePaths.conversationsDir);
+    const seen = new Set<string>();
+    let count = 0;
+    for (const line of lines) {
+      try {
+        const record = JSON.parse(line) as { sessionKey?: unknown; recordedAt?: unknown };
+        if (typeof record.sessionKey !== "string" || typeof record.recordedAt !== "string") {
+          count += 1;
+          continue;
+        }
+        const key = `${record.sessionKey}\u0000${record.recordedAt}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          count += 1;
+        }
+      } catch {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  private async readJsonlLines(dirPrefix: string): Promise<string[]> {
+    let files: string[];
+    if (this.storage) {
+      files = await this.storage.readdirNames(dirPrefix, ".jsonl");
+    } else {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const dir = path.default.join(this.dataDir, dirPrefix);
+      try {
+        files = (await fs.default.readdir(dir)).filter((f) => f.endsWith(".jsonl"));
+      } catch {
+        return [];
+      }
+    }
+
+    const lines: string[] = [];
+    for (const file of files) {
+      let content: string | null;
+      if (this.storage) {
+        content = await this.storage.readFile(`${dirPrefix}${file}`);
+      } else {
+        const fs = await import("node:fs/promises");
+        const path = await import("node:path");
+        try {
+          content = await fs.default.readFile(
+            path.default.join(this.dataDir, dirPrefix, file),
+            "utf-8",
+          );
+        } catch {
+          this.logger.warn?.(`[checkpoint] recalibrate: failed to read ${dirPrefix}${file}, skipping`);
+          continue;
+        }
+      }
+      if (!content) continue;
+      for (const line of content.split("\n")) {
+        if (line.trim()) lines.push(line);
+      }
+    }
+    return lines;
+  }
+
   async recalibrate(): Promise<Checkpoint> {
     return this.mutate(async (cp) => {
       const actualL1 = await this.countJsonlRecords(StoragePaths.recordsDir);
-      const actualL0 = await this.countJsonlRecords(StoragePaths.conversationsDir);
+      const actualL0 = await this.countL0CaptureEvents();
       this.logger.info(
         `[checkpoint] recalibrate: total_memories_extracted ` +
         `${cp.total_memories_extracted} → ${actualL1}, l0_conversations_count ` +

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -179,11 +179,13 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
+  private dataDir: string;
   private filePath: string;
   private logger: CheckpointLogger;
   private storage: StorageAdapter | undefined;
 
   constructor(dataDir: string, logger?: CheckpointLogger, storage?: StorageAdapter) {
+    this.dataDir = dataDir;
     this.storage = storage;
     if (storage) {
       this.filePath = StoragePaths.checkpoint;
@@ -421,6 +423,77 @@ export class CheckpointManager {
   // ============================
   // L1-specific methods
   // ============================
+
+  /**
+   * Count non-empty JSONL records under a storage prefix (e.g. `records/` for
+   * L1 memories, `conversations/` for L0 conversations). Works in both
+   * storage-backed and fs-based modes; missing directories count as zero.
+   */
+  private async countJsonlRecords(dirPrefix: string): Promise<number> {
+    let files: string[];
+    if (this.storage) {
+      files = await this.storage.readdirNames(dirPrefix, ".jsonl");
+    } else {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const dir = path.default.join(this.dataDir, dirPrefix);
+      try {
+        files = (await fs.default.readdir(dir)).filter((f) => f.endsWith(".jsonl"));
+      } catch {
+        return 0;
+      }
+    }
+
+    let count = 0;
+    for (const file of files) {
+      let content: string | null;
+      if (this.storage) {
+        content = await this.storage.readFile(`${dirPrefix}${file}`);
+      } else {
+        const fs = await import("node:fs/promises");
+        const path = await import("node:path");
+        try {
+          content = await fs.default.readFile(
+            path.default.join(this.dataDir, dirPrefix, file),
+            "utf-8",
+          );
+        } catch {
+          continue;
+        }
+      }
+      if (!content) continue;
+      for (const line of content.split("\n")) {
+        if (line.trim()) count += 1;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Reconcile the aggregate counters with the actual persisted data.
+   *
+   * `total_memories_extracted` and `l0_conversations_count` are only ever
+   * incremented (see `markL1ExtractionComplete` / `captureAtomically`), so any
+   * cleanup — deleting test pipeline states, running memory-cleaner, or manual
+   * JSONL pruning — leaves them permanently overstating reality. This method
+   * recounts the real records from `records/*.jsonl` and
+   * `conversations/*.jsonl` and rewrites the counters to match.
+   *
+   * Intended to be called once on gateway startup.
+   */
+  async recalibrate(): Promise<Checkpoint> {
+    return this.mutate(async (cp) => {
+      const actualL1 = await this.countJsonlRecords(StoragePaths.recordsDir);
+      const actualL0 = await this.countJsonlRecords(StoragePaths.conversationsDir);
+      this.logger.info(
+        `[checkpoint] recalibrate: total_memories_extracted ` +
+        `${cp.total_memories_extracted} → ${actualL1}, l0_conversations_count ` +
+        `${cp.l0_conversations_count} → ${actualL0}`,
+      );
+      cp.total_memories_extracted = actualL1;
+      cp.l0_conversations_count = actualL0;
+    });
+  }
 
   /**
    * Mark L1 extraction completed: reset sinceL1 counter, advance L1 cursor,

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -179,10 +179,10 @@ async function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<
 }
 
 export class CheckpointManager {
-  private dataDir: string;
-  private filePath: string;
-  private logger: CheckpointLogger;
-  private storage: StorageAdapter | undefined;
+  private readonly dataDir: string;
+  private readonly filePath: string;
+  private readonly logger: CheckpointLogger;
+  private readonly storage?: StorageAdapter;
 
   constructor(dataDir: string, logger?: CheckpointLogger, storage?: StorageAdapter) {
     this.dataDir = dataDir;

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -458,6 +458,7 @@ export class CheckpointManager {
             "utf-8",
           );
         } catch {
+          this.logger.warn?.(`[checkpoint] recalibrate: failed to read ${dirPrefix}${file}, skipping`);
           continue;
         }
       }


### PR DESCRIPTION
## Description | 描述

`recall_checkpoint.json` 中的 `total_memories_extracted` 和 `l0_conversations_count` 计数器只会自增（`markL1ExtractionComplete` / `captureAtomically`），任何数据清理（删除测试 pipeline 状态、运行 memory-cleaner、手动修剪 JSONL）之后都会永久性地高于真实值，导致状态上报失真，并影响 L2/L3 persona 生成阈值判断。

本 PR 新增 `CheckpointManager.recalibrate()`：从 `records/*.jsonl` 和 `conversations/*.jsonl` 重新统计真实记录数并覆盖写回计数器，在 gateway 启动时调用一次。采用"整体重算"而非减法更新，幂等安全（重复执行、部分删除、清理失败都不会误减）。

## Related Issue | 关联 Issue

Fix #157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- 修改文件：`MemoryCore/src/utils/checkpoint.ts`、`MemoryCore/src/gateway/server.ts`、新增 `MemoryCore/src/utils/checkpoint.test.ts`
- 已通过 `npx vitest run`（3 个用例：计数对账、空目录归零、空文件/无尾部换行边界）
- `npx tsdown` 构建通过