### PR TITLE
fix(proxy): resolve bare Hermes bridge session IDs

### DIFF
--- a/MemoryProxy/src/__tests__/hermes-bridge-session.test.ts
+++ b/MemoryProxy/src/__tests__/hermes-bridge-session.test.ts
@@ -1,0 +1,123 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../config.js";
+import { createMemoryBridgeHandler } from "../memory/memory-bridge.js";
+import { __resetSessionStoreForTests, getSessionStore } from "../session/store.js";
+import { createSkillBridgeHandler } from "../skill/skill-bridge.js";
+
+const SESSION_ID = "hermes-ops-test-001";
+
+function testConfig() {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.coreSkill = {
+    endpoint: "http://memory-core:8420",
+    serviceToken: "local",
+    serviceId: "default",
+    timeoutMs: 1_000,
+  };
+  return config;
+}
+
+async function seedHermesSession(): Promise<void> {
+  const store = getSessionStore();
+  const keyId = `hermes:${SESSION_ID}`;
+  store.bind(keyId, {
+    userId: "user-1",
+    agentSource: "hermes",
+    sessionId: SESSION_ID,
+    spaceId: "default",
+  });
+  await store.set(keyId, {
+    status: "initialized",
+    keyId,
+    startedAt: Date.now(),
+    attemptCount: 1,
+    bypassed: false,
+    sessionInfo: {
+      user_id: "user-1",
+      team_id: "team-1",
+      agent_id: "agent-1",
+      session_id: SESSION_ID,
+      task_id: "task-1",
+      space_id: "default",
+    },
+    agentDetail: null,
+    taskDetail: null,
+  });
+}
+
+describe("Hermes bridge session compatibility", () => {
+  beforeEach(() => {
+    __resetSessionStoreForTests();
+  });
+
+  it("resolves a bare Hermes conversation ID in memory-bridge", async () => {
+    await seedHermesSession();
+    let outboundBody: Record<string, unknown> | undefined;
+    const fetcher: typeof fetch = async (_input, init) => {
+      outboundBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({ code: 0, message: "upstream-ok", data: { items: [] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const app = new Hono();
+    app.post(
+      "/memory-bridge/v3/scenario/ls",
+      createMemoryBridgeHandler(testConfig(), { fetcher }),
+    );
+
+    const response = await app.request("http://proxy/memory-bridge/v3/scenario/ls", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-conversation-id": SESSION_ID,
+      },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ code: 0, message: "upstream-ok" });
+    expect(outboundBody).toMatchObject({
+      user_id: "user-1",
+      team_id: "team-1",
+      agent_id: "agent-1",
+      task_id: "task-1",
+    });
+  });
+
+  it("resolves a bare Hermes conversation ID in skill-bridge", async () => {
+    await seedHermesSession();
+    let outboundBody: Record<string, unknown> | undefined;
+    const fetcher: typeof fetch = async (_input, init) => {
+      outboundBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({ code: 0, message: "upstream-ok", data: { skill_id: "skill-1" } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const app = new Hono();
+    app.post(
+      "/skill-bridge/v3/skill/get",
+      createSkillBridgeHandler(testConfig(), { fetcher }),
+    );
+
+    const response = await app.request("http://proxy/skill-bridge/v3/skill/get", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-conversation-id": SESSION_ID,
+      },
+      body: JSON.stringify({ skill_id: "skill-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ code: 0, message: "upstream-ok" });
+    expect(outboundBody).toMatchObject({
+      user_id: "user-1",
+      team_id: "team-1",
+      agent_id: "agent-1",
+      skill_id: "skill-1",
+    });
+  });
+});

--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -140,7 +140,7 @@ function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   // 通常是 bare sessionId。按候选前缀顺序探,命中即返回。
   const candidates = sessionId.includes(":")
     ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
+    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`, `hermes:${sessionId}`];
   for (const k of candidates) {
     const state = getSessionStore().get(k);
     if (state) {

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -294,7 +294,7 @@ function bindingToIdFields(
 function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   const candidates = sessionId.includes(":")
     ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
+    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`, `hermes:${sessionId}`];
   for (const k of candidates) {
     const s = getSessionStore().get(k);
     if (s) {


### PR DESCRIPTION
## Description | 描述

修复 Hermes 调用 Skill Bridge / Memory Bridge 时，裸 `x-conversation-id` 无法命中 Proxy 内部 `hermes:<sessionId>` Session，最终返回 `40101 session not initialized` 的问题。

主请求按 `${agentSource}:${sessionId}` 保存 Session；Bridge 收到的却是裸 conversation ID。现有候选只覆盖 bare、`codebuddy:` 和 `claude-code:`，缺少 `hermes:`。本 PR 在两个 Bridge 的 L1 候选中补齐 `hermes:${sessionId}`，不引入 Redis、不修改存储结构、不改变 API。

同时增加两个 Handler 级回归测试，验证裸 Hermes conversation ID 能分别通过 Memory Bridge 和 Skill Bridge 恢复用户、团队与 Agent 身份。

## Related Issue | 关联 Issue

Refs #957。

与 #960 的 Hermes Session 修复部分重叠；#960 当前与最新 `feat/server_team` 存在冲突且同时包含 Knowledge 配置改动。本 PR 基于当前分支，仅提交 Session 识别的最小修复。

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

验证结果：

- `MemoryProxy`: `npm test`，2/2 通过；修复前两个测试均稳定返回 401，修复后均返回 200。
- macOS 本地源码镜像 + 飞书 Hermes 实测：
  - Skill Bridge 成功返回 `code: 0`，不再出现 `40101`。
  - Memory Bridge 日志为 `sub=conversation/search multi targets=1 ok=1 messages=5`。
  - Session 日志持续命中 `session=hermes:<id> L1 hit (terminal)`。
- 测试环境未启用 Redis，证明修复作用于单实例 L1 正常路径，而非依赖 Redis 兜底。
