### PR TITLE
fix(proxy): strip session-init form artifacts before forwarding

### DIFF
--- a/MemoryProxy/docs/patch-session-init-strip.md
+++ b/MemoryProxy/docs/patch-session-init-strip.md
@@ -1,0 +1,42 @@
+# Patch: strip session-init form artifacts before forwarding
+
+## 问题
+
+Claude Code 通过 MemoryProxy 使用 DeepSeek 的 Anthropic 兼容端点（extended thinking 模式）时，
+每个新会话的 session-init 表单交互结束后，后续请求报 400：
+
+```
+The `content[].thinking` in the thinking mode must be passed back to the API.
+```
+
+## 根因
+
+sessionInit 为了让 Claude Code 弹出选 team/agent 的 `AskUserQuestion` 表单，会合成一条
+带 `toolu_cc_session_init_` 前缀 tool_use 的假响应（无 thinking 块）。客户端回传
+tool_result 后，这些合成消息被保留在对话历史里并转发给上游。DeepSeek 的 Anthropic
+兼容端点在 extended-thinking 模式下要求**每个 assistant tool_use 必须带真实签名的
+thinking 块**，合成消息无有效签名 → 400。
+
+对应上游官方 issue / PR：
+- https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/963 (Open，未合并)
+
+## 修复
+
+在 `MemoryProxy/src/anthropicHandler.ts` 新增 `stripSessionInitArtifacts()`，并在转发
+边界（`buildUpstreamBody` 与 retry 路径）挂接：
+
+- assistant 消息中含 `toolu_cc_session_init_` tool_use → 整条丢弃
+- user/tool 消息中引用 session-init id 的 tool_result 块 → 移除（真实文本块保留）
+- 其余消息原样通过（identity），真实对话不受影响
+
+## 验证
+
+- 单测：`stripSessionInitArtifacts` 对表单残留剥离 2 条，对真实对话 0 条
+- 端到端：`msgs=6, stream=true`（含表单残留 + thinking mode）转发到 DeepSeek 返回 200
+- 回归：无表单残留的普通对话正常
+
+## 备注
+
+- 本补丁同时需要 `form.ts` 已导出 `isSessionInitToolCallId`（镜像内自带）
+- 宿主机分支 `feat/server_team` 比发布镜像 `agentmemory/memory-proxy:latest` 新
+  （含 request-prepare-adapter 重构、codex/workbuddy/dsh 模块），重建镜像时会一并包含

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -51,6 +51,7 @@ import { isExtractionAllowed, logExtractionSkipped } from "./extraction-gate.js"
 import type { CcRequestKind } from "./common/cc-request-classifier.js";
 import { buildRequestDebugMetadata } from "./common/langfuse-debug.js";
 import { resolveAgentAdapter } from "./agent-adapters/index.js";
+import { isSessionInitToolCallId } from "./session/claude-code/form.js";
 import {
   enforceRateLimit,
   isRateLimitExceededError,
@@ -311,6 +312,84 @@ export function sanitizeThinkingBlocks(
 }
 
 /**
+ * Strip session-init form artifacts from the message history before forwarding.
+ *
+ * Root cause (PR #963): sessionInit synthesizes an `AskUserQuestion` tool_use
+ * response whose id carries the `toolu_cc_session_init_` prefix. That synthetic
+ * tool_use has NO thinking block. When the client later replies with its
+ * tool_result, the assistant + tool messages get retained in the history and
+ * forwarded upstream. DeepSeek's Anthropic-compatible endpoint (extended
+ * thinking mode) rejects any assistant tool_use that lacks a signed thinking
+ * block → HTTP 400 `The content[].thinking in the thinking mode must be passed
+ * back to the API.`
+ *
+ * This drops synthetic session-init messages while leaving real conversation
+ * messages untouched:
+ *   - assistant messages containing a session-init tool_use → dropped
+ *   - user/tool messages whose tool_result references a session-init id → block
+ *     removed (real text blocks kept)
+ *   - everything else → identity
+ */
+export function stripSessionInitArtifacts(
+  body: Record<string, unknown>,
+): { body: Record<string, unknown>; removed: number } {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return { body, removed: 0 };
+
+  let removed = 0;
+  const out: unknown[] = [];
+
+  for (const raw of messages) {
+    const msg = raw as Record<string, unknown>;
+    const content = msg.content;
+    if (typeof msg.role !== "string") {
+      out.push(raw);
+      continue;
+    }
+
+    // Assistant: drop the whole message if it carries a session-init tool_use.
+    if (msg.role === "assistant" && Array.isArray(content)) {
+      const hasInitToolUse = (content as unknown[]).some((b) => {
+        const blk = b as Record<string, unknown>;
+        return blk.type === "tool_use" && isSessionInitToolCallId(String(blk.id ?? ""));
+      });
+      if (hasInitToolUse) {
+        removed += 1;
+        continue;
+      }
+      out.push(raw);
+      continue;
+    }
+
+    // User / tool: strip tool_result blocks that reference a session-init id,
+    // keep the rest of the content (real text blocks survive).
+    if ((msg.role === "user" || msg.role === "tool") && Array.isArray(content)) {
+      const newContent = (content as unknown[]).filter((b) => {
+        const blk = b as Record<string, unknown>;
+        if (blk.type !== "tool_result") return true;
+        if (isSessionInitToolCallId(String(blk.tool_use_id ?? ""))) {
+          removed += 1;
+          return false;
+        }
+        return true;
+      });
+      if (newContent.length === (content as unknown[]).length) {
+        out.push(raw);
+      } else if (newContent.length > 0) {
+        out.push({ ...msg, content: newContent });
+      }
+      // All content removed → drop the message entirely.
+      continue;
+    }
+
+    out.push(raw);
+  }
+
+  if (removed === 0) return { body, removed: 0 };
+  return { body: { ...body, messages: out }, removed };
+}
+
+/**
  * Build upstream body from original body + cost guard overrides.
  */
 function buildUpstreamBody(
@@ -322,7 +401,8 @@ function buildUpstreamBody(
     result = { ...result, ...target.bodyOverrides };
   }
   const sanitized = sanitizeThinkingBlocks(result);
-  return { body: sanitized.body, sanitizedCount: sanitized.removed };
+  const stripped = stripSessionInitArtifacts(sanitized.body);
+  return { body: stripped.body, sanitizedCount: sanitized.removed };
 }
 
 /**
@@ -1225,7 +1305,7 @@ export async function handleAnthropicMessages(
     delete originalHeaders["authorization"];
   }
 
-  const retryBody = sanitizeThinkingBlocks(body).body;
+  const retryBody = stripSessionInitArtifacts(sanitizeThinkingBlocks(body).body).body;
 
   // ── Forward to upstream (with automatic retry if configured) ──────────────
   const forwardTimeoutMs = config.server.forwardTimeoutMs ?? 600_000;


### PR DESCRIPTION
## 问题

Claude Code 通过 MemoryProxy 使用 DeepSeek 的 Anthropic 兼容端点（extended thinking 模式）时，session-init 表单结束后报：

API Error: 400 The content[].thinking in the thinking mode must be passed back to the API.

## 根因

sessionInit 合成的 `AskUserQuestion` tool_use（id 前缀 `toolu_cc_session_init_`）**没有 thinking 块**。客户端回传 tool_result 后，这些合成消息被保留在转发给上游的对话历史里。DeepSeek 的 Anthropic 兼容端点在 extended-thinking 模式下要求每个 assistant tool_use 必须带真实签名的 thinking 块 → HTTP 400。

## 修复

在 `MemoryProxy/src/anthropicHandler.ts` 新增 `stripSessionInitArtifacts()`，挂接在 `buildUpstreamBody` 和 retry 路径：

- assistant 消息中含 session-init tool_use → 整条丢弃
- user/tool 消息中引用 session-init id 的 tool_result 块 → 移除（真实文本块保留）
- 其余消息原样通过

真实对话消息完全不受影响。

## 验证

- 单测：表单残留剥离 2 条，真实对话 0 条
- 端到端：原 400 场景（thinking mode + 表单残留）→ HTTP 200
- 回归：普通对话正常

## 相关

- Refs #963