### PR TITLE
fix(memory-core): drain L3 cascade during pipeline destroy

### DIFF
--- a/MemoryCore/src/utils/pipeline-manager.test.ts
+++ b/MemoryCore/src/utils/pipeline-manager.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryPipelineManager, type PipelineConfig } from "./pipeline-manager.js";
+
+const config: PipelineConfig = {
+  everyNConversations: 1,
+  enableWarmup: false,
+  l1: { idleTimeoutSeconds: 60 },
+  l2: {
+    delayAfterL1Seconds: 60,
+    minIntervalSeconds: 60,
+    maxIntervalSeconds: 3600,
+    sessionActiveWindowHours: 24,
+  },
+};
+
+describe("MemoryPipelineManager", () => {
+  it("drains the L3 cascade produced by a flushed L2 task", async () => {
+    const l2Runs = vi.fn();
+    const l3Runs = vi.fn();
+    let releaseL3!: () => void;
+    const l3Finished = new Promise<void>((resolve) => {
+      releaseL3 = resolve;
+    });
+    const manager = new MemoryPipelineManager(config);
+
+    manager.setL1Runner(async () => ({ processedCount: 1 }));
+    manager.setL2Runner(async () => {
+      l2Runs();
+      return { latestCursor: "2026-08-19T00:00:00.000Z" };
+    });
+    manager.setL3Runner(async () => {
+      l3Runs();
+      await l3Finished;
+    });
+
+    await manager.notifyConversation("session-1", [{
+      role: "user",
+      content: "A captured message",
+      timestamp: "2026-08-19T00:00:00.000Z",
+    }]);
+
+    await vi.waitFor(() => {
+      expect(manager.getSessionState("session-1")?.l2_pending_l1_count).toBe(1);
+    });
+    expect(l2Runs).not.toHaveBeenCalled();
+    expect(l3Runs).not.toHaveBeenCalled();
+
+    let destroyFinished = false;
+    const destroyPromise = manager.destroy().then(() => {
+      destroyFinished = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(l3Runs).toHaveBeenCalledTimes(1);
+    });
+    expect(destroyFinished).toBe(false);
+
+    releaseL3();
+    await destroyPromise;
+
+    expect(l2Runs).toHaveBeenCalledTimes(1);
+    expect(l3Runs).toHaveBeenCalledTimes(1);
+    expect(manager.getQueueSizes()).toMatchObject({
+      l1Idle: true,
+      l2Idle: true,
+      l3Idle: true,
+    });
+  });
+});

--- a/MemoryCore/src/utils/pipeline-manager.ts
+++ b/MemoryCore/src/utils/pipeline-manager.ts
@@ -251,6 +251,8 @@ export class MemoryPipelineManager {
 
   // Lifecycle
   private destroyed = false;
+  /** True while destroy() is draining work that it has already accepted. */
+  private flushing = false;
 
   /** Plugin instance ID for metric reporting (set externally after async init). */
   instanceId?: string;
@@ -531,6 +533,7 @@ export class MemoryPipelineManager {
   async destroy(): Promise<void> {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.flushing = true;
 
     this.logger?.info(
       `${TAG} Destroying pipeline (timeout=${this.DESTROY_TIMEOUT_MS}ms)...`,
@@ -545,9 +548,12 @@ export class MemoryPipelineManager {
         }),
       ]).finally(() => {
         if (timeoutId !== undefined) clearTimeout(timeoutId);
+        // Do not accept new cascade work after a successful drain or timeout.
+        this.flushing = false;
       });
       this.logger?.info(`${TAG} Pipeline flushed successfully`);
     } catch (err) {
+      this.flushing = false;
       this.logger?.warn(
         `${TAG} Pipeline flush timed out or failed: ${err instanceof Error ? err.message : String(err)}. ` +
         `Pending work will be recovered on next startup.`,
@@ -597,12 +603,12 @@ export class MemoryPipelineManager {
       }
     }
 
-    // Step 4: Wait for all remaining queues to drain
+    // Step 4: Wait for all remaining queues to drain. L2 can enqueue its L3
+    // cascade before becoming idle, so observe the dependency order rather
+    // than checking both queues concurrently.
     this.logger?.debug?.(`${TAG} Waiting for queues to drain (l2=${this.l2Queue.size}, l3=${this.l3Queue.size})`);
-    await Promise.all([
-      this.l2Queue.onIdle(),
-      this.l3Queue.onIdle(),
-    ]);
+    await this.l2Queue.onIdle();
+    await this.l3Queue.onIdle();
   }
 
   // ============================
@@ -986,7 +992,10 @@ export class MemoryPipelineManager {
   // ============================
 
   private triggerL3(): void {
-    if (this.destroyed) return;
+    // destroy() marks the manager as destroyed before draining timers. Allow
+    // L2 work already accepted by that drain to enqueue its required L3
+    // cascade, but reject any cascade that arrives after the drain ends.
+    if (this.destroyed && !this.flushing) return;
 
     if (this.l3Running) {
       // L3 is in progress — mark pending so it runs again after current finishes
@@ -1015,7 +1024,7 @@ export class MemoryPipelineManager {
       this.l3Running = false;
 
       // If new L2 completions happened while L3 was running, run again
-      if (this.l3Pending && !this.destroyed) {
+      if (this.l3Pending && (!this.destroyed || this.flushing)) {
         this.logger?.debug?.(`${TAG} L3 has pending work, re-running`);
         this.enqueueL3();
       }


### PR DESCRIPTION
## Summary

- Keep the destroy-time drain window open long enough for an already-accepted L2 task to enqueue its L3 persona cascade.
- Drain the L2 queue before checking L3 idle, so an L3 task created by L2 cannot be missed by `destroy()`.
- Add a regression test that holds L3 open and verifies `destroy()` waits for it to finish.

## Root cause

`destroy()` marks the pipeline as destroyed before flushing pending L2 timers. The L2 task still runs, but `triggerL3()` immediately returns because of the destroyed guard. In addition, `_doFlush()` checked L2 and L3 idle concurrently; an idle L3 check could resolve before L2 enqueued its cascade.

Fixes #1049.

## Validation

- Focused Vitest: `vitest run src/utils/pipeline-manager.test.ts` — 1/1 passed.
- Focused TypeScript check with strict mode — passed.
- `git diff --check` — passed.
