### PR TITLE
fix(memorycore): normalize reasoning wrappers before structured extraction

### DIFF
--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -120,6 +120,7 @@ import type { PipelineWorker } from "../services/pipeline-worker.js";
 import type { StatefulPipelineManager } from "../utils/stateful-pipeline-manager.js";
 import type { PipelineLogger } from "../utils/pipeline-factory.js";
 import { parsePipelineTimerMember } from "../core/state/timer-member.js";
+import { extractOpenAiFinalAnswer } from "../utils/structured-output.js";
 
 const TAG = "[tdai-gateway]";
 const VERSION = "0.1.0";
@@ -3006,7 +3007,7 @@ export class TdaiGateway {
               `content=${content.length} chars`,
             );
           }
-          return json.choices?.[0]?.message?.content ?? "";
+          return extractOpenAiFinalAnswer(json);
         } catch (err) {
           clearTimeout(timer);
           throw err;

--- a/MemoryCore/src/offload/local-llm/index.ts
+++ b/MemoryCore/src/offload/local-llm/index.ts
@@ -15,6 +15,7 @@ import { parseL15Response } from "./parsers/l15-parser.js";
 import { parseL2Response, type L2ParsedResponse } from "./parsers/l2-parser.js";
 import type { OffloadEntry, TaskJudgment, PluginLogger } from "../types.js";
 import type { L1Request, L1Response, L15Request, L15Response, L2Request, L2Response } from "../backend-client.js";
+import { StructuredOutputParseError } from "../../utils/structured-output.js";
 
 const TAG = "[context-offload] [local-llm]";
 
@@ -66,7 +67,7 @@ export class LocalLlmClient {
 
     const entries = parseL1Response(raw);
     if (entries.length === 0) {
-      this.logger?.warn?.(`${TAG} L1: parsed 0 entries from LLM response (${raw.length} chars)`);
+      throw new StructuredOutputParseError("L1", raw);
     }
 
     return { entries };

--- a/MemoryCore/src/offload/local-llm/parsers/json-utils.ts
+++ b/MemoryCore/src/offload/local-llm/parsers/json-utils.ts
@@ -2,58 +2,18 @@
  * Tolerant JSON parsing utilities for LLM responses.
  *
  * LLMs often wrap JSON in markdown code fences, include trailing commas,
- * or prepend explanatory text. These utilities handle common deviations.
+ * or prepend known reasoning wrappers. These utilities handle those bounded
+ * deviations without searching arbitrary prose for JSON.
  */
 
+import { extractStructuredJson } from "../../../utils/structured-output.js";
+
 /**
- * Extract JSON from LLM output — handles code fences, prefix text, etc.
+ * Extract JSON from LLM output — handles code fences and known wrappers.
  * Returns the parsed object/array, or null if parsing fails.
  */
 export function extractJson<T = unknown>(raw: string): T | null {
-  if (!raw || typeof raw !== "string") return null;
-
-  const trimmed = raw.trim();
-
-  // Strategy 1: Direct parse (ideal case)
-  const direct = tryParse<T>(trimmed);
-  if (direct !== null) return direct;
-
-  // Strategy 2: Extract from markdown code fence (```json ... ``` or ``` ... ```)
-  const fenceMatch = trimmed.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
-  if (fenceMatch) {
-    const inner = fenceMatch[1].trim();
-    const parsed = tryParse<T>(inner);
-    if (parsed !== null) return parsed;
-  }
-
-  // Strategy 3: Find first { to last } (or first [ to last ])
-  const firstBrace = trimmed.indexOf("{");
-  const lastBrace = trimmed.lastIndexOf("}");
-  if (firstBrace >= 0 && lastBrace > firstBrace) {
-    const candidate = trimmed.slice(firstBrace, lastBrace + 1);
-    const parsed = tryParse<T>(candidate);
-    if (parsed !== null) return parsed;
-
-    // Try with trailing comma fix
-    const fixed = fixTrailingCommas(candidate);
-    const parsedFixed = tryParse<T>(fixed);
-    if (parsedFixed !== null) return parsedFixed;
-  }
-
-  const firstBracket = trimmed.indexOf("[");
-  const lastBracket = trimmed.lastIndexOf("]");
-  if (firstBracket >= 0 && lastBracket > firstBracket) {
-    const candidate = trimmed.slice(firstBracket, lastBracket + 1);
-    const parsed = tryParse<T>(candidate);
-    if (parsed !== null) return parsed;
-  }
-
-  // Strategy 4: Try fixing the entire string
-  const fixed = fixTrailingCommas(trimmed);
-  const parsedFixed = tryParse<T>(fixed);
-  if (parsedFixed !== null) return parsedFixed;
-
-  return null;
+  return extractStructuredJson<T>(raw);
 }
 
 /**
@@ -70,16 +30,3 @@ export function extractMermaidFromFence(text: string): string | null {
 }
 
 // ─── Internal Helpers ────────────────────────────────────────────────────────
-
-function tryParse<T>(s: string): T | null {
-  try {
-    return JSON.parse(s) as T;
-  } catch {
-    return null;
-  }
-}
-
-function fixTrailingCommas(s: string): string {
-  // Remove trailing commas before } or ]
-  return s.replace(/,\s*([}\]])/g, "$1");
-}

--- a/MemoryCore/src/offload_server/offload-task-executor.ts
+++ b/MemoryCore/src/offload_server/offload-task-executor.ts
@@ -22,6 +22,7 @@ import { L2_SYSTEM_PROMPT, buildL2UserPrompt } from "./prompts/l2-prompt.js";
 import { handleTaskTransition, extractMmdMeta } from "./task-transition.js";
 import { buildOffloadBasePath } from "./session-utils.js";
 import { traceServerModelIo, traceServerTaskDecision } from "./opik-tracer.js";
+import { StructuredOutputParseError } from "../utils/structured-output.js";
 
 // ─── LLM Client Interface ────────────────────────────────────────────────────
 
@@ -146,6 +147,9 @@ export class OffloadTaskExecutor {
       });
       l1RawResponse = response;
       newEntries = parseL1Response(response);
+      if (newEntries.length === 0) {
+        throw new StructuredOutputParseError("L1", response);
+      }
       traceServerModelIo({
         sessionId,
         stage: "L1",
@@ -164,7 +168,7 @@ export class OffloadTaskExecutor {
         model: this.config.l1Model,
         systemPrompt: L1_SYSTEM_PROMPT,
         userPrompt,
-        responseContent: l1RawResponse ?? "",
+        responseContent: err instanceof StructuredOutputParseError ? "" : (l1RawResponse ?? ""),
         status: "error",
         errorMessage: String(err),
         durationMs: Date.now() - l1LlmStart,

--- a/MemoryCore/src/offload_server/parsers/json-utils.ts
+++ b/MemoryCore/src/offload_server/parsers/json-utils.ts
@@ -2,54 +2,13 @@
  * JSON / Mermaid extraction utilities for LLM response parsing.
  */
 
+import { extractStructuredJson } from "../../utils/structured-output.js";
+
 /**
- * Extract JSON from raw LLM output. Tolerates markdown fences, extra text.
+ * Extract JSON from raw LLM output. Tolerates fences and known wrappers.
  */
 export function extractJson<T>(raw: string): T | null {
-  if (!raw || typeof raw !== "string") return null;
-
-  const trimmed = raw.trim();
-
-  // 1. Direct parse
-  try {
-    return JSON.parse(trimmed) as T;
-  } catch {
-    // continue
-  }
-
-  // 2. Extract from ```json ... ``` fence
-  const jsonFenceMatch = trimmed.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
-  if (jsonFenceMatch) {
-    try {
-      return JSON.parse(jsonFenceMatch[1].trim()) as T;
-    } catch {
-      // continue
-    }
-  }
-
-  // 3. Extract first { ... } (greedy last })
-  const objStart = trimmed.indexOf("{");
-  const objEnd = trimmed.lastIndexOf("}");
-  if (objStart !== -1 && objEnd > objStart) {
-    try {
-      return JSON.parse(trimmed.slice(objStart, objEnd + 1)) as T;
-    } catch {
-      // continue
-    }
-  }
-
-  // 4. Extract first [ ... ] (greedy last ])
-  const arrStart = trimmed.indexOf("[");
-  const arrEnd = trimmed.lastIndexOf("]");
-  if (arrStart !== -1 && arrEnd > arrStart) {
-    try {
-      return JSON.parse(trimmed.slice(arrStart, arrEnd + 1)) as T;
-    } catch {
-      // continue
-    }
-  }
-
-  return null;
+  return extractStructuredJson<T>(raw);
 }
 
 /**

--- a/MemoryCore/src/utils/structured-output.test.ts
+++ b/MemoryCore/src/utils/structured-output.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  extractOpenAiFinalAnswer,
+  extractStructuredJson,
+  StructuredOutputParseError,
+} from "./structured-output.js";
+import { parseL1Response as parseLocalL1 } from "../offload/local-llm/parsers/l1-parser.js";
+import { parseL1Response as parseStandaloneL1 } from "../offload_server/parsers/l1-parser.js";
+import { OffloadTaskExecutor } from "../offload_server/offload-task-executor.js";
+import { buildOffloadBasePath } from "../offload_server/session-utils.js";
+import { LocalStorageBackend } from "../core/storage/local-backend.js";
+import { StorageAdapter } from "../core/storage/adapter.js";
+import type { IStateBackend, TaskPayload } from "../core/state/types.js";
+
+const VALID_L1 = JSON.stringify([{
+  tool_call_id: "call-1",
+  tool_call: "read_file",
+  summary: "Read the requested file",
+  timestamp: "2026-08-23T00:00:00.000Z",
+  score: 5,
+}]);
+
+describe("structured LLM output normalization", () => {
+  it.each([
+    ["already-clean JSON", VALID_L1],
+    ["a JSON fence", `\`\`\`json\n${VALID_L1}\n\`\`\``],
+    ["a Qwen think wrapper", `<think>private reasoning with {\"wrong\":true}</think>\n${VALID_L1}`],
+    ["a think wrapper around a fence", `<think>private reasoning</think>\n\`\`\`json\n${VALID_L1}\n\`\`\``],
+  ])("parses %s consistently in local and standalone callers", (_label, raw) => {
+    expect(parseLocalL1(raw)).toHaveLength(1);
+    expect(parseStandaloneL1(raw)).toHaveLength(1);
+    expect(parseLocalL1(raw)[0].tool_call_id).toBe("call-1");
+    expect(parseStandaloneL1(raw)[0].tool_call_id).toBe("call-1");
+  });
+
+  it("uses visible content and ignores a separate reasoning_content field", () => {
+    const raw = extractOpenAiFinalAnswer({
+      choices: [{
+        message: {
+          content: VALID_L1,
+          reasoning_content: "private chain of thought containing different JSON",
+        },
+      }],
+    });
+
+    expect(raw).toBe(VALID_L1);
+    expect(parseStandaloneL1(raw)[0].tool_call_id).toBe("call-1");
+  });
+
+  it("does not promote hidden reasoning when visible content is absent", () => {
+    expect(extractOpenAiFinalAnswer({
+      choices: [{ message: { content: null, reasoning_content: VALID_L1 } }],
+    })).toBe("");
+  });
+
+  it.each([
+    ["reasoning only", "<think>private reasoning</think>"],
+    ["unclosed reasoning", "<think>private reasoning"],
+    ["malformed JSON", "{not-json}"],
+    ["arbitrary prose around JSON", `Here is the answer: ${VALID_L1}`],
+  ])("rejects %s instead of recovering arbitrary content", (_label, raw) => {
+    expect(extractStructuredJson(raw)).toBeNull();
+    expect(parseLocalL1(raw)).toEqual([]);
+    expect(parseStandaloneL1(raw)).toEqual([]);
+  });
+
+  it("produces a bounded diagnostic without response content", () => {
+    const secret = "private-reasoning-secret";
+    const error = new StructuredOutputParseError("L1", `<think>${secret}</think>`);
+
+    expect(error.message).toContain("kind=reasoning-only");
+    expect(error.message).not.toContain(secret);
+    expect(error.message.length).toBeLessThan(120);
+  });
+});
+
+describe("standalone L1 write safety", () => {
+  let rootDir: string;
+  let storage: StorageAdapter;
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "memorycore-structured-output-"));
+    storage = new StorageAdapter(new LocalStorageBackend(rootDir));
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("retains the claimed L0 input for retry and does not write L1 on reasoning-only output", async () => {
+    const sessionId = "session-reasoning-only";
+    const taskId = "task-reasoning-only";
+    const basePath = buildOffloadBasePath(sessionId);
+    const pendingPath = `${basePath}/pending.jsonl`;
+    const processingPath = `${basePath}/pending-processing-${taskId}.jsonl`;
+    const entriesPath = `${basePath}/entries.jsonl`;
+    const pending = JSON.stringify({
+      toolCallId: "call-1",
+      toolName: "read_file",
+      params: {},
+      result: "a result long enough to have been persisted as a reference",
+      timestamp: "2026-08-23T00:00:00.000Z",
+    }) + "\n";
+    await storage.writeFile(pendingPath, pending);
+
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const executor = new OffloadTaskExecutor({
+      resolveStorage: async () => storage,
+      llmClient: { chat: async () => "<think>private reasoning only</think>" },
+      stateBackend: {} as IStateBackend,
+      logger,
+    });
+    const task: TaskPayload = {
+      id: taskId,
+      type: "offload-l1",
+      instanceId: "instance-1",
+      sessionId,
+      priority: 1,
+      createdAt: Date.now(),
+    };
+
+    await expect(executor.executeOffloadL1(task)).rejects.toBeInstanceOf(StructuredOutputParseError);
+    expect(await storage.readFile(pendingPath)).toBeNull();
+    expect(await storage.readFile(processingPath)).toBe(pending);
+    expect(await storage.readFile(entriesPath)).toBeNull();
+    expect(JSON.stringify(logger.error.mock.calls)).not.toContain("private reasoning only");
+  });
+});

--- a/MemoryCore/src/utils/structured-output.ts
+++ b/MemoryCore/src/utils/structured-output.ts
@@ -1,0 +1,121 @@
+/**
+ * Safe normalization for structured LLM output.
+ *
+ * Only known transport wrappers are removed. Arbitrary prose is deliberately
+ * not searched for JSON because doing so can mistake hidden reasoning for the
+ * model's final answer.
+ */
+
+const REASONING_TAGS = new Set(["think", "reasoning"]);
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as UnknownRecord
+    : null;
+}
+
+function stripLeadingReasoningBlocks(value: string): string | null {
+  let remaining = value.trim();
+
+  while (remaining.startsWith("<")) {
+    const open = remaining.match(/^<([a-zA-Z][\w-]*)(?:\s[^>]*)?>/);
+    if (!open || !REASONING_TAGS.has(open[1].toLowerCase())) break;
+
+    const closeTag = `</${open[1]}>`;
+    const closeIndex = remaining.toLowerCase().indexOf(closeTag.toLowerCase(), open[0].length);
+    if (closeIndex < 0) return null;
+
+    remaining = remaining.slice(closeIndex + closeTag.length).trim();
+  }
+
+  return remaining;
+}
+
+function unwrapJsonFence(value: string): string | null {
+  const match = value.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/i);
+  return match ? match[1].trim() : null;
+}
+
+function prepareStructuredPayload(raw: string): string | null {
+  let payload = raw.replace(/^\uFEFF/, "").trim();
+
+  // Support a known reasoning wrapper outside or inside a JSON code fence.
+  for (let pass = 0; pass < 3; pass += 1) {
+    const withoutReasoning = stripLeadingReasoningBlocks(payload);
+    if (withoutReasoning === null) return null;
+    payload = withoutReasoning;
+
+    const unfenced = unwrapJsonFence(payload);
+    if (unfenced === null) break;
+    payload = unfenced;
+  }
+
+  return payload;
+}
+
+function fixTrailingCommas(value: string): string {
+  return value.replace(/,\s*([}\]])/g, "$1");
+}
+
+/** Parse a final-answer payload after removing only known wrappers. */
+export function extractStructuredJson<T = unknown>(raw: string): T | null {
+  if (!raw || typeof raw !== "string") return null;
+
+  const payload = prepareStructuredPayload(raw);
+  if (!payload) return null;
+
+  try {
+    return JSON.parse(payload) as T;
+  } catch {
+    // Preserve the local parser's existing tolerance for trailing commas.
+    try {
+      return JSON.parse(fixTrailingCommas(payload)) as T;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Select the visible final-answer channel from an OpenAI-compatible response.
+ * Hidden reasoning fields are intentionally never used as a fallback.
+ */
+export function extractOpenAiFinalAnswer(response: unknown): string {
+  const root = asRecord(response);
+  const choices = root?.choices;
+  if (!Array.isArray(choices)) return "";
+
+  const choice = asRecord(choices[0]);
+  const message = asRecord(choice?.message);
+  const content = message?.content;
+  if (typeof content === "string") return content;
+
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        const item = asRecord(block);
+        return item?.type === "text" && typeof item.text === "string" ? item.text : "";
+      })
+      .join("");
+  }
+
+  return "";
+}
+
+function classifyFailure(raw: string): "empty" | "reasoning-only" | "unclosed-reasoning" | "malformed" {
+  if (!raw.trim()) return "empty";
+  const withoutReasoning = stripLeadingReasoningBlocks(raw.replace(/^\uFEFF/, "").trim());
+  if (withoutReasoning === null) return "unclosed-reasoning";
+  if (!withoutReasoning || unwrapJsonFence(withoutReasoning) === "") return "reasoning-only";
+  return "malformed";
+}
+
+/** A bounded, content-free parse failure suitable for logs and telemetry. */
+export class StructuredOutputParseError extends Error {
+  constructor(stage: string, raw: string) {
+    super(`${stage} structured output parse failed (kind=${classifyFailure(raw)}, chars=${raw.length})`);
+    this.name = "StructuredOutputParseError";
+  }
+}


### PR DESCRIPTION
## Summary

- share a bounded structured-output normalizer across local and standalone offload parsers
- select only the visible OpenAI-compatible content channel and ignore `reasoning_content`
- reject reasoning-only/malformed L1 output before L1/ref mutations while retaining the claimed L0 batch for retry
- emit content-free bounded parse diagnostics

Downstream context: https://github.com/gavinlouuu-kpt/codex-discord-bridge/issues/249

## Tests

- `npm test` (12 passed)
- `npm run build:plugin`
- `npm run lint:skill-isolation`

`npm pack --dry-run` reaches the repository-wide script build but then hits an existing base-tree error: `scripts/seed-v2/tsconfig.json` is referenced by `build:seed-v2` but is absent.