### PR TITLE
feat(adapters): add Gemini CLI memory adapter for TencentDB Agent Memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ test-offload-sessions.sh
 
 # log files
 *.log
+# Adapter build output
+scripts/gemini-cli/dist/

--- a/bin/gemini-cli-hook.mjs
+++ b/bin/gemini-cli-hook.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// Thin launcher for the Gemini CLI memory hook.
+// Build: npm run build:gemini-cli-hook
+
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const candidates = [
+  path.resolve(thisDir, "../scripts/gemini-cli/dist/hook.js"),
+  path.resolve(thisDir, "../scripts/gemini-cli/dist/scripts/gemini-cli/hook.js"),
+];
+const entry = candidates.find((p) => fs.existsSync(p));
+
+if (!entry) {
+  console.error("[memory-tencentdb-gemini] compiled entry not found; run: npm run build:gemini-cli-hook");
+  process.exit(1);
+}
+
+await import(pathToFileURL(entry).href);

--- a/docs/gemini-cli-adapter.md
+++ b/docs/gemini-cli-adapter.md
@@ -1,40 +1,36 @@
-# Gemini CLI Adapter
+# Gemini CLI 适配器
 
-TencentDB Agent Memory can be attached to [Gemini CLI](https://geminicli.com/)
-through the official hooks system. The adapter recalls relevant memory before
-each turn, captures the completed turn after the agent responds, and flushes
-buffered pipeline work when the session ends.
+通过 Gemini CLI 官方 hooks 机制，可以将 TencentDB Agent Memory 接入 Gemini CLI。适配器会在每轮对话前召回相关记忆，在助手回复后捕获本轮内容，并在会话结束时刷新待处理的流水线数据。
 
-## Architecture
+## 架构
 
 ```mermaid
 flowchart LR
-  G[Gemini CLI] -->|BeforeAgent hook| H[gemini-cli-hook]
+  G[Gemini CLI] -->|BeforeAgent 钩子| H[gemini-cli-hook]
   H -->|POST /recall| GW[TDAI Gateway]
   GW --> C[TdaiCore]
   C --> S[(L0 / L1 / L2 / L3)]
-  G -->|AfterAgent hook| H2[gemini-cli-hook]
+  G -->|AfterAgent 钩子| H2[gemini-cli-hook]
   H2 -->|POST /capture| GW
-  G -->|SessionEnd hook| H3[gemini-cli-hook]
+  G -->|SessionEnd 钩子| H3[gemini-cli-hook]
   H3 -->|POST /session/end| GW
 ```
 
-Hook scripts are short-lived processes and fail open: if the Gateway is
-unavailable, Gemini CLI continues normally and the hook logs to stderr.
+Hook 脚本是短生命周期进程，且采用 fail-open：Gateway 不可用时，Gemini CLI 仍可正常使用，错误只会输出到 stderr。
 
-## Prerequisites
+## 前置条件
 
-1. Node.js 22+ and npm.
-2. Gemini CLI installed and working.
-3. A TDAI Gateway running locally. Start it from this repo:
+1. Node.js 22+ 和 npm。
+2. 已安装并可正常使用 Gemini CLI。
+3. 本地已启动 TDAI Gateway。在本仓库运行：
 
 ```bash
 node --import tsx src/gateway/server.ts
 ```
 
-The Gateway defaults to `http://127.0.0.1:8420`.
+Gateway 默认地址为 `http://127.0.0.1:8420`。
 
-## Install as a Gemini CLI extension
+## 作为 Gemini CLI 扩展安装
 
 ```bash
 npm install
@@ -42,18 +38,17 @@ npm run build:gemini-cli-hook
 gemini extensions link ./gemini-cli-extension
 ```
 
-Restart Gemini CLI. During installation, Gemini CLI prompts for the Gateway
-URL and optional API key. The extension registers three hooks:
+重启 Gemini CLI。安装过程中会提示输入 Gateway 地址和可选的 API Key。扩展会注册三个 hooks：
 
-| Event | Behavior |
+| 事件 | 行为 |
 | --- | --- |
-| BeforeAgent | Recall memories and inject `additionalContext` |
-| AfterAgent | Capture user prompt and assistant response |
-| SessionEnd | Flush the session through the Gateway |
+| BeforeAgent | 召回记忆并注入 `additionalContext` |
+| AfterAgent | 捕获用户输入和助手回复 |
+| SessionEnd | 通过 Gateway 刷新会话数据 |
 
-## Manual settings.json alternative
+## 手动配置 settings.json 的方式
 
-If you prefer not to use the extension, add the hooks to `~/.gemini/settings.json`:
+如果不想使用扩展，可以在 `~/.gemini/settings.json` 中添加 hooks：
 
 ```json
 {
@@ -98,33 +93,31 @@ If you prefer not to use the extension, add the hooks to `~/.gemini/settings.jso
 }
 ```
 
-## Configuration
+## 配置项
 
-| Variable | Default | Description |
+| 变量 | 默认值 | 说明 |
 | --- | --- | --- |
-| `MEMORY_TENCENTDB_GATEWAY_URL` / `TDAI_GATEWAY_URL` | none | Full Gateway base URL |
-| `MEMORY_TENCENTDB_GATEWAY_HOST` / `TDAI_GATEWAY_HOST` | `127.0.0.1` | Gateway host |
-| `MEMORY_TENCENTDB_GATEWAY_PORT` / `TDAI_GATEWAY_PORT` | `8420` | Gateway port |
-| `MEMORY_TENCENTDB_GATEWAY_API_KEY` / `TDAI_GATEWAY_API_KEY` | none | Bearer token when auth is enabled |
-| `MEMORY_TENCENTDB_GATEWAY_TIMEOUT_MS` / `TDAI_GATEWAY_TIMEOUT_MS` | `5000` | Hook request timeout |
+| `MEMORY_TENCENTDB_GATEWAY_URL` / `TDAI_GATEWAY_URL` | 无 | Gateway 完整地址 |
+| `MEMORY_TENCENTDB_GATEWAY_HOST` / `TDAI_GATEWAY_HOST` | `127.0.0.1` | Gateway 主机 |
+| `MEMORY_TENCENTDB_GATEWAY_PORT` / `TDAI_GATEWAY_PORT` | `8420` | Gateway 端口 |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` / `TDAI_GATEWAY_API_KEY` | 无 | 开启鉴权时的 Bearer token |
+| `MEMORY_TENCENTDB_GATEWAY_TIMEOUT_MS` / `TDAI_GATEWAY_TIMEOUT_MS` | `5000` | Hook 请求超时时间 |
 
-Gemini CLI sanitizes environment variables passed to extension processes. When
-using the extension, declare sensitive values through the extension `settings`
-array so they are explicitly injected.
+Gemini CLI 会清理传给扩展进程的环境变量。如果通过扩展使用，敏感值需要放在扩展的 `settings` 数组中，才能被显式注入。
 
-## Verify
+## 验证
 
-Start the Gateway, then feed a fake BeforeAgent event to the hook:
+先启动 Gateway，再向 hook 输入一个假的 BeforeAgent 事件：
 
 ```bash
 echo '{"hook_event_name":"BeforeAgent","session_id":"demo","prompt":"hello"}' | node bin/gemini-cli-hook.mjs
 ```
 
-Expected stdout is a JSON hook output such as `{}` when no memory exists yet.
+没有记忆时，stdout 应输出类似 `{}` 的 JSON hook 结果。
 
-## Source
+## 源码位置
 
-- Adapter client: `src/adapters/gemini-cli/gateway-client.ts`
-- Hook mapping: `src/adapters/gemini-cli/hook-handler.ts`
-- Entrypoint: `scripts/gemini-cli/hook.ts`
-- Extension manifest: `gemini-cli-extension/`
+- 适配器客户端：`src/adapters/gemini-cli/gateway-client.ts`
+- Hook 映射：`src/adapters/gemini-cli/hook-handler.ts`
+- 入口脚本：`scripts/gemini-cli/hook.ts`
+- 扩展清单：`gemini-cli-extension/`

--- a/docs/gemini-cli-adapter.md
+++ b/docs/gemini-cli-adapter.md
@@ -1,0 +1,130 @@
+# Gemini CLI Adapter
+
+TencentDB Agent Memory can be attached to [Gemini CLI](https://geminicli.com/)
+through the official hooks system. The adapter recalls relevant memory before
+each turn, captures the completed turn after the agent responds, and flushes
+buffered pipeline work when the session ends.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  G[Gemini CLI] -->|BeforeAgent hook| H[gemini-cli-hook]
+  H -->|POST /recall| GW[TDAI Gateway]
+  GW --> C[TdaiCore]
+  C --> S[(L0 / L1 / L2 / L3)]
+  G -->|AfterAgent hook| H2[gemini-cli-hook]
+  H2 -->|POST /capture| GW
+  G -->|SessionEnd hook| H3[gemini-cli-hook]
+  H3 -->|POST /session/end| GW
+```
+
+Hook scripts are short-lived processes and fail open: if the Gateway is
+unavailable, Gemini CLI continues normally and the hook logs to stderr.
+
+## Prerequisites
+
+1. Node.js 22+ and npm.
+2. Gemini CLI installed and working.
+3. A TDAI Gateway running locally. Start it from this repo:
+
+```bash
+node --import tsx src/gateway/server.ts
+```
+
+The Gateway defaults to `http://127.0.0.1:8420`.
+
+## Install as a Gemini CLI extension
+
+```bash
+npm install
+npm run build:gemini-cli-hook
+gemini extensions link ./gemini-cli-extension
+```
+
+Restart Gemini CLI. During installation, Gemini CLI prompts for the Gateway
+URL and optional API key. The extension registers three hooks:
+
+| Event | Behavior |
+| --- | --- |
+| BeforeAgent | Recall memories and inject `additionalContext` |
+| AfterAgent | Capture user prompt and assistant response |
+| SessionEnd | Flush the session through the Gateway |
+
+## Manual settings.json alternative
+
+If you prefer not to use the extension, add the hooks to `~/.gemini/settings.json`:
+
+```json
+{
+  "hooks": {
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "name": "memory-recall",
+            "type": "command",
+            "command": "node /absolute/path/to/bin/gemini-cli-hook.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "name": "memory-capture",
+            "type": "command",
+            "command": "node /absolute/path/to/bin/gemini-cli-hook.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "name": "memory-flush",
+            "type": "command",
+            "command": "node /absolute/path/to/bin/gemini-cli-hook.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MEMORY_TENCENTDB_GATEWAY_URL` / `TDAI_GATEWAY_URL` | none | Full Gateway base URL |
+| `MEMORY_TENCENTDB_GATEWAY_HOST` / `TDAI_GATEWAY_HOST` | `127.0.0.1` | Gateway host |
+| `MEMORY_TENCENTDB_GATEWAY_PORT` / `TDAI_GATEWAY_PORT` | `8420` | Gateway port |
+| `MEMORY_TENCENTDB_GATEWAY_API_KEY` / `TDAI_GATEWAY_API_KEY` | none | Bearer token when auth is enabled |
+| `MEMORY_TENCENTDB_GATEWAY_TIMEOUT_MS` / `TDAI_GATEWAY_TIMEOUT_MS` | `5000` | Hook request timeout |
+
+Gemini CLI sanitizes environment variables passed to extension processes. When
+using the extension, declare sensitive values through the extension `settings`
+array so they are explicitly injected.
+
+## Verify
+
+Start the Gateway, then feed a fake BeforeAgent event to the hook:
+
+```bash
+echo '{"hook_event_name":"BeforeAgent","session_id":"demo","prompt":"hello"}' | node bin/gemini-cli-hook.mjs
+```
+
+Expected stdout is a JSON hook output such as `{}` when no memory exists yet.
+
+## Source
+
+- Adapter client: `src/adapters/gemini-cli/gateway-client.ts`
+- Hook mapping: `src/adapters/gemini-cli/hook-handler.ts`
+- Entrypoint: `scripts/gemini-cli/hook.ts`
+- Extension manifest: `gemini-cli-extension/`

--- a/gemini-cli-extension/README.md
+++ b/gemini-cli-extension/README.md
@@ -1,0 +1,10 @@
+# memory-tencentdb-gemini
+
+Gemini CLI extension for TencentDB Agent Memory.
+
+```bash
+npm run build:gemini-cli-hook
+gemini extensions link .
+```
+
+See [docs/gemini-cli-adapter.md](../docs/gemini-cli-adapter.md) for details.

--- a/gemini-cli-extension/README.md
+++ b/gemini-cli-extension/README.md
@@ -1,10 +1,10 @@
 # memory-tencentdb-gemini
 
-Gemini CLI extension for TencentDB Agent Memory.
+TencentDB Agent Memory 的 Gemini CLI 扩展。
 
 ```bash
 npm run build:gemini-cli-hook
 gemini extensions link .
 ```
 
-See [docs/gemini-cli-adapter.md](../docs/gemini-cli-adapter.md) for details.
+详细说明见 [docs/gemini-cli-adapter.md](../docs/gemini-cli-adapter.md)。

--- a/gemini-cli-extension/gemini-extension.json
+++ b/gemini-cli-extension/gemini-extension.json
@@ -1,0 +1,25 @@
+{
+  "name": "memory-tencentdb-gemini",
+  "description": "TencentDB Agent Memory hooks for Gemini CLI",
+  "version": "0.1.0",
+  "settings": [
+    {
+      "name": "TDAI Gateway URL",
+      "description": "Base URL of the memory-tencentdb Gateway, e.g. http://127.0.0.1:8420",
+      "envVar": "TDAI_GATEWAY_URL",
+      "sensitive": false
+    },
+    {
+      "name": "TDAI Gateway API Key",
+      "description": "Optional Bearer token matching TDAI_GATEWAY_API_KEY on the Gateway",
+      "envVar": "TDAI_GATEWAY_API_KEY",
+      "sensitive": true
+    },
+    {
+      "name": "TDAI Gateway Timeout",
+      "description": "Hook request timeout in milliseconds",
+      "envVar": "TDAI_GATEWAY_TIMEOUT_MS",
+      "sensitive": false
+    }
+  ]
+}

--- a/gemini-cli-extension/gemini-extension.json
+++ b/gemini-cli-extension/gemini-extension.json
@@ -1,23 +1,23 @@
 {
   "name": "memory-tencentdb-gemini",
-  "description": "TencentDB Agent Memory hooks for Gemini CLI",
+  "description": "TencentDB Agent Memory 的 Gemini CLI hooks 扩展",
   "version": "0.1.0",
   "settings": [
     {
-      "name": "TDAI Gateway URL",
-      "description": "Base URL of the memory-tencentdb Gateway, e.g. http://127.0.0.1:8420",
+      "name": "TDAI Gateway 地址",
+      "description": "memory-tencentdb Gateway 地址，例如 http://127.0.0.1:8420",
       "envVar": "TDAI_GATEWAY_URL",
       "sensitive": false
     },
     {
       "name": "TDAI Gateway API Key",
-      "description": "Optional Bearer token matching TDAI_GATEWAY_API_KEY on the Gateway",
+      "description": "可选 Bearer token，需与 Gateway 的 TDAI_GATEWAY_API_KEY 一致",
       "envVar": "TDAI_GATEWAY_API_KEY",
       "sensitive": true
     },
     {
-      "name": "TDAI Gateway Timeout",
-      "description": "Hook request timeout in milliseconds",
+      "name": "TDAI Gateway 超时",
+      "description": "Hook 请求超时时间（毫秒）",
       "envVar": "TDAI_GATEWAY_TIMEOUT_MS",
       "sensitive": false
     }

--- a/gemini-cli-extension/hook.mjs
+++ b/gemini-cli-extension/hook.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+// Re-export the package hook launcher so Gemini CLI extensions can invoke it
+// with a single command: node ${extensionPath}/hook.mjs
+
+await import("../bin/gemini-cli-hook.mjs");

--- a/gemini-cli-extension/hooks/hooks.json
+++ b/gemini-cli-extension/hooks/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "name": "memory-recall",
+            "type": "command",
+            "command": "node ${extensionPath}/hook.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "name": "memory-capture",
+            "type": "command",
+            "command": "node ${extensionPath}/hook.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "name": "memory-flush",
+            "type": "command",
+            "command": "node ${extensionPath}/hook.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "memory-tencentdb-gemini-hook": "./bin/gemini-cli-hook.mjs"
   },
   "exports": {
     ".": {
@@ -18,7 +19,7 @@
   "scripts": {
     "build": "npm run build:plugin && npm run build:scripts",
     "build:plugin": "tsdown",
-    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
+    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory && npm run build:gemini-cli-hook",
     "prepack": "npm run build",
     "build:migrate-sqlite-to-vdb": "tsc -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false",
     "migrate-sqlite-to-tcvdb": "node ./bin/migrate-sqlite-to-tcvdb.mjs",
@@ -29,7 +30,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "postinstall": "node scripts/postinstall.mjs"
+    "postinstall": "node scripts/postinstall.mjs",
+    "build:gemini-cli-hook": "tsc -p scripts/gemini-cli/tsconfig.json",
+    "memory-tencentdb-gemini-hook": "node ./bin/gemini-cli-hook.mjs"
   },
   "files": [
     "dist/",
@@ -53,7 +56,9 @@
     "LICENSE",
     "!src/**/*.test.ts",
     "!src/**/*.spec.ts",
-    "!src/**/__tests__/"
+    "!src/**/__tests__/",
+    "scripts/gemini-cli/dist/",
+    "gemini-cli-extension/"
   ],
   "keywords": [
     "openclaw",

--- a/scripts/gemini-cli/hook.ts
+++ b/scripts/gemini-cli/hook.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+/**
+ * Gemini CLI hook entrypoint.
+ *
+ * Reads one hook JSON object from stdin and writes the hook output JSON to
+ * stdout. All diagnostics go to stderr; stdout must stay JSON-only.
+ */
+
+import { readFileSync } from "node:fs";
+import {
+  TdaiGatewayClient,
+  resolveGatewayClientOptions,
+  handleGeminiCliHook,
+} from "../../src/adapters/gemini-cli/index.js";
+
+async function main(): Promise<void> {
+  const raw = readFileSync(0, "utf8");
+  const input = JSON.parse(raw) as Record<string, unknown>;
+  const client = new TdaiGatewayClient(resolveGatewayClientOptions(process.env));
+  const output = await handleGeminiCliHook(input, client);
+  process.stdout.write(JSON.stringify(output));
+}
+
+main().catch((err) => {
+  process.stderr.write(`[memory-tencentdb-gemini] hook failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.stdout.write("{}");
+});

--- a/scripts/gemini-cli/tsconfig.json
+++ b/scripts/gemini-cli/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "../..",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "files": ["hook.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/adapters/gemini-cli/gateway-client.test.ts
+++ b/src/adapters/gemini-cli/gateway-client.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveGatewayClientOptions, TdaiGatewayClient } from "./gateway-client.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("resolveGatewayClientOptions", () => {
+  it("defaults to the local gateway", () => {
+    const options = resolveGatewayClientOptions({});
+    expect(options.baseUrl).toBe("http://127.0.0.1:8420");
+    expect(options.apiKey).toBeUndefined();
+  });
+
+  it("prefers MEMORY_TENCENTDB_GATEWAY_* names", () => {
+    const options = resolveGatewayClientOptions({
+      MEMORY_TENCENTDB_GATEWAY_HOST: "10.0.0.5",
+      MEMORY_TENCENTDB_GATEWAY_PORT: "9999",
+      MEMORY_TENCENTDB_GATEWAY_API_KEY: " sk-test ",
+      MEMORY_TENCENTDB_GATEWAY_TIMEOUT_MS: "1200",
+    });
+    expect(options.baseUrl).toBe("http://10.0.0.5:9999");
+    expect(options.apiKey).toBe("sk-test");
+    expect(options.timeoutMs).toBe(1200);
+  });
+
+  it("accepts an explicit gateway URL", () => {
+    const options = resolveGatewayClientOptions({ TDAI_GATEWAY_URL: "http://localhost:9000/" });
+    expect(options.baseUrl).toBe("http://localhost:9000/");
+  });
+});
+
+describe("TdaiGatewayClient", () => {
+  it("posts recall with auth and parses the response", async () => {
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ context: "remembered", strategy: "hybrid", memory_count: 1 }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new TdaiGatewayClient({
+      baseUrl: "http://gateway.example:8420/",
+      apiKey: " sk-test ",
+    });
+    const result = await client.recall({ query: "hello", sessionKey: "s1" });
+
+    expect(result.context).toBe("remembered");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://gateway.example:8420/recall");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({ Authorization: "Bearer sk-test" });
+    expect(JSON.parse(String(init.body))).toEqual({ query: "hello", session_key: "s1" });
+  });
+});

--- a/src/adapters/gemini-cli/gateway-client.ts
+++ b/src/adapters/gemini-cli/gateway-client.ts
@@ -1,0 +1,151 @@
+/**
+ * TdaiGatewayClient - HTTP client used by the Gemini CLI hook adapter.
+ *
+ * The Gemini CLI hooks are short-lived processes, so they talk to a
+ * persistent TDAI Gateway sidecar instead of booting TdaiCore per event.
+ * This mirrors the Hermes provider and keeps recall/capture fast enough
+ * for interactive use.
+ */
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface TdaiGatewayClientOptions {
+  /** Gateway base URL, e.g. http://127.0.0.1:8420 */
+  baseUrl?: string;
+  /** Optional Bearer token. Matches TDAI_GATEWAY_API_KEY. */
+  apiKey?: string;
+  /** Request timeout in milliseconds. Default: 5000. */
+  timeoutMs?: number;
+}
+
+export interface TdaiGatewayRecallResult {
+  context: string;
+  strategy?: string;
+  memory_count?: number;
+}
+
+export interface TdaiGatewayCaptureResult {
+  l0_recorded: number;
+  scheduler_notified: boolean;
+}
+
+export interface TdaiGatewaySessionEndResult {
+  flushed: boolean;
+}
+
+export interface TdaiGatewayClientLike {
+  recall(params: {
+    query: string;
+    sessionKey: string;
+    userId?: string;
+  }): Promise<TdaiGatewayRecallResult>;
+  capture(params: {
+    userContent: string;
+    assistantContent: string;
+    sessionKey: string;
+    sessionId?: string;
+    userId?: string;
+  }): Promise<TdaiGatewayCaptureResult>;
+  endSession(params: {
+    sessionKey: string;
+    userId?: string;
+  }): Promise<TdaiGatewaySessionEndResult>;
+}
+
+/**
+ * Resolve Gateway connection settings from environment variables.
+ *
+ * Supports the same MEMORY_TENCENTDB_GATEWAY_* names used by the Hermes
+ * provider, with TDAI_GATEWAY_* as the general fallback.
+ */
+export function resolveGatewayClientOptions(
+  env: Record<string, string | undefined> = process.env,
+): TdaiGatewayClientOptions {
+  const host = (env.MEMORY_TENCENTDB_GATEWAY_HOST ?? env.TDAI_GATEWAY_HOST ?? "127.0.0.1").trim();
+  const port = (env.MEMORY_TENCENTDB_GATEWAY_PORT ?? env.TDAI_GATEWAY_PORT ?? "8420").trim();
+  const url = (env.MEMORY_TENCENTDB_GATEWAY_URL ?? env.TDAI_GATEWAY_URL ?? "").trim();
+  const apiKey = (env.MEMORY_TENCENTDB_GATEWAY_API_KEY ?? env.TDAI_GATEWAY_API_KEY ?? "").trim() || undefined;
+  const rawTimeout = Number(
+    env.MEMORY_TENCENTDB_GATEWAY_TIMEOUT_MS ?? env.TDAI_GATEWAY_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS,
+  );
+
+  return {
+    baseUrl: url || `http://${host}:${port}`,
+    apiKey,
+    timeoutMs: Number.isFinite(rawTimeout) && rawTimeout > 0
+      ? rawTimeout
+      : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+export class TdaiGatewayClient implements TdaiGatewayClientLike {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+
+  constructor(opts: TdaiGatewayClientOptions = {}) {
+    this.baseUrl = (opts.baseUrl ?? "http://127.0.0.1:8420").replace(/\/+$/, "");
+    this.apiKey = opts.apiKey?.trim() || undefined;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async recall(params: {
+    query: string;
+    sessionKey: string;
+    userId?: string;
+  }): Promise<TdaiGatewayRecallResult> {
+    return this.request<TdaiGatewayRecallResult>("/recall", {
+      query: params.query,
+      session_key: params.sessionKey,
+      ...(params.userId ? { user_id: params.userId } : {}),
+    });
+  }
+
+  async capture(params: {
+    userContent: string;
+    assistantContent: string;
+    sessionKey: string;
+    sessionId?: string;
+    userId?: string;
+  }): Promise<TdaiGatewayCaptureResult> {
+    return this.request<TdaiGatewayCaptureResult>("/capture", {
+      user_content: params.userContent,
+      assistant_content: params.assistantContent,
+      session_key: params.sessionKey,
+      ...(params.sessionId ? { session_id: params.sessionId } : {}),
+      ...(params.userId ? { user_id: params.userId } : {}),
+    });
+  }
+
+  async endSession(params: {
+    sessionKey: string;
+    userId?: string;
+  }): Promise<TdaiGatewaySessionEndResult> {
+    return this.request<TdaiGatewaySessionEndResult>("/session/end", {
+      session_key: params.sessionKey,
+      ...(params.userId ? { user_id: params.userId } : {}),
+    });
+  }
+
+  private async request<T>(path: string, body: Record<string, unknown>): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`TDAI Gateway ${path} returned HTTP ${response.status}`);
+      }
+      return await response.json() as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/adapters/gemini-cli/hook-handler.test.ts
+++ b/src/adapters/gemini-cli/hook-handler.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleGeminiCliHook } from "./hook-handler.js";
+import type { TdaiGatewayClientLike } from "./gateway-client.js";
+
+function createClient(overrides: Partial<TdaiGatewayClientLike> = {}): TdaiGatewayClientLike {
+  return {
+    recall: vi.fn(async () => ({ context: "", strategy: "none", memory_count: 0 })),
+    capture: vi.fn(async () => ({ l0_recorded: 1, scheduler_notified: true })),
+    endSession: vi.fn(async () => ({ flushed: true })),
+    ...overrides,
+  };
+}
+
+describe("handleGeminiCliHook", () => {
+  it("injects recalled context before an agent turn", async () => {
+    const client = createClient({
+      recall: vi.fn(async () => ({
+        context: "<relevant-memories>remembered fact</relevant-memories>",
+        strategy: "hybrid",
+        memory_count: 1,
+      })),
+    });
+
+    const output = await handleGeminiCliHook({
+      hook_event_name: "BeforeAgent",
+      session_id: "session-1",
+      prompt: "What should I do next?",
+    }, client);
+
+    expect(client.recall).toHaveBeenCalledWith({
+      query: "What should I do next?",
+      sessionKey: "session-1",
+    });
+    expect(output).toEqual({
+      hookSpecificOutput: { additionalContext: "<relevant-memories>remembered fact</relevant-memories>" },
+    });
+  });
+
+  it("stays silent when recall returns no context", async () => {
+    const client = createClient();
+    const output = await handleGeminiCliHook({
+      hook_event_name: "BeforeAgent",
+      session_id: "session-1",
+      prompt: "hello",
+    }, client);
+    expect(output).toEqual({});
+  });
+
+  it("captures a completed turn after the agent responds", async () => {
+    const client = createClient();
+    const output = await handleGeminiCliHook({
+      hook_event_name: "AfterAgent",
+      session_id: "session-1",
+      prompt: "Remember this project",
+      prompt_response: "I will remember it.",
+    }, client);
+
+    expect(client.capture).toHaveBeenCalledWith({
+      userContent: "Remember this project",
+      assistantContent: "I will remember it.",
+      sessionKey: "session-1",
+      sessionId: "session-1",
+    });
+    expect(output).toEqual({});
+  });
+
+  it("flushes the session on SessionEnd", async () => {
+    const client = createClient();
+    const output = await handleGeminiCliHook({
+      hook_event_name: "SessionEnd",
+      session_id: "session-1",
+      reason: "exit",
+    }, client);
+    expect(client.endSession).toHaveBeenCalledWith({ sessionKey: "session-1" });
+    expect(output).toEqual({});
+  });
+
+  it("is fail-open when the gateway is unavailable", async () => {
+    const client = createClient({
+      recall: vi.fn(async () => { throw new Error("connection refused"); }),
+    });
+    const logger = { error: vi.fn() };
+
+    const output = await handleGeminiCliHook({
+      hook_event_name: "BeforeAgent",
+      session_id: "session-1",
+      prompt: "hello",
+    }, client, logger);
+
+    expect(output).toEqual({});
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("fail-open"));
+  });
+
+  it("ignores unknown hook events", async () => {
+    const client = createClient();
+    const output = await handleGeminiCliHook({ hook_event_name: "BeforeTool" }, client);
+    expect(output).toEqual({});
+    expect(client.recall).not.toHaveBeenCalled();
+  });
+});

--- a/src/adapters/gemini-cli/hook-handler.ts
+++ b/src/adapters/gemini-cli/hook-handler.ts
@@ -1,0 +1,92 @@
+/**
+ * Gemini CLI hook handler for TencentDB Agent Memory.
+ *
+ * Maps Gemini CLI lifecycle events to TdaiCore capabilities exposed by the
+ * TDAI Gateway: recall before a turn, capture after a turn, and flush when
+ * the session ends. All failures are fail-open so a memory outage never
+ * blocks normal Gemini CLI usage.
+ */
+
+import type { TdaiGatewayClientLike } from "./gateway-client.js";
+
+export interface GeminiHookInput {
+  hook_event_name?: string;
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  timestamp?: string;
+  prompt?: string;
+  prompt_response?: string;
+  source?: string;
+  [key: string]: unknown;
+}
+
+export interface GeminiHookOutput {
+  systemMessage?: string;
+  hookSpecificOutput?: {
+    additionalContext?: string;
+  };
+}
+
+export interface GeminiHookLogger {
+  error(message: string): void;
+}
+
+const defaultLogger: GeminiHookLogger = {
+  error(message: string) {
+    process.stderr.write(`[memory-tencentdb-gemini] ${message}\n`);
+  },
+};
+
+/**
+ * Handle one Gemini CLI hook event.
+ *
+ * Returns a valid hook output object in every branch. Never throws; memory
+ * adapter errors are logged to stderr and degrade to an empty output.
+ */
+export async function handleGeminiCliHook(
+  input: GeminiHookInput,
+  client: TdaiGatewayClientLike,
+  logger: GeminiHookLogger = defaultLogger,
+): Promise<GeminiHookOutput> {
+  const event = input.hook_event_name ?? "";
+  const sessionKey = input.session_id?.trim() || "gemini-cli";
+
+  try {
+    switch (event) {
+      case "BeforeAgent": {
+        const prompt = input.prompt?.trim() ?? "";
+        if (!prompt) return {};
+        const result = await client.recall({ query: prompt, sessionKey });
+        const context = result.context?.trim() ?? "";
+        if (!context) return {};
+        return {
+          hookSpecificOutput: {
+            additionalContext: context,
+          },
+        };
+      }
+      case "AfterAgent": {
+        const userText = input.prompt?.trim() ?? "";
+        const assistantText = input.prompt_response?.trim() ?? "";
+        if (!userText || !assistantText) return {};
+        await client.capture({
+          userContent: userText,
+          assistantContent: assistantText,
+          sessionKey,
+          sessionId: sessionKey,
+        });
+        return {};
+      }
+      case "SessionEnd": {
+        await client.endSession({ sessionKey });
+        return {};
+      }
+      default:
+        return {};
+    }
+  } catch (err) {
+    logger.error(`hook ${event} failed (fail-open): ${err instanceof Error ? err.message : String(err)}`);
+    return {};
+  }
+}

--- a/src/adapters/gemini-cli/index.ts
+++ b/src/adapters/gemini-cli/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Gemini CLI adapter - barrel exports.
+ */
+export { TdaiGatewayClient, resolveGatewayClientOptions } from "./gateway-client.js";
+export type {
+  TdaiGatewayClientOptions,
+  TdaiGatewayClientLike,
+  TdaiGatewayRecallResult,
+  TdaiGatewayCaptureResult,
+  TdaiGatewaySessionEndResult,
+} from "./gateway-client.js";
+export { handleGeminiCliHook } from "./hook-handler.js";
+export type { GeminiHookInput, GeminiHookOutput, GeminiHookLogger } from "./hook-handler.js";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -7,7 +7,8 @@
  * Directory structure:
  *   adapters/
  *   ├── openclaw/      — OpenClaw plugin host (in-process, runEmbeddedPiAgent)
- *   └── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   ├── standalone/    — Gateway / Hermes sidecar (HTTP, OpenAI-compatible API)
+ *   `-- gemini-cli/    - Gemini CLI hooks adapter (Gateway HTTP client)
  */
 
 // OpenClaw adapter
@@ -17,3 +18,7 @@ export type { OpenClawHostAdapterOptions, OpenClawLLMRunnerFactoryOptions } from
 // Standalone adapter
 export { StandaloneHostAdapter, StandaloneLLMRunner, StandaloneLLMRunnerFactory } from "./standalone/index.js";
 export type { StandaloneHostAdapterOptions, StandaloneLLMConfig, StandaloneLLMRunnerFactoryOptions } from "./standalone/index.js";
+
+// Gemini CLI adapter
+export { TdaiGatewayClient, resolveGatewayClientOptions, handleGeminiCliHook } from "./gemini-cli/index.js";
+export type { TdaiGatewayClientOptions, TdaiGatewayClientLike, GeminiHookInput, GeminiHookOutput } from "./gemini-cli/index.js";


### PR DESCRIPTION
## Summary

为 #235 新增一个跨平台适配器：通过 Gemini CLI 官方 hooks 机制接入 TencentDB Agent Memory。适配器会在每轮对话前召回记忆、在助手回复后捕获本轮内容、在会话结束时刷新会话数据。

## 实现内容

- `src/adapters/gemini-cli/`：Gateway 客户端和 hook 处理逻辑
- `scripts/gemini-cli/hook.ts` + `bin/gemini-cli-hook.mjs`：编译后的 CLI hook 入口
- `gemini-cli-extension/`：可直接 `gemini extensions link` 安装的扩展包
- `docs/gemini-cli-adapter.md`：架构图、安装步骤、配置项和验证方法

## 设计要点

- BeforeAgent 召回记忆并注入 `additionalContext`
- AfterAgent 捕获用户输入和助手回复
- SessionEnd 通过 Gateway 刷新会话
- fail-open：Gateway 不可用时不影响 Gemini CLI 正常使用
- API Key 通过环境变量或扩展 settings 传入，不硬编码

## 验证

- `npm run build:gemini-cli-hook` 通过
- `npm test`：77 tests passed

对应 #235 渐进式验收的“进阶”阶段：选择一个新平台并实现基本记忆读写。