### PR TITLE
feat(compatibility): update OpenClaw version compatibility settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tencentdb-agent-memory/memory-tencentdb",
   "version": "0.3.6",
-  "description": "Four-layer local memory system plugin for OpenClaw — auto-captures, structures, and profiles conversational knowledge using local LLM + SQLite vector search (L0→L1→L2→L3 pipeline)",
+  "description": "Four-layer local memory system plugin for OpenClaw \u2014 auto-captures, structures, and profiles conversational knowledge using local LLM + SQLite vector search (L0\u2192L1\u2192L2\u2192L3 pipeline)",
   "type": "module",
   "main": "./dist/index.mjs",
   "bin": {
@@ -107,12 +107,12 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.3.13",
-      "minGatewayVersion": ">=2026.3.13"
+      "pluginApi": ">=2026.3.13 <2027.0.0",
+      "minGatewayVersion": ">=2026.3.13 <2027.0.0"
     },
     "build": {
-      "openclawVersion": "2026.3.13",
-      "pluginSdkVersion": "2026.3.13"
+      "openclawVersion": ">=2026.3.13 <2027.0.0",
+      "pluginSdkVersion": ">=2026.3.13 <2027.0.0"
     },
     "bundle": {
       "stageRuntimeDependencies": true


### PR DESCRIPTION
## Overview

Update TencentDB Agent Memory plugin compatibility settings to explicitly support OpenClaw versions >=2026.3.13 <2027.0.0, ensuring compatibility with both current stable and beta versions.

### Changes
- Updated `openclaw.compat.pluginApi` and `openclaw.compat.minGatewayVersion` to include upper bound `<2027.0.0`
- Updated `openclaw.build.openclawVersion` and `openclaw.build.pluginSdkVersion` to include upper bound
- This maintains backward compatibility while allowing newer versions within the same major version range

### Versions
- OpenClaw Stable: v2026.7.1-2
- OpenClaw Beta: v2026.7.2-beta.7
- TencentDB: 0.3.6

### Verification
- Plugin should install and initialize correctly on both versions
- All core functionality should work as expected
- No breaking changes expected within the same major version range

### Related
- Issue #910: enhance(compatibility): update OpenClaw version compatibility settings and test against latest stable and beta versions