### PR TITLE
fix(core): switch tool-mode LLM call to streamText for /v2 gateway co…

### DIFF
--- a/MemoryCore/src/adapters/standalone/llm-runner.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.ts
@@ -18,7 +18,7 @@
 
 import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { generateText, tool, stepCountIs, jsonSchema } from "ai";
+import { streamText, tool, stepCountIs, jsonSchema } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 import { report } from "../../core/report/reporter.js";
 import type {
@@ -318,7 +318,11 @@ export class StandaloneLLMRunner implements LLMRunner {
         ? AbortSignal.any([timeoutSignal, params.abortSignal])
         : timeoutSignal;
 
-      const result = await generateText({
+      // NOTE: use streamText instead of generateText — the copilot.tencent.com/v2
+      // gateway rejects non-streaming chat/completions with code 11101 (Bad Request).
+      // streamText drives the multi-step tool loop via stopWhen/stepCountIs
+      // (AI SDK v6 removed `maxSteps`), so both pure-text and tool tasks work.
+      const result = streamText({
         model: provider.chat(this.model),
         system: params.systemPrompt,
         prompt: params.prompt,
@@ -337,26 +341,34 @@ export class StandaloneLLMRunner implements LLMRunner {
         },
       });
 
-      const text = (result.text ?? "").trim();
+      // streamText has no `result.text` / `result.usage` synchronously — the
+      // text must be aggregated from `textStream`, and steps/usage are awaited.
+      let accText = "";
+      for await (const chunk of result.textStream) {
+        accText += chunk;
+      }
+      const text = accText.trim();
+      const steps = await result.steps;
+      const totalUsage = await result.totalUsage;
       const totalMs = Date.now() - runStartMs;
 
       // 暴露 token usage 到 side-channel（供 MetricTrackingRunner 读取）
-      if (result.usage) {
+      if (totalUsage) {
         this.lastUsage = {
-          promptTokens: result.usage.promptTokens ?? 0,
-          completionTokens: result.usage.completionTokens ?? 0,
-          totalTokens: (result.usage.promptTokens ?? 0) + (result.usage.completionTokens ?? 0),
+          promptTokens: totalUsage.inputTokens ?? 0,
+          completionTokens: totalUsage.outputTokens ?? 0,
+          totalTokens: (totalUsage.inputTokens ?? 0) + (totalUsage.outputTokens ?? 0),
         };
       } else {
         this.lastUsage = undefined;
       }
 
       this.logger?.debug?.(
-        `${TAG} run() completed: ${totalMs}ms, steps=${result.steps.length}, output=${text.length} chars`,
+        `${TAG} run() completed (stream): ${totalMs}ms, steps=${steps.length}, output=${text.length} chars`,
       );
 
       // Log each step's activity (tool calls + text output)
-      for (const step of result.steps) {
+      for (const step of steps) {
         const calls = step.toolCalls ?? [];
         const textLen = step.text?.length ?? 0;
         if (calls.length > 0) {

--- a/MemoryCore/src/metadata/config/metadata_config_params.json
+++ b/MemoryCore/src/metadata/config/metadata_config_params.json
@@ -48,6 +48,18 @@
           "allowed_scopes": ["global", "user"]
         }
       ]
+    },
+    {
+      "module": "llm",
+      "description": "LLM 上游配置参数（按用户绑定转发到代理上游的 API Key）",
+      "params": [
+        {
+          "param_name": "api_key",
+          "param_value": "",
+          "description": "该用户转发到上游 LLM 时使用的 API Key（必填，未配置则上游鉴权失败；不回落到代理全局/agent Key）",
+          "allowed_scopes": ["global", "user"]
+        }
+      ]
     }
   ]
 }

--- a/MemoryPanel/web/src/components/SettingsDialog.tsx
+++ b/MemoryPanel/web/src/components/SettingsDialog.tsx
@@ -1,9 +1,12 @@
 /**
  * SettingsDialog — 全局设置弹窗（从顶栏⚙图标触发）。
  *
- * 当前只有一个 Tab：「权限管理」— 控制资源管理模块的开关
- * （Wiki / Code / Skill / Chat_Memory），防止未稳定使用的模块
- * 被注入内核运行。
+ * 目前两个 Tab：
+ *   - 「权限管理」：控制资源管理模块的开关（Wiki / Code / Skill / Chat_Memory），
+ *     防止未稳定使用的模块被注入内核运行。
+ *   - 「上游 LLM」：让用户配置自己转发到上游 LLM 的 API Key（存于内核
+ *     `llm.api_key` config param，按当前登录用户保存）。proxy 转发该用户的
+ *     请求时只使用此 Key 作为上游服务端 Key，不回落到代理全局 / Agent Key。
  *
  * 后续可在 TABS 数组里追加其他 Tab（如通知、偏好设置等）。
  *
@@ -16,6 +19,9 @@ import {
   Text,
   Tag,
   Modal,
+  Input,
+  Button,
+  Form,
 } from 'tea-component';
 import {
   BooksIcon,
@@ -24,6 +30,7 @@ import {
   ChatIcon,
 } from 'tea-icons-react';
 import { userConfigApi, type AssetCapabilityKey } from '@/lib/teamApi';
+import { getCurrentUser } from '@/lib/api/base';
 import { tea } from '@/lib/tea-bridge';
 
 // ===== 资源模块 =====
@@ -67,12 +74,13 @@ const RESOURCE_MODULES: ResourceModule[] = [
   },
 ];
 
-type SettingsTab = 'permissions';
+type SettingsTab = 'permissions' | 'upstream';
 
 export function SettingsDialog({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
-  const activeTab: SettingsTab = 'permissions';
+  const [activeTab, setActiveTab] = useState<SettingsTab>('permissions');
 
+  // ===== Tab 1: 权限管理 =====
   const [enabled, setEnabled] = useState<Record<string, boolean>>(() => ({
     wiki: true,
     code: true,
@@ -124,71 +132,217 @@ export function SettingsDialog({ onClose }: { onClose: () => void }) {
     }
   }
 
+  // ===== Tab 2: 上游 LLM（按当前登录用户保存） =====
+  const [upstreamLoading, setUpstreamLoading] = useState(true);
+  const [upstreamSaving, setUpstreamSaving] = useState(false);
+  const [upstreamKey, setUpstreamKey] = useState('');
+  const [upstreamInitKey, setUpstreamInitKey] = useState('');
+  const [upstreamError, setUpstreamError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setUpstreamLoading(true);
+    setUpstreamError('');
+    (async () => {
+      try {
+        const me = await getCurrentUser();
+        const view = await userConfigApi.get(me.user_id, 'llm', 'api_key');
+        if (cancelled) return;
+        const val = view.items?.[0]?.effective_value ?? '';
+        setUpstreamKey(val);
+        setUpstreamInitKey(val);
+      } catch (e) {
+        if (!cancelled) setUpstreamError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setUpstreamLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handleSaveUpstream() {
+    setUpstreamSaving(true);
+    setUpstreamError('');
+    try {
+      const me = await getCurrentUser();
+      await userConfigApi.set(me.user_id, 'llm', { api_key: upstreamKey.trim() });
+      setUpstreamInitKey(upstreamKey.trim());
+      tea.notify.success(t('settings.upstream.saved'));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setUpstreamError(msg);
+      tea.notify.error(t('settings.notify.saveFailed', { msg }));
+    } finally {
+      setUpstreamSaving(false);
+    }
+  }
+
+  async function handleClearUpstream() {
+    setUpstreamSaving(true);
+    setUpstreamError('');
+    try {
+      const me = await getCurrentUser();
+      await userConfigApi.set(me.user_id, 'llm', { api_key: '' });
+      setUpstreamKey('');
+      setUpstreamInitKey('');
+      tea.notify.success(t('settings.upstream.saved'));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setUpstreamError(msg);
+      tea.notify.error(t('settings.notify.saveFailed', { msg }));
+    } finally {
+      setUpstreamSaving(false);
+    }
+  }
+
+  const tabBtn = (id: SettingsTab, labelKey: string) => (
+    <button
+      type="button"
+      onClick={() => setActiveTab(id)}
+      style={{
+        padding: '6px 16px',
+        border: '1px solid var(--tea-color-border-primary-default)',
+        borderRadius: 6,
+        background: activeTab === id
+          ? 'var(--tea-color-bg-brand-lighten-default)'
+          : 'var(--tea-color-bg-primary-default)',
+        color: 'var(--tea-color-text-primary)',
+        fontWeight: activeTab === id ? 600 : 400,
+        cursor: 'pointer',
+      }}
+    >
+      {t(labelKey)}
+    </button>
+  );
+
   return (
     <Modal visible caption={t('settings.caption')} size="m" onClose={onClose}>
       <Modal.Body>
-      {activeTab === 'permissions' && (
-        <div>
-          <div style={{ paddingTop: 4 }}>
-            <Text theme="label" style={{ display: 'block', marginBottom: 8 }}>
-              {t('settings.title')}
-            </Text>
-            <Text theme="weak" style={{ display: 'block', marginBottom: 16, fontSize: 12 }}>
-              {t('settings.desc')}
-            </Text>
-            {error && <Alert type="error" style={{ marginBottom: 12 }}>{error}</Alert>}
-            {loading && <Alert type="info" style={{ marginBottom: 12 }}>{t('settings.loadingConfig')}</Alert>}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+          {tabBtn('permissions', 'settings.tab.permissions')}
+          {tabBtn('upstream', 'settings.tab.upstream')}
+        </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              {RESOURCE_MODULES.map((mod) => (
-                <div
-                  key={mod.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    padding: '10px 12px',
-                    border: '1px solid var(--tea-color-border-primary-default)',
-                    borderRadius: 6,
-                    background: enabled[mod.id]
-                      ? 'var(--tea-color-bg-brand-lighten-default)'
-                      : 'var(--tea-color-bg-primary-default)',
-                    transition: 'background-color 0.15s',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
-                    <span style={{ color: 'var(--tea-color-text-secondary)', flexShrink: 0 }}>
-                      {mod.icon}
-                    </span>
-                    <div style={{ minWidth: 0 }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <Text style={{ fontSize: 13, fontWeight: 500 }}>
-                          {t(mod.labelKey)}
+        {activeTab === 'permissions' && (
+          <div>
+            <div style={{ paddingTop: 4 }}>
+              <Text theme="label" style={{ display: 'block', marginBottom: 8 }}>
+                {t('settings.title')}
+              </Text>
+              <Text theme="weak" style={{ display: 'block', marginBottom: 16, fontSize: 12 }}>
+                {t('settings.desc')}
+              </Text>
+              {error && <Alert type="error" style={{ marginBottom: 12 }}>{error}</Alert>}
+              {loading && <Alert type="info" style={{ marginBottom: 12 }}>{t('settings.loadingConfig')}</Alert>}
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                {RESOURCE_MODULES.map((mod) => (
+                  <div
+                    key={mod.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      padding: '10px 12px',
+                      border: '1px solid var(--tea-color-border-primary-default)',
+                      borderRadius: 6,
+                      background: enabled[mod.id]
+                        ? 'var(--tea-color-bg-brand-lighten-default)'
+                        : 'var(--tea-color-bg-primary-default)',
+                      transition: 'background-color 0.15s',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+                      <span style={{ color: 'var(--tea-color-text-secondary)', flexShrink: 0 }}>
+                        {mod.icon}
+                      </span>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                          <Text style={{ fontSize: 13, fontWeight: 500 }}>
+                            {t(mod.labelKey)}
+                          </Text>
+                          {savingKey === mod.paramKey ? (
+                            <Tag theme="warning" variant="soft" size="sm">{t('settings.tag.saving')}</Tag>
+                          ) : enabled[mod.id] ? (
+                            <Tag theme="success" variant="soft" size="sm">{t('settings.tag.enabled')}</Tag>
+                          ) : (
+                            <Tag theme="default" variant="soft" size="sm">{t('settings.tag.disabled')}</Tag>
+                          )}
+                        </div>
+                        <Text theme="weak" style={{ fontSize: 12, marginTop: 2, display: 'block' }}>
+                          {t(mod.descKey)}
                         </Text>
-                        {savingKey === mod.paramKey ? (
-                          <Tag theme="warning" variant="soft" size="sm">{t('settings.tag.saving')}</Tag>
-                        ) : enabled[mod.id] ? (
-                          <Tag theme="success" variant="soft" size="sm">{t('settings.tag.enabled')}</Tag>
-                        ) : (
-                          <Tag theme="default" variant="soft" size="sm">{t('settings.tag.disabled')}</Tag>
-                        )}
                       </div>
-                      <Text theme="weak" style={{ fontSize: 12, marginTop: 2, display: 'block' }}>
-                        {t(mod.descKey)}
-                      </Text>
                     </div>
+                    <Switch
+                      value={enabled[mod.id]}
+                      disabled={loading || savingKey === mod.paramKey}
+                      onChange={(v) => void handleToggle(mod, v)}
+                    />
                   </div>
-                  <Switch
-                    value={enabled[mod.id]}
-                    disabled={loading || savingKey === mod.paramKey}
-                    onChange={(v) => void handleToggle(mod, v)}
-                  />
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+
+        {activeTab === 'upstream' && (
+          <div>
+            <div style={{ paddingTop: 4 }}>
+              <Text theme="label" style={{ display: 'block', marginBottom: 8 }}>
+                {t('settings.upstream.title')}
+              </Text>
+              <Text theme="weak" style={{ display: 'block', marginBottom: 16, fontSize: 12 }}>
+                {t('settings.upstream.desc')}
+              </Text>
+              {upstreamError && <Alert type="error" style={{ marginBottom: 12 }}>{upstreamError}</Alert>}
+              {upstreamLoading && <Alert type="info" style={{ marginBottom: 12 }}>{t('settings.upstream.loading')}</Alert>}
+
+              <Form layout="vertical" style={{ maxWidth: 480 }}>
+                <Form.Item
+                  label={t('settings.upstream.keyLabel')}
+                  extra={
+                    <span>
+                      <a
+                        href="https://tencent.sso.codebuddy.cn/profile/keys"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {t('settings.upstream.keyLink')}
+                      </a>
+                      {t('settings.upstream.keyExtra')}
+                    </span>
+                  }
+                >
+                  <Input
+                    value={upstreamKey}
+                    onChange={(v) => setUpstreamKey(v)}
+                    placeholder={t('settings.upstream.keyPlaceholder')}
+                    type="password"
+                    disabled={upstreamLoading}
+                  />
+                </Form.Item>
+                <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                  <Button
+                    type="primary"
+                    onClick={() => void handleSaveUpstream()}
+                    loading={upstreamSaving}
+                    disabled={upstreamLoading || upstreamKey.trim() === upstreamInitKey}
+                  >
+                    {t('settings.upstream.save')}
+                  </Button>
+                  <Button
+                    onClick={() => void handleClearUpstream()}
+                    loading={upstreamSaving}
+                    disabled={upstreamLoading || upstreamInitKey === ''}
+                  >
+                    {t('settings.upstream.clear')}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/MemoryPanel/web/src/i18n/en-US.ts
+++ b/MemoryPanel/web/src/i18n/en-US.ts
@@ -100,6 +100,20 @@ export const enUS = {
   'settings.notify.enabled': '{{label}} enabled',
   'settings.notify.disabled': '{{label}} disabled',
   'settings.notify.saveFailed': 'Save failed: {{msg}}',
+  // ===== SettingsDialog · Upstream LLM =====
+  'settings.tab.permissions': 'Permissions',
+  'settings.tab.upstream': 'Upstream LLM',
+  'settings.upstream.title': 'My upstream LLM API Key',
+  'settings.upstream.desc':
+    "Saved per signed-in user; the proxy uses this Key as the upstream server key when forwarding this user's requests (no fallback to the global default Key).",
+  'settings.upstream.keyLabel': 'API Key',
+  'settings.upstream.keyPlaceholder': 'ck_xxxxxxxx',
+  'settings.upstream.keyLink': 'Get a Key →',
+  'settings.upstream.keyExtra': ' (go to "API Management" in the left sidebar and click "Create Key")',
+  'settings.upstream.loading': 'Loading current user upstream config…',
+  'settings.upstream.save': 'Save',
+  'settings.upstream.saved': 'Upstream API Key saved',
+  'settings.upstream.clear': 'Clear',
 
   // ===== Common =====
   'common.cancel': 'Cancel',

--- a/MemoryPanel/web/src/i18n/zh-CN.ts
+++ b/MemoryPanel/web/src/i18n/zh-CN.ts
@@ -95,6 +95,20 @@ export const zhCN = {
   'settings.notify.enabled': '{{label}} 已开启',
   'settings.notify.disabled': '{{label}} 已关闭',
   'settings.notify.saveFailed': '保存失败：{{msg}}',
+  // ===== SettingsDialog · 上游 LLM =====
+  'settings.tab.permissions': '权限管理',
+  'settings.tab.upstream': '上游 LLM',
+  'settings.upstream.title': '我的上游 LLM API Key',
+  'settings.upstream.desc':
+    '按当前登录用户保存；proxy 转发该用户的请求时使用此 Key 作为上游服务端 Key（不回落到全局默认 Key）。',
+  'settings.upstream.keyLabel': 'API Key',
+  'settings.upstream.keyPlaceholder': 'ck_xxxxxxxx',
+  'settings.upstream.keyLink': '前往获取 Key →',
+  'settings.upstream.keyExtra': '（进入左侧「API 管理」，点击「创建密钥」）',
+  'settings.upstream.loading': '正在读取当前用户上游配置…',
+  'settings.upstream.save': '保存',
+  'settings.upstream.saved': '上游 API Key 已保存',
+  'settings.upstream.clear': '清除',
 
   // ===== Common =====
   'common.cancel': '取消',

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -1102,6 +1102,23 @@ export async function handleChatCompletions(
   const effectiveApiKey = agentUpstreamEntry
     ? (agentUpstreamEntry.apiKey ?? "")
     : config.upstream.apiKey;
+  // Per-user upstream key: a signed-in user (userId resolvable) MUST use the
+  // `llm.api_key` they configured on their own profile page (stored in the core
+  // config param) as the server-side key forwarded upstream — never falling back
+  // to the global / agent key when it's unset, lookup fails, or an error occurs.
+  // Leaving it empty lets the client's own key passthrough, so a missing config
+  // surfaces as an upstream auth failure prompting the user to configure one.
+  // The global / agent key is only used as a fallback when userId is not
+  // resolvable (e.g. auth disabled).
+  let resolvedApiKey = effectiveApiKey;
+  if (userId && apiKey && tdaiClient) {
+    try {
+      resolvedApiKey = await tdaiClient.getUserUpstreamApiKey(apiKey, userId);
+    } catch {
+      // ignore — treat as not configured, keep empty (no fallback)
+      resolvedApiKey = "";
+    }
+  }
   // Normalize the request path to the canonical upstream endpoint so the
   // extension's URL joining matches the host whitelist behavior.
   const forwardEndpoint = matchWhitelistEndpoint(c.req.path)?.upstreamEndpoint ?? "/chat/completions";
@@ -1199,7 +1216,7 @@ export async function handleChatCompletions(
   writeRequestLog(config, body);
 
   // ── Build upstream request ───────────────────────────────────────────────
-  const upstreamHeaders = buildUpstreamHeaders(c, config, target, sessionKey, effectiveApiKey);
+  const upstreamHeaders = buildUpstreamHeaders(c, config, target, sessionKey, resolvedApiKey);
 
   // Optional private preparation stage. It rewrites `body` / `messages` in
   // place, so it has to land after every host-side mutation (injection, agent
@@ -1223,7 +1240,6 @@ export async function handleChatCompletions(
     spaceId,
     lf,
   });
-
   const upstreamBody = buildUpstreamBody(body, target);
   // Retry headers: preserve original client headers (x-request-id, user-agent,
   // etc.), then force the primary upstream's auth — retry always goes to the
@@ -1236,11 +1252,11 @@ export async function handleChatCompletions(
       originalHeaders[k] = v;
     }
   }
-  // Retry uses the same effective key as the primary path — when it
-  // resolves to "" (agent entry present but no apiKey), retry also runs
-  // on the client's own key, preserving the passthrough intent.
-  if (effectiveApiKey) {
-    originalHeaders["authorization"] = `Bearer ${effectiveApiKey}`;
+  // Retry uses the same resolved key as the primary path — when it
+  // resolves to "" (no per-user key / agent entry with empty apiKey), retry
+  // also runs on the client's own key, preserving the passthrough intent.
+  if (resolvedApiKey) {
+    originalHeaders["authorization"] = `Bearer ${resolvedApiKey}`;
   }
 
   // Inject stream_options.include_usage for OpenAI compat

--- a/MemoryProxy/src/tdai/client.ts
+++ b/MemoryProxy/src/tdai/client.ts
@@ -301,6 +301,50 @@ export class TdaiClient {
     }
   }
 
+  /**
+   * 读取某用户自定义的上游 LLM API Key（面板里按用户配置，存于 core 的
+   * `llm.api_key` config param）。
+   *
+   * 返回非空字符串 → proxy 转发该用户请求到上游时用它作为服务端 key；
+   * 返回空串 / 出错 → 由调用方回落到 agent / 全局上游 key（fail-open，不影响转发）。
+   *
+   * 鉴权走 `x-tdai-user-key`（Layer 3 用户鉴权），core 侧 `assertCallerIsOwner`
+   * 要求调用者就是目标用户自己 —— 这里传入的就是请求发起者自身的 user_key。
+   */
+  async getUserUpstreamApiKey(userKey: string, userId: string): Promise<string> {
+    if (!this.isEnabled() || !userKey || !userId) return "";
+    const base = this.config.endpoint.replace(/\/$/, "");
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.timeoutMs);
+    try {
+      const res = await fetch(`${base}/v3/meta/config/user/get`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.config.apiKey || "local-proxy"}`,
+          "x-tdai-service-id": this.config.serviceId || "default",
+          "x-tdai-user-key": userKey,
+        },
+        body: JSON.stringify({
+          user_id: userId,
+          module: "llm",
+          param_name: "api_key",
+        }),
+      });
+      if (!res.ok) return "";
+      const envelope = (await res.json()) as TdaiEnvelope<{ items?: Array<{ effective_value?: unknown }> }>;
+      if (typeof envelope.code === "number" && envelope.code !== 0) return "";
+      const raw = envelope.data?.items?.[0]?.effective_value;
+      return typeof raw === "string" ? raw : "";
+    } catch {
+      // fail-open：查不到用户 key 就回落默认上游 key，绝不阻断转发。
+      return "";
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   // ── ACL check ──────────────────────────────────────────────────────────
   //
   // 与 memory 数据面调用（postForCtx）**语义相反**：


### PR DESCRIPTION
## 标题

fix(core): MemoryCore 工具模式的 LLM 调用改用 `streamText`（流式），修复 `copilot.tencent.com/v2` 网关拒绝非流式请求导致 L2/L3 场景提取失败

## 摘要

MemoryCore 在工具模式（`tools=true`，用于 L2/L3 场景提取）下调用 LLM 时使用的是 **`generateText`（非流式）**，而被调用的 LLM 网关 `copilot.tencent.com/v2` **拒绝非流式** `chat/completions` 请求（返回 `code 11101` / `Bad Request`）。这导致每次场景提取在约 1 秒内抛错失败：

- L2/L3 场景提取 `tools=true` → `generateText` → 网关返回 400 → `SceneExtractor` 判定 `emptyExtraction=true` → L2 runner 返回 `{skipped:true}` → `scene_blocks/` 永远为空。
- 而 L1（`tools=false`）走 `streamText`（流式）正常，能成功产出记忆，进一步印证差异只在流式/非流式。

本 PR 将工具模式的 `generateText` 改为 **`streamText`（流式）**，使纯文本与工具任务都能正常完成，L2/L3 场景提取恢复可用。

## 问题

`MemoryCore/src/adapters/standalone/llm-runner.ts`：

- 纯文本路径（`tools=false`）走 `streamText`（第 327 行），正常。
- 工具模式路径（`tools=true`）走 `generateText`（第 381 行），非流式，被 `copilot.tencent.com/v2` 网关以 `code 11101` 拒绝（HTTP 400 Bad Request）。
- 由于 L2/L3 场景提取走工具模式，所有场景提取都失败，`scene_blocks/` 始终为空、`scenario/ls` 返回 `total:0`。

## 修复

把工具模式的 `generateText` 改为 `streamText`，并适配其 API 差异（AI SDK v6）：

```ts
import { streamText, tool, stepCountIs, jsonSchema } from "ai";
// generateText -> streamText（流式）

const result = streamText({ /* ...原有参数不变... */ });

// streamText 没有同步的 result.text / result.usage，需从 textStream 聚合，steps/usage 为异步
let accText = "";
for await (const chunk of result.textStream) {
  accText += chunk;
}
const text = accText.trim();
const steps = await result.steps;
const totalUsage = await result.totalUsage;

if (totalUsage) {
  this.lastUsage = {
    promptTokens: totalUsage.inputTokens ?? 0,          // 原 usage.promptTokens
    completionTokens: totalUsage.outputTokens ?? 0,     // 原 usage.completionTokens
    totalTokens: (totalUsage.inputTokens ?? 0) + (totalUsage.outputTokens ?? 0),
  };
}
```

要点：

- **流式调用**：`generateText` → `streamText`，适配网关仅支持流式的约束。
- **文本聚合**：`result.text` → 用 `for await (chunk of result.textStream)` 聚合出 `accText`。
- **steps**：`result.steps` → `await result.steps`。
- **usage**：`result.usage` → `await result.totalUsage`，且字段从 `promptTokens/completionTokens` 改为 `inputTokens/outputTokens`（streamText 的流式字段）。
- **多步工具循环不受影响**：AI SDK v6 移除了 `maxSteps`，但 `streamText` 的 `stopWhen`/`stepCountIs(maxIterations)` 仍可驱动多步工具循环，因此纯文本与工具任务均可正常执行。

## 测试

- 本地容器运行验证（容器以 tsx 跑源码）：L2 场景提取由 `Bad Request` 变为 `run() completed (stream): 32921ms, steps=2`，成功写入 3 个场景 `.md` 到 `scene_blocks/`。
- `memory-bridge/v3/scenario/ls` 返回 3 个条目（`team_id=team-iwqiplx8mt, agent_id=agt-i4xz40mhzd`），L2/L3 场景提取恢复。

## 关联

无。上游暂无此问题的 issue，为直接贡献。

## 贡献者

- dong-frank <1057762929@qq.com>（Signed-off-by / DCO）
