### PR TITLE
fix(proxy): honor x-tdai-user-key and preserve client credentials on codex passthrough

### DIFF
--- a/MemoryProxy/src/codexHandler.ts
+++ b/MemoryProxy/src/codexHandler.ts
@@ -283,7 +283,11 @@ export async function handleCodexEndpoint(
   const path = c.req.path;
 
   // ── 1. Auth ────────────────────────────────────────────────────────────────
+  // x-tdai-user-key 优先：passthrough 场景下 Authorization 已被上游真实凭据占用
+  // （如 ChatGPT OAuth），客户端用该头单独携带 sk-mem 身份。对齐 anthropicHandler
+  // 的 extractApiKey()。该头在 SKIP_REQUEST_HEADERS 中，不会透传给上游。
   const apiKey =
+    c.req.header("x-tdai-user-key") ??
     extractBearerToken(c.req.header("authorization") ?? c.req.header("Authorization") ?? "") ??
     c.req.header("x-api-key") ??
     "";
@@ -966,8 +970,15 @@ async function forwardToUpstream(
   if (agentUpstreamEntry) {
     if (agentUpstreamEntry.apiKey) {
       upstreamHeaders["authorization"] = `Bearer ${agentUpstreamEntry.apiKey}`;
+    } else {
+      // buildUpstreamHeaders() 已用全局 upstream.apiKey 无条件覆盖过 authorization，
+      // 所以 passthrough 必须在这里显式还原客户端原始凭据，否则上游收到的是全局
+      // key（例如把 DeepSeek key 发给 ChatGPT 后端 → 401）。
+      const clientAuth =
+        c.req.header("authorization") ?? c.req.header("Authorization");
+      if (clientAuth) upstreamHeaders["authorization"] = clientAuth;
+      else delete upstreamHeaders["authorization"];
     }
-    // else: 保留 c.req.header('authorization') 里的客户端 key 透传
   }
 
   pipe.forwardStart(upstreamUrl);


### PR DESCRIPTION
## Description | 描述

`codexHandler` cannot serve an upstream that authenticates with the **client's own** credential — the case where `upstream.agents.codex` has a `url` but no `apiKey`, which `types.ts:370-388` documents as passthrough. Two independent gaps cause this, and **both are already solved in `anthropicHandler`**:

**1. Identity extraction ignores `x-tdai-user-key`**

`codexHandler.ts:286` reads only `Authorization` / `x-api-key`. When the client puts an upstream credential in `Authorization` (e.g. Codex CLI with `requires_openai_auth = true`, carrying a ChatGPT OAuth token) and its platform identity in `x-tdai-user-key`, the OAuth token is passed to `verifyUserKey()` as if it were an `sk-mem` key, so every request fails:

```
401 {"error":"Authentication failed: invalid user_key"}
```

`anthropicHandler.ts:250-256` already prefers this header for exactly this scenario. The header is already listed in `SKIP_REQUEST_HEADERS`, so it is never forwarded upstream.

**2. Passthrough does not actually pass anything through**

`buildUpstreamHeaders()` (`codexHandler.ts:250-253`) overwrites `authorization` **unconditionally** whenever a global key exists:

```ts
if (config.upstream.apiKey) {
  headers["authorization"] = `Bearer ${config.upstream.apiKey}`;
  delete headers["x-api-key"];
}
```

By the time the per-agent branch runs, the client credential is already gone, so the `// else: 保留 c.req.header('authorization') 里的客户端 key 透传` comment describes behavior that cannot occur. In practice the global key reaches the per-agent upstream — e.g. a DeepSeek key sent to the ChatGPT backend, which rejects it.

**Fix:** prefer `x-tdai-user-key` when extracting the identity key, and when an agent entry has no `apiKey`, explicitly restore the client's original `Authorization` (deleting the header if the client sent none). Both changes are confined to the passthrough path — when `agentUpstreamEntry.apiKey` is set, or when no agent entry exists, behavior is byte-identical to before.

## Related Issue | 关联 Issue

None. Found while wiring Codex CLI to a ChatGPT-backend upstream through the proxy; happy to open one if you'd prefer it tracked separately.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

**How it was verified.** Codex CLI `0.145.0-alpha.27` pointed at `/codex/<spaceId>`, with a global DeepSeek key deliberately configured so a leak would be visible:

```yaml
upstream:
  url: "https://api.deepseek.com/anthropic"
  apiKey: "sk-..."                                 # must NOT reach the agent upstream
  agents:
    codex:
      url: "https://chatgpt.com/backend-api/codex" # no apiKey → passthrough
```

```toml
[model_providers.chatgpt-memory]
base_url = "http://127.0.0.1:8096/codex/default"
wire_api = "responses"
requires_openai_auth = true
http_headers = { "x-tdai-user-key" = "sk-mem-...", "x-team-id" = "...", "x-agent-id" = "...", "x-task-id" = "..." }
```

- **Before:** every request → `401 invalid user_key`.
- **After:** request accepted, the ChatGPT OAuth token reaches the upstream unmodified, the response streams back, and `tdai-recorder:write-l0` records the turn — confirmed in `docker logs` and by retrieving the message afterwards through `/v2/conversation/search`.

**No new type errors.** `npm run typecheck` reports the same 6 pre-existing errors before and after. The `codexHandler.ts` entry only shifts from line 1018 to 1029 because the patch adds 11 lines above it.

**Out of scope, but worth flagging.** `forwardToUpstream` resolves the agent entry through a hard-coded `config.upstream.agents?.["codex"]`, and the routes are fixed at `/codex/:spaceId/...`, so a deployment can only ever have one Codex upstream. `anthropicHandler` derives the key from the URL path instead, which lets several agent upstreams coexist — aligning the two would be a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
