### PR TITLE
feat(knowledge): support Code Graph sparse checkout (#941)

### DIFF
--- a/MemoryKnowledge/README.md
+++ b/MemoryKnowledge/README.md
@@ -17,6 +17,20 @@
 
 单独 `pnpm dev` 可以起服务；产品链路里必须有 Panel 推 `llm_binding`、收 callback、写远端元数据。
 
+### 大仓库稀疏检出
+
+创建 Code-Graph 时可通过 `sparse_paths` 指定需要索引的相对路径，减少大仓库的工作树和索引开销：
+
+```json
+{
+  "repo_url": "https://github.com/example/monorepo.git",
+  "branch": "main",
+  "sparse_paths": ["packages/memory", "packages/shared"]
+}
+```
+
+`sparse_paths` 只接受相对 POSIX 路径；不传或传空数组时保持完整浅克隆。配置会随 Code-Graph 资产保存，并在后续自动同步和手动同步时继续生效。路径不能包含绝对路径、`..`、空路径段或反斜杠。
+
 ## 源码结构
 
 ```text

--- a/MemoryKnowledge/openapi.yaml
+++ b/MemoryKnowledge/openapi.yaml
@@ -1060,6 +1060,12 @@ components:
               default: main
             repo_name:
               type: string
+            sparse_paths:
+              type: array
+              description: Optional relative POSIX paths to include in a sparse checkout. Empty or omitted means full checkout.
+              items:
+                type: string
+              example: [src, packages/shared]
 
     CodeGraphListRequest:
       allOf:

--- a/MemoryKnowledge/src/api-helpers.ts
+++ b/MemoryKnowledge/src/api-helpers.ts
@@ -143,6 +143,7 @@ export interface CodeGraphDetail {
   repo_name: string;
   repo_url: string;
   branch: string;
+  sparse_paths: string[];
   commit_hash: string | null;
   service_url: string | null;
   summary: string | null;
@@ -171,6 +172,7 @@ export function toCodeGraphDetail(row: CodeGraphRow): CodeGraphDetail {
     repo_name: row.repo_name,
     repo_url: row.repo_url,
     branch: row.branch,
+    sparse_paths: row.sparse_paths,
     commit_hash: row.commit_hash,
     service_url: row.service_url ?? null,
     summary: row.summary ?? null,

--- a/MemoryKnowledge/src/db/client.ts
+++ b/MemoryKnowledge/src/db/client.ts
@@ -56,6 +56,7 @@ export function migrate(_db: Db, raw: Database.Database): void {
       repo_name       TEXT NOT NULL DEFAULT '',
       repo_url        TEXT NOT NULL,
       branch          TEXT NOT NULL,
+      sparse_paths    TEXT,
       commit_hash     TEXT,
       owner_user_id   TEXT,
       user_id         TEXT,
@@ -156,6 +157,7 @@ export function migrate(_db: Db, raw: Database.Database): void {
   // so we check PRAGMA table_info first.
   addColumnIfMissing(raw, "knowledge_code_graph", "service_url", "TEXT");
   addColumnIfMissing(raw, "knowledge_code_graph", "summary", "TEXT");
+  addColumnIfMissing(raw, "knowledge_code_graph", "sparse_paths", "TEXT");
   addColumnIfMissing(raw, "knowledge_wiki", "service_url", "TEXT");
   addColumnIfMissing(raw, "knowledge_wiki", "summary", "TEXT");
   // service_id on audit tables is nullable → safe to add to existing dev DBs.

--- a/MemoryKnowledge/src/db/schema.ts
+++ b/MemoryKnowledge/src/db/schema.ts
@@ -24,6 +24,7 @@ export const knowledgeCodeGraph = sqliteTable(
     repoName: text("repo_name").notNull().default(""),
     repoUrl: text("repo_url").notNull(),
     branch: text("branch").notNull(),
+    sparsePaths: text("sparse_paths"),
     commitHash: text("commit_hash"),
     ownerUserId: text("owner_user_id"),
     userId: text("user_id"),

--- a/MemoryKnowledge/src/module.ts
+++ b/MemoryKnowledge/src/module.ts
@@ -111,7 +111,7 @@ export function createKnowledgeModule(config: KnowledgeModuleConfig): KnowledgeM
 
   // ── Real code-graph worker: fetch/sync via SourceFetcher + index ──
   const realCodeWorker: CodeGraphWorker = async (ctx) => {
-    const { dir, repoUrl, branch, codeGraphId, setInternalStatus } = ctx;
+    const { dir, repoUrl, branch, sparsePaths, codeGraphId, setInternalStatus } = ctx;
 
     // Resolve protocol-specific fetcher (validates url: https-only + SSRF blocklist).
     const fetcher = fetcherRegistry.resolve(repoUrl);
@@ -123,7 +123,7 @@ export function createKnowledgeModule(config: KnowledgeModuleConfig): KnowledgeM
     if (isExistingRepo) {
       try {
         setInternalStatus("fetching");
-        const res = await fetcher.sync(repoUrl, branch, dir);
+        const res = await fetcher.sync(repoUrl, branch, dir, sparsePaths);
         version = res.version;
 
         setInternalStatus("indexing");
@@ -145,7 +145,7 @@ export function createKnowledgeModule(config: KnowledgeModuleConfig): KnowledgeM
     if (!didIncrementalSync) {
       mkdirSync(dir, { recursive: true });
       setInternalStatus("cloning");
-      const res = await fetcher.fetch(repoUrl, branch, dir);
+      const res = await fetcher.fetch(repoUrl, branch, dir, sparsePaths);
       version = res.version;
 
       setInternalStatus("indexing");

--- a/MemoryKnowledge/src/routes/code-graph.ts
+++ b/MemoryKnowledge/src/routes/code-graph.ts
@@ -27,6 +27,7 @@ import {
   type BatchDeleteResult,
 } from "../api-helpers.js";
 import type { CodeGraphInstancePool } from "../module.js";
+import { normalizeSparsePaths } from "../source-fetcher/sparse-paths.js";
 
 export interface CodeGraphRouteDeps {
   cgService: CodeGraphService;
@@ -189,12 +190,19 @@ export function createCodeGraphRoutes(deps: CodeGraphRouteDeps): Hono {
 
     const branch = typeof body.branch === "string" && body.branch ? body.branch : "main";
     const repoName = typeof body.repo_name === "string" ? body.repo_name : undefined;
+    let sparsePaths: string[];
+    try {
+      sparsePaths = normalizeSparsePaths(body.sparse_paths ?? []);
+    } catch (err) {
+      return c.json(wrapError(400, err instanceof Error ? err.message : String(err)), 400);
+    }
 
     const { row, existed } = cgService.create({
       service_id: idFields.service_id,
       team_id: idFields.team_id,
       repo_url: repoUrl,
       branch,
+      sparse_paths: sparsePaths,
       repo_name: repoName,
       owner_user_id: idFields.user_id,
       user_id: idFields.user_id,

--- a/MemoryKnowledge/src/source-fetcher/git-fetcher.test.ts
+++ b/MemoryKnowledge/src/source-fetcher/git-fetcher.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gitMock = vi.hoisted(() => ({
+  clone: vi.fn(),
+  fetch: vi.fn(),
+  reset: vi.fn(),
+  clean: vi.fn(),
+  revparse: vi.fn().mockResolvedValue("abcdef1234567890\n"),
+  raw: vi.fn(),
+}));
+
+vi.mock("simple-git", () => ({
+  default: vi.fn(() => gitMock),
+  CleanOptions: { FORCE: "-f", RECURSIVE: "-d" },
+  ResetMode: { HARD: "--hard" },
+}));
+
+import { GitSourceFetcher } from "./git-fetcher.js";
+
+describe("GitSourceFetcher sparse checkout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitMock.revparse.mockResolvedValue("abcdef1234567890\n");
+  });
+
+  it("keeps the existing shallow clone options when sparse paths are absent", async () => {
+    await new GitSourceFetcher({ ssrfCheck: false }).fetch(
+      "https://github.com/example/repo.git",
+      "main",
+      "/tmp/repo",
+    );
+
+    expect(gitMock.clone).toHaveBeenCalledWith(
+      "https://github.com/example/repo.git",
+      "/tmp/repo",
+      { "--depth": 1, "--branch": "main" },
+    );
+    expect(gitMock.raw).not.toHaveBeenCalled();
+  });
+
+  it("uses a blobless sparse clone and selects the requested paths", async () => {
+    await new GitSourceFetcher({ ssrfCheck: false }).fetch(
+      "https://github.com/example/repo.git",
+      "main",
+      "/tmp/repo",
+      ["src", "docs/api"],
+    );
+
+    expect(gitMock.clone).toHaveBeenCalledWith(
+      "https://github.com/example/repo.git",
+      "/tmp/repo",
+      { "--depth": 1, "--branch": "main", "--filter": "blob:none", "--sparse": null },
+    );
+    expect(gitMock.raw).toHaveBeenCalledWith(["sparse-checkout", "set", "--cone", "src", "docs/api"]);
+  });
+
+  it("reapplies sparse paths after resetting an existing checkout", async () => {
+    await new GitSourceFetcher({ ssrfCheck: false }).sync(
+      "https://github.com/example/repo.git",
+      "main",
+      "/tmp/repo",
+      ["packages/core"],
+    );
+
+    expect(gitMock.fetch).toHaveBeenCalledWith("origin", "main", { "--depth": 1 });
+    expect(gitMock.reset).toHaveBeenCalledWith("--hard", ["origin/main"]);
+    expect(gitMock.raw).toHaveBeenCalledWith(["sparse-checkout", "set", "--cone", "packages/core"]);
+  });
+});

--- a/MemoryKnowledge/src/source-fetcher/git-fetcher.ts
+++ b/MemoryKnowledge/src/source-fetcher/git-fetcher.ts
@@ -12,6 +12,7 @@
 
 import simpleGit, { CleanOptions, ResetMode } from "simple-git";
 import type { ISourceFetcher, FetchResult, SourceType } from "./types.js";
+import { normalizeSparsePaths } from "./sparse-paths.js";
 
 /**
  * 内网 / 环回 / link-local 地址黑名单（标准网段）：
@@ -71,32 +72,49 @@ export class GitSourceFetcher implements ISourceFetcher {
     }
   }
 
-  async fetch(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
+  async fetch(sourceUrl: string, branch: string, localPath: string, sparsePaths?: string[]): Promise<FetchResult> {
     this.validate(sourceUrl);
+    const paths = normalizeSparsePaths(sparsePaths ?? []);
+    const cloneOptions: Record<string, string | number | null> = {
+      "--depth": 1,
+      "--branch": branch,
+    };
+    if (paths.length > 0) {
+      cloneOptions["--filter"] = "blob:none";
+      cloneOptions["--sparse"] = null;
+    }
     // 浅克隆单分支。注：git clone/fetch 不会拉取远端的 .git/hooks（hooks 是本地态），
     // 所以正常仓库 clone 出来不带可执行钩子；此处不再配置 core.hooksPath
     // （加固版 git 会拒绝该配置：需 allowUnsafeHooksPath）。
-    await simpleGit().clone(sourceUrl, localPath, {
-      "--depth": 1,
-      "--branch": branch,
-    });
+    await simpleGit().clone(sourceUrl, localPath, cloneOptions);
+    if (paths.length > 0) {
+      await this.applySparsePaths(localPath, paths);
+    }
     const version = await this.headCommit(localPath);
     return { localPath, version, sourceType: "git" };
   }
 
-  async sync(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
+  async sync(sourceUrl: string, branch: string, localPath: string, sparsePaths?: string[]): Promise<FetchResult> {
     this.validate(sourceUrl);
+    const paths = normalizeSparsePaths(sparsePaths ?? []);
     const git = simpleGit(localPath);
     await git.fetch("origin", branch, { "--depth": 1 });
     await git.reset(ResetMode.HARD, [`origin/${branch}`]);
     // Bug 修复（方案 A）：clean 排除 .codegraph/，否则会删掉 codegraph 的索引库，
     // 导致增量 sync 永远失败、每次回退到全量 clone。
     await git.clean(CleanOptions.FORCE + CleanOptions.RECURSIVE, ["-e", ".codegraph"]);
+    if (paths.length > 0) {
+      await this.applySparsePaths(localPath, paths);
+    }
     const version = await this.headCommit(localPath);
     return { localPath, version, sourceType: "git" };
   }
 
   // ── 内部 helper ──
+
+  private async applySparsePaths(localPath: string, paths: string[]): Promise<void> {
+    await simpleGit(localPath).raw(["sparse-checkout", "set", "--cone", ...paths]);
+  }
 
   private async headCommit(localPath: string): Promise<string | null> {
     try {

--- a/MemoryKnowledge/src/source-fetcher/sparse-paths.test.ts
+++ b/MemoryKnowledge/src/source-fetcher/sparse-paths.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSparsePaths } from "./sparse-paths.js";
+
+describe("normalizeSparsePaths", () => {
+  it("normalizes, deduplicates, and preserves the first-seen order", () => {
+    expect(normalizeSparsePaths([" src/", "src", "docs/api", "docs/api/changes.md "])).toEqual([
+      "src",
+      "docs/api",
+      "docs/api/changes.md",
+    ]);
+  });
+
+  it("accepts an empty array as full checkout", () => {
+    expect(normalizeSparsePaths([])).toEqual([]);
+  });
+
+  it.each([
+    ["absolute path", ["/src"]],
+    ["parent traversal", ["src/../docs"]],
+    ["dot path", ["."]],
+    ["empty segment", ["src//generated"]],
+    ["trailing empty segment", ["src//"]],
+    ["backslash path", ["src\\generated"]],
+    ["blank path", ["   "]],
+  ])("rejects %s", (_label, value) => {
+    expect(() => normalizeSparsePaths(value)).toThrow(/sparse_paths/);
+  });
+
+  it("rejects non-array input", () => {
+    expect(() => normalizeSparsePaths("src")).toThrow(/sparse_paths/);
+  });
+});

--- a/MemoryKnowledge/src/source-fetcher/sparse-paths.ts
+++ b/MemoryKnowledge/src/source-fetcher/sparse-paths.ts
@@ -1,0 +1,34 @@
+/** Normalize and validate user-provided Git sparse-checkout paths. */
+export function normalizeSparsePaths(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error("sparse_paths must be an array of relative paths");
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of value) {
+    if (typeof raw !== "string") {
+      throw new Error("sparse_paths entries must be strings");
+    }
+
+    const trimmed = raw.trim();
+    const path = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+    const segments = path.split("/");
+    if (
+      !path ||
+      path.startsWith("/") ||
+      raw.includes("\\") ||
+      segments.some((segment) => !segment || segment === "." || segment === "..")
+    ) {
+      throw new Error(`sparse_paths contains an invalid relative path: ${raw}`);
+    }
+
+    if (!seen.has(path)) {
+      seen.add(path);
+      normalized.push(path);
+    }
+  }
+
+  return normalized;
+}

--- a/MemoryKnowledge/src/source-fetcher/types.ts
+++ b/MemoryKnowledge/src/source-fetcher/types.ts
@@ -29,10 +29,10 @@ export interface FetchResult {
  */
 export interface ISourceFetcher {
   /** 首次拉取：把源码下载到 localPath。 */
-  fetch(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult>;
+  fetch(sourceUrl: string, branch: string, localPath: string, sparsePaths?: string[]): Promise<FetchResult>;
 
   /** 增量同步：更新已存在的 localPath 到最新版本。 */
-  sync(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult>;
+  sync(sourceUrl: string, branch: string, localPath: string, sparsePaths?: string[]): Promise<FetchResult>;
 
   /** 校验 sourceUrl 是否合法（协议白名单 + SSRF 防护）。非法则 throw。 */
   validate(sourceUrl: string): void;

--- a/MemoryKnowledge/src/store/code-graph-service.ts
+++ b/MemoryKnowledge/src/store/code-graph-service.ts
@@ -35,6 +35,7 @@ export interface CodeGraphBuildContext {
   teamId: string;
   repoUrl: string;
   branch: string;
+  sparsePaths: string[];
   /** 该资产的本地工作目录（checkout + 索引落此）。 */
   dir: string;
   /** worker 可调用以更新细粒度内部状态（cloning → indexing）。 */
@@ -87,6 +88,7 @@ export interface CreateCodeGraphParams {
   team_id: string;
   repo_url: string;
   branch: string;
+  sparse_paths?: string[];
   repo_name?: string;
   owner_user_id?: string;
   user_id?: string;
@@ -268,7 +270,7 @@ export class CodeGraphService {
 
   private enqueueBuild(row: CodeGraphRow): void {
     this.queue.enqueue(row.code_graph_id, () =>
-      this.runBuild(row.service_id, row.code_graph_id, row.team_id, row.repo_url, row.branch),
+      this.runBuild(row.service_id, row.code_graph_id, row.team_id, row.repo_url, row.branch, row.sparse_paths),
     );
   }
 
@@ -278,6 +280,7 @@ export class CodeGraphService {
     teamId: string,
     repoUrl: string,
     branch: string,
+    sparsePaths: string[],
   ): Promise<void> {
     // 入口检查点：pending 期间被删 → 直接跳过，不置 processing、不建图。
     if (this.isDeleted(serviceId, codeGraphId)) {
@@ -296,6 +299,7 @@ export class CodeGraphService {
         teamId,
         repoUrl,
         branch,
+        sparsePaths,
         dir: this.dirFor(serviceId, teamId, codeGraphId),
         setInternalStatus: (s) =>
           this.store.updateCodeGraphStatus(serviceId, codeGraphId, { status: "processing", internal_status: s }),

--- a/MemoryKnowledge/src/store/code-graph-sparse-propagation.test.ts
+++ b/MemoryKnowledge/src/store/code-graph-sparse-propagation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { BuildQueue, CodeGraphService } from "./index.js";
+import type { CodeGraphRow, IKnowledgeStore } from "./types.js";
+
+const baseRow = (): CodeGraphRow => ({
+  code_graph_id: "cg-test",
+  service_id: "svc",
+  team_id: "team",
+  repo_name: "repo",
+  repo_url: "https://github.com/example/repo.git",
+  branch: "main",
+  sparse_paths: ["src", "docs/api"],
+  commit_hash: null,
+  owner_user_id: null,
+  user_id: null,
+  agent_id: null,
+  task_id: null,
+  visibility: "team",
+  status: "pending",
+  internal_status: null,
+  sync_error: null,
+  stats_json: null,
+  service_url: null,
+  summary: null,
+  version: 0,
+  last_sync_at: null,
+  created_at: "now",
+  updated_at: "now",
+  deleted_at: null,
+});
+
+describe("CodeGraphService sparse path propagation", () => {
+  it("passes persisted sparse paths to the build worker", async () => {
+    const row = baseRow();
+    const calls: string[][] = [];
+    const store = {
+      createCodeGraph: () => ({ row, existed: false }),
+      getCodeGraphById: () => row,
+      updateCodeGraphStatus: () => undefined,
+      appendCodeGraphAudit: () => undefined,
+    } as unknown as IKnowledgeStore;
+    const queue = new BuildQueue();
+    const service = new CodeGraphService({
+      store,
+      dataRoot: "/tmp/code-graphs",
+      queue,
+      worker: async (ctx) => {
+        calls.push(ctx.sparsePaths);
+        return { stats: { files: 0, nodes: 0, edges: 0 } };
+      },
+    });
+
+    service.create({
+      service_id: "svc",
+      team_id: "team",
+      repo_url: row.repo_url,
+      branch: row.branch,
+    });
+    await queue.onIdle("cg-test");
+
+    expect(calls).toEqual([["src", "docs/api"]]);
+  });
+});

--- a/MemoryKnowledge/src/store/code-graph-sparse.test.ts
+++ b/MemoryKnowledge/src/store/code-graph-sparse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createDb } from "../db/client.js";
+import { SqliteKnowledgeStore } from "./sqlite-store.js";
+
+describe("code graph sparse paths", () => {
+  it("round-trips sparse paths through the metadata store", () => {
+    const { db } = createDb({ path: ":memory:" });
+    const store = new SqliteKnowledgeStore(db);
+
+    const created = store.createCodeGraph({
+      service_id: "svc",
+      team_id: "team",
+      repo_url: "https://github.com/example/repo.git",
+      branch: "main",
+      sparse_paths: ["src", "docs/api"],
+    });
+
+    expect(created.row.sparse_paths).toEqual(["src", "docs/api"]);
+    expect(store.getCodeGraphById("svc", created.row.code_graph_id)?.sparse_paths).toEqual([
+      "src",
+      "docs/api",
+    ]);
+  });
+
+  it("returns an empty sparse path list for legacy rows without configuration", () => {
+    const { db, raw } = createDb({ path: ":memory:" });
+    raw.prepare(
+      `INSERT INTO knowledge_code_graph
+        (code_graph_id, service_id, team_id, repo_name, repo_url, branch, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("cg-legacy", "svc", "team", "", "https://github.com/example/repo.git", "main", "pending", "now", "now");
+
+    const store = new SqliteKnowledgeStore(db);
+    expect(store.getCodeGraphById("svc", "cg-legacy")?.sparse_paths).toEqual([]);
+  });
+});

--- a/MemoryKnowledge/src/store/sqlite-store.ts
+++ b/MemoryKnowledge/src/store/sqlite-store.ts
@@ -95,6 +95,7 @@ export class SqliteKnowledgeStore implements IKnowledgeStore {
             repoName: input.repo_name ?? "",
             repoUrl: input.repo_url,
             branch: input.branch,
+            sparsePaths: input.sparse_paths?.length ? JSON.stringify(input.sparse_paths) : null,
             ownerUserId: input.owner_user_id ?? null,
             userId: input.user_id ?? null,
             agentId: input.agent_id ?? null,
@@ -594,6 +595,17 @@ export class SqliteKnowledgeStore implements IKnowledgeStore {
   // ═══════════════════════ Mappers ═══════════════════════
 
   private mapCgRow(r: typeof knowledgeCodeGraph.$inferSelect): CodeGraphRow {
+    let sparsePaths: string[] = [];
+    if (r.sparsePaths) {
+      try {
+        const parsed = JSON.parse(r.sparsePaths);
+        if (Array.isArray(parsed) && parsed.every((path): path is string => typeof path === "string")) {
+          sparsePaths = parsed;
+        }
+      } catch {
+        // malformed legacy metadata falls back to full checkout
+      }
+    }
     return {
       code_graph_id: r.codeGraphId,
       service_id: r.serviceId,
@@ -601,6 +613,7 @@ export class SqliteKnowledgeStore implements IKnowledgeStore {
       repo_name: r.repoName,
       repo_url: r.repoUrl,
       branch: r.branch,
+      sparse_paths: sparsePaths,
       commit_hash: r.commitHash,
       owner_user_id: r.ownerUserId,
       user_id: r.userId,

--- a/MemoryKnowledge/src/store/types.ts
+++ b/MemoryKnowledge/src/store/types.ts
@@ -34,6 +34,7 @@ export interface CodeGraphRow {
   repo_name: string;
   repo_url: string;
   branch: string;
+  sparse_paths: string[];
   commit_hash: string | null;
   owner_user_id: string | null;
   user_id: string | null;
@@ -58,6 +59,7 @@ export interface CreateCodeGraphInput {
   team_id: string;
   repo_url: string;
   branch: string;
+  sparse_paths?: string[];
   repo_name?: string;
   owner_user_id?: string;
   user_id?: string;

--- a/docs/superpowers/plans/2026-08-11-sparse-checkout.md
+++ b/docs/superpowers/plans/2026-08-11-sparse-checkout.md
@@ -1,0 +1,103 @@
+# Code Graph 稀疏检出 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 Code Graph 增加可持久化、可同步的 `sparse_paths` 配置，减少大仓库检出和索引的资源消耗。
+
+**Architecture:** 路由负责输入校验，SQLite 元数据保存规范化 JSON，CodeGraphService/worker 在构建和同步时传递配置，GitSourceFetcher 负责执行 sparse-checkout。默认空配置保持当前完整浅克隆行为。
+
+**Tech Stack:** TypeScript、Hono、Drizzle/better-sqlite3、simple-git、Vitest。
+
+## Global Constraints
+
+- 不增加运行时依赖。
+- `sparse_paths` 为空或缺省时保持完整检出兼容性。
+- Git 参数必须继续通过 simple-git 参数数组传递。
+- 路径必须是相对 POSIX 路径，拒绝绝对路径、`.`、`..`、空路径段和反斜杠。
+- 每完成一个任务运行对应测试，并只提交本任务文件。
+
+---
+
+### Task 1: 路径规范化与 Git fetcher 契约
+
+**Files:**
+- Create: `MemoryKnowledge/src/source-fetcher/sparse-paths.ts`
+- Create: `MemoryKnowledge/src/source-fetcher/sparse-paths.test.ts`
+- Modify: `MemoryKnowledge/src/source-fetcher/types.ts`
+
+**Interfaces:**
+- Produces `normalizeSparsePaths(value: unknown): string[]`, which throws on invalid input and returns deduplicated normalized paths.
+- Extends `ISourceFetcher.fetch` and `sync` with optional `sparsePaths?: string[]`.
+
+- [ ] **Step 1: Write failing tests** for valid paths, deduplication, empty arrays, absolute paths, traversal, empty segments, and non-array input.
+- [ ] **Step 2: Run** `cd MemoryKnowledge && npm test -- src/source-fetcher/sparse-paths.test.ts`; expect failure because the helper does not exist.
+- [ ] **Step 3: Implement** `normalizeSparsePaths` with the exact validation rules from the spec.
+- [ ] **Step 4: Run** the focused test and confirm all cases pass.
+- [ ] **Step 5: Extend** `ISourceFetcher` signatures with the optional argument and run `npm run typecheck` if available.
+
+### Task 2: Git sparse clone and sync
+
+**Files:**
+- Modify: `MemoryKnowledge/src/source-fetcher/git-fetcher.ts`
+- Create: `MemoryKnowledge/src/source-fetcher/git-fetcher.test.ts`
+
+**Interfaces:**
+- `GitSourceFetcher.fetch(sourceUrl, branch, localPath, sparsePaths?)`.
+- `GitSourceFetcher.sync(sourceUrl, branch, localPath, sparsePaths?)`.
+
+- [ ] **Step 1: Write failing tests** using a fake simple-git boundary to assert default clone options, sparse clone options, and sparse-checkout reapplication during sync.
+- [ ] **Step 2: Run** the focused test and confirm it fails because sparse arguments are not present.
+- [ ] **Step 3: Implement** sparse clone with `--filter=blob:none`, `--sparse`, and `sparseCheckout("set", ["--cone", ...paths])`; reapply it after sync reset.
+- [ ] **Step 4: Run** focused tests and confirm default and sparse paths both pass.
+- [ ] **Step 5: Run** `cd MemoryKnowledge && npm run typecheck` and fix only feature-related errors.
+
+### Task 3: Persist sparse configuration
+
+**Files:**
+- Modify: `MemoryKnowledge/src/db/schema.ts`
+- Modify: `MemoryKnowledge/src/db/client.ts`
+- Modify: `MemoryKnowledge/src/store/types.ts`
+- Modify: `MemoryKnowledge/src/store/sqlite-store.ts`
+- Create or modify: `MemoryKnowledge/src/store/code-graph-sparse.test.ts`
+
+**Interfaces:**
+- `CodeGraphRow.sparse_paths: string[]`.
+- `CreateCodeGraphInput.sparse_paths?: string[]`.
+- Store serialization uses JSON text and returns `[]` for legacy/null rows.
+
+- [ ] **Step 1: Write failing store tests** for create/read round-trip and legacy row default.
+- [ ] **Step 2: Run** the focused store test and confirm failure.
+- [ ] **Step 3: Add** nullable `sparse_paths` column to Drizzle schema and idempotent runtime migration.
+- [ ] **Step 4: Implement** JSON serialization/deserialization in create and row mapping.
+- [ ] **Step 5: Run** focused store tests and confirm pass.
+
+### Task 4: Route, service, and worker propagation
+
+**Files:**
+- Modify: `MemoryKnowledge/src/routes/code-graph.ts`
+- Modify: `MemoryKnowledge/src/store/code-graph-service.ts`
+- Modify: `MemoryKnowledge/src/module.ts`
+- Modify: `MemoryKnowledge/src/api-helpers.ts`
+- Create or modify: `MemoryKnowledge/src/routes/code-graph-sparse.test.ts`
+
+**Interfaces:**
+- `POST /create` accepts `sparse_paths` and returns it in the resource detail.
+- CodeGraphWorker context carries `sparsePaths: string[]`.
+- Fetcher calls receive the persisted paths for both clone and sync.
+
+- [ ] **Step 1: Write failing route/worker tests** for request validation and propagation.
+- [ ] **Step 2: Run** focused tests and confirm failure.
+- [ ] **Step 3: Implement** route normalization, service input propagation, detail serialization, and worker fetch/sync propagation.
+- [ ] **Step 4: Run** focused route/worker tests and confirm pass.
+- [ ] **Step 5: Run** MemoryKnowledge typecheck and full test suite.
+
+### Task 5: Documentation and final verification
+
+**Files:**
+- Modify: `MemoryKnowledge/README.md`
+- Modify: `MemoryKnowledge/openapi.yaml` if Code Graph create schema is documented there
+
+- [ ] **Step 1: Document** `sparse_paths`, its defaults, validation rules, and a large-monorepo example.
+- [ ] **Step 2: Run** `npm test`, `npm run build`, and `git diff --check` from the relevant package.
+- [ ] **Step 3: Review** the diff for unrelated changes and verify migration compatibility.
+- [ ] **Step 4: Commit**, push, and open a Draft PR referencing #941.

--- a/docs/superpowers/specs/2026-08-11-sparse-checkout-design.md
+++ b/docs/superpowers/specs/2026-08-11-sparse-checkout-design.md
@@ -1,0 +1,42 @@
+# Code Graph 稀疏检出设计
+
+## 背景
+
+大仓库完整检出会产生不必要的网络、磁盘和索引开销。#941 要求 Code Graph 支持稀疏检出，同时不能改变未配置该能力时的现有行为。
+
+## 目标
+
+- Code Graph 创建接口支持可选 `sparse_paths: string[]`。
+- 配置在 SQLite 中持久化，并在后续自动同步、手动同步和失败重试中保持一致。
+- 未提供或提供空数组时继续执行当前的浅克隆和完整工作树流程。
+- 指定路径时使用 Git partial clone 与 cone-mode sparse-checkout，减少工作树文件。
+- 对路径做统一、可预测的安全校验。
+
+## 非目标
+
+- 不支持按文件大小、扩展名或正则表达式筛选。
+- 不改变 CodeGraph 的索引器行为；索引器只处理检出后的工作树。
+- 不修改现有 repo/branch 唯一键语义。
+- 不引入新的 Git 或运行时依赖。
+
+## 方案
+
+`POST /create` 接收 `sparse_paths`，仅接受字符串数组。服务层将其作为 JSON 字符串存入 `knowledge_code_graph.sparse_paths`，详情接口反序列化为数组。构建 worker 从持久化行读取数组，并传给 `ISourceFetcher.fetch/sync`。
+
+Git 首次拉取保持 `--depth 1 --branch <branch>`；当配置非空时追加 `--filter=blob:none --sparse`，完成 clone 后执行 `sparse-checkout set --cone <paths>`。同步时在 fetch/reset 后重新执行 sparse-checkout，保证工作树与持久化配置一致。simple-git 继续通过参数数组调用，不拼接 shell 命令。
+
+路径校验规则：
+
+- 必须是非空字符串，去除首尾空白后保存规范化值。
+- 只允许相对 POSIX 路径。
+- 拒绝绝对路径、`.`、`..`、空路径段和包含 `\\` 的路径。
+- 去重并保持首次出现顺序。
+- 空数组表示完整检出；非法数组返回 400。
+
+## 测试策略
+
+- 路由测试：接受合法数组、拒绝非法类型/路径，并把配置传入 service。
+- Store 测试：创建、读取和旧数据库迁移保留 sparse 配置。
+- GitSourceFetcher 测试：默认 clone 参数、稀疏 clone 参数、同步重新应用 sparse 配置。
+- 端到端逻辑测试：worker 从 row 读取配置并传递给 fetcher。
+- 构建验证：MemoryKnowledge 类型检查、测试、`git diff --check`。


### PR DESCRIPTION
## Summary

- add optional `sparse_paths` to Code Graph creation
- persist normalized paths in SQLite and reuse them for manual/automatic sync
- use Git blobless clone plus `sparse-checkout --cone` for large repositories
- keep omitted/empty paths on the existing full shallow-clone behavior
- validate relative POSIX paths and reject traversal, absolute, empty-segment, and backslash paths
- document the API field and large-monorepo usage in README/OpenAPI

Fixes #941

## Verification

- `npm test` — 4 files, 16 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- `npm run typecheck` — baseline failure remains at `src/middleware/response-envelope.ts:47` (`Promise<string>` is not assignable to `string`), unrelated to this PR
