### PR TITLE
fix(hermes-plugin): always advertise tool schemas so they are routable before initialize()

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/hermes-plugin/memory/memory_tencentdb/README.md
@@ -287,11 +287,13 @@ aliases:
   preference list (in-tree first, then `$HOME`). If you want to pin a
   specific path, set `MEMORY_TENCENTDB_GATEWAY_CMD` explicitly — it always
   wins over discovery.
-- **Search tools silently missing from the LLM**: `get_tool_schemas()`
-  returns `[]` until either the Gateway is reachable or one of
-  `MEMORY_TENCENTDB_GATEWAY_CMD` / `MEMORY_TENCENTDB_GATEWAY_PORT` is set
-  in the environment. Set the env var so the tools are advertised
-  optimistically at registration time.
+- **Search tools silently missing / "Unknown tool: memory_tencentdb_*"**:
+  `MemoryManager.add_provider()` indexes `get_tool_schemas()` **before**
+  `initialize()`. Older builds returned `[]` until Gateway env was set, so
+  `_tool_to_provider` stayed empty forever and every call hit
+  `Unknown tool`. Current plugin always advertises both schemas; Hermes also
+  re-indexes after `initialize_all()`. If you still see 0 tools registered,
+  restart the gateway / agent process so the fixed plugin is loaded.
 - **"circuit breaker tripped"** warnings: five consecutive Gateway errors
   were observed. Calls are paused for 60 s; check Gateway health and logs.
 - **Capture backlog warnings**: Gateway is slow or hung — `sync_turn` is

--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -992,17 +992,17 @@ class MemoryTencentdbProvider(MemoryProvider):
     # -- Tools ----------------------------------------------------------------
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        # Optimistically return tool schemas if Gateway is configured or running.
-        # This is critical because MemoryManager.add_provider() calls
-        # get_tool_schemas() BEFORE initialize() to build the _tool_to_provider
-        # routing table. If we return [] here, tools won't be routable
-        # even after initialize() succeeds (despite _refresh_tool_registration).
-        if self._gateway_available or self._initialized:
-            return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
-        # Pre-init: check if Gateway is likely to be available
-        if os.environ.get("MEMORY_TENCENTDB_GATEWAY_CMD") or os.environ.get("MEMORY_TENCENTDB_GATEWAY_PORT"):
-            return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
-        return []
+        # ALWAYS advertise both search tools.
+        #
+        # MemoryManager.add_provider() indexes get_tool_schemas() into
+        # _tool_to_provider BEFORE initialize(). Returning [] here left the
+        # routing table empty forever (initialize_all never re-indexes), so
+        # the model saw tools via inject/system prompt but every call hit
+        # registry.dispatch -> "Unknown tool: memory_tencentdb_*".
+        #
+        # Schemas are static; Gateway health is enforced in handle_tool_call /
+        # _ensure_alive_for_request, not by hiding the tools.
+        return [MEMORY_SEARCH_SCHEMA, CONVERSATION_SEARCH_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         # Lazy probe — gives tool-call path the same self-heal opportunity

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_tool_schema_routing.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_tool_schema_routing.py
@@ -1,0 +1,133 @@
+"""Tests for memory-tencentdb tool-schema routing.
+
+Regression test for the "search tools silently unroutable" failure class:
+
+``MemoryManager.add_provider()`` indexes ``get_tool_schemas()`` into the
+tool routing table BEFORE ``initialize()`` runs. Older builds returned
+``[]`` from ``get_tool_schemas()`` until the Gateway was reachable or
+Gateway env vars were set, so the routing table stayed empty forever and
+every tool call failed with "Unknown tool" — even though initialize()
+later succeeded.
+
+The provider must therefore always advertise both static schemas; Gateway
+health is enforced at call time, not by hiding the tools.
+
+These tests construct the provider without initialize() and without any
+Gateway env, so they neither spawn Node processes nor open sockets.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Inject plugin + hermes-agent roots into sys.path so the provider module
+# can be imported regardless of whether tests are invoked from the plugin
+# tree (hermes-plugin/memory/memory_tencentdb/tests/) or from a hermes-agent
+# checkout. Mirrors the layout used by ``test_memory_tencentdb_recovery.py``
+# next door.
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_HERE = _THIS_FILE.parent
+for candidate in (
+    _HERE.parents[3] if len(_HERE.parents) >= 4 else None,    # plugin repo: hermes-plugin/
+    _HERE.parents[4] if len(_HERE.parents) >= 5 else None,    # hermes-agent root
+    _HERE.parents[2] if len(_HERE.parents) >= 3 else None,    # fallback
+):
+    if candidate is not None and (candidate / "plugins").is_dir():
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+# Optional: hermes-agent provides ``agent.memory_provider``. Tests can set
+# HERMES_AGENT_ROOT to point at a sibling checkout if needed.
+_hermes_root = os.environ.get("HERMES_AGENT_ROOT")
+if not _hermes_root:
+    sibling = _HERE.parents[4] / "hermes-agent" if len(_HERE.parents) >= 5 else None
+    if sibling is not None and (sibling / "agent").is_dir():
+        _hermes_root = str(sibling)
+if _hermes_root and _hermes_root not in sys.path:
+    sys.path.insert(0, _hermes_root)
+
+try:
+    from plugins.memory.memory_tencentdb import (
+        CONVERSATION_SEARCH_SCHEMA,
+        MEMORY_SEARCH_SCHEMA,
+        MemoryTencentdbProvider,
+    )
+except ImportError as e:  # pragma: no cover — env-dependent
+    pytest.skip(
+        f"memory_tencentdb provider not importable ({e}); set HERMES_AGENT_ROOT "
+        "to a hermes-agent checkout if running from the plugin repo.",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture()
+def no_gateway_env(monkeypatch):
+    """Ensure no Gateway reachability hints leak in from the environment."""
+    monkeypatch.delenv("MEMORY_TENCENTDB_GATEWAY_CMD", raising=False)
+    monkeypatch.delenv("MEMORY_TENCENTDB_GATEWAY_PORT", raising=False)
+    yield
+
+
+class TestToolSchemaRouting:
+    def test_schemas_advertised_before_initialize(self, no_gateway_env):
+        """Fresh (uninitialized) provider must advertise both tools.
+
+        MemoryManager indexes get_tool_schemas() before initialize(); an
+        empty result here leaves the tools unroutable forever.
+        """
+        provider = MemoryTencentdbProvider()
+        assert provider._initialized is False
+        assert provider._gateway_available is False
+
+        schemas = provider.get_tool_schemas()
+        names = [s.get("name") for s in schemas]
+        assert names == [
+            "memory_tencentdb_memory_search",
+            "memory_tencentdb_conversation_search",
+        ]
+
+    def test_schemas_are_the_static_canonical_objects(self, no_gateway_env):
+        provider = MemoryTencentdbProvider()
+        assert provider.get_tool_schemas() == [
+            MEMORY_SEARCH_SCHEMA,
+            CONVERSATION_SEARCH_SCHEMA,
+        ]
+
+    def test_advertised_names_are_dispatchable(self, no_gateway_env):
+        """Every advertised name must be accepted by handle_tool_call's
+        dispatch (i.e. not fall through to 'Unknown tool'). We only check
+        the routing decision, not execution: the client is replaced with a
+        stub so no Gateway call happens."""
+        provider = MemoryTencentdbProvider()
+        provider._gateway_available = True
+        provider._initialized = True
+        # Skip the lazy Gateway probe — no real Gateway is running.
+        provider._ensure_alive_for_request = lambda: None
+
+        class _StubClient:
+            def search_memories(self, **kwargs):
+                return {"memories": []}
+
+            def search_conversations(self, **kwargs):
+                return {"conversations": []}
+
+        provider._client = _StubClient()
+
+        for name in ("memory_tencentdb_memory_search",
+                     "memory_tencentdb_conversation_search"):
+            result = provider.handle_tool_call(name, {"query": "q"})
+            assert "Unknown tool" not in result
+
+    def test_unknown_tool_still_rejected(self, no_gateway_env):
+        provider = MemoryTencentdbProvider()
+        provider._gateway_available = True
+        provider._initialized = True
+        provider._ensure_alive_for_request = lambda: None
+        provider._client = MagicMock()
+        result = provider.handle_tool_call("totally_unknown_tool", {"query": "q"})
+        assert "Unknown tool" in result

--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -24,7 +24,8 @@ import { StoragePaths } from "../storage/types.js";
 import type { Logger } from "../types.js";
 
 const TAG = "[memory-tdai] [recall]";
-const RECALL_TRUNCATION_SUFFIX = "…（已截断；可用 tdai_memory_search 或 tdai_conversation_search 查看详情）";
+const RECALL_TRUNCATION_SUFFIX =
+  "…（已截断；可用 memory_tencentdb_memory_search 或 memory_tencentdb_conversation_search 查看详情）";
 const MIN_TRUNCATED_RECALL_LINE_CHARS = 40;
 const RECALL_LINE_SEPARATOR = "\n";
 
@@ -37,12 +38,12 @@ const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
 
 当上方注入的记忆片段不足以回答用户问题时，可主动调用以下工具获取更多信息：
 
-- **tdai_memory_search**：搜索结构化记忆（L1），适用于回忆用户偏好、历史事件节点、规则等关键信息。
-- **tdai_conversation_search**：搜索原始对话（L0），适用于查找具体消息原文、时间线、上下文细节；也可用于补充或校验 memory_search 的结果。
+- **memory_tencentdb_memory_search**：搜索结构化记忆（L1），适用于回忆用户偏好、历史事件节点、规则等关键信息。
+- **memory_tencentdb_conversation_search**：搜索原始对话（L0），适用于查找具体消息原文、时间线、上下文细节；也可用于补充或校验 memory_search 的结果。
 - **read_file**（Scene Navigation 中的路径）：当已定位到相关情境，且需要该场景的完整画像、事件经过或阶段结论时使用。
 
 ### ⚠️ 调用次数限制
-每轮对话中，tdai_memory_search 和 tdai_conversation_search **合计最多调用 3 次**。
+每轮对话中，memory_tencentdb_memory_search 和 memory_tencentdb_conversation_search **合计最多调用 3 次**。
 - 首次搜索无结果时，可换关键词或换工具重试，但总调用次数不要超过 3 次。
 - 若 3 次搜索后仍无结果，说明该信息不在记忆中，请直接根据已有信息回复用户，不要继续搜索。
 </memory-tools-guide>`


### PR DESCRIPTION
## What it does

`MemoryManager.add_provider()` indexes `get_tool_schemas()` into the tool-routing table BEFORE `initialize()`. The old gateway-availability gate returned `[]` when the Gateway was not yet reachable and no Gateway env var was set, so the routing table stayed empty forever and every tool call failed with `Unknown tool: memory_tencentdb_*` — even after `initialize()` succeeded.

Changes:
- `get_tool_schemas()` always returns both static schemas; Gateway health is enforced at call time (`handle_tool_call` / `_ensure_alive_for_request`).
- `src/core/hooks/auto-recall.ts`: MEMORY_TOOLS_GUIDE + truncation suffix now reference the tool names the plugin actually registers (removes legacy `tdai_*` names from advertised guidance).
- README troubleshooting entry updated.
- New test `tests/test_tool_schema_routing.py` (4 tests).

## Tests

```
PYTHONPATH=<hermes-agent checkout> python3 -m pytest tests/test_tool_schema_routing.py
# 4 passed
```

(schemas advertised while uninitialized and without Gateway env; advertised names dispatchable via stub client; unknown names rejected)
