### PR TITLE
fix(deploy): add upstream.agents, restart policy, and proxy data volume

### DIFF
--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -123,6 +123,7 @@ YAML
 
 info "启动 memory-core (image=$MEMORY_CORE_IMAGE, port=$MEMORY_CORE_PORT)"
 $DOCKER run -d --name "$CONTAINER" \
+  --restart unless-stopped \
   --network "$NETWORK" \
   --network-alias memory-core \
   -p "${MEMORY_CORE_PORT}:8420" \

--- a/deploy/global-images/start-memory-hub.sh
+++ b/deploy/global-images/start-memory-hub.sh
@@ -87,6 +87,7 @@ rm_container_if_exists "$CONTAINER"
 # LLM_MODE=custom → 不走 memory 的 LLM proxy，而是 knowledge 直连用户提供的端点
 info "启动 memory-hub (image=$MEMORY_HUB_IMAGE, panel=$PANEL_PORT knowledge=$KNOWLEDGE_PORT)"
 $DOCKER run -d --name "$CONTAINER" \
+  --restart unless-stopped \
   --network "$NETWORK" \
   --network-alias memory-hub \
   --add-host=host.docker.internal:host-gateway \

--- a/deploy/global-images/start-proxy.sh
+++ b/deploy/global-images/start-proxy.sh
@@ -84,6 +84,24 @@ server:
 upstream:
   url: "${PROXY_UPSTREAM_URL}"
   apiKey: "${PROXY_UPSTREAM_API_KEY}"
+  agents:
+    # OpenAI 协议 Agent —— 需要单独的 OpenAI 端点
+    workbuddy:
+      url: "${PROXY_UPSTREAM_OPENAI_URL:-${PROXY_UPSTREAM_URL//anthropic/openai}}"
+      apiKey: "${PROXY_UPSTREAM_OPENAI_API_KEY:-${PROXY_UPSTREAM_API_KEY}}"
+    codebuddy:
+      url: "${PROXY_UPSTREAM_OPENAI_URL:-${PROXY_UPSTREAM_URL//anthropic/openai}}"
+      apiKey: "${PROXY_UPSTREAM_OPENAI_API_KEY:-${PROXY_UPSTREAM_API_KEY}}"
+    dsh:
+      url: "${PROXY_UPSTREAM_OPENAI_URL:-${PROXY_UPSTREAM_URL//anthropic/openai}}"
+      apiKey: "${PROXY_UPSTREAM_OPENAI_API_KEY:-${PROXY_UPSTREAM_API_KEY}}"
+    opencode:
+      url: "${PROXY_UPSTREAM_OPENAI_URL:-${PROXY_UPSTREAM_URL//anthropic/openai}}"
+      apiKey: "${PROXY_UPSTREAM_OPENAI_API_KEY:-${PROXY_UPSTREAM_API_KEY}}"
+    # Responses API Agent（/v1/responses）
+    codex:
+      url: "${PROXY_UPSTREAM_OPENAI_URL:-${PROXY_UPSTREAM_URL//anthropic/openai}}"
+      apiKey: "${PROXY_UPSTREAM_OPENAI_API_KEY:-${PROXY_UPSTREAM_API_KEY}}"
 
 log:
   file: ""
@@ -140,13 +158,22 @@ redis:
   enabled: false
 YAML
 
+PROXY_VOLUME="${PROXY_VOLUME:-tdai-proxy-data}"
+# 确保 proxy 数据卷存在（session 状态、SQLite 等）
+if ! $DOCKER volume inspect "$PROXY_VOLUME" >/dev/null 2>&1; then
+  info "创建 proxy 数据卷 $PROXY_VOLUME"
+  $DOCKER volume create "$PROXY_VOLUME" >/dev/null
+fi
+
 info "启动 proxy (image=$PROXY_IMAGE, port=$PROXY_PORT)"
 $DOCKER run -d --name "$CONTAINER" \
+  --restart unless-stopped \
   --network "$NETWORK" \
   --network-alias proxy \
   --add-host=host.docker.internal:host-gateway \
   -p "${PROXY_PORT}:8096" \
   -v "$CONFIG_FILE:/data/config.yaml:ro" \
+  -v "$PROXY_VOLUME:/data/tdai-memory-proxy" \
   "$PROXY_IMAGE" >/dev/null
 
 wait_healthy "$CONTAINER" 90


### PR DESCRIPTION
## 修复内容

### 1. `start-proxy.sh` 模板缺少 `upstream.agents` 段
WorkBuddy、CodeBuddy、dsh、OpenCode、Codex 五个走 OpenAI 协议的 Agent 需要单独的 OpenAI 端点，但脚本模板只生成了全局 Anthropic 端点。新增 `upstream.agents` 段，通过 bash 变量替换自动从 Anthropic URL 推导 OpenAI URL：
```bash
${PROXY_UPSTREAM_OPENAI_URL:-${PROXY_UPSTREAM_URL//anthropic/openai}}
```

### 2. 三个容器都没有 `--restart unless-stopped`
服务器重启后容器不会自动启动，加上重启策略。

### 3. `start-proxy.sh` 没有挂载数据卷
proxy 的 session 状态（SQLite）存在容器内，每次 `docker rm -f` 重建容器就全部丢失。新增 `PROXY_VOLUME` 挂载到 `/data/tdai-memory-proxy`。

### 改动文件
- `deploy/global-images/start-proxy.sh` — +27 行
- `deploy/global-images/start-memory-core.sh` — +1 行
- `deploy/global-images/start-memory-hub.sh` — +1 行