### PR TITLE
fix(store): honor recordIds filter in sqlite queryL1Records

### DIFF
--- a/MemoryCore/src/core/store/sqlite.test.ts
+++ b/MemoryCore/src/core/store/sqlite.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/1027
+ *
+ * The sqlite store's queryL1Records() ignored `filter.recordIds`, returning
+ * rows from the whole table instead of the requested primary keys. The v3
+ * `/atomic/update` handler loads the target note via
+ * `queryL1Records({ recordIds: [id] })` and takes `existing[0]`, so with more
+ * than one row present it could read another agent's note and fail ownership
+ * checks with a spurious 403.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { VectorStore } from "./sqlite.js";
+import type { MemoryRecord } from "../record/l1-writer.js";
+
+function makeRecord(id: string, agentId: string): MemoryRecord {
+  const now = new Date().toISOString();
+  return {
+    id,
+    content: `note for ${id}`,
+    type: "episodic",
+    priority: 50,
+    scene_name: "default",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [now],
+    createdAt: now,
+    updatedAt: now,
+    version: 1,
+    sessionKey: "sess-1",
+    sessionId: "sess-1",
+    teamId: "team-1",
+    userId: "user-1",
+    agentId,
+  };
+}
+
+describe("VectorStore.queryL1Records recordIds filter", () => {
+  let dir: string;
+  let store: VectorStore;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "tdai-sqlite-test-"));
+    // dimensions=0 → metadata/FTS-only mode, no sqlite-vec extension needed.
+    store = new VectorStore(path.join(dir, "test.db"), 0);
+    store.init();
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns only the records matching filter.recordIds", async () => {
+    store.upsertL1(makeRecord("mem-a", "agent-a"), undefined);
+    store.upsertL1(makeRecord("mem-b", "agent-b"), undefined);
+
+    const rows = await store.queryL1Records({ recordIds: ["mem-b"] });
+
+    expect(rows.map((r) => r.record_id)).toEqual(["mem-b"]);
+  });
+
+  it("returns no rows when none of the recordIds exist", async () => {
+    store.upsertL1(makeRecord("mem-a", "agent-a"), undefined);
+
+    const rows = await store.queryL1Records({ recordIds: ["mem-missing"] });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("recordIds combine with isolation dimensions", async () => {
+    store.upsertL1(makeRecord("mem-a", "agent-a"), undefined);
+    store.upsertL1(makeRecord("mem-b", "agent-b"), undefined);
+
+    const rows = await store.queryL1Records({
+      recordIds: ["mem-a", "mem-b"],
+      agentId: "agent-b",
+    });
+
+    expect(rows.map((r) => r.record_id)).toEqual(["mem-b"]);
+  });
+});

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -1827,6 +1827,15 @@ export class VectorStore implements IMemoryStore {
       if (filter?.userId !== undefined) rows = rows.filter((r) => r.user_id === filter.userId);
       if (filter?.agentId !== undefined) rows = rows.filter((r) => r.agent_id === filter.agentId);
       if (taskId !== undefined) rows = rows.filter((r) => r.task_id === taskId);
+      // Primary-key filter — matches the tcvdb backend's documentIds path.
+      // /v3/atomic/update relies on this to load the exact note before the
+      // ownership check; without it, `existing[0]` is an arbitrary row from
+      // the whole table, which can trip the 403 "belongs to a different
+      // agent" guard on a correctly-scoped request.
+      if (filter?.recordIds && filter.recordIds.length > 0) {
+        const want = new Set(filter.recordIds);
+        rows = rows.filter((r) => want.has(r.record_id));
+      }
 
       this.logger?.info(
         `${TAG} [L1-query] filter={sessionKey=${sessionKey ?? "(all)"}, sessionId=${sessionId ?? "(all)"}, teamId=${filter?.teamId ?? "(all)"}, userId=${filter?.userId ?? "(all)"}, agentId=${filter?.agentId ?? "(all)"}, taskId=${taskId ?? "(all)"}, updatedAfter=${updatedAfter ?? "(none)"}}, ` +


### PR DESCRIPTION
## Description | 描述

Fixes #1027.

The sqlite backend's `queryL1Records()` ignored `filter.recordIds`: the prepared-statement matrix only handles session/time predicates, and the in-memory isolation filters only cover `teamId` / `userId` / `agentId` / `taskId`.

`POST /v3/atomic/update` loads the target note via `store.queryL1Records({ recordIds: [id] })` and takes `existing[0]`. With the filter dropped, that is an **arbitrary row from the whole table**, so on multi-agent sqlite deployments the ownership check can trip a spurious `403 "belongs to a different agent"` — or, worse, the update could inherit `user_id` / `agent_id` from an unrelated row.

Change: apply the `recordIds` primary-key filter in memory alongside the existing isolation-dimension filters, matching both the tcvdb backend's `documentIds` path and the documented `L1QueryFilter.recordIds` contract.

Verified while investigating: `handleAtomicDelete` is **not** affected — it deletes through `deleteL1`'s primary-key path, not via `queryL1Records`.

## Related Issue | 关联 Issue

Fixes #1027

## Change Type | 修改类型

- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Verification (Node v24.15.0, `node:sqlite`):

- **Red → green**: added `src/core/store/sqlite.test.ts` with three cases against a real on-disk sqlite store — `recordIds` selection, non-existent ids, and `recordIds` combined with an isolation dimension. The two filter-only cases fail before the fix (whole table returned) and pass after; the combined case guards the interaction with isolation filters. `npx vitest run` → 3/3 pass.
- `npm run build:plugin` (tsdown) passes.
- The filter is applied in memory (same pattern as the existing isolation dimensions), keeping the prepared-statement matrix unchanged.

---

> This PR was prepared with AI coding assistance; the reproduction analysis, patch, and verification were reviewed and run locally by me. 本 PR 在 AI 编码助手辅助下完成，分析、改动与验证均由本人本地执行并审查。
