### PR TITLE
fix: unbound variable crash in start-memory-core.sh admin-init log line

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then


### PR DESCRIPTION
## Description | 描述
`deploy/global-images/start-memory-core.sh` crashes on `./start-memory-core.sh` (and therefore `./start-all.sh`) during admin-user initialization, right after `memory-core` reports healthy.

Root cause: line 175 has an unbraced `$ADMIN_KEY_FILE` immediately followed by a full-width Chinese punctuation character (`）`) with no ASCII separator:

```bash
info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
```

Under a UTF-8 locale (the macOS default — reproduced with `en_US.UTF-8` on both bash 3.2 and bash 5.3), bash's tokenizer can absorb part of that multi-byte character into the variable name, so `set -u` fails with `ADMIN_KEY_FILE?: unbound variable` even though `ADMIN_KEY_FILE` is defined earlier in the script (line 29). It only avoids the bug under `LC_ALL=C`, which effectively no user has set by default. This means the script fails for essentially any user running it out of the box on macOS.

Fix: brace the reference (`${ADMIN_KEY_FILE}`) so bash's parser gets an unambiguous delimiter. Swept the rest of the repo's shell scripts for the same unbraced-`$VAR`-immediately-before-non-ASCII pattern; this was the only occurrence.

## Related Issue | 关联 Issue
Fixes #965

## Change Type | 修改类型
- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 — reproduced the crash in isolation on bash 3.2 and bash 5.3 under `en_US.UTF-8`, confirmed the braced form resolves it, and re-ran `./start-memory-core.sh` end-to-end successfully after the fix.
- [x] No existing features affected | 无影响现有功能 — one-line change, log message text/formatting unchanged.

## Additional Notes | 其他说明
🤖 Generated with [Claude Code](https://claude.com/claude-code)
