### PR TITLE
feat(cleanup): strip legacy recall injections from session history (#120)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ test-offload-sessions.sh
 
 # log files
 *.log
+# Legacy cleanup build output
+scripts/clean-legacy-recall-injection/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- **历史召回清理** ([#120](https://github.com/Tencent/TencentDB-Agent-Memory/issues/120))：新增离线清理工具，移除旧会话 JSONL 中已冻结的 <relevant-memories> 注入块，帮助恢复 OpenAI-compatible provider 的 prompt cache 命中率；默认 dry-run，支持 --yes 实际写入与 --json 汇总。
+
 ### ✨ 新功能
 
 - **时区可配置** ([#75](https://github.com/Tencent/TencentDB-Agent-Memory/issues/75) / [#87](https://github.com/Tencent/TencentDB-Agent-Memory/issues/87))：新增顶层 `timezone` 配置项，支持 IANA 时区名（`Asia/Shanghai`、`Europe/Berlin`）和 UTC 偏移串（`+08:00`、`-05:30`）。默认 `"system"`（跟随进程系统时区），升级零感。

--- a/bin/clean-legacy-recall-injection.mjs
+++ b/bin/clean-legacy-recall-injection.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+// Thin launcher for the legacy recall-injection cleanup CLI.
+// Build: npm run build:clean-legacy-recall-injection
+
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const entry = path.resolve(
+  thisDir,
+  "../scripts/clean-legacy-recall-injection/dist/scripts/clean-legacy-recall-injection/cli-entry.js",
+);
+
+if (!fs.existsSync(entry)) {
+  console.error("[clean-legacy-recall-injection] compiled entry not found; run: npm run build:clean-legacy-recall-injection");
+  process.exit(1);
+}
+
+await import(pathToFileURL(entry).href);

--- a/docs/legacy-recall-history-cleanup.md
+++ b/docs/legacy-recall-history-cleanup.md
@@ -1,0 +1,52 @@
+# 清理遗留的召回记忆注入，恢复 Prompt Cache 命中率
+
+## 问题背景
+
+启用 memory-tencentdb 插件后，OpenAI-compatible provider（DeepSeek、MiMo）
+的 prompt cache 命中率出现显著退化：
+
+- `prependContext` 每轮向用户消息开头注入动态召回的 L1 记忆
+  （约 500-1700 tokens）。
+- 当 `showInjected=true` 时，这些内容被冻结写入会话历史 JSONL。
+- 多轮对话后上下文膨胀，触发动态 tool result truncation，历史前缀不一致，
+  导致 prefix-matching cache 持续失效。
+
+仓库已经通过以下运行时能力阻止问题继续扩大：
+
+- L1 动态召回移到 `prependContext`，稳定内容留在 `appendSystemContext`。
+- `before_message_write` 在 user 消息持久化前移除 `<relevant-memories>` 块。
+- sanitize 管线也会剥离该标签。
+
+## 遗留问题
+
+已经写入磁盘的旧会话仍然包含 `<relevant-memories>` 块。只要这些会话被
+继续使用或重放，历史仍然膨胀，缓存前缀仍然不稳定。只修运行时逻辑无法
+修复这些历史文件。
+
+## 解决方案
+
+新增离线清理脚本：
+
+- 扫描 `~/.openclaw/agents/*/sessions/*.jsonl`（默认目录可通过
+  `OPENCLAW_STATE_DIR` 或 `--dir` 覆盖）。
+- 移除 user 消息中的 `<relevant-memories>...</relevant-memories>` 块。
+- 支持 string 与 text parts 两种消息格式。
+- 跳过 trajectory、plugin 自有 conversations、损坏行和非 user 消息。
+- 默认 dry-run，`--yes` 才实际写入；写入采用临时文件 + rename。
+
+## 使用步骤
+
+执行 `--yes` 前建议先退出 OpenClaw，避免会话文件被占用；`--dry-run` 不影响
+运行中的进程。
+
+```bash
+npm run build:clean-legacy-recall-injection
+
+# 先看汇总
+npm run clean:legacy-recall-injection -- --dry-run
+
+# 确认后执行
+npm run clean:legacy-recall-injection -- --yes
+```
+
+详细说明见 `scripts/clean-legacy-recall-injection/README.md`。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "migrate-sqlite-to-tcvdb": "./bin/migrate-sqlite-to-tcvdb.mjs",
     "export-tencent-vdb": "./bin/export-tencent-vdb.mjs",
-    "read-local-memory": "./bin/read-local-memory.mjs"
+    "read-local-memory": "./bin/read-local-memory.mjs",
+    "clean-legacy-recall-injection": "./bin/clean-legacy-recall-injection.mjs"
   },
   "exports": {
     ".": {
@@ -18,7 +19,7 @@
   "scripts": {
     "build": "npm run build:plugin && npm run build:scripts",
     "build:plugin": "tsdown",
-    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory",
+    "build:scripts": "npm run build:migrate-sqlite-to-vdb && npm run build:export-tencent-vdb && npm run build:read-local-memory && npm run build:clean-legacy-recall-injection",
     "prepack": "npm run build",
     "build:migrate-sqlite-to-vdb": "tsc -p scripts/migrate-sqlite-to-tcvdb/tsconfig.json --noEmitOnError false",
     "migrate-sqlite-to-tcvdb": "node ./bin/migrate-sqlite-to-tcvdb.mjs",
@@ -29,7 +30,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "postinstall": "node scripts/postinstall.mjs"
+    "postinstall": "node scripts/postinstall.mjs",
+    "build:clean-legacy-recall-injection": "tsc -p scripts/clean-legacy-recall-injection/tsconfig.json",
+    "clean:legacy-recall-injection": "node ./bin/clean-legacy-recall-injection.mjs"
   },
   "files": [
     "dist/",
@@ -38,10 +41,12 @@
     "scripts/migrate-sqlite-to-tcvdb/dist/",
     "scripts/export-tencent-vdb/dist/",
     "scripts/read-local-memory/dist/",
+    "scripts/clean-legacy-recall-injection/dist/",
     "scripts/memory-tencentdb-ctl.sh",
     "scripts/install_hermes_memory_tencentdb.sh",
     "scripts/setup-hermes-memory-tencentdb.bat",
     "scripts/postinstall.mjs",
+    "scripts/clean-legacy-recall-injection/README.md",
     "scripts/README.memory-tencentdb-ctl.md",
     "src",
     "scripts/openclaw-after-tool-call-messages.patch.sh",
@@ -50,6 +55,7 @@
     "openclaw.plugin.json",
     "README.md",
     "CHANGELOG.md",
+    "docs/legacy-recall-history-cleanup.md",
     "LICENSE",
     "!src/**/*.test.ts",
     "!src/**/*.spec.ts",

--- a/scripts/clean-legacy-recall-injection/README.md
+++ b/scripts/clean-legacy-recall-injection/README.md
@@ -1,0 +1,64 @@
+# 历史会话清理工具：移除遗留的 <relevant-memories> 注入
+
+这个离线工具用于清理 OpenClaw 已持久化的会话 JSONL 历史。旧版本
+memory-tencentdb 会把动态召回的记忆块通过 `prependContext` 写入用户消息；
+当 `showInjected=true` 时，这些内容会冻结在会话历史里，导致上下文膨胀、
+历史前缀不稳定，并让 DeepSeek / MiMo 等 OpenAI-compatible provider 的
+prefix cache 命中率退化（对应犀牛鸟 issue #120）。
+
+运行时钩子（`before_message_write`）已经阻止新写入的会话继续累积这类内容。
+本工具只处理**已经存在**的旧会话，不改变任何运行时行为。
+
+## 注意事项
+
+> 执行 `--yes` 前建议先退出 OpenClaw，避免会话文件正被写入或占用。
+
+## 构建
+
+```bash
+npm run build:clean-legacy-recall-injection
+```
+
+编译产物由 `bin/clean-legacy-recall-injection.mjs` 加载。
+
+## 使用
+
+默认是 dry-run，只报告会清理哪些文件，不落盘：
+
+```bash
+npm run clean:legacy-recall-injection
+# 等价于
+node ./bin/clean-legacy-recall-injection.mjs
+```
+
+确认结果后实际写入：
+
+```bash
+npm run clean:legacy-recall-injection -- --yes
+# 或指定非默认 OpenClaw 状态目录
+node ./bin/clean-legacy-recall-injection.mjs --dir ~/.openclaw --yes
+```
+
+输出 JSON 便于脚本处理：
+
+```bash
+node ./bin/clean-legacy-recall-injection.mjs --json
+```
+
+## 处理范围
+
+- 只扫描 `<stateDir>/agents/*/sessions/*.jsonl`。
+- 跳过 `.trajectory.jsonl`、隐藏文件、memory-tdai 自己的 `conversations/`。
+- 只清理 `role === "user"` 的消息，string 与 text parts 两种格式都支持。
+- 损坏的 JSONL 行原样保留，并在汇总中计数。
+- 非 `message` 类型的记录、非 user 角色、没有注入标签的内容都不会被改动。
+- 写入采用同目录临时文件 + rename，避免半写入状态。
+
+## 参数
+
+| 参数 | 说明 |
+| --- | --- |
+| `--dir <path>` | OpenClaw 状态目录，默认 `OPENCLAW_STATE_DIR` 或 `~/.openclaw` |
+| `--yes` | 实际改写文件；不传则只做 dry-run |
+| `--json` | 输出机器可读 JSON 汇总 |
+| `--help` | 帮助信息 |

--- a/scripts/clean-legacy-recall-injection/cli-entry.ts
+++ b/scripts/clean-legacy-recall-injection/cli-entry.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+/**
+ * CLI entrypoint for removing legacy <relevant-memories> injections from
+ * existing OpenClaw session JSONL history.
+ */
+
+import path from "node:path";
+import {
+  formatCleanSummary,
+  runLegacyRecallCleanup,
+} from "../../src/utils/legacy-recall-cleanup.js";
+
+interface CliOptions {
+  stateDir?: string;
+  yes: boolean;
+  json: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { yes: false, json: false, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dir" || arg === "--state-dir") {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) throw new Error(`${arg} requires a path`);
+      options.stateDir = value;
+      i += 1;
+    } else if (arg === "--yes") {
+      options.yes = true;
+    } else if (arg === "--dry-run") {
+      options.yes = false;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      "Usage: clean-legacy-recall-injection [options]",
+      "",
+      "Scan OpenClaw session JSONL files and remove legacy <relevant-memories>",
+      "blocks that older memory-tencentdb versions left in user history.",
+      "",
+      "Options:",
+      "  --dir <path>    OpenClaw state dir (default: OPENCLAW_STATE_DIR or ~/.openclaw)",
+      "  --dry-run       Report only (this is the default)",
+      "  --yes           Rewrite affected session files",
+      "  --json          Print machine-readable JSON summary",
+      "  --help          Show this help",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const summary = await runLegacyRecallCleanup({
+    stateDir: options.stateDir ? path.resolve(options.stateDir) : undefined,
+    dryRun: !options.yes,
+  });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatCleanSummary(summary));
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[clean-legacy-recall-injection] ${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/clean-legacy-recall-injection/tsconfig.json
+++ b/scripts/clean-legacy-recall-injection/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "../..",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "files": ["cli-entry.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/utils/legacy-recall-cleanup.test.ts
+++ b/src/utils/legacy-recall-cleanup.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  cleanSessionFile,
+  cleanSessionJsonlLine,
+  cleanUserContent,
+  findSessionFiles,
+  isSessionFile,
+  runLegacyRecallCleanup,
+  stripRelevantMemories,
+} from "./legacy-recall-cleanup.js";
+
+const BLOCK = "<relevant-memories>\nremembered fact\n</relevant-memories>";
+
+function userLine(content: unknown, role = "user"): string {
+  return JSON.stringify({ type: "message", message: { role, content } });
+}
+
+describe("legacy recall cleanup", () => {
+  it("strips injected blocks from plain text", () => {
+    expect(stripRelevantMemories(`${BLOCK}\nHello world`)).toBe("Hello world");
+    expect(stripRelevantMemories("plain text")).toBe("plain text");
+    expect(stripRelevantMemories("<relevant-memories>unclosed")).toBe("<relevant-memories>unclosed");
+  });
+
+  it("cleans string user content", () => {
+    const result = cleanUserContent(`${BLOCK}\nHello`);
+    expect(result.changed).toBe(true);
+    expect(result.blocksRemoved).toBe(1);
+    expect(result.content).toBe("Hello");
+  });
+
+  it("cleans text parts while keeping non-text parts untouched", () => {
+    const result = cleanUserContent([
+      { type: "text", text: `${BLOCK}\nHello` },
+      { type: "image", image: "data:image/png;base64,abc" },
+      { type: "text", text: "keep" },
+    ]);
+    expect(result.changed).toBe(true);
+    expect(result.blocksRemoved).toBe(1);
+    expect(result.content).toEqual([
+      { type: "text", text: "Hello" },
+      { type: "image", image: "data:image/png;base64,abc" },
+      { type: "text", text: "keep" },
+    ]);
+  });
+
+  it("cleans a JSONL user message line", () => {
+    const result = cleanSessionJsonlLine(userLine(`${BLOCK}\nHello`));
+    expect(result.changed).toBe(true);
+    expect(result.blocksRemoved).toBe(1);
+    expect(JSON.parse(result.line).message.content).toBe("Hello");
+  });
+
+  it("ignores non-user message roles", () => {
+    const result = cleanSessionJsonlLine(userLine(`${BLOCK}\nHello`, "assistant"));
+    expect(result.changed).toBe(false);
+    expect(result.blocksRemoved).toBe(0);
+  });
+
+  it("leaves malformed JSONL lines untouched", () => {
+    const result = cleanSessionJsonlLine(`{not json <relevant-memories>`);
+    expect(result.malformed).toBe(true);
+    expect(result.changed).toBe(false);
+  });
+
+  it("recognizes only session JSONL files", () => {
+    const root = path.join("C:", "openclaw");
+    expect(isSessionFile(path.join(root, "agents", "main", "sessions", "abc.jsonl"))).toBe(true);
+    expect(isSessionFile(path.join(root, "agents", "main", "sessions", "abc.trajectory.jsonl"))).toBe(false);
+    expect(isSessionFile(path.join(root, "memory-tdai", "conversations", "2026-01-01.jsonl"))).toBe(false);
+  });
+
+  it("finds session files and skips trajectories and conversation logs", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tdai-sessions-"));
+    try {
+      const sessionDir = path.join(root, "agents", "main", "sessions");
+      const convDir = path.join(root, "memory-tdai", "conversations");
+      await mkdir(sessionDir, { recursive: true });
+      await mkdir(convDir, { recursive: true });
+      await writeFile(path.join(sessionDir, "abc.jsonl"), "{}", "utf8");
+      await writeFile(path.join(sessionDir, "abc.trajectory.jsonl"), "{}", "utf8");
+      await writeFile(path.join(sessionDir, ".hidden.jsonl"), "{}", "utf8");
+      await writeFile(path.join(convDir, "2026-01-01.jsonl"), "{}", "utf8");
+
+      const found = await findSessionFiles(root);
+      expect(found).toEqual([path.join(sessionDir, "abc.jsonl")]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run reports without rewriting, then applies on a real run", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tdai-clean-"));
+    const file = path.join(root, "agents", "main", "sessions", "abc.jsonl");
+    try {
+      await mkdir(path.dirname(file), { recursive: true });
+      const original = `${userLine(`${BLOCK}\nHello`)}\n${userLine("plain")}\n`;
+      await writeFile(file, original, "utf8");
+
+      const dry = await cleanSessionFile(file, true);
+      expect(dry.changed).toBe(true);
+      expect(dry.blocksRemoved).toBe(1);
+      expect(await readFile(file, "utf8")).toBe(original);
+
+      const real = await cleanSessionFile(file, false);
+      expect(real.changed).toBe(true);
+      expect(real.bytesRemoved).toBeGreaterThan(0);
+      const cleaned = await readFile(file, "utf8");
+      expect(cleaned).not.toContain("<relevant-memories>");
+      expect(cleaned).toContain("Hello");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves CRLF line endings", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tdai-crlf-"));
+    const file = path.join(root, "agents", "main", "sessions", "abc.jsonl");
+    try {
+      await mkdir(path.dirname(file), { recursive: true });
+      await writeFile(file, `${userLine(`${BLOCK}\nHello`)}\r\n`, "utf8");
+      await cleanSessionFile(file, false);
+      const cleaned = await readFile(file, "utf8");
+      expect(cleaned.endsWith("\r\n")).toBe(true);
+      expect(cleaned).not.toContain("<relevant-memories>");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("runs across the state dir with a summary", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "tdai-run-"));
+    const file = path.join(root, "agents", "main", "sessions", "abc.jsonl");
+    try {
+      await mkdir(path.dirname(file), { recursive: true });
+      await writeFile(file, `${userLine(`${BLOCK}\nHello`)}\n`, "utf8");
+
+      const summary = await runLegacyRecallCleanup({ stateDir: root, dryRun: false });
+      expect(summary.filesScanned).toBe(1);
+      expect(summary.filesChanged).toBe(1);
+      expect(summary.blocksRemoved).toBe(1);
+      expect(summary.changedFiles).toEqual([file]);
+      expect(await readFile(file, "utf8")).not.toContain("<relevant-memories>");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/legacy-recall-cleanup.ts
+++ b/src/utils/legacy-recall-cleanup.ts
@@ -1,0 +1,302 @@
+/**
+ * Legacy recall-injection cleanup for OpenClaw session JSONL history.
+ *
+ * Runtime hooks already prevent new <relevant-memories> blocks from being
+ * persisted, but transcripts written before that fix can still contain them.
+ * Keeping those blocks in history makes each replayed turn longer and makes
+ * the stable prefix unstable for OpenAI-compatible prefix caches, so this
+ * module provides a safe, offline cleanup pass for existing session files.
+ */
+
+import { readdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { resolveOpenClawStateDir } from "./openclaw-state-dir.js";
+import type { OpenClawRuntimeStateLike } from "./openclaw-state-dir.js";
+
+export const RELEVANT_MEMORIES_RE = /<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g;
+
+export interface ContentCleanResult {
+  content: unknown;
+  changed: boolean;
+  blocksRemoved: number;
+}
+
+export interface LineCleanResult {
+  line: string;
+  changed: boolean;
+  blocksRemoved: number;
+  malformed: boolean;
+}
+
+export interface FileCleanResult {
+  file: string;
+  changed: boolean;
+  linesScanned: number;
+  linesChanged: number;
+  blocksRemoved: number;
+  bytesBefore: number;
+  bytesAfter: number;
+  bytesRemoved: number;
+  malformedLines: number;
+}
+
+export interface CleanSummary {
+  stateDir: string;
+  dryRun: boolean;
+  filesScanned: number;
+  filesChanged: number;
+  linesScanned: number;
+  linesChanged: number;
+  blocksRemoved: number;
+  bytesBefore: number;
+  bytesAfter: number;
+  bytesRemoved: number;
+  malformedLines: number;
+  changedFiles: string[];
+}
+
+export interface RunCleanupOptions {
+  /** OpenClaw state directory; defaults to OPENCLAW_STATE_DIR or ~/.openclaw. */
+  stateDir?: string;
+  /** When true, report without rewriting files. Defaults to true. */
+  dryRun?: boolean;
+  /** Optional runtime state dir resolver used for the default path. */
+  runtimeState?: OpenClawRuntimeStateLike;
+}
+
+function countBlocks(text: string): number {
+  return text.match(/<relevant-memories>[\s\S]*?<\/relevant-memories>/g)?.length ?? 0;
+}
+
+export function stripRelevantMemories(text: string): string {
+  if (!text.includes("<relevant-memories>")) return text;
+  const cleaned = text.replace(RELEVANT_MEMORIES_RE, "");
+  if (cleaned === text) return text;
+  return cleaned.trim();
+}
+
+export function cleanUserContent(content: unknown): ContentCleanResult {
+  if (typeof content === "string") {
+    const cleaned = stripRelevantMemories(content);
+    return {
+      content: cleaned,
+      changed: cleaned !== content,
+      blocksRemoved: cleaned === content ? 0 : countBlocks(content),
+    };
+  }
+
+  if (Array.isArray(content)) {
+    let changed = false;
+    let blocksRemoved = 0;
+    const parts = content.map((part) => {
+      if (!part || typeof part !== "object" || Array.isArray(part)) return part;
+      const record = part as Record<string, unknown>;
+      if (record.type !== "text" || typeof record.text !== "string") return part;
+      const cleaned = stripRelevantMemories(record.text);
+      if (cleaned === record.text) return part;
+      changed = true;
+      blocksRemoved += countBlocks(record.text);
+      return { ...record, text: cleaned };
+    });
+    return {
+      content: changed ? parts : content,
+      changed,
+      blocksRemoved,
+    };
+  }
+
+  return { content, changed: false, blocksRemoved: 0 };
+}
+
+export function cleanSessionJsonlLine(rawLine: string): LineCleanResult {
+  if (!rawLine.includes("<relevant-memories>")) {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: false };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawLine);
+  } catch {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: true };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: false };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (record.type !== "message") {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: false };
+  }
+
+  const message = record.message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: false };
+  }
+
+  const msg = message as Record<string, unknown>;
+  if (msg.role !== "user") {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: false };
+  }
+
+  const cleaned = cleanUserContent(msg.content);
+  if (!cleaned.changed) {
+    return { line: rawLine, changed: false, blocksRemoved: 0, malformed: false };
+  }
+
+  return {
+    line: JSON.stringify({ ...record, message: { ...msg, content: cleaned.content } }),
+    changed: true,
+    blocksRemoved: cleaned.blocksRemoved,
+    malformed: false,
+  };
+}
+
+export function isSessionFile(filePath: string): boolean {
+  const base = path.basename(filePath);
+  if (!base.endsWith(".jsonl") || base.endsWith(".trajectory.jsonl") || base.startsWith(".")) {
+    return false;
+  }
+  const parts = filePath.split(path.sep);
+  return parts.includes("agents") && parts.at(-2) === "sessions";
+}
+
+export async function findSessionFiles(rootDir: string): Promise<string[]> {
+  const found: string[] = [];
+  await walkSessionFiles(rootDir, found);
+  return found.sort();
+}
+
+async function walkSessionFiles(dir: string, out: string[]): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walkSessionFiles(fullPath, out);
+    } else if (entry.isFile() && isSessionFile(fullPath)) {
+      out.push(fullPath);
+    }
+  }
+}
+
+export async function cleanSessionFile(filePath: string, dryRun: boolean): Promise<FileCleanResult> {
+  const raw = await readFile(filePath, "utf8");
+  const newline = raw.includes("\r\n") ? "\r\n" : "\n";
+  const rawLines = raw.split(/\r?\n/);
+  const outputLines: string[] = [];
+  let changed = false;
+  let linesChanged = 0;
+  let blocksRemoved = 0;
+  let malformedLines = 0;
+
+  for (const line of rawLines) {
+    const result = cleanSessionJsonlLine(line);
+    if (result.malformed) malformedLines += 1;
+    if (result.changed) {
+      changed = true;
+      linesChanged += 1;
+      blocksRemoved += result.blocksRemoved;
+    }
+    outputLines.push(result.line);
+  }
+
+  const output = outputLines.join(newline);
+  const bytesBefore = Buffer.byteLength(raw, "utf8");
+  const bytesAfter = Buffer.byteLength(output, "utf8");
+
+  if (changed && !dryRun) {
+    const tmpPath = path.join(
+      path.dirname(filePath),
+      `.${path.basename(filePath)}.tdai-clean-${process.pid}-${Date.now()}.tmp`,
+    );
+    await writeFile(tmpPath, output, "utf8");
+    try {
+      await rename(tmpPath, filePath);
+    } catch (err) {
+      try {
+        await unlink(tmpPath);
+      } catch {
+        // Best-effort temp cleanup; the original error is more useful.
+      }
+      throw err;
+    }
+  }
+
+  return {
+    file: filePath,
+    changed,
+    linesScanned: rawLines.length,
+    linesChanged,
+    blocksRemoved,
+    bytesBefore,
+    bytesAfter,
+    bytesRemoved: bytesBefore - bytesAfter,
+    malformedLines,
+  };
+}
+
+export async function runLegacyRecallCleanup(options: RunCleanupOptions = {}): Promise<CleanSummary> {
+  const stateDir = options.stateDir ?? resolveOpenClawStateDir(options.runtimeState);
+  const dryRun = options.dryRun ?? true;
+  const files = await findSessionFiles(stateDir);
+  const changedFiles: string[] = [];
+  let filesChanged = 0;
+  let linesScanned = 0;
+  let linesChanged = 0;
+  let blocksRemoved = 0;
+  let malformedLines = 0;
+  let bytesBefore = 0;
+  let bytesAfter = 0;
+
+  for (const file of files) {
+    const result = await cleanSessionFile(file, dryRun);
+    linesScanned += result.linesScanned;
+    malformedLines += result.malformedLines;
+    bytesBefore += result.bytesBefore;
+    bytesAfter += result.bytesAfter;
+    if (result.changed) {
+      filesChanged += 1;
+      linesChanged += result.linesChanged;
+      blocksRemoved += result.blocksRemoved;
+      changedFiles.push(file);
+    }
+  }
+
+  return {
+    stateDir,
+    dryRun,
+    filesScanned: files.length,
+    filesChanged,
+    linesScanned,
+    linesChanged,
+    blocksRemoved,
+    bytesBefore,
+    bytesAfter,
+    bytesRemoved: bytesBefore - bytesAfter,
+    malformedLines,
+    changedFiles,
+  };
+}
+
+export function formatCleanSummary(summary: CleanSummary): string {
+  const lines = [
+    `Scanned ${summary.filesScanned} OpenClaw session file(s) under: ${summary.stateDir}`,
+    summary.dryRun
+      ? "Dry-run mode: no files were changed. Re-run with --yes to apply."
+      : `Cleaned ${summary.filesChanged} file(s).`,
+    `- lines scanned: ${summary.linesScanned}`,
+    `- lines changed: ${summary.linesChanged}`,
+    `- <relevant-memories> blocks removed: ${summary.blocksRemoved}`,
+    `- bytes before: ${summary.bytesBefore}`,
+    `- bytes after: ${summary.bytesAfter}`,
+    `- bytes removed: ${summary.bytesRemoved}`,
+  ];
+  if (summary.malformedLines > 0) {
+    lines.push(`- malformed JSONL lines left untouched: ${summary.malformedLines}`);
+  }
+  if (!summary.dryRun && summary.changedFiles.length > 0) {
+    lines.push("Changed files:");
+    for (const file of summary.changedFiles) lines.push(`  ${file}`);
+  }
+  return `${lines.join("\n")}\n`;
+}


### PR DESCRIPTION
## 背景

针对犀牛鸟 issue #120：启用 memory-tencentdb 后，`prependContext` 与 `showInjected=true` 会把动态召回的 `<relevant-memories>` 块写入会话历史，导致上下文膨胀、历史前缀不稳定，DeepSeek / MiMo 等 OpenAI-compatible provider 的 prompt cache 命中率退化。

运行时已经通过 `before_message_write` 阻止新的注入继续写入历史，但磁盘上已有的旧会话仍包含这些标签，重放时依然影响缓存前缀。本 PR 新增离线历史清理工具，修复存量会话。

## 实现内容

- `src/utils/legacy-recall-cleanup.ts`：扫描 `agents/*/sessions/*.jsonl`，移除 user 消息中的 `<relevant-memories>...</relevant-memories>` 块；
- 支持 string 与 text parts 两种消息格式，跳过 trajectory、plugin 自有 conversations、损坏行和非 user 消息；
- 默认 dry-run，`--yes` 才实际写入，写入采用临时文件 + rename；
- `bin/clean-legacy-recall-injection.mjs` + `scripts/clean-legacy-recall-injection/` CLI；
- 文档：`docs/legacy-recall-history-cleanup.md` 和 `scripts/clean-legacy-recall-injection/README.md`；
- Vitest 测试覆盖 text parts、user 消息、dry-run、CRLF 等场景。

## 验证

```bash
npm test
npm run build:scripts
```
