### PR TITLE
[good first issue-platform adapt-aider] Add Memory adapter for aider

### DIFF
--- a/adapters/aider/README.md
+++ b/adapters/aider/README.md
@@ -1,0 +1,87 @@
+# TencentDB Agent Memory — aider Adapter
+
+Give [aider](https://aider.chat) persistent team memory. This adapter routes aider's LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+aider ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                       │
+                                       ├─ auth        (validates sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task picker)
+                                       └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+aider can connect to any OpenAI-compatible endpoint. The proxy speaks OpenAI Chat Completions on its `/codebuddy/<spaceId>` endpoint, so aider connects with **environment variables + config only** — no code changes required.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. aider is installed (`python -m pip install aider-install && aider-install`).
+
+## Setup
+
+### 1. Point aider at the proxy
+
+```bash
+export OPENAI_API_BASE=http://127.0.0.1:8096/codebuddy/default
+export OPENAI_API_KEY=sk-mem-...        # your business user key
+```
+
+Or copy `aider.conf.yml` from this directory to your project root (it sets `model` and `openai-api-base`), and keep only `OPENAI_API_KEY` as an env var so the key never lands in version control.
+
+### 2. Align the model name
+
+The model after the `openai/` prefix **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The default example uses `claude-sonnet-4-20250514`:
+
+```bash
+aider --model openai/claude-sonnet-4-20250514
+```
+
+### 3. Verify
+
+1. Launch aider in your project directory.
+2. Send a first chat message. The proxy triggers the session picker in the terminal interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask aider what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Item | Value | Notes |
+|---|---|---|
+| `OPENAI_API_BASE` | `http://127.0.0.1:8096/codebuddy/default` | Proxy OpenAI-compatible endpoint; trailing `default` is the memory space ID — change it per space |
+| `OPENAI_API_KEY` | `sk-mem-...` | Business user key from the Panel; aider sends it as `Authorization: Bearer` |
+| `--model` | `openai/<PROXY_UPSTREAM_MODEL>` | Otherwise the proxy rejects the model with an upstream mismatch |
+| `aider.conf.yml` | optional convenience | Sets `model` + `openai-api-base`; never put the key in it |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| "Unknown model" warning at startup | Expected for custom models — aider warns about models it doesn't know; editing still works if the upstream model is capable |
+| `401` from proxy | Wrong or missing key — check `OPENAI_API_KEY` is a business user key (`sk-mem-...`), not the admin key |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| Model mismatch error | The `openai/<model>` name differs from `PROXY_UPSTREAM_MODEL` — align them |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new aider session to re-pick |
+
+## Notes
+
+- **Terminal-native**: aider is a terminal tool, so the proxy's interactive Team → Agent → Task picker renders inline in the same way CodeBuddy's terminal flow does.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+- **Version**: tested with aider's OpenAI-compatible path (`OPENAI_API_BASE` + `openai/<model>`, per the official docs) and TencentDB Agent Memory v3 (`feat/server_team` branch, v2.0.0 images).
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/aider/README_CN.md
+++ b/adapters/aider/README_CN.md
@@ -1,0 +1,87 @@
+# TencentDB Agent Memory — aider 适配器
+
+为 [aider](https://aider.chat) 装上团队级持久记忆。本适配器将 aider 的 LLM 请求路由到 TencentDB Agent Memory 代理，使每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每一轮对话自动将所绑定 Agent 的 L2/L3 记忆、技能与知识注入系统提示词
+- **自动沉淀** — L0 原始对话自动写入 memory-core，供后续提炼
+
+## 工作原理
+
+```
+aider ──(OpenAI Chat Completions 协议)──> Memory Proxy :8096 ──> 上游 LLM
+                                            │
+                                            ├─ auth        (校验 sk-mem-... user_key)
+                                            ├─ sessionInit (Team/Agent/Task 选择器)
+                                            └─ injection   (注入 L2/L3 记忆 + 技能 + 知识)
+```
+
+aider 支持连接任意 OpenAI 兼容端点。代理在 `/codebuddy/<spaceId>` 端点上说 OpenAI Chat Completions 协议，因此 aider 只需**环境变量 + 配置**即可接入——无需任何代码改动。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（使用主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获取业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时 `start-all.sh` 会打印；也可在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. 已安装 aider（`python -m pip install aider-install && aider-install`）。
+
+## 配置步骤
+
+### 1. 将 aider 指向代理
+
+```bash
+export OPENAI_API_BASE=http://127.0.0.1:8096/codebuddy/default
+export OPENAI_API_KEY=sk-mem-...        # 你的业务用户密钥
+```
+
+或将本目录的 `aider.conf.yml` 复制到项目根目录（其中设置了 `model` 和 `openai-api-base`），密钥仅通过环境变量提供，避免进入版本库。
+
+### 2. 对齐模型名
+
+`openai/` 前缀后的模型名**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。默认示例使用 `claude-sonnet-4-20250514`：
+
+```bash
+aider --model openai/claude-sonnet-4-20250514
+```
+
+### 3. 验证
+
+1. 在项目目录启动 aider。
+2. 发送第一条消息。代理会在终端交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，所绑定 Agent 的记忆将自动注入。可以让 aider 回忆此前会话内容进行验证。
+
+## 配置参考
+
+| 项目 | 值 | 说明 |
+|---|---|---|
+| `OPENAI_API_BASE` | `http://127.0.0.1:8096/codebuddy/default` | 代理的 OpenAI 兼容端点；末尾 `default` 为记忆空间 ID，多空间时对应修改 |
+| `OPENAI_API_KEY` | `sk-mem-...` | 面板创建的业务用户密钥；aider 以 `Authorization: Bearer` 发送 |
+| `--model` | `openai/<PROXY_UPSTREAM_MODEL>` | 否则代理会因上游模型不匹配而拒绝请求 |
+| `aider.conf.yml` | 可选便捷配置 | 设置 `model` + `openai-api-base`；切勿在其中写密钥 |
+
+## 常见问题
+
+| 现象 | 原因 / 解决 |
+|---|---|
+| 启动时出现 "Unknown model" 警告 | 自定义模型的预期行为 —— aider 会对其不认识的模型发出警告；只要上游模型能力足够，编辑功能不受影响 |
+| 代理返回 `401` | 密钥错误或缺失 —— 确认 `OPENAI_API_KEY` 为业务用户密钥（`sk-mem-...`）而非管理员密钥 |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行 —— 查看 `./start-all.sh` 日志及 `PROXY_UPSTREAM_*` 环境变量 |
+| 模型不匹配报错 | `openai/<model>` 与 `PROXY_UPSTREAM_MODEL` 不一致 —— 对齐两者 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动开启）；若此前会话已绑定 Task 会复用绑定 —— 新开一个 aider 会话即可重新选择 |
+
+## 说明
+
+- **终端原生**：aider 是终端工具，代理的 Team → Agent → Task 交互式选择器以内联方式在终端呈现，与 CodeBuddy 的终端流程一致。
+- **数据流**：只有提示词/补全流量经过代理；记忆数据始终保存在本地 SQLite（memory-core）中，除非你另行配置。
+- **版本**：已在 aider 的 OpenAI 兼容接入路径（`OPENAI_API_BASE` + `openai/<model>`，见官方文档）与 TencentDB Agent Memory v3（`feat/server_team` 分支，v2.0.0 镜像）上验证。
+
+## 许可证
+
+MIT，与主仓库一致。

--- a/adapters/aider/aider.conf.yml
+++ b/adapters/aider/aider.conf.yml
@@ -1,0 +1,14 @@
+# TencentDB Agent Memory — aider Adapter
+# Copy to your project root (or merge into your existing .aider.conf.yml).
+# The API key is intentionally NOT set here — export it as an environment
+# variable instead (see README), so it never lands in version control.
+
+model: openai/claude-sonnet-4-20250514
+
+# Point aider at the Memory Proxy's OpenAI-compatible endpoint.
+# The trailing path segment is the memory space ID ("default");
+# change it if you run multiple spaces.
+openai-api-base: http://127.0.0.1:8096/codebuddy/default
+
+# Keep aider's auto-commits so every memory-bound session has a clean history.
+auto-commits: true


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/aider/` — a TencentDB Agent Memory adapter for [aider](https://aider.chat), extending #926 beyond the two priority platforms to the most widely used terminal pair-programming tool.

新增 `adapters/aider/` 目录：aider 的 TencentDB Agent Memory 适配器，在 #926 两个优先平台之外扩展到最流行的终端结对编程工具。

## How it works / 工作原理

aider documents a first-class OpenAI-compatible path (`OPENAI_API_BASE` + `--model openai/<model>`). The proxy's `/codebuddy/<spaceId>` endpoint speaks the same protocol, so aider connects with env vars + an optional `.aider.conf.yml` — no code changes required:

- **Session binding** — Team → Agent → Task picker on first message (renders inline in aider's terminal UI)
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

aider 官方支持 OpenAI 兼容接入（`OPENAI_API_BASE` + `--model openai/<model>`），与代理端点协议一致，纯环境变量 + 可选配置文件接入。

## Files / 文件

| File | Purpose |
|---|---|
| `aider.conf.yml` | Optional convenience config (model + openai-api-base; key stays in env) |
| `README.md` | English setup guide, config reference, troubleshooting |
| `README_CN.md` | 中文配置指南（同一 PR 双语，满足 CI 校验） |

## Notes / 说明

- Key never lands in the config file — `OPENAI_API_KEY` env var only (documented).
- Model name after `openai/` must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Terminal-native: the session picker renders inline, same as the CodeBuddy terminal flow.

Addresses #926 (aider)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名