### PR TITLE
feat(proxy): support per-user upstream LLM API key configuration

### DIFF
--- a/MemoryCore/src/metadata/config/metadata_config_params.json
+++ b/MemoryCore/src/metadata/config/metadata_config_params.json
@@ -48,6 +48,18 @@
           "allowed_scopes": ["global", "user"]
         }
       ]
+    },
+    {
+      "module": "llm",
+      "description": "LLM 上游配置参数（按用户绑定转发到代理上游的 API Key）",
+      "params": [
+        {
+          "param_name": "api_key",
+          "param_value": "",
+          "description": "该用户转发到上游 LLM 时使用的 API Key（必填，未配置则上游鉴权失败；不回落到代理全局/agent Key）",
+          "allowed_scopes": ["global", "user"]
+        }
+      ]
     }
   ]
 }

--- a/MemoryPanel/web/src/components/SettingsDialog.tsx
+++ b/MemoryPanel/web/src/components/SettingsDialog.tsx
@@ -1,9 +1,12 @@
 /**
  * SettingsDialog — 全局设置弹窗（从顶栏⚙图标触发）。
  *
- * 当前只有一个 Tab：「权限管理」— 控制资源管理模块的开关
- * （Wiki / Code / Skill / Chat_Memory），防止未稳定使用的模块
- * 被注入内核运行。
+ * 目前两个 Tab：
+ *   - 「权限管理」：控制资源管理模块的开关（Wiki / Code / Skill / Chat_Memory），
+ *     防止未稳定使用的模块被注入内核运行。
+ *   - 「上游 LLM」：让用户配置自己转发到上游 LLM 的 API Key（存于内核
+ *     `llm.api_key` config param，按当前登录用户保存）。proxy 转发该用户的
+ *     请求时只使用此 Key 作为上游服务端 Key，不回落到代理全局 / Agent Key。
  *
  * 后续可在 TABS 数组里追加其他 Tab（如通知、偏好设置等）。
  *
@@ -16,6 +19,9 @@ import {
   Text,
   Tag,
   Modal,
+  Input,
+  Button,
+  Form,
 } from 'tea-component';
 import {
   BooksIcon,
@@ -24,6 +30,7 @@ import {
   ChatIcon,
 } from 'tea-icons-react';
 import { userConfigApi, type AssetCapabilityKey } from '@/lib/teamApi';
+import { getCurrentUser } from '@/lib/api/base';
 import { tea } from '@/lib/tea-bridge';
 
 // ===== 资源模块 =====
@@ -67,12 +74,13 @@ const RESOURCE_MODULES: ResourceModule[] = [
   },
 ];
 
-type SettingsTab = 'permissions';
+type SettingsTab = 'permissions' | 'upstream';
 
 export function SettingsDialog({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
-  const activeTab: SettingsTab = 'permissions';
+  const [activeTab, setActiveTab] = useState<SettingsTab>('permissions');
 
+  // ===== Tab 1: 权限管理 =====
   const [enabled, setEnabled] = useState<Record<string, boolean>>(() => ({
     wiki: true,
     code: true,
@@ -124,71 +132,217 @@ export function SettingsDialog({ onClose }: { onClose: () => void }) {
     }
   }
 
+  // ===== Tab 2: 上游 LLM（按当前登录用户保存） =====
+  const [upstreamLoading, setUpstreamLoading] = useState(true);
+  const [upstreamSaving, setUpstreamSaving] = useState(false);
+  const [upstreamKey, setUpstreamKey] = useState('');
+  const [upstreamInitKey, setUpstreamInitKey] = useState('');
+  const [upstreamError, setUpstreamError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setUpstreamLoading(true);
+    setUpstreamError('');
+    (async () => {
+      try {
+        const me = await getCurrentUser();
+        const view = await userConfigApi.get(me.user_id, 'llm', 'api_key');
+        if (cancelled) return;
+        const val = view.items?.[0]?.effective_value ?? '';
+        setUpstreamKey(val);
+        setUpstreamInitKey(val);
+      } catch (e) {
+        if (!cancelled) setUpstreamError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setUpstreamLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handleSaveUpstream() {
+    setUpstreamSaving(true);
+    setUpstreamError('');
+    try {
+      const me = await getCurrentUser();
+      await userConfigApi.set(me.user_id, 'llm', { api_key: upstreamKey.trim() });
+      setUpstreamInitKey(upstreamKey.trim());
+      tea.notify.success(t('settings.upstream.saved'));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setUpstreamError(msg);
+      tea.notify.error(t('settings.notify.saveFailed', { msg }));
+    } finally {
+      setUpstreamSaving(false);
+    }
+  }
+
+  async function handleClearUpstream() {
+    setUpstreamSaving(true);
+    setUpstreamError('');
+    try {
+      const me = await getCurrentUser();
+      await userConfigApi.set(me.user_id, 'llm', { api_key: '' });
+      setUpstreamKey('');
+      setUpstreamInitKey('');
+      tea.notify.success(t('settings.upstream.saved'));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setUpstreamError(msg);
+      tea.notify.error(t('settings.notify.saveFailed', { msg }));
+    } finally {
+      setUpstreamSaving(false);
+    }
+  }
+
+  const tabBtn = (id: SettingsTab, labelKey: string) => (
+    <button
+      type="button"
+      onClick={() => setActiveTab(id)}
+      style={{
+        padding: '6px 16px',
+        border: '1px solid var(--tea-color-border-primary-default)',
+        borderRadius: 6,
+        background: activeTab === id
+          ? 'var(--tea-color-bg-brand-lighten-default)'
+          : 'var(--tea-color-bg-primary-default)',
+        color: 'var(--tea-color-text-primary)',
+        fontWeight: activeTab === id ? 600 : 400,
+        cursor: 'pointer',
+      }}
+    >
+      {t(labelKey)}
+    </button>
+  );
+
   return (
     <Modal visible caption={t('settings.caption')} size="m" onClose={onClose}>
       <Modal.Body>
-      {activeTab === 'permissions' && (
-        <div>
-          <div style={{ paddingTop: 4 }}>
-            <Text theme="label" style={{ display: 'block', marginBottom: 8 }}>
-              {t('settings.title')}
-            </Text>
-            <Text theme="weak" style={{ display: 'block', marginBottom: 16, fontSize: 12 }}>
-              {t('settings.desc')}
-            </Text>
-            {error && <Alert type="error" style={{ marginBottom: 12 }}>{error}</Alert>}
-            {loading && <Alert type="info" style={{ marginBottom: 12 }}>{t('settings.loadingConfig')}</Alert>}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+          {tabBtn('permissions', 'settings.tab.permissions')}
+          {tabBtn('upstream', 'settings.tab.upstream')}
+        </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              {RESOURCE_MODULES.map((mod) => (
-                <div
-                  key={mod.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    padding: '10px 12px',
-                    border: '1px solid var(--tea-color-border-primary-default)',
-                    borderRadius: 6,
-                    background: enabled[mod.id]
-                      ? 'var(--tea-color-bg-brand-lighten-default)'
-                      : 'var(--tea-color-bg-primary-default)',
-                    transition: 'background-color 0.15s',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
-                    <span style={{ color: 'var(--tea-color-text-secondary)', flexShrink: 0 }}>
-                      {mod.icon}
-                    </span>
-                    <div style={{ minWidth: 0 }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <Text style={{ fontSize: 13, fontWeight: 500 }}>
-                          {t(mod.labelKey)}
+        {activeTab === 'permissions' && (
+          <div>
+            <div style={{ paddingTop: 4 }}>
+              <Text theme="label" style={{ display: 'block', marginBottom: 8 }}>
+                {t('settings.title')}
+              </Text>
+              <Text theme="weak" style={{ display: 'block', marginBottom: 16, fontSize: 12 }}>
+                {t('settings.desc')}
+              </Text>
+              {error && <Alert type="error" style={{ marginBottom: 12 }}>{error}</Alert>}
+              {loading && <Alert type="info" style={{ marginBottom: 12 }}>{t('settings.loadingConfig')}</Alert>}
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                {RESOURCE_MODULES.map((mod) => (
+                  <div
+                    key={mod.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      padding: '10px 12px',
+                      border: '1px solid var(--tea-color-border-primary-default)',
+                      borderRadius: 6,
+                      background: enabled[mod.id]
+                        ? 'var(--tea-color-bg-brand-lighten-default)'
+                        : 'var(--tea-color-bg-primary-default)',
+                      transition: 'background-color 0.15s',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+                      <span style={{ color: 'var(--tea-color-text-secondary)', flexShrink: 0 }}>
+                        {mod.icon}
+                      </span>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                          <Text style={{ fontSize: 13, fontWeight: 500 }}>
+                            {t(mod.labelKey)}
+                          </Text>
+                          {savingKey === mod.paramKey ? (
+                            <Tag theme="warning" variant="soft" size="sm">{t('settings.tag.saving')}</Tag>
+                          ) : enabled[mod.id] ? (
+                            <Tag theme="success" variant="soft" size="sm">{t('settings.tag.enabled')}</Tag>
+                          ) : (
+                            <Tag theme="default" variant="soft" size="sm">{t('settings.tag.disabled')}</Tag>
+                          )}
+                        </div>
+                        <Text theme="weak" style={{ fontSize: 12, marginTop: 2, display: 'block' }}>
+                          {t(mod.descKey)}
                         </Text>
-                        {savingKey === mod.paramKey ? (
-                          <Tag theme="warning" variant="soft" size="sm">{t('settings.tag.saving')}</Tag>
-                        ) : enabled[mod.id] ? (
-                          <Tag theme="success" variant="soft" size="sm">{t('settings.tag.enabled')}</Tag>
-                        ) : (
-                          <Tag theme="default" variant="soft" size="sm">{t('settings.tag.disabled')}</Tag>
-                        )}
                       </div>
-                      <Text theme="weak" style={{ fontSize: 12, marginTop: 2, display: 'block' }}>
-                        {t(mod.descKey)}
-                      </Text>
                     </div>
+                    <Switch
+                      value={enabled[mod.id]}
+                      disabled={loading || savingKey === mod.paramKey}
+                      onChange={(v) => void handleToggle(mod, v)}
+                    />
                   </div>
-                  <Switch
-                    value={enabled[mod.id]}
-                    disabled={loading || savingKey === mod.paramKey}
-                    onChange={(v) => void handleToggle(mod, v)}
-                  />
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+
+        {activeTab === 'upstream' && (
+          <div>
+            <div style={{ paddingTop: 4 }}>
+              <Text theme="label" style={{ display: 'block', marginBottom: 8 }}>
+                {t('settings.upstream.title')}
+              </Text>
+              <Text theme="weak" style={{ display: 'block', marginBottom: 16, fontSize: 12 }}>
+                {t('settings.upstream.desc')}
+              </Text>
+              {upstreamError && <Alert type="error" style={{ marginBottom: 12 }}>{upstreamError}</Alert>}
+              {upstreamLoading && <Alert type="info" style={{ marginBottom: 12 }}>{t('settings.upstream.loading')}</Alert>}
+
+              <Form layout="vertical" style={{ maxWidth: 480 }}>
+                <Form.Item
+                  label={t('settings.upstream.keyLabel')}
+                  extra={
+                    <span>
+                      <a
+                        href="https://tencent.sso.codebuddy.cn/profile/keys"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {t('settings.upstream.keyLink')}
+                      </a>
+                      {t('settings.upstream.keyExtra')}
+                    </span>
+                  }
+                >
+                  <Input
+                    value={upstreamKey}
+                    onChange={(v) => setUpstreamKey(v)}
+                    placeholder={t('settings.upstream.keyPlaceholder')}
+                    type="password"
+                    disabled={upstreamLoading}
+                  />
+                </Form.Item>
+                <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                  <Button
+                    type="primary"
+                    onClick={() => void handleSaveUpstream()}
+                    loading={upstreamSaving}
+                    disabled={upstreamLoading || upstreamKey.trim() === upstreamInitKey}
+                  >
+                    {t('settings.upstream.save')}
+                  </Button>
+                  <Button
+                    onClick={() => void handleClearUpstream()}
+                    loading={upstreamSaving}
+                    disabled={upstreamLoading || upstreamInitKey === ''}
+                  >
+                    {t('settings.upstream.clear')}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/MemoryPanel/web/src/i18n/en-US.ts
+++ b/MemoryPanel/web/src/i18n/en-US.ts
@@ -93,6 +93,20 @@ export const enUS = {
   'settings.notify.enabled': '{{label}} enabled',
   'settings.notify.disabled': '{{label}} disabled',
   'settings.notify.saveFailed': 'Save failed: {{msg}}',
+  // ===== SettingsDialog · Upstream LLM =====
+  'settings.tab.permissions': 'Permissions',
+  'settings.tab.upstream': 'Upstream LLM',
+  'settings.upstream.title': 'My upstream LLM API Key',
+  'settings.upstream.desc':
+    "Saved per signed-in user; the proxy uses this Key as the upstream server key when forwarding this user's requests (no fallback to the global default Key).",
+  'settings.upstream.keyLabel': 'API Key',
+  'settings.upstream.keyPlaceholder': 'ck_xxxxxxxx',
+  'settings.upstream.keyLink': 'Get a Key →',
+  'settings.upstream.keyExtra': ' (go to "API Management" in the left sidebar and click "Create Key")',
+  'settings.upstream.loading': 'Loading current user upstream config…',
+  'settings.upstream.save': 'Save',
+  'settings.upstream.saved': 'Upstream API Key saved',
+  'settings.upstream.clear': 'Clear',
 
   // ===== Common =====
   'common.cancel': 'Cancel',

--- a/MemoryPanel/web/src/i18n/zh-CN.ts
+++ b/MemoryPanel/web/src/i18n/zh-CN.ts
@@ -88,6 +88,20 @@ export const zhCN = {
   'settings.notify.enabled': '{{label}} 已开启',
   'settings.notify.disabled': '{{label}} 已关闭',
   'settings.notify.saveFailed': '保存失败：{{msg}}',
+  // ===== SettingsDialog · 上游 LLM =====
+  'settings.tab.permissions': '权限管理',
+  'settings.tab.upstream': '上游 LLM',
+  'settings.upstream.title': '我的上游 LLM API Key',
+  'settings.upstream.desc':
+    '按当前登录用户保存；proxy 转发该用户的请求时使用此 Key 作为上游服务端 Key（不回落到全局默认 Key）。',
+  'settings.upstream.keyLabel': 'API Key',
+  'settings.upstream.keyPlaceholder': 'ck_xxxxxxxx',
+  'settings.upstream.keyLink': '前往获取 Key →',
+  'settings.upstream.keyExtra': '（进入左侧「API 管理」，点击「创建密钥」）',
+  'settings.upstream.loading': '正在读取当前用户上游配置…',
+  'settings.upstream.save': '保存',
+  'settings.upstream.saved': '上游 API Key 已保存',
+  'settings.upstream.clear': '清除',
 
   // ===== Common =====
   'common.cancel': '取消',

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -902,6 +902,23 @@ export async function handleChatCompletions(
   const effectiveApiKey = agentUpstreamEntry
     ? (agentUpstreamEntry.apiKey ?? "")
     : config.upstream.apiKey;
+  // Per-user upstream key: a signed-in user (userId resolvable) MUST use the
+  // `llm.api_key` they configured on their own profile page (stored in the core
+  // config param) as the server-side key forwarded upstream — never falling back
+  // to the global / agent key when it's unset, lookup fails, or an error occurs.
+  // Leaving it empty lets the client's own key passthrough, so a missing config
+  // surfaces as an upstream auth failure prompting the user to configure one.
+  // The global / agent key is only used as a fallback when userId is not
+  // resolvable (e.g. auth disabled).
+  let resolvedApiKey = effectiveApiKey;
+  if (userId && apiKey && tdaiClient) {
+    try {
+      resolvedApiKey = await tdaiClient.getUserUpstreamApiKey(apiKey, userId);
+    } catch {
+      // ignore — treat as not configured, keep empty (no fallback)
+      resolvedApiKey = "";
+    }
+  }
   // Normalize the request path to the canonical upstream endpoint so the
   // extension's URL joining matches the host whitelist behavior.
   const forwardEndpoint = matchWhitelistEndpoint(c.req.path)?.upstreamEndpoint ?? "/chat/completions";
@@ -995,7 +1012,7 @@ export async function handleChatCompletions(
   writeRequestLog(config, body);
 
   // ── Build upstream request ───────────────────────────────────────────────
-  const upstreamHeaders = buildUpstreamHeaders(c, config, target, sessionKey, effectiveApiKey);
+  const upstreamHeaders = buildUpstreamHeaders(c, config, target, sessionKey, resolvedApiKey);
   const upstreamBody = buildUpstreamBody(body, target);
   // Retry headers: preserve original client headers (x-request-id, user-agent,
   // etc.), then force the primary upstream's auth — retry always goes to the
@@ -1008,11 +1025,11 @@ export async function handleChatCompletions(
       originalHeaders[k] = v;
     }
   }
-  // Retry uses the same effective key as the primary path — when it
-  // resolves to "" (agent entry present but no apiKey), retry also runs
-  // on the client's own key, preserving the passthrough intent.
-  if (effectiveApiKey) {
-    originalHeaders["authorization"] = `Bearer ${effectiveApiKey}`;
+  // Retry uses the same resolved key as the primary path — when it
+  // resolves to "" (no per-user key / agent entry with empty apiKey), retry
+  // also runs on the client's own key, preserving the passthrough intent.
+  if (resolvedApiKey) {
+    originalHeaders["authorization"] = `Bearer ${resolvedApiKey}`;
   }
 
   // Inject stream_options.include_usage for OpenAI compat

--- a/MemoryProxy/src/tdai/client.ts
+++ b/MemoryProxy/src/tdai/client.ts
@@ -298,6 +298,50 @@ export class TdaiClient {
     }
   }
 
+  /**
+   * 读取某用户自定义的上游 LLM API Key（面板里按用户配置，存于 core 的
+   * `llm.api_key` config param）。
+   *
+   * 返回非空字符串 → proxy 转发该用户请求到上游时用它作为服务端 key；
+   * 返回空串 / 出错 → 由调用方回落到 agent / 全局上游 key（fail-open，不影响转发）。
+   *
+   * 鉴权走 `x-tdai-user-key`（Layer 3 用户鉴权），core 侧 `assertCallerIsOwner`
+   * 要求调用者就是目标用户自己 —— 这里传入的就是请求发起者自身的 user_key。
+   */
+  async getUserUpstreamApiKey(userKey: string, userId: string): Promise<string> {
+    if (!this.isEnabled() || !userKey || !userId) return "";
+    const base = this.config.endpoint.replace(/\/$/, "");
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.timeoutMs);
+    try {
+      const res = await fetch(`${base}/v3/meta/config/user/get`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.config.apiKey || "local-proxy"}`,
+          "x-tdai-service-id": this.config.serviceId || "default",
+          "x-tdai-user-key": userKey,
+        },
+        body: JSON.stringify({
+          user_id: userId,
+          module: "llm",
+          param_name: "api_key",
+        }),
+      });
+      if (!res.ok) return "";
+      const envelope = (await res.json()) as TdaiEnvelope<{ items?: Array<{ effective_value?: unknown }> }>;
+      if (typeof envelope.code === "number" && envelope.code !== 0) return "";
+      const raw = envelope.data?.items?.[0]?.effective_value;
+      return typeof raw === "string" ? raw : "";
+    } catch {
+      // fail-open：查不到用户 key 就回落默认上游 key，绝不阻断转发。
+      return "";
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   // ── ACL check ──────────────────────────────────────────────────────────
   //
   // 与 memory 数据面调用（postForCtx）**语义相反**：


### PR DESCRIPTION
## Summary

Currently the proxy forwards each chat request to the upstream LLM using a single shared upstream
`apiKey` (global config or per-agent entry). This forces every user to share one key — a real problem
when different users are billed against their own accounts, or when an org wants each member to bring
their own provider key.

This PR lets each signed-in user bind **their own upstream LLM API key** from the panel, and makes the
proxy use **that user's key** (never the global/agent key) when forwarding to the upstream provider. The
key is stored in the core config params (scoped to `user`), read back dynamically at request time via a
new `getUserUpstreamApiKey` call, and injected into the upstream `authorization` header on both the primary
and retry paths.

Security-wise, the lookup is authenticated with the caller's own user key (`x-tdai-user-key`) and enforced
on the core side by `assertCallerIsOwner`, so a user can only ever read their own key — no cross-user access.

## Problem

`MemoryProxy/src/handler.ts` resolves the upstream key solely from `config.upstream.apiKey` / the agent
entry, so there is no notion of a per-user key. Consequences:

- Every user shares the same upstream key; there is no way for a user to supply their own provider key.
- Users who need their own key (billing isolation, personal providers, per-user rate limits) are stuck
  with the shared one, or must rely on the client passing its own key and hope the proxy doesn't override it.
- There is no UI to configure a per-user key.

## Fix

Three sides cooperate; the core config store is the single source of truth, the proxy reads it
dynamically at request time, and the panel exposes the configuration UI.

### 1. core — new `llm.api_key` config param (user-scoped)

`MemoryCore/src/metadata/config/metadata_config_params.json`: added an `llm` module with an `api_key`
param (default `""`, `allowed_scopes: ["global", "user"]`). User-scoped values are set via the existing
`config/user/set` route and automatically override the global value when read — no new storage logic.

### 2. proxy — resolve and inject the caller's own key

`MemoryProxy/src/handler.ts`:

```ts
let resolvedApiKey = effectiveApiKey;
if (userId && apiKey && tdaiClient) {
  try {
    resolvedApiKey = await tdaiClient.getUserUpstreamApiKey(apiKey, userId);
  } catch {
    resolvedApiKey = ""; // not configured — no fallback to global/agent key
  }
}
// buildUpstreamHeaders(..., resolvedApiKey) on primary and retry paths
```

- When `userId` is resolvable and the user has a configured key, that key is used.
- When unconfigured / lookup fails, `resolvedApiKey` stays `""` — the proxy does **not** fall back to the
  global/agent key, so the client's own key passes through and an upstream auth failure prompts the user
  to configure theirs.
- The global/agent key is only used as a fallback when `userId` cannot be resolved (e.g. auth disabled).

`MemoryProxy/src/tdai/client.ts`: added `getUserUpstreamApiKey(userKey, userId)` which POSTs
`/v3/meta/config/user/get` for `module:"llm", param_name:"api_key"`, authenticated with the caller's own
`x-tdai-user-key` so core's `assertCallerIsOwner` restricts reads to self. It is fail-open: on any
network/HTTP/envelope error it returns `""` (never throws, never blocks forwarding).

### 3. panel — "upstream LLM" configuration tab

`MemoryPanel/web/src/components/SettingsDialog.tsx`: added an **「上游 LLM / Upstream LLM」** tab that
reads the current logged-in user's `llm/api_key` (`config/user/get`) and lets them save (`config/user/set`)
or clear it, rendered as a `type="password"` field. I18n keys added in `en-US.ts` / `zh-CN.ts`.

## Test Plan

- Verified locally and on the cloud panel that the new "upstream LLM" tab shows the effective per-user key
  value, saves/clears it correctly, and persists to the core config store.
- Verified the proxy resolves a configured user key and injects it as `authorization: Bearer <user key>`
  into the upstream request on both the primary and retry paths.
- Verified the no-fallback semantics: with a user who has no configured key, the proxy leaves the header
  empty (client key passthrough) instead of substituting the global/agent key.
- `git diff` against the base `feat/server_team` confirms the PR touches only the 6 intended files
  (config param, panel tab, 2 i18n files, proxy handler, proxy tdai client) with no unrelated changes.

## Related Issues

None. No upstream issue exists for this capability; this is a direct contribution.

## Contributor

- dong-frank <1057762929@qq.com> (Signed-off-by / DCO)
