### PR TITLE
fix(hermes): allow configured v3 agent identity

### DIFF
--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/README.md
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/README.md
@@ -209,6 +209,17 @@ node --import tsx src/gateway/server.ts
 | `MEMORY_TENCENTDB_GATEWAY_CMD`    | —                   | If set, the provider auto-starts the Gateway with this command. If unset, the provider auto-discovers `src/gateway/server.ts` next to the checkout or under `$HOME` (see Option A above) |
 | `MEMORY_TENCENTDB_LOG_DIR`        | `~/.hermes/logs/memory_tencentdb` | Where the supervisor writes `gateway.stdout.log` / `gateway.stderr.log` |
 
+### v3 tenancy fallback
+
+When Hermes does not pass identity context to `initialize()`, the provider
+falls back to these optional variables before using the legacy `default` IDs:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MEMORY_TENCENTDB_TEAM_ID` | `default` | v3 team ID |
+| `MEMORY_TENCENTDB_AGENT_ID` | `default` | v3 agent ID; set this to the migrated `agt-...` ID to avoid new writes landing in the legacy `default` bucket |
+| `MEMORY_TENCENTDB_USER_ID` | `default` | v3 user ID |
+
 ### Gateway data directory (owned by the Gateway, not this provider)
 
 The L0~L3 data directory is resolved **inside the Gateway** (`src/gateway/config.ts`),

--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -17,6 +17,9 @@ Config via environment variables:
                                   unset, the provider auto-discovers
                                   ``src/gateway/server.ts`` next to the plugin
                                   checkout or under ``$HOME``)
+  MEMORY_TENCENTDB_TEAM_ID / MEMORY_TENCENTDB_AGENT_ID / MEMORY_TENCENTDB_USER_ID
+                                — Optional v3 tenancy IDs used when Hermes does
+                                  not pass IDs to ``initialize``
 
 The on-disk data directory (L0~L3 storage) is owned by the Gateway, not by
 this provider. Point the Gateway at a custom location with ``TDAI_DATA_DIR``
@@ -81,6 +84,20 @@ _DEFAULT_GATEWAY_PORT = 8420
 _DEFAULT_TEAM_ID = "default"
 _DEFAULT_AGENT_ID = "default"
 _DEFAULT_USER_ID = "default"
+
+
+def _resolve_identity_id(value: Any, env_var: str, default: str) -> str:
+    """Resolve one v3 tenancy ID without forcing the literal ``default``.
+
+    Hermes versions that do not expose team/agent context still need a way to
+    target an existing v2 agent after migration. An explicit initialize
+    argument wins, then the corresponding environment variable, and only then
+    do we retain the legacy default for backwards compatibility.
+    """
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    configured = os.environ.get(env_var, "").strip()
+    return configured or default
 
 
 def _resolve_gateway_port(default: int = _DEFAULT_GATEWAY_PORT) -> int:
@@ -537,9 +554,15 @@ class MemoryTencentdbProvider(MemoryProvider):
         All default to "default".
         """
         self._session_id = session_id
-        self._user_id = kwargs.get("user_id", _DEFAULT_USER_ID)
-        self._team_id = kwargs.get("team_id", _DEFAULT_TEAM_ID)
-        self._agent_id = kwargs.get("agent_id", _DEFAULT_AGENT_ID)
+        self._user_id = _resolve_identity_id(
+            kwargs.get("user_id"), "MEMORY_TENCENTDB_USER_ID", _DEFAULT_USER_ID,
+        )
+        self._team_id = _resolve_identity_id(
+            kwargs.get("team_id"), "MEMORY_TENCENTDB_TEAM_ID", _DEFAULT_TEAM_ID,
+        )
+        self._agent_id = _resolve_identity_id(
+            kwargs.get("agent_id"), "MEMORY_TENCENTDB_AGENT_ID", _DEFAULT_AGENT_ID,
+        )
 
         host = _resolve_gateway_host()
         port = _resolve_gateway_port()


### PR DESCRIPTION
## Summary

Addresses #995 with a low-risk identity configuration fallback for the Hermes plugin.

`initialize()` now resolves team, agent, and user IDs in this order: explicit function
arguments, environment variables, then the legacy defaults. The README documents the
optional `MEMORY_TENCENTDB_TEAM_ID`, `MEMORY_TENCENTDB_AGENT_ID`, and
`MEMORY_TENCENTDB_USER_ID` settings and recommends configuring a migrated `agt-...`
agent explicitly.

This is a partial mitigation: it does not implement lazy API list/create/discovery.

## Verification

- Inline import smoke test for explicit/env/default resolution
- `python3 -m py_compile MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py`
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
