### PR TITLE
docs: align contribution workflow with current branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ The simplest inner loop: run the full stack in Docker, then patch the target
 module locally.
 
 ```bash
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory/deploy/global-images
 cp .env.example .env && $EDITOR .env
 ./start-all.sh
@@ -59,9 +59,11 @@ it standalone (usually `cd <module> && npm install && npm run dev`).
 ## Submitting changes
 
 1. Fork the repo
-2. Cut a feature branch off `master` or the latest `develop_*` branch
+2. Cut a feature branch from the branch you plan to target. The default branch
+   is `feat/server_team`; use `main` or `feat/server` only when maintainers
+   direct the change there.
    ```bash
-   git checkout -b fix/xxx-issue
+   git switch -c fix/xxx-issue origin/feat/server_team
    ```
 3. Make your changes, run the relevant tests
    ```bash
@@ -69,8 +71,8 @@ it standalone (usually `cd <module> && npm install && npm run dev`).
    npm test          # or pnpm test
    ```
 4. Commit using Conventional Commits + DCO sign-off (see below)
-5. Push and open a PR against `develop_server_team` or `master` (follow the
-   maintainer's latest guidance)
+5. Push and open a PR against the same base branch, normally
+   `feat/server_team` (follow the maintainer's latest guidance)
 6. Get through CI + review, then merge
 
 ## Commit conventions

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -46,7 +46,7 @@ tdai-memory-openclaw-plugin/
 最简单的开发闭环是先用 Docker 起一套完整三件套，再本地开发目标模块：
 
 ```bash
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory/deploy/global-images
 cp .env.example .env && $EDITOR .env
 ./start-all.sh
@@ -58,9 +58,10 @@ cp .env.example .env && $EDITOR .env
 ## 提交流程
 
 1. Fork 仓库
-2. 从 `master` 或最新的 `develop_*` 分支切出 feature 分支
+2. 从计划提交到的目标分支切出 feature 分支。默认分支是
+   `feat/server_team`；只有维护者明确要求时才使用 `main` 或 `feat/server`
    ```bash
-   git checkout -b fix/xxx-issue
+   git switch -c fix/xxx-issue origin/feat/server_team
    ```
 3. 修改代码，跑相关测试
    ```bash
@@ -68,8 +69,8 @@ cp .env.example .env && $EDITOR .env
    npm test          # 或 pnpm test
    ```
 4. 提交（Conventional Commits + DCO 签名，见下文）
-5. 推到 fork，发起 PR 到 `develop_server_team` 或 `master`（按维护者最新
-   指示）
+5. 推到 fork，向同一基础分支发起 PR，通常是 `feat/server_team`（按维护者
+   最新指示）
 6. 通过 CI + Review 后合并
 
 ## Commit 规范


### PR DESCRIPTION
## Summary

Update the English and Chinese contribution guides to match the repository's current organization and branch topology.

## Problem

The guides currently:

- clone the pre-transfer `Tencent/TencentDB-Agent-Memory` path
- tell contributors to branch from `master` or `develop_*`
- tell contributors to target `develop_server_team` or `master`

The repository now lives under `TencentCloud`, its default branch is `feat/server_team`, and the active long-lived branches are `feat/server_team`, `feat/server`, and `main`. The documented branch names do not exist, so a new contributor cannot follow the commands as written.

## Changes

- use the canonical TencentCloud clone URL
- use `git switch` from `origin/feat/server_team` in the example
- explain that contributors should branch from and target the same intended base, normally `feat/server_team`
- keep English and Chinese guides aligned

## Verification

- queried the repository metadata and confirmed `feat/server_team` is the default branch
- queried the branch list and confirmed `feat/server_team`, `feat/server`, and `main` exist
- ran `git diff --check`

Documentation-only change; no runtime tests were required.