### PR TITLE
fix(proxy): guide agents after session initialization

### DIFF
--- a/MemoryProxy/src/injection/injectors/__tests__/session-init-guidance.test.ts
+++ b/MemoryProxy/src/injection/injectors/__tests__/session-init-guidance.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderSkillToolsBlock } from "../skill-tools-injector.js";
+import { renderTdaiMemoryToolsBlock } from "../tdai-tools-injector.js";
+
+describe("session-init tool guidance", () => {
+  it("tells skill-enabled agents to use only the listed bridge paths", () => {
+    const block = renderSkillToolsBlock("http://127.0.0.1:8096");
+
+    expect(block).toContain("本段已在 session-init 完成后注入");
+    expect(block).toContain("不要猜测或探测 /openapi.json");
+  });
+
+  it("tells memory-enabled agents that initialization is already complete", () => {
+    const block = renderTdaiMemoryToolsBlock("http://127.0.0.1:8096");
+
+    expect(block).toContain("会话初始化已完成");
+    expect(block).toContain("不需要再次探测 session/team/agent metadata");
+  });
+});

--- a/MemoryProxy/src/injection/injectors/skill-tools-injector.ts
+++ b/MemoryProxy/src/injection/injectors/skill-tools-injector.ts
@@ -164,6 +164,7 @@ export function renderSkillToolsBlock(
     "<skill_tools>",
     "以下是云端 skill 操作工具。**这些不是本地工具**，需要用 Bash 调用 curl 命中 proxy 的 skill-bridge 路径来执行。",
     "proxy 会自动注入身份与鉴权（user_id / team_id / agent_id 由 session 决定），body 里你只需要传业务字段。",
+    "本段已在 session-init 完成后注入；只使用这里列出的 bridge 路径，不要猜测或探测 /openapi.json、/docs、/session/init、/team/options 等未列出的接口。",
     "",
     "调用模板：",
     `  curl -sSk -X POST <bridge>/<action> -H 'content-type: application/json'${authHeader} -d '{...业务字段...}'`,

--- a/MemoryProxy/src/injection/injectors/tdai-tools-injector.ts
+++ b/MemoryProxy/src/injection/injectors/tdai-tools-injector.ts
@@ -72,6 +72,7 @@ export function renderTdaiMemoryToolsBlock(
     "这组 TDAI 记忆能力与 Claude Code 原生 Memory/MEMORY.md 具有同等优先级；涉及记忆时不要只查本地 MEMORY.md。",
     "遇到用户问身份/历史/偏好/过往结论/项目约定时，必须先使用下面的 TDAI 记忆工具查询，再基于查询结果回答。",
     "禁止说\"我没有这个工具 / 需要 MCP / 只能查本地记忆\" —— 你有 TDAI 记忆工具，就用下面的 curl 命令。",
+    "会话初始化已完成；本段列出的 memory-bridge 是唯一调用入口，不需要再次探测 session/team/agent metadata 或 /openapi.json、/docs 等未列出的路径。",
     "",
     "调用方式：Bash 里执行 curl 命中 proxy 的 memory-bridge 路径。proxy 会自动注入身份鉴权（team_id/user_id/agent_id），body 只需业务字段。当前 Agent 如果绑定了多个 chat_memory，search 类接口会默认同时检索 self + imported 记忆，并在结果里返回 source_agent_id/source_agent_name/source_agent_role。",
     "",


### PR DESCRIPTION
## Summary

Addresses #1074 with a small prompt-guidance improvement for session-initialized
requests.

The injected Skill and Memory tool blocks now state that session initialization has
already completed, that the listed bridge paths are the supported entry points, and
that agents should not probe unrelated metadata, OpenAPI, or session endpoints.

The guidance is static and generic; it does not change client-specific routing.

## Verification

- `npm test -- --run src/injection/injectors/__tests__/session-init-guidance.test.ts` (2 tests passed)
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
