### PR TITLE
fix: remove legacy monkey-patch postinstall reference

### DIFF
--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -43,8 +43,7 @@
     "smoke:skill:router": "tsx scripts/smoke-skill/smoke-skill-router.ts",
     "smoke:skill:inject": "tsx scripts/smoke-skill/smoke-skill-inject.ts",
     "smoke:skill:all": "tsx scripts/smoke-skill/smoke-skill-all.ts",
-    "import:opik": "tsx scripts/import-opik-to-memory-core/index.ts",
-    "postinstall": "bash scripts/openclaw-after-tool-call-messages.patch.sh 2>/dev/null || true"
+    "import:opik": "tsx scripts/import-opik-to-memory-core/index.ts"
   },
   "files": [
     "dist/",
@@ -62,7 +61,6 @@
     "scripts/install-openclaw-plugin.sh",
     "scripts/README.memory-tencentdb-ctl.md",
     "src",
-    "scripts/openclaw-after-tool-call-messages.patch.sh",
     "scripts/setup-offload.sh",
     "hermes-plugin/",
     "openclaw-plugin/",


### PR DESCRIPTION
## Summary

Removes the dangling `postinstall` script reference to the deleted `scripts/openclaw-after-tool-call-messages.patch.sh` (404). The patch has been superseded by the official `getSessionMessages` API (PR #865).

Also removes the `patch.sh` entry from the `files` array in `package.json`.

## Changes

- Deletes `scripts.postinstall` line from `MemoryCore/package.json`
- Removes `scripts/openclaw-after-tool-call-messages.patch.sh` from `files` array

## Rationale

The monkey-patch script was deleted in favor of the official OpenClaw API (`api.runtime.subagent.getSessionMessages`, per PR #865 / issue #851). The `postinstall` reference now causes a silent failure on every `npm install` (script runs but file doesn't exist).

## Related

- Issue #917: Legacy monkey-patch (postinstall) compatibility risk
- PR #865: refactor: replace dist-file patch with official OpenClaw getSessionMessages API