### PR TITLE
fix(config): treat empty/relative offload.dataDir as omitted (must be absolute)

### DIFF
--- a/MemoryCore/src/config.test.ts
+++ b/MemoryCore/src/config.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for #521 — offload.dataDir must be an absolute path; empty / relative
+ * values are treated as omitted so offload data never lands under the CWD.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig offload.dataDir (#521)", () => {
+  it("treats an empty offload.dataDir as omitted", () => {
+    expect(parseConfig({ offload: { dataDir: "" } }).offload.dataDir).toBeUndefined();
+  });
+
+  it("treats a relative offload.dataDir as omitted", () => {
+    expect(parseConfig({ offload: { dataDir: "relative-root" } }).offload.dataDir).toBeUndefined();
+  });
+
+  it("keeps an absolute offload.dataDir (POSIX)", () => {
+    const cfg = parseConfig({ offload: { dataDir: "/abs/offload" } });
+    expect(cfg.offload.dataDir).toBe("/abs/offload");
+  });
+
+  it("keeps an absolute offload.dataDir (Windows drive)", () => {
+    const cfg = parseConfig({ offload: { dataDir: "C:\\offload\\data" } });
+    expect(cfg.offload.dataDir).toBe("C:\\offload\\data");
+  });
+
+  it("defaults to undefined when offload.dataDir is not set", () => {
+    expect(parseConfig({}).offload.dataDir).toBeUndefined();
+  });
+});

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -513,7 +513,7 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     model: optStr(offloadGroup, "model"),
     temperature: num(offloadGroup, "temperature") ?? 0.2,
     forceTriggerThreshold: num(offloadGroup, "forceTriggerThreshold") ?? 4,
-    dataDir: optStr(offloadGroup, "dataDir"),
+    dataDir: optionalAbsoluteDir(offloadGroup, "dataDir"),
     defaultContextWindow: num(offloadGroup, "defaultContextWindow") ?? 200000,
     maxPairsPerBatch: num(offloadGroup, "maxPairsPerBatch") ?? 20,
     l2NullThreshold: num(offloadGroup, "l2NullThreshold") ?? 4,
@@ -668,6 +668,24 @@ function normalizePromptMode(value: string | undefined, fallback: MemoryPromptMo
 function optStr(src: Record<string, unknown>, key: string): string | undefined {
   const v = src[key];
   return typeof v === "string" ? v : undefined;
+}
+
+/** True when a string is a non-empty absolute path (POSIX or Windows). */
+function isAbsolutePath(p: string): boolean {
+  const trimmed = p.trim();
+  if (!trimmed) return false;
+  return /^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.startsWith("/");
+}
+
+/**
+ * offload.dataDir must be an absolute path per its contract. Empty or relative
+ * values would silently land offload data under the process CWD (issue #521),
+ * so they are treated as omitted (fall back to the default root).
+ */
+function optionalAbsoluteDir(src: Record<string, unknown>, key: string): string | undefined {
+  const v = optStr(src, key);
+  if (!v || !isAbsolutePath(v)) return undefined;
+  return v.trim();
 }
 
 function num(src: Record<string, unknown>, key: string): number | undefined {


### PR DESCRIPTION
Fixes #521.

## Problem

`offload.dataDir`'s contract requires an **absolute** path, but `optStr()` returned any string verbatim — including `""` and relative paths — which were then used as the context-offload storage root. Offload data (`offload.jsonl`, `refs/`, `mmds/`, `state.json`) silently landed under the process **CWD**, so a different working directory or service manager made it unreadable (or wrote into the source tree).

## Change

`config.ts` — `offload.dataDir` now only accepts a **non-empty absolute path** (POSIX `/…` or Windows drive `C:\…`). Empty / relative values are treated as **omitted** and fall back to the default root.

## Tests

`src/config.test.ts` (5): empty/relative → `undefined`; absolute POSIX + Windows drive kept; unset → `undefined`.

`npm test` passes, `npm run build:plugin` passes.