### PR TITLE
fix(embedding): chunk embedBatch by configurable maxBatchSize

### DIFF
--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -126,6 +126,12 @@ export interface EmbeddingConfig {
   proxyUrl?: string;
   /** Max input text length in characters before truncation (default: 5000). Texts exceeding this limit are truncated with a warning. */
   maxInputChars: number;
+  /**
+   * Max texts per embedding batch request (default: 256). Some providers
+   * enforce a stricter limit (e.g. Dashscope = 10) and reject larger batches
+   * with HTTP 400 — set this to match your provider (issue #236).
+   */
+  maxBatchSize: number;
   /** Timeout per embedding API call in milliseconds (default: 10000). */
   timeoutMs: number;
   /** Override timeoutMs for recall-path embedding calls (user-facing, should be shorter). Falls back to timeoutMs. */
@@ -588,6 +594,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       conflictRecallTopK: num(embeddingGroup, "conflictRecallTopK") ?? 5,
       proxyUrl: embeddingProxyUrl,
       maxInputChars: num(embeddingGroup, "maxInputChars") ?? 5000,
+      maxBatchSize: num(embeddingGroup, "maxBatchSize") ?? 256,
       timeoutMs: num(embeddingGroup, "timeoutMs") ?? 10_000,
       recallTimeoutMs: num(embeddingGroup, "recallTimeoutMs") ?? undefined,
       captureTimeoutMs: num(embeddingGroup, "captureTimeoutMs") ?? undefined,

--- a/MemoryCore/src/core/store/embedding.test.ts
+++ b/MemoryCore/src/core/store/embedding.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for #236 — embedBatch must chunk into provider-appropriate batch
+ * sizes (config.embedding.maxBatchSize) instead of sending up to 256 texts
+ * to APIs that reject large batches (e.g. Dashscope limit = 10).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { OpenAIEmbeddingService } from "./embedding.js";
+
+function makeService(maxBatchSize?: number) {
+  const svc = new OpenAIEmbeddingService({
+    provider: "openai",
+    baseUrl: "https://api.test/v1",
+    apiKey: "k",
+    model: "m",
+    dimensions: 3,
+    maxBatchSize,
+  } as never);
+
+  const calls: string[][] = [];
+  (svc as unknown as { _callApi: (t: string[]) => Promise<Float32Array[]> })._callApi = vi.fn(
+    async (texts: string[]) => texts.map(() => new Float32Array(3)),
+  ) as never;
+  const callApi = (svc as unknown as { _callApi: (t: string[]) => Promise<Float32Array[]> })._callApi as ReturnType<typeof vi.fn>;
+  callApi.mockImplementation(async (texts: string[]) => {
+    calls.push(texts);
+    return texts.map(() => new Float32Array(3));
+  });
+
+  return { svc, calls };
+}
+
+describe("embedBatch maxBatchSize (#236)", () => {
+  it("chunks texts above maxBatchSize into separate API calls", async () => {
+    const { svc, calls } = makeService(10);
+    const texts = Array.from({ length: 25 }, (_, i) => `text ${i}`);
+
+    await svc.embedBatch(texts);
+
+    // 25 texts / 10 per batch → 3 calls (10 / 10 / 5)
+    expect(calls.length).toBe(3);
+    expect(calls[0]).toHaveLength(10);
+    expect(calls[1]).toHaveLength(10);
+    expect(calls[2]).toHaveLength(5);
+  });
+
+  it("sends one call when under maxBatchSize", async () => {
+    const { svc, calls } = makeService(10);
+    await svc.embedBatch(["a", "b", "c"]);
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toHaveLength(3);
+  });
+
+  it("defaults to MAX_BATCH_SIZE (256) when not configured", async () => {
+    const { svc, calls } = makeService(undefined);
+    await svc.embedBatch(Array.from({ length: 300 }, (_, i) => `t${i}`));
+    // 300 / 256 → 2 calls (256 + 44)
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toHaveLength(256);
+    expect(calls[1]).toHaveLength(44);
+  });
+});

--- a/MemoryCore/src/core/store/embedding.ts
+++ b/MemoryCore/src/core/store/embedding.ts
@@ -41,6 +41,12 @@ export interface OpenAIEmbeddingConfig {
   proxyUrl?: string;
   /** Max input text length in characters before truncation (default: 5000). */
   maxInputChars?: number;
+  /**
+   * Max texts per embedding batch request. Some providers enforce a strict
+   * limit (e.g. Dashscope = 10); the default 256 exceeds it, causing L0
+   * embedding to fail with HTTP 400 for batches of 11..256 texts (issue #236).
+   */
+  maxBatchSize?: number;
   /** Timeout per API call in milliseconds (default: 10000). */
   timeoutMs?: number;
 }
@@ -408,6 +414,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
   private readonly providerName: string;
   private readonly proxyUrl?: string;
   private readonly maxInputChars?: number;
+  private readonly maxBatchSize: number;
   private readonly timeoutMs: number;
   private readonly logger?: Logger;
 
@@ -432,6 +439,7 @@ export class OpenAIEmbeddingService implements EmbeddingService {
     this.providerName = config.provider || "openai";
     this.proxyUrl = config.proxyUrl?.trim() || undefined;
     this.maxInputChars = config.maxInputChars && config.maxInputChars > 0 ? config.maxInputChars : undefined;
+    this.maxBatchSize = config.maxBatchSize && config.maxBatchSize > 0 ? config.maxBatchSize : MAX_BATCH_SIZE;
     this.timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_API_TIMEOUT_MS;
     this.logger = logger;
   }
@@ -467,11 +475,12 @@ export class OpenAIEmbeddingService implements EmbeddingService {
       ? texts.map((t) => this.truncateInput(t))
       : texts;
 
-    // Split into sub-batches if needed
-    if (processedTexts.length > MAX_BATCH_SIZE) {
+    // Split into sub-batches if needed (batch limit is provider-specific, see
+    // config.embedding.maxBatchSize — issue #236).
+    if (processedTexts.length > this.maxBatchSize) {
       const results: Float32Array[] = [];
-      for (let i = 0; i < processedTexts.length; i += MAX_BATCH_SIZE) {
-        const chunk = processedTexts.slice(i, i + MAX_BATCH_SIZE);
+      for (let i = 0; i < processedTexts.length; i += this.maxBatchSize) {
+        const chunk = processedTexts.slice(i, i + this.maxBatchSize);
         const chunkResults = await this._callApi(chunk, options?.timeoutMs);
         results.push(...chunkResults);
       }

--- a/MemoryCore/src/core/store/factory.ts
+++ b/MemoryCore/src/core/store/factory.ts
@@ -107,6 +107,7 @@ export function createStoreBundle(
           dimensions: config.embedding.dimensions,
           sendDimensions: config.embedding.sendDimensions,
           maxInputChars: config.embedding.maxInputChars,
+          maxBatchSize: config.embedding.maxBatchSize,
         }, logger);
       }
 

--- a/MemoryCore/src/core/store/store-pool.ts
+++ b/MemoryCore/src/core/store/store-pool.ts
@@ -381,6 +381,7 @@ export class StorePool {
         model: embCfg.model,
         dimensions: embCfg.dimensions,
         maxInputChars: embCfg.maxInputChars,
+        maxBatchSize: embCfg.maxBatchSize,
       }, this.logger as StoreLogger);
     }
 


### PR DESCRIPTION
Fixes #236.

## Problem

`MAX_BATCH_SIZE` was hardcoded to **256** in `embedding.ts`, but some providers (e.g. Dashscope) reject batches > **10** with HTTP 400. When L0 capture produced **11..256** texts, the chunking condition (`length > 256`) never fired and the whole batch was sent to the API — embedding permanently failed (`non-fatal WARN`, no retry) and hybrid recall silently degraded to keyword-only.

## Change

- `OpenAIEmbeddingConfig` / `EmbeddingConfig` gain `maxBatchSize` (default **256** — no regression for OpenAI-compatible providers)
- `OpenAIEmbeddingService` sub-batches using `config.maxBatchSize` (so `maxBatchSize: 10` fixes Dashscope)
- `config.ts` parses `embedding.maxBatchSize`; `factory.ts` / `store-pool.ts` pass it through

## Tests

`src/core/store/embedding.test.ts` (3): 25 texts with `maxBatchSize=10` → 3 API calls (10/10/5); under limit → 1 call; unset → default 256 (300 → 2 calls).

`npm test` passes, `npm run build:plugin` passes.