### PR TITLE
fix(proxy): strip session-init form artifacts before forwarding (400 in extended-thinking mode)

### DIFF
--- a/MemoryProxy/FIX-NOTES.md
+++ b/MemoryProxy/FIX-NOTES.md
@@ -1,0 +1,47 @@
+# Fix Notes — session-init form artifacts 400 (DeepSeek thinking)
+
+**Status**: 已修复并验证（2026-08-12），改动已 `docker cp` 进运行中 `tdai-proxy` 容器。
+
+## 问题
+
+代理 sessionInit 在首次请求时伪造 `AskUserQuestion`（id `toolu_cc_session_init_*`）消息，用户回答后这段
+**无 thinking 签名的合成消息被原样转发给上游**（DeepSeek thinking 模式）。DeepSeek 校验 assistant 消息
+thinking 签名真实性，合成消息无签名 → **400**：`The content[].thinking in the thinking mode must be passed back to the API.`
+
+触发窗口：仅首次请求（回答后下一条真实回复带有效签名压上去，历史合成消息不再触发校验）。
+答"是"（关联资产）路径 `init.ts` auto-register（单 team）必挂；答"否"（bypass）也受影响。
+
+## 修复
+
+3 个源码文件 + 1 个测试：
+
+| 文件 | 改动 |
+|------|------|
+| `src/session/claude-code/form.ts` | 新增 `stripSessionInitArtifacts()`：剥离合成 form 消息（assistant 含 init tool_use 整条删；user 含 init tool_result 的 block 删，保留真实文本；其余原样） |
+| `src/session/claude-code/init.ts` | `stripped = stripSessionInitArtifacts(messages)`（原 `= messages`） |
+| `src/anthropicHandler.ts` | 转发前兜底剥离（injection 之后、`resolveForwardTarget` 之前），覆盖 bypass/未拦截/fork/sidequery |
+| `src/session/claude-code/__tests__/form.test.ts` | 6 个回归测试 |
+
+## 验证
+
+- 单元测试 `npm test`：**6/6 PASS**（含真实 thinking+tool_use 保留、混合会话、identity）
+- tsc 无新增错误（6 个既有错误全在未触碰文件）
+- 端到端（本机 `<proxy-host>:8096`）：
+  - Step 1 新会话触发 form：✅
+  - Step 2 答"是"：**200**（修复前必 400）
+  - Step 3 历史含 form 对 + 续聊：✅ 200
+
+## 部署（重要）
+
+镜像用 **tsx 直接执行 TypeScript，不预编译**，所以运行中的容器只需 `docker cp` 3 个文件 + restart：
+
+```bash
+cd MemoryProxy
+docker cp src/session/claude-code/form.ts        tdai-proxy:/app/src/session/claude-code/form.ts
+docker cp src/session/claude-code/init.ts        tdai-proxy:/app/src/session/claude-code/init.ts
+docker cp src/anthropicHandler.ts                tdai-proxy:/app/src/anthropicHandler.ts
+docker restart tdai-proxy
+```
+
+⚠️ **容器重建会丢**：`docker rm` 或下次 `start-all.sh`（重新 `docker run` 拉旧镜像）后需重新应用，
+或重建镜像固化（`docker build` 直连 docker.io 超时，需先配 registry-mirrors）。

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -31,6 +31,7 @@ import {
   type ForwardTarget,
 } from "./guard-adapter.js";
 import { hasCostGuardMarker, matchWhitelistEndpoint } from "./routes/whitelist.js";
+import { stripSessionInitArtifacts } from "./session/claude-code/form.js";
 import { writeRequestLog } from "./requestLog.js";
 import { tryReportCreditFromPath, extractSpaceIdFromPath } from "./credit-reporter.js";
 import { resolveModelId, isModelInPricing } from "./pricing.js";
@@ -1017,6 +1018,24 @@ export async function handleAnthropicMessages(
     }
   } else if (skipInjection) {
     console.log(`[injection-debug] skipping injection for kind=sidequery session=${sessionKey}`);
+  }
+
+  // ── Strip session-init form artifacts (forwarding boundary) ──────────────
+  // session_init 合成 form 消息（toolu_cc_session_init_* tool_use / tool_result）
+  // 不转发上游：上游在 extended-thinking 模式下校验 assistant 消息 thinking
+  // 签名的真实性，无签名的合成消息必然 400。此处兜底剥离，覆盖 initResult
+  // 未携带 messages 的路径（bypass / 未拦截 / fork / sidequery 带 form 历史），
+  // 与 init.ts 内 completeRegistration 路径的剥离保持一致。
+  {
+    const preStrip = (body.messages as Array<Record<string, unknown>> | undefined) ?? [];
+    const postStrip = stripSessionInitArtifacts(preStrip);
+    if (postStrip.length !== preStrip.length || postStrip.some((m, i) => m !== preStrip[i])) {
+      body = { ...body, messages: postStrip };
+      messages = postStrip;
+      console.log(
+        `[session-init:cc] session=${sessionKey} stripped ${preStrip.length - postStrip.length} init-artifact message(s) before forwarding`,
+      );
+    }
   }
 
   // ── Cost guard: resolve forward target (opaque — no routing logic here) ──

--- a/MemoryProxy/src/session/claude-code/__tests__/form.test.ts
+++ b/MemoryProxy/src/session/claude-code/__tests__/form.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for session-init form artifact stripping.
+ *
+ * Context: the proxy synthesizes an `AskUserQuestion` tool_use (id prefixed
+ * `toolu_cc_session_init_`) and the client echoes it back with a `tool_result`.
+ * Upstream providers in extended-thinking mode (DeepSeek) validate that every
+ * assistant tool_use carries a real server-signed `thinking` block, so these
+ * synthetic, signature-less blocks are rejected with 400. `stripSessionInitArtifacts`
+ * removes them before forwarding.
+ */
+import { describe, it, expect } from "vitest";
+import { stripSessionInitArtifacts } from "../form.js";
+
+const INIT_TOOL_ID = "toolu_cc_session_init_1786532541855";
+
+describe("stripSessionInitArtifacts", () => {
+  it("drops a synthetic assistant form message", () => {
+    const out = stripSessionInitArtifacts([
+      { role: "user", content: "你好" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: INIT_TOOL_ID, name: "AskUserQuestion", input: {} }],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: INIT_TOOL_ID, content: "是" }] },
+    ]);
+    expect(out).toEqual([{ role: "user", content: "你好" }]);
+  });
+
+  it("preserves real (non-init) tool_use messages", () => {
+    const msg = {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_01abc", name: "Read", input: {} }],
+    };
+    expect(stripSessionInitArtifacts([msg])).toEqual([msg]);
+  });
+
+  it("keeps real text blocks when stripping an init tool_result", () => {
+    const out = stripSessionInitArtifacts([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "real question" },
+          { type: "tool_result", tool_use_id: INIT_TOOL_ID, content: "是" },
+        ],
+      },
+    ]);
+    expect(out).toEqual([{ role: "user", content: [{ type: "text", text: "real question" }] }]);
+  });
+
+  it("preserves real thinking + tool_use pairs", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "thinking text", signature: "sig_abc" },
+        { type: "tool_use", id: "toolu_real_1", name: "Bash", input: {} },
+      ],
+    };
+    expect(stripSessionInitArtifacts([msg])).toEqual([msg]);
+  });
+
+  it("returns identity for untouched input", () => {
+    const msgs = [{ role: "user", content: "hi" }, { role: "assistant", content: "hello" }];
+    const out = stripSessionInitArtifacts(msgs);
+    expect(out).toEqual(msgs);
+    // elements are the original references — nothing rebuilt, no mutation
+    expect(out[0]).toBe(msgs[0]);
+    expect(out[1]).toBe(msgs[1]);
+  });
+
+  it("strips init form from the middle of a conversation", () => {
+    const out = stripSessionInitArtifacts([
+      { role: "user", content: "你好" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: INIT_TOOL_ID, name: "AskUserQuestion", input: {} }],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: INIT_TOOL_ID, content: "否" }] },
+      { role: "assistant", content: "好的" },
+      { role: "user", content: "继续" },
+    ]);
+    expect(out).toEqual([
+      { role: "user", content: "你好" },
+      { role: "assistant", content: "好的" },
+      { role: "user", content: "继续" },
+    ]);
+  });
+});

--- a/MemoryProxy/src/session/claude-code/form.ts
+++ b/MemoryProxy/src/session/claude-code/form.ts
@@ -48,6 +48,51 @@ export function isSessionInitToolCallId(id: string): boolean {
   return id.startsWith(TOOLCALL_PREFIX);
 }
 
+/**
+ * Strip session-init form artifacts from a message array before forwarding
+ * upstream. The proxy synthesizes an `AskUserQuestion` tool_use (id prefixed
+ * `toolu_cc_session_init_`) and the client echoes it back with a matching
+ * `tool_result`. Upstream providers in extended-thinking mode (DeepSeek)
+ * validate that every assistant tool_use carries a *real* server-signed
+ * `thinking` block, so these synthetic, signature-less blocks are rejected
+ * with 400. The init state machine consumes the answers before this point
+ * (extractAssetConfirm / extractFromOptionText / ...), so the artifacts are
+ * never needed upstream — strip them.
+ *
+ * Rules:
+ *   - assistant message whose content contains a session-init tool_use
+ *     → dropped entirely (the synthetic form response is exactly one block).
+ *   - user message whose content contains a `tool_result` referencing a
+ *     session-init tool_use id → those blocks removed; a message left with
+ *     empty content is dropped (real text blocks are preserved).
+ *   - anything else passes through unchanged (identity for untouched input).
+ */
+export function stripSessionInitArtifacts<T extends { role?: string; content?: unknown }>(messages: T[]): T[] {
+  const out: T[] = [];
+  for (const m of messages) {
+    if (m.role === "assistant" && Array.isArray(m.content)) {
+      const hasInitToolUse = (m.content as Array<{ type?: string; id?: unknown }>).some(
+        (b) => b?.type === "tool_use" && typeof b.id === "string" && isSessionInitToolCallId(b.id),
+      );
+      if (hasInitToolUse) continue; // synthetic form response — drop whole message
+    }
+    if (m.role === "user" && Array.isArray(m.content)) {
+      const kept = (m.content as Array<{ type?: string; tool_use_id?: unknown }>).filter(
+        (b) => !(b?.type === "tool_result" && typeof b.tool_use_id === "string" && isSessionInitToolCallId(b.tool_use_id)),
+      );
+      if (kept.length === (m.content as unknown[]).length) {
+        out.push(m); // no init tool_result — untouched
+      } else if (kept.length > 0) {
+        out.push({ ...m, content: kept }); // keep remaining blocks (real text)
+      }
+      // else: emptied by stripping — drop
+      continue;
+    }
+    out.push(m);
+  }
+  return out;
+}
+
 // ── Form Data ──────────────────────────────────────────────────────────────────
 
 export type FormStage = "asset_confirm" | "team" | "agent_select" | "agent_task" | "task_select";

--- a/MemoryProxy/src/session/claude-code/init.ts
+++ b/MemoryProxy/src/session/claude-code/init.ts
@@ -28,7 +28,7 @@ import {
 import type { MetadataClient } from "../../meta/client.js";
 import { resolvePresetIdentity, type PresetIdentity } from "../preset.js";
 
-import { buildFormResponse, FormData, MORE_LABEL } from "./form.js";
+import { buildFormResponse, FormData, MORE_LABEL, stripSessionInitArtifacts } from "./form.js";
 import { computePagination } from "./pagination.js";
 import {
   extractFromOptionText,
@@ -573,10 +573,12 @@ export async function handleSessionInit(
   if (sessionKey === "unknown" || !sessionKey) return { intercepted: false };
 
   const state = store.get(compositeKey);
-  // 曾经这里会按 config.keepInitArtifacts 决定要不要 stripInitArtifacts,
-  // 现在**永远保留** session_init form 交互, 不做任何删除。变量名 stripped
-  // 保留只为下游调用点不用大改, 语义上就是 messages 本身。
-  const stripped = messages;
+  // session_init form 交互（toolu_cc_session_init_* 合成 tool_use / tool_result）
+  // 在转发上游前必须剥离：DeepSeek 等上游在 extended-thinking 模式下校验
+  // assistant 消息 thinking 签名的真实性，无签名的合成消息必然 400。
+  // 选择解析（extractAssetConfirm / extractFromOptionText / ...）在剥离前
+  // 已消费这些消息，剥离只影响发给上游的请求体，不影响初始化逻辑。
+  const stripped = stripSessionInitArtifacts(messages);
 
   // ── DEBUG BYPASS ─────────────────────────────────────────────────────────
   // When `sessionInit.debugForceIdentity` is set (developer/e2e config),

--- a/deploy/global-images/start-proxy.sh
+++ b/deploy/global-images/start-proxy.sh
@@ -117,6 +117,10 @@ sessionInit:
   maxRetries: 3
   injectAgentContext: true
   injectTaskContext: true
+  # 兜底虚拟 task：当 team 下没有真实 task 时，session-init 用这个 id 当作
+  # "已关联任务"完成注册（跳过 getTask，taskDetail=null，仅注入 agent 上下文）。
+  # 没有它时 team 无 task 会直接 bypass，用户选"是"也无任何注入。
+  defaultTaskId: "task-default-session-init"
   headerAutoSelect:
     enabled: true
     teamHeader: "x-team-id"


### PR DESCRIPTION
## Problem

When `sessionInit` is enabled and the upstream LLM runs in **extended-thinking mode** (e.g. DeepSeek's Anthropic-compatible endpoint), the first real request of every fresh session fails with:

```
API Error: 400 The `content[].thinking` in the thinking mode must be passed back to the API.
```

## Root cause

1. `sessionInit` synthesizes an `AskUserQuestion` tool_use (id prefix `toolu_cc_session_init_`) as a fake SSE response to Claude Code — with `stop_reason: tool_use` and **no `thinking` block**.
2. The client echoes that tool_use back with a matching `tool_result`.
3. Upstream providers in extended-thinking mode require every assistant tool_use to carry a **real, server-signed `thinking` block**. The synthetic form messages carry no valid signature, so the upstream rejects the whole request with 400.
4. These synthetic messages were forwarded to the upstream untouched (the previous `keepInitArtifacts` behavior), so the 400 occurred deterministically on the first request of every session.
5. Separately, when a team has **no real task**, session-init silently bypassed (team+agent+task contract), so a user who answered "yes, bind team assets" got no binding and no injection.

## Fix

- **`stripSessionInitArtifacts()`** in `src/session/claude-code/form.ts`: removes synthetic session-init messages before forwarding upstream:
  - assistant message containing a session-init tool_use → **dropped**
  - user message's `tool_result` referencing a session-init tool_use id → **block removed** (real text blocks preserved)
  - everything else passes through **unchanged** (identity for non-artifact input)
- Applied both in the session-init message pipeline (`init.ts`) **and** at the forwarding boundary (`anthropicHandler.ts`), so bypass / non-intercepted / fork / sidequery paths are covered too.
- **`sessionInit.defaultTaskId`** config: when a team has no real task, session-init can register with a virtual default task instead of silently bypassing — users can still bind and receive agent-context injection.

## Verification

- New unit tests for `stripSessionInitArtifacts` (6 cases) — all pass.
- E2E: fresh session → asset-confirm form → "yes" → auto-select team/agent → task → upstream **200** with injection active (system input tokens ~170 → ~3080).
- Real conversation messages and client-side history are untouched; only the upstream request body is stripped.

## Notes

- The pre-existing `sanitizeThinkingBlocks` logic in `anthropicHandler.ts` is separate and unchanged.
