### PR TITLE
docs: fix stale branch names in CONTRIBUTING and maxScenes default comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,8 @@ it standalone (usually `cd <module> && npm install && npm run dev`).
 ## Submitting changes
 
 1. Fork the repo
-2. Cut a feature branch off `master` or the latest `develop_*` branch
+2. Cut a feature branch off the branch you intend to target (see
+   [Branches](#branches) below)
    ```bash
    git checkout -b fix/xxx-issue
    ```
@@ -69,9 +70,22 @@ it standalone (usually `cd <module> && npm install && npm run dev`).
    npm test          # or pnpm test
    ```
 4. Commit using Conventional Commits + DCO sign-off (see below)
-5. Push and open a PR against `develop_server_team` or `master` (follow the
-   maintainer's latest guidance)
+5. Push and open a PR against the matching branch (see [Branches](#branches))
 6. Get through CI + review, then merge
+
+### Branches
+
+The repository maintains three long-lived branches:
+
+| Branch | Notes |
+|--------|-------|
+| `feat/server_team` | Default branch |
+| `feat/server` | |
+| `main` | The only branch CI (`.github/workflows/pr-ci.yml`) runs on |
+
+Target the branch your change applies to, and mention in the PR description
+whether it also applies to the other two — changes that are relevant to all
+three are currently landed separately on each.
 
 ## Commit conventions
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -58,7 +58,7 @@ cp .env.example .env && $EDITOR .env
 ## 提交流程
 
 1. Fork 仓库
-2. 从 `master` 或最新的 `develop_*` 分支切出 feature 分支
+2. 从你要提交的目标分支切出 feature 分支（见下方[分支说明](#分支说明)）
    ```bash
    git checkout -b fix/xxx-issue
    ```
@@ -68,9 +68,21 @@ cp .env.example .env && $EDITOR .env
    npm test          # 或 pnpm test
    ```
 4. 提交（Conventional Commits + DCO 签名，见下文）
-5. 推到 fork，发起 PR 到 `develop_server_team` 或 `master`（按维护者最新
-   指示）
+5. 推到 fork，发起 PR 到对应的目标分支（见下方[分支说明](#分支说明)）
 6. 通过 CI + Review 后合并
+
+### 分支说明
+
+仓库维护三条长期分支：
+
+| 分支 | 说明 |
+|------|------|
+| `feat/server_team` | 默认分支 |
+| `feat/server` | |
+| `main` | CI（`.github/workflows/pr-ci.yml`）目前只在这条分支上触发 |
+
+请提到你的改动实际所属的分支，并在 PR 描述里说明是否同样适用于另外两条 ——
+目前三条分支都需要时，改动是分别落到每条分支上的。
 
 ## Commit 规范
 

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -51,7 +51,7 @@ export interface ExtractionConfig {
 export interface PersonaConfig {
   /** Trigger persona generation every N new memories (default: 50) */
   triggerEveryN: number;
-  /** Max scene blocks (default: 20) */
+  /** Max scene blocks (default: 15) */
   maxScenes: number;
   /** Persona backup count (default: 3) */
   backupCount: number;


### PR DESCRIPTION
## Description | 描述

Two stale contributor-facing references on the default branch.

**1. `CONTRIBUTING.md` / `CONTRIBUTING_CN.md` — the contribution flow names branches that do not exist.**

Step 2 says to cut a feature branch off `master` or `develop_*`; step 5 says to open the PR against `develop_server_team` or `master`. None of those four branches exist. The repository has `feat/server_team` (default), `feat/server` and `main`, so a contributor following the guide verbatim is blocked at step 2.

Replaced both references with a short **Branches** section listing the three real branches, and noted that CI (`.github/workflows/pr-ci.yml`) is scoped to `branches: [main]` — so PRs opened against the default branch currently get no CI run. Applied to both the English and Chinese guides.

**2. `MemoryCore/src/config.ts` — `PersonaConfig.maxScenes` is documented as `default: 20`, implementation is 15.**

Every location that actually sets it uses 15:

| Location | Value |
|---|---|
| `src/config.ts:556` | `?? 15` |
| `src/core/scene/scene-extractor.ts:114` | `?? 15` |
| `tdai-gateway.yaml:58` | `15` |
| `tdai-gateway.standalone.yaml:39` | `15` |
| `openclaw.plugin.json:63` | `"default": 15` |
| `deploy/global-images/start-memory-core.sh:86` | `15` |
| `scripts/e2e-memory-prompt-vdb-cos.ts:382` | `15` |

Every neighbouring field in the same interface has a comment matching its implementation (`triggerEveryN` 50, `backupCount` 3, `sceneBackupCount` 10) — `maxScenes` is the only drift, so the comment is corrected rather than the code. If 20 was the intended default, the fix belongs on the other side and in the seven locations above; flagging for a maintainer either way.

## Related Issue | 关联 Issue

Item 2 was reported in #1038 (closed without the comment being synced).

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Comment-only and Markdown-only; no runtime behaviour changes. Verified the branch list against `GET /repos/TencentCloud/TencentDB-Agent-Memory/branches` and each `maxScenes` occurrence by grep. The diff touches none of the files guarded by `scripts/ci/check-skill-queue-isolation.sh`.

## Additional Notes | 其他说明

Targeting `feat/server_team` because that is where both issues live — `main` carries a different `CONTRIBUTING_CN.md` (its branch table lists only `main`, which is also inaccurate now that `feat/server_team` is the default) and its `config.ts` has no `maxScenes` field at all. Happy to send the corresponding `main` and `feat/server` variants if that is useful.

Note that CI will not run on this PR, since `pr-ci.yml` triggers only on `branches: [main]`.
