### PR TITLE
fix(deploy): 修复 macOS bash 3.2 下 $VAR 紧跟全角字符报 unbound variable

### DIFF
--- a/deploy/dockerhub/publish.sh
+++ b/deploy/dockerhub/publish.sh
@@ -57,7 +57,7 @@ TARGET="${1:-}"
 case "$TARGET" in
   memory-core|memory-proxy|memory-hub|all) ;;
   -h|--help|"") usage ;;
-  *) die "未知组件: $TARGET（可选 memory-core | memory-proxy | memory-hub | all）" ;;
+  *) die "未知组件: ${TARGET}（可选 memory-core | memory-proxy | memory-hub | all）" ;;
 esac
 
 [[ -n "${VERSION:-}" ]] || die "请显式指定 VERSION，例：VERSION=1.0.0 ./publish.sh $TARGET"
@@ -196,7 +196,7 @@ JSON
   scan "$ctx" src package.json packages
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    ok "DRY_RUN=1 → context 就绪在 $ctx，跳过 build/push"
+    ok "DRY_RUN=1 → context 就绪在 ${ctx}，跳过 build/push"
     return 0
   fi
   build_image "$image" "$ctx"
@@ -257,7 +257,7 @@ build_memory_hub() {
   scan "$ctx" panel knowledge Dockerfile start-combined.sh
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    ok "DRY_RUN=1 → context 就绪在 $ctx，跳过 build/push"
+    ok "DRY_RUN=1 → context 就绪在 ${ctx}，跳过 build/push"
     return 0
   fi
   build_image "$image" "$ctx"

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then

--- a/deploy/panel-knowledge-combined/build.sh
+++ b/deploy/panel-knowledge-combined/build.sh
@@ -36,9 +36,9 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 err() { echo "[build-combined] error: $*" >&2; exit 1; }
 
 [[ -d "$TMC_DIR/package.json" || -f "$TMC_DIR/package.json" ]] \
-  || err "MemoryPanel 不在 $TMC_DIR（设 TMC_DIR=<path> 指定）"
+  || err "MemoryPanel 不在 ${TMC_DIR}（设 TMC_DIR=<path> 指定）"
 [[ -f "$KNOWLEDGE_DIR/package.json" ]] \
-  || err "MemoryKnowledge 不在 $KNOWLEDGE_DIR（设 KNOWLEDGE_DIR=<path> 指定）"
+  || err "MemoryKnowledge 不在 ${KNOWLEDGE_DIR}（设 KNOWLEDGE_DIR=<path> 指定）"
 [[ -f "$SCRIPT_DIR/Dockerfile" ]] || err "Dockerfile 不在 $SCRIPT_DIR"
 [[ -f "$SCRIPT_DIR/start-combined.sh" ]] || err "start-combined.sh 不在 $SCRIPT_DIR"
 
@@ -129,4 +129,4 @@ docker build --platform "$PLATFORM" -t "$IMAGE_NAME:$IMAGE_TAG" "$CTX_DIR"
 
 echo ""
 echo "[build-combined] ✅ done: $IMAGE_NAME:$IMAGE_TAG"
-echo "[build-combined] context 保留在 $CTX_DIR（KEEP_CTX=0 时下次会清掉）"
+echo "[build-combined] context 保留在 ${CTX_DIR}（KEEP_CTX=0 时下次会清掉）"


### PR DESCRIPTION
## 问题描述

运行 `./start-all.sh`（或单独运行 `./start-memory-core.sh`）时，memory-core 启动成功（healthy）后，脚本立刻报错退出：

```
/Users/.../deploy/global-images/start-memory-core.sh: line 175: ADMIN_KEY_FILE�: unbound variable
```

注意报错里的变量名是 `ADMIN_KEY_FILE` 后跟一个乱码字符 `�` —— bash 把紧跟其后的**全角右括号 `）`（U+FF09）误解析进了变量名**，转去查找一个根本不存在的变量。而 `ADMIN_KEY_FILE` 在脚本前面明明已经定义（`ADMIN_KEY_FILE="${MEMORY_CORE_ADMIN_KEY_FILE:-$SCRIPT_DIR/.admin-key}"`）。

## 根因

这是 **macOS 自带 bash 3.2.57 的一个解析缺陷**：在 UTF-8 locale 下，`$VAR` 后**立即紧跟一个多字节字符**（如中文标点 `（`、`）`、`，`）时，bash 3.2 会把该字符误当作变量名的一部分。本仓库 deploy 脚本统一 `set -euo pipefail`，`-u` 遇到未定义变量直接致命退出。

## 为什么只在特定环境触发

| 条件 | 说明 |
|---|---|
| 操作系统 | macOS 默认 bash 是 **3.2.57**（Apple 长期锁死旧版）；**bash ≥ 4 已修复**该解析行为 |
| locale | 需为 UTF-8（`LANG=*.UTF-8`），全角字符才以多字节形式出现 |
| shell 选项 | `set -u`（本仓库 3 个 deploy 脚本全部开启） |

因此在 **Linux / CI（bash 4/5）上无法复现**，这也是该 bug 长期未被发现的原因；只有在 macOS（或任意 bash < 4 环境）运行才会暴露。需要特别说明：**即使不开 `set -u`，`$VAR）` 也会被静默解析成空字符串**，消息里的变量值直接丢失——所以即使后续有人去掉 `set -u`，同样需要修复。

## 最小复现

```bash
bash -c "set -u; VAR=1; echo \"\$VAR（\""
# → bash: VAR�: unbound variable（变量 VAR 明明已定义）
```

## 修复

把紧邻全角字符的 `$VAR` 改为 `${VAR}`，显式界定变量名。共 **7 处、3 个文件**：

- `deploy/global-images/start-memory-core.sh:175` —— `$ADMIN_KEY_FILE）`
- `deploy/panel-knowledge-combined/build.sh:39/41/132` —— `$TMC_DIR（`、`$KNOWLEDGE_DIR（`、`$CTX_DIR（`
- `deploy/dockerhub/publish.sh:60/199/260` —— `$TARGET（`、`$ctx，`（两处）

这些脚本全部开启 `set -euo pipefail`，在 macOS 上运行同样会炸，故一并修复。

## 验证

- ✅ 三个脚本 `bash -n` 语法检查通过
- ✅ 隔离展开第 175 行输出正确（`key 持久化 → /path/.admin-key`），无 unbound 错误
- ✅ 全仓扫描 `$VAR`+全角字符模式：修复后无残留

## 测试建议（给评审/合入者）

- [ ] macOS 上运行 `./start-all.sh` 不再报 `unbound variable`
- [ ] 三个脚本 `bash -n` 通过

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
