### PR TITLE
fix(metadata): authorize v3 team/agent/task get by caller

### DIFF
--- a/MemoryCore/src/metadata/router/v3-meta-router.ts
+++ b/MemoryCore/src/metadata/router/v3-meta-router.ts
@@ -128,7 +128,7 @@ const routeTable: Record<string, Handler> = {
 
   // Team
   [`${V3_PREFIX}/team/create`]: bind(S.teamCreateSchema, (d, c, s) => s.createTeamForCaller(d, c)),
-  [`${V3_PREFIX}/team/get`]: bind(S.teamGetSchema, async (d, _c, s) => orNotFound(await s.getTeamById(d.team_id), "team_not_found", d.team_id)),
+  [`${V3_PREFIX}/team/get`]: bind(S.teamGetSchema, async (d, c, s) => orNotFound(await s.getTeamForCaller(d.team_id, c), "team_not_found", d.team_id)),
   [`${V3_PREFIX}/team/update`]: bind(S.teamUpdateSchema, async (d, c, s) => {
     const { team_id, ...patch } = d;
     return s.updateTeamForCaller(team_id, patch, c);
@@ -158,7 +158,7 @@ const routeTable: Record<string, Handler> = {
 
   // Agent
   [`${V3_PREFIX}/agent/create`]: bind(S.agentCreateSchema, (d, c, s) => s.createAgentForCaller(d, c)),
-  [`${V3_PREFIX}/agent/get`]: bind(S.agentGetSchema, async (d, _c, s) => orNotFound(await s.getAgentById(d.agent_id), "agent_not_found", d.agent_id)),
+  [`${V3_PREFIX}/agent/get`]: bind(S.agentGetSchema, async (d, c, s) => orNotFound(await s.getAgentForCaller(d.agent_id, c), "agent_not_found", d.agent_id)),
   [`${V3_PREFIX}/agent/update`]: bind(S.agentUpdateSchema, async (d, c, s) => {
     const { agent_id, ...patch } = d;
     return s.updateAgentForCaller(agent_id, patch, c);
@@ -185,7 +185,7 @@ const routeTable: Record<string, Handler> = {
 
   // Task
   [`${V3_PREFIX}/task/create`]: bind(S.taskCreateSchema, (d, c, s) => s.createTaskForCaller(d, c)),
-  [`${V3_PREFIX}/task/get`]: bind(S.taskGetSchema, async (d, _c, s) => orNotFound(await s.getTaskById(d.task_id), "task_not_found", d.task_id)),
+  [`${V3_PREFIX}/task/get`]: bind(S.taskGetSchema, async (d, c, s) => orNotFound(await s.getTaskForCaller(d.task_id, c), "task_not_found", d.task_id)),
   [`${V3_PREFIX}/task/update`]: bind(S.taskUpdateSchema, (d, c, s) => {
     const { task_id, ...patch } = d;
     return s.updateTaskForCaller(task_id, patch, c);

--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -1596,6 +1596,50 @@ export class MetadataService {
     return member;
   }
 
+  /**
+   * Caller-scoped team read. Plain getTeamById has no membership check, so any
+   * authenticated key holder can load arbitrary team rows by id. Denial returns
+   * null (router maps to team_not_found) rather than becoming an existence oracle.
+   */
+  async getTeamForCaller(teamId: string, ctx: V3AuthContext): Promise<TeamEntity | null> {
+    const team = await this.getTeamById(teamId);
+    if (!team) return null;
+    const callerId = this.requireCallerId(ctx);
+    const member = await this.store.getTeamMember(teamId, callerId);
+    if (!member || member.status !== "active") return null;
+    return team;
+  }
+
+  /**
+   * Caller-scoped agent read. Plain getAgentById returns the full agent row
+   * including prompt with no authz. Require active membership of the agent's
+   * team; visibility=private is owner-only (same private semantics as assets).
+   * Denial returns null → agent_not_found (no existence oracle).
+   */
+  async getAgentForCaller(agentId: string, ctx: V3AuthContext): Promise<AgentEntity | null> {
+    const agent = await this.getAgentById(agentId);
+    if (!agent) return null;
+    const callerId = this.requireCallerId(ctx);
+    if (agent.owner_user_id === callerId) return agent;
+    if (agent.visibility === "private") return null;
+    const member = await this.store.getTeamMember(agent.team_id, callerId);
+    if (!member || member.status !== "active") return null;
+    return agent;
+  }
+
+  /**
+   * Caller-scoped task read. Plain getTaskById has no membership check.
+   * Denial returns null → task_not_found.
+   */
+  async getTaskForCaller(taskId: string, ctx: V3AuthContext): Promise<TaskEntity | null> {
+    const task = await this.getTaskById(taskId);
+    if (!task) return null;
+    const callerId = this.requireCallerId(ctx);
+    const member = await this.store.getTeamMember(task.team_id, callerId);
+    if (!member || member.status !== "active") return null;
+    return task;
+  }
+
   async createAgentForCaller(input: CreateAgentInput, ctx: V3AuthContext): Promise<AgentEntity> {
     await this.assertTeamExists(input.team_id);
     await this.requireActiveTeamMember(ctx, input.team_id);


### PR DESCRIPTION
## Problem

Follow-up to #848 / #856 (same `_c` authz gap on entity reads).

`handleV3MetaRoute` authenticates `x-tdai-user-key` into a `V3AuthContext`, and write handlers already route through caller-scoped wrappers. The read handlers for `team/get`, `agent/get`, and `task/get` instead discarded the context (`_c`) and called the raw store getters:

```ts
// before
[`${V3_PREFIX}/team/get`]:  bind(..., async (d, _c, s) => orNotFound(await s.getTeamById(d.team_id), ...)),
[`${V3_PREFIX}/agent/get`]: bind(..., async (d, _c, s) => orNotFound(await s.getAgentById(d.agent_id), ...)),
[`${V3_PREFIX}/task/get`]:  bind(..., async (d, _c, s) => orNotFound(await s.getTaskById(d.task_id), ...)),
```

Consequence: any holder of a valid user key can `POST /v3/meta/agent/get` with an arbitrary `agent_id` and receive the full agent row, including `prompt`, plus team/task metadata for any id. That bypasses the membership model already enforced on writes and on `team-member/*` reads.

## Fix

Three caller-scoped getters, mirroring the `getAssetForCaller` / `listTeamMembersForCaller` pattern:

- `getTeamForCaller` / `getTaskForCaller` — require active membership of the entity's team; denial returns `null` so the router renders `*_not_found` (no existence oracle).
- `getAgentForCaller` — same membership gate; `visibility: "private"` is owner-only (aligned with asset private semantics). Owner short-circuit still works.

Handlers now pass `c` instead of discarding it. Legitimate teammates and owners see identical results for team-visible agents.

## Verification

Local stub-store repro against the real service methods:

- Pre-fix: outsider `getAgentById` returns the victim prompt (`SYSTEM: ... xyzzy`).
- Post-fix: outsider `*ForCaller` returns `null` for team/agent/task.
- Teammate still reads team-visibility agent (prompt intact); private agent denied to non-owner teammate; owner reads private agent.

## Scope note

Same `_c` IDOR pattern remains on `agent/list`, `task/list`, `task-agent/list`, and `agent-fixed-asset/*` (notably `list-with-detail` returns `agent.prompt` + bound asset metadata). Left out to keep this PR reviewable; happy to follow up.

Made with [Cursor](https://cursor.com)