### PR TITLE
docs: fix github org name Tencent -> TencentCloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ The simplest inner loop: run the full stack in Docker, then patch the target
 module locally.
 
 ```bash
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory/deploy/global-images
 cp .env.example .env && $EDITOR .env
 ./start-all.sh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 Start all three services in one go (`memory-core` + `memory-hub` + `proxy`):
 
 ```bash
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory/deploy/global-images
 cp .env.example .env
 $EDITOR .env       # Fill in two sets of LLM parameters (memory group + proxy group)
@@ -314,8 +314,8 @@ We are grateful to the authors and contributors of these projects.
 
 We welcome contributions of all kinds — bug reports, feature suggestions, documentation fixes, benchmark reproductions, ecosystem integrations, or pull requests. Agent memory is far from settled, and we hope to build it together with the community.
 
-- 🐞 **Found a bug or have a question?** Open an issue in [GitHub Issues](https://github.com/Tencent/TencentDB-Agent-Memory/issues) — we respond within 24 hours.
-- 💡 **Have an idea to share?** Start a thread in [GitHub Discussions](https://github.com/Tencent/TencentDB-Agent-Memory/discussions).
+- 🐞 **Found a bug or have a question?** Open an issue in [GitHub Issues](https://github.com/TencentCloud/TencentDB-Agent-Memory/issues) — we respond within 24 hours.
+- 💡 **Have an idea to share?** Start a thread in [GitHub Discussions](https://github.com/TencentCloud/TencentDB-Agent-Memory/discussions).
 - 🛠️ **Want to contribute code?** Please read [CONTRIBUTING.md](./CONTRIBUTING.md) first.
 - 💬 **Want to chat with us?** Join our [Discord community](https://discord.gg/dJQM6mKMF) and talk to the core developers directly.
 
@@ -361,7 +361,7 @@ We welcome contributions of all kinds — bug reports, feature suggestions, docu
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#Tencent/TencentDB-Agent-Memory&Date">
+  <a href="https://www.star-history.com/#TencentCloud/TencentDB-Agent-Memory&Date">
     <img src="https://github.com/user-attachments/assets/16753a90-8bc9-471b-819e-311947ed94f7" alt="Star History Chart" width="600" />
   </a>
 </p>


### PR DESCRIPTION
### What does this PR do

Fix wrong GitHub organization name: replace `Tencent/TencentDB-Agent-Memory` with correct `TencentCloud/TencentDB-Agent-Memory`.

**Updated links in:**
- `README.md`: clone url, issues link, discussions link, star-history link
- `CONTRIBUTING.md`: git clone example url

This is a pure documentation fix, no logic / code change.

**Files changed:** 2 files, 5 insertions(+), 5 deletions(-)

Signed-off-by: yu3394 <yu3394@users.noreply.github.com>