### PR TITLE
fix(proxy): keep /v1/ in the forwarded path for Anthropic endpoints

### DIFF
--- a/MemoryProxy/src/__tests__/whitelist.test.ts
+++ b/MemoryProxy/src/__tests__/whitelist.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for #825 — the whitelist upstream endpoint for Anthropic paths must
+ * keep the /v1/ segment (dropping it made forwarded calls hit /messages → 404).
+ */
+
+import { describe, expect, it } from "vitest";
+import { matchWhitelistEndpoint } from "../routes/whitelist.js";
+
+describe("matchWhitelistEndpoint (#825)", () => {
+  it("keeps /v1/ for anthropic /messages after stripping the agent+space prefix", () => {
+    const ep = matchWhitelistEndpoint("/claude-code/default/v1/messages");
+    expect(ep?.protocol).toBe("anthropic");
+    expect(ep?.upstreamEndpoint).toBe("/v1/messages");
+  });
+
+  it("keeps /v1/ regardless of agent prefix form", () => {
+    expect(matchWhitelistEndpoint("/claude-code/v1/messages")?.upstreamEndpoint).toBe("/v1/messages");
+    expect(matchWhitelistEndpoint("/codebuddy/space-1/v1/messages")?.upstreamEndpoint).toBe("/v1/messages");
+  });
+
+  it("keeps /v1/ for anthropic count_tokens", () => {
+    expect(matchWhitelistEndpoint("/claude-code/default/v1/messages/count_tokens")?.upstreamEndpoint)
+      .toBe("/v1/messages/count_tokens");
+  });
+
+  it("keeps openai chat completions without a duplicated v1", () => {
+    // OpenAI-compatible upstreams put /v1 in their base URL; forwarding
+    // /chat/completions is correct and must stay unchanged.
+    expect(matchWhitelistEndpoint("/v1/chat/completions")?.upstreamEndpoint).toBe("/chat/completions");
+  });
+});

--- a/MemoryProxy/src/routes/whitelist.ts
+++ b/MemoryProxy/src/routes/whitelist.ts
@@ -46,7 +46,11 @@ export const WHITELIST_ENDPOINTS: readonly WhitelistEndpoint[] = [
   // ── 主端点（由现有 handler 处理，含路由）────────────────────────
   {
     pathSuffix: "/v1/messages",
-    upstreamEndpoint: "/messages",
+    // Anthropic upstream bases do not include the /v1 segment
+    // (e.g. https://api.anthropic.com or a custom base), so the /v1/ must be
+    // kept — dropping it made every forwarded call hit /messages → 404
+    // (issue #825).
+    upstreamEndpoint: "/v1/messages",
     protocol: "anthropic",
     supportsStream: true,
     isPrimary: true,
@@ -61,7 +65,7 @@ export const WHITELIST_ENDPOINTS: readonly WhitelistEndpoint[] = [
   // ── 辅助端点（由 handleAuxiliaryEndpoint 处理，不走路由）─────────
   {
     pathSuffix: "/v1/messages/count_tokens",
-    upstreamEndpoint: "/messages/count_tokens",
+    upstreamEndpoint: "/v1/messages/count_tokens",
     protocol: "anthropic",
     supportsStream: false,
     isPrimary: false,


### PR DESCRIPTION
Fixes #825.

## Problem

`WHITELIST_ENDPOINTS` mapped `/v1/messages` → upstream `"/messages"`, so every Anthropic-compatible call routed through memory-proxy hit the upstream at `/messages` (e.g. `/anthropic/messages`) instead of `/v1/messages` → **404**. This broke Claude Code / Cursor / any SDK routed through the proxy (memory injection, skill, session-init all fail).

## Root cause

- Client path: `/claude-code/{spaceId}/v1/messages`
- `normalizeWhitelistRequestPath` correctly strips the agent+space prefix → `/v1/messages`
- But the matched entry's `upstreamEndpoint` was `"/messages"` (dropped `/v1/`), and `anthropicHandler.ts` forwards `base + upstreamEndpoint`

## Change

Anthropic upstream bases do **not** include `/v1` (`https://api.anthropic.com` or a custom base like `/anthropic`), so the `/v1/` segment must be kept:

- `/v1/messages` → `upstreamEndpoint: "/v1/messages"`
- `/v1/messages/count_tokens` → `upstreamEndpoint: "/v1/messages/count_tokens"`

OpenAI-compatible entries are unchanged (their bases include `/v1`, so `/chat/completions` forwarding is correct).

## Tests

`MemoryProxy/src/__tests__/whitelist.test.ts` (4): anthropic `/messages` and `count_tokens` resolve to `/v1/...` after prefix stripping; openai entries unchanged.

`npm test` (vitest) passes.