### PR TITLE
fix: brace $ADMIN_KEY_FILE before full-width paren to avoid unbound variable under POSIX locale

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then


### PR DESCRIPTION
## Description | 描述
`deploy/global-images/start-memory-core.sh:175` 的字符串中 `$ADMIN_KEY_FILE` 后紧跟全角右括号 `）`（UTF-8 字节 `ef bc 89`）。在 C/POSIX locale 下 bash 按单字节解析，把全角括号的字节拼进变量名，触发 `set -u` 的 `unbound variable` 错误，导致 `start-all.sh` 在 memory-core 容器 healthy 之后中断。

修复：改为 `${ADMIN_KEY_FILE}）`，用花括号界定变量名。已全目录扫描 `deploy/global-images/*.sh`，无其他 `$VAR` 后紧跟多字节字符的同类问题。

## Related Issue | 关联 Issue
Fix #1065

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
本地验证：macOS (Darwin 24.5.0) 下重跑 `./start-all.sh`，memory-core 启动 + admin 初始化 + key 校验全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)