### PR TITLE
Add a request timeout to the MCP http client

### DIFF
--- a/MemoryKnowledge/src/mcp/http-client.ts
+++ b/MemoryKnowledge/src/mcp/http-client.ts
@@ -10,10 +10,15 @@ import { createLogger } from "../logger.js";
 
 const log = createLogger("mcp-http");
 
+/** Default per-call timeout in ms; aborts a request if the upstream never responds. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 export interface HttpClientOptions {
   baseUrl: string;
   /** Optional bearer token for auth. */
   token?: string;
+  /** Optional per-call timeout in ms (default: 30000). */
+  timeoutMs?: number;
 }
 
 export interface ApiResponse {
@@ -45,6 +50,7 @@ export async function callApi(
       method: "POST",
       headers,
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
I noticed callApi in MemoryKnowledge/src/mcp/http-client.ts fires its fetch with no timeout or abort signal. If the knowledge service is slow or hangs (a stuck CodeGraph or Wiki query, for example), the MCP tool call just sits there open forever and never returns, which ties up the caller.

Every other HTTP client in the repo already bounds its requests (auth.ts, the tcvdb and bm25 clients, meta/client, tdai/client, core-client all use AbortSignal.timeout or an abort controller), so this one looked like an oversight. I added a default 30s timeout with an optional timeoutMs override on HttpClientOptions so it lines up with the rest of the code. The existing catch block already handles the abort, so there is no behavior change on the happy path.