### PR TITLE
docs: example gateway_endpoint uses non-resolving host (memory.ap-shanghai.tencenttdai.com)

### DIFF
--- a/deploy/panel-knowledge-combined/README.md
+++ b/deploy/panel-knowledge-combined/README.md
@@ -21,7 +21,7 @@
     {
       "id": "mem-xxxxxxxx",
       "name": "我的 Memory 实例",
-      "gateway_endpoint": "https://memory.ap-shanghai.tencenttdai.com",
+      "gateway_endpoint": "<your-gateway>.ap-shanghai",
       "api_key": "your-gateway-api-key"
     }
   ]
@@ -44,7 +44,7 @@ KS 的 Wiki ingest / 总结等能力会调用大模型，默认走 Memory 提供
 
 `KNOWLEDGE_LLM_PROXY_BASE_URL` 与上面的 `gateway_endpoint` **是同一个地址**：从 Memory 控制台拿到的 Gateway 地址。例如上海地域：
 
-`https://memory.ap-shanghai.tencenttdai.com`
+`<your-gateway>.ap-shanghai`
 
 （其它地域按控制台实际地址填写。）
 
@@ -60,7 +60,7 @@ docker run -d --name memory-hub \
   -v memory-hub:/data/knowledge \
   -v /path/to/metadata-instances.json:/app/panel/config/metadata-instances.json:ro \
   -e KNOWLEDGE_PUBLIC_BASE_URL=http://10.2.3.4:8424/v3 \
-  -e KNOWLEDGE_LLM_PROXY_BASE_URL=https://memory.ap-shanghai.tencenttdai.com \
+  -e KNOWLEDGE_LLM_PROXY_BASE_URL=<your-gateway>.ap-shanghai \
   agentmemory/memory-hub:latest
 ```
 


### PR DESCRIPTION
`deploy/panel-knowledge-combined/README.md` 把 `https://memory.ap-shanghai.tencenttdai.com` 当作示例 gateway_endpoint 写在三处：

- `metadata-instances.json` 示例（第 24 行）
- 第 45-47 行的文字说明
- 第 63 行的 docker run 示例

这个域名 (`tencenttdai.com`) 实际不解析（任何人都连不上），但文档没说它是占位，只说"按实际地址填写"。直接照搬的新用户会拷到一个永远连不上的地址。

改成 `<your-gateway>.ap-shanghai` 形式的占位符，把"必须替换"这层意思显式写出来，与下文注释"按控制台实际地址填写"一致。

只改了 `deploy/panel-knowledge-combined/README.md` 那一处；其它地方如果有同样的示例域名再分别修。