### PR TITLE
fix(deploy): make host IP detection OS-aware and IPv4-safe

### DIFF
--- a/deploy/global-images/start-memory-hub.sh
+++ b/deploy/global-images/start-memory-hub.sh
@@ -36,24 +36,41 @@ MEMORY_CORE_GATEWAY_API_KEY="${MEMORY_CORE_GATEWAY_API_KEY:-local}"
 # 显式设了 MEMORY_HUB_PROXY_PUBLIC_URL 环境变量则完全按你给的值来。
 # 显式设为空字符串则 Panel 前端回落到 gateway_endpoint（老行为）。
 # Panel 后端 → Kernel 的转发地址始终走 REMOTE_INSTANCE_URL，不受此变量影响。
+is_usable_ipv4() {
+  local address="${1:-}" octet
+  local -a octets
+
+  [[ "$address" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || return 1
+  IFS='.' read -r -a octets <<< "$address"
+  for octet in "${octets[@]}"; do
+    ((10#$octet <= 255)) || return 1
+  done
+  [[ "$address" != "0.0.0.0" && "$address" != 127.* && "$address" != 169.254.* ]]
+}
+
 detect_host_ip() {
   local ip=""
   # Linux
   if command -v hostname >/dev/null 2>&1; then
-    ip=$(hostname -I 2>/dev/null | tr ' ' '\n' | awk '/^[0-9]+\./ && $0 !~ /^127\./ && $0 !~ /^169\.254\./' | head -n1)
-    [[ -n "$ip" ]] && { echo "$ip"; return; }
+    while IFS= read -r ip; do
+      is_usable_ipv4 "$ip" && { echo "$ip"; return; }
+    done < <(hostname -I 2>/dev/null | tr ' ' '\n')
   fi
   # macOS
-  if command -v ipconfig >/dev/null 2>&1; then
+  # Git Bash exposes Windows ipconfig.exe, which is incompatible with the
+  # macOS-only `getifaddr` subcommand and can print multi-line prose (issue #817).
+  if [[ "$(uname -s 2>/dev/null)" == "Darwin" ]] && command -v ipconfig >/dev/null 2>&1; then
     for iface in en0 en1 en2; do
-      ip=$(ipconfig getifaddr "$iface" 2>/dev/null)
-      [[ -n "$ip" ]] && { echo "$ip"; return; }
+      if ip=$(ipconfig getifaddr "$iface" 2>/dev/null); then
+        is_usable_ipv4 "$ip" && { echo "$ip"; return; }
+      fi
     done
   fi
   # 兜底：ip route（Linux 无 hostname -I 时）
   if command -v ip >/dev/null 2>&1; then
-    ip=$(ip -4 route get 1 2>/dev/null | awk '/src/ {for (i=1;i<=NF;i++) if ($i=="src") print $(i+1); exit}')
-    [[ -n "$ip" ]] && { echo "$ip"; return; }
+    if ip=$(ip -4 route get 1 2>/dev/null | awk '/src/ {for (i=1;i<NF;i++) if ($i=="src") {print $(i+1); exit}}'); then
+      is_usable_ipv4 "$ip" && { echo "$ip"; return; }
+    fi
   fi
   echo "localhost"
 }

--- a/tests/test_detect_host_ip.sh
+++ b/tests/test_detect_host_ip.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression coverage for deploy/global-images/start-memory-hub.sh host IP probes.
+
+set -euo pipefail
+shopt -s inherit_errexit 2>/dev/null || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HUB_SH="$SCRIPT_DIR/../deploy/global-images/start-memory-hub.sh"
+FUNCTIONS_FILE="$(mktemp -t detect-host-ip.XXXXXX)"
+trap 'rm -f "$FUNCTIONS_FILE"' EXIT
+
+# Source only the side-effect-free helpers under test. Sourcing the complete
+# deployment script would load .env and start containers.
+awk '
+  /^is_usable_ipv4\(\)/ { capture=1 }
+  capture && /^if \[\[ -z .*MEMORY_HUB_PROXY_PUBLIC_URL/ { exit }
+  capture { print }
+' "$HUB_SH" > "$FUNCTIONS_FILE"
+
+if [[ ! -s "$FUNCTIONS_FILE" ]]; then
+  echo "FAIL: could not extract host IP helpers from $HUB_SH" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$FUNCTIONS_FILE"
+
+detect_with() (
+  local os="$1" hostname_output="$2" ipconfig_output="$3" route_output="$4"
+
+  # All probes are intentionally available. Their output controls which branch
+  # succeeds, while the OS value decides whether ipconfig may be consulted.
+  # shellcheck disable=SC2329  # Invoked indirectly by detect_host_ip.
+  command() { [[ "${1:-}" == "-v" ]]; }
+  # shellcheck disable=SC2329
+  uname() { printf '%s\n' "$os"; }
+  # shellcheck disable=SC2329
+  hostname() { printf '%s' "$hostname_output"; }
+  # shellcheck disable=SC2329
+  ipconfig() { printf '%s' "$ipconfig_output"; }
+  # shellcheck disable=SC2329
+  ip() { printf '%s' "$route_output"; }
+
+  detect_host_ip
+)
+
+failures=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf 'PASS: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n  expected: %q\n  actual:   %q\n' \
+      "$label" "$expected" "$actual" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_eq "Linux selects a usable hostname address" "10.0.0.5" \
+  "$(detect_with Linux $'127.0.0.1 10.0.0.5\n' '' '')"
+
+assert_eq "macOS accepts ipconfig getifaddr output" "192.168.1.10" \
+  "$(detect_with Darwin '' $'192.168.1.10\n' '')"
+
+assert_eq "Windows skips the macOS ipconfig probe" "localhost" \
+  "$(detect_with MINGW64_NT-10.0 '' $'Windows IP Configuration\n\nIPv4 Address: 192.168.1.100\n' '')"
+
+assert_eq "Windows ignores even valid-looking ipconfig output" "localhost" \
+  "$(detect_with MINGW64_NT-10.0 '' $'192.168.1.100\n' '')"
+
+assert_eq "Linux accepts a valid ip route source" "10.0.0.7" \
+  "$(detect_with Linux '' '' $'1.0.0.0 via 10.0.0.1 dev eth0 src 10.0.0.7 uid 1000\n')"
+
+assert_eq "Link-local hostname output falls through to ip route" "10.0.0.8" \
+  "$(detect_with Linux $'169.254.1.9\n' '' $'1.0.0.0 dev eth0 src 10.0.0.8\n')"
+
+assert_eq "Malformed ip route output falls back safely" "localhost" \
+  "$(detect_with Linux '' '' $'1.0.0.0 dev eth0 src not-an-ip\n')"
+
+assert_eq "ip route output without src falls back safely" "localhost" \
+  "$(detect_with Linux '' '' $'1.0.0.0 dev eth0\n')"
+
+assert_eq "Out-of-range IPv4 output is rejected" "localhost" \
+  "$(detect_with Darwin '' $'999.1.1.1\n' '')"
+
+if ((failures > 0)); then
+  printf '\n%d regression test(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nAll host IP detection regression tests passed\n'


### PR DESCRIPTION
Fixes #817

## Summary

`detect_host_ip()` feeds its result directly into
`MEMORY_HUB_PROXY_PUBLIC_URL`, so its output must be exactly one usable IPv4
literal or the documented `localhost` fallback.

This PR enforces that invariant across every host-IP probe:

- Run `ipconfig getifaddr` only on Darwin. Git Bash exposes the unrelated
  Windows `ipconfig.exe`, whose multi-line output caused #817.
- Validate candidates from Linux `hostname -I`, macOS `ipconfig`, and Linux
  `ip route` with one Bash-native validator.
- Reject malformed and multi-line output, out-of-range octets, `0.0.0.0`,
  loopback, and link-local addresses before they can enter a URL.
- Preserve `localhost` as the safe fallback when no usable address is found.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Windows Git Bash resolves `ipconfig.exe` | Multi-line Windows configuration could be used as the host IP and break generated config | The macOS probe is skipped; detection continues to a valid probe or `localhost` |
| macOS returns a valid `getifaddr` address | Accepted | Preserved |
| Linux `hostname -I` returns several addresses | First non-loopback/link-local IPv4 accepted | First candidate that passes strict validation accepted |
| Linux `ip route` returns a malformed, loopback, or link-local `src` | Any non-empty extracted value could be accepted | Rejected; falls back safely |

## Scope and related work

This remains intentionally limited to host-IP detection and deterministic
regression coverage.

- #837 addresses #817 by validating only the macOS probe output.
- #816 covers broader Windows/MSYS deployment concerns.
- This PR combines the explicit OS boundary with one validation rule shared by
  all probes, without taking on the unrelated deployment changes from #816.

## Verification

The regression test extracts the live production helpers, replaces external
commands with deterministic Bash stubs, and runs with `set -euo pipefail` plus
`inherit_errexit` enabled.

```bash
git diff --check upstream/feat/server_team
bash -n deploy/global-images/start-memory-hub.sh
bash -n tests/test_detect_host_ip.sh
bash tests/test_detect_host_ip.sh
bash -O inherit_errexit tests/test_detect_host_ip.sh
(cd deploy/global-images && shellcheck -x start-memory-hub.sh)
shellcheck -x tests/test_detect_host_ip.sh
```

Results on Linux x86_64 with Bash 5.2.15 and ShellCheck 0.11.0:

- 9/9 deterministic cases passed in normal strict mode.
- 9/9 deterministic cases passed with inherited `errexit`.
- The pre-fix implementation reproduced the bug by returning three lines of
  simulated Windows `ipconfig.exe` output.
- ShellCheck completed without findings.

GitHub CI currently does not trigger for pull requests targeting
`feat/server_team`; the commands above provide the equivalent focused checks
for this shell-only change.
