### PR TITLE
fix(gateway): accept Hermes LLM environment aliases

### DIFF
--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/README.md
@@ -231,14 +231,19 @@ eliminates a silent no-op.
 
 ### Gateway LLM (consumed by the Node sidecar, not by this provider)
 
+The Gateway accepts the canonical `TDAI_LLM_*` variables and the
+`MEMORY_TENCENTDB_LLM_*` names used by this Hermes provider. If both are set,
+the canonical `TDAI_LLM_*` value takes precedence.
+
 | Variable                          | Default                      | Description                         |
 |-----------------------------------|------------------------------|-------------------------------------|
 | `MEMORY_TENCENTDB_LLM_API_KEY`    | —                            | LLM API key (required for L1/L2/L3) |
 | `MEMORY_TENCENTDB_LLM_BASE_URL`   | `https://api.openai.com/v1`  | OpenAI-compatible API base URL      |
 | `MEMORY_TENCENTDB_LLM_MODEL`      | `gpt-4o`                     | Model name                          |
 
-> ⚠️ Only `MEMORY_TENCENTDB_*` env vars are honored by this provider for the
-> Gateway location and LLM credentials. Data-directory resolution is
+> ⚠️ The Hermes provider uses `MEMORY_TENCENTDB_*` env vars for its own Gateway
+> location and LLM settings. The child Gateway also accepts the canonical
+> `TDAI_LLM_*` aliases. Data-directory resolution is
 > deliberately delegated to the Gateway via `TDAI_DATA_DIR` (see above) so
 > the provider and the Gateway can never disagree about where L0~L3 live.
 

--- a/MemoryCore/src/gateway/config.test.ts
+++ b/MemoryCore/src/gateway/config.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadGatewayConfig } from "./config.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Gateway LLM environment compatibility", () => {
+  it("accepts the Hermes MEMORY_TENCENTDB_LLM_* names", () => {
+    vi.stubEnv("TDAI_LLM_API_KEY", "");
+    vi.stubEnv("TDAI_LLM_BASE_URL", "");
+    vi.stubEnv("TDAI_LLM_MODEL", "");
+    vi.stubEnv("MEMORY_TENCENTDB_LLM_API_KEY", "hermes-key");
+    vi.stubEnv("MEMORY_TENCENTDB_LLM_BASE_URL", "https://hermes.example/v1");
+    vi.stubEnv("MEMORY_TENCENTDB_LLM_MODEL", "hermes-model");
+
+    const config = loadGatewayConfig();
+
+    expect(config.llm.apiKey).toBe("hermes-key");
+    expect(config.llm.baseUrl).toBe("https://hermes.example/v1");
+    expect(config.llm.model).toBe("hermes-model");
+  });
+
+  it("prefers canonical TDAI_LLM_* values when both names are set", () => {
+    vi.stubEnv("TDAI_LLM_API_KEY", "tdai-key");
+    vi.stubEnv("TDAI_LLM_BASE_URL", "https://tdai.example/v1");
+    vi.stubEnv("TDAI_LLM_MODEL", "tdai-model");
+    vi.stubEnv("MEMORY_TENCENTDB_LLM_API_KEY", "hermes-key");
+    vi.stubEnv("MEMORY_TENCENTDB_LLM_BASE_URL", "https://hermes.example/v1");
+    vi.stubEnv("MEMORY_TENCENTDB_LLM_MODEL", "hermes-model");
+
+    const config = loadGatewayConfig();
+
+    expect(config.llm.apiKey).toBe("tdai-key");
+    expect(config.llm.baseUrl).toBe("https://tdai.example/v1");
+    expect(config.llm.model).toBe("tdai-model");
+  });
+});

--- a/MemoryCore/src/gateway/config.ts
+++ b/MemoryCore/src/gateway/config.ts
@@ -444,15 +444,26 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   //             见 src/gateway/llm-resolver.ts 的 resolveEffectiveLlmConfig。
   const llmConfig = obj(fileConfig, "llm");
   const llmProxyConfig = obj(llmConfig, "proxy");
-  const rawLlmProvider = env("TDAI_LLM_PROVIDER") ?? str(llmConfig, "provider");
+  // Hermes historically exposed MEMORY_TENCENTDB_LLM_* variables while the
+  // standalone Gateway used TDAI_LLM_*. Accept both names so the provider's
+  // child Gateway receives the credentials documented for its installation.
+  // The canonical TDAI_* variables win when both are present.
+  const rawLlmProvider =
+    env("TDAI_LLM_PROVIDER") ?? env("MEMORY_TENCENTDB_LLM_PROVIDER") ?? str(llmConfig, "provider");
   const llmProvider: "openai" | "proxy" =
     rawLlmProvider === "proxy" ? "proxy" : "openai";
   const llm: StandaloneLLMConfig = {
-    baseUrl: env("TDAI_LLM_BASE_URL") ?? str(llmConfig, "baseUrl") ?? "https://api.openai.com/v1",
-    apiKey: env("TDAI_LLM_API_KEY") ?? str(llmConfig, "apiKey") ?? "",
-    model: env("TDAI_LLM_MODEL") ?? str(llmConfig, "model") ?? "gpt-4o",
-    maxTokens: envInt("TDAI_LLM_MAX_TOKENS") ?? num(llmConfig, "maxTokens") ?? 4096,
-    timeoutMs: envInt("TDAI_LLM_TIMEOUT_MS") ?? num(llmConfig, "timeoutMs") ?? 120_000,
+    baseUrl:
+      env("TDAI_LLM_BASE_URL") ?? env("MEMORY_TENCENTDB_LLM_BASE_URL") ??
+      str(llmConfig, "baseUrl") ?? "https://api.openai.com/v1",
+    apiKey: env("TDAI_LLM_API_KEY") ?? env("MEMORY_TENCENTDB_LLM_API_KEY") ?? str(llmConfig, "apiKey") ?? "",
+    model: env("TDAI_LLM_MODEL") ?? env("MEMORY_TENCENTDB_LLM_MODEL") ?? str(llmConfig, "model") ?? "gpt-4o",
+    maxTokens:
+      envInt("TDAI_LLM_MAX_TOKENS") ?? envInt("MEMORY_TENCENTDB_LLM_MAX_TOKENS") ??
+      num(llmConfig, "maxTokens") ?? 4096,
+    timeoutMs:
+      envInt("TDAI_LLM_TIMEOUT_MS") ?? envInt("MEMORY_TENCENTDB_LLM_TIMEOUT_MS") ??
+      num(llmConfig, "timeoutMs") ?? 120_000,
     provider: llmProvider,
     proxy: {
       useMemorySystemUserKey: bool(llmProxyConfig, "useMemorySystemUserKey") ?? true,


### PR DESCRIPTION
Partially addresses #1096, focusing on the Hermes/Gateway LLM environment-variable mismatch.

## Summary

- Accept `MEMORY_TENCENTDB_LLM_*` aliases in the Node Gateway alongside canonical `TDAI_LLM_*` variables.
- Keep `TDAI_LLM_*` precedence when both names are present.
- Cover provider, endpoint, model, max-token, and timeout aliases in the config path.
- Clarify the compatibility contract in the Hermes provider README.

## Validation

- `npm exec vitest run src/gateway/config.test.ts` — 2 passed.
- `git diff --check` — passed.
- A targeted TypeScript compile also reports pre-existing repository errors in unrelated AI SDK/observability files and the existing `instanceId` typing; it is not reported as a pass here.
