### PR TITLE
fix(memory-core): stamp cold-start floor at construction time, not capture time

### DIFF
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
@@ -122,6 +122,9 @@ export class TdaiCore {
    */
   private readonly bgTasks = new Set<Promise<void>>();
 
+  /** Epoch ms when this core was constructed — the actual cold-start time. */
+  private readonly processStartedAt = Date.now();
+
   constructor(opts: TdaiCoreOptions) {
     this.hostAdapter = opts.hostAdapter;
     this.cfg = opts.config;
@@ -276,7 +279,7 @@ export class TdaiCore {
       scheduler: this.scheduler,
       originalUserText: turn.userText,
       originalUserMessageCount: turn.originalUserMessageCount,
-      pluginStartTimestamp: turn.startedAt ?? Date.now(),
+      pluginStartTimestamp: turn.startedAt ?? this.processStartedAt,
       vectorStore: this.vectorStore,
       embeddingService: this.embeddingService,
       bgTaskRegistry: this.bgTasks,


### PR DESCRIPTION
## Summary

`pluginStartTimestamp` is the cold-start cursor floor used to filter messages on a sessions first capture. It was set to `Date.now()` at capture time (`handleTurnCommitted`), not at process start.

Gateway-synthesized messages also get `Date.now()` assigned microseconds later. When both land in the same millisecond, the strict `>` filter in `l0-recorder.ts` drops every message of the first turn. No error, no warning, `/capture` returns 200.

Measured by the issue reporter: **19 of 40 brand-new sessions lost their opening turn entirely**.

## Root cause

Four things line up:

1. `tdai-core.ts` resolves `pluginStartTimestamp` with `Date.now()` at the moment of capture
2. `checkpoint.ts` adopts that value as the cursor when no prior checkpoint exists
3. `server.ts` synthesizes messages without a `timestamp` field, so `l0-recorder.ts` assigns `Date.now()` at extraction time -- microseconds after step 1
4. `l0-recorder.ts` filters with strict `>`: same millisecond = dropped

## Fix

Store the timestamp once when `TdaiCore` is constructed (`processStartedAt`), use that as the fallback instead of a fresh `Date.now()` at each capture call. This matches the documented contract of the field ("epoch ms when the plugin was registered") and guarantees a time gap between the floor and gateway-assigned message timestamps.

```diff
--- a/src/core/tdai-core.ts
+++ b/src/core/tdai-core.ts
   private readonly bgTasks = new Set<Promise<void>>();

+  /** Epoch ms when this core was constructed -- the actual cold-start time. */
+  private readonly processStartedAt = Date.now();
+
   constructor(opts: TdaiCoreOptions) {
@@ handleTurnCommitted
-      pluginStartTimestamp: turn.startedAt ?? Date.now(),
+      pluginStartTimestamp: turn.startedAt ?? this.processStartedAt,
```

## Why not change `>` to `>=`

For every turn after the first, the cursor is the timestamp of the last stored message. `>=` would re-import it as a duplicate. The strict comparison is correct; the cursor value was not.

## Tests

All 67 existing tests pass (`vitest run`).

Fixes #903