### PR TITLE
docs(deploy): remove stale Kubernetes manifest references

### DIFF
--- a/README.deployment.md
+++ b/README.deployment.md
@@ -537,7 +537,7 @@ export TDAI_MEMORY_SERVICE_ID="agent-customer-support"
 
 ### 示例 4：K8s 生产部署
 
-参考 `MemoryCore/deploy/k8s/tdai-memory.yaml`（Gateway + Redis Cluster）和 `MemoryCore/deploy/k8s/multi-hermes.yaml`（多 Hermes Agent 编排）。
+本仓库当前未提交可直接应用的 Kubernetes manifests；请使用本节的 Deployment、ConfigMap 和 Secret 示例作为配置模板，并按实际镜像、域名和集群环境调整。
 
 ---
 

--- a/README.docker.md
+++ b/README.docker.md
@@ -181,7 +181,7 @@ memory:                      # 记忆引擎调参
 
 ## K8s / TKE 部署
 
-参考 `MemoryCore/deploy/k8s/tdai-memory.yaml`，核心做法：
+本仓库当前未提交可直接应用的 Kubernetes manifests；下面列出 K8s/TKE 部署所需的核心配置做法：
 
 1. **ConfigMap** 挂载 `tdai-gateway.yaml` 到 `/app/config/`
 2. **Secret** 通过环境变量注入 `TDAI_LLM_API_KEY` + `REDIS_PASSWORD`
@@ -256,7 +256,6 @@ volumes:
 │   ├── tdai-gateway.standalone.yaml     # Standalone 配置模板
 │   ├── tdai-gateway.service.yaml        # Service 配置模板
 │   ├── tdai-gateway.real.yaml           # 本地测试配置 (连真实服务)
-│   ├── deploy/k8s/tdai-memory.yaml      # K8s/TKE 部署清单
 │   ├── scripts/mock-shark-server.ts     # Mock Shark (本地开发)
 │   └── src/gateway/server.ts            # 服务入口
 ```


### PR DESCRIPTION
## Summary

- Remove references to the missing `MemoryCore/deploy/k8s/tdai-memory.yaml` and `multi-hermes.yaml` files.
- Clarify that the current K8s/TKE sections are configuration templates, not committed manifests.
- Remove the same stale path from the documented repository tree.

## Why

Fixes #668. The referenced `MemoryCore/deploy/k8s/` directory is not present in this branch, so following the documentation leads to dead links and an unusable manifest path.

## Validation

- Searched the repository for `MemoryCore/deploy/k8s`, `tdai-memory.yaml`, and `multi-hermes.yaml`: no stale references remain.
- `git diff --check`
