### PR TITLE
fix: resolve compact session manager without session key

### DIFF
--- a/MemoryCore/src/offload/index.ts
+++ b/MemoryCore/src/offload/index.ts
@@ -2150,9 +2150,10 @@ class OffloadContextEngine {
     const logger = this._logger;
     logger.debug?.(`[context-offload] >>> CE.compact CALLED: sessionKey=${params.sessionKey ?? "?"}`);
     let stateManager: OffloadStateManager | undefined = params._offloadManager;
-    if (!stateManager && params.sessionKey) {
+    const effectiveSessionKey = params.sessionKey ?? params.sessionTarget?.sessionKey ?? params.sessionId;
+    if (!stateManager && effectiveSessionKey) {
       try {
-        const entry = await this._sessions.resolveIfAllowed(params.sessionKey, params.sessionId);
+        const entry = await this._sessions.resolveIfAllowed(effectiveSessionKey, params.sessionId);
         if (entry) stateManager = entry.manager;
       } catch { /* ignore */ }
     }


### PR DESCRIPTION
Fixes #862

## Summary
- fall back from missing `params.sessionKey` to `sessionTarget.sessionKey` or `sessionId` when resolving the offload session manager in `compact()`
- preserve the existing runtime delegation and emergency compression behavior

## Verification
- `git apply --check --recount` passed
- `git diff --check` passed
- local verification not run; relying on upstream CI (worktree has no `node_modules`)
