### PR TITLE
feat(gateway): add retry-safe conversation idempotency

### DIFF
--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -185,6 +185,27 @@ An adapter generally has three responsibilities:
 
 The v3 memory data plane requires `team_id`, `agent_id`, and `user_id`. Supply them in the request body or the corresponding `x-tdai-*` headers. `session_id` is optional and narrows operations to a session when provided.
 
+### Retrying `/v3/conversation/add`
+
+Clients that may retry a completed turn can pass an optional `idempotency_key` on `POST /v3/conversation/add`. Reuse the same key for the same service, team, agent, user, session, and message payload:
+
+```json
+{
+  "session_id": "session-1",
+  "team_id": "team-1",
+  "agent_id": "agent-1",
+  "user_id": "user-1",
+  "idempotency_key": "opencode-turn-01",
+  "messages": [
+    { "role": "user", "content": "hello", "timestamp": "2026-08-24T00:00:00.000Z" }
+  ]
+}
+```
+
+The key is scoped by `x-tdai-service-id`, `team_id`, `agent_id`, `user_id`, `session_id`, and `idempotency_key`. A replay with the same normalized payload returns the original `accepted_ids` and does not write L0 or notify the pipeline again. Reusing the same key with a different payload returns `409`. A backend that cannot provide atomic receipt, L0 write, and outbox ACK semantics returns `503` for keyed requests; unkeyed requests keep the existing behavior.
+
+SQLite provides the public transactional guarantee. Redis and TCVDB deployments must implement equivalent atomic claim and outbox acknowledgement before they should be advertised as exactly-once across replicas.
+
 ## Configuration
 
 The Gateway resolves configuration in this order:

--- a/MemoryCore/README_CN.md
+++ b/MemoryCore/README_CN.md
@@ -189,6 +189,27 @@ TDAI_MEMORY_INSTANCE_ID=default
 
 v3 记忆数据面要求 `team_id`、`agent_id`、`user_id`，可以通过请求体或对应的 `x-tdai-*` Header 传入；`session_id` 可选，用于限定会话范围。
 
+### 重试 `/v3/conversation/add`
+
+如果客户端可能重试一轮已完成对话，可以在 `POST /v3/conversation/add` 里传可选的 `idempotency_key`。同一个 service、team、agent、user、session 和消息正文必须复用同一个 key：
+
+```json
+{
+  "session_id": "session-1",
+  "team_id": "team-1",
+  "agent_id": "agent-1",
+  "user_id": "user-1",
+  "idempotency_key": "opencode-turn-01",
+  "messages": [
+    { "role": "user", "content": "hello", "timestamp": "2026-08-24T00:00:00.000Z" }
+  ]
+}
+```
+
+幂等范围由 `x-tdai-service-id`、`team_id`、`agent_id`、`user_id`、`session_id` 和 `idempotency_key` 共同决定。相同规范化正文的重放会返回首次成功的 `accepted_ids`，不会再次写入 L0，也不会再次通知 pipeline。相同 key 搭配不同正文会返回 `409`。无法提供原子 receipt、L0 写入和 outbox ACK 语义的后端，会对带 key 的请求返回 `503`；不带 key 的请求保持原有行为。
+
+SQLite 已提供公开版本的事务性保证。Redis 和 TCVDB 部署需要实现等价的 atomic claim 与 outbox acknowledgement 后，才能宣称跨副本 exactly-once。
+
 ## 自定义 Prompt 与生成溯源
 
 每个 Memory Instance 最多创建 500 个自定义 Prompt，单个 Prompt 内容最长 10,000 个 Unicode 字符。Prompt 本体和目标绑定分开存储，更新时保持 `memory_prompt_id` 不变并执行 `version += 1`，已有绑定的新生成任务会使用最新版本。

--- a/MemoryCore/src/core/store/sqlite-idempotency.test.ts
+++ b/MemoryCore/src/core/store/sqlite-idempotency.test.ts
@@ -298,6 +298,55 @@ describe("VectorStore conversation add idempotency", () => {
     expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM conversation_add_outbox WHERE event_id = 'legacy-outbox'").get()).toEqual({ count: 0 });
   });
 
+  it("does not reclaim when an accepted ID has no canonical L0 metadata but its outbox remains", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt", scopeHash(), scope.serviceId, scope.teamId, scope.agentId,
+      scope.userId, scope.sessionId, scope.idempotencyKey, "digest-1",
+      "[\"legacy-message\"]", "processing", 1, 1,
+    );
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_outbox (
+        event_id, receipt_id, service_id, session_id, rounds, team_id, agent_id,
+        status, created_at_ms, acknowledged_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
+    `).run("legacy-outbox", "legacy-receipt", scope.serviceId, scope.sessionId, 2, scope.teamId, scope.agentId, 1);
+
+    expect(store.claimConversationAdd(input())).toEqual({ status: "unsupported" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_outbox WHERE event_id = 'legacy-outbox'").get()).toEqual({ status: "pending" });
+  });
+
+  it("does not reclaim when a legacy outbox payload is outside the receipt scope", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt", scopeHash(), scope.serviceId, scope.teamId, scope.agentId,
+      scope.userId, scope.sessionId, scope.idempotencyKey, "digest-1",
+      "[\"legacy-message\"]", "processing", 1, 1,
+    );
+    store.upsertL0({ ...input().records[0], id: "legacy-message" }, undefined);
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_outbox (
+        event_id, receipt_id, service_id, session_id, rounds, team_id, agent_id,
+        status, created_at_ms, acknowledged_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
+    `).run("legacy-outbox", "legacy-receipt", "other-service", scope.sessionId, 2, scope.teamId, scope.agentId, 1);
+
+    expect(store.claimConversationAdd(input())).toEqual({ status: "unsupported" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
+    expect(store.getRawDb().prepare("SELECT service_id FROM conversation_add_outbox WHERE event_id = 'legacy-outbox'").get()).toEqual({ service_id: "other-service" });
+  });
+
   it("does not reclaim a processing receipt when an accepted ID belongs to another isolation scope", () => {
     const store = createStore();
     store.getRawDb().prepare(`

--- a/MemoryCore/src/core/store/sqlite-idempotency.test.ts
+++ b/MemoryCore/src/core/store/sqlite-idempotency.test.ts
@@ -61,6 +61,23 @@ function scopeHash(value: ConversationIdempotencyScope = scope): string {
   ].map(([name, field]) => `${name}=${encodeURIComponent(field)}`).join("&")).digest("hex");
 }
 
+function enableLegacyFtsResidues(store: VectorStore): void {
+  store.getRawDb().exec(`
+    CREATE TABLE l0_fts (
+      record_id TEXT NOT NULL,
+      session_key TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      team_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL
+    )
+  `);
+  // This runtime lacks FTS5. The recovery branch only needs the availability
+  // flag to exercise its real SQL validation and deletion against a legacy
+  // table shape.
+  (store as unknown as { ftsAvailable: boolean }).ftsAvailable = true;
+}
+
 describe("VectorStore conversation add idempotency", () => {
   const stores: VectorStore[] = [];
   const directories: string[] = [];
@@ -345,6 +362,57 @@ describe("VectorStore conversation add idempotency", () => {
     expect(store.claimConversationAdd(input())).toEqual({ status: "unsupported" });
     expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
     expect(store.getRawDb().prepare("SELECT service_id FROM conversation_add_outbox WHERE event_id = 'legacy-outbox'").get()).toEqual({ service_id: "other-service" });
+  });
+
+  it("does not delete any FTS residue when one duplicate record ID has another scope", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt", scopeHash(), scope.serviceId, scope.teamId, scope.agentId,
+      scope.userId, scope.sessionId, scope.idempotencyKey, "digest-1",
+      "[\"legacy-message\"]", "processing", 1, 1,
+    );
+    store.upsertL0({ ...input().records[0], id: "legacy-message" }, undefined);
+    enableLegacyFtsResidues(store);
+    const insertFts = store.getRawDb().prepare(`
+      INSERT INTO l0_fts (record_id, session_key, session_id, team_id, user_id, agent_id)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    insertFts.run("legacy-message", scope.sessionId, scope.sessionId, scope.teamId, scope.userId, scope.agentId);
+    insertFts.run("legacy-message", scope.sessionId, scope.sessionId, scope.teamId, "other-user", scope.agentId);
+
+    expect(store.claimConversationAdd(input())).toEqual({ status: "unsupported" });
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM l0_fts WHERE record_id = 'legacy-message'").get()).toEqual({ count: 2 });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
+  });
+
+  it("cleans all same-scope duplicate FTS residues before reclaiming", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt", scopeHash(), scope.serviceId, scope.teamId, scope.agentId,
+      scope.userId, scope.sessionId, scope.idempotencyKey, "digest-1",
+      "[\"legacy-message\"]", "processing", 1, 1,
+    );
+    store.upsertL0({ ...input().records[0], id: "legacy-message" }, undefined);
+    enableLegacyFtsResidues(store);
+    const insertFts = store.getRawDb().prepare(`
+      INSERT INTO l0_fts (record_id, session_key, session_id, team_id, user_id, agent_id)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    insertFts.run("legacy-message", scope.sessionId, scope.sessionId, scope.teamId, scope.userId, scope.agentId);
+    insertFts.run("legacy-message", scope.sessionId, scope.sessionId, scope.teamId, scope.userId, scope.agentId);
+
+    expect(store.claimConversationAdd(input({ records: [] })).status).toBe("claimed");
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM l0_fts WHERE record_id = 'legacy-message'").get()).toEqual({ count: 0 });
   });
 
   it("does not reclaim a processing receipt when an accepted ID belongs to another isolation scope", () => {

--- a/MemoryCore/src/core/store/sqlite-idempotency.test.ts
+++ b/MemoryCore/src/core/store/sqlite-idempotency.test.ts
@@ -1,0 +1,225 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { VectorStore } from "./sqlite.js";
+import type { ClaimConversationAddInput, ConversationIdempotencyScope } from "./types.js";
+
+const scope: ConversationIdempotencyScope = {
+  serviceId: "service-1",
+  teamId: "team-1",
+  agentId: "agent-1",
+  userId: "user-1",
+  sessionId: "session-1",
+  idempotencyKey: "turn-1",
+};
+
+function input(overrides: Partial<ClaimConversationAddInput> = {}): ClaimConversationAddInput {
+  return {
+    scope,
+    payloadDigest: "digest-1",
+    pipelineRounds: 2,
+    records: [
+      {
+        id: "message-1",
+        sessionKey: "session-1",
+        sessionId: "session-1",
+        teamId: "team-1",
+        agentId: "agent-1",
+        userId: "user-1",
+        role: "user",
+        messageText: "hello",
+        recordedAt: "2026-08-24T00:00:00.000Z",
+        timestamp: 1787529600000,
+      },
+      {
+        id: "message-2",
+        sessionKey: "session-1",
+        sessionId: "session-1",
+        teamId: "team-1",
+        agentId: "agent-1",
+        userId: "user-1",
+        role: "assistant",
+        messageText: "world",
+        recordedAt: "2026-08-24T00:00:01.000Z",
+        timestamp: 1787529601000,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("VectorStore conversation add idempotency", () => {
+  const stores: VectorStore[] = [];
+  const directories: string[] = [];
+
+  function createStore(): VectorStore {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "tdai-sqlite-idempotency-"));
+    directories.push(directory);
+    const store = new VectorStore(path.join(directory, "vectors.db"), 0);
+    store.init();
+    stores.push(store);
+    return store;
+  }
+
+  afterEach(() => {
+    for (const store of stores.splice(0)) store.close();
+    for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("persists a claimed receipt, all L0 rows, and one pending outbox event together", () => {
+    const store = createStore();
+
+    const claim = store.claimConversationAdd(input());
+
+    expect(claim.status).toBe("claimed");
+    if (claim.status !== "claimed") return;
+    expect(claim.receipt).toMatchObject({
+      scope,
+      payloadDigest: "digest-1",
+      acceptedIds: ["message-1", "message-2"],
+      status: "pending",
+    });
+    expect(claim.outboxEvent).toMatchObject({
+      receiptId: claim.receipt.receiptId,
+      serviceId: "service-1",
+      sessionId: "session-1",
+      teamId: "team-1",
+      agentId: "agent-1",
+      rounds: 2,
+      status: "pending",
+    });
+    expect(store.queryL0ForL1("session-1", undefined, 10).map((row) => row.record_id)).toEqual([
+      "message-1",
+      "message-2",
+    ]);
+    expect(store.readConversationAddReceipt(scope)).toMatchObject({
+      receiptId: claim.receipt.receiptId,
+      acceptedIds: ["message-1", "message-2"],
+      status: "pending",
+    });
+  });
+
+  it("replays the original IDs for a repeated scope and digest", () => {
+    const store = createStore();
+    const first = store.claimConversationAdd(input());
+    const replay = store.claimConversationAdd(input({
+      records: [{ ...input().records[0], id: "would-be-duplicate" }],
+    }));
+
+    expect(first.status).toBe("claimed");
+    expect(replay.status).toBe("replay");
+    if (first.status !== "claimed" || replay.status !== "replay") return;
+    expect(replay.receipt.receiptId).toBe(first.receipt.receiptId);
+    expect(replay.receipt.acceptedIds).toEqual(["message-1", "message-2"]);
+    expect(replay.outboxEvent?.eventId).toBe(first.outboxEvent.eventId);
+    expect(store.queryL0ForL1("session-1", undefined, 10).map((row) => row.record_id)).toEqual([
+      "message-1",
+      "message-2",
+    ]);
+  });
+
+  it("rejects a repeated scope with a different payload digest", () => {
+    const store = createStore();
+    store.claimConversationAdd(input());
+
+    expect(store.claimConversationAdd(input({ payloadDigest: "different-digest" }))).toEqual({ status: "conflict" });
+  });
+
+  it("rolls back an L0 write failure so the same request can be claimed again", () => {
+    const store = createStore();
+    store.getRawDb().exec(`
+      CREATE TRIGGER fail_l0_admission
+      BEFORE INSERT ON l0_conversations
+      WHEN NEW.record_id = 'message-1'
+      BEGIN
+        SELECT RAISE(ABORT, 'inject l0 failure');
+      END
+    `);
+
+    expect(() => store.claimConversationAdd(input())).toThrow("inject l0 failure");
+    expect(store.readConversationAddReceipt(scope)).toBeNull();
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM conversation_add_outbox").get()).toEqual({ count: 0 });
+    expect(store.queryL0ForL1("session-1", undefined, 10)).toEqual([]);
+
+    store.getRawDb().exec("DROP TRIGGER fail_l0_admission");
+    expect(store.claimConversationAdd(input()).status).toBe("claimed");
+  });
+
+  it("atomically leaves receipt and outbox pending when acknowledgement cannot complete the receipt", () => {
+    const store = createStore();
+    const claim = store.claimConversationAdd(input());
+    expect(claim.status).toBe("claimed");
+    if (claim.status !== "claimed") return;
+    store.getRawDb().exec(`
+      CREATE TRIGGER fail_receipt_completion
+      BEFORE UPDATE OF status ON conversation_add_receipts
+      WHEN NEW.status = 'completed'
+      BEGIN
+        SELECT RAISE(ABORT, 'inject receipt completion failure');
+      END
+    `);
+
+    expect(() => store.ackConversationOutbox(claim.outboxEvent.eventId)).toThrow("inject receipt completion failure");
+    expect(store.readConversationAddReceipt(scope)?.status).toBe("pending");
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_outbox WHERE event_id = ?").get(claim.outboxEvent.eventId)).toEqual({ status: "pending" });
+
+    store.getRawDb().exec("DROP TRIGGER fail_receipt_completion");
+    expect(store.ackConversationOutbox(claim.outboxEvent.eventId)).toBe(true);
+    expect(store.readConversationAddReceipt(scope)?.status).toBe("completed");
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_outbox WHERE event_id = ?").get(claim.outboxEvent.eventId)).toEqual({ status: "acknowledged" });
+  });
+
+  it("completes the receipt and acknowledges its outbox in one transaction", () => {
+    const store = createStore();
+    const claim = store.claimConversationAdd(input());
+    expect(claim.status).toBe("claimed");
+    if (claim.status !== "claimed") return;
+
+    expect(store.completeConversationAdd(claim.receipt.receiptId)?.status).toBe("completed");
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_outbox WHERE event_id = ?").get(claim.outboxEvent.eventId)).toEqual({ status: "acknowledged" });
+  });
+
+  it("safely reclaims a legacy processing receipt", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt",
+      createHash("sha256").update([
+        ["service_id", scope.serviceId],
+        ["team_id", scope.teamId],
+        ["agent_id", scope.agentId],
+        ["user_id", scope.userId],
+        ["session_id", scope.sessionId],
+        ["idempotency_key", scope.idempotencyKey],
+      ].map(([name, value]) => `${name}=${encodeURIComponent(value)}`).join("&")).digest("hex"),
+      scope.serviceId,
+      scope.teamId,
+      scope.agentId,
+      scope.userId,
+      scope.sessionId,
+      scope.idempotencyKey,
+      "digest-1",
+      "[]",
+      "processing",
+      1,
+      1,
+    );
+
+    const claim = store.claimConversationAdd(input());
+
+    expect(claim.status).toBe("claimed");
+    if (claim.status !== "claimed") return;
+    expect(claim.receipt.receiptId).not.toBe("legacy-receipt");
+    expect(store.readConversationAddReceipt(scope)).toMatchObject({
+      receiptId: claim.receipt.receiptId,
+      status: "pending",
+    });
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM conversation_add_receipts").get()).toEqual({ count: 1 });
+  });
+});

--- a/MemoryCore/src/core/store/sqlite-idempotency.test.ts
+++ b/MemoryCore/src/core/store/sqlite-idempotency.test.ts
@@ -50,6 +50,17 @@ function input(overrides: Partial<ClaimConversationAddInput> = {}): ClaimConvers
   };
 }
 
+function scopeHash(value: ConversationIdempotencyScope = scope): string {
+  return createHash("sha256").update([
+    ["service_id", value.serviceId],
+    ["team_id", value.teamId],
+    ["agent_id", value.agentId],
+    ["user_id", value.userId],
+    ["session_id", value.sessionId],
+    ["idempotency_key", value.idempotencyKey],
+  ].map(([name, field]) => `${name}=${encodeURIComponent(field)}`).join("&")).digest("hex");
+}
+
 describe("VectorStore conversation add idempotency", () => {
   const stores: VectorStore[] = [];
   const directories: string[] = [];
@@ -190,14 +201,7 @@ describe("VectorStore conversation add idempotency", () => {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       "legacy-receipt",
-      createHash("sha256").update([
-        ["service_id", scope.serviceId],
-        ["team_id", scope.teamId],
-        ["agent_id", scope.agentId],
-        ["user_id", scope.userId],
-        ["session_id", scope.sessionId],
-        ["idempotency_key", scope.idempotencyKey],
-      ].map(([name, value]) => `${name}=${encodeURIComponent(value)}`).join("&")).digest("hex"),
+      scopeHash(),
       scope.serviceId,
       scope.teamId,
       scope.agentId,
@@ -221,5 +225,175 @@ describe("VectorStore conversation add idempotency", () => {
       status: "pending",
     });
     expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM conversation_add_receipts").get()).toEqual({ count: 1 });
+  });
+
+  it("conflicts when a legacy processing receipt has a different digest", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt",
+      scopeHash(),
+      scope.serviceId,
+      scope.teamId,
+      scope.agentId,
+      scope.userId,
+      scope.sessionId,
+      scope.idempotencyKey,
+      "digest-1",
+      "[]",
+      "processing",
+      1,
+      1,
+    );
+
+    expect(store.claimConversationAdd(input({ payloadDigest: "different-digest" }))).toEqual({ status: "conflict" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = ?").get("legacy-receipt")).toEqual({ status: "processing" });
+  });
+
+  it("removes identifiable legacy processing L0, FTS, and outbox remnants before reclaiming", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt",
+      scopeHash(),
+      scope.serviceId,
+      scope.teamId,
+      scope.agentId,
+      scope.userId,
+      scope.sessionId,
+      scope.idempotencyKey,
+      "digest-1",
+      "[\"legacy-message\"]",
+      "processing",
+      1,
+      1,
+    );
+    store.upsertL0({
+      ...input().records[0],
+      id: "legacy-message",
+      messageText: "legacy partial message",
+    }, undefined);
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_outbox (
+        event_id, receipt_id, service_id, session_id, rounds, team_id, agent_id,
+        status, created_at_ms, acknowledged_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
+    `).run("legacy-outbox", "legacy-receipt", scope.serviceId, scope.sessionId, 2, scope.teamId, scope.agentId, 1);
+
+    const claim = store.claimConversationAdd(input());
+
+    expect(claim.status).toBe("claimed");
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM l0_conversations WHERE record_id = 'legacy-message'").get()).toEqual({ count: 0 });
+    if (store.isFtsAvailable()) {
+      expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM l0_fts WHERE record_id = 'legacy-message'").get()).toEqual({ count: 0 });
+    }
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM conversation_add_outbox WHERE event_id = 'legacy-outbox'").get()).toEqual({ count: 0 });
+  });
+
+  it("does not reclaim a processing receipt when an accepted ID belongs to another isolation scope", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt",
+      scopeHash(),
+      scope.serviceId,
+      scope.teamId,
+      scope.agentId,
+      scope.userId,
+      scope.sessionId,
+      scope.idempotencyKey,
+      "digest-1",
+      "[\"legacy-message\"]",
+      "processing",
+      1,
+      1,
+    );
+    store.upsertL0({
+      ...input().records[0],
+      id: "legacy-message",
+      userId: "other-user",
+    }, undefined);
+
+    expect(store.claimConversationAdd(input())).toEqual({ status: "unsupported" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
+    expect(store.getRawDb().prepare("SELECT user_id FROM l0_conversations WHERE record_id = 'legacy-message'").get()).toEqual({ user_id: "other-user" });
+  });
+
+  it("does not reclaim a processing receipt when an unavailable vector residue cannot be cleaned", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt",
+      scopeHash(),
+      scope.serviceId,
+      scope.teamId,
+      scope.agentId,
+      scope.userId,
+      scope.sessionId,
+      scope.idempotencyKey,
+      "digest-1",
+      "[\"legacy-message\"]",
+      "processing",
+      1,
+      1,
+    );
+    // dimensions=0 deliberately has no vec0 handle; this table models an
+    // old vector residue that this store instance cannot clean safely.
+    store.getRawDb().exec("CREATE TABLE l0_vec (record_id TEXT PRIMARY KEY)");
+    store.getRawDb().prepare("INSERT INTO l0_vec (record_id) VALUES (?)").run("legacy-message");
+
+    expect(store.claimConversationAdd(input())).toEqual({ status: "unsupported" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
+    expect(store.getRawDb().prepare("SELECT COUNT(*) AS count FROM l0_vec WHERE record_id = 'legacy-message'").get()).toEqual({ count: 1 });
+  });
+
+  it("refuses to acknowledge an outbox attached to a processing receipt", () => {
+    const store = createStore();
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_receipts (
+        receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+        idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      "legacy-receipt",
+      scopeHash(),
+      scope.serviceId,
+      scope.teamId,
+      scope.agentId,
+      scope.userId,
+      scope.sessionId,
+      scope.idempotencyKey,
+      "digest-1",
+      "[]",
+      "processing",
+      1,
+      1,
+    );
+    store.getRawDb().prepare(`
+      INSERT INTO conversation_add_outbox (
+        event_id, receipt_id, service_id, session_id, rounds, team_id, agent_id,
+        status, created_at_ms, acknowledged_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
+    `).run("legacy-outbox", "legacy-receipt", scope.serviceId, scope.sessionId, 2, scope.teamId, scope.agentId, 1);
+
+    expect(store.ackConversationOutbox("legacy-outbox")).toBe(false);
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_receipts WHERE receipt_id = 'legacy-receipt'").get()).toEqual({ status: "processing" });
+    expect(store.getRawDb().prepare("SELECT status FROM conversation_add_outbox WHERE event_id = 'legacy-outbox'").get()).toEqual({ status: "pending" });
   });
 });

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -3559,12 +3559,13 @@ export class VectorStore implements IMemoryStore {
         "SELECT * FROM conversation_add_receipts WHERE scope_hash = ?",
       ).get(scopeHash) as ConversationReceiptRow | undefined;
 
+      if (existing && existing.payload_digest !== input.payloadDigest) {
+        this.db.exec("COMMIT");
+        return { status: "conflict" };
+      }
+
       if (existing && existing.status !== "processing") {
         const receipt = this.toConversationReceipt(existing);
-        if (receipt.payloadDigest !== input.payloadDigest) {
-          this.db.exec("COMMIT");
-          return { status: "conflict" };
-        }
         const outbox = this.db.prepare(
           "SELECT * FROM conversation_add_outbox WHERE receipt_id = ?",
         ).get(receipt.receiptId) as ConversationOutboxRow | undefined;
@@ -3577,11 +3578,14 @@ export class VectorStore implements IMemoryStore {
       }
 
       // A `processing` row can only originate from an older interrupted
-      // implementation. It never represents a committed admission here, so
-      // reclaiming it is safe and preserves retry availability.
+      // implementation. It never represents a committed admission here, but
+      // it may have left recognizable L0/outbox remnants. Reclaim only after
+      // those remnants are cleared in this same transaction.
       if (existing) {
-        this.db.prepare("DELETE FROM conversation_add_outbox WHERE receipt_id = ?").run(existing.receipt_id);
-        this.db.prepare("DELETE FROM conversation_add_receipts WHERE receipt_id = ?").run(existing.receipt_id);
+        if (!this.clearLegacyProcessingConversationAdmission(existing)) {
+          this.db.exec("COMMIT");
+          return { status: "unsupported" };
+        }
       }
 
       const now = Date.now();
@@ -3704,16 +3708,20 @@ export class VectorStore implements IMemoryStore {
     this.db.exec("BEGIN IMMEDIATE");
     try {
       const event = this.db.prepare(
-        "SELECT receipt_id FROM conversation_add_outbox WHERE event_id = ?",
-      ).get(eventId) as { receipt_id: string } | undefined;
-      if (!event) {
+        "SELECT receipt_id, status FROM conversation_add_outbox WHERE event_id = ?",
+      ).get(eventId) as { receipt_id: string; status: string } | undefined;
+      if (!event || event.status !== "pending") {
         this.db.exec("COMMIT");
         return false;
       }
       const receipt = this.db.prepare(
-        "SELECT receipt_id FROM conversation_add_receipts WHERE receipt_id = ?",
-      ).get(event.receipt_id) as { receipt_id: string } | undefined;
+        "SELECT receipt_id, status FROM conversation_add_receipts WHERE receipt_id = ?",
+      ).get(event.receipt_id) as { receipt_id: string; status: string } | undefined;
       if (!receipt) throw new Error(`conversation outbox ${eventId} references a missing receipt`);
+      if (receipt.status !== "pending") {
+        this.db.exec("COMMIT");
+        return false;
+      }
 
       const now = Date.now();
       this.ackConversationOutboxInTransaction(eventId, event.receipt_id, now);
@@ -3736,6 +3744,67 @@ export class VectorStore implements IMemoryStore {
       "UPDATE conversation_add_outbox SET status = 'acknowledged', acknowledged_at_ms = ? WHERE event_id = ?",
     ).run(now, eventId);
     this.completeConversationAddInTransaction(receiptId, now);
+  }
+
+  /**
+   * Clear the only remnants a legacy non-atomic `processing` admission can
+   * identify. A malformed accepted-ID payload cannot be cleaned safely, so
+   * the caller retains the receipt and reports `unsupported` instead.
+   */
+  private clearLegacyProcessingConversationAdmission(receipt: ConversationReceiptRow): boolean {
+    let acceptedIds: unknown;
+    try {
+      acceptedIds = JSON.parse(receipt.accepted_ids_json);
+    } catch {
+      return false;
+    }
+    if (!Array.isArray(acceptedIds) || !acceptedIds.every((id) => typeof id === "string")) {
+      return false;
+    }
+
+    const uniqueIds = [...new Set(acceptedIds)];
+    if (uniqueIds.length > 0 && (
+      (this.hasSqliteTable("l0_fts") && !this.ftsAvailable) ||
+      (this.hasSqliteTable("l0_vec") && !this.vecTablesReady)
+    )) {
+      return false;
+    }
+    for (const recordId of uniqueIds) {
+      const l0 = this.db.prepare(`
+        SELECT session_key, session_id, team_id, user_id, agent_id
+        FROM l0_conversations WHERE record_id = ?
+      `).get(recordId) as {
+        session_key: string;
+        session_id: string;
+        team_id: string;
+        user_id: string;
+        agent_id: string;
+      } | undefined;
+      if (l0 && (
+        l0.session_key !== receipt.session_id ||
+        l0.session_id !== receipt.session_id ||
+        l0.team_id !== receipt.team_id ||
+        l0.user_id !== receipt.user_id ||
+        l0.agent_id !== receipt.agent_id
+      )) {
+        return false;
+      }
+    }
+
+    for (const recordId of uniqueIds) {
+      if (this.ftsAvailable) this.stmtL0FtsDelete.run(recordId);
+      if (this.vecTablesReady) this.stmtL0DeleteVec!.run(recordId);
+      this.stmtL0DeleteMeta.run(recordId);
+    }
+    this.db.prepare("DELETE FROM conversation_add_outbox WHERE receipt_id = ?").run(receipt.receipt_id);
+    this.db.prepare("DELETE FROM conversation_add_receipts WHERE receipt_id = ?").run(receipt.receipt_id);
+    return true;
+  }
+
+  private hasSqliteTable(name: string): boolean {
+    return this.db.prepare(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+    ).get(name) !== undefined;
   }
 
   private writeL0ForConversationAdmission(record: L0Record): void {

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -20,7 +20,7 @@
  * - Thread-safe via WAL mode.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
@@ -57,6 +57,11 @@ import type {
   MemoryContentClearResult,
   AuditEntry,
   AuditQueryFilter,
+  ClaimConversationAddInput,
+  ConversationAddClaim,
+  ConversationIdempotencyScope,
+  ConversationOutboxEvent,
+  ConversationReceipt,
 } from "./types.js";
 import { DEFAULT_ISOLATION_ID, rowMatchesIsolation } from "./types.js";
 import { SKILLS_DDL, SKILL_FTS_DDL } from "../skill/skill-store-ddl.js";
@@ -130,6 +135,35 @@ export interface L0RecordRow {
   message_text: string;
   recorded_at: string;
   timestamp: number;
+}
+
+interface ConversationReceiptRow {
+  receipt_id: string;
+  scope_hash: string;
+  service_id: string;
+  team_id: string;
+  agent_id: string;
+  user_id: string;
+  session_id: string;
+  idempotency_key: string;
+  payload_digest: string;
+  accepted_ids_json: string;
+  status: string;
+  created_at_ms: number;
+  updated_at_ms: number;
+}
+
+interface ConversationOutboxRow {
+  event_id: string;
+  receipt_id: string;
+  service_id: string;
+  session_id: string;
+  rounds: number;
+  team_id: string;
+  agent_id: string;
+  status: string;
+  created_at_ms: number;
+  acknowledged_at_ms: number | null;
 }
 
 const TAG = "[memory-tdai][sqlite]";
@@ -799,6 +833,46 @@ export class VectorStore implements IMemoryStore {
     this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_user_agent_session ON l0_conversations(user_id, agent_id, session_id)");
     this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_user_recorded  ON l0_conversations(user_id, recorded_at)");
     this.db.exec("CREATE INDEX IF NOT EXISTS idx_l0_agent_recorded ON l0_conversations(agent_id, recorded_at)");
+
+    // Conversation-add idempotency is co-located with L0 so receipt creation,
+    // raw-message admission, and pipeline delivery intent can share one SQLite
+    // transaction. `processing` exists only for legacy/crash recovery; fresh
+    // claims commit as `pending` until the pipeline acknowledges the outbox.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS conversation_add_receipts (
+        receipt_id TEXT PRIMARY KEY,
+        scope_hash TEXT NOT NULL UNIQUE,
+        service_id TEXT NOT NULL,
+        team_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        payload_digest TEXT NOT NULL,
+        accepted_ids_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at_ms INTEGER NOT NULL,
+        updated_at_ms INTEGER NOT NULL
+      )
+    `);
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS conversation_add_outbox (
+        event_id TEXT PRIMARY KEY,
+        receipt_id TEXT NOT NULL UNIQUE,
+        service_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        rounds INTEGER NOT NULL,
+        team_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at_ms INTEGER NOT NULL,
+        acknowledged_at_ms INTEGER
+      )
+    `);
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_conversation_add_outbox_pending " +
+      "ON conversation_add_outbox(status, created_at_ms) WHERE status = 'pending'",
+    );
 
     // L0 vector virtual table (cosine distance, same dimensions as L1) — deferred when dimensions=0
     if (this.dimensions > 0) {
@@ -3465,6 +3539,291 @@ export class VectorStore implements IMemoryStore {
       ftsSearch: this.ftsAvailable,
       nativeHybridSearch: false,
       sparseVectors: false,
+    };
+  }
+
+  // ── Conversation add idempotency ────────────────────────────
+
+  /**
+   * Atomically create a pending conversation receipt, its L0 records, and one
+   * durable pipeline outbox event. A receipt becomes completed only through a
+   * later acknowledgement after the pipeline notification has succeeded.
+   */
+  claimConversationAdd(input: ClaimConversationAddInput): ConversationAddClaim {
+    if (this.degraded) return { status: "unsupported" };
+
+    const scopeHash = this.hashConversationScope(input.scope);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const existing = this.db.prepare(
+        "SELECT * FROM conversation_add_receipts WHERE scope_hash = ?",
+      ).get(scopeHash) as ConversationReceiptRow | undefined;
+
+      if (existing && existing.status !== "processing") {
+        const receipt = this.toConversationReceipt(existing);
+        if (receipt.payloadDigest !== input.payloadDigest) {
+          this.db.exec("COMMIT");
+          return { status: "conflict" };
+        }
+        const outbox = this.db.prepare(
+          "SELECT * FROM conversation_add_outbox WHERE receipt_id = ?",
+        ).get(receipt.receiptId) as ConversationOutboxRow | undefined;
+        this.db.exec("COMMIT");
+        return {
+          status: "replay",
+          receipt,
+          outboxEvent: outbox ? this.toConversationOutboxEvent(outbox) : undefined,
+        };
+      }
+
+      // A `processing` row can only originate from an older interrupted
+      // implementation. It never represents a committed admission here, so
+      // reclaiming it is safe and preserves retry availability.
+      if (existing) {
+        this.db.prepare("DELETE FROM conversation_add_outbox WHERE receipt_id = ?").run(existing.receipt_id);
+        this.db.prepare("DELETE FROM conversation_add_receipts WHERE receipt_id = ?").run(existing.receipt_id);
+      }
+
+      const now = Date.now();
+      const receiptId = randomUUID();
+      const eventId = randomUUID();
+      const acceptedIds = input.records.map((record) => record.id);
+      this.db.prepare(`
+        INSERT INTO conversation_add_receipts (
+          receipt_id, scope_hash, service_id, team_id, agent_id, user_id, session_id,
+          idempotency_key, payload_digest, accepted_ids_json, status, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'processing', ?, ?)
+      `).run(
+        receiptId,
+        scopeHash,
+        input.scope.serviceId,
+        input.scope.teamId,
+        input.scope.agentId,
+        input.scope.userId,
+        input.scope.sessionId,
+        input.scope.idempotencyKey,
+        input.payloadDigest,
+        JSON.stringify(acceptedIds),
+        now,
+        now,
+      );
+
+      for (const record of input.records) this.writeL0ForConversationAdmission(record);
+
+      this.db.prepare(`
+        INSERT INTO conversation_add_outbox (
+          event_id, receipt_id, service_id, session_id, rounds, team_id, agent_id,
+          status, created_at_ms, acknowledged_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL)
+      `).run(
+        eventId,
+        receiptId,
+        input.scope.serviceId,
+        input.scope.sessionId,
+        input.pipelineRounds,
+        input.scope.teamId,
+        input.scope.agentId,
+        now,
+      );
+      this.db.prepare(
+        "UPDATE conversation_add_receipts SET status = 'pending', updated_at_ms = ? WHERE receipt_id = ?",
+      ).run(now, receiptId);
+      this.db.exec("COMMIT");
+
+      return {
+        status: "claimed",
+        receipt: {
+          receiptId,
+          scope: { ...input.scope },
+          payloadDigest: input.payloadDigest,
+          acceptedIds,
+          status: "pending",
+          createdAtMs: now,
+          updatedAtMs: now,
+        },
+        outboxEvent: {
+          eventId,
+          receiptId,
+          serviceId: input.scope.serviceId,
+          sessionId: input.scope.sessionId,
+          rounds: input.pipelineRounds,
+          teamId: input.scope.teamId,
+          agentId: input.scope.agentId,
+          status: "pending",
+          createdAtMs: now,
+        },
+      };
+    } catch (err) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw err;
+    }
+  }
+
+  readConversationAddReceipt(scope: ConversationIdempotencyScope): ConversationReceipt | null {
+    if (this.degraded) return null;
+    const row = this.db.prepare(
+      "SELECT * FROM conversation_add_receipts WHERE scope_hash = ?",
+    ).get(this.hashConversationScope(scope)) as ConversationReceiptRow | undefined;
+    // `processing` is an obsolete, uncommitted state. It is intentionally not
+    // exposed as a valid receipt and will be reclaimed by the next claim.
+    if (!row || row.status === "processing") return null;
+    return this.toConversationReceipt(row);
+  }
+
+  completeConversationAdd(receiptId: string): ConversationReceipt | null {
+    if (this.degraded) return null;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const row = this.db.prepare(
+        "SELECT * FROM conversation_add_receipts WHERE receipt_id = ?",
+      ).get(receiptId) as ConversationReceiptRow | undefined;
+      if (!row || row.status === "processing") {
+        this.db.exec("COMMIT");
+        return null;
+      }
+      const outbox = this.db.prepare(
+        "SELECT event_id FROM conversation_add_outbox WHERE receipt_id = ?",
+      ).get(receiptId) as { event_id: string } | undefined;
+      if (!outbox) throw new Error(`conversation receipt ${receiptId} has no outbox event to acknowledge`);
+      const now = Date.now();
+      this.ackConversationOutboxInTransaction(outbox.event_id, receiptId, now);
+      const completed = this.db.prepare(
+        "SELECT * FROM conversation_add_receipts WHERE receipt_id = ?",
+      ).get(receiptId) as ConversationReceiptRow;
+      this.db.exec("COMMIT");
+      return this.toConversationReceipt(completed);
+    } catch (err) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw err;
+    }
+  }
+
+  /** Acknowledgement and receipt completion commit (or roll back) together. */
+  ackConversationOutbox(eventId: string): boolean {
+    if (this.degraded) return false;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const event = this.db.prepare(
+        "SELECT receipt_id FROM conversation_add_outbox WHERE event_id = ?",
+      ).get(eventId) as { receipt_id: string } | undefined;
+      if (!event) {
+        this.db.exec("COMMIT");
+        return false;
+      }
+      const receipt = this.db.prepare(
+        "SELECT receipt_id FROM conversation_add_receipts WHERE receipt_id = ?",
+      ).get(event.receipt_id) as { receipt_id: string } | undefined;
+      if (!receipt) throw new Error(`conversation outbox ${eventId} references a missing receipt`);
+
+      const now = Date.now();
+      this.ackConversationOutboxInTransaction(eventId, event.receipt_id, now);
+      this.db.exec("COMMIT");
+      return true;
+    } catch (err) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw err;
+    }
+  }
+
+  private completeConversationAddInTransaction(receiptId: string, now: number): void {
+    this.db.prepare(
+      "UPDATE conversation_add_receipts SET status = 'completed', updated_at_ms = ? WHERE receipt_id = ?",
+    ).run(now, receiptId);
+  }
+
+  private ackConversationOutboxInTransaction(eventId: string, receiptId: string, now: number): void {
+    this.db.prepare(
+      "UPDATE conversation_add_outbox SET status = 'acknowledged', acknowledged_at_ms = ? WHERE event_id = ?",
+    ).run(now, eventId);
+    this.completeConversationAddInTransaction(receiptId, now);
+  }
+
+  private writeL0ForConversationAdmission(record: L0Record): void {
+    this.stmtL0UpsertMeta.run(
+      record.id,
+      record.sessionKey,
+      record.sessionId || DEFAULT_ISOLATION_ID,
+      record.teamId || DEFAULT_ISOLATION_ID,
+      record.taskId || "",
+      record.role,
+      record.messageText,
+      record.recordedAt,
+      record.timestamp,
+      record.userId || DEFAULT_ISOLATION_ID,
+      record.agentId || DEFAULT_ISOLATION_ID,
+    );
+    if (this.ftsAvailable) {
+      this.stmtL0FtsDelete.run(record.id);
+      this.stmtL0FtsInsert.run(
+        tokenizeForFts(record.messageText),
+        record.messageText,
+        record.id,
+        record.sessionKey,
+        record.sessionId || DEFAULT_ISOLATION_ID,
+        record.teamId || DEFAULT_ISOLATION_ID,
+        record.taskId || "",
+        record.userId || DEFAULT_ISOLATION_ID,
+        record.agentId || DEFAULT_ISOLATION_ID,
+        record.role,
+        record.recordedAt,
+        record.timestamp,
+      );
+    }
+  }
+
+  private hashConversationScope(scope: ConversationIdempotencyScope): string {
+    const serialized = [
+      ["service_id", scope.serviceId],
+      ["team_id", scope.teamId],
+      ["agent_id", scope.agentId],
+      ["user_id", scope.userId],
+      ["session_id", scope.sessionId],
+      ["idempotency_key", scope.idempotencyKey],
+    ].map(([name, value]) => `${name}=${encodeURIComponent(value)}`).join("&");
+    return createHash("sha256").update(serialized).digest("hex");
+  }
+
+  private toConversationReceipt(row: ConversationReceiptRow): ConversationReceipt {
+    const acceptedIds = JSON.parse(row.accepted_ids_json) as unknown;
+    if (!Array.isArray(acceptedIds) || !acceptedIds.every((id) => typeof id === "string")) {
+      throw new Error(`conversation receipt ${row.receipt_id} has invalid accepted IDs`);
+    }
+    if (row.status !== "pending" && row.status !== "completed") {
+      throw new Error(`conversation receipt ${row.receipt_id} has unsupported status ${row.status}`);
+    }
+    return {
+      receiptId: row.receipt_id,
+      scope: {
+        serviceId: row.service_id,
+        teamId: row.team_id,
+        agentId: row.agent_id,
+        userId: row.user_id,
+        sessionId: row.session_id,
+        idempotencyKey: row.idempotency_key,
+      },
+      payloadDigest: row.payload_digest,
+      acceptedIds,
+      status: row.status,
+      createdAtMs: row.created_at_ms,
+      updatedAtMs: row.updated_at_ms,
+    };
+  }
+
+  private toConversationOutboxEvent(row: ConversationOutboxRow): ConversationOutboxEvent {
+    if (row.status !== "pending" && row.status !== "acknowledged") {
+      throw new Error(`conversation outbox ${row.event_id} has unsupported status ${row.status}`);
+    }
+    return {
+      eventId: row.event_id,
+      receiptId: row.receipt_id,
+      serviceId: row.service_id,
+      sessionId: row.session_id,
+      rounds: row.rounds,
+      teamId: row.team_id,
+      agentId: row.agent_id,
+      status: row.status,
+      createdAtMs: row.created_at_ms,
+      ...(row.acknowledged_at_ms === null ? {} : { acknowledgedAtMs: row.acknowledged_at_ms }),
     };
   }
 

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -166,6 +166,23 @@ interface ConversationOutboxRow {
   acknowledged_at_ms: number | null;
 }
 
+interface ConversationL0ScopeRow {
+  session_key: string;
+  session_id: string;
+  team_id: string;
+  user_id: string;
+  agent_id: string;
+}
+
+interface ConversationOutboxRecoveryRow {
+  event_id: string;
+  service_id: string;
+  session_id: string;
+  team_id: string;
+  agent_id: string;
+  status: string;
+}
+
 const TAG = "[memory-tdai][sqlite]";
 
 /** Persisted metadata about the embedding provider used to generate stored vectors. */
@@ -3769,25 +3786,42 @@ export class VectorStore implements IMemoryStore {
     )) {
       return false;
     }
+
+    // The outbox has no user_id, so its receipt_id relationship plus every
+    // scope-bearing event field must agree with the canonical receipt before
+    // it is safe to delete. Acknowledged events may have already notified the
+    // pipeline and are not safe to replay as a fresh claim.
+    const outboxRows = this.db.prepare(`
+      SELECT event_id, service_id, session_id, team_id, agent_id, status
+      FROM conversation_add_outbox WHERE receipt_id = ?
+    `).all(receipt.receipt_id) as ConversationOutboxRecoveryRow[];
+    if (!outboxRows.every((outbox) =>
+      outbox.service_id === receipt.service_id &&
+      outbox.session_id === receipt.session_id &&
+      outbox.team_id === receipt.team_id &&
+      outbox.agent_id === receipt.agent_id &&
+      outbox.status === "pending",
+    )) {
+      return false;
+    }
+
     for (const recordId of uniqueIds) {
       const l0 = this.db.prepare(`
         SELECT session_key, session_id, team_id, user_id, agent_id
         FROM l0_conversations WHERE record_id = ?
-      `).get(recordId) as {
-        session_key: string;
-        session_id: string;
-        team_id: string;
-        user_id: string;
-        agent_id: string;
-      } | undefined;
-      if (l0 && (
-        l0.session_key !== receipt.session_id ||
-        l0.session_id !== receipt.session_id ||
-        l0.team_id !== receipt.team_id ||
-        l0.user_id !== receipt.user_id ||
-        l0.agent_id !== receipt.agent_id
-      )) {
+      `).get(recordId) as ConversationL0ScopeRow | undefined;
+      // A vec0 row has no isolation fields and an FTS row is only trustworthy
+      // when its canonical L0 counterpart is present. Never remove either
+      // side table without this proof of ownership.
+      if (!l0 || !this.l0MatchesConversationReceipt(l0, receipt)) {
         return false;
+      }
+      if (this.ftsAvailable) {
+        const fts = this.db.prepare(`
+          SELECT session_key, session_id, team_id, user_id, agent_id
+          FROM l0_fts WHERE record_id = ?
+        `).get(recordId) as ConversationL0ScopeRow | undefined;
+        if (fts && !this.l0MatchesConversationReceipt(fts, receipt)) return false;
       }
     }
 
@@ -3799,6 +3833,14 @@ export class VectorStore implements IMemoryStore {
     this.db.prepare("DELETE FROM conversation_add_outbox WHERE receipt_id = ?").run(receipt.receipt_id);
     this.db.prepare("DELETE FROM conversation_add_receipts WHERE receipt_id = ?").run(receipt.receipt_id);
     return true;
+  }
+
+  private l0MatchesConversationReceipt(row: ConversationL0ScopeRow, receipt: ConversationReceiptRow): boolean {
+    return row.session_key === receipt.session_id &&
+      row.session_id === receipt.session_id &&
+      row.team_id === receipt.team_id &&
+      row.user_id === receipt.user_id &&
+      row.agent_id === receipt.agent_id;
   }
 
   private hasSqliteTable(name: string): boolean {

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -3817,16 +3817,16 @@ export class VectorStore implements IMemoryStore {
         return false;
       }
       if (this.ftsAvailable) {
-        const fts = this.db.prepare(`
+        const ftsRows = this.db.prepare(`
           SELECT session_key, session_id, team_id, user_id, agent_id
           FROM l0_fts WHERE record_id = ?
-        `).get(recordId) as ConversationL0ScopeRow | undefined;
-        if (fts && !this.l0MatchesConversationReceipt(fts, receipt)) return false;
+        `).all(recordId) as ConversationL0ScopeRow[];
+        if (!ftsRows.every((fts) => this.l0MatchesConversationReceipt(fts, receipt))) return false;
       }
     }
 
     for (const recordId of uniqueIds) {
-      if (this.ftsAvailable) this.stmtL0FtsDelete.run(recordId);
+      if (this.ftsAvailable) this.db.prepare("DELETE FROM l0_fts WHERE record_id = ?").run(recordId);
       if (this.vecTablesReady) this.stmtL0DeleteVec!.run(recordId);
       this.stmtL0DeleteMeta.run(recordId);
     }

--- a/MemoryCore/src/core/store/types.ts
+++ b/MemoryCore/src/core/store/types.ts
@@ -49,6 +49,65 @@ export {
 export type StoreLogger = Logger;
 
 // ============================
+// Conversation Add Idempotency
+// ============================
+
+/**
+ * Full tenant-scoped identity for a keyed `/v3/conversation/add` request.
+ * All fields are required: a key is never reusable across any of these
+ * isolation dimensions.
+ */
+export interface ConversationIdempotencyScope {
+  serviceId: string;
+  teamId: string;
+  agentId: string;
+  userId: string;
+  sessionId: string;
+  idempotencyKey: string;
+}
+
+/** Durable result of a keyed conversation admission. */
+export interface ConversationReceipt {
+  receiptId: string;
+  scope: ConversationIdempotencyScope;
+  payloadDigest: string;
+  acceptedIds: string[];
+  /** Pending until the pipeline outbox event has been acknowledged. */
+  status: "pending" | "completed";
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+/** A durable post-commit pipeline notification for one conversation receipt. */
+export interface ConversationOutboxEvent {
+  eventId: string;
+  receiptId: string;
+  serviceId: string;
+  sessionId: string;
+  rounds: number;
+  teamId: string;
+  agentId: string;
+  status: "pending" | "acknowledged";
+  createdAtMs: number;
+  acknowledgedAtMs?: number;
+}
+
+/** Outcome of atomically admitting (or reading) a keyed conversation add. */
+export type ConversationAddClaim =
+  | { status: "claimed"; receipt: ConversationReceipt; outboxEvent: ConversationOutboxEvent }
+  | { status: "replay"; receipt: ConversationReceipt; outboxEvent?: ConversationOutboxEvent }
+  | { status: "conflict" }
+  | { status: "unsupported" };
+
+/** Input that a capable store persists in one admission transaction. */
+export interface ClaimConversationAddInput {
+  scope: ConversationIdempotencyScope;
+  payloadDigest: string;
+  records: L0Record[];
+  pipelineRounds: number;
+}
+
+// ============================
 // L1 Types (Structured Memories)
 // ============================
 
@@ -559,6 +618,30 @@ export interface IMemoryStore extends MemoryPromptStore, MemoryGenerationRefStor
    * When `false` or absent, embedding is computed inline and passed to `upsertL0()`.
    */
   readonly supportsDeferredEmbedding?: boolean;
+
+  // ── Conversation add idempotency (optional backend capability) ──────
+
+  /**
+   * Atomically persist a new pending receipt, its L0 rows, and one pending
+   * pipeline outbox event; alternatively return a replay, conflict, or
+   * unsupported result. Backends without this method must reject keyed calls.
+   */
+  claimConversationAdd?(input: ClaimConversationAddInput): MaybePromise<ConversationAddClaim>;
+
+  /** Read a receipt by its complete, tenant-scoped identity. */
+  readConversationAddReceipt?(scope: ConversationIdempotencyScope): MaybePromise<ConversationReceipt | null>;
+
+  /**
+   * Mark a receipt completed only after its pipeline notification succeeds.
+   * This must not be used to mark the initial storage transaction complete.
+   */
+  completeConversationAdd?(receiptId: string): MaybePromise<ConversationReceipt | null>;
+
+  /**
+   * Acknowledge durable outbox delivery. SQLite implementations should update
+   * the outbox event and receipt completion state atomically.
+   */
+  ackConversationOutbox?(eventId: string): MaybePromise<boolean>;
 
   // ── Lifecycle (always sync) ──────────────────────────────
 

--- a/MemoryCore/src/gateway/v2-router-idempotency.test.ts
+++ b/MemoryCore/src/gateway/v2-router-idempotency.test.ts
@@ -46,10 +46,10 @@ describe("conversation add idempotency contract", () => {
 
   it("digests the normalized payload without its idempotency key", () => {
     expect(digestConversationAddPayload({ ...request, idempotency_key: "turn-1" })).toBe(
-      "7393f98ee3fd81dcae482a29a7465f2c3268431b561843b763eae91018719d9f",
+      "a0ff7418e47523b72d298b3489ce8a2ff8acf214663e8db0351936483daf72e6",
     );
     expect(digestConversationAddPayload({ ...request, idempotency_key: "turn-2" })).toBe(
-      "7393f98ee3fd81dcae482a29a7465f2c3268431b561843b763eae91018719d9f",
+      "a0ff7418e47523b72d298b3489ce8a2ff8acf214663e8db0351936483daf72e6",
     );
   });
 
@@ -58,6 +58,19 @@ describe("conversation add idempotency contract", () => {
     const changed = digestConversationAddPayload({
       ...request,
       messages: [{ ...request.messages[0], content: "goodbye" }],
+    });
+
+    expect(changed).not.toBe(original);
+  });
+
+  it("does not reuse a digest when a message recorded_at changes", () => {
+    const original = digestConversationAddPayload({
+      ...request,
+      messages: [{ ...request.messages[0], recorded_at: "2026-08-24T00:01:00.000Z" }],
+    });
+    const changed = digestConversationAddPayload({
+      ...request,
+      messages: [{ ...request.messages[0], recorded_at: "2026-08-24T00:02:00.000Z" }],
     });
 
     expect(changed).not.toBe(original);

--- a/MemoryCore/src/gateway/v2-router-idempotency.test.ts
+++ b/MemoryCore/src/gateway/v2-router-idempotency.test.ts
@@ -75,4 +75,17 @@ describe("conversation add idempotency contract", () => {
 
     expect(changed).not.toBe(original);
   });
+
+  it("normalizes equivalent message recorded_at formats before digesting", () => {
+    const utcWithoutMilliseconds = digestConversationAddPayload({
+      ...request,
+      messages: [{ ...request.messages[0], recorded_at: "2026-08-24T00:01:00Z" }],
+    });
+    const utcWithMilliseconds = digestConversationAddPayload({
+      ...request,
+      messages: [{ ...request.messages[0], recorded_at: "2026-08-24T00:01:00.000Z" }],
+    });
+
+    expect(utcWithoutMilliseconds).toBe(utcWithMilliseconds);
+  });
 });

--- a/MemoryCore/src/gateway/v2-router-idempotency.test.ts
+++ b/MemoryCore/src/gateway/v2-router-idempotency.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildConversationIdempotencyScope,
+  conversationAddRequestSchema,
+  digestConversationAddPayload,
+  serializeConversationIdempotencyScope,
+} from "./v2-schemas.js";
+
+describe("conversation add idempotency contract", () => {
+  const request = {
+    session_id: "session-1",
+    messages: [{ role: "user" as const, content: "hello", timestamp: "2026-08-24T00:00:00.000Z" }],
+  };
+
+  it("preserves unkeyed conversation add requests", () => {
+    expect(conversationAddRequestSchema.safeParse(request).success).toBe(true);
+  });
+
+  it("accepts an opaque idempotency key", () => {
+    const parsed = conversationAddRequestSchema.safeParse({ ...request, idempotency_key: "turn_01-ABC.def:retry" });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it.each(["", "   ", "has spaces", "slash/key", "x".repeat(257)])(
+    "rejects invalid idempotency key %j",
+    (idempotency_key) => {
+      expect(conversationAddRequestSchema.safeParse({ ...request, idempotency_key }).success).toBe(false);
+    },
+  );
+
+  it("serializes every scope dimension in a stable field order", () => {
+    const scope = buildConversationIdempotencyScope({
+      serviceId: "service-1",
+      teamId: "team-1",
+      agentId: "agent-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      idempotencyKey: "turn-1",
+    });
+
+    expect(serializeConversationIdempotencyScope(scope)).toBe(
+      "service_id=service-1&team_id=team-1&agent_id=agent-1&user_id=user-1&session_id=session-1&idempotency_key=turn-1",
+    );
+  });
+
+  it("digests the normalized payload without its idempotency key", () => {
+    expect(digestConversationAddPayload({ ...request, idempotency_key: "turn-1" })).toBe(
+      "7393f98ee3fd81dcae482a29a7465f2c3268431b561843b763eae91018719d9f",
+    );
+    expect(digestConversationAddPayload({ ...request, idempotency_key: "turn-2" })).toBe(
+      "7393f98ee3fd81dcae482a29a7465f2c3268431b561843b763eae91018719d9f",
+    );
+  });
+
+  it("does not reuse a digest when an ordered message changes", () => {
+    const original = digestConversationAddPayload(request);
+    const changed = digestConversationAddPayload({
+      ...request,
+      messages: [{ ...request.messages[0], content: "goodbye" }],
+    });
+
+    expect(changed).not.toBe(original);
+  });
+});

--- a/MemoryCore/src/gateway/v2-router-idempotency.test.ts
+++ b/MemoryCore/src/gateway/v2-router-idempotency.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ClaimConversationAddInput,
+  ConversationAddClaim,
+  ConversationReceipt,
+  IMemoryStore,
+  L0Record,
+} from "../core/store/types.js";
+import { handleConversationAdd, type V2RouterDeps } from "./v2-router.js";
 import {
   buildConversationIdempotencyScope,
   conversationAddRequestSchema,
   digestConversationAddPayload,
   serializeConversationIdempotencyScope,
+  type V2AuthContext,
 } from "./v2-schemas.js";
+
+vi.mock("../core/report/metric-tracking-recall.js", () => ({
+  reportRecallMetrics: vi.fn(),
+}));
 
 describe("conversation add idempotency contract", () => {
   const request = {
@@ -87,5 +100,163 @@ describe("conversation add idempotency contract", () => {
     });
 
     expect(utcWithoutMilliseconds).toBe(utcWithMilliseconds);
+  });
+});
+
+describe("conversation add idempotency router", () => {
+  const auth: V2AuthContext = { apiKey: "api-key", serviceId: "service-1" };
+  const body = {
+    session_id: "session-1",
+    idempotency_key: "turn-1",
+    messages: [{ role: "user" as const, content: "hello", timestamp: "2026-08-24T00:00:00.000Z" }],
+  };
+
+  function depsFor(store: Partial<IMemoryStore>, overrides: Partial<V2RouterDeps> = {}): V2RouterDeps {
+    return {
+      getStore: () => store as IMemoryStore,
+      getEmbedding: () => undefined,
+      getStorage: () => undefined,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      deployMode: "service",
+      requestIsolation: {
+        teamId: "team-1",
+        userId: "user-1",
+        agentId: "agent-1",
+        sessionId: "session-1",
+      },
+      notifyPipeline: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  function receiptFor(input: ClaimConversationAddInput, acceptedIds: string[], status: ConversationReceipt["status"] = "pending"): ConversationReceipt {
+    return {
+      receiptId: "receipt-1",
+      scope: { ...input.scope },
+      payloadDigest: input.payloadDigest,
+      acceptedIds,
+      status,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+  }
+
+  it("replays the first accepted IDs without writing or notifying again", async () => {
+    let saved: { receipt: ConversationReceipt; outboxEvent: Extract<ConversationAddClaim, { status: "claimed" }>["outboxEvent"] } | undefined;
+    const upsertL0 = vi.fn();
+    const notifyPipeline = vi.fn().mockResolvedValue(undefined);
+    const ackConversationOutbox = vi.fn().mockResolvedValue(true);
+    const store: Partial<IMemoryStore> = {
+      upsertL0,
+      claimConversationAdd: vi.fn(async (input: ClaimConversationAddInput): Promise<ConversationAddClaim> => {
+        if (saved) return { status: "replay", ...saved };
+        saved = {
+          receipt: receiptFor(input, input.records.map((record: L0Record) => record.id)),
+          outboxEvent: {
+            eventId: "event-1",
+            receiptId: "receipt-1",
+            serviceId: input.scope.serviceId,
+            sessionId: input.scope.sessionId,
+            rounds: input.pipelineRounds,
+            teamId: input.scope.teamId,
+            agentId: input.scope.agentId,
+            status: "pending",
+            createdAtMs: 1,
+          },
+        };
+        return { status: "claimed", ...saved };
+      }),
+      readConversationAddReceipt: vi.fn(async () => null),
+      ackConversationOutbox,
+    };
+
+    const first = await handleConversationAdd(body, auth, "req-1", depsFor(store, { notifyPipeline }));
+    const second = await handleConversationAdd(body, auth, "req-2", depsFor(store, { notifyPipeline }));
+
+    expect(first.code).toBe(0);
+    expect(second.code).toBe(0);
+    expect(second.data).toEqual(first.data);
+    expect(upsertL0).not.toHaveBeenCalled();
+    expect(notifyPipeline).toHaveBeenCalledTimes(1);
+    expect(ackConversationOutbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects the same key with a different payload", async () => {
+    const store: Partial<IMemoryStore> = {
+      upsertL0: vi.fn(),
+      claimConversationAdd: vi.fn(async () => ({ status: "conflict" })),
+    };
+    const notifyPipeline = vi.fn();
+
+    const response = await handleConversationAdd(body, auth, "req-1", depsFor(store, { notifyPipeline }));
+
+    expect(response.code).toBe(409);
+    expect(response.message).toMatch(/idempotency/i);
+    expect(store.upsertL0).not.toHaveBeenCalled();
+    expect(notifyPipeline).not.toHaveBeenCalled();
+  });
+
+  it("rejects keyed requests when the store has no atomic idempotency capability", async () => {
+    const store: Partial<IMemoryStore> = { upsertL0: vi.fn() };
+    const notifyPipeline = vi.fn();
+
+    const response = await handleConversationAdd(body, auth, "req-1", depsFor(store, { notifyPipeline }));
+
+    expect(response.code).toBe(503);
+    expect(response.message).toMatch(/idempotency/i);
+    expect(store.upsertL0).not.toHaveBeenCalled();
+    expect(notifyPipeline).not.toHaveBeenCalled();
+  });
+
+  it("keeps the outbox pending when post-commit pipeline notification fails", async () => {
+    const notifyPipeline = vi.fn().mockRejectedValue(new Error("pipeline down"));
+    const ackConversationOutbox = vi.fn();
+    const store: Partial<IMemoryStore> = {
+      upsertL0: vi.fn(),
+      claimConversationAdd: vi.fn(async (input: ClaimConversationAddInput): Promise<ConversationAddClaim> => ({
+        status: "claimed",
+        receipt: receiptFor(input, input.records.map((record: L0Record) => record.id)),
+        outboxEvent: {
+          eventId: "event-1",
+          receiptId: "receipt-1",
+          serviceId: input.scope.serviceId,
+          sessionId: input.scope.sessionId,
+          rounds: input.pipelineRounds,
+          teamId: input.scope.teamId,
+          agentId: input.scope.agentId,
+          status: "pending",
+          createdAtMs: 1,
+        },
+      })),
+      ackConversationOutbox,
+    };
+
+    const response = await handleConversationAdd(body, auth, "req-1", depsFor(store, { notifyPipeline }));
+
+    expect(response.code).toBe(0);
+    expect(notifyPipeline).toHaveBeenCalledTimes(1);
+    expect(ackConversationOutbox).not.toHaveBeenCalled();
+  });
+
+  it("preserves the legacy unkeyed write path", async () => {
+    const upsertL0 = vi.fn().mockResolvedValue(true);
+    const notifyPipeline = vi.fn().mockResolvedValue(undefined);
+    const store: Partial<IMemoryStore> = { upsertL0 };
+
+    const response = await handleConversationAdd(
+      { session_id: "session-1", messages: body.messages },
+      auth,
+      "req-1",
+      depsFor(store, { notifyPipeline }),
+    );
+
+    expect(response.code).toBe(0);
+    expect(upsertL0).toHaveBeenCalledTimes(1);
+    expect(notifyPipeline).toHaveBeenCalledTimes(1);
   });
 });

--- a/MemoryCore/src/gateway/v2-router-idempotency.test.ts
+++ b/MemoryCore/src/gateway/v2-router-idempotency.test.ts
@@ -189,6 +189,7 @@ describe("conversation add idempotency router", () => {
   it("rejects the same key with a different payload", async () => {
     const store: Partial<IMemoryStore> = {
       upsertL0: vi.fn(),
+      readConversationAddReceipt: vi.fn(async () => null),
       claimConversationAdd: vi.fn(async () => ({ status: "conflict" })),
     };
     const notifyPipeline = vi.fn();
@@ -218,6 +219,7 @@ describe("conversation add idempotency router", () => {
     const ackConversationOutbox = vi.fn();
     const store: Partial<IMemoryStore> = {
       upsertL0: vi.fn(),
+      readConversationAddReceipt: vi.fn(async () => null),
       claimConversationAdd: vi.fn(async (input: ClaimConversationAddInput): Promise<ConversationAddClaim> => ({
         status: "claimed",
         receipt: receiptFor(input, input.records.map((record: L0Record) => record.id)),

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -698,32 +698,30 @@ async function handleConversationAdd(body: unknown, auth: V2AuthContext, request
   const payloadDigest = idempotency_key ? digestConversationAddPayload(parsed.data) : undefined;
 
   if (idempotencyScope) {
-    if (!store.claimConversationAdd) {
+    if (!store.claimConversationAdd || !store.readConversationAddReceipt) {
       return errorEnvelope(
         503,
         "Store does not support transactional conversation idempotency for keyed requests",
         requestId,
       );
     }
-    if (store.readConversationAddReceipt) {
-      const receipt = await store.readConversationAddReceipt(idempotencyScope);
-      if (receipt) {
-        if (receipt.payloadDigest !== payloadDigest) {
-          return errorEnvelope(
-            409,
-            "Idempotency key already used with a different conversation payload",
-            requestId,
-          );
-        }
-        return successEnvelope<ConversationAddData>(
-          {
-            accepted_ids: receipt.acceptedIds,
-            accepted_versions: receipt.acceptedIds.map(() => "v1"),
-            total_count: receipt.acceptedIds.length,
-          },
+    const receipt = await store.readConversationAddReceipt(idempotencyScope);
+    if (receipt) {
+      if (receipt.payloadDigest !== payloadDigest) {
+        return errorEnvelope(
+          409,
+          "Idempotency key already used with a different conversation payload",
           requestId,
         );
       }
+      return successEnvelope<ConversationAddData>(
+        {
+          accepted_ids: receipt.acceptedIds,
+          accepted_versions: receipt.acceptedIds.map(() => "v1"),
+          total_count: receipt.acceptedIds.length,
+        },
+        requestId,
+      );
     }
   }
 

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -17,7 +17,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import type http from "node:http";
 import { classifyError } from "./error-handler.js";
-import type { IMemoryStore, L0Record, ProfileSyncRecord } from "../core/store/types.js";
+import { DEFAULT_ISOLATION_ID, type IMemoryStore, type L0Record, type ProfileSyncRecord } from "../core/store/types.js";
 import type { EmbeddingService } from "../core/store/embedding.js";
 import { createScopedStorageAdapter, type StorageAdapter } from "../core/storage/adapter.js";
 import { StoragePaths } from "../core/storage/types.js";
@@ -32,6 +32,8 @@ import { reportRecallMetrics } from "../core/report/metric-tracking-recall.js";
 // ── Zod schemas (validated types + defaults) ──
 import {
   conversationAddRequestSchema,
+  buildConversationIdempotencyScope,
+  digestConversationAddPayload,
   conversationQueryRequestSchema,
   conversationSearchRequestSchema,
   conversationDeleteRequestSchema,
@@ -664,7 +666,7 @@ export async function handleV2Route(
 async function handleConversationAdd(body: unknown, auth: V2AuthContext, requestId: string, deps: V2RouterDeps): Promise<ApiResponseEnvelope> {
   const parsed = conversationAddRequestSchema.safeParse(body);
   if (!parsed.success) return errorEnvelope(400, formatZodError(parsed.error), requestId);
-  const { session_id, messages } = parsed.data;
+  const { session_id, messages, idempotency_key } = parsed.data;
 
   // Enforce three-dim isolation. user_id / agent_id come from request body
   // or x-tdai-* headers (resolved in dispatchV2Request).  When the gateway's
@@ -682,6 +684,48 @@ async function handleConversationAdd(body: unknown, auth: V2AuthContext, request
 
   const store = deps.getStore();
   if (!store) return errorEnvelope(503, "Store not available", requestId);
+
+  const idempotencyScope = idempotency_key
+    ? buildConversationIdempotencyScope({
+      serviceId: auth.serviceId,
+      teamId: iso?.teamId ?? DEFAULT_ISOLATION_ID,
+      agentId: iso?.agentId ?? DEFAULT_ISOLATION_ID,
+      userId: iso?.userId ?? DEFAULT_ISOLATION_ID,
+      sessionId: session_id,
+      idempotencyKey: idempotency_key,
+    })
+    : undefined;
+  const payloadDigest = idempotency_key ? digestConversationAddPayload(parsed.data) : undefined;
+
+  if (idempotencyScope) {
+    if (!store.claimConversationAdd) {
+      return errorEnvelope(
+        503,
+        "Store does not support transactional conversation idempotency for keyed requests",
+        requestId,
+      );
+    }
+    if (store.readConversationAddReceipt) {
+      const receipt = await store.readConversationAddReceipt(idempotencyScope);
+      if (receipt) {
+        if (receipt.payloadDigest !== payloadDigest) {
+          return errorEnvelope(
+            409,
+            "Idempotency key already used with a different conversation payload",
+            requestId,
+          );
+        }
+        return successEnvelope<ConversationAddData>(
+          {
+            accepted_ids: receipt.acceptedIds,
+            accepted_versions: receipt.acceptedIds.map(() => "v1"),
+            total_count: receipt.acceptedIds.length,
+          },
+          requestId,
+        );
+      }
+    }
+  }
 
   // Quota check: memory limit
   if (deps.quotaManager) {
@@ -710,10 +754,10 @@ async function handleConversationAdd(body: unknown, auth: V2AuthContext, request
     }
   }
 
-  const embedding = deps.getEmbedding();
   const acceptedIds: string[] = [];
   const acceptedRecords: L0Record[] = [];
   const ingestBaseMs = Date.now();
+  const rounds = messages.filter((m) => m.role === "user").length;
 
   for (const [index, msg] of messages.entries()) {
     const id = `msg-${randomUUID().replace(/-/g, "").slice(0, 12)}`;
@@ -736,30 +780,81 @@ async function handleConversationAdd(body: unknown, auth: V2AuthContext, request
       timestamp: msg.timestamp ? new Date(msg.timestamp).getTime() : recordedAtMs,
     };
 
-    let emb: Float32Array | undefined;
-    if (embedding) {
-      try { emb = await embedding.embed(msg.content); } catch (e) { console.warn(`[v2-router] L0 embedding failed:`, e); }
-    }
-
-    await store.upsertL0(record, emb);
-    acceptedIds.push(id);
     acceptedRecords.push(record);
+  }
+
+  let idempotencyOutboxEventId: string | undefined;
+  if (idempotencyScope && payloadDigest) {
+    const claim = await store.claimConversationAdd!({
+      scope: idempotencyScope,
+      payloadDigest,
+      records: acceptedRecords,
+      pipelineRounds: rounds,
+    });
+    if (claim.status === "conflict") {
+      return errorEnvelope(
+        409,
+        "Idempotency key already used with a different conversation payload",
+        requestId,
+      );
+    }
+    if (claim.status === "unsupported") {
+      return errorEnvelope(
+        503,
+        "Store does not support transactional conversation idempotency for keyed requests",
+        requestId,
+      );
+    }
+    if (claim.status === "replay") {
+      return successEnvelope<ConversationAddData>(
+        {
+          accepted_ids: claim.receipt.acceptedIds,
+          accepted_versions: claim.receipt.acceptedIds.map(() => "v1"),
+          total_count: claim.receipt.acceptedIds.length,
+        },
+        requestId,
+      );
+    }
+    acceptedIds.push(...claim.receipt.acceptedIds);
+    idempotencyOutboxEventId = claim.outboxEvent.eventId;
+  } else {
+    const embedding = deps.getEmbedding();
+    for (const record of acceptedRecords) {
+      let emb: Float32Array | undefined;
+      if (embedding) {
+        try { emb = await embedding.embed(record.messageText); } catch (e) { console.warn(`[v2-router] L0 embedding failed:`, e); }
+      }
+
+      await store.upsertL0(record, emb);
+      acceptedIds.push(record.id);
+    }
   }
 
   // Notify pipeline: trigger async L1 extraction (service mode).
   // Each role=user message counts as one conversation round for threshold/timer logic.
   // teamId/agentId 透传给 captureAtomic 决定 hash slot 与锁粒度。
+  const ackIdempotencyOutbox = async () => {
+    if (!idempotencyOutboxEventId || !store.ackConversationOutbox) return;
+    try {
+      await store.ackConversationOutbox(idempotencyOutboxEventId);
+    } catch (err) {
+      deps.logger.warn(`${TAG} Pipeline outbox ack failed for ${session_id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
   if (deps.notifyPipeline) {
-    const rounds = messages.filter((m) => m.role === "user").length;
     if (rounds > 0) {
+      let pipelineNotified = false;
       try {
         await deps.notifyPipeline(auth.serviceId, session_id, rounds, iso?.teamId, iso?.agentId);
+        pipelineNotified = true;
       } catch (err) {
         // Non-fatal: L0 is already persisted, pipeline will catch up later
         deps.logger.warn(`${TAG} Pipeline notify failed for ${session_id}: ${err instanceof Error ? err.message : String(err)}`);
       }
+      if (pipelineNotified) await ackIdempotencyOutbox();
     }
   }
+  if (rounds === 0) await ackIdempotencyOutbox();
 
   // Standalone-only: mirror L0 to <dataDir>/conversations/<date>.jsonl.
   // Parity with v1 /capture (l0-recorder) path — gives humans a grep-able audit

--- a/MemoryCore/src/gateway/v2-schemas.ts
+++ b/MemoryCore/src/gateway/v2-schemas.ts
@@ -10,8 +10,9 @@
  *   - formatZodError utility
  */
 
+import { createHash } from "node:crypto";
 import { z } from "zod";
-import { DEFAULT_ISOLATION_ID } from "../core/store/types.js";
+import { DEFAULT_ISOLATION_ID, type ConversationIdempotencyScope } from "../core/store/types.js";
 
 // ============================
 // Re-export all generated schemas as-is
@@ -110,8 +111,48 @@ import {
 export const conversationAddRequestSchema = z.object({
   session_id: z.string().min(1).default(DEFAULT_ISOLATION_ID),
   messages: z.array(_conversationItemSchema).min(1).max(100),
+  // Opaque client retry token. It intentionally permits common UUID/ULID and
+  // turn identifiers while excluding whitespace and path-like separators.
+  idempotency_key: z.string().min(1).max(256).regex(/^[A-Za-z0-9._:-]+$/).optional(),
 });
 export type ConversationAddRequest = z.infer<typeof conversationAddRequestSchema>;
+
+/** Build the complete receipt identity for a keyed conversation-add request. */
+export function buildConversationIdempotencyScope(scope: ConversationIdempotencyScope): ConversationIdempotencyScope {
+  return { ...scope };
+}
+
+/**
+ * Stable, inspectable representation used as the input to the store's scope
+ * hash. Field order is fixed so every backend derives the same identity.
+ */
+export function serializeConversationIdempotencyScope(scope: ConversationIdempotencyScope): string {
+  return [
+    ["service_id", scope.serviceId],
+    ["team_id", scope.teamId],
+    ["agent_id", scope.agentId],
+    ["user_id", scope.userId],
+    ["session_id", scope.sessionId],
+    ["idempotency_key", scope.idempotencyKey],
+  ].map(([name, value]) => `${name}=${encodeURIComponent(value)}`).join("&");
+}
+
+/**
+ * SHA-256 over the semantic conversation-add payload. The idempotency key is
+ * deliberately excluded: it selects a receipt, while this digest detects a
+ * conflicting reuse of that receipt.
+ */
+export function digestConversationAddPayload(request: Pick<ConversationAddRequest, "session_id" | "messages">): string {
+  const normalized = {
+    messages: request.messages.map((message) => ({
+      content: message.content,
+      role: message.role,
+      timestamp: message.timestamp ?? null,
+    })),
+    session_id: request.session_id,
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+}
 
 // ============================
 // Count endpoints (sdk-v3.yaml)

--- a/MemoryCore/src/gateway/v2-schemas.ts
+++ b/MemoryCore/src/gateway/v2-schemas.ts
@@ -146,6 +146,7 @@ export function digestConversationAddPayload(request: Pick<ConversationAddReques
   const normalized = {
     messages: request.messages.map((message) => ({
       content: message.content,
+      recorded_at: message.recorded_at ?? null,
       role: message.role,
       timestamp: message.timestamp ?? null,
     })),

--- a/MemoryCore/src/gateway/v2-schemas.ts
+++ b/MemoryCore/src/gateway/v2-schemas.ts
@@ -146,7 +146,7 @@ export function digestConversationAddPayload(request: Pick<ConversationAddReques
   const normalized = {
     messages: request.messages.map((message) => ({
       content: message.content,
-      recorded_at: message.recorded_at ?? null,
+      recorded_at: message.recorded_at ? new Date(message.recorded_at).toISOString() : null,
       role: message.role,
       timestamp: message.timestamp ?? null,
     })),


### PR DESCRIPTION
## Summary

Refs #1087.

This PR adds optional retry idempotency for `POST /v3/conversation/add`, aimed at OpenCode/OpenClaw-style completed-turn retries:

- accepts an optional `idempotency_key` and scopes it by service/team/agent/user/session/key
- stores SQLite receipts, L0 rows, and a pending pipeline outbox event in one transaction
- replays the original `accepted_ids` for the same normalized payload without writing L0 or notifying the pipeline again
- returns `409` when the same key is reused with a different payload
- returns `503` for keyed requests when the active store cannot provide atomic idempotency semantics
- ACKs the durable outbox only after post-commit pipeline notification succeeds
- documents the SQLite guarantee and the Redis/TCVDB boundary

## Backend support boundary

The public SQLite store now has the verified transactional behavior. Redis/TCVDB/private deployments should not claim cross-replica exactly-once until they implement equivalent atomic claim/read receipt/outbox ACK semantics.

## Validation

- `cd MemoryCore && npm test` -> 2 files, 33 tests passed
- `cd MemoryCore && npm run build:plugin` -> passed
- `git diff --check upstream/feat/server_team...HEAD` -> passed

Note: `npm run build:plugin` reports the existing tsdown warning that Node.js v22.14.0 is deprecated and v22.18.0+ will be required in a future tsdown minor release.
