### PR TITLE
docs(benchmark): align SWE-bench token reduction (#813)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,14 @@ This makes documents and code part of memory as well — but they remain availab
 
 ## Benchmark
 
-| Benchmark | Without TencentDB Agent Memory | With it enabled | Relative improvement |
-| :--- | :---: | :---: | :---: |
-| **PersonaMem** | 48% | **76%** | **+59%** |
+| Memory capability | Benchmark | OpenClaw success | With TencentDB Agent Memory | Relative Δ | OpenClaw tokens | With TencentDB Agent Memory | Relative Δ |
+| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Short-term** | WideSearch | 33% | **50%** | **+51.52%** | 221.31M | **85.64M** | **−61.38%** |
+| **Short-term** | SWE-bench | 58.4% | **64.2%** | **+9.93%** | 3474.1M | **2375.4M** | **−31.63%** |
+| **Short-term** | AA-LCR | 44.0% | **47.5%** | **+7.95%** | 112.0M | **77.3M** | **−30.98%** |
+| **Long-term** | PersonaMem | 48% | **76%** | **+59%** | — | — | — |
+
+These results are measured over continuous long-horizon sessions rather than isolated turns. Token totals are rounded for display; the SWE-bench percentage is aligned with the displayed before/after totals (`(3474.1M − 2375.4M) / 3474.1M = 31.63%`).
 
 PersonaMem tests whether an Agent can correctly understand and apply user information after extended interactions.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -247,9 +247,14 @@ Chat Memory、Skill、Wiki 和 CodeGraph 都被统一登记为 Memory Asset。Me
 
 ## Benchmark
 
-| Benchmark | 无 TencentDB Agent Memory | 启用后 | 相对提升 |
-| :--- | :---: | :---: | :---: |
-| **PersonaMem** | 48% | **76%** | **+59%** |
+| 记忆能力 | Benchmark | OpenClaw 成功率 | 启用 TencentDB Agent Memory | 相对变化 | OpenClaw Tokens | 启用 TencentDB Agent Memory | 相对变化 |
+| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: |
+| **短期记忆** | WideSearch | 33% | **50%** | **+51.52%** | 221.31M | **85.64M** | **−61.38%** |
+| **短期记忆** | SWE-bench | 58.4% | **64.2%** | **+9.93%** | 3474.1M | **2375.4M** | **−31.63%** |
+| **短期记忆** | AA-LCR | 44.0% | **47.5%** | **+7.95%** | 112.0M | **77.3M** | **−30.98%** |
+| **长期记忆** | PersonaMem | 48% | **76%** | **+59%** | — | — | — |
+
+以上结果来自连续长任务会话，而不是孤立的单轮测试。Token 总量在展示时经过四舍五入；SWE-bench 的降幅已与表中前后总量对齐（`(3474.1M − 2375.4M) / 3474.1M = 31.63%`）。
 
 PersonaMem 检验 Agent 能否在长期交互后正确理解和运用用户信息。
 


### PR DESCRIPTION
## Summary

- sync the benchmark table into the default `feat/server_team` README pages
- correct the SWE-bench token reduction from `-33.09%` to `-31.63%`, matching the displayed `3474.1M` and `2375.4M` totals
- document that displayed token totals are rounded and explain the calculation
- keep English and Chinese README benchmark sections consistent

Fixes #813

## Verification

- Recomputed `(3474.1 - 2375.4) / 3474.1 = 31.63%`
- `git diff --check`
- Reviewed both `README.md` and `README_CN.md` for matching benchmark rows
