### PR TITLE
[good first issue-platform adapt-LobeChat] Add Memory adapter for LobeChat

### DIFF
--- a/adapters/lobechat/README.md
+++ b/adapters/lobechat/README.md
@@ -1,0 +1,96 @@
+# TencentDB Agent Memory — LobeChat Adapter
+
+Give [LobeChat](https://github.com/lobehub/lobe-chat) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every conversation automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+LobeChat ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                         │
+                                         ├─ auth        (validates sk-mem-... user_key)
+                                         ├─ sessionInit (Team/Agent/Task picker)
+                                         └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+LobeChat's built-in OpenAI provider honors `OPENAI_PROXY_URL` — the environment variable that overrides the default OpenAI API base URL ([official deployment docs](https://lobehub.com/docs/self-hosting/environment-variables/basic)). Pointing it at the proxy's `/codebuddy/<spaceId>` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. LobeChat is deployed (Docker or Vercel — see the [official docs](https://lobehub.com/docs/self-hosting/platform/docker-compose)).
+
+## Setup
+
+### 1. Point LobeChat's OpenAI provider at the proxy
+
+For a Docker deployment:
+
+```bash
+docker run -d -p 3210:3210 \
+  -e OPENAI_API_KEY=sk-mem-xxxxxxxx \
+  -e OPENAI_PROXY_URL=http://127.0.0.1:8096/codebuddy/default \
+  -e OPENAI_MODEL_LIST=+claude-sonnet-4-20250514 \
+  -e ACCESS_CODE=your-access-code \
+  --name lobe-chat lobehub/lobe-chat
+```
+
+- `OPENAI_API_KEY` — your business user key (`sk-mem-...`)
+- `OPENAI_PROXY_URL` — the proxy endpoint; replace `default` with your memory space ID if you use another space. Pass it exactly as shown, **without** a trailing `/v1` (the proxy's `/codebuddy/<spaceId>` path has no `/v1` segment; LobeChat appends the chat-completions path itself)
+- `OPENAI_MODEL_LIST` — adds the proxy's upstream model to the model picker
+- `ACCESS_CODE` — access protection for your LobeChat instance (recommended)
+
+For an existing deployment, set the same variables in your `docker-compose.yml` / hosting env, or configure them at runtime in **Settings → Language Model → OpenAI** (API Proxy URL + API Key).
+
+### 2. Align the model ID
+
+The model name **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 3. Verify
+
+1. Open LobeChat (`http://localhost:3210`), enter the access code, and pick `claude-sonnet-4-20250514` as the model.
+2. Send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask LobeChat what it remembers from previous conversations to confirm.
+
+## Configuration reference
+
+| Variable | Value | Notes |
+|---|---|---|
+| `OPENAI_PROXY_URL` | `http://127.0.0.1:8096/codebuddy/default` | Proxy endpoint; `default` is the memory space ID — change it per space; no trailing `/v1` |
+| `OPENAI_API_KEY` | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| `OPENAI_MODEL_LIST` | `+claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+| `ACCESS_CODE` | any strong code | Protects your LobeChat instance (optional but recommended) |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| Empty AI responses | `OPENAI_PROXY_URL` suffix mismatch — do **not** append `/v1`; pass exactly `http://<host>:8096/codebuddy/<spaceId>` |
+| "Model Not Found" / upstream mismatch | Model name differs from `PROXY_UPSTREAM_MODEL` — align them and re-check `OPENAI_MODEL_LIST` |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new topic to re-pick |
+
+## Notes
+
+- **Env-configured**: the key lives only in LobeChat's environment / runtime settings, never in a committed file; this adapter therefore ships docs only (same as the Open WebUI / LibreChat adapters).
+- **All conversations flow through it**: every topic using the configured model gets memory injection — assistants, agents and plugins included.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/lobechat/README_CN.md
+++ b/adapters/lobechat/README_CN.md
@@ -1,0 +1,94 @@
+# TencentDB Agent Memory — LobeChat 适配器
+
+为 [LobeChat](https://github.com/lobehub/lobe-chat) 注入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每段对话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、技能与知识融入系统提示词
+- **自动捕获** — L0 原始对话持久化到 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+LobeChat ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                         │
+                                         ├─ auth        (校验 sk-mem-... user_key)
+                                         ├─ sessionInit (Team/Agent/Task 选择器)
+                                         └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+LobeChat 内置 OpenAI Provider 支持 `OPENAI_PROXY_URL` 环境变量覆盖默认 OpenAI 基础地址（[官方部署文档](https://lobehub.com/zh/docs/self-hosting/environment-variables/basic)）。将其指向代理的 `/codebuddy/<spaceId>` 端点即可接入——**无需任何代码改动**。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 持有业务用户的 `user_key`（`sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. 已部署 LobeChat（Docker 或 Vercel——见[官方文档](https://lobehub.com/zh/docs/self-hosting/platform/docker-compose)）。
+
+## 配置步骤
+
+### 1. 将 LobeChat 的 OpenAI Provider 指向代理
+
+Docker 部署示例：
+
+```bash
+docker run -d -p 3210:3210 \
+  -e OPENAI_API_KEY=sk-mem-xxxxxxxx \
+  -e OPENAI_PROXY_URL=http://127.0.0.1:8096/codebuddy/default \
+  -e OPENAI_MODEL_LIST=+claude-sonnet-4-20250514 \
+  -e ACCESS_CODE=your-access-code \
+  --name lobe-chat lobehub/lobe-chat
+```
+
+- `OPENAI_API_KEY` — 业务用户密钥（`sk-mem-...`）
+- `OPENAI_PROXY_URL` — 代理端点；如使用其他记忆空间，将 `default` 替换为对应 space ID。请原样填写、**不要**以 `/v1` 结尾（代理的 `/codebuddy/<spaceId>` 路径不含 `/v1` 段；LobeChat 会自行拼接 chat-completions 路径）
+- `OPENAI_MODEL_LIST` — 将代理的上游模型加入模型选择器
+- `ACCESS_CODE` — LobeChat 实例的访问保护（建议开启）
+
+已有部署可在 `docker-compose.yml` / 托管环境中设置相同变量，或运行时在 **设置 → 语言模型 → OpenAI** 中配置（API 代理地址 + API Key）。
+
+### 2. 对齐模型 ID
+
+模型名**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。示例使用 `claude-sonnet-4-20250514`，若代理指向其他上游请相应修改。
+
+### 3. 验证
+
+1. 打开 LobeChat（`http://localhost:3210`），输入访问码，选择 `claude-sonnet-4-20250514` 模型。
+2. 发送首条消息。代理会在对话交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，绑定 Agent 的记忆自动注入。询问 LobeChat 此前对话记得什么即可确认。
+
+## 配置参考
+
+| 变量 | 值 | 说明 |
+|---|---|---|
+| `OPENAI_PROXY_URL` | `http://127.0.0.1:8096/codebuddy/default` | 代理端点；`default` 为记忆空间 ID，按空间替换；结尾不带 `/v1` |
+| `OPENAI_API_KEY` | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+| `OPENAI_MODEL_LIST` | `+claude-sonnet-4-20250514` | 必须等于 `PROXY_UPSTREAM_MODEL`，否则代理以上游不匹配拒绝 |
+| `ACCESS_CODE` | 任意强口令 | 保护 LobeChat 实例（可选，建议开启） |
+
+## 故障排查
+
+| 现象 | 原因 / 修复 |
+|---|---|
+| `401` / "Invalid API Key" | 密钥必须是 Panel 的业务用户密钥（`sk-mem-...`）——不是 `./.admin-key` 管理员密钥 |
+| AI 返回空消息 | `OPENAI_PROXY_URL` 后缀不匹配——**不要**追加 `/v1`；必须恰为 `http://<host>:8096/codebuddy/<spaceId>` |
+| "Model Not Found" / 上游不匹配 | 模型名与 `PROXY_UPSTREAM_MODEL` 不一致——对齐并检查 `OPENAI_MODEL_LIST` |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行——查看 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开话题可重新选择 |
+
+## 说明
+
+- **环境变量配置**：密钥仅存在于 LobeChat 的环境/运行时设置中，不落入被提交的文件，因此本适配器仅提供文档（与 Open WebUI / LibreChat 适配器一致）。
+- **所有对话全覆盖**：使用该模型的所有话题均获得记忆注入——助手、Agent 与插件皆然。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/lobechat/` — a TencentDB Agent Memory adapter for LobeChat (the open-source AI chat framework), extending #926 to another widely used tool.

新增 `adapters/lobechat/` 目录：LobeChat（开源 AI 聊天框架）的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流工具。

## How it works / 工作原理

LobeChat's built-in OpenAI provider honors `OPENAI_PROXY_URL` (the env var that overrides the default OpenAI base URL, per the official deployment docs). Pointing it at `http://127.0.0.1:8096/codebuddy/default` (no trailing `/v1` — the proxy path has no `/v1` segment) plus `OPENAI_MODEL_LIST=+<PROXY_UPSTREAM_MODEL>` connects it.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

LobeChat 内置 OpenAI Provider 支持 `OPENAI_PROXY_URL` 覆盖默认基础地址（官方部署文档）。指向 `http://127.0.0.1:8096/codebuddy/default`（结尾不带 `/v1`）并以 `OPENAI_MODEL_LIST=+<PROXY_UPSTREAM_MODEL>` 添加模型即可接入。

## Files / 文件

| File | Purpose |
|---|---|
| `adapters/lobechat/README.md` / `README_CN.md` | bilingual setup guide (docker run + runtime settings), config reference, troubleshooting |

## Notes / 说明

- Env-configured (docs only) — the key lives in LobeChat's environment / runtime settings, never in a committed file.
- The model name must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against LobeChat's official environment-variable docs (OPENAI_PROXY_URL / OPENAI_MODEL_LIST semantics incl. the `/v1` suffix caveat).

Addresses #926 (LobeChat)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
