### PR TITLE
fix(skill-bridge): stop excluding skills the live listing sees as "already injected"

### DIFF
--- a/MemoryProxy/src/skill/__tests__/skill-bridge.test.ts
+++ b/MemoryProxy/src/skill/__tests__/skill-bridge.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Context } from "hono";
+
+import { buildConfig } from "../../config.js";
+import { getSessionStore } from "../../session/store.js";
+import { createSkillBridgeHandler } from "../skill-bridge.js";
+import type { CoreSkillClient } from "../core-client.js";
+
+// Regression test for issue #1006: skill_search used to subtract a
+// real-time /v3/skill/listing call ("C") from the whitelist, but the
+// listing is a live snapshot while <available_skills> is a session-init
+// snapshot. A skill created after session init showed up in the live
+// listing, got treated as "already injected", and was excluded from
+// search forever -- even though it was never actually in the prompt.
+// The fix drops that exclusion entirely: whitelist = A (team-shared) ∪ B
+// (agent-owned), no C subtraction.
+
+const SESSION_ID = "test-session-1006";
+const TEAM_ID = "team-1";
+const AGENT_ID = "agent-1";
+const USER_ID = "user-1";
+const SPACE_ID = "space-1";
+
+function seedSession(): void {
+  getSessionStore().set(`claude-code:${SESSION_ID}`, {
+    status: "initialized",
+    keyId: `claude-code:${SESSION_ID}`,
+    startedAt: Date.now(),
+    attemptCount: 0,
+    sessionInfo: {
+      session_id: SESSION_ID,
+      team_id: TEAM_ID,
+      agent_id: AGENT_ID,
+      user_id: USER_ID,
+      space_id: SPACE_ID,
+      user_key: "test-user-key",
+    },
+  });
+}
+
+function searchRequest(query = "toy"): Context {
+  const req = new Request("http://localhost/skill-bridge/v3/skill/search", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-conversation-id": SESSION_ID,
+      "x-tdai-service-id": SPACE_ID,
+    },
+    body: JSON.stringify({ query }),
+  });
+  return new Context(req);
+}
+
+describe("skill-bridge team search whitelist", () => {
+  beforeEach(() => {
+    seedSession();
+  });
+
+  afterEach(() => {
+    getSessionStore().delete(`claude-code:${SESSION_ID}`);
+  });
+
+  it("does not exclude a skill created after session init (issue #1006)", async () => {
+    // A: no team-shared skills (isolate the bug to B, matching the report's
+    // repro where the new skill is the agent's own, not a team asset).
+    const resolveVisibleSkillIds = async () => ({ ids: [] });
+
+    // B: the agent's full owned-skill listing -- includes a skill that was
+    // created mid-session, after the <available_skills> snapshot was taken.
+    const coreClient = {
+      listSkills: async () => ({
+        items: [{ skill_id: "new-skill-created-mid-session" }],
+      }),
+      // listListing (C) intentionally NOT called by the fixed code anymore --
+      // if the fix regresses and starts calling it again, this mock would
+      // throw and fail the test loudly rather than silently reporting the
+      // old buggy result.
+    } as unknown as CoreSkillClient;
+
+    // Upstream plugin search response: returns the mid-session skill among
+    // its hits (it's a real skill in the pool, findable by keyword/BM25).
+    const fetcher = (async () =>
+      new Response(
+        JSON.stringify({
+          code: 0,
+          message: "ok",
+          request_id: "test-req-1",
+          data: {
+            items: [
+              { skill_id: "new-skill-created-mid-session", name: "toy skill" },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    const config = buildConfig({});
+    const handler = createSkillBridgeHandler(config, {
+      resolveVisibleSkillIds,
+      coreClient,
+      fetcher,
+    });
+
+    const res = await handler(searchRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const ids = (body.data.items as Array<{ skill_id: string }>).map(
+      (item) => item.skill_id,
+    );
+    // The mid-session skill must survive the whitelist filter -- pre-fix,
+    // it would have been silently dropped to an empty items list.
+    expect(ids).toContain("new-skill-created-mid-session");
+  });
+});

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -677,16 +677,35 @@ export function createSkillBridgeHandler(
           return envelope(50001, `${TAG} team search misconfigured: session has no user_key`, 500);
         }
 
-        // Whitelist 三路并行（见 docs/design/2026-08-10-skill-search-scope-fix.md §4）：
+        // Whitelist 两路并行：
         //   A = meta list-accessible(visibility='team') — team-shared skill
         //   B = core /v3/skill/list(agent 自有全量)   — 含 private
-        //   C = core /v3/skill/listing                — 本会话已注入
-        // whitelist = (A ∪ B) − C
+        // whitelist = A ∪ B
         //
-        // 失败降级策略（三路各自 try/catch）：
+        // 曾经还有第三路 C = core /v3/skill/listing，试图扣掉"本会话已注入"的
+        // skill 以避免 skill_search 重复出现已经在 <available_skills> 里的条目。
+        // 但 C 是"当前时刻"的实时 listing，而 <available_skills> 是
+        // SkillInjector 在 session_init 时刻打的快照（cacheStrategy:
+        // "session_init"，见 skill-injector.ts）——两者在会话期间会分叉：
+        // 会话初始化之后才创建/共享的 skill 会被 C 实时捕获、当作"已注入"从
+        // whitelist 里扣掉，但它从未真正出现在这个会话的 <available_skills>
+        // 里。结果是这类 skill 既不在 prompt 里，也搜不到，直到用户开新会话
+        // 才能用上（见 issue #1006，日志 `merged=0` 稳定复现）。
+        //
+        // 去掉 C：换来的代价是 skill_search 偶尔会返回一个已经在
+        // <available_skills> 里的 skill（轻微冗余，LLM 看到重复条目，不是
+        // 错误）；换到的收益是消灭一个永久性的不可发现盲区。要精确实现"只
+        // 扣掉本会话真正注入的 skill"，需要 SkillInjector 在 prewarm 时把
+        // 实际注入的 skill id 列表（而不是当前只存的 count）落进
+        // HookCacheRepo，再让这里去读那份 session-init 快照而不是实时查
+        // listing——这是更彻底的修法，但要跨两个模块、两套身份体系
+        // （skill 域的 team_id/agent_id vs. 缓存层的 userId/agentSource/
+        // spaceId），影响面更大；这次先用更小、更能确认正确性的改法堵住
+        // 报告的具体 bug。
+        //
+        // 失败降级策略（两路各自 try/catch）：
         //   A 失败 → fail-closed 返回空（安全兜底：绝不让 LLM 看到未过滤结果）
-        //   B 失败 → 当空集，退化为 A−C（约等于修复前行为）
-        //   C 失败 → 当空集，不做减法（无害，最多让已注入 skill 占槽位）
+        //   B 失败 → 当空集，退化为仅 A
         const coreClient = deps.coreClient ?? getCoreSkillClient(config.coreSkill);
         const resolver = deps.resolveVisibleSkillIds
           ?? defaultVisibleSkillIdsResolver(config);
@@ -714,19 +733,7 @@ export function createSkillBridgeHandler(
             return [] as string[];
           });
 
-        // C 不传 query → 走 mode=full 拿 head 列表，跟 session-init 无 query 场景一致。
-        // 严格来说 session-init 可能带 query 走 BM25，结果不完全一致；这里作为"排除已知重复"
-        // 的近似，允许少量重复占槽位，不追求 100% 精确。
-        const promiseC = coreClient.listListing(
-          { team_id: ids.team_id, agent_id: ids.agent_id },
-          { serviceId: ids.space_id },
-        ).then(r => (r.hits ?? []).map(h => h.skill_id))
-          .catch(err => {
-            console.warn(`${TAG} team search C (listing) failed, treating as empty: ${(err as Error).message}`);
-            return [] as string[];
-          });
-
-        const [aResult, bIds, cIds] = await Promise.all([promiseA, promiseB, promiseC]);
+        const [aResult, bIds] = await Promise.all([promiseA, promiseB]);
 
         if (!aResult.ok) {
           // Fail-closed: A 挂掉不能降级到不过滤搜索。
@@ -738,10 +745,9 @@ export function createSkillBridgeHandler(
         }
 
         const merged = new Set<string>([...aResult.ids, ...bIds]);
-        for (const id of cIds) merged.delete(id);
         const whitelist: string[] = Array.from(merged);
         console.log(
-          `${TAG} team search whitelist A=${aResult.ids.length} B=${bIds.length} C=${cIds.length}`
+          `${TAG} team search whitelist A=${aResult.ids.length} B=${bIds.length}`
             + ` merged=${whitelist.length} user=${ids.user_id} team=${ids.team_id}`,
         );
 


### PR DESCRIPTION
Fixes #1006.

`skill_search` built its whitelist as `(A ∪ B) − C`, where C came from a real-time `/v3/skill/listing` call meant to represent "skills already injected this session". But `<available_skills>` is a snapshot taken once at session_init (`SkillInjector`'s `cacheStrategy: "session_init"`), while C is whatever the listing endpoint returns right now — the two diverge the moment a skill is created or shared mid-session. A skill created after session init shows up in the live C call, gets treated as "already injected", and gets subtracted from the whitelist — even though it was never actually in the prompt. Result: permanently undiscoverable via `skill_search` until a new session starts. Matches the reported logs (`merged=0`, stable repro).

Doing this precisely would mean having `SkillInjector` persist the actual injected skill IDs at prewarm time (it currently only stores a count) and reading that session-init snapshot here instead of querying listing live — a real fix, but one spanning two modules and two separate identity systems (skill domain's `team_id`/`agent_id` vs. the injection cache's `userId`/`agentSource`/`spaceId`). Given the risk of getting that cross-module plumbing subtly wrong without a way to verify it against live infra, I went with the smaller, safe alternative your issue also proposed: drop the C exclusion entirely. `whitelist = A ∪ B`, full stop. Cost is a skill occasionally showing up in both `<available_skills>` and a search result (mild redundancy); benefit is no more permanent blind spot.

Added the first test file in this package's skill module (`src/skill/__tests__/skill-bridge.test.ts`), driving the real `createSkillBridgeHandler` end to end — seeds a session via `getSessionStore().set()` the same way "tests that bypass bind" already do per that method's own comment, injects a fake `resolveVisibleSkillIds`/`coreClient`/`fetcher`, and asserts a mid-session-created skill survives the whitelist filter and reaches the response. The `coreClient` mock deliberately has no `listListing` method, so if the fix ever regresses back to calling it, the test fails loudly instead of silently passing on the old behavior. Confirmed it fails against unpatched code (`git stash`) with exactly that `TypeError`, passes after. Full `vitest run`: 1 passed (this is the only test file in the package so far). `tsc --noEmit`: same pre-existing unrelated errors on both sides (`anthropicHandler.ts`, `codexHandler.ts`, `config.ts`, `@context-proxy/cost-guard` module resolution), confirmed via `git stash` comparison.