### PR TITLE
fix(memory-core): carry instance ID through local timer callbacks

### DIFF
--- a/MemoryCore/src/core/state/local-backend.ts
+++ b/MemoryCore/src/core/state/local-backend.ts
@@ -106,7 +106,10 @@ export class LocalStateBackend implements IStateBackend {
 
     const delay = Math.max(0, fireAtMs - Date.now());
     const handle = this.onTimerExpired
-      ? setTimeout(() => { this.timers.delete(key); this.onTimerExpired!({ member, fireAtMs }); }, delay)
+      ? setTimeout(() => {
+          this.timers.delete(key);
+          this.onTimerExpired!({ instanceId, member, fireAtMs });
+        }, delay)
       : undefined;
     if (handle) handle.unref();
     this.timers.set(key, { member, fireAtMs, handle });

--- a/MemoryCore/src/core/state/types.ts
+++ b/MemoryCore/src/core/state/types.ts
@@ -46,6 +46,8 @@ export const DEFAULT_PIPELINE_STATE: PipelineSessionState = {
 // ============================
 
 export interface TimerEntry {
+  /** Present for local in-process timers so callbacks preserve request-scoped instances. */
+  instanceId?: string;
   member: string;
   fireAtMs: number;
 }

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -1633,7 +1633,7 @@ export class TdaiGateway {
             taskType = parsed.taskType;
             teamId = parsed.teamId;
             agentId = parsed.agentId;
-            instanceId = this.config.instanceId ?? "default";
+            instanceId = entry.instanceId ?? this.config.instanceId ?? "default";
           }
           const now = Date.now();
           // Extract targetMmdFile from member for offload-l2 (needed by pipeline-worker lockKey)


### PR DESCRIPTION
## Summary

Preserve the request-scoped instance ID when local state timers trigger deferred MemoryCore pipeline tasks. This was found while running the gateway standalone with multiple instances.

## Root cause

The local timer callback dropped `instanceId`. The gateway therefore rebuilt the L2 scene-extraction task under the `default` instance, queried the wrong SQLite store, found 0 L1 records, and never created scenes for non-default instances.

## Reproduction

1. Run the gateway standalone.
2. Send requests with a non-default `x-tdai-service-id` and push conversations.
3. Wait for L2 extraction to complete.
4. Observe that L2 reports 0 L1 records and `scene_blocks` remains empty.

## Fix

- Add the originating `instanceId` to local timer entries.
- Include it in local timer callbacks.
- Prefer the timer entry instance when reconstructing deferred tasks.

## Verification

- Before: L2 found 0 L1 records and `scene_blocks` was empty.
- After: L2 queried the 2 L1 records and created `scene_blocks/Quartz-Harbor-Pipeline-Preferences.md`.
- `npm run build:plugin` passes.

## Related Issue | 关联 Issue

None.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

The full upstream build currently reaches an unrelated missing `scripts/seed-v2/tsconfig.json`; the MemoryCore plugin build covering this change passes.