### PR TITLE
fix(sdk/python): annotate context manager exit arguments with object

### DIFF
--- a/sdk/memory-core/python/tencentdb_agent_memory/v3/skill_client.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/v3/skill_client.py
@@ -581,7 +581,7 @@ class SkillClient:
     def __enter__(self) -> "SkillClient":
         return self
 
-    def __exit__(self, *exc: Any) -> None:
+    def __exit__(self, *exc: object) -> None:
         self.close()
 
 
@@ -952,5 +952,5 @@ class AsyncSkillClient:
     async def __aenter__(self) -> "AsyncSkillClient":
         return self
 
-    async def __aexit__(self, *exc: Any) -> None:
+    async def __aexit__(self, *exc: object) -> None:
         await self.close()


### PR DESCRIPTION
### Summary
- Update `__exit__` and `__aexit__` in `SkillClient` and `AsyncSkillClient` to annotate `*exc` with `object` instead of `Any`, following Python typing standards (PYI036).
- Ensures full compatibility with strict type checkers (MyPy, Pyright, Ruff).