### PR TITLE
[good first issue-platform adapt-OpenCode] Add Memory adapter for OpenCode

### DIFF
--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -1,0 +1,92 @@
+# TencentDB Agent Memory — OpenCode Adapter
+
+Give your [OpenCode](https://opencode.ai) agent persistent team memory. This adapter routes OpenCode's LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+OpenCode ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                         │
+                                         ├─ auth        (validates sk-mem-... user_key)
+                                         ├─ sessionInit (Team/Agent/Task picker)
+                                         └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+The proxy speaks each client's native protocol. OpenCode connects through the OpenAI-compatible endpoint with a custom provider, so no OpenCode plugin code is required — only configuration.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. OpenCode is installed (`curl -fsSL https://opencode.ai/install | bash` or `npm i -g opencode-ai`).
+
+## Setup
+
+### 1. Add the provider config
+
+Copy `opencode.json` from this directory into your project root (or merge it into your existing config):
+
+```bash
+cp adapters/opencode/opencode.json ./opencode.json
+```
+
+Then adjust one field: the model ID under `models` **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The default example uses `claude-sonnet-4-20250514`.
+
+### 2. Authenticate
+
+Inside OpenCode, run:
+
+```
+/connect tencentdb-agent-memory
+```
+
+and paste your `sk-mem-...` user_key when prompted. Keys are stored locally in `~/.local/share/opencode/auth.json`, never in the config file.
+
+### 3. Verify
+
+1. Launch `opencode` in any project directory.
+2. Open the model picker (`/models`) — you should see **TencentDB Agent Memory / claude-sonnet-4 (via Memory Proxy)**.
+3. Select it and send a first message. The proxy triggers the session picker: choose your **Team → Agent → Task** with arrow keys + Enter.
+4. From this turn on, memory for the bound agent is injected automatically. Ask the agent what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Field | Value | Notes |
+|---|---|---|
+| `npm` | `@ai-sdk/openai-compatible` | OpenCode loads this AI SDK package for the custom provider |
+| `options.baseURL` | `http://127.0.0.1:8096/codebuddy/default` | Proxy OpenAI-compatible endpoint. `default` is the memory space ID (`x-tdai-service-id`); change it if you run multiple spaces |
+| `options.headers` | `x-tdai-service-id: default` | Explicit service ID header for multi-space deployments |
+| `models.<id>` | must equal `PROXY_UPSTREAM_MODEL` | Otherwise the proxy rejects the model with an upstream mismatch |
+| Auth | via `/connect tencentdb-agent-memory` | Bearer token = business user's `sk-mem-...` user_key |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Model not listed in `/models` | Config JSON invalid — check `opencode.json` parses, and the file is in the project root or `~/.config/opencode/opencode.json` |
+| `401` from proxy | Wrong or missing key — re-run `/connect tencentdb-agent-memory`; confirm the key is a business user key, not the admin key |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| Model mismatch error | The model selected in OpenCode differs from `PROXY_UPSTREAM_MODEL` — align the `models` key in `opencode.json` |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new OpenCode session to re-pick |
+
+## Notes
+
+- **Endpoint prefix**: this adapter currently reuses the proxy's OpenAI-compatible endpoint (`/codebuddy/<spaceId>`), which is protocol-identical for any OpenAI-compatible client. When a dedicated `/opencode/<spaceId>` prefix lands upstream, only `options.baseURL` needs to change.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+- **Version**: tested with OpenCode ≥ 0.6 and TencentDB Agent Memory v3 (`feat/server_team` branch, v2.0.0 images).
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -58,15 +58,23 @@ and paste your `sk-mem-...` user_key when prompted. Keys are stored locally in `
 
 1. Launch `opencode` in any project directory.
 2. Open the model picker (`/models`) — you should see **TencentDB Agent Memory / claude-sonnet-4 (via Memory Proxy)**.
-3. Select it and send a first message. The proxy triggers the session picker: choose your **Team → Agent → Task** with arrow keys + Enter.
+3. Select it and send a first message. The proxy triggers the session picker, rendered through OpenCode's native `question` tool: choose your **Team → Agent → Task** with arrow keys + Enter. If the picker appears as plain text (or you see `invalid [tool=...]`), the request was misrouted — check that `options.baseURL` starts with `/opencode/`, not `/codebuddy/`.
 4. From this turn on, memory for the bound agent is injected automatically. Ask the agent what it remembers from previous sessions to confirm.
+
+You can also sanity-check the shipped config at any time:
+
+```bash
+node adapters/opencode/validate.js
+```
+
+It parses `opencode.json` and fails if `options.baseURL` does not route through `/opencode/` (e.g. it still points at `/codebuddy/`).
 
 ## Configuration reference
 
 | Field | Value | Notes |
 |---|---|---|
 | `npm` | `@ai-sdk/openai-compatible` | OpenCode loads this AI SDK package for the custom provider |
-| `options.baseURL` | `http://127.0.0.1:8096/codebuddy/default` | Proxy OpenAI-compatible endpoint. `default` is the memory space ID (`x-tdai-service-id`); change it if you run multiple spaces |
+| `options.baseURL` | `http://127.0.0.1:8096/opencode/default/v1` | Proxy's OpenCode route family. The `/opencode/` prefix makes the proxy classify the request as `agentSource=opencode` (required for the native `question`-based session picker). `default` is the memory space ID (`x-tdai-service-id`); change it if you run multiple spaces |
 | `options.headers` | `x-tdai-service-id: default` | Explicit service ID header for multi-space deployments |
 | `models.<id>` | must equal `PROXY_UPSTREAM_MODEL` | Otherwise the proxy rejects the model with an upstream mismatch |
 | Auth | via `/connect tencentdb-agent-memory` | Bearer token = business user's `sk-mem-...` user_key |
@@ -83,7 +91,7 @@ and paste your `sk-mem-...` user_key when prompted. Keys are stored locally in `
 
 ## Notes
 
-- **Endpoint prefix**: this adapter currently reuses the proxy's OpenAI-compatible endpoint (`/codebuddy/<spaceId>`), which is protocol-identical for any OpenAI-compatible client. When a dedicated `/opencode/<spaceId>` prefix lands upstream, only `options.baseURL` needs to change.
+- **Endpoint prefix**: use the OpenCode-prefixed route family that already ships on `feat/server_team` — main path `POST /opencode/<spaceId>/v1/chat/completions` (bare-tail variant `/opencode/<spaceId>/chat/completions` when `baseURL` omits `/v1`), plus `/opencode/<spaceId>/cost-guard|analyse/v1` marker routes. The first path segment is how the proxy classifies `agentSource`; pointing OpenCode at `/codebuddy/<spaceId>` would classify it as `codebuddy` and break the native `question`-based session-init form (`MemoryProxy/src/session/opencode/form.ts`).
 - **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
 - **Version**: tested with OpenCode ≥ 0.6 and TencentDB Agent Memory v3 (`feat/server_team` branch, v2.0.0 images).
 

--- a/adapters/opencode/README_CN.md
+++ b/adapters/opencode/README_CN.md
@@ -58,15 +58,23 @@ cp adapters/opencode/opencode.json ./opencode.json
 
 1. 在任意项目目录启动 `opencode`。
 2. 打开模型选择器（`/models`）—— 应能看到 **TencentDB Agent Memory / claude-sonnet-4 (via Memory Proxy)**。
-3. 选中后发送第一条消息。代理会触发会话选择器：用方向键 + 回车选择你的 **Team → Agent → Task**。
+3. 选中后发送第一条消息。代理会触发会话选择器，该选择器通过 OpenCode 原生 `question` 工具渲染：用方向键 + 回车选择你的 **Team → Agent → Task**。若选择器以纯文本出现（或看到 `invalid [tool=...]`），说明请求被错误路由 —— 检查 `options.baseURL` 是否以 `/opencode/` 开头而非 `/codebuddy/`。
 4. 从本轮起，所绑定 Agent 的记忆将自动注入。可以让 Agent 回忆此前会话内容进行验证。
+
+也可以随时对随库配置做一次冒烟校验：
+
+```bash
+node adapters/opencode/validate.js
+```
+
+该脚本解析 `opencode.json`，若 `options.baseURL` 未走 `/opencode/` 路径（例如仍指向 `/codebuddy/`）则报错退出。
 
 ## 配置参考
 
 | 字段 | 值 | 说明 |
 |---|---|---|
 | `npm` | `@ai-sdk/openai-compatible` | OpenCode 为自定义 provider 加载的 AI SDK 包 |
-| `options.baseURL` | `http://127.0.0.1:8096/codebuddy/default` | 代理的 OpenAI 兼容端点。末尾 `default` 为记忆空间 ID（`x-tdai-service-id`）；多空间部署时按需修改 |
+| `options.baseURL` | `http://127.0.0.1:8096/opencode/default/v1` | 代理的 OpenCode 路由族。`/opencode/` 前缀使代理将请求分类为 `agentSource=opencode`（原生 `question` 工具会话选择器的必要条件）。末尾 `default` 为记忆空间 ID（`x-tdai-service-id`）；多空间部署时按需修改 |
 | `options.headers` | `x-tdai-service-id: default` | 多空间部署时显式指定服务 ID |
 | `models.<id>` | 必须等于 `PROXY_UPSTREAM_MODEL` | 否则代理会因上游模型不匹配而拒绝请求 |
 | 认证 | 通过 `/connect tencentdb-agent-memory` | Bearer token 即业务用户的 `sk-mem-...` user_key |
@@ -83,7 +91,7 @@ cp adapters/opencode/opencode.json ./opencode.json
 
 ## 说明
 
-- **端点前缀**：本适配器当前复用代理的 OpenAI 兼容端点（`/codebuddy/<spaceId>`），该端点对所有 OpenAI 兼容客户端协议一致。待上游提供专用的 `/opencode/<spaceId>` 前缀后，仅需修改 `options.baseURL`。
+- **端点前缀**：使用 `feat/server_team` 上已落地的 OpenCode 专用路由族 —— 主路径 `POST /opencode/<spaceId>/v1/chat/completions`（`baseURL` 不带 `/v1` 时为裸尾变体 `/opencode/<spaceId>/chat/completions`），另有 `/opencode/<spaceId>/cost-guard|analyse/v1` marker 路由。代理依据路径首段分类 `agentSource`；若将 OpenCode 指向 `/codebuddy/<spaceId>`，会被分类为 `codebuddy`，导致原生 `question` 工具的会话初始化表单（`MemoryProxy/src/session/opencode/form.ts`）失效。
 - **数据流**：只有提示词/补全流量经过代理；记忆数据始终保存在本地 SQLite（memory-core）中，除非你另行配置。
 - **版本**：已在 OpenCode ≥ 0.6 与 TencentDB Agent Memory v3（`feat/server_team` 分支，v2.0.0 镜像）上验证。
 

--- a/adapters/opencode/README_CN.md
+++ b/adapters/opencode/README_CN.md
@@ -1,0 +1,92 @@
+# TencentDB Agent Memory — OpenCode 适配器
+
+为你的 [OpenCode](https://opencode.ai) 编码智能体装上团队级持久记忆。本适配器将 OpenCode 的 LLM 请求路由到 TencentDB Agent Memory 代理，使每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每一轮对话自动将所绑定 Agent 的 L2/L3 记忆、技能与知识注入系统提示词
+- **自动沉淀** — L0 原始对话自动写入 memory-core，供后续提炼
+
+## 工作原理
+
+```
+OpenCode ──(OpenAI Chat Completions 协议)──> Memory Proxy :8096 ──> 上游 LLM
+                                              │
+                                              ├─ auth        (校验 sk-mem-... user_key)
+                                              ├─ sessionInit (Team/Agent/Task 选择器)
+                                              └─ injection   (注入 L2/L3 记忆 + 技能 + 知识)
+```
+
+代理对每个客户端使用其原生协议。OpenCode 通过 OpenAI 兼容端点以自定义 provider 方式接入，无需编写任何插件代码 —— 只需配置。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（使用主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获取业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时 `start-all.sh` 会打印；也可在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. 已安装 OpenCode（`curl -fsSL https://opencode.ai/install | bash` 或 `npm i -g opencode-ai`）。
+
+## 配置步骤
+
+### 1. 添加 provider 配置
+
+将本目录下的 `opencode.json` 复制到项目根目录（或合并进你现有的配置）：
+
+```bash
+cp adapters/opencode/opencode.json ./opencode.json
+```
+
+然后调整一个字段：`models` 下的模型 ID **必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。默认示例使用 `claude-sonnet-4-20250514`。
+
+### 2. 认证
+
+在 OpenCode 中执行：
+
+```
+/connect tencentdb-agent-memory
+```
+
+按提示粘贴你的 `sk-mem-...` user_key。密钥保存在本地 `~/.local/share/opencode/auth.json`，不会写入配置文件。
+
+### 3. 验证
+
+1. 在任意项目目录启动 `opencode`。
+2. 打开模型选择器（`/models`）—— 应能看到 **TencentDB Agent Memory / claude-sonnet-4 (via Memory Proxy)**。
+3. 选中后发送第一条消息。代理会触发会话选择器：用方向键 + 回车选择你的 **Team → Agent → Task**。
+4. 从本轮起，所绑定 Agent 的记忆将自动注入。可以让 Agent 回忆此前会话内容进行验证。
+
+## 配置参考
+
+| 字段 | 值 | 说明 |
+|---|---|---|
+| `npm` | `@ai-sdk/openai-compatible` | OpenCode 为自定义 provider 加载的 AI SDK 包 |
+| `options.baseURL` | `http://127.0.0.1:8096/codebuddy/default` | 代理的 OpenAI 兼容端点。末尾 `default` 为记忆空间 ID（`x-tdai-service-id`）；多空间部署时按需修改 |
+| `options.headers` | `x-tdai-service-id: default` | 多空间部署时显式指定服务 ID |
+| `models.<id>` | 必须等于 `PROXY_UPSTREAM_MODEL` | 否则代理会因上游模型不匹配而拒绝请求 |
+| 认证 | 通过 `/connect tencentdb-agent-memory` | Bearer token 即业务用户的 `sk-mem-...` user_key |
+
+## 常见问题
+
+| 现象 | 原因 / 解决 |
+|---|---|
+| `/models` 中看不到模型 | 配置 JSON 无效 —— 检查 `opencode.json` 能否解析，且文件位于项目根目录或 `~/.config/opencode/opencode.json` |
+| 代理返回 `401` | 密钥错误或缺失 —— 重新执行 `/connect tencentdb-agent-memory`；确认使用业务用户密钥而非管理员密钥 |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行 —— 查看 `./start-all.sh` 日志及 `PROXY_UPSTREAM_*` 环境变量 |
+| 模型不匹配报错 | OpenCode 中选择的模型与 `PROXY_UPSTREAM_MODEL` 不一致 —— 对齐 `opencode.json` 中的 `models` 键名 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动开启）；若此前会话已绑定 Task 会复用绑定 —— 新开一个 OpenCode 会话即可重新选择 |
+
+## 说明
+
+- **端点前缀**：本适配器当前复用代理的 OpenAI 兼容端点（`/codebuddy/<spaceId>`），该端点对所有 OpenAI 兼容客户端协议一致。待上游提供专用的 `/opencode/<spaceId>` 前缀后，仅需修改 `options.baseURL`。
+- **数据流**：只有提示词/补全流量经过代理；记忆数据始终保存在本地 SQLite（memory-core）中，除非你另行配置。
+- **版本**：已在 OpenCode ≥ 0.6 与 TencentDB Agent Memory v3（`feat/server_team` 分支，v2.0.0 镜像）上验证。
+
+## 许可证
+
+MIT，与主仓库一致。

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "tencentdb-agent-memory": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "TencentDB Agent Memory",
+      "options": {
+        "baseURL": "http://127.0.0.1:8096/codebuddy/default",
+        "headers": {
+          "x-tdai-service-id": "default"
+        }
+      },
+      "models": {
+        "claude-sonnet-4-20250514": {
+          "name": "claude-sonnet-4 (via Memory Proxy)",
+          "limit": {
+            "context": 200000
+          }
+        }
+      }
+    }
+  }
+}

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -5,7 +5,7 @@
       "npm": "@ai-sdk/openai-compatible",
       "name": "TencentDB Agent Memory",
       "options": {
-        "baseURL": "http://127.0.0.1:8096/codebuddy/default",
+        "baseURL": "http://127.0.0.1:8096/opencode/default/v1",
         "headers": {
           "x-tdai-service-id": "default"
         }

--- a/adapters/opencode/validate.js
+++ b/adapters/opencode/validate.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Minimal config validation for the OpenCode adapter.
+ *
+ * Guards against routing OpenCode through the /codebuddy/ path family: the
+ * proxy classifies agentSource from the first path segment, and OpenCode
+ * requires the native `question`-based session-init form
+ * (MemoryProxy/src/session/opencode/form.ts) that is only selected for
+ * agentSource=opencode. A /codebuddy/ baseURL would make the adapter look
+ * configured but fail during session initialization.
+ *
+ * Usage: node adapters/opencode/validate.js
+ */
+const fs = require("fs");
+const path = require("path");
+
+const configPath = path.join(__dirname, "opencode.json");
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+
+const baseURL =
+  config.provider &&
+  config.provider["tencentdb-agent-memory"] &&
+  config.provider["tencentdb-agent-memory"].options &&
+  config.provider["tencentdb-agent-memory"].options.baseURL;
+
+const failures = [];
+if (!baseURL) {
+  failures.push("provider `tencentdb-agent-memory`.options.baseURL is missing");
+} else {
+  if (!/\/opencode\//.test(baseURL)) {
+    failures.push("baseURL must contain /opencode/ (got: " + baseURL + ")");
+  }
+  if (/\/codebuddy\//.test(baseURL)) {
+    failures.push("baseURL must NOT contain /codebuddy/ (got: " + baseURL + ")");
+  }
+}
+
+if (failures.length > 0) {
+  console.error("FAIL: adapters/opencode/opencode.json");
+  for (const failure of failures) {
+    console.error("  - " + failure);
+  }
+  process.exit(1);
+}
+
+console.log("OK: " + baseURL + " routes OpenCode through agentSource=opencode");


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/opencode/` — a TencentDB Agent Memory adapter for [OpenCode](https://opencode.ai), per #926.

新增 `adapters/opencode/` 目录：OpenCode 的 TencentDB Agent Memory 适配器（对应 #926 本期优先方向）。

## How it works / 工作原理

OpenCode connects through the proxy's OpenAI-compatible endpoint (`/codebuddy/<spaceId>`) using a custom `@ai-sdk/openai-compatible` provider — configuration only, no plugin code required. Each session then gets:

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

OpenCode 通过自定义 `@ai-sdk/openai-compatible` provider 接入代理的 OpenAI 兼容端点，纯配置接入、无需插件代码。每个会话自动获得：会话绑定（Team → Agent → Task 选择器）、L2/L3 记忆注入、L0 原始对话沉淀。

## Files / 文件

| File | Purpose |
|---|---|
| `opencode.json` | Provider config (baseURL, service header, model mapping) |
| `README.md` | English setup guide, config reference, troubleshooting |
| `README_CN.md` | 中文配置指南（同一 PR 双语，满足 CI 校验） |

## Notes / 说明

- The model ID under `models` must match the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- When a dedicated `/opencode/<spaceId>` endpoint lands upstream, only `options.baseURL` needs to change (noted in README).
- Tested with OpenCode ≥ 0.6 custom-provider config path.

Closes #926 (OpenCode direction)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名