### PR TITLE
[good first issue-platform adapt-codecompanion.nvim] Add Memory adapter for codecompanion.nvim

### DIFF
--- a/adapters/codecompanion/README.md
+++ b/adapters/codecompanion/README.md
@@ -1,0 +1,113 @@
+# TencentDB Agent Memory — codecompanion.nvim Adapter
+
+Give [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+codecompanion.nvim ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                                    │
+                                                    ├─ auth        (validates sk-mem-... user_key)
+                                                    ├─ sessionInit (Team/Agent/Task picker)
+                                                    └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+codecompanion.nvim ships an `openai_compatible` adapter precisely for self-hosted and third-party OpenAI-compatible endpoints — you extend it with your `url`, `api_key` (environment variable name) and `chat_url` ([official docs — Configuring HTTP Adapters](https://codecompanion.olimorris.dev/configuration/adapters_http.html); the built-in llama.cpp example follows the same pattern). Pointing it at the proxy's `/codebuddy/<spaceId>` base connects it — **no code changes required**.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. codecompanion.nvim is installed in Neovim (0.10+) with its `plenary.nvim` and tree-sitter `markdown` / `markdown_inline` dependencies, as described in the [README](https://github.com/olimorris/codecompanion.nvim#installation).
+
+## Setup
+
+### 1. Export the API key
+
+```bash
+export MEMORY_PROXY_API_KEY=sk-mem-xxxxxxxx   # your business user key
+```
+
+The adapter's `env.api_key` names this environment variable; codecompanion reads it at request time.
+
+### 2. Declare the adapter
+
+In your setup, extend `openai_compatible` and select it as the strategy adapter:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    http = {
+      tencentdb_memory = function()
+        return require("codecompanion.adapters").extend("openai_compatible", {
+          env = {
+            url = "http://127.0.0.1:8096/codebuddy/default",
+            api_key = "MEMORY_PROXY_API_KEY",
+            chat_url = "/v1/chat/completions",
+          },
+          schema = {
+            model = { default = "claude-sonnet-4-20250514" },
+          },
+        })
+      end,
+    },
+  },
+  strategies = {
+    chat = { adapter = "tencentdb_memory" },
+    inline = { adapter = "tencentdb_memory" },
+    cmd = { adapter = "tencentdb_memory" },
+  },
+})
+```
+
+Replace `default` with your memory space ID if you use another space.
+
+### 3. Align the model ID
+
+The `schema.model.default` value **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 4. Verify
+
+1. Restart Neovim (or re-source your config) so the adapter takes effect.
+2. Open a chat buffer (`:CodeCompanionChat`) and send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask codecompanion what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Field (adapters.http entry) | Value | Notes |
+|---|---|---|
+| `env.url` | `http://127.0.0.1:8096/codebuddy/default` | Base URL without the chat path; `default` is the memory space ID — change it per space |
+| `env.api_key` | `MEMORY_PROXY_API_KEY` | Name of the env var holding the `sk-mem-...` key; sent as `Authorization: Bearer` |
+| `env.chat_url` | `/v1/chat/completions` | Appended to `env.url`; the default of `openai_compatible`, kept explicit for clarity |
+| `schema.model.default` | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `404` / connection refused | URL typo or proxy not running on `:8096` — the effective chat endpoint must be `http://<host>:8096/codebuddy/<spaceId>/v1/chat/completions` (`env.url` + `env.chat_url`); check `./start-all.sh` logs |
+| "Invalid API Key" / authentication error | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key`; confirm the env var is exported in the environment Neovim starts from |
+| "Model Not Found" / upstream mismatch | `schema.model.default` differs from `PROXY_UPSTREAM_MODEL` — align them |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new task to re-pick |
+
+## Notes
+
+- **Docs-only adapter**: the adapter lives in your own Neovim config, so the key never lands in workspace files; this adapter ships documentation only (same as the Kilo Code / Roo Code adapters).
+- **Chat, inline and cmd strategies all flow through it**: point each `strategies` entry at the adapter and every interaction gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/codecompanion/README_CN.md
+++ b/adapters/codecompanion/README_CN.md
@@ -1,0 +1,113 @@
+# TencentDB Agent Memory — codecompanion.nvim 适配器
+
+为 [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) 注入持久化团队记忆。本适配器将其 LLM 流量路由到 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、技能与知识融入系统提示词
+- **自动捕获** — L0 原始对话持久化到 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+codecompanion.nvim ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                                    │
+                                                    ├─ auth        (校验 sk-mem-... user_key)
+                                                    ├─ sessionInit (Team/Agent/Task 选择器)
+                                                    └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+codecompanion.nvim 内置 `openai_compatible` 适配器，专用于自建及第三方 OpenAI 兼容端点——扩展它并填写 `url`、`api_key`（环境变量名）与 `chat_url` 即可（[官方文档 — Configuring HTTP Adapters](https://codecompanion.olimorris.dev/configuration/adapters_http.html)；内置 llama.cpp 示例采用同样结构）。将其指向代理的 `/codebuddy/<spaceId>` 基础地址即可接入——**无需任何代码改动**。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 持有业务用户的 `user_key`（`sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. 已在 Neovim（0.10+）中安装 codecompanion.nvim，并按 [README](https://github.com/olimorris/codecompanion.nvim#installation) 配置 `plenary.nvim` 与 tree-sitter `markdown` / `markdown_inline` 依赖。
+
+## 配置步骤
+
+### 1. 导出 API 密钥
+
+```bash
+export MEMORY_PROXY_API_KEY=sk-mem-xxxxxxxx   # 你的业务用户密钥
+```
+
+适配器的 `env.api_key` 指定该环境变量的名字，codecompanion 在请求时读取。
+
+### 2. 声明适配器
+
+在 setup 中扩展 `openai_compatible` 并将其选为策略适配器：
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    http = {
+      tencentdb_memory = function()
+        return require("codecompanion.adapters").extend("openai_compatible", {
+          env = {
+            url = "http://127.0.0.1:8096/codebuddy/default",
+            api_key = "MEMORY_PROXY_API_KEY",
+            chat_url = "/v1/chat/completions",
+          },
+          schema = {
+            model = { default = "claude-sonnet-4-20250514" },
+          },
+        })
+      end,
+    },
+  },
+  strategies = {
+    chat = { adapter = "tencentdb_memory" },
+    inline = { adapter = "tencentdb_memory" },
+    cmd = { adapter = "tencentdb_memory" },
+  },
+})
+```
+
+如使用其他记忆空间，将 `default` 替换为对应 space ID。
+
+### 3. 对齐模型 ID
+
+`schema.model.default` 值**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。示例使用 `claude-sonnet-4-20250514`，若代理指向其他上游请相应修改。
+
+### 4. 验证
+
+1. 重启 Neovim（或重新加载配置）使适配器生效。
+2. 打开对话缓冲区（`:CodeCompanionChat`）发送首条消息。代理会在对话交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，绑定 Agent 的记忆自动注入。询问 codecompanion 此前会话记得什么即可确认。
+
+## 配置参考
+
+| 字段（adapters.http 条目） | 值 | 说明 |
+|---|---|---|
+| `env.url` | `http://127.0.0.1:8096/codebuddy/default` | 不含 chat 路径的基础地址；`default` 为记忆空间 ID，按空间替换 |
+| `env.api_key` | `MEMORY_PROXY_API_KEY` | 存放 `sk-mem-...` 密钥的环境变量名；以 `Authorization: Bearer` 发送 |
+| `env.chat_url` | `/v1/chat/completions` | 拼接在 `env.url` 之后；`openai_compatible` 的默认值，显式写出以示清晰 |
+| `schema.model.default` | `claude-sonnet-4-20250514` | 必须等于 `PROXY_UPSTREAM_MODEL`，否则代理以上游不匹配拒绝 |
+
+## 故障排查
+
+| 现象 | 原因 / 修复 |
+|---|---|
+| `404` / 连接被拒 | URL 拼写错误或代理未在 `:8096` 运行——实际 chat 端点必须为 `http://<host>:8096/codebuddy/<spaceId>/v1/chat/completions`（`env.url` + `env.chat_url`）；查看 `./start-all.sh` 日志 |
+| "Invalid API Key" / 认证错误 | 密钥必须是 Panel 的业务用户密钥（`sk-mem-...`）——不是 `./.admin-key` 管理员密钥；确认环境变量在 Neovim 启动环境中已导出 |
+| "Model Not Found" / 上游不匹配 | `schema.model.default` 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若会话已绑定过任务会复用绑定——新开任务可重新选择 |
+
+## 说明
+
+- **仅文档适配器**：适配器配置位于用户自己的 Neovim 配置中，密钥不会落入工作区文件，因此本适配器仅提供文档（与 Kilo Code / Roo Code 适配器一致）。
+- **chat / inline / cmd 策略全覆盖**：将各 `strategies` 条目指向该适配器，所有交互均获得记忆注入。
+- **数据流**：仅提示词/补全流量经过代理；记忆数据默认保存在本地 SQLite（memory-core）。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
### Summary

Adds a docs-only adapter for **codecompanion.nvim** ([olimorris/codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim), a popular Neovim AI coding assistant), connecting it to the TencentDB Agent Memory proxy through its built-in `openai_compatible` adapter.

- `adapters/codecompanion/README.md` + `README_CN.md` (EN/CN, same structure as the Kilo Code / Roo Code / Trae docs-only adapters)
- No code changes: the adapter entry (`extend("openai_compatible", { env = { url, api_key, chat_url }, schema.model.default })`) lives in the user's own Neovim config, so no files ship with the adapter.

### How it connects (verified against official sources)

- codecompanion ships an `openai_compatible` adapter documented on the official docs site ([Configuring HTTP Adapters](https://codecompanion.olimorris.dev/configuration/adapters_http.html)) — the built-in llama.cpp example extends it with `env.url`, `env.api_key` (an environment variable **name**) and `env.chat_url = "/v1/chat/completions"`, exactly the pattern used here.
- The proxy's catch-all route `http://127.0.0.1:8096/codebuddy/<spaceId>/v1/chat/completions` is reachable via `env.url = "http://127.0.0.1:8096/codebuddy/<spaceId>"` + the default `chat_url`.
- The `schema.model.default` mechanism for setting the model on an adapter is documented in the same official docs.

### Contents

- Prerequisites (one-command stack, business `sk-mem-...` user key)
- Setup: export key → declare adapter → align model with `PROXY_UPSTREAM_MODEL` → verify via `:CodeCompanionChat` and the session picker
- Configuration reference table + troubleshooting table (404/key/model-id/session-picker rows)
- Notes: docs-only rationale, chat/inline/cmd strategy coverage, data-flow statement

Part of the platform-adapt batch tracked in #926.
