### PR TITLE
fix(panel): restore skill asset actions

### DIFF
--- a/MemoryPanel/docs/api/meta-api.openapi.yaml
+++ b/MemoryPanel/docs/api/meta-api.openapi.yaml
@@ -1397,7 +1397,7 @@ paths:
       tags: ["Meta · Agent Fixed Asset"]
       operationId: meta_agent-fixed-asset_list-with-detail
       summary: agent-fixed-asset/list-with-detail
-      description: "新面板一期 **不转发** 至内核；Control 返回 HTTP 501、`message=NOT_IN_SCOPE`。"
+      description: "分页 list；body 可选 limit（默认 20，最大 100）、offset（默认 0）。默认 created_at DESC（v3.1.2+；team-member 为 joined_at DESC）。须 Header 双凭证。"
       security: []
       parameters:
         - $ref: '#/components/parameters/TdaiServiceId'
@@ -1416,8 +1416,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
-        '501':
-          $ref: "#/components/responses/NotInScope"
         '400':
           $ref: "#/components/responses/ControlBadRequest"
         '502':
@@ -1728,7 +1726,7 @@ components:
             request_id: req-example
             data: null
     NotInScope:
-      description: 新面板一期禁用的 action 域（asset / agent-fixed-asset）
+      description: 未通过面板公开代理转发的 meta action
       content:
         application/json:
           schema:

--- a/MemoryPanel/scripts/e2e-skill-authz.sh
+++ b/MemoryPanel/scripts/e2e-skill-authz.sh
@@ -182,14 +182,12 @@ ALLOWED2=$(jget "$R" data.allowed)
 pass "撤销后 acl/check allowed=$ALLOWED2"
 
 # ============================
-info "⑮ agent-fixed-asset/list-with-detail → 预期 501 NOT_IN_SCOPE（stateless 模式挡着）"
+info "⑮ agent-fixed-asset/list-with-detail → 面板代理应正常转发"
 R=$(call_meta agent-fixed-asset/list-with-detail "$ADMIN_KEY" "{\"agent_id\":\"$AGENT_ID\",\"limit\":100,\"offset\":0}")
-STATUS=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('code', 'no-code'))")
-if [[ $STATUS == "501" ]] || echo "$R" | grep -q "NOT_IN_SCOPE"; then
-  pass "预期挡住：$R"
-else
-  echo -e "  ${YELLOW}⚠${NC} agent-fixed-asset/list-with-detail 竟然通了？response: $R"
-fi
+[[ $(jcode "$R") == "0" ]] || fail "agent-fixed-asset/list-with-detail" "$R"
+COUNT_FIXED=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for i in d['data']['items'] if i['asset_id']=='$SKILL_ID'))")
+[[ $COUNT_FIXED == "1" ]] || fail "固定资产详情应包含刚建的 skill" "$R"
+pass "固定资产详情已正常转发 ($COUNT_FIXED/1)"
 
 # ============================
 info "⑯ 内容面 skill/list → 验证固定资产 Tab 现用的接口"

--- a/MemoryPanel/scripts/generate-meta-openapi.ts
+++ b/MemoryPanel/scripts/generate-meta-openapi.ts
@@ -226,7 +226,7 @@ components:
             request_id: req-example
             data: null
     NotInScope:
-      description: 新面板一期禁用的 action 域（asset / agent-fixed-asset）
+      description: 未通过面板公开代理转发的 meta action
       content:
         application/json:
           schema:

--- a/MemoryPanel/src/panel/api/meta-actions.ts
+++ b/MemoryPanel/src/panel/api/meta-actions.ts
@@ -1,7 +1,7 @@
 /**
  * 内核 /v3/meta/* 公开 action 列表（v3.2：55 条，不含 internal）。
- * 注：agent-fixed-asset/* 仍在 META_ACTIONS 登记但公开 proxy 501 NOT_IN_SCOPE；
- * Control 业务路由可通过 metaKernel.invoke 直调。
+ * 注：agent-fixed-asset/list-with-detail 已供面板按 Agent 读取绑定详情；
+ * 其余 agent-fixed-asset action 仍由 Control 业务路由通过 metaKernel.invoke 直调。
  */
 
 export const META_LIST_ACTIONS = new Set([
@@ -83,16 +83,21 @@ export const META_ACTIONS = [
 export type MetaAction = (typeof META_ACTIONS)[number];
 
 /**
- * 暂未开放给面板的 action 前缀。
+ * 暂未开放给面板的 action。
  *
  * asset/* 已放开：skill「分配到 Agent」走授权接口（acl/grant）时，需先把 skill
  * 登记为 meta 资产（asset/create，owner=当前登录用户），再授予目标 agent use 权限。
- * agent-fixed-asset/*（运行时固定注入绑定）仍暂不开放。
+ * agent-fixed-asset/list-with-detail 已由 Skill 固定资产页使用；写入、原始绑定列表
+ * 与批量汇总仍不通过公开 proxy 暴露。
  */
-const NOT_IN_SCOPE_PREFIXES = ['agent-fixed-asset/'] as const;
+const NOT_IN_SCOPE_ACTIONS = new Set([
+  'agent-fixed-asset/set',
+  'agent-fixed-asset/list',
+  'agent-fixed-asset/summary-by-agents',
+]);
 
 export function isNotInScopeAction(action: string): boolean {
-  return NOT_IN_SCOPE_PREFIXES.some((prefix) => action.startsWith(prefix));
+  return NOT_IN_SCOPE_ACTIONS.has(action);
 }
 
 export const ALLOWED_PANEL_ACTIONS = new Set(

--- a/MemoryPanel/src/panel/http/routes/chat-memory.ts
+++ b/MemoryPanel/src/panel/http/routes/chat-memory.ts
@@ -2,10 +2,9 @@
  * /api/v1/chat-memory/* —— Chat Memory 面板专用业务路由（stateless panel 架构）。
  *
  * 为什么单独一层而不是走 /meta/{action}：
- *   - 新面板 §0 决策 12.3：`asset/*` 与 `agent-fixed-asset/*` 一期在 meta pass-through
- *     里 501（NOT_IN_SCOPE）。
- *   - 但 Chat Memory 面板 3-tab 页面需要这些资产操作。本文件就是那个"12.3 决策例外"
- *     的落点：只对 chat_memory 这一类 asset 做业务化包装，跟 skill/wiki/code_graph 隔离。
+ *   - Chat Memory 需要组合多个 meta / 数据面调用，并额外执行 caller、资产类型与
+ *     借入数量校验，不能由通用 meta pass-through 单次调用完成。
+ *   - 本文件仅包装 chat_memory 业务，跟 skill/wiki/code_graph 隔离。
  *
  * 请求约定（跟 /meta/* 相同）：
  *   - 全部 POST

--- a/MemoryPanel/tests/meta-proxy-agent-fixed-asset.test.ts
+++ b/MemoryPanel/tests/meta-proxy-agent-fixed-asset.test.ts
@@ -1,0 +1,95 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InstanceRegistry } from '../src/panel/config/instance-registry.js';
+import { registerMetaProxyRoutes } from '../src/panel/http/routes/meta/proxy.js';
+import type { PanelDeps } from '../src/panel/panel-deps.js';
+
+const headers = {
+  'content-type': 'application/json',
+  'X-Tdai-Service-Id': 'default',
+  'X-Tdai-User-Key': 'user-key',
+};
+
+function buildApp(invoke: PanelDeps['metaKernel']['invoke']) {
+  const app = new Hono();
+  const deps = {
+    instanceRegistry: new InstanceRegistry([
+      {
+        instance_id: 'default',
+        name: 'Default',
+        gateway_endpoint: 'http://memory-core.test',
+        api_key: 'gateway-key',
+      },
+    ]),
+    metaKernel: { invoke },
+  } as unknown as PanelDeps;
+  registerMetaProxyRoutes(app, deps);
+  return app;
+}
+
+describe('agent-fixed-asset meta proxy policy', () => {
+  it('forwards list-with-detail to MemoryCore', async () => {
+    const invoke = vi.fn(async () => ({
+      code: 0,
+      message: 'ok',
+      request_id: 'req-1',
+      data: { items: [], total: 0, limit: 100, offset: 0 },
+    }));
+    const app = buildApp(invoke);
+
+    const response = await app.request('/meta/agent-fixed-asset/list-with-detail', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        agent_id: 'agent-1',
+        apply_visibility_filter: true,
+        touch_usage: false,
+        limit: 100,
+        offset: 0,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      code: 0,
+      data: { items: [], total: 0 },
+    });
+    expect(invoke).toHaveBeenCalledWith(
+      'agent-fixed-asset/list-with-detail',
+      {
+        agent_id: 'agent-1',
+        apply_visibility_filter: true,
+        touch_usage: false,
+        limit: 100,
+        offset: 0,
+      },
+      expect.objectContaining({
+        instanceId: 'default',
+        userKey: 'user-key',
+      }),
+    );
+  });
+
+  it.each([
+    ['set', { agent_id: 'agent-1', bindings: [] }],
+    ['list', { agent_id: 'agent-1' }],
+    ['summary-by-agents', { agent_ids: ['agent-1'] }],
+  ])('keeps %s outside the public Panel proxy scope', async (action, body) => {
+    const invoke = vi.fn();
+    const app = buildApp(invoke);
+
+    const response = await app.request(`/meta/agent-fixed-asset/${action}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({
+      code: 501,
+      message: 'NOT_IN_SCOPE',
+    });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryPanel/web/src/lib/api/base.ts
+++ b/MemoryPanel/web/src/lib/api/base.ts
@@ -6,8 +6,8 @@
  *   - 鉴权由前端 sessionStorage 缓存 instance_id + user_key（见 lib/panelSession.ts），
  *     每次请求注入 Header X-Tdai-Service-Id + X-Tdai-User-Key（auth/verify 除外，
  *     该接口 user_key 只放 body，不放 Header）；
- *   - agent-fixed-asset/* 不适用通用「资产」UI（PANEL_CAPABILITIES.assets 为 false），
- *     skill 挂载走 v3 数据面 fork（skillApi.forkToAgent）；
+ *   - agent-fixed-asset/list-with-detail 已供 Skill 固定资产页读取；其余 action
+ *     不适用通用「资产」UI（PANEL_CAPABILITIES.assets 为 false）；
  *   - 所有函数返回 Promise<T>，失败抛 ApiError。
  */
 import { getPanelSession, clearPanelSession } from '../panelSession';
@@ -16,7 +16,7 @@ import type { MetaEnvelope, PaginatedResult, PublicUser } from './types';
 
 /**
  * 通用「资产」能力开关。
- * UI 消费 assetsApi / agentsApi.getAssets|getFixedAssets|setFixedAssets 前应先判断
+ * UI 消费 assetsApi / agentsApi.getFixedAssets|setFixedAssets 前应先判断
  * `PANEL_CAPABILITIES.assets`，为 false 时展示"暂未开放"占位，不要发起注定 501 的请求。
  */
 export const PANEL_CAPABILITIES = {

--- a/MemoryPanel/web/src/pages/skills/SkillsPage/components/skills-list.css
+++ b/MemoryPanel/web/src/pages/skills/SkillsPage/components/skills-list.css
@@ -206,8 +206,8 @@
   flex-shrink: 0;
 }
 
-._memory-skill-item:hover ._memory-skill-item-delete,
-._memory-skill-item.is-selected ._memory-skill-item-delete {
+._alp-item:hover ._memory-skill-item-delete,
+._alp-item--selected ._memory-skill-item-delete {
   visibility: visible;
   opacity: 1;
 }


### PR DESCRIPTION
## Description | 描述

修复 MemoryPanel 的 Skill 资产页无法读取 Agent 固定资产详情，以及删除按钮无法显示的问题。

根因有两处：

1. `agent-fixed-asset/*` 被按前缀整体标记为 `NOT_IN_SCOPE`，导致面板已经采用的只读接口 `agent-fixed-asset/list-with-detail` 也被通用 Meta Proxy 拒绝；
2. Skill 列表重构为通用 `_alp-item` 样式后，删除按钮仍使用旧的 `_memory-skill-item` hover/selected 选择器，因此按钮始终隐藏。

本 PR 按现有设计做最小修复：

- 只开放面板当前需要的 `agent-fixed-asset/list-with-detail`；
- `set`、原始 `list` 和 `summary-by-agents` 继续保持不可公开访问；
- 同步 Meta Action、OpenAPI 生成规则和 E2E 授权校验；
- 更新删除按钮选择器，使其在 hover 或选中 Skill 时可见；
- 增加 Meta Proxy 回归测试，覆盖允许的只读 action 与继续阻止的写入/内部 action。

不新增 API，不改变 Skill Fork、共享或删除的数据语义。

## Related Issue | 关联 Issue

未关联现有 Issue。该问题由 MemoryPanel 实际部署验证发现。

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Validation | 验证结果

自动化检查：

- `MemoryPanel`: `npm test`，1 个测试文件、4/4 测试通过；
- `MemoryPanel`: `npm run typecheck` 通过；
- `MemoryPanel`: `npm run build` 通过；
- `MemoryPanel/web`: `npm run lint:check` 退出码 0，无 error；
- `MemoryPanel/web`: `npm run build` 通过；
- `git diff --check upstream/feat/server_team...HEAD` 通过。

实际部署验收：

- 团队资产页能够列出 Skill；
- Skill 删除入口恢复显示；
- 点击删除入口能够打开彻底删除确认框；
- 后续发现的 `skill_search` 跨 Agent 搜索/读取问题属于 MemoryProxy 的独立调用链，不是本 PR 的回归。
