### PR TITLE
fix(metadata): authorize v3 agent-fixed-asset read endpoints by caller

### DIFF
--- a/MemoryCore/src/metadata/router/v3-meta-router.ts
+++ b/MemoryCore/src/metadata/router/v3-meta-router.ts
@@ -259,12 +259,17 @@ const routeTable: Record<string, Handler> = {
     await s.setAgentFixedAssetsForCaller(d.agent_id, d.bindings, c);
     return OK;
   }),
-  [`${V3_PREFIX}/agent-fixed-asset/list`]: bind(S.fixedAssetListSchema, (d, _c, s) =>
-    s.listAgentFixedAssets(d.agent_id, resolvePagination(d)),
+  [`${V3_PREFIX}/agent-fixed-asset/list`]: bind(S.fixedAssetListSchema, (d, c, s) =>
+    s.listAgentFixedAssetsForCaller(d.agent_id, c, resolvePagination(d)),
   ),
-  [`${V3_PREFIX}/agent-fixed-asset/list-with-detail`]: bind(S.fixedAssetListWithDetailSchema, (d, _c, s) => s.listAgentFixedAssetsWithDetail(d)),
-  [`${V3_PREFIX}/agent-fixed-asset/summary-by-agents`]: bind(S.fixedAssetSummaryByAgentsSchema, (d, _c, s) =>
-    s.summarizeAgentFixedAssetsByAgents({ agent_ids: d.agent_ids, asset_id: d.asset_id }),
+  [`${V3_PREFIX}/agent-fixed-asset/list-with-detail`]: bind(S.fixedAssetListWithDetailSchema, (d, c, s) =>
+    s.listAgentFixedAssetsWithDetailForCaller(d, c),
+  ),
+  [`${V3_PREFIX}/agent-fixed-asset/summary-by-agents`]: bind(S.fixedAssetSummaryByAgentsSchema, (d, c, s) =>
+    s.summarizeAgentFixedAssetsByAgentsForCaller(
+      { agent_ids: d.agent_ids, asset_id: d.asset_id },
+      c,
+    ),
   ),
 
   // ACL

--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -1499,6 +1499,36 @@ export class MetadataService {
     return team;
   }
 
+  /**
+   * Agent readable by caller: owner always; visibility=private is owner-only;
+   * otherwise active membership of the agent's team. Same read model as the
+   * entity-get ForCaller path. Returns null on denial (no existence oracle).
+   */
+  private async readableAgentForCaller(
+    agentId: string,
+    ctx: V3AuthContext,
+  ): Promise<AgentEntity | null> {
+    const agent = await this.getAgentById(agentId);
+    if (!agent) return null;
+    const callerId = this.requireCallerId(ctx);
+    if (agent.owner_user_id === callerId) return agent;
+    if (agent.visibility === "private") return null;
+    const member = await this.store.getTeamMember(agent.team_id, callerId);
+    if (!member || member.status !== "active") return null;
+    return agent;
+  }
+
+  private async requireReadableAgentForCaller(
+    agentId: string,
+    ctx: V3AuthContext,
+  ): Promise<AgentEntity> {
+    const agent = await this.readableAgentForCaller(agentId, ctx);
+    if (!agent) {
+      throw new MetadataError("agent_not_found", `agent not found: ${agentId}`);
+    }
+    return agent;
+  }
+
   private async assertCallerIsAgentOwner(ctx: V3AuthContext, agentId: string): Promise<AgentEntity> {
     const agent = await this.getAgentById(agentId);
     if (!agent) throw new MetadataError("agent_not_found", `agent not found: ${agentId}`);
@@ -1726,6 +1756,75 @@ export class MetadataService {
   ): Promise<void> {
     await this.assertCallerIsAgentOwner(ctx, agentId);
     return this.setAgentFixedAssets(agentId, bindings);
+  }
+
+  /**
+   * Caller-scoped fixed-asset binding list. Plain listAgentFixedAssets has no
+   * authz, so any key holder can enumerate bindings for an arbitrary agent_id.
+   * Gate on the same agent-read model as entity get (membership / private owner).
+   */
+  async listAgentFixedAssetsForCaller(
+    agentId: string,
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+  ): Promise<PaginatedResult<FixedAssetBindingEntity>> {
+    await this.requireReadableAgentForCaller(agentId, ctx);
+    return this.listAgentFixedAssets(agentId, pagination);
+  }
+
+  /**
+   * Caller-scoped list-with-detail. The raw path returns agent.prompt plus bound
+   * asset metadata with no authz. Denial maps to agent_not_found.
+   */
+  async listAgentFixedAssetsWithDetailForCaller(
+    params: ListWithDetailParams,
+    ctx: V3AuthContext,
+  ): Promise<AgentFixedAssetDetailResult> {
+    await this.requireReadableAgentForCaller(params.agent_id, ctx);
+    return this.listAgentFixedAssetsWithDetail(params);
+  }
+
+  /**
+   * Caller-scoped summary-by-agents. Plain summarize accepts arbitrary agent_ids
+   * and returns binding-type counts with no membership check. Filter the request
+   * to agents the caller can read; unauthorized ids get empty counts so the
+   * response shape stays stable without leaking binding inventory.
+   */
+  async summarizeAgentFixedAssetsByAgentsForCaller(
+    params: SummarizeAgentFixedAssetsParams,
+    ctx: V3AuthContext,
+  ): Promise<AgentFixedAssetSummaryResult> {
+    const requested = [...new Set(params.agent_ids.filter((id) => id.length > 0))];
+    if (requested.length === 0) {
+      return { items: [], total: 0 };
+    }
+
+    const allowed: string[] = [];
+    for (const agentId of requested) {
+      if (await this.readableAgentForCaller(agentId, ctx)) {
+        allowed.push(agentId);
+      }
+    }
+
+    const summarized = await this.summarizeAgentFixedAssetsByAgents({
+      agent_ids: allowed,
+      asset_id: params.asset_id,
+    });
+    const byAgent = new Map(summarized.items.map((item) => [item.agent_id, item]));
+    const emptyCounts = (): FixedAssetTypeCounts => ({
+      skill: 0,
+      code_graph: 0,
+      llm_wiki: 0,
+      chat_memory: 0,
+    });
+
+    const items: AgentFixedAssetSummary[] = requested.map((agent_id) => {
+      const hit = byAgent.get(agent_id);
+      if (hit) return hit;
+      return { agent_id, counts: emptyCounts(), total: 0 };
+    });
+
+    return { items, total: items.length };
   }
 
   async grantAclForCaller(input: GrantAclInput, ctx: V3AuthContext): Promise<AclEntity> {


### PR DESCRIPTION
## Problem

`handleV3MetaRoute` authenticates `x-tdai-user-key` into a `V3AuthContext`, and `agent-fixed-asset/set` already routes through `setAgentFixedAssetsForCaller` (owner-only). The three read handlers discarded that context (`_c`) and called raw helpers:

```ts
// before
[`${V3_PREFIX}/agent-fixed-asset/list`]: bind(..., (d, _c, s) =>
  s.listAgentFixedAssets(d.agent_id, ...)),
[`${V3_PREFIX}/agent-fixed-asset/list-with-detail`]: bind(..., (d, _c, s) =>
  s.listAgentFixedAssetsWithDetail(d)),
[`${V3_PREFIX}/agent-fixed-asset/summary-by-agents`]: bind(..., (d, _c, s) =>
  s.summarizeAgentFixedAssetsByAgents(...)),
```

None of those helpers check team membership or agent visibility. Consequence: any holder of a valid user key can:

1. `POST /v3/meta/agent-fixed-asset/list-with-detail` with an arbitrary `agent_id` and receive `agent.prompt` plus bound asset metadata (`name`, `description`, `visibility`, `injection_mode`, ...)
2. `POST /v3/meta/agent-fixed-asset/list` to enumerate binding rows for that agent
3. `POST /v3/meta/agent-fixed-asset/summary-by-agents` to read per-agent asset-type binding counts across arbitrary `agent_ids`

This is the same incomplete-authz class as open #848 / #857 (reads that skip the ForCaller wrappers writes already use).

## Fix

- Add `listAgentFixedAssetsForCaller`, `listAgentFixedAssetsWithDetailForCaller`, and `summarizeAgentFixedAssetsByAgentsForCaller`.
- Gate on the same agent-read model as entity get: owner always; `visibility: "private"` is owner-only; otherwise require active membership of the agent's team.
- `list` / `list-with-detail` denial → `agent_not_found` (no existence oracle).
- `summary-by-agents` keeps request order; unauthorized ids get empty counts so binding inventory does not leak.

## Test plan

- [ ] Outsider key + victim `agent_id` on `list-with-detail` → `agent_not_found` (no prompt / asset meta)
- [ ] Outsider on `list` → `agent_not_found`
- [ ] Outsider on `summary-by-agents` → empty counts for unauthorized ids
- [ ] Active teammate can read team-visibility agent list / list-with-detail
- [ ] Non-owner teammate denied on `visibility: "private"` agent
- [ ] Owner can still read private agent detail and summary counts
- [ ] `agent-fixed-asset/set` path unchanged (still owner-only)

Tooling assistance used for drafting; commit author/committer is Sasha Mitchell only (no bot co-author trailer).

Made with [Cursor](https://cursor.com)