### PR TITLE
fix(openclaw): log hook policy status during startup

### DIFF
--- a/MemoryCore/src/utils/ensure-hook-policy.test.ts
+++ b/MemoryCore/src/utils/ensure-hook-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensurePluginHookPolicy } from "./ensure-hook-policy.js";
+
+describe("ensurePluginHookPolicy diagnostics", () => {
+  it("reports when the hook policy is already enabled", () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    ensurePluginHookPolicy({
+      rootConfig: {
+        plugins: {
+          entries: {
+            "memory-tencentdb": { hooks: { allowConversationAccess: true } },
+          },
+        },
+      },
+      logger,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("allowConversationAccess is already active"),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryCore/src/utils/ensure-hook-policy.ts
+++ b/MemoryCore/src/utils/ensure-hook-policy.ts
@@ -182,8 +182,14 @@ export function ensurePluginHookPolicy(params: {
   const { logger } = params;
   const TAG = "[memory-tdai] [hook-policy]";
 
-  if (!isGatewayStart()) return;
-  if (hasPolicyAlready(params.rootConfig)) return;
+  if (!isGatewayStart()) {
+    logger.debug?.(`${TAG} Skipped: current process is not the OpenClaw gateway start command.`);
+    return;
+  }
+  if (hasPolicyAlready(params.rootConfig)) {
+    logger.info(`${TAG} allowConversationAccess is already active; no config patch needed.`);
+    return;
+  }
 
   // Try SDK path first (handles everything + triggers restart)
   if (params.runtimeConfig?.mutateConfigFile) {


### PR DESCRIPTION
## Summary

Addresses #921 with startup diagnostics for the OpenClaw hook policy.

The helper now logs when policy setup is skipped outside gateway startup and when
`allowConversationAccess` is already active, so operators can distinguish an intended
no-op from a failed configuration patch.

## Verification

- `npm test -- --run src/utils/ensure-hook-policy.test.ts` (1 test passed)
- `git diff --check`

Signed-off-by: Gout999 <gout999@users.noreply.github.com>
