### PR TITLE
fix(panel): preserve agent asset bindings beyond one page

### DIFF
--- a/MemoryPanel/src/panel/http/routes/knowledge/allocate-routes.ts
+++ b/MemoryPanel/src/panel/http/routes/knowledge/allocate-routes.ts
@@ -17,6 +17,7 @@ import {
   str,
   okEnvelope,
   extractListItems,
+  fetchAllAgentFixedAssetBindings,
   resolveCallerUserId,
   isTeamMember,
   ASSET_TYPE_WIKI,
@@ -85,9 +86,9 @@ export function registerKnowledgeAllocateRoutes(api: Hono, deps: PanelDeps): voi
     const agent = agentEnv.data as AgentRaw;
     if (agent.team_id !== teamId) return respondControlError(c, 400, 'AGENT_NOT_IN_TEAM');
 
-    const bindEnv = await deps.metaKernel.invoke('agent-fixed-asset/list', { agent_id: agentId }, ctx);
-    if (bindEnv.code !== 0) return respondEnvelope(c, bindEnv);
-    const bindings = extractListItems<BindingRaw>(bindEnv);
+    const bindingResult = await fetchAllAgentFixedAssetBindings<BindingRaw>(deps, ctx, agentId);
+    if (bindingResult.error) return respondEnvelope(c, bindingResult.error);
+    const bindings = bindingResult.items;
     if (bindings.some((b) => b.asset_id === knowledgeId)) {
       return respondControlError(c, 409, 'ALREADY_ALLOCATED');
     }
@@ -124,9 +125,9 @@ export function registerKnowledgeAllocateRoutes(api: Hono, deps: PanelDeps): voi
     if (!agent) return respondControlError(c, 404, 'AGENT_NOT_FOUND');
     if (agent.owner_user_id !== caller) return respondControlError(c, 403, 'NOT_YOUR_AGENT');
 
-    const bindEnv = await deps.metaKernel.invoke('agent-fixed-asset/list', { agent_id: agentId }, ctx);
-    if (bindEnv.code !== 0) return respondEnvelope(c, bindEnv);
-    const bindings = extractListItems<BindingRaw>(bindEnv);
+    const bindingResult = await fetchAllAgentFixedAssetBindings<BindingRaw>(deps, ctx, agentId);
+    if (bindingResult.error) return respondEnvelope(c, bindingResult.error);
+    const bindings = bindingResult.items;
     const remaining = bindings.filter((b) => b.asset_id !== knowledgeId);
     if (remaining.length === bindings.length) return respondControlError(c, 404, 'BINDING_NOT_FOUND');
 

--- a/MemoryPanel/src/panel/http/routes/knowledge/common.ts
+++ b/MemoryPanel/src/panel/http/routes/knowledge/common.ts
@@ -229,6 +229,36 @@ export async function deleteKnowledgeCascade(
 const META_LIST_PAGE = 100;
 const FILTERED_ASSET_STATUSES = new Set(['archived', 'deprecated', 'failed']);
 
+/**
+ * Fetch every fixed-asset binding before a read-modify-write operation.
+ *
+ * The metadata API is paginated (20 items by default).  Allocation and
+ * unbinding replace the complete binding set, so using a single default page
+ * would silently drop bindings once an agent has more than 20 assets.
+ */
+export async function fetchAllAgentFixedAssetBindings<T>(
+  deps: PanelDeps,
+  ctx: MetaCallContext,
+  agentId: string,
+): Promise<{ items: T[]; error?: MetaEnvelope<unknown> }> {
+  const all: T[] = [];
+  let offset = 0;
+  for (;;) {
+    const env = await deps.metaKernel.invoke(
+      'agent-fixed-asset/list',
+      { agent_id: agentId, limit: META_LIST_PAGE, offset },
+      ctx,
+    );
+    if (env.code !== 0) return { items: all, error: env };
+    const batch = extractListItems<T>(env);
+    all.push(...batch);
+    const total = (env.data as { total?: number } | null)?.total ?? all.length;
+    if (all.length >= total || batch.length === 0) break;
+    offset += META_LIST_PAGE;
+  }
+  return { items: all };
+}
+
 export interface KnowledgeAssetMetaRaw {
   asset_id: string;
   team_id: string;

--- a/MemoryPanel/tests/knowledge-allocate-pagination.test.ts
+++ b/MemoryPanel/tests/knowledge-allocate-pagination.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchAllAgentFixedAssetBindings } from '../src/panel/http/routes/knowledge/common.js';
+
+describe('fetchAllAgentFixedAssetBindings', () => {
+  it('loads every page before a read-modify-write allocation', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({ asset_id: `asset-${i}` }));
+    const secondPage = Array.from({ length: 25 }, (_, i) => ({ asset_id: `asset-${i + 100}` }));
+    const invoke = vi.fn()
+      .mockResolvedValueOnce({ code: 0, data: { items: firstPage, total: 125 } })
+      .mockResolvedValueOnce({ code: 0, data: { items: secondPage, total: 125 } });
+
+    const result = await fetchAllAgentFixedAssetBindings(
+      { metaKernel: { invoke } } as never,
+      {} as never,
+      'agent-1',
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.items).toHaveLength(125);
+    expect(invoke).toHaveBeenNthCalledWith(
+      1,
+      'agent-fixed-asset/list',
+      { agent_id: 'agent-1', limit: 100, offset: 0 },
+      {},
+    );
+    expect(invoke).toHaveBeenNthCalledWith(
+      2,
+      'agent-fixed-asset/list',
+      { agent_id: 'agent-1', limit: 100, offset: 100 },
+      {},
+    );
+  });
+
+  it('returns the upstream error without fabricating bindings', async () => {
+    const error = { code: 502, message: 'upstream unavailable' };
+    const invoke = vi.fn().mockResolvedValue(error);
+    const result = await fetchAllAgentFixedAssetBindings(
+      { metaKernel: { invoke } } as never,
+      {} as never,
+      'agent-1',
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.error).toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #928. Knowledge allocation and unbinding now fetch all agent fixed-asset bindings before replacing the complete binding set. The previous default metadata page (20 items) silently dropped bindings when an agent had more than 20 assets.

## Changes

- Add paginated binding retrieval with the API maximum page size and offsets.
- Reuse it for `/knowledge/allocate` and `/knowledge/unbind`.
- Add regression tests for multi-page retrieval and upstream errors.

## Validation

- `npm.cmd test -- --run tests/knowledge-allocate-pagination.test.ts` (2 passed)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `git diff --check`

## Real behavior proof

- Setup: Windows 11, Node 22, MemoryPanel dependencies installed with `npm.cmd ci --ignore-scripts`.
- Exact steps: ran the focused Vitest regression suite with 125 simulated bindings split across two metadata pages; ran TypeScript typecheck and build.
- Observed result: both pages were requested (`limit=100`, offsets 0 and 100) and all 125 bindings were preserved for the read-modify-write path; upstream errors are returned without fabricating bindings.
- Not tested: a live multi-service deployment with a real metadata backend; the regression test exercises the route helper with the same paginated response shape.

## Review Readiness

- [x] Reproduction/root cause documented in #928
- [x] Regression tests added
- [x] Typecheck/build pass
- [x] No dependencies or generated files changed

Signed-off-by: Suliman Abdulrazzaq <suliman9000a@gmail.com>
