### PR TITLE
fix(gateway): honor TDAI_EMBEDDING_* env vars and report real version in /health

### DIFF
--- a/MemoryCore/src/gateway/config.ts
+++ b/MemoryCore/src/gateway/config.ts
@@ -516,6 +516,39 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
     };
   }
 
+  // ── Standalone embedding env-var override ──
+  // Mirror the LLM env overrides: TDAI_EMBEDDING_* take precedence over both the
+  // memory.embedding and top-level embedding blocks, so vector search can be
+  // configured via a single .env without editing the yaml. Because
+  // parseMemoryConfig derives enabled=false when provider defaults to "none",
+  // we also force enabled=true whenever a remote provider + apiKey is supplied
+  // via env, otherwise the vector store is short-circuited downstream.
+  const embProviderEnv = env("TDAI_EMBEDDING_PROVIDER");
+  const embBaseUrlEnv = env("TDAI_EMBEDDING_BASE_URL");
+  const embApiKeyEnv = env("TDAI_EMBEDDING_API_KEY");
+  const embModelEnv = env("TDAI_EMBEDDING_MODEL");
+  const embDimensionsEnv = envInt("TDAI_EMBEDDING_DIMENSIONS");
+  // Infer an OpenAI-compatible remote provider when a full remote config is
+  // supplied via env without an explicit provider (e.g. only
+  // baseUrl/apiKey/model/dimensions are set, matching the .env template).
+  const embProviderInferred =
+    embProviderEnv ??
+    (embBaseUrlEnv && embApiKeyEnv && embModelEnv && embDimensionsEnv ? "openai" : undefined);
+  if (embProviderInferred || embBaseUrlEnv || embApiKeyEnv || embModelEnv || embDimensionsEnv) {
+    const provider = embProviderInferred ?? memory.embedding.provider;
+    const apiKey = embApiKeyEnv ?? memory.embedding.apiKey;
+    const enableRemote = provider !== "none" && provider !== "local" && apiKey !== "";
+    memory.embedding = {
+      ...memory.embedding,
+      provider,
+      baseUrl: embBaseUrlEnv ?? memory.embedding.baseUrl,
+      apiKey,
+      model: embModelEnv ?? memory.embedding.model,
+      dimensions: embDimensionsEnv ?? memory.embedding.dimensions,
+      enabled: enableRemote ? true : memory.embedding.enabled,
+    };
+  }
+
   // ── Skill module config ──
   // Resolution order:
   //   1. Top-level `skill` block in yaml (preferred — skill is a top-level

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -108,9 +108,10 @@ import type { PipelineWorker } from "../services/pipeline-worker.js";
 import type { StatefulPipelineManager } from "../utils/stateful-pipeline-manager.js";
 import type { PipelineLogger } from "../utils/pipeline-factory.js";
 import { parsePipelineTimerMember } from "../core/state/timer-member.js";
+import packageJson from "../../package.json" with { type: "json" };
 
 const TAG = "[tdai-gateway]";
-const VERSION = "0.1.0";
+const VERSION = packageJson.version;
 
 // ============================
 // Console logger (for standalone gateway — no OpenClaw logger available)


### PR DESCRIPTION
## Summary

Two small standalone-gateway fixes in `MemoryCore`:

1. **Honor `TDAI_EMBEDDING_*` env vars** — the embedding config previously ignored them and silently fell back to pure BM25.
2. **Report the real package version in `/health`** — `VERSION` was hardcoded to `0.1.0`.

## Problem & fix 1 — embedding env vars are silently ignored

`src/gateway/config.ts` applies LLM env overrides (`TDAI_LLM_BASE_URL` / `TDAI_LLM_API_KEY` / `TDAI_LLM_MODEL`) but the embedding block only read from the YAML file, with no `env()` path. As a result, setting `TDAI_EMBEDDING_BASE_URL` / `TDAI_EMBEDDING_API_KEY` / `TDAI_EMBEDDING_MODEL` / `TDAI_EMBEDDING_DIMENSIONS` in `.env` did nothing: standalone defaults to `provider: "none"` (pure BM25) and logs zero-vector writes without any warning, so semantic recall disappears silently.

This change mirrors the LLM pattern by adding env overrides to the embedding block. It also:

- infers `provider: "openai"` when a full remote config (`baseUrl` + `apiKey` + `model` + `dimensions`) is supplied via env without an explicit `TDAI_EMBEDDING_PROVIDER` (matching the `.env` template, which only lists the four fields);
- forces `enabled: true` when a remote provider + apiKey is present, because `parseMemoryConfig` derives `enabled=false` when provider defaults to `"none"`, which would otherwise short-circuit the vector store downstream (`src/core/store/factory.ts`, `src/core/tdai-core.ts`).

### Before / after

Before (`TDAI_EMBEDDING_*` set in `.env`):

```
GET /health → "stores": { "vectorStore": true, "embeddingService": false }
[vec-dual-write] Embedding OK: dims=0, norm=0.0000
```

After:

```
GET /health → "stores": { "vectorStore": true, "embeddingService": true }
[factory] Store created: backend=sqlite, dimensions=3072, embedding=enabled
[embedding] Using remote embedding (provider=openai, model=text-embedding-3-large)
```

## Problem & fix 2 — `/health` reports hardcoded `0.1.0`

`src/gateway/server.ts` had `const VERSION = "0.1.0"` while `MemoryCore/package.json` reports `2.0.0-beta.1`, so `/health` returned a stale version. The fix reads the version from `package.json` at build time (same `import ... with { type: "json" }` pattern already used by `tsdown.config.ts`), keeping it in sync automatically.

## Testing

- `npm run build:plugin` succeeds.
- Started the standalone gateway with `TDAI_EMBEDDING_*` set in `.env`: `/health` now reports `version: "2.0.0-beta.1"` and `embeddingService: true`, and the store initializes with the configured embedding (provider=openai, dimensions=3072).
- Environment: Node v22.23.2, commit 4dca55c, standalone mode.

---

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
