### PR TITLE
fix(proxy): skip DSH runtime-context when writing L0

### DIFF
--- a/MemoryProxy/src/common/__tests__/user-query-extractor.test.ts
+++ b/MemoryProxy/src/common/__tests__/user-query-extractor.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractUserQueryText,
+  isDshRuntimeContextSnapshot,
+} from "../user-query-extractor.js";
+import { extractLatestUserMessage } from "../../tdai/recorder.js";
+
+describe("isDshRuntimeContextSnapshot", () => {
+  it("matches the DSH runtime-context prefix", () => {
+    expect(isDshRuntimeContextSnapshot("Current runtime context. cwd=/workspace")).toBe(true);
+    expect(isDshRuntimeContextSnapshot("  Current runtime context. policy=danger-full-access")).toBe(true);
+  });
+
+  it("does not match a real user question that only mentions the phrase", () => {
+    expect(isDshRuntimeContextSnapshot("请解释 Current runtime context. 是什么")).toBe(false);
+  });
+});
+
+describe("extractUserQueryText", () => {
+  it("discards a DSH runtime-context snapshot", () => {
+    const raw = [
+      "Current runtime context. This snapshot supersedes earlier runtime-context snapshots.",
+      "Current DSH file policy: danger-full-access.",
+      "cwd=/workspace",
+    ].join("\n");
+    expect(extractUserQueryText(raw)).toBe("");
+  });
+
+  it("strips a standalone system-reminder to empty", () => {
+    expect(extractUserQueryText("<system-reminder>internal metadata</system-reminder>")).toBe("");
+  });
+
+  it("keeps a real user question", () => {
+    expect(extractUserQueryText("请检查这个项目并修复问题")).toBe("请检查这个项目并修复问题");
+  });
+
+  it("still extracts an explicit user_query block", () => {
+    expect(extractUserQueryText("<user_query>fix the login bug</user_query>")).toBe("fix the login bug");
+  });
+});
+
+describe("extractLatestUserMessage", () => {
+  it("skips DSH metadata and returns the real user prompt", () => {
+    const got = extractLatestUserMessage([
+      { role: "user", content: "请检查这个项目并修复问题" },
+      { role: "user", content: "Current runtime context. cwd=/workspace ..." },
+      { role: "user", content: "<system-reminder>internal metadata</system-reminder>" },
+    ]);
+    expect(got).toEqual({ role: "user", content: "请检查这个项目并修复问题" });
+  });
+
+  it("returns null when every user message is harness noise", () => {
+    const got = extractLatestUserMessage([
+      { role: "user", content: "Current runtime context. cwd=/tmp" },
+      { role: "user", content: "<system-reminder>workspace rules</system-reminder>" },
+    ]);
+    expect(got).toBeNull();
+  });
+});

--- a/MemoryProxy/src/common/user-query-extractor.ts
+++ b/MemoryProxy/src/common/user-query-extractor.ts
@@ -10,8 +10,9 @@
  *
  * 抽取语义（按优先级排列）：
  *
- *   0) CC 客户端内部 prompt / tool_result 伪装 / session-init 回执整条丢弃
- *      → 返回 ""，调用方据此决定本轮不写 L0 / 不进 skill buffer
+ *   0) CC 客户端内部 prompt / tool_result 伪装 / session-init 回执，
+ *      以及 DSH 纯文本 `Current runtime context.` 快照 → 整条丢弃，返回 ""，
+ *      调用方据此决定本轮不写 L0 / 不进 skill buffer
  *
  *   1) 显式 `<user_query>...</user_query>` 块（CodeBuddy 标准 + CC 部分模板）
  *      → 只提取块内 join，即便同条消息同时含 session-init 表单也不受影响
@@ -76,6 +77,17 @@ function isClaudeCodeInternalPrompt(text: string): boolean {
 }
 
 /**
+ * DSH 把运行环境快照作为独立 `role=user` 消息追加在真实提问之后。
+ * 固定开头，与 session-init 跳过逻辑同一锚点，避免 L0 把 harness 元数据
+ * 当成用户输入。真实用户提问不会以这段英文开头。
+ */
+export const DSH_RUNTIME_CONTEXT_PREFIX = "Current runtime context.";
+
+export function isDshRuntimeContextSnapshot(text: string): boolean {
+  return text.trimStart().startsWith(DSH_RUNTIME_CONTEXT_PREFIX);
+}
+
+/**
  * 从原始 user content 文本抽取用户真实键入。
  *
  * 返回空字符串意味着"这条 user message 全是 harness 噪声"，调用方应据此
@@ -89,6 +101,9 @@ export function extractUserQueryText(raw: string): string {
   //    这是最高优先级：即便同时含 <user_query> 也整条判定为非人类输入。
   //    真实用户输入不会命中这些锚定在开头/整串的模式。
   if (isClaudeCodeInternalPrompt(raw)) return "";
+  // DSH runtime-context 快照：纯文本、无 XML wrapper，必须整条丢弃，
+  // 否则 extractLatestUserMessage 从后往前扫会把它当成真实提问写入 L0。
+  if (isDshRuntimeContextSnapshot(raw)) return "";
 
   // 1) 优先：显式 <user_query> 块（即便同一条消息里还夹着 session-init 问答，
   //    也只取真实 query，用户输入完整保留）。

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -39,6 +39,7 @@ import {
 } from "./extractor.js";
 import { getLastUserMessageText } from "./cleaner.js";
 import { emitSessionInitTelemetryIfCompleted } from "../init-telemetry.js";
+import { isDshRuntimeContextSnapshot } from "../../common/user-query-extractor.js";
 import {
   CODEX_MORE_LABEL,
   DEFAULT_GATE_PREFIX,
@@ -258,7 +259,7 @@ function isFreshCBConversation(messages: MessageArr): boolean {
     if (typeof c === "string") {
       if (
         c.startsWith("<system-reminder>") ||
-        c.startsWith("Current runtime context.")
+        isDshRuntimeContextSnapshot(c)
       ) {
         continue;
       }

--- a/MemoryProxy/src/session/store.ts
+++ b/MemoryProxy/src/session/store.ts
@@ -27,6 +27,7 @@ import type { SessionInitState, SessionInitStatus, SessionInfo, AgentDetail, Tas
 import { getSessionRepo, type SessionRepo } from "../db/sessionRepo.js";
 import type { BindingRepo, SessionBinding } from "../db/binding-repo.js";
 import type { MetadataClient } from "../meta/client.js";
+import { isDshRuntimeContextSnapshot } from "../common/user-query-extractor.js";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -699,7 +700,7 @@ export class SessionStore {
       if (typeof c === "string") {
         if (
           c.startsWith("<system-reminder>") ||
-          c.startsWith("Current runtime context.") ||
+          isDshRuntimeContextSnapshot(c) ||
           c.startsWith("<system-reminder>\nA skill is a reusable")
         ) {
           continue;

--- a/MemoryProxy/src/tdai/recorder.ts
+++ b/MemoryProxy/src/tdai/recorder.ts
@@ -5,10 +5,10 @@ import { extractUserQueryText } from "../common/user-query-extractor.js";
 /**
  * 从最后一条 user 消息中抽取「真正的用户提问」，写入 L0。
  *
- * 背景：CodeBuddy / Claude Code 等编码 agent 的 user 消息里除了真实问题，
- * 还塞了大量 harness 上下文（<additional_data> 打开的文件、current_time、
- * <system_reminder> 等）。如果把整条消息原样写进 L0，记忆会被这些噪声污染，
- * 而且每轮都不一样、检索价值极低。因此这里只保留 <user_query> 正文。
+ * 背景：CodeBuddy / Claude Code / DSH 等编码 agent 的 user 消息里除了真实问题，
+ * 还塞了大量 harness 上下文（<additional_data>、current_time、<system_reminder>、
+ * DSH 的 `Current runtime context.` 快照等）。如果把整条消息原样写进 L0，记忆
+ * 会被这些噪声污染，而且每轮都不一样、检索价值极低。因此这里只保留真实提问。
  *
  * 抽取算法在 `common/user-query-extractor.ts` 内实现（tdai / mem-command /
  * codebuddy adapter 共用同一份，避免语义漂移）；本模块只负责"取最后一条


### PR DESCRIPTION
## Description | 描述
DSH appends a standalone `role=user` snapshot starting with `Current runtime context.` after the real prompt. Session-init already skipped that message, but L0 extraction walked backward and treated the snapshot as the user query. Tool-loop turns then wrote the same harness metadata into L0 repeatedly and L1 extracted scenes about runtime context.

This change discards that snapshot in `extractUserQueryText` (so `extractLatestUserMessage` keeps walking to the real prompt) and reuses the same helper in session-init so the two paths cannot drift.

## Related Issue | 关联 Issue
Fixes #1149

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

`npx vitest run src/common/__tests__/user-query-extractor.test.ts` — 8 passed.

## Additional Notes | 其他说明
`npm run typecheck` still reports pre-existing SessionInfo / resetFlow errors on this branch; none are in the extractor change.

Made with [Cursor](https://cursor.com)