### PR TITLE
fix(gateway): search TDAI_DATA_DIR when resolving the config file

### DIFF
--- a/src/gateway/config.test.ts
+++ b/src/gateway/config.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadGatewayConfig } from "./config.js";
+
+/**
+ * Config-file resolution, focused on the `TDAI_DATA_DIR` search step:
+ * a config file stored next to the relocated data dir must be picked up
+ * (previously only CWD and the *default* data dir were searched, so the
+ * gateway silently ran on defaults whenever `TDAI_DATA_DIR` was set).
+ */
+describe("loadGatewayConfig config-file resolution", () => {
+  let dataDir: string;
+  let emptyCwd: string;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-data-"));
+    emptyCwd = fs.mkdtempSync(path.join(os.tmpdir(), "tdai-cwd-"));
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(emptyCwd);
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    vi.unstubAllEnvs();
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    fs.rmSync(emptyCwd, { recursive: true, force: true });
+  });
+
+  it("finds tdai-gateway.json inside TDAI_DATA_DIR", () => {
+    fs.writeFileSync(
+      path.join(dataDir, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 9999 } }),
+    );
+    vi.stubEnv("TDAI_DATA_DIR", dataDir);
+
+    const config = loadGatewayConfig();
+
+    expect(config.server.port).toBe(9999);
+    expect(config.data.baseDir).toBe(dataDir);
+  });
+
+  it("ignores the data-dir config when TDAI_DATA_DIR is not set", () => {
+    fs.writeFileSync(
+      path.join(dataDir, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 9999 } }),
+    );
+
+    const config = loadGatewayConfig();
+
+    expect(config.server.port).toBe(8420);
+  });
+
+  it("prefers a CWD config over the TDAI_DATA_DIR config", () => {
+    fs.writeFileSync(
+      path.join(emptyCwd, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 7777 } }),
+    );
+    fs.writeFileSync(
+      path.join(dataDir, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 9999 } }),
+    );
+    vi.stubEnv("TDAI_DATA_DIR", dataDir);
+
+    const config = loadGatewayConfig();
+
+    expect(config.server.port).toBe(7777);
+  });
+
+  it("prefers an explicit TDAI_GATEWAY_CONFIG over the TDAI_DATA_DIR config", () => {
+    const explicit = path.join(dataDir, "explicit.json");
+    fs.writeFileSync(explicit, JSON.stringify({ server: { port: 6666 } }));
+    fs.writeFileSync(
+      path.join(dataDir, "tdai-gateway.json"),
+      JSON.stringify({ server: { port: 9999 } }),
+    );
+    vi.stubEnv("TDAI_GATEWAY_CONFIG", explicit);
+    vi.stubEnv("TDAI_DATA_DIR", dataDir);
+
+    const config = loadGatewayConfig();
+
+    expect(config.server.port).toBe(6666);
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -78,8 +78,9 @@ export interface GatewayConfig {
  * Resolution order for config file:
  * 1. `TDAI_GATEWAY_CONFIG` env var (explicit path)
  * 2. `./tdai-gateway.yaml` or `./tdai-gateway.json` in CWD
- * 3. `<dataDir>/tdai-gateway.yaml` or `<dataDir>/tdai-gateway.json`
- * 4. Pure environment-variable config (no file)
+ * 3. `$TDAI_DATA_DIR/tdai-gateway.yaml` or `.json` (when `TDAI_DATA_DIR` is set)
+ * 4. `<default dataDir>/tdai-gateway.yaml` or `<default dataDir>/tdai-gateway.json`
+ * 5. Pure environment-variable config (no file)
  */
 export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
   let fileConfig: Record<string, unknown> = {};
@@ -177,7 +178,24 @@ function resolveConfigPath(): string | null {
     if (fs.existsSync(p)) return p;
   }
 
-  // 3. Default data dir
+  // 3. Explicit data dir. `TDAI_DATA_DIR` relocates the gateway's data storage
+  //    (see loadGatewayConfig), so a config file kept next to that data must be
+  //    found too — otherwise the gateway silently runs on defaults while its
+  //    data dir env var is honoured. Mirrors the `~/` expansion applied to
+  //    `data.baseDir`.
+  const explicitDataDir = env("TDAI_DATA_DIR");
+  if (explicitDataDir) {
+    const home = getEnv("HOME") ?? getEnv("USERPROFILE") ?? "/tmp";
+    const dir = explicitDataDir.startsWith("~/")
+      ? path.join(home, explicitDataDir.slice(2))
+      : explicitDataDir;
+    for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
+      const p = path.join(dir, name);
+      if (fs.existsSync(p)) return p;
+    }
+  }
+
+  // 4. Default data dir
   const dataDir = resolveDefaultDataDir();
   for (const name of ["tdai-gateway.yaml", "tdai-gateway.json"]) {
     const p = path.join(dataDir, name);


### PR DESCRIPTION
## Description | 描述

`resolveConfigPath()` searches `TDAI_GATEWAY_CONFIG`, the CWD, and the *default* data dir — but not the directory pointed to by `TDAI_DATA_DIR`. When that variable relocates the data storage, a `tdai-gateway.yaml`/`.json` kept next to the data is never found and the gateway silently runs on built-in defaults.

Observed on 1.0.1 (attach-to-Hermes setup, Linux container): `TDAI_DATA_DIR` was set and honored for data storage, the config file sat in that directory, yet the gateway kept `bm25.language: zh` — the first German record was tokenized with jieba and keyword recall returned score 0.000 until the gateway was restarted with an explicit `TDAI_GATEWAY_CONFIG`.

This PR inserts the `TDAI_DATA_DIR` location into the search order between CWD and the default data dir (mirroring the `~/` expansion used for `data.baseDir`), and updates the resolution-order doc comment.

## Related Issue | 关联 Issue

—

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 — `vitest run`: 71/71 passing, incl. 4 new cases in `src/gateway/config.test.ts` (found via `TDAI_DATA_DIR`; ignored when unset; CWD precedence; `TDAI_GATEWAY_CONFIG` precedence)
- [x] No existing features affected | 无影响现有功能 — the new step only runs when `TDAI_DATA_DIR` is set and only *adds* a search location; all existing steps and their order are unchanged

## Additional Notes | 其他说明

Found while evaluating the 1.0.1 npm package in a sandboxed Hermes 0.20.4 deployment; the bug is still present on `main`.