### PR TITLE
fix(deploy): wrap UTF-8-adjacent variable in braces for bash 3.2

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then


### PR DESCRIPTION
## 问题

macOS 自带的 bash 3.2.57 在执行 `start-memory-core.sh` 时报：

start-memory-core.sh: line 175: ADMIN_KEY_FILE: unbound variable

## 根因

bash 3.2 存在解析 quirk：变量引用后直接紧跟 UTF-8 全角字符（这里是中文信息里的全角右括号 `）`）时，会吞掉该字符首字节进变量名，导致变量被误判为未定义。

## 修复

`start-memory-core.sh:175` 把 `$ADMIN_KEY_FILE` 改为 `${ADMIN_KEY_FILE}`，消除歧义。

## 验证

`/bin/bash 3.2.57` 下该行现在正确执行。