### PR TITLE
feat(memory-core): implement GitStorageBackend (experimental)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -67,6 +67,27 @@ jobs:
           path: "MemoryCore/*.tgz"
           retention-days: 7
 
+  # ── 3. Unit tests ───────────────────────────────────────────
+  test:
+    name: Unit Tests
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: MemoryCore/node_modules
+          key: deps-${{ runner.os }}-${{ hashFiles('MemoryCore/package.json') }}
+
+      - name: npm test
+        run: npm test
+
   # ── 5. Plugin manifest validation ──────────────────────────
   manifest:
     name: Manifest

--- a/MemoryCore/docs/design/git-storage-backend-implementation-plan.md
+++ b/MemoryCore/docs/design/git-storage-backend-implementation-plan.md
@@ -19,8 +19,8 @@ RFC 已核实：文中每处代码引用都逐字节对照当前源码验证过�
 其余关键决定：
 - **Shell 出系统 `git` 二进制**（`execFile`，参数用数组不用字符串，杜绝 shell 注入），不加 `simple-git`/`isomorphic-git` 依赖——本仓库已有的风险姿态是"外部依赖是可以接受的"（COS 需要网络+密钥），这里只是换成"需要 PATH 上有 git"，且免去 COS 那套动态 import + optionalDependency 的仪式。
 - **`factory.ts` 静态 import** `GitStorageBackend`（不是 COS 式动态 import）——没有重量级可选依赖需要延迟加载。
-- **每个记忆空间一个独立 `git clone`**，不用 `git worktree add`——独立 clone 避免共享 `.git` 目录带来的跨 worktree 锁竞争，是更"无特例"的方案。
-- **`appendObject` 的幂等键 = 该次调用内容的 SHA-256**，不解析 JSONL 里业务自带的 `record_id`/`id`（已核实 L0/L1 writer 确实有这些字段）——在存储层解析业务内容格式是分层违规；SHA-256 dedup 足够覆盖现有调用方"每次调用一个完整批次"的模式。
+- **每个记忆空间一个独立 `git clone --single-branch --no-tags`**，不用 `git worktree add`——独立 clone 运维更简单、无需管理跨 worktree 共享对象库的 GC；`--single-branch` 是必须的，否则普通 clone 会把远端其余所有空间的分支历史也拉下来，磁盘/网络开销随空间数量接近平方增长（Codex 检查点 A 指出的问题，已修订）。首次创建空间（分支在远端还不存在）时改用 `git init` + `git remote add` + 本地建 orphan branch，而不是 `clone`。
+- **`appendObject` 的幂等键 = 后端自生成的操作 UUID**，不解析 JSONL 里业务自带的 `record_id`/`id`（已核实 L0/L1 writer 确实有这些字段，但在存储层解析业务内容格式是分层违规），也**不是**内容 SHA-256（Codex 检查点 A 指出：内容哈希会把"合法的重复内容"误判成"崩溃重放"，静默丢数据，已修订为操作 UUID + commit message trailer 记账，见下方"关键设计细节"）。
 - **`fileStorageBackend` 配置新增 `"auto"` 默认值**（RFC 原文是 `local|cos|git` 三选一）——因为这个字段今天在 `config.ts` 里完全不存在，现网服务模式是靠 `deployMode`+运行时 COS client 存在与否临时推断的；如果默认值是 `"local"`，会静默改变现网行为。`"auto"` = 保留现状推断，显式设置才生效。
 
 ## 实现范围
@@ -44,28 +44,50 @@ RFC 已核实：文中每处代码引用都逐字节对照当前源码验证过�
 - `../../gateway/storage-resolver.ts` — `resolveFileStorageBackend()`，替掉 `server.ts` 里两处几乎重复的 resolve 逻辑
 - `git-backend.test.ts` / `git-backend.git-specific.test.ts`
 
-**关键设计细节**
+**关键设计细节（已按下方"Codex 检查点 A 评审结论"修订，此处是修订后的最终版本）**
 
-分支命名：`memory/{sanitize(tenantId)}/{sanitize(instanceId)}-{sha256(rawSeed).slice(0,8)}`，`sanitize()` 只留 `[a-z0-9_-]`；末尾 8 位哈希防止 sanitize 后碰撞。构造时跑 `git check-ref-format --branch` 兜底校验。
+分支命名：对 `(tenantId, instanceId)` 做长度前缀编码后取完整 SHA-256（32 位十六进制，128 bit），拼成 `memory/{sanitizeSlug(tenantId)}/{sanitizeSlug(instanceId)}-{hash32hex}`；`sanitizeSlug()` 只留 `[a-z0-9_-]`，截断到 40 字节，清空后用占位符 `"empty"` 兜底。构造时跑 `git check-ref-format --branch` + 显式总长度校验兜底。
 
-暂存纪律（消掉好几个 RFC 特例的一条规则）：永远不跑 `git add -A`，每次改动只 `git add -- <相对路径>` 那一个文件。`.meta.json` sidecar 自动不会被提交，put/append/delete 三种操作用同一条暂存调用。
+Git 保留路径防护：任何首段等于 `.git` 的 key 在委托给内部 `LocalStorageBackend` 之前直接拒绝（clone 根目录下真实存在 `.git/`，委托是"直接转发"不是"沙箱隔离"，必须显式挡住）。
 
-`appendObject`（RFC 结论 4 最难的方法）：`IStateBackend.acquireLock`（依赖注入，绝不导入红线文件）+ `SerialQueue`（`utils/serial-queue.ts` 现成的，进程内并发=1）双重保护 → fetch/append/commit/push → push 被拒时基于 SHA-256 内容哈希去重重放，不盲合并。
+暂存纪律（消掉好几个 RFC 特例的一条规则）：永远不跑 `git add -A`，每次改动只 `git add -- <相对路径>` 那一个文件。`.meta.json` sidecar 自动不会被提交（仅本地可见，跨 clone 后消失，这是接受的限制，需有测试显式验证），put/append/delete/deleteByPrefix 都走同一条暂存调用。
 
-持久化状态机：`clean → dirty-local → pushing → clean`，或 `→ push-rejected → replaying → pushing`，或 `→ push-failed`。落盘在 `state/{branch}/sync-state.json`（tmp+rename 原子写），WAL 放在 git 工作目录**之外**的兄弟目录，永远不会被误暂存。崩溃恢复不是独立代码路径，就是同一个 `flush()` 函数在进程重启后第一次访问该空间时被懒调用；`recoveryMode: "manual"`（默认）遇到 WAL 之外的未知脏改动拒绝自动 flush。
+`appendObject`（RFC 结论 4 最难的方法）：锁的获取/续约检查放进每个 `SerialQueue` 入队任务内部（不是外面获取一次就不管），续约失败置 `lockLost`、下一步 git 操作前检查、命中即中止并保留 WAL。流程：fetch → append → commit（message trailer 写入本批次全部操作 UUID）→ push；push 被拒时 `git log origin/<branch>` 扫最近提交的 message，命中已知操作 UUID 的视为已落地跳过，其余重放——**幂等键是后端自生成的操作 UUID，不是内容哈希**（内容哈希会把"合法的重复内容"误判成"已处理"，静默丢数据）。锁本身只降低写者互踩概率，真正的正确性兜底是 git 非强制 push 的 ref CAS；多实例部署必须注入真实分布式 `IStateBackend`，进程内 `LocalStateBackend` 在多实例场景下等于无锁。
+
+持久化状态机：`clean → dirty-local → pushing → clean`，或 `→ push-rejected → replaying → pushing`，或 `→ push-failed`。落盘在 `state/{branch}/sync-state.json`（tmp+rename 原子写），WAL 放在 git 工作目录**之外**的兄弟目录，永远不会被误暂存。崩溃恢复不是独立代码路径，就是同一个 `flush()` 函数在进程重启后第一次访问该空间时被懒调用；`recoveryMode: "manual"`（默认）遇到 WAL 之外的未知脏改动拒绝自动 flush。`deleteByPrefix` 和其他写操作走同一条批处理防抖路径（不再立即 flush——实际调用点如 `skill-versioning.ts` 会在循环里连续调用，立即 flush 会产生一次删除一次 push），需要同步完成信号的调用方改用显式的 `flush()`/durability-barrier 方法，在整个工作流结束后调用一次。
 
 健康检查：`HealthResponse.services.gitStorage = {enabledSpaceCount, unsyncedSpaceCount, oldestPendingPushAgeMs, worstStatus}`，读内存里已有的同步状态，不做 I/O。
 
 测试：Git 专属测试用 `git init --bare` 临时目录当 remote（不需要真实网络），覆盖崩溃恢复、push-rejected 重放去重、分支名编码。COS 不参与测试（源码在这个 checkout 里本来就不存在）。
 
-## 请 Codex 重点评审
+## Codex 检查点 A：评审结论与修订（2026-08-15）
 
-1. **特例/投机抽象**：组合优于重写的原则有没有真的贯彻？有没有哪里应该复用却重新实现了？
-2. **`git clone` per space vs `git worktree add` off 共享 bare repo**：本计划选了前者（独立 clone，避免共享 `.git` 锁竞争），是否有更好的方案？磁盘开销 trade-off 是否可接受？
-3. **分支编码方案**：`sanitize()` + 8 位哈希后缀，是否存在遗漏的边界情况（如 `..`、`@{`、尾部 `.lock`、超长 tenant/instance ID）？
-4. **`appendObject` 的 SHA-256 幂等键设计**：是否足以覆盖所有现实调用模式？"每次调用一个完整批次"这个假设是否站得住？
-5. **锁设计**：`IStateBackend.acquireLock` + `SerialQueue` 双重保护是否有竞态漏洞（例如锁续期失败但 `SerialQueue` 未感知）？
-6. **`deleteByPrefix` 立即 flush（跳过批处理防抖）vs 走同一批处理路径**：这个决定是否合理？
+六项全部判定"需要改设计"，逐条核实（对照实际调用点）后全部属实，采纳如下修订：
+
+**1. 组合掩盖了 Git 专属策略（needs-change → 已修订）**
+`LocalStorageBackend` 的委托没有过滤掉 `.git/` 这个真实存在于 clone 根目录下的保留路径——一个形如 `.git/config` 的 key 会被当作普通业务 key 正常读写，直接暴露/篡改 git 自身控制文件。修订：`GitStorageBackend` 在委托前拒绝任何首段等于 `.git` 的 key（大小写敏感，精确匹配）。另外，`.meta.json` sidecar 不同步到远端这件事本来就在计划里被标注为"接受的限制"，现在补一条要求——必须有测试显式验证"跨 clone 后 metadata 消失"，不能只在文档里嘴上说说。
+
+**2. `git clone` per space 需要限定单分支（needs-change → 已修订）**
+普通 `git clone` 默认拉取远端所有分支；如果一个 remote 上有 N 个记忆空间各一个分支，每个空间的 clone 都会带上其余所有空间的历史，磁盘/网络开销接近 N² 级别。修订：改用 `git clone --single-branch --branch <branch> --no-tags <remote> <dir>`；首次创建空间时（分支在远端还不存在）不能用 `clone`（会因分支不存在而失败），改为 `git init` + `git remote add origin <remote>` + 本地建 orphan branch。保留"独立 clone、不用 `git worktree add`"的整体选择——Codex 指出"共享 worktree 锁竞争"这个顾虑本身被夸大了（index/HEAD 是 per-worktree 的，只有对象库/引用维护是共享的），但独立 clone 仍是运维更简单、无需管理跨 worktree 对象库 GC 的更保守方案，只是必须限定单分支来避免历史膨胀。
+
+**3. 分支命名需要更强的抗碰撞设计（needs-change → 已修订）**
+原方案 8 位十六进制哈希只有 32 bit，在几千个记忆空间量级上有实打实的生日碰撞风险；`sanitize()` 也没处理"清空后变成空字符串"的边界（如 tenantId 全是被过滤字符）；`check-ref-format` 只做语法校验，不检查长度/碰撞。修订：
+- 哈希后缀从 8 位十六进制（32 bit）改为完整 SHA-256 的 32 位十六进制前缀（128 bit）；
+- 哈希输入改成对 `(tenantId, instanceId)` 做无歧义的长度前缀编码（如 `` `${tenantId.length}:${tenantId}${instanceId.length}:${instanceId}` ``），避免"ab"+"c" 和 "a"+"bc" 拼接后撞成同一个哈希输入；
+- sanitize 后为空的分量用固定占位符（如 `"empty"`）兜底，不允许空分量直接进入分支名；
+- 每个分量截断到固定字节上限（如 40 字节，按 UTF-8 字节而非字符计数），并在跑 `check-ref-format` 之外额外显式校验总长度。
+
+**4. `appendObject` 幂等键必须是操作 ID，不能是内容哈希（needs-change → 已修订，最重要的一条）**
+这是最严重的一处：用内容 SHA-256 做幂等键，会把"同一操作因崩溃重放"和"业务上合法地追加了两次完全相同的内容"混为一谈——后者是真实场景（如两条完全相同的日志行），用内容哈希去重会**静默丢数据**。修订：
+- 每次 `appendObject` 调用在真正写入前，由后端自己生成一个操作 UUID（`crypto.randomUUID()`），写入 WAL 条目；
+- 不新增单独的 receipts 账本文件，而是把已应用的操作 ID 复用 git 自己的历史作为唯一真相来源：每次 flush 提交时，把本批次包含的所有操作 ID 写进 commit message trailer（如 `Ops: <opId1> <opId2> ...`）；push 被拒后 `git log origin/<branch>` 往回扫最近若干条提交的 message，命中的 op ID 视为已落地，只重放未命中的；
+- 明确写清楚一个接受的限制：`IStorageBackend.appendObject` 接口本身不接受调用方传入的幂等 token，所以"调用方自己重试导致的重复"（不是我们这边崩溃触发的重放）无法被区分和去重——这是接口层面的限制，不在这次改动范围内（改接口签名会影响 local/COS 两个现有实现）。
+
+**5. 锁与 `SerialQueue` 的组合需要让续约失败真正打断执行（needs-change → 已修订）**
+`SerialQueue`（`utils/serial-queue.ts`）是纯本地 FIFO，对外部锁的租约状态完全无感知——锁续约在别处静默失败时，`SerialQueue` 里已入队/正在跑的任务不会自动停下来。修订：把锁的获取/续约检查放进每个入队任务内部（而不是只在外面获取一次），续约失败时设置 `lockLost` 标志，在下一步 git 子进程操作前检查该标志，命中就中止本次 flush、保留 WAL 不动、要求下次操作重新获取锁——这正是 `pipeline-worker.ts` 续约失败时用 `AbortController` 中断执行的现成模式，直接照抄。同时明确一点：`IStateBackend` 没有 fencing token，锁本身只能降低"多个写者互相踩"的概率、减少无用功，**真正的正确性兜底是 git 自己的非强制 push 被拒（ref 层面的 CAS）+ 冲突重放**——多实例部署时必须注入真实的分布式 `IStateBackend`（如 Redis 后端），进程内 `LocalStateBackend` 在多实例场景下等于没锁，这一点要在文档里显式写成硬性运维要求。
+
+**6. `deleteByPrefix` 不应该跳过批处理防抖（needs-change → 已修订）**
+原方案假设 `deleteByPrefix` 是"罕见的管理员操作、需要强完成保证"，但实际调用点 `skill-versioning.ts:361` 是在循环里对每个版本各调一次——如果每次都立即 flush，会产生"每个版本一次 commit+push"，既慢又会把中间态的残缺树暴露到远端，还完全违背批处理的初衷。修订：`deleteByPrefix` 回归和 put/append/delete 一样的路径——WAL 立即写入，但 commit/push 走正常的防抖/最大延迟策略；如果调用方确实需要"确认已经推送成功"的同步信号（比如整个批量删除工作流跑完后要确认落地），提供一个显式的 `flush()`/durability-barrier 方法供调用方在**整个工作流结束后调用一次**，而不是让每次 `deleteByPrefix` 都单方面加上网络依赖的强完成语义。
 
 ## 验证方式（实现完成后）
 

--- a/MemoryCore/docs/design/git-storage-backend-implementation-plan.md
+++ b/MemoryCore/docs/design/git-storage-backend-implementation-plan.md
@@ -1,8 +1,29 @@
 # 实现计划：GitStorageBackend
 
-- 状态：设计评审中（Codex 检查点 A）
+- 状态：实现完成，两轮 Codex 评审已处理，待提 PR
 - 关联：[docs/rfc/git-storage-backend.md](../rfc/git-storage-backend.md)、上游 RFC PR [#894](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/894)
 - 分支：`feat/git-storage-backend`，基于 `feat/server_team`（**注意**：不是 `main` —— `main` 是另一条落后且结构不同的分支，`IStorageBackend` 在那条线上不存在；`feat/server_team` 才是 PR #894 实际的 base branch）
+
+## Codex 检查点 B：diff 评审结论与修复（2026-08-15）
+
+代码写完后，把真实 diff（而非设计文档）交给 Codex 复核。分两部分：
+
+**A. 检查点 A 六条修复的落地核查**：4 条完全落地（`.git` 保留路径拒绝、`--single-branch`/`-t <branch>` 限制、分支编码方案、`deleteByPrefix` 批处理路径），2 条"落地但不完整"——操作 UUID/commit trailer/重放去重都实现了但 WAL 条目仍在文件变更**之后**才写入；锁的获取/续约在 flush 内部但变更本身发生在拿锁**之前**，续约失败也没有真正中断正在跑的 git 子进程。
+
+**B. 新发现的 10 个问题**（3 critical、4 high、3 warning），全部核实后修复：
+
+1. **Critical** `.meta.json` sidecar 永远不会被 `git add`，重启后 `git status` 会一直显示这个未跟踪文件，被误判为"无法解释的脏改动"，默认 `recoveryMode=manual` 下永久拒绝写入——任何用过 `contentType`/`metadata` 的空间重启后都会被拉黑。修复：`recoverIfNeeded()` 判断"无法解释的脏改动"前先过滤掉 `.meta.json` 和当前 pending 操作覆盖的路径。
+2. **Critical** WAL 条目写入顺序反了——先执行文件变更，后写 WAL，崩溃窗口在两者之间会导致"变更已发生但无任何记录，不可恢复"。修复：WAL 先写（真正的 write-ahead），恢复时用逐路径 `git status` 作为"这个操作是否已经落盘"的依据，只有该路径完全没有改动痕迹时才重放（对非幂等的 append 也能保证恰好重放一次）。
+3. **Critical** `startLockRenewal()`/`writeSyncState("pushing")` 在 `try` 块之外执行，其中任何一步失败都会导致续约定时器和分布式锁泄漏（续约还在成功续期，等于锁被永久持有）。修复：挪进 `try`。
+4. **High** `cloneOrInitSpace()` 先创建 `.git` 再执行剩余步骤，中途失败会留下"看起来已初始化但实际上是半成品"的仓库，后续每次重试都直接跳过初始化、在残缺仓库上继续操作。修复：整个初始化流程在临时目录里完成，全部成功后才原子 rename 到正式位置。
+5. **High** 实例销毁时只是把 cache 条目删掉，既没调用 `dispose()`（续约定时器泄漏）也没做最后一次 flush（可能悄悄丢掉本地待推送的写入）。修复：销毁前尽力 flush 一次再 dispose；明确不删除远端分支/本地 clone——Git 做不到可验证的历史删除（RFC 结论 8），这不是这次该补的能力。
+6. **High** `initSharedCosClient()` 只要 COS 可达就无条件覆盖默认存储，完全忽略显式配置的 `fileStorageBackend=local|git`；反过来，service 模式下 COS 初始化失败时，新代码会直接抛错，而旧代码是静默降级到 local——这是真实的行为回归。修复：COS 只在没有显式选择时才接管默认存储；`start()` 里默认存储解析调用加了 `allowLocalFallbackOnCosUnavailable`（只有这个调用点历史上有"从不失败"的约定，`resolveStorageForInstance`/worker 任务闭包该抛还是抛）。
+7. **High（部分修复，作为已知限制记录）** 锁丢失无法真正中断正在执行的 git 子进程，push 成功但锁在过程中已丢失的情况也没有任何信号。修复：`confirmAllPending()` 在这种情况下打一条醒目的 warning；真正的正确性兜底始终是 git 自己的非强制 push 拒绝（ref 层面的 CAS），这一点在设计文档里本来就写清楚了。
+8. **Warning** `confirmAllPending()` 先清内存状态再持久化 WAL trim，如果 rewrite 在 push 成功后失败，内存里 `pendingOps`/`uncommittedOpIds` 已经空了，后续每次 `flush()` 都会直接返回、什么也不重试，只有进程重启重新加载 WAL 文件才能恢复。修复：先持久化再清内存。
+9. **Warning** `GitCliError` 把包含 Base64 认证头的完整 argv 通过公开的 `args` 属性暴露出去，日志或 `JSON.stringify` 序列化错误对象时会带出凭据。修复：构造时脱敏。
+10. **Warning** 健康检查只扫 `cosStorageCache`，扫不到默认存储走的那个一次性 Map；`oldestPendingPushAgeMs` 用的是"距上次成功推送多久"而不是"最老的待推送操作等了多久"，从未推送成功过的空间会报出当前时间戳。修复：`GitSyncSummary` 直接暴露 `oldestPendingOpTs`；健康检查同时查 `this.core.getStorage()`。
+
+两个新增回归测试专门钉住 #1 和 #2 这两条 critical。修完后 101 个测试全过，`tsc --strict` 对照基线零新增错误。
 
 ## Context
 

--- a/MemoryCore/docs/design/git-storage-backend-implementation-plan.md
+++ b/MemoryCore/docs/design/git-storage-backend-implementation-plan.md
@@ -1,0 +1,76 @@
+# 实现计划：GitStorageBackend
+
+- 状态：设计评审中（Codex 检查点 A）
+- 关联：[docs/rfc/git-storage-backend.md](../rfc/git-storage-backend.md)、上游 RFC PR [#894](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/894)
+- 分支：`feat/git-storage-backend`，基于 `feat/server_team`（**注意**：不是 `main` —— `main` 是另一条落后且结构不同的分支，`IStorageBackend` 在那条线上不存在；`feat/server_team` 才是 PR #894 实际的 base branch）
+
+## Context
+
+RFC 已核实：文中每处代码引用都逐字节对照当前源码验证过，工程判断（单写者约束、本地/远端持久化状态分离、Git 无法真正删除历史）站得住。现在把它变成真代码。
+
+本仓库存储层此前**没有任何测试**（`vitest` 配置好但零 `.test.ts` 文件），CI 也不跑测试/lint/typecheck。`createStorageBackend()` 工厂函数**零调用**——不是"被绕过"，是从未被真正接入。因此这次实现顺带把存储层测试基线和工厂接入补齐。
+
+目标：在不违反 CI 红线（禁止改动 `src/core/state/{types,local-backend}.ts`、`src/services/pipeline-worker.ts`、`src/integrations/redis/**`，禁止 `src/core/skill/**` 新增直接 `fs` import）的前提下，实现 `GitStorageBackend`，接入配置与 `server.ts` 的 3 个构造点，然后过一轮 Codex 交叉评审再考虑对外提 PR。
+
+## 架构决策（组合优于重写）
+
+`GitStorageBackend` 内部持有一个 `LocalStorageBackend` 实例（指向本地 clone 的工作目录），纯文件 I/O（`getObject`/`exists`/`listObjects`，以及 put/append/delete 的文件落盘部分）直接委托给它——白得 `.meta.json` sidecar 处理、marker 分页逻辑，只在"写入"路径上叠加一层薄的 git 同步层（WAL、暂存、批量 commit/push、冲突重放）。4 个方法几乎不用新写代码，且复用已验证正确的 `resolvePath` 逻辑（现已抽成 `path-safety.ts`）而不是再抄一份。
+
+其余关键决定：
+- **Shell 出系统 `git` 二进制**（`execFile`，参数用数组不用字符串，杜绝 shell 注入），不加 `simple-git`/`isomorphic-git` 依赖——本仓库已有的风险姿态是"外部依赖是可以接受的"（COS 需要网络+密钥），这里只是换成"需要 PATH 上有 git"，且免去 COS 那套动态 import + optionalDependency 的仪式。
+- **`factory.ts` 静态 import** `GitStorageBackend`（不是 COS 式动态 import）——没有重量级可选依赖需要延迟加载。
+- **每个记忆空间一个独立 `git clone`**，不用 `git worktree add`——独立 clone 避免共享 `.git` 目录带来的跨 worktree 锁竞争，是更"无特例"的方案。
+- **`appendObject` 的幂等键 = 该次调用内容的 SHA-256**，不解析 JSONL 里业务自带的 `record_id`/`id`（已核实 L0/L1 writer 确实有这些字段）——在存储层解析业务内容格式是分层违规；SHA-256 dedup 足够覆盖现有调用方"每次调用一个完整批次"的模式。
+- **`fileStorageBackend` 配置新增 `"auto"` 默认值**（RFC 原文是 `local|cos|git` 三选一）——因为这个字段今天在 `config.ts` 里完全不存在，现网服务模式是靠 `deployMode`+运行时 COS client 存在与否临时推断的；如果默认值是 `"local"`，会静默改变现网行为。`"auto"` = 保留现状推断，显式设置才生效。
+
+## 实现范围
+
+**不包含**：RFC §8 的迁移工具（未来工作）、Option B（每对象一个 ref 的 git plumbing 方案）、修复 `StorageAdapter.rename` 的非原子性（adapter 层限制，本次不动）、任何对红线文件的改动。
+
+## 已完成（阶段 1-3，先于本次设计评审落地）
+
+- 合同测试框架 `storage-backend.contract.ts`（覆盖 7 方法 + 路径穿越 + 分页 + 幂等删除）+ `LocalStorageBackend` 首个测试覆盖（35 用例）
+- CI 新增 `test:` job 跑 `vitest run`（**已知缺口**：`pr-ci.yml` 目前只在 `pull_request.branches: [main]` 触发，而本 PR 及上游 RFC PR #894 都以 `feat/server_team` 为 base——`gh pr checks 894` 显示"no checks reported"，说明这条 CI 目前对这条分支的 PR 完全不触发。这是仓库级触发范围问题，本次未修改，留给维护者定夺）
+- 配置骨架：`fileStorageBackend`/`git` 字段与解析块（`config.ts`）、`configSchema` 镜像 `tcvdb` 块（`openclaw.plugin.json`）、`IStorageBackend.type`/`StorageBackendConfig.type` 拓宽加 `"git"`、新增 `IGitCredentialProvider`/`GitCredential`（`types.ts`）；顺带修了 `ScopedStorageBackend.type`（`adapter.ts:17`，RFC 结论 2 漏掉的第三处需要拓宽的地方）
+- `path-safety.ts` 抽取（`resolveSafeRelativePath()`），`local-backend.ts` 改用它，纯行为保持型重构，35 用例回归全过 + 12 个新增单测
+- 每步都做了 `tsc --strict --noEmit` 全量对照检查：改动前后 325 行历史遗留类型错误数量完全一致，零新增
+
+## 待实现（阶段 5-8，Codex 检查点 A 通过后开始）
+
+**新增文件**
+- `git-cli.ts` — `execFile` 封装的 git 子命令（fetch/push/commit/add/status/init/clone/check-ref-format），结构化返回值 + 超时
+- `git-credential.ts` — `IGitCredentialProvider` 具体实现（镜像 `credential-provider.ts` 的 Mock/Static 分法）
+- `git-backend.ts` — `GitStorageBackend` 主体
+- `../../gateway/storage-resolver.ts` — `resolveFileStorageBackend()`，替掉 `server.ts` 里两处几乎重复的 resolve 逻辑
+- `git-backend.test.ts` / `git-backend.git-specific.test.ts`
+
+**关键设计细节**
+
+分支命名：`memory/{sanitize(tenantId)}/{sanitize(instanceId)}-{sha256(rawSeed).slice(0,8)}`，`sanitize()` 只留 `[a-z0-9_-]`；末尾 8 位哈希防止 sanitize 后碰撞。构造时跑 `git check-ref-format --branch` 兜底校验。
+
+暂存纪律（消掉好几个 RFC 特例的一条规则）：永远不跑 `git add -A`，每次改动只 `git add -- <相对路径>` 那一个文件。`.meta.json` sidecar 自动不会被提交，put/append/delete 三种操作用同一条暂存调用。
+
+`appendObject`（RFC 结论 4 最难的方法）：`IStateBackend.acquireLock`（依赖注入，绝不导入红线文件）+ `SerialQueue`（`utils/serial-queue.ts` 现成的，进程内并发=1）双重保护 → fetch/append/commit/push → push 被拒时基于 SHA-256 内容哈希去重重放，不盲合并。
+
+持久化状态机：`clean → dirty-local → pushing → clean`，或 `→ push-rejected → replaying → pushing`，或 `→ push-failed`。落盘在 `state/{branch}/sync-state.json`（tmp+rename 原子写），WAL 放在 git 工作目录**之外**的兄弟目录，永远不会被误暂存。崩溃恢复不是独立代码路径，就是同一个 `flush()` 函数在进程重启后第一次访问该空间时被懒调用；`recoveryMode: "manual"`（默认）遇到 WAL 之外的未知脏改动拒绝自动 flush。
+
+健康检查：`HealthResponse.services.gitStorage = {enabledSpaceCount, unsyncedSpaceCount, oldestPendingPushAgeMs, worstStatus}`，读内存里已有的同步状态，不做 I/O。
+
+测试：Git 专属测试用 `git init --bare` 临时目录当 remote（不需要真实网络），覆盖崩溃恢复、push-rejected 重放去重、分支名编码。COS 不参与测试（源码在这个 checkout 里本来就不存在）。
+
+## 请 Codex 重点评审
+
+1. **特例/投机抽象**：组合优于重写的原则有没有真的贯彻？有没有哪里应该复用却重新实现了？
+2. **`git clone` per space vs `git worktree add` off 共享 bare repo**：本计划选了前者（独立 clone，避免共享 `.git` 锁竞争），是否有更好的方案？磁盘开销 trade-off 是否可接受？
+3. **分支编码方案**：`sanitize()` + 8 位哈希后缀，是否存在遗漏的边界情况（如 `..`、`@{`、尾部 `.lock`、超长 tenant/instance ID）？
+4. **`appendObject` 的 SHA-256 幂等键设计**：是否足以覆盖所有现实调用模式？"每次调用一个完整批次"这个假设是否站得住？
+5. **锁设计**：`IStateBackend.acquireLock` + `SerialQueue` 双重保护是否有竞态漏洞（例如锁续期失败但 `SerialQueue` 未感知）？
+6. **`deleteByPrefix` 立即 flush（跳过批处理防抖）vs 走同一批处理路径**：这个决定是否合理？
+
+## 验证方式（实现完成后）
+
+- `cd MemoryCore && npm test`（`vitest run`）——本地跑通全部合同测试（local + git）
+- 手动构造 `git init --bare /tmp/fixture-remote`，起一个真实的 `GitStorageBackend` 实例，跑 put/append/delete 全流程，人工 `git log`/`git show` 检查提交历史里只有 6 个约定前缀下的文件，没有 `.meta.json`、没有凭据
+- 杀掉进程模拟崩溃（flush 中途 kill -9），重启后验证新实例能正确识别未推送的 WAL 并续跑
+- 两个后端实例并发 append 同一 key，制造 non-fast-forward，验证重放去重不产生重复行
+- `npm pack --dry-run` 确认没有意外新增依赖体积

--- a/MemoryCore/docs/rfc/git-storage-backend.md
+++ b/MemoryCore/docs/rfc/git-storage-backend.md
@@ -1,0 +1,152 @@
+# RFC：以 Git 作为记忆文件存储后端
+
+- 状态：提议
+- 日期：2026-08-09
+- 决策范围：只讨论 `IStorageBackend` 所承载的文件记忆；不替换向量数据库
+
+## 摘要与建议
+
+建议**有条件推进一个实验版**：新增工作树型 `GitStorageBackend`，复用现有文件语义，在单写者、私有远端、按批次提交的约束下试点；不要把它作为高并发在线写入的默认后端。若业务需要多实例同时追加同一 JSONL 且不能经过单写者协调器，则结论是“不做”，因为 Git push 的分支更新与业务追加之间没有跨主机原子事务。
+
+本文的“后端”指工作树中的对象读写；Git commit/push 是其持久化与同步阶段。必须先定义可观测的同步状态，不能把一次本地写成功等同于已经远端持久化。
+
+## 八条硬结论
+
+### 结论 1：正确接缝是 `IStorageBackend`，不是 `IMemoryStore`
+
+文件记忆已经由 `IStorageBackend` 抽象：合同位于 `MemoryCore/src/core/storage/types.ts:95-158`，上层由 `StorageAdapter` 包成类 fs API（`MemoryCore/src/core/storage/adapter.ts:80-283`）。向量/结构化记忆走独立的 `storeBackend: "sqlite" | "tcvdb"`（`MemoryCore/src/config.ts:183,320-323,479-480`）。因此 Git 应成为第三种**文件存储**实现，不能塞进 SQLite/TCVDB 层。
+
+可复跑：
+
+```bash
+grep -n -E 'export interface IStorageBackend|storeBackendRaw|type StoreBackend' \
+  MemoryCore/src/core/storage/types.ts MemoryCore/src/config.ts
+```
+
+### 结论 2：接口实际是 7 个方法加 1 个属性，不是 8 个方法
+
+`IStorageBackend` 有 `type` 属性，以及 `putObject`、`appendObject`、`getObject`、`exists`、`listObjects`、`deleteObject`、`deleteByPrefix` 七个方法（`MemoryCore/src/core/storage/types.ts:95-158`）。设计与验收必须以源码合同为准；若把 `type` 口头计入“8 项”，也应明确它不是方法。`type` 联合类型及 `StorageBackendConfig.type` 都需在未来实现中加入 `"git"`（`MemoryCore/src/core/storage/types.ts:97,210`）。
+
+可复跑：
+
+```bash
+sed -n '95,158p' MemoryCore/src/core/storage/types.ts
+```
+
+### 结论 3：Git 保存文件记忆对象，坚决不保存向量库、凭据和运行时锁
+
+纳入版本控制的 key 空间是 `persona.md`、`scene_blocks/`、`conversations/`、`records/`、`.metadata/`、`.backup/`（`MemoryCore/src/core/storage/types.ts:248-276`）。这是合同声明的 L0–L3 文件与恢复所需元数据/备份；迁移时应保留所有这些 key，不能只挑 Markdown。
+
+坚决不提交：SQLite/TCVDB 内容（属于另一抽象，证据见结论 1）、Git/云端认证凭据、进程锁、临时文件、clone 缓存，以及本地后端为了 `contentType/metadata` 生成的 `.meta.json` 内部 sidecar。最后一项不是业务 key：它由本地实现额外生成并在列举时主动跳过（`MemoryCore/src/core/storage/local-backend.ts:97-104,265`）；Git 后端若需保留对象元数据，应使用实现私有索引且禁止泄露密钥。远端仓库必须是私有仓库，并应用组织侧访问控制和保留策略。
+
+可复跑：
+
+```bash
+grep -n -E 'persona:|sceneBlocksDir:|conversationsDir:|recordsDir:|metadataDir:|backupDir:|meta.json' \
+  MemoryCore/src/core/storage/types.ts MemoryCore/src/core/storage/local-backend.ts
+```
+
+### 结论 4：最难的是 `appendObject`；多写者下不能承诺现有原子追加语义
+
+现有合同明确要求追加，调用适配器会直接委托给后端（`MemoryCore/src/core/storage/types.ts:107-125`；`MemoryCore/src/core/storage/adapter.ts:109-125`）。本地实现依赖 `appendFile`（`MemoryCore/src/core/storage/local-backend.ts:108-124`）。Git 没有“远端原子追加文件”操作：两个写者从同一父提交追加后，只能由其中一个先更新分支，另一个必须拉取、合并/重放、校验后重试。
+
+实验版必须在每个仓库内串行化 `fetch → 读取最新分支 → append → commit → push`；push 被拒后重新读取远端文件并重放**尚未确认的完整记录**，不能对字节串盲合并。唯一能给出清晰语义的部署约束是每个记忆空间单写者。没有单写者或外部排序服务时，跨主机“每次调用原子且恰好一次”无解，Git 后端必须拒绝启动或明确降级，不能悄悄声称兼容。
+
+可复跑：
+
+```bash
+grep -n -E 'appendObject|appendFile' \
+  MemoryCore/src/core/storage/types.ts MemoryCore/src/core/storage/local-backend.ts MemoryCore/src/core/storage/adapter.ts
+```
+
+### 结论 5：其余 6 个方法可映射，但提交边界必须与对象操作分开说明
+
+逐项语义如下（加上最难的追加，共覆盖全部 7 个方法）：
+
+| 合同项 | Git 后端提议实现 | 失败/一致性边界 |
+|---|---|---|
+| `putObject` | 校验 key 在工作树根内，原子写临时文件后 rename，加入暂存区；批次末 commit | 本地写成功但 push 失败时返回“本地已提交、远端待同步”状态；不能伪装完全成功 |
+| `appendObject` | 单写者锁内追加完整记录并提交；远端拒绝时基于最新分支重放 | 最难；多写者严格原子语义无解，见结论 4 |
+| `getObject` | 从当前已检出工作树读取 Buffer，并由 `stat` 填充大小/时间 | 默认读本地已确认提交；若要求 read-after-remote-write，先同步或报陈旧状态 |
+| `exists` | 安全解析 key 后检查工作树文件 | 不把 Git tree 中未检出的对象算存在 |
+| `listObjects` | 遍历工作树，按 key 排序，再应用 `marker/maxKeys/recursive` | 必须稳定排序；现有本地实现是收集后按 marker 分页（`local-backend.ts:176-204`） |
+| `deleteObject` | 幂等删除工作树文件并暂存删除 | 只有 commit/push 后才完成远端删除；历史仍保留内容 |
+| `deleteByPrefix` | 先枚举并计数，再删除前缀下文件并暂存 | 返回业务对象数，不计实现私有文件；历史仍保留内容 |
+| `type` 属性 | 返回字面量 `"git"` | 需扩展两个联合类型；它是属性而非第 8 个方法 |
+
+现有适配器的 `rename` 本来就是 get → put → delete，源码已注明非原子（`MemoryCore/src/core/storage/adapter.ts:188-202`）；Git commit 可以把最终树变化一起提交，但进程在暂存前后崩溃仍需启动恢复。目录在对象存储语义中是隐式的，`mkdir` 当前也是 no-op（`MemoryCore/src/core/storage/adapter.ts:158-164`）。
+
+可复跑：
+
+```bash
+sed -n '90,240p' MemoryCore/src/core/storage/local-backend.ts
+sed -n '180,205p' MemoryCore/src/core/storage/adapter.ts
+```
+
+### 结论 6：推荐工作树后端；“每对象一个分支/提交”不推荐
+
+比较两个可实现方案：
+
+| 方案 | 做法 | 代价 | 适用场景 |
+|---|---|---|---|
+| A. 每个记忆空间一个工作树与分支（推荐） | key 直接映射相对路径；本地批次写，单队列 commit/push | 需要磁盘工作树、锁、崩溃恢复和后台同步；仓库会持续增长 | 单写者、希望人工审阅/回滚、写入量中低的试点 |
+| B. 每个对象版本用 Git plumbing/独立引用 | 内容写 blob/tree，用自定义 ref 或每对象分支更新 | 列举与快照需自建索引；引用数量爆炸；跨对象一致快照困难；运维工具不直观 | 极少对象、强对象隔离、团队能维护 Git plumbing 的专用系统 |
+
+A 与当前本地映射最接近：`LocalStorageBackend` 已把 key 解析到根目录下并防目录穿越（`MemoryCore/src/core/storage/local-backend.ts:61-86`），且 `StorageAdapter` 无需理解 Git。不要“一次方法调用一次 push”；应以流水线批次/短时间窗口合并 commit，否则 L0/L1 JSONL 的高频追加会产生大量提交和网络往返。批处理意味着必须把本地持久化状态与远端同步状态分别暴露。
+
+可复跑：
+
+```bash
+sed -n '61,86p' MemoryCore/src/core/storage/local-backend.ts
+git check-ref-format --branch 'memory/tenant-a'
+```
+
+### 结论 7：配置必须独立命名，并统一三个绕过工厂的构造点
+
+新增配置应叫 `fileStorageBackend: "local" | "cos" | "git"`（名称可在实现 RFC 中最终确定），绝不能复用现有 `storeBackend`，后者只控制 SQLite/TCVDB。Git 专属配置至少包括：本地工作树根、私有 remote URL、目标 branch、同步模式、批次窗口、单写者开关、认证引用（只引用秘密管理器，不接受 token 明文）。默认仍为 local；service 现有 COS 配置保持可选，三者互斥选择，回滚只需切回原后端。
+
+不能只改 `factory.ts`。虽然工厂已有 local/cos 分支（`MemoryCore/src/core/storage/factory.ts:24-63`），`server.ts` 至少在 `592`、`2187`、`2352` 直接构造 `LocalStorageBackend`，另有多处直接构造 COS。因此未来实现必须让这些路径统一走解析器/工厂，否则 standalone、按实例 API 与 worker 会出现不同后端。
+
+可复跑：
+
+```bash
+grep -n 'new LocalStorageBackend(' MemoryCore/src/gateway/server.ts
+grep -n -E 'switch \(config.type\)|case "cos"|case "local"' MemoryCore/src/core/storage/factory.ts
+```
+
+### 结论 8：迁移可做成可回滚复制，但 Git 不能满足“真正删除历史”
+
+迁移步骤：进入维护/单写者模式；冻结源端写入；对六个约定前缀递归 `listObjects`，逐项 `getObject → putObject` 到 Git 后端；比较对象数、每个 key 的字节数和 SHA-256；生成一次基线 commit 并推私有远端；以只读方式抽查；切换 `fileStorageBackend`；保留原 local/COS 快照直至观察期结束。失败时停止 Git 写入并切回只读源快照，避免双写分叉。现有 `copyTree` 已采用 list/get/put 组合（`MemoryCore/src/core/storage/adapter.ts:232-275`），说明迁移无需扩展接口，但正式工具需要分页循环，不能照搬其固定 `maxKeys: 100_000` 上限。
+
+Git 删除只会从新树移除文件，旧 commit 仍可恢复。因此涉及“用户要求彻底删除”、凭据误提交或隐私保留期到期时，普通 `deleteObject/deleteByPrefix` 不足：需要重写历史并协调所有 clone；已被复制或拉取的内容无法追回。这条对已分发副本**无解**。若法规要求可验证擦除，不应选择 Git 作主存储。
+
+可复跑：
+
+```bash
+sed -n '232,275p' MemoryCore/src/core/storage/adapter.ts
+sed -n '248,276p' MemoryCore/src/core/storage/types.ts
+```
+
+## 风险登记
+
+| 风险 | 触发条件 | 缓解 |
+|---|---|---|
+| 并发追加冲突/重复记录 | 两个实例同时追加同一 JSONL，或 push 成功但客户端超时后重试 | 每空间单写者；记录稳定事件 ID；远端拒绝后按记录重放并去重。没有协调器时严格原子恰好一次无解 |
+| 敏感记忆永久留史 | persona/会话包含隐私，或凭据误写入业务 key | 私有仓库、最小权限、提交前 secret/PII 策略、短保留与加密；已被第三方拉取的历史无法追回 |
+| 仓库体积与延迟持续增长 | 高频 JSONL 追加、备份累计、一次调用一次提交 | 批量提交、按租户/时间分仓、监控 pack 大小与 push 延迟、到阈值后归档；不要把二进制/向量库放入 Git |
+| 本地成功、远端失败造成耐久性误判 | 网络中断、权限撤销、non-fast-forward | 状态机区分 working-tree/committed/pushed；持久化待推队列；健康检查暴露最后成功 push 时间；超过 RPO 阈值拒绝继续写 |
+| 崩溃留下脏工作树/锁 | 写入、暂存、提交之间进程退出 | 单仓库进程锁；启动时检查 index/worktree，只能重放带事件 ID 的日志；不自动丢弃未知修改 |
+| 分支/key 注入与目录穿越 | tenant/instance/key 来自外部输入 | 复用并强化 `resolvePath` 规则；分支名用固定编码映射并经 `git check-ref-format`；不把用户输入拼进 shell |
+| 配置路径不一致 | 只扩展工厂，三个直接构造点仍走 local | 用同一解析器覆盖启动、按实例与 worker 路径；合同测试逐路径断言 backend type |
+
+## 验收门槛与试点退出条件
+
+在写产线实现前，先补合同测试（当前仓库任务书确认无可用测试基线，且本次 RFC 不改测试/依赖）：同一套用例覆盖 7 个方法、路径穿越、分页、崩溃恢复、push 拒绝、重复事件与两写者冲突。缺少的 COS 后端源码也必须在完整构建源中跑相同合同测试。
+
+试点仅限脱敏数据、私有远端、单写者；记录 p95 写入延迟、待推队列长度、最后 push 年龄、仓库 pack 大小与冲突重试数。出现任一情况即退出：无法保证单写者、远端落后超过约定 RPO、历史删除成为硬性要求、仓库增长超预算，或追加重试出现无法去重的数据。
+
+## 拍板结论
+
+- 若目标是低到中频、单写者、可人工审阅和回滚的文件记忆：做工作树型实验版，Git 作为有延迟的同步持久层。
+- 若目标是高频多写者在线主存储，或要求可验证彻底删除：不做；继续使用 local/COS 文件层，并把审计/版本能力做在外围。
+- 本 RFC 不建议改向量存储，也不建议双写作为长期架构；迁移期双写会引入无法可靠判定主副本的分叉。

--- a/MemoryCore/openclaw.plugin.json
+++ b/MemoryCore/openclaw.plugin.json
@@ -125,6 +125,28 @@
           "caPemPath": { "type": "string", "description": "CA 证书 PEM 文件路径（HTTPS 连接时使用）" }
         }
       },
+      "fileStorageBackend": {
+        "type": "string",
+        "enum": ["auto", "local", "cos", "git"],
+        "default": "auto",
+        "description": "文件存储后端（L2/L3 Markdown、会话/记忆 JSONL 等）：auto（默认，保持现有 deployMode/COS 客户端推断行为不变）、local、cos，或实验性的 git（见 docs/rfc/git-storage-backend.md）"
+      },
+      "git": {
+        "type": "object",
+        "description": "Git 文件存储后端配置（仅 fileStorageBackend=git 时生效，实验特性）",
+        "properties": {
+          "localRootDir": { "type": "string", "default": "./data/git-storage", "description": "本地 clone 根目录，每个记忆空间一个子目录" },
+          "remoteUrl": { "type": "string", "description": "私有远端仓库地址（必填，https:// 或 git@ ssh）" },
+          "credentialRef": { "type": "string", "description": "凭据引用名（必填），由宿主环境解析为实际凭据；绝不接受明文 token" },
+          "authMethod": { "type": "string", "enum": ["http-token", "ssh"], "default": "http-token", "description": "认证方式" },
+          "sshKeyPath": { "type": "string", "description": "SSH 私钥路径（authMethod=ssh 时必填）" },
+          "batchWindowMs": { "type": "number", "default": 2000, "description": "写入合批的防抖窗口（毫秒），0 表示每次调用单独提交" },
+          "maxBatchDelayMs": { "type": "number", "default": 10000, "description": "持续高负载下防抖延迟的硬上限（毫秒）" },
+          "lockTtlMs": { "type": "number", "default": 30000, "description": "单写者分布式锁 TTL（毫秒）" },
+          "maxPushRetries": { "type": "number", "default": 5, "description": "push 被拒后的最大重放重试次数" },
+          "recoveryMode": { "type": "string", "enum": ["manual", "auto-wal-only"], "default": "manual", "description": "崩溃恢复策略：manual（默认，遇到 WAL 之外的未知改动拒绝自动 flush）或 auto-wal-only（丢弃未知改动，仅重放 WAL）" }
+        }
+      },
       "bm25": {
         "type": "object",
         "description": "BM25 稀疏向量编码设置（主要用于 tcvdb 后端）",

--- a/MemoryCore/src/config.test.ts
+++ b/MemoryCore/src/config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseConfig } from "./config.js";
+
+describe("parseConfig — git storage fields", () => {
+  it("defaults fileStorageBackend to auto and applies git defaults", () => {
+    const cfg = parseConfig({});
+    expect(cfg.fileStorageBackend).toBe("auto");
+    expect(cfg.git.localRootDir).toBe("./data/git-storage");
+    expect(cfg.git.authMethod).toBe("http-token");
+    expect(cfg.git.recoveryMode).toBe("manual");
+    expect(cfg.git.batchWindowMs).toBe(2000);
+  });
+
+  it("parses an explicit git config block", () => {
+    const cfg = parseConfig({
+      fileStorageBackend: "git",
+      git: {
+        remoteUrl: "https://example.com/org/repo.git",
+        credentialRef: "vault:git-token",
+        authMethod: "ssh",
+        sshKeyPath: "/keys/id_ed25519",
+        batchWindowMs: 500,
+        recoveryMode: "auto-wal-only",
+      },
+    });
+    expect(cfg.fileStorageBackend).toBe("git");
+    expect(cfg.git.remoteUrl).toBe("https://example.com/org/repo.git");
+    expect(cfg.git.credentialRef).toBe("vault:git-token");
+    expect(cfg.git.authMethod).toBe("ssh");
+    expect(cfg.git.sshKeyPath).toBe("/keys/id_ed25519");
+    expect(cfg.git.batchWindowMs).toBe(500);
+    expect(cfg.git.recoveryMode).toBe("auto-wal-only");
+  });
+
+  it("rejects an unrecognized fileStorageBackend value by falling back to auto", () => {
+    const cfg = parseConfig({ fileStorageBackend: "s3" });
+    expect(cfg.fileStorageBackend).toBe("auto");
+  });
+});

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -182,6 +182,51 @@ export interface TcvdbConfig {
 /** Storage backend type. */
 export type StoreBackend = "sqlite" | "tcvdb";
 
+/**
+ * File storage backend selection ("local" | "cos" | "git").
+ *
+ * "auto" (default) preserves today's behavior exactly: the gateway infers
+ * local-vs-COS from `deployMode` + whether a shared COS client is configured,
+ * the same way it always has. Set this explicitly only to opt into "git", or
+ * to force "local"/"cos" instead of the runtime inference.
+ */
+export type FileStorageBackend = "auto" | "local" | "cos" | "git";
+
+/**
+ * Git file storage backend configuration (experimental — see
+ * docs/rfc/git-storage-backend.md). Only read when fileStorageBackend="git".
+ */
+export interface GitStorageConfig {
+  /** Local clone root; one subdirectory per memory-space branch. */
+  localRootDir: string;
+  /** Private remote URL (https://, git@ ssh, or file:// for local/testing). */
+  remoteUrl: string;
+  /**
+   * Opaque reference to a secret resolved externally by the host wiring
+   * layer into an IGitCredentialProvider — never a plaintext token here.
+   */
+  credentialRef: string;
+  /** Auth transport: "http-token" (default) or "ssh". */
+  authMethod: "http-token" | "ssh";
+  /** SSH private key path; required when authMethod="ssh". */
+  sshKeyPath?: string;
+  /** Debounce window for batching writes into one commit, in ms. 0 = commit per call. */
+  batchWindowMs: number;
+  /** Hard cap on debounce delay under sustained write load, in ms. */
+  maxBatchDelayMs: number;
+  /** Distributed lock TTL for the single-writer guarantee, in ms. */
+  lockTtlMs: number;
+  /** Max push-rejected replay attempts before surfacing push-failed. */
+  maxPushRetries: number;
+  /**
+   * Crash-recovery strategy on first use of a space after process start:
+   * "manual" (default) refuses to auto-flush a space with unknown dirt in
+   * its worktree (only known WAL ops are replayed); "auto-wal-only" opt-in
+   * discards unknown dirt via `git checkout --` before replaying.
+   */
+  recoveryMode: "manual" | "auto-wal-only";
+}
+
 /** Report settings — controls metric/event reporting. */
 export interface ReportConfig {
   /** Enable reporting (default: true) */
@@ -321,6 +366,10 @@ export interface MemoryTdaiConfig {
   storeBackend: StoreBackend;
   /** Tencent Cloud VectorDB configuration (required when storeBackend = "tcvdb") */
   tcvdb: TcvdbConfig;
+  /** File storage backend selection: "auto" (default, preserves current runtime inference) | "local" | "cos" | "git" */
+  fileStorageBackend: FileStorageBackend;
+  /** Git file storage backend configuration (only read when fileStorageBackend = "git") */
+  git: GitStorageConfig;
   /** BM25 sparse vector encoding (local @tencentdb-agent-memory/tcvdb-text) */
   bm25: BM25Config;
   /** Local JSONL cleanup settings */
@@ -482,6 +531,21 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
   // --- TCVDB config ---
   const tcvdbGroup = obj(c, "tcvdb");
 
+  // --- File storage backend selection ---
+  const fileStorageBackendRaw = str(c, "fileStorageBackend") ?? "auto";
+  const fileStorageBackend: FileStorageBackend =
+    (["auto", "local", "cos", "git"] as const).includes(fileStorageBackendRaw as FileStorageBackend)
+      ? (fileStorageBackendRaw as FileStorageBackend)
+      : "auto";
+
+  // --- Git storage backend config (only relevant when fileStorageBackend="git") ---
+  const gitGroup = obj(c, "git");
+  const gitAuthMethodRaw = str(gitGroup, "authMethod") ?? "http-token";
+  const gitAuthMethod: GitStorageConfig["authMethod"] = gitAuthMethodRaw === "ssh" ? "ssh" : "http-token";
+  const gitRecoveryModeRaw = str(gitGroup, "recoveryMode") ?? "manual";
+  const gitRecoveryMode: GitStorageConfig["recoveryMode"] =
+    gitRecoveryModeRaw === "auto-wal-only" ? "auto-wal-only" : "manual";
+
   const memoryCleanup: MemoryCleanupConfig = {
     retentionDays,
     enabled: retentionDays != null,
@@ -605,6 +669,19 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
       embeddingModel: str(tcvdbGroup, "embeddingModel") ?? "bge-large-zh",
       timeout: num(tcvdbGroup, "timeout") ?? 10000,
       caPemPath: str(tcvdbGroup, "caPemPath") || undefined,
+    },
+    fileStorageBackend,
+    git: {
+      localRootDir: str(gitGroup, "localRootDir") ?? "./data/git-storage",
+      remoteUrl: str(gitGroup, "remoteUrl") ?? "",
+      credentialRef: str(gitGroup, "credentialRef") ?? "",
+      authMethod: gitAuthMethod,
+      sshKeyPath: optStr(gitGroup, "sshKeyPath"),
+      batchWindowMs: num(gitGroup, "batchWindowMs") ?? 2000,
+      maxBatchDelayMs: num(gitGroup, "maxBatchDelayMs") ?? 10000,
+      lockTtlMs: num(gitGroup, "lockTtlMs") ?? 30000,
+      maxPushRetries: num(gitGroup, "maxPushRetries") ?? 5,
+      recoveryMode: gitRecoveryMode,
     },
     bm25: {
       enabled: bool(bm25Group, "enabled") ?? true,

--- a/MemoryCore/src/core/storage/__tests__/fake-state-backend.ts
+++ b/MemoryCore/src/core/storage/__tests__/fake-state-backend.ts
@@ -1,0 +1,94 @@
+/**
+ * Minimal in-memory IStateBackend test double — only the Lock section is
+ * functional (mirrors LocalStateBackend's actual semantics: ownerId + TTL).
+ * Everything else throws if called, since GitStorageBackend only ever uses
+ * acquireLock/renewLock/releaseLock.
+ */
+import type {
+  CaptureAtomicResult,
+  IStateBackend,
+  PipelineSessionState,
+  TaskPayload,
+  TimerEntry,
+} from "../../state/types.js";
+
+interface LockEntry {
+  ownerId: string;
+  expireAt: number;
+}
+
+export class FakeStateBackend implements IStateBackend {
+  private locks = new Map<string, LockEntry>();
+  /** Test hook: the next renewLock call for this key returns false once. */
+  public forceRenewalFailureOnce = new Set<string>();
+
+  async acquireLock(key: string, ownerId: string, ttlMs: number): Promise<boolean> {
+    const existing = this.locks.get(key);
+    const now = Date.now();
+    if (existing && existing.expireAt > now && existing.ownerId !== ownerId) return false;
+    this.locks.set(key, { ownerId, expireAt: now + ttlMs });
+    return true;
+  }
+
+  async renewLock(key: string, ownerId: string, ttlMs: number): Promise<boolean> {
+    if (this.forceRenewalFailureOnce.delete(key)) return false;
+    const existing = this.locks.get(key);
+    if (!existing || existing.ownerId !== ownerId) return false;
+    existing.expireAt = Date.now() + ttlMs;
+    return true;
+  }
+
+  async releaseLock(key: string, ownerId: string): Promise<void> {
+    const existing = this.locks.get(key);
+    if (existing && existing.ownerId === ownerId) this.locks.delete(key);
+  }
+
+  async appendBuffer(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async drainBuffer(): Promise<string[]> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async getBufferLength(): Promise<number> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async getSessionState(): Promise<PipelineSessionState | null> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async updateSessionState(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async deleteSessionState(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async listActiveSessions(): Promise<string[]> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async setTimer(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async setTimerIfEarlier(): Promise<boolean> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async removeTimer(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async getExpiredTimers(): Promise<TimerEntry[]> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async enqueueTask(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async consumeTask(): Promise<TaskPayload | null> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async ackTask(): Promise<void> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async getQueueDepth(): Promise<{ high: number; low: number }> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+  async captureAtomic(): Promise<CaptureAtomicResult> {
+    throw new Error("FakeStateBackend: not implemented");
+  }
+}

--- a/MemoryCore/src/core/storage/__tests__/storage-backend.contract.ts
+++ b/MemoryCore/src/core/storage/__tests__/storage-backend.contract.ts
@@ -1,0 +1,205 @@
+/**
+ * Shared contract test suite for IStorageBackend implementations.
+ *
+ * Every backend (local, cos, git, ...) must satisfy this suite. Import and
+ * call `runStorageBackendContractTests()` from a real `*.test.ts` file — this
+ * file has no `.test.ts` suffix on purpose so vitest's `include` glob does
+ * not try to run it directly (it has no backend to test against on its own).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { IStorageBackend } from "../types.js";
+
+export interface ContractTestContext {
+  backend: IStorageBackend;
+  /** Called after every test to release backend-specific resources (tmpdirs, clones, locks). */
+  teardown?: () => Promise<void>;
+}
+
+/**
+ * Register the shared IStorageBackend contract suite under `describe(name, ...)`.
+ * `setup` must return a *fresh* backend instance per call — tests assume no
+ * state leaks between them.
+ */
+export function runStorageBackendContractTests(
+  name: string,
+  setup: () => Promise<ContractTestContext> | ContractTestContext,
+): void {
+  describe(`IStorageBackend contract: ${name}`, () => {
+    let ctx: ContractTestContext;
+
+    beforeEach(async () => {
+      ctx = await setup();
+    });
+
+    afterEach(async () => {
+      await ctx.teardown?.();
+    });
+
+    // ── putObject / getObject ──────────────────────────────────────────
+
+    it("putObject then getObject returns the same content", async () => {
+      await ctx.backend.putObject("scene_blocks/work.md", "hello world");
+      const obj = await ctx.backend.getObject("scene_blocks/work.md");
+      expect(obj).not.toBeNull();
+      expect(obj!.content.toString("utf-8")).toBe("hello world");
+      expect(obj!.key).toBe("scene_blocks/work.md");
+    });
+
+    it("putObject accepts Buffer content", async () => {
+      const buf = Buffer.from([0x00, 0x01, 0xff]);
+      await ctx.backend.putObject("records/binary.bin", buf);
+      const obj = await ctx.backend.getObject("records/binary.bin");
+      expect(obj!.content.equals(buf)).toBe(true);
+    });
+
+    it("putObject overwrites an existing object", async () => {
+      await ctx.backend.putObject("persona.md", "v1");
+      await ctx.backend.putObject("persona.md", "v2");
+      const obj = await ctx.backend.getObject("persona.md");
+      expect(obj!.content.toString("utf-8")).toBe("v2");
+    });
+
+    it("getObject returns null for a missing key", async () => {
+      const obj = await ctx.backend.getObject("does/not/exist.md");
+      expect(obj).toBeNull();
+    });
+
+    it("getObject reports size and lastModified", async () => {
+      await ctx.backend.putObject("records/2026-08-15.jsonl", "abcde");
+      const obj = await ctx.backend.getObject("records/2026-08-15.jsonl");
+      expect(obj!.size).toBe(5);
+      expect(obj!.lastModified).toBeInstanceOf(Date);
+    });
+
+    // ── appendObject ────────────────────────────────────────────────────
+
+    it("appendObject creates the object if it does not exist", async () => {
+      await ctx.backend.appendObject("records/2026-08-15.jsonl", "line1\n");
+      const obj = await ctx.backend.getObject("records/2026-08-15.jsonl");
+      expect(obj!.content.toString("utf-8")).toBe("line1\n");
+    });
+
+    it("appendObject adds to the end of an existing object", async () => {
+      await ctx.backend.putObject("records/2026-08-15.jsonl", "line1\n");
+      await ctx.backend.appendObject("records/2026-08-15.jsonl", "line2\n");
+      const obj = await ctx.backend.getObject("records/2026-08-15.jsonl");
+      expect(obj!.content.toString("utf-8")).toBe("line1\nline2\n");
+    });
+
+    it("sequential appendObject calls preserve order", async () => {
+      for (let i = 0; i < 5; i++) {
+        await ctx.backend.appendObject("records/seq.jsonl", `${i}\n`);
+      }
+      const obj = await ctx.backend.getObject("records/seq.jsonl");
+      expect(obj!.content.toString("utf-8")).toBe("0\n1\n2\n3\n4\n");
+    });
+
+    // ── exists ───────────────────────────────────────────────────────────
+
+    it("exists returns false for a missing key and true after put", async () => {
+      expect(await ctx.backend.exists("scene_blocks/x.md")).toBe(false);
+      await ctx.backend.putObject("scene_blocks/x.md", "x");
+      expect(await ctx.backend.exists("scene_blocks/x.md")).toBe(true);
+    });
+
+    // ── deleteObject ─────────────────────────────────────────────────────
+
+    it("deleteObject removes the object", async () => {
+      await ctx.backend.putObject("scene_blocks/x.md", "x");
+      await ctx.backend.deleteObject("scene_blocks/x.md");
+      expect(await ctx.backend.exists("scene_blocks/x.md")).toBe(false);
+    });
+
+    it("deleteObject on a missing key is idempotent (no throw)", async () => {
+      await expect(ctx.backend.deleteObject("does/not/exist.md")).resolves.toBeUndefined();
+    });
+
+    // ── listObjects ──────────────────────────────────────────────────────
+
+    it("listObjects returns entries under a prefix", async () => {
+      await ctx.backend.putObject("scene_blocks/a.md", "a");
+      await ctx.backend.putObject("scene_blocks/b.md", "b");
+      const result = await ctx.backend.listObjects("scene_blocks/");
+      const keys = result.entries.map((e) => e.key).sort();
+      expect(keys).toEqual(["scene_blocks/a.md", "scene_blocks/b.md"]);
+    });
+
+    it("listObjects on a missing prefix returns an empty result", async () => {
+      const result = await ctx.backend.listObjects("nowhere/");
+      expect(result.entries).toEqual([]);
+    });
+
+    it("listObjects respects maxKeys and paginates via nextMarker", async () => {
+      for (let i = 0; i < 5; i++) {
+        await ctx.backend.putObject(`scene_blocks/${i}.md`, String(i));
+      }
+      const page1 = await ctx.backend.listObjects("scene_blocks/", { maxKeys: 2 });
+      expect(page1.entries).toHaveLength(2);
+      expect(page1.nextMarker).toBeDefined();
+
+      const page2 = await ctx.backend.listObjects("scene_blocks/", {
+        maxKeys: 2,
+        marker: page1.nextMarker,
+      });
+      expect(page2.entries).toHaveLength(2);
+      expect(page2.entries[0]!.key).not.toBe(page1.entries[0]!.key);
+
+      const seen = new Set([...page1.entries, ...page2.entries].map((e) => e.key));
+      expect(seen.size).toBe(4); // two pages of 2, no overlap
+    });
+
+    it("listObjects with recursive:false does not descend into subdirectories", async () => {
+      await ctx.backend.putObject("conversations/2026-08-15.jsonl", "a");
+      await ctx.backend.putObject("conversations/nested/deep.jsonl", "b");
+      const result = await ctx.backend.listObjects("conversations/", { recursive: false });
+      const keys = result.entries.map((e) => e.key);
+      expect(keys).toContain("conversations/2026-08-15.jsonl");
+      expect(keys.some((k) => k.includes("deep.jsonl"))).toBe(false);
+    });
+
+    it("listObjects with recursive:true descends into subdirectories", async () => {
+      await ctx.backend.putObject("conversations/2026-08-15.jsonl", "a");
+      await ctx.backend.putObject("conversations/nested/deep.jsonl", "b");
+      const result = await ctx.backend.listObjects("conversations/", { recursive: true });
+      const keys = result.entries.map((e) => e.key);
+      expect(keys.some((k) => k.endsWith("deep.jsonl"))).toBe(true);
+    });
+
+    // ── deleteByPrefix ───────────────────────────────────────────────────
+
+    it("deleteByPrefix removes all objects under a prefix and returns the count", async () => {
+      await ctx.backend.putObject("scene_blocks/a.md", "a");
+      await ctx.backend.putObject("scene_blocks/b.md", "b");
+      await ctx.backend.putObject("scene_blocks/nested/c.md", "c");
+      const count = await ctx.backend.deleteByPrefix("scene_blocks/");
+      expect(count).toBe(3);
+      expect((await ctx.backend.listObjects("scene_blocks/", { recursive: true })).entries).toEqual([]);
+    });
+
+    it("deleteByPrefix on a missing prefix returns 0", async () => {
+      const count = await ctx.backend.deleteByPrefix("nowhere/");
+      expect(count).toBe(0);
+    });
+
+    // ── path traversal / key validation ─────────────────────────────────
+
+    const badKeys = [
+      ["empty string", ""],
+      ["NUL byte", "records/\0evil"],
+      ["leading slash (absolute)", "/etc/passwd"],
+      ["leading backslash", "\\evil"],
+      ["parent traversal", "../../../etc/passwd"],
+      ["parent traversal with valid prefix", "scene_blocks/../../../etc/passwd"],
+    ] as const;
+
+    for (const [label, key] of badKeys) {
+      it(`putObject rejects ${label}`, async () => {
+        await expect(ctx.backend.putObject(key, "x")).rejects.toThrow();
+      });
+
+      it(`getObject rejects ${label}`, async () => {
+        await expect(ctx.backend.getObject(key)).rejects.toThrow();
+      });
+    }
+  });
+}

--- a/MemoryCore/src/core/storage/adapter.ts
+++ b/MemoryCore/src/core/storage/adapter.ts
@@ -14,7 +14,7 @@
 import type { IStorageBackend, StorageObject, ListEntry, ListObjectsOptions, ListResult, PutObjectOptions } from "./types.js";
 
 class ScopedStorageBackend implements IStorageBackend {
-  readonly type: "local" | "cos";
+  readonly type: "local" | "cos" | "git";
   private readonly prefix: string;
 
   constructor(private readonly base: IStorageBackend, prefix: string) {

--- a/MemoryCore/src/core/storage/factory.ts
+++ b/MemoryCore/src/core/storage/factory.ts
@@ -9,6 +9,8 @@
 
 import type { IStorageBackend, StorageBackendConfig, StorageLogger } from "./types.js";
 import { LocalStorageBackend } from "./local-backend.js";
+import { GitStorageBackend } from "./git-backend.js";
+import { gitVersion } from "./git-cli.js";
 
 const TAG = "[storage][factory]";
 
@@ -26,6 +28,22 @@ export async function createStorageBackend(
   logger?: StorageLogger,
 ): Promise<IStorageBackend> {
   switch (config.type) {
+    case "git": {
+      if (!config.git) {
+        throw new Error(`${TAG} git backend requires config.git`);
+      }
+      try {
+        await gitVersion();
+      } catch (err) {
+        throw new Error(
+          `${TAG} git binary not found on PATH; required for storage type=git. ` +
+            `Original error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      logger?.info(`${TAG} Creating git storage backend (branch seed: ${JSON.stringify(config.git.branchNameSeed)})`);
+      return new GitStorageBackend({ ...config.git, logger });
+    }
+
     case "cos": {
       if (!config.credentialProvider) {
         throw new Error(`${TAG} COS backend requires a credentialProvider`);

--- a/MemoryCore/src/core/storage/git-backend.git-specific.test.ts
+++ b/MemoryCore/src/core/storage/git-backend.git-specific.test.ts
@@ -80,6 +80,65 @@ describe("GitStorageBackend — crash recovery", () => {
       await rm(checkoutDir, { recursive: true, force: true });
     }
   });
+
+  it("a metadata write does not permanently block recovery after a restart (Codex checkpoint B #1)", async () => {
+    // .meta.json sidecars are never staged (local-only by design) and show
+    // up as an untracked file in `git status` forever after — recovery must
+    // not mistake that for unexplained dirt, or every space that ever used
+    // contentType/metadata would brick itself (recoveryBlocked) on restart.
+    const seed = { tenantId: "meta-restart", instanceId: "space-1" };
+    const backendA = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed });
+    await backendA.putObject("persona.md", "hello", { contentType: "text/markdown", metadata: { a: "b" } });
+    await backendA.flush();
+    expect(backendA.getSyncSummary().status).toBe("clean");
+
+    const backendB = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed, stateBackend: new FakeStateBackend() });
+    await backendB.putObject("scene_blocks/x.md", "y");
+    await backendB.flush();
+    expect(backendB.getSyncSummary().status).toBe("clean");
+    expect(backendB.getSyncSummary().pendingCount).toBe(0);
+  });
+
+  it("recovery reapplies a WAL-recorded op whose mutation never reached disk (Codex checkpoint B #2)", async () => {
+    // Simulates a crash landing exactly between the WAL append (now
+    // write-ahead) and the actual file mutation: hand-write a WAL entry
+    // whose content was never applied to the worktree, then start a fresh
+    // instance and confirm recovery reapplies (not silently drops) it.
+    const seed = { tenantId: "wal-order", instanceId: "space-1" };
+    const backendA = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed });
+    await backendA.putObject("persona.md", "base");
+    await backendA.flush();
+
+    const branchDirName = buildBranchName(seed).replace(/\//g, "_");
+    const stateDir = join(localRootDir, "state", branchDirName);
+    const { mkdir: mkdirFn, appendFile, readFile: readFileFn } = await import("node:fs/promises");
+    const { randomUUID } = await import("node:crypto");
+    await mkdirFn(stateDir, { recursive: true });
+    const entry = {
+      opId: randomUUID(),
+      kind: "append",
+      key: "records/log.jsonl",
+      contentBase64: Buffer.from("line1\n", "utf-8").toString("base64"),
+      ts: Date.now(),
+    };
+    await appendFile(join(stateDir, "pending-ops.jsonl"), `${JSON.stringify(entry)}\n`);
+
+    const backendB = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed, stateBackend: new FakeStateBackend() });
+    await backendB.flush();
+    expect(backendB.getSyncSummary().status).toBe("clean");
+
+    const checkoutDir = await mkdtemp(join(tmpdir(), "storage-git-checkout-"));
+    try {
+      const branchName = buildBranchName(seed);
+      await runGit(["clone", "--quiet", "--single-branch", "--branch", branchName, remoteDir, checkoutDir], {
+        cwd: process.cwd(),
+      });
+      const content = await readFileFn(join(checkoutDir, "records/log.jsonl"), "utf-8");
+      expect(content).toBe("line1\n");
+    } finally {
+      await rm(checkoutDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("GitStorageBackend — push-rejected replay", () => {

--- a/MemoryCore/src/core/storage/git-backend.git-specific.test.ts
+++ b/MemoryCore/src/core/storage/git-backend.git-specific.test.ts
@@ -1,0 +1,249 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GitStorageBackend, buildBranchName, type GitStorageBackendOptions } from "./git-backend.js";
+import { StaticGitCredentialProvider } from "./git-credential.js";
+import { gitCheckRefFormat, runGit } from "./git-cli.js";
+import { FakeStateBackend } from "./__tests__/fake-state-backend.js";
+
+async function makeBareRemote(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "storage-git-remote-"));
+  await runGit(["init", "--quiet", "--bare"], { cwd: dir });
+  return dir;
+}
+
+function makeBackend(remoteDir: string, localRootDir: string, overrides: Partial<GitStorageBackendOptions> = {}) {
+  return new GitStorageBackend({
+    localRootDir,
+    remoteUrl: remoteDir,
+    credentialProvider: new StaticGitCredentialProvider({ authMethod: "http-token", token: "unused-for-local-remote" }),
+    branchNameSeed: { tenantId: "test-tenant", instanceId: "default-instance" },
+    stateBackend: new FakeStateBackend(),
+    batchWindowMs: 0,
+    ...overrides,
+  });
+}
+
+describe("GitStorageBackend — crash recovery", () => {
+  let remoteDir: string;
+  let localRootDir: string;
+
+  beforeEach(async () => {
+    remoteDir = await makeBareRemote();
+    localRootDir = await mkdtemp(join(tmpdir(), "storage-git-local-"));
+  });
+
+  afterEach(async () => {
+    await rm(remoteDir, { recursive: true, force: true });
+    await rm(localRootDir, { recursive: true, force: true });
+  });
+
+  it("recovers a local commit that landed before a crash cut off the push, and completes the push", async () => {
+    const seed = { tenantId: "recover", instanceId: "space-1" };
+
+    // Backend A: write, then force the push half of flush() to fail by
+    // moving the remote out of the way after commit-but-before-push would
+    // run — simulating "process crashed after local commit, before push
+    // confirmed", the scenario the WAL + local-commit-trailer scan exist for.
+    const backendA = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed, batchWindowMs: 999_999 });
+    await backendA.putObject("persona.md", "hello");
+
+    const movedAwayRemote = `${remoteDir}-moved-away`;
+    const { rename } = await import("node:fs/promises");
+    await rename(remoteDir, movedAwayRemote);
+    await expect(backendA.flush()).rejects.toThrow();
+    expect(backendA.getSyncSummary().status).toBe("push-failed");
+    await rename(movedAwayRemote, remoteDir);
+
+    // Backend B: fresh instance, same localRootDir + same branch seed —
+    // simulates a process restart reusing the same on-disk clone.
+    const backendB = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed });
+    const obj = await backendB.getObject("persona.md");
+    expect(obj!.content.toString("utf-8")).toBe("hello");
+
+    await backendB.flush();
+    expect(backendB.getSyncSummary().status).toBe("clean");
+    expect(backendB.getSyncSummary().pendingCount).toBe(0);
+
+    // Confirm it's actually on the remote now, from an independent checkout.
+    const checkoutDir = await mkdtemp(join(tmpdir(), "storage-git-checkout-"));
+    try {
+      const branchName = buildBranchName(seed);
+      await runGit(["clone", "--quiet", "--single-branch", "--branch", branchName, remoteDir, checkoutDir], {
+        cwd: process.cwd(),
+      });
+      const { readFile } = await import("node:fs/promises");
+      const content = await readFile(join(checkoutDir, "persona.md"), "utf-8");
+      expect(content).toBe("hello");
+    } finally {
+      await rm(checkoutDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("GitStorageBackend — push-rejected replay", () => {
+  let remoteDir: string;
+  let localRootA: string;
+  let localRootB: string;
+
+  beforeEach(async () => {
+    remoteDir = await makeBareRemote();
+    localRootA = await mkdtemp(join(tmpdir(), "storage-git-local-a-"));
+    localRootB = await mkdtemp(join(tmpdir(), "storage-git-local-b-"));
+  });
+
+  afterEach(async () => {
+    await rm(remoteDir, { recursive: true, force: true });
+    await rm(localRootA, { recursive: true, force: true });
+    await rm(localRootB, { recursive: true, force: true });
+  });
+
+  it("replays only the un-landed op after a non-fast-forward rejection, with no duplication", async () => {
+    const seed = { tenantId: "replay", instanceId: "space-1" };
+
+    // Two independent "processes" — separate local clones AND separate
+    // FakeStateBackend instances (uncoordinated locks), which is exactly
+    // the multi-writer scenario that produces a real push rejection.
+    const backendA = makeBackend(remoteDir, localRootA, { branchNameSeed: seed, stateBackend: new FakeStateBackend() });
+    await backendA.putObject("records/log.jsonl", "");
+    await backendA.flush();
+
+    // backendB clones after the base state exists.
+    const backendB = makeBackend(remoteDir, localRootB, { branchNameSeed: seed, stateBackend: new FakeStateBackend() });
+    await backendB.getObject("records/log.jsonl"); // triggers clone
+
+    // backendA advances the branch first.
+    await backendA.appendObject("records/log.jsonl", "fromA\n");
+    await backendA.flush();
+    expect(backendA.getSyncSummary().status).toBe("clean");
+
+    // backendB, still based on the pre-fromA state, appends and flushes —
+    // its first push attempt must be rejected and trigger a replay.
+    await backendB.appendObject("records/log.jsonl", "fromB\n");
+    await backendB.flush();
+    expect(backendB.getSyncSummary().status).toBe("clean");
+    expect(backendB.getSyncSummary().pendingCount).toBe(0);
+
+    const checkoutDir = await mkdtemp(join(tmpdir(), "storage-git-checkout-"));
+    try {
+      const branchName = buildBranchName(seed);
+      await runGit(["clone", "--quiet", "--single-branch", "--branch", branchName, remoteDir, checkoutDir], {
+        cwd: process.cwd(),
+      });
+      const { readFile } = await import("node:fs/promises");
+      const content = await readFile(join(checkoutDir, "records/log.jsonl"), "utf-8");
+      expect(content).toBe("fromA\nfromB\n");
+
+      const log = await runGit(["log", "--oneline", branchName], { cwd: checkoutDir });
+      const commitCount = log.stdout.trim().split("\n").filter(Boolean).length;
+      // init + base put + fromA + fromB(replayed) = 4 commits, no duplicate/extra commits from replay.
+      expect(commitCount).toBe(4);
+    } finally {
+      await rm(checkoutDir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovery does not re-apply an op whose trailer is already in the cloned history (lost-ack scenario)", async () => {
+    // Simulates: a push actually succeeded on the remote, but the local
+    // process crashed/timed out before persisting that fact (WAL never got
+    // trimmed). A *fresh* instance clones the space — its local history
+    // already contains the pushed commit's "Ops: <id>" trailer — and its WAL
+    // is hand-seeded with a pending entry using that exact op id, exactly as
+    // if this process had written it but never confirmed the push. Recovery
+    // must recognize the op as already-committed (trailer scan) and must
+    // not append the content again.
+    const seed = { tenantId: "replay", instanceId: "lost-ack" };
+    const branchName = buildBranchName(seed);
+    const branchDirName = branchName.replace(/\//g, "_");
+
+    const backendA = makeBackend(remoteDir, localRootA, { branchNameSeed: seed });
+    await backendA.appendObject("records/log.jsonl", "once\n");
+    await backendA.flush();
+    expect(backendA.getSyncSummary().status).toBe("clean");
+
+    const realOpId = await extractLastCommitOpId(remoteDir, branchName);
+    expect(realOpId).toBeTruthy();
+
+    // Pre-seed a fresh clone dir + a WAL claiming that same op is still
+    // pending, without going through the class (which would generate its
+    // own random op id and actually append content again).
+    const cloneDirD = join(localRootB, "clones", branchDirName);
+    const stateDirD = join(localRootB, "state", branchDirName);
+    const { mkdir: mkdirFn, writeFile } = await import("node:fs/promises");
+    await mkdirFn(stateDirD, { recursive: true });
+    await runGit(["clone", "--quiet", "--single-branch", "--branch", branchName, remoteDir, cloneDirD], {
+      cwd: process.cwd(),
+    });
+    const walEntry = {
+      opId: realOpId,
+      kind: "append",
+      key: "records/log.jsonl",
+      contentBase64: Buffer.from("once\n", "utf-8").toString("base64"),
+      ts: Date.now(),
+    };
+    await writeFile(join(stateDirD, "pending-ops.jsonl"), `${JSON.stringify(walEntry)}\n`);
+
+    const backendD = makeBackend(remoteDir, localRootB, { branchNameSeed: seed, stateBackend: new FakeStateBackend() });
+    await backendD.flush(); // triggers ensureInitialized -> recovery -> a (no-op) flush
+
+    const checkoutDir = await mkdtemp(join(tmpdir(), "storage-git-checkout-"));
+    try {
+      await runGit(["clone", "--quiet", "--single-branch", "--branch", branchName, remoteDir, checkoutDir], {
+        cwd: process.cwd(),
+      });
+      const { readFile } = await import("node:fs/promises");
+      const finalContent = await readFile(join(checkoutDir, "records/log.jsonl"), "utf-8");
+      expect(finalContent).toBe("once\n"); // not "once\nonce\n"
+    } finally {
+      await rm(checkoutDir, { recursive: true, force: true });
+    }
+  });
+});
+
+async function extractLastCommitOpId(remoteDir: string, branchName: string): Promise<string> {
+  const checkoutDir = await mkdtemp(join(tmpdir(), "storage-git-extract-"));
+  try {
+    await runGit(["clone", "--quiet", "--single-branch", "--branch", branchName, remoteDir, checkoutDir], {
+      cwd: process.cwd(),
+    });
+    const { stdout } = await runGit(["log", "-1", "--format=%B"], { cwd: checkoutDir });
+    const match = /^Ops: (.+)$/m.exec(stdout);
+    return match?.[1]?.trim().split(/\s+/)[0] ?? "";
+  } finally {
+    await rm(checkoutDir, { recursive: true, force: true });
+  }
+}
+
+describe("GitStorageBackend — branch name encoding", () => {
+  const adversarialSeeds: Array<[string, { tenantId: string; instanceId: string }]> = [
+    ["empty tenant and instance", { tenantId: "", instanceId: "" }],
+    ["parent traversal chars", { tenantId: "..", instanceId: "../../etc" }],
+    ["ref @{ sequence", { tenantId: "a@{b", instanceId: "c@{d" }],
+    ["trailing .lock", { tenantId: "foo.lock", instanceId: "bar.lock" }],
+    ["unicode", { tenantId: "租户名字", instanceId: "インスタンス" }],
+    ["overlong ids", { tenantId: "t".repeat(500), instanceId: "i".repeat(500) }],
+    ["slashes", { tenantId: "a/b/c", instanceId: "d/e/f" }],
+    ["only reserved chars", { tenantId: "@{~^:?*[\\", instanceId: "@{~^:?*[\\" }],
+  ];
+
+  for (const [label, seed] of adversarialSeeds) {
+    it(`produces a check-ref-format-valid branch name for ${label}`, async () => {
+      const branchName = buildBranchName(seed);
+      expect(branchName.length).toBeLessThanOrEqual(200);
+      const valid = await gitCheckRefFormat(branchName);
+      expect(valid).toBe(true);
+    });
+  }
+
+  it("does not collide when sanitized tenant/instance concatenation would be ambiguous", () => {
+    const a = buildBranchName({ tenantId: "ab", instanceId: "c" });
+    const b = buildBranchName({ tenantId: "a", instanceId: "bc" });
+    expect(a).not.toBe(b);
+  });
+
+  it("is deterministic for the same seed", () => {
+    const seed = { tenantId: "tenant-x", instanceId: "instance-y" };
+    expect(buildBranchName(seed)).toBe(buildBranchName(seed));
+  });
+});

--- a/MemoryCore/src/core/storage/git-backend.test.ts
+++ b/MemoryCore/src/core/storage/git-backend.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GitStorageBackend, buildBranchName, type GitStorageBackendOptions } from "./git-backend.js";
+import { StaticGitCredentialProvider } from "./git-credential.js";
+import { runGit } from "./git-cli.js";
+import { runStorageBackendContractTests } from "./__tests__/storage-backend.contract.js";
+import { FakeStateBackend } from "./__tests__/fake-state-backend.js";
+
+async function makeBareRemote(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "storage-git-remote-"));
+  await runGit(["init", "--quiet", "--bare"], { cwd: dir });
+  return dir;
+}
+
+function makeBackend(remoteDir: string, localRootDir: string, overrides: Partial<GitStorageBackendOptions> = {}) {
+  return new GitStorageBackend({
+    localRootDir,
+    remoteUrl: remoteDir,
+    credentialProvider: new StaticGitCredentialProvider({ authMethod: "http-token", token: "unused-for-local-remote" }),
+    branchNameSeed: { tenantId: "test-tenant", instanceId: randomUUID() },
+    stateBackend: new FakeStateBackend(),
+    batchWindowMs: 0,
+    ...overrides,
+  });
+}
+
+runStorageBackendContractTests("GitStorageBackend", async () => {
+  const remoteDir = await makeBareRemote();
+  const localRootDir = await mkdtemp(join(tmpdir(), "storage-git-local-"));
+  const backend = makeBackend(remoteDir, localRootDir);
+  return {
+    backend,
+    teardown: async () => {
+      await backend.flush().catch(() => {});
+      await rm(remoteDir, { recursive: true, force: true });
+      await rm(localRootDir, { recursive: true, force: true });
+    },
+  };
+});
+
+describe("GitStorageBackend — backend-specific behavior", () => {
+  let remoteDir: string;
+  let localRootDir: string;
+
+  beforeEach(async () => {
+    remoteDir = await makeBareRemote();
+    localRootDir = await mkdtemp(join(tmpdir(), "storage-git-local-"));
+  });
+
+  afterEach(async () => {
+    await rm(remoteDir, { recursive: true, force: true });
+    await rm(localRootDir, { recursive: true, force: true });
+  });
+
+  it("reports type 'git'", () => {
+    const backend = makeBackend(remoteDir, localRootDir);
+    expect(backend.type).toBe("git");
+  });
+
+  it("pushes a commit to the remote containing only the written key, no .meta.json sidecar", async () => {
+    const backend = makeBackend(remoteDir, localRootDir);
+    await backend.putObject("scene_blocks/note.md", "hello", { contentType: "text/markdown", metadata: { a: "b" } });
+    await backend.flush();
+
+    const checkoutDir = await mkdtemp(join(tmpdir(), "storage-git-checkout-"));
+    try {
+      await runGit(["clone", "--quiet", remoteDir, checkoutDir], { cwd: process.cwd() });
+      const branches = await runGit(["branch", "-r"], { cwd: checkoutDir });
+      const branchName = branches.stdout.trim().split("\n").map((l) => l.replace("origin/", "").trim())[0]!;
+      await runGit(["checkout", "--quiet", branchName], { cwd: checkoutDir });
+      const lsFiles = await runGit(["ls-files"], { cwd: checkoutDir });
+      const files = lsFiles.stdout.trim().split("\n").filter(Boolean);
+      expect(files).toContain("scene_blocks/note.md");
+      expect(files.some((f) => f.endsWith(".meta.json"))).toBe(false);
+      expect(files.some((f) => f.startsWith(".git"))).toBe(false);
+    } finally {
+      await rm(checkoutDir, { recursive: true, force: true });
+    }
+  });
+
+  it("metadata does not survive a fresh clone of the same space (accepted limitation)", async () => {
+    const seed = { tenantId: "meta-tenant", instanceId: randomUUID() };
+    const stateBackend = new FakeStateBackend();
+    const backendA = makeBackend(remoteDir, localRootDir, { branchNameSeed: seed, stateBackend });
+    await backendA.putObject("persona.md", "v1", { contentType: "text/markdown", metadata: { a: "b" } });
+    await backendA.flush();
+    const objA = await backendA.getObject("persona.md");
+    expect(objA!.contentType).toBe("text/markdown");
+
+    const otherRoot = await mkdtemp(join(tmpdir(), "storage-git-local2-"));
+    try {
+      const backendB = makeBackend(remoteDir, otherRoot, { branchNameSeed: seed, stateBackend: new FakeStateBackend() });
+      const objB = await backendB.getObject("persona.md");
+      expect(objB!.content.toString("utf-8")).toBe("v1");
+      expect(objB!.contentType).toBeUndefined();
+    } finally {
+      await rm(otherRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a key resolving into the .git control directory", async () => {
+    const backend = makeBackend(remoteDir, localRootDir);
+    await expect(backend.putObject(".git/config", "evil")).rejects.toThrow(/git control directory/i);
+    await expect(backend.getObject(".git/HEAD")).rejects.toThrow(/git control directory/i);
+  });
+
+  it("initializes a brand-new space with an orphan branch when the remote has no matching branch yet", async () => {
+    const backend = makeBackend(remoteDir, localRootDir);
+    await backend.putObject("persona.md", "hello");
+    await backend.flush();
+    const summary = backend.getSyncSummary();
+    expect(summary.status).toBe("clean");
+    expect(summary.pendingCount).toBe(0);
+    expect(summary.lastPushedAt).not.toBeNull();
+  });
+
+  it("second space's clone only contains its own branch (single-branch fetch)", async () => {
+    const stateBackend = new FakeStateBackend();
+    const seedA = { tenantId: "t", instanceId: "space-a" };
+    const seedB = { tenantId: "t", instanceId: "space-b" };
+
+    const backendA = makeBackend(remoteDir, localRootDir, { branchNameSeed: seedA, stateBackend });
+    await backendA.putObject("persona.md", "a");
+    await backendA.flush();
+
+    // backendB clones after space-a's branch already exists on the remote —
+    // this is the scenario `--single-branch` matters for.
+    const backendB = makeBackend(remoteDir, localRootDir, { branchNameSeed: seedB, stateBackend: new FakeStateBackend() });
+    await backendB.putObject("persona.md", "b");
+    await backendB.flush();
+
+    const branchNameA = buildBranchName(seedA);
+    const branchNameB = buildBranchName(seedB);
+    const cloneDirB = join(localRootDir, "clones", branchNameB.replace(/\//g, "_"));
+
+    const remoteRefs = await runGit(["branch", "-r"], { cwd: cloneDirB });
+    const refs = remoteRefs.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+    expect(refs).toEqual([`origin/${branchNameB}`]);
+    expect(refs.some((r) => r.includes(branchNameA))).toBe(false);
+
+    const objInB = await backendB.getObject("persona.md");
+    expect(objInB!.content.toString("utf-8")).toBe("b");
+  });
+});

--- a/MemoryCore/src/core/storage/git-backend.ts
+++ b/MemoryCore/src/core/storage/git-backend.ts
@@ -9,7 +9,7 @@
  * mutating methods only. Experimental — single-writer-per-space pilot scope.
  */
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile, appendFile, rename } from "node:fs/promises";
+import { mkdir, readFile, writeFile, appendFile, rename, rm } from "node:fs/promises";
 import { dirname, join, sep } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import type {
@@ -42,6 +42,7 @@ import {
   gitRemoteAdd,
   gitResetHard,
   gitStatusPorcelain,
+  gitStatusPorcelainForPath,
   type GitAuth,
 } from "./git-cli.js";
 
@@ -139,6 +140,40 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Extract the path from one `git status --porcelain` line ("XY path", quoted, or a "orig -> new" rename). */
+function parsePorcelainPath(line: string): string {
+  let rest = line.slice(3);
+  const arrowIdx = rest.indexOf(" -> ");
+  if (arrowIdx >= 0) rest = rest.slice(arrowIdx + 4);
+  if (rest.startsWith('"') && rest.endsWith('"')) rest = rest.slice(1, -1);
+  // git always reports paths with forward slashes regardless of OS.
+  return rest;
+}
+
+/**
+ * Drop status lines that are expected, not "unexplained" dirt: the
+ * never-staged `.meta.json` sidecar (local-only by design — see path-safety
+ * discussion in the design doc) and paths covered by a currently-pending WAL
+ * op (exact match for put/append/delete, prefix match for deleteByPrefix).
+ */
+function filterUnexplainedDirt(
+  statusOutput: string,
+  explainedExactPaths: Set<string>,
+  explainedPrefixes: string[],
+): string {
+  return statusOutput
+    .split("\n")
+    .filter((line) => {
+      if (!line.trim()) return false;
+      const path = parsePorcelainPath(line);
+      if (path.endsWith(".meta.json")) return false;
+      if (explainedExactPaths.has(path)) return false;
+      if (explainedPrefixes.some((prefix) => path.startsWith(prefix))) return false;
+      return true;
+    })
+    .join("\n");
+}
+
 // ============================
 // GitStorageBackend
 // ============================
@@ -149,6 +184,8 @@ export interface GitSyncSummary {
   status: GitSyncStatus;
   pendingCount: number;
   lastPushedAt: number | null;
+  /** WAL timestamp of the oldest still-pending op, or null if nothing is pending. Distinct from lastPushedAt — a space that has never pushed successfully still has a real, computable pending age via this field. */
+  oldestPendingOpTs: number | null;
 }
 
 export interface GitStorageBackendOptions {
@@ -269,17 +306,23 @@ export class GitStorageBackend implements IStorageBackend {
     await this.ensureInitialized();
     const relPath = this.safeRelPath(key);
     await this.queue.add(async () => {
+      if (this.recoveryBlocked) {
+        throw new Error(`${TAG} writes blocked for ${this.branchName}: recovery required (recoveryMode=manual)`);
+      }
       // `git add -- <path>` fails with "pathspec did not match any files" for
       // a path git has never tracked — unlike a path it tracked and that was
-      // since removed, where `git add` correctly stages the deletion. Only
-      // stage when something actually existed to delete; deleteObject is
-      // idempotent (IStorageBackend contract), so a no-op delete needs no
-      // WAL entry or commit either.
+      // since removed, where `git add` correctly stages the deletion. This
+      // existence check is read-only (no write-ahead concern) — only a
+      // genuine deletion needs a WAL entry; deleteObject is idempotent
+      // (IStorageBackend contract), so a no-op delete needs no record.
       const existed = await this.inner.exists(key);
+      if (!existed) return;
+      const entry: WalEntry = { opId: randomUUID(), kind: "delete", key, ts: Date.now() };
+      await this.recordIntent(entry);
       await this.inner.deleteObject(key);
-      if (existed) {
-        await this.stageEntry({ opId: randomUUID(), kind: "delete", key, ts: Date.now() }, relPath);
-      }
+      await gitAdd(this.cloneDir, relPath);
+      await this.writeSyncState("dirty-local");
+      this.scheduleFlush();
     });
   }
 
@@ -287,9 +330,21 @@ export class GitStorageBackend implements IStorageBackend {
     await this.ensureInitialized();
     const relPath = this.safeRelPath(prefix);
     return this.queue.add(async () => {
+      if (this.recoveryBlocked) {
+        throw new Error(`${TAG} writes blocked for ${this.branchName}: recovery required (recoveryMode=manual)`);
+      }
+      // Unlike deleteObject, whether this will be a no-op is only known
+      // after actually calling deleteByPrefix — so record intent first
+      // (write-ahead) and retract it if it turns out nothing existed.
+      const entry: WalEntry = { opId: randomUUID(), kind: "deleteByPrefix", key: prefix, ts: Date.now() };
+      await this.recordIntent(entry);
       const count = await this.inner.deleteByPrefix(prefix);
       if (count > 0) {
-        await this.stageEntry({ opId: randomUUID(), kind: "deleteByPrefix", key: prefix, ts: Date.now() }, relPath);
+        await gitAdd(this.cloneDir, relPath);
+        await this.writeSyncState("dirty-local");
+        this.scheduleFlush();
+      } else {
+        await this.retractIntent(entry.opId);
       }
       return count;
     });
@@ -313,7 +368,13 @@ export class GitStorageBackend implements IStorageBackend {
 
   /** Sync-state snapshot for health-check exposure. Reads in-memory state only, no I/O. */
   getSyncSummary(): GitSyncSummary {
-    return { status: this.syncStatus, pendingCount: this.pendingOps.length, lastPushedAt: this.lastPushedAt };
+    const oldestPendingOpTs = this.pendingOps.length > 0 ? Math.min(...this.pendingOps.map((op) => op.ts)) : null;
+    return {
+      status: this.syncStatus,
+      pendingCount: this.pendingOps.length,
+      lastPushedAt: this.lastPushedAt,
+      oldestPendingOpTs,
+    };
   }
 
   /** Clear any live timers. Call when this instance is being discarded (e.g. cache eviction). */
@@ -371,22 +432,38 @@ export class GitStorageBackend implements IStorageBackend {
     return buildGitAuth(credential);
   }
 
+  /**
+   * Builds the clone into a staging directory and only renames it into place
+   * (`this.cloneDir`) once every step succeeds. `doInitialize()` treats
+   * "`.git` exists at cloneDir" as "fully initialized" — building in place
+   * would let a step that fails partway (e.g. checkout-orphan succeeds but
+   * the initial commit fails) leave a `.git` behind with no remote or wrong
+   * branch; every later `ensureInitialized()` call would then see `.git`,
+   * skip this method entirely, and proceed against a broken repo forever.
+   */
   private async cloneOrInitSpace(): Promise<void> {
     await gitCheckRefFormat(this.branchName).then((ok) => {
       if (!ok) throw new Error(`${TAG} generated branch name fails check-ref-format: ${this.branchName}`);
     });
     const auth = await this.auth();
     const remoteHasBranch = await gitLsRemoteHasBranch(this.opts.remoteUrl, this.branchName, auth);
-    if (remoteHasBranch) {
-      this.logger?.info(`${TAG} cloning existing space ${this.branchName}`);
-      await gitClone(this.opts.remoteUrl, this.cloneDir, this.branchName, auth);
-    } else {
-      this.logger?.info(`${TAG} initializing new space ${this.branchName}`);
-      await mkdir(this.cloneDir, { recursive: true });
-      await gitInit(this.cloneDir);
-      await gitRemoteAdd(this.cloneDir, "origin", this.opts.remoteUrl, this.branchName);
-      await gitCheckoutOrphan(this.cloneDir, this.branchName);
-      await gitCommit(this.cloneDir, "git-storage: initialize space", { allowEmpty: true });
+    const stagingDir = `${this.cloneDir}.init-${process.pid}-${Date.now()}`;
+    try {
+      if (remoteHasBranch) {
+        this.logger?.info(`${TAG} cloning existing space ${this.branchName}`);
+        await gitClone(this.opts.remoteUrl, stagingDir, this.branchName, auth);
+      } else {
+        this.logger?.info(`${TAG} initializing new space ${this.branchName}`);
+        await mkdir(stagingDir, { recursive: true });
+        await gitInit(stagingDir);
+        await gitRemoteAdd(stagingDir, "origin", this.opts.remoteUrl, this.branchName);
+        await gitCheckoutOrphan(stagingDir, this.branchName);
+        await gitCommit(stagingDir, "git-storage: initialize space", { allowEmpty: true });
+      }
+      await rename(stagingDir, this.cloneDir);
+    } catch (err) {
+      await rm(stagingDir, { recursive: true, force: true }).catch(() => {});
+      throw err;
     }
   }
 
@@ -402,16 +479,31 @@ export class GitStorageBackend implements IStorageBackend {
   }
 
   private async recoverIfNeeded(): Promise<void> {
-    const status = await gitStatusPorcelain(this.cloneDir);
     const locallyCommittedOpIds = await gitLogOpIds(this.cloneDir, "-500");
     this.uncommittedOpIds = new Set(
       this.pendingOps.filter((e) => !locallyCommittedOpIds.has(e.opId)).map((e) => e.opId),
     );
 
-    const hasWorktreeDirt = status.trim().length > 0;
-    const explainedByPendingOps = this.uncommittedOpIds.size > 0;
+    // Snapshot status BEFORE reapplying anything below, so the
+    // unexplained-dirt judgment reflects only pre-existing, genuinely
+    // unaccounted-for changes — not the staging we're about to do ourselves.
+    // `.meta.json` sidecars are never staged by design (local-only metadata,
+    // see design doc) and would otherwise show up as permanent "unexplained"
+    // dirt on every restart after any putObject call that used
+    // contentType/metadata, incorrectly tripping recoveryBlocked.
+    const rawStatus = await gitStatusPorcelain(this.cloneDir);
+    const explainedExactPaths = new Set<string>();
+    const explainedPrefixes: string[] = [];
+    for (const op of this.pendingOps) {
+      if (!this.uncommittedOpIds.has(op.opId)) continue;
+      const relPath = resolveSafeRelativePath(this.cloneDir, op.key).split(sep).join("/");
+      if (op.kind === "deleteByPrefix") explainedPrefixes.push(relPath);
+      else explainedExactPaths.add(relPath);
+    }
+    const unexplainedDirt = filterUnexplainedDirt(rawStatus, explainedExactPaths, explainedPrefixes);
+    const hasUnexplainedDirt = unexplainedDirt.trim().length > 0;
 
-    if (hasWorktreeDirt && !explainedByPendingOps) {
+    if (hasUnexplainedDirt) {
       if (this.recoveryMode === "auto-wal-only") {
         this.logger?.warn(`${TAG} discarding unexplained worktree dirt (recoveryMode=auto-wal-only): ${this.branchName}`);
         await gitCheckoutDiscard(this.cloneDir);
@@ -425,7 +517,23 @@ export class GitStorageBackend implements IStorageBackend {
       }
     }
 
-    if (this.pendingOps.length > 0 || hasWorktreeDirt) {
+    // A crash can land between a pending op's WAL-append and its apply()/
+    // gitAdd() — per-path status is the ground truth for whether apply()
+    // already ran: reapply (exactly once) only when nothing shows for that
+    // path yet, otherwise just ensure it's staged. Reapplying an "append"
+    // that already landed would double its content.
+    for (const op of this.pendingOps) {
+      if (!this.uncommittedOpIds.has(op.opId)) continue;
+      const relPath = resolveSafeRelativePath(this.cloneDir, op.key);
+      const pathStatus = await gitStatusPorcelainForPath(this.cloneDir, relPath);
+      if (pathStatus.trim().length === 0) {
+        await this.reapplyOp(op);
+      } else {
+        await gitAdd(this.cloneDir, relPath).catch(() => {});
+      }
+    }
+
+    if (this.pendingOps.length > 0 || rawStatus.trim().length > 0) {
       await this.writeSyncState("dirty-local");
       this.scheduleFlush();
     }
@@ -433,21 +541,35 @@ export class GitStorageBackend implements IStorageBackend {
 
   // ── Write path ───────────────────────────────────────────────
 
+  /**
+   * Write-ahead: record intent in the WAL and in-memory pendingOps BEFORE
+   * mutating the worktree, so a crash between them leaves a durable record
+   * that recovery can reapply exactly once (see recoverIfNeeded's per-path
+   * status check). Writing the WAL entry after apply() — the original
+   * ordering — left a window where the mutation could happen with no record
+   * of it at all, undetectable and unrecoverable on restart.
+   */
   private async applyAndStage(entry: WalEntry, relPath: string, apply: () => Promise<void>): Promise<void> {
     if (this.recoveryBlocked) {
       throw new Error(`${TAG} writes blocked for ${this.branchName}: recovery required (recoveryMode=manual)`);
     }
+    await this.recordIntent(entry);
     await apply();
-    await this.stageEntry(entry, relPath);
-  }
-
-  private async stageEntry(entry: WalEntry, relPath: string): Promise<void> {
-    await appendWalLine(this.walPath, entry);
     await gitAdd(this.cloneDir, relPath);
-    this.pendingOps.push(entry);
-    this.uncommittedOpIds.add(entry.opId);
     await this.writeSyncState("dirty-local");
     this.scheduleFlush();
+  }
+
+  private async recordIntent(entry: WalEntry): Promise<void> {
+    await appendWalLine(this.walPath, entry);
+    this.pendingOps.push(entry);
+    this.uncommittedOpIds.add(entry.opId);
+  }
+
+  private async retractIntent(opId: string): Promise<void> {
+    this.pendingOps = this.pendingOps.filter((e) => e.opId !== opId);
+    this.uncommittedOpIds.delete(opId);
+    await rewriteWalFile(this.walPath, this.pendingOps);
   }
 
   private scheduleFlush(): void {
@@ -483,10 +605,15 @@ export class GitStorageBackend implements IStorageBackend {
     }
 
     this.lockLost = false;
-    this.startLockRenewal();
-    await this.writeSyncState("pushing");
 
     try {
+      // Lock renewal and the "pushing" state write both happen inside the
+      // try so a failure in either (e.g. sync-state rename fails) still
+      // reaches finally and releases the lock/timer instead of leaking them
+      // for up to lockTtlMs (or, since renewal would otherwise keep
+      // succeeding, effectively indefinitely).
+      this.startLockRenewal();
+      await this.writeSyncState("pushing");
       await this.commitUncommittedOps();
       await this.pushWithReplay();
       await this.writeSyncState("clean");
@@ -570,10 +697,22 @@ export class GitStorageBackend implements IStorageBackend {
   }
 
   private async confirmAllPending(): Promise<void> {
+    // Persist the WAL trim BEFORE clearing in-memory state: if the rewrite
+    // fails after the push already succeeded, flushLocked's catch marks
+    // "push-failed" but pendingOps/uncommittedOpIds must still reflect
+    // reality, or every later flush() call would return immediately (both
+    // collections already empty) and only a process restart — which
+    // reloads the still-populated WAL file — would ever retry the trim.
+    await rewriteWalFile(this.walPath, []);
     this.pendingOps = [];
     this.uncommittedOpIds.clear();
     this.lastPushedAt = Date.now();
-    await rewriteWalFile(this.walPath, []);
+    if (this.lockLost) {
+      this.logger?.warn(
+        `${TAG} push for ${this.branchName} succeeded but the lock lease was lost during the attempt; ` +
+          `data is safe (git's non-fast-forward push is the real CAS), but the single-writer lease was not held throughout.`,
+      );
+    }
   }
 
   /**

--- a/MemoryCore/src/core/storage/git-backend.ts
+++ b/MemoryCore/src/core/storage/git-backend.ts
@@ -1,0 +1,654 @@
+/**
+ * GitStorageBackend — Git-backed implementation of IStorageBackend.
+ *
+ * See docs/rfc/git-storage-backend.md and
+ * docs/design/git-storage-backend-implementation-plan.md for the full design
+ * rationale. Summary: one independent `git clone --single-branch` per memory
+ * space, delegating ordinary file I/O to an inner LocalStorageBackend and
+ * layering a WAL + batched commit/push + replay-on-rejection on top of the
+ * mutating methods only. Experimental — single-writer-per-space pilot scope.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile, appendFile, rename } from "node:fs/promises";
+import { dirname, join, sep } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  IStorageBackend,
+  StorageObject,
+  PutObjectOptions,
+  ListObjectsOptions,
+  ListResult,
+  StorageLogger,
+  IGitCredentialProvider,
+} from "./types.js";
+import type { IStateBackend } from "../state/types.js";
+import { LocalStorageBackend } from "./local-backend.js";
+import { resolveSafeRelativePath } from "./path-safety.js";
+import { SerialQueue } from "../../utils/serial-queue.js";
+import {
+  buildGitAuth,
+  gitAdd,
+  gitCheckoutDiscard,
+  gitCheckoutOrphan,
+  gitCheckRefFormat,
+  gitClone,
+  gitCommit,
+  gitFetch,
+  gitInit,
+  gitLogOpIds,
+  gitLsRemoteHasBranch,
+  gitMergeBase,
+  gitPush,
+  gitRemoteAdd,
+  gitResetHard,
+  gitStatusPorcelain,
+  type GitAuth,
+} from "./git-cli.js";
+
+const TAG = "[storage][git]";
+const MAX_SLUG_CHARS = 40;
+const MAX_BRANCH_NAME_CHARS = 200;
+
+// ============================
+// Branch naming
+// ============================
+
+function sanitizeSlug(input: string): string {
+  let slug = "";
+  for (const ch of input.toLowerCase()) {
+    slug += /[a-z0-9_-]/.test(ch) ? ch : "-";
+  }
+  slug = slug.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+  if (slug.length === 0) return "empty";
+  return slug.length > MAX_SLUG_CHARS ? slug.slice(0, MAX_SLUG_CHARS) : slug;
+}
+
+export interface BranchNameSeed {
+  tenantId: string;
+  instanceId: string;
+}
+
+/**
+ * memory/{tenantSlug}/{instanceSlug}-{hash32hex}. The hash covers a
+ * length-prefixed encoding of the raw (unsanitized) seed so two different
+ * (tenantId, instanceId) pairs can never sanitize+concatenate to the same
+ * hash input (e.g. ("ab","c") vs ("a","bc")); 32 hex chars = 128 bit, wide
+ * enough that collisions aren't a realistic concern at pilot scale.
+ */
+export function buildBranchName(seed: BranchNameSeed): string {
+  const tenantSlug = sanitizeSlug(seed.tenantId);
+  const instanceSlug = sanitizeSlug(seed.instanceId);
+  const encoded = `${seed.tenantId.length}:${seed.tenantId}${seed.instanceId.length}:${seed.instanceId}`;
+  const hash = createHash("sha256").update(encoded, "utf-8").digest("hex").slice(0, 32);
+  const branchName = `memory/${tenantSlug}/${instanceSlug}-${hash}`;
+  if (branchName.length > MAX_BRANCH_NAME_CHARS) {
+    throw new Error(`${TAG} branch name exceeds ${MAX_BRANCH_NAME_CHARS} chars: ${branchName.length}`);
+  }
+  return branchName;
+}
+
+// ============================
+// WAL (write-ahead log)
+// ============================
+
+interface WalEntry {
+  opId: string;
+  kind: "put" | "append" | "delete" | "deleteByPrefix";
+  key: string;
+  /** base64 content, for put/append replay. */
+  contentBase64?: string;
+  opts?: PutObjectOptions;
+  ts: number;
+}
+
+async function loadWalFile(path: string): Promise<WalEntry[]> {
+  if (!existsSync(path)) return [];
+  const raw = await readFile(path, "utf-8");
+  const entries: WalEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line) as WalEntry);
+    } catch {
+      // skip a corrupt/truncated line (e.g. process killed mid-write)
+    }
+  }
+  return entries;
+}
+
+async function appendWalLine(path: string, entry: WalEntry): Promise<void> {
+  await appendFile(path, `${JSON.stringify(entry)}\n`);
+}
+
+async function rewriteWalFile(path: string, entries: WalEntry[]): Promise<void> {
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  const body = entries.map((e) => JSON.stringify(e)).join("\n");
+  await writeFile(tmpPath, entries.length ? `${body}\n` : "");
+  await rename(tmpPath, path);
+}
+
+function toBase64(content: string | Buffer): string {
+  return (typeof content === "string" ? Buffer.from(content, "utf-8") : content).toString("base64");
+}
+
+function fromBase64(b64: string): Buffer {
+  return Buffer.from(b64, "base64");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ============================
+// GitStorageBackend
+// ============================
+
+export type GitSyncStatus = "clean" | "dirty-local" | "pushing" | "replaying" | "push-failed";
+
+export interface GitSyncSummary {
+  status: GitSyncStatus;
+  pendingCount: number;
+  lastPushedAt: number | null;
+}
+
+export interface GitStorageBackendOptions {
+  /** Local clone root; one subdirectory under it for this space's clone + state. */
+  localRootDir: string;
+  remoteUrl: string;
+  credentialProvider: IGitCredentialProvider;
+  branchNameSeed: BranchNameSeed;
+  /** Injected, never imported from src/core/state/* directly (CI red-line). */
+  stateBackend: IStateBackend;
+  /** Debounce window for batching writes into one commit, ms. 0 = commit per call. Default 2000. */
+  batchWindowMs?: number;
+  /** Hard cap on debounce delay under sustained load, ms. Default 10000. */
+  maxBatchDelayMs?: number;
+  /** Distributed lock TTL, ms. Default 30000. */
+  lockTtlMs?: number;
+  /** Max push-rejected replay attempts. Default 5. */
+  maxPushRetries?: number;
+  /** Default "manual". */
+  recoveryMode?: "manual" | "auto-wal-only";
+  logger?: StorageLogger;
+}
+
+export class GitStorageBackend implements IStorageBackend {
+  readonly type = "git" as const;
+
+  private readonly branchName: string;
+  private readonly cloneDir: string;
+  private readonly stateDir: string;
+  private readonly walPath: string;
+  private readonly syncStatePath: string;
+  private readonly ownerId: string;
+  private readonly lockKey: string;
+  private readonly queue: SerialQueue;
+  private readonly logger?: StorageLogger;
+  private readonly batchWindowMs: number;
+  private readonly maxBatchDelayMs: number;
+  private readonly lockTtlMs: number;
+  private readonly maxPushRetries: number;
+  private readonly recoveryMode: "manual" | "auto-wal-only";
+
+  private inner!: LocalStorageBackend;
+  private initPromise?: Promise<void>;
+  private recoveryBlocked = false;
+
+  private pendingOps: WalEntry[] = [];
+  private uncommittedOpIds = new Set<string>();
+  private syncStatus: GitSyncStatus = "clean";
+  private lastPushedAt: number | null = null;
+
+  private flushTimer?: ReturnType<typeof setTimeout>;
+  private lockRenewTimer?: ReturnType<typeof setInterval>;
+  private lockLost = false;
+
+  constructor(private readonly opts: GitStorageBackendOptions) {
+    this.logger = opts.logger;
+    this.branchName = buildBranchName(opts.branchNameSeed);
+    const branchDirName = this.branchName.replace(/\//g, "_");
+    this.cloneDir = join(opts.localRootDir, "clones", branchDirName);
+    this.stateDir = join(opts.localRootDir, "state", branchDirName);
+    this.walPath = join(this.stateDir, "pending-ops.jsonl");
+    this.syncStatePath = join(this.stateDir, "sync-state.json");
+    this.ownerId = `git-storage-${randomUUID()}`;
+    this.lockKey = `git-storage:${this.branchName}`;
+    this.queue = new SerialQueue(`git-storage:${branchDirName}`);
+    this.batchWindowMs = opts.batchWindowMs ?? 2000;
+    this.maxBatchDelayMs = opts.maxBatchDelayMs ?? 10000;
+    this.lockTtlMs = opts.lockTtlMs ?? 30000;
+    this.maxPushRetries = opts.maxPushRetries ?? 5;
+    this.recoveryMode = opts.recoveryMode ?? "manual";
+  }
+
+  // ── IStorageBackend ──────────────────────────────────────────
+
+  async putObject(key: string, content: string | Buffer, opts?: PutObjectOptions): Promise<void> {
+    await this.ensureInitialized();
+    const relPath = this.safeRelPath(key);
+    await this.queue.add(() =>
+      this.applyAndStage(
+        { opId: randomUUID(), kind: "put", key, contentBase64: toBase64(content), opts, ts: Date.now() },
+        relPath,
+        () => this.inner.putObject(key, content, opts),
+      ),
+    );
+  }
+
+  async appendObject(key: string, content: string | Buffer): Promise<void> {
+    await this.ensureInitialized();
+    const relPath = this.safeRelPath(key);
+    await this.queue.add(() =>
+      this.applyAndStage(
+        { opId: randomUUID(), kind: "append", key, contentBase64: toBase64(content), ts: Date.now() },
+        relPath,
+        () => this.inner.appendObject(key, content),
+      ),
+    );
+  }
+
+  async getObject(key: string): Promise<StorageObject | null> {
+    await this.ensureInitialized();
+    this.safeRelPath(key);
+    return this.inner.getObject(key);
+  }
+
+  async exists(key: string): Promise<boolean> {
+    await this.ensureInitialized();
+    this.safeRelPath(key);
+    return this.inner.exists(key);
+  }
+
+  async listObjects(prefix: string, opts?: ListObjectsOptions): Promise<ListResult> {
+    await this.ensureInitialized();
+    this.safeRelPath(prefix);
+    return this.inner.listObjects(prefix, opts);
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    await this.ensureInitialized();
+    const relPath = this.safeRelPath(key);
+    await this.queue.add(async () => {
+      // `git add -- <path>` fails with "pathspec did not match any files" for
+      // a path git has never tracked — unlike a path it tracked and that was
+      // since removed, where `git add` correctly stages the deletion. Only
+      // stage when something actually existed to delete; deleteObject is
+      // idempotent (IStorageBackend contract), so a no-op delete needs no
+      // WAL entry or commit either.
+      const existed = await this.inner.exists(key);
+      await this.inner.deleteObject(key);
+      if (existed) {
+        await this.stageEntry({ opId: randomUUID(), kind: "delete", key, ts: Date.now() }, relPath);
+      }
+    });
+  }
+
+  async deleteByPrefix(prefix: string): Promise<number> {
+    await this.ensureInitialized();
+    const relPath = this.safeRelPath(prefix);
+    return this.queue.add(async () => {
+      const count = await this.inner.deleteByPrefix(prefix);
+      if (count > 0) {
+        await this.stageEntry({ opId: randomUUID(), kind: "deleteByPrefix", key: prefix, ts: Date.now() }, relPath);
+      }
+      return count;
+    });
+  }
+
+  /**
+   * Force an immediate flush and wait for it to complete (or throw).
+   * NOT part of IStorageBackend — a Git-specific durability barrier for
+   * callers that need a synchronous "confirmed pushed" signal once, after a
+   * whole workflow (e.g. several deleteByPrefix calls), rather than after
+   * every individual mutation.
+   */
+  async flush(): Promise<void> {
+    await this.ensureInitialized();
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    await this.queue.add(() => this.flushLocked());
+  }
+
+  /** Sync-state snapshot for health-check exposure. Reads in-memory state only, no I/O. */
+  getSyncSummary(): GitSyncSummary {
+    return { status: this.syncStatus, pendingCount: this.pendingOps.length, lastPushedAt: this.lastPushedAt };
+  }
+
+  /** Clear any live timers. Call when this instance is being discarded (e.g. cache eviction). */
+  dispose(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    this.stopLockRenewal();
+  }
+
+  // ── Key validation ──────────────────────────────────────────
+
+  /**
+   * Validates the key (same traversal guard as LocalStorageBackend) and
+   * additionally rejects any key resolving into `.git/` — the clone
+   * directory's control files are reachable through ordinary keys unless
+   * explicitly blocked, since delegation to the inner LocalStorageBackend is
+   * a plain forward, not a sandboxed view.
+   */
+  private safeRelPath(key: string): string {
+    const relPath = resolveSafeRelativePath(this.cloneDir, key);
+    const firstSegment = relPath.split(sep)[0];
+    if (firstSegment === ".git") {
+      throw new Error(`${TAG} storage key resolves into git control directory: ${key}`);
+    }
+    return relPath;
+  }
+
+  // ── Initialization & recovery ───────────────────────────────
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.doInitialize().catch((err) => {
+        this.initPromise = undefined; // allow retry on next call
+        throw err;
+      });
+    }
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
+    await mkdir(this.stateDir, { recursive: true });
+    await mkdir(dirname(this.cloneDir), { recursive: true });
+    if (!existsSync(join(this.cloneDir, ".git"))) {
+      await this.cloneOrInitSpace();
+    }
+    this.inner = new LocalStorageBackend({ rootDir: this.cloneDir, logger: this.logger });
+    await this.loadPersistedState();
+    await this.recoverIfNeeded();
+  }
+
+  private async auth(): Promise<GitAuth> {
+    const credential = await this.opts.credentialProvider.getGitCredential();
+    return buildGitAuth(credential);
+  }
+
+  private async cloneOrInitSpace(): Promise<void> {
+    await gitCheckRefFormat(this.branchName).then((ok) => {
+      if (!ok) throw new Error(`${TAG} generated branch name fails check-ref-format: ${this.branchName}`);
+    });
+    const auth = await this.auth();
+    const remoteHasBranch = await gitLsRemoteHasBranch(this.opts.remoteUrl, this.branchName, auth);
+    if (remoteHasBranch) {
+      this.logger?.info(`${TAG} cloning existing space ${this.branchName}`);
+      await gitClone(this.opts.remoteUrl, this.cloneDir, this.branchName, auth);
+    } else {
+      this.logger?.info(`${TAG} initializing new space ${this.branchName}`);
+      await mkdir(this.cloneDir, { recursive: true });
+      await gitInit(this.cloneDir);
+      await gitRemoteAdd(this.cloneDir, "origin", this.opts.remoteUrl, this.branchName);
+      await gitCheckoutOrphan(this.cloneDir, this.branchName);
+      await gitCommit(this.cloneDir, "git-storage: initialize space", { allowEmpty: true });
+    }
+  }
+
+  private async loadPersistedState(): Promise<void> {
+    this.pendingOps = await loadWalFile(this.walPath);
+    try {
+      const raw = await readFile(this.syncStatePath, "utf-8");
+      const parsed = JSON.parse(raw) as { lastPushedAt: number | null };
+      this.lastPushedAt = parsed.lastPushedAt ?? null;
+    } catch {
+      this.lastPushedAt = null;
+    }
+  }
+
+  private async recoverIfNeeded(): Promise<void> {
+    const status = await gitStatusPorcelain(this.cloneDir);
+    const locallyCommittedOpIds = await gitLogOpIds(this.cloneDir, "-500");
+    this.uncommittedOpIds = new Set(
+      this.pendingOps.filter((e) => !locallyCommittedOpIds.has(e.opId)).map((e) => e.opId),
+    );
+
+    const hasWorktreeDirt = status.trim().length > 0;
+    const explainedByPendingOps = this.uncommittedOpIds.size > 0;
+
+    if (hasWorktreeDirt && !explainedByPendingOps) {
+      if (this.recoveryMode === "auto-wal-only") {
+        this.logger?.warn(`${TAG} discarding unexplained worktree dirt (recoveryMode=auto-wal-only): ${this.branchName}`);
+        await gitCheckoutDiscard(this.cloneDir);
+      } else {
+        this.recoveryBlocked = true;
+        this.logger?.error(
+          `${TAG} unexplained worktree dirt for ${this.branchName}; refusing to auto-flush ` +
+            `(recoveryMode=manual). Reads still work; writes will throw until resolved manually.`,
+        );
+        return;
+      }
+    }
+
+    if (this.pendingOps.length > 0 || hasWorktreeDirt) {
+      await this.writeSyncState("dirty-local");
+      this.scheduleFlush();
+    }
+  }
+
+  // ── Write path ───────────────────────────────────────────────
+
+  private async applyAndStage(entry: WalEntry, relPath: string, apply: () => Promise<void>): Promise<void> {
+    if (this.recoveryBlocked) {
+      throw new Error(`${TAG} writes blocked for ${this.branchName}: recovery required (recoveryMode=manual)`);
+    }
+    await apply();
+    await this.stageEntry(entry, relPath);
+  }
+
+  private async stageEntry(entry: WalEntry, relPath: string): Promise<void> {
+    await appendWalLine(this.walPath, entry);
+    await gitAdd(this.cloneDir, relPath);
+    this.pendingOps.push(entry);
+    this.uncommittedOpIds.add(entry.opId);
+    await this.writeSyncState("dirty-local");
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.recoveryBlocked) return;
+    const runFlush = () => {
+      this.queue.add(() => this.flushLocked()).catch((err) => {
+        this.logger?.error(`${TAG} flush failed for ${this.branchName}: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    };
+    if (this.batchWindowMs <= 0) {
+      runFlush();
+      return;
+    }
+    if (this.flushTimer) return;
+    const delay = Math.min(this.batchWindowMs, this.maxBatchDelayMs);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined;
+      runFlush();
+    }, delay);
+  }
+
+  // ── Flush: lock → commit → push (with replay on rejection) ────
+
+  private async flushLocked(): Promise<void> {
+    if (this.recoveryBlocked) return;
+    if (this.uncommittedOpIds.size === 0 && this.pendingOps.length === 0) return;
+
+    const acquired = await this.opts.stateBackend.acquireLock(this.lockKey, this.ownerId, this.lockTtlMs);
+    if (!acquired) {
+      this.logger?.warn(`${TAG} lock busy for ${this.branchName}, retrying later`);
+      this.scheduleFlush();
+      return;
+    }
+
+    this.lockLost = false;
+    this.startLockRenewal();
+    await this.writeSyncState("pushing");
+
+    try {
+      await this.commitUncommittedOps();
+      await this.pushWithReplay();
+      await this.writeSyncState("clean");
+    } catch (err) {
+      // WAL and any local commits are left intact either way — nothing is
+      // discarded, so a later flush (triggered by the next write, or an
+      // explicit flush() call) can pick up where this attempt left off.
+      await this.writeSyncState(this.lockLost ? "dirty-local" : "push-failed");
+      this.logger?.error(
+        `${TAG} flush ${this.lockLost ? "aborted (lock lost)" : "failed"} for ${this.branchName}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    } finally {
+      this.stopLockRenewal();
+      await this.opts.stateBackend.releaseLock(this.lockKey, this.ownerId).catch(() => {});
+    }
+  }
+
+  private startLockRenewal(): void {
+    const interval = Math.max(1000, Math.floor(this.lockTtlMs / 2));
+    this.lockRenewTimer = setInterval(() => {
+      this.opts.stateBackend
+        .renewLock(this.lockKey, this.ownerId, this.lockTtlMs)
+        .then((renewed) => {
+          if (!renewed) {
+            this.lockLost = true;
+            this.logger?.error(`${TAG} lock renewal failed for ${this.branchName}; aborting in-flight flush`);
+          }
+        })
+        .catch(() => {
+          this.lockLost = true;
+        });
+    }, interval);
+  }
+
+  private stopLockRenewal(): void {
+    if (this.lockRenewTimer) {
+      clearInterval(this.lockRenewTimer);
+      this.lockRenewTimer = undefined;
+    }
+  }
+
+  private assertLockHeld(): void {
+    if (this.lockLost) {
+      throw new Error(`${TAG} lock lost mid-flush for ${this.branchName}`);
+    }
+  }
+
+  private async commitUncommittedOps(): Promise<void> {
+    this.assertLockHeld();
+    if (this.uncommittedOpIds.size === 0) return;
+    const opIds = [...this.uncommittedOpIds];
+    const message = `git-storage: batch commit\n\nOps: ${opIds.join(" ")}`;
+    const committed = await gitCommit(this.cloneDir, message);
+    if (committed) {
+      this.uncommittedOpIds.clear();
+    }
+  }
+
+  private async pushWithReplay(): Promise<void> {
+    for (let attempt = 0; attempt <= this.maxPushRetries; attempt++) {
+      this.assertLockHeld();
+      const auth = await this.auth();
+      await gitFetch(this.cloneDir, auth);
+      this.assertLockHeld();
+      const result = await gitPush(this.cloneDir, this.branchName, auth);
+      if (!result.rejected) {
+        await this.confirmAllPending();
+        return;
+      }
+
+      await this.writeSyncState("replaying");
+      await this.replayOntoNewTip();
+
+      if (attempt < this.maxPushRetries) {
+        await sleep(500 * 2 ** attempt);
+      }
+    }
+    throw new Error(`${TAG} push rejected after ${this.maxPushRetries} replay attempts for ${this.branchName}`);
+  }
+
+  private async confirmAllPending(): Promise<void> {
+    this.pendingOps = [];
+    this.uncommittedOpIds.clear();
+    this.lastPushedAt = Date.now();
+    await rewriteWalFile(this.walPath, []);
+  }
+
+  /**
+   * Push was rejected (non-fast-forward). Reset to the fresh remote tip and
+   * replay only the ops that didn't already land there — replay, not a
+   * blind merge (RFC结论4). "Already landed" is determined by scanning the
+   * new commits' `Ops:` trailers, not by comparing content bytes, so
+   * legitimately-duplicate content is never mistaken for an already-applied
+   * operation (Codex checkpoint A finding #4).
+   */
+  private async replayOntoNewTip(): Promise<void> {
+    this.assertLockHeld();
+    const originRef = `origin/${this.branchName}`;
+    const base = await gitMergeBase(this.cloneDir, "HEAD", originRef);
+    const alreadyLanded = base ? await gitLogOpIds(this.cloneDir, `${base}..${originRef}`) : new Set<string>();
+
+    const remaining = this.pendingOps.filter((op) => !alreadyLanded.has(op.opId));
+    for (const op of this.pendingOps) {
+      if (alreadyLanded.has(op.opId)) {
+        this.logger?.info(`${TAG} op ${op.opId} already landed on remote, skipping replay`);
+      }
+    }
+
+    this.assertLockHeld();
+    await gitResetHard(this.cloneDir, originRef);
+
+    for (const op of remaining) {
+      this.assertLockHeld();
+      await this.reapplyOp(op);
+    }
+
+    this.pendingOps = remaining;
+    this.uncommittedOpIds = new Set(remaining.map((op) => op.opId));
+    await rewriteWalFile(this.walPath, remaining);
+
+    if (this.uncommittedOpIds.size > 0) {
+      await this.commitUncommittedOps();
+    }
+  }
+
+  private async reapplyOp(op: WalEntry): Promise<void> {
+    const relPath = resolveSafeRelativePath(this.cloneDir, op.key);
+    switch (op.kind) {
+      case "put":
+        await this.inner.putObject(op.key, fromBase64(op.contentBase64 ?? ""), op.opts);
+        break;
+      case "append":
+        await this.inner.appendObject(op.key, fromBase64(op.contentBase64 ?? ""));
+        break;
+      case "delete": {
+        // Same "git add fails on a never-tracked path" hazard as the live
+        // deleteObject() path: after gitResetHard, the file may no longer
+        // exist at all (e.g. it was created and deleted within the same
+        // unpushed batch), in which case there's nothing to stage.
+        const existed = await this.inner.exists(op.key);
+        await this.inner.deleteObject(op.key);
+        if (!existed) return;
+        break;
+      }
+      case "deleteByPrefix": {
+        const count = await this.inner.deleteByPrefix(op.key);
+        if (count === 0) return;
+        break;
+      }
+    }
+    await gitAdd(this.cloneDir, relPath);
+  }
+
+  // ── Sync-state persistence ──────────────────────────────────
+
+  private async writeSyncState(status: GitSyncStatus): Promise<void> {
+    this.syncStatus = status;
+    const payload = JSON.stringify({ status, lastPushedAt: this.lastPushedAt, updatedAt: Date.now() });
+    const tmpPath = `${this.syncStatePath}.tmp-${process.pid}-${Date.now()}`;
+    await writeFile(tmpPath, payload);
+    await rename(tmpPath, this.syncStatePath);
+  }
+}

--- a/MemoryCore/src/core/storage/git-cli.ts
+++ b/MemoryCore/src/core/storage/git-cli.ts
@@ -1,0 +1,245 @@
+/**
+ * Thin execFile wrapper around the system `git` binary.
+ *
+ * No shelling through `sh -c` — every invocation passes argv as an array,
+ * so caller-controlled strings (branch names, keys, remote URLs) can never
+ * be interpreted by a shell. Auth material (tokens, SSH keys) is passed via
+ * per-invocation `-c` config args / env vars, never written to `.git/config`
+ * or any file on disk.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { GitCredential } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const COMMIT_IDENTITY_ARGS = ["-c", "user.name=git-storage-backend", "-c", "user.email=git-storage-backend@localhost"];
+
+export class GitCliError extends Error {
+  constructor(
+    message: string,
+    public readonly args: string[],
+    public readonly exitCode: number | null,
+    public readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "GitCliError";
+  }
+}
+
+export interface GitAuth {
+  /** Extra `-c` args inserted right after `git`, before the subcommand. */
+  configArgs: string[];
+  /** Extra env vars for the spawned process (e.g. GIT_SSH_COMMAND). */
+  env?: NodeJS.ProcessEnv;
+}
+
+/** POSIX single-quote shell escaping, for values embedded in GIT_SSH_COMMAND. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildGitAuth(credential: GitCredential): GitAuth {
+  if (credential.authMethod === "ssh") {
+    const hostKeyArg = credential.knownHostsPath
+      ? `-o UserKnownHostsFile=${shellQuote(credential.knownHostsPath)}`
+      : "-o StrictHostKeyChecking=accept-new";
+    return {
+      configArgs: [],
+      env: {
+        GIT_SSH_COMMAND: `ssh -i ${shellQuote(credential.privateKeyPath)} -o IdentitiesOnly=yes -o BatchMode=yes ${hostKeyArg}`,
+      },
+    };
+  }
+  const username = credential.username && credential.username.length > 0 ? credential.username : "x-access-token";
+  const basic = Buffer.from(`${username}:${credential.token}`, "utf-8").toString("base64");
+  return {
+    // credential.helper= (empty) disables any configured helper so nothing
+    // else tries to prompt for or supply credentials for this invocation.
+    configArgs: ["-c", `http.extraHeader=Authorization: Basic ${basic}`, "-c", "credential.helper="],
+  };
+}
+
+export interface RunGitOptions {
+  cwd: string;
+  /** Extra `-c` args (e.g. from buildGitAuth) inserted before the subcommand. */
+  configArgs?: string[];
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  /** Allow specific non-zero exit codes without throwing (caller inspects stderr/exit code itself). */
+  allowExitCodes?: number[];
+}
+
+export async function runGit(args: string[], opts: RunGitOptions): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const fullArgs = [...(opts.configArgs ?? []), ...args];
+  try {
+    const { stdout, stderr } = await execFileAsync("git", fullArgs, {
+      cwd: opts.cwd,
+      env: opts.env ? { ...process.env, ...opts.env } : process.env,
+      timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err) {
+    const e = err as { code?: number | string; killed?: boolean; signal?: string; stdout?: string; stderr?: string };
+    const exitCode = typeof e.code === "number" ? e.code : null;
+    if (exitCode !== null && opts.allowExitCodes?.includes(exitCode)) {
+      return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode };
+    }
+    if (e.code === "ENOENT") {
+      throw new GitCliError(`git binary not found on PATH`, fullArgs, null, "");
+    }
+    throw new GitCliError(
+      `git ${args.join(" ")} failed${exitCode !== null ? ` (exit ${exitCode})` : ""}: ${(e.stderr ?? String(err)).trim()}`,
+      fullArgs,
+      exitCode,
+      e.stderr ?? "",
+    );
+  }
+}
+
+export async function gitVersion(): Promise<string> {
+  const { stdout } = await runGit(["--version"], { cwd: process.cwd() });
+  return stdout.trim();
+}
+
+export async function gitCheckRefFormat(branchName: string): Promise<boolean> {
+  const { exitCode } = await runGit(["check-ref-format", "--branch", branchName], {
+    cwd: process.cwd(),
+    allowExitCodes: [1],
+  });
+  return exitCode === 0;
+}
+
+export async function gitLsRemoteHasBranch(remoteUrl: string, branch: string, auth: GitAuth): Promise<boolean> {
+  const { stdout } = await runGit(["ls-remote", "--heads", remoteUrl, branch], {
+    cwd: process.cwd(),
+    configArgs: auth.configArgs,
+    env: auth.env,
+    timeoutMs: 30_000,
+  });
+  return stdout.trim().length > 0;
+}
+
+export async function gitInit(dir: string): Promise<void> {
+  await runGit(["init", "--quiet"], { cwd: dir });
+}
+
+/**
+ * `-t branch` restricts the remote's configured fetch refspec to that one
+ * branch — without it, a plain `git remote add` leaves the default
+ * `+refs/heads/*:refs/remotes/origin/*` refspec in place, so every later
+ * `git fetch` (not just the initial clone) would pull every other memory
+ * space's branch history too.
+ */
+export async function gitRemoteAdd(dir: string, name: string, url: string, restrictToBranch?: string): Promise<void> {
+  const args = restrictToBranch
+    ? ["remote", "add", "--no-tags", "-t", restrictToBranch, name, url]
+    : ["remote", "add", "--no-tags", name, url];
+  await runGit(args, { cwd: dir });
+}
+
+export async function gitCheckoutOrphan(dir: string, branch: string): Promise<void> {
+  await runGit(["checkout", "--orphan", branch], { cwd: dir });
+}
+
+export async function gitClone(remoteUrl: string, dir: string, branch: string, auth: GitAuth): Promise<void> {
+  await runGit(
+    ["clone", "--quiet", "--single-branch", "--no-tags", "--branch", branch, "--", remoteUrl, dir],
+    { cwd: process.cwd(), configArgs: auth.configArgs, env: auth.env, timeoutMs: 120_000 },
+  );
+}
+
+export async function gitAdd(dir: string, relPath: string): Promise<void> {
+  await runGit(["add", "--", relPath], { cwd: dir });
+}
+
+/** Commit whatever is currently staged. Returns false if there was nothing to commit. */
+export async function gitCommit(dir: string, message: string, opts: { allowEmpty?: boolean } = {}): Promise<boolean> {
+  const args = ["commit", "--quiet", ...(opts.allowEmpty ? ["--allow-empty"] : []), "-m", message];
+  const { exitCode } = await runGit([...COMMIT_IDENTITY_ARGS, ...args], { cwd: dir, allowExitCodes: [1] });
+  return exitCode === 0;
+}
+
+export async function gitFetch(dir: string, auth: GitAuth, remote = "origin"): Promise<void> {
+  try {
+    await runGit(["fetch", "--quiet", "--no-tags", remote], {
+      cwd: dir,
+      configArgs: auth.configArgs,
+      env: auth.env,
+      timeoutMs: 60_000,
+    });
+  } catch (err) {
+    // With a single-branch-restricted fetch refspec (see gitRemoteAdd), the
+    // very first fetch for a brand-new orphan branch that hasn't been
+    // pushed yet has a specifically-named remote ref that doesn't exist —
+    // git treats that as fatal instead of "nothing to fetch". Swallow it:
+    // semantically this is the same as the old wildcard refspec matching
+    // zero branches, not a real failure.
+    if (err instanceof GitCliError && /couldn't find remote ref/i.test(err.stderr)) {
+      return;
+    }
+    throw err;
+  }
+}
+
+export interface GitPushResult {
+  rejected: boolean;
+}
+
+const NON_FAST_FORWARD_PATTERNS = [/non-fast-forward/i, /failed to push some refs/i, /rejected/i, /stale info/i];
+
+export async function gitPush(dir: string, branch: string, auth: GitAuth, remote = "origin"): Promise<GitPushResult> {
+  try {
+    await runGit(["push", "--quiet", remote, `${branch}:${branch}`], {
+      cwd: dir,
+      configArgs: auth.configArgs,
+      env: auth.env,
+      timeoutMs: 60_000,
+    });
+    return { rejected: false };
+  } catch (err) {
+    if (err instanceof GitCliError && NON_FAST_FORWARD_PATTERNS.some((re) => re.test(err.stderr))) {
+      return { rejected: true };
+    }
+    throw err;
+  }
+}
+
+export async function gitMergeBase(dir: string, refA: string, refB: string): Promise<string | null> {
+  const { stdout, exitCode } = await runGit(["merge-base", refA, refB], { cwd: dir, allowExitCodes: [1, 128] });
+  return exitCode === 0 ? stdout.trim() : null;
+}
+
+export async function gitResetHard(dir: string, ref: string): Promise<void> {
+  await runGit(["reset", "--hard", ref], { cwd: dir });
+}
+
+export async function gitCheckoutDiscard(dir: string): Promise<void> {
+  await runGit(["checkout", "--", "."], { cwd: dir, allowExitCodes: [1] });
+  await runGit(["clean", "-fd"], { cwd: dir });
+}
+
+export async function gitStatusPorcelain(dir: string): Promise<string> {
+  const { stdout } = await runGit(["status", "--porcelain"], { cwd: dir });
+  return stdout;
+}
+
+export async function gitRevParse(dir: string, ref: string): Promise<string | null> {
+  const { stdout, exitCode } = await runGit(["rev-parse", "--verify", ref], { cwd: dir, allowExitCodes: [1, 128] });
+  return exitCode === 0 ? stdout.trim() : null;
+}
+
+/** Extract "Ops: <id> <id> ..." trailer values from commit messages in `range` (e.g. "abc123..origin/main"). */
+export async function gitLogOpIds(dir: string, range: string): Promise<Set<string>> {
+  const { stdout } = await runGit(["log", "--format=%B%x00", range], { cwd: dir, allowExitCodes: [128] });
+  const opIds = new Set<string>();
+  for (const body of stdout.split("\x00")) {
+    const match = /^Ops: (.+)$/m.exec(body);
+    if (match?.[1]) {
+      for (const id of match[1].trim().split(/\s+/)) opIds.add(id);
+    }
+  }
+  return opIds;
+}

--- a/MemoryCore/src/core/storage/git-cli.ts
+++ b/MemoryCore/src/core/storage/git-cli.ts
@@ -16,15 +16,30 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_TIMEOUT_MS = 30_000;
 const COMMIT_IDENTITY_ARGS = ["-c", "user.name=git-storage-backend", "-c", "user.email=git-storage-backend@localhost"];
 
+/**
+ * Redact any `-c http.extraHeader=Authorization: ...` value before it can
+ * reach a public error property — GitCliError.args is exactly the kind of
+ * field a logger or `JSON.stringify` inspects without knowing it might hold
+ * a credential (argv itself is still OS-visible via `ps`/procfs, an
+ * inherent limitation of passing auth through `-c`/argv at all; this only
+ * closes the easier, more casual leak surface of serialized error objects).
+ */
+function redactConfigArgs(args: string[]): string[] {
+  return args.map((arg) => (/^http\.extraHeader=Authorization:/i.test(arg) ? "http.extraHeader=Authorization: [REDACTED]" : arg));
+}
+
 export class GitCliError extends Error {
+  public readonly args: string[];
+
   constructor(
     message: string,
-    public readonly args: string[],
+    args: string[],
     public readonly exitCode: number | null,
     public readonly stderr: string,
   ) {
     super(message);
     this.name = "GitCliError";
+    this.args = redactConfigArgs(args);
   }
 }
 
@@ -223,6 +238,12 @@ export async function gitCheckoutDiscard(dir: string): Promise<void> {
 
 export async function gitStatusPorcelain(dir: string): Promise<string> {
   const { stdout } = await runGit(["status", "--porcelain"], { cwd: dir });
+  return stdout;
+}
+
+/** `git status --porcelain -- <relPath>` — restricted to one key/prefix, for recovery's per-op reapply decision. */
+export async function gitStatusPorcelainForPath(dir: string, relPath: string): Promise<string> {
+  const { stdout } = await runGit(["status", "--porcelain", "--", relPath], { cwd: dir });
   return stdout;
 }
 

--- a/MemoryCore/src/core/storage/git-credential.ts
+++ b/MemoryCore/src/core/storage/git-credential.ts
@@ -1,0 +1,82 @@
+/**
+ * Git credential providers — mirrors credential-provider.ts's Static/Cached
+ * split, for git auth instead of COS.
+ */
+import type { GitCredential, IGitCredentialProvider, StorageLogger } from "./types.js";
+
+/** Returns a fixed credential. Use for local dev, tests, or a pre-resolved secret. */
+export class StaticGitCredentialProvider implements IGitCredentialProvider {
+  constructor(private readonly credential: GitCredential) {}
+
+  async getGitCredential(): Promise<GitCredential> {
+    return this.credential;
+  }
+
+  invalidate(): void {
+    // no-op for a static credential
+  }
+}
+
+/** A function that fetches a fresh git credential from an external source (e.g. a secret manager). */
+export type GitCredentialFetcher = () => Promise<GitCredential>;
+
+export interface CachedGitCredentialProviderOptions {
+  fetcher: GitCredentialFetcher;
+  /** Refresh buffer in ms since last fetch (no expiresAt concept on GitCredential, so this is a flat TTL). Default: 10 minutes. */
+  cacheTtlMs?: number;
+  logger?: StorageLogger;
+}
+
+const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000;
+
+/** Generic cached git credential provider — in-memory cache, forced invalidation on push auth failure. */
+export class CachedGitCredentialProvider implements IGitCredentialProvider {
+  private cached: GitCredential | null = null;
+  private fetchedAt = 0;
+  private readonly cacheTtlMs: number;
+  private readonly fetcher: GitCredentialFetcher;
+  private readonly logger?: StorageLogger;
+  private fetchPromise: Promise<GitCredential> | null = null;
+
+  constructor(opts: CachedGitCredentialProviderOptions) {
+    this.fetcher = opts.fetcher;
+    this.cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.logger = opts.logger;
+  }
+
+  async getGitCredential(): Promise<GitCredential> {
+    if (this.cached && Date.now() - this.fetchedAt < this.cacheTtlMs) {
+      return this.cached;
+    }
+    if (!this.fetchPromise) {
+      this.fetchPromise = this.refresh();
+    }
+    try {
+      return await this.fetchPromise;
+    } finally {
+      this.fetchPromise = null;
+    }
+  }
+
+  invalidate(): void {
+    this.logger?.debug?.(`[storage][git-credential] cache invalidated`);
+    this.cached = null;
+    this.fetchedAt = 0;
+    this.fetchPromise = null;
+  }
+
+  private async refresh(): Promise<GitCredential> {
+    try {
+      const credential = await this.fetcher();
+      this.cached = credential;
+      this.fetchedAt = Date.now();
+      return credential;
+    } catch (err) {
+      if (this.cached) {
+        this.logger?.warn(`[storage][git-credential] refresh failed, using stale cache: ${err}`);
+        return this.cached;
+      }
+      throw err;
+    }
+  }
+}

--- a/MemoryCore/src/core/storage/index.ts
+++ b/MemoryCore/src/core/storage/index.ts
@@ -13,7 +13,10 @@
 export type {
   IStorageBackend,
   ICredentialProvider,
+  IGitCredentialProvider,
+  GitCredential,
   StorageBackendConfig,
+  GitStorageBackendConfig,
   StorageObject,
   PutObjectOptions,
   ListObjectsOptions,
@@ -28,6 +31,13 @@ export { StoragePaths } from "./types.js";
 export { LocalStorageBackend } from "./local-backend.js";
 export type { LocalStorageBackendOptions } from "./local-backend.js";
 export { StorageAdapter } from "./adapter.js";
+export { resolveSafeRelativePath } from "./path-safety.js";
+
+// Git backend (experimental — see docs/rfc/git-storage-backend.md). No
+// optional npm dependency (shells out to the system `git` binary), so unlike
+// COS it doesn't need dynamic import — always available like local.
+export { GitStorageBackend, buildBranchName } from "./git-backend.js";
+export type { GitStorageBackendOptions, GitSyncStatus, GitSyncSummary, BranchNameSeed } from "./git-backend.js";
 
 // Generic credential primitives (no cloud-vendor dependency)
 export {
@@ -43,6 +53,14 @@ export type {
   CredentialFetcher,
   CachedCredentialProviderOptions,
 } from "./credential-provider.js";
+export {
+  StaticGitCredentialProvider,
+  CachedGitCredentialProvider,
+} from "./git-credential.js";
+export type {
+  GitCredentialFetcher,
+  CachedGitCredentialProviderOptions,
+} from "./git-credential.js";
 
 // Factory (dynamically loads optional COS backend when requested)
 export {

--- a/MemoryCore/src/core/storage/local-backend.test.ts
+++ b/MemoryCore/src/core/storage/local-backend.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { LocalStorageBackend } from "./local-backend.js";
+import { runStorageBackendContractTests } from "./__tests__/storage-backend.contract.js";
+
+runStorageBackendContractTests("LocalStorageBackend", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "storage-local-"));
+  return {
+    backend: new LocalStorageBackend({ rootDir }),
+    teardown: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+});
+
+describe("LocalStorageBackend — backend-specific behavior", () => {
+  it("reports type 'local'", () => {
+    const backend = new LocalStorageBackend({ rootDir: "/tmp/unused" });
+    expect(backend.type).toBe("local");
+  });
+
+  it("accepts a bare string rootDir for backwards compatibility", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "storage-local-strctor-"));
+    try {
+      const backend = new LocalStorageBackend(rootDir);
+      await backend.putObject("a.md", "x");
+      expect(await backend.exists("a.md")).toBe(true);
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stores contentType/metadata in a sidecar .meta.json and hides it from listObjects", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "storage-local-meta-"));
+    try {
+      const backend = new LocalStorageBackend({ rootDir });
+      await backend.putObject("scene_blocks/note.md", "hi", {
+        contentType: "text/markdown",
+        metadata: { author: "test" },
+      });
+      const obj = await backend.getObject("scene_blocks/note.md");
+      expect(obj!.contentType).toBe("text/markdown");
+      expect(obj!.metadata).toEqual({ author: "test" });
+
+      const listed = await backend.listObjects("scene_blocks/", { recursive: true });
+      const keys = listed.entries.map((e) => e.key);
+      expect(keys).toContain("scene_blocks/note.md");
+      expect(keys.some((k) => k.endsWith(".meta.json"))).toBe(false);
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("deleteObject also removes the .meta.json sidecar", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "storage-local-meta-del-"));
+    try {
+      const backend = new LocalStorageBackend({ rootDir });
+      await backend.putObject("persona.md", "hi", { contentType: "text/markdown" });
+      await backend.deleteObject("persona.md");
+      expect(await backend.exists("persona.md")).toBe(false);
+      // No direct way to check the sidecar via IStorageBackend; re-put without
+      // metadata and confirm getObject doesn't resurrect stale contentType.
+      await backend.putObject("persona.md", "hi again");
+      const obj = await backend.getObject("persona.md");
+      expect(obj!.contentType).toBeUndefined();
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a key that escapes rootDir via a sibling-directory-name trick", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "storage-local-sibling-"));
+    try {
+      const backend = new LocalStorageBackend({ rootDir });
+      // e.g. rootDir = "/tmp/storage-local-sibling-abc", key tries to escape
+      // to a sibling dir whose name starts with the same prefix.
+      await expect(
+        backend.putObject(`../${rootDir.split("/").pop()}-evil/x.md`, "x"),
+      ).rejects.toThrow(/traversal/i);
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/MemoryCore/src/core/storage/local-backend.ts
+++ b/MemoryCore/src/core/storage/local-backend.ts
@@ -7,7 +7,7 @@
 
 import { readFile, writeFile, mkdir, readdir, unlink, stat, rm, appendFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, dirname, sep, resolve } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import type {
   IStorageBackend,
   StorageObject,
@@ -17,6 +17,7 @@ import type {
   ListEntry,
   StorageLogger,
 } from "./types.js";
+import { resolveSafeRelativePath } from "./path-safety.js";
 
 const TAG = "[storage][local]";
 
@@ -51,40 +52,11 @@ export class LocalStorageBackend implements IStorageBackend {
    * rootDir). Affects standalone mode where user-controllable fields like
    * instanceId / sceneName / sessionKey end up in the key.
    *
-   * Rejected:
-   * - Empty key
-   * - Keys containing NUL (\0) — POSIX/Linux path terminator, can confuse
-   *   downstream tooling (sqlite, file managers).
-   * - Keys with leading "/" or "\" (absolute paths).
-   * - Keys whose resolved path falls outside rootDir (../ traversal).
+   * Validation itself lives in `path-safety.ts`, shared with other backends
+   * (e.g. GitStorageBackend) that need the same guard.
    */
   private resolvePath(key: string): string {
-    if (!key || typeof key !== "string") {
-      throw new Error(`Invalid storage key: ${JSON.stringify(key)}`);
-    }
-    if (key.includes("\0")) {
-      throw new Error("Storage key must not contain NUL character");
-    }
-    if (key.startsWith("/") || key.startsWith("\\")) {
-      throw new Error(`Storage key must be relative, got absolute: ${key}`);
-    }
-
-    // Normalize key separators to OS path separators
-    const normalized = key.split("/").join(sep);
-
-    // Compute the absolute resolved path; resolve() collapses ".." segments.
-    const absRoot = resolve(this.rootDir);
-    const absResolved = resolve(absRoot, normalized);
-
-    // Ensure the resolved path stays inside rootDir. Append sep so that
-    // a key like "../rootDir2/foo" (which resolves to a sibling directory
-    // whose name happens to start with rootDir's name) is also rejected.
-    const rootWithSep = absRoot.endsWith(sep) ? absRoot : absRoot + sep;
-    if (absResolved !== absRoot && !absResolved.startsWith(rootWithSep)) {
-      throw new Error(`Path traversal rejected: key "${key}" escapes rootDir`);
-    }
-
-    return absResolved;
+    return resolve(this.rootDir, resolveSafeRelativePath(this.rootDir, key));
   }
 
   async putObject(key: string, content: string | Buffer, opts?: PutObjectOptions): Promise<void> {

--- a/MemoryCore/src/core/storage/path-safety.test.ts
+++ b/MemoryCore/src/core/storage/path-safety.test.ts
@@ -1,0 +1,45 @@
+import { resolve, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveSafeRelativePath } from "./path-safety.js";
+
+const ROOT = "/tmp/path-safety-fixture-root";
+
+describe("resolveSafeRelativePath", () => {
+  it("resolves a simple relative key", () => {
+    expect(resolveSafeRelativePath(ROOT, "a.md")).toBe("a.md");
+  });
+
+  it("resolves a nested relative key using OS separators", () => {
+    expect(resolveSafeRelativePath(ROOT, "scene_blocks/a.md")).toBe(`scene_blocks${sep}a.md`);
+  });
+
+  it("collapses '.' segments to the empty relative path", () => {
+    expect(resolveSafeRelativePath(ROOT, ".")).toBe("");
+  });
+
+  it("round-trips with resolve(rootDir, result) back to the same absolute path", () => {
+    const rel = resolveSafeRelativePath(ROOT, "conversations/2026-08-15.jsonl");
+    expect(resolve(ROOT, rel)).toBe(resolve(ROOT, "conversations", "2026-08-15.jsonl"));
+  });
+
+  const badKeys: Array<[string, string]> = [
+    ["empty string", ""],
+    ["NUL byte", "records/\0evil"],
+    ["leading slash (absolute)", "/etc/passwd"],
+    ["leading backslash", "\\evil"],
+    ["parent traversal", "../../../etc/passwd"],
+    ["parent traversal with valid prefix", "scene_blocks/../../../etc/passwd"],
+    ["sibling-directory-name bypass", `../${ROOT.split("/").pop()}-evil/x.md`],
+  ];
+
+  for (const [label, key] of badKeys) {
+    it(`rejects ${label}`, () => {
+      expect(() => resolveSafeRelativePath(ROOT, key)).toThrow();
+    });
+  }
+
+  it("rejects a non-string key", () => {
+    // @ts-expect-error — deliberately passing a bad type to prove the runtime guard
+    expect(() => resolveSafeRelativePath(ROOT, null)).toThrow();
+  });
+});

--- a/MemoryCore/src/core/storage/path-safety.ts
+++ b/MemoryCore/src/core/storage/path-safety.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared storage-key traversal guard.
+ *
+ * Extracted from LocalStorageBackend's `resolvePath` (CR-6 fix, 2026-05-19)
+ * so every IStorageBackend implementation that maps a key onto a real
+ * filesystem path (local, git, ...) validates it identically instead of
+ * carrying its own copy that could drift.
+ */
+import { sep, resolve, relative } from "node:path";
+
+/**
+ * Validate a storage key and resolve it to a safe path relative to `rootDir`.
+ *
+ * Rejected:
+ * - Empty key
+ * - Keys containing NUL (\0)
+ * - Keys with a leading "/" or "\" (absolute paths)
+ * - Keys whose resolved path falls outside rootDir (../ traversal, including
+ *   the "sibling directory with the same name prefix" bypass)
+ *
+ * @returns The key's path relative to rootDir, using OS-native separators
+ *   (e.g. "" for the root itself, "scene_blocks/a.md" → "scene_blocks<sep>a.md").
+ *   Callers that need an absolute path can `resolve(rootDir, result)`.
+ */
+export function resolveSafeRelativePath(rootDir: string, key: string): string {
+  if (!key || typeof key !== "string") {
+    throw new Error(`Invalid storage key: ${JSON.stringify(key)}`);
+  }
+  if (key.includes("\0")) {
+    throw new Error("Storage key must not contain NUL character");
+  }
+  if (key.startsWith("/") || key.startsWith("\\")) {
+    throw new Error(`Storage key must be relative, got absolute: ${key}`);
+  }
+
+  // Normalize key separators to OS path separators
+  const normalized = key.split("/").join(sep);
+
+  // Compute the absolute resolved path; resolve() collapses ".." segments.
+  const absRoot = resolve(rootDir);
+  const absResolved = resolve(absRoot, normalized);
+
+  // Ensure the resolved path stays inside rootDir. Append sep so that
+  // a key like "../rootDir2/foo" (which resolves to a sibling directory
+  // whose name happens to start with rootDir's name) is also rejected.
+  const rootWithSep = absRoot.endsWith(sep) ? absRoot : absRoot + sep;
+  if (absResolved !== absRoot && !absResolved.startsWith(rootWithSep)) {
+    throw new Error(`Path traversal rejected: key "${key}" escapes rootDir`);
+  }
+
+  return relative(absRoot, absResolved);
+}

--- a/MemoryCore/src/core/storage/types.ts
+++ b/MemoryCore/src/core/storage/types.ts
@@ -240,15 +240,17 @@ export interface GitStorageBackendConfig {
   localRootDir: string;
   /** Private remote URL. */
   remoteUrl: string;
-  /** Resolved credential provider (never a plaintext token). */
+  /** Resolved credential provider (never a plaintext token). Encapsulates authMethod. */
   credentialProvider: IGitCredentialProvider;
-  authMethod: "http-token" | "ssh";
-  sshKeyPath?: string;
-  batchWindowMs: number;
-  maxBatchDelayMs: number;
-  lockTtlMs: number;
-  maxPushRetries: number;
-  recoveryMode: "manual" | "auto-wal-only";
+  /** Raw (unsanitized) tenant/instance identifiers this backend instance's branch is derived from. */
+  branchNameSeed: { tenantId: string; instanceId: string };
+  /** Single-writer lock backend — injected, never imported from src/core/state/* directly. */
+  stateBackend: import("../state/types.js").IStateBackend;
+  batchWindowMs?: number;
+  maxBatchDelayMs?: number;
+  lockTtlMs?: number;
+  maxPushRetries?: number;
+  recoveryMode?: "manual" | "auto-wal-only";
 }
 
 /** Configuration for creating a storage backend. */

--- a/MemoryCore/src/core/storage/types.ts
+++ b/MemoryCore/src/core/storage/types.ts
@@ -96,7 +96,7 @@ export interface ListResult {
  */
 export interface IStorageBackend {
   /** Storage backend identifier for logging/diagnostics. */
-  readonly type: "local" | "cos";
+  readonly type: "local" | "cos" | "git";
 
   /**
    * Write an object (create or overwrite).
@@ -203,19 +203,67 @@ export interface ICredentialProvider {
 }
 
 // ============================
+// Credential Types (for Git backend)
+// ============================
+
+/**
+ * Git auth credential — a reference is resolved into one of these by an
+ * `IGitCredentialProvider` implementation supplied by the host wiring layer.
+ * Never stored in config as a plaintext token (config only ever holds a
+ * `credentialRef: string` — see `GitStorageConfig` in src/config.ts).
+ */
+export type GitCredential =
+  | { authMethod: "http-token"; token: string; username?: string }
+  | { authMethod: "ssh"; privateKeyPath: string; knownHostsPath?: string };
+
+/**
+ * Credential provider abstraction for the Git storage backend — mirrors
+ * `ICredentialProvider`'s shape (cached, invalidate-on-rejection) but for
+ * git auth instead of COS. Deployment-specific resolution of a
+ * `credentialRef` into a real `GitCredential` lives outside core storage.
+ */
+export interface IGitCredentialProvider {
+  /** Get current valid git credentials (may return cached). */
+  getGitCredential(): Promise<GitCredential>;
+
+  /** Force invalidate cached credentials, e.g. after an auth-rejected push. */
+  invalidate(): void;
+}
+
+// ============================
 // Storage Configuration
 // ============================
 
+/** Git backend configuration, resolved and ready to construct a GitStorageBackend. */
+export interface GitStorageBackendConfig {
+  /** Local clone root; one subdirectory per memory-space branch. */
+  localRootDir: string;
+  /** Private remote URL. */
+  remoteUrl: string;
+  /** Resolved credential provider (never a plaintext token). */
+  credentialProvider: IGitCredentialProvider;
+  authMethod: "http-token" | "ssh";
+  sshKeyPath?: string;
+  batchWindowMs: number;
+  maxBatchDelayMs: number;
+  lockTtlMs: number;
+  maxPushRetries: number;
+  recoveryMode: "manual" | "auto-wal-only";
+}
+
 /** Configuration for creating a storage backend. */
 export interface StorageBackendConfig {
-  /** Backend type: "local" for dev, "cos" for production. */
-  type: "local" | "cos";
+  /** Backend type: "local" for dev, "cos" for production, "git" (experimental). */
+  type: "local" | "cos" | "git";
 
   /** Local backend: root directory for file storage. */
   localRootDir?: string;
 
   /** COS backend: credential provider instance. */
   credentialProvider?: ICredentialProvider;
+
+  /** Git backend: resolved config (only used when type === "git"). */
+  git?: GitStorageBackendConfig;
 }
 
 /** Minimal logger interface for storage operations. */

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -633,6 +633,9 @@ export class TdaiGateway {
         getSharedCosClient: () => this.sharedCosClient,
         getConfigProvider: () => this.configProvider,
         getStateBackend: () => this.stateBackend,
+        // Historically this call site never threw — it always fell back to
+        // local storage when COS wasn't available, regardless of deployMode.
+        allowLocalFallbackOnCosUnavailable: true,
         errorContext: "default storage",
       });
       this.core.setStorage(adapter);
@@ -1310,9 +1313,30 @@ export class TdaiGateway {
       }
     }
 
-    // 3. Delete COS objects for this instance
+    // 3. Delete COS objects for this instance / dispose git storage.
+    // git storage's remote branch and local clone are deliberately NOT
+    // deleted here — Git cannot verifiably erase history (RFC结论8), so
+    // "instance destroy" only stops this process from tracking the space
+    // further, it does not attempt the out-of-scope deletion semantics COS
+    // gets below. Best-effort flush first so a pending local write isn't
+    // silently stranded the moment the adapter is evicted and its timers
+    // disposed.
+    const evictedAdapter = this.cosStorageCache?.get(instanceId);
     if (this.cosStorageCache?.has(instanceId)) {
       this.cosStorageCache.delete(instanceId);
+    }
+    if (evictedAdapter?.getBackend().type === "git") {
+      const gitBackend = evictedAdapter.getBackend() as GitStorageBackend;
+      try {
+        await gitBackend.flush();
+      } catch (err) {
+        this.logger.warn(
+          `${tag} final git storage flush before instance destroy failed (pending local writes may be stranded): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      gitBackend.dispose();
+      cleaned.git_storage_disposed = true;
+      this.logger.info(`${tag} git storage adapter disposed for instance ${instanceId} (remote branch and local clone not deleted)`);
     }
     if (this.sharedCosClient && this.configProvider) {
       try {
@@ -1395,15 +1419,25 @@ export class TdaiGateway {
    * summary.
    */
   private collectGitStorageHealth(): GitStorageHealthSummary | undefined {
-    if (!this.cosStorageCache) return undefined;
     let enabledSpaceCount = 0;
     let unsyncedSpaceCount = 0;
     let oldestPendingPushAgeMs: number | null = null;
     const severityOrder: GitStorageHealthSummary["worstStatus"][] = ["clean", "dirty-local", "pushing", "replaying", "push-failed"];
     let worstIdx = 0;
     const now = Date.now();
+    const seen = new Set<StorageAdapter>();
 
-    for (const adapter of this.cosStorageCache.values()) {
+    // start()'s core-default-storage resolution uses a throwaway cache Map
+    // (it's a single one-off value, not per-instance), so it would never
+    // show up by scanning cosStorageCache alone — check this.core.getStorage()
+    // too, deduped by reference in case a future change makes them overlap.
+    const defaultStorage = this.core.getStorage();
+    const candidates: StorageAdapter[] = defaultStorage ? [defaultStorage] : [];
+    if (this.cosStorageCache) candidates.push(...this.cosStorageCache.values());
+
+    for (const adapter of candidates) {
+      if (seen.has(adapter)) continue;
+      seen.add(adapter);
       const backend = adapter.getBackend();
       if (backend.type !== "git") continue;
       enabledSpaceCount++;
@@ -1411,8 +1445,8 @@ export class TdaiGateway {
       if (summary.status !== "clean") unsyncedSpaceCount++;
       const idx = severityOrder.indexOf(summary.status);
       if (idx > worstIdx) worstIdx = idx;
-      if (summary.status !== "clean") {
-        const age = summary.lastPushedAt ? now - summary.lastPushedAt : now;
+      if (summary.oldestPendingOpTs !== null) {
+        const age = now - summary.oldestPendingOpTs;
         if (oldestPendingPushAgeMs === null || age > oldestPendingPushAgeMs) oldestPendingPushAgeMs = age;
       }
     }
@@ -2568,16 +2602,28 @@ export class TdaiGateway {
           }
         }
 
-        // Set Core default storage to COS
-        const defaultInstanceId = this.config.instanceId ?? "default";
-        const defaultPrefix = `${cosConfig.pathPrefix.replace(/\/$/, '')}/${defaultInstanceId}/`;
-        const cosBackend = new CosStorageBackend({
-          sharedClient: this.sharedCosClient,
-          prefix: defaultPrefix,
-          logger: this.logger,
-        });
-        this.core.setStorage(new StorageAdapter(cosBackend));
-        this.logger.info(`${TAG} Core default storage switched to COS (prefix=${defaultPrefix})`);
+        // Set Core default storage to COS — unless the operator explicitly
+        // selected a different backend for it. Without this check, an
+        // explicit fileStorageBackend="local"|"git" would be silently
+        // overridden here whenever COS itself is reachable, even though
+        // resolveFileStorageBackend() correctly honors the selection for
+        // every per-instance path.
+        const explicitSelection = this.config.memory.fileStorageBackend;
+        if (explicitSelection !== "local" && explicitSelection !== "git") {
+          const defaultInstanceId = this.config.instanceId ?? "default";
+          const defaultPrefix = `${cosConfig.pathPrefix.replace(/\/$/, '')}/${defaultInstanceId}/`;
+          const cosBackend = new CosStorageBackend({
+            sharedClient: this.sharedCosClient,
+            prefix: defaultPrefix,
+            logger: this.logger,
+          });
+          this.core.setStorage(new StorageAdapter(cosBackend));
+          this.logger.info(`${TAG} Core default storage switched to COS (prefix=${defaultPrefix})`);
+        } else {
+          this.logger.info(
+            `${TAG} SharedCosClient ready, but core default storage left for fileStorageBackend=${explicitSelection} to claim`,
+          );
+        }
         return;
       } catch (err) {
         this.logger.warn(`${TAG} COS init attempt ${attempt}/${maxRetries} failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -32,6 +32,7 @@ import { createExtractorAdapter, SkillExtractor as SkillExtractorClass } from ".
 import type { SkillCore as SkillCoreType } from "../core/skill/skill-core.js";
 import type {
   HealthResponse,
+  GitStorageHealthSummary,
   RecallRequest,
   RecallResponse,
   CaptureRequest,
@@ -110,8 +111,9 @@ import type { OffloadV2Deps } from "../offload_server/router.js";
 import { resolveV3StrictIsolation } from "../utils/env-config.js";
 import { initServerOpikTracer } from "../offload_server/opik-tracer.js";
 import { classifyError } from "./error-handler.js";
-import { LocalStorageBackend } from "../core/storage/local-backend.js";
 import { StorageAdapter } from "../core/storage/adapter.js";
+import type { GitStorageBackend } from "../core/storage/git-backend.js";
+import { resolveFileStorageBackend } from "./storage-resolver.js";
 import type { TaskPayload } from "../core/state/types.js";
 import type { TaskExecutor } from "../services/pipeline-worker.js";
 import type { IStateBackend } from "../core/state/types.js";
@@ -618,12 +620,23 @@ export class TdaiGateway {
     await this.startIntegratedServices();
 
     // ── Initialize StorageAdapter for v2 API ──
-    // In standalone mode, use LocalStorageBackend pointing to dataDir.
+    // In standalone mode, use local/git storage pointing to dataDir.
     // In service mode, CosStorageBackend was already injected above.
     if (!this.core.getStorage()) {
-      const backend = new LocalStorageBackend(this.config.data.baseDir);
-      this.core.setStorage(new StorageAdapter(backend));
-      this.logger.info(`${TAG} StorageAdapter initialized (local: ${this.config.data.baseDir})`);
+      // Single default storage for the whole deployment (not per-instance),
+      // so a throwaway one-entry cache is fine — nothing else reads it.
+      const adapter = await resolveFileStorageBackend({
+        instanceId: "default",
+        config: this.config,
+        logger: this.logger,
+        cache: new Map(),
+        getSharedCosClient: () => this.sharedCosClient,
+        getConfigProvider: () => this.configProvider,
+        getStateBackend: () => this.stateBackend,
+        errorContext: "default storage",
+      });
+      this.core.setStorage(adapter);
+      this.logger.info(`${TAG} StorageAdapter initialized (${adapter.type}: ${this.config.data.baseDir})`);
     }
 
     // ── Skill module post-wiring (after storage is set) ──
@@ -1372,6 +1385,42 @@ export class TdaiGateway {
     }
   }
 
+  /**
+   * Aggregate sync status across every live GitStorageBackend instance
+   * cached in `cosStorageCache` (the name is historical — it holds
+   * local/COS/git adapters). Reads each instance's already-in-memory sync
+   * state only, no I/O, to stay consistent with /health's "cheap, k8s
+   * liveness-probe-safe" convention. Returns undefined when git storage
+   * isn't in use, so the field is simply absent rather than a zeroed-out
+   * summary.
+   */
+  private collectGitStorageHealth(): GitStorageHealthSummary | undefined {
+    if (!this.cosStorageCache) return undefined;
+    let enabledSpaceCount = 0;
+    let unsyncedSpaceCount = 0;
+    let oldestPendingPushAgeMs: number | null = null;
+    const severityOrder: GitStorageHealthSummary["worstStatus"][] = ["clean", "dirty-local", "pushing", "replaying", "push-failed"];
+    let worstIdx = 0;
+    const now = Date.now();
+
+    for (const adapter of this.cosStorageCache.values()) {
+      const backend = adapter.getBackend();
+      if (backend.type !== "git") continue;
+      enabledSpaceCount++;
+      const summary = (backend as GitStorageBackend).getSyncSummary();
+      if (summary.status !== "clean") unsyncedSpaceCount++;
+      const idx = severityOrder.indexOf(summary.status);
+      if (idx > worstIdx) worstIdx = idx;
+      if (summary.status !== "clean") {
+        const age = summary.lastPushedAt ? now - summary.lastPushedAt : now;
+        if (oldestPendingPushAgeMs === null || age > oldestPendingPushAgeMs) oldestPendingPushAgeMs = age;
+      }
+    }
+
+    if (enabledSpaceCount === 0) return undefined;
+    return { enabledSpaceCount, unsyncedSpaceCount, oldestPendingPushAgeMs, worstStatus: severityOrder[worstIdx]! };
+  }
+
   private handleHealth(res: http.ServerResponse): void {
     const response: HealthResponse = {
       status: this.core.getVectorStore() ? "ok" : "degraded",
@@ -1386,6 +1435,7 @@ export class TdaiGateway {
         timerScanner: this.timerScanner?.getMetrics() ?? null,
         pipelineWorker: this.pipelineWorker?.getMetrics() ?? null,
         stateBackend: this.stateBackend ? "connected" : "none",
+        gitStorage: this.collectGitStorageHealth(),
       },
     };
     sendJson(res, 200, response);
@@ -2409,55 +2459,30 @@ export class TdaiGateway {
   /**
    * Resolve per-instance StorageAdapter.
    *
-   * Two paths (both cached in `cosStorageCache` — the name is historical; it
-   * also holds LocalStorageBackend adapters in standalone mode):
-   *   - Standalone (sharedCosClient == null && deployMode==='standalone'):
-   *     LocalStorageBackend rooted at data.baseDir.
-   *   - Service: per-instance CosStorageBackend with `${pathPrefix}/${instanceId}/`.
+   * Three paths (all cached in `cosStorageCache` — the name is historical;
+   * it also holds LocalStorageBackend/GitStorageBackend adapters), decided
+   * by `resolveFileStorageBackend()`:
+   *   - fileStorageBackend="git": GitStorageBackend (experimental).
+   *   - "auto" + standalone + no shared COS client: LocalStorageBackend
+   *     rooted at data.baseDir.
+   *   - otherwise: per-instance CosStorageBackend with `${pathPrefix}/${instanceId}/`.
    *
    * Both `/v2/*` (memory) and `/v3/skill/conversation/add` need per-instance
    * storage; keeping this in one method keeps the fallback semantics identical
    * on both paths.
    */
   private async resolveStorageForInstance(instanceId: string): Promise<StorageAdapter> {
-    const cached = this.cosStorageCache?.get(instanceId);
-    if (cached) return cached;
-
-    // Standalone mode: fall back to local storage (no COS needed)
-    if (!this.sharedCosClient && this.config.deployMode === "standalone") {
-      const localDir = this.config.data.baseDir;
-      const backend = new LocalStorageBackend({ rootDir: localDir, logger: this.logger });
-      const adapter = new StorageAdapter(backend);
-      if (!this.cosStorageCache) this.cosStorageCache = new Map();
-      this.cosStorageCache.set(instanceId, adapter);
-      return adapter;
-    }
-
-    if (!this.sharedCosClient) {
-      throw new Error(`SharedCosClient not initialized for instance ${instanceId}`);
-    }
-    if (!this.configProvider) {
-      throw new Error(`configProvider not initialized for instance ${instanceId}`);
-    }
-
-    // Get current COS config to determine prefix
-    const cosConfig = await this.configProvider.resolveCos();
-    if (!cosConfig?.cosUrl) {
-      throw new Error(`COS config not available for instance ${instanceId} (Shark returned null or empty CosUrl)`);
-    }
-
-    // Per-instance CosStorageBackend: lightweight, only holds prefix
-    const { CosStorageBackend } = await import("../integrations/cos/cos-backend.js");
-    const prefix = `${cosConfig.pathPrefix.replace(/\/$/, '')}/${instanceId}/`;
-    const backend = new CosStorageBackend({
-      sharedClient: this.sharedCosClient,
-      prefix,
-      logger: this.logger,
-    });
-    const adapter = new StorageAdapter(backend);
     if (!this.cosStorageCache) this.cosStorageCache = new Map();
-    this.cosStorageCache.set(instanceId, adapter);
-    return adapter;
+    return resolveFileStorageBackend({
+      instanceId,
+      config: this.config,
+      logger: this.logger,
+      cache: this.cosStorageCache,
+      getSharedCosClient: () => this.sharedCosClient,
+      getConfigProvider: () => this.configProvider,
+      getStateBackend: () => this.stateBackend,
+      errorContext: `instance ${instanceId}`,
+    });
   }
 
   /**
@@ -2594,44 +2619,20 @@ export class TdaiGateway {
       if (!instanceId) {
         throw new Error(`Task ${task.id} missing instanceId in service mode (task.data.instanceId is required)`);
       }
-
-      // Standalone mode: use local storage (no COS needed)
-      if (!gateway.sharedCosClient && gateway.config.deployMode === "standalone") {
-        const cached = gateway.cosStorageCache?.get(instanceId);
-        if (cached) return cached;
-        const localDir = gateway.config.data.baseDir;
-        const backend = new LocalStorageBackend({ rootDir: localDir, logger: gateway.logger });
-        const adapter = new StorageAdapter(backend);
-        if (!gateway.cosStorageCache) gateway.cosStorageCache = new Map();
-        gateway.cosStorageCache.set(instanceId, adapter);
-        return adapter;
-      }
-
-      // Lazy-init COS if not yet initialized (startup may have failed)
-      if (!gateway.sharedCosClient) {
-        await gateway.initSharedCosClient();
-      }
-
-      if (!gateway.sharedCosClient) {
-        throw new Error(`SharedCosClient not initialized for worker task ${task.id} (instance=${instanceId})`);
-      }
-      const cached = gateway.cosStorageCache?.get(instanceId);
-      if (cached) return cached;
-      const cosConfig = await configProvider.resolveCos();
-      if (!cosConfig) {
-        throw new Error(`COS config not available for worker task ${task.id} (instance=${instanceId}, Shark returned null)`);
-      }
-      const { CosStorageBackend } = await import("../integrations/cos/cos-backend.js");
-      const prefix = `${cosConfig.pathPrefix.replace(/\/$/, '')}/${instanceId}/`;
-      const backend = new CosStorageBackend({
-        sharedClient: gateway.sharedCosClient,
-        prefix,
-        logger: gateway.logger,
-      });
-      const adapter = new StorageAdapter(backend);
       if (!gateway.cosStorageCache) gateway.cosStorageCache = new Map();
-      gateway.cosStorageCache.set(instanceId, adapter);
-      return adapter;
+      return resolveFileStorageBackend({
+        instanceId,
+        config: gateway.config,
+        logger: gateway.logger,
+        cache: gateway.cosStorageCache,
+        getSharedCosClient: () => gateway.sharedCosClient,
+        getConfigProvider: () => configProvider,
+        getStateBackend: () => gateway.stateBackend,
+        // Only this worker-task path lazily initializes a missing COS client
+        // (startup may have failed) — resolveStorageForInstance does not.
+        ensureCosClient: () => gateway.initSharedCosClient(),
+        errorContext: `worker task ${task.id} (instance=${instanceId})`,
+      });
     };
 
     /**

--- a/MemoryCore/src/gateway/storage-resolver.ts
+++ b/MemoryCore/src/gateway/storage-resolver.ts
@@ -54,6 +54,15 @@ export interface ResolveFileStorageBackendOptions {
   getStateBackend: () => IStateBackend | null;
   /** Only the worker-task path lazily initializes a missing COS client; resolveStorageForInstance does not (preserves existing behavior at both call sites). */
   ensureCosClient?: () => Promise<void>;
+  /**
+   * Only `start()`'s core-default-storage call site historically had an
+   * unconditional-success contract: pre-this-diff it always fell back to
+   * LocalStorageBackend rather than ever throwing, regardless of deployMode.
+   * resolveStorageForInstance/the worker-task closure correctly throw when
+   * COS is unavailable in service mode — this must default to false so
+   * their stricter behavior isn't accidentally loosened.
+   */
+  allowLocalFallbackOnCosUnavailable?: boolean;
   /** For error messages, e.g. "instance abc123" vs "worker task xyz (instance=abc123)". */
   errorContext: string;
 }
@@ -118,6 +127,12 @@ export async function resolveFileStorageBackend(opts: ResolveFileStorageBackendO
   }
   const sharedCosClient = opts.getSharedCosClient();
   if (!sharedCosClient) {
+    if (opts.allowLocalFallbackOnCosUnavailable) {
+      const backend = new LocalStorageBackend({ rootDir: opts.config.data.baseDir, logger: opts.logger });
+      const adapter = new StorageAdapterCtor(backend);
+      opts.cache.set(opts.instanceId, adapter);
+      return adapter;
+    }
     throw new Error(`SharedCosClient not initialized for ${opts.errorContext}`);
   }
   const configProvider = opts.getConfigProvider();

--- a/MemoryCore/src/gateway/storage-resolver.ts
+++ b/MemoryCore/src/gateway/storage-resolver.ts
@@ -1,0 +1,137 @@
+/**
+ * resolveFileStorageBackend — the single place that decides local vs. COS
+ * vs. git file storage for a given instance and constructs+caches its
+ * StorageAdapter.
+ *
+ * Extracted from two near-identical call sites in server.ts
+ * (`resolveStorageForInstance` and the `resolveStorage` closure inside
+ * `buildTaskExecutor`) that had drifted into slightly different shapes for
+ * the same local/COS decision. Both now delegate here; this is also where
+ * the "git" branch is added, per docs/rfc/git-storage-backend.md.
+ */
+import type { StorageAdapter } from "../core/storage/adapter.js";
+import { LocalStorageBackend, GitStorageBackend } from "../core/storage/index.js";
+import type { IGitCredentialProvider, StorageLogger } from "../core/storage/types.js";
+import { StaticGitCredentialProvider } from "../core/storage/git-credential.js";
+import type { GatewayConfig } from "./config.js";
+import type { IStateBackend } from "../core/state/types.js";
+import type { InstanceConfigProvider } from "../core/instance-config-provider.js";
+
+/**
+ * Default credentialRef resolution: treat it as an environment variable
+ * name holding the token (http-token) or nothing (ssh, where sshKeyPath
+ * itself is the secret-adjacent material, expected to already be
+ * permission-restricted on disk by the deployment). This codebase has no
+ * existing secret-manager integration to hook into for git auth — swap this
+ * for a real one as needed; the contract callers rely on is just
+ * `IGitCredentialProvider`.
+ */
+function resolveGitCredentialProvider(git: GatewayConfig["memory"]["git"]): IGitCredentialProvider {
+  if (git.authMethod === "ssh") {
+    if (!git.sshKeyPath) {
+      throw new Error(`fileStorageBackend=git authMethod=ssh requires memory.git.sshKeyPath`);
+    }
+    return new StaticGitCredentialProvider({ authMethod: "ssh", privateKeyPath: git.sshKeyPath });
+  }
+  const token = git.credentialRef ? process.env[git.credentialRef] : undefined;
+  if (!token) {
+    throw new Error(
+      `fileStorageBackend=git authMethod=http-token requires memory.git.credentialRef to name a set ` +
+        `environment variable (got credentialRef=${JSON.stringify(git.credentialRef)})`,
+    );
+  }
+  return new StaticGitCredentialProvider({ authMethod: "http-token", token });
+}
+
+export interface ResolveFileStorageBackendOptions {
+  instanceId: string;
+  config: GatewayConfig;
+  logger: StorageLogger;
+  cache: Map<string, StorageAdapter>;
+  /** Read live, not snapshotted — a COS client initialized mid-call must be visible immediately. */
+  getSharedCosClient: () => import("../integrations/cos/cos-backend.js").SharedCosClient | null;
+  getConfigProvider: () => InstanceConfigProvider | null;
+  getStateBackend: () => IStateBackend | null;
+  /** Only the worker-task path lazily initializes a missing COS client; resolveStorageForInstance does not (preserves existing behavior at both call sites). */
+  ensureCosClient?: () => Promise<void>;
+  /** For error messages, e.g. "instance abc123" vs "worker task xyz (instance=abc123)". */
+  errorContext: string;
+}
+
+export async function resolveFileStorageBackend(opts: ResolveFileStorageBackendOptions): Promise<StorageAdapter> {
+  const { StorageAdapter: StorageAdapterCtor } = await import("../core/storage/adapter.js");
+  const cached = opts.cache.get(opts.instanceId);
+  if (cached) return cached;
+
+  const selection = opts.config.memory.fileStorageBackend ?? "auto";
+
+  if (selection === "git") {
+    const git = opts.config.memory.git;
+    if (!git?.remoteUrl) {
+      throw new Error(`fileStorageBackend=git requires memory.git.remoteUrl (${opts.errorContext})`);
+    }
+    const stateBackend = opts.getStateBackend();
+    if (!stateBackend) {
+      throw new Error(
+        `fileStorageBackend=git requires a configured state backend for the single-writer lock, ` +
+          `but none is available (${opts.errorContext}). A process-local state backend would provide ` +
+          `no cross-process protection in a multi-instance deployment; configure a real distributed ` +
+          `IStateBackend before enabling the git storage backend.`,
+      );
+    }
+    const backend = new GitStorageBackend({
+      localRootDir: git.localRootDir,
+      remoteUrl: git.remoteUrl,
+      credentialProvider: resolveGitCredentialProvider(git),
+      // This codebase's isolation unit is instanceId; there's no separate
+      // tenant concept at this layer (contrast COS, which shares one bucket
+      // across instances via pathPrefix). "default" keeps the branch
+      // hierarchy shape from the RFC without inventing a fake tenant id.
+      branchNameSeed: { tenantId: "default", instanceId: opts.instanceId },
+      stateBackend,
+      batchWindowMs: git.batchWindowMs,
+      maxBatchDelayMs: git.maxBatchDelayMs,
+      lockTtlMs: git.lockTtlMs,
+      maxPushRetries: git.maxPushRetries,
+      recoveryMode: git.recoveryMode,
+      logger: opts.logger,
+    });
+    const adapter = new StorageAdapterCtor(backend);
+    opts.cache.set(opts.instanceId, adapter);
+    return adapter;
+  }
+
+  const useLocal =
+    selection === "local" ||
+    (selection === "auto" && !opts.getSharedCosClient() && opts.config.deployMode === "standalone");
+
+  if (useLocal) {
+    const backend = new LocalStorageBackend({ rootDir: opts.config.data.baseDir, logger: opts.logger });
+    const adapter = new StorageAdapterCtor(backend);
+    opts.cache.set(opts.instanceId, adapter);
+    return adapter;
+  }
+
+  // COS path
+  if (!opts.getSharedCosClient() && opts.ensureCosClient) {
+    await opts.ensureCosClient();
+  }
+  const sharedCosClient = opts.getSharedCosClient();
+  if (!sharedCosClient) {
+    throw new Error(`SharedCosClient not initialized for ${opts.errorContext}`);
+  }
+  const configProvider = opts.getConfigProvider();
+  if (!configProvider) {
+    throw new Error(`configProvider not initialized for ${opts.errorContext}`);
+  }
+  const cosConfig = await configProvider.resolveCos();
+  if (!cosConfig?.cosUrl) {
+    throw new Error(`COS config not available for ${opts.errorContext} (Shark returned null or empty CosUrl)`);
+  }
+  const { CosStorageBackend } = await import("../integrations/cos/cos-backend.js");
+  const prefix = `${cosConfig.pathPrefix.replace(/\/$/, "")}/${opts.instanceId}/`;
+  const backend = new CosStorageBackend({ sharedClient: sharedCosClient, prefix, logger: opts.logger });
+  const adapter = new StorageAdapterCtor(backend);
+  opts.cache.set(opts.instanceId, adapter);
+  return adapter;
+}

--- a/MemoryCore/src/gateway/types.ts
+++ b/MemoryCore/src/gateway/types.ts
@@ -15,6 +15,14 @@ export interface GatewayErrorResponse {
 // /health
 // ============================
 
+/** Aggregate sync status across all live GitStorageBackend instances (experimental — see docs/rfc/git-storage-backend.md). Only present when at least one instance has resolved a git-backed StorageAdapter. */
+export interface GitStorageHealthSummary {
+  enabledSpaceCount: number;
+  unsyncedSpaceCount: number;
+  oldestPendingPushAgeMs: number | null;
+  worstStatus: "clean" | "dirty-local" | "pushing" | "replaying" | "push-failed";
+}
+
 export interface HealthResponse {
   status: "ok" | "degraded";
   version: string;
@@ -28,6 +36,7 @@ export interface HealthResponse {
     timerScanner: unknown;
     pipelineWorker: unknown;
     stateBackend: string;
+    gitStorage?: GitStorageHealthSummary;
   };
 }
 


### PR DESCRIPTION
## Summary

Implements `GitStorageBackend` for `IStorageBackend`, per the RFC in #894 (`docs/rfc/git-storage-backend.md`). Experimental / single-writer-per-space pilot scope, per the RFC's own recommendation — not a default, not for high-frequency multi-writer online storage.

- **Composes, doesn't reimplement**: wraps an inner `LocalStorageBackend` for pure file I/O (`getObject`/`exists`/`listObjects`, and the file-write half of put/append/delete), layering a WAL + `SerialQueue`-serialized batched commit/push on the mutating path only.
- One independent `git clone --single-branch --no-tags` per memory space; branch names are a 128-bit hash of a length-prefixed `(tenantId, instanceId)` encoding, validated via `check-ref-format`.
- `appendObject`'s idempotency key is a backend-generated operation UUID recorded in each commit's message trailer — not a content hash, which would silently drop legitimately-duplicate content on replay.
- Single-writer lock via injected `IStateBackend` (dependency-injected, never imports `src/core/state/*` directly — respects the CI isolation red line) + in-process `SerialQueue`; git's own non-fast-forward push rejection remains the real correctness backstop.
- Shells out to the system `git` binary (`execFile`, argv arrays, never a shell string) — zero new npm dependencies.
- `server.ts` had three near-identical inline blocks deciding local-vs-COS storage; extracted into `gateway/storage-resolver.ts`'s `resolveFileStorageBackend()`, which both call sites now share, plus the new `"git"` branch. Existing local/COS behavior for deployments not using git storage is preserved (see commit `fix(memory-core): address Codex checkpoint B findings` for two real regressions caught and fixed during review).
- First-ever storage-layer test coverage in this repo: a shared `IStorageBackend` contract suite (7 methods, path traversal, pagination) runs against both `LocalStorageBackend` and `GitStorageBackend` (using a local `git init --bare` fixture, no network); git-specific tests cover crash recovery, push-rejected replay with no duplication across two uncoordinated writers, and 8 adversarial branch-name encodings. New CI `test:` job so these actually gate PRs going forward.
- **Security-sensitive**: this touches git credential handling (HTTP token / SSH key). Per `CONTRIBUTING.md`, flagging for security-focused review attention.

**Known CI gap** (not introduced by this PR, discovered while adding the `test:` job): `pr-ci.yml` triggers only on `pull_request.branches: [main]`, but this PR (like #894) targets `feat/server_team` — so none of `pr-ci.yml`'s jobs, including the new `test:` job, will actually run against this PR. Flagging for maintainers to decide whether to widen the trigger; left untouched here since it's a repo-wide CI policy decision beyond this PR's scope.

**Explicitly out of scope**: the RFC §8 migration tool (future work), Option B (per-object-version git plumbing), fixing `StorageAdapter.rename`'s pre-existing non-atomicity.

Design doc with full rationale and two rounds of Codex cross-review (design-only, then diff review) at `MemoryCore/docs/design/git-storage-backend-implementation-plan.md`.

## Test plan

- [x] `cd MemoryCore && npm test` — 101 tests pass (contract suite × local + git, crash recovery, replay dedup, branch-name edge cases, config parsing)
- [x] `tsc --strict --noEmit` against the full source tree: zero new errors vs. the pre-existing 325-error baseline (all pre-existing, unrelated to this change — e.g. optional COS/Redis modules absent from this checkout)
- [x] Manual: constructed a real `GitStorageBackend` against a `git init --bare` fixture, ran put/append/delete, inspected commit history — only the 6 RFC-declared key prefixes present, no `.meta.json`, no credentials
- [x] Manual: killed a flush mid-push, restarted with a fresh instance pointed at the same local clone, confirmed recovery resumed and completed the push without loss or duplication
- [x] Manual: two uncoordinated writers (separate local clones, separate lock backends) concurrently appending to the same key — non-fast-forward rejection correctly triggered replay, final content had both writers' lines with no duplication
- [x] `npm pack --dry-run` — no unexpected dependency/size changes (this PR adds zero new npm dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)