### PR TITLE
fix(memory-core): don't fail npm run build when scripts/seed-v2/ source is absent

### DIFF
--- a/MemoryCore/package.json
+++ b/MemoryCore/package.json
@@ -26,7 +26,7 @@
     "export-tencent-vdb": "node ./bin/export-tencent-vdb.mjs",
     "build:read-local-memory": "tsc --project scripts/read-local-memory/tsconfig.json",
     "read-local-memory": "node ./bin/read-local-memory.mjs",
-    "build:seed-v2": "tsc --project scripts/seed-v2/tsconfig.json",
+    "build:seed-v2": "node -e \"const fs=require('fs');if(fs.existsSync('scripts/seed-v2/tsconfig.json')){require('child_process').execSync('tsc --project scripts/seed-v2/tsconfig.json',{stdio:'inherit'})}else{console.log('[build:seed-v2] scripts/seed-v2/ is not present in this checkout yet -- skipping (bin/seed-v2.mjs already falls back gracefully at runtime if neither dist nor source exists)')}\"",
     "seed-v2": "node ./bin/seed-v2.mjs",
     "test": "vitest run",
     "test:oss": "vitest run -c vitest.oss.config.ts",


### PR DESCRIPTION
## What

`MemoryCore/package.json`'s `build:seed-v2` script unconditionally runs `tsc --project scripts/seed-v2/tsconfig.json`, but `scripts/seed-v2/` doesn't exist in this checkout — only the compiled fallback launcher `bin/seed-v2.mjs` is present, and `seed-v2` isn't listed in the package's own `"bin"` map yet (unlike `migrate-sqlite-to-tcvdb`, `export-tencent-vdb`, and `read-local-memory`, which all are). This makes the top-level `npm run build` (`build:plugin && build:scripts`) hard-fail on a completely fresh install, even though the actual product — the gateway server, its plugin bundle, and the three shipped CLI tools — builds and runs correctly on its own.

## Repro

```bash
cd MemoryCore
npm install
npm run build
# ...
# > build:seed-v2
# > tsc --project scripts/seed-v2/tsconfig.json
#
# error TS5058: The specified path does not exist: 'scripts/seed-v2/tsconfig.json'.
```

I hit this while standing up a standalone (non-Docker) MemoryCore instance locally to test an unrelated integration — `npm run build` failed on a totally clean clone of this branch.

## Fix

`build:seed-v2` now checks for `scripts/seed-v2/tsconfig.json` before invoking `tsc`, and skips with an informational message when the source isn't present — mirroring the graceful degradation `bin/seed-v2.mjs` already performs at runtime ("neither dist nor source found... run: npm run build:seed-v2"). No application behavior changes; this only makes the build tolerant of `seed-v2` not having landed yet in a given checkout. Once `scripts/seed-v2/` is added, this script transparently starts compiling it again — no further change needed.

## Verification

```bash
npm install && npm run build
```

Completes with exit 0 from a fresh clone of this branch, both with and without `scripts/seed-v2/` present (verified by toggling the directory locally).