### PR TITLE
feat(proxy): add pi agent support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -607,6 +607,57 @@ Edit `~/.openclaw/openclaw.json`, add a provider under `models.providers`:
 - `headers`: must include `x-team-id`, `x-agent-id`, `x-task-id`, `x-conversation-id`. `x-task-id` is required in the current version (see [Known limitation: x-task-id](#known-limitation-x-task-id))
 - `models[].id`: must match the model ID configured in the Proxy upstream
 
+## Using Proxy with pi
+
+[pi](https://github.com/earendil-works/pi-mono) is an open-source coding agent harness. By configuring a custom model provider, pi requests can be routed through the Proxy.
+
+### Configuration
+
+Edit `~/.pi/agent/models.json`, add a provider under `providers`:
+
+```jsonc
+{
+  "providers": {
+    "tdai-proxy": {
+      "baseUrl": "http://<proxy-host>:<port>/pi/<spaceId>/v1",
+      "api": "openai-completions",
+      "apiKey": "<business user's sk-mem-... user_key>",
+      "authHeader": true,
+      "headers": {
+        "x-team-id": "<team_id>",
+        "x-agent-id": "<agent_id>",
+        "x-task-id": "<task_id>"
+      },
+      "models": [
+        { "id": "gpt-5.5", "reasoning": false, "input": ["text"], "contextWindow": 128000, "maxTokens": 32000 }
+      ]
+    }
+  }
+}
+```
+
+- `baseUrl`: Proxy address + `/pi/<spaceId>/v1` path. pi appends `/chat/completions` to this value (the standard OpenAI path), matching the Proxy route `/pi/{spaceId}/v1/chat/completions`
+- `apiKey`: the business user's `user_key`; `authHeader: true` makes pi send `Authorization: Bearer <key>`
+- `headers`: must include `x-team-id`, `x-agent-id`, `x-task-id`. `x-task-id` is required in the current version (see [Known limitation: x-task-id](#known-limitation-x-task-id))
+- `models[].id`: must match a model ID supported by the Proxy upstream
+
+`x-conversation-id` is a per-session value that pi's static provider headers cannot supply, so it must be injected per request. Add a small pi extension that hooks `before_provider_headers`:
+
+```typescript
+// ~/.pi/agent/extensions/tdai-proxy/index.ts
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  pi.on("before_provider_headers", (event, ctx) => {
+    if (!event.headers["x-team-id"]) return; // only the tdai-proxy provider sets this
+    const sid = ctx.sessionManager.getSessionId();
+    if (sid) event.headers["x-conversation-id"] = sid;
+  });
+}
+```
+
+Then select the `tdai-proxy` model in pi (`/model`, or `pi --model tdai-proxy/<id>`).
+
 ## Using Proxy with Other Platforms (Generic)
 
 Beyond ClaudeCode / CodeBuddy / WorkBuddy / Codex / Hermes / OpenClaw, any OpenAI-compatible platform or custom-built agent can connect to the Proxy to access team memory capabilities.

--- a/MemoryProxy/src/agent-adapters/index.ts
+++ b/MemoryProxy/src/agent-adapters/index.ts
@@ -17,6 +17,7 @@ import { codebuddyAdapter } from "./codebuddy.js";
 import { codexAdapter } from "./codex.js";
 import { workbuddyAdapter } from "./workbuddy.js";
 import { dshAdapter } from "./dsh.js";
+import { piAdapter } from "./pi.js";
 import { defaultAdapter } from "./default.js";
 
 export type { AgentAdapter, AgentKind, RequestKind } from "./types.js";
@@ -33,6 +34,8 @@ export function resolveAgentAdapter(agentSource: string): AgentAdapter {
       return workbuddyAdapter;
     case "dsh":
       return dshAdapter;
+    case "pi":
+      return piAdapter;
     default:
       return defaultAdapter;
   }

--- a/MemoryProxy/src/agent-adapters/pi.ts
+++ b/MemoryProxy/src/agent-adapters/pi.ts
@@ -1,0 +1,20 @@
+/**
+ * pi 客户端适配器。
+ *
+ * pi（https://github.com/earendil-works/pi-mono）是一个 coding agent，走标准
+ * OpenAI Chat Completions 协议（`/pi/{spaceId}/v1/chat/completions`）。
+ *
+ * 与 CodeBuddy 不同，pi 的 message.content 是标准 OpenAI 形态（字符串或
+ * content-block 数组，无 CB 的 pseudo-XML wrapper），没有 cache_control /
+ * fork / sidequery 分流特征。因此两个适配点都复用 default 的保守行为：
+ *   - `classifyRequest`: 恒 `"main"`（走完整 injection + L0 + skill 链路）
+ *   - `extractUserText`: 字符串直接返回，数组则拼接所有 text block
+ */
+
+import { defaultAdapter } from "./default.js";
+import type { AgentAdapter } from "./types.js";
+
+export const piAdapter: AgentAdapter = {
+  ...defaultAdapter,
+  agentKind: "pi",
+};

--- a/MemoryProxy/src/agent-adapters/types.ts
+++ b/MemoryProxy/src/agent-adapters/types.ts
@@ -20,7 +20,7 @@
  * 只是**取用户输入的规则**和**分类规则**按 agent 适配。
  */
 
-export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "unknown";
+export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "pi" | "unknown";
 
 export type RequestKind = "main" | "fork" | "sidequery" | "auxiliary";
 

--- a/MemoryProxy/src/routes/whitelist.ts
+++ b/MemoryProxy/src/routes/whitelist.ts
@@ -172,7 +172,7 @@ const PROXY_PREFIX_RE = /^\/proxy\/[^/]+/;
  * 白名单入口 `/v1/messages`、`/responses` 自身不会被误剥（因为它们不匹配 agent
  * 段——agent 段限定为已知名字）。
  */
-const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|anthropic|openai)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
+const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|anthropic|openai|pi)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
 
 /**
  * `/cost-guard` marker 正则：位于 `/{agent}/{spaceId}` 之后的独立 segment。


### PR DESCRIPTION
## Summary

Adds native Proxy support for [pi](https://github.com/earendil-works/pi-mono), an open-source coding agent harness that speaks the standard OpenAI Chat Completions protocol.

## Changes

- **`MemoryProxy/src/routes/whitelist.ts`**: register `pi` in `AGENT_PREFIX_RE` so `/pi/{spaceId}/v1/chat/completions` requests are recognized and prefix-stripped.
- **`MemoryProxy/src/agent-adapters/pi.ts`**: new adapter, reuses the conservative default behaviour (classify `main`, join text blocks), with `agentKind: "pi"`.
- **`MemoryProxy/src/agent-adapters/types.ts`**: add `"pi"` to the `AgentKind` union.
- **`MemoryProxy/src/agent-adapters/index.ts`**: route `"pi"` → `piAdapter`.
- **`INSTALL.md`**: add "Using Proxy with pi" section.

## Verification

Deployed the full stack (memory-core + memory-hub + proxy) and pointed a pi client at `http://<proxy>:8096/pi/default/v1` with `x-team-id` / `x-agent-id` / `x-task-id` headers plus a per-session `x-conversation-id` injected via a pi extension's `before_provider_headers` hook. Confirmed:

- sessionInit completes via header auto-select (no interactive form)
- L2/L3 profile memory + memory tools injected into the system prompt
- L0 conversation recorded, L1 extraction runs

## Notes

pi's provider headers are static, so the per-session `x-conversation-id` needs the small extension shown in the INSTALL section; this matches the existing Hermes/OpenClaw pattern where the client manages that header.