### PR TITLE
test(panel): add unit tests for domain + kernel transport, type wiki graph

### DIFF
--- a/MemoryPanel/src/panel/kernel/ports/knowledge-client-port.ts
+++ b/MemoryPanel/src/panel/kernel/ports/knowledge-client-port.ts
@@ -99,10 +99,35 @@ export interface WikiPageRmResult {
   rewritten_files: number;
 }
 
+/** 图谱节点（与 Knowledge 服务 /graph 返回的 GraphNode 对齐）。 */
+export interface WikiGraphNode {
+  id: string;
+  label: string;
+  type: string;
+  path: string;
+  linkCount: number;
+  community: number;
+}
+
+/** 图谱边（`source`/`target` 为节点 id）。 */
+export interface WikiGraphEdge {
+  source: string;
+  target: string;
+  weight: number;
+}
+
+/** 社区划分结果。 */
+export interface WikiGraphCommunity {
+  id: number;
+  nodeCount: number;
+  cohesion: number;
+  topNodes: string[];
+}
+
 export interface WikiGraphData {
-  nodes: any[];
-  edges: any[];
-  communities?: any[];
+  nodes: WikiGraphNode[];
+  edges: WikiGraphEdge[];
+  communities?: WikiGraphCommunity[];
 }
 
 export interface WikiSearchResult {

--- a/MemoryPanel/tests/domain/asset-id.test.ts
+++ b/MemoryPanel/tests/domain/asset-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { newExternalAssetId } from '../../src/panel/domain/asset-id.js';
+
+describe('newExternalAssetId', () => {
+  const prefixes: Array<[Parameters<typeof newExternalAssetId>[0], string]> = [
+    ['skill', 'skl'],
+    ['llm_wiki', 'wiki'],
+    ['code_graph', 'cg'],
+    ['chat_memory', 'mem'],
+  ];
+
+  it.each(prefixes)('%s → "%s-" prefix', (type, prefix) => {
+    const id = newExternalAssetId(type);
+    expect(id.startsWith(`${prefix}-`)).toBe(true);
+  });
+
+  it('produces 12 lowercase alphanumeric chars after the prefix', () => {
+    for (const [type] of prefixes) {
+      const id = newExternalAssetId(type);
+      const suffix = id.split('-')[1];
+      expect(suffix).toMatch(/^[a-z0-9]{12}$/);
+    }
+  });
+
+  it('is unique across consecutive calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 100; i++) seen.add(newExternalAssetId('skill'));
+    expect(seen.size).toBe(100);
+  });
+});

--- a/MemoryPanel/tests/domain/chat-memory-governance.test.ts
+++ b/MemoryPanel/tests/domain/chat-memory-governance.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CHAT_MEMORY_REL,
+  MAX_IMPORTED_AGENTS,
+  readChatMemoryRel,
+  validateImportedAgents,
+  writeChatMemoryRel,
+} from '../../src/panel/domain/chat-memory-governance.js';
+
+const team = [{ agent_id: 'a1' }, { agent_id: 'a2' }, { agent_id: 'a3' }];
+
+describe('validateImportedAgents', () => {
+  it('accepts an empty list', () => {
+    expect(validateImportedAgents('self', [], team)).toEqual({ ok: true });
+  });
+
+  it('accepts up to MAX_IMPORTED_AGENTS valid agents', () => {
+    expect(validateImportedAgents('self', ['a1', 'a2'], team)).toEqual({ ok: true });
+  });
+
+  it('rejects more than MAX_IMPORTED_AGENTS', () => {
+    const r = validateImportedAgents('self', ['a1', 'a2', 'a3'], team);
+    expect(r).toEqual({ ok: false, reason: `最多只能借入 ${MAX_IMPORTED_AGENTS} 个 agent` });
+  });
+
+  it('rejects importing oneself', () => {
+    const r = validateImportedAgents('a1', ['a1'], team);
+    expect(r).toEqual({ ok: false, reason: '不能借入自己的记忆' });
+  });
+
+  it('rejects an agent outside the team', () => {
+    const r = validateImportedAgents('self', ['outsider'], team);
+    expect(r).toEqual({ ok: false, reason: 'agent_id "outsider" 不在当前 team 中' });
+  });
+
+  it('rejects duplicate ids', () => {
+    const r = validateImportedAgents('self', ['a1', 'a1'], team);
+    expect(r).toEqual({ ok: false, reason: '借入列表中存在重复 agent' });
+  });
+
+  it('rejects non-string ids', () => {
+    const r = validateImportedAgents('self', ['a1', 42 as unknown as string], team);
+    expect(r).toEqual({ ok: false, reason: '存在无效的 agent_id' });
+  });
+
+  it('rejects a non-array', () => {
+    const r = validateImportedAgents('self', 'a1' as unknown as string[], team);
+    expect(r).toEqual({ ok: false, reason: 'imported_agent_ids 必须是数组' });
+  });
+});
+
+describe('readChatMemoryRel', () => {
+  it('returns defaults when metadata_json is absent', () => {
+    expect(readChatMemoryRel({ agent_id: 'a1' })).toEqual(DEFAULT_CHAT_MEMORY_REL);
+  });
+
+  it('returns defaults when the chat_memory slot is absent', () => {
+    const agent = { agent_id: 'a1', metadata_json: JSON.stringify({ other: 1 }) };
+    expect(readChatMemoryRel(agent)).toEqual(DEFAULT_CHAT_MEMORY_REL);
+  });
+
+  it('returns defaults on malformed JSON', () => {
+    const agent = { agent_id: 'a1', metadata_json: '{not json' };
+    expect(readChatMemoryRel(agent)).toEqual(DEFAULT_CHAT_MEMORY_REL);
+  });
+
+  it('reads and normalizes a valid rel', () => {
+    const agent = {
+      agent_id: 'a1',
+      metadata_json: JSON.stringify({
+        chat_memory: { memory_shared_with_team: false, imported_agent_ids: ['a2'] },
+      }),
+    };
+    expect(readChatMemoryRel(agent)).toEqual({
+      memory_shared_with_team: false,
+      imported_agent_ids: ['a2'],
+    });
+  });
+
+  it('caps imported_agent_ids to MAX_IMPORTED_AGENTS when normalizing', () => {
+    const agent = {
+      agent_id: 'a1',
+      metadata_json: JSON.stringify({
+        chat_memory: { imported_agent_ids: ['a1', 'a2', 'a3', 'a4'] },
+      }),
+    };
+    const rel = readChatMemoryRel(agent);
+    expect(rel.imported_agent_ids).toHaveLength(MAX_IMPORTED_AGENTS);
+  });
+});
+
+describe('writeChatMemoryRel', () => {
+  it('writes only the chat_memory slot when no previous metadata exists', () => {
+    const out = writeChatMemoryRel(undefined, DEFAULT_CHAT_MEMORY_REL);
+    expect(JSON.parse(out)).toEqual({ chat_memory: DEFAULT_CHAT_MEMORY_REL });
+  });
+
+  it('preserves unrelated keys while writing the rel', () => {
+    const prev = JSON.stringify({ other: 42 });
+    const out = writeChatMemoryRel(prev, DEFAULT_CHAT_MEMORY_REL);
+    expect(JSON.parse(out)).toEqual({ other: 42, chat_memory: DEFAULT_CHAT_MEMORY_REL });
+  });
+
+  it('discards malformed previous metadata', () => {
+    const out = writeChatMemoryRel('{broken', DEFAULT_CHAT_MEMORY_REL);
+    expect(JSON.parse(out)).toEqual({ chat_memory: DEFAULT_CHAT_MEMORY_REL });
+  });
+
+  it('does not mutate the input rel object', () => {
+    const rel = { ...DEFAULT_CHAT_MEMORY_REL, imported_agent_ids: ['a1'] };
+    writeChatMemoryRel(undefined, rel);
+    expect(rel).toEqual({ ...DEFAULT_CHAT_MEMORY_REL, imported_agent_ids: ['a1'] });
+  });
+});

--- a/MemoryPanel/tests/domain/errors.test.ts
+++ b/MemoryPanel/tests/domain/errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ConflictError,
+  CoreUpstreamError,
+  DomainError,
+  ForbiddenError,
+  NotFoundError,
+} from '../../src/panel/domain/errors.js';
+
+describe('DomainError', () => {
+  it('sets name/code/httpStatus', () => {
+    const e = new DomainError('boom', 'BAD', 422);
+    expect(e.name).toBe('DomainError');
+    expect(e.message).toBe('boom');
+    expect(e.code).toBe('BAD');
+    expect(e.httpStatus).toBe(422);
+    expect(e).toBeInstanceOf(Error);
+  });
+
+  it('defaults httpStatus to 400', () => {
+    expect(new DomainError('x', 'X').httpStatus).toBe(400);
+  });
+});
+
+describe('error subclasses', () => {
+  it('NotFoundError', () => {
+    const e = new NotFoundError('team');
+    expect(e.code).toBe('NOT_FOUND');
+    expect(e.httpStatus).toBe(404);
+    expect(e.message).toBe('team not found');
+  });
+
+  it('ForbiddenError', () => {
+    const e = new ForbiddenError();
+    expect(e.code).toBe('FORBIDDEN');
+    expect(e.httpStatus).toBe(403);
+    expect(e.message).toBe('forbidden');
+  });
+
+  it('ConflictError', () => {
+    const e = new ConflictError('already exists');
+    expect(e.code).toBe('CONFLICT');
+    expect(e.httpStatus).toBe(409);
+  });
+});
+
+describe('CoreUpstreamError', () => {
+  it('carries upstreamCode while mapping to a local code', () => {
+    const e = new CoreUpstreamError('FORBIDDEN', 403, 'no permission', 40301);
+    expect(e).toBeInstanceOf(DomainError);
+    expect(e.name).toBe('CoreUpstreamError');
+    expect(e.code).toBe('FORBIDDEN');
+    expect(e.httpStatus).toBe(403);
+    expect(e.upstreamCode).toBe(40301);
+  });
+
+  it('upstreamCode is optional', () => {
+    const e = new CoreUpstreamError('NOT_FOUND', 404, 'missing');
+    expect(e.upstreamCode).toBeUndefined();
+  });
+});

--- a/MemoryPanel/tests/kernel/envelope.test.ts
+++ b/MemoryPanel/tests/kernel/envelope.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { mapHttpStatusFromEnvelopeCode } from '../../src/panel/kernel/envelope.js';
+
+describe('mapHttpStatusFromEnvelopeCode', () => {
+  it('maps code 0 to 200', () => {
+    expect(mapHttpStatusFromEnvelopeCode(0)).toBe(200);
+  });
+
+  it.each([
+    [400, 400],
+    [403, 403],
+    [499, 499],
+    [500, 500],
+    [599, 599],
+  ])('maps %i → %i', (code, expected) => {
+    expect(mapHttpStatusFromEnvelopeCode(code)).toBe(expected);
+  });
+
+  it.each([
+    [399, 502],
+    [600, 502],
+    [-1, 502],
+    [3, 502],
+  ])('maps non-0, non-4xx/5xx %i → 502', (code) => {
+    expect(mapHttpStatusFromEnvelopeCode(code)).toBe(502);
+  });
+});

--- a/MemoryPanel/tests/kernel/transport-fetch.test.ts
+++ b/MemoryPanel/tests/kernel/transport-fetch.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from '../../src/panel/infra/logger.js';
+import { executeMetaFetch, KernelFetchError } from '../../src/panel/kernel/transport-fetch.js';
+
+const cfg = { endpoint: 'https://core.example.com/', apiKey: 'sk-test', serviceId: 'svc-1' };
+
+function jsonResponse(env: unknown, status = 200) {
+  return { status, json: async () => env };
+}
+
+function makeLogger() {
+  const info = vi.fn();
+  const warn = vi.fn();
+  const logger: Logger = {
+    debug: vi.fn(),
+    info,
+    warn,
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return { logger, info, warn };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('executeMetaFetch — data mode', () => {
+  it('returns data on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ code: 0, data: { ok: 1 } })));
+    await expect(executeMetaFetch(cfg, '/v3/meta/x', {}, 'data')).resolves.toEqual({ ok: 1 });
+  });
+
+  it('throws KernelFetchError with the envelope code on business error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ code: 403, message: 'forbidden', data: null })),
+    );
+    const err = await executeMetaFetch(cfg, '/v3/meta/x', {}, 'data').catch((e) => e);
+    expect(err).toBeInstanceOf(KernelFetchError);
+    expect(err.code).toBe(403);
+    expect(err.httpStatus).toBe(403);
+  });
+
+  it('throws 502 on an invalid (non-envelope) response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ foo: 'bar' })));
+    const err = await executeMetaFetch(cfg, '/v3/meta/x', {}, 'data').catch((e) => e);
+    expect(err).toBeInstanceOf(KernelFetchError);
+    expect(err.code).toBe(502);
+  });
+
+  it('throws 502 on a network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const err = await executeMetaFetch(cfg, '/v3/meta/x', {}, 'data').catch((e) => e);
+    expect(err.code).toBe(502);
+    expect(err.message).toContain('ECONNREFUSED');
+  });
+
+  it('throws 504 on an abort (timeout)', async () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abort));
+    const err = await executeMetaFetch(cfg, '/v3/meta/x', {}, 'data').catch((e) => e);
+    expect(err.code).toBe(504);
+  });
+});
+
+describe('executeMetaFetch — envelope mode', () => {
+  it('returns the full envelope even when code != 0', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ code: 404, message: 'nf', data: null })),
+    );
+    const env = await executeMetaFetch(cfg, '/v3/meta/x', {}, 'envelope');
+    expect(env).toMatchObject({ code: 404, message: 'nf' });
+  });
+});
+
+describe('executeMetaFetch — request-body redaction', () => {
+  it('masks sensitive fields in the request log', async () => {
+    const { logger, info } = makeLogger();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ code: 0, data: {} })));
+
+    await executeMetaFetch(
+      { ...cfg, logger },
+      '/v3/meta/user/create',
+      { password: 'secret12345', api_key: 'sk-abcdef12345', name: 'alice' },
+      'data',
+    );
+
+    const requestLog = info.mock.calls.find((c) => c[0].includes('api.remote.request'));
+    const body = requestLog?.[1]?.requestBody as string;
+    expect(body).toBeDefined();
+    expect(body).not.toContain('secret12345');
+    expect(body).not.toContain('sk-abcdef12345');
+    expect(body).toContain('secret12…');
+    expect(body).toContain('sk-abcde…');
+    expect(body).toContain('alice');
+  });
+});


### PR DESCRIPTION
## Description | 描述

MemoryPanel（Memory Hub）目前**零单元测试**，且 `knowledge-client-port.ts` 的 Wiki 图谱类型用了 3 处 `any[]`。本 PR 补齐第一批单元测试并消除这 3 处 `any`。

给 MemoryPanel 后端补上首批单元测试（此前 `vitest` 已配置但 `tests/` 为空），并把 `WikiGraphData` 的 `nodes/edges/communities` 从 `any[]` 收紧为具体类型，与 Knowledge 服务 `/graph` 返回结构对齐。

## Related Issue | 关联 Issue

N/A

## Change Type | 修改类型

- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## What changed | 变更内容

**测试（47 个，全部通过）**

- `tests/domain/chat-memory-governance.test.ts` — `validateImportedAgents` 的边界规则（上限/自己/跨 team/重复/非字符串）、`readChatMemoryRel` 的缺省回退与归一化、`writeChatMemoryRel` 的合并写回与不修改入参。
- `tests/domain/errors.test.ts` — `DomainError` 及子类的 `code`/`httpStatus`/`name`，`CoreUpstreamError` 的 `upstreamCode` 透传。
- `tests/domain/asset-id.test.ts` — 四种资产类型前缀、12 位小写字母数字格式、唯一性。
- `tests/kernel/envelope.test.ts` — `mapHttpStatusFromEnvelopeCode` 的 `0→200 / 4xx-5xx 透传 / 其余→502`。
- `tests/kernel/transport-fetch.test.ts` — `executeMetaFetch` 的 data/envelope 两种模式、业务码错误映射、无效信封→502、网络错误→502、超时→504、敏感字段（password/api_key）脱敏。

**类型收紧**

- `knowledge-client-port.ts` 新增 `WikiGraphNode` / `WikiGraphEdge` / `WikiGraphCommunity`，替换 `WikiGraphData` 中的 3 处 `any[]`。字段名与 Knowledge 服务 `MemoryKnowledge/src/engines/wiki/types.ts` 的 `GraphNode`/`GraphEdge`/`CommunityInfo` 及前端 `web/src/lib/knowledge-api.ts` 的 `GraphData` 完全一致。

## Verification | 验证

```
MemoryPanel % npm test        # 47 passed (5 files)
MemoryPanel % npm run typecheck   # 无错误
```

## Additional Notes | 其他说明

- 未改动任何运行时行为——测试与类型收紧均为纯增量/纯类型变更。
- 本地 `npm install` 重写了 `MemoryPanel/package-lock.json`（剥离了 package.json 中已不存在的 drizzle/better-sqlite3 残留），该变更与本 PR 无关，已 revert，未纳入提交。
