### PR TITLE
fix(memory-core): track persona counters per profile scope

### DIFF
--- a/MemoryCore/src/utils/checkpoint.test.ts
+++ b/MemoryCore/src/utils/checkpoint.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CheckpointManager } from "./checkpoint.js";
+
+describe("CheckpointManager persona counters", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("increments the persona counter without requiring a global L1 cursor", async () => {
+    const dataDir = await mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+    tempDirs.push(dataDir);
+    const logger = { info: vi.fn() };
+    const checkpoint = new CheckpointManager(dataDir, logger);
+
+    await checkpoint.incrementMemoriesSinceLastPersona(3);
+
+    await expect(checkpoint.read()).resolves.toMatchObject({
+      memories_since_last_persona: 3,
+      total_memories_extracted: 0,
+    });
+  });
+
+  it("can update the L1 cursor while leaving the global persona counter untouched", async () => {
+    const dataDir = await mkdtemp(path.join(os.tmpdir(), "tdai-checkpoint-"));
+    tempDirs.push(dataDir);
+    const checkpoint = new CheckpointManager(dataDir, { info: vi.fn() });
+
+    await checkpoint.markL1ExtractionComplete(
+      "session-1",
+      4,
+      123,
+      undefined,
+      { countForPersona: false },
+    );
+
+    await expect(checkpoint.read()).resolves.toMatchObject({
+      memories_since_last_persona: 0,
+      total_memories_extracted: 4,
+      runner_states: { "session-1": { last_l1_cursor: 123 } },
+    });
+  });
+});

--- a/MemoryCore/src/utils/checkpoint.ts
+++ b/MemoryCore/src/utils/checkpoint.ts
@@ -618,6 +618,7 @@ export class CheckpointManager {
     memoriesExtracted: number,
     cursorRecordedAtMs?: number,
     lastSceneName?: string,
+    options?: { countForPersona?: boolean },
   ): Promise<void> {
     let regressed = false;
     await this.mutate((cp) => {
@@ -639,7 +640,9 @@ export class CheckpointManager {
         state.last_scene_name = lastSceneName;
       }
       cp.total_memories_extracted += memoriesExtracted;
-      cp.memories_since_last_persona += memoriesExtracted;
+      if (options?.countForPersona !== false) {
+        cp.memories_since_last_persona += memoriesExtracted;
+      }
     });
     if (regressed) {
       this.logger.warn?.(
@@ -652,6 +655,23 @@ export class CheckpointManager {
       `[checkpoint] markL1ExtractionComplete session=${sessionKey}: ` +
       `extracted=${memoriesExtracted}, cursor=${cursorRecordedAtMs ?? "(unchanged)"}, ` +
       `lastScene="${lastSceneName ?? "(unchanged)"}"`,
+    );
+  }
+
+  /**
+   * Add newly extracted L1 memories to the profile-scoped persona counter.
+   *
+   * L1's cursor is session-scoped, while the L3 trigger is profile-scoped.
+   * Keeping this increment separate prevents a global checkpoint from being
+   * mistaken for the team+agent profile checkpoint during threshold checks.
+   */
+  async incrementMemoriesSinceLastPersona(memoriesExtracted: number): Promise<void> {
+    if (!Number.isFinite(memoriesExtracted) || memoriesExtracted <= 0) return;
+    await this.mutate((cp) => {
+      cp.memories_since_last_persona += memoriesExtracted;
+    });
+    this.logger.info(
+      `[checkpoint] incrementMemoriesSinceLastPersona extracted=${memoriesExtracted}`,
     );
   }
 

--- a/MemoryCore/src/utils/pipeline-factory.ts
+++ b/MemoryCore/src/utils/pipeline-factory.ts
@@ -636,6 +636,22 @@ export function createL1Runner(opts: {
             agentId: group.agentId,
             sessionId: group.sessionId,
           }));
+
+          // PersonaTrigger reads the team+agent profile checkpoint. The L1
+          // cursor checkpoint above is global/session-scoped, so mirror only
+          // the persona counter into the same scoped directory L3 will read.
+          const profileScope = buildIsolationScope({
+            teamId: group.teamId,
+            userId: group.userId,
+            agentId: group.agentId,
+          });
+          const profileCheckpoint = new CheckpointManager(
+            scopedDataDirForScope(pluginDataDir, profileScope),
+            logger,
+            scopedStorageForScope(storage, profileScope),
+            checkpointLock,
+          );
+          await profileCheckpoint.incrementMemoriesSinceLastPersona(l1Result.storedCount);
         }
         if (l1Result.lastSceneName) {
           lastSceneName = l1Result.lastSceneName;
@@ -645,7 +661,13 @@ export function createL1Runner(opts: {
       // Use maxRecordedAtMs (write time) of the **processed** slice as cursor —
       // always positive, TCVDB-safe. Boundary alignment guarantees we will not
       // skip same-ms siblings on the next round.
-      await checkpoint.markL1ExtractionComplete(sessionKey, totalStored, maxRecordedAtMs || undefined, lastSceneName);
+      await checkpoint.markL1ExtractionComplete(
+        sessionKey,
+        totalStored,
+        maxRecordedAtMs || undefined,
+        lastSceneName,
+        { countForPersona: false },
+      );
       logger.info(
         `${TAG} [l1] L1 complete: extracted=${totalExtracted}, stored=${totalStored} (${groups.length} group(s))`,
       );


### PR DESCRIPTION
## Summary

Addresses #1084 by separating the global L1 cursor from the profile-scoped persona
counter.

The pipeline still records the global L1 extraction cursor, but increments
`memories_since_last_persona` in the same team+agent scoped checkpoint used by L3
reads. The counter can also be updated explicitly through the checkpoint manager.

## Verification

- `npm test -- --run src/utils/checkpoint.test.ts` (2 tests passed)
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
