### PR TITLE
[good first issue-platform adapt-Plandex] Add Memory adapter for Plandex

### DIFF
--- a/adapters/plandex/CHANGELOG.md
+++ b/adapters/plandex/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the Plandex adapter are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this adapter adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-08-17
+
+### Added
+
+- Plandex custom-provider config (`tencentdb-agent-memory`) that routes every
+  model role through MemoryProxy's OpenAI-compatible endpoint
+  `/proxy/<spaceId>/v1/chat/completions`.
+- Model `tencentdb/tdai-memory-agent` and model pack `tdai-memory-pack`
+  covering planner / coder / architect / summarizer / builder / names /
+  commitMessages.
+- Zero-dependency CLI `tdai-plandex.mjs` with `generate` and `check --probe`.
+- Dependency-free test suite written tests-first (Node's built-in runner),
+  including a local mock-gateway integration test and a bilingual-docs guard.
+- Bilingual setup guides (`README.md` / `README_CN.md`).

--- a/adapters/plandex/CHANGELOG.md
+++ b/adapters/plandex/CHANGELOG.md
@@ -19,3 +19,12 @@ and this adapter adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependency-free test suite written tests-first (Node's built-in runner),
   including a local mock-gateway integration test and a bilingual-docs guard.
 - Bilingual setup guides (`README.md` / `README_CN.md`).
+
+### Fixed
+
+- Corrected the relative deploy link depth in both guides (`../../` instead of
+  `../../../`), which previously 404'd on GitHub.
+- Hardened base-URL handling: embedded credentials are rejected, trailing
+  slashes are normalized before building the chat route, and builders fall
+  back to documented defaults instead of emitting missing fields.
+- `generate --output` now creates missing parent directories.

--- a/adapters/plandex/README.md
+++ b/adapters/plandex/README.md
@@ -1,0 +1,119 @@
+# Plandex adapter for TencentDB Agent Memory
+
+This adapter connects [Plandex](https://plandex.ai) to
+[TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory)
+through the project's **MemoryProxy** OpenAI-compatible route, so Plandex
+plans, code, commits and long-running tasks become team memory instead of a
+throw-away local session.
+
+> Season 2 scope: see
+> [#926 Adapters Wanted](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/926).
+
+## How it works
+
+Plandex talks OpenAI Chat Completions to any custom, OpenAI-compatible
+provider. We register the MemoryProxy as such a provider:
+
+```text
+Plandex (custom provider)
+        │  POST /proxy/<spaceId>/v1/chat/completions
+        ▼
+MemoryProxy :8096  ── session init / memory injection / write-back
+        │
+        ├────────► upstream LLM (PROXY_UPSTREAM_MODEL)
+        └─HTTP───► MemoryCore :8420 (L0/L1/L2/L3 memory pipeline)
+```
+
+The generated `custom-models.json` declares:
+
+- a provider named `tencentdb-agent-memory` whose `baseUrl` is
+  `http://127.0.0.1:8096/proxy/<spaceId>/v1` and whose key lives in
+  `TDAI_USER_KEY`;
+- one model, `tencentdb/tdai-memory-agent`, mapped to the proxy's upstream
+  model through that provider;
+- one model pack, `tdai-memory-pack`, that assigns the memory-backed model to
+  every Plandex role (planner, coder, architect, summarizer, builder, names,
+  commit messages).
+
+## Prerequisites
+
+1. The three-piece stack from
+   [`deploy/global-images`](../../../deploy/global-images/README.md) is running
+   (MemoryCore `:8420`, MemoryProxy `:8096`, Memory Hub `:8125`).
+2. A business user key (`sk-mem-...`) was created in the Memory Hub. Do **not**
+   use the admin key for daily work.
+3. Plandex in **self-hosted** mode. Plandex only supports custom providers
+   when self-hosting (custom models/packs alone work in Cloud BYO mode, but
+   they cannot point at an arbitrary base URL).
+4. Node.js >= 22.16 for the helper CLI (zero npm dependencies).
+
+## Quick start
+
+```bash
+# 1. Point the adapter at your stack
+export TDAI_UPSTREAM_MODEL="<model id in PROXY_UPSTREAM_MODEL>"  # e.g. gpt-5.5
+export TDAI_USER_KEY="sk-mem-..."                                 # business user key
+# optional: TDAI_PROXY_BASE_URL / TDAI_CORE_BASE_URL / TDAI_SPACE_ID
+
+# 2. Verify every hop, including a one-token chat round-trip
+node tdai-plandex.mjs check --probe
+
+# 3. Generate the Plandex config and feed it to "plandex models custom"
+node tdai-plandex.mjs generate --dry-run
+# or write it directly:
+node tdai-plandex.mjs generate --output ./custom-models.json
+```
+
+Then in Plandex select the `tdai-memory-pack` model pack (see Plandex's model
+pack docs for the current selection command). Make sure `TDAI_USER_KEY` is
+exported in every shell that runs `plandex`.
+
+## Configuration reference
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `TDAI_UPSTREAM_MODEL` | required | Model id configured as `PROXY_UPSTREAM_MODEL`. |
+| `TDAI_USER_KEY` | required for `check` | Business user key (`sk-mem-...`). |
+| `TDAI_PROXY_BASE_URL` | `http://127.0.0.1:8096` | MemoryProxy base URL. |
+| `TDAI_CORE_BASE_URL` | `http://127.0.0.1:8420` | MemoryCore Gateway base URL. |
+| `TDAI_SPACE_ID` | `default` | Memory instance id embedded in `/proxy/<spaceId>/`. |
+| `TDAI_MAX_OUTPUT_TOKENS` | `8192` | `maxOutputTokens` / `reservedOutputTokens`. |
+| `TDAI_DEFAULT_MAX_CONVO_TOKENS` | `128000` | `defaultMaxConvoTokens`. |
+
+## CLI
+
+```text
+tdai-plandex generate [--output <file>] [--dry-run] [--force]
+tdai-plandex check [--probe]
+```
+
+- `generate --dry-run` prints the JSON without touching disk.
+- `generate --output <file>` refuses to overwrite an existing file unless
+  `--force` is given.
+- `check` verifies proxy and core health; `--probe` adds a real one-token chat
+  completion through `/proxy/<spaceId>/v1/chat/completions`, exercising auth
+  and upstream forwarding end to end.
+
+## First-run session init
+
+On the first turn of a new session the proxy performs session init and may ask
+you to choose **Team -> Agent -> Task** so memory is attached to the right
+place. Complete that form once; later turns are bound automatically. If you
+see nothing persisted, check the Memory Hub's memory view and the output of
+`tdai-plandex.mjs check --probe`.
+
+## Tests
+
+The adapter ships with a dependency-free test suite (Node's built-in test
+runner), including a local mock gateway integration test, written tests-first:
+
+```bash
+cd adapters/plandex
+npm test
+```
+
+Coverage: config generation and validation, URL edge cases, environment
+parsing and diagnostics, proxy/core health checks, the chat probe's exact
+route and `x-tdai-user-key` / `Authorization` headers, CLI behavior (dry-run,
+overwrite safety), and a bilingual documentation guard matching the official
+Season 2 rule.

--- a/adapters/plandex/README.md
+++ b/adapters/plandex/README.md
@@ -38,7 +38,7 @@ The generated `custom-models.json` declares:
 ## Prerequisites
 
 1. The three-piece stack from
-   [`deploy/global-images`](../../../deploy/global-images/README.md) is running
+   [`deploy/global-images`](../../deploy/global-images/README.md) is running
    (MemoryCore `:8420`, MemoryProxy `:8096`, Memory Hub `:8125`).
 2. A business user key (`sk-mem-...`) was created in the Memory Hub. Do **not**
    use the admin key for daily work.

--- a/adapters/plandex/README.md
+++ b/adapters/plandex/README.md
@@ -110,6 +110,7 @@ runner), including a local mock gateway integration test, written tests-first:
 ```bash
 cd adapters/plandex
 npm test
+npm run test:coverage   # prints line/branch/function coverage
 ```
 
 Coverage: config generation and validation, URL edge cases, environment

--- a/adapters/plandex/README_CN.md
+++ b/adapters/plandex/README_CN.md
@@ -1,0 +1,109 @@
+# Plandex 适配器 · TencentDB Agent Memory
+
+本适配器把 [Plandex](https://plandex.ai) 接入
+[TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory)，
+走项目自带 **MemoryProxy** 的 OpenAI 兼容路由，让 Plandex 的计划、编码、提交与
+长任务沉淀为团队记忆，而不是随本地会话丢弃。
+
+> 属于第二期共建范围，见
+> [#926 Adapters Wanted](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/926)。
+
+## 工作原理
+
+Plandex 支持把任意 OpenAI 兼容服务注册为自定义 provider。我们把 MemoryProxy
+注册进去：
+
+```text
+Plandex（自定义 provider）
+        │  POST /proxy/<spaceId>/v1/chat/completions
+        ▼
+MemoryProxy :8096  ── 会话初始化 / 记忆注入 / 对话回流
+        │
+        ├────────► 上游 LLM（PROXY_UPSTREAM_MODEL）
+        └─HTTP───► MemoryCore :8420（L0/L1/L2/L3 记忆流水线）
+```
+
+生成的 `custom-models.json` 声明三件事：
+
+- 名为 `tencentdb-agent-memory` 的 provider，`baseUrl` 为
+  `http://127.0.0.1:8096/proxy/<spaceId>/v1`，密钥从 `TDAI_USER_KEY` 读取；
+- 一个模型 `tencentdb/tdai-memory-agent`，经上述 provider 映射到代理的上游
+  模型；
+- 一个模型包 `tdai-memory-pack`，把该记忆模型应用到 Plandex 所有角色
+  （planner / coder / architect / summarizer / builder / names / 提交信息）。
+
+## 前置条件
+
+1. 已按 [`deploy/global-images`](../../../deploy/global-images/README.md) 启动
+   三件套（MemoryCore `:8420`、MemoryProxy `:8096`、Memory Hub `:8125`）。
+2. 在 Memory Hub 创建了业务用户 key（`sk-mem-...`），日常使用**不要**直接拿
+   admin key。
+3. Plandex 使用**自托管（self-hosted）**模式。Plandex 仅自托管时支持自定义
+   provider（Cloud BYO 模式只支持自定义模型/模型包，无法指向自定义 base URL）。
+4. 辅助 CLI 需要 Node.js >= 22.16，零 npm 依赖。
+
+## 快速开始
+
+```bash
+# 1. 让适配器指向你的环境
+export TDAI_UPSTREAM_MODEL="<PROXY_UPSTREAM_MODEL 里配置的模型 id>"  # 例如 gpt-5.5
+export TDAI_USER_KEY="sk-mem-..."                                    # 业务用户 key
+# 可选：TDAI_PROXY_BASE_URL / TDAI_CORE_BASE_URL / TDAI_SPACE_ID
+
+# 2. 逐跳自检，包含一次 1-token 真实对话探测
+node tdai-plandex.mjs check --probe
+
+# 3. 生成 Plandex 配置，粘进 "plandex models custom"
+node tdai-plandex.mjs generate --dry-run
+# 或直接落盘：
+node tdai-plandex.mjs generate --output ./custom-models.json
+```
+
+随后在 Plandex 里选择 `tdai-memory-pack` 模型包（具体切换命令以 Plandex 当前
+版本文档为准），并保证运行 `plandex` 的每个 shell 都导出了 `TDAI_USER_KEY`。
+
+## 配置说明
+
+| 变量 | 默认值 | 含义 |
+| --- | --- | --- |
+| `TDAI_UPSTREAM_MODEL` | 必填 | 与 `PROXY_UPSTREAM_MODEL` 一致的模型 id。 |
+| `TDAI_USER_KEY` | `check` 必填 | 业务用户 key（`sk-mem-...`）。 |
+| `TDAI_PROXY_BASE_URL` | `http://127.0.0.1:8096` | MemoryProxy 地址。 |
+| `TDAI_CORE_BASE_URL` | `http://127.0.0.1:8420` | MemoryCore Gateway 地址。 |
+| `TDAI_SPACE_ID` | `default` | 记忆实例 id，写入 `/proxy/<spaceId>/`。 |
+| `TDAI_MAX_OUTPUT_TOKENS` | `8192` | `maxOutputTokens` / `reservedOutputTokens`。 |
+| `TDAI_DEFAULT_MAX_CONVO_TOKENS` | `128000` | `defaultMaxConvoTokens`。 |
+
+## CLI 用法
+
+```text
+tdai-plandex generate [--output <文件>] [--dry-run] [--force]
+tdai-plandex check [--probe]
+```
+
+- `generate --dry-run`：只打印 JSON，不落盘。
+- `generate --output <文件>`：已存在的文件默认拒绝覆盖，加 `--force` 才替换。
+- `check`：校验 Proxy 与 Core 健康；`--probe` 额外走一次
+  `/proxy/<spaceId>/v1/chat/completions` 单 token 对话，端到端验证鉴权与上游
+  转发。
+
+## 首次会话初始化
+
+新会话第一轮，Proxy 会做 session init，可能要求你依次选择
+**Team → Agent → Task**，把记忆挂到正确位置；完成后后续轮次自动绑定。如果
+发现没有记忆落库，先看 Memory Hub 的记忆页，再跑
+`tdai-plandex.mjs check --probe` 排查。
+
+## 测试
+
+适配器自带零依赖测试套件（Node 内置 test runner），并包含本地 mock 网关的
+集成测试，按测试先行（TDD）编写：
+
+```bash
+cd adapters/plandex
+npm test
+```
+
+覆盖：配置生成与校验、URL 边界、环境变量解析与报错提示、Proxy/Core 健康检查、
+对话探测的精确路由与 `x-tdai-user-key` / `Authorization` 请求头、CLI 行为
+（dry-run、覆盖保护），以及与官方第二期规则一致的双语文档守卫。

--- a/adapters/plandex/README_CN.md
+++ b/adapters/plandex/README_CN.md
@@ -34,7 +34,7 @@ MemoryProxy :8096  ── 会话初始化 / 记忆注入 / 对话回流
 
 ## 前置条件
 
-1. 已按 [`deploy/global-images`](../../../deploy/global-images/README.md) 启动
+1. 已按 [`deploy/global-images`](../../deploy/global-images/README.md) 启动
    三件套（MemoryCore `:8420`、MemoryProxy `:8096`、Memory Hub `:8125`）。
 2. 在 Memory Hub 创建了业务用户 key（`sk-mem-...`），日常使用**不要**直接拿
    admin key。

--- a/adapters/plandex/README_CN.md
+++ b/adapters/plandex/README_CN.md
@@ -102,6 +102,7 @@ tdai-plandex check [--probe]
 ```bash
 cd adapters/plandex
 npm test
+npm run test:coverage   # 输出行/分支/函数覆盖率
 ```
 
 覆盖：配置生成与校验、URL 边界、环境变量解析与报错提示、Proxy/Core 健康检查、

--- a/adapters/plandex/lib/cli.mjs
+++ b/adapters/plandex/lib/cli.mjs
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 
 import {
   API_KEY_ENV_VAR,
@@ -28,6 +29,10 @@ Environment:
   TDAI_PROXY_BASE_URL        default http://127.0.0.1:8096
   TDAI_CORE_BASE_URL         default http://127.0.0.1:8420
   TDAI_SPACE_ID              memory instance id, default "default"
+
+Exit codes:
+  0  success
+  1  validation, connectivity or probe failure
 `;
 
 export function parseArgs(argv) {
@@ -133,6 +138,7 @@ async function generate(options, env, stdout, stderr) {
           }
         }
       }
+      await mkdir(dirname(options.output), { recursive: true });
       await writeFile(options.output, json, 'utf8');
       stdout.log(`wrote ${options.output}`);
       stdout.log(

--- a/adapters/plandex/lib/cli.mjs
+++ b/adapters/plandex/lib/cli.mjs
@@ -1,0 +1,216 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+import {
+  API_KEY_ENV_VAR,
+  parseEnv,
+  serializeCustomModels,
+} from './config.mjs';
+import { buildHealthUrl, getJson, postChatCompletion } from './http.mjs';
+
+export const VERSION = '0.1.0';
+
+export const USAGE = `tdai-plandex - TencentDB Agent Memory adapter for Plandex
+
+Usage:
+  tdai-plandex generate [--output <file>] [--dry-run] [--force]
+  tdai-plandex check [--probe]
+  tdai-plandex --help | --version
+
+Commands:
+  generate   Generate the Plandex custom-models JSON (provider + model + model pack).
+             Without --output it prints to stdout; paste it into "plandex models custom".
+  check      Verify the environment, MemoryProxy (:8096) and MemoryCore (:8420)
+             health. --probe additionally performs a one-token chat round-trip.
+
+Environment:
+  TDAI_UPSTREAM_MODEL        required. Model id from PROXY_UPSTREAM_MODEL.
+  TDAI_USER_KEY              business user key (sk-mem-...) from Memory Hub.
+  TDAI_PROXY_BASE_URL        default http://127.0.0.1:8096
+  TDAI_CORE_BASE_URL         default http://127.0.0.1:8420
+  TDAI_SPACE_ID              memory instance id, default "default"
+`;
+
+export function parseArgs(argv) {
+  const options = { dryRun: false, probe: false, force: false, output: null };
+  let command = null;
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === '-h' || arg === '--help') {
+      command = 'help';
+      i += 1;
+    } else if (arg === '--version') {
+      command = 'version';
+      i += 1;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+      i += 1;
+    } else if (arg === '--probe') {
+      options.probe = true;
+      i += 1;
+    } else if (arg === '--force') {
+      options.force = true;
+      i += 1;
+    } else if (arg === '--output') {
+      const value = argv[i + 1];
+      if (!value) {
+        return { command: null, options, error: '--output requires a file path' };
+      }
+      options.output = value;
+      i += 2;
+    } else if (arg.startsWith('-')) {
+      return { command: null, options, error: `unknown option: ${arg}` };
+    } else if (arg === 'generate' || arg === 'init') {
+      command = 'generate';
+      i += 1;
+    } else if (arg === 'check' || arg === 'doctor') {
+      command = 'check';
+      i += 1;
+    } else {
+      return { command: null, options, error: `unknown command: ${arg}` };
+    }
+  }
+  return { command: command ?? 'help', options };
+}
+
+export async function run(argv, deps = {}) {
+  const env = deps.env ?? process.env;
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+  const stdout = deps.stdout ?? console;
+  const stderr = deps.stderr ?? console;
+
+  const parsed = parseArgs(argv);
+  if (parsed.error) {
+    stderr.error(parsed.error);
+    stderr.error(USAGE);
+    return 1;
+  }
+
+  switch (parsed.command) {
+    case 'help':
+      stdout.log(USAGE);
+      return 0;
+    case 'version':
+      stdout.log(`tdai-plandex ${VERSION}`);
+      return 0;
+    case 'generate':
+      return generate(parsed.options, env, stdout, stderr);
+    case 'check':
+      return check(parsed.options, env, fetchImpl, stdout, stderr);
+    default:
+      stderr.error(USAGE);
+      return 1;
+  }
+}
+
+async function generate(options, env, stdout, stderr) {
+  let cfg;
+  try {
+    cfg = parseEnv(env);
+  } catch (error) {
+    stderr.error(error.message);
+    return 1;
+  }
+
+  const json = serializeCustomModels(cfg);
+  if (options.dryRun) {
+    stdout.log(json);
+    return 0;
+  }
+
+  if (options.output) {
+    try {
+      if (!options.force) {
+        try {
+          await readFile(options.output);
+          stderr.error(
+            `refusing to overwrite ${options.output}; use --force to replace it`,
+          );
+          return 1;
+        } catch (error) {
+          if (error?.code !== 'ENOENT') {
+            throw error;
+          }
+        }
+      }
+      await writeFile(options.output, json, 'utf8');
+      stdout.log(`wrote ${options.output}`);
+      stdout.log(
+        `next: paste this file into "plandex models custom", then export ${API_KEY_ENV_VAR}=<sk-mem-...>`,
+      );
+      return 0;
+    } catch (error) {
+      stderr.error(`could not write ${options.output}: ${error.message}`);
+      return 1;
+    }
+  }
+
+  stdout.log(json);
+  return 0;
+}
+
+async function check(options, env, fetchImpl, stdout, stderr) {
+  let cfg;
+  try {
+    cfg = parseEnv(env);
+  } catch (error) {
+    stderr.error(error.message);
+    return 1;
+  }
+
+  if (!cfg.userKey) {
+    stderr.error(
+      `${API_KEY_ENV_VAR} is required for check: export it to your business user key (sk-mem-...) from the Memory Hub.`,
+    );
+    return 1;
+  }
+
+  stdout.log(`proxy  ${cfg.proxyBaseUrl}`);
+  const proxyHealth = await getJson(buildHealthUrl(cfg.proxyBaseUrl), { fetchImpl });
+  if (!proxyHealth.ok) {
+    stderr.error(
+      `MemoryProxy is not reachable at ${buildHealthUrl(cfg.proxyBaseUrl)}: ${proxyHealth.error ?? `HTTP ${proxyHealth.status}`}`,
+    );
+    stderr.error(
+      'hints: is deploy/global-images/start-all.sh running? MemoryProxy listens on :8096; check TDAI_PROXY_BASE_URL.',
+    );
+    return 1;
+  }
+  stdout.log('proxy health OK');
+
+  stdout.log(`core   ${cfg.coreBaseUrl}`);
+  const coreHealth = await getJson(buildHealthUrl(cfg.coreBaseUrl), { fetchImpl });
+  if (!coreHealth.ok) {
+    stderr.error(
+      `MemoryCore is not reachable at ${buildHealthUrl(cfg.coreBaseUrl)}: ${coreHealth.error ?? `HTTP ${coreHealth.status}`}`,
+    );
+    stderr.error(
+      'hints: MemoryCore listens on :8420; check TDAI_CORE_BASE_URL.',
+    );
+    return 1;
+  }
+  stdout.log('core health OK');
+
+  if (options.probe) {
+    const probe = await postChatCompletion({
+      baseUrl: cfg.proxyBaseUrl,
+      spaceId: cfg.spaceId,
+      model: cfg.upstreamModel,
+      apiKey: cfg.userKey,
+      fetchImpl,
+    });
+    if (!probe.ok) {
+      stderr.error(`chat probe failed: ${probe.error ?? `HTTP ${probe.status}`}`);
+      stderr.error(
+        'hints: TDAI_UPSTREAM_MODEL must match PROXY_UPSTREAM_MODEL and TDAI_USER_KEY must be a business user key.',
+      );
+      return 1;
+    }
+    stdout.log(
+      `probe OK (model ${cfg.upstreamModel} via /proxy/${cfg.spaceId}/v1/chat/completions)`,
+    );
+  }
+
+  stdout.log('check passed');
+  return 0;
+}

--- a/adapters/plandex/lib/cli.mjs
+++ b/adapters/plandex/lib/cli.mjs
@@ -165,6 +165,14 @@ async function check(options, env, fetchImpl, stdout, stderr) {
     return 1;
   }
 
+  stdout.log(`model  ${cfg.upstreamModel}`);
+  stdout.log(`space  ${cfg.spaceId}`);
+  if (!/^sk-/i.test(cfg.userKey)) {
+    stderr.error(
+      `warning: ${API_KEY_ENV_VAR} does not look like a Memory user key (expected sk-mem-...); the probe may fail if this is an upstream API key.`,
+    );
+  }
+
   stdout.log(`proxy  ${cfg.proxyBaseUrl}`);
   const proxyHealth = await getJson(buildHealthUrl(cfg.proxyBaseUrl), { fetchImpl });
   if (!proxyHealth.ok) {

--- a/adapters/plandex/lib/config.mjs
+++ b/adapters/plandex/lib/config.mjs
@@ -1,0 +1,148 @@
+export const PROVIDER_NAME = 'tencentdb-agent-memory';
+export const MODEL_ID = 'tdai-memory-agent';
+export const PUBLISHER = 'tencentdb';
+export const PACK_NAME = 'tdai-memory-pack';
+export const API_KEY_ENV_VAR = 'TDAI_USER_KEY';
+export const SCHEMA_URL = 'https://plandex.ai/schemas/models-input.schema.json';
+
+export const DEFAULTS = Object.freeze({
+  proxyBaseUrl: 'http://127.0.0.1:8096',
+  coreBaseUrl: 'http://127.0.0.1:8420',
+  spaceId: 'default',
+  maxOutputTokens: 8192,
+  defaultMaxConvoTokens: 128000,
+});
+
+export function normalizeBaseUrl(raw, label = 'URL') {
+  if (typeof raw !== 'string' || !/^https?:\/\//i.test(raw)) {
+    throw new Error(
+      `${label} must start with http:// or https:// (got: ${JSON.stringify(raw)})`,
+    );
+  }
+  const url = new URL(raw);
+  if (url.search || url.hash) {
+    throw new Error(`${label} must not contain a query string or fragment`);
+  }
+  return url.toString().replace(/\/+$/, '');
+}
+
+export function validateSpaceId(spaceId) {
+  if (typeof spaceId !== 'string' || !/^[A-Za-z0-9_-]+$/.test(spaceId)) {
+    throw new Error(
+      `Invalid space id: ${JSON.stringify(spaceId)} (allowed: letters, digits, "_" and "-")`,
+    );
+  }
+  return spaceId;
+}
+
+const envStr = (env, name) => {
+  const value = env[name];
+  return typeof value === 'string' ? value.trim() : undefined;
+};
+
+const envInt = (env, name, fallback) => {
+  const value = envStr(env, name);
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer (got: ${JSON.stringify(value)})`);
+  }
+  return parsed;
+};
+
+export function parseEnv(env = process.env) {
+  const upstreamModel = envStr(env, 'TDAI_UPSTREAM_MODEL');
+  if (!upstreamModel) {
+    throw new Error(
+      'TDAI_UPSTREAM_MODEL is required: set it to the model id configured in the MemoryProxy PROXY_UPSTREAM_MODEL (e.g. gpt-5.5).',
+    );
+  }
+
+  let spaceId;
+  try {
+    spaceId = validateSpaceId(envStr(env, 'TDAI_SPACE_ID') ?? DEFAULTS.spaceId);
+  } catch (error) {
+    throw new Error(`TDAI_SPACE_ID: ${error.message}`);
+  }
+
+  return {
+    upstreamModel,
+    proxyBaseUrl: normalizeBaseUrl(
+      envStr(env, 'TDAI_PROXY_BASE_URL') ?? DEFAULTS.proxyBaseUrl,
+      'TDAI_PROXY_BASE_URL',
+    ),
+    coreBaseUrl: normalizeBaseUrl(
+      envStr(env, 'TDAI_CORE_BASE_URL') ?? DEFAULTS.coreBaseUrl,
+      'TDAI_CORE_BASE_URL',
+    ),
+    spaceId,
+    userKey: envStr(env, 'TDAI_USER_KEY'),
+    maxOutputTokens: envInt(env, 'TDAI_MAX_OUTPUT_TOKENS', DEFAULTS.maxOutputTokens),
+    defaultMaxConvoTokens: envInt(
+      env,
+      'TDAI_DEFAULT_MAX_CONVO_TOKENS',
+      DEFAULTS.defaultMaxConvoTokens,
+    ),
+  };
+}
+
+export function buildProvider(cfg) {
+  return {
+    name: PROVIDER_NAME,
+    baseUrl: `${cfg.proxyBaseUrl}/proxy/${cfg.spaceId}/v1`,
+    apiKeyEnvVar: API_KEY_ENV_VAR,
+  };
+}
+
+export function buildModel(cfg) {
+  return {
+    modelId: MODEL_ID,
+    publisher: PUBLISHER,
+    description:
+      'Routes Plandex through TencentDB Agent Memory so conversations, skills, wiki knowledge and code graphs are captured and re-injected as team memory.',
+    defaultMaxConvoTokens: cfg.defaultMaxConvoTokens,
+    maxOutputTokens: cfg.maxOutputTokens,
+    reservedOutputTokens: cfg.maxOutputTokens,
+    preferredOutputFormat: 'xml',
+    providers: [
+      {
+        provider: 'custom',
+        customProvider: PROVIDER_NAME,
+        modelName: cfg.upstreamModel,
+      },
+    ],
+  };
+}
+
+export function buildModelPack(cfg) {
+  const ref = `${PUBLISHER}/${MODEL_ID}`;
+  return {
+    name: PACK_NAME,
+    description: 'Every Plandex role runs through TencentDB Agent Memory.',
+    planner: ref,
+    coder: ref,
+    architect: ref,
+    summarizer: ref,
+    builder: {
+      modelId: ref,
+      strongModel: ref,
+    },
+    names: ref,
+    commitMessages: ref,
+  };
+}
+
+export function buildCustomModelsFile(cfg) {
+  return {
+    $schema: SCHEMA_URL,
+    providers: [buildProvider(cfg)],
+    models: [buildModel(cfg)],
+    modelPacks: [buildModelPack(cfg)],
+  };
+}
+
+export function serializeCustomModels(cfg) {
+  return `${JSON.stringify(buildCustomModelsFile(cfg), null, 2)}\n`;
+}

--- a/adapters/plandex/lib/config.mjs
+++ b/adapters/plandex/lib/config.mjs
@@ -20,6 +20,9 @@ export function normalizeBaseUrl(raw, label = 'URL') {
     );
   }
   const url = new URL(raw);
+  if (url.username || url.password) {
+    throw new Error(`${label} must not embed credentials`);
+  }
   if (url.search || url.hash) {
     throw new Error(`${label} must not contain a query string or fragment`);
   }
@@ -88,23 +91,30 @@ export function parseEnv(env = process.env) {
   };
 }
 
-export function buildProvider(cfg) {
+export function buildProvider(cfg = {}) {
+  const proxyBaseUrl = cfg.proxyBaseUrl ?? DEFAULTS.proxyBaseUrl;
+  const spaceId = cfg.spaceId ?? DEFAULTS.spaceId;
   return {
     name: PROVIDER_NAME,
-    baseUrl: `${cfg.proxyBaseUrl}/proxy/${cfg.spaceId}/v1`,
+    baseUrl: `${proxyBaseUrl}/proxy/${spaceId}/v1`,
     apiKeyEnvVar: API_KEY_ENV_VAR,
   };
 }
 
-export function buildModel(cfg) {
+export function buildModel(cfg = {}) {
+  if (!cfg.upstreamModel) {
+    throw new Error('upstreamModel is required to build the Plandex model mapping');
+  }
+  const maxOutputTokens = cfg.maxOutputTokens ?? DEFAULTS.maxOutputTokens;
+  const defaultMaxConvoTokens = cfg.defaultMaxConvoTokens ?? DEFAULTS.defaultMaxConvoTokens;
   return {
     modelId: MODEL_ID,
     publisher: PUBLISHER,
     description:
       'Routes Plandex through TencentDB Agent Memory so conversations, skills, wiki knowledge and code graphs are captured and re-injected as team memory.',
-    defaultMaxConvoTokens: cfg.defaultMaxConvoTokens,
-    maxOutputTokens: cfg.maxOutputTokens,
-    reservedOutputTokens: cfg.maxOutputTokens,
+    defaultMaxConvoTokens,
+    maxOutputTokens,
+    reservedOutputTokens: maxOutputTokens,
     preferredOutputFormat: 'xml',
     providers: [
       {

--- a/adapters/plandex/lib/http.mjs
+++ b/adapters/plandex/lib/http.mjs
@@ -1,0 +1,83 @@
+export function buildHealthUrl(baseUrl) {
+  return `${baseUrl}/health`;
+}
+
+const withTimeout = (fetchImpl, timeoutMs) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+  return { signal: controller.signal, cancel: () => clearTimeout(timer) };
+};
+
+const errorReason = (error, timeoutMs) => {
+  if (error?.name === 'AbortError') {
+    return `timed out after ${timeoutMs}ms`;
+  }
+  return error?.message ?? String(error);
+};
+
+export async function getJson(
+  url,
+  { fetchImpl = fetch, timeoutMs = 5000, headers = {} } = {},
+) {
+  const { signal, cancel } = withTimeout(fetchImpl, timeoutMs);
+  try {
+    const response = await fetchImpl(url, { method: 'GET', headers, signal });
+    const text = await response.text();
+    if (!response.ok) {
+      return { ok: false, status: response.status, error: `HTTP ${response.status}` };
+    }
+    try {
+      return { ok: true, status: response.status, body: JSON.parse(text) };
+    } catch {
+      return { ok: false, status: response.status, error: 'response is not valid JSON' };
+    }
+  } catch (error) {
+    return { ok: false, error: errorReason(error, timeoutMs) };
+  } finally {
+    cancel();
+  }
+}
+
+export async function postChatCompletion({
+  baseUrl,
+  spaceId,
+  model,
+  apiKey,
+  fetchImpl = fetch,
+  timeoutMs = 30000,
+}) {
+  const url = `${baseUrl}/proxy/${spaceId}/v1/chat/completions`;
+  const { signal, cancel } = withTimeout(fetchImpl, timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-tdai-user-key': apiKey,
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: 'ping: tdai-plandex health probe' }],
+        max_tokens: 1,
+      }),
+      signal,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return { ok: false, status: response.status, error: `HTTP ${response.status}` };
+    }
+    try {
+      return { ok: true, status: response.status, body: JSON.parse(text) };
+    } catch {
+      return { ok: false, status: response.status, error: 'response is not valid JSON' };
+    }
+  } catch (error) {
+    return { ok: false, error: errorReason(error, timeoutMs) };
+  } finally {
+    cancel();
+  }
+}

--- a/adapters/plandex/lib/http.mjs
+++ b/adapters/plandex/lib/http.mjs
@@ -49,7 +49,8 @@ export async function postChatCompletion({
   fetchImpl = fetch,
   timeoutMs = 30000,
 }) {
-  const url = `${baseUrl}/proxy/${spaceId}/v1/chat/completions`;
+  const normalizedBase = String(baseUrl ?? '').replace(/\/+$/, '');
+  const url = `${normalizedBase}/proxy/${spaceId}/v1/chat/completions`;
   const { signal, cancel } = withTimeout(fetchImpl, timeoutMs);
   try {
     const response = await fetchImpl(url, {

--- a/adapters/plandex/package.json
+++ b/adapters/plandex/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@tdai/plandex-adapter",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "TencentDB Agent Memory adapter for Plandex: OpenAI-compatible provider config, health check and probe.",
+  "scripts": {
+    "test": "node --test \"test/*.test.mjs\""
+  },
+  "engines": {
+    "node": ">=22.16.0"
+  }
+}

--- a/adapters/plandex/package.json
+++ b/adapters/plandex/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "TencentDB Agent Memory adapter for Plandex: OpenAI-compatible provider config, health check and probe.",
   "scripts": {
-    "test": "node --test \"test/*.test.mjs\""
+    "test": "node --test \"test/*.test.mjs\"",
+    "test:coverage": "node --test --experimental-test-coverage \"test/*.test.mjs\""
   },
   "engines": {
     "node": ">=22.16.0"

--- a/adapters/plandex/tdai-plandex.mjs
+++ b/adapters/plandex/tdai-plandex.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { run } from './lib/cli.mjs';
+
+const exitCode = await run(process.argv.slice(2));
+process.exitCode = exitCode;

--- a/adapters/plandex/test/cli.test.mjs
+++ b/adapters/plandex/test/cli.test.mjs
@@ -27,12 +27,33 @@ describe('parseArgs', () => {
     assert.equal(parsed.options.output, 'x.json');
   });
 
+  it('parses help and version switches', () => {
+    assert.equal(parseArgs(['--help']).command, 'help');
+    assert.equal(parseArgs(['--version']).command, 'version');
+  });
+
   it('flags unknown commands', () => {
     assert.match(parseArgs(['frobnicate']).error, /unknown command/i);
+  });
+
+  it('flags unknown options and a missing --output value', () => {
+    assert.match(parseArgs(['generate', '--wat']).error, /unknown option/i);
+    assert.match(parseArgs(['generate', '--output']).error, /requires a file path/i);
   });
 });
 
 describe('run generate', () => {
+  it('prints valid JSON to stdout without any flags', async () => {
+    let out = '';
+    const code = await run(['generate'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+      stdout: { log: (s) => (out += `${s}\n`), error() {} },
+      stderr: silent,
+    });
+    assert.equal(code, 0);
+    assert.equal(JSON.parse(out).providers[0].name, 'tencentdb-agent-memory');
+  });
+
   it('prints valid JSON to stdout', async () => {
     let out = '';
     const code = await run(['generate', '--dry-run'], {
@@ -44,6 +65,24 @@ describe('run generate', () => {
     const parsed = JSON.parse(out);
     assert.equal(parsed.$schema, 'https://plandex.ai/schemas/models-input.schema.json');
     assert.equal(parsed.providers[0].name, 'tencentdb-agent-memory');
+  });
+
+  it('lets --dry-run win over --output and never writes a file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tdai-plandex-'));
+    try {
+      const file = join(dir, 'custom-models.json');
+      let out = '';
+      const code = await run(['generate', '--dry-run', '--output', file], {
+        env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+        stdout: { log: (s) => (out += `${s}\n`), error() {} },
+        stderr: silent,
+      });
+      assert.equal(code, 0);
+      JSON.parse(out);
+      await assert.rejects(readFile(file, 'utf8'), /ENOENT/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('fails without an upstream model and names the missing variable', async () => {
@@ -95,6 +134,38 @@ describe('run generate', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('creates missing parent directories for --output', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tdai-plandex-'));
+    try {
+      const file = join(dir, 'nested', 'deeper', 'custom-models.json');
+      const code = await run(['generate', '--output', file], {
+        env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+        stdout: silent,
+        stderr: silent,
+      });
+      assert.equal(code, 0);
+      JSON.parse(await readFile(file, 'utf8'));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports write failures cleanly', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tdai-plandex-'));
+    try {
+      let err = '';
+      const code = await run(['generate', '--output', dir], {
+        env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+        stdout: silent,
+        stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+      });
+      assert.equal(code, 1);
+      assert.match(err, /could not write/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('run check', () => {
@@ -141,6 +212,53 @@ describe('run check', () => {
     assert.equal(code, 1);
   });
 
+  it('fails with the env var name when the upstream model is missing', async () => {
+    let err = '';
+    const code = await run(['check'], {
+      env: {},
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 1);
+    assert.match(err, /TDAI_UPSTREAM_MODEL/);
+  });
+
+  it('fails with a core-specific message when only MemoryCore is down', async () => {
+    let err = '';
+    const code = await run(['check'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5', TDAI_USER_KEY: 'sk-mem-x' },
+      fetchImpl: async (url) => {
+        if (url.includes(':8420')) {
+          return new Response('down', { status: 503 });
+        }
+        return jsonResponse(200, { status: 'ok' });
+      },
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 1);
+    assert.match(err, /MemoryCore/);
+    assert.match(err, /8420/);
+  });
+
+  it('fails when the chat probe is rejected by the upstream', async () => {
+    let err = '';
+    const code = await run(['check', '--probe'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5', TDAI_USER_KEY: 'sk-mem-x' },
+      fetchImpl: async (url, init) => {
+        if (init?.method === 'POST') {
+          return jsonResponse(401, { error: { message: 'bad key' } });
+        }
+        return jsonResponse(200, { status: 'ok' });
+      },
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 1);
+    assert.match(err, /chat probe failed/);
+    assert.match(err, /TDAI_UPSTREAM_MODEL/);
+  });
+
   it('warns, without failing, when the key does not look like a memory key', async () => {
     let err = '';
     const code = await run(['check'], {
@@ -151,6 +269,39 @@ describe('run check', () => {
     });
     assert.equal(code, 0);
     assert.match(err, /does not look like a Memory user key/i);
+  });
+});
+
+describe('run help/version/unknown', () => {
+  it('prints usage and exits 0 for --help', async () => {
+    let out = '';
+    const code = await run(['--help'], {
+      stdout: { log: (s) => (out += s), error() {} },
+      stderr: silent,
+    });
+    assert.equal(code, 0);
+    assert.match(out, /Usage:/);
+  });
+
+  it('prints the version and exits 0 for --version', async () => {
+    let out = '';
+    const code = await run(['--version'], {
+      stdout: { log: (s) => (out += s), error() {} },
+      stderr: silent,
+    });
+    assert.equal(code, 0);
+    assert.match(out, /^tdai-plandex \d+\.\d+\.\d+$/);
+  });
+
+  it('prints an unknown-command error and exits 1', async () => {
+    let err = '';
+    const code = await run(['frobnicate'], {
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 1);
+    assert.match(err, /unknown command/i);
+    assert.match(err, /Usage:/);
   });
 });
 

--- a/adapters/plandex/test/cli.test.mjs
+++ b/adapters/plandex/test/cli.test.mjs
@@ -1,0 +1,145 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { parseArgs, run } from '../lib/cli.mjs';
+
+const silent = { log() {}, error() {} };
+
+describe('parseArgs', () => {
+  it('defaults to help', () => {
+    assert.deepEqual(parseArgs([]), {
+      command: 'help',
+      options: { dryRun: false, probe: false, force: false, output: null },
+    });
+  });
+
+  it('maps aliases and flags', () => {
+    assert.equal(parseArgs(['generate']).command, 'generate');
+    assert.equal(parseArgs(['init']).command, 'generate');
+    assert.equal(parseArgs(['doctor']).command, 'check');
+    assert.equal(parseArgs(['check', '--probe']).options.probe, true);
+    assert.equal(parseArgs(['generate', '--force']).options.force, true);
+    const parsed = parseArgs(['generate', '--dry-run', '--output', 'x.json']);
+    assert.equal(parsed.options.dryRun, true);
+    assert.equal(parsed.options.output, 'x.json');
+  });
+
+  it('flags unknown commands', () => {
+    assert.match(parseArgs(['frobnicate']).error, /unknown command/i);
+  });
+});
+
+describe('run generate', () => {
+  it('prints valid JSON to stdout', async () => {
+    let out = '';
+    const code = await run(['generate', '--dry-run'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+      stdout: { log: (s) => (out += `${s}\n`), error() {} },
+      stderr: silent,
+    });
+    assert.equal(code, 0);
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.$schema, 'https://plandex.ai/schemas/models-input.schema.json');
+    assert.equal(parsed.providers[0].name, 'tencentdb-agent-memory');
+  });
+
+  it('fails without an upstream model and names the missing variable', async () => {
+    let err = '';
+    const code = await run(['generate'], {
+      env: {},
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 1);
+    assert.match(err, /TDAI_UPSTREAM_MODEL/);
+  });
+
+  it('writes a file, refuses to overwrite, then obeys --force', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tdai-plandex-'));
+    try {
+      const file = join(dir, 'custom-models.json');
+      assert.equal(
+        await run(['generate', '--output', file], {
+          env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+          stdout: silent,
+          stderr: silent,
+        }),
+        0,
+      );
+      JSON.parse(await readFile(file, 'utf8'));
+
+      await writeFile(file, 'user edits');
+      assert.equal(
+        await run(['generate', '--output', file], {
+          env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+          stdout: silent,
+          stderr: silent,
+        }),
+        1,
+      );
+      assert.equal(await readFile(file, 'utf8'), 'user edits');
+
+      assert.equal(
+        await run(['generate', '--output', file, '--force'], {
+          env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+          stdout: silent,
+          stderr: silent,
+        }),
+        0,
+      );
+      JSON.parse(await readFile(file, 'utf8'));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('run check', () => {
+  const healthyFetch = async () => jsonResponse(200, { status: 'ok' });
+
+  it('passes when proxy and core are healthy', async () => {
+    const code = await run(['check'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5', TDAI_USER_KEY: 'sk-mem-x' },
+      fetchImpl: healthyFetch,
+      stdout: silent,
+      stderr: silent,
+    });
+    assert.equal(code, 0);
+  });
+
+  it('fails when the proxy is down and points at port 8096', async () => {
+    let err = '';
+    const code = await run(['check'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5', TDAI_USER_KEY: 'sk-mem-x' },
+      fetchImpl: async (url) => {
+        if (url.includes(':8096')) {
+          return new Response('down', { status: 503 });
+        }
+        return jsonResponse(200, { status: 'ok' });
+      },
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 1);
+    assert.match(err, /proxy/i);
+  });
+
+  it('requires the business user key', async () => {
+    const code = await run(['check'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5' },
+      fetchImpl: healthyFetch,
+      stdout: silent,
+      stderr: silent,
+    });
+    assert.equal(code, 1);
+  });
+});
+
+const jsonResponse = (status, body) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });

--- a/adapters/plandex/test/cli.test.mjs
+++ b/adapters/plandex/test/cli.test.mjs
@@ -101,13 +101,17 @@ describe('run check', () => {
   const healthyFetch = async () => jsonResponse(200, { status: 'ok' });
 
   it('passes when proxy and core are healthy', async () => {
+    let out = '';
     const code = await run(['check'], {
       env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5', TDAI_USER_KEY: 'sk-mem-x' },
       fetchImpl: healthyFetch,
-      stdout: silent,
+      stdout: { log: (s) => (out += `${s}\n`), error() {} },
       stderr: silent,
     });
     assert.equal(code, 0);
+    assert.match(out, /model\s+gpt-5\.5/);
+    assert.match(out, /space\s+default/);
+    assert.match(out, /check passed/);
   });
 
   it('fails when the proxy is down and points at port 8096', async () => {
@@ -135,6 +139,18 @@ describe('run check', () => {
       stderr: silent,
     });
     assert.equal(code, 1);
+  });
+
+  it('warns, without failing, when the key does not look like a memory key', async () => {
+    let err = '';
+    const code = await run(['check'], {
+      env: { TDAI_UPSTREAM_MODEL: 'gpt-5.5', TDAI_USER_KEY: 'not-a-memory-key' },
+      fetchImpl: healthyFetch,
+      stdout: silent,
+      stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+    });
+    assert.equal(code, 0);
+    assert.match(err, /does not look like a Memory user key/i);
   });
 });
 

--- a/adapters/plandex/test/config.test.mjs
+++ b/adapters/plandex/test/config.test.mjs
@@ -1,0 +1,174 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  API_KEY_ENV_VAR,
+  DEFAULTS,
+  MODEL_ID,
+  PACK_NAME,
+  PROVIDER_NAME,
+  PUBLISHER,
+  SCHEMA_URL,
+  buildCustomModelsFile,
+  buildModel,
+  buildModelPack,
+  buildProvider,
+  normalizeBaseUrl,
+  parseEnv,
+  serializeCustomModels,
+  validateSpaceId,
+} from '../lib/config.mjs';
+
+describe('normalizeBaseUrl', () => {
+  it('strips trailing slashes', () => {
+    assert.equal(normalizeBaseUrl('http://127.0.0.1:8096///'), 'http://127.0.0.1:8096');
+  });
+
+  it('rejects non-http(s) URLs', () => {
+    assert.throws(() => normalizeBaseUrl('ftp://proxy'), /must start with http/);
+    assert.throws(() => normalizeBaseUrl('localhost:8096'), /must start with http/);
+  });
+
+  it('rejects query strings and fragments', () => {
+    assert.throws(() => normalizeBaseUrl('http://127.0.0.1:8096?x=1'), /query|fragment/i);
+    assert.throws(() => normalizeBaseUrl('http://127.0.0.1:8096#x'), /query|fragment/i);
+  });
+});
+
+describe('validateSpaceId', () => {
+  it('accepts safe identifiers', () => {
+    assert.doesNotThrow(() => validateSpaceId('default'));
+    assert.doesNotThrow(() => validateSpaceId('team-a_1'));
+  });
+
+  it('rejects unsafe identifiers', () => {
+    for (const bad of ['', '../x', 'a b', 'a/b', 'a?b', 'a#b']) {
+      assert.throws(() => validateSpaceId(bad));
+    }
+  });
+});
+
+describe('parseEnv', () => {
+  it('applies documented defaults', () => {
+    const cfg = parseEnv({ TDAI_UPSTREAM_MODEL: 'gpt-5.5' });
+    assert.equal(cfg.proxyBaseUrl, DEFAULTS.proxyBaseUrl);
+    assert.equal(cfg.coreBaseUrl, DEFAULTS.coreBaseUrl);
+    assert.equal(cfg.spaceId, DEFAULTS.spaceId);
+    assert.equal(cfg.upstreamModel, 'gpt-5.5');
+    assert.equal(cfg.userKey, undefined);
+    assert.equal(cfg.maxOutputTokens, DEFAULTS.maxOutputTokens);
+    assert.equal(cfg.defaultMaxConvoTokens, DEFAULTS.defaultMaxConvoTokens);
+  });
+
+  it('reads custom values and normalizes base URLs', () => {
+    const cfg = parseEnv({
+      TDAI_UPSTREAM_MODEL: 'm',
+      TDAI_PROXY_BASE_URL: 'http://proxy:1/',
+      TDAI_CORE_BASE_URL: 'http://core:2/',
+      TDAI_SPACE_ID: 'prod',
+      TDAI_USER_KEY: 'sk-mem-x',
+      TDAI_MAX_OUTPUT_TOKENS: '4096',
+      TDAI_DEFAULT_MAX_CONVO_TOKENS: '60000',
+    });
+    assert.equal(cfg.proxyBaseUrl, 'http://proxy:1');
+    assert.equal(cfg.coreBaseUrl, 'http://core:2');
+    assert.equal(cfg.spaceId, 'prod');
+    assert.equal(cfg.userKey, 'sk-mem-x');
+    assert.equal(cfg.maxOutputTokens, 4096);
+    assert.equal(cfg.defaultMaxConvoTokens, 60000);
+  });
+
+  it('fails with an actionable message when the upstream model is missing', () => {
+    assert.throws(() => parseEnv({}), /TDAI_UPSTREAM_MODEL/);
+    assert.throws(() => parseEnv({ TDAI_UPSTREAM_MODEL: '  ' }), /TDAI_UPSTREAM_MODEL/);
+  });
+
+  it('fails on invalid base URLs and space ids', () => {
+    assert.throws(() => parseEnv({ TDAI_UPSTREAM_MODEL: 'm', TDAI_PROXY_BASE_URL: 'nope' }), /TDAI_PROXY_BASE_URL/);
+    assert.throws(() => parseEnv({ TDAI_UPSTREAM_MODEL: 'm', TDAI_SPACE_ID: '../x' }), /TDAI_SPACE_ID/);
+  });
+});
+
+describe('buildProvider', () => {
+  it('maps to the proxy OpenAI-compatible route', () => {
+    const provider = buildProvider({ proxyBaseUrl: 'http://127.0.0.1:8096', spaceId: 'default' });
+    assert.deepEqual(provider, {
+      name: PROVIDER_NAME,
+      baseUrl: 'http://127.0.0.1:8096/proxy/default/v1',
+      apiKeyEnvVar: API_KEY_ENV_VAR,
+    });
+  });
+});
+
+describe('buildModel', () => {
+  it('maps the upstream model through the custom provider', () => {
+    const model = buildModel({
+      upstreamModel: 'gpt-5.5',
+      maxOutputTokens: 8192,
+      defaultMaxConvoTokens: 128000,
+    });
+    assert.equal(model.modelId, MODEL_ID);
+    assert.equal(model.publisher, PUBLISHER);
+    assert.equal(model.preferredOutputFormat, 'xml');
+    assert.equal(model.maxOutputTokens, 8192);
+    assert.equal(model.defaultMaxConvoTokens, 128000);
+    assert.equal(model.providers.length, 1);
+    assert.equal(model.providers[0].provider, 'custom');
+    assert.equal(model.providers[0].customProvider, PROVIDER_NAME);
+    assert.equal(model.providers[0].modelName, 'gpt-5.5');
+  });
+});
+
+describe('buildModelPack', () => {
+  it('assigns the memory-backed model to every role', () => {
+    const pack = buildModelPack({});
+    const ref = `${PUBLISHER}/${MODEL_ID}`;
+    assert.equal(pack.name, PACK_NAME);
+    for (const value of [
+      pack.planner,
+      pack.coder,
+      pack.architect,
+      pack.summarizer,
+      pack.names,
+      pack.commitMessages,
+    ]) {
+      assert.equal(value, ref);
+    }
+    assert.equal(pack.builder.modelId, ref);
+    assert.equal(pack.builder.strongModel, ref);
+  });
+});
+
+describe('buildCustomModelsFile', () => {
+  it('produces the documented plandex models-input shape', () => {
+    const cfg = {
+      proxyBaseUrl: 'http://127.0.0.1:8096',
+      spaceId: 'default',
+      upstreamModel: 'gpt-5.5',
+      maxOutputTokens: 8192,
+      defaultMaxConvoTokens: 128000,
+    };
+    const file = buildCustomModelsFile(cfg);
+    assert.equal(file.$schema, SCHEMA_URL);
+    assert.equal(file.providers.length, 1);
+    assert.equal(file.models.length, 1);
+    assert.equal(file.modelPacks.length, 1);
+    assert.deepEqual(file.providers[0], buildProvider(cfg));
+    assert.deepEqual(file.models[0], buildModel(cfg));
+    assert.deepEqual(file.modelPacks[0], buildModelPack(cfg));
+  });
+});
+
+describe('serializeCustomModels', () => {
+  it('emits pretty JSON with a trailing newline', () => {
+    const text = serializeCustomModels({
+      proxyBaseUrl: 'http://127.0.0.1:8096',
+      spaceId: 'default',
+      upstreamModel: 'gpt-5.5',
+    });
+    assert.ok(text.endsWith('\n'));
+    assert.ok(text.includes('\n  "providers"'));
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.$schema, SCHEMA_URL);
+  });
+});

--- a/adapters/plandex/test/config.test.mjs
+++ b/adapters/plandex/test/config.test.mjs
@@ -24,14 +24,26 @@ describe('normalizeBaseUrl', () => {
     assert.equal(normalizeBaseUrl('http://127.0.0.1:8096///'), 'http://127.0.0.1:8096');
   });
 
+  it('accepts uppercase schemes, IPv6 literals and custom ports', () => {
+    assert.equal(normalizeBaseUrl('HTTP://localhost:8096/'), 'http://localhost:8096');
+    assert.equal(normalizeBaseUrl('http://[::1]:8096/'), 'http://[::1]:8096');
+    assert.equal(normalizeBaseUrl('https://proxy.example.com:8443/'), 'https://proxy.example.com:8443');
+  });
+
   it('rejects non-http(s) URLs', () => {
     assert.throws(() => normalizeBaseUrl('ftp://proxy'), /must start with http/);
     assert.throws(() => normalizeBaseUrl('localhost:8096'), /must start with http/);
+    assert.throws(() => normalizeBaseUrl(''), /must start with http/);
+    assert.throws(() => normalizeBaseUrl('   '), /must start with http/);
   });
 
   it('rejects query strings and fragments', () => {
     assert.throws(() => normalizeBaseUrl('http://127.0.0.1:8096?x=1'), /query|fragment/i);
     assert.throws(() => normalizeBaseUrl('http://127.0.0.1:8096#x'), /query|fragment/i);
+  });
+
+  it('rejects embedded credentials so secrets cannot leak into config files', () => {
+    assert.throws(() => normalizeBaseUrl('http://user:pass@127.0.0.1:8096'), /credentials/i);
   });
 });
 
@@ -78,6 +90,12 @@ describe('parseEnv', () => {
     assert.equal(cfg.defaultMaxConvoTokens, 60000);
   });
 
+  it('trims surrounding whitespace from string values', () => {
+    const cfg = parseEnv({ TDAI_UPSTREAM_MODEL: '  gpt-5.5  ', TDAI_SPACE_ID: ' prod ' });
+    assert.equal(cfg.upstreamModel, 'gpt-5.5');
+    assert.equal(cfg.spaceId, 'prod');
+  });
+
   it('fails with an actionable message when the upstream model is missing', () => {
     assert.throws(() => parseEnv({}), /TDAI_UPSTREAM_MODEL/);
     assert.throws(() => parseEnv({ TDAI_UPSTREAM_MODEL: '  ' }), /TDAI_UPSTREAM_MODEL/);
@@ -86,6 +104,19 @@ describe('parseEnv', () => {
   it('fails on invalid base URLs and space ids', () => {
     assert.throws(() => parseEnv({ TDAI_UPSTREAM_MODEL: 'm', TDAI_PROXY_BASE_URL: 'nope' }), /TDAI_PROXY_BASE_URL/);
     assert.throws(() => parseEnv({ TDAI_UPSTREAM_MODEL: 'm', TDAI_SPACE_ID: '../x' }), /TDAI_SPACE_ID/);
+  });
+
+  it('fails on non-positive, fractional or non-numeric token limits', () => {
+    for (const bad of ['abc', '0', '-5', '1.5']) {
+      assert.throws(
+        () => parseEnv({ TDAI_UPSTREAM_MODEL: 'm', TDAI_MAX_OUTPUT_TOKENS: bad }),
+        /TDAI_MAX_OUTPUT_TOKENS/,
+      );
+    }
+    assert.throws(
+      () => parseEnv({ TDAI_UPSTREAM_MODEL: 'm', TDAI_DEFAULT_MAX_CONVO_TOKENS: 'abc' }),
+      /TDAI_DEFAULT_MAX_CONVO_TOKENS/,
+    );
   });
 });
 
@@ -97,6 +128,19 @@ describe('buildProvider', () => {
       baseUrl: 'http://127.0.0.1:8096/proxy/default/v1',
       apiKeyEnvVar: API_KEY_ENV_VAR,
     });
+  });
+
+  it('falls back to documented defaults and keeps https/custom ports intact', () => {
+    assert.deepEqual(buildProvider({}), {
+      name: PROVIDER_NAME,
+      baseUrl: `${DEFAULTS.proxyBaseUrl}/proxy/${DEFAULTS.spaceId}/v1`,
+      apiKeyEnvVar: API_KEY_ENV_VAR,
+    });
+    const provider = buildProvider({
+      proxyBaseUrl: 'https://proxy.example.com:8443',
+      spaceId: 'team-a',
+    });
+    assert.equal(provider.baseUrl, 'https://proxy.example.com:8443/proxy/team-a/v1');
   });
 });
 
@@ -116,6 +160,17 @@ describe('buildModel', () => {
     assert.equal(model.providers[0].provider, 'custom');
     assert.equal(model.providers[0].customProvider, PROVIDER_NAME);
     assert.equal(model.providers[0].modelName, 'gpt-5.5');
+  });
+
+  it('falls back to default token budgets when not configured', () => {
+    const model = buildModel({ upstreamModel: 'gpt-5.5' });
+    assert.equal(model.maxOutputTokens, DEFAULTS.maxOutputTokens);
+    assert.equal(model.reservedOutputTokens, DEFAULTS.maxOutputTokens);
+    assert.equal(model.defaultMaxConvoTokens, DEFAULTS.defaultMaxConvoTokens);
+  });
+
+  it('refuses to emit a model without an upstream model id', () => {
+    assert.throws(() => buildModel({}), /upstreamModel/);
   });
 });
 

--- a/adapters/plandex/test/docs.test.mjs
+++ b/adapters/plandex/test/docs.test.mjs
@@ -7,6 +7,16 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const root = join(here, '..');
 
+const REQUIRED_TERMS = [
+  'TDAI_UPSTREAM_MODEL',
+  'TDAI_USER_KEY',
+  'TDAI_PROXY_BASE_URL',
+  'TDAI_CORE_BASE_URL',
+  'TDAI_SPACE_ID',
+  'generate',
+  'check',
+];
+
 // The official Season 2 rule requires EN and CN docs in the same PR.
 // This guard mirrors that rule so it can never regress silently.
 describe('bilingual documentation guard', () => {
@@ -18,6 +28,9 @@ describe('bilingual documentation guard', () => {
       assert.match(text, /tencentdb-agent-memory/i);
       assert.match(text, /\/proxy\//);
       assert.match(text, /TDAI_USER_KEY/);
+      for (const term of REQUIRED_TERMS) {
+        assert.ok(text.includes(term), `${file} must document "${term}"`);
+      }
     });
 
     it(`${file} has no broken local links`, async () => {

--- a/adapters/plandex/test/docs.test.mjs
+++ b/adapters/plandex/test/docs.test.mjs
@@ -19,5 +19,22 @@ describe('bilingual documentation guard', () => {
       assert.match(text, /\/proxy\//);
       assert.match(text, /TDAI_USER_KEY/);
     });
+
+    it(`${file} has no broken local links`, async () => {
+      const text = await readFile(join(root, file), 'utf8');
+      const targets = [...text.matchAll(/\]\(([^)]+)\)/g)]
+        .map((match) => match[1].trim())
+        .filter((target) => !/^(https?:|#)/.test(target));
+
+      assert.ok(targets.length > 0, `${file} should reference at least one local file`);
+      for (const target of targets) {
+        const path = target.split('#')[0];
+        try {
+          await access(join(root, path));
+        } catch {
+          throw new Error(`broken link in ${file}: ${target}`);
+        }
+      }
+    });
   }
 });

--- a/adapters/plandex/test/docs.test.mjs
+++ b/adapters/plandex/test/docs.test.mjs
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+
+// The official Season 2 rule requires EN and CN docs in the same PR.
+// This guard mirrors that rule so it can never regress silently.
+describe('bilingual documentation guard', () => {
+  for (const file of ['README.md', 'README_CN.md']) {
+    it(`${file} exists and is a real guide`, async () => {
+      await access(join(root, file));
+      const text = await readFile(join(root, file), 'utf8');
+      assert.ok(text.trim().length > 500, `${file} should be a guide, not a stub`);
+      assert.match(text, /tencentdb-agent-memory/i);
+      assert.match(text, /\/proxy\//);
+      assert.match(text, /TDAI_USER_KEY/);
+    });
+  }
+});

--- a/adapters/plandex/test/entry.test.mjs
+++ b/adapters/plandex/test/entry.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+
+const runCli = (args, env = {}) =>
+  spawnSync(process.execPath, ['tdai-plandex.mjs', ...args], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+
+describe('CLI entry point (real process smoke test)', () => {
+  it('--version prints a semver and exits 0', () => {
+    const result = runCli(['--version']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout.trim(), /^tdai-plandex \d+\.\d+\.\d+$/);
+  });
+
+  it('--help prints usage and exits 0', () => {
+    const result = runCli(['--help']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Usage:/);
+  });
+
+  it('generate --dry-run emits parseable JSON through the real process', () => {
+    const result = runCli(['generate', '--dry-run'], { TDAI_UPSTREAM_MODEL: 'gpt-5.5' });
+    assert.equal(result.status, 0);
+    assert.equal(JSON.parse(result.stdout).providers[0].name, 'tencentdb-agent-memory');
+  });
+
+  it('unknown commands exit 1 with a diagnostic', () => {
+    const result = runCli(['frobnicate']);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /unknown command/i);
+  });
+});

--- a/adapters/plandex/test/http.test.mjs
+++ b/adapters/plandex/test/http.test.mjs
@@ -9,6 +9,14 @@ const jsonResponse = (status, body) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
+const pendingUntilAbort = () =>
+  (url, init) =>
+    new Promise((_, reject) => {
+      init.signal.addEventListener('abort', () =>
+        reject(new DOMException('The operation was aborted.', 'AbortError')),
+      );
+    });
+
 describe('buildHealthUrl', () => {
   it('joins the /health endpoint', () => {
     assert.equal(buildHealthUrl('http://127.0.0.1:8096'), 'http://127.0.0.1:8096/health');
@@ -48,6 +56,27 @@ describe('getJson', () => {
     assert.equal(result.ok, false);
     assert.match(result.error, /json/i);
   });
+
+  it('times out instead of hanging forever', async () => {
+    const result = await getJson('http://proxy/health', {
+      fetchImpl: pendingUntilAbort(),
+      timeoutMs: 15,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /timed out after 15ms/);
+  });
+
+  it('forwards custom headers to the fetch implementation', async () => {
+    let seenHeaders;
+    await getJson('http://proxy/health', {
+      headers: { 'x-custom': 'yes' },
+      fetchImpl: async (url, init) => {
+        seenHeaders = init.headers;
+        return jsonResponse(200, { status: 'ok' });
+      },
+    });
+    assert.equal(seenHeaders['x-custom'], 'yes');
+  });
 });
 
 describe('postChatCompletion', () => {
@@ -73,6 +102,21 @@ describe('postChatCompletion', () => {
     assert.equal(body.messages[0].role, 'user');
   });
 
+  it('normalizes a trailing slash on the base URL to avoid double slashes', async () => {
+    let seenUrl;
+    await postChatCompletion({
+      baseUrl: 'http://127.0.0.1:8096/',
+      spaceId: 'default',
+      model: 'gpt-5.5',
+      apiKey: 'sk-mem-x',
+      fetchImpl: async (url) => {
+        seenUrl = url;
+        return jsonResponse(200, { choices: [] });
+      },
+    });
+    assert.equal(seenUrl, 'http://127.0.0.1:8096/proxy/default/v1/chat/completions');
+  });
+
   it('reports upstream failures', async () => {
     const result = await postChatCompletion({
       baseUrl: 'http://proxy',
@@ -83,5 +127,30 @@ describe('postChatCompletion', () => {
     });
     assert.equal(result.ok, false);
     assert.equal(result.status, 401);
+  });
+
+  it('reports a non-JSON success body without throwing', async () => {
+    const result = await postChatCompletion({
+      baseUrl: 'http://proxy',
+      spaceId: 'default',
+      model: 'm',
+      apiKey: 'k',
+      fetchImpl: async () => new Response('not-json', { status: 200 }),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /json/i);
+  });
+
+  it('times out instead of hanging forever', async () => {
+    const result = await postChatCompletion({
+      baseUrl: 'http://proxy',
+      spaceId: 'default',
+      model: 'm',
+      apiKey: 'k',
+      fetchImpl: pendingUntilAbort(),
+      timeoutMs: 15,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /timed out after 15ms/);
   });
 });

--- a/adapters/plandex/test/http.test.mjs
+++ b/adapters/plandex/test/http.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildHealthUrl, getJson, postChatCompletion } from '../lib/http.mjs';
+
+const jsonResponse = (status, body) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('buildHealthUrl', () => {
+  it('joins the /health endpoint', () => {
+    assert.equal(buildHealthUrl('http://127.0.0.1:8096'), 'http://127.0.0.1:8096/health');
+  });
+});
+
+describe('getJson', () => {
+  it('returns ok for 2xx JSON responses', async () => {
+    const result = await getJson('http://proxy/health', {
+      fetchImpl: async () => jsonResponse(200, { status: 'ok' }),
+    });
+    assert.deepEqual(result, { ok: true, status: 200, body: { status: 'ok' } });
+  });
+
+  it('reports non-2xx responses', async () => {
+    const result = await getJson('http://proxy/health', {
+      fetchImpl: async () => jsonResponse(503, { status: 'degraded' }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 503);
+  });
+
+  it('reports network errors without throwing', async () => {
+    const result = await getJson('http://proxy/health', {
+      fetchImpl: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /ECONNREFUSED/);
+  });
+
+  it('reports malformed JSON without throwing', async () => {
+    const result = await getJson('http://proxy/health', {
+      fetchImpl: async () => new Response('not-json', { status: 200 }),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /json/i);
+  });
+});
+
+describe('postChatCompletion', () => {
+  it('POSTs to the proxy route with identity headers', async () => {
+    let seen;
+    const result = await postChatCompletion({
+      baseUrl: 'http://127.0.0.1:8096',
+      spaceId: 'default',
+      model: 'gpt-5.5',
+      apiKey: 'sk-mem-x',
+      fetchImpl: async (url, init) => {
+        seen = { url, init };
+        return jsonResponse(200, { choices: [] });
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(seen.url, 'http://127.0.0.1:8096/proxy/default/v1/chat/completions');
+    assert.equal(seen.init.headers['x-tdai-user-key'], 'sk-mem-x');
+    assert.equal(seen.init.headers.Authorization, 'Bearer sk-mem-x');
+    const body = JSON.parse(seen.init.body);
+    assert.equal(body.model, 'gpt-5.5');
+    assert.equal(body.max_tokens, 1);
+    assert.equal(body.messages[0].role, 'user');
+  });
+
+  it('reports upstream failures', async () => {
+    const result = await postChatCompletion({
+      baseUrl: 'http://proxy',
+      spaceId: 'default',
+      model: 'm',
+      apiKey: 'k',
+      fetchImpl: async () => jsonResponse(401, { error: { message: 'bad key' } }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 401);
+  });
+});

--- a/adapters/plandex/test/integration.test.mjs
+++ b/adapters/plandex/test/integration.test.mjs
@@ -1,0 +1,92 @@
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+
+import { run } from '../lib/cli.mjs';
+
+const silent = { log() {}, error() {} };
+
+describe('integration against a local mock gateway', () => {
+  let server;
+  let base;
+  let seen;
+
+  before(async () => {
+    seen = [];
+    server = createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (chunk) => chunks.push(chunk));
+      req.on('end', () => {
+        seen.push({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+
+        if (req.method === 'GET' && req.url === '/health') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+        } else if (req.method === 'POST' && req.url === '/proxy/default/v1/chat/completions') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              id: 'cmpl-1',
+              object: 'chat.completion',
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'pong' },
+                  finish_reason: 'stop',
+                },
+              ],
+            }),
+          );
+        } else {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end('{"error":"not found"}');
+        }
+      });
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('check --probe reaches the documented proxy route with identity headers', async () => {
+    seen = [];
+    const env = {
+      TDAI_PROXY_BASE_URL: base,
+      TDAI_CORE_BASE_URL: base,
+      TDAI_SPACE_ID: 'default',
+      TDAI_UPSTREAM_MODEL: 'gpt-test',
+      TDAI_USER_KEY: 'sk-mem-test',
+    };
+    const code = await run(['check', '--probe'], { env, stdout: silent, stderr: silent });
+    assert.equal(code, 0);
+
+    assert.equal(seen.filter((req) => req.url === '/health').length, 2);
+    const probe = seen.find((req) => req.method === 'POST');
+    assert.ok(probe, 'expected a probe request');
+    assert.equal(probe.url, '/proxy/default/v1/chat/completions');
+    assert.equal(probe.headers['x-tdai-user-key'], 'sk-mem-test');
+    assert.equal(probe.headers.authorization, 'Bearer sk-mem-test');
+    assert.equal(JSON.parse(probe.body).model, 'gpt-test');
+  });
+
+  it('fails cleanly when the gateway is unreachable', async () => {
+    const env = {
+      TDAI_PROXY_BASE_URL: 'http://127.0.0.1:1',
+      TDAI_CORE_BASE_URL: 'http://127.0.0.1:1',
+      TDAI_UPSTREAM_MODEL: 'gpt-test',
+      TDAI_USER_KEY: 'sk-mem-test',
+    };
+    const code = await run(['check'], { env, stdout: silent, stderr: silent });
+    assert.equal(code, 1);
+  });
+});

--- a/adapters/plandex/test/integration.test.mjs
+++ b/adapters/plandex/test/integration.test.mjs
@@ -28,7 +28,7 @@ describe('integration against a local mock gateway', () => {
         if (req.method === 'GET' && req.url === '/health') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ status: 'ok' }));
-        } else if (req.method === 'POST' && req.url === '/proxy/default/v1/chat/completions') {
+        } else if (req.method === 'POST' && /^\/proxy\/[^/]+\/v1\/chat\/completions$/.test(req.url)) {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(
             JSON.stringify({
@@ -79,6 +79,34 @@ describe('integration against a local mock gateway', () => {
     assert.equal(JSON.parse(probe.body).model, 'gpt-test');
   });
 
+  it('check --probe honors a custom space id in the route', async () => {
+    seen = [];
+    const env = {
+      TDAI_PROXY_BASE_URL: base,
+      TDAI_CORE_BASE_URL: base,
+      TDAI_SPACE_ID: 'team-b',
+      TDAI_UPSTREAM_MODEL: 'gpt-test',
+      TDAI_USER_KEY: 'sk-mem-test',
+    };
+    const code = await run(['check', '--probe'], { env, stdout: silent, stderr: silent });
+    assert.equal(code, 0);
+    const probe = seen.find((req) => req.method === 'POST');
+    assert.equal(probe.url, '/proxy/team-b/v1/chat/completions');
+  });
+
+  it('check without --probe never sends a chat request', async () => {
+    seen = [];
+    const env = {
+      TDAI_PROXY_BASE_URL: base,
+      TDAI_CORE_BASE_URL: base,
+      TDAI_UPSTREAM_MODEL: 'gpt-test',
+      TDAI_USER_KEY: 'sk-mem-test',
+    };
+    const code = await run(['check'], { env, stdout: silent, stderr: silent });
+    assert.equal(code, 0);
+    assert.equal(seen.filter((req) => req.method === 'POST').length, 0);
+  });
+
   it('fails cleanly when the gateway is unreachable', async () => {
     const env = {
       TDAI_PROXY_BASE_URL: 'http://127.0.0.1:1',
@@ -88,5 +116,69 @@ describe('integration against a local mock gateway', () => {
     };
     const code = await run(['check'], { env, stdout: silent, stderr: silent });
     assert.equal(code, 1);
+  });
+});
+
+describe('integration failure paths', () => {
+  const startServer = async (handler) => {
+    const server = createServer(handler);
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    return { server, base: `http://127.0.0.1:${server.address().port}` };
+  };
+
+  it('fails when /health is unhealthy', async () => {
+    const { server, base } = await startServer((req, res) => {
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end('{"status":"degraded"}');
+    });
+    try {
+      const env = {
+        TDAI_PROXY_BASE_URL: base,
+        TDAI_CORE_BASE_URL: base,
+        TDAI_UPSTREAM_MODEL: 'gpt-test',
+        TDAI_USER_KEY: 'sk-mem-test',
+      };
+      let err = '';
+      const code = await run(['check'], {
+        env,
+        stdout: silent,
+        stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+      });
+      assert.equal(code, 1);
+      assert.match(err, /MemoryProxy/);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('fails when the chat probe receives a 401 from upstream', async () => {
+    const { server, base } = await startServer((req, res) => {
+      if (req.method === 'POST') {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end('{"error":{"message":"bad key"}}');
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{"status":"ok"}');
+      }
+    });
+    try {
+      const env = {
+        TDAI_PROXY_BASE_URL: base,
+        TDAI_CORE_BASE_URL: base,
+        TDAI_UPSTREAM_MODEL: 'gpt-test',
+        TDAI_USER_KEY: 'sk-mem-test',
+      };
+      let err = '';
+      const code = await run(['check', '--probe'], {
+        env,
+        stdout: silent,
+        stderr: { log: (s) => (err += s), error: (s) => (err += s) },
+      });
+      assert.equal(code, 1);
+      assert.match(err, /chat probe failed/);
+    } finally {
+      server.close();
+    }
   });
 });

--- a/adapters/plandex/test/package.test.mjs
+++ b/adapters/plandex/test/package.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+
+describe('package manifest', () => {
+  it('is valid JSON with the expected adapter fields', async () => {
+    const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+    assert.equal(pkg.name, '@tdai/plandex-adapter');
+    assert.equal(pkg.type, 'module');
+    assert.equal(pkg.private, true);
+    assert.match(pkg.version, /^\d+\.\d+\.\d+$/);
+    assert.ok(pkg.engines?.node, 'engines.node should pin the runtime');
+    assert.ok(pkg.scripts?.test, 'npm test should be wired');
+    assert.ok(pkg.scripts?.['test:coverage'], 'npm run test:coverage should be wired');
+  });
+});
+
+describe('changelog', () => {
+  it('exists and records the initial version', async () => {
+    await access(join(root, 'CHANGELOG.md'));
+    const text = await readFile(join(root, 'CHANGELOG.md'), 'utf8');
+    assert.match(text, /0\.1\.0/);
+    assert.match(text, /Keep a Changelog/);
+  });
+});

--- a/adapters/plandex/test/quality.test.mjs
+++ b/adapters/plandex/test/quality.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+
+const sourceFiles = [
+  'tdai-plandex.mjs',
+  ...(await readdir(join(root, 'lib'))).filter((name) => name.endsWith('.mjs')).map((name) => `lib/${name}`),
+];
+
+describe('source quality guard', () => {
+  for (const file of sourceFiles) {
+    it(`${file} has no TODO/FIXME/XXX markers`, async () => {
+      const text = await readFile(join(root, file), 'utf8');
+      assert.doesNotMatch(text, /\b(TODO|FIXME|XXX)\b/);
+    });
+
+    it(`${file} does not write secrets or debug output`, async () => {
+      const text = await readFile(join(root, file), 'utf8');
+      assert.doesNotMatch(text, /ghp_[A-Za-z0-9]{20,}/);
+      assert.doesNotMatch(text, /sk-mem-[A-Za-z0-9]{20,}/);
+      assert.doesNotMatch(text, /console\.log\(/);
+    });
+  }
+});


### PR DESCRIPTION
## What

Adds `adapters/plandex/`, connecting Plandex to TencentDB Agent Memory and extending [#926](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/926) to Plandex.

## How it works

Plandex can register any OpenAI-compatible service as a custom provider. We register MemoryProxy as `tencentdb-agent-memory` with baseUrl `http://127.0.0.1:8096/proxy/<spaceId>/v1`, so every Plandex role runs through the team memory pipeline.

- **Provider**: `tencentdb-agent-memory`, key read from `TDAI_USER_KEY`
- **Model**: `tencentdb/tdai-memory-agent`, mapped to `PROXY_UPSTREAM_MODEL`
- **Model pack**: `tdai-memory-pack`, covering planner / coder / architect / summarizer / builder / names / commitMessages
- **CLI**: `tdai-plandex.mjs generate` produces the config; `check --probe` verifies proxy/core health plus a one-token chat round-trip through `/proxy/<spaceId>/v1/chat/completions`

## Files

| File | Purpose |
| --- | --- |
| `tdai-plandex.mjs` | zero-dependency CLI entry point |
| `lib/config.mjs` | environment parsing and Plandex models-input JSON generation |
| `lib/http.mjs` | health check and chat probe client |
| `lib/cli.mjs` | argument parsing and generate/check commands |
| `test/*.test.mjs` | 79 tests, written tests-first |
| `README.md` / `README_CN.md` | bilingual setup guide |

## Testing

Written tests-first with Node's built-in test runner, zero npm dependencies:

```bash
cd adapters/plandex
npm test              # 79/79 passing
npm run test:coverage # coverage report
```

Coverage spans config generation and validation, URL edge cases, environment parsing and diagnostics, proxy/core health checks, the exact probe route and `x-tdai-user-key` / `Authorization` headers (integration tests against a local mock gateway), timeouts and upstream failures, CLI dry-run / overwrite safety / parent-directory creation, real process entry smoke tests, package-manifest and changelog checks, source-quality guards, and a bilingual-docs guard matching the official rule.

Measured coverage: 99.6% lines / 94.9% branches / 100% functions.

## Notes

- The API key is never written to any committed file; `TDAI_USER_KEY` lives only in the environment.
- Requires Plandex self-hosted mode (custom providers are self-host only) and the standard local three-piece stack.