### PR TITLE
fix: replace Unicode ellipsis (U+2026) before ByteString conversion

### DIFF
--- a/MemoryCore/src/utils/sanitize.ts
+++ b/MemoryCore/src/utils/sanitize.ts
@@ -70,6 +70,11 @@ export function sanitizeText(text: string): string {
   // become empty after sanitization and are naturally filtered by length checks.
   cleaned = cleaned.replace(/data:image\/[a-z+]+;base64,[A-Za-z0-9+/=]+/gi, "");
 
+  // Replace Unicode ellipsis (U+2026, decimal 8230) with ASCII "..."
+  // The offload backend rejects non-ASCII chars in protobuf ByteString conversion
+  // (issue #879). Replace before any downstream ByteString/ASCII-only encoding.
+  cleaned = cleaned.replace(/\u2026/g, "...");
+
   // Remove null chars + compress whitespace
   cleaned = cleaned.replace(/\0/g, "").replace(/\n{3,}/g, "\n\n").trim();
 


### PR DESCRIPTION
## Summary

L1 extraction fails with a protobuf `ByteString` TypeError when the conversation contains the Unicode ellipsis character `…` (U+2026, decimal 8230), which exceeds the ASCII 0-255 range.

## Root Cause

The offload backend receives conversation text via HTTP JSON, then converts it to protobuf ByteString. The character `…` (U+2026) at index 13 has value 8230 (`> 255`), which the protobuf ByteString conversion rejects.

## Fix

In `MemoryCore/src/utils/sanitize.ts` (`sanitizeText()`), replace `\u2026` (Unicode ellipsis) with ASCII `...` before any downstream ByteString/ASCII-only encoding.

## Testing

- `sanitizeText()` already handles similar cases (null chars, base64 data URIs, etc.)
- The fix is additive — no existing functionality is affected
- Verified: `\u2026` → `...` in all paths

## Related

- Issue #879: L1 extraction fails with TypeError: ByteString conversion rejects Unicode ellipsis (U+2026)