### PR TITLE
fix(pipeline): keep L1 drain chain alive and force L1 on session end

### DIFF
--- a/MemoryCore/src/services/pipeline-worker.ts
+++ b/MemoryCore/src/services/pipeline-worker.ts
@@ -366,13 +366,35 @@ export class PipelineWorker {
         delay = Math.min(delay * 3, 5000);
       }
       if (!acquired) {
-        this.logger?.warn?.(`${TAG} Lock conflict timeout [${task.type}] (task=${task.id}): ${lockKey}, dropping task`);
-        // CR-1 fix: ACK to prevent stale recovery from re-claiming this message in an
-        // infinite loop. Without it, XPENDING keeps returning this msgId every
-        // pendingRecoveryIntervalMs, exhausting worker slots.
+        // Issue #549: dropping an L1 drain task breaks the self-enqueue drain
+        // chain (the next batch only exists because the previous one enqueued
+        // it), silently stalling extraction. Re-enqueue with a bounded retry
+        // budget; dead-letter once exhausted. Non-drain tasks keep the old
+        // ACK-and-drop behavior (their timers re-trigger).
+        const prevRetry = ((task.data as Record<string, unknown>)?.retryCount ?? 0) as number;
+        const isL1Drain = task.type === "L1" && task.id.startsWith("L1-drain");
+        const retryCount = isL1Drain ? prevRetry + 1 : prevRetry;
         const msgId = (task as any)._msgId;
-        if (msgId) {
-          try { await this.backend.ackTask(msgId); } catch { /* best effort */ }
+
+        if (isL1Drain && retryCount <= this.config.maxRetries) {
+          if (msgId) { try { await this.backend.ackTask(msgId); } catch { /* best effort */ } }
+          await this.reEnqueue(task, retryCount);
+          this.metrics.tasksRetried++;
+          this.logger?.warn?.(
+            `${TAG} L1 drain lock conflict — re-enqueued (retry ${retryCount}/${this.config.maxRetries}): ${lockKey}`,
+          );
+        } else if (isL1Drain) {
+          if (msgId) { try { await this.backend.ackTask(msgId); } catch { /* best effort */ } }
+          await this.moveToDeadLetter(task, "L1 drain lock conflict after retry budget exhausted", retryCount);
+          this.logger?.warn?.(
+            `${TAG} L1 drain lock conflict — dead-lettered after ${retryCount} retries: ${lockKey}`,
+          );
+        } else {
+          // CR-1 fix: ACK to prevent stale recovery from re-claiming this
+          // message in an infinite loop.
+          if (msgId) {
+            try { await this.backend.ackTask(msgId); } catch { /* best effort */ }
+          }
         }
         releasePermitOnce();
         return;

--- a/MemoryCore/src/utils/stateful-pipeline-manager.ts
+++ b/MemoryCore/src/utils/stateful-pipeline-manager.ts
@@ -261,6 +261,22 @@ export class StatefulPipelineManager {
     // 取消 idle timer
     await this.stateBackend.removeTimer(effectiveInstanceId, buildPipelineTimerMember(sessionKey, "L1_idle", { teamId, agentId }));
 
+    // Issue #549: /session/end must actually fire L1 with whatever has
+    // accumulated (the documented "session ends → L1 fires" semantics), not
+    // just cancel the idle timer. Enqueue an L1 task to force extraction.
+    const now = Date.now();
+    await this.stateBackend.enqueueTask({
+      id: `L1-${sessionKey}-${now}`,
+      type: "L1",
+      instanceId: effectiveInstanceId,
+      sessionId: sessionKey,
+      teamId,
+      agentId,
+      priority: 0,
+      data: { instanceId: effectiveInstanceId, teamId, agentId, ...serializeTraceContext() },
+      createdAt: now,
+    });
+
     // 入队 flush task
     await this.stateBackend.enqueueTask({
       id: `flush-${sessionKey}-${Date.now()}`,


### PR DESCRIPTION
Fixes #549.

## Defect 1 — L1 drain task dropped on lock-conflict timeout

An `L1-drain` task whose lock-retry budget expired was **ACK-dropped**. Since the drain is a self-enqueue chain (each batch enqueues the next), one drop **silently ended the whole drain** — observed: zero L1 activity for 2+ hours while `last_l1_cursor` stayed frozen and `last_captured_timestamp` advanced (33h of L0 backlog stranded). L2 timers competing for the same session lock made lock conflicts the norm.

**Fix (`pipeline-worker.ts`)**: a lock-conflicted `L1-drain` task is **re-enqueued** with a bounded retry budget (`config.maxRetries`), then **dead-lettered with a warning** instead of silently dropped. Non-drain tasks keep the old ACK-and-drop behavior (their timers re-trigger).

## Defect 2 — `/session/end` flush never forces L1

`flushSession` cancelled the `L1_idle` timer and enqueued a flush task, but **no code path invoked L1 extraction** — "idle-time catch-up" became "idle-time cancellation". Combined with Defect 1, extraction was left with only "keep chatting until the next everyNConversations threshold".

**Fix (`stateful-pipeline-manager.ts`)**: `flushSession` now **enqueues an L1 task** when `conversation_count > 0`, restoring the documented "session ends → L1 fires with whatever accumulated" semantics.

## Verification

`npm run build:plugin` passes.