### PR TITLE
fix(proxy): 补全 bridge L1 会话前缀候选，修复 dsh/codex/workbuddy 检索 401

### DIFF
--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -138,9 +138,18 @@ function bindingToIdFields(
 function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   // handler 层存的 L1 key 形如 `${agentSource}:${sessionId}`; curl 拿到的
   // 通常是 bare sessionId。按候选前缀顺序探,命中即返回。
+  // ⚠️ 前缀列表必须覆盖 agent-adapters 的全部 agentSource;新增客户端时
+  // 同步更新此处与 skill-bridge.ts 的 loadSessionIdsL1（两处同构）。
   const candidates = sessionId.includes(":")
     ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
+    : [
+        sessionId,
+        `codebuddy:${sessionId}`,
+        `claude-code:${sessionId}`,
+        `codex:${sessionId}`,
+        `workbuddy:${sessionId}`,
+        `dsh:${sessionId}`,
+      ];
   for (const k of candidates) {
     const state = getSessionStore().get(k);
     if (state) {

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -292,9 +292,18 @@ function bindingToIdFields(
  * 恢复而不 401。
  */
 function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
+  // ⚠️ 前缀列表必须覆盖 agent-adapters 的全部 agentSource;新增客户端时
+  // 同步更新此处与 memory-bridge.ts 的 loadSessionIdsL1（两处同构）。
   const candidates = sessionId.includes(":")
     ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
+    : [
+        sessionId,
+        `codebuddy:${sessionId}`,
+        `claude-code:${sessionId}`,
+        `codex:${sessionId}`,
+        `workbuddy:${sessionId}`,
+        `dsh:${sessionId}`,
+      ];
   for (const k of candidates) {
     const s = getSessionStore().get(k);
     if (s) {


### PR DESCRIPTION
skill-bridge 与 memory-bridge 的 loadSessionIdsL1 按前缀轮询内存缓存， 候选列表只有 codebuddy/claude-code 两个旧客户端。dsh/codex/workbuddy 会话注册的 L1 key 形如 `<agentSource>:<sessionId>`，bridge 拿 bare sessionId 永远探不到；在未部署 redis/storage（L2 binding 不可用）的 场景下，这三类客户端的 skill/记忆检索恒 40101。

补全候选至 agent-adapters 全部 agentSource，并加维护注释：新增客户端
时需同步两处列表。

## Description | 描述
<!-- Describe what this PR does | 请描述这个 PR 做了什么 -->

## Related Issue | 关联 Issue
<!-- Example: Fix #123 | 例如：Fix #123 -->

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ] Verified locally | 本地验证通过
- [ ] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
<!-- Optional | 可选 -->