### PR TITLE
fix(proxy): accept SSE data fields without the optional space

### DIFF
--- a/MemoryProxy/src/__tests__/sseDataValue.test.ts
+++ b/MemoryProxy/src/__tests__/sseDataValue.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { sseDataValue } from "../anthropicHandler.js";
+
+describe("sseDataValue", () => {
+  it("reads a data field written with the conventional space", () => {
+    expect(sseDataValue('data: {"type":"ping"}')).toBe('{"type":"ping"}');
+  });
+
+  // Previously the SSE parsers matched only `"data: "`, so a conforming
+  // upstream that omitted the optional space had its frames skipped — and the
+  // thinking-fix stream exists precisely for upstreams that do not conform.
+  it("reads a data field written without the optional space", () => {
+    expect(sseDataValue('data:{"type":"ping"}')).toBe('{"type":"ping"}');
+  });
+
+  it("strips only the single framing space", () => {
+    expect(sseDataValue("data:  padded")).toBe(" padded");
+  });
+
+  it("reads an empty data field either way", () => {
+    expect(sseDataValue("data:")).toBe("");
+    expect(sseDataValue("data: ")).toBe("");
+  });
+
+  it("ignores lines that are not data fields", () => {
+    expect(sseDataValue("event: message")).toBeUndefined();
+    expect(sseDataValue(": keep-alive")).toBeUndefined();
+    expect(sseDataValue("")).toBeUndefined();
+  });
+
+  it("does not treat a longer field name as data", () => {
+    expect(sseDataValue("database: value")).toBeUndefined();
+  });
+
+  it("distinguishes a missing data field from an empty one", () => {
+    // The stream loop relies on `undefined` meaning "no data line in this
+    // frame"; an empty string is a real, empty data field.
+    expect(sseDataValue("data:")).not.toBeUndefined();
+    expect(sseDataValue("id: 1")).toBeUndefined();
+  });
+});

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -1627,6 +1627,20 @@ export async function handleAnthropicMessages(
 
 
 /**
+ * Value of an SSE `data` field, or undefined when the line is not one.
+ *
+ * The space after the colon is optional framing per the SSE spec, and the
+ * non-Anthropic upstreams this module exists to patch are exactly the ones
+ * that may omit it — so matching only `"data: "` would skip the frames that
+ * most need patching.
+ */
+export function sseDataValue(line: string): string | undefined {
+  if (!line.startsWith("data:")) return undefined;
+  const value = line.slice(5);
+  return value.startsWith(" ") ? value.slice(1) : value;
+}
+
+/**
  * Create a TransformStream that patches Anthropic SSE events in-band.
  */
 function createSseThinkingFixStream(
@@ -1646,20 +1660,22 @@ function createSseThinkingFixStream(
 
       for (const part of parts) {
         const lines = part.split("\n");
-        let dataLine = "";
+        let dataStr = "";
+        let dataLineIndex = -1;
 
-        for (const line of lines) {
-          if (line.startsWith("data: ")) {
-            dataLine = line;
+        for (let i = 0; i < lines.length; i++) {
+          const value = sseDataValue(lines[i]!);
+          if (value !== undefined) {
+            dataStr = value;
+            dataLineIndex = i;
           }
         }
 
-        if (!dataLine) {
+        if (dataLineIndex === -1) {
           controller.enqueue(encoder.encode(part + "\n\n"));
           continue;
         }
 
-        const dataStr = dataLine.slice(6);
         if (!dataStr || dataStr === "[DONE]") {
           controller.enqueue(encoder.encode(part + "\n\n"));
           continue;
@@ -1701,9 +1717,9 @@ function createSseThinkingFixStream(
           if (patched) {
             patchedCount++;
             const newDataLine = "data: " + JSON.stringify(evt);
-            const newLines = lines.map((l) =>
-              l.startsWith("data: ") ? newDataLine : l,
-            );
+            // Replace the data line we actually parsed. Matching by prefix
+            // would rewrite every data line in the frame with the same value.
+            const newLines = lines.map((l, i) => (i === dataLineIndex ? newDataLine : l));
             controller.enqueue(encoder.encode(newLines.join("\n") + "\n\n"));
           } else {
             controller.enqueue(encoder.encode(part + "\n\n"));
@@ -2103,9 +2119,8 @@ function consumeAnthropicStream(stream: ReadableStream<Uint8Array>, ctx: Anthrop
         const lines = sseBuf.split("\n");
         let dataStr = "";
         for (const line of lines) {
-          if (line.startsWith("data: ")) {
-            dataStr = line.slice(6);
-          }
+          const value = sseDataValue(line);
+          if (value !== undefined) dataStr = value;
         }
         if (dataStr && dataStr !== "[DONE]") {
           try {

--- a/MemoryProxy/src/workbuddyHandler.ts
+++ b/MemoryProxy/src/workbuddyHandler.ts
@@ -26,6 +26,7 @@ import { joinUrl } from "./guard-adapter.js";
 import { verifyUserKey } from "./auth.js";
 import { resolveModelId } from "./pricing.js";
 import { workbuddyAdapter } from "./agent-adapters/workbuddy.js";
+import { sseDataValue } from "./anthropicHandler.js";
 import {
   buildWorkbuddyInjectionBlock,
   type WorkbuddyInjectionInput,
@@ -693,8 +694,8 @@ async function consumeWorkbuddyStream(
       for (const frame of frames) {
         const dataLines = frame
           .split("\n")
-          .filter((l) => l.startsWith("data: "))
-          .map((l) => l.slice(6));
+          .map((l) => sseDataValue(l))
+          .filter((v): v is string => v !== undefined);
         if (dataLines.length === 0) continue;
         const payload = dataLines.join("\n");
         if (payload === "[DONE]") continue;


### PR DESCRIPTION
## Problem

`createSseThinkingFixStream` in `anthropicHandler.ts` found the data line with:

```ts
if (line.startsWith("data: ")) dataLine = line;
...
if (!dataLine) { controller.enqueue(part + "\n\n"); continue; }
```

Per the SSE spec the space after the colon is optional framing, so `data:{...}` is a well-formed frame. It was not matched, and the stream enqueued the frame **unchanged**:

```
old detection -> ""  (SKIPPED - frame passes through with thinking:null)
new detection -> (patched)
```

That gap lands exactly where it hurts. This stream exists as a workaround for upstreams that emit `thinking: null` — its own comment says Claude Code then does `contentBlock.thinking += delta.thinking` and produces `"null"` strings. Those non-Anthropic upstreams (cf. #990, DeepSeek) are the ones least likely to follow the space convention, so the frames most in need of patching are the ones most likely to be skipped.

The codebase already knows about this: `codexHandler.ts` and `systemUserPassthrough.ts` both check `data: ` **and** `data:`. `anthropicHandler.ts` is internally inconsistent — line 2042 handles both forms while the two sites fixed here did not.

## Change

- Add `sseDataValue(line)`, which strips at most one framing space and returns `undefined` for non-data lines, so "no data field" stays distinguishable from "empty data field".
- Use it in the thinking-fix stream, in the tail-buffer usage parse, and in `workbuddyHandler`.
- The patched-frame rebuild matched `startsWith("data: ")` to substitute the new payload; it now targets the index of the line actually parsed, so a frame with more than one data line can't have them all overwritten with the same value.

## Testing

`MemoryProxy/src/__tests__/sseDataValue.test.ts` — 7 cases: both framing forms, single-space stripping, empty data field, non-data lines, and `database:` not being read as `data`. `npx vitest run` in `MemoryProxy` passes.

`npx tsc --noEmit` reports 6 errors in `anthropicHandler.ts:567`, `codexHandler.ts`, `config.ts` and `storage/factory.ts` — all present on an unmodified checkout, none from this change.

## Note

While looking for this I tried to reproduce #965 (`start-memory-core.sh` aborting on macOS on a full-width `）` after a variable). It does not reproduce for me: bash 3.2.57 and zsh both expand `$ADMIN_KEY_FILE` correctly there and exit 0, and `bash -n` is clean across every script in the repo. That issue may need a different diagnosis.