### PR TITLE
fix(metadata): bind v3 subject-scoped list endpoints to caller

### DIFF
--- a/MemoryCore/src/metadata/router/v3-meta-router.ts
+++ b/MemoryCore/src/metadata/router/v3-meta-router.ts
@@ -134,11 +134,9 @@ const routeTable: Record<string, Handler> = {
     return s.updateTeamForCaller(team_id, patch, c);
   }),
   [`${V3_PREFIX}/team/delete`]: bind(S.teamDeleteSchema, (d, c, s) => s.deleteTeamsForCaller(d.team_ids, c)),
-  [`${V3_PREFIX}/team/list`]: bind(S.teamListSchema, async (d, _c, s) => {
-    const userId = await resolveUserId(s, d);
-    const filter = d.name ? { name: d.name } : undefined;
-    return s.listTeamsByUser(userId, resolvePagination(d), filter);
-  }),
+  [`${V3_PREFIX}/team/list`]: bind(S.teamListSchema, (d, c, s) =>
+    s.listTeamsByUserForCaller(d, c, resolvePagination(d)),
+  ),
 
   // TeamMember
   [`${V3_PREFIX}/team-member/add`]: bind(S.teamMemberAddSchema, async (d, c, s) => {
@@ -164,7 +162,7 @@ const routeTable: Record<string, Handler> = {
     return s.updateAgentForCaller(agent_id, patch, c);
   }),
   [`${V3_PREFIX}/agent/delete`]: bind(S.agentDeleteSchema, (d, c, s) => s.deleteAgentsForCaller(d.agent_ids, c)),
-  [`${V3_PREFIX}/agent/list`]: bind(S.agentListSchema, async (d, _c, s) => {
+  [`${V3_PREFIX}/agent/list`]: bind(S.agentListSchema, async (d, c, s) => {
     const pagination = resolvePagination(d);
     if (d.team_id) {
       // team_id 分支：owner_user_id 若同传则叠加过滤（"团队内我 owner 的 agent"），
@@ -175,11 +173,15 @@ const routeTable: Record<string, Handler> = {
       if (d.name) filter.name = d.name;
       return s.listAgentsByTeam(d.team_id, pagination, filter);
     }
-    const ownerId = d.owner_user_id ?? await resolveUserId(s, { user_key: d.owner_user_key });
     const filter2: AgentFilter = {};
     if (d.status) filter2.status = d.status;
     if (d.name) filter2.name = d.name;
-    return s.listAgentsByOwner(ownerId, pagination, Object.keys(filter2).length ? filter2 : undefined);
+    return s.listAgentsByOwnerForCaller(
+      { owner_user_id: d.owner_user_id, owner_user_key: d.owner_user_key },
+      c,
+      pagination,
+      Object.keys(filter2).length ? filter2 : undefined,
+    );
   }),
   [`${V3_PREFIX}/agent/archive`]: bind(S.agentArchiveSchema, (d, c, s) => s.archiveAgentForCaller(d.agent_id, c)),
 
@@ -191,7 +193,7 @@ const routeTable: Record<string, Handler> = {
     return s.updateTaskForCaller(task_id, patch, c);
   }),
   [`${V3_PREFIX}/task/delete`]: bind(S.taskDeleteSchema, (d, c, s) => s.deleteTasksForCaller(d.task_ids, c)),
-  [`${V3_PREFIX}/task/list`]: bind(S.taskListSchema, async (d, _c, s) => {
+  [`${V3_PREFIX}/task/list`]: bind(S.taskListSchema, async (d, c, s) => {
     const filter: TaskFilter = {};
     if (d.status) filter.status = d.status;
     if (d.title) filter.title = d.title;
@@ -202,7 +204,7 @@ const routeTable: Record<string, Handler> = {
     }
     const pagination = resolvePagination(d);
     if (d.team_id) return s.listTasksByTeam(d.team_id, pagination, filter);
-    return s.listTasks(filter, pagination);
+    return s.listTasksByCreatorForCaller(filter, c, pagination);
   }),
   [`${V3_PREFIX}/task/archive`]: bind(S.taskArchiveSchema, (d, c, s) => s.archiveTaskForCaller(d.task_id, c)),
 

--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -1752,4 +1752,60 @@ export class MetadataService {
     await this.assertCallerIsAssetOwnerOrTeamAdmin(ctx, assetId);
     return this.listAclByAsset(assetId, pagination);
   }
+
+  /**
+   * Caller-scoped team listing. Plain listTeamsByUser trusts body user_id /
+   * user_key, so any valid key holder can enumerate another user's teams.
+   * Scope matches user-key/list (admins may still query other users).
+   */
+  async listTeamsByUserForCaller(
+    params: { user_id?: string; user_key?: string; name?: string },
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+  ): Promise<PaginatedResult<TeamEntity>> {
+    const userId = await resolveUserId(this, params);
+    this.assertUserScope(userId, ctx.userId, ctx.isAdmin, ctx.isSystemAdmin);
+    const filter = params.name ? { name: params.name } : undefined;
+    return this.listTeamsByUser(userId, pagination, filter);
+  }
+
+  /**
+   * Caller-scoped owner agent listing. Plain listAgentsByOwner trusts body
+   * owner_user_id / owner_user_key, so an outsider can dump another user's
+   * agents including prompt. Scope matches user-key/list.
+   */
+  async listAgentsByOwnerForCaller(
+    params: { owner_user_id?: string; owner_user_key?: string },
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+    filter?: AgentFilter,
+  ): Promise<PaginatedResult<AgentEntity>> {
+    const ownerId =
+      params.owner_user_id ??
+      (await resolveUserId(this, { user_key: params.owner_user_key }));
+    this.assertUserScope(ownerId, ctx.userId, ctx.isAdmin, ctx.isSystemAdmin);
+    return this.listAgentsByOwner(ownerId, pagination, filter);
+  }
+
+  /**
+   * Caller-scoped creator task listing (non-team branch). Plain listTasks
+   * with a body creator_user_id / creator_user_key lets any key holder
+   * enumerate another user's tasks. Scope matches user-key/list.
+   */
+  async listTasksByCreatorForCaller(
+    filter: TaskFilter,
+    ctx: V3AuthContext,
+    pagination: PaginationParams = DEFAULT_PAGINATION,
+  ): Promise<PaginatedResult<TaskEntity>> {
+    if (!filter.creator_user_id) {
+      throw new MetadataError("invalid_request", "creator_user_id required");
+    }
+    this.assertUserScope(
+      filter.creator_user_id,
+      ctx.userId,
+      ctx.isAdmin,
+      ctx.isSystemAdmin,
+    );
+    return this.listTasks(filter, pagination);
+  }
 }


### PR DESCRIPTION
## Problem

Follow-up to #848 / #856 / #857 / #858 / #859 (same subject-spoof / body-`resolveUserId` family left in #859's scope note).

`handleV3MetaRoute` authenticates `x-tdai-user-key` into a `V3AuthContext`, and user-key handlers already call `assertUserScope`. These list handlers instead discarded the context and trusted the body subject:

```ts
// before
[`${V3_PREFIX}/team/list`]: bind(..., async (d, _c, s) => {
  const userId = await resolveUserId(s, d);
  return s.listTeamsByUser(userId, ...);
}),
[`${V3_PREFIX}/agent/list`]: bind(..., async (d, _c, s) => {
  // team_id branch omitted
  const ownerId = d.owner_user_id ?? await resolveUserId(s, { user_key: d.owner_user_key });
  return s.listAgentsByOwner(ownerId, ...);
}),
[`${V3_PREFIX}/task/list`]: bind(..., async (d, _c, s) => {
  // team_id branch omitted
  return s.listTasks(filter, ...); // filter.creator_user_id from body
}),
```

Consequence: any holder of a valid user key can:

- `POST /v3/meta/team/list` with another user's `user_id` / `user_key` and enumerate their teams
- `POST /v3/meta/agent/list` with another user's `owner_user_id` / `owner_user_key` and dump their agents **including `prompt`**
- `POST /v3/meta/task/list` with another user's `creator_user_id` / `creator_user_key` and list their tasks

## Fix

Three caller-scoped wrappers, mirroring `user-key/list` (`assertUserScope`):

- `listTeamsByUserForCaller`
- `listAgentsByOwnerForCaller`
- `listTasksByCreatorForCaller` (non-`team_id` branch only)

Body subject that disagrees with the authenticated caller → `permission_denied`. Admins / system admins retain cross-user listing. Team-scoped `agent/list` / `task/list` branches are unchanged here (covered by #859).

## Verification

Local stub-store repro against the real service methods:

- Pre-fix: outsider raw `listTeamsByUser` / `listAgentsByOwner` / `listTasks({creator})` returns victim inventory (agent prompt includes `xyzzy`).
- Post-fix: outsider `*ForCaller` → `permission_denied` on all three.
- Self-scoped lists still return the caller's own teams / agents / tasks.

## Scope note

Team-scoped list membership gates remain in #859. Entity gets / fixed-asset reads / asset subject spoof remain in #848 / #856 / #857 / #858.

Made with [Cursor](https://cursor.com)