### PR TITLE
fix(knowledge): exit when server startup fails

### DIFF
--- a/MemoryKnowledge/src/server.test.ts
+++ b/MemoryKnowledge/src/server.test.ts
@@ -1,0 +1,77 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, test } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+test("exits after a startup failure when Langfuse telemetry is enabled", async () => {
+  const invalidDbPath = await mkdtemp(join(tmpdir(), "knowledge-db-directory-"));
+  temporaryDirectories.push(invalidDbPath);
+
+  const result = await runServerProcess(invalidDbPath);
+
+  expect(result.output).toContain("Knowledge service failed to start");
+  expect(result.code).toBe(1);
+}, 10_000);
+
+function runServerProcess(
+  invalidDbPath: string,
+): Promise<{ code: number | null; output: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--eval",
+        'import("./src/server.ts").then(({ runServer }) => runServer())',
+      ],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        env: {
+          ...process.env,
+          KNOWLEDGE_DB_PATH: invalidDbPath,
+          LANGFUSE_SECRET_KEY: "test-secret",
+          LANGFUSE_PUBLIC_KEY: "test-public",
+          LANGFUSE_BASE_URL: "http://127.0.0.1:9",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let output = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      output += chunk;
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`server process did not exit after startup failure:\n${output}`));
+    }, 5_000);
+
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ code, output });
+    });
+  });
+}

--- a/MemoryKnowledge/src/server.ts
+++ b/MemoryKnowledge/src/server.ts
@@ -139,12 +139,18 @@ async function startServer(): Promise<void> {
   process.once("SIGINT", () => void shutdown("SIGINT"));
 }
 
-// Start server when run directly
-if (import.meta.url === `file://${process.argv[1]}`) {
-  void startServer().catch((err) => {
+export async function runServer(): Promise<void> {
+  try {
+    await startServer();
+  } catch (err) {
     log.error("Knowledge service failed to start", {
       error: err instanceof Error ? err.message : String(err),
     });
-    process.exitCode = 1;
-  });
+    process.exit(1);
+  }
+}
+
+// Start server when run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void runServer();
 }


### PR DESCRIPTION
## Summary

- exit with status 1 when MemoryKnowledge fails during startup
- add a regression test for an invalid SQLite path while Langfuse telemetry is active

## Problem

The existing handler only assigned `process.exitCode`. If telemetry had already created active handles, the HTTP listener never started but the process stayed alive.

## Testing

- `pnpm test`
- `pnpm build`
- Ubuntu, Node.js 22: invalid `KNOWLEDGE_DB_PATH` with Langfuse enabled exits with status 1

`pnpm typecheck` currently fails in the unchanged `src/middleware/response-envelope.ts:47` because `Promise<string>` is assigned to `string`.

Closes #1140