### PR TITLE
[good first issue-platform adapt-Void] Add Memory adapter for Void editor

### DIFF
--- a/adapters/void/README.md
+++ b/adapters/void/README.md
@@ -1,0 +1,90 @@
+# TencentDB Agent Memory — Void Adapter
+
+Give [Void](https://github.com/voideditor/void) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Void ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                    │
+                                    ├─ auth        (validates sk-mem-... user_key)
+                                    ├─ sessionInit (Team/Agent/Task picker)
+                                    └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Void (the open-source AI editor, a VS Code fork) ships an **OpenAI-Compatible** provider in its AI settings whose `baseURL` accepts any OpenAI-compatible endpoint. Pointing it at the proxy's `/codebuddy/<spaceId>` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. Void is installed — download from [voideditor.com](https://voideditor.com) or build from [voideditor/void](https://github.com/voideditor/void).
+
+## Setup
+
+### 1. Register the proxy as an OpenAI-Compatible provider
+
+1. Open **Settings** (gear icon in the lower-left corner) → **AI Settings**.
+2. Under providers, select **OpenAI-Compatible**.
+3. Fill in:
+   - **API Key**: your business user key (`sk-mem-...`)
+   - **baseURL**: `http://127.0.0.1:8096/codebuddy/default`
+     (replace `default` with your memory space ID if you use another space)
+   - Do **not** append `/chat/completions` — Void adds the request path itself (the baseURL field is documented in Void's settings as "do not include /chat/completions")
+4. Under **Models**, click **Add Model** and enter the model ID `claude-sonnet-4-20250514`.
+
+### 2. Align the model ID
+
+The model ID **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 3. Select the model for Void's features
+
+In the model selection dropdowns, pick the custom model for **Chat** (sidebar, `Ctrl+L` / `Cmd+L`), **Ctrl+K** inline edits and **Apply**. Autocomplete requires Fill-in-the-Middle models — leave it on its own provider.
+
+### 4. Verify
+
+1. Open the chat sidebar (`Ctrl+L` / `Cmd+L`) with the custom model selected.
+2. Send a first chat message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask Void what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Field (OpenAI-Compatible provider) | Value | Notes |
+|---|---|---|
+| API Key | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| baseURL | `http://127.0.0.1:8096/codebuddy/default` | Proxy endpoint; `default` is the memory space ID — change it per space; no `/chat/completions` suffix |
+| Model ID | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| `404` | baseURL typo — it must be exactly `http://<host>:8096/codebuddy/<spaceId>` with no path suffix appended |
+| "Model Not Found" / upstream mismatch | Model ID differs from `PROXY_UPSTREAM_MODEL` — align them |
+| Connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new task to re-pick |
+
+## Notes
+
+- **UI-configured**: Void stores provider settings (including the API key, encrypted) in its own settings storage, so the key never lands in workspace files; this adapter therefore ships docs only (same as the Kilo Code / Trae adapters).
+- **Chat / Ctrl+K / Apply flow through it**: each feature set to the custom model gets memory injection; Autocomplete stays on its dedicated FIM provider.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/void/README_CN.md
+++ b/adapters/void/README_CN.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Void 适配器
+
+为 [Void](https://github.com/voideditor/void) 注入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、技能与知识融入系统提示词
+- **自动捕获** — L0 原始对话持久化到 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Void ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                    │
+                                    ├─ auth        (校验 sk-mem-... user_key)
+                                    ├─ sessionInit (Team/Agent/Task 选择器)
+                                    └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+Void（开源 AI 编辑器，VS Code 分叉）在 AI 设置中内置 **OpenAI-Compatible** Provider，其 `baseURL` 可指向任意 OpenAI 兼容端点。将其指向代理的 `/codebuddy/<spaceId>` 端点即可接入——**无需任何代码改动**。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 持有业务用户的 `user_key`（`sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. 已安装 Void——从 [voideditor.com](https://voideditor.com) 下载或基于 [voideditor/void](https://github.com/voideditor/void) 构建。
+
+## 配置步骤
+
+### 1. 将代理注册为 OpenAI-Compatible Provider
+
+1. 打开 **Settings**（左下角齿轮）→ **AI Settings**。
+2. 在 Provider 列表中选择 **OpenAI-Compatible**。
+3. 填写：
+   - **API Key**：业务用户密钥（`sk-mem-...`）
+   - **baseURL**：`http://127.0.0.1:8096/codebuddy/default`
+     （如使用其他记忆空间，将 `default` 替换为对应 space ID）
+   - **不要**追加 `/chat/completions`——Void 会自行拼接请求路径（其 baseURL 字段官方提示为 "do not include /chat/completions"）
+4. 在 **Models** 下点击 **Add Model**，输入模型 ID `claude-sonnet-4-20250514`。
+
+### 2. 对齐模型 ID
+
+模型 ID **必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。示例使用 `claude-sonnet-4-20250514`，若代理指向其他上游请相应修改。
+
+### 3. 为 Void 各功能选择该模型
+
+在模型选择下拉中，为 **Chat**（侧边栏，`Ctrl+L` / `Cmd+L`）、**Ctrl+K** 内联编辑与 **Apply** 选择自定义模型。Autocomplete 需要 Fill-in-the-Middle 模型——请保持其独立 Provider。
+
+### 4. 验证
+
+1. 打开聊天侧边栏（`Ctrl+L` / `Cmd+L`），选中自定义模型。
+2. 发送首条消息。代理会在对话交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，绑定 Agent 的记忆自动注入。询问 Void 此前会话记得什么即可确认。
+
+## 配置参考
+
+| 字段（OpenAI-Compatible Provider） | 值 | 说明 |
+|---|---|---|
+| API Key | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+| baseURL | `http://127.0.0.1:8096/codebuddy/default` | 代理端点；`default` 为记忆空间 ID，按空间替换；不带 `/chat/completions` 后缀 |
+| 模型 ID | `claude-sonnet-4-20250514` | 必须等于 `PROXY_UPSTREAM_MODEL`，否则代理以上游不匹配拒绝 |
+
+## 故障排查
+
+| 现象 | 原因 / 修复 |
+|---|---|
+| `401` / "Invalid API Key" | 密钥必须是 Panel 的业务用户密钥（`sk-mem-...`）——不是 `./.admin-key` 管理员密钥 |
+| `404` | baseURL 拼写错误——必须恰为 `http://<host>:8096/codebuddy/<spaceId>`，不追加任何路径 |
+| "Model Not Found" / 上游不匹配 | 模型 ID 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 连接被拒 | 代理未在 `:8096` 运行——查看 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开任务可重新选择 |
+
+## 说明
+
+- **UI 配置**：Void 将 Provider 设置（含加密后的 API 密钥）保存在自身设置存储中，密钥不会落入工作区文件，因此本适配器仅提供文档（与 Kilo Code / Trae 适配器一致）。
+- **Chat / Ctrl+K / Apply 全覆盖**：选为自定义模型的各功能均获得记忆注入；Autocomplete 保持独立的 FIM Provider。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/void/` — a TencentDB Agent Memory adapter for Void (the open-source AI editor), extending #926 to another widely used tool.

新增 `adapters/void/` 目录：Void（开源 AI 编辑器）的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流工具。

## How it works / 工作原理

Void ships an **OpenAI-Compatible** provider in its AI settings whose `baseURL` accepts any OpenAI-compatible endpoint (Void's own field hint: "do not include /chat/completions"). Pointing `baseURL` at the proxy's `/codebuddy/default` endpoint connects it — the added model entry carries `PROXY_UPSTREAM_MODEL`.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

Void 在 AI 设置中内置 OpenAI-Compatible Provider，其 `baseURL` 可指向任意 OpenAI 兼容端点（官方字段提示 "do not include /chat/completions"）。将 `baseURL` 指向代理 `/codebuddy/default` 端点即可接入，添加的模型条目携带 `PROXY_UPSTREAM_MODEL`。

## Files / 文件

| File | Purpose |
|---|---|
| `adapters/void/README.md` / `README_CN.md` | bilingual setup guide (OpenAI-Compatible provider), config reference, troubleshooting |

## Notes / 说明

- UI-configured (docs only) — Void stores provider settings (API key encrypted) in its own settings storage.
- Chat / Ctrl+K / Apply get memory injection; Autocomplete stays on its dedicated FIM provider (documented).
- Setup steps verified against Void's official source (voideditor/void, voidSettingsTypes.ts) for the `openAICompatible` provider semantics.

Addresses #926 (Void)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
