### PR TITLE
fix(proxy): fallback conversation id for CodeBuddy session

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -280,13 +280,15 @@ Disable the full pipeline (passthrough only): `PROXY_FULL_STACK=0 ./start-proxy.
 
 [CodeBuddy](https://www.codebuddy.ai/) is Tencent's AI coding assistant IDE plugin. By configuring a custom model, you can route CodeBuddy's chat requests through the Proxy to get the same memory capabilities as Claude Code, directly within your IDE.
 
-### ⚠️ Version Restrictions
+### ⚠️ Known Session-Init Limitation
 
-> CodeBuddy versions **4.10.2, 4.10.3, and 4.10.4** have a known bug: these
-> versions do not send a `sessionId` in requests, preventing the Proxy from
-> completing session initialization.
->
-> **Use CodeBuddy ≥ 4.10.5 or ≤ 4.10.1.**
+CodeBuddy versions **4.10.2, 4.10.3, and 4.10.4** have a known bug: these
+versions do not send a `sessionId` / conversation header in requests, preventing
+the Proxy from completing session initialization. The Proxy mitigates this via a
+[`SessionStart` hook](https://www.codebuddy.ai/docs/zh/ide/User-guide/Hooks) that
+injects the conversation ID into the prompt, which the Proxy then extracts and
+uses as a fallback (see [below](#optional-fix-conversation-id-for-broken-codebuddy-versions)).
+If the hook is not configured on these versions, session init will fail.
 
 ### Configuration
 
@@ -321,6 +323,36 @@ Create or edit `~/.codebuddy/models.json` on your development machine (replace t
 
 Once configured, select the model name in CodeBuddy's chat panel and start chatting.
 The session init flow is the same as Claude Code (pick Team → Agent → Task).
+
+#### Optional: fix conversation ID for broken CodeBuddy versions
+
+For CodeBuddy **4.10.2 ~ 4.10.4** (which omit the conversation header), enable the
+provided `SessionStart` hook so the conversation ID is injected into the prompt
+and used by the Proxy as a fallback. Set the hook to point at
+`deploy/global-images/hooks/session_start.py` (absolute path):
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python /absolute/path/to/deploy/global-images/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Place this under CodeBuddy's project-level config (or `settings.json`) on the
+development machine. The hook only injects the session ID and never blocks
+startup; newer versions (≥ 4.10.5 or ≤ 4.10.1) that already send the header are
+unaffected.
 
 ## Using Proxy with Hermes
 

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -256,12 +256,14 @@ Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/age
 
 [CodeBuddy](https://www.codebuddy.ai/) 是腾讯推出的 AI 编程助手 IDE 插件。通过自定义模型配置，你可以把 CodeBuddy 的对话请求路由到 Proxy，在 IDE 内获得与 Claude Code 相同的记忆能力。
 
-### ⚠️ 版本限制
+### ⚠️ 已知的会话初始化限制
 
-> CodeBuddy **4.10.2、4.10.3、4.10.4** 存在已知 Bug：这些版本不会在请求中
-> 携带 `sessionId`，导致 Proxy 无法完成 Session 初始化。
->
-> **请使用 CodeBuddy ≥ 4.10.5 或 ≤ 4.10.1。**
+CodeBuddy **4.10.2、4.10.3、4.10.4** 存在已知 Bug：这些版本不会在请求中
+携带 `sessionId` / 会话头，导致 Proxy 无法完成 Session 初始化。Proxy 通过
+[`SessionStart` hook](https://www.codebuddy.ai/docs/zh/ide/User-guide/Hooks) 兜底：
+将会话 ID 注入到 prompt 中，Proxy 端提取后作为回退（见下方
+[「为有问题的 CodeBuddy 版本修复会话 ID」](#为有问题的-codebuddy-版本修复会话-id)）。
+若这些版本未配置 hook，会话初始化将失败。
 
 ### 配置
 
@@ -295,6 +297,34 @@ Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/age
 
 配置完成后，在 CodeBuddy 对话框中选择刚才配置的模型名称即可开始对话。
 Session init 流程与 Claude Code 一致（选 Team → Agent → Task）。
+
+#### 可选：为有问题的 CodeBuddy 版本修复会话 ID
+
+针对 **4.10.2 ~ 4.10.4**（这些版本不携带会话头），启用项目自带的
+`SessionStart` hook，将会话 ID 注入到 prompt，供 Proxy 端兜底提取。
+将 hook 指向 `deploy/global-images/hooks/session_start.py`（绝对路径）：
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python /绝对路径/deploy/global-images/hooks/session_start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+将该配置放到开发机 CodeBuddy 的**项目级配置**（或 `settings.json`）中。
+hook 仅注入会话 ID，不会阻断启动；已能正常携带会话头的版本（≥ 4.10.5 或
+≤ 4.10.1）不受影响。
 
 ## 通过 Proxy 使用 Hermes
 

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -640,9 +640,13 @@ export async function handleAnthropicMessages(
   }
 
 // ── Session key: prefer conversation header, fallback to agent profile ───────────
-  const { resolveConversationId } = await import("./session/session-key.js");
-  const conversationId = resolveConversationId(c);
+  // Clients without a conversation header (e.g. CodeBuddy 4.10.2~4.10.4) fall back
+  // to the ID injected into the prompt by the SessionStart hook.
+  const { resolveConversationId, extractConversationIdFromPrompt, stripConversationMarker } = await import("./session/session-key.js");
+  const conversationId = resolveConversationId(c) ?? extractConversationIdFromPrompt(body);
   const sessionKey = conversationId ?? resolveSessionKey(config, lcHeaders, c.req.path, body, keyId);
+  // Drop the injected marker before forwarding — it is metadata only, not for the upstream LLM.
+  stripConversationMarker(body?.messages as Array<Record<string, unknown>> | undefined);
 
   // ── Auth verification (user_key → user_id) ──────────────────────────────────────
   // Reuse the early verify result — it ran before body parse to decide the

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -542,9 +542,13 @@ export async function handleChatCompletions(
   }
 
   // ── Session key: prefer conversation header, fallback to agent profile ───────────
-  const { resolveConversationId } = await import("./session/session-key.js");
-  const conversationId = resolveConversationId(c);
+  // Clients without a conversation header (e.g. CodeBuddy 4.10.2~4.10.4) fall back
+  // to the ID injected into the prompt by the SessionStart hook.
+  const { resolveConversationId, extractConversationIdFromPrompt, stripConversationMarker } = await import("./session/session-key.js");
+  const conversationId = resolveConversationId(c) ?? extractConversationIdFromPrompt(body);
   const sessionKey = conversationId ?? resolveSessionKey(config, lcHeaders, c.req.path, body, keyId);
+  // Drop the injected marker before forwarding — it is metadata only, not for the upstream LLM.
+  stripConversationMarker(body?.messages as Array<Record<string, unknown>> | undefined);
 
   // ── Auth verification (user_key → user_id) ──────────────────────────────────────
   // Reuse the early verify result — it ran before body parse to decide the

--- a/MemoryProxy/src/session/session-key.ts
+++ b/MemoryProxy/src/session/session-key.ts
@@ -17,6 +17,68 @@ export function resolveConversationId(c: Context): string | null {
   return id && id.length > 0 ? id : null;
 }
 
+/**
+ * Extract a conversation ID embedded in the request body's system/user prompt.
+ *
+ * Some clients (e.g. CodeBuddy 4.10.2~4.10.4) do not send a conversation header,
+ * so the ID is injected into the prompt by the SessionStart hook instead. The
+ * hook (deploy/global-images/hooks/session_start.py) writes it into the first
+ * user message's `<additional_data>` block, so both system and user messages
+ * are scanned. Prefers the tagged format, falls back to generic field names.
+ */
+export function extractConversationIdFromPrompt(
+  body: Record<string, unknown> | undefined,
+): string | null {
+  if (!body || !Array.isArray(body.messages) || body.messages.length === 0) return null;
+
+  let text = "";
+  for (const m of body.messages as Array<{ role?: string; content?: unknown }>) {
+    const role = m.role ?? "";
+    if (role !== "system" && role !== "user") continue;
+    let content = "";
+    if (typeof m.content === "string") {
+      content = m.content;
+    } else if (Array.isArray(m.content)) {
+      content = (m.content as Array<{ type?: string; text?: string }>)
+        .filter((c) => c.type === "text")
+        .map((c) => c.text ?? "")
+        .join("\n");
+    }
+    if (content) text += content + "\n";
+  }
+  if (!text) return null;
+
+  // Tagged marker injected by the hook takes precedence.
+  const tagged = text.match(
+    /\[tdai-proxy-session\]\s*conversation_id:\s*([A-Za-z0-9._-]{6,})/i,
+  );
+  if (tagged && tagged[1]) return tagged[1];
+
+  // Fall back to generic conversation/session id field names.
+  const generic = text.match(
+    /(?:conversation|session|chat)[_\s-]?id["\s:=]+([A-Za-z0-9._-]{6,})/i,
+  );
+  if (generic && generic[1]) return generic[1];
+
+  return null;
+}
+
+/**
+ * Strip the injected conversation marker from messages in place.
+ *
+ * The marker is only metadata for conversation identification; it must not be
+ * forwarded to the upstream LLM nor persist into memory. Idempotent, and only
+ * matches the exact tagged format so user input is never touched.
+ */
+export function stripConversationMarker(messages: Array<Record<string, unknown>> | undefined): void {
+  if (!messages || !Array.isArray(messages)) return;
+  const re = /\[tdai-proxy-session\]\s*conversation_id:\s*[A-Za-z0-9._-]{6,}\s*/gi;
+  for (const m of messages) {
+    if (typeof m.content !== "string" || !m.content.includes("[tdai-proxy-session]")) continue;
+    m.content = m.content.replace(re, "");
+  }
+}
+
 /** Check whether the messages look like a fresh conversation (at most 1 user message, no assistant/tool). */
 export function isFreshConversation(
   messages: Array<{ role?: string }>,

--- a/deploy/global-images/hooks/session_start.py
+++ b/deploy/global-images/hooks/session_start.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+CodeBuddy `SessionStart` hook — 把会话 ID 注入到 system prompt，供 MemoryProxy
+在客户端不携带会话头（如 4.10.2 ~ 4.10.4）时兜底识别会话。
+
+流程：读 stdin 的 `session_id` → 安全过滤 → 以 `[tdai-proxy-session] conversation_id: <id>`
+写入 `additionalContext`；MemoryProxy 端经 `extractConversationIdFromPrompt` 提取，
+转发前由 `stripConversationMarker` 剔除。
+
+配置（CodeBuddy settings.json / 项目级配置，指向本脚本绝对路径）:
+  "hooks": { "SessionStart": [ { "hooks": [ { "type": "command",
+             "command": "python <path>/session_start.py", "timeout": 10 } ] } ] }
+
+仅做会话 ID 注入；stdin 无输入 / 解析失败 / 无 session_id 均放行，不阻断启动。
+"""
+import json
+import sys
+
+# 与 MemoryProxy/src/session/session-key.ts 的 extractConversationIdFromPrompt 保持一致
+MARKER_TAG = "[tdai-proxy-session]"
+
+
+def _safe_session_id(session_id: str) -> str:
+    """仅保留安全字符，避免注入异常文本。"""
+    return "".join(ch for ch in session_id if ch.isalnum() or ch in "-_.")
+
+
+def main() -> None:
+    # Windows 默认 GBK，强制 UTF-8 以便 CodeBuddy 正确解析 stdout JSON
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"continue": True, "suppressOutput": False}, ensure_ascii=False))
+        return
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        print(json.dumps({"continue": True, "suppressOutput": False}, ensure_ascii=False))
+        return
+
+    session_id = str(data.get("session_id", "") or "").strip()
+
+    context_parts = []
+    if session_id:
+        safe_id = _safe_session_id(session_id)
+        if safe_id:
+            context_parts.append(f"{MARKER_TAG} conversation_id: {safe_id}")
+
+    out = {
+        "continue": True,
+        "suppressOutput": False,
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "permissionDecision": "allow",
+        },
+    }
+    if context_parts:
+        out["hookSpecificOutput"]["additionalContext"] = "\n".join(context_parts)
+
+    sys.stdout.write(json.dumps(out, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

CodeBuddy client versions `4.10.2`–`4.10.4` do not send a `sessionId`/conversation header on requests. When such a request reaches the MemoryProxy, the session cannot be initialized: `sessionId=none` / `conversationId=null`, so the conversation never gets recorded in memory. The current documentation (`INSTALL.md`) only instructs users to avoid these broken versions.

## Root cause

The proxy's session resolution depends entirely on an incoming session header. When the header is absent, `resolveConversationId` returns `null` and the request falls through without a session key, so no memory write can be associated with a conversation.

## Change

Add a fallback that recovers the conversation id from the client instead of relying solely on the header:

- `deploy/global-images/hooks/session_start.py` — a CodeBuddy `SessionStart` hook that injects a `[tdai-proxy-session] conversation_id: <id>` marker into the prompt.
- `MemoryProxy/src/session/session-key.ts` — new `extractConversationIdFromPrompt` parses the marker (with a generic fallback); `stripConversationMarker` removes it before forwarding so the upstream LLM never sees the injected text.
- `MemoryProxy/src/handler.ts` / `MemoryProxy/src/anthropicHandler.ts` — wire extraction + stripping into both OpenAI- and Anthropic-style request paths.
- `INSTALL.md` / `INSTALL_CN.md` — reframe the CodeBuddy known-bug workaround from an avoid-only limitation into a documented fallback (optional `SessionStart` hook setup), with anchor links between the two docs.

## Tests

- Pure-function unit tests: `session-key.ts` extraction + stripping, 13/13 pass (`npx tsx`).
- End-to-end checks against a local fake LLM across three scenarios:
  - OpenAI request with marker → `conversationId` extracted, marker stripped.
  - OpenAI request without marker (control) → `null` / body unchanged (no false positives).
  - Anthropic request with marker → `conversationId` extracted, marker stripped.

## Related Issue

N/A — resolves a documented known limitation (CodeBuddy `4.10.2`–`4.10.4` missing session header) rather than a filed issue.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Code optimization

## Self-test Checklist

- [x] Verified locally
- [x] No existing features affected

## Additional Notes

- Split into two commits on `dev/codebuddy-adaptation`:
  - `ea1209c fix(proxy): fallback conversation id from SessionStart hook prompt` — proxy code + hook script.
  - `1ba5075 docs(proxy): document SessionStart hook workaround for broken CodeBuddy versions` — `INSTALL.md` / `INSTALL_CN.md`.
- Both commits carry a DCO `Signed-off-by: dong-frank <1057762929@qq.com>`.
- The hook directory artifacts (`__pycache__/`, `session_start.log`) are excluded via `.gitignore`.
- Target branch: `feat/server_team`.
