### PR TITLE
test(proxy): lock WorkBuddy question tool schema

### DIFF
--- a/MemoryProxy/src/session/workbuddy/__tests__/form.test.ts
+++ b/MemoryProxy/src/session/workbuddy/__tests__/form.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildFormResponse, TOOL_NAME } from "../form.js";
+
+describe("WorkBuddy session-init form", () => {
+  it("uses WorkBuddy's AskUserQuestion tool with an array of questions", async () => {
+    const response = buildFormResponse({
+      teams: [
+        { team_id: "team-1", team_name: "Demo Team" },
+        { team_id: "team-2", team_name: "Other Team" },
+      ],
+      stage: "team",
+      modelId: "test-model",
+      stream: false,
+    });
+    const body = await response.json();
+    const toolCall = body.choices[0].message.tool_calls[0];
+    const args = JSON.parse(toolCall.function.arguments);
+
+    expect(toolCall.function.name).toBe(TOOL_NAME);
+    expect(TOOL_NAME).toBe("AskUserQuestion");
+    expect(args.questions).toHaveLength(1);
+    expect(args.questions[0].options[0].label).toContain("Demo Team");
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for #887.

The test uses a two-team fixture and locks the WorkBuddy non-stream response contract:
the response includes the `AskUserQuestion` tool with a `questions[]` array.

The current implementation already exposes this schema; this PR protects the contract
from future regressions.

## Verification

- `npm test -- --run src/session/workbuddy/__tests__/form.test.ts` (1 test passed)
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
