### PR TITLE
fix(memory-core): drop sessionId from dedup recall/delete filter so c…

### DIFF
--- a/MemoryCore/src/core/record/l1-extractor.ts
+++ b/MemoryCore/src/core/record/l1-extractor.ts
@@ -16,6 +16,7 @@ import type { ConversationMessage } from "../conversation/l0-recorder.js";
 import { formatExtractionPrompt, getExtractMemoriesSystemPrompt, type MemoryPromptMode } from "../prompts/l1-extraction.js";
 import { batchDedup } from "./l1-dedup.js";
 import { writeMemory, generateMemoryId } from "./l1-writer.js";
+import { buildDedupScopeFilter } from "../store/isolation.js";
 import type { ExtractedMemory, MemoryRecord, MemoryType, DedupDecision } from "./l1-writer.js";
 import { CleanContextRunner } from "../../utils/clean-context-runner.js";
 import { sanitizeJsonForParse, shouldExtractL1 } from "../../utils/sanitize.js";
@@ -268,7 +269,15 @@ export async function extractL1Memories(params: {
         embeddingTimeoutMs: options.embeddingTimeoutMs,
         llmRunner: options.llmRunner,
         traceContext: { teamId, userId, agentId, sessionId },
-        ...(teamId || userId || agentId || sessionId || taskId ? { filter: { teamId, userId, agentId, sessionId, taskId } } : {}),
+        // Dedup recall detects same-fact conflicts across sessions/tasks by scope
+        // (team/user/agent) only, without sessionId/taskId — otherwise cross-session
+        // old memories would be filtered out by rowMatchesIsolation, so correction /
+        // duplicate scenes could not recall candidates and dedup would degrade to
+        // within the current session only.
+        // buildDedupScopeFilter always returns a non-empty filter (user/agent
+        // normalized to "default") to avoid the filter disappearing when all three
+        // scope fields are empty, which would cause cross-tenant recall.
+        filter: buildDedupScopeFilter(teamId, userId, agentId),
       });
       dedupLatencyMs = Date.now() - dedupStartMs;
 

--- a/MemoryCore/src/core/record/l1-writer.test.ts
+++ b/MemoryCore/src/core/record/l1-writer.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for writeMemory — batch intra-dedup branches.
+ *
+ * Focus:
+ * - skip → returns null, writes/appends nothing
+ * - merge with empty target_ids (pure batch dedup) → appends merged content,
+ *   does NOT call deleteL1Batch, upserts merged record
+ *
+ * Mock style: hand-written mocks (MockVectorStore / MockStorage), matching the
+ * repo's existing convention (see sdk/typescript/tests/client.test.ts).
+ */
+
+import { describe, it, expect } from "vitest";
+import { writeMemory } from "./l1-writer.js";
+import type { ExtractedMemory, DedupDecision, MemoryRecord } from "./l1-writer.js";
+import type { IMemoryStore } from "../store/types.js";
+import type { StorageAdapter } from "../storage/adapter.js";
+
+function mkMemory(): ExtractedMemory {
+  return {
+    content: "用户决定前端框架从 Vue 2 迁移到 Vue 3",
+    type: "episodic",
+    priority: 80,
+    source_message_ids: ["msg-1"],
+    metadata: {},
+    scene_name: "default",
+  };
+}
+
+interface MockVectorStore {
+  /** Records the (ids, filter) passed to each deleteL1Batch call. */
+  deleted: Array<{ ids: string[]; filter: unknown }>;
+  upserted: Array<{ record: MemoryRecord; hasEmbedding: boolean }>;
+  /** Existing records returned by queryL1Records (used by update/merge to read version). */
+  existing: MemoryRecord[];
+}
+
+/**
+ * Minimal IMemoryStore mock recording deleteL1Batch / upsertL1 / queryL1Records calls.
+ * deleteL1Batch 记录传入的 filter，以便断言隔离过滤器的形状。
+ */
+function mkVectorStore(existing: MemoryRecord[] = []): IMemoryStore & MockVectorStore {
+  const mock: MockVectorStore = { deleted: [], upserted: [], existing };
+  return {
+    ...mock,
+    deleteL1Batch: async (ids: string[], filter?: unknown) => {
+      mock.deleted.push({ ids, filter });
+      return true;
+    },
+    upsertL1: async (record: MemoryRecord, embedding?: Float32Array) => {
+      mock.upserted.push({ record, hasEmbedding: embedding !== undefined });
+      return true;
+    },
+    queryL1Records: async (_params: { recordIds: string[] }) => mock.existing,
+  } as unknown as IMemoryStore & MockVectorStore;
+}
+
+interface MockStorage {
+  appended: Array<{ key: string; content: string }>;
+}
+
+/** Minimal StorageAdapter mock recording appendFile calls. */
+function mkStorage(): StorageAdapter & MockStorage {
+  const mock: MockStorage = { appended: [] };
+  return {
+    ...mock,
+    appendFile: async (key: string, content: string) => {
+      mock.appended.push({ key, content });
+    },
+  } as unknown as StorageAdapter & MockStorage;
+}
+
+describe("writeMemory - batch intra-dedup branches", () => {
+  it("skip returns null and writes/appends nothing", async () => {
+    const vs = mkVectorStore();
+    const storage = mkStorage();
+
+    const result = await writeMemory({
+      memory: mkMemory(),
+      decision: { record_id: "m4", action: "skip", target_ids: [] } satisfies DedupDecision,
+      baseDir: "/tmp",
+      sessionKey: "s1",
+      vectorStore: vs,
+      storage,
+    });
+
+    expect(result).toBeNull();
+    expect(storage.appended).toHaveLength(0);
+    expect(vs.deleted).toHaveLength(0);
+    expect(vs.upserted).toHaveLength(0);
+  });
+
+  it("merge with empty target_ids appends merged content, does not delete, upserts merged record", async () => {
+    const vs = mkVectorStore();
+    const storage = mkStorage();
+    const merged = "用户决定前端框架从 Vue 2 迁移到 Vue 3，预计 Q3 完成";
+
+    const result = await writeMemory({
+      memory: mkMemory(),
+      decision: {
+        record_id: "m1",
+        action: "merge",
+        target_ids: [],
+        merged_content: merged,
+        merged_type: "episodic",
+        merged_priority: 85,
+        merged_timestamps: ["t1", "t2"],
+      } satisfies DedupDecision,
+      baseDir: "/tmp",
+      sessionKey: "s1",
+      vectorStore: vs,
+      storage,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe(merged);
+    expect(result!.priority).toBe(85);
+    // empty target_ids → goes through the append (store-like) branch, no deletion
+    expect(vs.deleted).toHaveLength(0);
+    // merged record appended to JSONL
+    expect(storage.appended).toHaveLength(1);
+    expect(storage.appended[0]!.content).toContain(merged);
+    // dual-write upserts the merged record (no embedding service → undefined embedding)
+    expect(vs.upserted).toHaveLength(1);
+    expect(vs.upserted[0]!.record.content).toBe(merged);
+    expect(vs.upserted[0]!.hasEmbedding).toBe(false);
+  });
+
+  it("update with non-empty target_ids deletes targets with scope-only filter (no sessionId/sessionKey)", async () => {
+    // Regression guard: when update replaces a cross-session old record, the delete
+    // filter must isolate only by scope (team/user/agent) without sessionId/sessionKey
+    // — otherwise rowMatchesIsolation filters out the cross-session old record and
+    // update cannot actually delete it (old and new coexist). See deleteFilter in l1-writer.ts.
+    const existingOld = { id: "c1", version: 2 } as unknown as MemoryRecord;
+    const vs = mkVectorStore([existingOld]);
+    const storage = mkStorage();
+    const updated = "用户不喜欢喝单丛茶。";
+
+    const result = await writeMemory({
+      memory: mkMemory(),
+      decision: {
+        record_id: "m1",
+        action: "update",
+        target_ids: ["c1"],
+        merged_content: updated,
+        merged_type: "persona",
+        merged_priority: 85,
+        merged_timestamps: ["t1", "t2"],
+      } satisfies DedupDecision,
+      baseDir: "/tmp",
+      sessionKey: "sess-correct-tea-vfy3",
+      sessionId: "sess-correct-tea-vfy3",
+      teamId: "team-vswf3d49st",
+      userId: "usr-tnw0vg7cdv",
+      agentId: "agt-vswfutdjgl",
+      vectorStore: vs,
+      storage,
+    });
+
+    expect(result).not.toBeNull();
+    // Old record deleted
+    expect(vs.deleted).toHaveLength(1);
+    expect(vs.deleted[0]!.ids).toEqual(["c1"]);
+    // Key assertion: filter contains only the scope triple, no sessionId / sessionKey
+    const filter = vs.deleted[0]!.filter as Record<string, unknown>;
+    expect(filter).toEqual({
+      teamId: "team-vswf3d49st",
+      userId: "usr-tnw0vg7cdv",
+      agentId: "agt-vswfutdjgl",
+    });
+    expect(filter).not.toHaveProperty("sessionId");
+    expect(filter).not.toHaveProperty("sessionKey");
+    // New record written, version = old version + 1
+    expect(vs.upserted).toHaveLength(1);
+    expect(vs.upserted[0]!.record.content).toBe(updated);
+    expect(vs.upserted[0]!.record.version).toBe(3);
+  });
+
+  it("update without scope fields still passes a normalised default-bucket filter", async () => {
+    // When team/user/agent are all absent, the filter must not disappear (that would
+    // allow cross-tenant unisolated deletes); instead it normalizes to the default
+    // bucket: { userId: "default", agentId: "default" } with no teamId key.
+    const existingOld = { id: "c1", version: 0 } as unknown as MemoryRecord;
+    const vs = mkVectorStore([existingOld]);
+    const storage = mkStorage();
+
+    await writeMemory({
+      memory: mkMemory(),
+      decision: {
+        record_id: "m1",
+        action: "update",
+        target_ids: ["c1"],
+        merged_content: "更新后的内容",
+        merged_type: "episodic",
+        merged_priority: 80,
+        merged_timestamps: ["t1"],
+      } satisfies DedupDecision,
+      baseDir: "/tmp",
+      sessionKey: "s1",
+      vectorStore: vs,
+      storage,
+    });
+
+    expect(vs.deleted).toHaveLength(1);
+    expect(vs.deleted[0]!.ids).toEqual(["c1"]);
+    const filter = vs.deleted[0]!.filter as Record<string, unknown>;
+    expect(filter).toEqual({ userId: "default", agentId: "default" });
+    expect(filter).not.toHaveProperty("teamId");
+    expect(filter).not.toHaveProperty("sessionId");
+  });
+});

--- a/MemoryCore/src/core/record/l1-writer.ts
+++ b/MemoryCore/src/core/record/l1-writer.ts
@@ -18,6 +18,7 @@
 
 import crypto from "node:crypto";
 import { DEFAULT_ISOLATION_ID, type IMemoryStore } from "../store/types.js";
+import { buildDedupScopeFilter } from "../store/isolation.js";
 import type { EmbeddingService } from "../store/embedding.js";
 import type { StorageAdapter } from "../storage/adapter.js";
 import { StoragePaths } from "../storage/types.js";
@@ -278,14 +279,17 @@ export async function writeMemory(params: {
     // by memory-cleaner (which reconciles against VectorStore as source of truth).
     if (vectorStore) {
       try {
-        const deleteFilter = teamId || userId || agentId || sessionId
-          ? { teamId, userId, agentId, sessionId: sessionId || undefined, sessionKey }
-          : undefined;
-        if (deleteFilter) {
-          await vectorStore.deleteL1Batch(decision.target_ids, deleteFilter);
-        } else {
-          await vectorStore.deleteL1Batch(decision.target_ids);
-        }
+        // When deleting by ID, isolate only by scope (team/user/agent) without
+        // sessionId/sessionKey — target_ids are cross-session old records the LLM
+        // explicitly decided to replace; including the current sessionId would let
+        // rowMatchesIsolation filter out those cross-session old records, so
+        // update/merge could not actually delete them (old and new coexist). This
+        // matches atomic/delete, which omits sessionId when deleting by id.
+        // buildDedupScopeFilter always returns a non-empty filter (user/agent
+        // normalized to "default") to avoid the filter disappearing when all three
+        // scope fields are empty, which would cause cross-tenant unisolated deletes.
+        const deleteFilter = buildDedupScopeFilter(teamId, userId, agentId);
+        await vectorStore.deleteL1Batch(decision.target_ids, deleteFilter);
         logger?.debug?.(`${TAG} VectorStore: deleted ${decision.target_ids.length} target record(s) for ${decision.action}`);
       } catch (err) {
         logger?.warn?.(

--- a/MemoryCore/src/core/store/isolation.ts
+++ b/MemoryCore/src/core/store/isolation.ts
@@ -169,3 +169,32 @@ export function rowMatchesIsolation(
   if (filter.sessionKey !== undefined && row.session_key !== filter.sessionKey) return false;
   return true;
 }
+
+/**
+ * Build the scope-only isolation filter for L1 dedup — used by both the recall
+ * path (l1-extractor → batchDedup) and the update/merge delete path (l1-writer).
+ *
+ * Dedup operates across sessions within the same scope (team/user/agent), so the
+ * filter intentionally omits sessionId / sessionKey / taskId — carrying the
+ * current sessionId would cause `rowMatchesIsolation` to filter out cross-session
+ * records, breaking correction/dedup across conversations.
+ *
+ * userId / agentId are normalised to `DEFAULT_ISOLATION_ID`, matching the write
+ * side (l1-writer fills missing values with "default"). This keeps the filter
+ * always non-empty: a caller that passes no scope fields still gets
+ * default-bucket isolation instead of an unfiltered cross-tenant scan. teamId is
+ * spread conditionally so an empty string is never emitted — "" would participate
+ * in strict-equality and silently match nothing, since rows store "default" or a
+ * real id.
+ */
+export function buildDedupScopeFilter(
+  teamId?: string,
+  userId?: string,
+  agentId?: string,
+): IsolationFilter {
+  return {
+    ...(teamId ? { teamId } : {}),
+    userId: userId || DEFAULT_ISOLATION_ID,
+    agentId: agentId || DEFAULT_ISOLATION_ID,
+  };
+}


### PR DESCRIPTION
…ross-session corrections update old L1 memories

## Description | 描述

当记忆**纠正/更新**的目标是一条来自**其他会话**的旧 L1 记录时，去重召回过滤器和按 id 删除过滤器都带了 `sessionId`/`sessionKey`。`rowMatchesIsolation` 会把这条跨会话旧记录过滤掉，导致两个问题：

1. **去重召回**无法召回旧候选 → 去重退化为仅当前会话内生效，跨会话的纠正/重复场景永远匹配不到。
2. **update/merge** 实际删不掉旧记录 → 新旧记录并存，"纠正后的值"无法替换过期值。

### 修复
- `l1-extractor.ts`：去重召回改用**仅 scope**（team/user/agent）的过滤器，不带 `sessionId`/`taskId`，使跨会话旧记忆可被召回。
- `l1-writer.ts`：update/merge 按 `target_ids` 删除时使用**仅 scope**的过滤器，不带 `sessionId`/`sessionKey`，与现有 `handleAtomicDelete`（按 id 删除不传 sessionId）的做法一致。
- `buildDedupScopeFilter` 始终返回非空过滤器，当三个 scope 字段全空时将 user/agent 归一化为 `"default"`，避免过滤器消失导致跨租户召回/删除。
- 新增 `l1-writer.test.ts` 回归测试，覆盖"仅 scope 删除过滤器"和"default bucket 归一化"。

## Related Issue | 关联 Issue

无对应 issue。相关 PR：
- #818 —— 同一隔离过滤器模式在 **L0 会话删除 API 层**（`v2-router.ts`）的修复。本 PR 将同一模式应用到 **L1 去重 writer 层**，两者都参照 `handleAtomicDelete`。
- #778 —— 同为 L1 correction 话题，但在**抽取提示词层**，关注点不同。

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
  （`npx vitest run src/core/record/l1-writer.test.ts` —— 4 项全通过）
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
- 仅改动 L1 去重路径，按 `session_id` 整段删除的分支未改动。
