### PR TITLE
fix(openclaw): isolate remote memory by runtime agent

### DIFF
--- a/MemoryCore/openclaw-plugin/README.md
+++ b/MemoryCore/openclaw-plugin/README.md
@@ -138,6 +138,10 @@ The installer writes config by default. Edit manually only when using `WRITE_OPE
           },
           "capture": {
             "enabled": true
+          },
+          "agentFilter": {
+            "include": ["coding-agent"],
+            "exclude": []
           }
         }
       }
@@ -145,6 +149,11 @@ The installer writes config by default. Edit manually only when using `WRITE_OPE
   }
 }
 ```
+
+`agentFilter` scopes automatic recall, automatic capture, and the remote memory
+tools to specific OpenClaw runtime agent ids. When `include` is non-empty,
+unknown or unlisted agents are denied. `exclude` takes precedence over
+`include`. Leave both lists empty to preserve the previous all-agent behavior.
 
 **Example B — OpenClaw `< 2026.4.24`:** omit the `hooks` block entirely; keep the same `config` (including isolation).
 

--- a/MemoryCore/openclaw-plugin/README_CN.md
+++ b/MemoryCore/openclaw-plugin/README_CN.md
@@ -138,6 +138,10 @@ openclaw plugins install -l .
           },
           "capture": {
             "enabled": true
+          },
+          "agentFilter": {
+            "include": ["coding-agent"],
+            "exclude": []
           }
         }
       }
@@ -145,6 +149,11 @@ openclaw plugins install -l .
   }
 }
 ```
+
+`agentFilter` 用于把自动召回、自动捕获和远端记忆工具限制到指定的
+OpenClaw runtime agent id。`include` 非空时，未列出的 agent 和无法识别
+agent id 的上下文都会被拒绝；`exclude` 的优先级高于 `include`。两个列表
+均为空时保持原有的“所有 Agent 可用”行为。
 
 **示例 B —— OpenClaw `< 2026.4.24`：** 完全省略 `hooks` 块；`config`（含 isolation）保持一致。
 

--- a/MemoryCore/openclaw-plugin/index.ts
+++ b/MemoryCore/openclaw-plugin/index.ts
@@ -11,6 +11,7 @@
  */
 
 import { MemoryClient, createMemoryFileReader } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import { isAgentAllowed, type AgentFilterConfig } from "./src/agent-filter.js";
 import { performRecall } from "./src/hooks/recall.js";
 import { performCapture } from "./src/hooks/capture.js";
 import { handleMemorySearch } from "./src/tools/memory-search.js";
@@ -41,6 +42,7 @@ interface PluginConfig {
   server?: ServerConfig;
   recall?: RecallConfig;
   capture?: CaptureConfig;
+  agentFilter?: AgentFilterConfig;
 }
 
 // Matches OpenClaw plugin register() signature: export default function register(api)
@@ -50,6 +52,7 @@ export default function register(api: any) {
   const server = cfg.server ?? {};
   const recall = cfg.recall ?? {};
   const capture = cfg.capture ?? {};
+  const agentFilter = cfg.agentFilter ?? {};
 
   const serverUrl = server.url || "http://127.0.0.1:8420";
   const apiKey = server.apiKey || "local";
@@ -62,6 +65,16 @@ export default function register(api: any) {
   const includeSceneNav = recall.includeSceneNav !== false;
   const captureEnabled = capture.enabled !== false;
   const rejectUnauthorized = server.rejectUnauthorized !== false;
+
+  const shouldHandleAgent = (ctx: any): boolean =>
+    isAgentAllowed(ctx?.agentId, agentFilter);
+
+  const registerScopedTool = (tool: any, options: any) => {
+    api.registerTool(
+      (ctx: any) => (shouldHandleAgent(ctx) ? tool : null),
+      options,
+    );
+  };
 
   // ── Initialize v3 SDK ──
   // Isolation (team/agent/user) is required by Gateway /v3/*; sessionId may be
@@ -93,7 +106,7 @@ export default function register(api: any) {
 
   // ── Register Tools (same pattern as extensions/memory-tencentdb/index.ts) ──
 
-  api.registerTool(
+  registerScopedTool(
     {
       name: "tdai_memory_search",
       label: "Memory Search",
@@ -116,7 +129,7 @@ export default function register(api: any) {
     { name: "tdai_memory_search" },
   );
 
-  api.registerTool(
+  registerScopedTool(
     {
       name: "tdai_conversation_search",
       label: "Conversation Search",
@@ -138,7 +151,7 @@ export default function register(api: any) {
     { name: "tdai_conversation_search" },
   );
 
-  api.registerTool(
+  registerScopedTool(
     {
       name: "tdai_read_cos",
       label: "Read Memory File",
@@ -176,6 +189,13 @@ export default function register(api: any) {
   const sessionCursors = new Map<string, number>();
 
   api.on("before_prompt_build", async (event: any, ctx: any) => {
+    if (!shouldHandleAgent(ctx)) {
+      api.logger.debug?.(
+        `${TAG} [before_prompt_build] skipped agent=${ctx?.agentId ?? "(unknown)"}`,
+      );
+      return;
+    }
+
     const sessionKey = ctx?.sessionKey;
     if (!sessionKey) return;
 
@@ -217,6 +237,13 @@ export default function register(api: any) {
   if (captureEnabled) {
     api.logger.info?.(`${TAG} Registering agent_end hook for auto-capture`);
     api.on("agent_end", async (event: any, ctx: any) => {
+      if (!shouldHandleAgent(ctx)) {
+        api.logger.debug?.(
+          `${TAG} [agent_end] skipped agent=${ctx?.agentId ?? "(unknown)"}`,
+        );
+        return;
+      }
+
       const startMs = Date.now();
       const sessionKey = ctx?.sessionKey;
       const messages = (event?.messages ?? []) as unknown[];

--- a/MemoryCore/openclaw-plugin/openclaw.plugin.json
+++ b/MemoryCore/openclaw-plugin/openclaw.plugin.json
@@ -89,6 +89,24 @@
             "description": "是否启用自动对话捕获 (L0)"
           }
         }
+      },
+      "agentFilter": {
+        "type": "object",
+        "description": "限制哪些 OpenClaw runtime agent 可以使用远端记忆",
+        "properties": {
+          "include": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "允许使用插件的 runtime agent id。非空时，其他 agent 和未知 agent 均跳过"
+          },
+          "exclude": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "禁止使用插件的 runtime agent id；优先级高于 include"
+          }
+        }
       }
     }
   }

--- a/MemoryCore/openclaw-plugin/package.json
+++ b/MemoryCore/openclaw-plugin/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "clean": "rm -rf dist *.tgz",
     "build": "tsc",
+    "test": "npm run build && node --test tests/*.test.mjs",
     "prepack": "npm run clean && npm install --no-save --no-audit --no-fund && npm run build"
   },
   "dependencies": {

--- a/MemoryCore/openclaw-plugin/src/agent-filter.ts
+++ b/MemoryCore/openclaw-plugin/src/agent-filter.ts
@@ -1,0 +1,36 @@
+export interface AgentFilterConfig {
+  include?: string[];
+  exclude?: string[];
+}
+
+function normalizedAgentIds(values: string[] | undefined): Set<string> {
+  return new Set(
+    (values ?? [])
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Decide whether the current OpenClaw runtime agent may use this plugin.
+ *
+ * Exclusions take precedence. When an include list is configured, contexts
+ * without an agent id are denied so they cannot accidentally share the fixed
+ * remote team/agent/user isolation configured for another runtime agent.
+ */
+export function isAgentAllowed(
+  runtimeAgentId: string | undefined,
+  filter: AgentFilterConfig,
+): boolean {
+  const include = normalizedAgentIds(filter.include);
+  const exclude = normalizedAgentIds(filter.exclude);
+  const agentId = runtimeAgentId?.trim();
+
+  if (agentId && exclude.has(agentId)) {
+    return false;
+  }
+  if (include.size > 0) {
+    return Boolean(agentId && include.has(agentId));
+  }
+  return true;
+}

--- a/MemoryCore/openclaw-plugin/tests/agent-filter.test.mjs
+++ b/MemoryCore/openclaw-plugin/tests/agent-filter.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isAgentAllowed } from "../dist/src/agent-filter.js";
+
+test("allows all runtime agents by default", () => {
+  assert.equal(isAgentAllowed("main", {}), true);
+  assert.equal(isAgentAllowed(undefined, {}), true);
+});
+
+test("allows only explicitly included runtime agents", () => {
+  const filter = { include: ["coding-agent"] };
+
+  assert.equal(isAgentAllowed("coding-agent", filter), true);
+  assert.equal(isAgentAllowed("main", filter), false);
+  assert.equal(isAgentAllowed(undefined, filter), false);
+});
+
+test("exclusions take precedence over inclusions", () => {
+  const filter = {
+    include: ["coding-agent", "main"],
+    exclude: ["main"],
+  };
+
+  assert.equal(isAgentAllowed("coding-agent", filter), true);
+  assert.equal(isAgentAllowed("main", filter), false);
+});
+
+test("ignores empty values in filter lists", () => {
+  const filter = { include: ["", "  ", "coding-agent"] };
+
+  assert.equal(isAgentAllowed("coding-agent", filter), true);
+  assert.equal(isAgentAllowed("main", filter), false);
+});

--- a/MemoryCore/openclaw-plugin/tests/plugin-agent-filter.test.mjs
+++ b/MemoryCore/openclaw-plugin/tests/plugin-agent-filter.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import register from "../dist/index.js";
+
+function createApi() {
+  const tools = [];
+  const hooks = new Map();
+  const api = {
+    pluginConfig: {
+      server: {
+        url: "http://127.0.0.1:8420",
+        apiKey: "test",
+        instanceId: "default",
+        teamId: "team-test",
+        agentId: "agent-remote",
+        userId: "user-test",
+      },
+      agentFilter: { include: ["coding-agent"] },
+      capture: { enabled: true },
+    },
+    logger: {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    },
+    registerTool(factory, options) {
+      tools.push({ factory, options });
+    },
+    on(name, handler) {
+      hooks.set(name, handler);
+    },
+  };
+
+  register(api);
+  return { tools, hooks };
+}
+
+test("hides all remote memory tools from unlisted runtime agents", () => {
+  const { tools } = createApi();
+
+  assert.equal(tools.length, 3);
+  for (const { factory } of tools) {
+    assert.equal(factory({ agentId: "main" }), null);
+    assert.notEqual(factory({ agentId: "coding-agent" }), null);
+  }
+});
+
+test("skips recall and capture hooks for unlisted runtime agents", async () => {
+  const { hooks } = createApi();
+  const recall = hooks.get("before_prompt_build");
+  const capture = hooks.get("agent_end");
+
+  assert.equal(typeof recall, "function");
+  assert.equal(typeof capture, "function");
+
+  assert.equal(
+    await recall({}, { agentId: "main", sessionKey: "agent:main:test" }),
+    undefined,
+  );
+  assert.equal(
+    await capture(
+      { success: true, messages: [{ role: "user", content: "must not upload" }] },
+      { agentId: "main", sessionKey: "agent:main:test" },
+    ),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Description | 描述

Add an optional runtime-agent filter to `memory-tencentdb-client` so one global OpenClaw plugin entry does not unintentionally share its fixed remote `teamId / agentId / userId` isolation with every agent in the Gateway.

The new `agentFilter` configuration supports exact runtime agent ids:

```json
{
  "agentFilter": {
    "include": ["coding-agent"],
    "exclude": []
  }
}
```

Behavior:

- `exclude` takes precedence over `include`;
- when `include` is non-empty, unknown or unlisted agents are denied;
- empty lists preserve the previous all-agent behavior;
- filtering applies to `before_prompt_build`, `agent_end`, and all three remote-memory tools.

The tool registrations now use OpenClaw tool factories so disallowed agents do not see the remote-memory tools at all.

## Related Issue | 关联 Issue

Fixes #1041

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Test Evidence | 测试证据

```text
npm test

6 tests passed:
- default backward-compatible behavior
- include allowlist
- exclude precedence
- empty-value normalization
- remote tools hidden from unlisted agents
- recall/capture hooks skipped before remote calls
```

Additional checks:

```text
npm pack --dry-run  # passed
npm run build       # passed
git diff --check    # passed
jq schema validation # passed
```

## Additional Notes | 其他说明

- The configuration remains optional and backward compatible.
- The filter uses OpenClaw's trusted runtime `agentId` from hook/tool contexts, not the configured remote Memory Gateway `server.agentId`.
- No API keys, user ids, team ids, or memory content are included in this change.
