### PR TITLE
feat(gateway): llm.disableThinking — inject thinking={type:disabled} into chat-completions bodies

### DIFF
--- a/src/adapters/standalone/llm-runner.ts
+++ b/src/adapters/standalone/llm-runner.ts
@@ -50,6 +50,45 @@ export interface StandaloneLLMConfig {
   maxTokens?: number;
   /** Request timeout in milliseconds (default: 120_000). */
   timeoutMs?: number;
+  /**
+   * When true, every chat-completions request body is injected with
+   * `thinking: { type: "disabled" }` via a custom fetch wrapper.
+   *
+   * Required for some reasoning models served via OpenAI-compatible
+   * endpoints: without it, reasoning tokens consume the whole max_tokens
+   * budget and structured (JSON) extraction output gets truncated to nothing.
+   *
+   * AI SDK v6 `providerOptions` is NOT forwarded to the OpenAI-compatible
+   * request body by @ai-sdk/openai, hence the fetch-level injection.
+   */
+  disableThinking?: boolean;
+}
+
+// ============================
+// Thinking-suppression fetch wrapper
+// ============================
+
+/**
+ * Wrap global fetch so every chat-completions request body carries
+ * `thinking: { type: "disabled" }`. Some reasoning models otherwise spend
+ * the max_tokens budget on reasoning tokens and truncate structured
+ * extraction output. Non-JSON / non-chat bodies pass through untouched.
+ */
+export function createThinkingDisabledFetch(): typeof fetch {
+  return async (input, init) => {
+    if (init?.body && typeof init.body === "string") {
+      try {
+        const parsed = JSON.parse(init.body);
+        if (parsed && typeof parsed === "object" && Array.isArray((parsed as Record<string, unknown>).messages)) {
+          (parsed as Record<string, unknown>).thinking = { type: "disabled" };
+          init = { ...init, body: JSON.stringify(parsed) };
+        }
+      } catch {
+        // Non-JSON body — pass through unchanged.
+      }
+    }
+    return fetch(input, init);
+  };
 }
 
 // ============================
@@ -230,6 +269,9 @@ export class StandaloneLLMRunner implements LLMRunner {
       baseURL: this.config.baseUrl,
       apiKey: this.config.apiKey,
       compatibility: "compatible",
+      // Reasoning models need thinking suppressed for structured extraction;
+      // AI SDK doesn't forward providerOptions to the body, so inject at fetch level.
+      ...(this.config.disableThinking ? { fetch: createThinkingDisabledFetch() } : {}),
     });
 
     // Select tools based on mode + storage

--- a/src/adapters/standalone/thinking-disabled-fetch.test.ts
+++ b/src/adapters/standalone/thinking-disabled-fetch.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createThinkingDisabledFetch } from "./llm-runner.js";
+
+/**
+ * createThinkingDisabledFetch() must inject `thinking: { type: "disabled" }`
+ * into every chat-completions request body and leave everything else
+ * untouched. Some reasoning models otherwise spend the whole max_tokens
+ * budget on reasoning tokens and truncate structured (JSON) extraction
+ * output to nothing.
+ */
+describe("createThinkingDisabledFetch", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  function captureFetch() {
+    const calls: Array<{ input: unknown; init?: RequestInit }> = [];
+    globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    return calls;
+  }
+
+  it("injects thinking={type:disabled} into chat-completions bodies", async () => {
+    const calls = captureFetch();
+    const wrapped = createThinkingDisabledFetch();
+
+    await wrapped("http://localhost:1/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "some-reasoning-model",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 8192,
+      }),
+    });
+
+    expect(calls).toHaveLength(1);
+    const sent = JSON.parse(String(calls[0].init?.body));
+    expect(sent.thinking).toEqual({ type: "disabled" });
+    // Original fields survive the injection.
+    expect(sent.messages).toHaveLength(1);
+    expect(sent.max_tokens).toBe(8192);
+  });
+
+  it("does not mutate init when the body is not a chat request", async () => {
+    const calls = captureFetch();
+    const wrapped = createThinkingDisabledFetch();
+
+    const body = JSON.stringify({ model: "m", prompt: "x" });
+    await wrapped("http://localhost:1/v1/completions", { method: "POST", body });
+
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].init?.body)).toBe(body);
+  });
+
+  it("passes non-JSON bodies through untouched", async () => {
+    const calls = captureFetch();
+    const wrapped = createThinkingDisabledFetch();
+
+    await wrapped("http://localhost:1/raw", { method: "POST", body: "not-json{{" });
+
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0].init?.body)).toBe("not-json{{");
+  });
+
+  it("passes requests without a body through untouched", async () => {
+    const calls = captureFetch();
+    const wrapped = createThinkingDisabledFetch();
+
+    await wrapped("http://localhost:1/health");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init?.body).toBeUndefined();
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -398,6 +398,11 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
     model: env("TDAI_LLM_MODEL") ?? str(llmConfig, "model") ?? "gpt-4o",
     maxTokens: envInt("TDAI_LLM_MAX_TOKENS") ?? num(llmConfig, "maxTokens") ?? 4096,
     timeoutMs: envInt("TDAI_LLM_TIMEOUT_MS") ?? num(llmConfig, "timeoutMs") ?? 120_000,
+    // Reasoning models: inject thinking={type:disabled}
+    // into every chat-completions body. yaml: llm.disableThinking / env: TDAI_LLM_DISABLE_THINKING
+    disableThinking: env("TDAI_LLM_DISABLE_THINKING") !== undefined
+      ? env("TDAI_LLM_DISABLE_THINKING") === "true"
+      : (llmConfig["disableThinking"] === true),
   };
 
   // Memory config (reuse the plugin's parseConfig for full compatibility)

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1686,6 +1686,9 @@ export class TdaiGateway {
               messages: params.messages,
               temperature: params.temperature,
               max_tokens: params.max_tokens,
+              // Some reasoning models need thinking disabled or reasoning tokens
+              // eat the max_tokens budget (mirrors llm-runner).
+              ...(llmCfg.disableThinking ? { thinking: { type: "disabled" } } : {}),
             }),
             signal: controller.signal,
           });


### PR DESCRIPTION
## What it does

Some reasoning models served via OpenAI-compatible endpoints spend the entire `max_tokens` budget on reasoning tokens unless thinking is explicitly disabled; the gateway's structured (JSON) extraction then gets truncated to nothing. `@ai-sdk/openai` does not forward `providerOptions` into the OpenAI-compatible request body (AI SDK v6), so injection happens at fetch level.

- `src/adapters/standalone/llm-runner.ts`: opt-in `disableThinking` → fetch wrapper injects `thinking: {type:"disabled"}` into every JSON body carrying a `messages` array; non-chat/non-JSON bodies pass through.
- `src/gateway/config.ts`: yaml `llm.disableThinking` / env `TDAI_LLM_DISABLE_THINKING`.
- `src/gateway/server.ts`: same injection on the gateway offload LLM path.

## Tests

New `src/adapters/standalone/thinking-disabled-fetch.test.ts` (4 tests). `vitest run` → **3 files, 19 passed** (incl. repo's existing suites). esbuild transpile check clean.
