### PR TITLE
fix(core): keep Node's global proxy dispatcher when loading undici@8

### DIFF
--- a/MemoryCore/src/core/store/tcvdb-client.test.ts
+++ b/MemoryCore/src/core/store/tcvdb-client.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression tests for https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/1157
+ *
+ * undici@8 runs `setGlobalDispatcher(new Agent())` at module load when
+ * `Symbol.for("undici.globalDispatcher.2")` is unset. That also overwrites the
+ * legacy `Symbol.for("undici.globalDispatcher.1")` slot that Node's built-in
+ * fetch reads — discarding a pre-configured dispatcher such as Node's
+ * EnvHttpProxyAgent (NODE_USE_ENV_PROXY=1), so process-wide fetch() silently
+ * bypasses HTTP(S)_PROXY.
+ *
+ * Importing this module (via the static import chain
+ * gateway/server.ts → store-pool.ts → tcvdb.ts → tcvdb-client.ts) must not
+ * clobber a pre-existing legacy global dispatcher.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import http from "node:http";
+import { AddressInfo } from "node:net";
+
+const LEGACY_GLOBAL_DISPATCHER = Symbol.for("undici.globalDispatcher.1");
+const V2_GLOBAL_DISPATCHER = Symbol.for("undici.globalDispatcher.2");
+
+/** Minimal dispatcher stand-in: only needs a dispatch method to be a valid sentinel. */
+class SentinelDispatcher {
+  dispatch(): boolean {
+    return false;
+  }
+}
+
+describe("tcvdb-client import side effects", () => {
+  const g = globalThis as Record<symbol, unknown>;
+  let savedV1: unknown;
+  let savedV2: unknown;
+
+  afterEach(() => {
+    // restore whatever the test run had before, so other suites are unaffected.
+    // (the globals are defined with configurable:false — reassign, don't delete)
+    if (savedV1 !== undefined) g[LEGACY_GLOBAL_DISPATCHER] = savedV1;
+    if (savedV2 !== undefined) g[V2_GLOBAL_DISPATCHER] = savedV2;
+  });
+
+  it("does not clobber a pre-existing legacy global dispatcher on import", async () => {
+    savedV1 = g[LEGACY_GLOBAL_DISPATCHER];
+    savedV2 = g[V2_GLOBAL_DISPATCHER];
+    const sentinel = new SentinelDispatcher();
+    g[LEGACY_GLOBAL_DISPATCHER] = sentinel;
+    // simulate a fresh process where undici@8 has not initialized .2 yet
+    // (reassignment, since the property may be defined as configurable:false)
+    g[V2_GLOBAL_DISPATCHER] = undefined;
+
+    await import("./tcvdb-client.js");
+
+    expect(g[LEGACY_GLOBAL_DISPATCHER]).toBe(sentinel);
+  });
+});
+
+describe("TcvdbClient.request", () => {
+  it("round-trips a VectorDB API envelope over HTTP", async () => {
+    const seen: Array<{ path: string; auth: string | undefined; body: string }> = [];
+    const server = http.createServer((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => {
+        seen.push({ path: req.url ?? "", auth: req.headers.authorization, body: raw });
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ code: 0, msg: "ok", affectedCount: 3 }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      // import after the side-effect test above has restored globals
+      const { TcvdbClient } = await import("./tcvdb-client.js");
+      const client = new TcvdbClient({
+        url: `127.0.0.1:${port}`, // intentionally scheme-less: constructor must prepend http://
+        username: "root",
+        apiKey: "test-key",
+        database: "db_test",
+        timeout: 5000,
+      });
+
+      const affected = await client.deleteDoc("coll", { filter: "1=1" });
+      expect(affected).toBe(3);
+      expect(seen).toHaveLength(1);
+      expect(seen[0].path).toBe("/document/delete");
+      expect(seen[0].auth).toBe("Bearer account=root&api_key=test-key");
+      expect(JSON.parse(seen[0].body)).toMatchObject({
+        database: "db_test",
+        collection: "coll",
+        filter: "1=1",
+      });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/MemoryCore/src/core/store/tcvdb-client.ts
+++ b/MemoryCore/src/core/store/tcvdb-client.ts
@@ -8,9 +8,41 @@
  */
 
 import fs from "node:fs";
-import { request as undiciRequest, Agent as UndiciAgent } from "undici";
 import type { Dispatcher } from "undici";
 import type { StoreLogger } from "./types.js";
+
+// ── Lazy undici loading + global dispatcher guard ─────────────
+// undici@8 runs `setGlobalDispatcher(new Agent())` at module load when
+// Symbol.for("undici.globalDispatcher.2") is unset (see undici's
+// lib/global.js). That also overwrites the legacy
+// Symbol.for("undici.globalDispatcher.1") slot that Node's built-in fetch
+// reads — silently discarding a pre-configured dispatcher such as Node's
+// EnvHttpProxyAgent (NODE_USE_ENV_PROXY=1), which makes process-wide fetch()
+// bypass HTTP(S)_PROXY.
+//
+// To avoid that side effect for every consumer of this module (including
+// standalone SQLite mode, where the TCVDB client is imported eagerly but never
+// used), undici is loaded lazily on first request, and the legacy dispatcher
+// slot is snapshotted before the import and restored afterwards.
+const LEGACY_GLOBAL_DISPATCHER = Symbol.for("undici.globalDispatcher.1");
+
+type UndiciModule = typeof import("undici");
+
+let undiciModulePromise: Promise<UndiciModule> | undefined;
+
+function loadUndici(): Promise<UndiciModule> {
+  if (!undiciModulePromise) {
+    const g = globalThis as Record<symbol, unknown>;
+    const previousLegacy = g[LEGACY_GLOBAL_DISPATCHER];
+    undiciModulePromise = import("undici").then((mod) => {
+      if (previousLegacy !== undefined && g[LEGACY_GLOBAL_DISPATCHER] !== previousLegacy) {
+        g[LEGACY_GLOBAL_DISPATCHER] = previousLegacy;
+      }
+      return mod;
+    });
+  }
+  return undiciModulePromise;
+}
 
 // ============================
 // Types
@@ -85,8 +117,12 @@ export class TcvdbClient {
   private readonly database: string;
   private readonly timeout: number;
   private readonly logger?: StoreLogger;
-  /** undici dispatcher for HTTPS + custom CA. */
-  private readonly dispatcher?: Dispatcher;
+  /** undici dispatcher for HTTPS + custom CA. Created lazily on first request. */
+  private dispatcher?: Dispatcher;
+  /** Set once dispatcher creation failed, so we don't retry (and re-log) per request. */
+  private dispatcherFailed = false;
+  /** Path to CA certificate PEM file (for HTTPS connections). */
+  private readonly caPemPath?: string;
 
   constructor(config: TcvdbClientConfig, logger?: StoreLogger) {
     // 防御性 normalize：Shark 某些实例的 VdbUrl 可能只返回 `host:port`（缺 scheme），
@@ -105,17 +141,25 @@ export class TcvdbClient {
     // Log connection info at construction time.
     this.logger?.debug?.(`${TAG} url=${this.baseUrl} db=${this.database} timeout=${this.timeout}${this.baseUrl.startsWith("https://") ? ` https=true caPemPath=${config.caPemPath ?? "(none)"}` : ""}`);
 
-    // For HTTPS with a custom CA certificate, create a dedicated undici Agent.
-    // We use undici.request() instead of global fetch because fetch's
-    // `dispatcher` option is unreliable across Node versions.
-    if (this.baseUrl.startsWith("https://") && config.caPemPath) {
-      try {
-        const ca = fs.readFileSync(config.caPemPath, "utf-8");
-        this.dispatcher = new UndiciAgent({ connect: { ca } });
-        this.logger?.debug?.(`${TAG} HTTPS enabled with CA from ${config.caPemPath}`);
-      } catch (err) {
-        this.logger?.error(`${TAG} Failed to load CA PEM from ${config.caPemPath}: ${err instanceof Error ? err.message : String(err)}`);
-      }
+    this.caPemPath = config.caPemPath;
+  }
+
+  /**
+   * Lazily create the dedicated undici Agent for HTTPS + custom CA on first
+   * request (undici is only loaded at that point — see loadUndici above).
+   * We use undici.request() instead of global fetch because fetch's
+   * `dispatcher` option is unreliable across Node versions.
+   */
+  private ensureDispatcher(UndiciAgent: UndiciModule["Agent"]): void {
+    if (this.dispatcher || this.dispatcherFailed) return;
+    if (!(this.baseUrl.startsWith("https://") && this.caPemPath)) return;
+    try {
+      const ca = fs.readFileSync(this.caPemPath, "utf-8");
+      this.dispatcher = new UndiciAgent({ connect: { ca } });
+      this.logger?.debug?.(`${TAG} HTTPS enabled with CA from ${this.caPemPath}`);
+    } catch (err) {
+      this.dispatcherFailed = true;
+      this.logger?.error(`${TAG} Failed to load CA PEM from ${this.caPemPath}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -126,6 +170,9 @@ export class TcvdbClient {
    * Handles auth, timeout, retries (5xx/timeout), and error unwrapping.
    */
   async request<T = ApiResponse>(path: string, body: Record<string, unknown>): Promise<T> {
+    const { request: undiciRequest, Agent: UndiciAgent } = await loadUndici();
+    this.ensureDispatcher(UndiciAgent);
+
     let lastError: Error | undefined;
     const t0 = performance.now();
 


### PR DESCRIPTION
## Description | 描述

Fixes the proxy regression reported in #1157.

MemoryCore's TCVDB client statically imported `undici` at module top level. On load, undici@8 runs `setGlobalDispatcher(new Agent())` whenever `Symbol.for("undici.globalDispatcher.2")` is unset (see undici's `lib/global.js`), and that call **also overwrites the legacy `Symbol.for("undici.globalDispatcher.1")` slot that Node's built-in `fetch` reads**.

With `NODE_USE_ENV_PROXY=1`, that legacy slot holds Node's `EnvHttpProxyAgent`. Once overwritten, every `fetch()` in the process — including AI SDK calls to model providers — silently bypasses `HTTP(S)_PROXY`, so L1/Skill extraction fails with `Cannot connect to API`. Standalone SQLite mode is affected too, because the gateway eagerly loads the TCVDB implementation (`gateway/server.ts → store-pool.ts → tcvdb.ts → tcvdb-client.ts`).

Changes:

- Load undici **lazily on first request** via dynamic `import()`. SQLite mode (which instantiates but never queries TCVDB) no longer loads undici at all.
- Snapshot the legacy dispatcher slot before the import and restore it afterwards, so a pre-configured dispatcher (e.g. `EnvHttpProxyAgent`) survives. undici's own `.2` slot is left untouched, keeping TCVDB's direct internal connections unchanged.
- HTTPS custom-CA `Agent` creation moves to the same lazy path; construction is now side-effect free. Failure semantics are unchanged (logs once, does not retry per request).

Out of scope: the eager TCVDB loading in `store-pool.ts` is a separate concern and is intentionally not touched here.

## Related Issue | 关联 Issue

Fixes #1157

## Change Type | 修改类型

- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verification (Node v24.15.0, undici 8.x):

- **Red → green**: the new test `does not clobber a pre-existing legacy global dispatcher on import` fails before the fix (slot overwritten with `Dispatcher1Wrapper`) and passes after. A second test round-trips a full request against a local HTTP server (envelope parsing, auth header, scheme-less URL normalization). `npx vitest run` → 2/2 pass.
- **Sandbox reproduction**: with `NODE_USE_ENV_PROXY=1`, importing undici@8 changes the legacy slot from `EnvHttpProxyAgent` to `Dispatcher1Wrapper`; with the snapshot/restore guard, `fetch()` goes through the configured proxy again.
- `npm run build:plugin` (tsdown) passes; the emitted bundle keeps `import("undici")` as a runtime external.
- Also verified that the SDK's undici@^6 dependency is **not** affected: undici 6 shares the legacy slot with Node and skips initialization when it is already set.
- Pre-existing upstream issue, unrelated to this PR (reproduces on a clean HEAD): `npm run build` fails at `build:seed-v2` because `scripts/seed-v2/tsconfig.json` does not exist, which also breaks the `prepack` hook of `npm pack`.

---

> This PR was prepared with AI coding assistance; the reproduction, patch, and verification were reviewed and run locally by me. 本 PR 在 AI 编码助手辅助下完成，复现、改动与验证均由本人本地执行并审查。
