### PR TITLE
fix(deploy): brace admin key path expansion

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then

--- a/deploy/global-images/tests/start-memory-core.test.sh
+++ b/deploy/global-images/tests/start-memory-core.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GLOBAL_IMAGES_DIR="$(dirname "$TEST_DIR")"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/bin"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'case "${1:-}" in' \
+  '  network) exit 0 ;;' \
+  '  ps) exit 0 ;;' \
+  '  run) exit 0 ;;' \
+  '  inspect)' \
+  '    if [[ "$*" == *State.Status* ]]; then' \
+  '      echo running' \
+  '    else' \
+  '      echo none' \
+  '    fi' \
+  '    exit 0' \
+  '    ;;' \
+  'esac' \
+  'exit 0' \
+  > "$TMP_ROOT/bin/docker"
+chmod +x "$TMP_ROOT/bin/docker"
+
+printf '%s\n' \
+  'MEMORY_CORE_IMAGE=test/memory-core:latest' \
+  'MEMORY_CORE_PORT=1' \
+  'MEMORY_CORE_VOLUME=test-memory-core-data' \
+  > "$TMP_ROOT/.env"
+
+OUTPUT_FILE="$TMP_ROOT/output.log"
+
+set +e
+PATH="$TMP_ROOT/bin:$PATH" \
+  ENV_FILE="$TMP_ROOT/.env" \
+  MEMORY_CORE_CONFIG_DIR="$TMP_ROOT/config" \
+  MEMORY_CORE_ADMIN_KEY_FILE="$TMP_ROOT/admin-key" \
+  bash "$GLOBAL_IMAGES_DIR/start-memory-core.sh" > "$OUTPUT_FILE" 2>&1
+set -e
+
+if ! grep -F '初始化 admin user' "$OUTPUT_FILE" >/dev/null; then
+  cat "$OUTPUT_FILE" >&2
+  exit 1
+fi
+
+if grep -F 'unbound variable' "$OUTPUT_FILE" >/dev/null; then
+  cat "$OUTPUT_FILE" >&2
+  exit 1
+fi
+
+if ! grep -F 'init-admin 返回 HTTP=' "$OUTPUT_FILE" >/dev/null; then
+  cat "$OUTPUT_FILE" >&2
+  exit 1
+fi
+
+echo "start-memory-core admin initialization logging: ok"


### PR DESCRIPTION
## Summary

- brace the admin key path expansion in start-memory-core.sh so Bash set -u does not treat the following fullwidth parenthesis as part of the variable name
- add an isolated regression test with a fake Docker command that verifies execution reaches admin initialization and handles the init-admin result

Fixes #906

## Testing

- bash deploy/global-images/tests/start-memory-core.test.sh
- bash -n deploy/global-images/start-memory-core.sh deploy/global-images/tests/start-memory-core.test.sh
- git diff --check HEAD^ HEAD

## Commit

- includes DCO Signed-off-by trailer