### PR TITLE
fix(metadata): enforce caller authorization on v3 asset read endpoints

### DIFF
--- a/MemoryCore/src/metadata/router/v3-meta-router.ts
+++ b/MemoryCore/src/metadata/router/v3-meta-router.ts
@@ -236,15 +236,15 @@ const routeTable: Record<string, Handler> = {
 
   // Asset
   [`${V3_PREFIX}/asset/create`]: bind(S.assetCreateSchema, (d, c, s) => s.createAssetForCaller(d, c)),
-  [`${V3_PREFIX}/asset/get`]: bind(S.assetGetSchema, async (d, _c, s) => orNotFound(await s.getAssetById(d.asset_id), "asset_not_found", d.asset_id)),
+  [`${V3_PREFIX}/asset/get`]: bind(S.assetGetSchema, async (d, c, s) => orNotFound(await s.getAssetForCaller(d.asset_id, c), "asset_not_found", d.asset_id)),
   [`${V3_PREFIX}/asset/update`]: bind(S.assetUpdateSchema, (d, c, s) => {
     const { asset_id, ...patch } = d;
     return s.updateAssetForCaller(asset_id, patch, c);
   }),
   [`${V3_PREFIX}/asset/delete`]: bind(S.assetDeleteSchema, (d, c, s) => s.deleteAssetsForCaller(d.asset_ids, c)),
-  [`${V3_PREFIX}/asset/list`]: bind(S.assetListSchema, (d, _c, s) => {
+  [`${V3_PREFIX}/asset/list`]: bind(S.assetListSchema, (d, c, s) => {
     const { team_id, limit, offset, ...filter } = d;
-    return s.listAssetsByTeam(team_id, resolvePagination({ limit, offset }), filter);
+    return s.listAssetsForCaller(team_id, c, resolvePagination({ limit, offset }), filter);
   }),
   [`${V3_PREFIX}/asset/list-accessible`]: bind(S.assetListAccessibleSchema, (d, _c, s) =>
     s.listAccessibleAssets(d)),

--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -952,6 +952,72 @@ export class MetadataService {
     return formatListResult({ items, total: page.total }, pagination);
   }
 
+  /**
+   * Caller-scoped read of a single asset. The plain getAssetById performs no
+   * authorization; this variant applies the same permission model as
+   * checkAssetPermission but with the identity taken from the authenticated
+   * context. Returns null (rendered as asset_not_found upstream) on denial so
+   * the endpoint does not become an existence oracle.
+   */
+  async getAssetForCaller(assetId: string, ctx: V3AuthContext): Promise<AssetEntity | null> {
+    const asset = await this.getAssetById(assetId);
+    if (!asset || asset.status === "archived") return null;
+    const callerId = this.requireCallerId(ctx);
+    if (asset.owner_user_id === callerId) return asset;
+    const membership = await this.store.getTeamMember(asset.team_id, callerId);
+    const perm = checkPermission({
+      user: { user_id: callerId },
+      asset,
+      membership,
+      action: "read",
+      aclRecords: [],
+      logger: this.logger,
+    });
+    return perm.allowed ? asset : null;
+  }
+
+  /**
+   * Caller-scoped team asset listing. The plain listAssetsByTeam accepts any
+   * team_id with no membership requirement and returns private rows of other
+   * users; this variant requires the caller to be an active member of the
+   * team and filters each row through the read permission model (owner
+   * short-circuit, visibility, role defaults), mirroring listAccessibleAssets.
+   */
+  async listAssetsForCaller(
+    teamId: string,
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+    filter?: AssetFilter,
+  ): Promise<PaginatedResult<AssetEntity>> {
+    const callerId = this.requireCallerId(ctx);
+    const membership = await this.requireActiveTeamMember(ctx, teamId);
+    const result: AssetEntity[] = [];
+    let offset = 0;
+    const limit = 100;
+    while (true) {
+      const page = await this.store.listAssetsByTeam(teamId, { limit, offset }, filter);
+      for (const asset of page.items) {
+        if (FILTERED_STATUSES.includes(asset.status)) continue;
+        if (asset.owner_user_id === callerId) {
+          result.push(asset);
+          continue;
+        }
+        const perm = checkPermission({
+          user: { user_id: callerId },
+          asset,
+          membership,
+          action: "read",
+          aclRecords: [],
+          logger: this.logger,
+        });
+        if (perm.allowed) result.push(asset);
+      }
+      if (offset + page.items.length >= page.total) break;
+      offset += limit;
+    }
+    return paginateArray(result, pagination);
+  }
+
   async touchAssetUsage(assetId: string): Promise<void> {
     if (!(await this.getAssetById(assetId))) throw new MetadataError("asset_not_found", `asset not found: ${assetId}`);
     await this.store.touchAssetUsage(assetId);


### PR DESCRIPTION
## Problem

`handleV3MetaRoute` authenticates `x-tdai-user-key` into a `V3AuthContext`, and every write handler routes through caller-scoped wrappers (`updateAssetForCaller`, `deleteAssetsForCaller`, `grantAclForCaller`, ...) that assert ownership or team membership. The read handlers for `asset/get` and `asset/list` instead bind with the context parameter discarded (`_c`) and call the raw store getters:

```ts
// before
[`${V3_PREFIX}/asset/get`]:  bind(..., async (d, _c, s) => orNotFound(await s.getAssetById(d.asset_id), ...)),
[`${V3_PREFIX}/asset/list`]: bind(..., (d, _c, s) => s.listAssetsByTeam(team_id, ...)),
```

`getAssetById` / `listAssetsByTeam` perform no authorization at all. Consequence: any holder of a valid user key — including an ordinary low-privilege member of an unrelated team — can `POST /v3/meta/asset/list` with an arbitrary `team_id` and receive every asset row of that team, including `visibility: "private"` rows owned by other users, then `POST /v3/meta/asset/get` to read `name`, `description`, `source_ref`, `content_ref`, `metadata_json`. This bypasses the visibility/ACL model the same codebase implements carefully in `checkPermission`, whose `private` branch explicitly denies even team admins.

## Fix

Two caller-scoped service methods, mirroring the existing `listAccessibleAssets` pattern:

- `getAssetForCaller(assetId, ctx)` — identity from the authenticated context; runs `checkPermission` (owner short-circuit, visibility, role defaults); denial returns `null` so the endpoint renders `asset_not_found` rather than becoming an existence oracle.
- `listAssetsForCaller(teamId, ctx, pagination, filter)` — requires the caller to be an **active member of the requested team**, aggregates and filters each row through the same read-permission check, then paginates post-filter (same as `listAccessibleAssets`, so counts don't leak hidden rows).

Both read handlers now pass `c` instead of discarding it. No behavior change for legitimate callers: owners, and members reading `team`/`agent`/`task`-visibility assets, get identical results.

## Verification

Unit-verified against the real service with a stubbed store (7 cases pass):

- private asset read denied for non-member, for active member, **and for team admin** (matches `checkPermission`'s private semantics)
- owner read allowed
- `list` rejects a non-member of the requested team
- `list` filters other users' private rows for a member, still returns team-visibility rows
- `tsc --noEmit --strict` on the touched files: identical baseline before/after (no new type errors)

## Scope note

Same root cause exists in the other `_c` read handlers (`team/get`, `agent/get`, `task/get`, `agent-fixed-asset/*`) and in `acl/check` / `asset/list-accessible` resolving the subject from the request body via `resolveUserId` rather than from the auth context (a caller can evaluate permissions as another user). Left out of this PR to keep it reviewable; happy to follow up. If the deployment model intentionally trusts every key holder across all teams on an instance, this is at minimum a documentation gap — the three-layer auth comment in `router/auth.ts` suggests otherwise.

Made with [Cursor](https://cursor.com)