### PR TITLE
fix(proxy): send ask_followup_question questions as array, not string

### DIFF
--- a/MemoryProxy/src/session/codebuddy/form.ts
+++ b/MemoryProxy/src/session/codebuddy/form.ts
@@ -99,9 +99,17 @@ export interface FormData {
   taskPage?: number;
 }
 
+/** A single question rendered by the CodeBuddy `ask_followup_question` form. */
+export interface FollowupQuestion {
+  id: string;
+  question: string;
+  options: string[];
+  multiSelect: boolean;
+}
+
 // ── Form Builder ───────────────────────────────────────────────────────────────
 
-function buildFollowupQuestionArgs(data: FormData): { title: string; questions: string } {
+function buildFollowupQuestionArgs(data: FormData): { title: string; questions: FollowupQuestion[] } {
   const { teams, stage, selectedTeamId, retry } = data;
 
   const title = retry
@@ -112,12 +120,7 @@ function buildFollowupQuestionArgs(data: FormData): { title: string; questions: 
         ? TEAM_FORM_TITLE
         : AGENT_TASK_FORM_TITLE;
 
-  const questions: Array<{
-    id: string;
-    question: string;
-    options: string[];
-    multiSelect: boolean;
-  }> = [];
+  const questions: FollowupQuestion[] = [];
 
   if (stage === "asset_confirm") {
     questions.push({
@@ -126,7 +129,7 @@ function buildFollowupQuestionArgs(data: FormData): { title: string; questions: 
       options: [ASSET_CONFIRM_YES, ASSET_CONFIRM_NO],
       multiSelect: false,
     });
-    return { title, questions: JSON.stringify(questions) };
+    return { title, questions };
   }
 
   if (stage === "team") {
@@ -138,7 +141,7 @@ function buildFollowupQuestionArgs(data: FormData): { title: string; questions: 
       ],
       multiSelect: false,
     });
-    return { title, questions: JSON.stringify(questions) };
+    return { title, questions };
   }
 
   // stage in { "agent_task" (CB one-shot), "agent_select" / "task_select"
@@ -146,7 +149,7 @@ function buildFollowupQuestionArgs(data: FormData): { title: string; questions: 
   // codex form.ts 重渲染，不会调 CB `buildFollowupQuestionArgs`。分支保留
   // 是防御性兜底，让 CB fallback render 也能出合法结构。
   const team = teams.find((t) => t.team_id === selectedTeamId) ?? teams[0];
-  if (!team) return { title, questions: JSON.stringify(questions) };
+  if (!team) return { title, questions };
 
   const wantAgent = stage === "agent_task" || stage === "agent_select";
   const wantTask = stage === "agent_task" || stage === "task_select";
@@ -183,7 +186,7 @@ function buildFollowupQuestionArgs(data: FormData): { title: string; questions: 
     }
   }
 
-  return { title, questions: JSON.stringify(questions) };
+  return { title, questions };
 }
 
 /**
@@ -221,7 +224,7 @@ function buildOpenAINonStreamingResponse(
   created: number,
   model: string,
   toolCallId: string,
-  args: { title: string; questions: string },
+  args: { title: string; questions: FollowupQuestion[] },
 ): Response {
   return new Response(JSON.stringify({
     id,
@@ -255,7 +258,7 @@ function buildOpenAIStreamingResponse(
   created: number,
   model: string,
   toolCallId: string,
-  args: { title: string; questions: string },
+  args: { title: string; questions: FollowupQuestion[] },
 ): Response {
   const encoder = new TextEncoder();
   const argsStr = JSON.stringify(args);
@@ -321,7 +324,7 @@ function buildAnthropicNonStreamingResponse(
   msgId: string,
   model: string,
   toolUseId: string,
-  args: { title: string; questions: string },
+  args: { title: string; questions: FollowupQuestion[] },
 ): Response {
   return new Response(JSON.stringify({
     id: msgId,
@@ -346,7 +349,7 @@ function buildAnthropicStreamingResponse(
   msgId: string,
   model: string,
   toolUseId: string,
-  args: { title: string; questions: string },
+  args: { title: string; questions: FollowupQuestion[] },
 ): Response {
   const encoder = new TextEncoder();
   const inputJson = JSON.stringify(args);


### PR DESCRIPTION
## Problem

Fixes #1101.

CodeBuddy's `ask_followup_question` tool schema requires the `questions` parameter to be an **array**. However `MemoryProxy/src/session/codebuddy/form.ts`'s `buildFollowupQuestionArgs()` wraps the question list with `JSON.stringify()`, producing:

```json
{"title":"...","questions":"[{\"id\":\"team\",...}]"}
```

Newer CodeBuddy clients reject this tool call with:

```
Error calling tool: Tool call arguments for ask_followup_question were invalid:
invalid argument type for questions, expected array, received string
```

As a result the session-init form never renders, the user cannot pick an agent/task, retries exhaust (`asset-confirm max retries, abandoning`), and the whole conversation bypasses the memory pipeline.

## Root cause

The only CodeBuddy form builder stringifies `questions`, while every other client form builder (`claude-code`, `codex`, `dsh`, `workbuddy`) already emits `questions` as a real array (e.g. `return { questions }` / `JSON.stringify({ questions })`).

## Fix

- Return the `questions` array directly from `buildFollowupQuestionArgs()`.
- Introduce a `FollowupQuestion` interface and type the downstream response builders (OpenAI/Anthropic, streaming and non-streaming) with `questions: FollowupQuestion[]` instead of `questions: string`.

## Verification

- `tsc --noEmit` — no new type errors in `src/session/codebuddy/` (remaining errors are pre-existing and unrelated).
- Runtime check via `buildFormResponse()` for OpenAI non-streaming / OpenAI streaming / Anthropic non-streaming: `questions` is now serialized as a JSON array in all three paths.

```json
{"title":"...","questions":[{"id":"team","question":"...","options":["OTA-Platform (h45wed8k)"],"multiSelect":false}]}
```