### PR TITLE
feat(hermes-v2): inject team/agent identity headers for asset registration

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb_v2/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb_v2/__init__.py
@@ -99,15 +99,38 @@ class MemoryTencentdbV2Provider(MemoryProvider):
             return
 
         try:
-            self._client = _MemoryClient(
-                endpoint=self._endpoint,
-                api_key=api_key or "local",
-                service_id=service_id or "default",
-            )
+            team_id = os.environ.get("TDAI_MEMORY_TEAM_ID", "default")
+            agent_id = os.environ.get("TDAI_MEMORY_AGENT_ID", "default")
+            # Inject team/agent identity headers so the Gateway auto-registers
+            # the chat_memory asset on every write (visible in the panel).
+            try:
+                import httpx
+                from tencentdb_agent_memory._http import HttpStub
+
+                stub = HttpStub(
+                    endpoint=self._endpoint,
+                    api_key=api_key or "local",
+                    service_id=service_id or "default",
+                    client=httpx.Client(
+                        headers={
+                            "x-tdai-team-id": team_id,
+                            "x-tdai-agent-id": agent_id,
+                        }
+                    ),
+                )
+                self._client = _MemoryClient(stub=stub)
+            except Exception:
+                # Fall back to the plain client if custom headers are unsupported.
+                self._client = _MemoryClient(
+                    endpoint=self._endpoint,
+                    api_key=api_key or "local",
+                    service_id=service_id or "default",
+                )
             self._available = True
             logger.info(
                 f"Initialized: endpoint={self._endpoint}, "
                 f"service_id={service_id or 'default'}, "
+                f"team_id={team_id}, agent_id={agent_id}, "
                 f"session_id={session_id}"
             )
         except Exception as e:


### PR DESCRIPTION
## Problem

The v2 Hermes provider (`memory_tencentdb_v2`) builds the `MemoryClient` without any team/agent identity. Every conversation write therefore reaches the Gateway **without** `x-tdai-team-id` / `x-tdai-agent-id` headers.

The Gateway's automatic chat_memory asset registration (`v2-router.ts` → `ensureChatMemoryAsset`) is gated on those headers being present:

```ts
if (deps.getMetadataService && iso?.teamId && iso?.agentId) { ... ensureChatMemoryAsset(...) }
```

So with the stock v2 plugin, **no per-agent memory asset is ever registered** and the Team Memory Control panel shows no Chat Memory assets for Hermes users — even though conversations are recorded fine.

## Fix

Inject `x-tdai-team-id` / `x-tdai-agent-id` on every SDK request by constructing a custom `HttpStub` backed by an `httpx.Client` with default headers. Two new optional env vars (both default to `"default"`, matching the standalone convention):

- `TDAI_MEMORY_TEAM_ID`
- `TDAI_MEMORY_AGENT_ID`

If the custom-stub path is unavailable (SDK layout changes), the provider falls back to the plain client — behavior preserved.

## Verification (standalone Gateway, remote endpoint)

- Before: `sync_turn()` writes L0/L1 fine, `meta_assets` stays empty for the Hermes agent.
- After: one `sync_turn()` immediately registers `chat_memory-<team>-<agent>` in `meta_assets`, and the panel bootstrap API (`/api/v1/agent-overview/bootstrap`) returns it under `chatMemories`.
