### PR TITLE
fix(core): self-heal store init cache after failed init or closed store

### DIFF
--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -3832,4 +3832,9 @@ export class VectorStore implements IMemoryStore {
       );
     }
   }
+
+  /** Whether close() has been called (see IMemoryStore.isClosed). */
+  isClosed(): boolean {
+    return this.closed;
+  }
 }

--- a/MemoryCore/src/core/store/types.ts
+++ b/MemoryCore/src/core/store/types.ts
@@ -566,6 +566,13 @@ export interface IMemoryStore extends MemoryPromptStore, MemoryGenerationRefStor
   isDegraded(): boolean;
   getCapabilities(): StoreCapabilities;
   close(): void;
+  /**
+   * Whether close() has been called. Optional: only stores holding closable
+   * resources (e.g. SQLite) implement it. Used by initStores() to detect a
+   * cached store that was closed outside the normal reset path (restart /
+   * compaction races) and re-initialize instead of reusing a dead handle.
+   */
+  isClosed?(): boolean;
 
   // ── L1 Write ─────────────────────────────────────────────
 

--- a/MemoryCore/src/utils/pipeline-factory.test.ts
+++ b/MemoryCore/src/utils/pipeline-factory.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/1155
+ *
+ * initStores() caches the promise returned by _doInitStores() per dataDir.
+ * Two lifecycle flaws made that cache permanent in failure scenarios:
+ *
+ * 1. A failed init (e.g. sqlite busy during a restart race) resolves to a
+ *    bundle with vectorStore/embeddingService = undefined — and that failure
+ *    bundle stayed cached forever, permanently disabling vector/FTS recall.
+ * 2. A store that was closed later (compaction teardown / restart race outside
+ *    the gateway_stop reset path) kept being served from the cache, producing
+ *    "statement has been finalized" / "database is not open" on every turn.
+ *
+ * initStores() must not cache failed bundles, and must re-initialize when the
+ * cached bundle's store has been closed.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IMemoryStore } from "../core/store/types.js";
+
+const createStoreBundleMock = vi.fn();
+
+vi.mock("../core/store/factory.js", () => ({
+  createStoreBundle: (...args: unknown[]) => createStoreBundleMock(...args),
+}));
+
+// Keep the manifest side effects (fs) out of these unit tests.
+vi.mock("./manifest.js", () => ({
+  readManifest: () => undefined,
+  writeManifest: () => undefined,
+  buildStoreInfo: () => ({}),
+  diffStoreBinding: () => [],
+}));
+
+import { initStores, resetStores } from "./pipeline-factory.js";
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+const cfg = {
+  storeBackend: "sqlite",
+  embedding: { provider: "none" },
+  bm25: {},
+} as never;
+
+function makeStore(overrides?: { closed?: boolean }) {
+  const state = { closed: overrides?.closed ?? false };
+  const store: Partial<IMemoryStore> & { isClosed(): boolean } = {
+    init: vi.fn(async () => ({ needsReindex: false })),
+    isDegraded: () => false,
+    isClosed: () => state.closed,
+    close: vi.fn(() => {
+      state.closed = true;
+    }),
+  };
+  return store as IMemoryStore & { isClosed(): boolean };
+}
+
+function healthyBundle(store: IMemoryStore) {
+  return {
+    store,
+    embedding: undefined,
+    bm25Encoder: undefined,
+    storeSnapshot: { type: "sqlite" },
+  };
+}
+
+describe("initStores cache lifecycle", () => {
+  beforeEach(() => {
+    createStoreBundleMock.mockReset();
+    resetStores();
+    vi.clearAllMocks();
+  });
+
+  it("reuses a healthy cached bundle (single init)", async () => {
+    const store = makeStore();
+    createStoreBundleMock.mockReturnValue(healthyBundle(store));
+
+    const a = await initStores(cfg, "/data/dir-a", logger);
+    const b = await initStores(cfg, "/data/dir-a", logger);
+
+    expect(a.vectorStore).toBe(store);
+    expect(b.vectorStore).toBe(store);
+    expect(createStoreBundleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a failed init bundle — a later call re-initializes", async () => {
+    createStoreBundleMock.mockImplementationOnce(() => {
+      throw new Error("SQLITE_BUSY: database is locked");
+    });
+    const store = makeStore();
+    createStoreBundleMock.mockImplementationOnce(() => healthyBundle(store));
+
+    const failed = await initStores(cfg, "/data/dir-b", logger);
+    expect(failed.vectorStore).toBeUndefined();
+
+    const recovered = await initStores(cfg, "/data/dir-b", logger);
+    expect(recovered.vectorStore).toBe(store);
+    expect(createStoreBundleMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-initializes when the cached store has been closed", async () => {
+    const first = makeStore();
+    const second = makeStore();
+    createStoreBundleMock
+      .mockImplementationOnce(() => healthyBundle(first))
+      .mockImplementationOnce(() => healthyBundle(second));
+
+    const a = await initStores(cfg, "/data/dir-c", logger);
+    expect(a.vectorStore).toBe(first);
+
+    first.close();
+
+    const b = await initStores(cfg, "/data/dir-c", logger);
+    expect(b.vectorStore).toBe(second);
+    expect(createStoreBundleMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetStores(dataDir) still forces re-initialization (existing contract)", async () => {
+    const first = makeStore();
+    const second = makeStore();
+    createStoreBundleMock
+      .mockImplementationOnce(() => healthyBundle(first))
+      .mockImplementationOnce(() => healthyBundle(second));
+
+    await initStores(cfg, "/data/dir-d", logger);
+    resetStores("/data/dir-d");
+    const b = await initStores(cfg, "/data/dir-d", logger);
+
+    expect(b.vectorStore).toBe(second);
+    expect(createStoreBundleMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/MemoryCore/src/utils/pipeline-factory.ts
+++ b/MemoryCore/src/utils/pipeline-factory.ts
@@ -245,12 +245,31 @@ export interface StoreInitResult {
 const _storeInitCache = new Map<string, Promise<StoreInitResult>>();
 
 /**
+ * Whether a cached init result is no longer usable and must be rebuilt:
+ * - the init failed (the catch path in _doInitStores returns
+ *   `vectorStore: undefined`), or
+ * - the store was closed after it entered the cache (restart / compaction
+ *   races that bypass the gateway_stop → resetStores path).
+ */
+function isStaleBundle(bundle: StoreInitResult): boolean {
+  const store = bundle.vectorStore;
+  if (!store) return true;
+  if (typeof store.isClosed === "function" && store.isClosed()) return true;
+  return false;
+}
+
+/**
  * Initialize store backend and (optionally) EmbeddingService.
  *
  * **Once-async semantics per dataDir**: the first call for a given
  * `pluginDataDir` creates the store and caches the result; subsequent
  * calls with the same dir return the cached Promise immediately.
  * Call `resetStores()` during shutdown to clear the cache.
+ *
+ * **Self-healing**: a failed init bundle is evicted once it resolves so the
+ * next call retries initialization, and a cached bundle whose store was
+ * closed behind our back is transparently rebuilt (see issue #1155).
+ * Concurrent callers still share the same in-flight promise.
  *
  * Supports both SQLite (sync init) and TCVDB (async init) backends.
  */
@@ -260,10 +279,29 @@ export function initStores(
   logger: PipelineLogger,
 ): Promise<StoreInitResult> {
   const key = pluginDataDir;
-  if (!_storeInitCache.has(key)) {
-    _storeInitCache.set(key, _doInitStores(cfg, pluginDataDir, logger));
+  const cached = _storeInitCache.get(key);
+  if (cached) {
+    return cached.then((bundle) => {
+      if (!isStaleBundle(bundle)) return bundle;
+      // Only evict if the cache still points at this exact promise, so a
+      // concurrent rebuild is never clobbered.
+      if (_storeInitCache.get(key) === cached) _storeInitCache.delete(key);
+      logger.warn?.(
+        `${TAG} Cached store for "${key}" is unusable (failed init or closed store) — re-initializing`,
+      );
+      return initStores(cfg, pluginDataDir, logger);
+    });
   }
-  return _storeInitCache.get(key)!;
+  const promise = _doInitStores(cfg, pluginDataDir, logger);
+  _storeInitCache.set(key, promise);
+  // A failed bundle is still delivered to current callers (unchanged failure
+  // semantics), but it is evicted afterwards so the next call retries.
+  void promise.then((bundle) => {
+    if (isStaleBundle(bundle) && _storeInitCache.get(key) === promise) {
+      _storeInitCache.delete(key);
+    }
+  });
+  return promise;
 }
 
 /**


### PR DESCRIPTION
## Description | 描述

Fixes the stale-store-cache failure reported in #1155.

`initStores()` caches the `_doInitStores()` promise per `pluginDataDir`. Two lifecycle gaps made that cache permanent in exactly the scenarios where a retry would have recovered:

1. **Failed init is cached forever.** The catch path in `_doInitStores()` still returns a bundle (with `vectorStore`/`embeddingService` set to `undefined`), so one transient error — e.g. `SQLITE_BUSY` during a restart race — permanently disabled vector/FTS recall and embedding for the rest of the process lifetime.
2. **Closed stores keep being served from the cache.** `VectorStore.close()` marks the store closed, but nothing invalidates `_storeInitCache`. When close happens outside the `gateway_stop → resetStores()` path (observed around compaction teardown and restart races), every later call reuses the closed instance and fails with `statement has been finalized` / `database is not open` until a full process restart.

Changes:

- `initStores()` evicts a resolved **failed** bundle from the cache (current callers still receive it — failure semantics unchanged), so the next call retries initialization.
- `initStores()` validates the cached bundle on access: if its store reports closed via the new optional `IMemoryStore.isClosed()` (implemented by the SQLite store), the bundle is transparently rebuilt.
- Eviction is guarded by an identity check (`_storeInitCache.get(key) === promise`) so concurrent rebuilds can never clobber each other; concurrent callers still share one in-flight init.
- `resetStores()` behavior is unchanged.

Intentionally out of scope: rebuilding on *degraded* stores (a much larger behavioral surface) and the complementary degrade-strategy approach in #809.

## Related Issue | 关联 Issue

Fixes #1155

## Change Type | 修改类型

- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verification (Node v24.15.0, `npx vitest run` → 4/4 pass):

- **Red → green**: on the unpatched code, the new tests "does not cache a failed init bundle" and "re-initializes when the cached store has been closed" fail; the healthy-cache reuse and `resetStores()` contract tests pass before and after.
- The new `src/utils/pipeline-factory.test.ts` covers all four scenarios with a mocked store factory.
- `npm run build:plugin` (tsdown) passes.

---

> This PR was prepared with AI coding assistance; the reproduction analysis, patch, and verification were reviewed and run locally by me. 本 PR 在 AI 编码助手辅助下完成，分析、改动与验证均由本人本地执行并审查。
