### PR TITLE
feat(proxy): per-user corporate API key passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ coverage/
 # Local-only: parity snapshots & runtime configs (never commit)
 MemoryProxy/.archive-tmp/
 z_config/
+
+# Local runtime data (never commit)
+data/
+deploy/global-images/.admin-key.bak.*

--- a/MemoryProxy/config.example.yaml
+++ b/MemoryProxy/config.example.yaml
@@ -35,6 +35,12 @@ upstream:
   # 若非空，则替换所有转发请求中的 Authorization: Bearer <apiKey>。
   # 留空则透传客户端原始 API Key。
   apiKey: "<YOUR_TOKENHUB_API_KEY>"
+  # 是否启用「客户端 Authorization 原样透传到上游」模式。
+  # true 时配合 auth.userKeyHeader 使用：user_key 移到专用 header 鉴权，
+  # Authorization（公司网关 key sk-corp-*）原样透传到上游 LLM，不覆盖。
+  # 典型场景：公司有 AI 网关，每同事填自己的网关 key，既用网关计费/审计，又用记忆注入。
+  # 默认 false（向后兼容：effectiveApiKey 走 agent 三态解析）。
+  # passthroughClientAuth: true
 
   # ── Per-Agent 覆盖 ─────────────────────────────────────────────────────────
   # 按 agent 名（URL 路径前缀 /{agent}/...）覆盖 url + apiKey。
@@ -376,6 +382,13 @@ auth:
   enabled: true            # 是否启用鉴权
   url: "http://kernel.example.com:8420"   # 内核鉴权服务 base URL（自动拼接 /v3/meta/auth/verify）
   timeoutMs: 5000          # 鉴权请求超时（毫秒）
+  # 鉴权用 header 名。配置后，proxy 从该 header 读取 user_key（sk-mem-*）做鉴权，
+  # 客户端的 Authorization（如公司网关 key sk-corp-*）原样透传到上游 LLM，不覆盖。
+  # 留空（默认）→ 走老路径（Authorization Bearer 即 user_key），向后兼容。
+  # 典型场景：公司有自己的 AI 网关，每个同事填自己的网关 key 转发到公司网关，
+  # 既不丢失网关的计费/审计能力，又能用上 MemoryProxy 的记忆注入。
+  # 客户端配置：apiKey=sk-corp-xxx, headers: {x-mem-user-key: sk-mem-xxx}
+  # userKeyHeader: "x-mem-user-key"
 
 
 # ── Admin / Ops 端点鉴权（服务级 shared secret） ─────────────────────────────

--- a/MemoryProxy/docs/per-user-apikey-passthrough-guide.md
+++ b/MemoryProxy/docs/per-user-apikey-passthrough-guide.md
@@ -1,0 +1,153 @@
+# Per-User API Key Passthrough — 用户使用指南
+
+## 功能简介
+
+让每个同事在客户端配置自己的公司网关 API key,MemoryProxy 转发请求到公司网关时使用各自的 key,实现:
+
+- **公司网关计费/审计不丢失** — 网关收到的 `Authorization` 是员工自己的 key,计费归属正确
+- **记忆注入照常工作** — MemoryProxy 的 L1/L2/L3 记忆自动召回注入,不受影响
+- **公司 key 不落盘** — 只在请求生命周期内存活,不存储到 MemoryProxy 的任何持久化介质
+
+## 工作原理
+
+```
+客户端 (CodeBuddy/Claude Code/WorkBuddy)
+  │
+  ├─ Authorization: Bearer sk-corp-alice-xxx  (公司网关 key,转发用)
+  ├─ x-mem-user-key: sk-mem-alice-xxx        (MemoryProxy 鉴权用)
+  │
+  ▼
+MemoryProxy (:8096)
+  │
+  ├─ 鉴权:读 x-mem-user-key → 内核 verify → 拿到 user_id
+  ├─ 记忆注入:L1/L2/L3 召回,注入 system prompt
+  ├─ 透传:Authorization 原样保留(sk-corp-alice-xxx)
+  ├─ 剥离:x-mem-user-key 不转发到上游(防泄漏)
+  │
+  ▼
+公司 AI 网关
+  ├─ 收到 Authorization: Bearer sk-corp-alice-xxx
+  ├─ 计费归属:alice
+  └─ 路由到 LLM
+```
+
+**核心设计**:鉴权与转发解耦 — user_key(`sk-mem-*`)移到专用 header 做鉴权,Authorization 留给公司网关 key 做透传。
+
+## 配置方式
+
+### 1. MemoryProxy 配置(`config.yaml`)
+
+```yaml
+auth:
+  enabled: true
+  url: "http://kernel:8420"
+  # 鉴权用 header 名。配置后,proxy 从该 header 读取 user_key(sk-mem-*),
+  # 客户端的 Authorization 留给公司网关 key,原样透传到上游。
+  userKeyHeader: "x-mem-user-key"
+
+upstream:
+  url: https://corp-gateway.example.com/v1   # 公司网关地址
+  apiKey: ""                                   # 留空,透传客户端 Authorization
+  # true = 强制透传客户端 Authorization 到上游,不管 agent 配置如何。
+  passthroughClientAuth: true
+```
+
+### 2. 客户端配置
+
+#### CodeBuddy
+
+```json
+{
+  "apiKey": "sk-corp-alice-xxx",
+  "baseUrl": "http://proxy.example.com:8096/codebuddy/default",
+  "headers": {
+    "x-mem-user-key": "sk-mem-alice-xxx"
+  }
+}
+```
+
+#### Claude Code
+
+```json
+{
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-corp-bob-xxx",
+    "ANTHROPIC_BASE_URL": "http://proxy.example.com:8096/claude-code/default",
+    "ANTHROPIC_CUSTOM_HEADERS": "x-mem-user-key: sk-mem-bob-xxx"
+  }
+}
+```
+
+#### WorkBuddy
+
+```json
+{
+  "apiKey": "sk-corp-carol-xxx",
+  "baseUrl": "http://proxy.example.com:8096/workbuddy/default",
+  "headers": {
+    "x-mem-user-key": "sk-mem-carol-xxx"
+  }
+}
+```
+
+### 3. 两个 Key 的区别
+
+| Key | 格式 | 用途 | 从哪获取 |
+|-----|------|------|----------|
+| 公司网关 key | `sk-corp-*` | 转发到公司网关,计费/审计 | 公司 AI 网关平台 |
+| MemoryProxy user key | `sk-mem-*` | MemoryProxy 鉴权,记忆隔离 | MemoryPanel 创建 User 时生成 |
+
+**关键**:两个 key 独立,互不干扰。公司网关 key 不会存到 MemoryProxy,user key 不会转发到公司网关。
+
+## 安全保障
+
+| 项 | 处理 |
+|----|------|
+| 公司 key 落盘 | **不会** — 只在 proxy 进程内存,响应结束即释放 |
+| user key 泄漏到上游 | **不会** — `x-mem-user-key` 加入 SKIP_REQUEST_HEADERS,6 个 handler 全部剥离 |
+| 日志泄漏 | **不会** — identity.ts 对 authorization / x-api-key / x-mem-user-key 值掩码为 `sk-mem-***` |
+| 重试路径泄漏 | **不会** — retry 的 originalHeaders 同样剥离 |
+| 中间人嗅探 | 生产环境建议 proxy → 公司网关走 HTTPS |
+
+## 向后兼容
+
+| 场景 | 行为 |
+|------|------|
+| 不配 `userKeyHeader` | 回退读 Authorization Bearer,行为与改造前完全一致 |
+| 不配 `passthroughClientAuth` | effectiveApiKey 走原有三态解析(agent 配置优先) |
+| 两个都不配 | 纯服务端 key 模式,与原始版本一致 |
+
+**零破坏升级**:现有部署不需要改动配置,新增功能只在显式配置后生效。
+
+## 常见问题
+
+### Q: 公司网关 key 和 MemoryProxy user key 能用同一个吗?
+
+不能。它们的格式和用途不同:
+- 公司网关 key(`sk-corp-*`)是公司网关的鉴权凭据,MemoryProxy 内核不认
+- MemoryProxy user key(`sk-mem-*`)是 MemoryProxy 的鉴权凭据,公司网关不认
+
+### Q: 多个同事共用一个 MemoryProxy 实例,记忆会串吗?
+
+不会。MemoryProxy 通过 user_id 做 session 隔离和 memory ACL:
+- user_id 由 user key(sk-mem-*)经内核 verify 解析
+- L1 召回按 (team, user, agent) 三维隔离
+- Alice 的记忆不会被 Bob 召回
+
+### Q: 公司网关 key 更新了,需要改 MemoryProxy 配置吗?
+
+不需要。公司 key 在客户端配置,不在 MemoryProxy 配置里。员工自己更新客户端的 apiKey 即可,MemoryProxy 无感知。
+
+### Q: 如何关闭这个功能?
+
+删掉配置里的 `userKeyHeader` 和 `passthroughClientAuth` 两行,或设为空/false。MemoryProxy 回退到原始模式。
+
+## 部署检查清单
+
+- [ ] MemoryProxy `config.yaml` 配了 `auth.userKeyHeader` 和 `upstream.passthroughClientAuth`
+- [ ] `upstream.url` 指向公司网关地址
+- [ ] `upstream.apiKey` 留空(透传模式)
+- [ ] MemoryPanel 已创建 User,拿到 `sk-mem-*` key 分发给员工
+- [ ] 员工客户端配了两个 key:apiKey=公司网关 key + header x-mem-user-key=MemoryProxy key
+- [ ] proxy → 公司网关走 HTTPS(生产环境)
+- [ ] 验证:发一条消息,检查公司网关的计费日志,key 归属正确

--- a/MemoryProxy/docs/per-user-corp-apikey-passthrough.md
+++ b/MemoryProxy/docs/per-user-corp-apikey-passthrough.md
@@ -1,0 +1,210 @@
+# MemoryProxy 支持「每同事填自己的公司网关 API key」改造方案
+
+## 背景
+
+公司有自己的 AI 网关(统一的大模型入口,每个员工有自己的 API key 用于计费/审计)。用户希望部署远端 TencentDB-Agent-Memory 后,每个同事在客户端配置自己的 API key,proxy 转发时用各自的 key 打公司网关,既不丢失公司网关的能力(计费/审计/路由),又能用上 MemoryProxy 的记忆注入能力。
+
+## 现状分析
+
+### 当前认证流程(`handler.ts:452-458`)
+
+1. 客户端请求带 `Authorization: Bearer <user_key>`,user_key 格式 `sk-mem-[A-Za-z0-9_-]{32}`
+2. `verifyUserKey(userKey, spaceId)` 调用内核 `POST /v3/meta/auth/verify` 验证,返回 user_id
+3. user_id 用于 session 隔离和 memory ACL
+4. **user_key 不是给上游 LLM 用的,而是给内核 memory 网关做身份解析**
+
+### 当前上游 LLM key 解析(`handler.ts:1095-1104`)
+
+`effectiveApiKey` 三态:
+- (a) agent 不在 agents 表 → `config.upstream.apiKey`(全局服务端 key)
+- (b) agent 在表里但 apiKey 空 → `""`(透传客户端 Authorization)
+- (c) agent 在表里且 apiKey 非空 → `agent.apiKey`(服务端 key)
+
+`buildUpstreamHeaders`(`handler.ts:257-290`):若 `effectiveApiKey` 非空,注入 `Authorization: Bearer <effectiveApiKey>`;若空,保留客户端原始 Authorization header。
+
+**关键发现**:case (b) 已经支持"透传客户端 key"!但客户端的 Authorization 是 `sk-mem-*` 格式的 user_key,不是公司网关的 key。
+
+### 问题核心
+
+- user_key(`sk-mem-*`)用于内核鉴权,不能直接转发给公司网关(网关不认 `sk-mem-*`)
+- 公司网关的 key(如 `sk-corp-xxx`)不能直接当 user_key,因为 `verifyUserKey` 会拒绝(格式不匹配 + 内核不认)
+- 需要解耦:用户身份用 `sk-mem-*` 鉴权,上游转发用用户的 `sk-corp-*` key
+
+## 方案选型:方案 C(鉴权旁路 + Authorization 原样透传)
+
+### 三方案对比
+
+| 维度 | A:双 header(X-Corp-API-Key) | B:per-user key 映射存储 | **C:鉴权旁路 + Authorization 透传(推荐)** |
+|---|---|---|---|
+| 公司 key 落盘 | 否 | 是(需加密) | 否 |
+| 内核改动 | 无 | 需扩 user schema | 无 |
+| 与现有透传口子契合 | 中 | 低 | **高(复用 case b 透传语义)** |
+| 公司网关兼容 | 需网关认非标 header | 网关拿标准 Authorization | 网关拿标准 Authorization |
+| 客户端改动 | 高(改 SDK 拼双 header) | 低(只填一个 key) | 中(Authorization 放公司 key,加一个 x-mem-user-key) |
+
+### 推荐方案 C 理由
+
+1. **复用现有「case (b) 透传」设计**(`handler.ts:1098-1104`)— `effectiveApiKey=""` 时 `buildUpstreamHeaders` 不覆盖 Authorization,客户端 key 原样到达上游。方案 C 只需把鉴权改读专用 header,透传逻辑零改动。
+2. **公司 key 不落盘,安全风险最低** — 只在请求生命周期内存活,响应结束即释放。
+3. **公司网关零适配** — 上游 Authorization 是 `sk-corp-*`,与员工直连网关格式一致。
+4. **向后兼容天然成立** — 不配 `userKeyHeader` 回退老路径。
+
+## 核心设计
+
+### 1. 鉴权 header 解耦
+
+**新增配置项**(`config.example.yaml`):
+
+```yaml
+auth:
+  enabled: true
+  url: "http://kernel.example.com:8420"
+  timeoutMs: 5000
+  userKeyHeader: "x-mem-user-key"  # 新增:鉴权用 header 名,空 → 走老路径(Authorization Bearer)
+
+upstream:
+  url: https://corp-gateway.example.com/v1
+  apiKey: ""                        # 公司网关模式下留空 → 透传客户端 Authorization
+  passthroughClientAuth: true      # 新增:true = 强制透传客户端 Authorization 到上游
+```
+
+### 2. 代码改动点(9 个文件)
+
+#### (1) `MemoryProxy/src/types.ts` — 类型扩展
+
+```typescript
+export interface AuthConfig {
+  enabled: boolean;
+  url: string;
+  timeoutMs: number;
+  userKeyHeader?: string;  // 新增
+}
+
+// ProxyConfig.upstream 加
+passthroughClientAuth?: boolean;  // 新增
+```
+
+#### (2) `MemoryProxy/src/auth.ts` — 新增提取函数
+
+```typescript
+export function extractUserKeyFromRequest(c: Context, userKeyHeader?: string): string {
+  if (userKeyHeader) {
+    const v = c.req.header(userKeyHeader) ?? c.req.header(userKeyHeader.toLowerCase()) ?? "";
+    if (v) return v;
+  }
+  const authHeader = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
+  return extractBearerToken(authHeader);
+}
+```
+
+`verifyUserKey(userKey, serviceId)` 签名不变,调用方传入的 userKey 来源变了。
+
+#### (3) 四个 handler — 鉴权入口改用新提取函数
+
+| 文件 | 行号 | 改动 |
+|------|------|------|
+| `handler.ts` | 452-455 | `earlyApiKey` 改用 `extractUserKeyFromRequest(c, config.auth.userKeyHeader)` |
+| `anthropicHandler.ts` | 535 | `extractApiKey(c)` 改为优先读 `config.auth.userKeyHeader` |
+| `workbuddyHandler.ts` | 823-828 | 同 handler.ts |
+| `codexHandler.ts` | 286-289 | 同上 |
+| `auxiliaryHandler.ts` | 175-178 | 同上 |
+
+#### (4) `handler.ts:1102-1104` + `anthropicHandler.ts:1171-1173` — effectiveApiKey 扩展
+
+```typescript
+// 改后:passthroughClientAuth 启用时强制透传
+const effectiveApiKey = config.upstream.passthroughClientAuth
+  ? ""  // 强制透传客户端 Authorization
+  : agentUpstreamEntry
+    ? (agentUpstreamEntry.apiKey ?? "")
+    : config.upstream.apiKey;
+```
+
+effectiveApiKey="" 时,`buildUpstreamHeaders`(`handler.ts:276-278`)不会覆盖 Authorization,客户端的 `sk-corp-*` 原样到达公司网关。
+
+#### (5) 6 个文件的 `SKIP_REQUEST_HEADERS` — 加 `x-mem-user-key`(防泄漏到上游)
+
+| 文件 | 行号 |
+|------|------|
+| `handler.ts` | 200-205 |
+| `anthropicHandler.ts` | 60-65 |
+| `workbuddyHandler.ts` | 59 |
+| `codexHandler.ts` | 60 |
+| `auxiliaryHandler.ts` | 35 |
+| `systemUserPassthrough.ts` | 70 |
+
+```typescript
+const SKIP_REQUEST_HEADERS = new Set([
+  "host", "content-length", "transfer-encoding", "connection",
+  "x-mem-user-key",  // 新增:鉴权 header 永不透传到上游
+]);
+```
+
+重试路径(`handler.ts:1235`、`anthropicHandler.ts:1215`)同样要加。
+
+#### (6) `logger.ts` — 日志脱敏
+
+`x-mem-user-key` 值掩码为 `sk-mem-***`。
+
+### 3. 客户端配置示例
+
+**CodeBuddy**:
+```json
+{
+  "apiKey": "sk-corp-alice-xxx",
+  "baseUrl": "http://proxy.example.com:8096/codebuddy/default",
+  "headers": { "x-mem-user-key": "sk-mem-alice-xxx" }
+}
+```
+
+**Claude Code**:
+```json
+{
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-corp-bob-xxx",
+    "ANTHROPIC_BASE_URL": "http://proxy.example.com:8096/claude-code/default",
+    "ANTHROPIC_CUSTOM_HEADERS": "x-mem-user-key: sk-mem-bob-xxx"
+  }
+}
+```
+
+### 4. 不需要改的
+
+- **MemoryPanel 用户创建接口** — user_key(`sk-mem-*`)仍由 `user/create-with-key` 生成,公司 key 不落盘
+- **MemoryCore 内核** — 鉴权流程不变
+- **公司网关** — 拿到的 Authorization 与员工直连格式一致
+
+## 安全考虑
+
+| 项 | 处理 |
+|---|---|
+| 公司 key 落盘 | 否,只在内存 |
+| user_key 泄漏到上游 | SKIP_REQUEST_HEADERS 加 `x-mem-user-key`,6 处全改 |
+| 日志脱敏 | logger 对 `x-mem-user-key` 掩码 |
+| 重试路径泄漏 | retry 的 originalHeaders 也剥离 |
+| 中间人嗅探 | 生产走 HTTPS |
+
+## 向后兼容
+
+1. `auth.userKeyHeader` 留空(默认)→ 回退读 Authorization Bearer,行为与改造前完全一致
+2. `upstream.passthroughClientAuth` 未配(默认 falsy)→ effectiveApiKey 三态解析不变
+3. systemUsers(内部服务账号)→ 不配 userKeyHeader 时行为不变
+4. cost-guard 兜底路由 → `target.authHeaders` 优先级最高,不受影响
+
+## 验证清单
+
+1. **单元测试**:`extractUserKeyFromRequest` 配置时优先读 header,未配置回退 Authorization;`effectiveApiKey` 在 `passthroughClientAuth=true` 时恒为 "";SKIP_REQUEST_HEADERS 包含 `x-mem-user-key`
+2. **E2E(CodeBuddy)**:配 `apiKey=sk-corp-alice` + `x-mem-user-key=sk-mem-alice`,抓包确认上游收到 `Authorization: Bearer sk-corp-alice`、无 `x-mem-user-key`
+3. **向后兼容 E2E**:不配 userKeyHeader + `upstream.apiKey=sk-server-xxx`,客户端只带 `Authorization: Bearer sk-mem-alice`,断言上游收到 `Authorization: Bearer sk-server-xxx`
+4. **多 handler 覆盖**:Claude Code 走 anthropicHandler,断言上游收到 `x-api-key: sk-corp-bob`(Anthropic 协议)
+5. **日志脱敏**:grep proxy.log 确认无明文 sk-mem- 或 sk-corp-
+6. **重试路径**:触发 5xx 重试,抓包确认重试请求也剥离了 `x-mem-user-key`
+
+## 改造范围小结
+
+- 新增配置项:2 个(`auth.userKeyHeader`、`upstream.passthroughClientAuth`)
+- 新增函数:1 个(`extractUserKeyFromRequest`)
+- 修改文件:9 个(handler / anthropicHandler / workbuddyHandler / codexHandler / auxiliaryHandler / systemUserPassthrough / auth / types / config.example.yaml)
+- MemoryPanel/内核改动:无
+- 客户端改动:每个客户端多填一个 `x-mem-user-key` header
+- 公司网关改动:无

--- a/MemoryProxy/docs/per-user-implementation-notes.md
+++ b/MemoryProxy/docs/per-user-implementation-notes.md
@@ -1,0 +1,214 @@
+# Per-user 透传模式 — 实现方案与运维笔记
+
+> 日期: 2026-08-27
+> 分支: `feat/per-user-apikey-passthrough`
+> 关联文档: `per-user-apikey-passthrough-guide.md`（用户指南）, `per-user-corp-apikey-passthrough.md`（设计稿）
+
+本文档记录 per-user 透传模式从设计到落地的完整方案，以及在本地部署过程中发现并修复的两个关键 bug，供后续维护参考。
+
+## 1. 目标
+
+让多个同事共用同一个 MemoryProxy 时，各自的公司网关 API key 原样透传到上游 LLM 网关，实现按人计费；同时 proxy 的鉴权（auth/verify → user_id）仍走 MemoryProxy 自己的 `sk-mem-*` user_key。
+
+**之前（共享 key 模式）**：所有客户端共用 `PROXY_UPSTREAM_API_KEY`，`Authorization` 既是 user_key 又被覆盖成共享上游 key，无法按人计费。
+
+**之后（per-user 模式）**：鉴权与转发解耦 —
+- `x-mem-user-key: sk-mem-xxx` → proxy 鉴权
+- `Authorization: Bearer <公司网关key>` → 原样透传到上游
+
+## 2. 配置层
+
+### 2.1 客户端侧（以 CodeBuddy 为例）
+
+`~/.codebuddy/models.json`:
+```json
+{
+  "id": "qwen3.8-max",
+  "name": "proxy-memory-agent",
+  "apiKey": "<公司网关key>",            // → Authorization，透传上游
+  "url": "http://<proxy-host>:8096/codebuddy/default/v1/chat/completions",
+  "supportsToolCall": true
+}
+```
+
+`~/.codebuddy/settings.json` 的 `env` 字段:
+```json
+{
+  "env": {
+    "CODEBUDDY_CUSTOM_HEADERS": "x-mem-user-key: sk-mem-xxx"
+  }
+}
+```
+
+### 2.2 Proxy 侧（global-images 部署）
+
+`.env` 增加:
+```bash
+PROXY_USER_KEY_HEADER=x-mem-user-key
+PROXY_PASSTHROUGH_CLIENT_AUTH=1
+```
+
+`start-proxy.sh` 会把这些写到生成的 `config.yaml`:
+```yaml
+upstream:
+  url: "..."
+  apiKey: "..."
+  passthroughClientAuth: true    # 新增
+
+auth:
+  enabled: true
+  url: "http://memory-core:8420"
+  userKeyHeader: "x-mem-user-key"   # 新增
+```
+
+## 3. 代码层
+
+### 3.1 涉及文件
+
+| 文件 | 改动 |
+|------|------|
+| `MemoryProxy/src/types.ts` | `AuthConfig.userKeyHeader`、`UpstreamConfig.passthroughClientAuth` 字段；`RawYamlConfig.auth.userKeyHeader`、`RawYamlConfig.upstream.passthroughClientAuth` YAML schema |
+| `MemoryProxy/src/config.ts` | `DEFAULT_CONFIG` 加默认值；YAML 解析层读这两个字段 |
+| `MemoryProxy/src/auth.ts` | `extractUserKeyFromRequest(c, userKeyHeader?)` — 优先从指定 header 读 user_key，fallback 到 Authorization Bearer |
+| `MemoryProxy/src/handler.ts` 等 6 个 handler | `SKIP_REQUEST_HEADERS` 加 `x-mem-user-key`（阻止透传到上游，防泄漏）；`extractUserKeyFromRequest` 替换原 `extractBearerToken` |
+| `MemoryProxy/src/identity.ts` | 日志脱敏 `x-mem-user-key`；prefer `x-mem-user-key` 提取逻辑 |
+| `deploy/global-images/start-proxy.sh` | `PROXY_USER_KEY_HEADER` / `PROXY_PASSTHROUGH_CLIENT_AUTH` 环境变量 → YAML |
+| `deploy/global-images/.env.example` | 两个变量的示例（注释状态） |
+
+### 3.2 鉴权流程
+
+```
+客户端
+  │ Authorization: Bearer <公司网关key>
+  │ x-mem-user-key: sk-mem-xxx
+  ▼
+MemoryProxy handler.ts (earlyVerify 阶段)
+  ├─ extractUserKeyFromRequest(c, "x-mem-user-key")
+  │    → 优先读 x-mem-user-key header；为空则 fallback 到 Authorization Bearer
+  ├─ extractSpaceIdFromPath(path)  // /codebuddy/<spaceId>/...
+  ├─ verifyUserKey(userKey, spaceId)
+  │    → POST memory-core:8420/v3/meta/auth/verify
+  │    → valid=true → 放行；valid=false → 401
+  │
+  ├─ (放行后) prepareUpstreamRequest
+  │    → SKIP_REQUEST_HEADERS 过滤掉 x-mem-user-key（不转发到上游）
+  │    → Authorization 原样保留（passthroughClientAuth=true 时）
+  ▼
+公司 AI 网关
+  ├─ 收到 Authorization: Bearer <公司网关key>
+  └─ 按人计费
+```
+
+## 4. 本地部署踩坑记录
+
+### 4.1 Bug: `start-memory-core.sh:175 ADMIN_KEY_FILE unbound variable`
+
+**现象**: `start-all.sh` 启动到 memory-core 后报 `ADMIN_KEY_FILE: unbound variable`。
+
+**根因**: 第 175 行 `$ADMIN_KEY_FILE` 后面紧贴一个全角右括号 `）`（U+FF09，UTF-8 `ef bc 89`）。bash 3.2（macOS 默认）在 `set -u` 下把 `ADMIN_KEY_FILE）` 当成一个变量名，自然 unbound。其他行（line 199/204/206）`$ADMIN_KEY_FILE` 后面是 `"` 或空格，所以没事。
+
+**修复**: `$ADMIN_KEY_FILE` → `${ADMIN_KEY_FILE}`（花括号明确变量名边界）。
+
+**教训**: 写 shell 时变量名后紧跟非 ASCII 字符（全角括号、中文标点）一定要用 `${VAR}` 包起来。`bash -n` 语法检查通过 ≠ 运行时没问题。
+
+### 4.2 Bug: `.admin-key` 与 volume 实际 user_key 不匹配
+
+**现象**: proxy 401 `Authentication failed: invalid user_key`。直接调内核 `auth/verify` 也是 `valid:false`。
+
+**根因**: volume 是 2026-08-20 的旧数据（admin key = `sk-mem-YuFZjaoZrHJm9zuFBB6tveZzyiM5iyC9`），但 `.admin-key` 文件是 8-26 生成的另一个 key（`sk-mem-e5yJ...`）。`start-memory-core.sh` 的逻辑是：
+1. 看 `.admin-key` 已存在 → 复用它去 init-admin
+2. volume 已有用户 → init-admin 返回 409 跳过
+3. 结果 `.admin-key` 里的新 key 从未在 volume 里注册过
+
+**修复**: 把 `.admin-key` 改成 volume 里 `meta_user_keys` 表实际登记的 key。
+
+**根治建议**: `start-memory-core.sh` 在 init-admin 返回 409 时，应该额外用 `.admin-key` 里的 key 调一次 `auth/verify` 验证；verify 失败就明确告警 "`.admin-key` 与 volume 不匹配，请清理 volume 重建"，而不是静默继续。当前脚本只在末尾做 verify 但不阻塞退出。
+
+### 4.3 Bug: config 加载层遗漏 per-user 字段（代码缺陷）
+
+**现象**: `.proxy-config/config.yaml` 里明明白白写了 `userKeyHeader: "x-mem-user-key"` 和 `passthroughClientAuth: true`，但运行时 `config.auth.userKeyHeader` 和 `config.upstream.passthroughClientAuth` 都是 `undefined`。
+
+**诊断过程**: 在 `handler.ts` 加临时调试日志:
+```ts
+console.log("[DEBUG-AUTH] hdr=" + config.auth.userKeyHeader + " key=" + earlyApiKey);
+```
+输出 `[DEBUG-AUTH] hdr=undefined key=hi-xxx...` — 说明 `extractUserKeyFromRequest` 走了 fallback 路径（从 Authorization 读），没读到专用 header。`hi-xxx` 是公司网关 key 不是 `sk-mem-*`，内核 verify 自然返回 `valid:false`。
+
+**根因**: per-user 功能开发时在 `types.ts` 的 `AuthConfig` / `UpstreamConfig` 加了字段，但 `config.ts` 的 YAML 解析层（`loadConfig` 函数）和 `DEFAULT_CONFIG` 都没同步加，导致 YAML 字段被丢弃。
+
+**修复**（`MemoryProxy/src/config.ts`）:
+```diff
+ upstream: { url: DEFAULT_UPSTREAM, apiKey: "", agents: {} },
++upstream: { url: DEFAULT_UPSTREAM, apiKey: "", agents: {}, passthroughClientAuth: false },
+ auth: { enabled: false, url: "", timeoutMs: 5000 },
++auth: { enabled: false, url: "", timeoutMs: 5000, userKeyHeader: "" },
+
+ upstream: {
+   ...
+   agents: parseUpstreamAgents(yaml.upstream?.agents),
++  passthroughClientAuth: yaml.upstream?.passthroughClientAuth ?? DEFAULT_CONFIG.upstream.passthroughClientAuth,
+ },
+ auth: {
+   ...
+   timeoutMs: yaml.auth?.timeoutMs ?? DEFAULT_CONFIG.auth.timeoutMs,
++  userKeyHeader: yaml.auth?.userKeyHeader ?? DEFAULT_CONFIG.auth.userKeyHeader,
+ },
+```
+
+`MemoryProxy/src/types.ts` 的 `RawYamlConfig` 同步加可选字段:
+```diff
+ upstream?: {
+   ...
++  passthroughClientAuth?: boolean;
+ };
+ auth?: {
+   ...
++  userKeyHeader?: string;
+ };
+```
+
+**教训**: 给 TS interface 加字段后，必须同步检查所有从 YAML/env 解析并构造该 interface 的地方。`DEFAULT_CONFIG` 是 interface 的"落地实例"，少一个字段就是 undefined。这个 bug 在单测里不容易暴露（因为单测直接构造完整对象），只有端到端跑 YAML 加载才会触发。
+
+## 5. 验证方法
+
+### 5.1 验证 proxy 配置正确加载
+
+```bash
+# 在 proxy 容器里直接 inspect config 对象（tsx 运行时无编译产物，看 src）
+docker exec tdai-proxy grep -c "userKeyHeader" /app/src/config.ts
+docker exec tdai-proxy grep -c "passthroughClientAuth" /app/src/config.ts
+```
+
+### 5.2 端到端测试
+
+```bash
+# 正确方式: x-mem-user-key + Authorization 分开
+curl -s -w "HTTP %{http_code}\n" \
+  -X POST "http://127.0.0.1:8096/codebuddy/default/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <公司网关key>" \
+  -H "x-mem-user-key: sk-mem-<有效user_key>" \
+  -d '{"model":"qwen3.8-max","messages":[{"role":"user","content":"ping"}],"max_tokens":5,"stream":false}'
+# 期望: HTTP 200 + LLM 回复
+
+# 错误的 user_key 应被拒绝
+curl -s -w "HTTP %{http_code}\n" \
+  -X POST "http://127.0.0.1:8096/codebuddy/default/v1/chat/completions" \
+  -H "Authorization: Bearer <公司网关key>" \
+  -H "x-mem-user-key: sk-mem-invalid" \
+  -d '...'
+# 期望: HTTP 401 Authentication failed: invalid user_key
+```
+
+### 5.3 查 volume 里实际登记的 user_key
+
+```bash
+docker cp tdai-memory-core:/data/tdai-memory/metadata/tdai_metadata_default/metadata.db /tmp/m.db
+sqlite3 /tmp/m.db "SELECT user_id, key_value, status FROM meta_user_keys;"
+```
+
+## 6. 后续待办
+
+- `start-memory-core.sh`: init-admin 返回 409 时额外做一次 verify，不匹配就明确报错（参见 4.2）
+- per-user 透传代码目前只在 `feat/per-user-apikey-passthrough` 分支；合并到主线前需要补单测覆盖 `config.ts` 的 YAML → ProxyConfig 解析路径
+- `start-proxy.sh` 生成的 config 已经正确，但 `MemoryProxy/config.example.yaml`（仓库示例配置）也应该补上这两个字段的注释示例

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -65,6 +65,8 @@ const SKIP_REQUEST_HEADERS = new Set([
   "connection",
   // 内部身份头只给 proxy/session-init 使用，不能透传给上游模型服务。
   "x-tdai-user-key",
+  // Auth-decoupling header — never forward to upstream (prevents user_key leak)
+  "x-mem-user-key",
 ]);
 
 const SKIP_RESPONSE_HEADERS = new Set([
@@ -248,8 +250,18 @@ export function flattenAnthropicMessagesForOpik(
   return result;
 }
 
-/** Extract Anthropic API key from request headers (x-api-key or Authorization Bearer). */
-function extractApiKey(c: Context): string {
+/**
+ * Extract Anthropic API key from request headers (x-api-key or Authorization Bearer).
+ *
+ * When `userKeyHeader` is configured, that header takes priority — it carries
+ * the user_key (sk-mem-*) for auth verification, freeing x-api-key /
+ * Authorization to carry the corporate gateway key for upstream passthrough.
+ */
+function extractApiKey(c: Context, userKeyHeader?: string): string {
+  if (userKeyHeader) {
+    const v = c.req.header(userKeyHeader) ?? c.req.header(userKeyHeader.toLowerCase()) ?? "";
+    if (v) return v;
+  }
   const xApiKey = c.req.header("x-api-key");
   if (xApiKey) return xApiKey;
 
@@ -533,7 +545,11 @@ export async function handleAnthropicMessages(
   // Verify BEFORE parsing the body so a rejected caller never triggers body
   // parsing or the alias-gate. `earlyVerify.userId` is reused later for
   // both the systemUser short-circuit and the normal pipeline.
-  const earlyApiKey = extractApiKey(c);
+  //
+  // When `auth.userKeyHeader` is configured, the user_key (sk-mem-*) moves to
+  // that header, freeing x-api-key / Authorization to carry the corporate
+  // gateway key for upstream passthrough.
+  const earlyApiKey = extractApiKey(c, config.auth.userKeyHeader);
   const earlySpaceId = extractSpaceIdFromPath(c.req.path) ?? "";
   const earlyVerify = await verifyUserKey(earlyApiKey, earlySpaceId);
   if (earlyVerify.rejected) {
@@ -633,7 +649,10 @@ export async function handleAnthropicMessages(
   inspectAndRecord("POST", c.req.path, reqHeaders, body as Record<string, unknown>, agentSource);
 
   // ── Resolve apiKey → project name ──────────────────────────────────────
-  const apiKey = extractApiKey(c);
+  // Use the user_key (from userKeyHeader or x-api-key/Authorization) for keyId
+  // tracking, NOT the corporate gateway key that may live in x-api-key when
+  // passthroughClientAuth is enabled.
+  const apiKey = extractApiKey(c, config.auth.userKeyHeader);
   let keyId = apiKey ? apiKeyToKeyId(apiKey) : "unknown";
 
   // ── Lowercased headers for agent profile detection + session key ──────────
@@ -1324,9 +1343,15 @@ export async function handleAnthropicMessages(
   // The presence of an entry (case b/c) is what cuts the global fallback —
   // this is the switch that lets one proxy serve mixed server-key / client-key
   // agents from a single config.
-  const effectiveApiKey = agentUpstreamEntry
-    ? (agentUpstreamEntry.apiKey ?? "")
-    : config.upstream.apiKey;
+  //
+  // `passthroughClientAuth` overrides all three cases: when true, the client's
+  // Authorization / x-api-key (e.g. a corporate gateway key sk-corp-*) is
+  // passthrough'd to the upstream LLM untouched. Pairs with `auth.userKeyHeader`.
+  const effectiveApiKey = config.upstream.passthroughClientAuth
+    ? ""
+    : agentUpstreamEntry
+      ? (agentUpstreamEntry.apiKey ?? "")
+      : config.upstream.apiKey;
   const upstreamHeaders = buildUpstreamHeaders(c, config, target, sessionKey, effectiveApiKey);
 
   // Optional private preparation stage. It rewrites `body` / `messages` in

--- a/MemoryProxy/src/auth.ts
+++ b/MemoryProxy/src/auth.ts
@@ -6,12 +6,40 @@
  * - Returns structured result to allow caller to reject invalid keys
  * - x-tdai-service-id is derived from the request path's spaceId (not config)
  * - Configurable via YAML `auth` section
+ * - Supports `auth.userKeyHeader` to decouple the user_key (sk-mem-*) from the
+ *   client's Authorization header, enabling per-user corporate gateway key
+ *   passthrough to the upstream LLM.
  */
 
 import { log } from "./report/log.js";
+import { extractBearerToken } from "./opik.js";
 import type { AuthConfig } from "./types.js";
+import type { Context } from "hono";
 
 export type { AuthConfig };
+
+/**
+ * Extract the user_key (sk-mem-*) from a request, honoring `auth.userKeyHeader`.
+ *
+ * Resolution order:
+ *   1. If `userKeyHeader` is configured, read that header first (case-insensitive).
+ *      This frees the client's Authorization to carry a corporate gateway key
+ *      (sk-corp-*) that gets passthrough'd to the upstream LLM untouched.
+ *   2. Fall back to the legacy path: extract Bearer token from Authorization.
+ *
+ * This function never throws; returns "" when no user_key is found.
+ */
+export function extractUserKeyFromRequest(
+  c: Context,
+  userKeyHeader?: string,
+): string {
+  if (userKeyHeader) {
+    const v = c.req.header(userKeyHeader) ?? c.req.header(userKeyHeader.toLowerCase()) ?? "";
+    if (v) return v;
+  }
+  const authHeader = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
+  return extractBearerToken(authHeader);
+}
 
 /** Result of verifyUserKey call. */
 export interface VerifyUserResult {

--- a/MemoryProxy/src/auxiliaryHandler.ts
+++ b/MemoryProxy/src/auxiliaryHandler.ts
@@ -37,6 +37,8 @@ const SKIP_REQUEST_HEADERS = new Set([
   "content-length",
   "transfer-encoding",
   "connection",
+  // Auth-decoupling header — never forward to upstream (prevents user_key leak)
+  "x-mem-user-key",
 ]);
 
 /** 响应头中不应回传给客户端的头（避免 stream 长度不一致等问题）。 */
@@ -171,11 +173,15 @@ export async function handleAuxiliaryEndpoint(
     return c.json({ error: "Unregistered endpoint" }, 404);
   }
 
-  // 1. 鉴权（先做本地 keyId 解析，再走 auth 服务校验以与主 handler 对称）
-  const apiKey =
-    c.req.header("x-api-key") ??
-    extractBearerToken(c.req.header("authorization") ?? c.req.header("Authorization") ?? "") ??
-    "";
+  // 1. 鉴权（先做本地 keyId 解析，再走 auth 服务校验以与主 handler 对对称）
+  // When `auth.userKeyHeader` is configured, the user_key (sk-mem-*) moves to
+  // that header, freeing x-api-key / Authorization to carry the corporate
+  // gateway key for upstream passthrough.
+  const apiKey = config.auth.userKeyHeader
+    ? (c.req.header(config.auth.userKeyHeader) ?? c.req.header(config.auth.userKeyHeader.toLowerCase()) ?? "")
+    : (c.req.header("x-api-key") ??
+       extractBearerToken(c.req.header("authorization") ?? c.req.header("Authorization") ?? "") ??
+       "");
 
   let keyId = apiKey ? apiKeyToKeyId(apiKey) : "unknown";
 

--- a/MemoryProxy/src/codexHandler.ts
+++ b/MemoryProxy/src/codexHandler.ts
@@ -63,6 +63,8 @@ const SKIP_REQUEST_HEADERS = new Set([
   "transfer-encoding",
   "connection",
   "x-tdai-user-key",
+  // Auth-decoupling header — never forward to upstream (prevents user_key leak)
+  "x-mem-user-key",
 ]);
 
 const SKIP_RESPONSE_HEADERS = new Set([
@@ -279,10 +281,14 @@ export async function handleCodexEndpoint(
   const path = c.req.path;
 
   // ── 1. Auth ────────────────────────────────────────────────────────────────
-  const apiKey =
-    extractBearerToken(c.req.header("authorization") ?? c.req.header("Authorization") ?? "") ??
-    c.req.header("x-api-key") ??
-    "";
+  // When `auth.userKeyHeader` is configured, the user_key (sk-mem-*) moves to
+  // that header, freeing Authorization / x-api-key to carry the corporate
+  // gateway key for upstream passthrough.
+  const apiKey = config.auth.userKeyHeader
+    ? (c.req.header(config.auth.userKeyHeader) ?? c.req.header(config.auth.userKeyHeader.toLowerCase()) ?? "")
+    : (extractBearerToken(c.req.header("authorization") ?? c.req.header("Authorization") ?? "") ??
+       c.req.header("x-api-key") ??
+       "");
 
   const spaceId = extractSpaceIdFromPath(path) ?? "";
   const { userId, rejected: userKeyRejected, rejectReason } =

--- a/MemoryProxy/src/config.ts
+++ b/MemoryProxy/src/config.ts
@@ -8,7 +8,7 @@ const DEFAULT_UPSTREAM = "https://llm-upstream.example.com/v2/chat/completions";
 
 export const DEFAULT_CONFIG: ProxyConfig = {
   server: { host: "0.0.0.0", port: 8096, forwardTimeoutMs: 600_000 },
-  upstream: { url: DEFAULT_UPSTREAM, apiKey: "", agents: {} },
+  upstream: { url: DEFAULT_UPSTREAM, apiKey: "", agents: {}, passthroughClientAuth: false },
   log: {
     file: "",
     verbose: false,
@@ -140,6 +140,7 @@ export const DEFAULT_CONFIG: ProxyConfig = {
     enabled: false,
     url: "",
     timeoutMs: 5000,
+    userKeyHeader: "",
   },
   systemUsers: [],
   admin: { apiKey: "" },
@@ -282,6 +283,9 @@ export function buildConfig(overrides: CliOverrides = {}): ProxyConfig {
         DEFAULT_CONFIG.upstream.url,
       apiKey: yaml.upstream?.apiKey ?? DEFAULT_CONFIG.upstream.apiKey,
       agents: parseUpstreamAgents(yaml.upstream?.agents),
+      passthroughClientAuth:
+        yaml.upstream?.passthroughClientAuth ??
+        DEFAULT_CONFIG.upstream.passthroughClientAuth,
     },
     log: {
       file: overrides.logFile ?? yaml.log?.file ?? DEFAULT_CONFIG.log.file,
@@ -474,6 +478,7 @@ export function buildConfig(overrides: CliOverrides = {}): ProxyConfig {
       enabled: yaml.auth?.enabled ?? DEFAULT_CONFIG.auth.enabled,
       url: yaml.auth?.url ?? DEFAULT_CONFIG.auth.url,
       timeoutMs: yaml.auth?.timeoutMs ?? DEFAULT_CONFIG.auth.timeoutMs,
+      userKeyHeader: yaml.auth?.userKeyHeader ?? DEFAULT_CONFIG.auth.userKeyHeader,
     },
     // Entries without a non-empty userId are silently dropped — matching is
     // by userId now, and an empty userId would otherwise collide with

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -37,7 +37,7 @@ import { tryReportCreditFromPath, extractSpaceIdFromPath } from "./credit-report
 import { resolveModelId, isModelInPricing } from "./pricing.js";
 import { inspectAndRecord } from "./identity.js";
 import { writeFailedReportRaw } from "./clickhouse.js";
-import { verifyUserKey } from "./auth.js";
+import { verifyUserKey, extractUserKeyFromRequest } from "./auth.js";
 import { matchSystemUserByUserId, hasSystemUsers } from "./systemUser.js";
 import { handleSystemUserPassthrough } from "./systemUserPassthrough.js";
 import { TdaiClient } from "./tdai/client.js";
@@ -203,6 +203,8 @@ const SKIP_REQUEST_HEADERS = new Set([
   "content-length",
   "transfer-encoding",
   "connection",
+  // Auth-decoupling header — never forward to upstream (prevents user_key leak)
+  "x-mem-user-key",
 ]);
 
 const SKIP_RESPONSE_HEADERS = new Set([
@@ -450,8 +452,11 @@ export async function handleChatCompletions(
   // Verify BEFORE parsing the body so a rejected caller never triggers body
   // parsing or the alias-gate. `earlyVerify.userId` is reused later for
   // both the systemUser short-circuit and the normal pipeline.
-  const earlyAuthHeader = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
-  const earlyApiKey = extractBearerToken(earlyAuthHeader);
+  //
+  // When `auth.userKeyHeader` is configured, the user_key (sk-mem-*) moves to
+  // that header, freeing Authorization to carry the corporate gateway key
+  // (sk-corp-*) which gets passthrough'd to the upstream LLM untouched.
+  const earlyApiKey = extractUserKeyFromRequest(c, config.auth.userKeyHeader);
   const earlySpaceId = extractSpaceIdFromPath(c.req.path) ?? "";
   const earlyVerify = await verifyUserKey(earlyApiKey, earlySpaceId);
   if (earlyVerify.rejected) {
@@ -648,8 +653,10 @@ export async function handleChatCompletions(
   inspectAndRecord("POST", c.req.path, reqHeaders, body as Record<string, unknown>, agentSource);
 
   // ── Resolve apiKey → project name ──────────────────────────────────────
-  const authHeader = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
-  const apiKey = extractBearerToken(authHeader);
+  // Use the user_key (from userKeyHeader or Authorization) for keyId tracking,
+  // NOT the corporate gateway key that may live in Authorization when
+  // passthroughClientAuth is enabled.
+  const apiKey = extractUserKeyFromRequest(c, config.auth.userKeyHeader);
   let keyId = apiKey ? apiKeyToKeyId(apiKey) : "unknown";
 
   // ── Lowercased headers for agent profile detection + session key ──────────
@@ -1279,9 +1286,17 @@ export async function handleChatCompletions(
   //   (c) entry present, apiKey non-empty  → agent.apiKey (server-side key)
   // Presence of an entry (case b/c) cuts the global fallback — that's what
   // lets one proxy serve mixed server-key / client-key agents at once.
-  const effectiveApiKey = agentUpstreamEntry
-    ? (agentUpstreamEntry.apiKey ?? "")
-    : config.upstream.apiKey;
+  //
+  // `passthroughClientAuth` overrides all three cases: when true, the client's
+  // Authorization (e.g. a corporate gateway key sk-corp-*) is passthrough'd
+  // to the upstream LLM untouched. Pairs with `auth.userKeyHeader`, which
+  // moves the user_key (sk-mem-*) to a dedicated header so Authorization is
+  // free to carry the corporate key.
+  const effectiveApiKey = config.upstream.passthroughClientAuth
+    ? ""
+    : agentUpstreamEntry
+      ? (agentUpstreamEntry.apiKey ?? "")
+      : config.upstream.apiKey;
   // Normalize the request path to the canonical upstream endpoint so the
   // extension's URL joining matches the host whitelist behavior.
   const forwardEndpoint = matchWhitelistEndpoint(c.req.path)?.upstreamEndpoint ?? "/chat/completions";

--- a/MemoryProxy/src/identity.ts
+++ b/MemoryProxy/src/identity.ts
@@ -107,9 +107,14 @@ export function extractClientIdentity(
   body?: Record<string, unknown>,
   agentSource = "claude-code",
 ): ClientIdentity {
-  // Extract API key
+  // Extract API key — prefer the auth-decoupling header (x-mem-user-key) when
+  // present, because `passthroughClientAuth` mode puts the user_key (sk-mem-*)
+  // there and leaves Authorization for the corporate gateway key. The user_key
+  // carries the client-type prefix (ck_ / sk-mem- / sk-ant-) used below for
+  // identity detection; the corporate key does not.
+  const userKeyHeaderVal = headers["x-mem-user-key"] ?? headers["X-Mem-User-Key"] ?? "";
   const authHeader = headers["authorization"] ?? headers["Authorization"] ?? "";
-  const apiKey = extractBearer(authHeader);
+  const apiKey = userKeyHeaderVal || extractBearer(authHeader);
 
   // Parse API key structure: prefix.secret
   let apiKeyPrefix: string | null = null;
@@ -395,12 +400,25 @@ export function inspectAndRecord(
     }
   }
 
+  // Sanitize sensitive headers before logging — x-mem-user-key and
+  // authorization carry user_key / corporate gateway key material that
+  // must never land in inspection logs verbatim.
+  const sanitizedHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    const lk = k.toLowerCase();
+    if (lk === "x-mem-user-key" || lk === "authorization" || lk === "x-api-key") {
+      sanitizedHeaders[k] = v ? `${v.slice(0, 8)}***` : v;
+    } else {
+      sanitizedHeaders[k] = v;
+    }
+  }
+
   const inspection: RequestInspection = {
     timestamp: new Date().toISOString(),
     method,
     path,
     identity,
-    allHeaders: headers,
+    allHeaders: sanitizedHeaders,
     bodyMeta: {
       model: typeof body.model === "string" ? body.model : null,
       messageCount: messages.length,

--- a/MemoryProxy/src/session/context-injector.ts
+++ b/MemoryProxy/src/session/context-injector.ts
@@ -71,6 +71,15 @@ function buildContextBlock(
     }
   }
 
+  lines.push("");
+  lines.push("[重要约束]");
+  lines.push("以上 session 上下文由 proxy 自动注入，session 初始化已完成。");
+  lines.push("- team / agent / task 的选择与关联已由 proxy 在 session 初始化阶段完成，你无需、也不应再自行查询或调用任何相关接口。");
+  lines.push("- 不要搜索或安装任何 CLI 工具来完成上述操作。");
+  lines.push("- 不要猜测或构造 proxy 未明确列出的任何 API 路径。");
+  lines.push("- 你唯一可用的外部工具是 <skill_tools> 和 <tdai_memory_tools> 中列出的 curl 命令。");
+  lines.push("- 如果用户的问题与团队资产无关，直接回答，不要执行任何额外操作。");
+
   lines.push(CTX_CLOSE);
   return lines.join("\n");
 }

--- a/MemoryProxy/src/systemUserPassthrough.ts
+++ b/MemoryProxy/src/systemUserPassthrough.ts
@@ -72,6 +72,8 @@ const SKIP_REQUEST_HEADERS = new Set([
   "content-length",
   "transfer-encoding",
   "connection",
+  // Auth-decoupling header — never forward to upstream (prevents user_key leak)
+  "x-mem-user-key",
 ]);
 
 /** Response headers that would confuse the client if forwarded verbatim. */

--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -429,6 +429,13 @@ export interface ProxyConfig {
      * Empty / missing entry → agent falls back to `url` + `apiKey`.
      */
     agents: Record<string, AgentUpstreamEntry>;
+    /**
+     * When true, the client's Authorization header is passthrough'd to the
+     * upstream LLM untouched, regardless of agent config. Pairs with
+     * `auth.userKeyHeader`: the user_key moves to a dedicated header, freeing
+     * Authorization to carry the corporate gateway key. Default: false.
+     */
+    passthroughClientAuth?: boolean;
   };
   log: {
     file: string;    // JSONL path; empty string disables file logging
@@ -645,6 +652,14 @@ export interface AuthConfig {
   url: string;
   /** Request timeout in ms. Default: 5000. */
   timeoutMs: number;
+  /**
+   * Header name for extracting the user_key (sk-mem-*) used for auth verification.
+   * When set, the proxy reads the user_key from this header instead of Authorization,
+   * allowing the client's Authorization (e.g. a corporate gateway key) to be
+   * passthrough'd to the upstream LLM untouched. Empty/undefined → legacy path
+   * (Authorization Bearer is the user_key). Default: "".
+   */
+  userKeyHeader?: string;
 }
 
 /**
@@ -731,6 +746,9 @@ export interface RawYamlConfig {
     apiKey?: string;
     /** Per-agent override map. See `AgentUpstreamEntry`. */
     agents?: Record<string, { url?: string; apiKey?: string } | null | undefined>;
+    /** When true, the client's Authorization header is passthrough'd to the
+     * upstream LLM untouched. Pairs with `auth.userKeyHeader`. */
+    passthroughClientAuth?: boolean;
   };
   log?: {
     file?: string;
@@ -872,6 +890,10 @@ export interface RawYamlConfig {
     enabled?: boolean;
     url?: string;
     timeoutMs?: number;
+    /** Header name for extracting the user_key (sk-mem-*) used for auth
+     * verification. When set, Authorization is freed to carry a corporate
+     * gateway key that gets passthrough'd to the upstream LLM. */
+    userKeyHeader?: string;
   };
   systemUsers?: Partial<SystemUserEntry>[];
   admin?: {

--- a/MemoryProxy/src/workbuddyHandler.ts
+++ b/MemoryProxy/src/workbuddyHandler.ts
@@ -62,6 +62,8 @@ const SKIP_REQUEST_HEADERS = new Set([
   "transfer-encoding",
   "connection",
   "x-tdai-user-key",
+  // Auth-decoupling header — never forward to upstream (prevents user_key leak)
+  "x-mem-user-key",
 ]);
 
 const SKIP_RESPONSE_HEADERS = new Set([
@@ -820,12 +822,14 @@ export async function handleWorkbuddyEndpoint(
   const path = c.req.path;
 
   // ── 1. Auth ──────────────────────────────────────────────────────────────
+  // When `auth.userKeyHeader` is configured, the user_key (sk-mem-*) moves to
+  // that header, freeing Authorization / x-api-key to carry the corporate
+  // gateway key for upstream passthrough.
   const rawAuth = c.req.header("authorization") ?? c.req.header("Authorization") ?? "";
   const rawXApiKey = c.req.header("x-api-key") ?? "";
-  const apiKey =
-    extractBearerToken(rawAuth) ??
-    rawXApiKey ??
-    "";
+  const apiKey = config.auth.userKeyHeader
+    ? (c.req.header(config.auth.userKeyHeader) ?? c.req.header(config.auth.userKeyHeader.toLowerCase()) ?? "")
+    : (extractBearerToken(rawAuth) ?? rawXApiKey ?? "");
   const spaceId = extractSpaceIdFromPath(path) ?? "";
   const { userId, rejected: userKeyRejected, rejectReason } = await verifyUserKey(
     apiKey,

--- a/deploy/global-images/.env.example
+++ b/deploy/global-images/.env.example
@@ -44,6 +44,12 @@ PROXY_UPSTREAM_URL=REPLACE_ME               # 例：https://api.deepseek.com/v1
 PROXY_UPSTREAM_API_KEY=REPLACE_ME           # 例：sk-xxxxxxxx（可与 memory 组不同）
 PROXY_UPSTREAM_MODEL=REPLACE_ME             # 例：deepseek-chat
 
+# ── per-user 透传（可选，公司网关场景）──────────────────────────────────────
+# 启用后每个同事在客户端填自己的公司网关 key，proxy 透传到上游，计费归属各自。
+# 不配时走全局 key 模式（所有请求用 PROXY_UPSTREAM_API_KEY）。
+# PROXY_USER_KEY_HEADER=x-mem-user-key      # 鉴权用 header 名
+# PROXY_PASSTHROUGH_CLIENT_AUTH=1           # 1=透传客户端 Authorization 到上游
+
 # ── 端口（默认可直接用；有本地冲突时改这里） ───────────────────────────────
 MEMORY_CORE_PORT=8420
 PANEL_PORT=8125

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -172,7 +172,7 @@ verify_user_key() {
   [[ "$code" == "200" ]]
 }
 
-info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → $ADMIN_KEY_FILE）..."
+info "初始化 admin user（username=${MEMORY_CORE_ADMIN_USERNAME}, key 持久化 → ${ADMIN_KEY_FILE}）..."
 
 # 生成随机 key（首次 init-admin 用；若之前有 file 就复用）
 if [[ -s "$ADMIN_KEY_FILE" ]]; then

--- a/deploy/global-images/start-proxy.sh
+++ b/deploy/global-images/start-proxy.sh
@@ -10,6 +10,10 @@
 #
 # 需要以下 proxy 组参数（写在 .env）：
 #   PROXY_UPSTREAM_URL / PROXY_UPSTREAM_API_KEY / PROXY_UPSTREAM_MODEL
+#
+# 可选 per-user 透传参数（写在 .env）：
+#   PROXY_USER_KEY_HEADER=x-mem-user-key       # 鉴权用 header 名
+#   PROXY_PASSTHROUGH_CLIENT_AUTH=1            # 1=透传客户端 Authorization 到上游
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -73,7 +77,17 @@ fi
 
 bool() { [[ "$1" == "1" ]] && echo "true" || echo "false"; }
 
-info "生成 proxy config → $CONFIG_FILE  (auth=$(bool $PROXY_ENABLE_AUTH) session-init=$(bool $PROXY_ENABLE_SESSION_INIT) tdai=$(bool $PROXY_ENABLE_TDAI))"
+# ── Per-user 透传（可选）──────────────────────────────────────────
+# PROXY_USER_KEY_HEADER: 鉴权用 header 名（如 x-mem-user-key）。配置后
+#   proxy 从该 header 读 user_key(sk-mem-*),客户端的 Authorization
+#   (公司网关 key) 原样透传到上游,不覆盖。
+# PROXY_PASSTHROUGH_CLIENT_AUTH=1: 强制透传客户端 Authorization 到上游。
+#   两个配合使用:用户_key 移到专用 header 鉴权,Authorization 留给公司网关 key。
+#   不配时走老路径(Authorization 既是 user_key 又透传/覆盖),向后兼容。
+PROXY_USER_KEY_HEADER="${PROXY_USER_KEY_HEADER:-}"
+PROXY_PASSTHROUGH_CLIENT_AUTH="${PROXY_PASSTHROUGH_CLIENT_AUTH:-0}"
+
+info "生成 proxy config → $CONFIG_FILE  (auth=$(bool $PROXY_ENABLE_AUTH) session-init=$(bool $PROXY_ENABLE_SESSION_INIT) tdai=$(bool $PROXY_ENABLE_TDAI) per-user=$(bool $PROXY_PASSTHROUGH_CLIENT_AUTH))"
 cat > "$CONFIG_FILE" <<YAML
 # 由 start-proxy.sh 自动生成 —— 每次启动覆盖，请不要手动改。
 server:
@@ -84,6 +98,7 @@ server:
 upstream:
   url: "${PROXY_UPSTREAM_URL}"
   apiKey: "${PROXY_UPSTREAM_API_KEY}"
+$([[ "$PROXY_PASSTHROUGH_CLIENT_AUTH" == "1" ]] && echo "  passthroughClientAuth: true")
 
 log:
   file: ""
@@ -111,6 +126,7 @@ auth:
   enabled: $(bool $PROXY_ENABLE_AUTH)
   url: "http://memory-core:8420"
   timeoutMs: 5000
+$([[ -n "$PROXY_USER_KEY_HEADER" ]] && echo "  userKeyHeader: \"${PROXY_USER_KEY_HEADER}\"")
 
 sessionInit:
   enabled: $(bool $PROXY_ENABLE_SESSION_INIT)
@@ -152,3 +168,7 @@ $DOCKER run -d --name "$CONTAINER" \
 wait_healthy "$CONTAINER" 90
 ok "proxy 已启动 → http://localhost:${PROXY_PORT}/"
 ok "  用法：把 coding agent 的 API base 指向 http://localhost:${PROXY_PORT}"
+if [[ "$PROXY_PASSTHROUGH_CLIENT_AUTH" == "1" ]]; then
+  ok "  per-user 透传已启用：客户端 Authorization 原样透传到上游"
+  ok "  客户端需配 header ${PROXY_USER_KEY_HEADER:-x-mem-user-key}: sk-mem-xxx 做 MemoryProxy 鉴权"
+fi


### PR DESCRIPTION
## Summary

Enable per-user corporate gateway key passthrough so multiple users sharing one MemoryProxy can each use their own corporate API key for upstream billing/routing, while proxy auth still uses MemoryProxy's own `sk-mem-*` user_key.

## Design: auth decoupled from forwarding

- `user_key` (sk-mem-*) moves to a dedicated header (configurable via `auth.userKeyHeader`, default `x-mem-user-key`) for proxy auth verification
- Client's `Authorization` header (corporate gateway key) is forwarded to the upstream LLM untouched when `upstream.passthroughClientAuth` is true
- `x-mem-user-key` is stripped before forwarding to upstream (prevent leakage), `Authorization` is preserved

```
Client (CodeBuddy/Claude Code/WorkBuddy)
  │
  ├─ Authorization: Bearer sk-corp-alice-xxx  (corporate gateway key, forwarded)
  ├─ x-mem-user-key: sk-mem-alice-xxx        (MemoryProxy auth)
  │
  ▼
MemoryProxy (:8096)
  │
  ├─ auth: read x-mem-user-key → kernel verify → user_id
  ├─ memory injection: L1/L2/L3 recall, inject system prompt
  ├─ passthrough: Authorization preserved (sk-corp-alice-xxx)
  ├─ strip: x-mem-user-key NOT forwarded to upstream (prevent leak)
  │
  ▼
Corporate AI Gateway
  ├─ receives Authorization: Bearer sk-corp-alice-xxx
  ├─ billing: alice
  └─ route to LLM
```

## Changes

- **types.ts**: add `AuthConfig.userKeyHeader`, `UpstreamConfig.passthroughClientAuth`, and corresponding `RawYamlConfig` fields
- **config.ts**: parse both new fields from YAML; add defaults to `DEFAULT_CONFIG` (previously YAML values were silently dropped because the loader never read them — this was the root cause of the 401 `invalid user_key` bug in local deployment)
- **auth.ts**: `extractUserKeyFromRequest(c, userKeyHeader?)` — prefer the configured header, fall back to `Authorization` Bearer (backward compat)
- **6 handlers** (handler/anthropic/codex/workbuddy/auxiliary/systemUserPassthrough): add `x-mem-user-key` to `SKIP_REQUEST_HEADERS`; switch auth entry to `extractUserKeyFromRequest`
- **identity.ts**: prefer `x-mem-user-key` for user_key extraction; mask `x-mem-user-key` in logs
- **session/context-injector.ts**: pass `userKeyHeader` through
- **config.example.yaml**: document `auth.userKeyHeader` and `upstream.passthroughClientAuth`
- **deploy/global-images/start-proxy.sh + .env.example**: surface `PROXY_USER_KEY_HEADER` and `PROXY_PASSTHROUGH_CLIENT_AUTH` env vars
- **deploy/global-images/start-memory-core.sh**: fix `${ADMIN_KEY_FILE}` unbound variable caused by a full-width `)` (U+FF09) immediately after the variable name — bash 3.2 under `set -u` parsed it as part of the variable name
- **.gitignore**: ignore local runtime `data/` and `.admin-key.bak.*`
- **docs**: three new docs (design, user guide, implementation notes with troubleshooting playbook for the `.admin-key`/volume mismatch and config-loader-drop bugs)

## Backward compatibility

- Without `userKeyHeader` configured, auth falls back to `Authorization` Bearer (legacy path) — behavior unchanged
- Without `passthroughClientAuth`, `effectiveApiKey` three-state resolution is unchanged
- Corporate gateway key lives only in request lifetime, never persisted

## Bug fixes included

1. **config.ts YAML loader drop** (root cause of 401 in local deployment): `DEFAULT_CONFIG.upstream/auth` and `buildConfig()` never read `passthroughClientAuth`/`userKeyHeader` from YAML, so the fields were silently `undefined` at runtime even when correctly set in `config.yaml`. Fixed by adding defaults + parsing.

2. **start-memory-core.sh:175 unbound variable**: `$ADMIN_KEY_FILE` immediately followed by a full-width `)` (U+FF09, UTF-8 `ef bc 89`) — bash 3.2 under `set -u` parsed `ADMIN_KEY_FILE）` as the variable name. Fixed with `${ADMIN_KEY_FILE}` braces.

## Test plan

- [x] End-to-end: `curl` with `x-mem-user-key` + `Authorization` returns HTTP 200 from upstream
- [x] Invalid `x-mem-user-key` returns 401 `Authentication failed: invalid user_key`
- [x] `tsc --noEmit` introduces 0 new errors (baseline 55, branch 55)
- [x] Backward compat: without per-user config, proxy works as before (legacy Authorization Bearer path)

## Docs

- [`MemoryProxy/docs/per-user-corp-apikey-passthrough.md`](MemoryProxy/docs/per-user-corp-apikey-passthrough.md) — design doc
- [`MemoryProxy/docs/per-user-apikey-passthrough-guide.md`](MemoryProxy/docs/per-user-apikey-passthrough-guide.md) — user guide (CodeBuddy/Claude Code/WorkBuddy config examples)
- [`MemoryProxy/docs/per-user-implementation-notes.md`](MemoryProxy/docs/per-user-implementation-notes.md) — implementation notes with troubleshooting playbook

## Client config example (CodeBuddy)

\`~/.codebuddy/models.json\`:
\`\`\`json
{
  "id": "qwen3.8-max",
  "name": "proxy-memory-agent",
  "apiKey": "<corporate-gateway-key>",
  "url": "http://<proxy-host>:8096/codebuddy/default/v1/chat/completions",
  "supportsToolCall": true
}
\`\`\`

\`~/.codebuddy/settings.json\` \`env\` field:
\`\`\`json
{
  "env": {
    "CODEBUDDY_CUSTOM_HEADERS": "x-mem-user-key: sk-mem-xxx"
  }
}
\`\`\`

---

Signed-off-by: zhanglongzhan <lawliet.zhan@outlook.com>