### PR TITLE
fix(install): make OpenClaw runtime patch opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
 openclaw gateway restart
 ```
 
+Plain installation does not patch OpenClaw runtime files. The runtime patch is only needed for optional short-term compression and must be applied explicitly.
+
 > Please use the native OpenClaw command to upgrade the plugin. This approach prevents the plugin from being disabled caused by semantic version ranges.
 > ```bash
 > openclaw plugins update @tencentdb-agent-memory/memory-tencentdb
@@ -191,13 +193,15 @@ Add the `slots` field so OpenClaw routes context-offload requests to this plugin
 
 #### Step 2 — Apply the runtime patch
 
-For the best results, run the patch script below. It hooks `after-tool-call` messages so they can be offloaded and recovered correctly:
+For the best short-term compression results, run the patch script deliberately. It hooks `after-tool-call` messages so they can be offloaded and recovered correctly:
 
 ```bash
 bash scripts/openclaw-after-tool-call-messages.patch.sh
 ```
 
-> 💡 The patch only needs to be applied once per OpenClaw installation. After upgrading OpenClaw, re-run the script to re-apply.
+If you intentionally want npm `postinstall` to run the same patch, set `MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH=1` for that install.
+
+> 💡 The patch only needs to be applied once per OpenClaw installation. After upgrading OpenClaw, re-run the script to re-apply. Long-term memory capture, extraction, and recall work without this patch.
 
 
 ### 2. Hermes

--- a/README_CN.md
+++ b/README_CN.md
@@ -145,6 +145,8 @@ openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
 openclaw gateway restart
 ```
 
+普通安装不会修改 OpenClaw 运行时文件。运行时 patch 仅用于可选的短期记忆压缩，需要用户显式执行。
+
 > 升级插件请优先使用 OpenClaw 原生更新命令，该方式可以避免因语义化版本范围导致插件禁用：
 > ```bash
 > openclaw plugins update @tencentdb-agent-memory/memory-tencentdb
@@ -196,13 +198,15 @@ openclaw gateway restart
 
 #### 步骤 2 —— 执行 patch 脚本
 
-为保证最佳效果，请执行以下 patch 脚本。该脚本会注入 `after-tool-call` 消息钩子，让工具调用结果能被正确卸载与回溯：
+为保证短期记忆压缩的最佳效果，请主动执行以下 patch 脚本。该脚本会注入 `after-tool-call` 消息钩子，让工具调用结果能被正确卸载与回溯：
 
 ```bash
 bash scripts/openclaw-after-tool-call-messages.patch.sh
 ```
 
-> 💡 patch 每次 OpenClaw 安装只需执行一次。升级 OpenClaw 后建议重新执行以确保钩子生效。
+如果你确实希望 npm `postinstall` 阶段自动执行同一个 patch，请在安装时显式设置 `MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH=1`。
+
+> 💡 patch 每次 OpenClaw 安装只需执行一次。升级 OpenClaw 后建议重新执行以确保钩子生效。长期记忆的采集、提取和召回不依赖该 patch。
 
 
 ### 2. Hermes

--- a/__tests__/postinstall.test.ts
+++ b/__tests__/postinstall.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { runPostinstall } from "../scripts/postinstall.mjs";
+
+function spawnOk() {
+  return { status: 0, error: undefined };
+}
+
+describe("postinstall OpenClaw patch", () => {
+  it("does not patch OpenClaw unless explicitly opted in", () => {
+    const spawn = vi.fn(spawnOk);
+    const logger = vi.fn();
+
+    runPostinstall({
+      platform: "linux",
+      env: {},
+      exists: () => true,
+      spawn,
+      logger,
+      directory: "/repo/scripts",
+    });
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("requires MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH=1"));
+  });
+
+  it("runs the OpenClaw patch when explicitly opted in", () => {
+    const spawn = vi.fn(spawnOk);
+
+    runPostinstall({
+      platform: "linux",
+      env: { MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH: "1" },
+      exists: () => true,
+      spawn,
+      logger: vi.fn(),
+      directory: "/repo/scripts",
+    });
+
+    expect(spawn).toHaveBeenCalledWith("bash", ["--version"], { stdio: "ignore" });
+    expect(spawn).toHaveBeenCalledWith("bash", ["/repo/scripts/openclaw-after-tool-call-messages.patch.sh"], {
+      cwd: "/repo",
+      env: { MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH: "1" },
+      stdio: "inherit",
+    });
+  });
+});

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -3,7 +3,7 @@
  * Cross-platform postinstall hook.
  *
  * The OpenClaw runtime patch is a Bash-only convenience. It should never make
- * npm install fail, and it is not relevant for Windows-native Hermes installs.
+ * npm install fail or modify an installed OpenClaw unless the operator opts in.
  */
 
 import { spawnSync } from "node:child_process";
@@ -41,8 +41,15 @@ export function runPostinstall({
     return skip(`unsupported platform ${platform}`);
   }
 
+  if (!isTruthy(env.MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH)) {
+    return skip("OpenClaw patch requires MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH=1");
+  }
+
+  if (isTruthy(env.MEMORY_TENCENTDB_SKIP_OPENCLAW_PATCH)) {
+    return skip("MEMORY_TENCENTDB_SKIP_OPENCLAW_PATCH is set");
+  }
+
   if (
-    isTruthy(env.MEMORY_TENCENTDB_SKIP_OPENCLAW_PATCH) ||
     env.MEMORY_TENCENTDB_MODE === "hermes" ||
     env.HERMES_HOME ||
     env.HERMES_AGENT_DIR


### PR DESCRIPTION
## Summary

Fixes #1095.

This changes the npm `postinstall` behavior so installing `@tencentdb-agent-memory/memory-tencentdb` no longer patches an installed OpenClaw runtime by default.

- Require `MEMORY_TENCENTDB_APPLY_OPENCLAW_PATCH=1` before postinstall runs `scripts/openclaw-after-tool-call-messages.patch.sh`
- Keep `MEMORY_TENCENTDB_SKIP_OPENCLAW_PATCH` as an explicit disable guard
- Preserve the Hermes-context skip behavior
- Document that normal installation does not modify OpenClaw dist files
- Document that the patch is only needed for optional short-term compression; long-term memory capture/extraction/recall works without it
- Add postinstall unit coverage for default skip vs explicit opt-in

## Validation

- `npm test` -> 5 files, 69 tests passed
- `npm run build` -> passed
- `git diff --check upstream/main...HEAD` -> passed

Note: `npm run build` reports the existing tsdown warning that Node.js v22.14.0 is deprecated and v22.18.0+ will be required in a future tsdown minor release.
