### PR TITLE
fix(store-pool): pass sendDimensions when creating embedding service

### DIFF
--- a/MemoryCore/src/core/store/store-pool.ts
+++ b/MemoryCore/src/core/store/store-pool.ts
@@ -380,6 +380,7 @@ export class StorePool {
         apiKey: embCfg.apiKey,
         model: embCfg.model,
         dimensions: embCfg.dimensions,
+        sendDimensions: embCfg.sendDimensions,
         maxInputChars: embCfg.maxInputChars,
       }, this.logger as StoreLogger);
     }


### PR DESCRIPTION
## Problem

When using a self-hosted / OSS embedding model (e.g. BGE-M3) behind an OpenAI-compatible endpoint that **rejects the `dimensions` parameter** (HTTP 400 "The parameter is invalid"), the **L1 extraction write path** always fails to vectorize:

```
[l1-writer] [vec-dual-write] Embedding FAILED ... Embedding API error: HTTP 400 Bad Request — The parameter is invalid
```

while the **recall path works fine** (query embedding succeeds).

## Root cause

`StorePool.createSqliteStore` constructs the `OpenAIEmbeddingService` **without passing `sendDimensions`**:

https://github.com/TencentCloud/TencentDB-Agent-Memory/blob/main/MemoryCore/src/core/store/store-pool.ts#L377-L384

`OpenAIEmbeddingService` defaults `sendDimensions` to `true` (`config.sendDimensions ?? true`), so every embedding request from this path includes `dimensions: 1024`, which BGE-M3 and similar models reject.

The other creation site (`factory.ts` → `createStoreBundle`, used by the recall/pipeline path) **does** pass `config.embedding.sendDimensions`, which is why only the L1 writer path breaks.

## Fix

Pass `sendDimensions: embCfg.sendDimensions` through to `createEmbeddingService` in `createSqliteStore`, so both paths honor the configured value (users can already set `memory.embedding.sendDimensions: false` in `tdai-gateway.yaml`).

## Verification

Deployed with `memory.embedding.sendDimensions: false` and model `BAAI/bge-m3` (1024 dims):

- Before fix: `vec-dual-write Embedding FAILED ... HTTP 400` on every L1 write
- After fix: `vec-dual-write Embedding OK: dims=1024, norm=1.0000`, and hybrid recall returns `(keyword=2, embedding=1)`