### PR TITLE
fix(queue): resolve idle waiters when clearing queued tasks

### DIFF
--- a/MemoryCore/src/utils/serial-queue.test.ts
+++ b/MemoryCore/src/utils/serial-queue.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { SerialQueue } from "./serial-queue.js";
+
+describe("SerialQueue", () => {
+  it("resolves existing idle waiters when a paused queue is cleared", async () => {
+    const queue = new SerialQueue("test");
+    queue.pause();
+
+    const task = queue.add(async () => "never runs");
+    const rejection = expect(task).rejects.toThrow("Queue cleared");
+    let idle = false;
+    void queue.onIdle().then(() => {
+      idle = true;
+    });
+
+    queue.clear();
+    await rejection;
+    await Promise.resolve();
+
+    expect(queue.idle).toBe(true);
+    expect(idle).toBe(true);
+  });
+});

--- a/MemoryCore/src/utils/serial-queue.ts
+++ b/MemoryCore/src/utils/serial-queue.ts
@@ -95,6 +95,11 @@ export class SerialQueue {
       entry.reject(new Error("Queue cleared"));
     }
     this.queue = [];
+    if (!this.running) {
+      const resolvers = this.idleResolvers;
+      this.idleResolvers = [];
+      for (const resolve of resolvers) resolve();
+    }
   }
 
   private drain(): void {

--- a/MemoryKnowledge/src/store/serial-queue.test.ts
+++ b/MemoryKnowledge/src/store/serial-queue.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { SerialQueue } from "./serial-queue.js";
+
+describe("SerialQueue", () => {
+  it("resolves existing idle waiters when a paused queue is cleared", async () => {
+    const queue = new SerialQueue("test");
+    queue.pause();
+
+    const task = queue.add(async () => "never runs");
+    const rejection = expect(task).rejects.toThrow("Queue cleared");
+    let idle = false;
+    void queue.onIdle().then(() => {
+      idle = true;
+    });
+
+    queue.clear();
+    await rejection;
+    await Promise.resolve();
+
+    expect(queue.idle).toBe(true);
+    expect(idle).toBe(true);
+  });
+});

--- a/MemoryKnowledge/src/store/serial-queue.ts
+++ b/MemoryKnowledge/src/store/serial-queue.ts
@@ -76,6 +76,11 @@ export class SerialQueue {
       entry.reject(new Error("Queue cleared"));
     }
     this.queue = [];
+    if (!this.running) {
+      const resolvers = this.idleResolvers;
+      this.idleResolvers = [];
+      for (const resolve of resolvers) resolve();
+    }
   }
 
   private drain(): void {


### PR DESCRIPTION
## Description | 描述

Resolve existing `onIdle()` waiters when `clear()` makes a non-running `SerialQueue` idle. The same bug and focused regression test are addressed in both the MemoryCore and MemoryKnowledge implementations.

If a task is already running, `clear()` leaves notification to the existing task completion path, so waiters are not resolved early.

## Related Issue | 关联 Issue

Fixes #1039

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Focused verification:

- Both new Vitest regression tests pass.
- Both changed `SerialQueue` source files pass TypeScript checking.
- The source-level reproduction now returns `{"task":"cleared","onIdle":"idle","idleState":true}` instead of timing out.

AI assistance was used for investigation, implementation, and test drafting; the reproduction and tests were run locally.
