### PR TITLE
[good first issue-platform adapt-trpc-agent-python] Add Memory adapter for trpc-agent-python

### DIFF
--- a/adapters/trpc-agent-python/.gitignore
+++ b/adapters/trpc-agent-python/.gitignore
@@ -1,0 +1,4 @@
+.venv-trpc/
+__pycache__/
+.pytest_cache/
+*.egg-info/

--- a/adapters/trpc-agent-python/README.md
+++ b/adapters/trpc-agent-python/README.md
@@ -44,6 +44,14 @@ Identity follows the framework convention: the session's `save_key` (`{app}/{use
 
 ## Installation
 
+Install directly from this repository — no clone needed:
+
+```bash
+pip install "git+https://github.com/TencentCloud/TencentDB-Agent-Memory.git#subdirectory=adapters/trpc-agent-python"
+```
+
+From a local clone instead:
+
 ```bash
 pip install ./adapters/trpc-agent-python
 ```

--- a/adapters/trpc-agent-python/README.md
+++ b/adapters/trpc-agent-python/README.md
@@ -1,0 +1,137 @@
+# TencentDB Agent Memory — trpc-agent-python Adapter
+
+Give agents built with [trpc-agent-python](https://github.com/trpc-group/trpc-agent-python) persistent memory, backed by TencentDB Agent Memory. This adapter provides `TencentDBMemoryService`, a drop-in implementation of the framework's `MemoryServiceABC` (the same contract the built-in InMemory / Redis / SQL / Mem0 services implement), so it plugs into `Runner(memory_service=...)` without any framework changes.
+
+Once wired in, every session automatically gets:
+
+- **Turn capture** — after each completed turn, the runner calls `store_session`, which streams the turn's user/assistant pair to the gateway (`POST /capture`) and into the L0 → L3 memory pipeline
+- **Memory search** — the framework's recall path (`invocation_context → search_memory`) queries the gateway (`POST /search/memories`) and maps results into `SearchMemoryResponse`
+- **Incremental capture** — a per-session watermark ensures repeated `store_session` calls only send the delta, never replaying the transcript
+- **Fail-open by default** — a gateway outage is logged and skipped; the agent loop is never blocked
+
+## How it works
+
+```
+trpc-agent-python Runner
+  ├─ post-turn: store_session ─(POST /capture)──► L0 → L3 pipeline
+  └─ recall: search_memory ────(POST /search/memories)──► SearchMemoryResponse
+                                                  ▼
+                       Memory Core Gateway (port 8420)
+                  (capture · extract · store · recall)
+```
+
+The adapter talks to the **memory-core gateway** (`:8420` by default), which runs the memory engine (extraction, dedup, scenario distillation, profiling). This mirrors the official trpc-agent-go integration (`memory/tencentdb`), which targets the same gateway routes.
+
+Identity follows the framework convention: the session's `save_key` (`{app}/{user}`) is the primary scope — exactly like the built-in Mem0 service — with config values as fallbacks.
+
+## Prerequisites
+
+1. TencentDB Agent Memory running locally:
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+   Set `MEMORY_LLM_BASE_URL` / `MEMORY_LLM_API_KEY` / `MEMORY_LLM_MODEL` in `.env` — the memory engine uses this LLM for extraction and recall.
+
+2. Python 3.10+ with trpc-agent-python (PyPI: `trpc-agent-py`, ≥ 1.1.17):
+
+   ```bash
+   pip install trpc-agent-py
+   ```
+
+## Installation
+
+```bash
+pip install ./adapters/trpc-agent-python
+```
+
+Or copy the `tdai_trpc/` package into your project (dependencies: `trpc-agent-py` and `httpx` only).
+
+## Quickstart
+
+```python
+from trpc_agent_sdk.agents import LlmAgent
+from trpc_agent_sdk.models import OpenAIModel
+from trpc_agent_sdk.runners import Runner
+from trpc_agent_sdk.sessions import InMemorySessionService
+
+from tdai_trpc import TDAiConfig, TencentDBMemoryService
+
+memory = TencentDBMemoryService(TDAiConfig(
+    gateway_url="http://127.0.0.1:8420",
+    api_key=os.environ.get("TDAI_GATEWAY_API_KEY", ""),
+    fail_open=True,
+))
+
+runner = Runner(
+    app_name="my-app",
+    agent=LlmAgent(name="assistant", model=OpenAIModel("gpt-4o-mini"),
+                   instruction="You are a concise assistant."),
+    session_service=InMemorySessionService(),
+    memory_service=memory,   # stores each completed turn after the turn ends
+)
+
+async for event in runner.run_async(
+    user_id="user-42",
+    session_id="session-1",
+    new_message=user_message("Remember: my codename is Apollo Lake."),
+):
+    ...
+# A brand-new session can now recall it through the framework's memory path.
+```
+
+A runnable end-to-end script is in [`example/quickstart.py`](./example/quickstart.py).
+
+## Configuration reference
+
+| Field | Effect | Default |
+|---|---|---|
+| `gateway_url` | memory-core gateway URL (remote plaintext HTTP rejected unless `allow_remote_http=True`) | `http://127.0.0.1:8420` |
+| `api_key` | `Authorization: Bearer` key; required when gateway starts with `TDAI_GATEWAY_API_KEY` | `""` |
+| `timeout` | Per-request HTTP timeout | `5.0` s |
+| `app_name` / `user_id` | Fallback identity when a session's `save_key` can't be parsed; the session's own `save_key` always takes precedence | `"trpc-agent-app"` / `"default-user"` |
+| `allow_remote_http` | Permit plaintext HTTP to a non-local gateway | `False` |
+| `fail_open` | gateway errors logged-and-swallowed (empty search results) instead of raised | `True` |
+
+Pass a framework `MemoryServiceConfig` as the second constructor argument to control `enabled` / TTL settings; `TTL` eviction is delegated to the gateway (the memory engine owns retention).
+
+## Security and behavior
+
+- **Identity scoping**: every request carries the app/user resolved from `session.save_key`; these are provenance fields, not an authorization boundary — hard multi-tenant isolation depends on the gateway.
+- **No cleartext credentials to remote hosts**: `http://` is only allowed for loopback gateways by default.
+- **Fail-open by default**: store/search failures are logged and skipped so the agent loop never blocks; set `fail_open=False` when memory is a hard requirement.
+- **Capture retries**: the per-session watermark advances only after a successful response, so failed captures are retried. Narrow duplicate window: if the gateway persists a turn but the response is lost, the retry resends the same delta (message IDs are server-assigned).
+- **`enabled` gate**: `store_session` / `search_memory` are no-ops when the framework config disables the service, independent of the runner's own gating.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `GatewayError` on health check | Stack not running — start it and check `MEMORY_CORE_PORT` (8420). |
+| Gateway returns 401 | Gateway started with `TDAI_GATEWAY_API_KEY` — pass it via `TDAiConfig(api_key=...)`. |
+| Nothing captured | Verify the service is enabled (`memory.enabled`) — the runner gates persistence on it; and check that sessions carry a non-empty `id` and `save_key`. |
+| No memory recalled in new sessions | Extraction is asynchronous — wait a few seconds and retry. |
+| Duplicate captures | Rare: the gateway persisted a turn but its response was lost, so the retry resent the delta. |
+
+## Testing
+
+Tests run against a fake gateway and real `trpc_agent_sdk` classes (no stack or LLM needed) — 34 cases across five files:
+
+```bash
+cd adapters/trpc-agent-python
+pip install -e ".[test]"
+pytest
+```
+
+## Notes
+
+- **Companion adapters**: the Go counterpart (`adapters/trpc-agent-go`) wires the same gateway routes into trpc-agent-go's native integration; a Semantic Kernel adapter (`adapters/semantic-kernel`) is also available.
+- **Upstream**: this adapter is self-contained (subclasses the published PyPI package). Moving it into `trpc_agent_sdk/memory/` upstream remains a natural follow-up.
+- **Version**: verified with `trpc-agent-py` 1.1.17 and TencentDB Agent Memory v2 images (`feat/server_team` branch).
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/trpc-agent-python/README.md
+++ b/adapters/trpc-agent-python/README.md
@@ -118,7 +118,7 @@ Pass a framework `MemoryServiceConfig` as the second constructor argument to con
 
 ## Testing
 
-Tests run against a fake gateway and real `trpc_agent_sdk` classes (no stack or LLM needed) — 34 cases across five files:
+Tests run against a fake gateway and real `trpc_agent_sdk` classes (no stack or LLM needed) — 36 cases across five files:
 
 ```bash
 cd adapters/trpc-agent-python

--- a/adapters/trpc-agent-python/README.md
+++ b/adapters/trpc-agent-python/README.md
@@ -118,7 +118,7 @@ Pass a framework `MemoryServiceConfig` as the second constructor argument to con
 
 ## Testing
 
-Tests run against a fake gateway and real `trpc_agent_sdk` classes (no stack or LLM needed) — 36 cases across five files:
+Tests run against a fake gateway and real `trpc_agent_sdk` classes (no stack or LLM needed) — 39 cases across five files:
 
 ```bash
 cd adapters/trpc-agent-python

--- a/adapters/trpc-agent-python/README.md
+++ b/adapters/trpc-agent-python/README.md
@@ -128,7 +128,6 @@ pytest
 
 ## Notes
 
-- **Companion adapters**: the Go counterpart (`adapters/trpc-agent-go`) wires the same gateway routes into trpc-agent-go's native integration; a Semantic Kernel adapter (`adapters/semantic-kernel`) is also available.
 - **Upstream**: this adapter is self-contained (subclasses the published PyPI package). Moving it into `trpc_agent_sdk/memory/` upstream remains a natural follow-up.
 - **Version**: verified with `trpc-agent-py` 1.1.17 and TencentDB Agent Memory v2 images (`feat/server_team` branch).
 

--- a/adapters/trpc-agent-python/README_CN.md
+++ b/adapters/trpc-agent-python/README_CN.md
@@ -44,6 +44,14 @@ trpc-agent-python Runner
 
 ## 安装
 
+直接从本仓库远程安装 —— 无需克隆源码：
+
+```bash
+pip install "git+https://github.com/TencentCloud/TencentDB-Agent-Memory.git#subdirectory=adapters/trpc-agent-python"
+```
+
+或从本地克隆安装：
+
 ```bash
 pip install ./adapters/trpc-agent-python
 ```

--- a/adapters/trpc-agent-python/README_CN.md
+++ b/adapters/trpc-agent-python/README_CN.md
@@ -1,0 +1,137 @@
+# TencentDB Agent Memory — trpc-agent-python 适配器
+
+为基于 [trpc-agent-python](https://github.com/trpc-group/trpc-agent-python) 构建的智能体装上持久记忆。本适配器提供 `TencentDBMemoryService` —— 框架 `MemoryServiceABC` 契约的直接实现（与内置的 InMemory / Redis / SQL / Mem0 记忆服务同级），接入 `Runner(memory_service=...)` 无需任何框架改动。
+
+接入后，每个会话自动获得：
+
+- **对话捕获** —— 每轮完成后，runner 调用 `store_session`，将该轮 user/assistant 对话流式发送到 gateway（`POST /capture`），进入 L0 → L3 记忆流水线
+- **记忆检索** —— 框架的召回路径（`invocation_context → search_memory`）查询 gateway（`POST /search/memories`）并映射为 `SearchMemoryResponse`
+- **增量捕获** —— 每会话水位线保证重复的 `store_session` 调用只发增量，绝不重放整个会话
+- **默认 fail-open** —— gateway 故障仅记日志并跳过，绝不阻断智能体主循环
+
+## 工作原理
+
+```
+trpc-agent-python Runner
+  ├─ 轮后: store_session ──(POST /capture)──► L0 → L3 流水线
+  └─ 召回: search_memory ──(POST /search/memories)──► SearchMemoryResponse
+                                            ▼
+                     Memory Core Gateway（端口 8420）
+                    （捕获 · 提取 · 存储 · 召回）
+```
+
+适配器对接 **memory-core gateway**（默认 `:8420`），记忆引擎（提取/去重/场景沉淀/画像）运行在 gateway 侧 —— 与官方 trpc-agent-go 集成（`memory/tencentdb`）对接的是同一组 gateway 路由。
+
+身份映射遵循框架约定：session 的 `save_key`（`{app}/{user}`）是主作用域 —— 与内置 Mem0 服务完全一致 —— 配置值仅作兜底。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已在本地运行：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+   在 `.env` 中设置 `MEMORY_LLM_BASE_URL` / `MEMORY_LLM_API_KEY` / `MEMORY_LLM_MODEL` —— 记忆引擎用该 LLM 完成提取与召回。
+
+2. Python 3.10+ 与 trpc-agent-python（PyPI 包名 `trpc-agent-py`，≥ 1.1.17）：
+
+   ```bash
+   pip install trpc-agent-py
+   ```
+
+## 安装
+
+```bash
+pip install ./adapters/trpc-agent-python
+```
+
+或将 `tdai_trpc/` 包直接复制进你的项目（仅依赖 `trpc-agent-py` 与 `httpx`）。
+
+## 快速上手
+
+```python
+from trpc_agent_sdk.agents import LlmAgent
+from trpc_agent_sdk.models import OpenAIModel
+from trpc_agent_sdk.runners import Runner
+from trpc_agent_sdk.sessions import InMemorySessionService
+
+from tdai_trpc import TDAiConfig, TencentDBMemoryService
+
+memory = TencentDBMemoryService(TDAiConfig(
+    gateway_url="http://127.0.0.1:8420",
+    api_key=os.environ.get("TDAI_GATEWAY_API_KEY", ""),
+    fail_open=True,
+))
+
+runner = Runner(
+    app_name="my-app",
+    agent=LlmAgent(name="assistant", model=OpenAIModel("gpt-4o-mini"),
+                   instruction="You are a concise assistant."),
+    session_service=InMemorySessionService(),
+    memory_service=memory,   # 每轮结束后自动持久化到 gateway
+)
+
+async for event in runner.run_async(
+    user_id="user-42",
+    session_id="session-1",
+    new_message=user_message("记住：我的项目代号是 Apollo Lake。"),
+):
+    ...
+# 全新会话即可通过框架记忆路径召回该事实
+```
+
+可运行的端到端脚本见 [`example/quickstart.py`](./example/quickstart.py)。
+
+## 配置参考
+
+| 字段 | 作用 | 默认值 |
+|---|---|---|
+| `gateway_url` | memory-core gateway 地址（非本地明文 HTTP 默认拒绝，除非 `allow_remote_http=True`） | `http://127.0.0.1:8420` |
+| `api_key` | `Authorization: Bearer` 密钥；gateway 以 `TDAI_GATEWAY_API_KEY` 启动时必填 | `""` |
+| `timeout` | 单请求 HTTP 超时 | `5.0` 秒 |
+| `app_name` / `user_id` | session 的 `save_key` 无法解析时的兜底身份；session 自身的 `save_key` 始终优先 | `"trpc-agent-app"` / `"default-user"` |
+| `allow_remote_http` | 允许对非本地 gateway 使用明文 HTTP | `False` |
+| `fail_open` | gateway 错误记日志并吞掉（检索返回空结果），而非抛出 | `True` |
+
+构造函数第二个参数可传框架的 `MemoryServiceConfig` 控制 `enabled` / TTL；TTL 淘汰委托给 gateway（记忆引擎拥有保留策略）。
+
+## 安全与行为
+
+- **身份作用域**：每个请求携带从 `session.save_key` 解析的 app/user；它们是溯源字段而非鉴权边界 —— 硬性多租户隔离依赖 gateway 侧。
+- **远程明文禁运凭证**：默认仅允许回环地址使用 `http://`。
+- **默认 fail-open**：存储/检索失败仅记日志并跳过；记忆为硬性依赖时设置 `fail_open=False`。
+- **捕获重试**：每会话水位线仅在成功响应后推进，失败捕获会在下次调用重试。存在窄重复窗口：gateway 已持久化但响应丢失时，重试会重发相同增量（消息 ID 由服务端分配）。
+- **`enabled` 门**：框架配置禁用服务时 `store_session` / `search_memory` 直接空操作，独立于 runner 自身的门控。
+
+## 常见问题
+
+| 现象 | 原因 / 解决 |
+|---|---|
+| 健康检查报 `GatewayError` | 服务未启动 —— 启动后检查 `MEMORY_CORE_PORT`（8420）。 |
+| gateway 返回 401 | gateway 以 API key 启动 —— 通过 `TDAiConfig(api_key=...)` 传入。 |
+| 没有任何捕获 | 确认服务已启用（`memory.enabled`，runner 以此门控持久化）；检查 session 的 `id` 与 `save_key` 非空。 |
+| 新会话召回不到记忆 | 提取是异步的 —— 稍等几秒重试。 |
+| 捕获重复 | 罕见：gateway 已持久化该轮但响应丢失，重试重发了增量。 |
+
+## 测试
+
+测试基于假 gateway 与真实的 `trpc_agent_sdk` 类运行（无需服务或 LLM）—— 5 个文件、34 个用例：
+
+```bash
+cd adapters/trpc-agent-python
+pip install -e ".[test]"
+pytest
+```
+
+## 说明
+
+- **姊妹适配器**：Go 侧（`adapters/trpc-agent-go`）将同一组 gateway 路由接入 trpc-agent-go 官方集成；另有 Semantic Kernel 适配器（`adapters/semantic-kernel`）。
+- **上游化**：本适配器自包含（子类化已发布的 PyPI 包）。将来合入 `trpc_agent_sdk/memory/` 上游是自然的后续演进。
+- **版本**：已在 `trpc-agent-py` 1.1.17 与 TencentDB Agent Memory v2 镜像（`feat/server_team` 分支）上验证。
+
+## 许可证
+
+MIT，与主仓库一致。

--- a/adapters/trpc-agent-python/README_CN.md
+++ b/adapters/trpc-agent-python/README_CN.md
@@ -118,7 +118,7 @@ async for event in runner.run_async(
 
 ## 测试
 
-测试基于假 gateway 与真实的 `trpc_agent_sdk` 类运行（无需服务或 LLM）—— 5 个文件、34 个用例：
+测试基于假 gateway 与真实的 `trpc_agent_sdk` 类运行（无需服务或 LLM）—— 5 个文件、36 个用例：
 
 ```bash
 cd adapters/trpc-agent-python

--- a/adapters/trpc-agent-python/README_CN.md
+++ b/adapters/trpc-agent-python/README_CN.md
@@ -118,7 +118,7 @@ async for event in runner.run_async(
 
 ## 测试
 
-测试基于假 gateway 与真实的 `trpc_agent_sdk` 类运行（无需服务或 LLM）—— 5 个文件、36 个用例：
+测试基于假 gateway 与真实的 `trpc_agent_sdk` 类运行（无需服务或 LLM）—— 5 个文件、39 个用例：
 
 ```bash
 cd adapters/trpc-agent-python

--- a/adapters/trpc-agent-python/README_CN.md
+++ b/adapters/trpc-agent-python/README_CN.md
@@ -128,7 +128,6 @@ pytest
 
 ## 说明
 
-- **姊妹适配器**：Go 侧（`adapters/trpc-agent-go`）将同一组 gateway 路由接入 trpc-agent-go 官方集成；另有 Semantic Kernel 适配器（`adapters/semantic-kernel`）。
 - **上游化**：本适配器自包含（子类化已发布的 PyPI 包）。将来合入 `trpc_agent_sdk/memory/` 上游是自然的后续演进。
 - **版本**：已在 `trpc-agent-py` 1.1.17 与 TencentDB Agent Memory v2 镜像（`feat/server_team` 分支）上验证。
 

--- a/adapters/trpc-agent-python/example/quickstart.py
+++ b/adapters/trpc-agent-python/example/quickstart.py
@@ -1,0 +1,90 @@
+"""Quickstart: TencentDBMemoryService plugged into a trpc-agent-python Runner.
+
+Prerequisites:
+  1. TencentDB Agent Memory stack running locally:
+       cd deploy/global-images && cp .env.example .env && ./start-all.sh
+     (set MEMORY_LLM_BASE_URL / MEMORY_LLM_API_KEY / MEMORY_LLM_MODEL in .env;
+      the gateway listens on :8420)
+  2. An OpenAI-compatible key for the agent's chat model (OPENAI_API_KEY).
+
+Run:
+       cd adapters/trpc-agent-python
+       export OPENAI_API_KEY="sk-..."
+       python example/quickstart.py
+"""
+
+import asyncio
+import os
+
+from trpc_agent_sdk.agents import LlmAgent
+from trpc_agent_sdk.models import OpenAIModel
+from trpc_agent_sdk.runners import Runner
+from trpc_agent_sdk.sessions import InMemorySessionService
+from trpc_agent_sdk.types import Content, Part
+
+from tdai_trpc import TDAiConfig, TencentDBMemoryService
+
+
+def user_message(text: str) -> Content:
+    return Content(role="user", parts=[Part.from_text(text=text)])
+
+
+def event_text(event) -> str:
+    if not event.content or not event.content.parts:
+        return ""
+    return "".join(part.text or "" for part in event.content.parts).strip()
+
+
+async def main() -> None:
+    gateway_url = os.environ.get("TENCENTDB_AGENT_MEMORY_GATEWAY", "http://127.0.0.1:8420")
+    api_key = os.environ.get("TDAI_GATEWAY_API_KEY", "")
+    model_name = os.environ.get("OPENAI_MODEL_ID", "gpt-4o-mini")
+
+    memory = TencentDBMemoryService(
+        TDAiConfig(
+            gateway_url=gateway_url,
+            api_key=api_key,
+            fail_open=True,  # gateway outage never breaks the chat loop
+        )
+    )
+    health = await memory.health()
+    print(f"Gateway: {gateway_url} (status={health.status} version={health.version})")
+
+    agent = LlmAgent(
+        name="memory-assistant",
+        model=OpenAIModel(model_name),
+        instruction="You are a concise assistant backed by TencentDB Agent Memory.",
+    )
+
+    runner = Runner(
+        app_name="tdai-quickstart",
+        agent=agent,
+        session_service=InMemorySessionService(),
+        # After each completed turn the runner calls memory.store_session,
+        # which streams the turn's user/assistant pair to POST /capture.
+        memory_service=memory,
+    )
+
+    user_id = "demo-user"
+
+    async def turn(session_id: str, text: str) -> None:
+        async for event in runner.run_async(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=user_message(text),
+        ):
+            reply = event_text(event)
+            if reply:
+                print("Assistant:", reply)
+
+    # 1) Teach a fact in one session (captured to the gateway after the turn).
+    await turn("demo-session-1", "Remember: my project codename is Apollo Lake.")
+    # 2) Ask in a brand-new session; recall flows through the framework's
+    #    memory search path (invocation context -> memory_service.search_memory).
+    await turn("demo-session-2", "What is my project codename?")
+
+    await memory.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/adapters/trpc-agent-python/pyproject.toml
+++ b/adapters/trpc-agent-python/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tdai-trpc"
+version = "0.1.0"
+description = "TencentDB Agent Memory memory service for trpc-agent-python"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "TencentDB Agent Memory Contributors" }]
+keywords = ["trpc-agent", "agents", "memory", "tencentdb"]
+dependencies = [
+    "trpc-agent-py>=1.1.17",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "aiohttp>=3.9",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["tdai_trpc"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/adapters/trpc-agent-python/tdai_trpc/__init__.py
+++ b/adapters/trpc-agent-python/tdai_trpc/__init__.py
@@ -1,0 +1,20 @@
+"""TencentDB Agent Memory integration for trpc-agent-python.
+
+Provides :class:`TencentDBMemoryService`, a ``MemoryServiceABC``
+implementation backed by the TencentDB Agent Memory gateway. See the package
+README for the full guide.
+"""
+
+from __future__ import annotations
+
+from .config import ConfigError, TDAiConfig
+from .gateway_client import GatewayError, MemoryGatewayClient
+from .service import TencentDBMemoryService
+
+__all__ = [
+    "ConfigError",
+    "GatewayError",
+    "MemoryGatewayClient",
+    "TDAiConfig",
+    "TencentDBMemoryService",
+]

--- a/adapters/trpc-agent-python/tdai_trpc/config.py
+++ b/adapters/trpc-agent-python/tdai_trpc/config.py
@@ -1,0 +1,73 @@
+"""Configuration for the TencentDB Agent Memory trpc-agent-python adapter.
+
+Validation mirrors the security posture of the sibling adapters: remote
+plaintext HTTP is rejected by default so bearer tokens are never sent in
+cleartext to a non-local gateway.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+class ConfigError(ValueError):
+    """Raised when the adapter configuration is invalid."""
+
+
+@dataclass
+class TDAiConfig:
+    """Gateway configuration for :class:`TencentDBMemoryService`.
+
+    Attributes:
+        gateway_url: memory-core gateway base URL (default local sidecar).
+        api_key: Optional bearer key; required when the gateway is started
+            with ``TDAI_GATEWAY_API_KEY``.
+        timeout: Per-request HTTP timeout in seconds.
+        app_name / user_id: Fallback identity scope used when a session's
+            ``save_key`` cannot be parsed into ``{app}/{user}`` parts. The
+            session's own ``save_key`` takes precedence so memories are
+            scoped exactly like the framework's other memory services.
+        allow_remote_http: Permit plaintext HTTP to a non-local gateway.
+            Off by default; bearer tokens must not transit cleartext.
+        fail_open: When True (default), gateway errors during
+            ``store_session`` / ``search_memory`` are logged and swallowed
+            (returning an empty response) so the agent loop is never blocked,
+            matching the failure posture of the framework's other remote
+            memory services.
+    """
+
+    gateway_url: str = "http://127.0.0.1:8420"
+    api_key: str = ""
+    timeout: float = 5.0
+    app_name: str = "trpc-agent-app"
+    user_id: str = "default-user"
+    allow_remote_http: bool = False
+    fail_open: bool = True
+
+    def validate(self) -> None:
+        """Validate the configuration; raise :class:`ConfigError` on issues."""
+        if self.timeout <= 0:
+            raise ConfigError("timeout must be positive")
+        if not self.app_name.strip():
+            raise ConfigError("app_name must be a non-empty string")
+        if not self.user_id.strip():
+            raise ConfigError("user_id must be a non-empty string")
+
+        parsed = urlparse(self.gateway_url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ConfigError(
+                f"gateway_url must be an http(s) URL, got: {self.gateway_url!r}"
+            )
+        if (
+            parsed.scheme == "http"
+            and parsed.hostname not in _LOCAL_HOSTS
+            and not self.allow_remote_http
+        ):
+            raise ConfigError(
+                "refusing to send the gateway API key over plaintext HTTP to a "
+                "non-local host; use https, loopback http, or set "
+                "allow_remote_http=True explicitly"
+            )

--- a/adapters/trpc-agent-python/tdai_trpc/gateway_client.py
+++ b/adapters/trpc-agent-python/tdai_trpc/gateway_client.py
@@ -1,0 +1,202 @@
+"""Async HTTP client for the TencentDB Agent Memory memory-core gateway.
+
+Implements the gateway routes consumed by this adapter:
+
+- ``GET  /health``
+- ``POST /capture``             (turn capture, L0)
+- ``POST /search/memories``     (long-term memory search)
+- ``POST /search/conversations``(session-scoped conversation search)
+- ``POST /session/end``         (flush short-term session state)
+
+Request/response shapes mirror the official trpc-agent-go ``memory/tencentdb``
+adapter (v1.11.1) which targets the same gateway.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+_DEFAULT_TIMEOUT = 5.0
+
+
+class GatewayError(RuntimeError):
+    """Raised when the TencentDB Agent Memory gateway returns an error."""
+
+
+@dataclass
+class GatewayMessage:
+    """One transcript message sent to /capture."""
+
+    role: str
+    content: str
+    timestamp: int  # Unix seconds
+    id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "role": self.role,
+            "content": self.content,
+            "timestamp": self.timestamp,
+        }
+        if self.id:
+            payload["id"] = self.id
+        return payload
+
+
+@dataclass
+class CaptureRequest:
+    """Payload for POST /capture."""
+
+    user_content: str
+    assistant_content: str
+    session_key: str
+    messages: list[GatewayMessage] = field(default_factory=list)
+    session_id: str = ""
+    user_id: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "user_content": self.user_content,
+            "assistant_content": self.assistant_content,
+            "session_key": self.session_key,
+            "messages": [m.to_dict() for m in self.messages],
+        }
+        if self.session_id:
+            payload["session_id"] = self.session_id
+        if self.user_id:
+            payload["user_id"] = self.user_id
+        return payload
+
+
+@dataclass
+class SearchResult:
+    """Normalized search results returned by the search paths."""
+
+    results: str = ""
+    total: int = 0
+
+
+@dataclass
+class HealthStatus:
+    status: str = ""
+    version: str = ""
+
+
+class MemoryGatewayClient:
+    """Thin async client over the memory-core gateway HTTP API.
+
+    Args:
+        gateway_url: Base URL, e.g. ``http://127.0.0.1:8420``.
+        api_key: Optional bearer key; required when the gateway is started
+            with ``TDAI_GATEWAY_API_KEY``.
+        timeout: Per-request timeout in seconds.
+        client: Optional pre-configured ``httpx.AsyncClient`` (tests inject
+            a client bound to a fake gateway here).
+    """
+
+    def __init__(
+        self,
+        gateway_url: str = "http://127.0.0.1:8420",
+        api_key: str = "",
+        timeout: float = _DEFAULT_TIMEOUT,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = gateway_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        self._client = client or httpx.AsyncClient(timeout=timeout)
+        self._owns_client = client is None
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    async def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        headers: dict[str, str] = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        try:
+            response = await self._client.post(
+                f"{self._base_url}{path}", json=payload, headers=headers
+            )
+        except httpx.HTTPError as exc:
+            raise GatewayError(f"gateway request failed: {path}: {exc}") from exc
+        if response.status_code >= 400:
+            raise GatewayError(
+                f"gateway returned {response.status_code} for {path}: {response.text[:512]}"
+            )
+        return response.json()
+
+    async def health(self) -> HealthStatus:
+        try:
+            response = await self._client.get(f"{self._base_url}/health")
+        except httpx.HTTPError as exc:
+            raise GatewayError(f"gateway health check failed: {exc}") from exc
+        if response.status_code >= 400:
+            raise GatewayError(f"gateway health returned {response.status_code}")
+        data = response.json()
+        return HealthStatus(status=data.get("status", ""), version=data.get("version", ""))
+
+    async def capture(self, request: CaptureRequest) -> dict[str, Any]:
+        return await self._post("/capture", request.to_dict())
+
+    async def search_memories(
+        self, query: str, limit: int = 10, user_id: str = ""
+    ) -> SearchResult:
+        payload: dict[str, Any] = {"query": query, "limit": limit}
+        if user_id:
+            payload["user_id"] = user_id
+        data = await self._post("/search/memories", payload)
+        return SearchResult(results=data.get("results", ""), total=data.get("total", 0))
+
+    async def search_conversations(
+        self, query: str, session_key: str = "", limit: int = 10, user_id: str = ""
+    ) -> SearchResult:
+        payload: dict[str, Any] = {"query": query, "limit": limit}
+        if session_key:
+            payload["session_key"] = session_key
+        if user_id:
+            payload["user_id"] = user_id
+        data = await self._post("/search/conversations", payload)
+        return SearchResult(results=data.get("results", ""), total=data.get("total", 0))
+
+    async def end_session(self, session_key: str, user_id: str = "") -> bool:
+        payload: dict[str, Any] = {"session_key": session_key}
+        if user_id:
+            payload["user_id"] = user_id
+        data = await self._post("/session/end", payload)
+        return bool(data.get("flushed", False))
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "MemoryGatewayClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+
+def default_session_key(app_name: str, user_id: str, session_id: str) -> str:
+    """Build the default gateway session_key.
+
+    Mirrors the trpc-agent-go adapter: urlsafe-base64(app):urlsafe-base64(user):
+    urlsafe-base64(session). Avoids collisions across app/user/session ids
+    without assuming delimiter-free values.
+    """
+
+    import base64
+
+    def enc(value: str) -> str:
+        return base64.urlsafe_b64encode(value.encode("utf-8")).rstrip(b"=").decode("ascii")
+
+    return ":".join(enc(v) for v in (app_name, user_id, session_id))
+
+
+def now_ts() -> int:
+    return int(time.time())

--- a/adapters/trpc-agent-python/tdai_trpc/service.py
+++ b/adapters/trpc-agent-python/tdai_trpc/service.py
@@ -1,0 +1,283 @@
+"""TencentDBMemoryService: a trpc-agent-python memory service backed by the
+TencentDB Agent Memory gateway.
+
+Implements the framework's ``MemoryServiceABC`` contract (``store_session`` /
+``search_memory`` / ``close``) the same way the built-in remote memory
+services do, so it plugs into ``Runner(memory_service=...)`` without any
+framework changes:
+
+- ``store_session``: incrementally streams each completed user/assistant
+  turn of a session to ``POST /capture`` (L0). The gateway owns extraction,
+  storage, and the L0 → L3 pipeline; this service never extracts locally.
+- ``search_memory``: resolves the two-level key (``session.save_key`` →
+  gateway user scope, ``session.id`` → gateway session scope) and queries
+  ``POST /search/memories``, mapping results into the framework's
+  ``SearchMemoryResponse``.
+- ``close``: releases the underlying HTTP client.
+
+Identity follows the framework convention: the session's ``save_key``
+(``{app}/{user}``) is the primary scope, exactly like the built-in Mem0
+service. Config values are only fallbacks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from trpc_agent_sdk.abc import MemoryServiceABC as BaseMemoryService
+from trpc_agent_sdk.abc import MemoryServiceConfig
+from trpc_agent_sdk.context import AgentContext
+from trpc_agent_sdk.log import logger
+from trpc_agent_sdk.sessions import Session
+from trpc_agent_sdk.types import Content
+from trpc_agent_sdk.types import MemoryEntry
+from trpc_agent_sdk.types import Part
+from trpc_agent_sdk.types import SearchMemoryResponse
+
+from .config import TDAiConfig
+from .gateway_client import (
+    CaptureRequest,
+    GatewayMessage,
+    MemoryGatewayClient,
+    default_session_key,
+    now_ts,
+)
+
+_EVENT_ROLE_USER = "user"
+
+
+def _event_to_role(event: Any) -> str:
+    """Map a framework event author to a chat role (user/assistant)."""
+    return _EVENT_ROLE_USER if getattr(event, "author", None) == _EVENT_ROLE_USER else "assistant"
+
+
+def _event_to_text(event: Any) -> str:
+    """Extract joined text parts from an event's content."""
+    content = getattr(event, "content", None)
+    parts = getattr(content, "parts", None)
+    if not parts:
+        return ""
+    texts = [part.text for part in parts if getattr(part, "text", None)]
+    return " ".join(texts).strip()
+
+
+class TencentDBMemoryService(BaseMemoryService):
+    """Memory service storing/searching through the TencentDB gateway.
+
+    Two-level key strategy (mirrors the built-in Mem0 service):
+    - level 1 (primary): ``session.save_key`` → gateway user scope
+    - level 2 (sub-key): ``session.id`` → gateway session scope
+    """
+
+    def __init__(
+        self,
+        tdai_config: Optional[TDAiConfig] = None,
+        memory_service_config: Optional[MemoryServiceConfig] = None,
+        client: Optional[MemoryGatewayClient] = None,
+        validate_config: bool = True,
+    ) -> None:
+        """Initialize the service.
+
+        Args:
+            tdai_config: Gateway settings (URL, key, timeouts, fail-open).
+            memory_service_config: Framework memory-service settings; when
+                omitted, an enabled no-TTL config is used so the runner's
+                post-turn persistence calls ``store_session``.
+            client: Optional pre-built gateway client (tests inject fakes).
+            validate_config: Skip config validation when False (for callers
+                that construct their own transport).
+        """
+        self._tdai = tdai_config or TDAiConfig()
+        if validate_config:
+            self._tdai.validate()
+        if memory_service_config is None:
+            memory_service_config = MemoryServiceConfig(enabled=True)
+            memory_service_config.clean_ttl_config()
+        super().__init__(memory_service_config=memory_service_config)
+        self._client = client or MemoryGatewayClient(
+            gateway_url=self._tdai.gateway_url,
+            api_key=self._tdai.api_key,
+            timeout=self._tdai.timeout,
+        )
+        self._owns_client = client is None
+        # Watermark of the last captured event position per session id, so
+        # repeated store_session calls (runner calls after every turn) only
+        # send the delta instead of replaying the whole transcript.
+        self._captured_counts: dict[str, int] = {}
+
+    @property
+    def tdai_config(self) -> TDAiConfig:
+        return self._tdai
+
+    @property
+    def client(self) -> MemoryGatewayClient:
+        return self._client
+
+    # ------------------------------------------------------------------
+    # MemoryServiceABC
+    # ------------------------------------------------------------------
+
+    async def store_session(
+        self, session: Session, agent_context: Optional[AgentContext] = None
+    ) -> None:
+        """Store the uncaptured delta of a session into the gateway.
+
+        Only completed user/assistant pairs are captured; a trailing lone
+        user message waits for its assistant reply. The per-session
+        watermark advances only after a successful gateway response, so a
+        failed capture is retried on the next call.
+
+        Failures are logged and swallowed when ``fail_open`` (default), so a
+        gateway outage never breaks the agent loop.
+        """
+        if not self.enabled:
+            return
+        try:
+            await self._store_session_inner(session)
+        except Exception as exc:  # pylint: disable=broad-except
+            if self._tdai.fail_open:
+                logger.warning(
+                    "Failed to store session in TencentDB Agent Memory. "
+                    "save_key=%s, session_id=%s, err=%s",
+                    getattr(session, "save_key", "?"),
+                    getattr(session, "id", "?"),
+                    exc,
+                )
+            else:
+                raise
+
+    async def _store_session_inner(self, session: Session) -> None:
+        events = list(getattr(session, "events", []) or [])
+        session_id = str(getattr(session, "id", "") or "")
+        if not session_id:
+            return
+        start = self._captured_counts.get(session_id, 0)
+        delta = events[start:]
+        if not delta:
+            return
+
+        user_text = ""
+        assistant_text = ""
+        gateway_messages: list[GatewayMessage] = []
+        for event in delta:
+            text = _event_to_text(event)
+            if not text:
+                continue
+            role = _event_to_role(event)
+            gateway_messages.append(
+                GatewayMessage(role=role, content=text, timestamp=now_ts())
+            )
+            if role == _EVENT_ROLE_USER and not user_text:
+                user_text = text
+            elif role != _EVENT_ROLE_USER and not assistant_text:
+                assistant_text = text
+
+        if gateway_messages and not (user_text and assistant_text):
+            # Incomplete turn; wait for the assistant reply before capturing.
+            return
+        if not gateway_messages:
+            self._captured_counts[session_id] = len(events)
+            return
+
+        app_name, user_id = self._resolve_scope(session)
+        request = CaptureRequest(
+            user_content=user_text,
+            assistant_content=assistant_text,
+            session_key=default_session_key(app_name, user_id, session_id),
+            session_id=session_id,
+            user_id=user_id,
+            messages=gateway_messages,
+        )
+        await self._client.capture(request)
+        self._captured_counts[session_id] = len(events)
+
+    async def search_memory(
+        self,
+        key: str,
+        query: str,
+        limit: int = 10,
+        agent_context: Optional[AgentContext] = None,
+    ) -> SearchMemoryResponse:
+        """Search long-term memories for the user behind ``key`` (save_key)."""
+        response = SearchMemoryResponse()
+        if not self.enabled:
+            return response
+        app_name, user_id = self._resolve_save_key(key)
+        try:
+            result = await self._client.search_memories(query=query, limit=limit, user_id=user_id)
+        except Exception as exc:  # pylint: disable=broad-except
+            if self._tdai.fail_open:
+                logger.warning(
+                    "Failed to search TencentDB Agent Memory. key=%s, query=%s, err=%s",
+                    key,
+                    query,
+                    exc,
+                )
+                return response
+            raise
+        if result.results:
+            response.memories.append(
+                MemoryEntry(
+                    content=Content(parts=[Part.from_text(text=result.results)], role="assistant"),
+                    author="tencentdb-memory",
+                    timestamp=datetime.now().isoformat(),
+                )
+            )
+        return response
+
+    async def close(self) -> None:
+        """Release the underlying HTTP client when owned by this service."""
+        if self._owns_client:
+            await self._client.close()
+
+    # ------------------------------------------------------------------
+    # Non-contract helpers (optional lifecycle conveniences)
+    # ------------------------------------------------------------------
+
+    async def health(self):
+        """Probe the gateway readiness endpoint."""
+        return await self._client.health()
+
+    async def end_session(self, session: Session) -> bool:
+        """Flush gateway-side session state (``POST /session/end``)."""
+        session_id = str(getattr(session, "id", "") or "")
+        app_name, user_id = self._resolve_scope(session)
+        try:
+            return await self._client.end_session(
+                session_key=default_session_key(app_name, user_id, session_id),
+                user_id=user_id,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            if self._tdai.fail_open:
+                logger.warning("TencentDB end_session failed: %s", exc)
+                return False
+            raise
+
+    # ------------------------------------------------------------------
+    # Identity mapping
+    # ------------------------------------------------------------------
+
+    def _resolve_scope(self, session: Session) -> tuple[str, str]:
+        """Resolve (app_name, user_id) from the session, with config fallback."""
+        save_key = str(getattr(session, "save_key", "") or "")
+        session_id = str(getattr(session, "id", "") or "")
+        app_name, user_id = self._resolve_save_key(save_key)
+        # save_key does not carry the session id; keep it out of the app/user
+        # scope and use the framework session id for the session dimension.
+        del session_id
+        return app_name, user_id
+
+    def _resolve_save_key(self, save_key: str) -> tuple[str, str]:
+        """Parse ``{app}/{user}`` save_key into (app, user).
+
+        Falls back to the configured identity when the key is empty or has
+        no ``/`` separator.
+        """
+        key = (save_key or "").strip()
+        if not key:
+            return self._tdai.app_name, self._tdai.user_id
+        parts = key.split("/", 1)
+        if len(parts) == 2 and parts[1].strip():
+            return parts[0].strip(), parts[1].strip()
+        return self._tdai.app_name, key

--- a/adapters/trpc-agent-python/tdai_trpc/service.py
+++ b/adapters/trpc-agent-python/tdai_trpc/service.py
@@ -259,14 +259,8 @@ class TencentDBMemoryService(BaseMemoryService):
     # ------------------------------------------------------------------
 
     def _resolve_scope(self, session: Session) -> tuple[str, str]:
-        """Resolve (app_name, user_id) from the session, with config fallback."""
-        save_key = str(getattr(session, "save_key", "") or "")
-        session_id = str(getattr(session, "id", "") or "")
-        app_name, user_id = self._resolve_save_key(save_key)
-        # save_key does not carry the session id; keep it out of the app/user
-        # scope and use the framework session id for the session dimension.
-        del session_id
-        return app_name, user_id
+        """Resolve (app_name, user_id) from the session's save_key."""
+        return self._resolve_save_key(str(getattr(session, "save_key", "") or ""))
 
     def _resolve_save_key(self, save_key: str) -> tuple[str, str]:
         """Parse ``{app}/{user}`` save_key into (app, user).

--- a/adapters/trpc-agent-python/tests/conftest.py
+++ b/adapters/trpc-agent-python/tests/conftest.py
@@ -1,0 +1,129 @@
+"""Shared fixtures: a fake memory-core gateway and session/event factories."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class FakeGateway:
+    """Records requests and replies with contract-shaped responses.
+
+    Toggle ``fail_routes`` to simulate gateway errors for specific paths.
+    """
+
+    def __init__(self) -> None:
+        from aiohttp import web
+
+        self.requests: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.search_results = "[mem] codename=Apollo Lake"
+        self.fail_routes: set[str] = set()
+        self.app = web.Application()
+        self.app.router.add_get("/health", self._health)
+        self.app.router.add_post("/capture", self._capture)
+        self.app.router.add_post("/search/memories", self._search_memories)
+        self.app.router.add_post("/search/conversations", self._search_conversations)
+        self.app.router.add_post("/session/end", self._session_end)
+        self.runner: Any = None
+
+    async def start(self) -> str:
+        from aiohttp import web
+
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, "127.0.0.1", 0)
+        await site.start()
+        port = self.runner.addresses[0][1]
+        return f"http://127.0.0.1:{port}"
+
+    async def stop(self) -> None:
+        if self.runner:
+            await self.runner.cleanup()
+
+    def payloads(self, path: str) -> list[dict[str, Any]]:
+        return [b for p, _, b in self.requests if p == path and b is not None]
+
+    def _record(self, request, body: dict[str, Any] | None = None) -> None:
+        self.requests.append((request.path, request.headers.get("Authorization", ""), body))
+
+    async def _reply(self, request, payload: dict[str, Any]):
+        from aiohttp import web
+
+        if request.path in self.fail_routes:
+            return web.json_response({"error": "simulated failure"}, status=500)
+        return web.json_response(payload)
+
+    async def _health(self, request):
+        self._record(request)
+        return await self._reply(request, {"status": "ok", "version": "test-gateway"})
+
+    async def _capture(self, request):
+        body = await request.json()
+        self._record(request, body)
+        return await self._reply(
+            request,
+            {"l0_recorded": len(body.get("messages", [])), "scheduler_notified": True},
+        )
+
+    async def _search_memories(self, request):
+        body = await request.json()
+        self._record(request, body)
+        return await self._reply(request, {"results": self.search_results, "total": 1})
+
+    async def _search_conversations(self, request):
+        body = await request.json()
+        self._record(request, body)
+        return await self._reply(request, {"results": "[conv] asked about codename", "total": 1})
+
+    async def _session_end(self, request):
+        body = await request.json()
+        self._record(request, body)
+        return await self._reply(request, {"flushed": True})
+
+
+@pytest.fixture
+async def fake_gw():
+    gw = FakeGateway()
+    url = await gw.start()
+    yield gw, url
+    await gw.stop()
+
+
+# ---------------------------------------------------------------------------
+# trpc-agent-python session/event factories
+# ---------------------------------------------------------------------------
+
+
+def make_event(author: str, text: str):
+    """Build a framework Event carrying a single text part."""
+    from trpc_agent_sdk.events import Event
+    from trpc_agent_sdk.types import Content, Part
+
+    return Event(
+        invocation_id="inv-1",
+        author=author,
+        content=Content(role=author, parts=[Part.from_text(text=text)]),
+    )
+
+
+def make_session(
+    session_id: str = "s-1",
+    app_name: str = "app",
+    user_id: str = "user",
+    pairs: int = 1,
+):
+    """Build a Session whose events contain ``pairs`` user/assistant turns."""
+    from trpc_agent_sdk.sessions import Session
+
+    events = []
+    for i in range(pairs):
+        events.append(make_event("user", f"Remember fact {i + 1}: codename is Apollo Lake."))
+        events.append(make_event("agent", f"Noted fact {i + 1}."))
+    return Session(
+        id=session_id,
+        app_name=app_name,
+        user_id=user_id,
+        save_key=f"{app_name}/{user_id}",
+        events=events,
+    )

--- a/adapters/trpc-agent-python/tests/test_config.py
+++ b/adapters/trpc-agent-python/tests/test_config.py
@@ -1,0 +1,43 @@
+"""Config validation tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tdai_trpc import ConfigError, TDAiConfig
+
+
+def test_defaults_are_local_http():
+    TDAiConfig().validate()  # loopback http is allowed by default
+
+
+def test_remote_plaintext_http_rejected_by_default():
+    config = TDAiConfig(gateway_url="http://memory.example.com:8420")
+    with pytest.raises(ConfigError, match="plaintext HTTP"):
+        config.validate()
+
+
+def test_remote_plaintext_http_allowed_when_explicit():
+    TDAiConfig(
+        gateway_url="http://memory.example.com:8420", allow_remote_http=True
+    ).validate()
+
+
+def test_remote_https_allowed():
+    TDAiConfig(gateway_url="https://memory.example.com:8420").validate()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout": 0},
+        {"timeout": -1.0},
+        {"app_name": " "},
+        {"user_id": ""},
+        {"gateway_url": "ftp://example.com"},
+        {"gateway_url": "not-a-url"},
+    ],
+)
+def test_invalid_values_rejected(kwargs):
+    with pytest.raises(ConfigError):
+        TDAiConfig(**kwargs).validate()

--- a/adapters/trpc-agent-python/tests/test_gateway_client.py
+++ b/adapters/trpc-agent-python/tests/test_gateway_client.py
@@ -1,0 +1,54 @@
+"""Gateway client contract tests: payloads, auth, error mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from tdai_trpc import GatewayError, MemoryGatewayClient
+
+
+async def test_health_and_bearer_auth_on_write_paths(fake_gw):
+    gw, url = fake_gw
+    async with MemoryGatewayClient(gateway_url=url, api_key="k1") as client:
+        health = await client.health()
+        assert health.status == "ok"
+        await client.search_memories("q", user_id="u")
+        await client.search_conversations("q", session_key="s:k")
+        await client.end_session("s:k", user_id="u")
+    auth_by_path = {p: a for p, a, _ in gw.requests}
+    assert auth_by_path["/search/memories"] == "Bearer k1"
+    assert auth_by_path["/search/conversations"] == "Bearer k1"
+    assert auth_by_path["/session/end"] == "Bearer k1"
+
+
+async def test_search_payload_shapes(fake_gw):
+    gw, url = fake_gw
+    async with MemoryGatewayClient(gateway_url=url) as client:
+        result = await client.search_memories("codename", limit=3, user_id="u")
+        assert "Apollo Lake" in result.results
+        await client.search_conversations("codename", session_key="s:k", limit=2)
+    assert gw.payloads("/search/memories")[0] == {
+        "query": "codename",
+        "limit": 3,
+        "user_id": "u",
+    }
+    assert gw.payloads("/search/conversations")[0] == {
+        "query": "codename",
+        "limit": 2,
+        "session_key": "s:k",
+    }
+
+
+async def test_server_error_raises_gateway_error(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/search/memories")
+    async with MemoryGatewayClient(gateway_url=url) as client:
+        with pytest.raises(GatewayError, match="500"):
+            await client.search_memories("q")
+
+
+async def test_unreachable_gateway_raises_gateway_error():
+    # port 1 on loopback: nothing listens there
+    async with MemoryGatewayClient(gateway_url="http://127.0.0.1:1") as client:
+        with pytest.raises(GatewayError):
+            await client.health()

--- a/adapters/trpc-agent-python/tests/test_package.py
+++ b/adapters/trpc-agent-python/tests/test_package.py
@@ -1,0 +1,54 @@
+"""Package-level tests: public API surface, packaging, credential scan."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_public_api_exports():
+    import tdai_trpc
+
+    for name in (
+        "ConfigError",
+        "GatewayError",
+        "MemoryGatewayClient",
+        "TDAiConfig",
+        "TencentDBMemoryService",
+    ):
+        assert hasattr(tdai_trpc, name), f"missing public export: {name}"
+
+
+def test_service_implements_framework_contract():
+    from trpc_agent_sdk.abc import MemoryServiceABC
+
+    from tdai_trpc import TencentDBMemoryService
+
+    assert issubclass(TencentDBMemoryService, MemoryServiceABC)
+    for method in ("store_session", "search_memory", "close"):
+        assert callable(getattr(TencentDBMemoryService, method))
+
+
+def test_package_config_includes_runtime_package():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    assert 'packages = ["tdai_trpc"]' in content
+    assert 'name = "tdai-trpc"' in content
+    assert "trpc-agent-py" in content
+
+
+def test_no_credentials_in_sources():
+    """The contribution must not contain real credentials or absolute paths."""
+    root = Path(__file__).resolve().parents[1]
+    pattern = re.compile(r"sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{30,}|[A-Z]:\\\\Users\\\\")
+    paths = (
+        list((root / "tdai_trpc").rglob("*.py"))
+        + list((root / "tests").rglob("*.py"))
+        + [root / "example" / "quickstart.py"]
+    )
+    for path in paths:
+        if not path.exists():
+            continue
+        assert not pattern.search(path.read_text(encoding="utf-8")), (
+            f"suspicious content in {path}"
+        )

--- a/adapters/trpc-agent-python/tests/test_service.py
+++ b/adapters/trpc-agent-python/tests/test_service.py
@@ -231,6 +231,44 @@ async def test_save_key_fallback_to_config_identity(fake_gw):
     await service.close()
 
 
+async def test_save_key_without_slash_treated_as_user(fake_gw):
+    """A bare save_key (no ``/``) scopes the user to the whole key."""
+    gw, url = fake_gw
+    service = make_service(url, app_name="cfg-app")
+
+    await service.search_memory("just-a-user-id", "q")
+    payload = gw.payloads("/search/memories")[0]
+    assert payload["user_id"] == "just-a-user-id"
+    await service.close()
+
+
+async def test_store_session_skips_events_without_text(fake_gw):
+    """Events with no text parts are skipped; an all-empty delta captures
+    nothing but still advances the watermark."""
+    from trpc_agent_sdk.events import Event
+
+    gw, url = fake_gw
+    service = make_service(url)
+    session = make_session(pairs=0)
+    session.add_event(Event(invocation_id="i1", author="user", content=None))
+    session.add_event(Event(invocation_id="i2", author="agent", content=None))
+
+    await service.store_session(session)
+    assert gw.payloads("/capture") == []
+    assert service._captured_counts.get("s-1") == 2  # watermark advanced anyway
+    await service.close()
+
+
+async def test_end_session_fail_closed_raises(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/session/end")
+    service = make_service(url, fail_open=False)
+
+    with pytest.raises(Exception, match="500"):
+        await service.end_session(make_session())
+    await service.close()
+
+
 async def test_end_session_flushes(fake_gw):
     gw, url = fake_gw
     service = make_service(url)

--- a/adapters/trpc-agent-python/tests/test_service.py
+++ b/adapters/trpc-agent-python/tests/test_service.py
@@ -1,0 +1,225 @@
+"""TencentDBMemoryService contract tests: store/search/lifecycle paths."""
+
+from __future__ import annotations
+
+import pytest
+
+from tdai_trpc import TDAiConfig, TencentDBMemoryService
+
+from conftest import make_event, make_session
+
+
+def make_service(url: str, **config_kwargs) -> TencentDBMemoryService:
+    return TencentDBMemoryService(TDAiConfig(gateway_url=url, **config_kwargs))
+
+
+async def test_enabled_by_default():
+    service = TencentDBMemoryService(
+        TDAiConfig(gateway_url="http://127.0.0.1:1"), validate_config=False
+    )
+    assert service.enabled is True  # runner gates store_session on this
+    await service.close()
+
+
+async def test_store_session_sends_full_payload(fake_gw):
+    gw, url = fake_gw
+    service = make_service(url, api_key="k1")
+    session = make_session(pairs=1)
+
+    await service.store_session(session)
+
+    payload = gw.payloads("/capture")[0]
+    assert payload["user_content"] == "Remember fact 1: codename is Apollo Lake."
+    assert payload["assistant_content"] == "Noted fact 1."
+    assert payload["session_id"] == "s-1"
+    assert payload["user_id"] == "user"
+    assert len(payload["messages"]) == 2
+    assert payload["messages"][0]["role"] == "user"
+    assert payload["messages"][1]["role"] == "assistant"
+    # session_key = b64url("app"):b64url("user"):b64url("s-1") from save_key
+    assert payload["session_key"].count(":") == 2
+    await service.close()
+
+
+async def test_store_session_is_incremental(fake_gw):
+    gw, url = fake_gw
+    service = make_service(url)
+    session = make_session(pairs=1)
+
+    await service.store_session(session)
+    session.add_event(make_event("user", "Second question?"))
+    session.add_event(make_event("agent", "Second answer."))
+
+    await service.store_session(session)
+    captures = gw.payloads("/capture")
+    assert len(captures) == 2
+    assert captures[1]["user_content"] == "Second question?"
+    assert captures[1]["assistant_content"] == "Second answer."
+    # Nothing new: third call sends nothing.
+    await service.store_session(session)
+    assert len(gw.payloads("/capture")) == 2
+    await service.close()
+
+
+async def test_store_session_ignores_incomplete_turn(fake_gw):
+    gw, url = fake_gw
+    service = make_service(url)
+    session = make_session(pairs=1)
+    await service.store_session(session)
+
+    session.add_event(make_event("user", "orphan question"))
+    await service.store_session(session)
+    assert len(gw.payloads("/capture")) == 1  # nothing sent for the lone user msg
+
+    # Once the assistant replies, the pending pair is captured.
+    session.add_event(make_event("agent", "late answer"))
+    await service.store_session(session)
+    captures = gw.payloads("/capture")
+    assert len(captures) == 2
+    assert captures[1]["user_content"] == "orphan question"
+    await service.close()
+
+
+async def test_store_session_fail_open_swallows(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/capture")
+    service = make_service(url, fail_open=True)
+    session = make_session(pairs=1)
+
+    await service.store_session(session)  # must not raise
+    # watermark NOT advanced → the delta will be retried next call
+    assert service._captured_counts.get("s-1") is None
+    await service.close()
+
+
+async def test_store_session_fail_closed_raises(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/capture")
+    service = make_service(url, fail_open=False)
+    session = make_session(pairs=1)
+
+    with pytest.raises(Exception, match="500"):
+        await service.store_session(session)
+    await service.close()
+
+
+async def test_store_session_skips_when_disabled(fake_gw):
+    from trpc_agent_sdk.abc import MemoryServiceConfig
+
+    gw, url = fake_gw
+    service = TencentDBMemoryService(
+        TDAiConfig(gateway_url=url),
+        memory_service_config=MemoryServiceConfig(enabled=False),
+    )
+    assert service.enabled is False
+    await service.store_session(make_session(pairs=1))
+    assert gw.payloads("/capture") == []
+    await service.close()
+
+
+async def test_store_session_no_session_id_is_noop(fake_gw):
+    from trpc_agent_sdk.sessions import Session
+
+    gw, url = fake_gw
+    service = make_service(url)
+    session = Session(id="", app_name="a", user_id="u", save_key="a/u", events=[])
+    await service.store_session(session)
+    assert gw.payloads("/capture") == []
+    await service.close()
+
+
+async def test_search_memory_maps_results(fake_gw):
+    gw, url = fake_gw
+    service = make_service(url)
+
+    response = await service.search_memory("app/user", "project codename", limit=5)
+
+    assert len(response.memories) == 1
+    entry = response.memories[0]
+    assert "Apollo Lake" in entry.content.parts[0].text
+    assert entry.author == "tencentdb-memory"
+    assert entry.timestamp  # ISO string forwarded to the LLM
+    payload = gw.payloads("/search/memories")[0]
+    assert payload == {"query": "project codename", "limit": 5, "user_id": "user"}
+    await service.close()
+
+
+async def test_search_memory_empty_results(fake_gw):
+    gw, url = fake_gw
+    gw.search_results = ""
+    service = make_service(url)
+
+    response = await service.search_memory("app/user", "nothing")
+    assert response.memories == []
+    await service.close()
+
+
+async def test_search_memory_fail_open_returns_empty(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/search/memories")
+    service = make_service(url, fail_open=True)
+
+    response = await service.search_memory("app/user", "q")
+    assert response.memories == []
+    await service.close()
+
+
+async def test_search_memory_fail_closed_raises(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/search/memories")
+    service = make_service(url, fail_open=False)
+
+    with pytest.raises(Exception, match="500"):
+        await service.search_memory("app/user", "q")
+    await service.close()
+
+
+async def test_save_key_fallback_to_config_identity(fake_gw):
+    gw, url = fake_gw
+    service = make_service(url, app_name="cfg-app", user_id="cfg-user")
+
+    await service.search_memory("", "q")  # empty key → config fallback
+    payload = gw.payloads("/search/memories")[0]
+    assert payload["user_id"] == "cfg-user"
+    await service.close()
+
+
+async def test_end_session_flushes(fake_gw):
+    gw, url = fake_gw
+    service = make_service(url)
+    session = make_session()
+
+    assert await service.end_session(session) is True
+    payload = gw.payloads("/session/end")[0]
+    assert payload["user_id"] == "user"
+    await service.close()
+
+
+async def test_end_session_fail_open_returns_false(fake_gw):
+    gw, url = fake_gw
+    gw.fail_routes.add("/session/end")
+    service = make_service(url, fail_open=True)
+
+    assert await service.end_session(make_session()) is False
+    await service.close()
+
+
+async def test_runner_integration_shape(fake_gw):
+    """The service satisfies the framework call sites used by Runner.
+
+    runners.py: ``if self.memory_service and self.memory_service.enabled:
+    await self.memory_service.store_session(session, agent_context=...)``
+    and invocation_context.py: ``await self.memory_service.search_memory(key,
+    query, limit, agent_context=...)``.
+    """
+    from trpc_agent_sdk.abc import MemoryServiceABC
+
+    gw, url = fake_gw
+    service = make_service(url)
+    assert isinstance(service, MemoryServiceABC)
+
+    await service.store_session(make_session(), agent_context=None)
+    await service.search_memory("app/user", "codename", limit=3, agent_context=None)
+    assert len(gw.payloads("/capture")) == 1
+    assert len(gw.payloads("/search/memories")) == 1
+    await service.close()

--- a/adapters/trpc-agent-python/tests/test_service.py
+++ b/adapters/trpc-agent-python/tests/test_service.py
@@ -92,6 +92,53 @@ async def test_store_session_fail_open_swallows(fake_gw):
     await service.close()
 
 
+async def test_store_session_retries_after_failure(fake_gw):
+    """A failed capture is resent once the gateway recovers, exactly once."""
+    gw, url = fake_gw
+    gw.fail_routes.add("/capture")
+    service = make_service(url, fail_open=True)
+    session = make_session(pairs=1)
+
+    await service.store_session(session)  # reaches gateway, gets 500, swallowed
+    gw.fail_routes.clear()                # gateway recovers
+    await service.store_session(session)  # resends the same delta, succeeds
+    captures = gw.payloads("/capture")
+    # Exactly two attempts — the failed one and the retry — with identical
+    # content (the watermark only advances on success).
+    assert len(captures) == 2
+    assert captures[0]["user_content"] == captures[1]["user_content"]
+    assert captures[1]["user_content"] == "Remember fact 1: codename is Apollo Lake."
+    # And a third call is a no-op (watermark advanced by the success).
+    await service.store_session(session)
+    assert len(gw.payloads("/capture")) == 2
+    await service.close()
+
+
+async def test_watermarks_are_isolated_per_session(fake_gw):
+    """Two sessions sharing one service never leak capture deltas."""
+    gw, url = fake_gw
+    service = make_service(url)
+    session_a = make_session(session_id="a", pairs=1)
+    session_b = make_session(session_id="b", pairs=1)
+
+    await service.store_session(session_a)
+    # b's first capture must send its own full pair, not be skipped because
+    # a already captured a same-shaped delta.
+    await service.store_session(session_b)
+    captures = gw.payloads("/capture")
+    assert len(captures) == 2
+    assert {c["session_id"] for c in captures} == {"a", "b"}
+    # Growing a afterwards must not affect b.
+    session_a.add_event(make_event("user", "second question"))
+    session_a.add_event(make_event("agent", "second answer"))
+    await service.store_session(session_a)
+    await service.store_session(session_b)  # nothing new for b
+    captures = gw.payloads("/capture")
+    assert len(captures) == 3
+    assert captures[2]["session_id"] == "a"
+    await service.close()
+
+
 async def test_store_session_fail_closed_raises(fake_gw):
     gw, url = fake_gw
     gw.fail_routes.add("/capture")


### PR DESCRIPTION
## Description | 描述
Adds `adapters/trpc-agent-python/`: a self-contained Python package (`tdai_trpc`) implementing the framework''s `MemoryServiceABC` contract — `store_session` / `search_memory` / `close` — against the memory-core gateway, plugging into `Runner(memory_service=...)` with zero framework changes. Includes incremental per-session capture watermark (only deltas are sent), `save_key`-based identity scoping (`{app}/{user}`, same convention as the built-in Mem0 service), config validation (remote plaintext HTTP rejected by default), fail-open semantics, a runnable quickstart on real `trpc_agent_sdk` APIs, bilingual docs, and 34 pytest cases over a fake gateway. Companion to the Go adapter (#1068).
新增 `adapters/trpc-agent-python/`：自包含 Python 包（`tdai_trpc`），实现框架 `MemoryServiceABC` 契约（`store_session` / `search_memory` / `close`），接入 `Runner(memory_service=...)` 零框架改动。包含每会话增量捕获水位线（只发增量）、基于 `save_key` 的身份作用域（`{app}/{user}`，与内置 Mem0 服务同一约定）、配置校验（默认拒绝远程明文 HTTP）、fail-open 语义、基于真实 `trpc_agent_sdk` API 的可运行示例、双语文档，以及 34 个基于假 gateway 的 pytest 用例。与 Go 适配器（#1068）互为姊妹篇。

## Related Issue | 关联 Issue
#926

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
One new standalone directory only (`adapters/trpc-agent-python/`); no existing files touched. Verified with trpc-agent-py 1.1.17 from PyPI, pyflakes clean, `pytest` 34/34 green. The service subclasses the published SDK, so this works today; upstreaming into `trpc_agent_sdk/memory/` remains a natural follow-up.