### PR TITLE
fix(metadata): authorize v3 team-scoped list endpoints by caller

### DIFF
--- a/MemoryCore/src/metadata/router/v3-meta-router.ts
+++ b/MemoryCore/src/metadata/router/v3-meta-router.ts
@@ -164,7 +164,7 @@ const routeTable: Record<string, Handler> = {
     return s.updateAgentForCaller(agent_id, patch, c);
   }),
   [`${V3_PREFIX}/agent/delete`]: bind(S.agentDeleteSchema, (d, c, s) => s.deleteAgentsForCaller(d.agent_ids, c)),
-  [`${V3_PREFIX}/agent/list`]: bind(S.agentListSchema, async (d, _c, s) => {
+  [`${V3_PREFIX}/agent/list`]: bind(S.agentListSchema, async (d, c, s) => {
     const pagination = resolvePagination(d);
     if (d.team_id) {
       // team_id 分支：owner_user_id 若同传则叠加过滤（"团队内我 owner 的 agent"），
@@ -173,7 +173,7 @@ const routeTable: Record<string, Handler> = {
       if (d.status) filter.status = d.status;
       if (d.owner_user_id) filter.owner_user_id = d.owner_user_id;
       if (d.name) filter.name = d.name;
-      return s.listAgentsByTeam(d.team_id, pagination, filter);
+      return s.listAgentsByTeamForCaller(d.team_id, c, pagination, filter);
     }
     const ownerId = d.owner_user_id ?? await resolveUserId(s, { user_key: d.owner_user_key });
     const filter2: AgentFilter = {};
@@ -191,7 +191,7 @@ const routeTable: Record<string, Handler> = {
     return s.updateTaskForCaller(task_id, patch, c);
   }),
   [`${V3_PREFIX}/task/delete`]: bind(S.taskDeleteSchema, (d, c, s) => s.deleteTasksForCaller(d.task_ids, c)),
-  [`${V3_PREFIX}/task/list`]: bind(S.taskListSchema, async (d, _c, s) => {
+  [`${V3_PREFIX}/task/list`]: bind(S.taskListSchema, async (d, c, s) => {
     const filter: TaskFilter = {};
     if (d.status) filter.status = d.status;
     if (d.title) filter.title = d.title;
@@ -201,7 +201,7 @@ const routeTable: Record<string, Handler> = {
       filter.creator_user_id = await resolveUserId(s, { user_key: d.creator_user_key });
     }
     const pagination = resolvePagination(d);
-    if (d.team_id) return s.listTasksByTeam(d.team_id, pagination, filter);
+    if (d.team_id) return s.listTasksByTeamForCaller(d.team_id, c, pagination, filter);
     return s.listTasks(filter, pagination);
   }),
   [`${V3_PREFIX}/task/archive`]: bind(S.taskArchiveSchema, (d, c, s) => s.archiveTaskForCaller(d.task_id, c)),
@@ -215,8 +215,8 @@ const routeTable: Record<string, Handler> = {
     await s.unlinkTaskAgentForCaller(d.task_id, d.agent_id, c);
     return OK;
   }),
-  [`${V3_PREFIX}/task-agent/list`]: bind(S.taskAgentListSchema, (d, _c, s) =>
-    s.listTaskAgents(d.task_id, resolvePagination(d)),
+  [`${V3_PREFIX}/task-agent/list`]: bind(S.taskAgentListSchema, (d, c, s) =>
+    s.listTaskAgentsForCaller(d.task_id, c, resolvePagination(d)),
   ),
 
   // ParticipationLog

--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -1624,6 +1624,29 @@ export class MetadataService {
     return this.archiveAgent(agentId);
   }
 
+  /**
+   * Caller-scoped team agent list. Plain listAgentsByTeam has no membership
+   * check, so any key holder can enumerate agents (including prompt) for an
+   * arbitrary team_id. Gate on active membership, same as listTeamMembersForCaller.
+   * visibility=private rows stay owner-only (aligned with getAgentForCaller).
+   */
+  async listAgentsByTeamForCaller(
+    teamId: string,
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+    filter?: AgentFilter,
+  ): Promise<PaginatedResult<AgentEntity>> {
+    await this.requireActiveTeamMember(ctx, teamId);
+    const page = await this.listAgentsByTeam(teamId, pagination, filter);
+    const callerId = this.requireCallerId(ctx);
+    const items = page.items.filter(
+      (agent) => agent.visibility !== "private" || agent.owner_user_id === callerId,
+    );
+    if (items.length === page.items.length) return page;
+    const hidden = page.items.length - items.length;
+    return { ...page, items, total: Math.max(0, page.total - hidden) };
+  }
+
   async createTaskForCaller(input: CreateTaskInput, ctx: V3AuthContext): Promise<TaskEntity> {
     await this.assertTeamExists(input.team_id);
     await this.requireActiveTeamMember(ctx, input.team_id);
@@ -1652,6 +1675,19 @@ export class MetadataService {
     return this.archiveTask(taskId);
   }
 
+  /**
+   * Caller-scoped team task list. Plain listTasksByTeam has no membership check.
+   */
+  async listTasksByTeamForCaller(
+    teamId: string,
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+    filter?: TaskFilter,
+  ): Promise<PaginatedResult<TaskEntity>> {
+    await this.requireActiveTeamMember(ctx, teamId);
+    return this.listTasksByTeam(teamId, pagination, filter);
+  }
+
   async linkTaskAgentForCaller(
     taskId: string,
     agentId: string,
@@ -1665,6 +1701,22 @@ export class MetadataService {
   async unlinkTaskAgentForCaller(taskId: string, agentId: string, ctx: V3AuthContext): Promise<void> {
     await this.assertCallerIsTaskCreator(ctx, taskId);
     return this.unlinkTaskAgent(taskId, agentId);
+  }
+
+  /**
+   * Caller-scoped task-agent link list. Plain listTaskAgents has no authz, so any
+   * key holder can enumerate agents linked to an arbitrary task_id. Require the
+   * task to exist and the caller to be an active member of that task's team.
+   */
+  async listTaskAgentsForCaller(
+    taskId: string,
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+  ): Promise<PaginatedResult<TaskAgentEntity>> {
+    const task = await this.getTaskById(taskId);
+    if (!task) throw new MetadataError("task_not_found", `task not found: ${taskId}`);
+    await this.requireActiveTeamMember(ctx, task.team_id);
+    return this.listTaskAgents(taskId, pagination);
   }
 
   async appendParticipationLogForCaller(


### PR DESCRIPTION
## Problem

Follow-up to #848 / #856 / #857 / #858 (same `_c` authz gap on team-scoped reads).

`handleV3MetaRoute` authenticates `x-tdai-user-key` into a `V3AuthContext`, and write / member-list handlers already route through caller-scoped wrappers. The read handlers for team-scoped lists instead discarded the context (`_c`) and called the raw store list methods:

```ts
// before
[`${V3_PREFIX}/agent/list`]: bind(..., async (d, _c, s) => {
  if (d.team_id) return s.listAgentsByTeam(d.team_id, ...);
  ...
}),
[`${V3_PREFIX}/task/list`]: bind(..., async (d, _c, s) => {
  if (d.team_id) return s.listTasksByTeam(d.team_id, ...);
  ...
}),
[`${V3_PREFIX}/task-agent/list`]: bind(..., (d, _c, s) =>
  s.listTaskAgents(d.task_id, ...)),
```

Consequence: any holder of a valid user key can `POST /v3/meta/agent/list` with an arbitrary `team_id` and receive that team's agents (including `prompt`), list arbitrary team tasks, or enumerate agents linked to any `task_id`. That bypasses the membership model already enforced on writes and on `team-member/list` / `participation-log/list`.

## Fix

Three caller-scoped list wrappers, mirroring `listTeamMembersForCaller` / `listParticipationLogsForCaller`:

- `listAgentsByTeamForCaller` / `listTasksByTeamForCaller` — require active membership of the requested team.
- `listTaskAgentsForCaller` — require the task to exist, then active membership of that task's team.
- `visibility: "private"` agents remain owner-only in the team agent list (aligned with the entity-get read model).

Handlers for the team-scoped branches now pass `c` instead of discarding it. Owner-scoped `agent/list` / creator-scoped `task/list` branches are unchanged in this PR.

## Verification

Local stub-store repro against the real service methods:

- Pre-fix: outsider `listAgentsByTeam` / `listTasksByTeam` / `listTaskAgents` returns victim inventory (agent prompts include `xyzzy`).
- Post-fix: outsider `*ForCaller` → `permission_denied` on all three.
- Teammate still lists team-visibility agents + tasks + links; private agent hidden from non-owner teammate; owner still sees private agent.

## Scope note

Same subject-spoof / body-`resolveUserId` family remains on `team/list` and the owner/creator branches of `agent/list` / `task/list`. Left out to keep this PR reviewable; happy to follow up.

Made with [Cursor](https://cursor.com)