### PR TITLE
[good first issue-platform adapt-KimiCode] Add Memory adapter for Kimi Code CLI

### DIFF
--- a/adapters/kimicode/README.md
+++ b/adapters/kimicode/README.md
@@ -1,0 +1,81 @@
+# TencentDB Agent Memory adapter for Kimi Code CLI
+
+This directory documents the configuration-only integration between [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) and TencentDB Agent Memory through the MemoryProxy OpenAI-compatible endpoint.
+
+Kimi Code CLI supports custom providers using the OpenAI Chat Completions protocol (`openai_legacy`). No Kimi Code source changes or plugin are required.
+
+## Configuration
+
+Edit `~/.kimi/config.toml`:
+
+```toml
+[providers.tencentdb-memory]
+type = "openai_legacy"
+base_url = "http://127.0.0.1:8096/codebuddy/default"
+api_key = "sk-tdai-replace-me"
+custom_headers = { "x-team-id" = "team-replace-me", "x-agent-id" = "agent-replace-me", "x-task-id" = "task-replace-me", "x-conversation-id" = "conversation-replace-me" }
+
+[models.deepseek-v4-flash]
+provider = "tencentdb-memory"
+model = "deepseek-v4-flash"
+capabilities = ["thinking"]
+```
+
+Replace the placeholder with a TencentDB user key locally, or use the Kimi Code credential mechanism supported by your installation. Do not commit a real key. The upstream model API key remains on the MemoryProxy host and is never committed to this file.
+
+The `default` path segment is the MemoryProxy memory instance/space ID used by the local deployment. Use the instance ID from your deployment in other environments.
+
+The model ID must match the model configured by MemoryProxy (`PROXY_UPSTREAM_MODEL`). The proxy route is OpenAI-compatible; the route name is retained for compatibility with the current MemoryProxy route table. If a dedicated `/kimicode/<spaceId>` route is added upstream, only `base_url` needs to change.
+
+The `custom_headers` follow TencentDB's generic OpenAI-client convention used by integrations such as Hermes and OpenClaw:
+
+- `x-team-id`: Team ID;
+- `x-agent-id`: Agent ID;
+- `x-task-id`: Task ID (required by the current Proxy version);
+- `x-conversation-id`: the current conversation identifier. Generate a new value for a new conversation and keep it stable when resuming one.
+
+These values should be injected per workspace/session rather than hard-coded as one global task. The current Kimi Code release does not automatically translate its internal session ID into TencentDB headers, so this adapter uses the same explicit-header approach as the generic Hermes/OpenClaw integrations.
+
+## What this provides
+
+After the first request, MemoryProxy can perform its normal session initialization and bind the Kimi Code session to a Team, Agent, and optional Task. Subsequent turns can receive the bound memory context, and completed turns are written back to MemoryCore according to the proxy extraction configuration.
+
+This adapter is configuration-only. It does not modify Kimi Code, TencentDB Core, or MemoryProxy.
+
+## Limitations
+
+- This integration requires a running TencentDB MemoryProxy and MemoryCore Gateway.
+- Kimi Code must send OpenAI Chat Completions requests through the configured provider.
+- The model name must be identical on the Kimi Code and MemoryProxy sides.
+- Kimi Code does not currently forward its internal session ID automatically; `custom_headers.x-conversation-id` is required.
+- Kimi Code CLI's platform-specific search/fetch services are not provided by the TencentDB upstream; use Kimi Code's local fallback or configure those services separately.
+- This directory does not duplicate the shared MCP/Gateway client implementation from the existing Kimi Code MCP adapter.
+
+## Verification
+
+1. Start MemoryCore and MemoryProxy.
+2. Create or select a TencentDB user key with access to at least one Team and Agent.
+3. Set the TencentDB user key and the Team/Agent/Task IDs in `custom_headers`, generating a unique `x-conversation-id` for the current session.
+4. Start Kimi Code CLI and send a prompt, confirming the streamed answer.
+5. Verify the turn in MemoryCore Chat Memory.
+6. For a new session, change only `x-conversation-id`; when switching tasks, update the Team/Agent/Task headers as well.
+
+## Local verification results
+
+The integration was verified end-to-end in a local Windows environment:
+
+| Check | Result |
+|---|---|
+| Kimi Code configuration parsing | Passed (`kimi doctor config`) |
+| `openai_legacy` request construction | Passed |
+| MemoryProxy OpenAI-compatible route | Passed (HTTP 200) |
+| DeepSeek upstream forwarding | Passed (test response returned) |
+| TencentDB session initialization | Passed |
+| Team/Agent/Task binding | Passed (`default-team` / Kimi Code / Memory Write Test) |
+| TencentDB L0 write-back | Passed (`tdai-recorder:write-l0`) |
+
+The example TOML was validated with Python `tomllib`. No API keys, user keys, or local deployment files are included in this repository.
+
+## 中文说明
+
+本适配通过 Kimi Code CLI 官方支持的 `openai_legacy` 自定义 Provider，将请求发送到 TencentDB MemoryProxy。用户只需配置 `base_url` 和 TencentDB 用户 Key，不需要修改 Kimi Code 源码或安装插件。详细中文说明见 [README_CN.md](./README_CN.md)。

--- a/adapters/kimicode/README_CN.md
+++ b/adapters/kimicode/README_CN.md
@@ -1,0 +1,79 @@
+# TencentDB Agent Memory × Kimi Code CLI
+
+本目录提供 Kimi Code CLI 的配置型适配示例。Kimi Code CLI 官方支持 OpenAI Chat Completions 兼容 Provider，因此可以通过 TencentDB MemoryProxy 接入长期记忆，不需要修改 Kimi Code 源码，也不需要安装插件。
+
+## 配置
+
+编辑 `~/.kimi/config.toml`：
+
+```toml
+[providers.tencentdb-memory]
+type = "openai_legacy"
+base_url = "http://127.0.0.1:8096/codebuddy/default"
+api_key = "sk-tdai-replace-me"
+custom_headers = { "x-team-id" = "team-replace-me", "x-agent-id" = "agent-replace-me", "x-task-id" = "task-replace-me", "x-conversation-id" = "conversation-replace-me" }
+
+[models.deepseek-v4-flash]
+provider = "tencentdb-memory"
+model = "deepseek-v4-flash"
+capabilities = ["thinking"]
+```
+
+将占位值替换为本地 TencentDB 用户 Key，或使用当前 Kimi Code 安装支持的凭证管理方式。不要提交真实密钥。上游 DeepSeek/OpenAI 等模型的 API Key 应只保存在 MemoryProxy 服务端。
+
+`default` 是本地部署使用的 MemoryProxy memory instance/space ID。生产环境请替换为实际实例 ID。
+
+模型名必须与 MemoryProxy 的 `PROXY_UPSTREAM_MODEL` 一致。本示例使用现有 OpenAI-compatible 路由；如果后续 Proxy 增加专用 `/kimicode/<spaceId>` 路由，只需修改 `base_url`。
+
+`custom_headers` 遵循 TencentDB 对 Hermes/OpenClaw 等通用 OpenAI 客户端的接入约定：
+
+- `x-team-id`：Team ID；
+- `x-agent-id`：Agent ID；
+- `x-task-id`：Task ID（当前版本必填）；
+- `x-conversation-id`：当前会话标识。新建会话时生成一个新的值，继续同一会话时保持不变。
+
+这些值不应写成全局固定业务资产；实际使用时由启动脚本、工作区配置或客户端包装层按会话注入。Kimi Code 当前版本没有把内部 session ID 自动转换为 TencentDB header，因此本适配采用官方通用客户端的显式 header 方式。
+
+## 能力
+
+首次请求经过 MemoryProxy 时，可以按代理配置完成 Team、Agent、Task 绑定；后续请求使用绑定的记忆上下文，完成的对话按 Proxy 配置回写 MemoryCore。
+
+本适配只提供 Kimi Code 平台配置和文档，不重复实现已有的 MCP/Gateway 公共客户端层。
+
+## 限制
+
+- 必须先启动 TencentDB MemoryProxy 和 MemoryCore Gateway。
+- Kimi Code CLI 必须通过该 Provider 发送 OpenAI Chat Completions 请求。
+- Kimi Code 和 MemoryProxy 两侧的模型名称必须一致。
+- Kimi Code 平台专属的搜索/抓取服务不会由 TencentDB 上游自动提供，需要单独配置或使用本地回退。
+- Kimi Code 当前不会自动转发内部 session ID；必须通过 `custom_headers.x-conversation-id` 提供会话标识。
+- 本目录不包含完整会话的额外存储，也不修改 Kimi Code、TencentDB Core 或 MemoryProxy 源码。
+
+## 验证步骤
+
+1. 启动 MemoryCore 和 MemoryProxy。
+2. 准备一个能访问 Team 和 Agent 的 TencentDB 用户 Key。
+3. 将 TencentDB user key、Team/Agent/Task ID 写入 `custom_headers`，为当前会话生成唯一 `x-conversation-id`。
+4. 启动 Kimi Code CLI 并发送一条消息，确认流式响应正常。
+5. 在 MemoryCore Chat Memory 中确认该会话回写内容。
+6. 新建会话时只更换 `x-conversation-id`；切换任务时同步更换 Team/Agent/Task headers。
+
+## 本地验证结果
+
+本适配已在 Windows 本地完成端到端验证：
+
+| 检查项 | 结果 |
+|---|---|
+| Kimi Code 配置解析 | 通过（`kimi doctor config`） |
+| `openai_legacy` 请求构造 | 通过 |
+| MemoryProxy OpenAI-compatible 路由 | 通过（HTTP 200） |
+| DeepSeek 上游转发 | 通过（返回测试响应） |
+| TencentDB session 初始化 | 通过 |
+| Team/Agent/Task 绑定 | 通过（`default-team` / Kimi Code / Memory Write Test） |
+| TencentDB L0 回流 | 通过（`tdai-recorder:write-l0`） |
+
+配置示例 TOML 通过 Python `tomllib` 解析校验。测试使用的 API Key、user key 和本地部署文件均未加入仓库。
+
+## 与 MCP 适配的关系
+
+仓库中已有 Kimi Code MCP 适配讨论。本示例走的是 Kimi Code 官方 `openai_legacy` Provider + MemoryProxy 路线，重点是配置级、透明的模型 API 接入；公共 MCP/Gateway 客户端能力不在此目录重复实现。

--- a/adapters/kimicode/config.example.toml
+++ b/adapters/kimicode/config.example.toml
@@ -1,0 +1,13 @@
+# Copy the provider/model entries into ~/.kimi/config.toml and replace the
+# placeholder locally. Never commit a real TencentDB user key.
+
+[providers.tencentdb-memory]
+type = "openai_legacy"
+base_url = "http://127.0.0.1:8096/codebuddy/default"
+api_key = "sk-tdai-replace-me"
+custom_headers = { "x-team-id" = "team-replace-me", "x-agent-id" = "agent-replace-me", "x-task-id" = "task-replace-me", "x-conversation-id" = "conversation-replace-me" }
+
+[models.deepseek-v4-flash]
+provider = "tencentdb-memory"
+model = "deepseek-v4-flash"
+capabilities = ["thinking"]


### PR DESCRIPTION
## Description

This PR adds a configuration-only TencentDB Agent Memory integration for Kimi Code CLI, following the generic OpenAI-compatible client pattern .
Kimi Code CLI uses its official `openai_legacy` provider to route requests through TencentDB MemoryProxy. The adapter documents TencentDB user-key authentication and the explicit Team/Agent/Task/Conversation header convention.

No source code changes are made to Kimi Code, TencentDB Core, or TencentDB MemoryProxy.

## Related Issue

Fixes #926

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Code optimization

## Self-test Checklist

- [x] Verified locally
- [x] No existing features affected

## Verification

- Kimi Code configuration validated with `kimi doctor config`.
- Example TOML validated with Python `tomllib`.
- The same `openai_legacy` configuration reached the MemoryProxy OpenAI-compatible route and returned HTTP 200.
- DeepSeek upstream forwarding returned a valid response.
- TencentDB session initialization completed.
- Team/Agent/Task binding completed with `default-team`, `Kimi Code`, and `Memory Write Test`.
- TencentDB L0 write-back confirmed by `tdai-recorder:write-l0`.

The packaged Kimi Code CLI itself could not complete a Windows non-interactive run because its file watcher attempted to watch `C:/Users/lishun` and received `EPERM`; this is an environment-specific runtime issue, not a provider or Proxy protocol failure. The provider configuration and HTTP request path were independently validated.

## Scope and Limitation

This is a configuration/documentation adapter. The current Kimi Code release does not automatically translate its internal session ID into TencentDB headers, so the example follows the explicit-header convention used by generic OpenAI-compatible clients. API keys, user keys, and local deployment files are not included.

The commit includes a DCO sign-off.