### PR TITLE
fix(proxy): emit knowledge: config section so knowledge-tools injector registers (#957)

### DIFF
--- a/MemoryProxy/src/__tests__/knowledge-injector-registration.test.ts
+++ b/MemoryProxy/src/__tests__/knowledge-injector-registration.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression test for the deploy config-generation gap (issue #957).
+ *
+ * `start-proxy.sh` emits `injection.injectors: [skill, knowledge, tdai-memory]`
+ * but never emitted a `knowledge:` config section, so
+ * `shouldRegisterKnowledgeInjector` returned false at runtime and the
+ * `<knowledge_tools>` injector silently never registered — while the proxy
+ * logs showed skill/tdai injectors only.
+ *
+ * This test pins the predicate contract: the generated config shape (the
+ * `knowledge:` block now emitted by the deploy script) must activate the
+ * knowledge-tools injector.
+ */
+import { describe, expect, it } from "vitest";
+import { shouldRegisterKnowledgeInjector } from "../injection/should-register-knowledge.js";
+import type { ProxyConfig } from "../types.js";
+
+function makeConfig(overrides: {
+  injectors?: string[];
+  knowledgeEnabled?: boolean;
+  knowledgeServiceToken?: string;
+}): ProxyConfig {
+  const base = {
+    injection: {
+      injectors: overrides.injectors ?? ["skill", "knowledge", "tdai-memory"],
+    },
+    knowledge: {
+      enabled: overrides.knowledgeEnabled ?? true,
+      serviceToken: overrides.knowledgeServiceToken ?? "local",
+    },
+  };
+  return base as unknown as ProxyConfig;
+}
+
+describe("shouldRegisterKnowledgeInjector", () => {
+  it("registers when injectors include knowledge and the section is present (deploy default)", () => {
+    expect(shouldRegisterKnowledgeInjector(makeConfig({}))).toBe(true);
+  });
+
+  it("does not register when the knowledge section is missing (pre-fix generated config)", () => {
+    // The pre-fix deploy config declared the injector but never emitted a
+    // `knowledge:` section — knowledge.enabled fell back to false.
+    expect(shouldRegisterKnowledgeInjector(makeConfig({ knowledgeEnabled: false }))).toBe(false);
+  });
+
+  it("does not register when knowledge is not in the injector list", () => {
+    expect(shouldRegisterKnowledgeInjector(makeConfig({ injectors: ["skill", "tdai-memory"] }))).toBe(false);
+  });
+
+  it("does not register when serviceToken is empty", () => {
+    expect(shouldRegisterKnowledgeInjector(makeConfig({ knowledgeServiceToken: "" }))).toBe(false);
+  });
+});

--- a/MemoryProxy/src/injection/index.ts
+++ b/MemoryProxy/src/injection/index.ts
@@ -53,6 +53,7 @@ export {
 
 // Registry
 export { HookRegistryImpl } from "./registry.js";
+import { shouldRegisterKnowledgeInjector } from "./should-register-knowledge.js";
 
 // Pipeline
 export { InjectionPipeline } from "./pipeline.js";
@@ -430,18 +431,15 @@ export async function prewarmFromConfig(
 
 /**
  * Pure predicate: should the knowledge-tools injector be registered?
- * Exposed for unit tests (registry itself is not publicly introspectable).
+ * Re-exported from its own module so tests can import it without the
+ * pipeline bundle.
  *
  * Conditions (all must hold):
  *   1. `injection.injectors` includes "knowledge"
  *   2. `knowledge.enabled` is true
  *   3. `knowledge.serviceToken` is non-empty
  */
-export function shouldRegisterKnowledgeInjector(config: ProxyConfig): boolean {
-  return config.injection.injectors.includes("knowledge")
-    && config.knowledge.enabled
-    && !!config.knowledge.serviceToken;
-}
+export { shouldRegisterKnowledgeInjector } from "./should-register-knowledge.js";
 
 /** Test-only: drop the cached pipeline so the next call rebuilds from config. */
 export function __resetInjectionPipelineForTests(): void {

--- a/MemoryProxy/src/injection/should-register-knowledge.ts
+++ b/MemoryProxy/src/injection/should-register-knowledge.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure predicate: should the knowledge-tools injector be registered?
+ *
+ * Exposed as a standalone module so unit tests can import it without pulling
+ * in the whole injection pipeline bundle (which binds network ports).
+ *
+ * Conditions (all must hold):
+ *   1. `injection.injectors` includes "knowledge"
+ *   2. `knowledge.enabled` is true
+ *   3. `knowledge.serviceToken` is non-empty
+ */
+import type { ProxyConfig } from "../types.js";
+
+export function shouldRegisterKnowledgeInjector(config: ProxyConfig): boolean {
+  return config.injection.injectors.includes("knowledge")
+    && config.knowledge.enabled
+    && !!config.knowledge.serviceToken;
+}

--- a/deploy/global-images/start-proxy.sh
+++ b/deploy/global-images/start-proxy.sh
@@ -107,6 +107,13 @@ skill:
   endpoint: "http://memory-core:8420"
   serviceToken: "${MEMORY_CORE_GATEWAY_API_KEY}"
 
+knowledge:
+  enabled: true
+  endpoint: "http://memory-core:8420"
+  serviceToken: "${MEMORY_CORE_GATEWAY_API_KEY}"
+  serviceId: default
+  timeoutMs: 1500
+
 auth:
   enabled: $(bool $PROXY_ENABLE_AUTH)
   url: "http://memory-core:8420"


### PR DESCRIPTION
## Summary

Fixes #957 (Hermes integration: knowledge injector never registers).

`deploy/global-images/start-proxy.sh` generates a proxy config that declares `injection.injectors: [skill, knowledge, tdai-memory]` but never emits a `knowledge:` config section. At runtime `shouldRegisterKnowledgeInjector()` requires `knowledge.enabled === true` AND a non-empty `knowledge.serviceToken` — both undefined with the generated config — so the `knowledge-tools-injector` (wiki/code-graph `<knowledge_tools>` block) silently never registers, even though the deploy config advertises it. Proxy logs show only `skill-*`, `tdai-*` injectors; no `knowledge-tools-injector`.

## Changes

1. **`deploy/global-images/start-proxy.sh`** — emit a `knowledge:` config block (mirroring the existing `skill:` block): `enabled: true`, `endpoint: http://memory-core:8420`, `serviceToken: ${MEMORY_CORE_GATEWAY_API_KEY}`, `serviceId: default`, `timeoutMs: 1500`.
2. **`MemoryProxy/src/injection/should-register-knowledge.ts`** (new) — extract the pure `shouldRegisterKnowledgeInjector` predicate from `injection/index.ts` into its own module so unit tests can import it without pulling in the whole pipeline bundle (which binds network ports).
3. **`MemoryProxy/src/injection/index.ts`** — re-export the predicate from the new module (public API unchanged).
4. **`MemoryProxy/src/__tests__/knowledge-injector-registration.test.ts`** (new) — regression test pinning the contract: the generated-config shape (knowledge section present, injectors list includes `knowledge`) must register the injector; missing section / missing injector entry / empty token must not.

## Verification

- `npx vitest run` → 4/4 passing (this repo previously shipped zero test files despite the vitest configs; this PR adds the first).

## Notes

- Python/`start-proxy.sh` change is the deploy layer; TS changes are MemoryProxy (matches existing `MemoryProxy` TS setup).