### PR TITLE
fix(proxy): handle selected single-agent Team for OpenCode

### DIFF
--- a/MemoryProxy/src/session/__tests__/opencode-single-agent-team.test.ts
+++ b/MemoryProxy/src/session/__tests__/opencode-single-agent-team.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionInitConfig } from "../../types.js";
+import { handleSessionInit } from "../index.js";
+import { SessionStore } from "../store.js";
+import type { SessionInitState, TeamOption } from "../types.js";
+
+class InMemorySessionStore {
+  readonly states = new Map<string, SessionInitState>();
+
+  get(key: string): SessionInitState | undefined {
+    return this.states.get(key);
+  }
+
+  async set(key: string, state: SessionInitState): Promise<void> {
+    this.states.set(key, state);
+  }
+}
+
+const config: SessionInitConfig = {
+  enabled: true,
+  maxRetries: 3,
+};
+
+function sessionStore(initialState: SessionInitState): InMemorySessionStore {
+  const store = new InMemorySessionStore();
+  store.states.set("opencode:session-1", initialState);
+  return store;
+}
+
+function teams(tasksInSelectedTeam: TeamOption["tasks"]): TeamOption[] {
+  return [
+    {
+      team_id: "team-selected-0001",
+      team_name: "Selected Team",
+      agents: [{ agent_id: "agent-only-0001", agent_name: "Only Agent" }],
+      tasks: tasksInSelectedTeam,
+    },
+    {
+      team_id: "team-other-000002",
+      team_name: "Other Team",
+      agents: [{ agent_id: "agent-other-0002", agent_name: "Other Agent" }],
+      tasks: [{ task_id: "task-other-00002", task_name: "Other Task" }],
+    },
+  ];
+}
+
+function pendingTeamSelection(cachedTeams: TeamOption[]): SessionInitState {
+  return {
+    status: "pending_team_select",
+    keyId: "session-1",
+    startedAt: 1,
+    attemptCount: 0,
+    userId: "user-1",
+    cachedTeams,
+  };
+}
+
+function selectedTeamAnswer(): Record<string, unknown>[] {
+  return [{ role: "user", content: "Selected Team" }];
+}
+
+describe("OpenCode session initialization for a selected single-agent Team", () => {
+  it("skips agent selection and renders task selection when the selected Team has multiple Tasks", async () => {
+    const cachedTeams = teams([
+      { task_id: "task-first-00001", task_name: "First Task" },
+      { task_id: "task-second-0002", task_name: "Second Task" },
+    ]);
+    const store = sessionStore(pendingTeamSelection(cachedTeams));
+
+    const result = await handleSessionInit(
+      "session-1",
+      "user-1",
+      selectedTeamAnswer(),
+      config,
+      store as unknown as SessionStore,
+      { stream: false, modelId: "test-model" },
+      "opencode",
+    );
+
+    expect(result).toMatchObject({
+      intercepted: true,
+      formData: {
+        stage: "task_select",
+        selectedTeamId: "team-selected-0001",
+        selectedAgentId: "agent-only-0001",
+      },
+    });
+    expect(store.get("opencode:session-1")).toMatchObject({
+      status: "pending_task_select",
+      selectedTeamId: "team-selected-0001",
+      selectedAgentId: "agent-only-0001",
+    });
+  });
+
+  it("binds the only Agent and Task without emitting an agent selection form", async () => {
+    const cachedTeams = teams([
+      { task_id: "task-only-000001", task_name: "Only Task" },
+    ]);
+    const store = sessionStore(pendingTeamSelection(cachedTeams));
+
+    const result = await handleSessionInit(
+      "session-1",
+      "user-1",
+      selectedTeamAnswer(),
+      config,
+      store as unknown as SessionStore,
+      { stream: false, modelId: "test-model" },
+      "opencode",
+    );
+
+    expect(result).toMatchObject({
+      intercepted: false,
+      justRegistered: true,
+    });
+    expect(store.get("opencode:session-1")).toMatchObject({
+      status: "initialized",
+      selectedTeamId: "team-selected-0001",
+      sessionInfo: {
+        team_id: "team-selected-0001",
+        agent_id: "agent-only-0001",
+        task_id: "task-only-000001",
+      },
+    });
+  });
+});

--- a/MemoryProxy/src/session/__tests__/opencode-single-agent-team.test.ts
+++ b/MemoryProxy/src/session/__tests__/opencode-single-agent-team.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { SessionInitConfig } from "../../types.js";
+import type { MetadataClient } from "../../meta/client.js";
 import { handleSessionInit } from "../index.js";
 import { SessionStore } from "../store.js";
 import type { SessionInitState, TeamOption } from "../types.js";
@@ -20,6 +21,17 @@ class InMemorySessionStore {
 const config: SessionInitConfig = {
   enabled: true,
   maxRetries: 3,
+};
+
+const headerAutoSelectConfig: SessionInitConfig = {
+  ...config,
+  headerAutoSelect: {
+    enabled: true,
+    teamHeader: "x-team-id",
+    agentHeader: "x-agent-id",
+    taskHeader: "x-task-id",
+    onMismatch: "form",
+  },
 };
 
 function sessionStore(initialState: SessionInitState): InMemorySessionStore {
@@ -58,6 +70,42 @@ function pendingTeamSelection(cachedTeams: TeamOption[]): SessionInitState {
 
 function selectedTeamAnswer(): Record<string, unknown>[] {
   return [{ role: "user", content: "Selected Team" }];
+}
+
+function metadataClient(cachedTeams: TeamOption[]): MetadataClient {
+  return {
+    listTeams: async () => cachedTeams.map((team) => ({
+      team_id: team.team_id,
+      name: team.team_name,
+    })),
+    listAgents: async (teamId: string) => {
+      const team = cachedTeams.find((item) => item.team_id === teamId);
+      return (team?.agents ?? []).map((agent) => ({
+        agent_id: agent.agent_id,
+        team_id: teamId,
+        name: agent.agent_name,
+        description: agent.description,
+      }));
+    },
+    listTasks: async (teamId: string) => {
+      const team = cachedTeams.find((item) => item.team_id === teamId);
+      return (team?.tasks ?? []).map((task) => ({
+        task_id: task.task_id,
+        team_id: teamId,
+        title: task.task_name,
+      }));
+    },
+    getAgent: async (agentId: string) => ({
+      agent_id: agentId,
+      team_id: "team-selected-0001",
+      name: "Only Agent",
+    }),
+    getTask: async (taskId: string) => ({
+      task_id: taskId,
+      team_id: "team-selected-0001",
+      title: "Only Task",
+    }),
+  } as unknown as MetadataClient;
 }
 
 describe("OpenCode session initialization for a selected single-agent Team", () => {
@@ -107,6 +155,77 @@ describe("OpenCode session initialization for a selected single-agent Team", () 
       store as unknown as SessionStore,
       { stream: false, modelId: "test-model" },
       "opencode",
+    );
+
+    expect(result).toMatchObject({
+      intercepted: false,
+      justRegistered: true,
+    });
+    expect(store.get("opencode:session-1")).toMatchObject({
+      status: "initialized",
+      selectedTeamId: "team-selected-0001",
+      sessionInfo: {
+        team_id: "team-selected-0001",
+        agent_id: "agent-only-0001",
+        task_id: "task-only-000001",
+      },
+    });
+  });
+
+  it("uses task selection when a Team-only header resolves to one Agent and multiple Tasks", async () => {
+    const cachedTeams = teams([
+      { task_id: "task-first-00001", task_name: "First Task" },
+      { task_id: "task-second-0002", task_name: "Second Task" },
+    ]);
+    const store = new InMemorySessionStore();
+
+    const result = await handleSessionInit(
+      "session-1",
+      "user-1",
+      [{ role: "user", content: "Start a session" }],
+      headerAutoSelectConfig,
+      store as unknown as SessionStore,
+      { stream: false, modelId: "test-model" },
+      "opencode",
+      metadataClient(cachedTeams),
+      undefined,
+      undefined,
+      { teamId: "team-selected-0001" },
+    );
+
+    expect(result).toMatchObject({
+      intercepted: true,
+      formData: {
+        stage: "task_select",
+        selectedTeamId: "team-selected-0001",
+        selectedAgentId: "agent-only-0001",
+      },
+    });
+    expect(store.get("opencode:session-1")).toMatchObject({
+      status: "pending_task_select",
+      selectedTeamId: "team-selected-0001",
+      selectedAgentId: "agent-only-0001",
+    });
+  });
+
+  it("binds the only Agent and Task when a Team-only header resolves to one Task", async () => {
+    const cachedTeams = teams([
+      { task_id: "task-only-000001", task_name: "Only Task" },
+    ]);
+    const store = new InMemorySessionStore();
+
+    const result = await handleSessionInit(
+      "session-1",
+      "user-1",
+      [{ role: "user", content: "Start a session" }],
+      headerAutoSelectConfig,
+      store as unknown as SessionStore,
+      { stream: false, modelId: "test-model" },
+      "opencode",
+      metadataClient(cachedTeams),
+      undefined,
+      undefined,
+      { teamId: "team-selected-0001" },
     );
 
     expect(result).toMatchObject({

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -849,6 +849,72 @@ async function handleSessionInitInner(
         //
         // opencode 说明：opencode 客户端原生 `question` tool 每次只能弹一个题，
         // 无法承载"同时问 agent+task"的语义，必须拆 stage（同 codex/wb/dsh）。
+        // 已预选的 Team 若仅有一个 Agent，也必须继续级联自动选择；否则
+        // OpenCode 会收到单选项 agent_select，而其 `question` form 会拒绝该页。
+        const selectedTeam = teams.find((team) => team.team_id === pr.teamId);
+        if (selectedTeam?.agents.length === 1) {
+          const soloAgent = selectedTeam.agents[0];
+          const nextState: SessionInitState = {
+            status: "pending_agent_select",
+            keyId: sessionKey,
+            startedAt: Date.now(),
+            attemptCount: 0,
+            userId,
+            cachedTeams: teams,
+            selectedTeamId: pr.teamId,
+            selectedAgentId: soloAgent.agent_id,
+          };
+          console.log(
+            `[session-init:cb] session=${compositeKey} preset team=${pr.teamId} only-agent=${soloAgent.agent_id} auto-select`,
+          );
+
+          if (selectedTeam.tasks.length === 0) {
+            await store.set(compositeKey, {
+              ...nextState,
+              status: "initialized",
+              sessionInfo: null,
+              agentDetail: null,
+              taskDetail: null,
+              bypassed: true,
+            } as SessionInitState);
+            console.log(
+              `[session-init:cb] session=${compositeKey} preset team has 0 tasks → bypass`,
+            );
+            return { intercepted: false, bypassed: true, justRegistered: true };
+          }
+
+          if (selectedTeam.tasks.length === 1) {
+            const soleTaskId = selectedTeam.tasks[0].task_id;
+            console.log(
+              `[session-init:cb] session=${compositeKey} preset auto-select single task=${soleTaskId} → completeRegistration`,
+            );
+            return completeRegistration(
+              { agent_id: soloAgent.agent_id, task_id: soleTaskId },
+              nextState, teams, compositeKey, sessionKey, userId,
+              config, store, messages, metadataClient, userKey, spaceId,
+            );
+          }
+
+          await store.set(compositeKey, {
+            ...nextState,
+            status: "pending_task_select",
+          });
+          console.log(
+            `[session-init:cb] session=${compositeKey} preset → pending_task_select (tasks=${selectedTeam.tasks.length})`,
+          );
+          const fd: FormData = {
+            teams,
+            stage: "task_select",
+            selectedTeamId: pr.teamId,
+            selectedAgentId: soloAgent.agent_id,
+            stream: reqCtx.stream,
+            questionsAsArray: reqCtx.questionsAsArray,
+            modelId: reqCtx.modelId,
+            protocol: reqCtx.protocol,
+          };
+          return { intercepted: true, response: buildFormResponse(fd), formData: fd };
+        }
+
         const nextStatus = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "pending_agent_select" : "pending_agent_task";
         const nextStage: FormData["stage"] = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "agent_select" : "agent_task";
         await store.set(compositeKey, {

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -1097,19 +1097,87 @@ async function handleSessionInitInner(
     }
 
     if (teamId && teamId !== BYPASS_MARKER) {
+      const cachedTeams = state.cachedTeams ?? [];
+      const selectedTeam = cachedTeams.find((team) => team.team_id === teamId);
+
+      // 多 Team 场景也要按已选 Team 继续级联 auto-select。否则 OpenCode
+      // 会为仅一个 Agent 渲染 agent_select，而它的 question form 拒绝单选项。
+      if (selectedTeam?.agents.length === 1) {
+        const soloAgent = selectedTeam.agents[0];
+        const nextState: SessionInitState = {
+          ...state,
+          status: "pending_agent_select",
+          keyId: sessionKey,
+          attemptCount: 0,
+          cachedTeams,
+          selectedTeamId: teamId,
+          selectedAgentId: soloAgent.agent_id,
+        };
+        console.log(
+          `[session-init:cb] session=${compositeKey} team=${teamId} only-agent=${soloAgent.agent_id} auto-select`,
+        );
+
+        if (selectedTeam.tasks.length === 0) {
+          await store.set(compositeKey, {
+            ...nextState,
+            status: "initialized",
+            sessionInfo: null,
+            agentDetail: null,
+            taskDetail: null,
+            bypassed: true,
+          } as SessionInitState);
+          console.log(
+            `[session-init:cb] session=${compositeKey} team has 0 tasks → bypass`,
+          );
+          return { intercepted: false, bypassed: true, justRegistered: true };
+        }
+
+        if (selectedTeam.tasks.length === 1) {
+          const soleTaskId = selectedTeam.tasks[0].task_id;
+          console.log(
+            `[session-init:cb] session=${compositeKey} auto-select single task=${soleTaskId} → completeRegistration`,
+          );
+          return await completeRegistration(
+            { agent_id: soloAgent.agent_id, task_id: soleTaskId },
+            nextState, cachedTeams, compositeKey, sessionKey, userId,
+            config, store, messages, metadataClient, userKey, spaceId,
+          );
+        }
+
+        await store.set(compositeKey, {
+          ...nextState,
+          status: "pending_task_select",
+        });
+        console.log(
+          `[session-init:cb] session=${compositeKey} → pending_task_select (tasks=${selectedTeam.tasks.length})`,
+        );
+        const fd: FormData = {
+          teams: cachedTeams,
+          stage: "task_select",
+          selectedTeamId: teamId,
+          selectedAgentId: soloAgent.agent_id,
+          stream: reqCtx.stream,
+          questionsAsArray: reqCtx.questionsAsArray,
+          modelId: reqCtx.modelId,
+          protocol: reqCtx.protocol,
+        };
+        return { intercepted: true, response: buildFormResponse(fd), formData: fd };
+      }
+
       // codex/WB/dsh/opencode 拆 stage：先 agent_select → task_select；CB 老路径继续 agent_task 一发同时问。
       const nextStatus = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "pending_agent_select" : "pending_agent_task";
       const nextStage: FormData["stage"] = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "agent_select" : "agent_task";
       const next: SessionInitState = {
         ...state,
         status: nextStatus,
+        cachedTeams,
         selectedTeamId: teamId,
         attemptCount: 0,
       };
       await store.set(compositeKey, next);
       console.log(`[session-init:cb] session=${compositeKey} team=${teamId} → ${nextStatus}`);
       const fd: FormData = {
-        teams: state.cachedTeams ?? [],
+        teams: cachedTeams,
         stage: nextStage,
         selectedTeamId: teamId,
         stream: reqCtx.stream,


### PR DESCRIPTION
## Summary

- auto-select the sole Agent after a user selects a Team, including the multi-Team flow
- apply the same cascade when a request preselects only a Team through `x-team-id`
- register directly for one Task or render `task_select` for multiple Tasks
- add OpenCode regression coverage for both interactive and header-preselection paths

## Root cause

The shared session-init state machine only cascaded a sole Agent in the single-Team interactive path. Both selecting a Team from a multi-Team form and resolving only a Team from request headers could otherwise transition OpenCode to `pending_agent_select` with one Agent. OpenCode rejects a one-option `question` page, so session initialization failed before binding a valid identity.

## Validation

- `npx vitest run src/session/__tests__/opencode-single-agent-team.test.ts`
- `npm test` — 2 files, 12 tests passed
- `git diff --check` and `git show --check` — clean
- `npx tsc --noEmit` remains blocked by existing repository-wide type errors outside this change (including pre-existing `resetFlow` result typing errors); this change adds no new diagnostic

Fixes #1176