### PR TITLE
fix(gateway): add security headers, replace MD5 with SHA-256

### DIFF
--- a/src/core/profile/profile-sync.test.ts
+++ b/src/core/profile/profile-sync.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { buildProfileStableId } from "./profile-sync.js";
+
+describe("profile-sync SHA-256 hashing", () => {
+  describe("buildProfileStableId", () => {
+    it("should generate deterministic IDs for same input", () => {
+      const id1 = buildProfileStableId("global", "l2", "test.md");
+      const id2 = buildProfileStableId("global", "l2", "test.md");
+      expect(id1).toBe(id2);
+    });
+
+    it("should generate different IDs for different inputs", () => {
+      const id1 = buildProfileStableId("global", "l2", "file1.md");
+      const id2 = buildProfileStableId("global", "l2", "file2.md");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("should generate different IDs for different types", () => {
+      const id1 = buildProfileStableId("global", "l2", "test.md");
+      const id2 = buildProfileStableId("global", "l3", "test.md");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("should generate different IDs for different scopes", () => {
+      const id1 = buildProfileStableId("global", "l2", "test.md");
+      const id2 = buildProfileStableId("team", "l2", "test.md");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("should use SHA-256 (64 hex chars) not MD5 (32 hex chars)", () => {
+      const id = buildProfileStableId("global", "l2", "test.md");
+      // Extract the hash part after "profile:v1:"
+      const hash = id.replace("profile:v1:", "");
+      // SHA-256 produces 64 hex characters
+      expect(hash).toHaveLength(64);
+      // MD5 would produce 32 hex characters
+      expect(hash.length).not.toBe(32);
+    });
+
+    it("should match expected SHA-256 hash", () => {
+      const expectedHash = createHash("sha256")
+        .update(`global\u0000l2\u0000test.md`)
+        .digest("hex");
+      const id = buildProfileStableId("global", "l2", "test.md");
+      expect(id).toBe(`profile:v1:${expectedHash}`);
+    });
+
+    it("should start with profile:v1: prefix", () => {
+      const id = buildProfileStableId("global", "l2", "test.md");
+      expect(id).toMatch(/^profile:v1:/);
+    });
+  });
+});

--- a/src/core/profile/profile-sync.ts
+++ b/src/core/profile/profile-sync.ts
@@ -27,8 +27,8 @@ export function buildProfileStableId(scope: string, type: "l2" | "l3", filename:
   return `profile:v1:${hash}`;
 }
 
-function md5(text: string): string {
-  return createHash("md5").update(text).digest("hex");
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
 }
 
 async function statTimes(filePath: string): Promise<{ createdAtMs: number; updatedAtMs: number }> {
@@ -76,7 +76,7 @@ export async function listLocalProfiles(dataDir: string): Promise<ProfileRecord[
         type: "l2",
         filename,
         content,
-        contentMd5: md5(content),
+        contentMd5: sha256(content),
         version: 0,
         createdAtMs,
         updatedAtMs,
@@ -97,7 +97,7 @@ export async function listLocalProfiles(dataDir: string): Promise<ProfileRecord[
         type: "l3",
         filename: "persona.md",
         content: body,
-        contentMd5: md5(body),
+        contentMd5: sha256(body),
         version: 0,
         createdAtMs,
         updatedAtMs,
@@ -134,9 +134,9 @@ export async function pullProfilesToLocal(
       if (record.type === "l2") {
         const target = path.join(tempBlocksDir, record.filename);
         await fs.writeFile(target, record.content, "utf-8");
-        if (md5(record.content) !== record.contentMd5) {
+        if (sha256(record.content) !== record.contentMd5) {
           await fs.rm(target, { force: true });
-          logger.debug?.(`[memory-tdai][profile-sync] MD5 mismatch for ${record.filename} (will re-pull on next sync)`);
+          logger.debug?.(`[memory-tdai][profile-sync] SHA-256 mismatch for ${record.filename} (will re-pull on next sync)`);
         }
         continue;
       }
@@ -144,9 +144,9 @@ export async function pullProfilesToLocal(
       if (record.type === "l3") {
         const body = stripSceneNavigation(record.content).trim();
         await fs.writeFile(path.join(tempDir, "persona.md"), body, "utf-8");
-        if (md5(body) !== record.contentMd5) {
+        if (sha256(body) !== record.contentMd5) {
           await fs.rm(path.join(tempDir, "persona.md"), { force: true });
-          logger.debug?.(`[memory-tdai][profile-sync] MD5 mismatch for ${record.filename} (will re-pull on next sync)`);
+          logger.debug?.(`[memory-tdai][profile-sync] SHA-256 mismatch for ${record.filename} (will re-pull on next sync)`);
         }
       }
     }

--- a/src/gateway/server.test.ts
+++ b/src/gateway/server.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import http from "node:http";
+import { TdaiGateway } from "./server.js";
+
+describe("TdaiGateway security headers", () => {
+  let gateway: TdaiGateway;
+  let serverUrl: string;
+
+  beforeAll(async () => {
+    gateway = new TdaiGateway({
+      server: {
+        port: 0, // random available port
+        host: "127.0.0.1",
+        apiKey: "", // no auth for testing
+        corsOrigins: [],
+      },
+    });
+    await gateway.start();
+
+    // Get the actual port
+    const address = (gateway as any).server?.address();
+    const port = typeof address === "object" ? address?.port : 0;
+    serverUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await gateway.stop();
+  });
+
+  it("should include X-Content-Type-Options header", async () => {
+    const res = await fetch(`${serverUrl}/health`);
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("should include X-Frame-Options header", async () => {
+    const res = await fetch(`${serverUrl}/health`);
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+  });
+
+  it("should include X-XSS-Protection header", async () => {
+    const res = await fetch(`${serverUrl}/health`);
+    expect(res.headers.get("x-xss-protection")).toBe("1; mode=block");
+  });
+
+  it("should include Referrer-Policy header", async () => {
+    const res = await fetch(`${serverUrl}/health`);
+    expect(res.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("should include Permissions-Policy header", async () => {
+    const res = await fetch(`${serverUrl}/health`);
+    expect(res.headers.get("permissions-policy")).toBe(
+      "camera=(), microphone=(), geolocation=()"
+    );
+  });
+
+  it("should NOT include HSTS header on non-HTTPS connection", async () => {
+    const res = await fetch(`${serverUrl}/health`);
+    expect(res.headers.get("strict-transport-security")).toBeNull();
+  });
+
+  it("should include all security headers on POST endpoints", async () => {
+    const res = await fetch(`${serverUrl}/recall`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -237,6 +237,13 @@ export class TdaiGateway {
     const method = req.method?.toUpperCase() ?? "GET";
     const pathname = url.pathname;
 
+    // Security headers (OWASP A05:2021)
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("X-XSS-Protection", "1; mode=block");
+    res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+    res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+
     // Apply CORS headers based on configured allow-list (empty → no headers).
     this.applyCorsHeaders(req, res);
 


### PR DESCRIPTION
## Description

Security hardening addressing multiple findings from automated audit.

### Security Headers (OWASP A05:2021)
- **Gateway**: Add security headers to all HTTP responses
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `X-XSS-Protection: 1; mode=block`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()`

### Cryptography (CWE-328)
- **profile-sync**: Replace MD5 with SHA-256 for content integrity hashing
- Update all `md5()` calls to `sha256()`
- Update log messages to reflect SHA-256 usage

## Related Issues

- Relates to #808 (auth bypass, SSRF, git injection)
- Relates to #736 (authenticate session management routes)
- Relates to #765 (Dockerfile build issues)

## Files Changed

- `src/gateway/server.ts`: Add security headers in `handleRequest()`
- `src/core/profile/profile-sync.ts`: Replace MD5 with SHA-256
- `src/gateway/server.test.ts`: Unit tests for security headers
- `src/core/profile/profile-sync.test.ts`: Unit tests for SHA-256 hashing

## Testing

Added unit tests covering:

### Security Headers Tests (`server.test.ts`)
- ✅ Verify `X-Content-Type-Options: nosniff`
- ✅ Verify `X-Frame-Options: DENY`
- ✅ Verify `X-XSS-Protection: 1; mode=block`
- ✅ Verify `Referrer-Policy: strict-origin-when-cross-origin`
- ✅ Verify `Permissions-Policy` restrictions
- ✅ Verify HSTS not set on non-HTTPS
- ✅ Verify headers on POST endpoints

### SHA-256 Tests (`profile-sync.test.ts`)
- ✅ Verify SHA-256 produces 64 hex chars (not 32 for MD5)
- ✅ Verify deterministic hashing
- ✅ Verify different hashes for different inputs
- ✅ Verify `profile:v1:` prefix format

Run tests with: `npx vitest run src/gateway/server.test.ts src/core/profile/profile-sync.test.ts`