### PR TITLE
fix(offload): resolve session manager in compact() without sessionKey

### DIFF
--- a/MemoryCore/src/offload/index.ts
+++ b/MemoryCore/src/offload/index.ts
@@ -2150,11 +2150,20 @@ class OffloadContextEngine {
     const logger = this._logger;
     logger.debug?.(`[context-offload] >>> CE.compact CALLED: sessionKey=${params.sessionKey ?? "?"}`);
     let stateManager: OffloadStateManager | undefined = params._offloadManager;
-    if (!stateManager && params.sessionKey) {
-      try {
-        const entry = await this._sessions.resolveIfAllowed(params.sessionKey, params.sessionId);
-        if (entry) stateManager = entry.manager;
-      } catch { /* ignore */ }
+    if (!stateManager) {
+      // OpenClaw's /compact calls compact() without sessionKey (only sessionId
+      // + sessionTarget) — fall back to those so manual compaction works
+      // (issue #862).
+      const sessionKey = params.sessionKey ?? params.sessionId ?? params.sessionTarget?.sessionKey;
+      if (sessionKey) {
+        try {
+          const entry = await this._sessions.resolveIfAllowed(sessionKey, params.sessionId);
+          if (entry) {
+            stateManager = entry.manager;
+            params._offloadManager = entry.manager; // cache for subsequent calls
+          }
+        } catch { /* ignore */ }
+      }
     }
     const pCfg = this._pCfg;
     logger.debug?.(`[context-offload] >>> compact START: params=${JSON.stringify(params ?? {}).slice(0, 500)}`);


### PR DESCRIPTION
Fixes #862.

## Problem

OpenClaw's `/compact` calls `OffloadContextEngine.compact()` **without a `sessionKey`** — only `sessionId` + `sessionTarget` are present (confirmed by debug logs). The guard `if (!stateManager && params.sessionKey)` skipped session resolution, so **manual compaction** (`/compact` command, `sessions.compact` RPC) always returned `{ ok: false, reason: "no_session_manager" }`.

Automatic compaction (via `assemble()`) is unaffected.

## Change

`compact()` now resolves the session manager using `params.sessionKey ?? params.sessionId ?? params.sessionTarget?.sessionKey`, mirroring the `assemble()` resolution path. On success it also caches `params._offloadManager` for subsequent calls.

## Verification

`npm run build:plugin` passes.