### PR TITLE
fix(hermes): surface gateway outages instead of going silently dark

### DIFF
--- a/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -428,6 +428,26 @@ class MemoryTencentdbProvider(MemoryProvider):
         self._watchdog_thread: Optional[threading.Thread] = None
         self._watchdog_stop = threading.Event()
 
+        # Degraded-mode accounting.
+        # When the Gateway goes dark the provider must not vanish silently
+        # from the agent's context: system_prompt_block() used to return ""
+        # and dropped sync_turn() calls left nothing but logger.warning
+        # lines, so a 24/7 agent could run for days with memory dead and
+        # nobody the wiser. These fields track the outage instead:
+        #   * _gateway_down_since — wall-clock time of the first missed
+        #     request, so the degraded prompt block can say when it began.
+        #   * _lost_turn_count    — sync_turn() calls that were NOT captured.
+        #   * _last_outage_summary — filled by _mark_gateway_up() on
+        #     recovery and surfaced once in the restored prompt block, so
+        #     the agent can tell the user exactly how much went missing.
+        # _degraded_lock guards all three: _note_lost_turn() runs on
+        # background sync threads while _mark_gateway_up() may run on the
+        # request thread or inside recovery.
+        self._degraded_lock = threading.Lock()
+        self._gateway_down_since: Optional[float] = None
+        self._lost_turn_count = 0
+        self._last_outage_summary: Optional[str] = None
+
     # -- Properties -----------------------------------------------------------
 
     @property
@@ -455,6 +475,61 @@ class MemoryTencentdbProvider(MemoryProvider):
                 "memory-tencentdb circuit breaker tripped after %d failures. Pausing for %ds.",
                 self._consecutive_failures, _BREAKER_COOLDOWN_SECS,
             )
+
+    # -- Degraded-mode accounting ---------------------------------------------
+
+    def _note_gateway_down(self):
+        """Record the first missed request of an outage (idempotent)."""
+        with self._degraded_lock:
+            if self._gateway_down_since is None:
+                self._gateway_down_since = time.time()
+                logger.warning(
+                    "memory-tencentdb: Gateway unreachable; memory is running "
+                    "degraded until it comes back."
+                )
+
+    def _note_lost_turn(self):
+        """Count one conversation turn that will not be captured."""
+        with self._degraded_lock:
+            self._lost_turn_count += 1
+
+    def _mark_gateway_up(self):
+        """On recovery: summarize the outage once, then clear the counters.
+
+        The summary survives in _last_outage_summary so the next active
+        system_prompt_block() can tell the agent — and through it the user
+        — that a stretch of conversation went uncaptured. A later outage
+        replaces the summary rather than clearing it.
+        """
+        with self._degraded_lock:
+            if self._gateway_down_since is None and self._lost_turn_count == 0:
+                return
+            if self._lost_turn_count:
+                down_ts = (
+                    time.strftime(
+                        "%Y-%m-%d %H:%M", time.localtime(self._gateway_down_since)
+                    )
+                    if self._gateway_down_since is not None
+                    else "unknown time"
+                )
+                up_ts = time.strftime("%H:%M")
+                if self._lost_turn_count == 1:
+                    self._last_outage_summary = (
+                        f"1 conversation turn between {down_ts} and {up_ts} "
+                        "was NOT saved because the memory Gateway was down."
+                    )
+                else:
+                    self._last_outage_summary = (
+                        f"{self._lost_turn_count} conversation turns between "
+                        f"{down_ts} and {up_ts} were NOT saved because the "
+                        "memory Gateway was down."
+                    )
+                logger.warning(
+                    "memory-tencentdb: Gateway recovered; %s",
+                    self._last_outage_summary,
+                )
+            self._gateway_down_since = None
+            self._lost_turn_count = 0
 
     # -- Gateway auto-resurrect ----------------------------------------------
 
@@ -535,6 +610,9 @@ class MemoryTencentdbProvider(MemoryProvider):
                 # immediately instead of being blocked by the 60s cooldown.
                 self._consecutive_failures = 0
                 self._breaker_open_until = 0.0
+                # If this recovery ends a tracked outage, summarize it now
+                # so the next prompt block can report the lost turns.
+                self._mark_gateway_up()
                 logger.info("memory-tencentdb Gateway recovery succeeded.")
                 return True
 
@@ -825,10 +903,47 @@ class MemoryTencentdbProvider(MemoryProvider):
         # requiring a hermes restart.
         self._start_watchdog()
 
+    def unavailable_reason(self) -> str:
+        """Short, user-facing hint for "provider unavailable" diagnostics."""
+        if self._gateway_available:
+            return ""
+        if not self._initialized:
+            return "not initialized (Gateway never started)"
+        if self._is_breaker_open():
+            remaining = max(0, int(self._breaker_open_until - time.monotonic()))
+            return (
+                "Gateway unreachable — circuit breaker open, next recovery "
+                f"attempt in ~{remaining}s"
+            )
+        return "Gateway unreachable"
+
     def system_prompt_block(self) -> str:
         if not self._gateway_available:
-            return ""
-        return (
+            # Degraded, not silent: the agent must know memory is down,
+            # otherwise it keeps assuming writes are being saved.
+            with self._degraded_lock:
+                down_since = self._gateway_down_since
+                lost = self._lost_turn_count
+            lines = [
+                "# memory-tencentdb Memory",
+                "STATUS: DEGRADED — the memory Gateway is unreachable, so "
+                "conversation capture and recall are failing.",
+            ]
+            if down_since is not None:
+                lines.append(
+                    "Outage began: "
+                    + time.strftime("%Y-%m-%d %H:%M", time.localtime(down_since))
+                    + "."
+                )
+            if lost:
+                noun = "turn" if lost == 1 else "turns"
+                lines.append(
+                    f"{lost} conversation {noun} have not been saved during "
+                    "this outage."
+                )
+            return "\n".join(lines)
+
+        block = (
             "# memory-tencentdb Memory\n"
             f"Active. User: {self._user_id}.\n"
             "Four-layer memory system (L0→L1→L2→L3) with automatic conversation "
@@ -836,6 +951,9 @@ class MemoryTencentdbProvider(MemoryProvider):
             "Use memory_tencentdb_memory_search to find specific memories, "
             "memory_tencentdb_conversation_search to search raw conversation history."
         )
+        if self._last_outage_summary:
+            block += "\nNote: " + self._last_outage_summary
+        return block
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Synchronous recall — fetch memories in real-time for the current turn."""
@@ -847,6 +965,9 @@ class MemoryTencentdbProvider(MemoryProvider):
         # returning "" forever. See _ensure_alive_for_request() for the
         # guarantees and rationale.
         if not self._ensure_alive_for_request() or not self._client:
+            # Track the outage even on the read path, so the degraded
+            # prompt block can state when it began.
+            self._note_gateway_down()
             return ""
 
         effective_session = session_id or self._session_id
@@ -858,11 +979,14 @@ class MemoryTencentdbProvider(MemoryProvider):
             )
             context = result.get("context", "")
             self._record_success()
+            # A successful recall also ends any tracked outage.
+            self._mark_gateway_up()
             if context:
                 return f"## memory-tencentdb Memory\n{context}"
             return ""
         except Exception as e:
             self._record_failure()
+            self._note_gateway_down()
             logger.debug("memory-tencentdb prefetch failed: %s", e)
             # Fire-and-forget attempt to bring the Gateway back for the next
             # call. Never blocks more than supervisor.ensure_running()'s own
@@ -895,6 +1019,11 @@ class MemoryTencentdbProvider(MemoryProvider):
         # drop every captured turn until the watchdog (or a manual
         # restart) revived it.
         if not self._ensure_alive_for_request() or not self._client:
+            # This turn will not be captured. Count it so the restored
+            # prompt block can tell the agent exactly how much went
+            # missing during the outage instead of dropping it silently.
+            self._note_gateway_down()
+            self._note_lost_turn()
             return
 
         effective_session = session_id or self._session_id
@@ -909,8 +1038,13 @@ class MemoryTencentdbProvider(MemoryProvider):
                     user_id=self._user_id,
                 )
                 self._record_success()
+                # A successful capture also ends any tracked outage and
+                # publishes the lost-turn summary for the next prompt.
+                self._mark_gateway_up()
             except Exception as e:
                 self._record_failure()
+                self._note_gateway_down()
+                self._note_lost_turn()
                 logger.warning("memory-tencentdb sync failed: %s", e)
                 # Trigger recovery from a background thread — safe because
                 # _try_recover_gateway itself is non-blocking under

--- a/hermes-plugin/memory/memory_tencentdb/tests/test_degraded_mode.py
+++ b/hermes-plugin/memory/memory_tencentdb/tests/test_degraded_mode.py
@@ -1,0 +1,257 @@
+"""Tests for degraded-mode visibility (silent-outage regression).
+
+Covers the failure mode behind the "10 days of silent memory loss"
+incident: when the Gateway dies, system_prompt_block() returned "" (the
+agent never learns memory is down) and dropped sync_turn() calls left
+nothing behind but logger.warning lines. After the fix:
+
+  1. system_prompt_block() reports a DEGRADED block while the Gateway is
+     unreachable, including when the outage began.
+  2. unavailable_reason() returns an actionable hint instead of "".
+  3. Conversation turns dropped during an outage are counted, and the
+     count is surfaced in the restored prompt block after recovery.
+
+Uses the same FakeSupervisor style as test_memory_tencentdb_recovery.py
+so no real Node processes are spawned and no sockets are opened.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+# Same sys.path dance as test_memory_tencentdb_recovery.py next door: make
+# the import work both from the plugin repo tree and from a hermes-agent
+# checkout.
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_HERE = _THIS_FILE.parent
+for candidate in (
+    _HERE.parents[3] if len(_HERE.parents) >= 4 else None,
+    _HERE.parents[4] if len(_HERE.parents) >= 5 else None,
+    _HERE.parents[2] if len(_HERE.parents) >= 3 else None,
+):
+    if candidate is not None and (candidate / "plugins").is_dir():
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+_hermes_root = os.environ.get("HERMES_AGENT_ROOT")
+if not _hermes_root:
+    sibling = _HERE.parents[4] / "hermes-agent" if len(_HERE.parents) >= 5 else None
+    if sibling is not None and (sibling / "agent").is_dir():
+        _hermes_root = str(sibling)
+if _hermes_root and _hermes_root not in sys.path:
+    sys.path.insert(0, _hermes_root)
+
+try:
+    import plugins.memory.memory_tencentdb as mod
+    from plugins.memory.memory_tencentdb import MemoryTencentdbProvider
+except ImportError as e:  # pragma: no cover — env-dependent
+    pytest.skip(
+        f"memory_tencentdb provider not importable ({e}); set HERMES_AGENT_ROOT "
+        "to a hermes-agent checkout if running from the plugin repo.",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class FakeSupervisor:
+    def __init__(self) -> None:
+        self.alive = True
+        self.healthy = True
+        self.respawn_succeeds = True
+        self.client = MagicMock(name="MemoryTencentdbSdkClient")
+
+    def is_running(self) -> bool:
+        return self.healthy
+
+    def is_process_alive(self) -> bool:
+        return self.alive
+
+    def ensure_running(self) -> bool:
+        if self.respawn_succeeds:
+            self.alive = True
+            self.healthy = True
+            return True
+        return False
+
+    def shutdown(self) -> None:
+        self.alive = False
+        self.healthy = False
+
+
+def _wait_until(predicate, *, timeout: float = 3.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+@pytest.fixture()
+def provider(monkeypatch):
+    """Provider wired to a FakeSupervisor with a fast watchdog."""
+    fake = FakeSupervisor()
+    monkeypatch.setattr(mod, "GatewaySupervisor", lambda *a, **kw: fake)
+    monkeypatch.setattr(mod, "_WATCHDOG_INTERVAL_SECS", 0.05)
+    monkeypatch.setattr(mod, "_WATCHDOG_SHUTDOWN_TIMEOUT_SECS", 0.5)
+    monkeypatch.setattr(mod, "_RECOVER_COOLDOWN_SECS", 0)
+    monkeypatch.setenv("MEMORY_TENCENTDB_GATEWAY_CMD", "fake-cmd")
+
+    p = MemoryTencentdbProvider()
+    p.initialize(session_id="test-session", user_id="test-user")
+    p._fake = fake
+
+    assert _wait_until(lambda: p._gateway_available, timeout=2.0)
+    try:
+        yield p
+    finally:
+        p.shutdown()
+
+
+def _park_in_outage(p) -> None:
+    """Stop the watchdog and park the provider in a real outage.
+
+    respawn_succeeds must be False here: with the default harness the lazy
+    probe would instantly resurrect the Gateway (the desired production
+    behavior), and no turn would ever actually be lost.
+    """
+    p._stop_watchdog()
+    p._gateway_available = False
+    p._client = None
+    p._fake.alive = False
+    p._fake.healthy = False
+    p._fake.respawn_succeeds = False
+
+
+# ---------------------------------------------------------------------------
+# system_prompt_block
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_block_degraded_while_gateway_down(provider):
+    _park_in_outage(provider)
+
+    block = provider.system_prompt_block()
+
+    assert "DEGRADED" in block, "agent must be told memory is down, got an empty/active block"
+    assert "Active" not in block
+
+
+def test_prompt_block_degraded_mentions_outage_start(provider):
+    _park_in_outage(provider)
+    provider._note_gateway_down()
+
+    block = provider.system_prompt_block()
+
+    assert "Outage began" in block
+
+
+def test_prompt_block_active_when_healthy(provider):
+    block = provider.system_prompt_block()
+    assert "Active" in block
+    assert "DEGRADED" not in block
+
+
+# ---------------------------------------------------------------------------
+# unavailable_reason
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_reason_empty_while_healthy(provider):
+    assert provider.unavailable_reason() == ""
+
+
+def test_unavailable_reason_while_down(provider):
+    _park_in_outage(provider)
+    assert provider.unavailable_reason() != ""
+
+
+def test_unavailable_reason_mentions_open_breaker(provider):
+    provider._stop_watchdog()
+    provider._gateway_available = False
+    provider._consecutive_failures = 999
+    provider._breaker_open_until = time.monotonic() + 60
+
+    reason = provider.unavailable_reason()
+
+    assert "breaker" in reason
+
+
+# ---------------------------------------------------------------------------
+# Lost-turn accounting
+# ---------------------------------------------------------------------------
+
+
+def test_lost_turns_counted_while_down(provider):
+    _park_in_outage(provider)
+
+    provider.sync_turn(user_content="u1", assistant_content="a1")
+    provider.sync_turn(user_content="u2", assistant_content="a2")
+
+    assert provider._lost_turn_count == 2
+
+
+def test_lost_turns_surfaced_after_recovery(provider):
+    _park_in_outage(provider)
+    provider.sync_turn(user_content="u1", assistant_content="a1")
+    provider.sync_turn(user_content="u2", assistant_content="a2")
+    assert provider._lost_turn_count == 2
+
+    # The Gateway comes back and the next capture goes through.
+    fake = provider._fake
+    fake.alive = True
+    fake.healthy = True
+    fake.respawn_succeeds = True
+    captured = threading.Event()
+    fake.client.capture.side_effect = lambda **kw: captured.set()
+    provider.sync_turn(user_content="u3", assistant_content="a3")
+    assert captured.wait(timeout=2.0), "capture never reached the Gateway"
+
+    assert provider._lost_turn_count == 0, "counters must reset after recovery"
+    assert provider._gateway_down_since is None
+    summary = provider._last_outage_summary
+    assert summary is not None, "recovery must publish an outage summary"
+    assert "2 conversation turns" in summary
+    # The restored (active) prompt block is where the agent learns about it.
+    assert summary in provider.system_prompt_block()
+
+
+def test_capture_failure_counts_as_lost_turn(provider):
+    provider._stop_watchdog()
+    fake = provider._fake
+    fake.client.capture.side_effect = RuntimeError("gateway exploded")
+
+    provider.sync_turn(user_content="u", assistant_content="a")
+
+    assert _wait_until(
+        lambda: provider._last_outage_summary is not None, timeout=2.0
+    ), "a failed capture must be accounted as a lost turn"
+    assert "1 conversation turn" in provider._last_outage_summary
+
+
+def test_transient_blip_leaves_no_degraded_block(provider):
+    """A single failed request that immediately recovers must not leave the
+    provider looking degraded — the outage summary is kept, but the block
+    goes straight back to Active."""
+    provider._stop_watchdog()
+    fake = provider._fake
+    fake.client.recall.side_effect = RuntimeError("blip")
+
+    provider.prefetch(query="hello")
+
+    assert _wait_until(
+        lambda: provider._gateway_available, timeout=2.0
+    ), "transient blip should self-heal via the recovery path"
+    assert "Active" in provider.system_prompt_block()
+    assert "DEGRADED" not in provider.system_prompt_block()


### PR DESCRIPTION
Fixes #1133.

When the Gateway goes down the provider used to go quietly dark: `system_prompt_block()` returned `""`, so the agent context flipped from "memory Active" to nothing with no signal, and dropped `sync_turn()` calls only left `logger.warning` lines. That is how my deployment lost 10 days of writes without a single visible error. This makes the outage visible at three points.

**1. Degraded prompt block while down**

`system_prompt_block()` no longer returns `""` when the Gateway is unreachable. The agent now sees:

    # memory-tencentdb Memory
    STATUS: DEGRADED — the memory Gateway is unreachable, so conversation capture and recall are failing.
    Outage began: 2026-08-18 14:22.
    3 conversation turns have not been saved during this outage.

**2. unavailable_reason() implemented**

The ABC hook was left at its default, so "provider unavailable" diagnostics had nothing to show. It now reports the actual state — breaker open with the cooldown remaining, or plain "Gateway unreachable".

**3. Lost-turn accounting on recovery**

Every `sync_turn()` that cannot be captured is counted. When the Gateway comes back, the next active prompt block carries one line:

    Note: 3 conversation turns between 2026-08-18 14:22 and 15:40 were NOT saved because the memory Gateway was down.

The agent can finally tell the user what went missing instead of pretending nothing happened. Transient blips that self-heal through the existing `_try_recover_gateway()` path leave no degraded block behind — the summary is only published when turns were actually lost.

**Testing**

New `tests/test_degraded_mode.py` (10 cases, same FakeSupervisor style as the recovery tests — no real processes or sockets): degraded block content, outage-start timestamp, breaker hint in `unavailable_reason()`, lost-turn counting on both the short-circuit and capture-failure paths, recovery summary surfacing, and a transient-blip case asserting no lingering DEGRADED state.

Full suite locally: 26 passed, 5 pre-existing env-skips (hermes-agent checkout / real-gateway gates). No existing tests were modified — `prefetch()` still returns `""` when unavailable, since its output feeds the model context and whether to inject a degraded notice there is a separate design question.
