### PR TITLE
fix(memory-proxy): allow members to select team-visible agents

### DIFF
--- a/MemoryProxy/src/session/__tests__/accessible-agents.test.ts
+++ b/MemoryProxy/src/session/__tests__/accessible-agents.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { MetadataClient } from "../../meta/client.js";
+import { listAccessibleAgentsForTeam } from "../accessible-agents.js";
+
+describe("listAccessibleAgentsForTeam", () => {
+  it("includes owned agents and team-visible agents without exposing other private agents", async () => {
+    const listAgents = vi.fn().mockResolvedValue([
+      {
+        agent_id: "agent-owned-private",
+        team_id: "team-1",
+        owner_user_id: "member-1",
+        name: "My private agent",
+        visibility: "private",
+      },
+      {
+        agent_id: "agent-admin-team",
+        team_id: "team-1",
+        owner_user_id: "admin-1",
+        name: "Shared team agent",
+        visibility: "team",
+      },
+      {
+        agent_id: "agent-admin-private",
+        team_id: "team-1",
+        owner_user_id: "admin-1",
+        name: "Admin private agent",
+        visibility: "private",
+      },
+    ]);
+    const metadataClient = { listAgents } as unknown as MetadataClient;
+
+    const result = await listAccessibleAgentsForTeam(
+      metadataClient,
+      "team-1",
+      "member-1",
+    );
+
+    expect(listAgents).toHaveBeenCalledWith("team-1");
+    expect(result.map((agent) => agent.agent_id)).toEqual([
+      "agent-owned-private",
+      "agent-admin-team",
+    ]);
+  });
+});

--- a/MemoryProxy/src/session/accessible-agents.ts
+++ b/MemoryProxy/src/session/accessible-agents.ts
@@ -1,0 +1,20 @@
+import type { AgentEntity, MetadataClient } from "../meta/client.js";
+
+/**
+ * List agents a team member may select during session initialization.
+ *
+ * The metadata list endpoint can filter by owner, but that would hide agents
+ * shared by another team member. Query the team once, then retain the caller's
+ * own agents and agents explicitly shared with the team.
+ */
+export async function listAccessibleAgentsForTeam(
+  metadataClient: Pick<MetadataClient, "listAgents">,
+  teamId: string,
+  userId: string,
+): Promise<AgentEntity[]> {
+  const agents = await metadataClient.listAgents(teamId);
+  return agents.filter(
+    (agent) =>
+      agent.owner_user_id === userId || agent.visibility === "team",
+  );
+}

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -23,6 +23,7 @@ import { buildSessionInfo } from "../registrar.js";
 import { injectSessionContextWithToggles } from "../context-injector.js";
 import type { MetadataClient } from "../../meta/client.js";
 import { resolvePresetIdentity, type PresetIdentity } from "../preset.js";
+import { listAccessibleAgentsForTeam } from "../accessible-agents.js";
 
 import { buildFormResponse, FormData } from "./form.js";
 import {
@@ -91,9 +92,7 @@ async function fetchTeamsAndAgents(
   const teamResults = await Promise.all(
     teamsRaw.map(async (t) => {
       const [agentsRaw, tasksRaw] = await Promise.all([
-        // Agents are scoped to (team, owner) — each user only sees the agents
-        // they created within the team. Tasks remain team-wide (unchanged).
-        metadataClient.listAgents(t.team_id, userId),
+        listAccessibleAgentsForTeam(metadataClient, t.team_id, userId),
         metadataClient.listTasks(t.team_id),
       ]);
       const tasks = tasksRaw.map((tk) => ({


### PR DESCRIPTION
## Summary

- Query active agents at team scope during CodeBuddy session initialization.
- Allow team members to select agents they own and agents with `visibility="team"`.
- Keep private agents owned by other team members hidden.
- Add a regression test covering owned private, team-visible, and other private agents.

## Root cause

CodeBuddy session initialization passed the current user ID to `MetadataClient.listAgents`, which added an `owner_user_id` filter to the team query. Team-visible agents created by an admin or another member were therefore omitted, causing session initialization and downstream memory injection to be bypassed.

## Impact

Team members can now select shared agents during CodeBuddy session initialization without gaining access to another member's private agents.

## Testing

- `npm test` in `MemoryProxy`
- Targeted strict TypeScript check for the new selector and regression test

Fixes #924
