### PR TITLE
[good first issue-platform adapt-Chatbox] Add Memory adapter for Chatbox

### DIFF
--- a/adapters/chatbox/README.md
+++ b/adapters/chatbox/README.md
@@ -1,0 +1,90 @@
+# TencentDB Agent Memory — Chatbox Adapter
+
+Give [Chatbox](https://chatboxai.app/) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every conversation automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Chatbox ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                        │
+                                        ├─ auth        (validates sk-mem-... user_key)
+                                        ├─ sessionInit (Team/Agent/Task picker)
+                                        └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Chatbox (the cross-platform desktop/mobile AI client) supports custom providers with the **OpenAI API Compatible** API type: you supply an **API Host** plus **API Key**, and Chatbox appends the API path itself (defaulting to `/v1/chat/completions`) — see the [official model configuration guide](https://docs.chatboxai.app/en/guides/providers). Pointing the API Host at the proxy's `/codebuddy/<spaceId>` endpoint connects it — **no code changes required**, and the default API path lands exactly on the proxy's canonical route.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. Chatbox is installed — download from [chatboxai.app](https://chatboxai.app/) (Windows / macOS / Linux / Android / iOS).
+
+## Setup
+
+### 1. Register the proxy as a custom provider
+
+1. Open **Settings** (gear icon in the sidebar) and go to the **Model** tab.
+2. In **Model Provider**, click **Add** (or pick **OpenAI API Compatible** if listed).
+3. Fill in:
+   - **API type**: `OpenAI API Compatible`
+   - **API Key**: your business user key (`sk-mem-...`)
+   - **API Host**: `http://127.0.0.1:8096/codebuddy/default`
+     (replace `default` with your memory space ID if you use another space)
+   - **API path**: leave the default `/v1/chat/completions` — Chatbox appends it to the host, which lands exactly on the proxy's canonical route
+4. Add a model with the name `claude-sonnet-4-20250514`.
+5. Save and click **Check** — it should report a successful connection.
+
+### 2. Align the model name
+
+The model name **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 3. Verify
+
+1. Return to the home page, create a new conversation, and select the custom model.
+2. Send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask Chatbox what it remembers from previous conversations to confirm.
+
+## Configuration reference
+
+| Field (custom provider) | Value | Notes |
+|---|---|---|
+| API type | `OpenAI API Compatible` | OpenAI Chat Completions protocol |
+| API Key | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| API Host | `http://127.0.0.1:8096/codebuddy/default` | Proxy endpoint; `default` is the memory space ID — change it per space; root only, no `/v1` and no API path |
+| API path | `/v1/chat/completions` (default) | Appended by Chatbox — matches the proxy's canonical route, no change needed |
+| Model name | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| "Invalid API Key" / check fails | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| `404` | API Host must be the root endpoint only — exactly `http://<host>:8096/codebuddy/<spaceId>`, without `/v1` and without an API path |
+| "Model Not Found" / upstream mismatch | Model name differs from `PROXY_UPSTREAM_MODEL` — align them |
+| Connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new conversation to re-pick |
+
+## Notes
+
+- **UI-configured**: Chatbox stores provider profiles (including the API key) in its local app storage, so the key never lands in workspace files; this adapter therefore ships docs only (same as the Open WebUI / LobeChat adapters).
+- **Every conversation flows through it**: all chats using the custom model get memory injection — across desktop and mobile clients sharing the same provider config.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/chatbox/README_CN.md
+++ b/adapters/chatbox/README_CN.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Chatbox 适配器
+
+为 [Chatbox](https://chatboxai.app/zh_CN) 注入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每段对话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、技能与知识融入系统提示词
+- **自动捕获** — L0 原始对话持久化到 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Chatbox ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                        │
+                                        ├─ auth        (校验 sk-mem-... user_key)
+                                        ├─ sessionInit (Team/Agent/Task 选择器)
+                                        └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+Chatbox（跨平台桌面/移动 AI 客户端）支持 **OpenAI API Compatible** 类型的自定义 Provider：填写 **API 域名（API Host）** 与 **API 密钥**，Chatbox 会自行拼接接口路径（默认 `/v1/chat/completions`）——见[官方模型配置指南](https://docs.chatboxai.app/zh_CN/guides/providers)。将 API 域名指向代理的 `/codebuddy/<spaceId>` 端点即可接入——**无需任何代码改动**，且默认接口路径恰好命中代理的规范路由。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 持有业务用户的 `user_key`（`sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. 已安装 Chatbox——从 [chatboxai.app](https://chatboxai.app/zh_CN) 下载（Windows / macOS / Linux / Android / iOS）。
+
+## 配置步骤
+
+### 1. 将代理注册为自定义 Provider
+
+1. 打开 **设置**（侧边栏齿轮）→ **模型** 选项卡。
+2. 在 **模型提供方（Model Provider）** 中点击 **添加**（或直接选择 **OpenAI API Compatible**）。
+3. 填写：
+   - **API 类型**：`OpenAI API Compatible`
+   - **API 密钥**：业务用户密钥（`sk-mem-...`）
+   - **API 域名（API Host）**：`http://127.0.0.1:8096/codebuddy/default`
+     （如使用其他记忆空间，将 `default` 替换为对应 space ID）
+   - **API 路径**：保持默认 `/v1/chat/completions`——Chatbox 自行拼接到域名后，恰好命中代理的规范路由
+4. 添加名称为 `claude-sonnet-4-20250514` 的模型。
+5. 保存并点击 **检查**——应显示连接成功。
+
+### 2. 对齐模型名
+
+模型名**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。示例使用 `claude-sonnet-4-20250514`，若代理指向其他上游请相应修改。
+
+### 3. 验证
+
+1. 返回首页，新建对话并选择自定义模型。
+2. 发送首条消息。代理会在对话交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，绑定 Agent 的记忆自动注入。询问 Chatbox 此前对话记得什么即可确认。
+
+## 配置参考
+
+| 字段（自定义 Provider） | 值 | 说明 |
+|---|---|---|
+| API 类型 | `OpenAI API Compatible` | OpenAI Chat Completions 协议 |
+| API 密钥 | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+| API 域名（API Host） | `http://127.0.0.1:8096/codebuddy/default` | 代理端点；`default` 为记忆空间 ID，按空间替换；仅填根地址，不带 `/v1`、不带接口路径 |
+| API 路径 | `/v1/chat/completions`（默认） | 由 Chatbox 自动拼接——与代理规范路由一致，无需修改 |
+| 模型名 | `claude-sonnet-4-20250514` | 必须等于 `PROXY_UPSTREAM_MODEL`，否则代理以上游不匹配拒绝 |
+
+## 故障排查
+
+| 现象 | 原因 / 修复 |
+|---|---|
+| "Invalid API Key" / 检查失败 | 密钥必须是 Panel 的业务用户密钥（`sk-mem-...`）——不是 `./.admin-key` 管理员密钥 |
+| `404` | API 域名必须仅为根端点——恰为 `http://<host>:8096/codebuddy/<spaceId>`，不带 `/v1`、不带接口路径 |
+| "Model Not Found" / 上游不匹配 | 模型名与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 连接被拒 | 代理未在 `:8096` 运行——查看 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开对话可重新选择 |
+
+## 说明
+
+- **UI 配置**：Chatbox 将 Provider 档案（含 API 密钥）保存在本地应用存储中，密钥不会落入工作区文件，因此本适配器仅提供文档（与 Open WebUI / LobeChat 适配器一致）。
+- **所有对话全覆盖**：使用自定义模型的全部对话均获得记忆注入——共享同一 Provider 配置的桌面与移动端皆然。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What / 做了什么

Adds `adapters/chatbox/` — a TencentDB Agent Memory adapter for Chatbox (the cross-platform desktop/mobile AI client), extending #926 to another widely used tool.

新增 `adapters/chatbox/` 目录：Chatbox（跨平台桌面/移动 AI 客户端）的 TencentDB Agent Memory 适配器，将 #926 扩展到又一主流工具。

## How it works / 工作原理

Chatbox supports custom providers with the **OpenAI API Compatible** API type: you set an **API Host** (root endpoint) plus **API Key**, and Chatbox appends the API path itself (default `/v1/chat/completions`, per the official model configuration guide) — which lands exactly on the proxy's canonical `/codebuddy/<spaceId>/v1/chat/completions` route.

- **Session binding** — Team → Agent → Task picker on first message
- **Memory injection** — L2/L3 memory, skills and knowledge blended into the system prompt every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core

Chatbox 支持 OpenAI API Compatible 类型的自定义 Provider：填写 API 域名（根端点）与 API 密钥，Chatbox 自行拼接接口路径（默认 `/v1/chat/completions`）——恰好命中代理的规范路由 `/codebuddy/<spaceId>/v1/chat/completions`。

## Files / 文件

| File | Purpose |
|---|---|
| `adapters/chatbox/README.md` / `README_CN.md` | bilingual setup guide (custom provider + connection check), config reference, troubleshooting |

## Notes / 说明

- UI-configured (docs only) — Chatbox stores provider profiles in its local app storage, the key never lands in workspace files.
- The model name must equal the proxy's `PROXY_UPSTREAM_MODEL`; documented in both READMEs.
- Setup steps verified against Chatbox's official docs (docs.chatboxai.app model configuration guide: API Host semantics + default API path `/v1/chat/completions`).

Addresses #926 (Chatbox)

---
- [x] Both EN and CN docs included in this PR / 中英文档同一 PR 提交
- [x] Standalone directory per adapter / 适配器独立目录
- [x] PR title follows the required format / PR 标题符合格式要求
- [x] DCO signed / 已 DCO 签名
