### PR TITLE
test(proxy): cover Claude Code tool-result capture

### DIFF
--- a/MemoryProxy/src/tdai/__tests__/recorder.test.ts
+++ b/MemoryProxy/src/tdai/__tests__/recorder.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { extractLatestUserMessage } from "../recorder.js";
+
+describe("extractLatestUserMessage", () => {
+  it("walks past a Claude Code tool result to the latest real user query", () => {
+    expect(extractLatestUserMessage([
+      { role: "user", content: "<user_query>Open the config file</user_query>" },
+      { role: "assistant", content: "I will inspect it." },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<tool_result>config contents...</tool_result>" },
+        ],
+      },
+    ])).toEqual({ role: "user", content: "Open the config file" });
+  });
+
+  it("returns null when all trailing user messages are harness output", () => {
+    expect(extractLatestUserMessage([
+      { role: "assistant", content: "done" },
+      { role: "user", content: "<tool_result>command output</tool_result>" },
+    ])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for #964.

The test locks the Claude Code capture rule that walks backwards past a harness
`<tool_result>` user message to find the real `<user_query>`, and returns no query when
all trailing user messages are harness output.

The current source already contains the backwards scan; this PR protects that behavior
from future regressions rather than claiming a new source rewrite.

## Verification

- `npm test -- --run src/tdai/__tests__/recorder.test.ts` (2 tests passed)
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
