### PR TITLE
gateway: end-to-end top_k for /recall (RecallRequest → handleRecall → auto-recall, clamp 1..50)

### DIFF
--- a/src/core/hooks/auto-recall.ts
+++ b/src/core/hooks/auto-recall.ts
@@ -94,6 +94,8 @@ export async function performAutoRecall(params: {
   embeddingService?: EmbeddingService;
   /** StorageAdapter for file operations (COS/local). Falls back to fs when absent. */
   storage?: StorageAdapter;
+  /** Optional L1 result-count override (clamped 1..50); see gateway /recall top_k. */
+  topK?: number;
 }): Promise<RecallResult | undefined> {
   const { cfg, logger } = params;
   const timeoutMs = cfg.recall.timeoutMs ?? 5000;
@@ -147,8 +149,9 @@ async function performAutoRecallCore(params: {
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
   storage?: StorageAdapter;
+  topK?: number;
 }): Promise<RecallResult | undefined> {
-  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService, storage } = params;
+  const { userText, cfg, pluginDataDir, logger, vectorStore, embeddingService, storage, topK } = params;
   const tRecallStart = performance.now();
 
   // Search relevant memories (L1 layer) — skip only when userText is empty/undefined
@@ -161,7 +164,7 @@ async function performAutoRecallCore(params: {
     logger?.debug?.(`${TAG} User text empty/undefined, skipping memory search (persona/scene still injected)`);
   } else {
     effectiveStrategy = cfg.recall.strategy ?? "hybrid";
-    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService);
+    const searchResult = await searchMemories(userText, pluginDataDir, cfg, logger, effectiveStrategy as "keyword" | "embedding" | "hybrid", vectorStore, embeddingService, topK);
     memoryLines = searchResult.lines;
     searchTiming = searchResult.timing;
     memoryLines = applyRecallBudget(memoryLines, cfg.recall, logger);
@@ -314,6 +317,7 @@ async function performAutoRecallInner(params: {
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
   storage?: StorageAdapter;
+  topK?: number;
 }): Promise<RecallResult | undefined> {
   try {
     return await performAutoRecallCore(params);
@@ -418,6 +422,8 @@ async function searchMemories(
   strategy: "keyword" | "embedding" | "hybrid",
   vectorStore?: IMemoryStore,
   embeddingService?: EmbeddingService,
+  /** Optional result-count override from the gateway (/recall top_k); clamped 1..50. */
+  topKOverride?: number,
 ): Promise<SearchResult> {
   const emptyResult: SearchResult = { lines: [], timing: { ftsMs: 0, embeddingMs: 0, ftsHits: 0, embeddingHits: 0 } };
   // Strip gateway-injected inbound metadata (Sender, timestamps, media markers,
@@ -435,7 +441,12 @@ async function searchMemories(
     );
   }
 
-  const maxResults = cfg.recall.maxResults ?? 5;
+  // top_k override (gateway /recall) wins over the configured default;
+  // clamp to 1..50 so neither a tiny nor a hostile value reaches the store.
+  const maxResults = Math.min(
+    50,
+    Math.max(1, topKOverride ?? cfg.recall.maxResults ?? 5),
+  );
   const threshold = cfg.recall.scoreThreshold ?? 0.3;
 
   const embeddingAvailable = !!vectorStore && !!embeddingService;

--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -247,8 +247,11 @@ export class TdaiCore {
   /**
    * Handle recall (memory retrieval) before an LLM turn.
    * Maps to: OpenClaw `before_prompt_build` / Hermes `prefetch()`.
+   *
+   * @param topK Optional override for the L1 result count (clamped to
+   *   1..50); when omitted the configured `recall.maxResults` applies.
    */
-  async handleBeforeRecall(userText: string, sessionKey: string): Promise<RecallResult> {
+  async handleBeforeRecall(userText: string, sessionKey: string, topK?: number): Promise<RecallResult> {
     await this.storeReady?.catch(() => {});
 
     const tStart = performance.now();
@@ -262,6 +265,7 @@ export class TdaiCore {
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
       storage: this.storage,
+      topK,
     });
     const recallLatencyMs = performance.now() - tStart;
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -890,8 +890,16 @@ export class TdaiGateway {
       return;
     }
 
+    // Optional top_k override (additive; ignored by older cores). Clamp to
+    // 1..50 here so the core never sees hostile values; non-numeric input
+    // falls back to the configured default.
+    let topK: number | undefined;
+    if (typeof body.top_k === "number" && Number.isFinite(body.top_k)) {
+      topK = Math.min(50, Math.max(1, Math.trunc(body.top_k)));
+    }
+
     const startMs = Date.now();
-    const result = await this.core.handleBeforeRecall(body.query, body.session_key);
+    const result = await this.core.handleBeforeRecall(body.query, body.session_key, topK);
     const elapsed = Date.now() - startMs;
 
     // H-15: distinguish "no recall content to inject" from "recall failed".

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -39,6 +39,13 @@ export interface RecallRequest {
   query: string;
   session_key: string;
   user_id?: string;
+  /**
+   * Optional override for the number of L1 memories to recall.
+   * Clamped to 1..50 by the gateway; when omitted the configured
+   * `memory.recall.maxResults` (default 5) is used. Additive field —
+   * older gateways simply ignore it.
+   */
+  top_k?: number;
 }
 
 export interface RecallResponse {


### PR DESCRIPTION
## What it does

Adds an optional, additive `top_k` override to the gateway `/recall` API:
- `src/gateway/types.ts`: `RecallRequest.top_k?: number` (documented; older gateways ignore it).
- `src/gateway/server.ts`: numeric validation + clamp 1..50 at the edge; non-numeric falls back to config default.
- `src/core/tdai-core.ts` / `src/core/hooks/auto-recall.ts`: topK plumbed to `searchMemories`, clamped again defensively, overrides `recall.maxResults`.

## Tests

Repo vitest suite: **2 files, 15 passed**. Happy to add a dedicated `top_k` unit test if maintainers want one.
