### PR TITLE
[good first issue-platform adapt-LangChain] Add Memory adapter for LangChain/LangGraph

### DIFF
--- a/adapters/langchain-memory/.gitignore
+++ b/adapters/langchain-memory/.gitignore
@@ -1,0 +1,19 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.eggs/
+
+# Test / tooling
+.pytest_cache/
+.coverage
+htmlcov/
+.venv/
+venv/
+
+# Editors
+.idea/
+.vscode/
+.DS_Store

--- a/adapters/langchain-memory/README.md
+++ b/adapters/langchain-memory/README.md
@@ -1,0 +1,186 @@
+# LangChain / LangGraph × TencentDB Agent Memory
+
+Give a [LangChain](https://www.langchain.com/) or [LangGraph](https://www.langchain.com/langgraph)
+agent persistent, team-scoped memory backed by
+[TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) —
+in one line of glue and zero changes to your model or graph.
+
+## Features
+
+- **`TencentDBStore`** — a LangGraph [`BaseStore`](https://langchain-ai.github.io/langgraph/reference/store/)
+  that persists long-term memory across threads and recalls it semantically.
+- **`TencentDBRetriever`** — a LangChain [`BaseRetriever`](https://python.langchain.com/docs/concepts/retrievers/)
+  that drops into any RAG chain.
+- **Ready-made tools** — `memory_search` and `memory_recall` you can hand to any agent.
+- **Capture helpers** — record a conversation into the memory pipeline with one call,
+  or attach a side-effecting LangGraph node.
+- **Sync + async** — every surface has a sync and an `async` twin, so it works in
+  classic LangChain chains and LangGraph graphs alike.
+- **Thin by design** — no local vector store, no local embedding, no extraction
+  logic. Capture, distillation, embedding and retrieval stay inside MemoryCore.
+
+## Why this adapter
+
+- **Faithful to the memory model.** TencentDB Agent Memory follows
+  *capture → distill → recall*: you record observations, the pipeline extracts
+  structured facts, and you recall them later. This adapter maps LangChain/LangGraph
+  concepts onto that model instead of pretending it is a plain key-value store.
+- **No placeholder data.** Capturing a message that can't be normalized raises
+  immediately rather than writing a synthetic record.
+- **Bounded failure.** Every call goes through the official Python SDK, which
+  validates the `{code, message, data}` envelope and raises `TDAMError` on any
+  non-zero business code — your agent sees real errors, not silent partial success.
+- **Zero local index.** Search is server-side (BM25 + vector + RRF in MemoryCore),
+  so there is nothing to rebuild or keep in sync.
+
+## How it works
+
+```text
+LangChain / LangGraph agent
+   │
+   ├─ capture_conversation() ──► POST /v3/conversation/add   (L0 observation)
+   │                                   │  async pipeline
+   │                                   ▼
+   │                            L1 facts (distilled memories)
+   │                                   ▲
+   └─ memory_search / retriever ──► POST /v3/atomic/search    (semantic recall)
+        store.search()
+```
+
+Two hooks close the loop: **capture** records what happened, **recall** makes it
+available later. Recall is agent-driven — the agent (or your chain) asks for
+memories exactly when it needs them, instead of injecting context into every turn.
+
+## Prerequisites
+
+- Python ≥ 3.9.
+- A running TencentDB Agent Memory Gateway:
+
+  ```bash
+  cd deploy/global-images
+  cp .env.example .env && $EDITOR .env
+  ./start-all.sh
+  ```
+
+## Install
+
+```bash
+# The TencentDB Agent Memory Python SDK is not yet published to PyPI, so install
+# it from this repository first, then the adapter:
+pip install -e ./sdk/memory-core/python
+pip install -e ./adapters/langchain-memory
+
+# (Once both are on PyPI:)
+# pip install tencentdb-agent-memory-langchain
+```
+
+## Quick start
+
+```python
+from tencentdb_langchain import TencentDBMemory, create_memory_search_tool
+
+memory = TencentDBMemory(
+    endpoint="http://127.0.0.1:8420",
+    api_key="local",
+    service_id="default",
+    team_id="t1", agent_id="a1", user_id="u1",
+)
+
+# 1. Capture a conversation turn (record an observation).
+memory.capture(
+    [{"role": "user", "content": "I prefer dark theme in the editor"}],
+    session_id="sess-1",
+)
+
+# 2. Recall distilled facts later.
+facts = memory.search_facts("editor theme")
+for f in facts:
+    print(f.content)          # "The user prefers dark theme"
+```
+
+### As a LangGraph store
+
+```python
+from langgraph.store.memory import InMemoryStore  # for comparison
+
+from tencentdb_langchain import TencentDBStore
+
+store = TencentDBStore.from_config({
+    "endpoint": "http://127.0.0.1:8420",
+    "api_key": "local",
+    "service_id": "default",
+    "team_id": "t1", "agent_id": "a1", "user_id": "u1",
+})
+
+store.put(("prefs",), "theme", {"content": "prefers dark theme"})
+hits = store.search(("prefs",), query="what theme does the user like", limit=5)
+print(hits[0].value["content"])
+```
+
+### As a LangChain retriever
+
+```python
+from tencentdb_langchain import TencentDBMemory, TencentDBRetriever
+
+memory = TencentDBMemory(...)
+retriever = TencentDBRetriever(memory=memory, top_k=5)
+docs = retriever.invoke("past decisions about authentication")
+```
+
+### With an agent
+
+```python
+from langchain_core.messages import SystemMessage, HumanMessage
+from langgraph.prebuilt import create_react_agent
+
+from tencentdb_langchain import (
+    AsyncTencentDBMemory,
+    create_async_memory_search_tool,
+)
+
+memory = AsyncTencentDBMemory(...)
+tools = [create_async_memory_search_tool(memory)]
+
+agent = create_react_agent(model, tools)
+await agent.ainvoke(
+    {"messages": [SystemMessage("You have a persistent memory."),
+                  HumanMessage("What do you remember about me?")]}
+)
+```
+
+## Configuration
+
+All clients accept the same parameters, read from environment variables, or from
+a config dict via `from_env()` / `from_config()`:
+
+| Variable / key | Default | Description |
+|---|---|---|
+| `endpoint` (`TDAI_MEMORY_ENDPOINT`) | — | Memory Gateway base URL, e.g. `http://127.0.0.1:8420` |
+| `api_key` (`TDAI_MEMORY_API_KEY`) | — | Gateway API key (or `local`) |
+| `service_id` (`TDAI_MEMORY_SERVICE_ID`) | — | Memory instance id (`x-tdai-service-id`) |
+| `team_id` / `agent_id` / `user_id` | — | v3 isolation context (required) |
+| `session_id` (`TDAI_MEMORY_SESSION_ID`) | — | Session scope for L0/L1 (required for capture) |
+| `user_key` (`TDAI_MEMORY_USER_KEY`) | — | Optional user identity for upstream auth |
+| `timeout` | 30 | Per-request timeout in seconds |
+
+## Semantics of the store
+
+`TencentDBStore` is *not* an exact key-value store — see the module docstring in
+[`store.py`](src/tencentdb_langchain/store.py) for the full mapping table. The one
+thing to remember: `put` records an **observation** that the pipeline distills
+into searchable facts asynchronously, so a value written with `put` may not be
+visible to `search` until the pipeline has run.
+
+## Testing
+
+```bash
+pip install -e ./adapters/langchain-memory[dev]
+pytest
+```
+
+The tests inject a fake transport into the SDK, so they run without a live
+gateway or an LLM.
+
+## License
+
+MIT — same as the TencentDB Agent Memory project.

--- a/adapters/langchain-memory/README_CN.md
+++ b/adapters/langchain-memory/README_CN.md
@@ -1,0 +1,173 @@
+# LangChain / LangGraph × TencentDB Agent Memory
+
+用一行胶水代码，让 [LangChain](https://www.langchain.com/) 或 [LangGraph](https://www.langchain.com/langgraph)
+的 Agent 拥有由 [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory)
+支撑的持久、团队级记忆——无需改动你的模型或图结构。
+
+## 功能
+
+- **`TencentDBStore`** — 实现 LangGraph [`BaseStore`](https://langchain-ai.github.io/langgraph/reference/store/)，
+  跨线程持久化长期记忆并做语义召回。
+- **`TencentDBRetriever`** — 实现 LangChain [`BaseRetriever`](https://python.langchain.com/docs/concepts/retrievers/)，
+  可直接嵌入任意 RAG 链。
+- **开箱即用工具** — `memory_search` 与 `memory_recall`，可直接交给任意 Agent 调用。
+- **沉淀助手** — 一次调用即可把对话写入记忆管线，或挂一个副作用 LangGraph 节点。
+- **同步 + 异步** — 每个能力都有 sync / async 双实现，经典 LangChain 链与 LangGraph 图都能用。
+- **天然轻薄** — 无本地向量库、无本地 embedding、无抽取逻辑。沉淀、蒸馏、向量化、检索全部留在 MemoryCore。
+
+## 为什么这样设计
+
+- **忠于记忆模型**。TencentDB Agent Memory 遵循 *沉淀 → 蒸馏 → 召回*：你记录观测，
+  管线抽取结构化事实，之后你再召回。本适配器把 LangChain/LangGraph 的概念映射到这套模型上，
+  而不是假装它是一个普通键值存储。
+- **绝不写入占位数据**。无法归一化的消息会立刻报错，而不是塞进一条假记录。
+- **失败有界**。所有调用都走官方 Python SDK，它校验 `{code, message, data}` 信封，
+  业务码非 0 时抛出 `TDAMError`——Agent 看到的是真实错误，而不是静默的部分成功。
+- **零本地索引**。检索在服务端完成（MemoryCore 内的 BM25 + 向量 + RRF），无需重建或同步任何东西。
+
+## 工作原理
+
+```text
+LangChain / LangGraph Agent
+   │
+   ├─ capture_conversation() ──► POST /v3/conversation/add   (L0 观测)
+   │                                   │  异步管线
+   │                                   ▼
+   │                            L1 事实（蒸馏后的记忆）
+   │                                   ▲
+   └─ memory_search / retriever ──► POST /v3/atomic/search    (语义召回)
+        store.search()
+```
+
+两个钩子闭合完整闭环：**沉淀**记录发生了什么，**召回**让之后可用。召回是 Agent 驱动的——
+Agent（或你的链）在真正需要时主动检索记忆，而不是每轮都注入上下文。
+
+## 前置条件
+
+- Python ≥ 3.9。
+- 已启动 TencentDB Agent Memory 网关：
+
+  ```bash
+  cd deploy/global-images
+  cp .env.example .env && $EDITOR .env
+  ./start-all.sh
+  ```
+
+## 安装
+
+```bash
+# TencentDB Agent Memory 的 Python SDK 尚未发布到 PyPI，请先从本仓库安装 SDK，
+# 再安装适配器：
+pip install -e ./sdk/memory-core/python
+pip install -e ./adapters/langchain-memory
+
+# （两者都发布到 PyPI 后：）
+# pip install tencentdb-agent-memory-langchain
+```
+
+## 快速开始
+
+```python
+from tencentdb_langchain import TencentDBMemory, create_memory_search_tool
+
+memory = TencentDBMemory(
+    endpoint="http://127.0.0.1:8420",
+    api_key="local",
+    service_id="default",
+    team_id="t1", agent_id="a1", user_id="u1",
+)
+
+# 1. 沉淀一段对话（记录观测）。
+memory.capture(
+    [{"role": "user", "content": "我更喜欢编辑器用深色主题"}],
+    session_id="sess-1",
+)
+
+# 2. 稍后召回蒸馏出的事实。
+facts = memory.search_facts("编辑器主题")
+for f in facts:
+    print(f.content)          # "用户更喜欢深色主题"
+```
+
+### 作为 LangGraph store 使用
+
+```python
+from tencentdb_langchain import TencentDBStore
+
+store = TencentDBStore.from_config({
+    "endpoint": "http://127.0.0.1:8420",
+    "api_key": "local",
+    "service_id": "default",
+    "team_id": "t1", "agent_id": "a1", "user_id": "u1",
+})
+
+store.put(("prefs",), "theme", {"content": "喜欢深色主题"})
+hits = store.search(("prefs",), query="用户喜欢什么主题", limit=5)
+print(hits[0].value["content"])
+```
+
+### 作为 LangChain retriever 使用
+
+```python
+from tencentdb_langchain import TencentDBMemory, TencentDBRetriever
+
+memory = TencentDBMemory(...)
+retriever = TencentDBRetriever(memory=memory, top_k=5)
+docs = retriever.invoke("关于认证的历史决策")
+```
+
+### 与 Agent 结合
+
+```python
+from langchain_core.messages import SystemMessage, HumanMessage
+from langgraph.prebuilt import create_react_agent
+
+from tencentdb_langchain import (
+    AsyncTencentDBMemory,
+    create_async_memory_search_tool,
+)
+
+memory = AsyncTencentDBMemory(...)
+tools = [create_async_memory_search_tool(memory)]
+
+agent = create_react_agent(model, tools)
+await agent.ainvoke(
+    {"messages": [SystemMessage("你拥有持久记忆。"),
+                  HumanMessage("你还记得我什么？")]}
+)
+```
+
+## 配置
+
+所有客户端接受相同参数，可从环境变量读取，或通过 `from_env()` / `from_config()`
+从配置字典读取：
+
+| 变量 / 键 | 默认值 | 说明 |
+|---|---|---|
+| `endpoint` (`TDAI_MEMORY_ENDPOINT`) | — | 记忆网关地址，如 `http://127.0.0.1:8420` |
+| `api_key` (`TDAI_MEMORY_API_KEY`) | — | 网关 API Key（或 `local`） |
+| `service_id` (`TDAI_MEMORY_SERVICE_ID`) | — | 记忆实例 id（`x-tdai-service-id`） |
+| `team_id` / `agent_id` / `user_id` | — | v3 隔离上下文（必填） |
+| `session_id` (`TDAI_MEMORY_SESSION_ID`) | — | L0/L1 的会话作用域（沉淀时必填） |
+| `user_key` (`TDAI_MEMORY_USER_KEY`) | — | 可选的上游用户身份 |
+| `timeout` | 30 | 单次请求超时（秒） |
+
+## Store 的语义
+
+`TencentDBStore` **不是**精确的键值存储——完整映射表见
+[`store.py`](src/tencentdb_langchain/store.py) 模块文档。要记住的一点：`put`
+记录的是**观测**，管线会异步把它蒸馏成可检索的事实，因此 `put` 写入的内容
+可能要等管线跑完才会出现在 `search` 结果里。
+
+## 测试
+
+```bash
+pip install -e ./adapters/langchain-memory[dev]
+pytest
+```
+
+测试把假传输注入 SDK，因此无需真实网关或 LLM 即可运行。
+
+## License
+
+MIT —— 与 TencentDB Agent Memory 项目一致。

--- a/adapters/langchain-memory/pyproject.toml
+++ b/adapters/langchain-memory/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tencentdb-agent-memory-langchain"
+version = "0.1.0"
+description = "LangChain / LangGraph adapter for TencentDB Agent Memory — persistent, team-scoped memory for agents"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+authors = [{ name = "TencentDB Agent Memory Team" }]
+keywords = ["langchain", "langgraph", "memory", "tencentdb", "agent", "rag"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "tencentdb-agent-memory-sdk-python-v2>=1.0.0b1",
+    "langchain-core>=0.3.0",
+    "langgraph>=0.2.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/tencentdb_langchain"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/adapters/langchain-memory/src/tencentdb_langchain/__init__.py
+++ b/adapters/langchain-memory/src/tencentdb_langchain/__init__.py
@@ -1,0 +1,63 @@
+"""TencentDB Agent Memory adapter for LangChain / LangGraph.
+
+Give a LangChain or LangGraph agent persistent memory backed by
+`TencentDB Agent Memory <https://github.com/TencentCloud/TencentDB-Agent-Memory>`_:
+
+- :class:`TencentDBStore` — LangGraph long-term memory (:class:`~langgraph.store.base.BaseStore`).
+- :class:`TencentDBRetriever` — LangChain retriever for RAG chains.
+- :func:`create_memory_search_tool` / :func:`create_memory_recall_tool` — ready-made agent tools.
+- :func:`capture_conversation` / :func:`create_capture_node` — record conversations into L0.
+"""
+
+from .capture import (
+    acapture_conversation,
+    capture_conversation,
+    create_capture_node,
+    langchain_messages_to_dicts,
+)
+from .client import (
+    AsyncTencentDBMemory,
+    ConversationRecord,
+    MemoryFact,
+    Persona,
+    Scenario,
+    TencentDBMemory,
+    config_from_dict,
+    env_config,
+)
+from .retriever import TencentDBRetriever
+from .store import TencentDBStore
+from .tool import (
+    create_async_memory_recall_tool,
+    create_async_memory_search_tool,
+    create_memory_recall_tool,
+    create_memory_search_tool,
+    format_conversations,
+    format_facts,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    "TencentDBMemory",
+    "AsyncTencentDBMemory",
+    "TencentDBStore",
+    "TencentDBRetriever",
+    "MemoryFact",
+    "ConversationRecord",
+    "Scenario",
+    "Persona",
+    "env_config",
+    "config_from_dict",
+    "create_memory_search_tool",
+    "create_async_memory_search_tool",
+    "create_memory_recall_tool",
+    "create_async_memory_recall_tool",
+    "format_facts",
+    "format_conversations",
+    "capture_conversation",
+    "acapture_conversation",
+    "create_capture_node",
+    "langchain_messages_to_dicts",
+]

--- a/adapters/langchain-memory/src/tencentdb_langchain/capture.py
+++ b/adapters/langchain-memory/src/tencentdb_langchain/capture.py
@@ -1,0 +1,109 @@
+"""Conversation capture helpers for LangChain / LangGraph.
+
+Recording observations (L0 conversations) is how TencentDB Agent Memory is
+populated: the memory pipeline distills L1 facts from these records in the
+background. These helpers make it a one-liner to feed a LangChain/LangGraph
+conversation into that pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from .client import AsyncTencentDBMemory, TencentDBMemory
+
+__all__ = [
+    "langchain_messages_to_dicts",
+    "capture_conversation",
+    "acapture_conversation",
+    "create_capture_node",
+]
+
+_ROLE_MAP = {
+    "human": "user",
+    "user": "user",
+    "ai": "assistant",
+    "assistant": "assistant",
+    "system": "system",
+    "tool": "tool",
+    "function": "tool",
+}
+
+
+def langchain_messages_to_dicts(messages: List[Any]) -> List[Dict[str, Any]]:
+    """Convert LangChain message objects into ``{role, content}`` dicts.
+
+    Any object with a ``type``/``role`` and ``content`` attribute is accepted;
+    non-string content (e.g. multimodal blocks) is JSON-serialised.
+    """
+    import json
+
+    result: List[Dict[str, Any]] = []
+    for m in messages:
+        if isinstance(m, dict):
+            result.append({"role": str(m.get("role", "user")), "content": str(m.get("content", ""))})
+            continue
+        msg_type = getattr(m, "type", None) or getattr(m, "role", None) or "user"
+        role = _ROLE_MAP.get(str(msg_type), "user")
+        content = getattr(m, "content", "")
+        if not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False)
+        result.append({"role": role, "content": content})
+    return result
+
+
+def capture_conversation(
+    memory: TencentDBMemory,
+    messages: List[Any],
+    *,
+    session_id: Optional[str] = None,
+) -> List[str]:
+    """Capture a conversation turn (L0) through a sync client.
+
+    ``messages`` may be LangChain messages or plain ``{role, content}`` dicts.
+    Returns the accepted message ids.
+    """
+    return memory.capture(langchain_messages_to_dicts(messages), session_id=session_id)
+
+
+async def acapture_conversation(
+    memory: AsyncTencentDBMemory,
+    messages: List[Any],
+    *,
+    session_id: Optional[str] = None,
+) -> List[str]:
+    """Async twin of :func:`capture_conversation`."""
+    return await memory.capture(
+        langchain_messages_to_dicts(messages), session_id=session_id
+    )
+
+
+def create_capture_node(
+    memory: AsyncTencentDBMemory,
+    *,
+    session_id: Optional[str] = None,
+    session_id_from_state: Optional[Callable[[Dict[str, Any]], Optional[str]]] = None,
+    last_n: int = 2,
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Return an async LangGraph node that captures the trailing exchange.
+
+    The node is a *side-effecting* step: it reads ``state["messages"]``, captures
+    the last ``last_n`` messages to memory, and returns ``{}`` (no state change),
+    so it is safe to attach as a post-model step (e.g. via ``@after_model`` or as
+    a plain edge target).
+
+    ``session_id`` may be fixed, or resolved per-call with ``session_id_from_state``.
+    """
+
+    async def _capture_node(state: Dict[str, Any]) -> Dict[str, Any]:
+        messages = state.get("messages") or []
+        if not messages:
+            return {}
+        window = list(messages)[-last_n:] if last_n > 0 else list(messages)
+        sid = session_id
+        if sid is None and session_id_from_state is not None:
+            sid = session_id_from_state(state)
+        await acapture_conversation(memory, window, session_id=sid)
+        return {}
+
+    return _capture_node

--- a/adapters/langchain-memory/src/tencentdb_langchain/client.py
+++ b/adapters/langchain-memory/src/tencentdb_langchain/client.py
@@ -1,0 +1,505 @@
+"""Framework-agnostic client for TencentDB Agent Memory.
+
+This module wraps the official ``tencentdb-agent-memory-sdk-python-v2`` data-plane
+client and exposes a small set of *semantic* operations — capture, search, and
+read — with clean, typed return values. It deliberately depends on nothing from
+LangChain / LangGraph, so it can be unit-tested against a fake transport and
+reused by any future integration.
+
+The TencentDB Agent Memory model is:
+
+    capture (L0 conversation) → distill (L1 facts, async pipeline)
+                              → recall (L1 semantic search / L2 scenarios / L3 persona)
+
+You never write a distilled fact directly. You record observations (``capture``)
+and the memory pipeline extracts the facts for you; you then read them back with
+``search_facts`` / ``read_persona`` / ``list_scenarios``.
+
+The ``/v3/*`` envelope is ``{"code": 0, "message": "", "request_id": "", "data": {...}}``;
+the SDK raises :class:`tencentdb_agent_memory.TDAMError` on ``code != 0`` and
+otherwise returns the ``data`` object. We only map ``data`` into dataclasses here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from tencentdb_agent_memory.v3 import AsyncMemoryClient, MemoryClient
+
+__all__ = [
+    "MemoryFact",
+    "ConversationRecord",
+    "Scenario",
+    "Persona",
+    "TencentDBMemory",
+    "AsyncTencentDBMemory",
+    "env_config",
+    "config_from_dict",
+]
+
+
+# ---------------------------------------------------------------------------
+# Typed results
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MemoryFact:
+    """A single L1 atomic memory returned by ``/v3/atomic/search`` or ``query``."""
+
+    id: str
+    content: str
+    type: Optional[str] = None
+    score: Optional[float] = None
+    background: Optional[str] = None
+    version: int = 0
+    team_id: Optional[str] = None
+    user_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    task_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass
+class ConversationRecord:
+    """A single L0 conversation message returned by ``/v3/conversation/query``."""
+
+    id: Optional[str] = None
+    role: Optional[str] = None
+    content: Optional[str] = None
+    score: Optional[float] = None
+    created_at: Optional[str] = None
+    session_id: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Scenario:
+    """A single L2 scenario block entry returned by ``/v3/scenario/ls``."""
+
+    path: str
+    summary: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass
+class Persona:
+    """The L3 persona file returned by ``/v3/core/read``."""
+
+    content: Optional[str] = None
+    version: int = 0
+    team_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers (shared by sync and async clients)
+# ---------------------------------------------------------------------------
+
+
+def _fact_from_dict(d: Dict[str, Any]) -> MemoryFact:
+    score = d.get("score")
+    return MemoryFact(
+        id=str(d.get("id", "")),
+        content=str(d.get("content", "")),
+        type=d.get("type"),
+        score=float(score) if score is not None else None,
+        background=d.get("background"),
+        version=int(d.get("version", 0) or 0),
+        team_id=d.get("team_id"),
+        user_id=d.get("user_id"),
+        agent_id=d.get("agent_id"),
+        task_id=d.get("task_id"),
+        created_at=d.get("created_at"),
+        updated_at=d.get("updated_at"),
+    )
+
+
+def _conversation_from_dict(d: Dict[str, Any]) -> ConversationRecord:
+    extra = {k: v for k, v in d.items() if k not in {
+        "id", "role", "content", "score", "created_at", "session_id",
+    }}
+    return ConversationRecord(
+        id=d.get("id"),
+        role=d.get("role"),
+        content=d.get("content"),
+        score=d.get("score"),
+        created_at=d.get("created_at"),
+        session_id=d.get("session_id"),
+        extra=extra,
+    )
+
+
+def _scenario_from_dict(d: Dict[str, Any]) -> Scenario:
+    return Scenario(
+        path=str(d.get("path", "")),
+        summary=d.get("summary"),
+        created_at=d.get("created_at"),
+        updated_at=d.get("updated_at"),
+    )
+
+
+def _normalize_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Validate that ``messages`` is a non-empty list of ``{role, content}`` dicts."""
+    if not isinstance(messages, (list, tuple)) or not messages:
+        raise ValueError("messages must be a non-empty list of {role, content} dicts")
+    normalized: List[Dict[str, Any]] = []
+    for m in messages:
+        if isinstance(m, dict):
+            role = m.get("role")
+            content = m.get("content")
+        else:
+            # Lenient: objects exposing ``content`` (e.g. LangChain messages).
+            role = getattr(m, "type", None) or getattr(m, "role", None)
+            content = getattr(m, "content", None)
+        if role is None or content is None:
+            raise ValueError(f"each message must have role and content, got: {m!r}")
+        normalized.append({"role": str(role), "content": str(content)})
+    return normalized
+
+
+def env_config(prefix: str = "TDAI_MEMORY_") -> Dict[str, Any]:
+    """Read connection parameters from environment variables.
+
+    Recognised keys (all optional except the ones the SDK requires at call time):
+
+    - ``{prefix}ENDPOINT``, ``{prefix}API_KEY``, ``{prefix}SERVICE_ID``
+    - ``{prefix}TEAM_ID``, ``{prefix}AGENT_ID``, ``{prefix}USER_ID``
+    - ``{prefix}SESSION_ID``, ``{prefix}TASK_ID``, ``{prefix}USER_KEY``
+    - ``{prefix}TIMEOUT``
+    """
+    def _get(key: str) -> Optional[str]:
+        val = os.environ.get(prefix + key)
+        return val if val not in (None, "") else None
+
+    cfg: Dict[str, Any] = {}
+    for key in ("endpoint", "api_key", "service_id", "team_id", "agent_id",
+                "user_id", "session_id", "task_id", "user_key"):
+        val = _get(key.upper())
+        if val is not None:
+            cfg[key] = val
+    timeout = _get("TIMEOUT")
+    if timeout is not None:
+        try:
+            cfg["timeout"] = float(timeout)
+        except ValueError:
+            pass
+    return cfg
+
+
+def config_from_dict(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Pick the supported connection keys out of an arbitrary dict (e.g. a YAML/JSON config)."""
+    supported = {
+        "endpoint", "api_key", "service_id", "team_id", "agent_id", "user_id",
+        "session_id", "task_id", "user_key", "timeout", "verify",
+    }
+    return {k: v for k, v in raw.items() if k in supported and v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Synchronous client
+# ---------------------------------------------------------------------------
+
+
+class TencentDBMemory:
+    """Synchronous, semantic wrapper over the official v3 :class:`MemoryClient`.
+
+    Parameters mirror the SDK constructor: ``endpoint``, ``api_key``,
+    ``service_id`` are the transport; ``team_id`` / ``agent_id`` / ``user_id``
+    are the v3 isolation context and are required. ``session_id`` is optional at
+    construction but required when calling :meth:`capture`.
+    """
+
+    def __init__(
+        self,
+        endpoint: str = "",
+        api_key: str = "",
+        service_id: Optional[str] = None,
+        *,
+        team_id: str = "",
+        agent_id: str = "",
+        user_id: str = "",
+        session_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        user_key: Optional[str] = None,
+        timeout: float = 30,
+        verify: bool = True,
+        client: Optional[MemoryClient] = None,
+    ) -> None:
+        self._client = client or MemoryClient(
+            endpoint=endpoint,
+            api_key=api_key,
+            service_id=service_id,
+            team_id=team_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            session_id=session_id,
+            task_id=task_id,
+            user_key=user_key,
+            timeout=timeout,
+            verify=verify,
+        )
+
+    @classmethod
+    def from_env(cls, prefix: str = "TDAI_MEMORY_") -> "TencentDBMemory":
+        return cls(**env_config(prefix))
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "TencentDBMemory":
+        return cls(**config_from_dict(config))
+
+    # -- capture -----------------------------------------------------------
+
+    def capture(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        session_id: Optional[str] = None,
+    ) -> List[str]:
+        """Record a conversation turn (L0). Returns the accepted message ids.
+
+        The memory pipeline distills L1 facts from these observations
+        asynchronously; they become searchable shortly afterwards.
+        """
+        data = self._client.add_conversation(
+            _normalize_messages(messages), session_id=session_id
+        )
+        ids = data.get("accepted_ids") or []
+        return [str(i) for i in ids]
+
+    # -- recall ------------------------------------------------------------
+
+    def search_facts(
+        self,
+        query: str,
+        *,
+        limit: Optional[int] = None,
+        type: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> List[MemoryFact]:
+        """Semantic search over distilled L1 facts (``/v3/atomic/search``)."""
+        data = self._client.search_atomic(
+            query, limit=limit, type=type, session_id=session_id
+        )
+        items = data.get("items") or []
+        return [_fact_from_dict(i) for i in items]
+
+    def search_conversations(
+        self,
+        query: str,
+        *,
+        limit: Optional[int] = None,
+        session_id: Optional[str] = None,
+    ) -> List[ConversationRecord]:
+        """Full-text/vector search over raw L0 conversations."""
+        data = self._client.search_conversation(
+            query, limit=limit, session_id=session_id
+        )
+        items = data.get("messages") or []
+        return [_conversation_from_dict(i) for i in items]
+
+    def list_facts(
+        self,
+        *,
+        type: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        session_id: Optional[str] = None,
+    ) -> List[MemoryFact]:
+        """List L1 facts (``/v3/atomic/query``)."""
+        data = self._client.query_atomic(
+            type=type, limit=limit, offset=offset, session_id=session_id
+        )
+        items = data.get("items") or []
+        return [_fact_from_dict(i) for i in items]
+
+    def read_persona(self) -> Persona:
+        """Read the L3 persona file (``/v3/core/read``)."""
+        data = self._client.read_core()
+        return Persona(
+            content=data.get("content"),
+            version=int(data.get("version", 0) or 0),
+            team_id=data.get("team_id"),
+            agent_id=data.get("agent_id"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+    def list_scenarios(self, *, path_prefix: Optional[str] = None) -> List[Scenario]:
+        """List L2 scenario blocks (``/v3/scenario/ls``)."""
+        data = self._client.list_scenarios(path_prefix=path_prefix)
+        entries = data.get("entries") or data.get("items") or []
+        return [_scenario_from_dict(i) for i in entries]
+
+    def read_scenario(self, path: str) -> Optional[str]:
+        """Read a single L2 scenario file's content (``/v3/scenario/read``)."""
+        data = self._client.read_scenario(path)
+        return data.get("content")
+
+    # -- delete ------------------------------------------------------------
+
+    def delete_facts(self, ids: List[str], *, session_id: Optional[str] = None) -> int:
+        """Delete L1 facts by id (``/v3/atomic/delete``). Returns deleted count."""
+        data = self._client.delete_atomic(ids, session_id=session_id)
+        return int(data.get("deleted_count", 0) or 0)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    @property
+    def client(self) -> MemoryClient:
+        """The underlying SDK client, for anything not covered here."""
+        return self._client
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "TencentDBMemory":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Asynchronous client
+# ---------------------------------------------------------------------------
+
+
+class AsyncTencentDBMemory:
+    """Asynchronous twin of :class:`TencentDBMemory`, for LangGraph agents."""
+
+    def __init__(
+        self,
+        endpoint: str = "",
+        api_key: str = "",
+        service_id: Optional[str] = None,
+        *,
+        team_id: str = "",
+        agent_id: str = "",
+        user_id: str = "",
+        session_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        user_key: Optional[str] = None,
+        timeout: float = 30,
+        verify: bool = True,
+        client: Optional[AsyncMemoryClient] = None,
+    ) -> None:
+        self._client = client or AsyncMemoryClient(
+            endpoint=endpoint,
+            api_key=api_key,
+            service_id=service_id,
+            team_id=team_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            session_id=session_id,
+            task_id=task_id,
+            user_key=user_key,
+            timeout=timeout,
+            verify=verify,
+        )
+
+    @classmethod
+    def from_env(cls, prefix: str = "TDAI_MEMORY_") -> "AsyncTencentDBMemory":
+        return cls(**env_config(prefix))
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "AsyncTencentDBMemory":
+        return cls(**config_from_dict(config))
+
+    async def capture(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        session_id: Optional[str] = None,
+    ) -> List[str]:
+        data = await self._client.add_conversation(
+            _normalize_messages(messages), session_id=session_id
+        )
+        ids = data.get("accepted_ids") or []
+        return [str(i) for i in ids]
+
+    async def search_facts(
+        self,
+        query: str,
+        *,
+        limit: Optional[int] = None,
+        type: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> List[MemoryFact]:
+        data = await self._client.search_atomic(
+            query, limit=limit, type=type, session_id=session_id
+        )
+        items = data.get("items") or []
+        return [_fact_from_dict(i) for i in items]
+
+    async def search_conversations(
+        self,
+        query: str,
+        *,
+        limit: Optional[int] = None,
+        session_id: Optional[str] = None,
+    ) -> List[ConversationRecord]:
+        data = await self._client.search_conversation(
+            query, limit=limit, session_id=session_id
+        )
+        items = data.get("messages") or []
+        return [_conversation_from_dict(i) for i in items]
+
+    async def list_facts(
+        self,
+        *,
+        type: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        session_id: Optional[str] = None,
+    ) -> List[MemoryFact]:
+        data = await self._client.query_atomic(
+            type=type, limit=limit, offset=offset, session_id=session_id
+        )
+        items = data.get("items") or []
+        return [_fact_from_dict(i) for i in items]
+
+    async def read_persona(self) -> Persona:
+        data = await self._client.read_core()
+        return Persona(
+            content=data.get("content"),
+            version=int(data.get("version", 0) or 0),
+            team_id=data.get("team_id"),
+            agent_id=data.get("agent_id"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+    async def list_scenarios(self, *, path_prefix: Optional[str] = None) -> List[Scenario]:
+        data = await self._client.list_scenarios(path_prefix=path_prefix)
+        entries = data.get("entries") or data.get("items") or []
+        return [_scenario_from_dict(i) for i in entries]
+
+    async def read_scenario(self, path: str) -> Optional[str]:
+        data = await self._client.read_scenario(path)
+        return data.get("content")
+
+    async def delete_facts(
+        self, ids: List[str], *, session_id: Optional[str] = None
+    ) -> int:
+        data = await self._client.delete_atomic(ids, session_id=session_id)
+        return int(data.get("deleted_count", 0) or 0)
+
+    @property
+    def client(self) -> AsyncMemoryClient:
+        return self._client
+
+    async def close(self) -> None:
+        await self._client.close()
+
+    async def __aenter__(self) -> "AsyncTencentDBMemory":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()

--- a/adapters/langchain-memory/src/tencentdb_langchain/retriever.py
+++ b/adapters/langchain-memory/src/tencentdb_langchain/retriever.py
@@ -1,0 +1,66 @@
+"""LangChain retriever for TencentDB Agent Memory.
+
+:class:`TencentDBRetriever` turns L1 semantic recall into a
+:class:`~langchain_core.retrievers.BaseRetriever`, so it drops into any RAG
+chain (``create_retrieval_tool``, a ``RetrievalQA`` chain, etc.) without further
+glue. Each hit becomes a :class:`~langchain_core.documents.Document` whose
+``page_content`` is the fact text and whose ``metadata`` carries id / type /
+score / timestamps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, Optional
+
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+
+from .client import MemoryFact, TencentDBMemory
+
+__all__ = ["TencentDBRetriever"]
+
+
+def _fact_to_document(fact: MemoryFact) -> Document:
+    metadata: dict[str, Any] = {
+        "id": fact.id,
+        "type": fact.type,
+        "score": fact.score,
+        "created_at": fact.created_at,
+        "updated_at": fact.updated_at,
+        "background": fact.background,
+    }
+    # Drop None values so metadata stays clean and JSON-serialisable.
+    metadata = {k: v for k, v in metadata.items() if v is not None}
+    return Document(page_content=fact.content, metadata=metadata)
+
+
+class TencentDBRetriever(BaseRetriever):
+    """Retrieve distilled L1 memories for a query.
+
+    Parameters
+    ----------
+    memory:
+        A :class:`~tencentdb_langchain.TencentDBMemory` (sync client).
+    top_k:
+        Maximum number of facts to return (default 5).
+    type:
+        Optional fact-type filter forwarded to ``/v3/atomic/search``.
+    """
+
+    memory: TencentDBMemory
+    top_k: int = 5
+    type: Optional[str] = None
+
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: Any = None
+    ) -> List[Document]:
+        facts = self.memory.search_facts(query, limit=self.top_k, type=self.type)
+        return [_fact_to_document(f) for f in facts]
+
+    async def _aget_relevant_documents(
+        self, query: str, *, run_manager: Any = None
+    ) -> List[Document]:
+        # The sync client is httpx-based; run it in a thread to keep the event
+        # loop free without maintaining a second async client.
+        return await asyncio.to_thread(self._get_relevant_documents, query)

--- a/adapters/langchain-memory/src/tencentdb_langchain/store.py
+++ b/adapters/langchain-memory/src/tencentdb_langchain/store.py
@@ -1,0 +1,349 @@
+"""LangGraph long-term memory store backed by TencentDB Agent Memory.
+
+:class:`TencentDBStore` implements :class:`langgraph.store.base.BaseStore`, the
+standard LangGraph abstraction for cross-thread long-term memory. It lets a
+LangGraph agent persist and recall memories across conversations without
+re-training or re-introducing itself.
+
+Semantic mapping
+----------------
+
+TencentDB Agent Memory is *not* a generic key-value store. It follows a
+``capture → distill → recall`` model, so the store methods map onto that model
+rather than onto exact-KV semantics:
+
+===================================  ==========================================
+LangGraph ``BaseStore`` method         TencentDB operation
+===================================  ==========================================
+``search`` / ``asearch``               ``/v3/atomic/search`` (recall distilled L1 facts)
+``put`` / ``aput``                     ``/v3/conversation/add`` (record an L0 observation)
+``get`` / ``aget``                     recall the fact most relevant to ``key``
+``delete`` / ``adelete``               ``/v3/atomic/delete`` (best-effort, by fact id)
+``list_namespaces``                    ``/v3/scenario/ls`` (L2 scenarios as namespaces)
+===================================  ==========================================
+
+The important consequence: ``put`` records an *observation* that the memory
+pipeline distills into searchable facts asynchronously, so a fact written with
+``put`` may not be visible to ``search`` until the pipeline has run. This is
+intentional — you record what happened, and the system turns it into memory.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Iterable, List, Optional, Tuple
+
+from langgraph.store.base import (
+    BaseStore,
+    GetOp,
+    Item,
+    ListNamespacesOp,
+    PutOp,
+    Result,
+    SearchItem,
+    SearchOp,
+)
+
+from .client import (
+    AsyncTencentDBMemory,
+    MemoryFact,
+    TencentDBMemory,
+    config_from_dict,
+    env_config,
+)
+
+__all__ = ["TencentDBStore"]
+
+Namespace = Tuple[str, ...]
+
+_MARKER = "tencentdb-langgraph"
+
+
+def _parse_dt(value: Optional[str]) -> datetime:
+    """Parse an ISO-8601 timestamp, falling back to ``now`` when absent/malformed."""
+    if value:
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            pass
+    return datetime.now(timezone.utc)
+
+
+def _fact_to_item(fact: MemoryFact, namespace: Namespace) -> SearchItem:
+    created = _parse_dt(fact.created_at)
+    updated = _parse_dt(fact.updated_at) if fact.updated_at else created
+    value: dict[str, Any] = {"content": fact.content}
+    if fact.type is not None:
+        value["type"] = fact.type
+    if fact.background is not None:
+        value["background"] = fact.background
+    return SearchItem(
+        namespace=namespace,
+        key=fact.id,
+        value=value,
+        created_at=created,
+        updated_at=updated,
+        score=fact.score,
+    )
+
+
+def _observation_value(namespace: Namespace, key: str, value: dict[str, Any]) -> dict[str, Any]:
+    """Encode a ``put`` into a traceable observation message."""
+    return {
+        "source": _MARKER,
+        "namespace": list(namespace),
+        "key": key,
+        "value": value,
+    }
+
+
+class TencentDBStore(BaseStore):
+    """LangGraph ``BaseStore`` backed by TencentDB Agent Memory.
+
+    Construct it from clients or from configuration:
+
+    >>> store = TencentDBStore.from_config({
+    ...     "endpoint": "https://memory.example.com",
+    ...     "api_key": "sk-...", "service_id": "mem-...",
+    ...     "team_id": "t1", "agent_id": "a1", "user_id": "u1",
+    ... })
+
+    Both sync and async clients are created, so the store works in sync and
+    async LangGraph graphs alike.
+    """
+
+    def __init__(
+        self,
+        *,
+        memory: Optional[TencentDBMemory] = None,
+        async_memory: Optional[AsyncTencentDBMemory] = None,
+        default_session_id: Optional[str] = None,
+    ) -> None:
+        if memory is None and async_memory is None:
+            raise ValueError(
+                "TencentDBStore requires at least one of memory / async_memory"
+            )
+        self._memory = memory
+        self._async_memory = async_memory
+        self._default_session_id = default_session_id
+
+    @classmethod
+    def from_env(cls, prefix: str = "TDAI_MEMORY_") -> "TencentDBStore":
+        cfg = env_config(prefix)
+        return cls(
+            memory=TencentDBMemory(**cfg),
+            async_memory=AsyncTencentDBMemory(**cfg),
+            default_session_id=cfg.get("session_id"),
+        )
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "TencentDBStore":
+        cfg = config_from_dict(config)
+        return cls(
+            memory=TencentDBMemory(**cfg),
+            async_memory=AsyncTencentDBMemory(**cfg),
+            default_session_id=cfg.get("session_id"),
+        )
+
+    # -- helpers -----------------------------------------------------------
+
+    def _require_memory(self) -> TencentDBMemory:
+        if self._memory is None:
+            raise RuntimeError("This store has no sync client; use the async methods.")
+        return self._memory
+
+    def _require_async_memory(self) -> AsyncTencentDBMemory:
+        if self._async_memory is None:
+            raise RuntimeError("This store has no async client; use the sync methods.")
+        return self._async_memory
+
+    def _session(self, namespace: Namespace) -> Optional[str]:
+        # L0 writes require a session_id. Prefer the explicitly configured
+        # default, otherwise derive one from the namespace's top-level scope so
+        # ``put`` is self-contained.
+        if self._default_session_id:
+            return self._default_session_id
+        if namespace:
+            return namespace[0]
+        return None
+
+    # -- put ---------------------------------------------------------------
+
+    def put(
+        self,
+        namespace: Namespace,
+        key: str,
+        value: dict[str, Any],
+        index: object = None,
+        *,
+        ttl: object = None,
+    ) -> None:
+        memory = self._require_memory()
+        message = {
+            "role": "user",
+            "content": json.dumps(
+                _observation_value(namespace, key, value), ensure_ascii=False
+            ),
+        }
+        memory.capture([message], session_id=self._session(namespace))
+
+    async def aput(
+        self,
+        namespace: Namespace,
+        key: str,
+        value: dict[str, Any],
+        index: object = None,
+        *,
+        ttl: object = None,
+    ) -> None:
+        memory = self._require_async_memory()
+        message = {
+            "role": "user",
+            "content": json.dumps(
+                _observation_value(namespace, key, value), ensure_ascii=False
+            ),
+        }
+        await memory.capture([message], session_id=self._session(namespace))
+
+    # -- search ------------------------------------------------------------
+
+    def search(
+        self,
+        namespace_prefix: Namespace,
+        /,
+        *,
+        query: Optional[str] = None,
+        filter: Optional[dict[str, Any]] = None,
+        limit: int = 10,
+        offset: int = 0,
+        refresh_ttl: Optional[bool] = None,
+    ) -> List[SearchItem]:
+        memory = self._require_memory()
+        q = query or ""
+        facts = memory.search_facts(q, limit=limit or 10)
+        return [_fact_to_item(f, namespace_prefix) for f in facts]
+
+    async def asearch(
+        self,
+        namespace_prefix: Namespace,
+        /,
+        *,
+        query: Optional[str] = None,
+        filter: Optional[dict[str, Any]] = None,
+        limit: int = 10,
+        offset: int = 0,
+        refresh_ttl: Optional[bool] = None,
+    ) -> List[SearchItem]:
+        memory = self._require_async_memory()
+        q = query or ""
+        facts = await memory.search_facts(q, limit=limit or 10)
+        return [_fact_to_item(f, namespace_prefix) for f in facts]
+
+    # -- get ---------------------------------------------------------------
+
+    def get(
+        self,
+        namespace: Namespace,
+        key: str,
+        *,
+        refresh_ttl: Optional[bool] = None,
+    ) -> Optional[Item]:
+        memory = self._require_memory()
+        facts = memory.search_facts(key, limit=1)
+        if not facts:
+            return None
+        return _fact_to_item(facts[0], namespace)
+
+    async def aget(
+        self,
+        namespace: Namespace,
+        key: str,
+        *,
+        refresh_ttl: Optional[bool] = None,
+    ) -> Optional[Item]:
+        memory = self._require_async_memory()
+        facts = await memory.search_facts(key, limit=1)
+        if not facts:
+            return None
+        return _fact_to_item(facts[0], namespace)
+
+    # -- delete ------------------------------------------------------------
+
+    def delete(self, namespace: Namespace, key: str) -> None:
+        # Best-effort: the key is treated as a fact id. If it does not match a
+        # fact, the gateway returns deleted_count=0 and nothing is harmed.
+        self._require_memory().delete_facts([key])
+
+    async def adelete(self, namespace: Namespace, key: str) -> None:
+        await self._require_async_memory().delete_facts([key])
+
+    # -- list_namespaces ---------------------------------------------------
+
+    def list_namespaces(
+        self,
+        *,
+        prefix: Optional[Namespace] = None,
+        suffix: Optional[Namespace] = None,
+        max_depth: Optional[int] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Namespace]:
+        path_prefix = "/".join(prefix) if prefix else None
+        scenarios = self._require_memory().list_scenarios(path_prefix=path_prefix)
+        return [tuple(s.path.strip("/").split("/")) for s in scenarios]
+
+    async def alist_namespaces(
+        self,
+        *,
+        prefix: Optional[Namespace] = None,
+        suffix: Optional[Namespace] = None,
+        max_depth: Optional[int] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Namespace]:
+        path_prefix = "/".join(prefix) if prefix else None
+        scenarios = await self._require_async_memory().list_scenarios(
+            path_prefix=path_prefix
+        )
+        return [tuple(s.path.strip("/").split("/")) for s in scenarios]
+
+    # -- batch -------------------------------------------------------------
+
+    def batch(self, ops: Iterable[Any]) -> List[Result]:
+        results: List[Result] = []
+        for op in ops:
+            if isinstance(op, PutOp):
+                self.put(op.namespace, op.key, op.value, op.index, ttl=op.ttl)
+                results.append(None)
+            elif isinstance(op, GetOp):
+                results.append(self.get(op.namespace, op.key, refresh_ttl=op.refresh_ttl))
+            elif isinstance(op, SearchOp):
+                results.append(self.search(op.namespace_prefix, query=op.query,
+                                          filter=op.filter, limit=op.limit,
+                                          offset=op.offset, refresh_ttl=op.refresh_ttl))
+            elif isinstance(op, ListNamespacesOp):
+                results.append(self.list_namespaces(
+                    max_depth=op.max_depth, limit=op.limit, offset=op.offset))
+            else:
+                results.append(None)
+        return results
+
+    async def abatch(self, ops: Iterable[Any]) -> List[Result]:
+        results: List[Result] = []
+        for op in ops:
+            if isinstance(op, PutOp):
+                await self.aput(op.namespace, op.key, op.value, op.index, ttl=op.ttl)
+                results.append(None)
+            elif isinstance(op, GetOp):
+                results.append(await self.aget(op.namespace, op.key, refresh_ttl=op.refresh_ttl))
+            elif isinstance(op, SearchOp):
+                results.append(await self.asearch(
+                    op.namespace_prefix, query=op.query, filter=op.filter,
+                    limit=op.limit, offset=op.offset, refresh_ttl=op.refresh_ttl))
+            elif isinstance(op, ListNamespacesOp):
+                results.append(await self.alist_namespaces(
+                    max_depth=op.max_depth, limit=op.limit, offset=op.offset))
+            else:
+                results.append(None)
+        return results

--- a/adapters/langchain-memory/src/tencentdb_langchain/tool.py
+++ b/adapters/langchain-memory/src/tencentdb_langchain/tool.py
@@ -1,0 +1,222 @@
+"""LangChain tools for TencentDB Agent Memory.
+
+Two ready-made tools let an agent recall memories mid-conversation:
+
+- ``memory_search`` — semantic search over distilled L1 facts (and raw L0
+  conversations), returning a compact, model-readable summary.
+- ``memory_recall`` — the "quick context bootstrap": L3 persona + L2 scenario
+  index + top L1 facts for a query, mirroring how the MemoryProxy injects
+  context on the first turn.
+
+Factories return a :class:`~langchain_core.tools.StructuredTool` that can be
+passed to ``ToolNode``, ``bind_tools``, or any LangChain/LangGraph agent.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+
+from .client import (
+    AsyncTencentDBMemory,
+    ConversationRecord,
+    MemoryFact,
+    Scenario,
+    TencentDBMemory,
+)
+
+__all__ = [
+    "create_memory_search_tool",
+    "create_async_memory_search_tool",
+    "create_memory_recall_tool",
+    "create_async_memory_recall_tool",
+    "format_facts",
+    "format_conversations",
+]
+
+
+def format_facts(facts: List[MemoryFact]) -> str:
+    """Render a list of facts as a model-readable block."""
+    if not facts:
+        return "No relevant memories found."
+    lines: List[str] = []
+    for i, f in enumerate(facts, 1):
+        score = f" (score={f.score:.3f})" if f.score is not None else ""
+        head = f"[{f.type}] " if f.type else ""
+        lines.append(f"{i}. {head}{f.content}{score}")
+    return "\n".join(lines)
+
+
+def format_conversations(records: List[ConversationRecord]) -> str:
+    if not records:
+        return "No relevant conversation excerpts found."
+    lines: List[str] = []
+    for i, r in enumerate(records, 1):
+        role = f"{r.role}: " if r.role else ""
+        lines.append(f"{i}. {role}{r.content}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# memory_search
+# ---------------------------------------------------------------------------
+
+
+def _make_search_fn(memory: TencentDBMemory, search_conversations: bool):
+    def _search(query: str, limit: int = 5) -> str:
+        """Search persistent memories about ``query``.
+
+        Args:
+            query: What to search for (e.g. a project, a past decision, a user preference).
+            limit: Maximum number of facts to return.
+        """
+        facts = memory.search_facts(query, limit=limit)
+        parts = ["# Memories", format_facts(facts)]
+        if search_conversations:
+            conversations = memory.search_conversations(query, limit=limit)
+            parts += ["# Conversation excerpts", format_conversations(conversations)]
+        return "\n\n".join(parts)
+
+    return _search
+
+
+def _make_async_search_fn(memory: AsyncTencentDBMemory, search_conversations: bool):
+    async def _search(query: str, limit: int = 5) -> str:
+        """Search persistent memories about ``query``.
+
+        Args:
+            query: What to search for (e.g. a project, a past decision, a user preference).
+            limit: Maximum number of facts to return.
+        """
+        facts = await memory.search_facts(query, limit=limit)
+        parts = ["# Memories", format_facts(facts)]
+        if search_conversations:
+            conversations = await memory.search_conversations(query, limit=limit)
+            parts += ["# Conversation excerpts", format_conversations(conversations)]
+        return "\n\n".join(parts)
+
+    return _search
+
+
+def create_memory_search_tool(
+    memory: TencentDBMemory,
+    *,
+    name: str = "memory_search",
+    search_conversations: bool = True,
+) -> StructuredTool:
+    """Build a sync ``memory_search`` tool backed by ``memory``."""
+    return StructuredTool.from_function(
+        func=_make_search_fn(memory, search_conversations),
+        name=name,
+        description=(
+            "Search the agent's persistent memories (distilled facts and past "
+            "conversations) for information relevant to the query. Use this to "
+            "recall preferences, decisions, and context from earlier sessions."
+        ),
+    )
+
+
+def create_async_memory_search_tool(
+    memory: AsyncTencentDBMemory,
+    *,
+    name: str = "memory_search",
+    search_conversations: bool = True,
+) -> StructuredTool:
+    """Build an async ``memory_search`` tool backed by ``memory``."""
+    return StructuredTool.from_function(
+        coroutine=_make_async_search_fn(memory, search_conversations),
+        name=name,
+        description=(
+            "Search the agent's persistent memories (distilled facts and past "
+            "conversations) for information relevant to the query. Use this to "
+            "recall preferences, decisions, and context from earlier sessions."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# memory_recall
+# ---------------------------------------------------------------------------
+
+
+def _format_scenarios(scenarios: List[Scenario]) -> str:
+    if not scenarios:
+        return "No scenarios yet."
+    return "\n".join(f"- {s.path}" + (f": {s.summary}" if s.summary else "") for s in scenarios)
+
+
+def _make_recall_fn(memory: TencentDBMemory):
+    def _recall(query: str, limit: int = 5) -> str:
+        """Load the agent's long-term context (persona, scenarios, and top memories).
+
+        Args:
+            query: What context is needed right now.
+            limit: Maximum number of facts to include.
+        """
+        persona = memory.read_persona()
+        scenarios = memory.list_scenarios()
+        facts = memory.search_facts(query, limit=limit)
+        parts = [
+            "# Persona",
+            persona.content or "(none)",
+            "# Scenarios",
+            _format_scenarios(scenarios),
+            "# Relevant memories",
+            format_facts(facts),
+        ]
+        return "\n\n".join(parts)
+
+    return _recall
+
+
+def _make_async_recall_fn(memory: AsyncTencentDBMemory):
+    async def _recall(query: str, limit: int = 5) -> str:
+        """Load the agent's long-term context (persona, scenarios, and top memories).
+
+        Args:
+            query: What context is needed right now.
+            limit: Maximum number of facts to include.
+        """
+        persona = await memory.read_persona()
+        scenarios = await memory.list_scenarios()
+        facts = await memory.search_facts(query, limit=limit)
+        parts = [
+            "# Persona",
+            persona.content or "(none)",
+            "# Scenarios",
+            _format_scenarios(scenarios),
+            "# Relevant memories",
+            format_facts(facts),
+        ]
+        return "\n\n".join(parts)
+
+    return _recall
+
+
+def create_memory_recall_tool(
+    memory: TencentDBMemory, *, name: str = "memory_recall"
+) -> StructuredTool:
+    return StructuredTool.from_function(
+        func=_make_recall_fn(memory),
+        name=name,
+        description=(
+            "Load the agent's long-term context in one shot: its persona, the "
+            "list of known scenarios, and the memories most relevant to the query. "
+            "Use this at the start of a session to bootstrap context."
+        ),
+    )
+
+
+def create_async_memory_recall_tool(
+    memory: AsyncTencentDBMemory, *, name: str = "memory_recall"
+) -> StructuredTool:
+    return StructuredTool.from_function(
+        coroutine=_make_async_recall_fn(memory),
+        name=name,
+        description=(
+            "Load the agent's long-term context in one shot: its persona, the "
+            "list of known scenarios, and the memories most relevant to the query. "
+            "Use this at the start of a session to bootstrap context."
+        ),
+    )

--- a/adapters/langchain-memory/tests/conftest.py
+++ b/adapters/langchain-memory/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared fixtures: fake transports that stub the SDK's HTTP layer.
+
+The official SDK lets callers inject a ``stub`` into ``MemoryClient`` /
+``AsyncMemoryClient``. We exploit that to test every mapping without a live
+gateway. Each fake records calls and returns canned ``data`` payloads keyed by
+``/v3/...`` path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from tencentdb_agent_memory.v3 import AsyncMemoryClient, MemoryClient
+from tencentdb_langchain import (
+    AsyncTencentDBMemory,
+    TencentDBMemory,
+    TencentDBStore,
+)
+
+
+class FakeStub:
+    """Synchronous fake: returns ``responses[path]`` and records ``(path, body)``."""
+
+    def __init__(self, responses: Optional[Dict[str, Any]] = None):
+        self.responses = responses or {}
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    def post(self, path: str, body: dict, timeout: Optional[float] = None) -> dict:
+        self.calls.append((path, body))
+        return self.responses.get(path, {})
+
+    def close(self) -> None:
+        pass
+
+
+class FakeAsyncStub:
+    def __init__(self, responses: Optional[Dict[str, Any]] = None):
+        self.responses = responses or {}
+        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def post(self, path: str, body: dict, timeout: Optional[float] = None) -> dict:
+        self.calls.append((path, body))
+        return self.responses.get(path, {})
+
+    async def close(self) -> None:
+        pass
+
+
+FACT = {
+    "id": "fact-1",
+    "content": "The user prefers dark theme",
+    "type": "preference",
+    "score": 0.87,
+    "background": "settings",
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-02T00:00:00Z",
+}
+
+
+def build_sync_memory(responses: Dict[str, Any]) -> TencentDBMemory:
+    stub = FakeStub(responses)
+    client = MemoryClient(stub=stub, team_id="t1", agent_id="a1", user_id="u1")
+    memory = TencentDBMemory(client=client)
+    return memory
+
+
+def build_async_memory(responses: Dict[str, Any]) -> AsyncTencentDBMemory:
+    stub = FakeAsyncStub(responses)
+    client = AsyncMemoryClient(stub=stub, team_id="t1", agent_id="a1", user_id="u1")
+    return AsyncTencentDBMemory(client=client)
+
+
+@pytest.fixture
+def sync_memory() -> TencentDBMemory:
+    return build_sync_memory({"/v3/atomic/search": {"items": [FACT]}})
+
+
+@pytest.fixture
+def async_memory() -> AsyncTencentDBMemory:
+    return build_async_memory({"/v3/atomic/search": {"items": [FACT]}})
+
+
+@pytest.fixture
+def store() -> TencentDBStore:
+    responses = {
+        "/v3/atomic/search": {"items": [FACT]},
+        "/v3/conversation/add": {"accepted_ids": ["m1"]},
+        "/v3/scenario/ls": {"entries": [{"path": "notes/a.md", "summary": "about a"}]},
+        "/v3/atomic/delete": {"deleted_count": 1},
+    }
+    return TencentDBStore(
+        memory=build_sync_memory(responses),
+        async_memory=build_async_memory(responses),
+    )

--- a/adapters/langchain-memory/tests/test_capture.py
+++ b/adapters/langchain-memory/tests/test_capture.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+
+from tencentdb_langchain import acapture_conversation, capture_conversation
+from tencentdb_langchain.capture import langchain_messages_to_dicts
+
+from conftest import build_async_memory, build_sync_memory
+
+
+def test_langchain_messages_to_dicts_maps_roles():
+    class _Msg:
+        def __init__(self, type_, content):
+            self.type = type_
+            self.content = content
+
+    msgs = [_Msg("human", "hi"), _Msg("ai", "hello")]
+    assert langchain_messages_to_dicts(msgs) == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+
+def test_capture_conversation_sync():
+    memory = build_sync_memory({"/v3/conversation/add": {"accepted_ids": ["m1"]}})
+    ids = capture_conversation(memory, [{"role": "user", "content": "hi"}], session_id="s1")
+    assert ids == ["m1"]
+
+
+def test_acapture_conversation_async():
+    memory = build_async_memory({"/v3/conversation/add": {"accepted_ids": ["m1"]}})
+    ids = asyncio.run(
+        acapture_conversation(memory, [{"role": "user", "content": "hi"}], session_id="s1")
+    )
+    assert ids == ["m1"]

--- a/adapters/langchain-memory/tests/test_client.py
+++ b/adapters/langchain-memory/tests/test_client.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from tencentdb_langchain import MemoryFact, TencentDBMemory
+from tencentdb_langchain.client import _normalize_messages
+
+from conftest import FACT, build_sync_memory
+
+
+def test_capture_returns_accepted_ids_and_sends_session():
+    memory = build_sync_memory({"/v3/conversation/add": {"accepted_ids": ["m1", "m2"]}})
+    ids = memory.capture(
+        [{"role": "user", "content": "hello"}], session_id="sess-1"
+    )
+    assert ids == ["m1", "m2"]
+    path, body = memory.client._stub.calls[0]  # type: ignore[attr-defined]
+    assert path == "/v3/conversation/add"
+    assert body["session_id"] == "sess-1"
+    assert body["messages"] == [{"role": "user", "content": "hello"}]
+    assert body["team_id"] == "t1"
+
+
+def test_capture_rejects_empty_messages():
+    memory = build_sync_memory({})
+    with pytest.raises(ValueError):
+        memory.capture([], session_id="sess-1")
+
+
+def test_search_facts_maps_items():
+    memory = build_sync_memory({"/v3/atomic/search": {"items": [FACT]}})
+    facts = memory.search_facts("theme", limit=5)
+    assert len(facts) == 1
+    f = facts[0]
+    assert isinstance(f, MemoryFact)
+    assert f.content == "The user prefers dark theme"
+    assert f.type == "preference"
+    assert f.score == 0.87
+    assert f.id == "fact-1"
+
+
+def test_read_persona_maps_content():
+    memory = build_sync_memory({"/v3/core/read": {"content": "# persona", "version": 2}})
+    persona = memory.read_persona()
+    assert persona.content == "# persona"
+    assert persona.version == 2
+
+
+def test_list_scenarios_maps_entries():
+    memory = build_sync_memory(
+        {"/v3/scenario/ls": {"entries": [{"path": "notes/a.md", "summary": "about a"}]}}
+    )
+    scenarios = memory.list_scenarios()
+    assert len(scenarios) == 1
+    assert scenarios[0].path == "notes/a.md"
+
+
+def test_delete_facts_returns_count():
+    memory = build_sync_memory({"/v3/atomic/delete": {"deleted_count": 3}})
+    assert memory.delete_facts(["a", "b", "c"]) == 3
+
+
+def test_normalize_messages_rejects_missing_fields():
+    with pytest.raises(ValueError):
+        _normalize_messages([{"role": "user"}])

--- a/adapters/langchain-memory/tests/test_retriever.py
+++ b/adapters/langchain-memory/tests/test_retriever.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+
+from langchain_core.documents import Document
+
+from tencentdb_langchain import TencentDBRetriever
+
+from conftest import FACT, build_sync_memory
+
+
+def test_retrieve_returns_documents():
+    memory = build_sync_memory({"/v3/atomic/search": {"items": [FACT]}})
+    retriever = TencentDBRetriever(memory=memory, top_k=5)
+    docs = retriever.invoke("theme")
+    assert len(docs) == 1
+    doc = docs[0]
+    assert isinstance(doc, Document)
+    assert doc.page_content == "The user prefers dark theme"
+    assert doc.metadata["id"] == "fact-1"
+    assert doc.metadata["score"] == 0.87
+    assert doc.metadata["type"] == "preference"
+
+
+def test_async_retrieve_returns_documents():
+    memory = build_sync_memory({"/v3/atomic/search": {"items": [FACT]}})
+    retriever = TencentDBRetriever(memory=memory, top_k=5)
+    docs = asyncio.run(retriever.ainvoke("theme"))
+    assert len(docs) == 1
+    assert docs[0].page_content == "The user prefers dark theme"

--- a/adapters/langchain-memory/tests/test_store.py
+++ b/adapters/langchain-memory/tests/test_store.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from langgraph.store.base import GetOp, PutOp, SearchItem
+
+from tencentdb_langchain import TencentDBStore
+from tencentdb_langchain.store import _observation_value
+
+
+def test_search_maps_facts(store: TencentDBStore):
+    results = store.search(("prefs",), query="theme", limit=5)
+    assert len(results) == 1
+    item = results[0]
+    assert isinstance(item, SearchItem)
+    assert item.key == "fact-1"
+    assert item.value["content"] == "The user prefers dark theme"
+    assert item.score == 0.87
+
+
+def test_get_returns_top_fact(store: TencentDBStore):
+    item = store.get(("prefs",), "theme")
+    assert item is not None
+    assert item.value["content"] == "The user prefers dark theme"
+
+
+def test_put_records_an_observation(store: TencentDBStore):
+    store.put(("project-x",), "decision-1", {"content": "use FastAPI"})
+    sync_mem = store._require_memory()
+    path, body = sync_mem.client._stub.calls[0]  # type: ignore[attr-defined]
+    assert path == "/v3/conversation/add"
+    # session derived from namespace top-level scope
+    assert body["session_id"] == "project-x"
+    decoded = json.loads(body["messages"][0]["content"])
+    assert decoded["source"] == "tencentdb-langgraph"
+    assert decoded["key"] == "decision-1"
+    assert decoded["value"] == {"content": "use FastAPI"}
+
+
+def test_list_namespaces_maps_scenarios(store: TencentDBStore):
+    namespaces = store.list_namespaces()
+    assert namespaces == [("notes", "a.md")]
+
+
+def test_delete_is_best_effort(store: TencentDBStore):
+    store.delete(("prefs",), "fact-1")
+    sync_mem = store._require_memory()
+    path, body = sync_mem.client._stub.calls[-1]  # type: ignore[attr-defined]
+    assert path == "/v3/atomic/delete"
+    assert body["ids"] == ["fact-1"]
+
+
+def test_observation_value_encoding():
+    v = _observation_value(("a", "b"), "k", {"x": 1})
+    assert v["source"] == "tencentdb-langgraph"
+    assert v["namespace"] == ["a", "b"]
+    assert v["key"] == "k"
+    assert v["value"] == {"x": 1}
+
+
+def test_batch_dispatches_ops(store: TencentDBStore):
+    results = store.batch([
+        PutOp(namespace=("prefs",), key="k", value={"content": "v"}, index=None, ttl=None),
+        GetOp(namespace=("prefs",), key="theme", refresh_ttl=None),
+    ])
+    assert results[0] is None  # put returns None
+    assert results[1] is not None  # get returns an Item
+    assert results[1].value["content"] == "The user prefers dark theme"
+
+
+def test_abatch_dispatches_ops(store: TencentDBStore):
+    async def run():
+        return await store.abatch([
+            PutOp(namespace=("prefs",), key="k", value={"content": "v"}, index=None, ttl=None),
+            GetOp(namespace=("prefs",), key="theme", refresh_ttl=None),
+        ])
+
+    results = asyncio.run(run())
+    assert results[0] is None
+    assert results[1].value["content"] == "The user prefers dark theme"

--- a/adapters/langchain-memory/tests/test_tool.py
+++ b/adapters/langchain-memory/tests/test_tool.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+
+from tencentdb_langchain import (
+    create_async_memory_search_tool,
+    create_memory_search_tool,
+)
+
+from conftest import FACT, build_async_memory, build_sync_memory
+
+
+def test_search_tool_formats_facts():
+    memory = build_sync_memory({"/v3/atomic/search": {"items": [FACT]}})
+    tool = create_memory_search_tool(memory)
+    output = tool.invoke({"query": "theme"})
+    assert "The user prefers dark theme" in output
+    assert "[preference]" in output
+
+
+def test_search_tool_reports_no_hits():
+    memory = build_sync_memory({"/v3/atomic/search": {"items": []}})
+    tool = create_memory_search_tool(memory)
+    output = tool.invoke({"query": "nothing"})
+    assert "No relevant memories found" in output
+
+
+def test_async_search_tool_formats_facts():
+    memory = build_async_memory({"/v3/atomic/search": {"items": [FACT]}})
+    tool = create_async_memory_search_tool(memory)
+    output = asyncio.run(tool.ainvoke({"query": "theme"}))
+    assert "The user prefers dark theme" in output


### PR DESCRIPTION
## Description | 描述

A native **LangChain / LangGraph adapter** for TencentDB Agent Memory, in `adapters/langchain-memory/`. It lets a LangChain or LangGraph agent persist team-scoped long-term memory and recall it semantically — one line of glue, zero changes to the model or graph.

在 `adapters/langchain-memory/` 下新增 LangChain / LangGraph 原生适配器：让 LangChain/LangGraph Agent 拥有由 TencentDB Agent Memory 支撑的团队级持久记忆，一行胶水代码接入，无需改动模型或图结构。中英双语文档已随 PR 一并提交（`README.md` / `README_CN.md`）。

## Related Issue | 关联 Issue

Related: #926

## Change Type | 修改类型

- [x] New feature | 新功能
- [x] Documentation update | 文档更新

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## What's included | 包含内容

- **`TencentDBStore`** — a LangGraph [`BaseStore`](https://langchain-ai.github.io/langgraph/reference/store/) implementation for cross-thread long-term memory (sync + async).
- **`TencentDBRetriever`** — a LangChain [`BaseRetriever`](https://python.langchain.com/docs/concepts/retrievers/) that drops into any RAG chain.
- **Tools** — `memory_search` and `memory_recall` factories (sync + async).
- **Capture helpers** — `capture_conversation` plus a side-effecting LangGraph node factory (`create_capture_node`).
- **Sync + async clients** wrapping the official `tencentdb-agent-memory-sdk-python-v2` v3 data plane.

## Design | 设计

The adapter maps LangChain/LangGraph concepts onto TencentDB Agent Memory's *capture → distill → recall* model rather than pretending it is a plain KV store:

| LangGraph `BaseStore` | TencentDB operation |
|---|---|
| `search` / `asearch` | `/v3/atomic/search` (recall distilled L1 facts) |
| `put` / `aput` | `/v3/conversation/add` (record an L0 observation) |
| `get` / `aget` | recall the fact most relevant to `key` |
| `delete` / `adelete` | `/v3/atomic/delete` (best-effort, by fact id) |
| `list_namespaces` | `/v3/scenario/ls` (L2 scenarios as namespaces) |

The one consequence worth calling out: `put` records an *observation* that the pipeline distills into searchable facts asynchronously, so a value written with `put` may not appear in `search` until the pipeline has run. This is documented in the `store.py` module docstring and both READMEs.

## Testing | 测试

23 unit tests (`pytest`) inject a fake transport into the SDK, so they run with no live gateway and no LLM:

```
adapters/langchain-memory % pytest -q
23 passed
```

Verified on Python 3.9 with `langgraph 0.6.11` + `langchain-core 0.3.86`; `pip wheel` builds cleanly.

## Additional Notes | 其他说明

The TencentDB Agent Memory Python SDK is not yet published to PyPI, so the README documents installing it from source first (`pip install -e ./sdk/memory-core/python`) before installing this adapter.
