### PR TITLE
fix(metadata): handle asynchronous relation id collision retries in mongodb store

### DIFF
--- a/MemoryCore/src/metadata/store/mongodb-adapter.ts
+++ b/MemoryCore/src/metadata/store/mongodb-adapter.ts
@@ -19,7 +19,7 @@ import { mapTeamMemberWithProfile } from "./team-member-view.js";
 import { generateId, generateRelationId, ID_PREFIX } from "../utils/id-generator.js";
 import {
   isMongoRelationIdCollision,
-  runWithGeneratedRelationId,
+  runWithGeneratedRelationIdAsync,
   RELATION_ID_RETRY_LIMIT,
 } from "./relation-id-insert.js";
 import { generateUserKey } from "../utils/crypto.js";
@@ -680,7 +680,7 @@ export class MongoMetadataStore implements IMetadataStore {
   // ============================================================
   async addTeamMember(input: AddTeamMemberInput): Promise<TeamMemberEntity> {
     const now = nowIso();
-    await runWithGeneratedRelationId(input.id, isMongoRelationIdCollision, async (id) => {
+    await runWithGeneratedRelationIdAsync(input.id, isMongoRelationIdCollision, async (id) => {
       await this.col("meta_team_members").updateOne(
         { team_id: input.team_id, user_id: input.user_id },
         {
@@ -911,7 +911,7 @@ export class MongoMetadataStore implements IMetadataStore {
   // ============================================================
   async linkTaskAgent(taskId: string, agentId: string, roleInTask?: string): Promise<TaskAgentEntity> {
     const now = nowIso();
-    await runWithGeneratedRelationId(undefined, isMongoRelationIdCollision, async (id) => {
+    await runWithGeneratedRelationIdAsync(undefined, isMongoRelationIdCollision, async (id) => {
       await this.col("meta_task_agents").updateOne(
         { task_id: taskId, agent_id: agentId },
         {
@@ -1195,7 +1195,7 @@ export class MongoMetadataStore implements IMetadataStore {
   // ============================================================
   async grantAcl(input: GrantAclInput): Promise<AclEntity> {
     const now = nowIso();
-    await runWithGeneratedRelationId(input.id, isMongoRelationIdCollision, async (id) => {
+    await runWithGeneratedRelationIdAsync(input.id, isMongoRelationIdCollision, async (id) => {
       await this.col("meta_asset_acl").updateOne(
         { asset_id: input.asset_id, subject_type: input.subject_type, subject_id: input.subject_id, permission: input.permission },
         {

--- a/MemoryCore/src/metadata/store/relation-id-insert.test.ts
+++ b/MemoryCore/src/metadata/store/relation-id-insert.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  runWithGeneratedRelationId,
+  runWithGeneratedRelationIdAsync,
+  isMongoRelationIdCollision,
+  isSqliteRelationIdCollision,
+} from "./relation-id-insert.js";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe("relation-id-insert", () => {
+  it("detects SQLite unique collision errors correctly", () => {
+    const sqliteErr = new Error("UNIQUE constraint failed: meta_team_members.id");
+    expect(isSqliteRelationIdCollision(sqliteErr)).toBe(true);
+
+    const otherErr = new Error("UNIQUE constraint failed: meta_team_members.user_id");
+    expect(isSqliteRelationIdCollision(otherErr)).toBe(false);
+  });
+
+  it("detects MongoDB E11000 duplicate key collision errors on id", () => {
+    const mongoCollisionErr = { code: 11000, keyPattern: { id: 1 } };
+    expect(isMongoRelationIdCollision(mongoCollisionErr)).toBe(true);
+
+    const mongoOtherCollision = { code: 11000, keyPattern: { team_id: 1, user_id: 1 } };
+    expect(isMongoRelationIdCollision(mongoOtherCollision)).toBe(false);
+  });
+
+  it("runWithGeneratedRelationId retries synchronous collision and succeeds", () => {
+    let attempts = 0;
+    const generatedIds: string[] = [];
+    const result = runWithGeneratedRelationId(undefined, isSqliteRelationIdCollision, (id) => {
+      attempts++;
+      generatedIds.push(id);
+      if (attempts === 1) {
+        throw new Error("UNIQUE constraint failed: meta_team_members.id");
+      }
+      return `inserted-${id}`;
+    });
+
+    expect(attempts).toBe(2);
+    expect(generatedIds[0]).toMatch(UUID_REGEX);
+    expect(generatedIds[1]).toMatch(UUID_REGEX);
+    expect(generatedIds[0]).not.toBe(generatedIds[1]);
+    expect(result).toBe(`inserted-${generatedIds[1]}`);
+  });
+
+  it("runWithGeneratedRelationIdAsync retries asynchronous collision and succeeds", async () => {
+    let attempts = 0;
+    const generatedIds: string[] = [];
+    const result = await runWithGeneratedRelationIdAsync(undefined, isMongoRelationIdCollision, async (id) => {
+      attempts++;
+      generatedIds.push(id);
+      if (attempts === 1) {
+        throw { code: 11000, keyPattern: { id: 1 } };
+      }
+      return `inserted-async-${id}`;
+    });
+
+    expect(attempts).toBe(2);
+    expect(generatedIds[0]).toMatch(UUID_REGEX);
+    expect(generatedIds[1]).toMatch(UUID_REGEX);
+    expect(generatedIds[0]).not.toBe(generatedIds[1]);
+    expect(result).toBe(`inserted-async-${generatedIds[1]}`);
+  });
+
+  it("runWithGeneratedRelationIdAsync throws when retries exhausted", async () => {
+    let attempts = 0;
+    await expect(
+      runWithGeneratedRelationIdAsync(undefined, isMongoRelationIdCollision, async () => {
+        attempts++;
+        throw { code: 11000, keyPattern: { id: 1 } };
+      }),
+    ).rejects.toThrow("relation id collision after max retries");
+
+    expect(attempts).toBe(3);
+  });
+
+  it("runWithGeneratedRelationIdAsync does not retry when fixedId is provided", async () => {
+    let attempts = 0;
+    await expect(
+      runWithGeneratedRelationIdAsync("fixed-123", isMongoRelationIdCollision, async (id) => {
+        attempts++;
+        throw { code: 11000, keyPattern: { id: 1 } };
+      }),
+    ).rejects.toEqual({ code: 11000, keyPattern: { id: 1 } });
+
+    expect(attempts).toBe(1);
+  });
+});

--- a/MemoryCore/src/metadata/store/relation-id-insert.ts
+++ b/MemoryCore/src/metadata/store/relation-id-insert.ts
@@ -42,3 +42,29 @@ export function runWithGeneratedRelationId<T>(
   if (lastErr instanceof Error) throw lastErr;
   throw new Error("relation id collision after max retries");
 }
+
+/**
+ * 异步版本：使用自动生成的 relation id 执行插入；`fixedId` 已指定时不重试。
+ */
+export async function runWithGeneratedRelationIdAsync<T>(
+  fixedId: string | undefined,
+  isCollision: (err: unknown) => boolean,
+  insert: (id: string) => Promise<T>,
+): Promise<T> {
+  if (fixedId) return await insert(fixedId);
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < RELATION_ID_RETRY_LIMIT; attempt++) {
+    try {
+      return await insert(generateRelationId());
+    } catch (err) {
+      if (isCollision(err)) {
+        lastErr = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+  if (lastErr instanceof Error) throw lastErr;
+  throw new Error("relation id collision after max retries");
+}
+


### PR DESCRIPTION
## Description | 描述
In `MongoMetadataStore` (`addTeamMember`, `linkTaskAgent`, `grantAcl`), primary key ID collisions are meant to be automatically retried with a newly generated relation ID. However, because `runWithGeneratedRelationId` was synchronous, passing an asynchronous callback caused MongoDB E11000 duplicate key rejections to bypass the synchronous catch block and skip collision retry.

This PR introduces `runWithGeneratedRelationIdAsync` to properly await asynchronous insertion callbacks and catch MongoDB duplicate key collisions, enabling retry up to `RELATION_ID_RETRY_LIMIT` times.

## Related Issue | 关联 Issue
Fixes #1104

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 (Unit tests pass, 20x stress loop passed)
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
Added unit tests in `MemoryCore/src/metadata/store/relation-id-insert.test.ts` covering synchronous & asynchronous collision handling, max retry exhaustion, and `fixedId` behavior.
