### PR TITLE
fix(proxy): finalize OpenAI streams on DONE

### DIFF
--- a/MemoryProxy/src/__tests__/handler-stream-finalization.test.ts
+++ b/MemoryProxy/src/__tests__/handler-stream-finalization.test.ts
@@ -1,0 +1,203 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_CONFIG } from "../config.js";
+import { createApp } from "../server.js";
+import type { ProxyConfig } from "../types.js";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(servers.splice(0).map(closeServer));
+});
+
+describe("OpenAI stream finalization", () => {
+  it("finalizes when the client cancels immediately after data: [DONE]", async () => {
+    const upstream = createSseUpstream({ sendDone: true, keepOpen: true });
+    servers.push(upstream);
+    const upstreamUrl = await listen(upstream);
+    const streamDoneCount = captureStreamDoneCount();
+    const response = await requestStream(upstreamUrl, "stream-cancel-test");
+
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    let received = "";
+    while (!/data:\s*\[DONE\]/.test(received)) {
+      const chunk = await reader!.read();
+      expect(chunk.done).toBe(false);
+      received += decoder.decode(chunk.value, { stream: true });
+    }
+    await reader!.cancel();
+
+    await vi.waitFor(() => expect(streamDoneCount()).toBe(1));
+  });
+
+  it("finalizes when the client cancels after the DONE line before the blank line arrives", async () => {
+    const upstream = createSseUpstream({
+      sendDone: true,
+      keepOpen: true,
+      doneFrame: "data: [DONE]\n",
+    });
+    servers.push(upstream);
+    const upstreamUrl = await listen(upstream);
+    const streamDoneCount = captureStreamDoneCount();
+    const response = await requestStream(upstreamUrl, "stream-split-done-test");
+
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    let received = "";
+    while (!/data:\s*\[DONE\]/.test(received)) {
+      const chunk = await reader!.read();
+      expect(chunk.done).toBe(false);
+      received += decoder.decode(chunk.value, { stream: true });
+    }
+    await reader!.cancel();
+
+    await vi.waitFor(() => expect(streamDoneCount()).toBe(1));
+  });
+
+  it("finalizes a CRLF DONE event without the optional data-field space", async () => {
+    const upstream = createSseUpstream({
+      sendDone: true,
+      keepOpen: true,
+      doneFrame: "data:[DONE]\r\n\r\n",
+    });
+    servers.push(upstream);
+    const upstreamUrl = await listen(upstream);
+    const streamDoneCount = captureStreamDoneCount();
+    const response = await requestStream(upstreamUrl, "stream-crlf-done-test");
+
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    expect(reader).toBeDefined();
+
+    const decoder = new TextDecoder();
+    let received = "";
+    while (!/data:\s*\[DONE\]/.test(received)) {
+      const chunk = await reader!.read();
+      expect(chunk.done).toBe(false);
+      received += decoder.decode(chunk.value, { stream: true });
+    }
+    await reader!.cancel();
+
+    await vi.waitFor(() => expect(streamDoneCount()).toBe(1));
+  });
+
+  it("finalizes once when data: [DONE] is followed by transport EOF", async () => {
+    const upstream = createSseUpstream({ sendDone: true, keepOpen: false });
+    servers.push(upstream);
+    const upstreamUrl = await listen(upstream);
+    const streamDoneCount = captureStreamDoneCount();
+
+    const response = await requestStream(upstreamUrl, "stream-done-eof-test");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("data: [DONE]");
+
+    await vi.waitFor(() => expect(streamDoneCount()).toBe(1));
+  });
+
+  it("finalizes once at transport EOF when the stream has no data: [DONE]", async () => {
+    const upstream = createSseUpstream({ sendDone: false, keepOpen: false });
+    servers.push(upstream);
+    const upstreamUrl = await listen(upstream);
+    const streamDoneCount = captureStreamDoneCount();
+
+    const response = await requestStream(upstreamUrl, "stream-eof-test");
+    expect(response.status).toBe(200);
+    expect(await response.text()).not.toContain("data: [DONE]");
+
+    await vi.waitFor(() => expect(streamDoneCount()).toBe(1));
+  });
+});
+
+function createSseUpstream(options: {
+  sendDone: boolean;
+  keepOpen: boolean;
+  doneFrame?: string;
+}): Server {
+  return createServer((request, response) => {
+    request.resume();
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+    });
+    response.write(
+      `data: ${JSON.stringify({
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk",
+        model: "test-model",
+        choices: [{ index: 0, delta: { content: "hello" }, finish_reason: null }],
+      })}\n\n`,
+    );
+    response.write(
+      `data: ${JSON.stringify({
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk",
+        model: "test-model",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })}\n\n`,
+    );
+    if (options.sendDone) response.write(options.doneFrame ?? "data: [DONE]\n\n");
+    if (!options.keepOpen) response.end();
+    // A kept-open body models OpenAI-compatible clients that stop at [DONE]
+    // and close the response without waiting for transport EOF.
+  });
+}
+
+function captureStreamDoneCount(): () => number {
+  let stderr = "";
+  vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write);
+  return () => stderr.split("✓ STREAM").length - 1;
+}
+
+async function requestStream(upstreamUrl: string, conversationId: string): Promise<Response> {
+  const app = createApp(testConfig(upstreamUrl));
+  return app.request("/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-conversation-id": conversationId,
+    },
+    body: JSON.stringify({
+      model: "test-model",
+      stream: true,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+function testConfig(upstreamUrl: string): ProxyConfig {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.upstream.url = upstreamUrl;
+  config.server.forwardTimeoutMs = 2_000;
+  config.rateLimit = { tpm: 0, qpm: 0 };
+  config.extraction = { enabled: false, extractors: [] };
+  return config;
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not expose a TCP address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -1466,6 +1466,20 @@ function mergeToolCallDeltas(
   }
 }
 
+/** Return true once a complete SSE data line carries the terminal sentinel. */
+function hasCompleteSseDoneLine(sseText: string): boolean {
+  const lastLineBreak = sseText.lastIndexOf("\n");
+  if (lastLineBreak < 0) return false;
+
+  return sseText
+    .slice(0, lastLineBreak)
+    .split("\n")
+    .some((line) => {
+      const trimmed = line.trim();
+      return trimmed.startsWith("data:") && trimmed.slice(5).trim() === "[DONE]";
+    });
+}
+
 /** Create a TransformStream that passes bytes through unchanged,
  *  while extracting usage/content/tool_calls from SSE events in-band.
  */
@@ -1478,8 +1492,11 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
   let assistantContent = "";
   const toolCallAccumulators = new Map<number, ToolCallAccumulator>();
 
-  function processSseChunk(chunk: string): void {
-    sseBuf += chunk;
+  function processSseChunk(chunk: string): boolean {
+    // Normalize CRLF only in the parsing buffer; forwarded bytes stay untouched.
+    // A trailing CR is retained until the next chunk arrives and completes CRLF.
+    sseBuf = (sseBuf + chunk).replace(/\r\n/g, "\n");
+    const sawDone = hasCompleteSseDoneLine(sseBuf);
     const parts = sseBuf.split("\n\n");
     sseBuf = parts.pop() ?? "";
     for (const part of parts) {
@@ -1489,6 +1506,18 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
       assistantContent += content;
       mergeToolCallDeltas(toolCallAccumulators, toolCallDeltas);
     }
+    return sawDone;
+  }
+
+  let finalizePromise: Promise<void> | null = null;
+
+  function finalizeOnce(): Promise<void> {
+    if (!finalizePromise) {
+      finalizePromise = finalize().catch((err: unknown) => {
+        pipe.error("STREAM_FINALIZE", err);
+      });
+    }
+    return finalizePromise;
   }
 
   async function finalize(): Promise<void> {
@@ -1705,17 +1734,15 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
     transform(chunk, controller) {
       controller.enqueue(chunk);
       try {
-        processSseChunk(decoder.decode(chunk, { stream: true }));
+        if (processSseChunk(decoder.decode(chunk, { stream: true }))) {
+          void finalizeOnce();
+        }
       } catch (err: unknown) {
         pipe.error("STREAM_TAP", err);
       }
     },
     async flush() {
-      try {
-        await finalize();
-      } catch (err: unknown) {
-        pipe.error("STREAM_FINALIZE", err);
-      }
+      await finalizeOnce();
     },
   });
 }


### PR DESCRIPTION
## Description | 描述

OpenAI-compatible clients may stop reading and cancel the response as soon as they receive the terminal `data: [DONE]` line. The proxy previously finalized streaming side effects only when the SSE event delimiter or transport EOF was observed, so cancellation could skip usage logging, Chat Memory L0 writeback, and skill extraction.

This PR:

- recognizes the terminal sentinel as soon as a complete SSE `data:` line arrives, without waiting for the following blank line or connection EOF;
- accepts LF and CRLF framing, with or without the optional space after `data:`;
- keeps response bytes unchanged by normalizing line endings only in the internal parsing buffer;
- uses a shared finalization promise so `[DONE]` and later EOF/flush paths remain idempotent;
- adds real HTTP regression coverage for immediate cancellation, a delayed blank-line terminator, CRLF framing, normal `[DONE]` plus EOF, and EOF without `[DONE]`.

## Related Issue | 关联 Issue

N/A — reproduced during Hermes/TencentDB Agent Memory integration testing.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

`cd MemoryProxy && npm test` passes 5/5 tests. `git diff --check` is clean. The commit includes the required DCO sign-off.
