### PR TITLE
fix(deploy): expose agent-reachable tool URLs

### DIFF
--- a/MemoryKnowledge/src/routes/code-graph.ts
+++ b/MemoryKnowledge/src/routes/code-graph.ts
@@ -206,10 +206,10 @@ export function createCodeGraphRoutes(deps: CodeGraphRouteDeps): Hono {
     // knowledge_id in request body, so the URL is service-level, not
     // resource-scoped). publicBaseUrl already includes the API prefix; proxy
     // appends `/tools/list` | `/tools/call` directly.
-    if (!existed && publicBaseUrl) {
+    if (publicBaseUrl && row.service_url !== publicBaseUrl) {
       const serviceUrl = publicBaseUrl;
       const updated = cgService.updateServiceUrl(idFields.service_id, row.code_graph_id, serviceUrl);
-      if (updated) return c.json(wrapOk(toCodeGraphDetail(updated)), 201);
+      if (updated) return c.json(wrapOk(toCodeGraphDetail(updated)), existed ? 200 : 201);
     }
 
     return c.json(wrapOk(toCodeGraphDetail(row)), existed ? 200 : 201);

--- a/MemoryKnowledge/src/routes/service-url-refresh.test.ts
+++ b/MemoryKnowledge/src/routes/service-url-refresh.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createDb } from "../db/client.js";
+import { SqliteKnowledgeStore, WikiService, CodeGraphService } from "../store/index.js";
+import { createWikiRoutes, type WikiRouteDeps } from "./wiki.js";
+import { createCodeGraphRoutes, type CodeGraphRouteDeps } from "./code-graph.js";
+
+const SERVICE_ID = "service-a";
+const TEAM_ID = "team-a";
+const OLD_BASE_URL = "http://host.docker.internal:8424/v3";
+const NEW_BASE_URL = "http://127.0.0.1:8424/v3";
+
+interface WikiCreateResponse {
+  data: {
+    wiki_id: string;
+    service_url: string | null;
+  };
+}
+
+interface CodeGraphCreateResponse {
+  data: {
+    code_graph_id: string;
+    service_url: string | null;
+  };
+}
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanupTasks.length > 0) {
+    await cleanupTasks.pop()?.();
+  }
+});
+
+function createServices() {
+  const dataRoot = mkdtempSync(join(tmpdir(), "knowledge-service-url-"));
+  const { db, raw } = createDb({ path: ":memory:" });
+  const store = new SqliteKnowledgeStore(db);
+  const wikiService = new WikiService({
+    store,
+    dataRoot: join(dataRoot, "wiki"),
+    worker: async () => ({ pageCount: 0 }),
+  });
+  const cgService = new CodeGraphService({
+    store,
+    dataRoot: join(dataRoot, "code-graph"),
+    worker: async () => ({}),
+  });
+
+  cleanupTasks.push(async () => {
+    await cgService.onIdle();
+    raw.close();
+    rmSync(dataRoot, { recursive: true, force: true });
+  });
+
+  return { wikiService, cgService };
+}
+
+function wikiRoutes(wikiService: WikiService, publicBaseUrl: string) {
+  return createWikiRoutes({
+    wikiService,
+    wikiMgr: {} as WikiRouteDeps["wikiMgr"],
+    publicBaseUrl,
+  });
+}
+
+function codeGraphRoutes(cgService: CodeGraphService, publicBaseUrl: string) {
+  const instancePool: CodeGraphRouteDeps["instancePool"] = {
+    get: () => undefined,
+    set: () => undefined,
+    delete: () => undefined,
+  };
+  return createCodeGraphRoutes({ cgService, instancePool, publicBaseUrl });
+}
+
+function postCreate(app: { request: (input: Request) => Response | Promise<Response> }, body: object) {
+  return app.request(new Request("http://localhost/create", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-tdai-service-id": SERVICE_ID,
+    },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe("knowledge service_url refresh", () => {
+  it("refreshes an existing wiki when the public base URL changes", async () => {
+    const { wikiService } = createServices();
+    const body = { team_id: TEAM_ID, name: "team-docs" };
+
+    const created = await postCreate(wikiRoutes(wikiService, OLD_BASE_URL), body);
+    const createdPayload = await created.json() as WikiCreateResponse;
+
+    expect(created.status).toBe(201);
+    expect(createdPayload.data.service_url).toBe(OLD_BASE_URL);
+
+    const refreshed = await postCreate(wikiRoutes(wikiService, NEW_BASE_URL), body);
+    const refreshedPayload = await refreshed.json() as WikiCreateResponse;
+
+    expect(refreshed.status).toBe(200);
+    expect(refreshedPayload.data.wiki_id).toBe(createdPayload.data.wiki_id);
+    expect(refreshedPayload.data.service_url).toBe(NEW_BASE_URL);
+  });
+
+  it("refreshes an existing code graph when the public base URL changes", async () => {
+    const { cgService } = createServices();
+    const body = {
+      team_id: TEAM_ID,
+      repo_url: "https://example.com/team/repo.git",
+      branch: "main",
+    };
+
+    const created = await postCreate(codeGraphRoutes(cgService, OLD_BASE_URL), body);
+    const createdPayload = await created.json() as CodeGraphCreateResponse;
+
+    expect(created.status).toBe(201);
+    expect(createdPayload.data.service_url).toBe(OLD_BASE_URL);
+
+    const refreshed = await postCreate(codeGraphRoutes(cgService, NEW_BASE_URL), body);
+    const refreshedPayload = await refreshed.json() as CodeGraphCreateResponse;
+
+    expect(refreshed.status).toBe(200);
+    expect(refreshedPayload.data.code_graph_id).toBe(createdPayload.data.code_graph_id);
+    expect(refreshedPayload.data.service_url).toBe(NEW_BASE_URL);
+  });
+});

--- a/MemoryKnowledge/src/routes/wiki.ts
+++ b/MemoryKnowledge/src/routes/wiki.ts
@@ -174,10 +174,10 @@ export function createWikiRoutes(deps: WikiRouteDeps): Hono {
     // knowledge_id in request body, so the URL is service-level, not
     // resource-scoped). publicBaseUrl already includes the API prefix; proxy
     // appends `/tools/list` | `/tools/call` directly.
-    if (!existed && publicBaseUrl) {
+    if (publicBaseUrl && row.service_url !== publicBaseUrl) {
       const serviceUrl = publicBaseUrl;
       const updated = wikiService.updateServiceUrl(ids.service_id, row.wiki_id, serviceUrl);
-      if (updated) return c.json(wrapOk(toWikiDetail(updated)), 201);
+      if (updated) return c.json(wrapOk(toWikiDetail(updated)), existed ? 200 : 201);
     }
 
     return c.json(wrapOk(toWikiDetail(row)), existed ? 200 : 201);

--- a/deploy/global-images/.env.example
+++ b/deploy/global-images/.env.example
@@ -50,10 +50,15 @@ PANEL_PORT=8125
 KNOWLEDGE_PORT=8424
 PROXY_PORT=8096
 
+# ── proxy 注入给 Agent 的外部可达地址 ────────────────────────────────────────
+# 用于 skill / memory 工具调用。默认适用于 Agent 与 Docker 同机；跨机部署请改为
+# Agent 可访问的 LAN IP 或域名，例如 http://192.168.1.100:8096。
+PROXY_EXTERNAL_GATEWAY_URL=http://127.0.0.1:8096
+
 # ── knowledge 外部可达地址（memory-hub 需要）─────────────────────────────────
 # 让 agent / gateway 能访问到 KS 的 tools 接口。必须含 /v3 前缀。
-# 本地场景默认用 host.docker.internal 让容器内可回环到宿主。
-KNOWLEDGE_PUBLIC_BASE_URL=http://host.docker.internal:8424/v3
+# 默认适用于 Agent 与 Docker 同机；跨机部署请改为 Agent 可访问的 LAN IP 或域名。
+KNOWLEDGE_PUBLIC_BASE_URL=http://127.0.0.1:8424/v3
 
 # ── Panel UI "客户端接入地址" 卡片显示的 base URL（开源本地部署专用）──────────
 # 开源部署 core 和 proxy 分开跑，coding agent 客户端要接的是 proxy，不是 core/gateway。

--- a/deploy/global-images/start-proxy.sh
+++ b/deploy/global-images/start-proxy.sh
@@ -23,6 +23,9 @@ require_vars \
 
 # 与 memory-core 保持一致的 gateway 内部凭据（默认 local，仅本地体验）
 MEMORY_CORE_GATEWAY_API_KEY="${MEMORY_CORE_GATEWAY_API_KEY:-local}"
+# 注入给 Agent 的工具地址必须从 Agent 所在环境可达。默认适用于 Agent 与
+# Docker 同机；跨机部署应在 .env 中显式配置 LAN IP 或域名。
+PROXY_EXTERNAL_GATEWAY_URL="${PROXY_EXTERNAL_GATEWAY_URL:-http://127.0.0.1:${PROXY_PORT}}"
 
 CONTAINER=tdai-proxy
 NETWORK=tdai-memory-stack
@@ -131,6 +134,7 @@ costGuard:
 # knowledge 依赖 memory-hub 起来，否则 hook 内部会降级为空块。
 injection:
   enabled: true
+  externalGatewayUrl: "${PROXY_EXTERNAL_GATEWAY_URL}"
   injectors:
     - skill
     - knowledge

--- a/deploy/global-images/tests/start-proxy-config.test.sh
+++ b/deploy/global-images/tests/start-proxy-config.test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GLOBAL_IMAGES_DIR="$(dirname "$TEST_DIR")"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/bin"
+
+cat > "$TMP_ROOT/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  network | run | rm | logs) exit 0 ;;
+  ps)
+    printf '%s\n' tdai-memory-core tdai-memory-hub
+    exit 0
+    ;;
+  inspect)
+    if [[ "$*" == *Health* ]]; then
+      echo healthy
+    else
+      echo running
+    fi
+    exit 0
+    ;;
+esac
+
+exit 0
+SH
+chmod +x "$TMP_ROOT/bin/docker"
+
+write_env() {
+  local target="$1"
+  shift
+  {
+    printf '%s\n' \
+      'PROXY_IMAGE=test/memory-proxy:latest' \
+      'PROXY_PORT=18096' \
+      'PROXY_UPSTREAM_URL=https://llm.example/v1' \
+      'PROXY_UPSTREAM_API_KEY=test-key' \
+      'PROXY_UPSTREAM_MODEL=test-model'
+    printf '%s\n' "$@"
+  } > "$target"
+}
+
+run_start() {
+  local env_file="$1"
+  local config_dir="$2"
+
+  PATH="$TMP_ROOT/bin:$PATH" \
+    ENV_FILE="$env_file" \
+    PROXY_CONFIG_DIR="$config_dir" \
+    bash "$GLOBAL_IMAGES_DIR/start-proxy.sh" >/dev/null 2>&1
+}
+
+test_explicit_external_gateway_url_is_written() {
+  local case_dir="$TMP_ROOT/explicit"
+  local env_file="$case_dir/.env"
+  local config_dir="$case_dir/config"
+
+  mkdir -p "$case_dir"
+  write_env "$env_file" \
+    'PROXY_EXTERNAL_GATEWAY_URL=https://memory.example.com'
+
+  run_start "$env_file" "$config_dir"
+
+  grep -F 'externalGatewayUrl: "https://memory.example.com"' "$config_dir/config.yaml" >/dev/null
+}
+
+test_default_external_gateway_url_uses_published_proxy_port() {
+  local case_dir="$TMP_ROOT/default"
+  local env_file="$case_dir/.env"
+  local config_dir="$case_dir/config"
+
+  mkdir -p "$case_dir"
+  write_env "$env_file"
+
+  run_start "$env_file" "$config_dir"
+
+  grep -F 'externalGatewayUrl: "http://127.0.0.1:18096"' "$config_dir/config.yaml" >/dev/null
+}
+
+test_explicit_external_gateway_url_is_written
+test_default_external_gateway_url_uses_published_proxy_port
+
+echo "start-proxy external gateway config: ok"


### PR DESCRIPTION
## Description | 描述

修复完整容器部署中注入给 Agent 的工具地址不可达，以及已有 Wiki / CodeGraph 资产保留旧 `service_url` 的问题。

- Proxy 配置新增 `injection.externalGatewayUrl`，由 `PROXY_EXTERNAL_GATEWAY_URL` 控制；默认使用宿主机可访问的 `http://127.0.0.1:${PROXY_PORT}`。
- `.env.example` 补充 Proxy 与 Knowledge 的外部可达地址说明。
- Wiki / CodeGraph 幂等创建命中已有资产时，若公开 Base URL 已变化，则同步刷新持久化的 `service_url`，避免继续返回旧的 `host.docker.internal` 等容器内部地址。
- 补充 Proxy 配置生成和 Knowledge 地址刷新的回归测试。

根因是容器内部服务地址被直接暴露给宿主机上的 Hermes，而已有 Knowledge 资产的幂等创建路径没有刷新外部访问地址。

## Related Issue | 关联 Issue

N/A — 未检索到直接对应的现有 Issue / PR。

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

验证结果：

- `MemoryKnowledge`: `npm test`，2/2 通过。
- `deploy/global-images/tests/start-proxy-config.test.sh` 通过。
- macOS 本地源码镜像部署实测：Hermes 成功通过 `http://127.0.0.1:8096` 调用 Skill Bridge 和 Memory Bridge。

`MemoryKnowledge npm run typecheck` 当前仍命中官方基线中 `src/middleware/response-envelope.ts` 的既有类型错误；该文件不在本 PR 改动范围内。
