### PR TITLE
[good first issue-platform adapt-OpenHands] Add Memory adapter for OpenHands

### DIFF
--- a/adapters/openhands/README.md
+++ b/adapters/openhands/README.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — OpenHands Adapter
+
+Give [OpenHands](https://github.com/All-Hands-AI/OpenHands) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+OpenHands ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                       │
+                                       ├─ auth        (validates sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task picker)
+                                       └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+[OpenHands](https://github.com/All-Hands-AI/OpenHands) routes all LLM calls through LiteLLM. Setting `LLM_MODEL=openai/<model>` together with `LLM_BASE_URL` points that OpenAI-compatible client at the proxy's `/codebuddy/<spaceId>` endpoint — no code changes required.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. OpenHands is installed (`docker pull openhands/all-hands-ai` or `pip install openhands-ai`, per [docs.openhands.dev](https://docs.openhands.dev)).
+
+## Setup
+
+### 1. Point OpenHands at the proxy
+
+Environment variables (recommended — they also work for the Docker image):
+
+```bash
+export LLM_MODEL=openai/claude-sonnet-4-20250514
+export LLM_BASE_URL=http://127.0.0.1:8096/codebuddy/default
+export LLM_API_KEY=sk-mem-...        # your business user key
+```
+
+Or persist them in `config.toml` (see `config.example.toml` in this directory). In the UI the same fields live under **Settings → LLM**: set Provider/Model and API Key there, with **Base URL** under *Advanced*.
+
+### 2. Align the model name
+
+The part after `openai/` **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream. The `openai/` prefix is what makes LiteLLM use the OpenAI-compatible client with your base URL.
+
+### 3. Verify
+
+1. Start a new OpenHands conversation/task.
+2. Send the first message. The proxy triggers the session picker in the conversation interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask OpenHands what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Item | Value | Notes |
+|---|---|---|
+| `LLM_MODEL` | `openai/claude-sonnet-4-20250514` | The `openai/` prefix selects LiteLLM's OpenAI-compatible client |
+| `LLM_BASE_URL` | `http://127.0.0.1:8096/codebuddy/default` | Proxy endpoint; trailing `default` is the memory space ID — change it per space |
+| `LLM_API_KEY` | `sk-mem-...` | Business user key; sent as `Authorization: Bearer` |
+| `LLM_DROP_PARAMS` | `true` (optional) | Drops params the upstream rejects (e.g. caching headers) instead of erroring |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` from proxy | Wrong or missing key — `LLM_API_KEY` must be a business user key (`sk-mem-...`), not the admin key |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| Model mismatch error | The `openai/<model>` name differs from `PROXY_UPSTREAM_MODEL` — align them |
+| Provider errors on unknown params | Set `LLM_DROP_PARAMS=true` so LiteLLM drops unsupported params instead of failing |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous conversation already bound a task, the binding is reused — start a new conversation to re-pick |
+
+## Notes
+
+- **Agent-heavy workload**: OpenHands issues many LLM calls per task; every one of them lands in the bound agent's L0 raw dialogue, which is exactly what memory distillation expects.
+- **UI parity**: the Settings UI serializes into the same `LLM_*` schema, so UI-configured and env-configured setups behave identically.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/openhands/README_CN.md
+++ b/adapters/openhands/README_CN.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — OpenHands 适配器
+
+为 [OpenHands](https://github.com/All-Hands-AI/OpenHands) 接入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词
+- **自动捕获** — L0 原始对话落盘 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+OpenHands ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游大模型
+                                       │
+                                       ├─ auth        (校验 sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task 选择器)
+                                       └─ injection   (L2/L3 记忆 + skills + knowledge 注入)
+```
+
+[OpenHands](https://github.com/All-Hands-AI/OpenHands) 的全部 LLM 调用经由 LiteLLM。设置 `LLM_MODEL=openai/<model>` 并配合 `LLM_BASE_URL`，即可将 OpenAI 兼容客户端指向代理的 `/codebuddy/<spaceId>` 端点，无需改动代码。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 交互式选择）、**记忆注入**（每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词）、**自动捕获**（L0 原始对话落盘 memory-core）全部开箱即用，无需改动任何代码。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获得业务用户的 `user_key`（`sk-mem-...` 开头），首次启动时由 `start-all.sh` 打印，或在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. 已安装 OpenHands（`docker pull openhands/all-hands-ai` 或 `pip install openhands-ai`，见 [docs.openhands.dev](https://docs.openhands.dev)）。
+
+## 配置步骤
+
+### 1. 将 OpenHands 指向代理
+
+环境变量方式（推荐，Docker 镜像同样适用）：
+
+```bash
+export LLM_MODEL=openai/claude-sonnet-4-20250514
+export LLM_BASE_URL=http://127.0.0.1:8096/codebuddy/default
+export LLM_API_KEY=sk-mem-...        # 业务用户 key
+```
+
+也可固化到 `config.toml`（见本目录 `config.example.toml`）。UI 中对应 **Settings → LLM**：Provider/Model 与 API Key 直接填写，**Base URL** 在 *Advanced* 中设置。
+
+### 2. 对齐模型名
+
+`openai/` 之后的部分**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（配置于 `deploy/global-images/.env`）。示例使用 `claude-sonnet-4-20250514`，如上游不同请同步修改。`openai/` 前缀使 LiteLLM 采用 OpenAI 兼容客户端并使用自定义 base URL。
+
+### 3. 验证
+
+1. 新建 OpenHands 会话/任务。
+2. 发送首条消息，代理会在会话交互中触发会话选择器：依次选择 **Team → Agent → Task**。
+3. 之后每轮自动注入绑定 Agent 的记忆。可让 OpenHands 复述之前会话的记忆以确认生效。
+
+## 配置参考
+
+| 配置项 | 值 | 说明 |
+|---|---|---|
+| `LLM_MODEL` | `openai/claude-sonnet-4-20250514` | `openai/` 前缀使 LiteLLM 选择 OpenAI 兼容客户端 |
+| `LLM_BASE_URL` | `http://127.0.0.1:8096/codebuddy/default` | 代理端点；末尾 `default` 为记忆空间 ID，可按空间替换 |
+| `LLM_API_KEY` | `sk-mem-...` | 业务用户 key，以 `Authorization: Bearer` 发送 |
+| `LLM_DROP_PARAMS` | `true`（可选） | 丢弃上游不支持的字段（如缓存头），避免直接报错 |
+
+## 故障排查
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| 代理返回 `401` | key 缺失或错误——`LLM_API_KEY` 必须为业务用户 key（`sk-mem-...`），不能用管理员 key |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行——查看 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 模型不匹配报错 | `openai/<model>` 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 上游报未知参数错误 | 设置 `LLM_DROP_PARAMS=true`，让 LiteLLM 丢弃不支持的字段而非失败 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新建会话可重新选择 |
+
+## 说明
+
+- **高频调用场景**：OpenHands 每个任务会发起大量 LLM 调用，全部进入绑定 Agent 的 L0 原始对话，恰好是记忆蒸馏所需的输入。
+- **UI 同构**：设置界面最终序列化为同一套 `LLM_*` 配置，UI 配置与环境变量配置行为一致。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。

--- a/adapters/openhands/config.example.toml
+++ b/adapters/openhands/config.example.toml
@@ -1,0 +1,6 @@
+# OpenHands config.toml — [llm] section (see docs.openhands.dev)
+# Equivalent env vars: LLM_MODEL / LLM_BASE_URL / LLM_API_KEY
+[llm]
+model = "openai/claude-sonnet-4-20250514"
+base_url = "http://127.0.0.1:8096/codebuddy/default"
+api_key = "sk-mem-..."   # prefer the LLM_API_KEY env var over committing the key


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/openhands/` — a TencentDB Agent Memory adapter for OpenHands, extending #926 to another widely used coding tool.

新增 `adapters/openhands/` 目录：OpenHands 的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流编码工具。

## How it works / 工作原理

OpenHands routes all LLM calls through LiteLLM: `LLM_MODEL=openai/<model>` + `LLM_BASE_URL` points its OpenAI-compatible client at the proxy. Agent-heavy workloads land fully in the bound agent's L0 raw dialogue.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

OpenHands 的全部 LLM 调用经由 LiteLLM：`LLM_MODEL=openai/<model>` + `LLM_BASE_URL` 将其 OpenAI 兼容客户端指向代理。Agent 高频调用量恰好完整落入绑定 Agent 的 L0 原始对话。

## Files / 文件

| File | Purpose |
|---|---|
| `config.example.toml` | `[llm]` section (model `openai/<upstream>` + `base_url` + key) |
| `README.md` / `README_CN.md` | bilingual setup guide, config reference, troubleshooting |

## Notes / 说明

- Key never lands in a committed file — documented as env-var references only.
- The configured model must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against OpenHands's official documentation of its OpenAI-compatible path.

Addresses #926 (OpenHands)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
