### PR TITLE
fix(memory-core): filter English FTS stop words

### DIFF
--- a/MemoryCore/src/core/store/sqlite-stop-words.test.ts
+++ b/MemoryCore/src/core/store/sqlite-stop-words.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetJiebaForTest,
+  _setJiebaForTest,
+  buildFtsQuery,
+} from "./sqlite.js";
+
+describe("buildFtsQuery English stop-word filtering", () => {
+  afterEach(() => {
+    _resetJiebaForTest();
+  });
+
+  it("filters English function words from jieba tokens while preserving content words", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["does", "the", "user", "live"],
+    });
+
+    expect(buildFtsQuery("does the user live")).toBe(
+      '"user" OR "live"',
+    );
+  });
+
+  it("filters English function words in the Unicode-regex fallback path", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("does the user live")).toBe(
+      '"user" OR "live"',
+    );
+  });
+
+  it("applies case-insensitive filtering and preserves negation in jieba", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["THE", "user", "IS", "not", "allergic"],
+    });
+
+    expect(buildFtsQuery("THE user IS not allergic")).toBe(
+      '"user" OR "not" OR "allergic"',
+    );
+  });
+
+  it("keeps technical tokens while filtering case-insensitive function words", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("THE user IS in Berlin")).toBe(
+      '"user" OR "in" OR "Berlin"',
+    );
+  });
+
+  it("keeps negation words searchable", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("user is not allergic to peanuts")).toBe(
+      '"user" OR "not" OR "allergic" OR "to" OR "peanuts"',
+    );
+  });
+
+  it("keeps technical query terms such as SQL keywords searchable", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("WHERE user_id IN table")).toBe(
+      '"WHERE" OR "user_id" OR "IN" OR "table"',
+    );
+  });
+
+  it("returns null when a query contains no searchable tokens", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("the does is are")).toBeNull();
+  });
+
+  it("preserves the existing Chinese stop-word behavior", () => {
+    _setJiebaForTest({
+      cutForSearch: () => ["用户", "的", "喜欢", "编程"],
+    });
+
+    expect(buildFtsQuery("用户的喜欢编程")).toBe(
+      '"用户" OR "喜欢" OR "编程"',
+    );
+  });
+
+  it("applies Chinese stop-word filtering in the Unicode-regex fallback path", () => {
+    _setJiebaForTest(null);
+
+    expect(buildFtsQuery("用户 的 喜欢 编程")).toBe(
+      '"用户" OR "喜欢" OR "编程"',
+    );
+  });
+});

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -184,6 +184,27 @@ const ZH_STOP_WORDS = new Set([
 ]);
 
 /**
+ * Common English function words that add noise to FTS5 OR queries.
+ * Keep this list conservative: negation, quantity, identity, and domain
+ * words should remain searchable.
+ */
+// Keep this list conservative: technical, negation, and relational terms can
+// be meaningful search tokens in database, code, and requirements content.
+const EN_STOP_WORDS = new Set([
+  "a", "an", "the",
+  "is", "are", "was", "were", "be", "been", "being",
+  "do", "does", "did", "have", "has", "had",
+]);
+
+function isSearchableFtsToken(token: string): boolean {
+  if (!token) return false;
+  if (!/[\p{L}\p{N}]/u.test(token)) return false;
+  if (ZH_STOP_WORDS.has(token)) return false;
+  if (EN_STOP_WORDS.has(token.toLowerCase())) return false;
+  return true;
+}
+
+/**
  * Build an FTS5 MATCH query from raw text.
  *
  * When `@node-rs/jieba` is available, uses jieba's search-engine mode
@@ -214,14 +235,7 @@ export function buildFtsQuery(raw: string): string | null {
     tokens = jieba
       .cutForSearch(raw, true)
       .map((t) => t.trim())
-      .filter((t) => {
-        if (!t) return false;
-        // Remove pure whitespace / punctuation tokens
-        if (!/[\p{L}\p{N}]/u.test(t)) return false;
-        // Remove common Chinese stop-words to reduce noise
-        if (ZH_STOP_WORDS.has(t)) return false;
-        return true;
-      });
+      .filter(isSearchableFtsToken);
     // Deduplicate (cutForSearch may produce duplicates for sub-words)
     tokens = [...new Set(tokens)];
   } else {
@@ -230,7 +244,7 @@ export function buildFtsQuery(raw: string): string | null {
       raw
         .match(/[\p{L}\p{N}_]+/gu)
         ?.map((t) => t.trim())
-        .filter(Boolean) ?? [];
+        .filter(isSearchableFtsToken) ?? [];
   }
 
   if (tokens.length === 0) return null;


### PR DESCRIPTION
## Description | 描述

Fixes Issue #901.

Filter low-signal English function words from `buildFtsQuery()` before generating SQLite FTS5 queries. The stop-word list is intentionally conservative to preserve technical, negation, and relational terms such as `where`, `in`, `or`, `not`, and `to`.

The same filtering predicate is applied to both jieba and Unicode-regex fallback paths. Existing Chinese stop-word behavior is preserved and covered by regression tests.

## Related Issue | 关联 Issue

Fix #901

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation completed:

- `npm.cmd test` — 9 tests passed
- `npm.cmd run build:plugin` — passed
- `npm.cmd pack --dry-run --ignore-scripts` — passed
- `git diff --check` — passed

The full `npm.cmd run build` remains blocked by the existing missing
`scripts/seed-v2/tsconfig.json` baseline issue, unrelated to this change.