### PR TITLE
[good first issue-platform adapt-Trae] Add Memory adapter for Trae

### DIFF
--- a/adapters/trae/README.md
+++ b/adapters/trae/README.md
@@ -1,0 +1,90 @@
+# TencentDB Agent Memory — Trae Adapter
+
+Give [Trae](https://trae.ai/) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Trae ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                    │
+                                    ├─ auth        (validates sk-mem-... user_key)
+                                    ├─ sessionInit (Team/Agent/Task picker)
+                                    └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Trae supports adding models through **自定义配置 (Custom Config)** with the **OpenAI Chat Completions** API format and a custom request URL ([official docs](https://docs.trae.ai/docs/models)). Pointing the request URL at the proxy's `/codebuddy/<spaceId>` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. Trae (the AI IDE from ByteDance) is installed — download from [trae.ai](https://www.trae.ai/).
+
+## Setup
+
+### 1. Add the proxy as a custom model
+
+1. Open **Settings** → **Model** to enter the model management panel.
+2. Click **Add Model**.
+3. Select **Custom Config** (自定义配置).
+4. Fill in the dialog:
+   - **API format**: `OpenAI Chat Completions`
+   - **Custom request URL**: turn on the **Full URL** toggle and enter the complete endpoint
+     `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions`
+     (replace `default` with your memory space ID if you use another space)
+   - **Model ID**: `claude-sonnet-4-20250514`
+   - **API key**: your business user key (`sk-mem-...`)
+   - *(optional)* expand **Advanced Config** to set a display name and context-window limits
+5. Click **Add Model**. Trae calls the provider to validate the API key — on success the model appears in the model list; on failure the error and provider logs are shown in the dialog.
+
+### 2. Align the model ID
+
+The model ID **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 3. Verify
+
+1. In the chat panel, click the current model name (bottom-right of the input box) and select the custom model.
+2. Send a first chat message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask Trae what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Field (Add Model → Custom Config) | Value | Notes |
+|---|---|---|
+| API format | `OpenAI Chat Completions` | OpenAI `/v1/chat/completions` protocol |
+| Custom request URL (Full URL on) | `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` | Proxy endpoint; `default` is the memory space ID — change it per space |
+| Model ID | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+| API key | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| "Invalid API Key" / validation fails on add | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key`; check the provider logs shown in the dialog |
+| "Model Not Found" / upstream mismatch | Model ID differs from `PROXY_UPSTREAM_MODEL` — align them |
+| `404` / connection refused | Full URL typo or proxy not running on `:8096` — the URL must be `http://<host>:8096/codebuddy/<spaceId>/v1/chat/completions`; check `./start-all.sh` logs |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new task to re-pick |
+
+## Notes
+
+- **UI-configured**: Trae stores custom model profiles in its own settings storage, so the key never lands in workspace files; this adapter therefore ships docs only (same as the Kilo Code / Roo Code adapters).
+- **Chat and agent modes both flow through it**: Trae's chat, inline completion and agent workflows all use the selected model, so each of them gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/trae/README_CN.md
+++ b/adapters/trae/README_CN.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Trae 适配器
+
+为 [Trae](https://www.trae.cn/) 注入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、技能与知识融入系统提示词
+- **自动捕获** — L0 原始对话持久化到 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Trae ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                    │
+                                    ├─ auth        (校验 sk-mem-... user_key)
+                                    ├─ sessionInit (Team/Agent/Task 选择器)
+                                    └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+Trae 支持**自定义配置**添加模型，API 格式选 **OpenAI Chat Completions** 并填写自定义请求地址（[官方文档](https://docs.trae.ai/docs/models)）。将请求地址指向代理的 `/codebuddy/<spaceId>` 端点即可接入——**无需任何代码改动**。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 持有业务用户的 `user_key`（`sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. 已安装 Trae（字节跳动的 AI IDE）——从 [trae.cn](https://www.trae.cn/) 下载。
+
+## 配置步骤
+
+### 1. 将代理添加为自定义模型
+
+1. 打开 **设置** → **模型**，进入模型管理面板。
+2. 点击 **添加模型**。
+3. 选择 **自定义配置**。
+4. 填写：
+   - **API 格式**：`OpenAI Chat Completions`
+   - **自定义请求地址**：打开 **完整 URL** 开关，填写完整端点
+     `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions`
+     （如使用其他记忆空间，将 `default` 替换为对应 space ID）
+   - **模型 ID**：`claude-sonnet-4-20250514`
+   - **API 密钥**：业务用户密钥（`sk-mem-...`）
+   - *（可选）* 展开 **高级配置** 设置展示名称与上下文窗口上限
+5. 点击 **添加模型**。Trae 会调用服务商接口校验 API 密钥——校验成功后模型出现在列表中；失败时窗口会展示错误信息与返回日志。
+
+### 2. 对齐模型 ID
+
+模型 ID **必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。示例使用 `claude-sonnet-4-20250514`，若代理指向其他上游请相应修改。
+
+### 3. 验证
+
+1. 在对话框右下角点击当前模型名，选择刚添加的自定义模型。
+2. 发送首条消息。代理会在对话交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，绑定 Agent 的记忆自动注入。询问 Trae 此前会话记得什么即可确认。
+
+## 配置参考
+
+| 字段（添加模型 → 自定义配置） | 值 | 说明 |
+|---|---|---|
+| API 格式 | `OpenAI Chat Completions` | OpenAI `/v1/chat/completions` 协议 |
+| 自定义请求地址（完整 URL 开） | `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` | 代理端点；`default` 为记忆空间 ID，按空间替换 |
+| 模型 ID | `claude-sonnet-4-20250514` | 必须等于 `PROXY_UPSTREAM_MODEL`，否则代理以上游不匹配拒绝 |
+| API 密钥 | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+
+## 故障排查
+
+| 现象 | 原因 / 修复 |
+|---|---|
+| "Invalid API Key" / 添加时校验失败 | 密钥必须是 Panel 的业务用户密钥（`sk-mem-...`）——不是 `./.admin-key` 管理员密钥；查看窗口中展示的服务商日志 |
+| "Model Not Found" / 上游不匹配 | 模型 ID 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| `404` / 连接被拒 | 完整 URL 拼写错误或代理未在 `:8096` 运行——URL 必须为 `http://<host>:8096/codebuddy/<spaceId>/v1/chat/completions`；查看 `./start-all.sh` 日志 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开任务可重新选择 |
+
+## 说明
+
+- **UI 配置**：Trae 将自定义模型档案保存在自身设置存储中，密钥不会落入工作区文件，因此本适配器仅提供文档（与 Kilo Code / Roo Code 适配器一致）。
+- **对话与 Agent 模式全覆盖**：Trae 的聊天、内联补全与 Agent 工作流均使用所选模型，全部获得记忆注入。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/trae/` — a TencentDB Agent Memory adapter for Trae (the AI IDE from ByteDance), extending #926 to another widely used tool.

新增 `adapters/trae/` 目录：Trae 的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流工具。

## How it works / 工作原理

Trae supports adding models via **Custom Config** with the **OpenAI Chat Completions** API format and a custom request URL (full-URL mode). Pointing the request URL at the proxy's `/codebuddy/default/v1/chat/completions` endpoint connects it — the model entry carries `PROXY_UPSTREAM_MODEL`.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

Trae 支持通过**自定义配置**添加模型（API 格式选 OpenAI Chat Completions、完整 URL 模式填写自定义请求地址）。将请求地址指向代理的 `/codebuddy/default/v1/chat/completions` 端点即可接入，模型条目携带 `PROXY_UPSTREAM_MODEL`。

## Files / 文件

| File | Purpose |
|---|---|
| `adapters/trae/README.md` / `README_CN.md` | bilingual setup guide (Add Model → Custom Config), config reference, troubleshooting |

## Notes / 说明

- UI-configured (docs only) — Trae stores custom model profiles in its own settings storage, the key never lands in workspace files.
- The configured model must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against Trae's official documentation (docs.trae.ai/docs/models) of the OpenAI-compatible custom model path.

Addresses #926 (Trae)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
