### PR TITLE
fix(proxy): add OpenAI-compatible model discovery

### DIFF
--- a/MemoryProxy/README.md
+++ b/MemoryProxy/README.md
@@ -196,6 +196,7 @@ Anthropic Messages client:
 | `POST` | `/v3/instance/proxy-destroy` | ops endpoint: clear COS cache on instance destroy |
 | `GET/PUT/DELETE` | `/v3/admin/rate-limits` | query / modify per-instance × model TPM/QPM |
 | `GET`  | `/health` | runtime health check (includes `storage.effective`) |
+| `GET`  | `/models`, `/v1/models`, `/<agent>/<spaceId>/models` | OpenAI-compatible model discovery from `creditPricing.models` |
 | `GET`  | `/whoami` | API Key → keyId (plain text, handy with curl) |
 
 ## Configuration

--- a/MemoryProxy/README_CN.md
+++ b/MemoryProxy/README_CN.md
@@ -196,6 +196,7 @@ Anthropic Messages 客户端：
 | `POST` | `/v3/instance/proxy-destroy` | 运维口：实例销毁时清 COS 缓存 |
 | `GET/PUT/DELETE` | `/v3/admin/rate-limits` | 查询 / 修改实例 × 模型 TPM/QPM |
 | `GET`  | `/health` | 运行时健康检查（含 `storage.effective`） |
+| `GET`  | `/models`、`/v1/models`、`/<agent>/<spaceId>/models` | 根据 `creditPricing.models` 返回 OpenAI 兼容模型列表 |
 | `GET`  | `/whoami` | API Key → keyId（纯文本，便于 curl） |
 
 ## 配置说明

--- a/MemoryProxy/src/__tests__/server-models.test.ts
+++ b/MemoryProxy/src/__tests__/server-models.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../config.js";
+import { createApp } from "../server.js";
+
+describe("OpenAI-compatible model discovery", () => {
+  it("serves public model aliases at the agent-scoped base URL", async () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      creditPricing: {
+        models: [
+          {
+            name: "internal-gpt-id",
+            modelName: "GPT Public",
+            input: 1,
+            output: 1,
+            cacheRead: 1,
+            cacheWrite5m: 1,
+            cacheWrite1h: 1,
+          },
+          {
+            name: "fallback-model",
+            input: 1,
+            output: 1,
+            cacheRead: 1,
+            cacheWrite5m: 1,
+            cacheWrite1h: 1,
+          },
+        ],
+      },
+    };
+
+    const app = createApp(config);
+    const response = await app.request("/hermes/default/v1/models");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      object: "list",
+      data: [
+        { id: "GPT Public", object: "model", owned_by: "memorydb" },
+        { id: "fallback-model", object: "model", owned_by: "memorydb" },
+      ],
+    });
+  });
+
+  it("returns an empty list when no pricing table is configured", async () => {
+    const app = createApp(DEFAULT_CONFIG);
+    const response = await app.request("/models");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ object: "list", data: [] });
+  });
+});

--- a/MemoryProxy/src/server.ts
+++ b/MemoryProxy/src/server.ts
@@ -1,6 +1,6 @@
 /** Hono app factory — registers all routes. */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { handleChatCompletions } from "./handler.js";
 import { handleAnthropicMessages } from "./anthropicHandler.js";
 import { handleAuxiliaryEndpoint } from "./auxiliaryHandler.js";
@@ -15,6 +15,19 @@ import { hasAnalyseMarker, hasCostGuardMarker } from "./routes/whitelist.js";
 import { tryActivateStorage, tryActivateRedis } from "./injection/index.js";
 import { getEffectiveBackend } from "./storage/factory.js";
 import type { ProxyConfig } from "./types.js";
+
+function createModelListResponse(config: ProxyConfig) {
+  const seen = new Set<string>();
+  const data = (config.creditPricing?.models ?? []).flatMap((entry) => {
+    // The public request path accepts modelName when a pricing table is
+    // configured, so expose that alias instead of leaking the upstream ID.
+    const id = entry.modelName?.trim() || entry.name.trim();
+    if (!id || seen.has(id)) return [];
+    seen.add(id);
+    return [{ id, object: "model", owned_by: "memorydb" }];
+  });
+  return { object: "list", data };
+}
 
 export function createApp(config: ProxyConfig): Hono {
   const app = new Hono();
@@ -102,6 +115,15 @@ export function createApp(config: ProxyConfig): Hono {
     };
     return c.json(body, degraded ? 503 : 200);
   });
+
+  // OpenAI-compatible model discovery. Hermes and other clients probe both
+  // `<base>/models` and `<base>/v1/models`; support the same shapes for the
+  // agent/space base URL used by the proxy's chat routes.
+  const modelListHandler = (c: Context) => c.json(createModelListResponse(config));
+  app.get("/models", modelListHandler);
+  app.get("/v1/models", modelListHandler);
+  app.get("/:agent/:spaceId/models", modelListHandler);
+  app.get("/:agent/:spaceId/v1/models", modelListHandler);
 
   // Whoami: resolve API key → key ID (plain text, easy to use with curl)
   app.get("/whoami", (c) => {


### PR DESCRIPTION
Addresses #1098.

## Summary

- Add OpenAI-compatible `GET /models` and `GET /v1/models` endpoints.
- Add the same model-listing paths under `/<agent>/<spaceId>/`, which covers Hermes custom-provider probes such as `/hermes/default/models`.
- Expose the configured public `modelName` alias when present, fall back to the configured model ID, and return an empty list when no pricing table is configured.
- Document the endpoint in both MemoryProxy READMEs.

## Validation

- `npm exec vitest run src/__tests__/server-models.test.ts` — 2 passed.
- `git diff --check` — passed.
- The package-wide `npm run typecheck` still reports existing errors in unrelated files (`anthropicHandler.ts`, `codexHandler.ts`, `config.ts`, and the cost-guard alias); it is not reported as a pass here.
