### PR TITLE
fix(skill): expose extraction action outcomes

### DIFF
--- a/MemoryCore/src/core/skill/conversation-add/candidate-outcome.test.ts
+++ b/MemoryCore/src/core/skill/conversation-add/candidate-outcome.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { summarizeCandidateOutcomes } from "./candidate-outcome.js";
+
+describe("summarizeCandidateOutcomes", () => {
+  it("separates creates from updates without retaining skill content", () => {
+    expect(summarizeCandidateOutcomes([
+      { action: "create", name: "new-skill", skill_id: "sk-1" },
+      { action: "update", name: "old-skill", skill_id: "sk-2" },
+      { action: "patch", name: "old-skill", skill_id: "sk-2" },
+    ])).toEqual({
+      total: 3,
+      created: 1,
+      updated: 2,
+      nonCreate: 2,
+      byAction: { create: 1, update: 1, patch: 1 },
+    });
+  });
+
+  it("reports an empty extraction as zero candidates", () => {
+    expect(summarizeCandidateOutcomes([])).toEqual({
+      total: 0,
+      created: 0,
+      updated: 0,
+      nonCreate: 0,
+      byAction: {},
+    });
+  });
+});

--- a/MemoryCore/src/core/skill/conversation-add/candidate-outcome.ts
+++ b/MemoryCore/src/core/skill/conversation-add/candidate-outcome.ts
@@ -1,0 +1,40 @@
+import type { ExtractedCandidate } from "../queue/types.js";
+
+export interface CandidateOutcomeSummary {
+  total: number;
+  created: number;
+  updated: number;
+  nonCreate: number;
+  byAction: Partial<Record<ExtractedCandidate["action"], number>>;
+}
+
+/**
+ * Turn extractor candidates into a privacy-preserving task outcome summary.
+ *
+ * The summary intentionally records action types and counts only. Skill names
+ * and content can contain user data, while action counts are enough to tell
+ * whether a task created a skill, edited one, or produced no candidates.
+ */
+export function summarizeCandidateOutcomes(
+  candidates: ExtractedCandidate[],
+): CandidateOutcomeSummary {
+  const byAction: Partial<Record<ExtractedCandidate["action"], number>> = {};
+  for (const candidate of candidates) {
+    byAction[candidate.action] = (byAction[candidate.action] ?? 0) + 1;
+  }
+
+  const created = byAction.create ?? 0;
+  const updated = (byAction.patch ?? 0)
+    + (byAction.edit ?? 0)
+    + (byAction.update ?? 0)
+    + (byAction.write_file ?? 0)
+    + (byAction.files_write ?? 0);
+
+  return {
+    total: candidates.length,
+    created,
+    updated,
+    nonCreate: candidates.length - created,
+    byAction,
+  };
+}

--- a/MemoryCore/src/core/skill/conversation-add/extract-worker.ts
+++ b/MemoryCore/src/core/skill/conversation-add/extract-worker.ts
@@ -34,6 +34,7 @@ import type {
 import { runInRootContext } from "../../report/otel-context.js";
 import { obsLogger } from "../../report/obs-logger.js";
 import { trace } from "../../report/trace.js";
+import { summarizeCandidateOutcomes } from "./candidate-outcome.js";
 
 /**
  * 把 candidates 落到业务侧（例如调 SkillCore.create/patch，或者直接写 SkillStore）。
@@ -398,14 +399,20 @@ export class SkillConversationExtractWorker {
                 : undefined,
             });
             candidates = result.candidates ?? [];
+            const outcome = summarizeCandidateOutcomes(candidates);
             obsLogger.info("skill.worker.extractor", {
               worker_id: workerId, task_id: head.task_id, instance_id: instanceId,
               dur_ms: Date.now() - t0Ext,
-              candidates: candidates.length,
+              candidates: outcome.total,
+              created: outcome.created,
+              updated: outcome.updated,
+              non_create: outcome.nonCreate,
+              actions: outcome.byAction,
               msg_count: conversation.length,
             });
             this.logger.info(
-              `[skill-conv-worker] extract done task_id=${head.task_id} candidates=${candidates.length}`,
+              `[skill-conv-worker] extract done task_id=${head.task_id} ` +
+                `candidates=${outcome.total} created=${outcome.created} updated=${outcome.updated}`,
             );
             const t0Sink = Date.now();
             await this.opts.sink.applyCandidates({
@@ -416,7 +423,11 @@ export class SkillConversationExtractWorker {
             obsLogger.info("skill.worker.apply_candidates", {
               worker_id: workerId, task_id: head.task_id, instance_id: instanceId,
               dur_ms: Date.now() - t0Sink,
-              candidates: candidates.length,
+              candidates: outcome.total,
+              created: outcome.created,
+              updated: outcome.updated,
+              non_create: outcome.nonCreate,
+              actions: outcome.byAction,
             });
           }
         } catch (err) {
@@ -508,6 +519,7 @@ export class SkillConversationExtractWorker {
           worker_id: workerId, task_id: head.task_id, instance_id: instanceId,
           outcome: isGhost ? "ghost" : "ok",
           candidates: candidates?.length ?? 0,
+          ...(candidates ? summarizeCandidateOutcomes(candidates) : {}),
           dur_ms: Date.now() - t0Task,
         });
 


### PR DESCRIPTION
## Summary

Addresses #1009 with a privacy-preserving observability slice for conversation-add
skill extraction.

The worker now reports aggregate candidate outcomes (`created`, `updated`,
`non_create`, and action counts) in its logs and task completion metadata. The helper
does not emit skill content or skill names.

This PR does not change the extractor's decision policy or add a new task-result API;
it makes the existing outcomes inspectable first.

## Verification

- `npm test -- --run src/core/skill/conversation-add/candidate-outcome.test.ts` (2 tests passed)
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
