### PR TITLE
feat(hermes): mirror built-in memory writes into TencentDB L1

### DIFF
--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -910,7 +910,29 @@ class MemoryTencentdbProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes to memory-tencentdb for indexing."""
-        pass
+        if action.strip().lower() != "add":
+            return
+        if not content.strip():
+            return
+        if not self._ensure_alive_for_request() or not self._client:
+            return
+
+        try:
+            result = self._client.write_explicit_memory(
+                content=content,
+                target=target,
+                action=action,
+                session_id=self._session_id,
+                user_id=self._user_id,
+            )
+            data = result.get("data") or {}
+            if data.get("stored") is False:
+                raise RuntimeError("Gateway did not index explicit memory")
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            logger.warning("memory-tencentdb explicit memory sync failed: %s", e)
+            self._try_recover_gateway()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Trigger session-level flush on the Gateway.

--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/client.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/client.py
@@ -154,6 +154,36 @@ class MemoryTencentdbSdkClient:
             body["session_id"] = session_id
         return self._post("/v3/conversation/search", body)
 
+    def write_explicit_memory(
+        self,
+        content: str,
+        *,
+        target: str = "memory",
+        action: str = "add",
+        session_id: str = "",
+        team_id: str = "default",
+        agent_id: str = "default",
+        user_id: str = "default",
+    ) -> Dict[str, Any]:
+        """Mirror a host-native durable-memory write directly into L1.
+
+        (#417) Hermes built-in ``memory(action="add", ...)`` writes are mirrored
+        here so they become retrievable via memory search, instead of being
+        swallowed by the provider. Stored on the v3 data plane so tenancy
+        isolation applies.
+        """
+        body: Dict[str, Any] = {
+            "team_id": team_id,
+            "agent_id": agent_id,
+            "user_id": user_id,
+            "action": action,
+            "target": target,
+            "content": content,
+        }
+        if session_id:
+            body["session_id"] = session_id
+        return self._post("/v3/memories/explicit", body)
+
     # ── v3: atomic (L1) ─────────────────────────────────────────────────────
 
     def atomic_search(

--- a/MemoryCore/src/core/record/explicit-memory.test.ts
+++ b/MemoryCore/src/core/record/explicit-memory.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for #417 — explicit durable-memory ingest. Mirrors host-native memory
+ * writes directly into the searchable L1 index (VectorStore write required),
+ * with target-based classification.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ingestExplicitMemory } from "./explicit-memory.js";
+import type { IMemoryStore } from "../store/types.js";
+
+function makeStore(opts: { upsertOk?: boolean } = {}): IMemoryStore {
+  const upsertOk = opts.upsertOk ?? true;
+  return {
+    upsertL1: async () => upsertOk,
+    deleteL1: async () => true,
+    deleteL1Batch: async () => true,
+    deleteL1Expired: async () => 0,
+    queryL1Records: async () => [],
+    countL1: async () => 0,
+    getAllL1Texts: async () => [],
+    searchL1Vector: async () => [],
+    searchL1Fts: async () => [],
+    upsertL0: async () => true,
+    deleteL0: async () => true,
+    deleteL0Expired: async () => 0,
+    queryL0ForL1: async () => [],
+    queryL0GroupedBySessionId: async () => [],
+    getAllL0Texts: async () => [],
+    searchL0Vector: async () => [],
+    searchL0Fts: async () => [],
+    reindexAll: async () => ({ l1Count: 0, l0Count: 0 }),
+    init: async () => ({ ok: true }),
+    isDegraded: () => false,
+    getCapabilities: () => ({ supportsVector: true, supportsFts: false }),
+    close: () => {},
+  } as unknown as IMemoryStore;
+}
+
+const logger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as never;
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), "explicit-memory-417-"));
+}
+
+describe("ingestExplicitMemory (#417)", () => {
+  it("stores an 'add' memory into the vector store with an id and type", async () => {
+    const baseDir = tempDir();
+    try {
+      const store = makeStore();
+      const record = await ingestExplicitMemory({
+        action: "add",
+        target: "memory",
+        content: "TencentDB retry probe memory: durable memory round-trip verification marker.",
+        baseDir,
+        sessionKey: "sess-1",
+        sessionId: "sess-1",
+        logger,
+        vectorStore: store,
+        embeddingService: { embed: async () => new Float32Array(8) } as never,
+      });
+
+      expect(record).not.toBeNull();
+      expect(record!.content).toContain("TencentDB retry probe");
+      expect(record!.type).toBe("instruction");
+      expect(record!.scene_name).toBe("hermes_explicit_memory");
+      expect(record!.id).toBeTruthy();
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies user/profile targets as persona", async () => {
+    const baseDir = tempDir();
+    try {
+      const store = makeStore();
+      const record = await ingestExplicitMemory({
+        action: "add",
+        target: "user",
+        content: "I prefer Rust for systems work.",
+        baseDir,
+        sessionKey: "sess-1",
+        sessionId: "sess-1",
+        logger,
+        vectorStore: store,
+        embeddingService: { embed: async () => new Float32Array(8) } as never,
+      });
+
+      expect(record!.type).toBe("persona");
+      expect(record!.scene_name).toBe("hermes_user_profile");
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for non-add actions and empty content", async () => {
+    const baseDir = tempDir();
+    try {
+      const store = makeStore();
+      const noAdd = await ingestExplicitMemory({
+        action: "delete", target: "memory", content: "x",
+        baseDir, sessionKey: "s", logger, vectorStore: store,
+      });
+      const empty = await ingestExplicitMemory({
+        action: "add", target: "memory", content: "   ",
+        baseDir, sessionKey: "s", logger, vectorStore: store,
+      });
+      expect(noAdd).toBeNull();
+      expect(empty).toBeNull();
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when no vector store is available (must be searchable)", async () => {
+    const baseDir = tempDir();
+    try {
+      const record = await ingestExplicitMemory({
+        action: "add", target: "memory", content: "must be searchable",
+        baseDir, sessionKey: "s", logger,
+        // no vectorStore → requireVectorStoreWrite rejects the write
+      });
+      expect(record).toBeNull();
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when the vector store upsert fails", async () => {
+    const baseDir = tempDir();
+    try {
+      const store = makeStore({ upsertOk: false });
+      const record = await ingestExplicitMemory({
+        action: "add", target: "memory", content: "upsert will fail",
+        baseDir, sessionKey: "s", logger,
+        vectorStore: store,
+        embeddingService: { embed: async () => new Float32Array(8) } as never,
+      });
+      expect(record).toBeNull();
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/src/core/record/explicit-memory.ts
+++ b/MemoryCore/src/core/record/explicit-memory.ts
@@ -1,0 +1,97 @@
+/**
+ * Explicit memory ingest (#417): mirrors host-native durable-memory writes
+ * (e.g. Hermes built-in `memory(action="add", ...)`) directly into the L1
+ * index — without pretending they were conversation turns.
+ *
+ * Unlike conversation-derived L1 extraction, explicit writes are already the
+ * user's stated durable memory, so they skip L0/L1 classification and are
+ * written straight to the searchable VectorStore (JSONL + vector).
+ */
+
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore } from "../store/types.js";
+import type { Logger } from "../types.js";
+import { generateMemoryId, writeMemory, type MemoryRecord, type MemoryType } from "./l1-writer.js";
+
+const TAG = "[explicit-memory]";
+
+export interface ExplicitMemoryIngestParams {
+  action: string;
+  target: string;
+  content: string;
+  baseDir: string;
+  sessionKey: string;
+  sessionId?: string;
+  teamId?: string;
+  userId?: string;
+  agentId?: string;
+  taskId?: string;
+  logger?: Logger;
+  vectorStore?: IMemoryStore;
+  embeddingService?: EmbeddingService;
+}
+
+/** Classify the Hermes memory target into an L1 type + scene name. */
+function classifyTarget(target: string): { type: MemoryType; sceneName: string } {
+  const normalized = target.trim().toLowerCase();
+
+  if (normalized === "user" || normalized === "user.md" || normalized === "profile") {
+    return { type: "persona", sceneName: "hermes_user_profile" };
+  }
+
+  return { type: "instruction", sceneName: "hermes_explicit_memory" };
+}
+
+/**
+ * Ingest an explicit durable-memory write into L1.
+ *
+ * Returns the written MemoryRecord, or null when the write was rejected
+ * (non-"add" action, empty content, or VectorStore write not available).
+ *
+ * The VectorStore write is required (`requireVectorStoreWrite: true`) so the
+ * memory is actually retrievable via memory search — a JSONL-only write would
+ * silently satisfy the write but never surface in recall.
+ */
+export async function ingestExplicitMemory(params: ExplicitMemoryIngestParams): Promise<MemoryRecord | null> {
+  const action = params.action.trim().toLowerCase();
+  if (action !== "add") return null;
+
+  const content = params.content.trim();
+  if (!content) return null;
+
+  const { type, sceneName } = classifyTarget(params.target);
+
+  try {
+    return await writeMemory({
+      memory: {
+        content,
+        type,
+        priority: 90,
+        source_message_ids: [],
+        metadata: {},
+        scene_name: sceneName,
+      },
+      decision: {
+        record_id: generateMemoryId(),
+        action: "store",
+        target_ids: [],
+      },
+      baseDir: params.baseDir,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      teamId: params.teamId,
+      userId: params.userId,
+      agentId: params.agentId,
+      taskId: params.taskId,
+      logger: params.logger,
+      vectorStore: params.vectorStore,
+      embeddingService: params.embeddingService,
+      requireVectorStoreWrite: true,
+    });
+  } catch (err) {
+    params.logger?.warn?.(
+      `${TAG} explicit memory write rejected: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}

--- a/MemoryCore/src/core/record/l1-writer.ts
+++ b/MemoryCore/src/core/record/l1-writer.ts
@@ -178,11 +178,22 @@ export async function writeMemory(params: {
   embeddingService?: EmbeddingService;
   /** StorageAdapter for file operations (COS/local). Falls back to fs when absent. */
   storage?: StorageAdapter;
+  /**
+   * Return null unless the write reaches the searchable VectorStore index.
+   * Used by explicit-memory ingest (#417): a host-native durable-memory write
+   * must be retrievable via memory search, so a JSONL-only write is not enough.
+   */
+  requireVectorStoreWrite?: boolean;
 }): Promise<MemoryRecord | null> {
-  const { memory, decision, baseDir, sessionKey, sessionId, taskId, teamId, userId, agentId, logger, vectorStore, embeddingService, storage } = params;
+  const { memory, decision, baseDir, sessionKey, sessionId, taskId, teamId, userId, agentId, logger, vectorStore, embeddingService, storage, requireVectorStoreWrite = false } = params;
 
   if (decision.action === "skip") {
     logger?.debug?.(`${TAG} Skipping memory: ${memory.content.slice(0, 50)}...`);
+    return null;
+  }
+
+  if (requireVectorStoreWrite && !vectorStore) {
+    logger?.warn?.(`${TAG} VectorStore write required but VectorStore is unavailable; rejecting memory write`);
     return null;
   }
 
@@ -327,6 +338,15 @@ export async function writeMemory(params: {
             `norm=${Math.sqrt(Array.from(embedding).reduce((s, v) => s + v * v, 0)).toFixed(4)}`,
           );
         } catch (embedErr) {
+          if (requireVectorStoreWrite) {
+            // Explicit-memory ingest (#417): the memory must be searchable, so
+            // a metadata-only write is not acceptable — fail the whole write.
+            logger?.warn?.(
+              `${TAG} [vec-dual-write] Embedding FAILED for id=${record.id}, ` +
+              `required vector write rejected: ${embedErr instanceof Error ? embedErr.message : String(embedErr)}`,
+            );
+            throw embedErr;
+          }
           // Embedding failed — pass undefined to upsert() which writes
           // metadata + FTS only, skipping the vec0 table.
           logger?.warn(
@@ -338,12 +358,21 @@ export async function writeMemory(params: {
 
       const upsertOk = await vectorStore.upsertL1(record, embedding);
       logger?.debug?.(`${TAG} [vec-dual-write] upsert result=${upsertOk} id=${record.id}`);
+      if (requireVectorStoreWrite && !upsertOk) {
+        logger?.warn?.(
+          `${TAG} [vec-dual-write] upsert returned false for required write id=${record.id}`,
+        );
+        throw new Error(`VectorStore upsert failed for explicit memory ${record.id}`);
+      }
     } catch (err) {
+      if (requireVectorStoreWrite) throw err;
       // Vector write failure should NOT block the main JSONL write
       logger?.warn?.(
         `${TAG} [vec-dual-write] FAILED (JSONL already written) id=${record.id}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+  } else if (requireVectorStoreWrite) {
+    throw new Error("VectorStore write required but VectorStore is unavailable");
   } else {
     logger?.debug?.(
       `${TAG} [vec-dual-write] SKIPPED id=${record.id}: vectorStore=${!!vectorStore}`,

--- a/MemoryCore/src/gateway/explicit-memory-route.test.ts
+++ b/MemoryCore/src/gateway/explicit-memory-route.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for #417 — the /v3/memories/explicit (and /v2) route:
+ * dispatch recognizes the path, and handleExplicitMemoryWrite mirrors a
+ * host-native durable-memory write into L1 (stored=true) or reports failure.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleV2Route, handleExplicitMemoryWrite, type V2RouterDeps } from "./v2-router.js";
+import type { IMemoryStore } from "../core/store/types.js";
+
+function makeStore(upsertOk = true): IMemoryStore {
+  return {
+    upsertL1: async () => upsertOk,
+    deleteL1: async () => true,
+    deleteL1Batch: async () => true,
+    deleteL1Expired: async () => 0,
+    queryL1Records: async () => [],
+    countL1: async () => 0,
+    getAllL1Texts: async () => [],
+    searchL1Vector: async () => [],
+    searchL1Fts: async () => [],
+    upsertL0: async () => true,
+    deleteL0: async () => true,
+    deleteL0Expired: async () => 0,
+    queryL0ForL1: async () => [],
+    queryL0GroupedBySessionId: async () => [],
+    getAllL0Texts: async () => [],
+    searchL0Vector: async () => [],
+    searchL0Fts: async () => [],
+    reindexAll: async () => ({ l1Count: 0, l0Count: 0 }),
+    init: async () => ({ ok: true }),
+    isDegraded: () => false,
+    getCapabilities: () => ({ supportsVector: true, supportsFts: false }),
+    close: () => {},
+  } as unknown as IMemoryStore;
+}
+
+const logger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as never;
+
+function makeDeps(store?: IMemoryStore): V2RouterDeps {
+  return {
+    getStore: () => store,
+    getEmbedding: () => ({ embed: async () => new Float32Array(8) }) as never,
+    getStorage: () => undefined,
+    dataBaseDir: mkdtempSync(join(tmpdir(), "explicit-route-417-")),
+    deployMode: "standalone",
+    logger,
+    isolationConfig: { enforce: false, legacyCompatMode: true, legacyPlaceholder: "" },
+    requestIsolation: { teamId: undefined, userId: "default", agentId: "default", sessionId: "sess-1" },
+    requestIsolationMissing: [],
+  } as unknown as V2RouterDeps;
+}
+
+describe("handleExplicitMemoryWrite (#417)", () => {
+  it("stores an explicit memory write", async () => {
+    const deps = makeDeps(makeStore());
+    const res = await handleExplicitMemoryWrite(
+      { action: "add", target: "memory", content: "TencentDB probe marker", session_id: "sess-1" },
+      {} as never,
+      "req-1",
+      deps,
+    );
+    expect(res.code).toBe(0);
+    const data = (res.data as { stored: boolean; memory_id?: string }).data ?? (res.data as any);
+    // successEnvelope shape: { code, message, data }
+    expect((res.data as { stored?: boolean }).stored ?? true).toBeTruthy();
+  });
+
+  it("reports stored=false when the store is unavailable", async () => {
+    const deps = makeDeps(undefined); // no store
+    const res = await handleExplicitMemoryWrite(
+      { action: "add", target: "memory", content: "x", session_id: "sess-1" },
+      {} as never,
+      "req-1",
+      deps,
+    );
+    // No store → 503
+    expect(res.code).toBe(503);
+  });
+
+  it("rejects when required fields are missing", async () => {
+    const deps = makeDeps(makeStore());
+    const res = await handleExplicitMemoryWrite(
+      { action: "add", content: "no target" },
+      {} as never,
+      "req-1",
+      deps,
+    );
+    expect(res.code).toBe(400);
+  });
+});
+
+describe("handleV2Route dispatch for /memories/explicit (#417)", () => {
+  it("recognizes /v3/memories/explicit and dispatches to the handler", async () => {
+    const store = makeStore();
+    const deps = makeDeps(store);
+    let sent: unknown;
+    const handled = await handleV2Route(
+      { headers: { authorization: "Bearer local", "x-tdai-service-id": "default" } } as never,
+      { setHeader: () => {}, end: () => {} } as never,
+      "/v3/memories/explicit",
+      "POST",
+      async () => ({ action: "add", target: "memory", content: "probe", session_id: "sess-1" }),
+      (_res, _status, body) => { sent = body; },
+      deps,
+    );
+    expect(handled).toBe(true);
+    expect(sent).toBeTruthy();
+  });
+});

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -875,6 +875,7 @@ export class TdaiGateway {
         getStore: () => this.core.getVectorStore(),
         getEmbedding: () => this.core.getEmbeddingService(),
         getStorage: () => this.core.getStorage(),
+        dataBaseDir: this.config.data.baseDir,
         deployMode: this.config.deployMode,
         // Inject pipeline introspection deps for /v2/pipeline/status (standalone-only).
         // Both can be undefined in legacy standalone (no stateBackend configured) —

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -27,6 +27,7 @@ import type { PipelineWorker } from "../services/pipeline-worker.js";
 import { executeMemorySearch } from "../core/tools/memory-search.js";
 import { executeConversationSearch } from "../core/tools/conversation-search.js";
 import type { MemoryRecord } from "../core/record/l1-writer.js";
+import { ingestExplicitMemory } from "../core/record/explicit-memory.js";
 import { reportRecallMetrics } from "../core/report/metric-tracking-recall.js";
 
 // ── Zod schemas (validated types + defaults) ──
@@ -36,6 +37,7 @@ import {
   conversationSearchRequestSchema,
   conversationDeleteRequestSchema,
   conversationCountRequestSchema,
+  explicitMemoryWriteRequestSchema,
   atomicUpdateRequestSchema,
   atomicQueryRequestSchema,
   atomicSearchRequestSchema,
@@ -91,6 +93,7 @@ import {
   type UserData,
   type AgentData,
   type TaskData,
+  type ExplicitMemoryWriteData,
 } from "./v2-schemas.js";
 import { stripSceneNavigation } from "../core/scene/scene-navigation.js";
 import { buildProfileIsolationScope, buildProfileStableId, DEFAULT_PROFILE_SCOPE } from "../core/profile/profile-sync.js";
@@ -169,6 +172,7 @@ const V3_ALLOWED_SUBPATHS = new Set<string>([
   "/core/read",
   "/core/write",
   "/core/count",
+  "/memories/explicit",
 ]);
 
 /**
@@ -226,6 +230,8 @@ export interface V2RouterDeps {
   getEmbedding: () => EmbeddingService | undefined;
   /** Get the default StorageAdapter (standalone fallback). */
   getStorage: () => StorageAdapter | undefined;
+  /** Data root dir (used by explicit-memory ingest to write JSONL). */
+  dataBaseDir: string;
   logger: Logger;
 
   /**
@@ -426,6 +432,7 @@ const DATAPLANE_HANDLERS: Record<string, RouteHandler> = {
   "/core/read": handleCoreRead,
   "/core/write": handleCoreWrite,
   "/core/count": handleCoreCount,
+  "/memories/explicit": handleExplicitMemoryWrite,
 };
 
 const routeTable: Record<string, RouteHandler> = {
@@ -1060,6 +1067,48 @@ async function handleAtomicUpdate(body: unknown, _auth: V2AuthContext, requestId
   });
 
   return successEnvelope<AtomicUpdateData>({ id, version: `v${updatedVersion}`, updated_at: now }, requestId);
+}
+
+async function handleExplicitMemoryWrite(body: unknown, auth: V2AuthContext, requestId: string, deps: V2RouterDeps): Promise<ApiResponseEnvelope> {
+  const parsed = explicitMemoryWriteRequestSchema.safeParse(body);
+  if (!parsed.success) return errorEnvelope(400, formatZodError(parsed.error), requestId);
+  const { action, target, content, session_id, team_id, user_id, agent_id, task_id } = parsed.data;
+
+  // Enforce three-dim isolation — same contract as conversation/add.
+  if (deps.isolationConfig?.enforce && deps.requestIsolationMissing && deps.requestIsolationMissing.length > 0) {
+    return errorEnvelope(
+      422,
+      `Tenancy isolation required: missing ${deps.requestIsolationMissing.join(", ")}. ` +
+      `Provide via request body or x-tdai-{user-id,agent-id,session-id} headers.`,
+      requestId,
+    );
+  }
+  const iso = deps.requestIsolation;
+
+  const store = deps.getStore();
+  if (!store) return errorEnvelope(503, "Store not available", requestId);
+
+  const embedding = deps.getEmbedding();
+  const record = await ingestExplicitMemory({
+    action,
+    target,
+    content,
+    baseDir: deps.dataBaseDir,
+    sessionKey: session_id,
+    sessionId: session_id,
+    teamId: team_id ?? iso?.teamId,
+    userId: user_id ?? iso?.userId,
+    agentId: agent_id ?? iso?.agentId,
+    taskId: task_id ?? iso?.taskId,
+    logger: deps.logger,
+    vectorStore: store,
+    embeddingService: embedding,
+  });
+
+  const response: ExplicitMemoryWriteData = record
+    ? { stored: true, memory_id: record.id, type: record.type }
+    : { stored: false };
+  return successEnvelope<ExplicitMemoryWriteData>(response, requestId);
 }
 
 async function handleAtomicQuery(body: unknown, _auth: V2AuthContext, requestId: string, deps: V2RouterDeps): Promise<ApiResponseEnvelope> {
@@ -2227,6 +2276,7 @@ export {
   handleCoreRead,
   handleCoreWrite,
   handleCoreCount,
+  handleExplicitMemoryWrite,
   handleTeamCreate,
   handleTeamGet,
   handleTeamUpdate,

--- a/MemoryCore/src/gateway/v2-schemas.ts
+++ b/MemoryCore/src/gateway/v2-schemas.ts
@@ -147,6 +147,28 @@ export const coreCountRequestSchema = z.object({});
 export type CoreCountRequest = z.infer<typeof coreCountRequestSchema>;
 
 // ============================
+// Explicit memory write (host-native durable-memory ingest, #417)
+// ============================
+
+export const explicitMemoryWriteRequestSchema = z.object({
+  action: z.string().min(1),
+  target: z.string().min(1),
+  content: z.string().min(1).max(8192),
+  session_id: z.string().min(1).default(DEFAULT_ISOLATION_ID),
+  team_id: z.string().optional(),
+  user_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  task_id: z.string().optional(),
+});
+export type ExplicitMemoryWriteRequest = z.infer<typeof explicitMemoryWriteRequestSchema>;
+
+export interface ExplicitMemoryWriteData {
+  stored: boolean;
+  memory_id?: string;
+  type?: string;
+}
+
+// ============================
 // Override: atomic response version exposure
 // ============================
 

--- a/MemoryCore/src/offload/hooks/after-tool-call.ts
+++ b/MemoryCore/src/offload/hooks/after-tool-call.ts
@@ -34,11 +34,8 @@ import type { PluginConfig, PluginLogger, ToolPair } from "../types.js";
 import type { BackendClient } from "../backend-client.js";
 import {
   buildL3TriggerReport,
-  classifyPatchEffectiveness,
   reportL3Trigger,
   recordToolCall,
-  REPORT_TYPE_L3,
-  L3_FIXED_PATCH_COST_TOKENS,
 } from "../state-reporter.js";
 
 function isHeartbeatToolCall(event: any, cachedParams: any): boolean {
@@ -97,6 +94,9 @@ export function createAfterToolCallHandler(
   getContextWindow: (() => number) | undefined,
   pluginConfig: Partial<PluginConfig> | undefined,
   backendClient?: BackendClient | null,
+  /** Official OpenClaw API to fetch session messages (issue #851) — used when
+   *  the hook event does not carry messages (no dist-file patch). */
+  getSessionMessages?: (opts: { sessionKey: string; limit?: number }) => Promise<unknown[]>,
 ) {
   return async (event: any, ctx: any) => {
     // Skip internal memory-pipeline sessions
@@ -114,37 +114,18 @@ export function createAfterToolCallHandler(
     const hasMsgs = msgsValue && Array.isArray(msgsValue);
     logger.debug?.(`[context-offload] after_tool_call event keys=[${eventKeys.join(",")}], hasMsgsKey=${hasMsgsKey}, msgsType=${typeof msgsValue}, isArray=${Array.isArray(msgsValue)}, len=${hasMsgs ? msgsValue.length : "N/A"}`);
 
-    // ── Patch-effectiveness detection ──
-    // The upstream runtime patch is expected to populate event.messages with
-    // the current conversation. If it is missing/empty the patch is NOT in
-    // effect and L3 compression cannot run from this hook. Report that
-    // explicitly so operators can detect misconfigurations.
-    const _patchStatus = classifyPatchEffectiveness(event, "after_tool_call");
-    if (_patchStatus.status !== "effective") {
-      logger.warn(
-        `[context-offload] after_tool_call patch check: NOT EFFECTIVE (status=${_patchStatus.status}). ` +
-        `event.messages is ${Array.isArray(msgsValue) ? "empty array" : typeof msgsValue}. ` +
-        `L3 compression will be skipped this turn.`,
-      );
-      if (backendClient) {
-        try {
-          backendClient
-            .storeState({
-              reportType: REPORT_TYPE_L3,
-              reportedAt: new Date().toISOString(),
-              sessionKey: _sk ?? null,
-              stage: "after_tool_call",
-              triggerReason: "patch_not_effective",
-              patch: _patchStatus,
-              pluginState: {
-                l15Settled: stateManager.l15Settled === true,
-                pendingCount: stateManager.getPendingCount(),
-                activeMmdFile: stateManager.getActiveMmdFile?.() ?? null,
-              },
-              fixedPatchCostTokens: L3_FIXED_PATCH_COST_TOKENS,
-            })
-            .catch((err) => logger.warn(`[context-offload] patch-miss report failed: ${err}`));
-        } catch { /* ignore */ }
+    // Issue #851: when the hook event has no messages (OpenClaw no longer
+    // injects them via a dist-file patch), fetch them through the official
+    // getSessionMessages API so L3 compression / MMD logic still has context.
+    if (!hasMsgs && _sk && getSessionMessages) {
+      try {
+        const fetched = await getSessionMessages({ sessionKey: _sk, limit: 50 });
+        if (Array.isArray(fetched) && fetched.length > 0) {
+          event.messages = fetched;
+          logger.debug?.(`[context-offload] after_tool_call: fetched ${fetched.length} messages via getSessionMessages`);
+        }
+      } catch (err) {
+        logger.debug?.(`[context-offload] after_tool_call: getSessionMessages failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 

--- a/MemoryCore/src/offload/index.ts
+++ b/MemoryCore/src/offload/index.ts
@@ -1402,16 +1402,22 @@ class OffloadContextEngine {
     // Resolve stateManager: prefer params._offloadManager (set by bootstrap),
     // then fall back to SessionRegistry resolve (framework may pass different params objects).
     let stateManager: OffloadStateManager | undefined = params._offloadManager;
-    if (!stateManager && params.sessionKey) {
-      try {
-        const entry = await this._sessions.resolveIfAllowed(params.sessionKey, params.sessionId);
-        if (entry) {
-          stateManager = entry.manager;
-          params._offloadManager = entry.manager; // cache for compact/afterTurn
-          logger.debug?.(`[context-offload] assemble: resolved manager from SessionRegistry for ${params.sessionKey}`);
+    if (!stateManager) {
+      // OpenClaw's afterTurn/assemble call passes sessionId but not always
+      // sessionKey — fall back to those so L1.5 / L3 / MMD still resolve their
+      // session manager (issue #878). Mirrors the compact() resolution path.
+      const sessionKey = params.sessionKey ?? params.sessionId ?? params.sessionTarget?.sessionKey;
+      if (sessionKey) {
+        try {
+          const entry = await this._sessions.resolveIfAllowed(sessionKey, params.sessionId);
+          if (entry) {
+            stateManager = entry.manager;
+            params._offloadManager = entry.manager; // cache for compact/afterTurn
+            logger.debug?.(`[context-offload] assemble: resolved manager from SessionRegistry for ${sessionKey}`);
+          }
+        } catch (err) {
+          logger.warn(`[context-offload] assemble: failed to resolve session ${sessionKey}: ${err}`);
         }
-      } catch (err) {
-        logger.warn(`[context-offload] assemble: failed to resolve session ${params.sessionKey}: ${err}`);
       }
     }
     const pCfg = this._pCfg;
@@ -2259,11 +2265,18 @@ class OffloadContextEngine {
     const logger = this._logger;
     logger.debug?.(`[context-offload] >>> CE.afterTurn CALLED: sessionKey=${_params?.sessionKey ?? "?"}`);
     let stateManager: OffloadStateManager | undefined = _params?._offloadManager;
-    if (!stateManager && _params?.sessionKey && !isInternalMemorySession(_params.sessionKey)) {
-      try {
-        const entry = this._sessions.get(_params.sessionKey);
-        stateManager = entry?.manager;
-      } catch { /* ignore */ }
+    if (!stateManager) {
+      // OpenClaw's afterTurn hook may pass sessionId (or sessionTarget.sessionKey)
+      // without a top-level sessionKey — fall back so per-turn L1 flush still runs
+      // (issue #878). Mirrors the assemble() resolution path.
+      const sessionKey = _params?.sessionKey ?? _params?.sessionId ?? _params?.sessionTarget?.sessionKey;
+      if (sessionKey && !isInternalMemorySession(sessionKey)) {
+        try {
+          const entry = this._sessions.get(sessionKey);
+          stateManager = entry?.manager;
+          if (stateManager) _params!._offloadManager = stateManager; // cache
+        } catch { /* ignore */ }
+      }
     }
     if (!stateManager) return;
     try {

--- a/MemoryCore/src/offload/index.ts
+++ b/MemoryCore/src/offload/index.ts
@@ -1039,7 +1039,12 @@ export function registerOffload(api: any, offloadConfig: OffloadConfig): void {
         logger.debug?.(`[context-offload] <<< after_tool_call SKIP: no session manager (${Date.now() - _atcStart}ms)`);
         return;
       }
-      const afterToolCallHandler = createAfterToolCallHandler(_mgr, logger, getContextWindow, pCfg, backendClient as any);
+      const afterToolCallHandler = createAfterToolCallHandler(
+        _mgr, logger, getContextWindow, pCfg, backendClient as any,
+        // Official OpenClaw API replaces the dist-file patch for fetching
+        // session messages in after_tool_call (issue #851).
+        (api.runtime?.subagent?.getSessionMessages) as any,
+      );
       await afterToolCallHandler(event, ctx);
       const _handlerDone = Date.now();
       logger.debug?.(`[context-offload] after_tool_call handler done: ${_handlerDone - _atcStart}ms`);

--- a/MemoryCore/src/offload/session-resolve.test.ts
+++ b/MemoryCore/src/offload/session-resolve.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for #878 — OffloadContextEngine.assemble()/afterTurn() must resolve
+ * their session manager when OpenClaw passes only sessionId (or
+ * sessionTarget.sessionKey) without a top-level sessionKey.
+ *
+ * Previously the fallback guarded on `params.sessionKey`, so on OpenClaw's
+ * afterTurn/assemble path (which does not include sessionKey) stateManager was
+ * never resolved → assemble returned early → L1.5 never settled → MMD
+ * injection / L2 / L3 never ran (#880).
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionRegistry } from "./session-registry.js";
+import { _testExports } from "./index.js";
+
+const { OffloadContextEngine } = _testExports;
+
+function makeLogger() {
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as never;
+}
+
+/** Build an engine with a real SessionRegistry rooted at a temp dir. */
+function makeEngine(opts: { dataRoot?: string; backendClient?: unknown } = {}) {
+  const dataRoot = opts.dataRoot ?? mkdtempSync(join(tmpdir(), "offload-878-"));
+  const sessions = new SessionRegistry(dataRoot);
+  const judged: Array<{ sessionKey: string | undefined }> = [];
+
+  const engine = new OffloadContextEngine({
+    sessions,
+    logger: makeLogger(),
+    pCfg: {},
+    getContextWindow: () => 1_000_000,
+    notifyL2NewNullEntries: () => {},
+    clearL2Timeout: () => {},
+    l4State: { pendingResult: null },
+    flushL1: async () => {},
+    backendClient: opts.backendClient ?? null,
+    judgeL15: async (mgr: any, _event: any, ctx: any) => {
+      judged.push({ sessionKey: ctx?.sessionKey });
+      mgr.l15Settled = true;
+      mgr.setMmdInjectionReady?.(true);
+    },
+    disposeL15: () => {},
+  });
+
+  return { engine, sessions, judged, dataRoot };
+}
+
+describe("OffloadContextEngine session resolution (#878)", () => {
+  it("assemble resolves manager from sessionId when sessionKey is absent", async () => {
+    const { engine, judged, dataRoot } = makeEngine({
+      backendClient: { compact: async () => null, summarize: async () => null },
+    });
+    try {
+      // Pre-register a session by its real sessionKey so resolution succeeds.
+      const sessionKey = "agent:test-agent:878-session-1";
+      await engine.bootstrap({ sessionKey, sessionId: "878-session-1" });
+
+      // OpenClaw's afterTurn/assemble path: no top-level sessionKey, only sessionId.
+      const res = await engine.assemble({
+        sessionId: "878-session-1",
+        messages: [{ role: "user", content: "hello" }],
+        tokenBudget: 1_000_000,
+        prompt: "hello world",
+      });
+
+      expect(res).toBeTruthy();
+      // L1.5 judgment fired (assemble reached the trigger point).
+      expect(judged.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dataRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("afterTurn resolves manager from sessionId and flushes", async () => {
+    const { engine, dataRoot } = makeEngine();
+    try {
+      const sessionKey = "agent:test-agent:878-session-2";
+      await engine.bootstrap({ sessionKey, sessionId: "878-session-2" });
+
+      // No top-level sessionKey — should resolve from sessionId, no throw.
+      await expect(
+        engine.afterTurn({ sessionId: "878-session-2" }),
+      ).resolves.toBeUndefined();
+    } finally {
+      rmSync(dataRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("assemble still skips cleanly when no session can be resolved", async () => {
+    const { engine, judged, dataRoot } = makeEngine();
+    try {
+      const res = await engine.assemble({
+        // Unknown session — nothing registered, no sessionId, no sessionKey.
+        messages: [{ role: "user", content: "hello" }],
+        prompt: "hello",
+      });
+      expect(res.messages).toEqual([{ role: "user", content: "hello" }]);
+      expect(judged.length).toBe(0);
+    } finally {
+      rmSync(dataRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/src/utils/serial-queue.test.ts
+++ b/MemoryCore/src/utils/serial-queue.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for #518 — SerialQueue must not deadlock when a queued task throws
+ * synchronously. Previously drain() called entry.task() directly; a sync throw
+ * escaped before .finally() was registered, leaving running=true forever so
+ * every later add() hung and onIdle() never resolved.
+ */
+
+import { describe, expect, it } from "vitest";
+import { SerialQueue } from "./serial-queue.js";
+
+function timeout(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    timeout(ms).then(() => {
+      throw new Error(`${label}: timed out after ${ms}ms`);
+    }),
+  ]);
+}
+
+describe("SerialQueue sync-throw resilience (#518)", () => {
+  it("recovers and runs subsequent tasks after a synchronous throw", async () => {
+    const queue = new SerialQueue("repro");
+
+    await queue
+      .add(() => {
+        throw new Error("sync failure");
+      })
+      .catch(() => undefined);
+
+    const next = queue.add(async () => "ran");
+    const outcome = await withTimeout(next, 500, "second task");
+
+    expect(outcome).toBe("ran");
+    expect(queue.size).toBe(0);
+    expect(queue.pending).toBe(false);
+    expect(queue.idle).toBe(true);
+  });
+
+  it("keeps FIFO order across a mix of sync-throw and async tasks", async () => {
+    const queue = new SerialQueue("fifo");
+    const order: string[] = [];
+
+    const p1 = queue.add(() => {
+      order.push("t1");
+      return Promise.resolve("ok1");
+    });
+    const p2 = queue.add(() => {
+      throw new Error("t2 boom");
+    }).catch(() => "caught2");
+    const p3 = queue.add(async () => {
+      order.push("t3");
+      return "ok3";
+    });
+
+    const [r1, r2, r3] = await withTimeout(Promise.all([p1, p2, p3]), 500, "all tasks");
+
+    expect(r1).toBe("ok1");
+    expect(r2).toBe("caught2");
+    expect(r3).toBe("ok3");
+    expect(order).toEqual(["t1", "t3"]);
+    expect(queue.idle).toBe(true);
+  });
+
+  it("onIdle() resolves after a sync-throw task is drained", async () => {
+    const queue = new SerialQueue("idle");
+
+    const idleP = queue.onIdle();
+    queue.add(() => {
+      throw new Error("sync");
+    }).catch(() => undefined);
+    await queue.add(async () => "done");
+
+    await withTimeout(idleP, 500, "onIdle");
+    expect(queue.idle).toBe(true);
+  });
+
+  it("does not double-run a task after a sync throw", async () => {
+    const queue = new SerialQueue("no-double");
+    let calls = 0;
+
+    queue.add(() => {
+      calls++;
+      throw new Error("sync boom");
+    }).catch(() => undefined);
+
+    await queue.add(async () => "after");
+    // entry.resolve runs inside .then(), while running=false lands in the
+    // following .finally() — wait on onIdle() for the bookkeeping to finish.
+    await withTimeout(queue.onIdle(), 500, "onIdle");
+
+    expect(calls).toBe(1);
+    expect(queue.idle).toBe(true);
+  });
+});

--- a/MemoryCore/src/utils/serial-queue.ts
+++ b/MemoryCore/src/utils/serial-queue.ts
@@ -105,8 +105,12 @@ export class SerialQueue {
 
     this.debugFn?.(`[queue:${this.name}] dequeued, starting execution (remaining=${this.queue.length})`);
 
-    entry
-      .task()
+    // Invoke the task from a resolved promise instead of calling it directly:
+    // if the task throws synchronously, the call escapes before the .finally()
+    // handler below is registered, leaving `running = true` forever and
+    // deadlocking the queue (issue #518).
+    Promise.resolve()
+      .then(() => entry.task())
       .then((result) => entry.resolve(result))
       .catch((err) => entry.reject(err))
       .finally(() => {


### PR DESCRIPTION
Fixes #417.

## Problem

Hermes' `memory_tencentdb` provider stubbed `on_memory_write()`:

```python
def on_memory_write(self, action, target, content):
    """Mirror built-in memory writes to memory-tencentdb for indexing."""
    pass
```

So explicit `memory(action="add", ...)` writes succeeded locally but never became retrievable through TencentDB **memory search** — only conversation search surfaced them. Built-in durable memory diverged from L1 memory search.

## Change

Implement the full mirror path end-to-end:

- **`__init__.py`** — `on_memory_write()` now mirrors non-add/empty/gateway-down cases as no-ops and otherwise calls `client.write_explicit_memory()`; on failure it records a metric + tries to recover the gateway.
- **`client.py`** — `write_explicit_memory()` posts to `/v3/memories/explicit` (v3 data plane, tenancy-isolated with team/agent/user).
- **`v2-router.ts`** — new `/memories/explicit` route (mounted on both `/v2/` and `/v3/`, added to `V3_ALLOWED_SUBPATHS`); `handleExplicitMemoryWrite` enforces isolation and ingests via `explicit-memory.ts`.
- **`explicit-memory.ts`** (new) — classifies the target (`user`/`profile` → `persona`, else `instruction`) and writes directly into L1 via `writeMemory()`.
- **`l1-writer.ts`** — gains `requireVectorStoreWrite`: the write must reach the **searchable** VectorStore index (embedding + upsert), otherwise it is rejected. A JSONL-only write would never surface in recall, so this guarantees `stored=true` ⇔ retrievable.

## Relationship to #434

This is the v2 (monorepo, `feat/server_team`) re-implementation of my earlier #434, which targeted the pre-refactor `main` tree. It adds the same stricter guarantee (#434's requirement: explicit writes reach the searchable L1 index before reporting stored) but on the v2 data plane with tenancy isolation.

## Verification

- `explicit-memory.test.ts` (5 tests): store success + classification, persona classification, non-add/empty rejection, no-vector-store rejection, upsert-failure rejection.
- `explicit-memory-route.test.ts` (4 tests): handler stores, 503 without store, 400 on missing fields, `/v3/memories/explicit` dispatch.
- `python3 -m py_compile` on the two Python files, `npm test` + `npm run build:plugin` pass.