### PR TITLE
fix(deploy): 修复 bash 3.2 下部署脚本因变量名解析中断

### DIFF
--- a/deploy/dockerhub/publish.sh
+++ b/deploy/dockerhub/publish.sh
@@ -57,7 +57,7 @@ TARGET="${1:-}"
 case "$TARGET" in
   memory-core|memory-proxy|memory-hub|all) ;;
   -h|--help|"") usage ;;
-  *) die "未知组件: $TARGET（可选 memory-core | memory-proxy | memory-hub | all）" ;;
+  *) die "未知组件: ${TARGET}（可选 memory-core | memory-proxy | memory-hub | all）" ;;
 esac
 
 [[ -n "${VERSION:-}" ]] || die "请显式指定 VERSION，例：VERSION=1.0.0 ./publish.sh $TARGET"
@@ -200,7 +200,7 @@ JSON
   scan "$ctx" src package.json packages
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    ok "DRY_RUN=1 → context 就绪在 $ctx，跳过 build/push"
+    ok "DRY_RUN=1 → context 就绪在 ${ctx}，跳过 build/push"
     return 0
   fi
   build_image "$image" "$ctx"
@@ -261,7 +261,7 @@ build_memory_hub() {
   scan "$ctx" panel knowledge Dockerfile start-combined.sh
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    ok "DRY_RUN=1 → context 就绪在 $ctx，跳过 build/push"
+    ok "DRY_RUN=1 → context 就绪在 ${ctx}，跳过 build/push"
     return 0
   fi
   build_image "$image" "$ctx"

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then

--- a/deploy/panel-knowledge-combined/build.sh
+++ b/deploy/panel-knowledge-combined/build.sh
@@ -36,9 +36,9 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 err() { echo "[build-combined] error: $*" >&2; exit 1; }
 
 [[ -d "$TMC_DIR/package.json" || -f "$TMC_DIR/package.json" ]] \
-  || err "MemoryPanel 不在 $TMC_DIR（设 TMC_DIR=<path> 指定）"
+  || err "MemoryPanel 不在 ${TMC_DIR}（设 TMC_DIR=<path> 指定）"
 [[ -f "$KNOWLEDGE_DIR/package.json" ]] \
-  || err "MemoryKnowledge 不在 $KNOWLEDGE_DIR（设 KNOWLEDGE_DIR=<path> 指定）"
+  || err "MemoryKnowledge 不在 ${KNOWLEDGE_DIR}（设 KNOWLEDGE_DIR=<path> 指定）"
 [[ -f "$SCRIPT_DIR/Dockerfile" ]] || err "Dockerfile 不在 $SCRIPT_DIR"
 [[ -f "$SCRIPT_DIR/start-combined.sh" ]] || err "start-combined.sh 不在 $SCRIPT_DIR"
 
@@ -129,4 +129,4 @@ docker build --platform "$PLATFORM" -t "$IMAGE_NAME:$IMAGE_TAG" "$CTX_DIR"
 
 echo ""
 echo "[build-combined] ✅ done: $IMAGE_NAME:$IMAGE_TAG"
-echo "[build-combined] context 保留在 $CTX_DIR（KEEP_CTX=0 时下次会清掉）"
+echo "[build-combined] context 保留在 ${CTX_DIR}（KEEP_CTX=0 时下次会清掉）"


### PR DESCRIPTION
## 问题

macOS 自带的 **bash 3.2** 在解析 `$VAR` 后紧跟全角字符（如 `）`）时，会把该多字节字符的首字节吞进变量名，在 `set -euo pipefail` 下触发 `unbound variable` 并中断脚本。

这导致在 macOS 上执行 `./start-all.sh` **必定失败**：

```
[ok] tdai-memory-core healthy
[ok] memory-core 已启动 → http://localhost:8420/
start-memory-core.sh: line 175: ADMIN_KEY_FILE?: unbound variable
```

中断时 `memory-core` 容器已 healthy，但 **admin user 尚未初始化、`.admin-key` 未生成**，因此后续 `memory-hub` 与 `proxy` 都不会启动，三件套只起来了一个。

`deploy/global-images/README.md` 中声明「bash 4+（macOS 自带 3.2 也能跑）」，与实际行为不符。

## 根因

bash 3.2 在此处不做多字节感知的标识符解析，会将 `）`（UTF-8 `ef bc 89`）的首字节 `0xef` 计入变量名。

已验证**与 locale 无关** —— `LC_CTYPE=UTF-8` 与合法的 `LC_CTYPE=en_US.UTF-8` 下均可复现；bash 5 下则正常。

最小复现：

```bash
cat > /tmp/t.sh <<'SH'
set -euo pipefail
FOO="/tmp/x"
echo "裸写法 → $FOO）..."
SH

/bin/bash /tmp/t.sh          # bash 3.2 → t.sh: line 3: FOO?: unbound variable
docker run --rm -v /tmp/t.sh:/t.sh:ro bash:5 bash /t.sh   # bash 5 → 正常输出
```

## 修改

统一改用 `${VAR}` 显式界定变量名边界，共 7 处（纯字符串插值写法调整，无逻辑变更）：

| 文件 | 处数 | 说明 |
|---|---|---|
| `deploy/global-images/start-memory-core.sh` | 1 | 实际中断点 |
| `deploy/dockerhub/publish.sh` | 3 | 同类潜在崩溃 |
| `deploy/panel-knowledge-combined/build.sh` | 3 | 同类潜在崩溃 |

后两个文件同样是 `set -euo pipefail`，其错误分支一旦触发会以 `unbound variable` 崩溃、而非打印本该给出的提示，因此一并修复。

## 验证

环境：macOS / `GNU bash 3.2.57(1)-release (arm64-apple-darwin25)`

**1. 错误分支修复前后对照**

```console
# 修复前（git show HEAD:deploy/dockerhub/publish.sh）
$ bash /tmp/publish-orig.sh bogus-component
/tmp/publish-orig.sh: line 60: TARGET?: unbound variable

# 修复后
$ bash deploy/dockerhub/publish.sh bogus-component
[error] 未知组件: bogus-component（可选 memory-core | memory-proxy | memory-hub | all）

$ TMC_DIR=/nonexistent bash deploy/panel-knowledge-combined/build.sh
[build-combined] error: MemoryPanel 不在 /nonexistent（设 TMC_DIR=<path> 指定）
```

**2. 语法检查**：三个脚本均通过 `bash -n`（bash 3.2）。

**3. 端到端**：修复后 `./start-all.sh` 可完整拉起三件套，均为 `healthy`：

```
tdai-proxy         Up (healthy)   0.0.0.0:8096->8096/tcp
tdai-memory-hub    Up (healthy)   0.0.0.0:8125->8125/tcp, 0.0.0.0:8424->8424/tcp
tdai-memory-core   Up (healthy)   0.0.0.0:8420->8420/tcp
```

Panel（8125）与 Knowledge docs（8424）均返回 200，admin user 初始化成功、`auth/verify` 返回 200。

**4. 回归扫描**：全仓 `*.sh` 已无同类写法残留

```bash
grep -rnP '\$[A-Za-z_][A-Za-z0-9_]*[^\x00-\x7F]' --include='*.sh' .   # 无输出
```

## 备注

- 已按 CONTRIBUTING 要求附 DCO `Signed-off-by`。
- base 分支选择：CONTRIBUTING 中提到的 `develop_server_team` / `master` 在上游均不存在，故按当前默认分支 `feat/server_team` 提交，如需改投其他分支请告知。