### PR TITLE
fix(seed): waitL1 returns once L1 is idle, not when conversation_count hits 0

### DIFF
--- a/MemoryCore/src/core/seed/seed-runtime.test.ts
+++ b/MemoryCore/src/core/seed/seed-runtime.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for #505 — waitForL1Idle must return promptly once L1 is idle and no
+ * messages are buffered, even when a residual conversation_count (rounds not
+ * yet reaching everyNConversations) is still non-zero. Previously it spun
+ * until maxWait, blocking the seed loop and stalling later rounds' L1
+ * extraction.
+ */
+
+import { describe, expect, it } from "vitest";
+import { waitForL1Idle } from "./seed-runtime.js";
+
+const logger = {
+  warn: () => {},
+  debug: () => {},
+  info: () => {},
+} as never;
+
+function makeScheduler(opts: {
+  l1Idle?: boolean;
+  buffered?: number;
+  conversationCount?: number;
+}) {
+  return {
+    getQueueSizes: () => ({
+      l1: 0, l2: 0, l3: 0,
+      l1Pending: false, l2Pending: false, l3Pending: false,
+      l1Idle: opts.l1Idle ?? true, l2Idle: true, l3Idle: true,
+    }),
+    getBufferedMessageCount: () => opts.buffered ?? 0,
+    getSessionState: () => ({ conversation_count: opts.conversationCount ?? 0 }),
+  } as never;
+}
+
+describe("waitForL1Idle (#505)", () => {
+  it("returns promptly when L1 is idle with a residual conversation_count", async () => {
+    const scheduler = makeScheduler({ l1Idle: true, buffered: 0, conversationCount: 5 });
+    const start = Date.now();
+    await waitForL1Idle(scheduler, ["sess-1"], logger, {
+      pollIntervalMs: 10, stableRounds: 2, maxWaitMs: 5000,
+    });
+    // Should satisfy the idle condition in a few polls — NOT spin to maxWait.
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it("waits while L1 is not idle, then returns once it becomes idle", async () => {
+    let busy = true;
+    const scheduler = {
+      getQueueSizes: () => ({
+        l1: 0, l2: 0, l3: 0,
+        l1Pending: false, l2Pending: false, l3Pending: false,
+        l1Idle: !busy, l2Idle: true, l3Idle: true,
+      }),
+      getBufferedMessageCount: () => 0,
+      getSessionState: () => ({ conversation_count: 1 }),
+    } as never;
+    setTimeout(() => { busy = false; }, 50);
+
+    const start = Date.now();
+    await waitForL1Idle(scheduler, ["sess-1"], logger, {
+      pollIntervalMs: 10, stableRounds: 2, maxWaitMs: 5000,
+    });
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40);
+  });
+});

--- a/MemoryCore/src/core/seed/seed-runtime.ts
+++ b/MemoryCore/src/core/seed/seed-runtime.ts
@@ -135,7 +135,7 @@ async function createSeedPipeline(opts: SeedRuntimeOptions): Promise<{ pipeline:
  * Poll pipeline queue status until L1 is idle for a given session.
  * Modeled after benchmark-ingest.ts waitForPipelineIdle() but focused on L1 only.
  */
-async function waitForL1Idle(
+export async function waitForL1Idle(
   scheduler: MemoryPipelineManager,
   sessionKeys: string[],
   logger: PipelineLogger,
@@ -174,8 +174,13 @@ async function waitForL1Idle(
 
     const isIdle =
       queues.l1Idle &&
-      totalBuffered === 0 &&
-      totalConversationCount === 0;
+      totalBuffered === 0;
+    // NOTE: totalConversationCount is intentionally NOT part of the idle
+    // condition. In seed mode, rounds that have not yet reached
+    // everyNConversations keep conversation_count > 0 while L1 is genuinely
+    // idle (they are picked up by the idle-timeout L1 run / the next batch).
+    // Requiring it to be 0 made waitL1 spin until maxWait, blocking the seed
+    // loop and stalling later rounds' L1 extraction (issue #505).
 
     if (isIdle) {
       consecutiveIdle++;


### PR DESCRIPTION
Fixes #505.

## Problem

`waitForL1Idle` required `totalConversationCount === 0` to consider the pipeline idle. In seed mode, rounds that have not yet reached `everyNConversations` keep `conversation_count > 0` while L1 is **genuinely idle** (they are picked up by the idle-timeout L1 run / the next batch). So the wait loop spun until `maxWait`:

- the seed loop was **blocked**, stalling later rounds' L1 extraction (only the first warmup round was extracted)
- the `/seed` request **hung until the client timed out** (300s)

## Change

`seed-runtime.ts` — the idle condition is now `l1Idle && totalBuffered === 0`. A residual `conversation_count` no longer blocks the loop, so all rounds feed L0/L1 normally and the request returns promptly once L1 is actually idle.

## Tests

`src/core/seed/seed-runtime.test.ts` (first tests for the module, 2):
- idle L1 + residual `conversation_count` → returns promptly (previously spun to maxWait)
- busy L1 → waits, then returns once idle

`npm test` passes, `npm run build:plugin` passes.