### PR TITLE
docs: clarify MemoryProxy auth and Codex startup

### DIFF
--- a/MemoryProxy/README.md
+++ b/MemoryProxy/README.md
@@ -183,6 +183,22 @@ Anthropic Messages client:
 }
 ```
 
+## FAQ
+
+### Is an API key mandatory?
+
+Starting the proxy itself needs **no** API key. A user key (`x-tdai-user-key` / the client `Authorization` header) only gates individual requests, and only when `auth.enabled=true`:
+
+- The code default is `auth.enabled: false`, while `config.example.yaml` sets it to `true`. For pure local development you may set `auth.enabled: false`: requests then pass without any key and the user identity falls back to `anonymous` (the system-user short-circuit needs a verified `user_id`, so it simply never matches).
+- With `auth.enabled=true`, a missing or invalid key is rejected with `401 Authentication failed` before the body is parsed. Keep it on when listening on non-loopback addresses or deploying multi-node.
+- Independently of user auth, an **upstream LLM credential** is still required at forward time: set `upstream.apiKey` (or a per-agent `upstream.agents[<agent>].apiKey`) in `config.yaml`, or leave it empty to pass the client's own key through unchanged.
+
+### Can the local Codex CLI be used to start the proxy?
+
+No. MemoryProxy is a standalone Node.js process — start it with `npm run start:config` (or `./proxy.sh start` / Docker). There is no Codex-CLI-based startup path: the proxy never shells out to any agent CLI, and startup is identical regardless of which coding agent connects later.
+
+Codex appears only as an agent-name routing boundary on an already-running proxy: the commented `codex` entry under `upstream.agents` in [config.example.yaml](./config.example.yaml) routes requests whose URL starts with the `/codex` prefix to a dedicated upstream, and because it declares no `apiKey`, the client's own key is forwarded (client-key passthrough instead of the global `upstream.apiKey` fallback). Configuring the Codex CLI itself — base URL, provider, key — happens on the Codex side and is outside this repository.
+
 ## Main HTTP endpoints
 
 | Method | Path | Description |


### PR DESCRIPTION
## Summary

- Document that the proxy itself does not require an API key to start.
- Explain request authentication defaults and upstream credential behavior.
- Clarify that Codex is an already-running proxy routing boundary, not a local startup mechanism.

Closes #819

## Verification

- git apply --check --recount passed.
- git apply --recount applied cleanly.
- git diff --check passed.
- Documentation-only change; no runtime test suite run.