### PR TITLE
fix(deploy): reject non-IPv4 output in host IP detection (Windows Git Bash)

### DIFF
--- a/deploy/global-images/start-memory-hub.sh
+++ b/deploy/global-images/start-memory-hub.sh
@@ -47,7 +47,14 @@ detect_host_ip() {
   if command -v ipconfig >/dev/null 2>&1; then
     for iface in en0 en1 en2; do
       ip=$(ipconfig getifaddr "$iface" 2>/dev/null)
-      [[ -n "$ip" ]] && { echo "$ip"; return; }
+      # Only accept a single IPv4 literal. Windows' ipconfig.exe also matches
+      # `command -v ipconfig` in Git Bash but does not support getifaddr and
+      # prints multi-line network-config text, which would be injected as the
+      # host IP and break the generated proxy_endpoint with newlines
+      # (issue #817).
+      if [[ "$ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] && [[ "$ip" != 127.* && "$ip" != 169.254.* ]]; then
+        echo "$ip"; return
+      fi
     done
   fi
   # 兜底：ip route（Linux 无 hostname -I 时）


### PR DESCRIPTION
Fixes #817.

## Problem

`detect_host_ip()` in `start-memory-hub.sh` used `ipconfig getifaddr` for macOS. In **Windows Git Bash**, `command -v ipconfig` matches Windows' `ipconfig.exe`, which does not support `getifaddr` and prints **multi-line** network-config text. The script only checked non-empty, so that multi-line text was used as the host IP and injected **newlines** into the generated `proxy_endpoint` → `Python SyntaxError: unterminated string literal` → memory-hub exits.

## Change

The macOS branch now only accepts a **single IPv4 literal** (and skips `127.` / `169.254.`), so Windows `ipconfig.exe` output is rejected and detection falls through to the next candidates → `localhost`.

## Verification

- `bash -n` passes
- Simulated a Windows `ipconfig` (multi-line) scenario: `detect_host_ip()` falls back to `localhost` instead of emitting newline-laden text