### PR TITLE
chore(knowledge): remove unused louvain dep & fix wiki_graph description

### DIFF
--- a/MemoryKnowledge/package.json
+++ b/MemoryKnowledge/package.json
@@ -41,7 +41,6 @@
     "dotenv": "^16.4.0",
     "drizzle-orm": "^0.44.0",
     "graphology": "^0.26.0",
-    "graphology-communities-louvain": "^2.0.2",
     "hono": "^4.7.0",
     "js-tiktoken": "^1.0.18",
     "js-yaml": "^4.2.0",

--- a/MemoryKnowledge/src/mcp/tools.ts
+++ b/MemoryKnowledge/src/mcp/tools.ts
@@ -210,7 +210,7 @@ export const MCP_TOOLS: McpToolDef[] = [
   },
   {
     name: "wiki_graph",
-    description: "Get the wiki knowledge graph (nodes, edges, communities).",
+    description: "Get the wiki knowledge graph (nodes, edges). communities reserved but not implemented (always empty).",
     inputSchema: {
       type: "object",
       properties: {

--- a/MemoryKnowledge/src/routes/tools.ts
+++ b/MemoryKnowledge/src/routes/tools.ts
@@ -74,7 +74,7 @@ const WIKI_TOOLS: HttpToolDef[] = [
   },
   {
     name: "get_graph",
-    description: "获取知识图谱结构（nodes, edges, communities）。",
+    description: "获取知识图谱结构（nodes, edges）。communities 字段保留但未实现（恒为空）。",
     params: {},
   },
   {


### PR DESCRIPTION
Closes #973.

`graphology-communities-louvain` 全仓零 import，communities 恒为空数组。本 PR：
- 删除未使用的 `graphology-communities-louvain` 依赖（graphology 主包保留，仍在使用：`manager.ts:14` / `graph-search.ts:15`）
- 修正 `wiki_graph` / `get_graph` 工具描述，去掉 communities 承诺（保留 `communities: []` 字段维持接口契约）

**改动：** `MemoryKnowledge/package.json`、`MemoryKnowledge/src/mcp/tools.ts`、`MemoryKnowledge/src/routes/tools.ts`

> 若维护者计划实现社区发现，可只采纳描述修正、保留依赖——请在 review 时指出，我会调整。
