### PR TITLE
[good first issue-platform adapt-gptel] Add Memory adapter for gptel

### DIFF
--- a/adapters/gptel/README.md
+++ b/adapters/gptel/README.md
@@ -1,0 +1,98 @@
+# TencentDB Agent Memory — gptel Adapter
+
+Give [gptel](https://github.com/karthink/gptel) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+gptel ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                       │
+                                       ├─ auth        (validates sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task picker)
+                                       └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+[gptel](https://github.com/karthink/gptel), the Emacs LLM client, registers any OpenAI-compatible API as a backend with `gptel-make-openai` ([official README](https://github.com/karthink/gptel#readme)). Pointing its `:host`/`:endpoint` at the proxy's `/codebuddy/<spaceId>` endpoint connects it — **no code changes required**.
+
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. gptel is installed (`M-x package-install RET gptel RET`; see the [gptel README](https://github.com/karthink/gptel#installation)).
+
+## Setup
+
+### 1. Register the proxy as a gptel backend
+
+Add to your Emacs config (see `gptel-tdb.el` in this directory for a ready-to-load version):
+
+```elisp
+(use-package gptel
+  :config
+  (setq gptel-model 'claude-sonnet-4-20250514
+        gptel-backend (gptel-make-openai "TencentDB Agent Memory"
+                        :protocol "http"
+                        :host "127.0.0.1:8096"
+                        :endpoint "/codebuddy/default/chat/completions"
+                        :stream t
+                        :key (lambda () (getenv "TDB_MEM_USER_KEY"))
+                        :models '(claude-sonnet-4-20250514))))
+```
+
+with `export TDB_MEM_USER_KEY=sk-mem-...` in your shell (Emacs must inherit the env — start it from that shell or use `exec-path-from-shell`). Alternative — keep the key out of dotfiles with `auth-source`: store an entry for host `127.0.0.1` port `8096` in `~/.authinfo.gpg` and read it in the `:key` function. The principle either way: the key lives in the environment or the secret store, never in version control.
+
+### 2. Align the model name
+
+The model symbol **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream (both in `gptel-model` and the `:models` list).
+
+### 3. Verify
+
+1. Restart Emacs / re-evaluate the config, then open any buffer and run `M-x gptel-send` (or `C-c RET` in a gptel session buffer).
+2. Send a first prompt. The proxy triggers the session picker in the request interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask gptel what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Item | Value | Notes |
+|---|---|---|
+| Backend constructor | `gptel-make-openai` | gptel's generic OpenAI-compatible backend |
+| `:protocol` | `"http"` | Plain HTTP for the local proxy |
+| `:host` | `"127.0.0.1:8096"` | Proxy host and port, no scheme |
+| `:endpoint` | `/codebuddy/default/chat/completions` | `default` is the memory space ID — change it per space |
+| `:key` | function | Reads the `sk-mem-...` business user key from env or auth-source; sent as `Authorization: Bearer` |
+| `:models` / `gptel-model` | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` from proxy | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key`; check the `:key` function actually returns it |
+| `404` / connection refused | Proxy not running on `:8096`, or wrong `:endpoint` — the path must include the full `/codebuddy/<spaceId>/chat/completions` route |
+| Env-based key returns nil | Emacs was not started from the shell that exports `TDB_MEM_USER_KEY` — use auth-source instead, or re-launch Emacs from that shell |
+| Model mismatch error | The model symbol differs from `PROXY_UPSTREAM_MODEL` — align `gptel-model` and the `:models` list |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new gptel conversation to re-pick |
+
+## Notes
+
+- **Any buffer is a session**: gptel chats live in regular Emacs buffers; each conversation you keep using retains its bound task and accumulates memory.
+- **Org-mode friendly**: responses insert as markdown/org text, so memory-injected answers are easy to archive or search from Emacs.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/gptel/README_CN.md
+++ b/adapters/gptel/README_CN.md
@@ -1,0 +1,100 @@
+# TencentDB Agent Memory — gptel 适配器
+
+为 [gptel](https://github.com/karthink/gptel) 接入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词
+- **自动捕获** — L0 原始对话落盘 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+gptel ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游大模型
+                                       │
+                                       ├─ auth        (校验 sk-mem-... user_key)
+                                       ├─ sessionInit (Team/Agent/Task 选择器)
+                                       └─ injection   (L2/L3 记忆 + skills + knowledge 注入)
+```
+
+[gptel](https://github.com/karthink/gptel)（Emacs 的 LLM 客户端）通过 `gptel-make-openai` 注册任意 OpenAI 兼容服务为后端（[官方 README](https://github.com/karthink/gptel#readme)）。将其 `:host`/`:endpoint` 指向代理的 `/codebuddy/<spaceId>` 端点即可接入，**无需改动代码**。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 交互式选择）、**记忆注入**（每轮对话将绑定 Agent 的 L2/L3 记忆、skills 与 knowledge 混入系统提示词）、**自动捕获**（L0 原始对话落盘 memory-core）全部开箱即用，无需改动任何代码。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已启动（主仓库 README 的一键部署）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 已获得业务用户的 `user_key`（`sk-mem-...` 开头），首次启动时由 `start-all.sh` 打印，或在面板 `http://localhost:8125` 中创建。不建议直接使用 `./.admin-key` 中的管理员密钥。
+
+3. 已安装 gptel（`M-x package-install RET gptel RET`，见 [gptel README](https://github.com/karthink/gptel#installation)）。
+
+## 配置步骤
+
+### 1. 将代理注册为 gptel 后端
+
+将以下配置加入 Emacs 配置（本目录 `gptel-tdb.el` 为可直接 load 的版本）：
+
+```elisp
+(use-package gptel
+  :config
+  (setq gptel-model 'claude-sonnet-4-20250514
+        gptel-backend (gptel-make-openai "TencentDB Agent Memory"
+                        :protocol "http"
+                        :host "127.0.0.1:8096"
+                        :endpoint "/codebuddy/default/chat/completions"
+                        :stream t
+                        :key (lambda () (getenv "TDB_MEM_USER_KEY"))
+                        :models '(claude-sonnet-4-20250514))))
+```
+
+密钥处理二选一，均避免明文进入版本库：
+
+- **环境变量**：`:key (lambda () (getenv "TDB_MEM_USER_KEY"))`，并在 shell 中 `export TDB_MEM_USER_KEY=sk-mem-...`（Emacs 需继承该环境——从该 shell 启动，或使用 `exec-path-from-shell`）；
+- **auth-source**：将 key 存入 `~/.authinfo.gpg`（host `127.0.0.1`、port `8096`），`:key` 改为从 auth-source 读取的函数。
+
+### 2. 对齐模型名
+
+模型 symbol **必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（配置于 `deploy/global-images/.env`）。示例使用 `claude-sonnet-4-20250514`，如上游不同请同步修改 `gptel-model` 与 `:models` 列表。
+
+### 3. 验证
+
+1. 重启 Emacs / 重新求值配置，在任意 buffer 执行 `M-x gptel-send`（或在 gptel 会话 buffer 中 `C-c RET`）。
+2. 发送首条提示词，代理会在请求交互中触发会话选择器：依次选择 **Team → Agent → Task**。
+3. 之后每轮自动注入绑定 Agent 的记忆。可让 gptel 复述之前会话的记忆以确认生效。
+
+## 配置参考
+
+| 配置项 | 值 | 说明 |
+|---|---|---|
+| 后端构造器 | `gptel-make-openai` | gptel 的通用 OpenAI 兼容后端 |
+| `:protocol` | `"http"` | 本地代理使用明文 HTTP |
+| `:host` | `"127.0.0.1:8096"` | 代理主机与端口，不含 scheme |
+| `:endpoint` | `/codebuddy/default/chat/completions` | `default` 为记忆空间 ID，可按空间替换 |
+| `:key` | 函数 | 从环境变量或 auth-source 读取 `sk-mem-...` 业务用户 key，以 `Authorization: Bearer` 发送 |
+| `:models` / `gptel-model` | `claude-sonnet-4-20250514` | 必须与 `PROXY_UPSTREAM_MODEL` 一致，否则代理报上游模型不匹配 |
+
+## 故障排查
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| 代理返回 `401` | 必须使用面板创建的业务用户 key（`sk-mem-...`），不能用 `./.admin-key` 的管理员 key；检查 `:key` 函数是否确实返回该值 |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行，或 `:endpoint` 有误——路径必须包含完整的 `/codebuddy/<spaceId>/chat/completions` |
+| 环境变量方式取到 nil | Emacs 不是从导出 `TDB_MEM_USER_KEY` 的 shell 启动的——改用 auth-source，或从该 shell 重新启动 Emacs |
+| 模型不匹配报错 | 模型 symbol 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐 `gptel-model` 与 `:models` |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开 gptel 对话可重新选择 |
+
+## 说明
+
+- **任意 buffer 即会话**：gptel 对话存在于普通 Emacs buffer 中；持续使用的每个对话保留其绑定的任务并不断积累记忆。
+- **Org-mode 友好**：响应以 markdown/org 文本插入，记忆注入的回答便于归档与检索。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。

--- a/adapters/gptel/gptel-tdb.el
+++ b/adapters/gptel/gptel-tdb.el
@@ -1,0 +1,19 @@
+;;; gptel-tdb.el --- gptel backend for the TencentDB Agent Memory proxy -*- lexical-binding: t; -*-
+;; Ready-to-load backend registration.  Key comes from the TDB_MEM_USER_KEY
+;; environment variable (sk-mem-... business user key) -- adjust if you keep
+;; it in auth-source instead.  The model symbol must equal the proxy's
+;; PROXY_UPSTREAM_MODEL.
+;;; Code:
+(require 'gptel)
+
+(setq gptel-model 'claude-sonnet-4-20250514
+      gptel-backend (gptel-make-openai "TencentDB Agent Memory"
+                      :protocol "http"
+                      :host "127.0.0.1:8096"
+                      :endpoint "/codebuddy/default/chat/completions"
+                      :stream t
+                      :key (lambda () (getenv "TDB_MEM_USER_KEY"))
+                      :models '(claude-sonnet-4-20250514)))
+
+(provide 'gptel-tdb)
+;;; gptel-tdb.el ends here


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/gptel/` — a TencentDB Agent Memory adapter for gptel (the Emacs LLM client), extending #926 to another widely used tool.

新增 `adapters/gptel/` 目录：gptel（Emacs LLM 客户端）的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流工具。

## How it works / 工作原理

gptel registers any OpenAI-compatible API as a backend with `gptel-make-openai`. Pointing `:host`/`:endpoint` at the proxy's `/codebuddy/default/chat/completions` route connects it — the `:models` entry carries `PROXY_UPSTREAM_MODEL`.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

gptel 通过 `gptel-make-openai` 注册任意 OpenAI 兼容服务为后端。将 `:host`/`:endpoint` 指向代理 `/codebuddy/default/chat/completions` 路由即可接入，`:models` 条目携带 `PROXY_UPSTREAM_MODEL`。

## Files / 文件

| File | Purpose |
|---|---|
| `gptel-tdb.el` | ready-to-load backend registration (env-var key reference) |
| `README.md` / `README_CN.md` | bilingual setup guide, config reference, troubleshooting |

## Notes / 说明

- Key never lands in a committed file — documented as an env-var / auth-source reference only.
- The configured model must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against gptel's official README (`gptel-make-openai` with `:host`/`:endpoint`).

Addresses #926 (gptel)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
