### PR TITLE
feat(knowledge): add LocalSourceFetcher for local git repositories

### DIFF
--- a/MemoryKnowledge/src/source-fetcher/local-fetcher.ts
+++ b/MemoryKnowledge/src/source-fetcher/local-fetcher.ts
@@ -1,0 +1,57 @@
+/**
+ * LocalSourceFetcher — локальные git-репозитории (абсолютный путь или file://).
+ *
+ * Пилот-патч 2026-08-18 (см. types.ts: «LocalSourceFetcher / FtpSourceFetcher — 未来扩展»).
+ * Безопасность: путь обязан существовать и содержать .git — произвольные каталоги
+ * без git-истории не принимаются (клон идёт штатным `git clone <path>`, hooks не тянутся).
+ */
+
+import { existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { simpleGit } from "simple-git";
+import type { ISourceFetcher, FetchResult, SourceType } from "./types.js";
+
+export class LocalSourceFetcher implements ISourceFetcher {
+  readonly supportedType: SourceType = "local";
+
+  validate(sourceUrl: string): void {
+    const p = this.toPath(sourceUrl);
+    if (!existsSync(p)) {
+      throw new Error(`local repo path does not exist: ${p}`);
+    }
+    if (!existsSync(join(p, ".git"))) {
+      throw new Error(`not a git repository (no .git): ${p}`);
+    }
+  }
+
+  async fetch(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
+    this.validate(sourceUrl);
+    const src = this.toPath(sourceUrl);
+    // Для локального клона --depth игнорируется git'ом без file:// — клонируем полно.
+    const opts: Record<string, string | null> = {};
+    if (branch) opts["--branch"] = branch;
+    await simpleGit().clone(src, localPath, opts);
+    return { localPath, version: await this.headCommit(localPath), sourceType: "local" };
+  }
+
+  async sync(sourceUrl: string, branch: string, localPath: string): Promise<FetchResult> {
+    this.validate(sourceUrl);
+    const git = simpleGit(localPath);
+    await git.fetch("origin", branch);
+    await git.reset(["--hard", `origin/${branch}`]);
+    return { localPath, version: await this.headCommit(localPath), sourceType: "local" };
+  }
+
+  private toPath(sourceUrl: string): string {
+    return sourceUrl.startsWith("file://") ? new URL(sourceUrl).pathname : resolve(sourceUrl);
+  }
+
+  private async headCommit(localPath: string): Promise<string | null> {
+    try {
+      const hash = await simpleGit(localPath).revparse(["HEAD"]);
+      return hash.trim().slice(0, 12) || null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/MemoryKnowledge/src/source-fetcher/registry.ts
+++ b/MemoryKnowledge/src/source-fetcher/registry.ts
@@ -7,13 +7,14 @@
 
 import type { ISourceFetcher, SourceType } from "./types.js";
 import { GitSourceFetcher } from "./git-fetcher.js";
+import { LocalSourceFetcher } from "./local-fetcher.js";
 
 export class SourceFetcherRegistry {
   private readonly fetchers = new Map<SourceType, ISourceFetcher>();
 
   constructor() {
     this.register(new GitSourceFetcher());
-    // 未来：this.register(new LocalSourceFetcher());
+    this.register(new LocalSourceFetcher()); // пилот-патч 2026-08-18: локальные git-репо
     // 未来：this.register(new FtpSourceFetcher());
   }
 


### PR DESCRIPTION
## What

Implements the `LocalSourceFetcher` stub referenced in `source-fetcher/types.ts` and `registry.ts` (`// 未来：this.register(new LocalSourceFetcher())`). Code-graph `create` now accepts absolute paths and `file://` URLs pointing to local git repositories.

## Why

Teams whose repositories live only on the local machine (private monorepos, air-gapped setups, no public HTTPS remote) currently cannot use Code-Graph at all: `create` accepts the path, then the worker fails with `unsupported source type: local`.

## How

- `validate()` requires an existing directory that contains `.git` — arbitrary non-git directories are rejected.
- `fetch()` uses plain `git clone <path>` into the service-owned data dir (git does not copy hooks on clone).
- `sync()` fetches and hard-resets the service-owned clone to `origin/<branch>`; the source repository is never written to.

## Tested

- macOS (Intel), source run via tsx.
- Negative: non-git path → clear validate error; pre-patch behavior (`unsupported source type: local`) reproduced first.
- Positive: a local repo indexed end-to-end (79 files / 5,232 nodes / 23,681 edges); `callers`/`impact` answers verified against manually-read ground truth; service restart re-syncs the graph successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)