### PR TITLE
[good first issue-platform adapt-gp.nvim] Add Memory adapter for gp.nvim

### DIFF
--- a/adapters/gp-nvim/README.md
+++ b/adapters/gp-nvim/README.md
@@ -1,0 +1,115 @@
+# TencentDB Agent Memory — gp.nvim Adapter
+
+Give [gp.nvim](https://github.com/Robitx/gp.nvim) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+gp.nvim ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                         │
+                                         ├─ auth        (validates sk-mem-... user_key)
+                                         ├─ sessionInit (Team/Agent/Task picker)
+                                         └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+gp.nvim supports any "OpenAI chat/completions" compatible endpoint through its `providers` table — each entry declares an `endpoint` (the **full chat completions URL**) and a `secret` (an API key, an `os.getenv` call, or a command that prints one), and an agent selects the provider by name ([official README](https://github.com/Robitx/gp.nvim#multiple-providers); the built-in `ollama` entry — `endpoint = "http://localhost:11434/v1/chat/completions"` — is the canonical local-endpoint example). Pointing `endpoint` at the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route connects it — **no code changes required**.
+
+**Session binding**, **memory injection** and **automatic capture** all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. gp.nvim is installed and loaded in Neovim via your plugin manager (see the [README](https://github.com/Robitx/gp.nvim# Installation)).
+
+## Setup
+
+### 1. Export the API key
+
+```bash
+export MEMORY_PROXY_API_KEY=sk-mem-xxxxxxxx   # your business user key
+```
+
+Neovim must inherit the variable — start it from that shell, or use `exec-path-from-shell` / `vim.fn` alternatives. The key is read with `os.getenv` in the config below, so it never lands in your dotfiles.
+
+### 2. Declare the provider and an agent
+
+In your gp.nvim setup, add a provider entry whose `endpoint` is the proxy's full chat completions URL, and an agent that uses it:
+
+```lua
+local conf = {
+  providers = {
+    tencentdb_memory = {
+      endpoint = "http://127.0.0.1:8096/codebuddy/default/v1/chat/completions",
+      secret = os.getenv("MEMORY_PROXY_API_KEY"),
+    },
+  },
+  agents = {
+    {
+      name = "TencentDBMemory",
+      provider = "tencentdb_memory",
+      chat = true,
+      command = true,
+      model = { model = "claude-sonnet-4-20250514" },
+      system_prompt = "You are a general assistant with persistent team memory.",
+    },
+  },
+}
+require("gp").setup(conf)
+```
+
+Replace `default` with your memory space ID if you use another space.
+
+**Note**: unlike base-URL clients (which append `/chat/completions` themselves), gp.nvim's `endpoint` is the **complete URL** — including the `/v1/chat/completions` suffix, exactly like its built-in `ollama` entry.
+
+### 3. Align the model name
+
+The agent's `model.model` value **must match your proxy's `PROXY_UPSTREAM_MODEL`** (set in `deploy/global-images/.env`). The example uses `claude-sonnet-4-20250514`; change it if your proxy targets a different upstream.
+
+### 4. Verify
+
+1. Restart Neovim (or re-source your config) so the provider takes effect.
+2. Open a gp.nvim chat (`:GpChatNew`) using the `TencentDBMemory` agent and send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask gp what it remembers from previous sessions to confirm.
+
+## Configuration reference
+
+| Field | Value | Notes |
+|---|---|---|
+| `providers.<name>.endpoint` | `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` | **Full URL** — gp.nvim posts to it verbatim; `default` is the memory space ID — change it per space |
+| `providers.<name>.secret` | `os.getenv("MEMORY_PROXY_API_KEY")` | Env-var lookup; also accepts a string or a command table; sent as `Authorization: Bearer` |
+| `agents[].provider` | `"tencentdb_memory"` | Links the agent to the provider entry (default `"openai"`) |
+| `agents[].model.model` | `claude-sonnet-4-20250514` | Must equal `PROXY_UPSTREAM_MODEL`, otherwise the proxy rejects with an upstream mismatch |
+| `agents[].chat` / `command` | `true` | Route both the chat and command workflows through the provider |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `404` / connection refused | `endpoint` must be the complete URL `http://<host>:8096/codebuddy/<spaceId>/v1/chat/completions` — check for a missing `/v1` or path typo, and that the proxy is running on `:8096` |
+| "Invalid API Key" / auth failures | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key`; confirm `MEMORY_PROXY_API_KEY` is exported in the environment Neovim starts from |
+| "Model Not Found" / upstream mismatch | `model.model` differs from `PROXY_UPSTREAM_MODEL` — align them |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new task to re-pick |
+| Key resolves to `nil` | `os.getenv` runs inside Neovim — GUI Neovim does not inherit shell exports unless launched from that shell (`exec-path-from-shell` fixes it) |
+
+## Notes
+
+- **Docs-only adapter**: the provider lives in your own Neovim config, so the key never lands in workspace files; this adapter ships documentation only (same as the avante.nvim / codecompanion.nvim adapters).
+- **Chat and command modes both flow through it**: agents with `chat = true` and `command = true` both use the selected provider, so each workflow gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/gp-nvim/README_CN.md
+++ b/adapters/gp-nvim/README_CN.md
@@ -1,0 +1,115 @@
+# TencentDB Agent Memory — gp.nvim 适配器
+
+为 [gp.nvim](https://github.com/Robitx/gp.nvim) 注入持久化团队记忆。本适配器将其 LLM 流量路由至 TencentDB Agent Memory 代理，每个会话自动获得：
+
+- **会话绑定** — 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** — 每轮对话将绑定 Agent 的 L2/L3 记忆、技能与知识融入 system prompt
+- **自动捕获** — L0 原始对话持久化到 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+gp.nvim ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                         │
+                                         ├─ auth        (校验 sk-mem-... user_key)
+                                         ├─ sessionInit (Team/Agent/Task 选择器)
+                                         └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+gp.nvim 通过 `providers` 表支持任意"OpenAI chat/completions"兼容端点 —— 每个条目声明一个 `endpoint`（**完整的 chat completions URL**）和一个 `secret`（API key、`os.getenv` 调用或输出 key 的命令），Agent 按名称选择 provider（[官方 README](https://github.com/Robitx/gp.nvim#multiple-providers)；内置的 `ollama` 条目 —— `endpoint = "http://localhost:11434/v1/chat/completions"` —— 是本地端点的标准范例）。将 `endpoint` 指向代理的 `/codebuddy/<spaceId>/v1/chat/completions` 路由即可接入 —— **无需任何代码改动**。
+
+**会话绑定**、**记忆注入**与**自动捕获**全部开箱即用。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 你持有业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动 `start-all.sh` 时打印，或在 Panel（`http://localhost:8125`）中创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. gp.nvim 已通过插件管理器安装并加载（见 [README](https://github.com/Robitx/gp.nvim# Installation)）。
+
+## 配置步骤
+
+### 1. 导出 API key
+
+```bash
+export MEMORY_PROXY_API_KEY=sk-mem-xxxxxxxx   # 你的业务用户 key
+```
+
+Neovim 必须继承该变量 —— 从该 shell 启动，或使用 `exec-path-from-shell`。下方配置用 `os.getenv` 读取，key 不会落入 dotfiles。
+
+### 2. 声明 provider 与 Agent
+
+在 gp.nvim 配置中，添加 `endpoint` 为代理完整 chat completions URL 的 provider 条目，以及使用它的 Agent：
+
+```lua
+local conf = {
+  providers = {
+    tencentdb_memory = {
+      endpoint = "http://127.0.0.1:8096/codebuddy/default/v1/chat/completions",
+      secret = os.getenv("MEMORY_PROXY_API_KEY"),
+    },
+  },
+  agents = {
+    {
+      name = "TencentDBMemory",
+      provider = "tencentdb_memory",
+      chat = true,
+      command = true,
+      model = { model = "claude-sonnet-4-20250514" },
+      system_prompt = "You are a general assistant with persistent team memory.",
+    },
+  },
+}
+require("gp").setup(conf)
+```
+
+若使用其他空间，将 `default` 替换为你的 memory space ID。
+
+**注意**：与自行拼接 `/chat/completions` 的 base-URL 型客户端不同，gp.nvim 的 `endpoint` 是**完整 URL** —— 必须包含 `/v1/chat/completions` 后缀，与内置 `ollama` 条目一致。
+
+### 3. 对齐模型名
+
+Agent 的 `model.model` 值**必须与代理的 `PROXY_UPSTREAM_MODEL` 一致**（在 `deploy/global-images/.env` 中设置）。示例使用 `claude-sonnet-4-20250514`；若代理指向其他上游请相应修改。
+
+### 4. 验证
+
+1. 重启 Neovim（或重新加载配置）使 provider 生效。
+2. 用 `TencentDBMemory` Agent 打开 gp.nvim 对话（`:GpChatNew`）并发送首条消息。代理在对话交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从本轮起，绑定 Agent 的记忆自动注入。询问 gp 它记得此前会话的哪些内容以确认。
+
+## 配置参考
+
+| 字段 | 取值 | 说明 |
+|---|---|---|
+| `providers.<name>.endpoint` | `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` | **完整 URL** —— gp.nvim 原样 POST；`default` 为 memory space ID，按空间修改 |
+| `providers.<name>.secret` | `os.getenv("MEMORY_PROXY_API_KEY")` | 环境变量读取；也接受字符串或命令表；以 `Authorization: Bearer` 发送 |
+| `agents[].provider` | `"tencentdb_memory"` | 将 Agent 链接到 provider 条目（默认 `"openai"`） |
+| `agents[].model.model` | `claude-sonnet-4-20250514` | 必须等于 `PROXY_UPSTREAM_MODEL`，否则代理以上游不匹配拒绝 |
+| `agents[].chat` / `command` | `true` | 对话与命令两种工作流均经由该 provider |
+
+## 故障排查
+
+| 症状 | 原因 / 修复 |
+|---|---|
+| `404` / 连接拒绝 | `endpoint` 必须是完整 URL `http://<host>:8096/codebuddy/<spaceId>/v1/chat/completions` —— 检查是否缺少 `/v1` 或路径笔误，并确认代理运行在 `:8096` |
+| "Invalid API Key" / 鉴权失败 | key 必须是 Panel 中的业务用户 key（`sk-mem-...`）—— 而非 `./.admin-key` 的管理员 key；确认 Neovim 启动环境已导出 `MEMORY_PROXY_API_KEY` |
+| "Model Not Found" / 上游不匹配 | `model.model` 与 `PROXY_UPSTREAM_MODEL` 不一致 —— 对齐两者 |
+| 未出现会话选择器 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 会自动设置）；若此前会话已绑定 task，绑定会被复用 —— 新建 task 以重新选择 |
+| key 解析为 `nil` | `os.getenv` 在 Neovim 内执行 —— GUI Neovim 不继承 shell 导出，除非从该 shell 启动（`exec-path-from-shell` 可解决） |
+
+## 说明
+
+- **纯文档适配器**：provider 位于你自己的 Neovim 配置中，key 不会落入工作区文件；本适配器仅包含文档（与 avante.nvim / codecompanion.nvim 适配器一致）。
+- **对话与命令模式均覆盖**：`chat = true` 与 `command = true` 的 Agent 都使用所选 provider，两种工作流均获得记忆注入。
+- **数据流向**：仅 prompt/completions 经过代理；记忆数据保留在本地 SQLite（memory-core），除非另行配置。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
### Summary

Adds a docs-only adapter for **gp.nvim** ([Robitx/gp.nvim](https://github.com/Robitx/gp.nvim), the GPT plugin for Neovim with chat/command/inplace workflows), connecting it to the TencentDB Agent Memory proxy through its native OpenAI-compatible `providers` table.

- `adapters/gp-nvim/README.md` + `README_CN.md` (EN/CN, same structure as the avante.nvim / codecompanion.nvim docs-only adapters)
- No code changes: the provider entry (`endpoint`, `secret`) and the agent link (`provider = ...`) live in the user's own Neovim config, so no files ship with the adapter.

### How it connects (verified against official sources)

- gp.nvim supports "Any other 'OpenAI chat/completions' compatible endpoint" via the `providers` table ([official README](https://github.com/Robitx/gp.nvim), *Multiple providers* section); the built-in `ollama` entry (`endpoint = "http://localhost:11434/v1/chat/completions"`, no `secret`) is the canonical local-endpoint example.
- Unlike base-URL clients, gp.nvim's `endpoint` is the **full chat completions URL** — the adapter points it at the proxy's canonical route `http://127.0.0.1:8096/codebuddy/<spaceId>/v1/chat/completions`.
- `secret` supports `os.getenv(...)` for API keys (same capability as the legacy `openai_api_key` field per the README), so the `sk-mem-...` business user key is sent as `Authorization: Bearer` without landing in dotfiles.

### Contents

- Prerequisites (one-command stack, business `sk-mem-...` user key)
- Setup: export key → declare provider + agent → align model with `PROXY_UPSTREAM_MODEL` → verify via `:GpChatNew` and the session picker
- Configuration reference table + troubleshooting table (404/key/model-id/session-picker/GUI-env rows)
- Notes: docs-only rationale, chat/command coverage, data-flow statement

Part of the platform-adapt batch tracked in #926.
