### PR TITLE
fix: quote admin key path next to full-width punctuation

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then


### PR DESCRIPTION
## Summary

- Quote `ADMIN_KEY_FILE` in the admin initialization log message.
- Prevent macOS Bash 3.2 from treating adjacent full-width punctuation as part of the variable name.

## Validation

- Passed `bash -n` for all deployment shell scripts.
- Reproduced and verified the fix with macOS Bash 3.2.