### PR TITLE
fix(memory-core): apply recall score threshold to vector search

### DIFF
--- a/MemoryCore/src/core/hooks/auto-recall.ts
+++ b/MemoryCore/src/core/hooks/auto-recall.ts
@@ -639,7 +639,7 @@ async function searchHybrid(
   userText: string,
   _pluginDataDir: string,
   maxResults: number,
-  _threshold: number,
+  threshold: number,
   vectorStore: IMemoryStore,
   embeddingService: EmbeddingService,
   logger?: Logger,
@@ -710,7 +710,17 @@ async function searchHybrid(
   ]);
 
   const keywordResults = keywordResult.records;
-  const embeddingResults = embeddingResult.results;
+  // Only vector scores are cosine similarities. Apply the configured floor
+  // before RRF while leaving BM25-derived keyword scores untouched.
+  const embeddingResults = threshold > 0
+    ? embeddingResult.results.filter((r) => r.score >= threshold)
+    : embeddingResult.results;
+  if (embeddingResults.length !== embeddingResult.results.length) {
+    logger?.debug?.(
+      `${TAG} [hybrid-embedding] Kept ${embeddingResults.length}/${embeddingResult.results.length} ` +
+      `candidates above threshold=${threshold}`,
+    );
+  }
   const timing: SearchTiming = {
     ftsMs: keywordResult.ms,
     embeddingMs: embeddingResult.ms,

--- a/MemoryCore/src/core/tdai-core.ts
+++ b/MemoryCore/src/core/tdai-core.ts
@@ -443,6 +443,7 @@ export class TdaiCore {
       scene: params.scene,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
+      scoreThreshold: this.cfg.recall.scoreThreshold,
       logger: this.logger,
     });
 
@@ -464,6 +465,7 @@ export class TdaiCore {
       sessionKey: params.sessionKey,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
+      scoreThreshold: this.cfg.recall.scoreThreshold,
       logger: this.logger,
     });
 
@@ -528,6 +530,11 @@ export class TdaiCore {
   /** Get the shared EmbeddingService (may be undefined if not configured). */
   getEmbeddingService(): EmbeddingService | undefined {
     return this.embeddingService;
+  }
+
+  /** Get the configured minimum cosine similarity for recall candidates. */
+  getRecallScoreThreshold(): number {
+    return this.cfg.recall.scoreThreshold;
   }
 
   /** Get the pipeline scheduler (may be undefined if extraction disabled). */

--- a/MemoryCore/src/core/tools/conversation-search.ts
+++ b/MemoryCore/src/core/tools/conversation-search.ts
@@ -90,6 +90,8 @@ export async function executeConversationSearch(params: {
   filter?: IsolationFilter;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  /** Minimum cosine similarity for vector candidates. A value of 0 disables filtering. */
+  scoreThreshold?: number;
   logger?: Logger;
 }): Promise<ConversationSearchResult> {
   const {
@@ -99,6 +101,7 @@ export async function executeConversationSearch(params: {
     filter: isolationFilter,
     vectorStore,
     embeddingService,
+    scoreThreshold = 0,
     logger,
   } = params;
 
@@ -213,10 +216,18 @@ export async function executeConversationSearch(params: {
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const vecResults: L0SearchResult[] = isolationFilter
+        const vecRaw: L0SearchResult[] = isolationFilter
           ? await vectorStore.searchL0Vector(queryEmbedding, candidateK, query, isolationFilter)
           : await vectorStore.searchL0Vector(queryEmbedding, candidateK, query);
-        logger?.debug?.(`${TAG} [hybrid-vec] Vector search returned ${vecResults.length} candidates`);
+        // Vector scores are cosine similarities; filter before RRF so weak
+        // candidates cannot gain relevance merely by occupying a rank slot.
+        const vecResults = scoreThreshold > 0
+          ? vecRaw.filter((r) => r.score >= scoreThreshold)
+          : vecRaw;
+        logger?.debug?.(
+          `${TAG} [hybrid-vec] Vector search returned ${vecResults.length}/${vecRaw.length} candidates ` +
+          `(threshold=${scoreThreshold})`,
+        );
         return vecResults.map((r) => ({
           id: r.record_id,
           session_key: r.session_key,

--- a/MemoryCore/src/core/tools/memory-search.ts
+++ b/MemoryCore/src/core/tools/memory-search.ts
@@ -92,6 +92,8 @@ export async function executeMemorySearch(params: {
   filter?: IsolationFilter;
   vectorStore?: IMemoryStore;
   embeddingService?: EmbeddingService;
+  /** Minimum cosine similarity for vector candidates. A value of 0 disables filtering. */
+  scoreThreshold?: number;
   logger?: Logger;
 }): Promise<MemorySearchResult> {
   const {
@@ -102,6 +104,7 @@ export async function executeMemorySearch(params: {
     filter: isolationFilter,
     vectorStore,
     embeddingService,
+    scoreThreshold = 0,
     logger,
   } = params;
 
@@ -229,10 +232,18 @@ export async function executeMemorySearch(params: {
         logger?.debug?.(
           `${TAG} [hybrid-vec] Embedding OK, dims=${queryEmbedding.length}, searching top-${candidateK}...`,
         );
-        const vecResults: L1SearchResult[] = isolationFilter
+        const vecRaw: L1SearchResult[] = isolationFilter
           ? await vectorStore.searchL1Vector(queryEmbedding, candidateK, query, isolationFilter)
           : await vectorStore.searchL1Vector(queryEmbedding, candidateK, query);
-        logger?.debug?.(`${TAG} [hybrid-vec] Vector search returned ${vecResults.length} candidates`);
+        // Vector scores are cosine similarities; filter before RRF so weak
+        // candidates cannot gain relevance merely by occupying a rank slot.
+        const vecResults = scoreThreshold > 0
+          ? vecRaw.filter((r) => r.score >= scoreThreshold)
+          : vecRaw;
+        logger?.debug?.(
+          `${TAG} [hybrid-vec] Vector search returned ${vecResults.length}/${vecRaw.length} candidates ` +
+          `(threshold=${scoreThreshold})`,
+        );
         return vecResults.map((r) => ({
           id: r.record_id,
           content: r.content,

--- a/MemoryCore/src/core/tools/search-score-threshold.test.ts
+++ b/MemoryCore/src/core/tools/search-score-threshold.test.ts
@@ -1,0 +1,164 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { MemoryTdaiConfig } from "../../config.js";
+import { performAutoRecall } from "../hooks/auto-recall.js";
+import type { EmbeddingService } from "../store/embedding.js";
+import type {
+  IMemoryStore,
+  L0FtsResult,
+  L0SearchResult,
+  L1FtsResult,
+  L1SearchResult,
+} from "../store/types.js";
+import { executeConversationSearch } from "./conversation-search.js";
+import { executeMemorySearch } from "./memory-search.js";
+
+const embeddingService = {
+  embed: vi.fn(async () => new Float32Array([1, 0])),
+} as unknown as EmbeddingService;
+
+function l1Result(record_id: string, score: number): L1SearchResult {
+  return {
+    record_id,
+    content: `memory ${record_id}`,
+    type: "fact",
+    priority: 1,
+    scene_name: "test",
+    score,
+    timestamp_str: "2026-08-10T00:00:00.000Z",
+    timestamp_start: "2026-08-10T00:00:00.000Z",
+    timestamp_end: "2026-08-10T00:00:00.000Z",
+    version: 1,
+    session_key: "session-1",
+    session_id: "session-1",
+    team_id: "team-1",
+    task_id: "task-1",
+    user_id: "user-1",
+    agent_id: "agent-1",
+    metadata_json: "{}",
+  };
+}
+
+function l0Result(record_id: string, score: number): L0SearchResult {
+  return {
+    record_id,
+    session_key: "session-1",
+    session_id: "session-1",
+    team_id: "team-1",
+    task_id: "task-1",
+    user_id: "user-1",
+    agent_id: "agent-1",
+    role: "user",
+    message_text: `message ${record_id}`,
+    score,
+    recorded_at: "2026-08-10T00:00:00.000Z",
+    timestamp: Date.parse("2026-08-10T00:00:00.000Z"),
+  };
+}
+
+function memoryStore(params: {
+  l1Fts?: L1FtsResult[];
+  l1Vector?: L1SearchResult[];
+  l0Fts?: L0FtsResult[];
+  l0Vector?: L0SearchResult[];
+}): IMemoryStore {
+  return {
+    getCapabilities: () => ({ nativeHybridSearch: false }),
+    isFtsAvailable: () => Boolean(params.l1Fts || params.l0Fts),
+    searchL1Fts: vi.fn(async () => params.l1Fts ?? []),
+    searchL1Vector: vi.fn(async () => params.l1Vector ?? []),
+    searchL0Fts: vi.fn(async () => params.l0Fts ?? []),
+    searchL0Vector: vi.fn(async () => params.l0Vector ?? []),
+  } as unknown as IMemoryStore;
+}
+
+describe("search score threshold", () => {
+  it("filters weak L1 vector candidates before RRF without filtering FTS matches", async () => {
+    const store = memoryStore({
+      l1Fts: [l1Result("lexical", 0.01)],
+      l1Vector: [l1Result("strong-vector", 0.8), l1Result("weak-vector", 0.2)],
+    });
+
+    const result = await executeMemorySearch({
+      query: "parental leave policy",
+      limit: 5,
+      vectorStore: store,
+      embeddingService,
+      scoreThreshold: 0.5,
+    });
+
+    expect(result.strategy).toBe("hybrid");
+    expect(result.results.map((item) => item.id)).toEqual(
+      expect.arrayContaining(["lexical", "strong-vector"]),
+    );
+    expect(result.results.map((item) => item.id)).not.toContain("weak-vector");
+  });
+
+  it("filters weak L0 vector candidates before RRF without filtering FTS matches", async () => {
+    const store = memoryStore({
+      l0Fts: [l0Result("lexical", 0.01)],
+      l0Vector: [l0Result("strong-vector", 0.8), l0Result("weak-vector", 0.2)],
+    });
+
+    const result = await executeConversationSearch({
+      query: "parental leave policy",
+      limit: 5,
+      vectorStore: store,
+      embeddingService,
+      scoreThreshold: 0.5,
+    });
+
+    expect(result.strategy).toBe("hybrid");
+    expect(result.results.map((item) => item.id)).toEqual(
+      expect.arrayContaining(["lexical", "strong-vector"]),
+    );
+    expect(result.results.map((item) => item.id)).not.toContain("weak-vector");
+  });
+
+  it("preserves vector candidates when the optional threshold is omitted", async () => {
+    const store = memoryStore({ l1Vector: [l1Result("weak-vector", 0.01)] });
+
+    const result = await executeMemorySearch({
+      query: "parental leave policy",
+      limit: 5,
+      vectorStore: store,
+      embeddingService,
+    });
+
+    expect(result.results.map((item) => item.id)).toEqual(["weak-vector"]);
+  });
+
+  it("applies the threshold to the default hybrid auto-recall vector branch", async () => {
+    const store = memoryStore({
+      l1Vector: [l1Result("strong-vector", 0.8), l1Result("weak-vector", 0.2)],
+    });
+    const cfg = {
+      recall: {
+        enabled: true,
+        maxResults: 5,
+        maxCharsPerMemory: 0,
+        maxTotalRecallChars: 0,
+        scoreThreshold: 0.5,
+        strategy: "hybrid",
+        timeoutMs: 5_000,
+      },
+      embedding: {},
+    } as MemoryTdaiConfig;
+
+    const result = await performAutoRecall({
+      userText: "parental leave policy",
+      actorId: "user-1",
+      sessionKey: "session-1",
+      cfg,
+      pluginDataDir: join(tmpdir(), "tdai-score-threshold-test-does-not-exist"),
+      vectorStore: store,
+      embeddingService,
+    });
+
+    expect(result?.prependContext).toContain("memory strong-vector");
+    expect(result?.prependContext).not.toContain("memory weak-vector");
+  });
+});

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -874,6 +874,7 @@ export class TdaiGateway {
       const v2Deps: V2RouterDeps = {
         getStore: () => this.core.getVectorStore(),
         getEmbedding: () => this.core.getEmbeddingService(),
+        getRecallScoreThreshold: () => this.core.getRecallScoreThreshold(),
         getStorage: () => this.core.getStorage(),
         deployMode: this.config.deployMode,
         // Inject pipeline introspection deps for /v2/pipeline/status (standalone-only).

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -224,6 +224,8 @@ export interface V2RouterDeps {
   getStore: () => IMemoryStore | undefined;
   /** Get the default EmbeddingService (standalone fallback). */
   getEmbedding: () => EmbeddingService | undefined;
+  /** Get the configured minimum cosine similarity for recall candidates. */
+  getRecallScoreThreshold?: () => number;
   /** Get the default StorageAdapter (standalone fallback). */
   getStorage: () => StorageAdapter | undefined;
   logger: Logger;
@@ -907,6 +909,7 @@ async function handleConversationSearch(body: unknown, auth: V2AuthContext, requ
     filter: searchFilter,
     vectorStore: deps.getStore(),
     embeddingService: deps.getEmbedding(),
+    scoreThreshold: deps.getRecallScoreThreshold?.() ?? 0,
     logger: deps.logger,
   });
   const recallLatencyMs = performance.now() - tStart;
@@ -1164,6 +1167,7 @@ async function handleAtomicSearch(body: unknown, auth: V2AuthContext, requestId:
     filter: searchFilter,
     vectorStore: deps.getStore(),
     embeddingService: deps.getEmbedding(),
+    scoreThreshold: deps.getRecallScoreThreshold?.() ?? 0,
     logger: deps.logger,
   });
   const recallLatencyMs = performance.now() - tStart;


### PR DESCRIPTION
## Description | 描述

- Apply the existing `recall.scoreThreshold` to L0 and L1 vector candidates before client-side RRF.
- Thread the configured threshold through `TdaiCore` and the v2 router while preserving a disabled-by-default value for direct tool callers.
- Honor the threshold in the default hybrid auto-recall path.
- Keep FTS and native-hybrid scores untouched because they are not raw cosine similarities.
- Add regression coverage for L0, L1, backward compatibility, and hybrid auto-recall.

## Related Issue | 关联 Issue

Fixes #902

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Validation:
- `npm test` — 1 file, 4 tests passed
- `npm run build:plugin` — passed
- `npm pack --dry-run --ignore-scripts` — passed
- `git diff --check` — passed

## Additional Notes | 其他说明

The repository-wide `npm run build` reaches and passes `build:plugin`, but its existing `build:seed-v2` step fails because `scripts/seed-v2/tsconfig.json` is absent from the current base branch.