### PR TITLE
[good first issue-platform adapt-Pi] Add zero-code MemoryProxy adapter for Pi

### DIFF
--- a/MemoryProxy/src/agent-adapters/__tests__/pi-config.test.ts
+++ b/MemoryProxy/src/agent-adapters/__tests__/pi-config.test.ts
@@ -1,0 +1,48 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+interface PiProviderExample {
+  baseUrl?: unknown;
+  api?: unknown;
+  headers?: Record<string, unknown>;
+  compat?: Record<string, unknown>;
+}
+
+/**
+ * 按 JSON 文件读取示例而非作为模块 import：既贴合 Pi 加载 `models.json` 的真实
+ * 路径，也能防止文档调整后把可复制配置改成不合法的 JSON。
+ */
+async function loadProviderExample(): Promise<PiProviderExample> {
+  const configUrl = new URL("../../../../adapters/pi/models.example.json", import.meta.url);
+  const config = JSON.parse(await readFile(configUrl, "utf8")) as {
+    providers?: Record<string, PiProviderExample>;
+  };
+  return config.providers?.["tdai-memory"] ?? {};
+}
+
+describe("Pi zero-code provider example", () => {
+  it("routes standard OpenAI completions through the Pi MemoryProxy prefix", async () => {
+    const provider = await loadProviderExample();
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.baseUrl).toBe("http://127.0.0.1:8096/pi/<space-id>/v1");
+  });
+
+  it("provides dynamic session identity and the complete static asset preset", async () => {
+    const provider = await loadProviderExample();
+
+    // openrouter affinity 格式会发送动态 `x-session-id`。Proxy 以它作为会话键；
+    // 如果这里改成静态 Header，所有 Pi 对话会错误共享同一个记忆 Session。
+    expect(provider.compat).toMatchObject({
+      sendSessionAffinityHeaders: true,
+      sessionAffinityFormat: "openrouter",
+    });
+
+    // Pi 的 Session Init 明确采用无 Form 模式，三个 preset 必须成组提供；部分
+    // preset 无法通过向客户端弹出资产选择工具来补全。
+    expect(provider.headers).toMatchObject({
+      "x-team-id": "$TDAI_MEMORY_TEAM_ID",
+      "x-agent-id": "$TDAI_MEMORY_AGENT_ID",
+      "x-task-id": "$TDAI_MEMORY_TASK_ID",
+    });
+  });
+});

--- a/MemoryProxy/src/agent-adapters/__tests__/pi.test.ts
+++ b/MemoryProxy/src/agent-adapters/__tests__/pi.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isPiSummaryRequest, piAdapter } from "../pi.js";
+
+const summarySystem = "You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then summarize it.";
+
+describe("piAdapter", () => {
+  it("classifies only Pi's strict summary shape as auxiliary", () => {
+    const summary = { messages: [
+      { role: "system", content: summarySystem },
+      { role: "user", content: "<conversation>history</conversation>" },
+    ] };
+    expect(isPiSummaryRequest(summary)).toBe(true);
+    expect(piAdapter.classifyRequest(summary)).toBe("auxiliary");
+    expect(isPiSummaryRequest({ ...summary, tools: [{ type: "function" }] })).toBe(false);
+    expect(isPiSummaryRequest({ messages: [...summary.messages, { role: "user", content: "real" }] })).toBe(false);
+  });
+
+  it("keeps unknown requests on the main path", () => {
+    expect(piAdapter.classifyRequest({ messages: [{ role: "user", content: "hello" }] })).toBe("main");
+  });
+
+  it("extracts string and text-block content without applying weak summary signals", () => {
+    expect(piAdapter.extractUserText(" hello ")).toBe("hello");
+    expect(piAdapter.extractUserText("<conversation>x</conversation>")).toBe("<conversation>x</conversation>");
+    expect(piAdapter.extractUserText([{ type: "text", text: "from block" }])).toBe("from block");
+  });
+
+  it("accepts Pi's developer-role and text-block summary variant", () => {
+    expect(isPiSummaryRequest({
+      messages: [
+        { role: "developer", content: [{ type: "text", text: summarySystem }] },
+        { role: "user", content: [{ type: "text", text: "  <conversation>history</conversation>" }] },
+      ],
+      tools: [],
+    })).toBe(true);
+  });
+
+  it("keeps malformed near-matches on the main path", () => {
+    expect(isPiSummaryRequest({
+      messages: [{ role: "user", content: "<conversation>real user XML</conversation>" }],
+    })).toBe(false);
+    expect(isPiSummaryRequest({
+      messages: [
+        { role: "system", content: summarySystem },
+        { role: "user", content: "<conversation>history" },
+      ],
+    })).toBe(false);
+    expect(isPiSummaryRequest({
+      messages: [
+        { role: "system", content: summarySystem },
+        { role: "assistant", content: "<conversation>history</conversation>" },
+      ],
+    })).toBe(false);
+  });
+});

--- a/MemoryProxy/src/agent-adapters/index.ts
+++ b/MemoryProxy/src/agent-adapters/index.ts
@@ -6,7 +6,8 @@
  *
  * 各点详见：
  *   - types.ts —— AgentAdapter 接口 + 三个适配点的说明
- *   - claude-code.ts —— CC 特化实现（当前唯一有源码/抓包依据的客户端）
+ *   - claude-code.ts —— CC 特化实现
+ *   - pi.ts —— Pi OpenAI-compatible 请求与内部摘要分流
  *   - codebuddy.ts —— CB stub（沿用 default 行为，等抓包再补 CB 特化）
  *   - default.ts —— unknown 兜底
  */
@@ -18,6 +19,7 @@ import { codexAdapter } from "./codex.js";
 import { workbuddyAdapter } from "./workbuddy.js";
 import { dshAdapter } from "./dsh.js";
 import { opencodeAdapter } from "./opencode.js";
+import { piAdapter } from "./pi.js";
 import { defaultAdapter } from "./default.js";
 
 export type { AgentAdapter, AgentKind, RequestKind } from "./types.js";
@@ -36,6 +38,8 @@ export function resolveAgentAdapter(agentSource: string): AgentAdapter {
       return dshAdapter;
     case "opencode":
       return opencodeAdapter;
+    case "pi":
+      return piAdapter;
     default:
       return defaultAdapter;
   }

--- a/MemoryProxy/src/agent-adapters/pi.ts
+++ b/MemoryProxy/src/agent-adapters/pi.ts
@@ -1,0 +1,89 @@
+/**
+ * Pi coding-agent 客户端适配器。
+ *
+ * 协议实证（Pi `v0.84.2` 源码 + `--no-extensions` 真实请求）：
+ *
+ *   - `~/.pi/agent/models.json` 使用 `api: "openai-completions"` 时，Pi 发送
+ *     标准流式 OpenAI Chat Completions 请求；因此直接复用共享 `handler.ts`，
+ *     路径为 `/pi/:spaceId/v1/chat/completions`，不需要新增 `piHandler.ts`
+ *   - Provider 开启 `sendSessionAffinityHeaders` 并选择 `openrouter` 格式后，
+ *     Pi 会把当前运行时 Session ID 写入 `x-session-id`；Proxy 现有
+ *     `resolveConversationId()` 已支持该 Header，不需要插件或 Header Hook
+ *   - `x-team-id` / `x-agent-id` / `x-task-id` 由 Provider 静态 Header 提供，
+ *     仍由共享 preset resolver 按当前用户可见资产校验，不能直接信任客户端值
+ *
+ * # 主请求与内部摘要请求
+ *
+ * Pi 的主 Agent Loop、自动 compaction、tree branch summary 共用同一 Provider。
+ * 如果把内部摘要误当主请求，会同时产生三类污染：摘要器收到记忆注入、合成的
+ * `<conversation>` 被记为真人输入、摘要结果进入 L0 / Skill。因此必须分流，
+ * 但 Pi 没有独立摘要 URL 或 Header，只能使用 `v0.84.2` 已验证的 body 组合信号：
+ *
+ *   1. messages 恰好两条；
+ *   2. 首条 role 为 system / developer，content 命中固定摘要 Prompt 前缀；
+ *   3. 第二条 role 为 user，并以 `<conversation>` 包裹历史；
+ *   4. tools 缺失或为空。
+ *
+ * 四项必须同时满足才判 auxiliary。任何未知或部分匹配都保守回落 main，避免 Pi
+ * 未来调整非关键字段后把正常短对话误判为摘要，导致整轮跳过注入和回流。
+ */
+
+import { defaultAdapter } from "./default.js";
+import type { AgentAdapter } from "./types.js";
+
+const SUMMARY_SYSTEM_PREFIX =
+  "You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant";
+const SUMMARY_OPEN = "<conversation>";
+const SUMMARY_CLOSE = "</conversation>";
+
+interface MessageLike {
+  role?: unknown;
+  content?: unknown;
+}
+
+function textContent(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  return defaultAdapter.extractUserText(content);
+}
+
+/**
+ * 判断请求是否为 Pi 内部摘要。
+ *
+ * handler 传入的是客户端 JSON 边界数据，故参数保留 `unknown`，逐字段收窄后再访问。
+ * 畸形请求或未来新增 shape 一律返回 false，继续走更安全的 main 路径。
+ */
+export function isPiSummaryRequest(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const candidate = body as { messages?: unknown; tools?: unknown };
+  if (!Array.isArray(candidate.messages) || candidate.messages.length !== 2) return false;
+  if (Array.isArray(candidate.tools) && candidate.tools.length > 0) return false;
+  if (candidate.tools !== undefined && !Array.isArray(candidate.tools)) return false;
+
+  const [system, user] = candidate.messages as MessageLike[];
+  if ((system?.role !== "system" && system?.role !== "developer") || user?.role !== "user") return false;
+  const systemText = textContent(system.content);
+  const userText = textContent(user.content);
+  return Boolean(
+    systemText?.startsWith(SUMMARY_SYSTEM_PREFIX) &&
+      userText?.trimStart().startsWith(SUMMARY_OPEN) &&
+      userText.includes(SUMMARY_CLOSE),
+  );
+}
+
+export const piAdapter: AgentAdapter = {
+  agentKind: "pi",
+
+  classifyRequest(body) {
+    // compaction 与 branch summary 共用严格 envelope；禁止只按消息数量或 tools
+    // 缺失这种单一弱信号判断，避免普通请求丢失记忆能力。
+    return isPiSummaryRequest(body) ? "auxiliary" : "main";
+  },
+
+  extractUserText(content) {
+    const text = textContent(content)?.trim();
+    // 摘要副作用由 classifyRequest 的完整 envelope 统一门禁。这里不能只凭
+    // `<conversation>` 单一弱信号丢弃文本，否则用户主动提交同名 XML 时，主请求
+    // 虽然正确归类为 main，Skill 侧却会静默漏掉该轮真人输入。
+    return text || null;
+  },
+};

--- a/MemoryProxy/src/agent-adapters/types.ts
+++ b/MemoryProxy/src/agent-adapters/types.ts
@@ -9,6 +9,8 @@
  *     marker 位置上跟主对话不同 (n-2 vs n-1)。
  *   - CodeBuddy (openai 协议): user content 常是字符串，可能夹杂 CB 内部
  *     标签 —— 结构和 CC 差异大。
+ *   - Pi (openai 协议): 主循环与内部摘要共用 chat/completions；适配器按已验证的
+ *     两消息摘要 envelope 分流，避免摘要请求触发注入、L0 与 skill 副作用。
  *   - 其他（cursor / windsurf / 自定义 SDK）: 未研究。
  *
  * proxy 里三个地方需要按客户端适配：
@@ -20,7 +22,7 @@
  * 只是**取用户输入的规则**和**分类规则**按 agent 适配。
  */
 
-export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "opencode" | "unknown";
+export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "opencode" | "pi" | "unknown";
 
 export type RequestKind = "main" | "fork" | "sidequery" | "auxiliary";
 

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -565,7 +565,11 @@ export async function handleAnthropicMessages(
     ? _pathPartsEarly[0] : undefined;
   const agentAdapter = resolveAgentAdapter(_agentFromPathEarly ?? "claude-code");
   const ccRoutingEnabled = config.ccRequestRouting?.enabled === true;
-  const requestKind: CcRequestKind = ccRoutingEnabled ? agentAdapter.classifyRequest(body) : "main";
+  const classifiedRequest = ccRoutingEnabled ? agentAdapter.classifyRequest(body) : "main";
+  // auxiliary 当前只用于 OpenAI handler 中的 Pi 内部摘要。Anthropic 路由没有对应
+  // 分支，且 Pi Chat Completions 不会进入此 handler；若未来 adapter 意外在这里
+  // 返回 auxiliary，保守按 main 处理，避免扩宽 CcRequestKind 影响既有 CC 分流。
+  const requestKind: CcRequestKind = classifiedRequest === "auxiliary" ? "main" : classifiedRequest;
 
   // ── Model gate: reject requests whose `model` is not a registered display name ──
   // 价目表已配置时，客户端 `model` 必须匹配某条 entry 的 `modelName`（展示名，

--- a/MemoryProxy/src/credit-reporter.ts
+++ b/MemoryProxy/src/credit-reporter.ts
@@ -69,12 +69,12 @@ export function extractSpaceIdFromPath(path: string): string | null {
   // /proxy/<spaceId>/...
   let match = /^\/?proxy\/([^/?]+)(?:\/|$)/.exec(safePath);
   if (match) return match[1] || null;
-  // /<agent>/<spaceId>/...  (e.g. /claude-code/mem-example001/v1/messages)
+  // /<agent>/<spaceId>/...，例如 CC 的 /v1/messages 或 Pi 的 /v1/chat/completions。
   match = /^\/[^/]+\/([^/?]+)(?:\/|$)/.exec(safePath);
   if (match) {
     const agent = safePath.split("/").filter(Boolean)[0] ?? "";
     // Only capture spaceId when the first segment looks like an agent name
-    if (/^(claude-code|codebuddy|codex|cursor|hermes|openclaw|workbuddy|dsh|opencode)$/i.test(agent)) {
+    if (/^(claude-code|codebuddy|codex|cursor|hermes|openclaw|workbuddy|dsh|opencode|pi)$/i.test(agent)) {
       return match[1] || null;
     }
   }

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -730,25 +730,45 @@ export async function handleChatCompletions(
   if (_dshHeadless) {
     console.log(`[request-classify] session=${sessionKey} agent=dsh headless/no-preset (no ask_user_question tool) → bypass session-init, direct passthrough`);
   }
+  // ── Pi 零代码 / 无 Form 策略 ────────────────────────────────────────────
+  //
+  // Pi 只通过 `~/.pi/agent/models.json` 即可把 OpenAI-compatible 模型指向
+  // MemoryProxy，不需要扩展。依赖两项 Pi 原生配置：
+  //
+  //   1. Provider `headers` 携带静态 Team / Agent / Task preset；
+  //   2. `compat.sendSessionAffinityHeaders=true` + `openrouter` 格式发送
+  //      逐会话 `x-session-id`，现有 resolveConversationId() 已原生支持。
+  //
+  // Pi 没有内置 question tool。若 Proxy 伪造 Form tool_call，未安装扩展的客户端会
+  // 按 unknown tool 失败，也违背零代码接入约束。因此 Pi 在所有运行模式都按无 Form
+  // 客户端处理：完整 preset 仍走共享状态机直接注册，已有终态 binding 仍可恢复并
+  // 注入；其余初始化结果只 bypass 当前请求，绝不能持久化到整个 Session。
+  const _piNoForm = agentSource === "pi";
+  let _piRequestBypassed = false;
 
   // ── mem:session-reset pre-hook ──
   // hermes / openclaw 走 header 预选身份, dsh headless 无 ask_user_question tool —
   // 三者都没有交互式 form UI 可以弹,reset 后 session 会永远卡在 pending_asset_confirm。
   // 直接返回"不支持"文案。
   const _headerOnlyAgents = new Set(["hermes", "openclaw"]);
-  const _noFormAgent = _headerOnlyAgents.has(agentSource) || _dshHeadless;
+  const _noFormAgent = _headerOnlyAgents.has(agentSource) || _dshHeadless || _piNoForm;
   if (config.memCommand?.enabled && !isAuxiliary && _noFormAgent) {
     const { isSessionResetCommand } = await import("./mem-command/pre-intercept.js");
     if (isSessionResetCommand(body as Record<string, unknown>, agentSource)) {
       const { buildMemResponse } = await import("./mem-command/response-builder.js");
       console.log(`[mem-command:pre] session-reset unsupported for agent=${agentSource} dshHeadless=${_dshHeadless}`);
-      const msg = _headerOnlyAgents.has(agentSource)
+      let msg = _headerOnlyAgents.has(agentSource)
         ? `⚠️ mem:session-reset 不支持 ${agentSource} 客户端。\n\n`
           + `${agentSource} 通过 x-team-id / x-agent-id / x-task-id 请求头预选身份，没有交互式表单入口。\n`
           + `请在客户端配置中直接更改这些请求头来切换 Team / Agent / Task。`
         : "⚠️ mem:session-reset 不支持 dsh headless 模式。\n\n"
           + "dsh 客户端在 headless / no-preset 场景下不挂 ask_user_question tool，无法弹出资产选择表单。\n"
           + "请在带 ask_user_question preset 的 dsh 环境下使用。";
+      if (_piNoForm) {
+        msg = "mem:session-reset 不支持 Pi 客户端。\n\n"
+          + "Pi 通过 models.json 中的 x-team-id / x-agent-id / x-task-id 请求头预选身份，没有交互式表单入口。\n"
+          + "请修改 Pi Provider 的静态请求头后，新建会话以切换 Team / Agent / Task。";
+      }
       return buildMemResponse(msg, {
         protocol: "openai",
         stream: isStream,
@@ -756,7 +776,7 @@ export async function handleChatCompletions(
       });
     }
   }
-  if (config.memCommand?.enabled && !isAuxiliary && !_dshHeadless && !_headerOnlyAgents.has(agentSource)) {
+  if (config.memCommand?.enabled && !isAuxiliary && !_dshHeadless && !_piNoForm && !_headerOnlyAgents.has(agentSource)) {
     const { isSessionResetCommand } = await import("./mem-command/pre-intercept.js");
     if (isSessionResetCommand(body as Record<string, unknown>, agentSource)) {
       const { isMemCommandAllowed, parseMemCommand } = await import("./mem-command/index.js");
@@ -868,7 +888,17 @@ export async function handleChatCompletions(
       const needsPrewarm =
         recovered?.__recoverySource === "l2b" ||
         recovered?.__recoverySource === "history-scan";
-      if (recovered && isTerminalState) {
+      const hasCompletePreset = Boolean(presetIdentity?.teamId && presetIdentity.agentId && presetIdentity.taskId);
+      if (_piNoForm && !isTerminalState && !hasCompletePreset) {
+        // 静态身份不完整时，无 Form 客户端不可能完成注册。这里不进入状态机，否则
+        // Pi 后续轮次会持续消耗 retry，最终把 bypass 错误持久化到整个 Session。
+        _piRequestBypassed = true;
+        injectedSkipped = true;
+        initResult = {
+          intercepted: false,
+          messages: (body.messages as Array<Record<string, unknown>>) ?? [],
+        };
+      } else if (recovered && isTerminalState) {
         // Recovery hit: keep original messages, only re-inject <session_context>
         // so this turn's system message carries agent/task context again.
         // 用户对话永远保留原样，包括 session_init form 交互 — 不做任何删除。
@@ -924,19 +954,39 @@ export async function handleChatCompletions(
           spaceId,
           presetIdentity,
         );
+        if (
+          _piNoForm &&
+          !isTerminalState &&
+          !initResult.intercepted &&
+          (initResult.bypassed || !initResult.sessionInfo)
+        ) {
+          // preset 无效或资产列表为空时，状态机可能不返回 Form 而直接落 bypass；
+          // Pi 同样必须把该结果限制在当前请求，并恢复进入状态机前的状态。
+          if (recovered) await store.set(compositeKey, recovered);
+          else store.delete(compositeKey);
+          _piRequestBypassed = true;
+          injectedSkipped = true;
+        }
       }
 
       // Case 1: Fake form returned → must not forward
       if (initResult.intercepted && initResult.response) {
-        return initResult.response;
+        if (!_piNoForm) return initResult.response;
+        // Header 字段齐全但校验失败时仍可能产出 Form。Pi 无法执行该 Form，因此恢复
+        // 请求前状态，避免无 UI 流量消耗 retry 或覆盖已进行中的交互状态。
+        if (recovered) await store.set(compositeKey, recovered);
+        else store.delete(compositeKey);
+        _piRequestBypassed = true;
+        injectedSkipped = true;
+        console.log(`[session-init] session=${sessionKey} pi no-form → suppressing interactive form for this request`);
       }
 
       console.log(`[injection-debug] initResult session=${sessionKey} intercepted=${initResult.intercepted} bypassed=${initResult.bypassed} justRegistered=${initResult.justRegistered} resetFlow=${(initResult as any).resetFlow} hasSessionInfo=${!!initResult.sessionInfo} hasAgentDetail=${!!initResult.agentDetail}`);
       // 见 anthropicHandler 对称位置：只在真正走 sessionInit state machine 时继承。
-      if (wentThroughSessionInitStateMachine && initResult.justRegistered) sessionJustRegistered = true;
+      if (!_piRequestBypassed && wentThroughSessionInitStateMachine && initResult.justRegistered) sessionJustRegistered = true;
 
       // Case 1.5: Bypass path → skip ALL injection hooks
-      if (initResult.bypassed) {
+      if (!_piRequestBypassed && initResult.bypassed) {
         injectedSkipped = true;
         console.log(`[session-init] session=${sessionKey} bypassed → skipping all injection`);
         if (initResult.resetFlow) {
@@ -944,7 +994,7 @@ export async function handleChatCompletions(
         }
       }
 
-      if (!initResult.bypassed && initResult.sessionInfo) {
+      if (!_piRequestBypassed && !initResult.bypassed && initResult.sessionInfo) {
         try {
           const { fetchAssetCapabilities } = await import("./tdai/capabilities.js");
           assetCapabilities = await fetchAssetCapabilities({
@@ -1008,6 +1058,7 @@ export async function handleChatCompletions(
       // the pipeline ran before the cache was populated, silently injecting
       // zero blocks for the entire first turn.
       if (
+        !_piRequestBypassed &&
         !initResult.bypassed &&
         initResult.justRegistered &&
         initResult.sessionInfo &&
@@ -1039,12 +1090,12 @@ export async function handleChatCompletions(
       }
 
       // Case 2: Messages were cleaned → update body
-      if (initResult.messages) {
+      if (!_piRequestBypassed && initResult.messages) {
         body = { ...body, messages: initResult.messages };
         messages = initResult.messages as unknown[];
       }
 
-      sessionInfo = initResult.sessionInfo as Record<string, unknown> | null | undefined;
+      sessionInfo = _piRequestBypassed ? undefined : initResult.sessionInfo as Record<string, unknown> | null | undefined;
       // Belt-and-suspenders: also restore on the local `sessionInfo` alias.
       // In practice this is the same object reference as
       // `initResult.sessionInfo` (already restored above), but the second
@@ -1108,7 +1159,7 @@ export async function handleChatCompletions(
   //
   // 请求分类：OpenAI 协议不做 CC 的 fork/sidequery 分流（handler.ts 没接 CC
   // routing），所有请求都视为 main —— 与 codebuddy adapter classifyRequest 一致。
-  if (config.memCommand?.enabled && !isAuxiliary && !_dshHeadless) {
+  if (config.memCommand?.enabled && !isAuxiliary && !_dshHeadless && !_piRequestBypassed) {
     const { parseMemCommand, isMemCommandAllowed, executeMemCommand, buildMemResponse, extractSimpleMessages, truncateArgs } = await import("./mem-command/index.js");
     // 常规检测：最后一条 user message
     let memCmd = parseMemCommand(body as Record<string, unknown>, agentSource);
@@ -1221,7 +1272,7 @@ export async function handleChatCompletions(
   }
 
   // aux 请求(compaction/title)/ dsh headless(无 UI 无 preset)不写 L0 —— 直接透传
-  const tdaiClient = isAuxiliary || _dshHeadless || assetCapabilities?.chat_memory === false ? null : createTdaiClient(config, spaceId);
+  const tdaiClient = isAuxiliary || _dshHeadless || _piRequestBypassed || assetCapabilities?.chat_memory === false ? null : createTdaiClient(config, spaceId);
   const tdaiIdentity = injectedSkipped
     ? null
     : deriveTdaiIdentity({
@@ -1577,7 +1628,7 @@ export async function handleChatCompletions(
       sessionKeyForSkill: sessionKey,
       agentSource,
       isAuxiliary,
-      isDshHeadless: _dshHeadless,
+      skipExtraction: _dshHeadless || _piRequestBypassed,
       sessionInfo,
       lf,
       spaceId,
@@ -1787,7 +1838,7 @@ export async function handleChatCompletions(
   // Skill extract trigger — count tool calls + buffer conversation.
   // 同步 await：直到 store 落盘再继续，保证下一轮跨节点读到最新数据。
   // aux 请求(compaction/title)/dsh headless 不触发 skill 提取 —— 保持归档 buffer 语义纯净
-  if (!isAuxiliary && !_dshHeadless && isExtractionAllowed(config, "skill")) {
+  if (!isAuxiliary && !_dshHeadless && !_piRequestBypassed && isExtractionAllowed(config, "skill")) {
     await triggerSkillExtractIfReady({
       config,
       sessionKey,
@@ -1890,9 +1941,12 @@ interface TapContext {
   /** True when this request was classified as auxiliary (compaction/title-gen) —
    * downstream L0/skill extract paths must skip to keep buffer semantics clean. */
   isAuxiliary: boolean;
-  /** True when this dsh request came from CLI headless / no-preset (no ask_user_question
-   * in tools) — behaves like aux for downstream side-effects. */
-  isDshHeadless: boolean;
+  /**
+   * main 请求仍需纯透传时为 true：包括缺少 question tool 的 dsh，以及没有可恢复
+   * binding 或完整 Header preset 的 Pi。下游 L0 / Skill 写入必须复用转发前的同一
+   * 判定，避免出现“未注入但仍回流”的半开启状态。
+   */
+  skipExtraction: boolean;
   sessionInfo: Record<string, unknown> | null | undefined;
   /** Langfuse turn-trace context (trace = one turn). */
   lf: LangfuseTurnContext;
@@ -2208,7 +2262,7 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
     // Skill extract trigger — after stream finalization.
     // 同步 await：直到 store 落盘再继续，保证下一轮跨节点读到最新数据。
     // aux 请求(compaction/title)/dsh headless 跳过 skill 触发,保持归档 buffer 语义纯净。
-    if (!ctx.isAuxiliary && !ctx.isDshHeadless && isExtractionAllowed(ctx.config, "skill")) {
+    if (!ctx.isAuxiliary && !ctx.skipExtraction && isExtractionAllowed(ctx.config, "skill")) {
       await triggerSkillExtractIfReady({
         config: ctx.config,
         sessionKey: ctx.sessionKeyForSkill,
@@ -2220,7 +2274,7 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
         assetCapabilities: ctx.assetCapabilities,
         toolCallCountOverride: toolCallAccumulators.size,
       });
-    } else if (!ctx.isAuxiliary && !ctx.isDshHeadless) {
+    } else if (!ctx.isAuxiliary && !ctx.skipExtraction) {
       logExtractionSkipped(ctx.config, "skill", ctx.sessionKeyForSkill);
     }
 

--- a/MemoryProxy/src/routes/__tests__/pi-route.test.ts
+++ b/MemoryProxy/src/routes/__tests__/pi-route.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { extractSpaceIdFromPath } from "../../credit-reporter.js";
+import { normalizeWhitelistRequestPath } from "../whitelist.js";
+
+describe("Pi routes", () => {
+  it("normalizes the generic Pi agent prefix", () => {
+    expect(normalizeWhitelistRequestPath("/pi/mem-example/v1/chat/completions")).toBe("/v1/chat/completions");
+  });
+
+  it("attributes Pi credit usage to its space", () => {
+    expect(extractSpaceIdFromPath("/pi/mem-example/v1/chat/completions")).toBe("mem-example");
+  });
+});

--- a/MemoryProxy/src/routes/whitelist.ts
+++ b/MemoryProxy/src/routes/whitelist.ts
@@ -166,13 +166,15 @@ const PROXY_PREFIX_RE = /^\/proxy\/[^/]+/;
  *   - `/codex/{spaceId}/responses`            → 剥 `/codex/{spaceId}`（codex 客户端
  *     不像 CC/CB 那样自拼 /v1/，源码 endpoint 常量就是 /responses，因此 base_url
  *     不带 /v1 时前缀后紧接的就是 /responses 或 /memories 等）
+ *   - `/pi/{spaceId}/v1/chat/completions`      → 剥 `/pi/{spaceId}`（Pi 的自定义
+ *     provider 仍使用标准 OpenAI Chat Completions 路径，Proxy 只需识别客户端前缀）
  * lookahead 允许 `/v1/`、`/responses`、`/responses/`、`/memories/`、`/realtime/`
  * 后紧邻，其中 `/v1/` 必须带尾斜杠避免误伤未来出现的 `/v1foo` 之类；responses
  * 等 codex 端点允许尾斜杠可选（如 `/responses` 是完整路径）。
  * 白名单入口 `/v1/messages`、`/responses` 自身不会被误剥（因为它们不匹配 agent
  * 段——agent 段限定为已知名字）。
  */
-const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|anthropic|openai)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
+const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|pi|anthropic|openai)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
 
 /**
  * `/cost-guard` marker 正则：位于 `/{agent}/{spaceId}` 之后的独立 segment。

--- a/adapters/pi/README.md
+++ b/adapters/pi/README.md
@@ -1,0 +1,206 @@
+# Pi
+
+> agentSource: `pi` | Protocol: OpenAI Chat Completions | Session Init: header preset (no interactive form)
+>
+> Chinese documentation: [README_CN.md](README_CN.md)
+
+---
+
+## 1. Client configuration
+
+Pi connects to MemoryProxy through the custom provider in `~/.pi/agent/models.json`.
+No plugin, hook, MCP server, or Pi source change is required.
+
+Merge [`models.example.json`](models.example.json) into `models.json`, then replace:
+
+- `<space-id>` with the Memory instance ID;
+- `<upstream-model-id>` with the model ID configured behind MemoryProxy.
+
+Set the environment variables referenced by the example:
+
+```bash
+export TDAI_MEMORY_USER_KEY='<sk-mem-user-key>'
+export TDAI_MEMORY_TEAM_ID='<team-id>'
+export TDAI_MEMORY_AGENT_ID='<agent-id>'
+export TDAI_MEMORY_TASK_ID='<task-id>'
+```
+
+PowerShell:
+
+```powershell
+$env:TDAI_MEMORY_USER_KEY = '<sk-mem-user-key>'
+$env:TDAI_MEMORY_TEAM_ID = '<team-id>'
+$env:TDAI_MEMORY_AGENT_ID = '<agent-id>'
+$env:TDAI_MEMORY_TASK_ID = '<task-id>'
+```
+
+Field summary:
+
+- `baseUrl` — MemoryProxy address plus `/pi/<spaceId>/v1`;
+- `api` — must be `"openai-completions"`;
+- `apiKey` — the authenticated user's `sk-mem-...` key;
+- `headers` — the Team, Agent, and Task preset used for non-interactive registration;
+- `compat` — enables Pi's native per-session `x-session-id` header;
+- `models[].id` — must match a model supported by the MemoryProxy upstream.
+
+Select `tdai-memory/<upstream-model-id>` from Pi's model selector after starting MemoryProxy.
+
+Request path: `POST /pi/:spaceId/v1/chat/completions`.
+
+---
+
+## 2. Session ID
+
+| Priority | Header | Source |
+|---|---|---|
+| 1 | `x-conversation-id` | Optional wrapper or upstream proxy |
+| 2 | `x-session-id` | Pi native session affinity |
+
+The example enables:
+
+```json
+{
+  "sendSessionAffinityHeaders": true,
+  "sessionAffinityFormat": "openrouter"
+}
+```
+
+Pi then sends its current runtime session ID as `x-session-id`. MemoryProxy already
+uses this header as a conversation identity, so new, resumed, and concurrent Pi
+sessions do not need a custom header hook.
+
+---
+
+## 3. Session Init
+
+### Core difference: header preset, no interactive form
+
+Pi does not provide a built-in question tool that MemoryProxy can use for asset
+selection. Session registration therefore depends on the provider headers:
+
+| Header | Description | Required |
+|---|---|---|
+| `x-team-id` | Team ID | Yes |
+| `x-agent-id` | Agent ID | Yes |
+| `x-task-id` | Task ID | Yes |
+
+Processing rules:
+
+- all three IDs exist and validate against the authenticated user's visible assets: register the session and enable memory;
+- a valid binding already exists for `x-session-id`: recover it and continue normally;
+- a preset is missing, partial, or invalid: pass through this request without injection;
+- the pass-through decision is request-local and never persists a bypass for the Pi session.
+
+MemoryProxy must enable `sessionInit.enabled` and `sessionInit.headerAutoSelect.enabled`.
+The default header names already match the example.
+
+---
+
+## 4. Request classification
+
+Pi uses the same Chat Completions provider for the main agent loop and internal
+summarization. The adapter distinguishes them as follows:
+
+| Request | Classification | Memory side effects |
+|---|---|---|
+| Normal turn | `main` | Enabled after session registration |
+| Tool-result turn | `main` | Enabled after binding recovery |
+| Automatic compaction | `auxiliary` | Disabled |
+| Branch summary | `auxiliary` | Disabled |
+| Unknown or partial match | `main` | Conservative fallback |
+
+An auxiliary match requires the complete Pi `0.84.2` summary envelope: exactly
+two messages, a known summary system prompt, a user `<conversation>` wrapper,
+and no tools. A single weak signal never disables memory behavior.
+
+---
+
+## 5. User text extraction
+
+Pi may send message content as a string or OpenAI text-content parts. The adapter
+reuses the shared extractor for both shapes. The strict auxiliary-request gate
+excludes synthetic `<conversation>` summary input from L0 and Skill side effects;
+the text extractor does not act on that weak signal alone.
+
+---
+
+## 6. Injection profile
+
+Pi shares `handleChatCompletions` with CodeBuddy, dsh, and OpenCode. After session
+registration, MemoryProxy injects the standard blocks into the system message:
+
+```xml
+<agent_skills>...</agent_skills>
+<user_memory>...</user_memory>
+<session_context>...</session_context>
+```
+
+The same shared pipeline handles binding recovery, L0 capture, Skill extraction,
+Knowledge injection, authentication, observability, and credit reporting.
+
+---
+
+## 7. Special behavior
+
+- **Shared handler**: Pi uses the generic OpenAI Chat Completions handler; there is no `piHandler.ts`.
+- **First-class attribution**: the `/pi/` route sets `agentSource=pi` for session keys and telemetry.
+- **No fabricated tool**: MemoryProxy never returns an unknown session-init tool to Pi.
+- **Request-local fail-open**: an unavailable asset selection path does not poison later requests.
+- **Session reset**: change the static asset headers and start a new Pi session; interactive `mem:session-reset` is not supported.
+
+---
+
+## 8. Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `TDAI_MEMORY_USER_KEY` | Memory user key used for authentication |
+| `TDAI_MEMORY_TEAM_ID` | Header preset Team ID |
+| `TDAI_MEMORY_AGENT_ID` | Header preset Agent ID |
+| `TDAI_MEMORY_TASK_ID` | Header preset Task ID |
+
+Pi resolves `$VARIABLE_NAME` values when loading `models.json`. Do not commit a
+populated configuration containing literal credentials.
+
+---
+
+## 9. Known limitations
+
+- Team, Agent, and Task IDs are static for one provider entry. Define another
+  provider entry when a different asset binding is needed.
+- Pi `0.84.2` has no built-in interactive asset-selection tool, so incomplete
+  presets cannot be repaired inside the current conversation.
+- Summary classification is validated against Pi `0.84.2`. Future Pi prompt-shape
+  changes remain on the safe `main` path until explicitly verified.
+
+---
+
+## 10. FAQ
+
+**Q: Is changing only `baseUrl` sufficient?**
+
+A: No. The integration is zero-code, not zero-configuration. Keep the `compat`
+session-affinity settings and all three asset headers from the example.
+
+**Q: Why use `sessionAffinityFormat: "openrouter"`?**
+
+A: This format sends `x-session-id`, which MemoryProxy already recognizes. It
+keeps each Pi runtime session isolated without an extension-owned hook.
+
+**Q: What happens when an asset ID is wrong?**
+
+A: MemoryProxy validates IDs against assets visible to the authenticated user.
+The current request passes upstream without memory, and no persistent bypass is written.
+
+**Q: Can model costs remain zero in `models.json`?**
+
+A: Yes. Those values are Pi-side display metadata; MemoryProxy performs upstream
+usage accounting independently.
+
+---
+
+## 11. Validation status
+
+- Pi `0.84.2` configuration-only smoke test passed with `--no-extensions`;
+- the captured request contained a dynamic `x-session-id` and all three preset headers;
+- route normalization, credit attribution, provider configuration, and request classification tests pass.

--- a/adapters/pi/README_CN.md
+++ b/adapters/pi/README_CN.md
@@ -1,0 +1,200 @@
+# Pi
+
+> agentSource: `pi` | 协议: OpenAI Chat Completions | Session Init: Header 预选（无交互 Form）
+>
+> 英文文档：[README.md](README.md)
+
+---
+
+## 1. 客户端接入配置
+
+Pi 通过 `~/.pi/agent/models.json` 中的自定义 Provider 接入 MemoryProxy，
+不需要插件、Hook、MCP Server，也不需要修改 Pi 源码。
+
+将 [`models.example.json`](models.example.json) 合并到 `models.json`，然后替换：
+
+- `<space-id>`：Memory 实例 ID；
+- `<upstream-model-id>`：MemoryProxy 后端配置的模型 ID。
+
+设置示例配置引用的环境变量：
+
+```bash
+export TDAI_MEMORY_USER_KEY='<sk-mem 用户密钥>'
+export TDAI_MEMORY_TEAM_ID='<team-id>'
+export TDAI_MEMORY_AGENT_ID='<agent-id>'
+export TDAI_MEMORY_TASK_ID='<task-id>'
+```
+
+PowerShell：
+
+```powershell
+$env:TDAI_MEMORY_USER_KEY = '<sk-mem 用户密钥>'
+$env:TDAI_MEMORY_TEAM_ID = '<team-id>'
+$env:TDAI_MEMORY_AGENT_ID = '<agent-id>'
+$env:TDAI_MEMORY_TASK_ID = '<task-id>'
+```
+
+字段说明：
+
+- `baseUrl` — Proxy 地址 + `/pi/<spaceId>/v1`；
+- `api` — 必须为 `"openai-completions"`；
+- `apiKey` — 业务用户的 `sk-mem-...` 用户密钥；
+- `headers` — 无交互注册所需的 Team、Agent、Task 预选值；
+- `compat` — 启用 Pi 原生的逐会话 `x-session-id` 请求头；
+- `models[].id` — 必须与 MemoryProxy 上游支持的模型 ID 匹配。
+
+启动 MemoryProxy 后，在 Pi 的模型选择器中选择
+`tdai-memory/<upstream-model-id>`。
+
+请求路径：`POST /pi/:spaceId/v1/chat/completions`。
+
+---
+
+## 2. Session ID
+
+| 优先级 | Header | 来源 |
+|---|---|---|
+| 1 | `x-conversation-id` | 可选 wrapper 或上层代理 |
+| 2 | `x-session-id` | Pi 原生 session affinity |
+
+示例配置启用：
+
+```json
+{
+  "sendSessionAffinityHeaders": true,
+  "sessionAffinityFormat": "openrouter"
+}
+```
+
+Pi 随后会把当前运行时 Session ID 写入 `x-session-id`。MemoryProxy 已将该请求头
+作为会话身份，因此新建、恢复和并行 Pi 会话都不需要自定义 Header Hook。
+
+---
+
+## 3. Session Init（会话初始化）
+
+### 核心差异：纯 Header 预选，无交互 Form
+
+Pi 没有可供 MemoryProxy 调用的内置问答工具，因此 Session 注册依赖 Provider Header：
+
+| Header | 说明 | 必填 |
+|---|---|---|
+| `x-team-id` | Team ID | 是 |
+| `x-agent-id` | Agent ID | 是 |
+| `x-task-id` | Task ID | 是 |
+
+处理逻辑：
+
+- 三个 ID 齐全，且属于当前认证用户可见资产 → 直接注册 Session 并启用记忆；
+- `x-session-id` 已有有效 binding → 恢复 binding，正常执行记忆链路；
+- 预选缺失、不完整或无效 → 当前请求直接透传，不执行注入；
+- 透传决定只对当前请求有效，不会为整个 Pi Session 持久化 bypass。
+
+MemoryProxy 必须启用 `sessionInit.enabled` 和
+`sessionInit.headerAutoSelect.enabled`；默认 Header 名称已与示例一致。
+
+---
+
+## 4. 请求分类
+
+Pi 的主 Agent Loop 和内部摘要共用同一个 Chat Completions Provider，适配器按下表分流：
+
+| 请求 | 分类 | Memory 副作用 |
+|---|---|---|
+| 普通对话 | `main` | Session 注册后启用 |
+| Tool Result 轮次 | `main` | binding 恢复后启用 |
+| 自动压缩 | `auxiliary` | 禁用 |
+| Branch Summary | `auxiliary` | 禁用 |
+| 未知或部分匹配 | `main` | 保守兜底 |
+
+辅助请求必须完整命中 Pi `0.84.2` 摘要 envelope：恰好两条消息、已知摘要
+System Prompt、User `<conversation>` 包裹，并且没有工具。任何单一弱信号都不会
+关闭记忆链路。
+
+---
+
+## 5. 用户文本提取
+
+Pi 的消息内容可能是字符串，也可能是 OpenAI text content parts。适配器对两种形态
+复用共享提取器；严格的辅助请求门禁会阻止合成的 `<conversation>` 摘要输入进入
+L0 或 Skill，而文本提取器不会仅凭这一项弱信号丢弃真人输入。
+
+---
+
+## 6. 注入 Profile
+
+Pi 与 CodeBuddy、dsh、OpenCode 共用 `handleChatCompletions`。Session 注册后，
+MemoryProxy 将标准内容块注入 System Message：
+
+```xml
+<agent_skills>...</agent_skills>
+<user_memory>...</user_memory>
+<session_context>...</session_context>
+```
+
+binding 恢复、L0 回流、Skill 提取、Knowledge 注入、鉴权、可观测和 Credit 上报
+均复用现有共享链路。
+
+---
+
+## 7. 特殊行为
+
+- **共享 Handler**：Pi 使用通用 OpenAI Chat Completions Handler，不新增 `piHandler.ts`；
+- **一等归因**：路由 `/pi/` 设置 `agentSource=pi`，用于 Session Key 和 Telemetry；
+- **不伪造工具**：MemoryProxy 不会向 Pi 返回无法执行的 Session Init 工具；
+- **请求级 fail-open**：资产选择不可用时，不会污染后续请求状态；
+- **Session Reset**：修改静态资产 Header 后新建 Pi 会话；不支持交互式 `mem:session-reset`。
+
+---
+
+## 8. 环境变量
+
+| 变量 | 用途 |
+|---|---|
+| `TDAI_MEMORY_USER_KEY` | Memory 用户鉴权密钥 |
+| `TDAI_MEMORY_TEAM_ID` | Header 预选 Team ID |
+| `TDAI_MEMORY_AGENT_ID` | Header 预选 Agent ID |
+| `TDAI_MEMORY_TASK_ID` | Header 预选 Task ID |
+
+Pi 加载 `models.json` 时会解析 `$VARIABLE_NAME`。不要提交包含明文凭据的实际配置。
+
+---
+
+## 9. 已知限制
+
+- 一个 Provider 条目的 Team、Agent、Task ID 是静态值；切换资产时需要新增或修改
+  Provider 条目；
+- Pi `0.84.2` 没有内置交互式资产选择工具，因此无法在当前会话内补全不完整预选；
+- 摘要分类基于 Pi `0.84.2` 验证；未来 Pi 请求形态变化时先按安全的 `main` 路径处理，
+  待验证后再扩展分类。
+
+---
+
+## 10. 常见问题
+
+**Q: 只修改 `baseUrl` 就够了吗？**
+
+A: 不够。该方案是零代码接入，不是零配置接入；必须保留示例中的 `compat` 会话设置
+和三个资产 Header。
+
+**Q: 为什么使用 `sessionAffinityFormat: "openrouter"`？**
+
+A: 该格式会发送 MemoryProxy 已支持的 `x-session-id`，无需扩展 Hook 即可隔离每个
+Pi 运行时会话。
+
+**Q: 资产 ID 配错会怎样？**
+
+A: MemoryProxy 会根据当前用户可见资产验证 ID。当前请求不带记忆直接透传，且不会
+写入持久化 bypass。
+
+**Q: `models.json` 中的 cost 可以填 0 吗？**
+
+A: 可以。这些字段是 Pi 客户端侧模型元数据；MemoryProxy 独立完成上游用量计算。
+
+---
+
+## 11. 当前验证状态
+
+- Pi `0.84.2` 使用 `--no-extensions` 的纯配置冒烟验证通过；
+- 真实请求包含动态 `x-session-id` 和三个资产预选 Header；
+- 路由规范化、Credit 归因、Provider 配置和请求分类测试通过。

--- a/adapters/pi/models.example.json
+++ b/adapters/pi/models.example.json
@@ -1,0 +1,35 @@
+{
+  "providers": {
+    "tdai-memory": {
+      "baseUrl": "http://127.0.0.1:8096/pi/<space-id>/v1",
+      "api": "openai-completions",
+      "apiKey": "$TDAI_MEMORY_USER_KEY",
+      "authHeader": true,
+      "headers": {
+        "x-team-id": "$TDAI_MEMORY_TEAM_ID",
+        "x-agent-id": "$TDAI_MEMORY_AGENT_ID",
+        "x-task-id": "$TDAI_MEMORY_TASK_ID"
+      },
+      "compat": {
+        "sendSessionAffinityHeaders": true,
+        "sessionAffinityFormat": "openrouter"
+      },
+      "models": [
+        {
+          "id": "<upstream-model-id>",
+          "name": "<upstream-model-id> via TencentDB Agent Memory",
+          "reasoning": false,
+          "input": ["text", "image"],
+          "contextWindow": 128000,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description | 描述

Adds Pi as a first-class MemoryProxy client through `/pi/<spaceId>/v1/chat/completions`.

The integration uses Pi's native `models.json` provider and dynamic `x-session-id`, requiring no plugin, hook, MCP server, or Pi source change. Static Team, Agent, and Task headers are validated before non-interactive session registration.

Pi reuses the existing authentication, session binding, Memory/Skill/Knowledge injection, write-back, observability, and credit pipelines. Compaction and branch summaries are strictly classified as auxiliary requests to prevent synthetic history from polluting memory. Missing or invalid presets fail open for the current request without persistently disabling the session.

Standalone English and Chinese setup guides are included under `adapters/pi/`.

## Related Issue | 关联 Issue

Related to #926

## Change Type | 修改类型

- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Validation:

- MemoryProxy test suite: 4 test files, 17 tests passed.
- Real Pi `0.84.2` tested with `--no-extensions`.
- Verified authentication, asset validation, session registration, `<session_context>` injection, streaming upstream forwarding, and credit reporting.
- Captured requests contained a dynamic Pi session ID and the complete Team/Agent/Task preset.

This is a zero-code, configuration-only integration. Pi `0.84.2` is the verified compatibility baseline.

`npm run typecheck` still reports pre-existing `SessionInfo`, `resetFlow`, and private cost-guard type errors on the target branch; none originate from the Pi adapter.