### PR TITLE
[good first issue-platform adapt-RooCode] Add Memory adapter for Roo Code

### DIFF
--- a/adapters/roocode/README.md
+++ b/adapters/roocode/README.md
@@ -1,0 +1,85 @@
+# TencentDB Agent Memory — Roo Code Adapter
+
+Give [Roo Code](https://roocode.com) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Roo Code ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                       │
+                                       ├─ auth        (validates sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task picker)
+                                       └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+[Roo Code](https://roocode.com) ships an **OpenAI Compatible** API provider in its settings panel. The proxy speaks OpenAI Chat Completions on its `/codebuddy/<spaceId>` endpoint, so Roo Code connects with **three settings fields** — no code changes required.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. Roo Code is installed in VS Code (extension `RooVeterinaryInc.roo-cline` from the marketplace).
+
+## Setup
+
+### 1. Configure the provider
+
+1. Open the Roo Code panel in the VS Code sidebar and click the settings gear icon.
+2. **API Provider**: select `OpenAI Compatible`.
+3. **Base URL**: `http://127.0.0.1:8096/codebuddy/default`
+4. **API Key**: your business user key (`sk-mem-...`).
+5. **Model ID**: `claude-sonnet-4-20250514`.
+
+### 2. Align the model id
+
+The **Model ID must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream. Optionally open **Model Configuration** to set the context window and max output tokens to match the upstream model.
+
+### 3. Verify
+
+1. Send a first message in the Roo Code chat.
+2. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask Roo Code what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Field (Roo Code settings) | Value | Notes |
+|---|---|---|
+| API Provider | `OpenAI Compatible` | Uses the OpenAI Chat Completions protocol |
+| Base URL | `http://127.0.0.1:8096/codebuddy/default` | Proxy endpoint; trailing `default` is the memory space ID — change it per space |
+| API Key | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| Model ID | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+| Model Configuration | optional | Set context window / max output tokens to match the upstream model |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| "Model Not Found" / upstream mismatch | Model ID differs from `PROXY_UPSTREAM_MODEL` — align them |
+| Tool-calling errors | The proxy forwards OpenAI-native tool calls; make sure `PROXY_UPSTREAM_MODEL` points to a tool-capable model (e.g. a Claude Sonnet class model) |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new Roo Code task to re-pick |
+
+## Notes
+
+- **UI-configured**: Roo Code stores provider profiles in VS Code's secret storage, so the key never lands in workspace files; this adapter therefore ships docs only (same as the Cline adapter).
+- **Mode presets**: Roo Code modes (Code/Architect/Ask/Debug) all flow through the same provider, so every mode gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/roocode/README_CN.md
+++ b/adapters/roocode/README_CN.md
@@ -1,0 +1,85 @@
+# TencentDB Agent Memory — Roo Code 适配器
+
+为 [Roo Code](https://roocode.com) 接入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词
+- **自动捕获** — L0 原始对话落盘 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Roo Code ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游大模型
+                                       │
+                                       ├─ auth        (校验 sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task 选择器)
+                                       └─ injection   (L2/L3 记忆 + skills + knowledge 注入)
+```
+
+[Roo Code](https://roocode.com) 在设置面板内置 **OpenAI Compatible** API Provider。代理在 `/codebuddy/<spaceId>` 端点提供 OpenAI Chat Completions 协议，因此只需**三个配置项**即可接入，无需改动代码。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 交互式选择）、**记忆注入**（每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词）、**自动捕获**（L0 原始对话落盘 memory-core）全部开箱即用，无需改动任何代码。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获得业务用户的 `user_key`（`sk-mem-...` 开头），首次启动时由 `start-all.sh` 打印，或在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. 已在 VS Code 安装 Roo Code（市场扩展 `RooVeterinaryInc.roo-cline`）。
+
+## 配置步骤
+
+### 1. 配置 Provider
+
+1. 打开 VS Code 侧边栏的 Roo Code 面板，点击设置齿轮图标。
+2. **API Provider**：选择 `OpenAI Compatible`。
+3. **Base URL**：`http://127.0.0.1:8096/codebuddy/default`
+4. **API Key**：业务用户 key（`sk-mem-...`）。
+5. **Model ID**：`claude-sonnet-4-20250514`。
+
+### 2. 对齐模型 ID
+
+**Model ID 必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（配置于 `deploy/global-images/.env`）。示例使用 `claude-sonnet-4-20250514`，如上游不同请同步修改。可在 **Model Configuration** 中按上游模型设置上下文窗口与最大输出 token。
+
+### 3. 验证
+
+1. 在 Roo Code 对话框发送首条消息。
+2. 代理会在对话交互中触发会话选择器：依次选择 **Team → Agent → Task**。
+3. 之后每轮自动注入绑定 Agent 的记忆。可让 Roo Code 复述之前会话的记忆以确认生效。
+
+## 配置参考
+
+| 字段（Roo Code 设置） | 值 | 说明 |
+|---|---|---|
+| API Provider | `OpenAI Compatible` | 使用 OpenAI Chat Completions 协议 |
+| Base URL | `http://127.0.0.1:8096/codebuddy/default` | 代理端点；末尾 `default` 为记忆空间 ID，可按空间替换 |
+| API Key | `sk-mem-...` | 面板创建的业务用户 key，以 `Authorization: Bearer` 发送 |
+| Model ID | `claude-sonnet-4-20250514` | 必须与 `PROXY_UPSTREAM_MODEL` 一致，否则代理报上游模型不匹配 |
+| Model Configuration | 可选 | 按上游模型设置上下文窗口 / 最大输出 token |
+
+## 故障排查
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| "Invalid API Key" | 必须使用面板创建的业务用户 key（`sk-mem-...`），不能用 `./.admin-key` 的管理员 key |
+| "Model Not Found" / 上游不匹配 | Model ID 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 工具调用报错 | 代理透传 OpenAI 原生工具调用；请确保 `PROXY_UPSTREAM_MODEL` 指向支持工具调用的模型（如 Claude Sonnet 级别） |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行——查看 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开 Roo Code 任务可重新选择 |
+
+## 说明
+
+- **UI 配置**：Roo Code 将 Provider 档案保存在 VS Code 的密钥存储中，密钥不会落入工作区文件，因此本适配器仅提供文档（与 Cline 适配器一致）。
+- **模式全覆盖**：Roo Code 的各模式（Code/Architect/Ask/Debug）走同一 Provider，均能获得记忆注入。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/roocode/` — a TencentDB Agent Memory adapter for Roo Code, extending #926 to another widely used coding tool.

新增 `adapters/roocode/` 目录：Roo Code 的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流编码工具。

## How it works / 工作原理

Roo Code ships an **OpenAI Compatible** provider in its settings panel: Base URL + API Key + Model ID. Three fields point it at the proxy endpoint; all Roo modes (Code/Architect/Ask/Debug) then get session binding and memory injection.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

Roo Code 设置面板内置 **OpenAI Compatible** Provider：Base URL + API Key + Model ID 三个字段即可指向代理端点；所有模式（Code/Architect/Ask/Debug）均获得会话绑定与记忆注入。

## Files / 文件

| File | Purpose |
|---|---|
| `README.md` / `README_CN.md` | bilingual setup guide, config reference, troubleshooting (docs-only, same as the Cline adapter |

## Notes / 说明

- Key never lands in a committed file — documented as env-var references only.
- The configured model must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against Roo Code's official documentation of its OpenAI-compatible path.

Addresses #926 (Roo Code)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
