### PR TITLE
fix(compact): call compressProtectedTail after emergency compression

### DIFF
--- a/MemoryCore/src/offload_server/compact/compaction-handler.ts
+++ b/MemoryCore/src/offload_server/compact/compaction-handler.ts
@@ -14,7 +14,7 @@ import { CompactionRequestSchemaV2 } from "../schemas.js";
 import { buildOffloadBasePath } from "../session-utils.js";
 import { applyFastPath } from "./fast-path.js";
 import { injectActiveMmd, injectHistoryMmds } from "./mmd-injector.js";
-import { resolveLevel, mildCompress, aggressiveCompress, emergencyCompress } from "./compressor.js";
+import { resolveLevel, mildCompress, aggressiveCompress, emergencyCompress, compressProtectedTail } from "./compressor.js";
 import { estimateMessageTokens, extractToolResultId } from "./helpers.js";
 import type { Message } from "./helpers.js";
 import { traceServerCompaction } from "../opik-tracer.js";
@@ -34,6 +34,8 @@ export interface CompactionReport {
   mildReplacements: number;
   aggressiveDeleted: number;
   emergencyDeleted: number;
+  protectedTailFreed: number;
+  protectedTailDeleted: number;
   mmdInjected: number;
 }
 
@@ -117,6 +119,8 @@ export async function handleCompaction(
     mildReplacements: 0,
     aggressiveDeleted: 0,
     emergencyDeleted: 0,
+    protectedTailFreed: 0,
+    protectedTailDeleted: 0,
     mmdInjected: 0,
   };
 
@@ -217,6 +221,23 @@ export async function handleCompaction(
     report.emergencyDeleted = em.deletedCount;
     aggRemainingTokens = em.remainingTokens;
     compactState.deletedOffloadIds.push(...em.deletedIds);
+
+    // Fallback: a single long agent step (many assistant/tool_result pairs) can
+    // leave emergency compaction still above the target. compressProtectedTail
+    // is the escape hatch for exactly this — it was defined but never called
+    // (issue #838).
+    if (aggRemainingTokens > emTargetTokens) {
+      const tail = compressProtectedTail(
+        messages,
+        tokenArray,
+        emTargetTokens,
+        aggRemainingTokens,
+        compactState.deletedOffloadIds,
+      );
+      report.protectedTailFreed = tail.freedTokens;
+      report.protectedTailDeleted = tail.deletedCount;
+      aggRemainingTokens -= tail.freedTokens;
+    }
   }
 
   // Step 7: Inject active MMD (after all compression, so position is correct)

--- a/MemoryCore/src/offload_server/compact/compressor-protected-tail.test.ts
+++ b/MemoryCore/src/offload_server/compact/compressor-protected-tail.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for #838 — compressProtectedTail must be usable as the escape hatch
+ * when emergency compaction still leaves the prompt above the target (it was
+ * previously never called).
+ *
+ * Note: the fine-grained truncation path inside compressProtectedTail is
+ * covered by #832's fix (truncateTailToolResults infinite loop); these tests
+ * exercise the fast batch-deletion path so they run on the unpatched trunk.
+ */
+
+import { describe, expect, it } from "vitest";
+import { compressProtectedTail } from "./compressor.js";
+import type { Message } from "./helpers.js";
+
+function assistantWithToolUse(): Message {
+  return {
+    role: "assistant",
+    content: "planning",
+    tool_calls: [{ function: { name: "f", arguments: "{}" } }],
+  } as unknown as Message;
+}
+
+function toolResult(content: string): Message {
+  return { role: "tool", content, tool_call_id: "t1" } as unknown as Message;
+}
+
+describe("compressProtectedTail (#838)", () => {
+  it("frees tokens from oversized tool pairs when above the target", () => {
+    // Two oversized tool pairs: fast batch deletion of the first pair alone is
+    // enough to bring the prompt under the target.
+    const messages: Message[] = [
+      { role: "user", content: "user question" } as Message,
+      assistantWithToolUse(),
+      toolResult("x".repeat(30000)),
+      assistantWithToolUse(),
+      toolResult("y".repeat(30000)),
+    ];
+    const tokens = [1, 10, 30000, 10, 30000];
+    const deletedIds: string[] = [];
+
+    const result = compressProtectedTail(messages, tokens, 35_000, 60_021, deletedIds);
+
+    expect(result.freedTokens).toBeGreaterThan(0);
+  });
+
+  it("returns zero when already within target", () => {
+    const messages = [{ role: "user", content: "q" } as Message];
+    const result = compressProtectedTail(messages, [1], 100, 1, []);
+    expect(result.freedTokens).toBe(0);
+    expect(result.deletedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #838.

## Problem

`compressProtectedTail` was defined (since v1.0.0) to handle exactly the case where a **single long agent step** (many assistant/tool_result pairs) leaves emergency compaction still **above the target budget** — but **nothing ever called it**. `git grep compressProtectedTail` only hit the definition, so an over-budget prompt was returned to the caller.

## Change

`compaction-handler.ts` Step 6 now falls back to `compressProtectedTail` when emergency compression still exceeds the target:

- truncates oversized tool results / deletes oldest tool pairs in the protected tail, while preserving the last user message and at least the most recent tool pair
- progress reported via `protectedTailFreed` / `protectedTailDeleted`

## Note

The fine-grained truncation path inside `compressProtectedTail` calls `truncateTailToolResults`, whose infinite-loop is fixed by **#832** (separate PR). Without #832, only the fast batch-deletion path is safe — matching this PR's tests, which run on the unpatched trunk.

## Tests

`compressor-protected-tail.test.ts` (2): frees tokens from oversized tool pairs when above the target; no-op when already within target.

`npm test` passes, `npm run build:plugin` passes.