### PR TITLE
feat(panel): add safe agent memory import CLI

### DIFF
--- a/MemoryPanel/.gitignore
+++ b/MemoryPanel/.gitignore
@@ -48,6 +48,7 @@ coverage/
 # Temporary
 tmp/
 .tmp/
+.agent-memory-import-state.json
 
 # iWiki plugin files
 .iwiki

--- a/MemoryPanel/README.md
+++ b/MemoryPanel/README.md
@@ -134,8 +134,9 @@ TDAI_USER_KEY=sk-mem-example TDAI_SERVICE_ID=default \
   pnpm import:agent-memory --source all --team-id team-example --agent-id agt-example --yes
 ```
 
-可用 `--output plan.json` 导出 ImportPlan v1 供审阅。该文件包含记忆正文，CLI 会以
-`0600` 权限写入，仍须按敏感数据保管。完整参数见 `pnpm import:agent-memory --help`。
+可用 `--output plan.json` 导出 ImportPlan v1 供审阅。该文件包含记忆正文；CLI 在
+POSIX 系统上以 `0600` 权限写入，Windows 上则继承所在目录的 ACL，因此应选择用户私有目录。
+无论平台都须按敏感数据保管。完整参数见 `pnpm import:agent-memory --help`。
 使用 `memory-hub` 合并镜像时，另传 `--panel-url http://127.0.0.1:8125`。
 
 ## 公开 API

--- a/MemoryPanel/README.md
+++ b/MemoryPanel/README.md
@@ -99,9 +99,43 @@ npm run dev
 | `pnpm generate:meta-openapi` | 生成 Meta OpenAPI 文档 |
 | `pnpm test:panel:e2e` | 运行 Panel Meta E2E |
 | `pnpm test:knowledge:e2e` | 运行 Knowledge E2E |
+| `pnpm import:agent-memory` | 预览或导入其他 agent 的生成态记忆 |
 | `cd web && npm run dev` | 启动前端开发服务器 |
 | `cd web && npm run build` | 构建前端到 `web/dist/` |
 | `bash scripts/secret-scan.sh` | 扫描敏感信息 |
+
+### 导入其他 agent 的生成态记忆
+
+CLI 支持以下已经沉淀为 Markdown 的记忆来源，不读取原始会话：
+
+- Codex：`$CODEX_HOME/memories/{memory_summary.md,MEMORY.md}`；
+- WorkBuddy/CodeBuddy：`~/.workbuddy/MEMORY.md`，以及显式 workspace 下的 `.workbuddy/memory/*.md`；
+- Claude Code Auto Memory：`~/.claude/projects/*/memory/*.md`，并支持用户设置中的 `autoMemoryDirectory`。
+
+默认扫描全部来源并只生成 dry-run 计划。WorkBuddy/CodeBuddy 的 workspace 可以重复指定：
+
+```bash
+pnpm import:agent-memory \
+  --workspace /path/to/project-a \
+  --workspace /path/to/project-b \
+  --team-id team-example \
+  --agent-id agt-example
+```
+
+也可用 `--source codex|workbuddy|codebuddy|claude|all` 只扫描指定格式；`workbuddy`
+和 `codebuddy` 是同一 `.workbuddy` adapter 的两个入口。
+
+显式 `--yes` 才会调用现有 Chat Memory Import API。用户密钥只能通过环境变量提供，
+不会接受命令行密钥参数；单次请求自动限制为 100 条，确认完整接收后才记录 checkpoint：
+
+```bash
+TDAI_USER_KEY=sk-mem-example TDAI_SERVICE_ID=default \
+  pnpm import:agent-memory --source all --team-id team-example --agent-id agt-example --yes
+```
+
+可用 `--output plan.json` 导出 ImportPlan v1 供审阅。该文件包含记忆正文，CLI 会以
+`0600` 权限写入，仍须按敏感数据保管。完整参数见 `pnpm import:agent-memory --help`。
+使用 `memory-hub` 合并镜像时，另传 `--panel-url http://127.0.0.1:8125`。
 
 ## 公开 API
 

--- a/MemoryPanel/README.md
+++ b/MemoryPanel/README.md
@@ -111,6 +111,7 @@ CLI 支持以下已经沉淀为 Markdown 的记忆来源，不读取原始会话
 - Codex：`$CODEX_HOME/memories/{memory_summary.md,MEMORY.md}`；
 - WorkBuddy/CodeBuddy：`~/.workbuddy/MEMORY.md`，以及显式 workspace 下的 `.workbuddy/memory/*.md`；
 - Claude Code Auto Memory：`~/.claude/projects/*/memory/*.md`，并支持用户设置中的 `autoMemoryDirectory`。
+  该路径契约来自 Claude Code 官方文档；当前 scanner 通过合成目录测试，尚未用本机真实样本验证。
 
 默认扫描全部来源并只生成 dry-run 计划。WorkBuddy/CodeBuddy 的 workspace 可以重复指定：
 

--- a/MemoryPanel/package.json
+++ b/MemoryPanel/package.json
@@ -17,6 +17,7 @@
     "test:panel:e2e": "tests/panel/e2e-panel-meta.sh",
     "test:knowledge:e2e": "tsx tests/knowledge/e2e-knowledge-chain.ts",
     "test:knowledge:e2e:full": "E2E_MODE=full tsx tests/knowledge/e2e-knowledge-chain.ts",
+    "import:agent-memory": "tsx scripts/import-agent-memory/cli.ts",
     "mock-kernel": "tsx scripts/mock-memory-server.ts"
   },
   "dependencies": {

--- a/MemoryPanel/scripts/import-agent-memory/cli.ts
+++ b/MemoryPanel/scripts/import-agent-memory/cli.ts
@@ -157,6 +157,10 @@ async function writePrivateJson(path: string, value: unknown): Promise<void> {
   await chmod(absolute, 0o600);
 }
 
+function importEndpoint(panelUrl: string): URL {
+  return new URL('/api/v1/chat-memory/import', `${panelUrl.replace(/\/+$/, '')}/`);
+}
+
 function printPlan(plan: ImportPlanV1, result: ScanResult, options: CliOptions): void {
   console.log(`Scanning generated memories (${options.yes ? 'write enabled' : 'dry-run; no remote writes'}):\n`);
   for (const report of result.reports) {
@@ -191,7 +195,7 @@ async function importBatch(
   userKey: string,
   serviceId: string,
 ): Promise<number> {
-  const endpoint = new URL('/api/v1/chat-memory/import', `${options.panelUrl.replace(/\/+$/, '')}/`);
+  const endpoint = importEndpoint(options.panelUrl);
   let response: Response;
   try {
     response = await fetch(endpoint, {
@@ -225,10 +229,16 @@ async function importBatch(
         + 'The batch was not checkpointed; inspect the target before rerunning.',
     );
   }
-  if (!response.ok || envelope.code !== 0) {
+  if (response.status >= 400 && response.status < 500) {
     throw new Error(
       `MemoryPanel rejected the batch (HTTP ${response.status}, code ${envelope.code}): `
         + (envelope.message ?? 'unknown error'),
+    );
+  }
+  if (!response.ok || envelope.code !== 0) {
+    throw new Error(
+      `Import outcome is unknown after MemoryPanel returned HTTP ${response.status}, code ${envelope.code}. `
+        + 'The batch was not checkpointed; inspect the target before rerunning.',
     );
   }
   if (typeof envelope.data?.accepted_count !== 'number') {
@@ -252,7 +262,12 @@ export async function run(argv = process.argv.slice(2)): Promise<void> {
       throw new Error('--output and --state-file must use different paths');
     }
     await writePrivateJson(options.output, plan);
-    console.log(`Import Plan written with mode 0600: ${resolve(options.output)}`);
+    if (process.platform === 'win32') {
+      console.log(`Import Plan written: ${resolve(options.output)}`);
+      console.log('Warning: on Windows the file inherits directory ACLs; use a private user directory.');
+    } else {
+      console.log(`Import Plan written with POSIX mode 0600: ${resolve(options.output)}`);
+    }
     console.log('Warning: the plan contains memory content and must be handled as sensitive data.');
   }
   if (!options.yes) {
@@ -263,6 +278,7 @@ export async function run(argv = process.argv.slice(2)): Promise<void> {
   const userKey = process.env.TDAI_USER_KEY;
   if (!userKey) throw new Error('TDAI_USER_KEY is required with --yes');
   const serviceId = process.env.TDAI_SERVICE_ID || 'default';
+  const endpoint = importEndpoint(options.panelUrl).href;
 
   const statePath = resolve(options.stateFile);
   let checkpoint = await readCheckpoint(statePath);
@@ -271,7 +287,11 @@ export async function run(argv = process.argv.slice(2)): Promise<void> {
   for (const session of plan.sessions) {
     const batches = batchMessages(session.messages);
     for (const [index, batch] of batches.entries()) {
-      const key = checkpointKey({ teamId: options.teamId, agentId: options.agentId }, session.session_id, batch);
+      const key = checkpointKey(
+        { endpoint, serviceId, teamId: options.teamId, agentId: options.agentId },
+        session.session_id,
+        batch,
+      );
       const completed = checkpoint.completed[key];
       if (completed && completed.accepted_count !== batch.length) {
         throw new Error(`Checkpoint entry does not match batch length for ${session.session_id}`);

--- a/MemoryPanel/scripts/import-agent-memory/cli.ts
+++ b/MemoryPanel/scripts/import-agent-memory/cli.ts
@@ -1,0 +1,307 @@
+import { chmod, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import {
+  batchMessages,
+  buildImportPlan,
+  checkpointKey,
+  emptyCheckpoint,
+  recordSuccessfulBatch,
+  type ImportCheckpointV1,
+  type ImportMessage,
+  type ImportPlanV1,
+  type MemorySource,
+} from './plan.js';
+import {
+  defaultAgentHomes,
+  scanClaude,
+  scanCodex,
+  scanWorkBuddy,
+  type ScanResult,
+} from './sources.js';
+
+const DEFAULT_PANEL_URL = 'http://127.0.0.1:8123';
+const DEFAULT_STATE_FILE = '.agent-memory-import-state.json';
+const SUPPORTED_SOURCES = ['codex', 'workbuddy', 'codebuddy', 'claude', 'all'] as const;
+
+interface CliOptions {
+  source: string;
+  teamId?: string;
+  agentId?: string;
+  codexHome: string;
+  workbuddyHome: string;
+  claudeHome: string;
+  workspaces: string[];
+  panelUrl: string;
+  output?: string;
+  stateFile: string;
+  yes: boolean;
+}
+
+function usage(): string {
+  return `Import generated memories from Codex, WorkBuddy/CodeBuddy, or Claude Code into Agent Memory L0.
+
+Default mode is dry-run and never sends memory content.
+
+Usage:
+  pnpm import:agent-memory [options]
+
+Options:
+  --source NAME         codex | workbuddy | codebuddy | claude | all (default: all)
+  --workspace PATH      Workspace to check for .workbuddy/memory (repeatable; default: cwd)
+  --codex-home PATH     Codex home (default: CODEX_HOME or ~/.codex)
+  --workbuddy-home PATH WorkBuddy/CodeBuddy user home (default: ~/.workbuddy)
+  --claude-home PATH    Claude config home (default: CLAUDE_CONFIG_DIR or ~/.claude)
+  --team-id ID          Target team (required with --yes)
+  --agent-id ID         Target owning agent (required with --yes)
+  --panel-url URL       MemoryPanel URL (default: ${DEFAULT_PANEL_URL})
+  --output PATH         Write sensitive ImportPlan v1 JSON for review
+  --state-file PATH     Successful batch checkpoint (default: ${DEFAULT_STATE_FILE})
+  --yes                 Send the plan; the only remote-write switch
+  --help                Show this help
+
+Credentials are read only from TDAI_USER_KEY and TDAI_SERVICE_ID.`;
+}
+
+function optionsFromArgv(argv: string[]): CliOptions | undefined {
+  const homes = defaultAgentHomes();
+  const { values } = parseArgs({
+    args: argv,
+    strict: true,
+    options: {
+      source: { type: 'string', default: 'all' },
+      workspace: { type: 'string', multiple: true },
+      'codex-home': { type: 'string', default: homes.codex },
+      'workbuddy-home': { type: 'string', default: homes.workbuddy },
+      'claude-home': { type: 'string', default: homes.claude },
+      'team-id': { type: 'string' },
+      'agent-id': { type: 'string' },
+      'panel-url': { type: 'string', default: DEFAULT_PANEL_URL },
+      output: { type: 'string' },
+      'state-file': { type: 'string', default: DEFAULT_STATE_FILE },
+      yes: { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+  });
+  if (values.help) {
+    console.log(usage());
+    return undefined;
+  }
+  return {
+    source: values.source ?? 'all',
+    teamId: values['team-id'],
+    agentId: values['agent-id'],
+    codexHome: values['codex-home'] ?? homes.codex,
+    workbuddyHome: values['workbuddy-home'] ?? homes.workbuddy,
+    claudeHome: values['claude-home'] ?? homes.claude,
+    workspaces: values.workspace?.length ? values.workspace : [process.cwd()],
+    panelUrl: values['panel-url'] ?? DEFAULT_PANEL_URL,
+    output: values.output,
+    stateFile: values['state-file'] ?? DEFAULT_STATE_FILE,
+    yes: values.yes ?? false,
+  };
+}
+
+function selectedSources(value: string): MemorySource[] {
+  if (!(SUPPORTED_SOURCES as readonly string[]).includes(value)) {
+    throw new Error(`Unsupported source: ${value}`);
+  }
+  if (value === 'all') return ['codex', 'workbuddy', 'claude'];
+  if (value === 'codebuddy') return ['workbuddy'];
+  return [value as MemorySource];
+}
+
+async function scan(options: CliOptions): Promise<ScanResult> {
+  const selected = selectedSources(options.source);
+  const results = await Promise.all(selected.map((source) => {
+    if (source === 'codex') return scanCodex(options.codexHome);
+    if (source === 'workbuddy') return scanWorkBuddy(options.workbuddyHome, options.workspaces);
+    return scanClaude(options.claudeHome);
+  }));
+  return {
+    documents: results.flatMap((result) => result.documents),
+    reports: results.flatMap((result) => result.reports),
+  };
+}
+
+async function readOptional(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+async function readCheckpoint(path: string): Promise<ImportCheckpointV1> {
+  const raw = await readOptional(path);
+  if (!raw) return emptyCheckpoint();
+  const parsed = JSON.parse(raw) as Partial<ImportCheckpointV1>;
+  if (
+    parsed.version !== 1
+    || !parsed.completed
+    || typeof parsed.completed !== 'object'
+    || Array.isArray(parsed.completed)
+  ) {
+    throw new Error(`Unsupported checkpoint format: ${path}`);
+  }
+  return parsed as ImportCheckpointV1;
+}
+
+async function writePrivateJson(path: string, value: unknown): Promise<void> {
+  const absolute = resolve(path);
+  const temporary = join(dirname(absolute), `.${process.pid}-${Date.now()}.tmp`);
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporary, absolute);
+  await chmod(absolute, 0o600);
+}
+
+function printPlan(plan: ImportPlanV1, result: ScanResult, options: CliOptions): void {
+  console.log(`Scanning generated memories (${options.yes ? 'write enabled' : 'dry-run; no remote writes'}):\n`);
+  for (const report of result.reports) {
+    console.log(`  ${report.source.padEnd(10)} files=${report.files} locations=${report.locations}`);
+    for (const note of report.notes) console.log(`    - ${note}`);
+  }
+  const messageCount = plan.sessions.reduce((sum, session) => sum + session.messages.length, 0);
+  const batchCount = plan.sessions.reduce((sum, session) => sum + batchMessages(session.messages).length, 0);
+  const messageLengths = plan.sessions.flatMap((session) => {
+    return session.messages.map((message) => message.content.length);
+  });
+  const maxMessageChars = Math.max(0, ...messageLengths);
+  console.log(
+    `\nPlan: version=1 sources=${plan.sources.join(',')} sessions=${plan.sessions.length} `
+      + `messages=${messageCount} batches=${batchCount} max_message_chars=${maxMessageChars}`,
+  );
+  if (options.teamId || options.agentId) {
+    console.log(`Target: team=${options.teamId ?? '(not set)'} agent=${options.agentId ?? '(not set)'}`);
+  }
+}
+
+interface PanelEnvelope {
+  code: number;
+  message?: string;
+  data?: { accepted_count?: number };
+}
+
+async function importBatch(
+  options: CliOptions,
+  sessionId: string,
+  messages: ImportMessage[],
+  userKey: string,
+  serviceId: string,
+): Promise<number> {
+  const endpoint = new URL('/api/v1/chat-memory/import', `${options.panelUrl.replace(/\/+$/, '')}/`);
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Tdai-Service-Id': serviceId,
+        'X-Tdai-User-Key': userKey,
+      },
+      body: JSON.stringify({
+        team_id: options.teamId,
+        agent_id: options.agentId,
+        session_id: sessionId,
+        messages,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    throw new Error(
+      `Import outcome is unknown after a network failure (${error instanceof Error ? error.message : String(error)}). `
+        + 'The batch was not checkpointed; inspect the target before rerunning.',
+    );
+  }
+
+  let envelope: PanelEnvelope;
+  try {
+    envelope = (await response.json()) as PanelEnvelope;
+  } catch {
+    throw new Error(
+      `Import outcome is unknown because MemoryPanel returned a non-JSON response (HTTP ${response.status}). `
+        + 'The batch was not checkpointed; inspect the target before rerunning.',
+    );
+  }
+  if (!response.ok || envelope.code !== 0) {
+    throw new Error(
+      `MemoryPanel rejected the batch (HTTP ${response.status}, code ${envelope.code}): `
+        + (envelope.message ?? 'unknown error'),
+    );
+  }
+  if (typeof envelope.data?.accepted_count !== 'number') {
+    throw new Error(
+      'Import outcome is unknown because MemoryPanel omitted accepted_count; inspect the target before rerunning.',
+    );
+  }
+  return envelope.data.accepted_count;
+}
+
+export async function run(argv = process.argv.slice(2)): Promise<void> {
+  const options = optionsFromArgv(argv);
+  if (!options) return;
+  const result = await scan(options);
+  const plan = buildImportPlan(result.documents);
+  printPlan(plan, result, options);
+  if (!plan.sessions.length) throw new Error('No supported generated memories were found');
+
+  if (options.output) {
+    if (resolve(options.output) === resolve(options.stateFile)) {
+      throw new Error('--output and --state-file must use different paths');
+    }
+    await writePrivateJson(options.output, plan);
+    console.log(`Import Plan written with mode 0600: ${resolve(options.output)}`);
+    console.log('Warning: the plan contains memory content and must be handled as sensitive data.');
+  }
+  if (!options.yes) {
+    console.log('Run again with --yes to import. Parsing uses no LLM; Agent Memory distillation is asynchronous.');
+    return;
+  }
+  if (!options.teamId || !options.agentId) throw new Error('--team-id and --agent-id are required with --yes');
+  const userKey = process.env.TDAI_USER_KEY;
+  if (!userKey) throw new Error('TDAI_USER_KEY is required with --yes');
+  const serviceId = process.env.TDAI_SERVICE_ID || 'default';
+
+  const statePath = resolve(options.stateFile);
+  let checkpoint = await readCheckpoint(statePath);
+  let imported = 0;
+  let skipped = 0;
+  for (const session of plan.sessions) {
+    const batches = batchMessages(session.messages);
+    for (const [index, batch] of batches.entries()) {
+      const key = checkpointKey({ teamId: options.teamId, agentId: options.agentId }, session.session_id, batch);
+      const completed = checkpoint.completed[key];
+      if (completed && completed.accepted_count !== batch.length) {
+        throw new Error(`Checkpoint entry does not match batch length for ${session.session_id}`);
+      }
+      if (completed) {
+        skipped += batch.length;
+        console.log(`Skip completed ${session.source} batch ${index + 1}/${batches.length}`);
+        continue;
+      }
+      console.log(`Import ${session.source} batch ${index + 1}/${batches.length} (${batch.length} messages)`);
+      const acceptedCount = await importBatch(options, session.session_id, batch, userKey, serviceId);
+      checkpoint = recordSuccessfulBatch(checkpoint, key, batch.length, acceptedCount);
+      try {
+        await writePrivateJson(statePath, checkpoint);
+      } catch (error) {
+        throw new Error(
+          `Batch imported but checkpoint write failed (${error instanceof Error ? error.message : String(error)}); `
+            + 'inspect the target and state file before rerunning.',
+        );
+      }
+      imported += acceptedCount;
+    }
+  }
+  console.log(`Import complete: imported=${imported} skipped_from_checkpoint=${skipped}`);
+}
+
+const entry = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (import.meta.url === entry) {
+  run().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/MemoryPanel/scripts/import-agent-memory/plan.ts
+++ b/MemoryPanel/scripts/import-agent-memory/plan.ts
@@ -7,6 +7,8 @@ export type DocumentSplit = 'h2' | 'codex-task-group';
 
 export interface MemoryDocument {
   source: MemorySource;
+  /** Stable scanner identity. It is never included in imported memory text. */
+  sourceKey: string;
   sourceLabel: string;
   content: string;
   split: DocumentSplit;
@@ -37,6 +39,7 @@ export interface ImportCheckpointV1 {
 
 interface SourceBlock {
   source: MemorySource;
+  sourceKey: string;
   sourceLabel: string;
   content: string;
 }
@@ -61,7 +64,8 @@ function splitDocument(document: MemoryDocument): SourceBlock[] {
   const lines = document.content.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n').split('\n');
   const blocks: SourceBlock[] = [];
   let preamble: string[] = [];
-  let current: { title: string; lines: string[] } | undefined;
+  let current: { title: string; occurrence: number; lines: string[] } | undefined;
+  const headingOccurrences = new Map<string, number>();
 
   const flush = () => {
     if (!current) return;
@@ -69,7 +73,9 @@ function splitDocument(document: MemoryDocument): SourceBlock[] {
     if (content) {
       blocks.push({
         source: document.source,
-        sourceLabel: `${document.sourceLabel}#${current.title}`,
+        sourceKey: `${document.sourceKey}\0${current.title}\0${current.occurrence}`,
+        sourceLabel: `${document.sourceLabel}#${current.title}`
+          + (current.occurrence > 1 ? ` [${current.occurrence}]` : ''),
         content,
       });
     }
@@ -84,8 +90,12 @@ function splitDocument(document: MemoryDocument): SourceBlock[] {
     }
     flush();
     const prefix = preamble.join('\n').trim();
+    const title = match[1]?.trim() || 'untitled';
+    const occurrence = (headingOccurrences.get(title) ?? 0) + 1;
+    headingOccurrences.set(title, occurrence);
     current = {
-      title: match[1]?.trim() || 'untitled',
+      title,
+      occurrence,
       lines: prefix ? [prefix, '', line] : [line],
     };
     preamble = [];
@@ -95,7 +105,12 @@ function splitDocument(document: MemoryDocument): SourceBlock[] {
   if (blocks.length === 0) {
     const content = preamble.join('\n').trim();
     if (content) {
-      blocks.push({ source: document.source, sourceLabel: document.sourceLabel, content });
+      blocks.push({
+        source: document.source,
+        sourceKey: document.sourceKey,
+        sourceLabel: document.sourceLabel,
+        content,
+      });
     }
   }
   return blocks;
@@ -159,7 +174,7 @@ export function buildImportPlan(documents: MemoryDocument[]): ImportPlanV1 {
     source: block.source,
     // Keep a section's session stable when its body changes. The checkpoint key
     // still includes the body, so only the changed section is imported again.
-    session_id: `import-${block.source}-${stableHash(block.sourceLabel)}`,
+    session_id: `import-${block.source}-${stableHash(block.sourceKey)}`,
     source_label: block.sourceLabel,
     messages: messagesFor(block),
   })));

--- a/MemoryPanel/scripts/import-agent-memory/plan.ts
+++ b/MemoryPanel/scripts/import-agent-memory/plan.ts
@@ -1,0 +1,224 @@
+export const IMPORT_PLAN_VERSION = 1 as const;
+export const MAX_MESSAGE_CHARS = 8_192;
+export const MAX_MESSAGES_PER_REQUEST = 100;
+
+export type MemorySource = 'codex' | 'workbuddy' | 'claude';
+export type DocumentSplit = 'h2' | 'codex-task-group';
+
+export interface MemoryDocument {
+  source: MemorySource;
+  sourceLabel: string;
+  content: string;
+  split: DocumentSplit;
+}
+
+export interface ImportMessage {
+  role: 'user';
+  content: string;
+}
+
+export interface ImportSession {
+  source: MemorySource;
+  session_id: string;
+  source_label: string;
+  messages: ImportMessage[];
+}
+
+export interface ImportPlanV1 {
+  version: typeof IMPORT_PLAN_VERSION;
+  sources: MemorySource[];
+  sessions: ImportSession[];
+}
+
+export interface ImportCheckpointV1 {
+  version: 1;
+  completed: Record<string, { accepted_count: number; imported_at: string }>;
+}
+
+interface SourceBlock {
+  source: MemorySource;
+  sourceLabel: string;
+  content: string;
+}
+
+/** Stable, non-cryptographic content identifier; it is not used for security. */
+export function stableHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    for (const byte of [code & 0xff, code >>> 8]) {
+      hash ^= BigInt(byte);
+      hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+    }
+  }
+  return hash.toString(16).padStart(16, '0');
+}
+
+function splitDocument(document: MemoryDocument): SourceBlock[] {
+  const heading = document.split === 'codex-task-group'
+    ? /^#\s+Task Group:\s*(.+?)\s*$/
+    : /^##\s+(.+?)\s*$/;
+  const lines = document.content.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n').split('\n');
+  const blocks: SourceBlock[] = [];
+  let preamble: string[] = [];
+  let current: { title: string; lines: string[] } | undefined;
+
+  const flush = () => {
+    if (!current) return;
+    const content = current.lines.join('\n').trim();
+    if (content) {
+      blocks.push({
+        source: document.source,
+        sourceLabel: `${document.sourceLabel}#${current.title}`,
+        content,
+      });
+    }
+  };
+
+  for (const line of lines) {
+    const match = heading.exec(line);
+    if (!match) {
+      if (current) current.lines.push(line);
+      else preamble.push(line);
+      continue;
+    }
+    flush();
+    const prefix = preamble.join('\n').trim();
+    current = {
+      title: match[1]?.trim() || 'untitled',
+      lines: prefix ? [prefix, '', line] : [line],
+    };
+    preamble = [];
+  }
+
+  flush();
+  if (blocks.length === 0) {
+    const content = preamble.join('\n').trim();
+    if (content) {
+      blocks.push({ source: document.source, sourceLabel: document.sourceLabel, content });
+    }
+  }
+  return blocks;
+}
+
+function splitToFit(content: string, maxChars: number): string[] {
+  if (content.length <= maxChars) return [content];
+  const chunks: string[] = [];
+  let current = '';
+  const push = () => {
+    if (current) chunks.push(current);
+    current = '';
+  };
+
+  for (const paragraph of content.split(/\n{2,}/)) {
+    const separator = current ? '\n\n' : '';
+    if (current.length + separator.length + paragraph.length <= maxChars) {
+      current += separator + paragraph;
+      continue;
+    }
+    push();
+    if (paragraph.length <= maxChars) {
+      current = paragraph;
+      continue;
+    }
+    for (let offset = 0; offset < paragraph.length; offset += maxChars) {
+      const slice = paragraph.slice(offset, offset + maxChars);
+      if (slice.length === maxChars) chunks.push(slice);
+      else current = slice;
+    }
+  }
+  push();
+  return chunks;
+}
+
+function importedContent(source: MemorySource, sourceLabel: string, body: string): string {
+  return `[Imported memory: ${source}/${sourceLabel}]\n\n${body}`;
+}
+
+function messagesFor(block: SourceBlock): ImportMessage[] {
+  const unsplit = importedContent(block.source, block.sourceLabel, block.content);
+  if (unsplit.length <= MAX_MESSAGE_CHARS) return [{ role: 'user', content: unsplit }];
+
+  const reservedLabel = `${block.sourceLabel} [part 9999/9999]`;
+  const maxBodyChars = MAX_MESSAGE_CHARS - importedContent(block.source, reservedLabel, '').length;
+  if (maxBodyChars < 1) throw new Error(`Source label is too long: ${block.sourceLabel}`);
+  const parts = splitToFit(block.content, maxBodyChars);
+  if (parts.length > 9_999) throw new Error(`Source block has too many parts: ${block.sourceLabel}`);
+  return parts.map((part, index) => ({
+    role: 'user',
+    content: importedContent(
+      block.source,
+      `${block.sourceLabel} [part ${index + 1}/${parts.length}]`,
+      part,
+    ),
+  }));
+}
+
+export function buildImportPlan(documents: MemoryDocument[]): ImportPlanV1 {
+  const sessions = documents.flatMap((document) => {
+    const blocks = splitDocument(document);
+    if (document.split === 'codex-task-group') {
+      return blocks.map((block) => ({
+        source: block.source,
+        session_id: `import-${block.source}-${stableHash(`${block.sourceLabel}\0${block.content}`)}`,
+        source_label: block.sourceLabel,
+        messages: messagesFor(block),
+      }));
+    }
+    if (!blocks.length) return [];
+    return [{
+      source: document.source,
+      session_id: `import-${document.source}-${stableHash(`${document.sourceLabel}\0${document.content}`)}`,
+      source_label: document.sourceLabel,
+      messages: blocks.flatMap(messagesFor),
+    }];
+  });
+  return {
+    version: IMPORT_PLAN_VERSION,
+    sources: [...new Set(documents.map((document) => document.source))],
+    sessions,
+  };
+}
+
+export function batchMessages<T>(messages: T[], size = MAX_MESSAGES_PER_REQUEST): T[][] {
+  if (!Number.isInteger(size) || size < 1) throw new Error('Batch size must be a positive integer');
+  const batches: T[][] = [];
+  for (let index = 0; index < messages.length; index += size) {
+    batches.push(messages.slice(index, index + size));
+  }
+  return batches;
+}
+
+export function emptyCheckpoint(): ImportCheckpointV1 {
+  return { version: 1, completed: {} };
+}
+
+export function checkpointKey(
+  target: { teamId: string; agentId: string },
+  sessionId: string,
+  batch: ImportMessage[],
+): string {
+  return stableHash(JSON.stringify([target.teamId, target.agentId, sessionId, batch]));
+}
+
+export function recordSuccessfulBatch(
+  checkpoint: ImportCheckpointV1,
+  key: string,
+  batchLength: number,
+  acceptedCount: number,
+  importedAt = new Date().toISOString(),
+): ImportCheckpointV1 {
+  if (acceptedCount !== batchLength) {
+    throw new Error(
+      `Batch accepted ${acceptedCount}/${batchLength} messages and was not checkpointed; `
+        + 'inspect the target before rerunning',
+    );
+  }
+  return {
+    version: 1,
+    completed: {
+      ...checkpoint.completed,
+      [key]: { accepted_count: acceptedCount, imported_at: importedAt },
+    },
+  };
+}

--- a/MemoryPanel/scripts/import-agent-memory/plan.ts
+++ b/MemoryPanel/scripts/import-agent-memory/plan.ts
@@ -155,24 +155,14 @@ function messagesFor(block: SourceBlock): ImportMessage[] {
 }
 
 export function buildImportPlan(documents: MemoryDocument[]): ImportPlanV1 {
-  const sessions = documents.flatMap((document) => {
-    const blocks = splitDocument(document);
-    if (document.split === 'codex-task-group') {
-      return blocks.map((block) => ({
-        source: block.source,
-        session_id: `import-${block.source}-${stableHash(`${block.sourceLabel}\0${block.content}`)}`,
-        source_label: block.sourceLabel,
-        messages: messagesFor(block),
-      }));
-    }
-    if (!blocks.length) return [];
-    return [{
-      source: document.source,
-      session_id: `import-${document.source}-${stableHash(`${document.sourceLabel}\0${document.content}`)}`,
-      source_label: document.sourceLabel,
-      messages: blocks.flatMap(messagesFor),
-    }];
-  });
+  const sessions = documents.flatMap((document) => splitDocument(document).map((block) => ({
+    source: block.source,
+    // Keep a section's session stable when its body changes. The checkpoint key
+    // still includes the body, so only the changed section is imported again.
+    session_id: `import-${block.source}-${stableHash(block.sourceLabel)}`,
+    source_label: block.sourceLabel,
+    messages: messagesFor(block),
+  })));
   return {
     version: IMPORT_PLAN_VERSION,
     sources: [...new Set(documents.map((document) => document.source))],
@@ -194,11 +184,18 @@ export function emptyCheckpoint(): ImportCheckpointV1 {
 }
 
 export function checkpointKey(
-  target: { teamId: string; agentId: string },
+  target: { endpoint: string; serviceId: string; teamId: string; agentId: string },
   sessionId: string,
   batch: ImportMessage[],
 ): string {
-  return stableHash(JSON.stringify([target.teamId, target.agentId, sessionId, batch]));
+  return stableHash(JSON.stringify([
+    target.endpoint,
+    target.serviceId,
+    target.teamId,
+    target.agentId,
+    sessionId,
+    batch,
+  ]));
 }
 
 export function recordSuccessfulBatch(

--- a/MemoryPanel/scripts/import-agent-memory/sources.ts
+++ b/MemoryPanel/scripts/import-agent-memory/sources.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, isAbsolute, join, resolve } from 'node:path';
-import { stableHash, type MemoryDocument, type MemorySource } from './plan.js';
+import type { MemoryDocument, MemorySource } from './plan.js';
 
 export interface SourceReport {
   source: MemorySource;
@@ -30,7 +30,7 @@ async function markdownFiles(path: string): Promise<string[]> {
     return entries
       .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.md'))
       .map((entry) => entry.name)
-      .sort((left, right) => left.localeCompare(right));
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw error;
@@ -99,9 +99,13 @@ export async function scanWorkBuddy(
   }
 
   let locations = userMemory ? 1 : 0;
-  for (const workspace of [...new Set(workspaces.map((path) => resolve(path)))]) {
+  const resolvedWorkspaces = [...new Set(workspaces.map((path) => resolve(path)))];
+  const nameCounts = new Map<string, number>();
+  for (const workspace of resolvedWorkspaces) {
     const shortName = basename(workspace).replace(/[^a-zA-Z0-9._-]+/g, '-') || 'workspace';
-    const label = `workspace/${shortName}-${stableHash(workspace).slice(0, 8)}`;
+    const occurrence = (nameCounts.get(shortName) ?? 0) + 1;
+    nameCounts.set(shortName, occurrence);
+    const label = `workspace/${shortName}${occurrence > 1 ? `-${occurrence}` : ''}`;
     const found = await documentsFromDirectory(
       join(workspace, '.workbuddy', 'memory'),
       'workbuddy',
@@ -132,17 +136,15 @@ export async function scanClaude(claudeHome: string): Promise<ScanResult> {
   let customDirectory: string | undefined;
   if (settings) {
     try {
-      const value = (JSON.parse(settings) as { autoMemoryDirectory?: unknown }).autoMemoryDirectory;
+      const value = (JSON.parse(settings.replace(/^\uFEFF/, '')) as {
+        autoMemoryDirectory?: unknown;
+      }).autoMemoryDirectory;
       if (typeof value === 'string') {
         customDirectory = configuredMemoryPath(value);
         if (!customDirectory) notes.push('autoMemoryDirectory ignored: expected an absolute or ~/ path');
       }
     } catch {
-      notes.push('settings.json is invalid JSON; default project memories were not scanned');
-      return {
-        documents: [],
-        reports: [{ source: 'claude', files: 0, locations: 0, notes }],
-      };
+      notes.push('settings.json is invalid JSON; scanning default project memories instead');
     }
   }
 
@@ -158,18 +160,21 @@ export async function scanClaude(claudeHome: string): Promise<ScanResult> {
   let projectDirectories: string[] = [];
   try {
     const entries = await readdir(join(root, 'projects'), { withFileTypes: true });
-    projectDirectories = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+    projectDirectories = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
 
   const documents: MemoryDocument[] = [];
   let locations = 0;
-  for (const projectDirectory of projectDirectories) {
+  for (const [index, projectDirectory] of projectDirectories.entries()) {
     const found = await documentsFromDirectory(
       join(root, 'projects', projectDirectory, 'memory'),
       'claude',
-      `project-${stableHash(projectDirectory).slice(0, 8)}`,
+      `project-${index + 1}`,
     );
     if (found.length) locations += 1;
     documents.push(...found);

--- a/MemoryPanel/scripts/import-agent-memory/sources.ts
+++ b/MemoryPanel/scripts/import-agent-memory/sources.ts
@@ -1,4 +1,5 @@
 import { readFile, readdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import type { MemoryDocument, MemorySource } from './plan.js';
@@ -40,16 +41,22 @@ async function markdownFiles(path: string): Promise<string[]> {
 async function documentsFromDirectory(
   path: string,
   source: MemorySource,
+  sourceKeyPrefix: string,
   labelPrefix: string,
 ): Promise<MemoryDocument[]> {
   const names = await markdownFiles(path);
   const documents = await Promise.all(names.map(async (name) => ({
     source,
+    sourceKey: `${sourceKeyPrefix}/${name}`,
     sourceLabel: `${labelPrefix}/${name}`,
     content: await readFile(join(path, name), 'utf8'),
     split: 'h2' as const,
   })));
   return documents.filter((document) => document.content.trim());
+}
+
+function privateSourceKey(kind: string, location: string): string {
+  return `${kind}:${createHash('sha256').update(location).digest('hex')}`;
 }
 
 export async function scanCodex(codexHome: string): Promise<ScanResult> {
@@ -60,10 +67,22 @@ export async function scanCodex(codexHome: string): Promise<ScanResult> {
   ]);
   const documents: MemoryDocument[] = [];
   if (summary) {
-    documents.push({ source: 'codex', sourceLabel: 'memory_summary.md', content: summary, split: 'h2' });
+    documents.push({
+      source: 'codex',
+      sourceKey: 'codex/memory_summary.md',
+      sourceLabel: 'memory_summary.md',
+      content: summary,
+      split: 'h2',
+    });
   }
   if (memory) {
-    documents.push({ source: 'codex', sourceLabel: 'MEMORY.md', content: memory, split: 'codex-task-group' });
+    documents.push({
+      source: 'codex',
+      sourceKey: 'codex/MEMORY.md',
+      sourceLabel: 'MEMORY.md',
+      content: memory,
+      split: 'codex-task-group',
+    });
   }
   return {
     documents,
@@ -89,6 +108,7 @@ export async function scanWorkBuddy(
   if (userMemory) {
     documents.push({
       source: 'workbuddy',
+      sourceKey: 'workbuddy/user/MEMORY.md',
       sourceLabel: 'user/MEMORY.md',
       content: userMemory,
       split: 'h2',
@@ -100,16 +120,13 @@ export async function scanWorkBuddy(
 
   let locations = userMemory ? 1 : 0;
   const resolvedWorkspaces = [...new Set(workspaces.map((path) => resolve(path)))];
-  const nameCounts = new Map<string, number>();
   for (const workspace of resolvedWorkspaces) {
     const shortName = basename(workspace).replace(/[^a-zA-Z0-9._-]+/g, '-') || 'workspace';
-    const occurrence = (nameCounts.get(shortName) ?? 0) + 1;
-    nameCounts.set(shortName, occurrence);
-    const label = `workspace/${shortName}${occurrence > 1 ? `-${occurrence}` : ''}`;
     const found = await documentsFromDirectory(
       join(workspace, '.workbuddy', 'memory'),
       'workbuddy',
-      label,
+      privateSourceKey('workbuddy-workspace', workspace),
+      `workspace/${shortName}`,
     );
     if (found.length) locations += 1;
     documents.push(...found);
@@ -149,7 +166,12 @@ export async function scanClaude(claudeHome: string): Promise<ScanResult> {
   }
 
   if (customDirectory) {
-    const documents = await documentsFromDirectory(customDirectory, 'claude', 'custom');
+    const documents = await documentsFromDirectory(
+      customDirectory,
+      'claude',
+      privateSourceKey('claude-custom', customDirectory),
+      'custom',
+    );
     notes.push('user autoMemoryDirectory checked');
     return {
       documents,
@@ -170,11 +192,12 @@ export async function scanClaude(claudeHome: string): Promise<ScanResult> {
 
   const documents: MemoryDocument[] = [];
   let locations = 0;
-  for (const [index, projectDirectory] of projectDirectories.entries()) {
+  for (const projectDirectory of projectDirectories) {
     const found = await documentsFromDirectory(
       join(root, 'projects', projectDirectory, 'memory'),
       'claude',
-      `project-${index + 1}`,
+      privateSourceKey('claude-project', projectDirectory),
+      'project',
     );
     if (found.length) locations += 1;
     documents.push(...found);

--- a/MemoryPanel/scripts/import-agent-memory/sources.ts
+++ b/MemoryPanel/scripts/import-agent-memory/sources.ts
@@ -1,0 +1,190 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, isAbsolute, join, resolve } from 'node:path';
+import { stableHash, type MemoryDocument, type MemorySource } from './plan.js';
+
+export interface SourceReport {
+  source: MemorySource;
+  files: number;
+  locations: number;
+  notes: string[];
+}
+
+export interface ScanResult {
+  documents: MemoryDocument[];
+  reports: SourceReport[];
+}
+
+async function readOptional(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+async function markdownFiles(path: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.md'))
+      .map((entry) => entry.name)
+      .sort((left, right) => left.localeCompare(right));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+async function documentsFromDirectory(
+  path: string,
+  source: MemorySource,
+  labelPrefix: string,
+): Promise<MemoryDocument[]> {
+  const names = await markdownFiles(path);
+  const documents = await Promise.all(names.map(async (name) => ({
+    source,
+    sourceLabel: `${labelPrefix}/${name}`,
+    content: await readFile(join(path, name), 'utf8'),
+    split: 'h2' as const,
+  })));
+  return documents.filter((document) => document.content.trim());
+}
+
+export async function scanCodex(codexHome: string): Promise<ScanResult> {
+  const root = join(resolve(codexHome), 'memories');
+  const [summary, memory] = await Promise.all([
+    readOptional(join(root, 'memory_summary.md')),
+    readOptional(join(root, 'MEMORY.md')),
+  ]);
+  const documents: MemoryDocument[] = [];
+  if (summary) {
+    documents.push({ source: 'codex', sourceLabel: 'memory_summary.md', content: summary, split: 'h2' });
+  }
+  if (memory) {
+    documents.push({ source: 'codex', sourceLabel: 'MEMORY.md', content: memory, split: 'codex-task-group' });
+  }
+  return {
+    documents,
+    reports: [{
+      source: 'codex',
+      files: documents.length,
+      locations: documents.length ? 1 : 0,
+      notes: [
+        summary ? 'memory_summary.md found' : 'memory_summary.md missing',
+        memory ? 'MEMORY.md found' : 'MEMORY.md missing',
+      ],
+    }],
+  };
+}
+
+export async function scanWorkBuddy(
+  workbuddyHome: string,
+  workspaces: string[],
+): Promise<ScanResult> {
+  const documents: MemoryDocument[] = [];
+  const notes: string[] = [];
+  const userMemory = await readOptional(join(resolve(workbuddyHome), 'MEMORY.md'));
+  if (userMemory) {
+    documents.push({
+      source: 'workbuddy',
+      sourceLabel: 'user/MEMORY.md',
+      content: userMemory,
+      split: 'h2',
+    });
+    notes.push('user MEMORY.md found');
+  } else {
+    notes.push('user MEMORY.md missing');
+  }
+
+  let locations = userMemory ? 1 : 0;
+  for (const workspace of [...new Set(workspaces.map((path) => resolve(path)))]) {
+    const shortName = basename(workspace).replace(/[^a-zA-Z0-9._-]+/g, '-') || 'workspace';
+    const label = `workspace/${shortName}-${stableHash(workspace).slice(0, 8)}`;
+    const found = await documentsFromDirectory(
+      join(workspace, '.workbuddy', 'memory'),
+      'workbuddy',
+      label,
+    );
+    if (found.length) locations += 1;
+    documents.push(...found);
+  }
+  notes.push(`${workspaces.length} workspace path(s) checked`);
+  return {
+    documents,
+    reports: [{ source: 'workbuddy', files: documents.length, locations, notes }],
+  };
+}
+
+function configuredMemoryPath(value: string): string | undefined {
+  if (value === '~') return homedir();
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return resolve(homedir(), value.slice(2));
+  }
+  return isAbsolute(value) ? resolve(value) : undefined;
+}
+
+export async function scanClaude(claudeHome: string): Promise<ScanResult> {
+  const root = resolve(claudeHome);
+  const notes: string[] = [];
+  const settings = await readOptional(join(root, 'settings.json'));
+  let customDirectory: string | undefined;
+  if (settings) {
+    try {
+      const value = (JSON.parse(settings) as { autoMemoryDirectory?: unknown }).autoMemoryDirectory;
+      if (typeof value === 'string') {
+        customDirectory = configuredMemoryPath(value);
+        if (!customDirectory) notes.push('autoMemoryDirectory ignored: expected an absolute or ~/ path');
+      }
+    } catch {
+      notes.push('settings.json is invalid JSON; default project memories were not scanned');
+      return {
+        documents: [],
+        reports: [{ source: 'claude', files: 0, locations: 0, notes }],
+      };
+    }
+  }
+
+  if (customDirectory) {
+    const documents = await documentsFromDirectory(customDirectory, 'claude', 'custom');
+    notes.push('user autoMemoryDirectory checked');
+    return {
+      documents,
+      reports: [{ source: 'claude', files: documents.length, locations: documents.length ? 1 : 0, notes }],
+    };
+  }
+
+  let projectDirectories: string[] = [];
+  try {
+    const entries = await readdir(join(root, 'projects'), { withFileTypes: true });
+    projectDirectories = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  const documents: MemoryDocument[] = [];
+  let locations = 0;
+  for (const projectDirectory of projectDirectories) {
+    const found = await documentsFromDirectory(
+      join(root, 'projects', projectDirectory, 'memory'),
+      'claude',
+      `project-${stableHash(projectDirectory).slice(0, 8)}`,
+    );
+    if (found.length) locations += 1;
+    documents.push(...found);
+  }
+  notes.push(`${projectDirectories.length} Claude project directories checked`);
+  return {
+    documents,
+    reports: [{ source: 'claude', files: documents.length, locations, notes }],
+  };
+}
+
+export function defaultAgentHomes(): { codex: string; workbuddy: string; claude: string } {
+  return {
+    codex: process.env.CODEX_HOME || join(homedir(), '.codex'),
+    workbuddy: join(homedir(), '.workbuddy'),
+    claude: process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude'),
+  };
+}

--- a/MemoryPanel/tests/import-agent-memory/plan.test.ts
+++ b/MemoryPanel/tests/import-agent-memory/plan.test.ts
@@ -1,0 +1,227 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { run } from '../../scripts/import-agent-memory/cli.js';
+import {
+  MAX_MESSAGE_CHARS,
+  batchMessages,
+  buildImportPlan,
+  checkpointKey,
+  emptyCheckpoint,
+  recordSuccessfulBatch,
+  type MemoryDocument,
+} from '../../scripts/import-agent-memory/plan.js';
+import {
+  scanClaude,
+  scanWorkBuddy,
+} from '../../scripts/import-agent-memory/sources.js';
+
+describe('multi-source ImportPlan v1', () => {
+  it('normalizes Codex, WorkBuddy/CodeBuddy, and Claude Code without assistant messages', () => {
+    const documents: MemoryDocument[] = [
+      {
+        source: 'codex',
+        sourceLabel: 'memory_summary.md',
+        content: 'v1\n\n## Profile\nFact A\n\n## Preferences\nFact B',
+        split: 'h2',
+      },
+      {
+        source: 'codex',
+        sourceLabel: 'MEMORY.md',
+        content: '# Task Group: Alpha\nKnowledge A',
+        split: 'codex-task-group',
+      },
+      {
+        source: 'workbuddy',
+        sourceLabel: 'workspace/demo/memory/2026-08-14.md',
+        content: '# Work log\n\n## Topic\nConclusion',
+        split: 'h2',
+      },
+      {
+        source: 'claude',
+        sourceLabel: 'project-demo/debugging.md',
+        content: '# Debugging\nUse pnpm for this project.',
+        split: 'h2',
+      },
+    ];
+    const plan = buildImportPlan(documents);
+
+    expect(plan.sources).toEqual(['codex', 'workbuddy', 'claude']);
+    expect(plan.sessions.map((session) => session.source)).toEqual([
+      'codex',
+      'codex',
+      'workbuddy',
+      'claude',
+    ]);
+    expect(plan.sessions[0]?.messages).toHaveLength(2);
+    expect(plan.sessions.flatMap((session) => session.messages).every((message) => message.role === 'user')).toBe(true);
+    expect(plan.sessions[2]?.messages[0]?.content).toContain('[Imported memory: workbuddy/');
+    expect(plan.sessions[3]?.messages[0]?.content).toContain('[Imported memory: claude/');
+  });
+
+  it('keeps an empty scan empty', () => {
+    expect(buildImportPlan([])).toEqual({ version: 1, sources: [], sessions: [] });
+  });
+
+  it('splits oversized blocks and keeps every L0 message within the Core limit', () => {
+    const payload = 'x'.repeat(MAX_MESSAGE_CHARS * 2);
+    const plan = buildImportPlan([{
+      source: 'claude',
+      sourceLabel: 'project-demo/large.md',
+      content: payload,
+      split: 'h2',
+    }]);
+    const messages = plan.sessions[0]?.messages ?? [];
+
+    expect(messages.length).toBeGreaterThan(2);
+    expect(messages.every((message) => message.content.length <= MAX_MESSAGE_CHARS)).toBe(true);
+    expect(messages[0]?.content).toContain('[part 1/');
+    const importedBodyChars = messages.reduce((sum, message) => {
+      return sum + message.content.slice(message.content.indexOf('\n\n') + 2).length;
+    }, 0);
+    expect(importedBodyChars).toBe(payload.length);
+  });
+
+  it('paginates the 101st message instead of dropping it', () => {
+    expect(batchMessages(Array.from({ length: 100 }, (_, index) => index))).toHaveLength(1);
+    expect(
+      batchMessages(Array.from({ length: 101 }, (_, index) => index)).map((batch) => batch.length),
+    ).toEqual([100, 1]);
+    const content = Array.from({ length: 101 }, (_, index) => `## Topic ${index}\nFact ${index}`).join('\n\n');
+    const plan = buildImportPlan([{
+      source: 'workbuddy',
+      sourceLabel: 'workspace/demo/memory/log.md',
+      content,
+      split: 'h2',
+    }]);
+    expect(plan.sessions).toHaveLength(1);
+    expect(batchMessages(plan.sessions[0]?.messages ?? []).map((batch) => batch.length)).toEqual([100, 1]);
+  });
+
+  it('checkpoints only a fully accepted batch and scopes resume keys to the target', () => {
+    const batch = [{ role: 'user' as const, content: 'memory' }];
+    const key = checkpointKey({ teamId: 'team-a', agentId: 'agent-a' }, 'session-a', batch);
+    const otherTargetKey = checkpointKey({ teamId: 'team-a', agentId: 'agent-b' }, 'session-a', batch);
+    expect(otherTargetKey).not.toBe(key);
+    expect(() => recordSuccessfulBatch(emptyCheckpoint(), key, 1, 0)).toThrow('accepted 0/1');
+
+    const state = recordSuccessfulBatch(emptyCheckpoint(), key, 1, 1, '2026-08-14T00:00:00.000Z');
+    expect(state.completed[key]).toEqual({ accepted_count: 1, imported_at: '2026-08-14T00:00:00.000Z' });
+  });
+
+  it('keeps session ids deterministic without embedding source filesystem paths', () => {
+    const document: MemoryDocument = {
+      source: 'workbuddy',
+      sourceLabel: 'workspace/demo/MEMORY.md',
+      content: '## Stable\nFact',
+      split: 'h2',
+    };
+    const first = buildImportPlan([document]);
+    const second = buildImportPlan([document]);
+    expect(first.sessions[0]?.session_id).toBe(second.sessions[0]?.session_id);
+    expect(first.sessions[0]?.session_id).toMatch(/^import-workbuddy-[0-9a-f]{16}$/);
+  });
+});
+
+describe('source scanners', () => {
+  it('scans WorkBuddy and CodeBuddy shared user/workspace memory layout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'workbuddy-import-'));
+    const home = join(root, 'home');
+    const workspace = join(root, 'demo-workspace');
+    try {
+      await mkdir(join(workspace, '.workbuddy', 'memory'), { recursive: true });
+      await mkdir(home);
+      await writeFile(join(home, 'MEMORY.md'), '## User memory\nPreference');
+      await writeFile(join(workspace, '.workbuddy', 'memory', 'MEMORY.md'), '## Project memory\nDecision');
+      await writeFile(join(workspace, '.workbuddy', 'memory', '2026-08-14.md'), '## Work log\nOutcome');
+
+      const result = await scanWorkBuddy(home, [workspace]);
+      expect(result.documents).toHaveLength(3);
+      expect(result.documents.every((document) => document.source === 'workbuddy')).toBe(true);
+      expect(JSON.stringify(result.documents.map((document) => document.sourceLabel))).not.toContain(root);
+      expect(result.reports[0]).toMatchObject({ source: 'workbuddy', files: 3, locations: 2 });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('scans Claude project MEMORY.md and topic files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-import-'));
+    const memory = join(root, 'projects', 'encoded-project-name', 'memory');
+    try {
+      await mkdir(memory, { recursive: true });
+      await writeFile(join(memory, 'MEMORY.md'), '# Index\n- See debugging.md');
+      await writeFile(join(memory, 'debugging.md'), '## Debugging\nUse pnpm');
+
+      const result = await scanClaude(root);
+      expect(result.documents).toHaveLength(2);
+      expect(result.documents.every((document) => document.source === 'claude')).toBe(true);
+      const labels = JSON.stringify(result.documents.map((document) => document.sourceLabel));
+      expect(labels).not.toContain('encoded-project-name');
+      expect(result.reports[0]).toMatchObject({ source: 'claude', files: 2, locations: 1 });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('honors Claude user-level autoMemoryDirectory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-custom-import-'));
+    const custom = join(root, 'custom-memory');
+    try {
+      await mkdir(custom);
+      await writeFile(join(root, 'settings.json'), JSON.stringify({ autoMemoryDirectory: custom }));
+      await writeFile(join(custom, 'MEMORY.md'), '# Custom index');
+
+      const result = await scanClaude(root);
+      expect(result.documents.map((document) => document.sourceLabel)).toEqual(['custom/MEMORY.md']);
+      expect(result.reports[0]?.notes).toContain('user autoMemoryDirectory checked');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('CLI resume', () => {
+  it('writes a checkpoint after full acceptance and skips the batch on resume', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-memory-import-'));
+    const memories = join(root, 'memories');
+    const stateFile = join(root, 'state.json');
+    await mkdir(memories);
+    await writeFile(join(memories, 'MEMORY.md'), '# Task Group: Resume\nOne fact');
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ code: 0, data: { accepted_count: 1 } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const previousUserKey = process.env.TDAI_USER_KEY;
+    process.env.TDAI_USER_KEY = 'test-user-key';
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const args = [
+      '--source', 'codex',
+      '--codex-home', root,
+      '--team-id', 'team-a',
+      '--agent-id', 'agent-a',
+      '--panel-url', 'http://example.invalid',
+      '--state-file', stateFile,
+      '--yes',
+    ];
+
+    try {
+      await run(args);
+      await run(args);
+      const state = JSON.parse(await readFile(stateFile, 'utf8')) as { completed: object };
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(Object.keys(state.completed)).toHaveLength(1);
+      expect((await stat(stateFile)).mode & 0o777).toBe(0o600);
+    } finally {
+      if (previousUserKey === undefined) delete process.env.TDAI_USER_KEY;
+      else process.env.TDAI_USER_KEY = previousUserKey;
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryPanel/tests/import-agent-memory/plan.test.ts
+++ b/MemoryPanel/tests/import-agent-memory/plan.test.ts
@@ -23,24 +23,28 @@ describe('multi-source ImportPlan v1', () => {
     const documents: MemoryDocument[] = [
       {
         source: 'codex',
+        sourceKey: 'codex/memory_summary.md',
         sourceLabel: 'memory_summary.md',
         content: 'v1\n\n## Profile\nFact A\n\n## Preferences\nFact B',
         split: 'h2',
       },
       {
         source: 'codex',
+        sourceKey: 'codex/MEMORY.md',
         sourceLabel: 'MEMORY.md',
         content: '# Task Group: Alpha\nKnowledge A',
         split: 'codex-task-group',
       },
       {
         source: 'workbuddy',
+        sourceKey: 'workbuddy/workspace/demo/memory/2026-08-14.md',
         sourceLabel: 'workspace/demo/memory/2026-08-14.md',
         content: '# Work log\n\n## Topic\nConclusion',
         split: 'h2',
       },
       {
         source: 'claude',
+        sourceKey: 'claude/project-demo/debugging.md',
         sourceLabel: 'project-demo/debugging.md',
         content: '# Debugging\nUse pnpm for this project.',
         split: 'h2',
@@ -70,6 +74,7 @@ describe('multi-source ImportPlan v1', () => {
     const payload = 'x'.repeat(MAX_MESSAGE_CHARS * 2);
     const plan = buildImportPlan([{
       source: 'claude',
+      sourceKey: 'claude/project-demo/large.md',
       sourceLabel: 'project-demo/large.md',
       content: payload,
       split: 'h2',
@@ -93,6 +98,7 @@ describe('multi-source ImportPlan v1', () => {
     const content = 'x'.repeat(MAX_MESSAGE_CHARS * 101);
     const plan = buildImportPlan([{
       source: 'workbuddy',
+      sourceKey: 'workbuddy/workspace/demo/memory/log.md',
       sourceLabel: 'workspace/demo/memory/log.md',
       content,
       split: 'h2',
@@ -127,6 +133,7 @@ describe('multi-source ImportPlan v1', () => {
   it('keeps session ids deterministic without embedding source filesystem paths', () => {
     const document: MemoryDocument = {
       source: 'workbuddy',
+      sourceKey: 'workbuddy/workspace/demo/MEMORY.md',
       sourceLabel: 'workspace/demo/MEMORY.md',
       content: '## Stable\nFact',
       split: 'h2',
@@ -140,12 +147,14 @@ describe('multi-source ImportPlan v1', () => {
   it('reimports only a changed H2 section', () => {
     const original = buildImportPlan([{
       source: 'codex',
+      sourceKey: 'codex/memory_summary.md',
       sourceLabel: 'memory_summary.md',
       content: 'v1\n\n## Profile\nFact A\n\n## Preferences\nFact B',
       split: 'h2',
     }]);
     const changed = buildImportPlan([{
       source: 'codex',
+      sourceKey: 'codex/memory_summary.md',
       sourceLabel: 'memory_summary.md',
       content: 'v1\n\n## Profile\nFact A\n\n## Preferences\nFact C',
       split: 'h2',
@@ -156,6 +165,37 @@ describe('multi-source ImportPlan v1', () => {
     );
     expect(changed.sessions[0]?.messages).toEqual(original.sessions[0]?.messages);
     expect(changed.sessions[1]?.messages).not.toEqual(original.sessions[1]?.messages);
+  });
+
+  it('gives repeated identical headings distinct block identities', () => {
+    const plan = buildImportPlan([{
+      source: 'codex',
+      sourceKey: 'codex/memory_summary.md',
+      sourceLabel: 'memory_summary.md',
+      content: '## Repeated\nSame fact\n\n## Repeated\nSame fact',
+      split: 'h2',
+    }]);
+
+    expect(plan.sessions).toHaveLength(2);
+    expect(plan.sessions[0]?.session_id).not.toBe(plan.sessions[1]?.session_id);
+    expect(plan.sessions[1]?.source_label).toBe('memory_summary.md#Repeated [2]');
+  });
+
+  it('uses one independently resumable session per H2 section', () => {
+    const content = Array.from(
+      { length: 101 },
+      (_, index) => `## Topic ${index}\nFact ${index}`,
+    ).join('\n\n');
+    const plan = buildImportPlan([{
+      source: 'workbuddy',
+      sourceKey: 'workbuddy/workspace/demo/memory/log.md',
+      sourceLabel: 'workspace/demo/memory/log.md',
+      content,
+      split: 'h2',
+    }]);
+
+    expect(plan.sessions).toHaveLength(101);
+    expect(plan.sessions.every((session) => session.messages.length === 1)).toBe(true);
   });
 });
 
@@ -228,7 +268,7 @@ describe('source scanners', () => {
       await writeFile(join(memory, 'MEMORY.md'), '## Default\nStill scanned');
 
       const result = await scanClaude(root);
-      expect(result.documents.map((document) => document.sourceLabel)).toEqual(['project-1/MEMORY.md']);
+      expect(result.documents.map((document) => document.sourceLabel)).toEqual(['project/MEMORY.md']);
       expect(result.reports[0]?.notes).toContain(
         'settings.json is invalid JSON; scanning default project memories instead',
       );
@@ -253,6 +293,55 @@ describe('source scanners', () => {
       const result = await scanCodex(root);
       expect(result.documents.map((document) => document.sourceLabel)).toEqual(['memory_summary.md']);
       expect(JSON.stringify(result.documents)).not.toMatch(/PRIVATE RAW|PRIVATE ROLLOUT|PRIVATE AD HOC|PRIVATE DATABASE/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps Claude project identities stable when an earlier project is added', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-stable-identity-'));
+    try {
+      for (const project of ['b', 'c']) {
+        const memory = join(root, 'projects', project, 'memory');
+        await mkdir(memory, { recursive: true });
+        await writeFile(join(memory, 'MEMORY.md'), `Project ${project.toUpperCase()}`);
+      }
+      const before = buildImportPlan((await scanClaude(root)).documents);
+      const beforeB = before.sessions.find((session) => session.messages[0]?.content.includes('Project B'));
+
+      const earlier = join(root, 'projects', 'a', 'memory');
+      await mkdir(earlier, { recursive: true });
+      await writeFile(join(earlier, 'MEMORY.md'), 'Project A');
+      const after = buildImportPlan((await scanClaude(root)).documents);
+      const afterB = after.sessions.find((session) => session.messages[0]?.content.includes('Project B'));
+
+      expect(afterB?.session_id).toBe(beforeB?.session_id);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps same-name WorkBuddy workspace identities stable when argument order changes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'workbuddy-stable-identity-'));
+    const first = join(root, 'one', 'repo');
+    const second = join(root, 'two', 'repo');
+    const home = join(root, 'home');
+    try {
+      await mkdir(join(first, '.workbuddy', 'memory'), { recursive: true });
+      await mkdir(join(second, '.workbuddy', 'memory'), { recursive: true });
+      await mkdir(home);
+      await writeFile(join(first, '.workbuddy', 'memory', 'MEMORY.md'), 'Workspace One');
+      await writeFile(join(second, '.workbuddy', 'memory', 'MEMORY.md'), 'Workspace Two');
+
+      const forward = buildImportPlan((await scanWorkBuddy(home, [first, second])).documents);
+      const reverse = buildImportPlan((await scanWorkBuddy(home, [second, first])).documents);
+      const sessionFor = (plan: ReturnType<typeof buildImportPlan>, marker: string) => (
+        plan.sessions.find((session) => session.messages[0]?.content.includes(marker))?.session_id
+      );
+
+      expect(sessionFor(reverse, 'Workspace One')).toBe(sessionFor(forward, 'Workspace One'));
+      expect(sessionFor(reverse, 'Workspace Two')).toBe(sessionFor(forward, 'Workspace Two'));
+      expect(JSON.stringify(forward)).not.toContain(root);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/MemoryPanel/tests/import-agent-memory/plan.test.ts
+++ b/MemoryPanel/tests/import-agent-memory/plan.test.ts
@@ -189,7 +189,7 @@ describe('CLI resume', () => {
     const stateFile = join(root, 'state.json');
     await mkdir(memories);
     await writeFile(join(memories, 'MEMORY.md'), '# Task Group: Resume\nOne fact');
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
       new Response(JSON.stringify({ code: 0, data: { accepted_count: 1 } }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -211,11 +211,68 @@ describe('CLI resume', () => {
 
     try {
       await run(args);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [requestUrl, requestInit] = fetchMock.mock.calls[0] ?? [];
+      expect(String(requestUrl)).toBe('http://example.invalid/api/v1/chat-memory/import');
+      expect(requestInit?.method).toBe('POST');
+      expect(requestInit?.headers).toMatchObject({
+        'Content-Type': 'application/json',
+        'X-Tdai-Service-Id': 'default',
+        'X-Tdai-User-Key': 'test-user-key',
+      });
+      const requestBody = JSON.parse(String(requestInit?.body)) as {
+        team_id: string;
+        agent_id: string;
+        session_id: string;
+        messages: Array<{ role: string; content: string }>;
+      };
+      expect(requestBody).toMatchObject({ team_id: 'team-a', agent_id: 'agent-a' });
+      expect(requestBody.session_id).toMatch(/^import-codex-[0-9a-f]{16}$/);
+      expect(requestBody.messages).toHaveLength(1);
+      expect(requestBody.messages[0]).toMatchObject({ role: 'user' });
+      expect(requestBody.messages[0]?.content).toContain('[Imported memory: codex/');
+
       await run(args);
       const state = JSON.parse(await readFile(stateFile, 'utf8')) as { completed: object };
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(Object.keys(state.completed)).toHaveLength(1);
       expect((await stat(stateFile)).mode & 0o777).toBe(0o600);
+    } finally {
+      if (previousUserKey === undefined) delete process.env.TDAI_USER_KEY;
+      else process.env.TDAI_USER_KEY = previousUserKey;
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to checkpoint an API response without accepted_count', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-memory-import-contract-'));
+    const memories = join(root, 'memories');
+    const stateFile = join(root, 'state.json');
+    await mkdir(memories);
+    await writeFile(join(memories, 'MEMORY.md'), '# Task Group: Contract\nOne fact');
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ code: 0, data: { imported: true } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+    const previousUserKey = process.env.TDAI_USER_KEY;
+    process.env.TDAI_USER_KEY = 'test-user-key';
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      await expect(run([
+        '--source', 'codex',
+        '--codex-home', root,
+        '--team-id', 'team-a',
+        '--agent-id', 'agent-a',
+        '--panel-url', 'http://example.invalid',
+        '--state-file', stateFile,
+        '--yes',
+      ])).rejects.toThrow('omitted accepted_count');
+      await expect(readFile(stateFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {
       if (previousUserKey === undefined) delete process.env.TDAI_USER_KEY;
       else process.env.TDAI_USER_KEY = previousUserKey;

--- a/MemoryPanel/tests/import-agent-memory/plan.test.ts
+++ b/MemoryPanel/tests/import-agent-memory/plan.test.ts
@@ -13,6 +13,7 @@ import {
   type MemoryDocument,
 } from '../../scripts/import-agent-memory/plan.js';
 import {
+  scanCodex,
   scanClaude,
   scanWorkBuddy,
 } from '../../scripts/import-agent-memory/sources.js';
@@ -51,13 +52,14 @@ describe('multi-source ImportPlan v1', () => {
     expect(plan.sessions.map((session) => session.source)).toEqual([
       'codex',
       'codex',
+      'codex',
       'workbuddy',
       'claude',
     ]);
-    expect(plan.sessions[0]?.messages).toHaveLength(2);
+    expect(plan.sessions[0]?.messages).toHaveLength(1);
     expect(plan.sessions.flatMap((session) => session.messages).every((message) => message.role === 'user')).toBe(true);
-    expect(plan.sessions[2]?.messages[0]?.content).toContain('[Imported memory: workbuddy/');
-    expect(plan.sessions[3]?.messages[0]?.content).toContain('[Imported memory: claude/');
+    expect(plan.sessions[3]?.messages[0]?.content).toContain('[Imported memory: workbuddy/');
+    expect(plan.sessions[4]?.messages[0]?.content).toContain('[Imported memory: claude/');
   });
 
   it('keeps an empty scan empty', () => {
@@ -88,7 +90,7 @@ describe('multi-source ImportPlan v1', () => {
     expect(
       batchMessages(Array.from({ length: 101 }, (_, index) => index)).map((batch) => batch.length),
     ).toEqual([100, 1]);
-    const content = Array.from({ length: 101 }, (_, index) => `## Topic ${index}\nFact ${index}`).join('\n\n');
+    const content = 'x'.repeat(MAX_MESSAGE_CHARS * 101);
     const plan = buildImportPlan([{
       source: 'workbuddy',
       sourceLabel: 'workspace/demo/memory/log.md',
@@ -96,14 +98,26 @@ describe('multi-source ImportPlan v1', () => {
       split: 'h2',
     }]);
     expect(plan.sessions).toHaveLength(1);
-    expect(batchMessages(plan.sessions[0]?.messages ?? []).map((batch) => batch.length)).toEqual([100, 1]);
+    const batches = batchMessages(plan.sessions[0]?.messages ?? []);
+    expect(batches.map((batch) => batch.length)).toEqual([100, 2]);
+    expect(batches.flat()).toHaveLength(102);
   });
 
   it('checkpoints only a fully accepted batch and scopes resume keys to the target', () => {
     const batch = [{ role: 'user' as const, content: 'memory' }];
-    const key = checkpointKey({ teamId: 'team-a', agentId: 'agent-a' }, 'session-a', batch);
-    const otherTargetKey = checkpointKey({ teamId: 'team-a', agentId: 'agent-b' }, 'session-a', batch);
+    const target = {
+      endpoint: 'http://panel-a/api/v1/chat-memory/import',
+      serviceId: 'default',
+      teamId: 'team-a',
+      agentId: 'agent-a',
+    };
+    const key = checkpointKey(target, 'session-a', batch);
+    const otherTargetKey = checkpointKey({ ...target, agentId: 'agent-b' }, 'session-a', batch);
+    const otherPanelKey = checkpointKey({ ...target, endpoint: 'http://panel-b/api/v1/chat-memory/import' }, 'session-a', batch);
+    const otherServiceKey = checkpointKey({ ...target, serviceId: 'service-b' }, 'session-a', batch);
     expect(otherTargetKey).not.toBe(key);
+    expect(otherPanelKey).not.toBe(key);
+    expect(otherServiceKey).not.toBe(key);
     expect(() => recordSuccessfulBatch(emptyCheckpoint(), key, 1, 0)).toThrow('accepted 0/1');
 
     const state = recordSuccessfulBatch(emptyCheckpoint(), key, 1, 1, '2026-08-14T00:00:00.000Z');
@@ -121,6 +135,27 @@ describe('multi-source ImportPlan v1', () => {
     const second = buildImportPlan([document]);
     expect(first.sessions[0]?.session_id).toBe(second.sessions[0]?.session_id);
     expect(first.sessions[0]?.session_id).toMatch(/^import-workbuddy-[0-9a-f]{16}$/);
+  });
+
+  it('reimports only a changed H2 section', () => {
+    const original = buildImportPlan([{
+      source: 'codex',
+      sourceLabel: 'memory_summary.md',
+      content: 'v1\n\n## Profile\nFact A\n\n## Preferences\nFact B',
+      split: 'h2',
+    }]);
+    const changed = buildImportPlan([{
+      source: 'codex',
+      sourceLabel: 'memory_summary.md',
+      content: 'v1\n\n## Profile\nFact A\n\n## Preferences\nFact C',
+      split: 'h2',
+    }]);
+
+    expect(changed.sessions.map((session) => session.session_id)).toEqual(
+      original.sessions.map((session) => session.session_id),
+    );
+    expect(changed.sessions[0]?.messages).toEqual(original.sessions[0]?.messages);
+    expect(changed.sessions[1]?.messages).not.toEqual(original.sessions[1]?.messages);
   });
 });
 
@@ -140,6 +175,9 @@ describe('source scanners', () => {
       expect(result.documents).toHaveLength(3);
       expect(result.documents.every((document) => document.source === 'workbuddy')).toBe(true);
       expect(JSON.stringify(result.documents.map((document) => document.sourceLabel))).not.toContain(root);
+      expect(result.documents.map((document) => document.sourceLabel)).toContain(
+        'workspace/demo-workspace/MEMORY.md',
+      );
       expect(result.reports[0]).toMatchObject({ source: 'workbuddy', files: 3, locations: 2 });
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -180,6 +218,45 @@ describe('source scanners', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('continues with default Claude projects when settings JSON is invalid', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-invalid-settings-'));
+    const memory = join(root, 'projects', 'project-a', 'memory');
+    try {
+      await mkdir(memory, { recursive: true });
+      await writeFile(join(root, 'settings.json'), '{invalid');
+      await writeFile(join(memory, 'MEMORY.md'), '## Default\nStill scanned');
+
+      const result = await scanClaude(root);
+      expect(result.documents.map((document) => document.sourceLabel)).toEqual(['project-1/MEMORY.md']);
+      expect(result.reports[0]?.notes).toContain(
+        'settings.json is invalid JSON; scanning default project memories instead',
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not scan adjacent Codex raw or ad-hoc data', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-privacy-boundary-'));
+    const memories = join(root, 'memories');
+    try {
+      await mkdir(join(root, 'sessions'), { recursive: true });
+      await mkdir(join(memories, 'rollout_summaries'), { recursive: true });
+      await mkdir(join(memories, 'extensions', 'ad_hoc'), { recursive: true });
+      await writeFile(join(memories, 'memory_summary.md'), '## Safe\nGenerated memory');
+      await writeFile(join(root, 'sessions', 'raw.jsonl'), 'PRIVATE RAW SESSION');
+      await writeFile(join(memories, 'rollout_summaries', 'raw.md'), 'PRIVATE ROLLOUT');
+      await writeFile(join(memories, 'extensions', 'ad_hoc', 'note.md'), 'PRIVATE AD HOC');
+      await writeFile(join(memories, 'memories.sqlite'), 'PRIVATE DATABASE');
+
+      const result = await scanCodex(root);
+      expect(result.documents.map((document) => document.sourceLabel)).toEqual(['memory_summary.md']);
+      expect(JSON.stringify(result.documents)).not.toMatch(/PRIVATE RAW|PRIVATE ROLLOUT|PRIVATE AD HOC|PRIVATE DATABASE/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('CLI resume', () => {
@@ -197,7 +274,9 @@ describe('CLI resume', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
     const previousUserKey = process.env.TDAI_USER_KEY;
+    const previousServiceId = process.env.TDAI_SERVICE_ID;
     process.env.TDAI_USER_KEY = 'test-user-key';
+    delete process.env.TDAI_SERVICE_ID;
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const args = [
       '--source', 'codex',
@@ -236,10 +315,22 @@ describe('CLI resume', () => {
       const state = JSON.parse(await readFile(stateFile, 'utf8')) as { completed: object };
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(Object.keys(state.completed)).toHaveLength(1);
-      expect((await stat(stateFile)).mode & 0o777).toBe(0o600);
+      if (process.platform !== 'win32') expect((await stat(stateFile)).mode & 0o777).toBe(0o600);
+
+      const otherPanelArgs = [...args];
+      otherPanelArgs[otherPanelArgs.indexOf('http://example.invalid')] = 'http://other.invalid';
+      await run(otherPanelArgs);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      process.env.TDAI_SERVICE_ID = 'service-b';
+      await run(otherPanelArgs);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(Object.keys((JSON.parse(await readFile(stateFile, 'utf8')) as { completed: object }).completed)).toHaveLength(3);
     } finally {
       if (previousUserKey === undefined) delete process.env.TDAI_USER_KEY;
       else process.env.TDAI_USER_KEY = previousUserKey;
+      if (previousServiceId === undefined) delete process.env.TDAI_SERVICE_ID;
+      else process.env.TDAI_SERVICE_ID = previousServiceId;
       vi.restoreAllMocks();
       vi.unstubAllGlobals();
       await rm(root, { recursive: true, force: true });
@@ -259,7 +350,9 @@ describe('CLI resume', () => {
       }),
     ));
     const previousUserKey = process.env.TDAI_USER_KEY;
+    const previousServiceId = process.env.TDAI_SERVICE_ID;
     process.env.TDAI_USER_KEY = 'test-user-key';
+    delete process.env.TDAI_SERVICE_ID;
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     try {
@@ -276,6 +369,48 @@ describe('CLI resume', () => {
     } finally {
       if (previousUserKey === undefined) delete process.env.TDAI_USER_KEY;
       else process.env.TDAI_USER_KEY = previousUserKey;
+      if (previousServiceId === undefined) delete process.env.TDAI_SERVICE_ID;
+      else process.env.TDAI_SERVICE_ID = previousServiceId;
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a JSON HTTP 500 as an unknown write outcome', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-memory-import-500-'));
+    const memories = join(root, 'memories');
+    const stateFile = join(root, 'state.json');
+    await mkdir(memories);
+    await writeFile(join(memories, 'MEMORY.md'), '# Task Group: Failure\nOne fact');
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ code: 500, message: 'internal error' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ));
+    const previousUserKey = process.env.TDAI_USER_KEY;
+    const previousServiceId = process.env.TDAI_SERVICE_ID;
+    process.env.TDAI_USER_KEY = 'test-user-key';
+    delete process.env.TDAI_SERVICE_ID;
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      await expect(run([
+        '--source', 'codex',
+        '--codex-home', root,
+        '--team-id', 'team-a',
+        '--agent-id', 'agent-a',
+        '--panel-url', 'http://example.invalid',
+        '--state-file', stateFile,
+        '--yes',
+      ])).rejects.toThrow('outcome is unknown');
+      await expect(readFile(stateFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      if (previousUserKey === undefined) delete process.env.TDAI_USER_KEY;
+      else process.env.TDAI_USER_KEY = previousUserKey;
+      if (previousServiceId === undefined) delete process.env.TDAI_SERVICE_ID;
+      else process.env.TDAI_SERVICE_ID = previousServiceId;
       vi.restoreAllMocks();
       vi.unstubAllGlobals();
       await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary | 概述

### English

Add an opt-in host-side CLI in MemoryPanel that imports generated Markdown memories from Codex, Claude Code, WorkBuddy, and CodeBuddy through the existing Chat Memory import API.

The importer is intentionally a small adapter around existing Agent Memory behavior:

- reads generated memory artifacts only, never raw conversations;
- converts them to deterministic ImportPlan v1 sessions without an LLM call;
- defaults to dry-run and requires `--yes` for every remote-write run;
- splits content to the existing 8,192-character limit and automatically batches at most 100 messages per request;
- checkpoints only after the server reports the exact accepted count;
- stops on ambiguous network outcomes instead of risking an unsafe retry.

### 中文

在 MemoryPanel 中增加一个宿主机 CLI，通过现有 Chat Memory Import API，把 Codex、Claude Code、WorkBuddy 和 CodeBuddy 已生成的 Markdown 记忆导入 Agent Memory。

导入器只做现有能力之上的轻量适配：

- 只读取各产品已经生成的记忆成品，明确不读取原始会话；
- 用纯规则生成确定性的 ImportPlan v1，导入器自身不调用 LLM；
- 默认只 dry-run，每次远程写入都必须显式传 `--yes`；
- 按现有单条 8,192 字符限制拆分，并自动按每请求最多 100 条分页；
- 只有服务端返回完整 `accepted_count` 后才写 checkpoint；
- 网络结果不明时立即停止，不做可能产生重复数据的自动重试。

## Supported sources | 支持来源

- Codex: `$CODEX_HOME/memories/memory_summary.md` and `MEMORY.md`
- WorkBuddy / CodeBuddy: `~/.workbuddy/MEMORY.md` and explicitly selected workspace `.workbuddy/memory/*.md`
- Claude Code Auto Memory: `~/.claude/projects/*/memory/*.md` and the user `autoMemoryDirectory` setting

- Codex：`$CODEX_HOME/memories/memory_summary.md` 与 `MEMORY.md`
- WorkBuddy / CodeBuddy：`~/.workbuddy/MEMORY.md` 与用户明确指定 workspace 中的 `.workbuddy/memory/*.md`
- Claude Code Auto Memory：`~/.claude/projects/*/memory/*.md` 与用户配置的 `autoMemoryDirectory`

Codex raw sessions, rollout summaries, SQLite state, and user-specific `extensions/ad_hoc` content are excluded. Claude raw history and handwritten rule files are also excluded.

Codex 原始 session、rollout summary、SQLite 内部状态及用户自定义的 `extensions/ad_hoc` 均明确排除；Claude 原始历史和手写规则文件也不混入自动记忆。

## Scope | 改动范围

This PR adds one package script, three focused modules, tests, documentation, and one local checkpoint ignore rule. It does not change MemoryPanel startup, UI, API schemas, dependencies, lockfiles, Proxy behavior, or existing runtime paths.

本 PR 只增加一个 package script、三个职责明确的模块、测试、文档和一条本地 checkpoint 忽略规则；不修改 MemoryPanel 启动、UI、API schema、依赖、lockfile、Proxy 或任何现有运行路径。

## Validation | 验证

- `pnpm test`: 19/19 passed
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- targeted credential-pattern scan for the changed CLI/tests/docs
- real local dry-run discovery for Codex and WorkBuddy/CodeBuddy
- synthetic filesystem coverage for Claude Code, invalid Claude settings, the Codex privacy boundary, oversized content, 100/101 batching, exact acceptance, and checkpoint resume
- request contract assertions for URL, authentication headers, payload, accepted count, and checkpoint behavior
- post-review hardening: checkpoint identity includes endpoint and service, each Markdown section has a stable private source key and resumes independently, ambiguous 5xx/application failures are not retried, and the `0600` claim is POSIX-only

- 19/19 测试通过，并完成主项目 typecheck、build 与 diff 检查。
- 用本机真实 Codex、WorkBuddy/CodeBuddy 目录完成只读 dry-run。
- 用合成目录覆盖 Claude Code、无效 Claude 配置、Codex 隐私边界、超长内容、100/101 条分页、完整接收及 checkpoint 续跑。
- 测试锁定请求 URL、鉴权 Header、payload、`accepted_count` 与 checkpoint 契约。
- 根据代码审查补强了 endpoint/service 隔离、稳定且不写入记忆正文的 source key、section 级续传、5xx 结果不明处理及 Windows ACL 说明。

No live import write was executed, and no real local Claude Code Auto Memory sample was available. Claude path support follows the official contract and is covered by synthetic fixtures: https://code.claude.com/docs/en/memory

没有执行真实导入写入，本机也没有真实 Claude Code Auto Memory 样本。Claude 路径实现遵循官方契约，并由合成 fixture 覆盖：https://code.claude.com/docs/en/memory

## Follow-up | 后续 PR

The independent interactive/package layer is kept out of this PR and reviewed separately at Andy-Huang-SZU/TencentDB-Agent-Memory#1. That follow-up removes the need to clone the repository or manually copy Team/Agent IDs.

无需 clone 仓库、无需手工复制 Team/Agent ID 的交互/package 层不塞进本 PR，而是在 Andy-Huang-SZU/TencentDB-Agent-Memory#1 中独立审阅。

This Draft targets `feat/server_team`. The repository workflow currently runs only for PRs against `main`, so GitHub reports no automated checks here; the validations above were run locally.

本 Draft PR 以 `feat/server_team` 为 base。仓库当前 workflow 只对 `main` 触发，因此 GitHub 不会显示自动检查；以上门禁均为本地真实执行结果。
