### PR TITLE
feat(panel): add manual refresh button to Memory page

### DIFF
--- a/MemoryPanel/web/src/i18n/en-US.ts
+++ b/MemoryPanel/web/src/i18n/en-US.ts
@@ -631,6 +631,7 @@ export const enUS = {
     'This memory has been set to private by its owner and cannot be allocated to other Agents',
   'memory.import': 'Import Memory',
   'memory.import.tooltip.noAgent': 'No agent in the current team. Please create an agent first.',
+  'memory.refresh': 'Refresh',
   'memory.blockList': 'Memory Blocks',
   'memory.blockCount': '{{filtered}} items',
   'memory.empty.filtered': 'No matching memory blocks.',

--- a/MemoryPanel/web/src/i18n/zh-CN.ts
+++ b/MemoryPanel/web/src/i18n/zh-CN.ts
@@ -611,6 +611,7 @@ export const zhCN = {
   'memory.allocate.privateDisabled': '该记忆已被 owner 设为私密，无法再分配给其他 Agent',
   'memory.import': '导入记忆',
   'memory.import.tooltip.noAgent': '当前 team 暂无 agent，请先创建 agent',
+  'memory.refresh': '刷新',
   'memory.blockList': '记忆块',
   'memory.blockCount': '{{filtered}} 条',
   'memory.empty.filtered': '没有匹配的记忆块。',

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/components/ChatMemoryPanel.tsx
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/components/ChatMemoryPanel.tsx
@@ -137,6 +137,13 @@ export default function ChatMemoryPanel(
               );
             })()}
             <Button
+              onClick={() => fetchBlocks()}
+              loading={blocksLoading}
+              disabled={blocksLoading}
+            >
+              {t('memory.refresh')}
+            </Button>
+            <Button
               type="primary"
               onClick={() => setShowImport(true)}
               disabled={ownedTeamAgents.length === 0}


### PR DESCRIPTION
## 改动内容

在 Chat Memory 页面头部添加手动刷新按钮，用户可以随时点击刷新记忆块列表。

### 修改文件
- `MemoryPanel/web/src/pages/ChatMemoryPage/components/ChatMemoryPanel.tsx` — 添加刷新按钮
- `MemoryPanel/web/src/i18n/zh-CN.ts` — 添加 `'memory.refresh': '刷新'`
- `MemoryPanel/web/src/i18n/en-US.ts` — 添加 `'memory.refresh': 'Refresh'`

### 效果
- 按钮位于"分配到 Agent"和"导入记忆"之间
- 点击后按钮显示 loading 状态，记忆块列表重新加载
