### PR TITLE
fix(compact): stop infinite loop when tool-result truncation frees no tokens

### DIFF
--- a/MemoryCore/src/offload_server/compact/compressor.test.ts
+++ b/MemoryCore/src/offload_server/compact/compressor.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression tests for #832 — tool-result truncation must terminate instead
+ * of spinning at 100% CPU when a single message cannot free enough tokens.
+ */
+
+import { describe, expect, it } from "vitest";
+import { truncateTailToolResults } from "./compressor.js";
+import type { Message } from "./helpers.js";
+
+function toolResult(content: string): Message {
+  return {
+    role: "user",
+    content: [{ type: "tool_result", content }],
+  } as unknown as Message;
+}
+
+function getToolResultContent(msg: Message): string {
+  const blocks = (msg as any).content as { type: string; content: string }[];
+  return blocks[0]?.content ?? "";
+}
+
+describe("truncateTailToolResults (#832)", () => {
+  it("terminates when a single message cannot free enough tokens", () => {
+    const content = "x".repeat(2500); // > default TOOL_RESULT_TRUNCATE_CHARS (2000)
+    const messages = [toolResult(content)];
+    const tokenArray = [Math.ceil(content.length / 4)]; // ~625
+    const estimate = (t: string) => Math.max(1, Math.ceil(t.length / 4));
+
+    // Would previously loop forever (freed=0 after round 1) until timeout.
+    const freed = truncateTailToolResults(messages, tokenArray, 0, 100_000, estimate);
+
+    expect(freed).toBeGreaterThan(0);
+    // Truncated result (including the notice) stays within the budget, so the
+    // same message is not re-selected on the next pass.
+    const result = getToolResultContent(messages[0]);
+    expect(result.length).toBeLessThanOrEqual(2000);
+    expect(result).toContain("content truncated");
+  });
+
+  it("leaves already-small tool results untouched", () => {
+    const content = "short";
+    const messages = [toolResult(content)];
+    const freed = truncateTailToolResults(messages, [5], 0, 100, (t) => t.length);
+    expect(freed).toBe(0);
+    expect(getToolResultContent(messages[0])).toBe("short");
+  });
+});

--- a/MemoryCore/src/offload_server/compact/compressor.ts
+++ b/MemoryCore/src/offload_server/compact/compressor.ts
@@ -245,10 +245,13 @@ export function truncateTailToolResults(
 
     if (maxIdx === -1) break; // nothing left to truncate
 
-    // Truncate
+    // Truncate, counting the notice against the budget so the result stays at
+    // or under truncateChars — otherwise the notice pushes it back over the
+    // threshold and the same message is re-selected forever (issue #832).
     const msg = messages[maxIdx];
     const oldContent = getTextContent(msg);
-    const truncated = oldContent.slice(0, truncateChars) + `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+    const notice = `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+    const truncated = oldContent.slice(0, Math.max(0, truncateChars - notice.length)) + notice;
     setTextContent(msg, truncated);
 
     // Recalculate token for this message
@@ -257,6 +260,9 @@ export function truncateTailToolResults(
     tokenArray[maxIdx] = newTokens;
     tokensToFree -= freed;
     totalFreed += freed;
+    // No progress (e.g. a fixed point where slicing yields the same string) —
+    // stop instead of spinning forever at 100% CPU.
+    if (freed <= 0) break;
   }
 
   return totalFreed;
@@ -296,10 +302,11 @@ function truncateRemainingToolResults(
 
     if (maxIdx === -1) break;
 
-    // Truncate
+    // Truncate, counting the notice against the budget so the result stays at
+    // or under truncateChars (issue #832).
     const oldContent = getTextContent(messages[maxIdx]);
-    const truncated = oldContent.slice(0, truncateChars) +
-      `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+    const notice = `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+    const truncated = oldContent.slice(0, Math.max(0, truncateChars - notice.length)) + notice;
     setTextContent(messages[maxIdx], truncated);
 
     // Recalculate token
@@ -311,6 +318,8 @@ function truncateRemainingToolResults(
     const freed = oldTokens - newTokens;
     tokensToFree -= freed;
     totalFreed += freed;
+    // No progress — stop instead of spinning forever at 100% CPU.
+    if (freed <= 0) break;
   }
 
   return totalFreed;


### PR DESCRIPTION
Fixes #832.

## Problem

`truncateTailToolResults` / `truncateRemainingToolResults` could **spin forever at 100% CPU** until the `compact` request timed out. Root cause: the truncation appended a notice without counting it against the budget, so the result (`2000 + ~66` chars) stayed **above** `TOOL_RESULT_TRUNCATE_CHARS`; the selection loop (`content.length <= truncateChars → skip`) re-picked the same message every pass, `freed` became `0`, and `tokensToFree` never decreased → `while (tokensToFree > 0)` never terminated.

## Change

Both functions:

- **count the notice against the budget**: slice to `truncateChars - notice.length`, so the truncated result (including the notice) is **at or under** `truncateChars` and is not re-selected
- **defensively break when a round frees `<= 0` tokens** (a fixed point) so the loop can never spin

## Tests

`src/offload_server/compact/compressor.test.ts` (first tests for the module):
- a single oversized `tool_result` terminates and stays within budget (the issue's repro: `tokensToFree=100000`, content 2500 chars)
- already-small tool results untouched

`npm test` passes, `npm run build:plugin` passes.