### PR TITLE
fix(proxy): pass thinking back after Claude Code session-init tool-call

### DIFF
--- a/MemoryProxy/src/__tests__/thinking-passback.test.ts
+++ b/MemoryProxy/src/__tests__/thinking-passback.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  ensureToolCallThinkingPassback,
+  prepareAnthropicUpstreamBody,
+  requiresThinkingPassback,
+  sanitizeThinkingBlocks,
+} from "../anthropicHandler.js";
+
+const VALID_ANTHROPIC_SIGNATURE = "A".repeat(48);
+
+function assistantWithToolUse(content: unknown[]) {
+  return {
+    role: "assistant",
+    content,
+  };
+}
+
+describe("requiresThinkingPassback", () => {
+  it("is true for DeepSeek Anthropic-compat upstreams", () => {
+    expect(
+      requiresThinkingPassback(
+        { url: "https://api.deepseek.com/anthropic", model: "deepseek-v4-flash" },
+        { model: "deepseek-v4-flash" },
+      ),
+    ).toBe(true);
+  });
+
+  it("is true when only the model id is DeepSeek", () => {
+    expect(
+      requiresThinkingPassback(
+        { url: "https://gateway.example.com/anthropic", model: "deepseek-v4-pro" },
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for native Anthropic", () => {
+    expect(
+      requiresThinkingPassback(
+        { url: "https://api.anthropic.com/v1/messages", model: "claude-sonnet-4-5" },
+        { model: "claude-sonnet-4-5" },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("sanitizeThinkingBlocks", () => {
+  it("still strips unsigned thinking for native Anthropic history", () => {
+    const body = {
+      messages: [
+        assistantWithToolUse([
+          { type: "thinking", thinking: "plan", signature: "" },
+          { type: "tool_use", id: "toolu_1", name: "AskUserQuestion", input: {} },
+        ]),
+      ],
+    };
+    const { body: out, removed } = sanitizeThinkingBlocks(body);
+    expect(removed).toBe(1);
+    expect((out.messages as Array<{ content: Array<{ type: string }> }>)[0].content.map((b) => b.type)).toEqual([
+      "tool_use",
+    ]);
+  });
+
+  it("keeps thinking blocks with a valid Anthropic signature", () => {
+    const body = {
+      messages: [
+        assistantWithToolUse([
+          { type: "thinking", thinking: "plan", signature: VALID_ANTHROPIC_SIGNATURE },
+          { type: "text", text: "hi" },
+        ]),
+      ],
+    };
+    const { body: out, removed } = sanitizeThinkingBlocks(body);
+    expect(removed).toBe(0);
+    expect(out).toBe(body);
+  });
+});
+
+describe("ensureToolCallThinkingPassback", () => {
+  it("injects a non-empty thinking block before tool_use when missing", () => {
+    const original = {
+      messages: [
+        { role: "user", content: "hello" },
+        assistantWithToolUse([
+          { type: "tool_use", id: "toolu_cc_session_init_1", name: "AskUserQuestion", input: {} },
+        ]),
+        { role: "user", content: "是，关联团队资产" },
+      ],
+    };
+    const snapshot = structuredClone(original);
+    const { body: out, injected } = ensureToolCallThinkingPassback(original);
+
+    expect(injected).toBe(1);
+    expect(original).toEqual(snapshot);
+
+    const assistant = (out.messages as Array<{ content: Array<Record<string, unknown>> }>)[1];
+    expect(assistant.content[0]?.type).toBe("thinking");
+    expect(String(assistant.content[0]?.thinking).length).toBeGreaterThan(0);
+    expect(assistant.content[1]?.type).toBe("tool_use");
+  });
+
+  it("does not replace an existing thinking block", () => {
+    const { body: out, injected } = ensureToolCallThinkingPassback({
+      messages: [
+        assistantWithToolUse([
+          { type: "thinking", thinking: "original plan", signature: "" },
+          { type: "tool_use", id: "toolu_1", name: "AskUserQuestion", input: {} },
+        ]),
+      ],
+    });
+    expect(injected).toBe(0);
+    const assistant = (out.messages as Array<{ content: Array<Record<string, unknown>> }>)[0];
+    expect(assistant.content[0]?.thinking).toBe("original plan");
+  });
+});
+
+describe("prepareAnthropicUpstreamBody issue #990", () => {
+  it("keeps unsigned thinking + tool_use when forwarding to DeepSeek", () => {
+    const body = {
+      model: "deepseek-v4-flash",
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "user", content: "hello" },
+        assistantWithToolUse([
+          { type: "thinking", thinking: "session-init", signature: "" },
+          { type: "tool_use", id: "toolu_cc_session_init_1", name: "AskUserQuestion", input: {} },
+        ]),
+        { role: "user", content: "是，关联团队资产" },
+      ],
+    };
+
+    const { body: out } = prepareAnthropicUpstreamBody(body, {
+      url: "https://api.deepseek.com/anthropic",
+      model: "deepseek-v4-flash",
+      bodyOverrides: null,
+    });
+
+    const assistant = (out.messages as Array<{ content: Array<Record<string, unknown>> }>)[1];
+    const types = assistant.content.map((b) => b.type);
+    expect(types).toContain("thinking");
+    expect(types).toContain("tool_use");
+    expect(assistant.content.find((b) => b.type === "thinking")?.thinking).toBe("session-init");
+  });
+
+  it("injects thinking when Claude Code session-init history has tool_use only", () => {
+    const body = {
+      model: "deepseek-v4-flash",
+      messages: [
+        { role: "user", content: "hello" },
+        assistantWithToolUse([
+          { type: "tool_use", id: "toolu_cc_session_init_1", name: "AskUserQuestion", input: {} },
+        ]),
+        { role: "user", content: "是，关联团队资产" },
+      ],
+    };
+
+    const { body: out } = prepareAnthropicUpstreamBody(body, {
+      url: "https://api.deepseek.com/anthropic",
+      model: "deepseek-v4-flash",
+      bodyOverrides: null,
+    });
+
+    const assistant = (out.messages as Array<{ content: Array<Record<string, unknown>> }>)[1];
+    expect(assistant.content[0]?.type).toBe("thinking");
+    expect(String(assistant.content[0]?.thinking).length).toBeGreaterThan(0);
+    expect(assistant.content.some((b) => b.type === "tool_use")).toBe(true);
+  });
+
+  it("still strips unsigned thinking when forwarding to native Anthropic", () => {
+    const body = {
+      model: "claude-sonnet-4-5",
+      messages: [
+        assistantWithToolUse([
+          { type: "thinking", thinking: "plan", signature: "" },
+          { type: "tool_use", id: "toolu_1", name: "AskUserQuestion", input: {} },
+        ]),
+      ],
+    };
+
+    const { body: out, sanitizedCount } = prepareAnthropicUpstreamBody(body, {
+      url: "https://api.anthropic.com/v1/messages",
+      model: "claude-sonnet-4-5",
+      bodyOverrides: null,
+    });
+
+    expect(sanitizedCount).toBe(1);
+    const assistant = (out.messages as Array<{ content: Array<{ type: string }> }>)[0];
+    expect(assistant.content.map((b) => b.type)).toEqual(["tool_use"]);
+  });
+});

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -272,6 +272,103 @@ function hasValidThinkingSignature(block: Record<string, unknown>): boolean {
   return /^[A-Za-z0-9+/=]+$/.test(sig);
 }
 
+/** Placeholder thinking text for DeepSeek tool-call replay. Must be non-empty. */
+const TOOL_CALL_THINKING_PLACEHOLDER = "[proxy tool-call thinking passback]";
+
+export type ThinkingPassbackTarget = {
+  url?: string;
+  model?: string;
+};
+
+/**
+ * DeepSeek Anthropic-compat thinking mode requires the previous assistant
+ * `content[].thinking` to be replayed after a tool-call turn (GitHub #990).
+ * Native Anthropic instead rejects unsigned / non-Anthropic signatures, so
+ * this path is only used for DeepSeek-like upstreams.
+ */
+export function requiresThinkingPassback(
+  target: ThinkingPassbackTarget,
+  body: Record<string, unknown>,
+): boolean {
+  const url = String(target.url ?? "").toLowerCase();
+  const model = String(target.model ?? body.model ?? "").toLowerCase();
+  return url.includes("deepseek") || model.includes("deepseek");
+}
+
+function contentHasToolUse(content: unknown[]): boolean {
+  return content.some((block) => {
+    const b = block as Record<string, unknown>;
+    return b.type === "tool_use";
+  });
+}
+
+function contentHasThinking(content: unknown[]): boolean {
+  return content.some((block) => {
+    const b = block as Record<string, unknown>;
+    return b.type === "thinking" || b.type === "redacted_thinking";
+  });
+}
+
+/**
+ * Ensure every assistant tool_use message carries a thinking block.
+ *
+ * DeepSeek returns 400 if thinking mode is on and the prior tool-call
+ * assistant turn has no `content[].thinking`. Session-init fake forms
+ * historically omitted it. Does not mutate `body`.
+ */
+export function ensureToolCallThinkingPassback(
+  body: Record<string, unknown>,
+): { body: Record<string, unknown>; injected: number } {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return { body, injected: 0 };
+
+  let injected = 0;
+  let changed = false;
+
+  const newMessages = messages.map((msg) => {
+    const m = msg as Record<string, unknown>;
+    if (m.role !== "assistant" || !Array.isArray(m.content)) return msg;
+    const content = m.content as unknown[];
+    if (!contentHasToolUse(content) || contentHasThinking(content)) return msg;
+
+    injected += 1;
+    changed = true;
+    return {
+      ...m,
+      content: [
+        { type: "thinking", thinking: TOOL_CALL_THINKING_PLACEHOLDER, signature: "" },
+        ...content,
+      ],
+    };
+  });
+
+  if (!changed) return { body, injected: 0 };
+  return { body: { ...body, messages: newMessages }, injected };
+}
+
+/**
+ * Prepare the Anthropic request body for a specific upstream.
+ *
+ * DeepSeek: skip Anthropic-signature stripping (those signatures are not
+ * DeepSeek's) and inject a thinking placeholder when a tool_use turn has none.
+ * Native Anthropic: keep stripping unsigned thinking blocks.
+ */
+export function prepareAnthropicUpstreamBody(
+  body: Record<string, unknown>,
+  target: { url: string; model: string; bodyOverrides: Record<string, unknown> | null },
+): { body: Record<string, unknown>; sanitizedCount: number } {
+  let result = body;
+  if (target.bodyOverrides) {
+    result = { ...result, ...target.bodyOverrides };
+  }
+  if (requiresThinkingPassback(target, result)) {
+    const ensured = ensureToolCallThinkingPassback(result);
+    return { body: ensured.body, sanitizedCount: 0 };
+  }
+  const sanitized = sanitizeThinkingBlocks(result);
+  return { body: sanitized.body, sanitizedCount: sanitized.removed };
+}
+
 /**
  * Sanitize `thinking` blocks across all assistant messages.
  *
@@ -317,12 +414,7 @@ function buildUpstreamBody(
   body: Record<string, unknown>,
   target: ForwardTarget,
 ): { body: Record<string, unknown>; sanitizedCount: number } {
-  let result = body;
-  if (target.bodyOverrides) {
-    result = { ...result, ...target.bodyOverrides };
-  }
-  const sanitized = sanitizeThinkingBlocks(result);
-  return { body: sanitized.body, sanitizedCount: sanitized.removed };
+  return prepareAnthropicUpstreamBody(body, target);
 }
 
 /**
@@ -1225,7 +1317,9 @@ export async function handleAnthropicMessages(
     delete originalHeaders["authorization"];
   }
 
-  const retryBody = sanitizeThinkingBlocks(body).body;
+  const retryBody = requiresThinkingPassback(target, body)
+    ? ensureToolCallThinkingPassback(body).body
+    : sanitizeThinkingBlocks(body).body;
 
   // ── Forward to upstream (with automatic retry if configured) ──────────────
   const forwardTimeoutMs = config.server.forwardTimeoutMs ?? 600_000;

--- a/MemoryProxy/src/session/claude-code/__tests__/form.test.ts
+++ b/MemoryProxy/src/session/claude-code/__tests__/form.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { ASSET_CONFIRM_YES, buildFormResponse, TOOL_NAME } from "../form.js";
+
+async function readSse(response: Response): Promise<string> {
+  return await response.text();
+}
+
+function parseSseEvents(raw: string): Array<{ event: string; data: Record<string, unknown> }> {
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  const chunks = raw.split("\n\n").map((c) => c.trim()).filter(Boolean);
+  for (const chunk of chunks) {
+    const lines = chunk.split("\n");
+    let event = "";
+    let dataRaw = "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) event = line.slice("event: ".length);
+      if (line.startsWith("data: ")) dataRaw = line.slice("data: ".length);
+    }
+    if (!event || !dataRaw) continue;
+    events.push({ event, data: JSON.parse(dataRaw) as Record<string, unknown> });
+  }
+  return events;
+}
+
+describe("claude-code session-init form SSE (#990)", () => {
+  it("emits a non-empty thinking block before AskUserQuestion tool_use", async () => {
+    const response = buildFormResponse({
+      teams: [],
+      stage: "asset_confirm",
+      modelId: "deepseek-v4-flash",
+    });
+
+    const sse = await readSse(response);
+    const events = parseSseEvents(sse);
+
+    const thinkingStart = events.find((e) => {
+      if (e.event !== "content_block_start") return false;
+      const block = e.data.content_block as Record<string, unknown> | undefined;
+      return block?.type === "thinking";
+    });
+    expect(thinkingStart, "session-init form must open a thinking content block").toBeTruthy();
+    expect(thinkingStart?.data.index).toBe(0);
+
+    const thinkingDelta = events.find((e) => {
+      if (e.event !== "content_block_delta") return false;
+      const delta = e.data.delta as Record<string, unknown> | undefined;
+      return delta?.type === "thinking_delta";
+    });
+    expect(thinkingDelta).toBeTruthy();
+    const thinkingText = (thinkingDelta?.data.delta as { thinking?: string } | undefined)?.thinking ?? "";
+    expect(thinkingText.length).toBeGreaterThan(0);
+
+    const toolStart = events.find((e) => {
+      if (e.event !== "content_block_start") return false;
+      const block = e.data.content_block as Record<string, unknown> | undefined;
+      return block?.type === "tool_use";
+    });
+    expect(toolStart).toBeTruthy();
+    expect(toolStart?.data.index).toBe(1);
+    const toolBlock = toolStart?.data.content_block as { name?: string };
+    expect(toolBlock.name).toBe(TOOL_NAME);
+
+    expect(sse).toContain(ASSET_CONFIRM_YES);
+  });
+});

--- a/MemoryProxy/src/session/claude-code/form.ts
+++ b/MemoryProxy/src/session/claude-code/form.ts
@@ -31,6 +31,18 @@ export const ASSET_CONFIRM_NO = "否，本次不关联";
 export const ASSET_CONFIRM_FORM_TITLE = "会话初始化 — 是否关联团队资产";
 
 /**
+ * Fake AskUserQuestion assistant 消息的占位 thinking。
+ *
+ * DeepSeek thinking 模式在 tool-call 之后硬校验：下一轮必须把
+ * `content[].thinking` 回传，否则 400
+ * `The content[].thinking in the thinking mode must be passed back to the API`
+ * （GitHub #990）。空 thinking 会被客户端丢掉，必须非空。
+ *
+ * 对齐 dsh/form.ts 的 REASONING_PLACEHOLDER。值本身不进真实模型生成。
+ */
+const SESSION_INIT_THINKING_PLACEHOLDER = "[proxy session-init form]";
+
+/**
  * 附在每步 question 文末的通用备注：告诉用户"选择跳过 = 本次 session init 跳过、不注入任何团队资产"。
  * Claude Code 的 AskUserQuestion 会给用户一个 "Other" 输入框，回复"跳过 / skip /
  * 不关联" 就走 SKIP_RE bypass；没识别到的自由文本会 unrecognized → 同样 bypass。
@@ -246,9 +258,23 @@ export function buildFormResponse(data: FormData): Response {
         },
       }));
 
+      // thinking 必须在 tool_use 之前。DeepSeek thinking 模式在 tool-call 后
+      // 要求回传 content[].thinking（#990）；无 thinking 的假表单会让下一轮 400。
       controller.enqueue(sse("content_block_start", {
         type: "content_block_start",
         index: 0,
+        content_block: { type: "thinking", thinking: "" },
+      }));
+      controller.enqueue(sse("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: SESSION_INIT_THINKING_PLACEHOLDER },
+      }));
+      controller.enqueue(sse("content_block_stop", { type: "content_block_stop", index: 0 }));
+
+      controller.enqueue(sse("content_block_start", {
+        type: "content_block_start",
+        index: 1,
         content_block: {
           type: "tool_use",
           id: toolUseId,
@@ -259,11 +285,11 @@ export function buildFormResponse(data: FormData): Response {
 
       controller.enqueue(sse("content_block_delta", {
         type: "content_block_delta",
-        index: 0,
+        index: 1,
         delta: { type: "input_json_delta", partial_json: inputJson },
       }));
 
-      controller.enqueue(sse("content_block_stop", { type: "content_block_stop", index: 0 }));
+      controller.enqueue(sse("content_block_stop", { type: "content_block_stop", index: 1 }));
 
       controller.enqueue(sse("message_delta", {
         type: "message_delta",


### PR DESCRIPTION
## Summary
- Fixes #990: Claude Code + Anthropic + DeepSeek thinking mode returned 400 `The content[].thinking in the thinking mode must be passed back to the API` after choosing 关联团队资产.
- Session-init `AskUserQuestion` SSE now emits a non-empty thinking block before `tool_use` (same class of bug as dsh `REASONING_PLACEHOLDER`).
- DeepSeek Anthropic-compat upstreams skip Anthropic-signature stripping and inject a thinking placeholder when a `tool_use` turn has none. Native Anthropic still strips unsigned thinking.

## Test plan
- [x] `npx vitest run` in MemoryProxy: 11/11 (form SSE + `prepareAnthropicUpstreamBody`)
- [x] Cloud `tdai-proxy` bind-mounted the patched files
- [x] Live `POST /claude-code/default/v1/messages` session-init SSE contains `thinking` then `AskUserQuestion`
- [ ] Maintainer: reproduce #990 against `PROXY_UPSTREAM_URL=https://api.deepseek.com/anthropic` + `deepseek-v4-flash`