### PR TITLE
fix(hermes): conversation_search must read the messages field (not items)

### DIFF
--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -872,7 +872,11 @@ class MemoryTencentdbProvider(MemoryProvider):
                     user_id=self._user_id,
                 )
                 self._record_success()
-                items = result.get("data", {}).get("items", [])
+                # Conversation search returns { data: { messages: [...] } } per
+                # the OpenAPI contract — "items" would be silently empty, so
+                # conversation_search always returned "No conversations found"
+                # (issue #823).
+                items = result.get("data", {}).get("messages", [])
                 if not items:
                     return "No conversations found for this query."
                 lines = []

--- a/MemoryCore/hermes-plugin/tests/test_search_field.py
+++ b/MemoryCore/hermes-plugin/tests/test_search_field.py
@@ -1,0 +1,79 @@
+"""Regression tests for #823 — the Hermes adapter must read the correct
+response fields: AtomicSearchData.items for memory search and
+ConversationSearchData.messages for conversation search.
+
+Run: python3 -m unittest tests.test_search_field
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_agent = types.ModuleType("agent")
+_mp = types.ModuleType("agent.memory_provider")
+
+
+class _MemoryProvider:  # noqa: N801
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+_mp.MemoryProvider = _MemoryProvider
+sys.modules.setdefault("agent", _agent)
+sys.modules.setdefault("agent.memory_provider", _mp)
+
+from memory.memory_tencentdb import MemoryTencentdbProvider  # noqa: E402
+
+
+class SearchFieldTest(unittest.TestCase):
+    def _provider(self):
+        p = MemoryTencentdbProvider()
+        p._client = mock.MagicMock()
+        return p, p._client
+
+    def _call(self, p, tool_name, args):
+        with mock.patch.object(p, "_ensure_alive_for_request", return_value=True), \
+             mock.patch.object(p, "_is_breaker_open", return_value=False):
+            return p.handle_tool_call(tool_name, args)
+
+    def test_conversation_search_reads_messages_field(self):
+        p, client = self._provider()
+        # Per ConversationSearchData: { data: { messages: [...] } }.
+        client.conversation_search.return_value = {
+            "code": 0,
+            "message": "ok",
+            "data": {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi there"},
+                ]
+            },
+        }
+
+        result = self._call(p, "memory_tencentdb_conversation_search", {"query": "hello"})
+
+        self.assertIn("[user] hello", result)
+        self.assertIn("[assistant] hi there", result)
+        self.assertNotIn("No conversations found", result)
+
+    def test_memory_search_reads_items_field(self):
+        p, client = self._provider()
+        # Per AtomicSearchData: { data: { items: [...] } }.
+        client.atomic_search.return_value = {
+            "code": 0,
+            "message": "ok",
+            "data": {"items": [{"type": "episodic", "content": "remembered fact"}]},
+        }
+
+        result = self._call(p, "memory_tencentdb_memory_search", {"query": "fact"})
+
+        self.assertIn("remembered fact", result)
+        self.assertNotIn("No memories found", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #823.

## Problem

The Hermes adapter read `.get("data").get("items")` for `conversation_search`, but the Gateway returns `{ data: { messages: [...] } }` per `ConversationSearchData` (see `v2-router.ts` → `successEnvelope<ConversationSearchData>({ messages })`). As a result `memory_tencentdb_conversation_search` always returned **"No conversations found"** even when the Gateway returned hits.

In v2, `memory_search` and `prefetch` already read the correct `items` field; the **`conversation_search` branch was the remaining broken one** (the same root cause the issue reports for the 1.x `memory_tencentdb_v2` adapter).

## Change

`memory_tencentdb/__init__.py` — `conversation_search` now reads `.get("data").get("messages", [])`.

## Tests

`MemoryCore/hermes-plugin/tests/test_search_field.py` (first tests for the Hermes provider):
- `conversation_search` parses `{ data: { messages } }`
- `memory_search` parses `{ data: { items } }`

`python3 -m unittest tests.test_search_field` passes.