### PR TITLE
fix(memory-core): upsert L1 notes in atomic/update and honor recordIds lookup

### DIFF
--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -1789,7 +1789,7 @@ export class VectorStore implements IMemoryStore {
       return [];
     }
     try {
-      const { sessionKey, sessionId, taskId, updatedAfter } = filter ?? {};
+      const { sessionKey, sessionId, taskId, updatedAfter, recordIds } = filter ?? {};
 
       let raw: Record<string, unknown>[];
 
@@ -1827,6 +1827,10 @@ export class VectorStore implements IMemoryStore {
       if (filter?.userId !== undefined) rows = rows.filter((r) => r.user_id === filter.userId);
       if (filter?.agentId !== undefined) rows = rows.filter((r) => r.agent_id === filter.agentId);
       if (taskId !== undefined) rows = rows.filter((r) => r.task_id === taskId);
+      // Primary-key lookups (recordIds) are applied in memory as well, so that
+      // queries without session/time predicates — e.g. handleAtomicUpdate reading
+      // a note by id — return only the target row instead of an arbitrary one.
+      if (recordIds !== undefined && recordIds.length > 0) rows = rows.filter((r) => recordIds.includes(r.record_id));
 
       this.logger?.info(
         `${TAG} [L1-query] filter={sessionKey=${sessionKey ?? "(all)"}, sessionId=${sessionId ?? "(all)"}, teamId=${filter?.teamId ?? "(all)"}, userId=${filter?.userId ?? "(all)"}, agentId=${filter?.agentId ?? "(all)"}, taskId=${taskId ?? "(all)"}, updatedAfter=${updatedAfter ?? "(none)"}}, ` +

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -26,7 +26,7 @@ import type { IStateBackend } from "../core/state/types.js";
 import type { PipelineWorker } from "../services/pipeline-worker.js";
 import { executeMemorySearch } from "../core/tools/memory-search.js";
 import { executeConversationSearch } from "../core/tools/conversation-search.js";
-import type { MemoryRecord } from "../core/record/l1-writer.js";
+import type { MemoryRecord, MemoryType } from "../core/record/l1-writer.js";
 import { reportRecallMetrics } from "../core/report/metric-tracking-recall.js";
 
 // ── Zod schemas (validated types + defaults) ──
@@ -1049,20 +1049,67 @@ async function handleAtomicUpdate(body: unknown, _auth: V2AuthContext, requestId
   const store = deps.getStore();
   if (!store) return errorEnvelope(503, "Store not available", requestId);
 
-  // Read existing record by primary key
+  // Read existing record by primary key. When absent, fall back to creating a
+  // new L1 note (upsert semantics): atomic notes are otherwise only produced by
+  // the L0→L1 extraction pipeline, which leaves no entry point for bulk import
+  // or seeding of historical memory. The new note is scoped to the request
+  // isolation triple (team/user/agent) and starts at version v1. An optional
+  // `type` (episodic | instruction | persona) may be supplied in the body and
+  // defaults to episodic.
   const existing = await store.queryL1Records({ recordIds: [id] });
+  const now = new Date().toISOString();
+  const iso = deps.requestIsolation;
   if (!existing || existing.length === 0) {
-    return errorEnvelope(404, `Atomic note not found: ${id}`, requestId);
+    const rawBody = body as Record<string, unknown> | undefined;
+    const requestedType =
+      typeof rawBody?.type === "string" ? (rawBody.type as MemoryType) : "episodic";
+    const created: MemoryRecord = {
+      id,
+      content,
+      type: requestedType,
+      priority: 50,
+      scene_name: background ?? "",
+      source_message_ids: [],
+      metadata: {},
+      timestamps: [],
+      createdAt: now,
+      updatedAt: now,
+      version: 0,
+      sessionKey: "",
+      sessionId: iso?.sessionId ?? "",
+      taskId: iso?.taskId,
+      teamId: iso?.teamId,
+      userId: iso?.userId,
+      agentId: iso?.agentId,
+    };
+    const embedding = deps.getEmbedding();
+    let emb: Float32Array | undefined;
+    if (embedding) {
+      try {
+        emb = await embedding.embed(content);
+      } catch (e) {
+        console.warn(`[v2-router] L1 embedding failed:`, e);
+      }
+    }
+    await store.upsertL1(created, emb);
+    await recordAudit(store, {
+      record_id: id,
+      layer: "L1",
+      action: "create",
+      iso,
+      version: 0,
+      requestId,
+      logger: deps.logger,
+    });
+    return successEnvelope<AtomicUpdateData>({ id, version: "v1", updated_at: now }, requestId);
   }
 
-  const now = new Date().toISOString();
   const record = existing[0];
 
   // Build update: content is always overwritten; background (scene_name) only if provided.
   // user_id / agent_id are preserved from the existing row — updates don't
   // re-derive them. If the caller supplied an isolation triple that does NOT
   // match the existing row, we treat it as a permission denial.
-  const iso = deps.requestIsolation;
   if (iso?.userId && record.user_id && record.user_id !== iso.userId) {
     return errorEnvelope(403, `Atomic note ${id} belongs to a different user`, requestId);
   }


### PR DESCRIPTION
## Summary

Two related fixes in **MemoryCore** so that `/v3/atomic/update` works as an **upsert** and correctly resolves notes by primary key:

1. **`sqlite.ts` — `queryL1Records` now honors `filter.recordIds`**
   The SQLite backend ignored `recordIds`, falling back to a full-table read, so `existing[0]` was an arbitrary row instead of the requested note. On a multi-agent team this surfaced as `403 Atomic note ... belongs to a different agent` for any non-default agent. The TCVDB backend already honors `recordIds` (`documentIds`), so this aligns SQLite with TCVDB.

2. **`v2-router.ts` — `handleAtomicUpdate` falls back to creating the note**
   Previously a missing id returned `404 Atomic note not found`. L1 notes were only ever produced by the L0→L1 extraction pipeline, leaving no entry point to bulk-import or seed historical memory. Now, when the id does not exist, a new L1 note is created (upsert semantics), scoped to the request isolation triple (`team_id`/`user_id`/`agent_id`), starting at `version v1`, with an optional body `type` (`episodic` | `instruction` | `persona`) defaulting to `episodic`.

## Motivation

Migrating a legacy memory store into a fresh team required writing thousands of L1 notes across multiple agents — neither possible before (no create path, and writes to non-default agents were 403'd).

## Relation to #821

PR #821 fixes the `recordIds` lookup alone. This PR keeps the pair self-contained because the upsert path depends on correct primary-key lookup; the `recordIds` part can be dropped if #821 lands first.

## Change Type
- [x] Bug fix

## Verification
- `atomic/update` on a fresh id + non-default agent now returns `200 version v1` (previously 403/404); update of an existing note still bumps `version`.
- No other callers of `queryL1Records` / `handleAtomicUpdate` are affected (the filter addition is a superset of previous behavior for non-`recordIds` queries).
