### PR TITLE
[good first issue-platform adapt-Continue] Add Memory adapter for Continue

### DIFF
--- a/adapters/continue/README.md
+++ b/adapters/continue/README.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Continue Adapter
+
+Give [Continue](https://docs.continue.dev) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Continue ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                       │
+                                       ├─ auth        (validates sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task picker)
+                                       └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+[Continue](https://docs.continue.dev) supports OpenAI-compatible providers in `config.yaml` via `provider: openai` plus a custom `apiBase`. Pointing `apiBase` at the proxy's `/codebuddy/<spaceId>` endpoint routes chat/edit/apply through TencentDB Agent Memory — no code changes required.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. The Continue extension is installed in VS Code / JetBrains (see [docs.continue.dev](https://docs.continue.dev)).
+
+## Setup
+
+### 1. Register the model in Continue
+
+Copy `config.example.yaml` from this directory into `~/.continue/config.yaml` (or merge the `models` entry into your existing config), then export the key:
+
+```bash
+export TDB_MEM_USER_KEY=sk-mem-...     # your business user key
+```
+
+Continue auto-reloads the config on save; the key stays in the environment and never lands in version control.
+
+### 2. Align the model id
+
+The `model` field **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 3. Verify
+
+1. Reload the VS Code window (`Ctrl/Cmd+Shift+P` → `Developer: Reload Window`).
+2. Open the Continue sidebar and pick **TencentDB Memory** in the model dropdown.
+3. Send a first chat message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+4. From this turn on, memory for the bound agent is injected automatically. Ask Continue what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Item | Value | Notes |
+|---|---|---|
+| `provider` | `openai` | Continue's OpenAI-compatible adapter |
+| `apiBase` | `http://127.0.0.1:8096/codebuddy/default` | Proxy endpoint; trailing `default` is the memory space ID — change it per space |
+| `apiKey` | `${TDB_MEM_USER_KEY}` | Env-var reference; the variable holds the `sk-mem-...` business user key |
+| `model` | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+| `roles` | `chat`, `edit`, `apply` | All three roles route through the proxy |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| "No models configured" / config not loaded | `name`, `version`, `schema` are required top-level fields — missing any of them makes the whole config fail to parse; also check YAML indentation |
+| `401` from proxy | Wrong or missing key — `TDB_MEM_USER_KEY` must be exported in the shell that launched VS Code and hold a business user key (`sk-mem-...`) |
+| `404` / connection refused | Proxy not running on `:8096`, or `apiBase` set to the full `/chat/completions` route — use the endpoint root `http://127.0.0.1:8096/codebuddy/default` only |
+| Model mismatch error | The `model` field differs from `PROXY_UPSTREAM_MODEL` — align them |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new chat to re-pick |
+
+## Notes
+
+- **Maintenance status**: the `continuedev/continue` repository concluded with its final 2.0.0 release; installed extensions keep working with custom `apiBase`, which this adapter relies on.
+- **Autocomplete excluded**: inline autocomplete is latency-sensitive — route only `chat`/`edit`/`apply` through the proxy and keep autocomplete on a direct provider.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/continue/README_CN.md
+++ b/adapters/continue/README_CN.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Continue 适配器
+
+为 [Continue](https://docs.continue.dev) 接入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词
+- **自动捕获** — L0 原始对话落盘 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Continue ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游大模型
+                                       │
+                                       ├─ auth        (校验 sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task 选择器)
+                                       └─ injection   (L2/L3 记忆 + skills + knowledge 注入)
+```
+
+[Continue](https://docs.continue.dev) 在 `config.yaml` 中通过 `provider: openai` 加自定义 `apiBase` 支持 OpenAI 兼容服务。将 `apiBase` 指向代理的 `/codebuddy/<spaceId>` 端点，即可让 chat/edit/apply 全部经由 TencentDB Agent Memory，无需改动代码。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 交互式选择）、**记忆注入**（每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词）、**自动捕获**（L0 原始对话落盘 memory-core）全部开箱即用，无需改动任何代码。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获得业务用户的 `user_key`（`sk-mem-...` 开头），首次启动时由 `start-all.sh` 打印，或在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. 已在 VS Code / JetBrains 安装 Continue 扩展（见 [docs.continue.dev](https://docs.continue.dev)）。
+
+## 配置步骤
+
+### 1. 在 Continue 中注册模型
+
+将本目录的 `config.example.yaml` 复制为 `~/.continue/config.yaml`（或将 `models` 条目合并进现有配置），并导出密钥：
+
+```bash
+export TDB_MEM_USER_KEY=sk-mem-...     # 业务用户 key
+```
+
+Continue 保存配置后自动重载；密钥保留在环境变量中，不会进入版本库。
+
+### 2. 对齐模型 ID
+
+`model` 字段**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（配置于 `deploy/global-images/.env`）。示例使用 `claude-sonnet-4-20250514`，如上游不同请同步修改。
+
+### 3. 验证
+
+1. 重载 VS Code 窗口（`Ctrl/Cmd+Shift+P` → `Developer: Reload Window`）。
+2. 打开 Continue 侧边栏，在模型下拉中选择 **TencentDB Memory**。
+3. 发送首条消息，代理会在对话交互中触发会话选择器：依次选择 **Team → Agent → Task**。
+4. 之后每轮自动注入绑定 Agent 的记忆。可让 Continue 复述之前会话的记忆以确认生效。
+
+## 配置参考
+
+| 配置项 | 值 | 说明 |
+|---|---|---|
+| `provider` | `openai` | Continue 的 OpenAI 兼容适配器 |
+| `apiBase` | `http://127.0.0.1:8096/codebuddy/default` | 代理端点；末尾 `default` 为记忆空间 ID，可按空间替换 |
+| `apiKey` | `${TDB_MEM_USER_KEY}` | 环境变量引用，变量值为 `sk-mem-...` 业务用户 key |
+| `model` | `claude-sonnet-4-20250514` | 必须与 `PROXY_UPSTREAM_MODEL` 一致，否则代理报上游模型不匹配 |
+| `roles` | `chat`、`edit`、`apply` | 三个角色均经由代理 |
+
+## 故障排查
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| "No models configured" / 配置未加载 | `name`、`version`、`schema` 为必填顶层字段——缺失任一项整份配置解析失败；同时检查 YAML 缩进 |
+| 代理返回 `401` | key 缺失或错误——启动 VS Code 的 shell 中必须导出 `TDB_MEM_USER_KEY`，且为业务用户 key（`sk-mem-...`） |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行，或 `apiBase` 误填了完整 `/chat/completions` 路径——只填端点根 `http://127.0.0.1:8096/codebuddy/default` |
+| 模型不匹配报错 | `model` 字段与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开对话可重新选择 |
+
+## 说明
+
+- **维护状态**：`continuedev/continue` 仓库止于最终版 2.0.0；已安装扩展的自定义 `apiBase` 能力仍然有效，本适配器即依赖该能力。
+- **自动补全不建议接入**：行内补全对延迟敏感——建议仅 `chat`/`edit`/`apply` 走代理，补全保持直连。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。

--- a/adapters/continue/config.example.yaml
+++ b/adapters/continue/config.example.yaml
@@ -1,0 +1,16 @@
+# ~/.continue/config.yaml  (Windows: %USERPROFILE%\.continue\config.yaml)
+name: TencentDB Agent Memory
+version: 0.0.1
+schema: v1
+
+models:
+  - name: TencentDB Memory
+    provider: openai
+    model: claude-sonnet-4-20250514
+    apiBase: http://127.0.0.1:8096/codebuddy/default
+    # keep the key in an env var instead of the file:
+    apiKey: ${TDB_MEM_USER_KEY}
+    roles:
+      - chat
+      - edit
+      - apply


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/continue/` — a TencentDB Agent Memory adapter for Continue, extending #926 to another widely used coding tool.

新增 `adapters/continue/` 目录：Continue 的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流编码工具。

## How it works / 工作原理

Continue supports OpenAI-compatible providers in `~/.continue/config.yaml` via `provider: openai` plus a custom `apiBase`. One model entry with chat/edit/apply roles routes the assistant's main traffic through the proxy.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

Continue 在 `~/.continue/config.yaml` 中通过 `provider: openai` 加自定义 `apiBase` 支持 OpenAI 兼容服务。一条携带 chat/edit/apply 角色的模型条目即可让助手主链路经由代理。

## Files / 文件

| File | Purpose |
|---|---|
| `config.example.yaml` | model entry (`provider: openai` + custom `apiBase`, env-var key) with chat/edit/apply roles |
| `README.md` / `README_CN.md` | bilingual setup guide, config reference, troubleshooting |

## Notes / 说明

- Key never lands in a committed file — documented as env-var references only.
- The configured model must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against Continue's official documentation of its OpenAI-compatible path.

Addresses #926 (Continue)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
