### PR TITLE
fix(proxy): surface failed L0 writes to retry wrapper

### DIFF
--- a/MemoryProxy/src/tdai/__tests__/client.test.ts
+++ b/MemoryProxy/src/tdai/__tests__/client.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TdaiClient } from "../client.js";
+import { withL0Retry } from "../pending-writes.js";
+import type { TdaiIdentity, TdaiMemoryConfig } from "../types.js";
+
+const config: TdaiMemoryConfig = {
+  enabled: true,
+  endpoint: "http://memory-core.test",
+  apiKey: "test-key",
+  serviceId: "test-service",
+  writeL0: true,
+  recallL1: false,
+  injectL2L3: false,
+  l1Limit: 5,
+  l2Limit: 3,
+  timeoutMs: 1_000,
+};
+
+const identity: TdaiIdentity = {
+  teamId: "team-1",
+  userId: "user-1",
+  agentId: "agent-1",
+  sessionId: "session-1",
+};
+
+const messages = [{ role: "user" as const, content: "hello" }];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("TdaiClient L0 writes", () => {
+  it("rejects HTTP failures so retryable 503 responses are retried", async () => {
+    const fetchMock = vi.fn(async () => new Response("temporarily unavailable", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new TdaiClient(config);
+    await expect(
+      withL0Retry(() => client.addConversation(identity, messages), { attempts: 3, baseMs: 0 }),
+    ).rejects.toThrow("HTTP 503");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-retryable HTTP failures", async () => {
+    const fetchMock = vi.fn(async () => new Response("bad request", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new TdaiClient(config);
+    await expect(
+      withL0Retry(() => client.addConversation(identity, messages), { attempts: 3, baseMs: 0 }),
+    ).rejects.toThrow("HTTP 400");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-zero gateway envelopes without retrying them", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ code: 40003, message: "invalid request" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new TdaiClient(config);
+    await expect(
+      withL0Retry(() => client.addConversation(identity, messages), { attempts: 3, baseMs: 0 }),
+    ).rejects.toThrow("envelope code=40003");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/MemoryProxy/src/tdai/client.ts
+++ b/MemoryProxy/src/tdai/client.ts
@@ -16,6 +16,21 @@ interface TdaiEnvelope<T = unknown> {
   data?: T;
 }
 
+export class TdaiRequestError extends Error {
+  readonly status?: number;
+  readonly retryable?: boolean;
+
+  constructor(
+    message: string,
+    options: { status?: number; retryable?: boolean } = {},
+  ) {
+    super(message);
+    this.name = "TdaiRequestError";
+    this.status = options.status;
+    this.retryable = options.retryable;
+  }
+}
+
 const TDAI_MESSAGE_CONTENT_MAX_CHARS = 8192;
 const TDAI_CONVERSATION_MAX_MESSAGES = 100;
 
@@ -118,7 +133,7 @@ export class TdaiClient {
         },
         identity.sessionId,
         identity.taskId,
-        { includeSession: true, includeTask: true },
+        { includeSession: true, includeTask: true, failOnError: true },
       );
     }
   }
@@ -267,7 +282,10 @@ export class TdaiClient {
     body: Record<string, unknown>,
     sessionId: string,
     taskId: string | undefined,
-    options: { includeSession: boolean; includeTask: boolean } = { includeSession: true, includeTask: true },
+    options: { includeSession: boolean; includeTask: boolean; failOnError?: boolean } = {
+      includeSession: true,
+      includeTask: true,
+    },
   ): Promise<T> {
     const base = this.config.endpoint.replace(/\/$/, "");
     const controller = new AbortController();
@@ -290,11 +308,37 @@ export class TdaiClient {
         headers,
         body: JSON.stringify(stripUndefined(body)),
       });
-      if (!res.ok) return {} as T;
-      const envelope = await res.json() as TdaiEnvelope<T>;
-      if (typeof envelope.code === "number" && envelope.code !== 0) return {} as T;
+      if (!res.ok) {
+        if (!options.failOnError) return {} as T;
+        const detail = await res.text().catch(() => "");
+        throw new TdaiRequestError(
+          `tdai POST ${path} failed: HTTP ${res.status}: ${detail.slice(0, 200)}`,
+          { status: res.status },
+        );
+      }
+
+      let envelope: TdaiEnvelope<T>;
+      try {
+        envelope = await res.json() as TdaiEnvelope<T>;
+      } catch (err) {
+        if (!options.failOnError) return {} as T;
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new TdaiRequestError(
+          `tdai POST ${path} returned invalid JSON: ${detail}`,
+          { retryable: false },
+        );
+      }
+
+      if (typeof envelope.code === "number" && envelope.code !== 0) {
+        if (!options.failOnError) return {} as T;
+        throw new TdaiRequestError(
+          `tdai POST ${path} failed: envelope code=${envelope.code} message=${envelope.message ?? ""}`,
+          { retryable: false },
+        );
+      }
       return (envelope.data ?? {}) as T;
-    } catch {
+    } catch (err) {
+      if (options.failOnError) throw err;
       return {} as T;
     } finally {
       clearTimeout(timer);
@@ -305,6 +349,7 @@ export class TdaiClient {
   //
   // 与 memory 数据面调用（postForCtx）**语义相反**：
   //   - postForCtx 网络/HTTP/envelope 错都吞掉返回空 —— 让注入路径静默降级
+  //   - addConversation opts into failOnError so the L0 retry wrapper can observe failures
   //   - checkAcl 网络/HTTP/envelope 错要抛出 —— 让上层 fail-closed 拒绝注入
   //     并打 error 日志（否则 acl 服务挂了会静默变成"全部允许"，越权）
   //

--- a/MemoryProxy/src/tdai/pending-writes.ts
+++ b/MemoryProxy/src/tdai/pending-writes.ts
@@ -98,6 +98,11 @@ export async function withL0Retry<T>(
  */
 function isRetryable(err: unknown): boolean {
   if (!err) return false;
+  const metadata = err as { retryable?: unknown; status?: unknown };
+  if (typeof metadata.retryable === "boolean") return metadata.retryable;
+  if (typeof metadata.status === "number") {
+    return metadata.status >= 500 || metadata.status === 408 || metadata.status === 429;
+  }
   const msg = err instanceof Error ? err.message : String(err);
   // 网络类：AbortError / ENOTFOUND / ECONNRESET / ETIMEDOUT / fetch failed
   if (/abort|econnreset|enotfound|etimedout|fetch failed|network|timeout/i.test(msg)) return true;


### PR DESCRIPTION
Fixes #1089.

## Summary

- Make the L0 `/v3/conversation/add` path reject HTTP failures, invalid JSON, and non-zero gateway envelopes instead of returning an empty success object.
- Preserve the existing fail-soft behavior for read/recall calls.
- Carry HTTP status and explicit retry metadata into `withL0Retry`, so 5xx/408/429 and network failures retry while 4xx and business-envelope failures stop immediately.
- Add regression tests for 503 retry, 400 no-retry, and non-zero envelope no-retry behavior.

## Validation

- `npm exec vitest run src/tdai/__tests__/client.test.ts` — 3 passed.
- Strict targeted TypeScript compile for the changed client/retry/test files — passed.
- `git diff --check` — passed.
