### PR TITLE
fix(gateway): fail loudly when conversation delete removes nothing

### DIFF
--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -985,6 +985,22 @@ async function handleConversationDelete(body: unknown, auth: V2AuthContext, requ
     }
   }
 
+  // Issue #871: an explicit delete that removed nothing must not silently
+  // return code 0 — the caller cannot distinguish "nothing matched" from
+  // "delete not implemented / isolation mismatch". Fail loudly so a memory
+  // store that cannot be corrected is never silently trusted.
+  if (deletedCount === 0 && (message_ids?.length || session_id)) {
+    return errorEnvelope(
+      400,
+      `No messages deleted: L0 backend did not remove ` +
+      (message_ids?.length
+        ? `${message_ids.length} message(s)`
+        : `session "${session_id}"`) +
+      ` (verify isolation ids match the records, or that delete is supported)`,
+      requestId,
+    );
+  }
+
   // Report memory deletion (non-fatal)
   if (deps.quotaManager && deletedCount > 0) {
     deps.quotaManager.reportMemoryDeleted(auth.serviceId, deletedCount).catch(() => {});


### PR DESCRIPTION
Fixes #871.

## Problem

`POST /v2/conversation/delete` returned `code: 0` / `"ok"` with `deleted_count: 0` even when **nothing was removed** — L0 is an append-only log and the delete either didn't match (isolation mismatch) or isn't supported. A caller had no signal that the delete was a no-op, so **L0 became effectively write-only**: a mistake could not be un-written (only `--purge` destroyed everything).

## Change

An explicit delete (`message_ids` or `session_id`) that removes **nothing** now returns a **non-zero code (400)** with a message explaining that nothing was deleted — callers fail loudly instead of silently trusting the no-op. Idempotent deletes that match no records still surface the failure.

This is the issue's short-term failure-visibility fix; tombstones honoured by query/L1-L3 workers + compaction remain a longer-term follow-up.

## Verification

`npm run build:plugin` passes.