### PR TITLE
fix(compact): compress protected tail after emergency

### DIFF
--- a/MemoryCore/src/offload_server/compact/compaction-handler.ts
+++ b/MemoryCore/src/offload_server/compact/compaction-handler.ts
@@ -14,7 +14,7 @@ import { CompactionRequestSchemaV2 } from "../schemas.js";
 import { buildOffloadBasePath } from "../session-utils.js";
 import { applyFastPath } from "./fast-path.js";
 import { injectActiveMmd, injectHistoryMmds } from "./mmd-injector.js";
-import { resolveLevel, mildCompress, aggressiveCompress, emergencyCompress } from "./compressor.js";
+import { resolveLevel, mildCompress, aggressiveCompress, emergencyCompress, compressProtectedTail } from "./compressor.js";
 import { estimateMessageTokens, extractToolResultId } from "./helpers.js";
 import type { Message } from "./helpers.js";
 import { traceServerCompaction } from "../opik-tracer.js";
@@ -217,6 +217,17 @@ export async function handleCompaction(
     report.emergencyDeleted = em.deletedCount;
     aggRemainingTokens = em.remainingTokens;
     compactState.deletedOffloadIds.push(...em.deletedIds);
+
+    // If tokens remain above the emergency target, compress the protected tail:
+    // delete the oldest complete tool-call groups inside the tail while
+    // preserving its documented invariants.
+    if (aggRemainingTokens > emTargetTokens) {
+      const tailDeletedIds: string[] = [];
+      const tail = compressProtectedTail(messages, tokenArray, emTargetTokens, aggRemainingTokens, tailDeletedIds);
+      report.emergencyDeleted += tail.deletedCount;
+      aggRemainingTokens = tail.remainingTokens;
+      compactState.deletedOffloadIds.push(...tailDeletedIds);
+    }
   }
 
   // Step 7: Inject active MMD (after all compression, so position is correct)


### PR DESCRIPTION
## Summary

- Wire the existing protected-tail compressor into emergency compaction when the emergency target is still exceeded.
- Preserve deleted tool-result IDs and emergency deletion reporting for the additional tail compression.

## Issue

Closes #838

## Verification

- `git apply --check --recount` passed for the reviewed artifact.
- `git apply --recount` applied cleanly.
- `git diff --check` passed.
- local verification not run; relying on upstream CI (this fresh worktree has no installed dependencies).

## Notes

The change is limited to `MemoryCore/src/offload_server/compact/compaction-handler.ts`.
