### PR TITLE
[good first issue-platform adapt-Cline] Add Memory adapter for Cline

### DIFF
--- a/adapters/cline/README.md
+++ b/adapters/cline/README.md
@@ -1,0 +1,89 @@
+# TencentDB Agent Memory — Cline Adapter
+
+Give [Cline](https://cline.bot) (the open-source VS Code AI agent) persistent team memory. This adapter routes Cline's LLM traffic through the TencentDB Agent Memory proxy, so every task automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Cline ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                        │
+                                        ├─ auth        (validates sk-mem-... user_key)
+                                        ├─ sessionInit (Team/Agent/Task picker)
+                                        └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Cline has a built-in **"OpenAI Compatible"** provider in its settings panel. The proxy speaks OpenAI Chat Completions on its `/codebuddy/<spaceId>` endpoint, so Cline connects through the UI with **no files and no code changes** — this adapter is a setup guide.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. The Cline extension is installed in VS Code ([marketplace](https://marketplace.visualstudio.com/items?itemName=Continue.continue) or `clines` — see [cline.bot](https://cline.bot)).
+
+## Setup
+
+### 1. Configure the provider
+
+Open the Cline panel in VS Code, click the settings icon (⚙️), and fill in:
+
+| Field | Value |
+|---|---|
+| **API Provider** | `OpenAI Compatible` |
+| **Base URL** | `http://127.0.0.1:8096/codebuddy/default` |
+| **API Key** | your `sk-mem-...` business user key |
+| **Model** | `claude-sonnet-4-20250514` |
+
+The trailing `default` in the Base URL is the memory space ID (`x-tdai-service-id`) — change it if you run multiple spaces.
+
+### 2. Align the model ID
+
+The **Model** field **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The default example uses `claude-sonnet-4-20250514`. A mismatched model is rejected by the proxy with an upstream error.
+
+### 3. Model configuration (recommended)
+
+Still in Cline's settings, under **Model Configuration**, set:
+
+- **Context Window size**: `200000` (align with your upstream model)
+- **Max Output Tokens**: `16384`
+- **Computer Use / tool calling**: enabled (Cline's agentic file edits need it)
+- **Input/Output price**: leave at 0 — upstream billing doesn't flow through Cline
+
+Click **Verify** to confirm the connection before saving.
+
+### 4. Verify memory
+
+1. Start a new Cline task and send a first message. The proxy triggers the session picker rendered in the Cline panel: choose your **Team → Agent → Task**.
+2. From this turn on, memory for the bound agent is injected automatically. Ask Cline what it remembers from previous sessions to confirm.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| "Invalid API Key" | Wrong key — confirm it is a business user key (`sk-mem-...`), not the admin key from `./.admin-key` |
+| "Model Not Found" | The Model field differs from `PROXY_UPSTREAM_MODEL` — align them |
+| Connection error / `404` | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars; also verify the Base URL includes the space ID path |
+| Verify button fails | Same three causes above — Base URL typo is the most common |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous task already bound a session, the binding is reused — start a new Cline task to re-pick |
+
+## Notes
+
+- **UI-based config**: Cline stores provider settings in VS Code's secret storage, which is why this adapter ships a guide instead of a config file — the key never lands in version control.
+- **Endpoint prefix**: reuses the proxy's OpenAI-compatible endpoint (`/codebuddy/<spaceId>`); when a dedicated prefix lands upstream, only the Base URL needs to change.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+- **Version**: tested with Cline's "OpenAI Compatible" provider (per the official docs) and TencentDB Agent Memory v3 (`feat/server_team` branch, v2.0.0 images).
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/cline/README_CN.md
+++ b/adapters/cline/README_CN.md
@@ -1,0 +1,89 @@
+# TencentDB Agent Memory — Cline 适配器
+
+为 [Cline](https://cline.bot)（开源 VS Code AI 智能体）装上团队级持久记忆。本适配器将 Cline 的 LLM 请求路由到 TencentDB Agent Memory 代理，使每个任务自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每一轮对话自动将所绑定 Agent 的 L2/L3 记忆、技能与知识注入系统提示词
+- **自动沉淀** — L0 原始对话自动写入 memory-core，供后续提炼
+
+## 工作原理
+
+```
+Cline ──(OpenAI Chat Completions 协议)──> Memory Proxy :8096 ──> 上游 LLM
+                                             │
+                                             ├─ auth        (校验 sk-mem-... user_key)
+                                             ├─ sessionInit (Team/Agent/Task 选择器)
+                                             └─ injection   (注入 L2/L3 记忆 + 技能 + 知识)
+```
+
+Cline 设置面板内置 **"OpenAI Compatible"** provider。代理在 `/codebuddy/<spaceId>` 端点上说 OpenAI Chat Completions 协议，因此 Cline 通过 UI 即可接入——**无需任何文件、无需代码改动**，本适配器为配置指南。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（使用主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获取业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时 `start-all.sh` 会打印；也可在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. VS Code 已安装 Cline 扩展（见 [cline.bot](https://cline.bot)）。
+
+## 配置步骤
+
+### 1. 配置 provider
+
+打开 VS Code 中的 Cline 面板，点击设置图标（⚙️），填入：
+
+| 字段 | 值 |
+|---|---|
+| **API Provider** | `OpenAI Compatible` |
+| **Base URL** | `http://127.0.0.1:8096/codebuddy/default` |
+| **API Key** | 你的 `sk-mem-...` 业务用户密钥 |
+| **Model** | `claude-sonnet-4-20250514` |
+
+Base URL 末尾的 `default` 为记忆空间 ID（`x-tdai-service-id`），多空间部署时对应修改。
+
+### 2. 对齐模型 ID
+
+**Model** 字段**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。默认示例使用 `claude-sonnet-4-20250514`。不匹配的模型会被代理以上游错误拒绝。
+
+### 3. 模型配置（建议）
+
+在 Cline 设置的 **Model Configuration** 中：
+
+- **Context Window size**：`200000`（按上游模型对齐）
+- **Max Output Tokens**：`16384`
+- **Computer Use / 工具调用**：启用（Cline 的文件编辑等 agentic 能力需要）
+- **Input/Output price**：保持 0 —— 上游计费不经过 Cline
+
+保存前点击 **Verify** 确认连接。
+
+### 4. 验证记忆
+
+1. 新建一个 Cline 任务并发送第一条消息。代理会在 Cline 面板中渲染会话选择器：选择你的 **Team → Agent → Task**。
+2. 从本轮起，所绑定 Agent 的记忆将自动注入。可以让 Cline 回忆此前会话内容进行验证。
+
+## 常见问题
+
+| 现象 | 原因 / 解决 |
+|---|---|
+| "Invalid API Key" | 密钥错误 —— 确认使用业务用户密钥（`sk-mem-...`）而非 `./.admin-key` 管理员密钥 |
+| "Model Not Found" | Model 字段与 `PROXY_UPSTREAM_MODEL` 不一致 —— 对齐两者 |
+| 连接错误 / `404` | 代理未在 `:8096` 运行 —— 查看 `./start-all.sh` 日志及 `PROXY_UPSTREAM_*` 环境变量；同时检查 Base URL 是否包含空间 ID 路径 |
+| Verify 按钮失败 | 同上三类原因 —— Base URL 笔误最常见 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动开启）；若此前任务已绑定会话会复用绑定 —— 新建一个 Cline 任务即可重新选择 |
+
+## 说明
+
+- **UI 配置**：Cline 将 provider 设置存入 VS Code 密钥存储，因此本适配器以指南形式提供——密钥永远不会进入版本库。
+- **端点前缀**：复用代理的 OpenAI 兼容端点（`/codebuddy/<spaceId>`）；待上游提供专用前缀后，仅需修改 Base URL。
+- **数据流**：只有提示词/补全流量经过代理；记忆数据始终保存在本地 SQLite（memory-core）中，除非你另行配置。
+- **版本**：已在 Cline 的 "OpenAI Compatible" provider（见官方文档）与 TencentDB Agent Memory v3（`feat/server_team` 分支，v2.0.0 镜像）上验证。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/cline/` — a TencentDB Agent Memory adapter for [Cline](https://cline.bot) (open-source VS Code AI agent). Addresses #926.

新增 `adapters/cline/` 目录：Cline（开源 VS Code AI 智能体）的 TencentDB Agent Memory 适配器。

## How it works / 工作原理

Cline has a built-in **OpenAI Compatible** provider in its settings panel. The proxy's `/codebuddy/<spaceId>` endpoint speaks the same protocol, so Cline connects through the UI — no files, no code changes:

- **Session binding** — Team → Agent → Task picker on first message (renders in the Cline panel)
- **Memory injection** — L2/L3 memory + skills blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

Cline 设置面板内置 OpenAI Compatible provider，与代理协议一致，纯 UI 配置接入。

## Files / 文件

| File | Purpose |
|---|---|
| `README.md` | English UI walkthrough (provider fields, model alignment, Model Configuration, troubleshooting) |
| `README_CN.md` | 中文配置指南（同一 PR 双语，满足 CI 校验） |

## Notes / 说明

- Cline stores provider settings in VS Code secret storage — hence a guide (not a config file); the key never lands in version control.
- Model field must equal the proxy's `PROXY_UPSTREAM_MODEL`; context window / tool-calling settings documented.
- Recommended Model Configuration: context window aligned to upstream, Computer Use enabled, prices at 0.

Addresses #926 (Cline)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名