### PR TITLE
refactor(offload): replace dist-patch dependency with getSessionMessages

### DIFF
--- a/MemoryCore/src/offload/hooks/after-tool-call.ts
+++ b/MemoryCore/src/offload/hooks/after-tool-call.ts
@@ -34,11 +34,8 @@ import type { PluginConfig, PluginLogger, ToolPair } from "../types.js";
 import type { BackendClient } from "../backend-client.js";
 import {
   buildL3TriggerReport,
-  classifyPatchEffectiveness,
   reportL3Trigger,
   recordToolCall,
-  REPORT_TYPE_L3,
-  L3_FIXED_PATCH_COST_TOKENS,
 } from "../state-reporter.js";
 
 function isHeartbeatToolCall(event: any, cachedParams: any): boolean {
@@ -97,6 +94,9 @@ export function createAfterToolCallHandler(
   getContextWindow: (() => number) | undefined,
   pluginConfig: Partial<PluginConfig> | undefined,
   backendClient?: BackendClient | null,
+  /** Official OpenClaw API to fetch session messages (issue #851) — used when
+   *  the hook event does not carry messages (no dist-file patch). */
+  getSessionMessages?: (opts: { sessionKey: string; limit?: number }) => Promise<unknown[]>,
 ) {
   return async (event: any, ctx: any) => {
     // Skip internal memory-pipeline sessions
@@ -114,37 +114,18 @@ export function createAfterToolCallHandler(
     const hasMsgs = msgsValue && Array.isArray(msgsValue);
     logger.debug?.(`[context-offload] after_tool_call event keys=[${eventKeys.join(",")}], hasMsgsKey=${hasMsgsKey}, msgsType=${typeof msgsValue}, isArray=${Array.isArray(msgsValue)}, len=${hasMsgs ? msgsValue.length : "N/A"}`);
 
-    // ── Patch-effectiveness detection ──
-    // The upstream runtime patch is expected to populate event.messages with
-    // the current conversation. If it is missing/empty the patch is NOT in
-    // effect and L3 compression cannot run from this hook. Report that
-    // explicitly so operators can detect misconfigurations.
-    const _patchStatus = classifyPatchEffectiveness(event, "after_tool_call");
-    if (_patchStatus.status !== "effective") {
-      logger.warn(
-        `[context-offload] after_tool_call patch check: NOT EFFECTIVE (status=${_patchStatus.status}). ` +
-        `event.messages is ${Array.isArray(msgsValue) ? "empty array" : typeof msgsValue}. ` +
-        `L3 compression will be skipped this turn.`,
-      );
-      if (backendClient) {
-        try {
-          backendClient
-            .storeState({
-              reportType: REPORT_TYPE_L3,
-              reportedAt: new Date().toISOString(),
-              sessionKey: _sk ?? null,
-              stage: "after_tool_call",
-              triggerReason: "patch_not_effective",
-              patch: _patchStatus,
-              pluginState: {
-                l15Settled: stateManager.l15Settled === true,
-                pendingCount: stateManager.getPendingCount(),
-                activeMmdFile: stateManager.getActiveMmdFile?.() ?? null,
-              },
-              fixedPatchCostTokens: L3_FIXED_PATCH_COST_TOKENS,
-            })
-            .catch((err) => logger.warn(`[context-offload] patch-miss report failed: ${err}`));
-        } catch { /* ignore */ }
+    // Issue #851: when the hook event has no messages (OpenClaw no longer
+    // injects them via a dist-file patch), fetch them through the official
+    // getSessionMessages API so L3 compression / MMD logic still has context.
+    if (!hasMsgs && _sk && getSessionMessages) {
+      try {
+        const fetched = await getSessionMessages({ sessionKey: _sk, limit: 50 });
+        if (Array.isArray(fetched) && fetched.length > 0) {
+          event.messages = fetched;
+          logger.debug?.(`[context-offload] after_tool_call: fetched ${fetched.length} messages via getSessionMessages`);
+        }
+      } catch (err) {
+        logger.debug?.(`[context-offload] after_tool_call: getSessionMessages failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 

--- a/MemoryCore/src/offload/index.ts
+++ b/MemoryCore/src/offload/index.ts
@@ -1039,7 +1039,12 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
         logger.debug?.(`[context-offload] <<< after_tool_call SKIP: no session manager (${Date.now() - _atcStart}ms)`);
         return;
       }
-      const afterToolCallHandler = createAfterToolCallHandler(_mgr, logger, getContextWindow, pCfg, backendClient as any);
+      const afterToolCallHandler = createAfterToolCallHandler(
+        _mgr, logger, getContextWindow, pCfg, backendClient as any,
+        // Official OpenClaw API replaces the dist-file patch for fetching
+        // session messages in after_tool_call (issue #851).
+        (api.runtime?.subagent?.getSessionMessages) as any,
+      );
       await afterToolCallHandler(event, ctx);
       const _handlerDone = Date.now();
       logger.debug?.(`[context-offload] after_tool_call handler done: ${_handlerDone - _atcStart}ms`);


### PR DESCRIPTION
Fixes #851.

## Problem

The plugin used to monkey-patch OpenClaw's compiled dist files to inject `event.messages` into `after_tool_call`. The patch script is already removed in v2, but the hook still:
- gated L3 compression on `classifyPatchEffectiveness()` (a check for the now-removed patch)
- relied on the injected `event.messages` — on current OpenClaw versions (`event.messages` absent) L3 compression / MMD never ran

## Change

- **`after_tool_call`** now fetches session messages via the official `api.runtime.subagent.getSessionMessages({ sessionKey, limit: 50 })` when the event carries none (issue's supported API)
- **Removed** the `classifyPatchEffectiveness()` patch check (the patch no longer exists; stale detection caused spurious "patch not effective" warnings)
- The handler takes an optional `getSessionMessages` callback, wired from the plugin `api` at registration

This replaces the fragile dist-patch approach with the supported API — stable across OpenClaw updates (introduced in v2026.3.2+).

## Verification

`npm run build:plugin` passes.