### PR TITLE
fix(memory-core): probe local LLM capabilities

### DIFF
--- a/MemoryCore/README.md
+++ b/MemoryCore/README.md
@@ -207,6 +207,11 @@ Environment variables override file configuration. Common settings:
 | `TDAI_LLM_API_KEY` | Empty | LLM API key |
 | `TDAI_LLM_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible API URL |
 | `TDAI_LLM_MODEL` | `gpt-4o` | LLM model |
+| `TDAI_LLM_BACKEND` | `openai-compatible` | `openai-compatible`, `ollama`, or `llama.cpp` capability profile |
+| `TDAI_LLM_CONTEXT_WINDOW` | Unset | Configured context window; oversized prompts are refused instead of silently truncated |
+| `TDAI_LLM_INPUT_BUDGET_TOKENS` | Derived | Optional stricter prompt-token budget |
+| `TDAI_LLM_REASONING_ENABLED` | Unset | Explicitly enable/disable local-model thinking |
+| `TDAI_LLM_STARTUP_PROBE_STRICT` | `false` | Fail startup when the configured local model is unavailable/incompatible |
 | `TDAI_SKILL_ENABLED` | File configuration | Force-enable the Skill module |
 
 Configuration templates:
@@ -214,6 +219,30 @@ Configuration templates:
 - `tdai-gateway.standalone.yaml`: minimal single-node Memory configuration.
 - `tdai-gateway.yaml`: default Standalone + Skill configuration.
 - `tdai-gateway.proxy.yaml`: LLM access through an OpenAI-compatible proxy.
+
+Local backends can be selected entirely in YAML; no runner edits are required. The
+gateway probes native Ollama (`/api/show`) or llama.cpp (`/health`, `/props`)
+capabilities at startup and publishes configured/effective limits in `/health`:
+
+```yaml
+llm:
+  backend: "llama.cpp"             # or "ollama"
+  baseUrl: "http://127.0.0.1:8080/v1"
+  apiKey: "local"
+  model: "qwen3.5-27b"
+  contextWindow: 8192              # fallback if the backend cannot report it
+  maxTokens: 2048
+  reasoning:
+    enabled: false                 # llama.cpp: enable_thinking=false; Ollama: effort=none
+    format: "none"                # optional llama.cpp reasoning_format
+  startupProbe:
+    enabled: true
+    strict: true
+    timeoutMs: 5000
+  extraBody:                       # explicit provider-specific chat fields
+    chat_template_kwargs:
+      custom_flag: "configured"
+```
 
 ## Storage and isolation
 

--- a/MemoryCore/src/adapters/standalone/llm-capabilities.test.ts
+++ b/MemoryCore/src/adapters/standalone/llm-capabilities.test.ts
@@ -112,6 +112,34 @@ describe("standalone local LLM capabilities", () => {
     });
   });
 
+  it("never widens an operator context cap to an Ollama model training limit", async () => {
+    const endpoint = await startEndpoint((req) => {
+      if (req.url === "/api/show") {
+        return {
+          body: {
+            model_info: { "qwen35.context_length": 262144 },
+            capabilities: ["completion", "thinking"],
+          },
+        };
+      }
+      return { body: chatResponse("qwen3.6:27b") };
+    });
+    const capability = await probeLlmCapabilities({
+      baseUrl: endpoint.baseUrl,
+      apiKey: "ollama",
+      model: "qwen3.6:27b",
+      maxTokens: 2048,
+      backend: "ollama",
+      contextWindow: 8192,
+    });
+    expect(capability).toMatchObject({
+      state: "ready",
+      configuredContextWindow: 8192,
+      effectiveContextWindow: 8192,
+      effectiveInputBudgetTokens: 6144,
+    });
+  });
+
   it("probes llama.cpp and applies Jinja reasoning/template options", async () => {
     const endpoint = await startEndpoint((req) => {
       if (req.url === "/health") return { body: { status: "ok" } };

--- a/MemoryCore/src/adapters/standalone/llm-capabilities.test.ts
+++ b/MemoryCore/src/adapters/standalone/llm-capabilities.test.ts
@@ -1,0 +1,215 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { StandaloneLLMRunner, type StandaloneLLMConfig } from "./llm-runner.js";
+import {
+  PromptContextLimitError,
+  probeLlmCapabilities,
+} from "./llm-capabilities.js";
+
+interface TestEndpoint {
+  baseUrl: string;
+  requests: Array<{ url: string; body: Record<string, unknown> }>;
+  close(): Promise<void>;
+}
+
+const endpoints: TestEndpoint[] = [];
+
+async function startEndpoint(
+  handler: (
+    req: http.IncomingMessage,
+    body: Record<string, unknown>,
+  ) => { status?: number; body: Record<string, unknown> },
+): Promise<TestEndpoint> {
+  const requests: TestEndpoint["requests"] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      const body = raw ? JSON.parse(raw) as Record<string, unknown> : {};
+      requests.push({ url: req.url ?? "", body });
+      const response = handler(req, body);
+      res.writeHead(response.status ?? 200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(response.body));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind TCP");
+  const endpoint: TestEndpoint = {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    close: () => new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
+  };
+  endpoints.push(endpoint);
+  return endpoint;
+}
+
+function chatResponse(model: string): Record<string, unknown> {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion",
+    created: 1,
+    model,
+    choices: [{
+      index: 0,
+      message: { role: "assistant", content: "ok" },
+      finish_reason: "stop",
+    }],
+    usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(endpoints.splice(0).map((endpoint) => endpoint.close()));
+});
+
+describe("standalone local LLM capabilities", () => {
+  it("probes an Ollama model and sends explicit reasoning controls", async () => {
+    const endpoint = await startEndpoint((req) => {
+      if (req.url === "/api/show") {
+        return {
+          body: {
+            parameters: "temperature 0.7\nnum_ctx 8192",
+            model_info: { "qwen3.context_length": 32768 },
+            capabilities: ["completion", "tools", "thinking"],
+          },
+        };
+      }
+      return { body: chatResponse("qwen3:8b") };
+    });
+    const config: StandaloneLLMConfig = {
+      baseUrl: endpoint.baseUrl,
+      apiKey: "ollama",
+      model: "qwen3:8b",
+      maxTokens: 1024,
+      backend: "ollama",
+      reasoning: { enabled: false },
+      extraBody: { keep_alive: "5m", model: "must-not-override" },
+    };
+
+    const capability = await probeLlmCapabilities(config);
+    expect(capability).toMatchObject({
+      state: "ready",
+      backend: "ollama",
+      effectiveContextWindow: 8192,
+      effectiveInputBudgetTokens: 7168,
+      extraBodyKeys: ["keep_alive"],
+    });
+    config.effectiveContextWindow = capability.effectiveContextWindow;
+
+    const result = await new StandaloneLLMRunner({ config }).run({
+      taskId: "ollama-compatible-integration",
+      systemPrompt: "Be brief.",
+      prompt: "Hello",
+    });
+    expect(result).toBe("ok");
+    const chat = endpoint.requests.find((request) => request.url === "/v1/chat/completions");
+    expect(chat?.body).toMatchObject({
+      model: "qwen3:8b",
+      reasoning_effort: "none",
+      keep_alive: "5m",
+    });
+  });
+
+  it("probes llama.cpp and applies Jinja reasoning/template options", async () => {
+    const endpoint = await startEndpoint((req) => {
+      if (req.url === "/health") return { body: { status: "ok" } };
+      if (req.url === "/props") {
+        return {
+          body: {
+            default_generation_settings: { n_ctx: 16384 },
+            chat_template: "qwen3",
+            chat_template_caps: { supports_tool_calls: true, supports_reasoning: true },
+          },
+        };
+      }
+      return { body: chatResponse("qwen3.5-27b") };
+    });
+    const config: StandaloneLLMConfig = {
+      baseUrl: endpoint.baseUrl,
+      apiKey: "local",
+      model: "qwen3.5-27b",
+      maxTokens: 2048,
+      backend: "llama.cpp",
+      reasoning: { enabled: false, format: "none" },
+      extraBody: { chat_template_kwargs: { custom_flag: "configured" } },
+    };
+
+    const capability = await probeLlmCapabilities(config);
+    expect(capability).toMatchObject({
+      state: "ready",
+      backend: "llama.cpp",
+      effectiveContextWindow: 16384,
+      effectiveInputBudgetTokens: 14336,
+    });
+    config.effectiveContextWindow = capability.effectiveContextWindow;
+
+    await new StandaloneLLMRunner({ config }).run({
+      taskId: "llama-cpp-integration",
+      prompt: "Extract memory",
+    });
+    const chat = endpoint.requests.find((request) => request.url === "/v1/chat/completions");
+    expect(chat?.body).toMatchObject({
+      model: "qwen3.5-27b",
+      reasoning_format: "none",
+      chat_template_kwargs: { custom_flag: "configured", enable_thinking: false },
+    });
+  });
+
+  it("reports an unloaded model without reflecting response secrets", async () => {
+    const endpoint = await startEndpoint(() => ({
+      status: 404,
+      body: { error: "model missing", reflected_api_key: "do-not-log-this" },
+    }));
+    const capability = await probeLlmCapabilities({
+      baseUrl: endpoint.baseUrl,
+      apiKey: "also-secret",
+      model: "missing-model",
+      backend: "ollama",
+    });
+    expect(capability.state).toBe("degraded");
+    expect(capability.detail).toContain("Ollama /api/show returned HTTP 404");
+    expect(JSON.stringify(capability)).not.toContain("do-not-log-this");
+    expect(JSON.stringify(capability)).not.toContain("also-secret");
+  });
+
+  it("reports a context configuration which leaves no prompt budget", async () => {
+    const endpoint = await startEndpoint((req) => {
+      if (req.url === "/health") return { body: { status: "ok" } };
+      return {
+        body: {
+          default_generation_settings: { n_ctx: 8192 },
+          chat_template_caps: { supports_reasoning: true },
+        },
+      };
+    });
+    const capability = await probeLlmCapabilities({
+      baseUrl: endpoint.baseUrl,
+      apiKey: "local",
+      model: "qwen",
+      backend: "llama.cpp",
+      maxTokens: 8192,
+    });
+    expect(capability.state).toBe("degraded");
+    expect(capability.detail).toContain("maxTokens 8192 leaves no input budget in context window 8192");
+  });
+
+  it("refuses an oversized prompt before contacting the endpoint", async () => {
+    const endpoint = await startEndpoint(() => ({ body: chatResponse("tiny") }));
+    const runner = new StandaloneLLMRunner({
+      config: {
+        baseUrl: endpoint.baseUrl,
+        apiKey: "local",
+        model: "tiny",
+        contextWindow: 64,
+        inputBudgetTokens: 8,
+      },
+    });
+    await expect(runner.run({
+      taskId: "prompt-budget",
+      prompt: "This request is deliberately longer than an eight token input budget.",
+    })).rejects.toBeInstanceOf(PromptContextLimitError);
+    expect(endpoint.requests).toHaveLength(0);
+  });
+});

--- a/MemoryCore/src/adapters/standalone/llm-capabilities.ts
+++ b/MemoryCore/src/adapters/standalone/llm-capabilities.ts
@@ -1,0 +1,345 @@
+import { tiktokenCount } from "../../offload/context-token-tracker.js";
+
+export type StandaloneLLMBackend = "openai-compatible" | "ollama" | "llama.cpp";
+
+export interface StandaloneLLMReasoningConfig {
+  /** Explicitly enable/disable thinking. Omit to preserve backend defaults. */
+  enabled?: boolean;
+  /** OpenAI/Ollama reasoning effort (for example: none, low, medium, high). */
+  effort?: string;
+  /** llama.cpp reasoning parser/format (for example: deepseek or none). */
+  format?: string;
+}
+
+export interface StandaloneLLMStartupProbeConfig {
+  /** Probe the model/backend during gateway startup. Defaults on for local backends. */
+  enabled?: boolean;
+  /** Refuse gateway startup rather than expose degraded health. */
+  strict?: boolean;
+  /** Probe timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+export interface StandaloneLLMCapabilityConfig {
+  backend?: StandaloneLLMBackend;
+  /** Operator-configured model context window. */
+  contextWindow?: number;
+  /** Optional tighter prompt budget; defaults to contextWindow - maxTokens. */
+  inputBudgetTokens?: number;
+  /** Explicit, provider-specific fields merged into /chat/completions requests. */
+  extraBody?: Record<string, unknown>;
+  reasoning?: StandaloneLLMReasoningConfig;
+  startupProbe?: StandaloneLLMStartupProbeConfig;
+  /** Populated from a successful startup probe; not read from config files. */
+  effectiveContextWindow?: number;
+}
+
+export interface LLMCapabilityStatus {
+  state: "ready" | "degraded" | "unchecked";
+  backend: StandaloneLLMBackend;
+  model: string;
+  configuredContextWindow?: number;
+  effectiveContextWindow?: number;
+  configuredInputBudgetTokens?: number;
+  effectiveInputBudgetTokens?: number;
+  reasoning: {
+    enabled?: boolean;
+    effort?: string;
+    format?: string;
+  };
+  /** Names only: values may contain private provider configuration. */
+  extraBodyKeys: string[];
+  detail: string;
+}
+
+export interface LLMProbeConfig extends StandaloneLLMCapabilityConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  maxTokens?: number;
+}
+
+const RESERVED_CHAT_FIELDS = new Set(["model", "messages", "stream"]);
+
+function positiveInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function nativeRoot(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
+}
+
+function safeExtraBody(config: StandaloneLLMCapabilityConfig): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config.extraBody ?? {})) {
+    if (!RESERVED_CHAT_FIELDS.has(key)) result[key] = value;
+  }
+  return result;
+}
+
+/** Apply only explicitly configured compatible-backend options to a chat request. */
+export function applyLlmRequestOptions(
+  body: Record<string, unknown>,
+  config: StandaloneLLMCapabilityConfig,
+): Record<string, unknown> {
+  const result = { ...body, ...safeExtraBody(config) };
+  const backend = config.backend ?? "openai-compatible";
+  const reasoning = config.reasoning;
+
+  if (backend === "llama.cpp") {
+    if (reasoning?.enabled !== undefined) {
+      const existing = result.chat_template_kwargs;
+      result.chat_template_kwargs = {
+        ...(existing && typeof existing === "object" && !Array.isArray(existing)
+          ? existing as Record<string, unknown>
+          : {}),
+        enable_thinking: reasoning.enabled,
+      };
+    }
+    if (reasoning?.format) result.reasoning_format = reasoning.format;
+  } else if (reasoning?.effort) {
+    result.reasoning_effort = reasoning.effort;
+  } else if (backend === "ollama" && reasoning?.enabled === false) {
+    // Ollama's OpenAI-compatible endpoint documents "none" as the disable value.
+    result.reasoning_effort = "none";
+  }
+
+  return result;
+}
+
+/** Fetch middleware used by the AI SDK compatible provider. */
+export function createLlmFetch(
+  config: StandaloneLLMCapabilityConfig,
+  fetchImpl: typeof fetch = fetch,
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (!url.match(/\/chat\/completions(?:\?|$)/) || typeof init?.body !== "string") {
+      return fetchImpl(input, init);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(init.body);
+    } catch {
+      return fetchImpl(input, init);
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return fetchImpl(input, init);
+    }
+    return fetchImpl(input, {
+      ...init,
+      body: JSON.stringify(applyLlmRequestOptions(parsed as Record<string, unknown>, config)),
+    });
+  }) as typeof fetch;
+}
+
+function effectiveBudget(config: LLMProbeConfig, effectiveContextWindow?: number): number | undefined {
+  const explicit = positiveInt(config.inputBudgetTokens);
+  if (explicit) return explicit;
+  const context = effectiveContextWindow ?? positiveInt(config.contextWindow);
+  return context ? Math.max(1, context - (positiveInt(config.maxTokens) ?? 4096)) : undefined;
+}
+
+function contextConfigurationError(
+  config: LLMProbeConfig,
+  effectiveContextWindow?: number,
+): string | undefined {
+  const context = effectiveContextWindow ?? positiveInt(config.contextWindow);
+  const maxTokens = positiveInt(config.maxTokens) ?? 4096;
+  if (context && !positiveInt(config.inputBudgetTokens) && maxTokens >= context) {
+    return `maxTokens ${maxTokens} leaves no input budget in context window ${context}`;
+  }
+  const explicitBudget = positiveInt(config.inputBudgetTokens);
+  if (context && explicitBudget && explicitBudget + maxTokens > context) {
+    return `inputBudgetTokens ${explicitBudget} + maxTokens ${maxTokens} exceeds context window ${context}`;
+  }
+  return undefined;
+}
+
+function baseStatus(config: LLMProbeConfig): LLMCapabilityStatus {
+  const effectiveContext = positiveInt(config.effectiveContextWindow);
+  return {
+    state: "unchecked",
+    backend: config.backend ?? "openai-compatible",
+    model: config.model,
+    configuredContextWindow: positiveInt(config.contextWindow),
+    effectiveContextWindow: effectiveContext,
+    configuredInputBudgetTokens: positiveInt(config.inputBudgetTokens),
+    effectiveInputBudgetTokens: effectiveBudget(config, effectiveContext),
+    reasoning: {
+      enabled: config.reasoning?.enabled,
+      effort: config.reasoning?.effort,
+      format: config.reasoning?.format,
+    },
+    extraBodyKeys: Object.keys(safeExtraBody(config)).sort(),
+    detail: "startup capability probe disabled",
+  };
+}
+
+async function fetchJson(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  fetchImpl: typeof fetch,
+): Promise<{ response: Response; json?: Record<string, unknown>; text: string }> {
+  const response = await fetchImpl(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  const text = await response.text();
+  let json: Record<string, unknown> | undefined;
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) json = parsed;
+  } catch {
+    // The status and a bounded, redacted diagnostic are enough below.
+  }
+  return { response, json, text };
+}
+
+function boundedDiagnostic(text: string): string {
+  return text.replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").slice(0, 240);
+}
+
+function parseOllamaContext(json: Record<string, unknown> | undefined): number | undefined {
+  if (!json) return undefined;
+  const parameters = typeof json.parameters === "string" ? json.parameters : "";
+  const paramMatch = parameters.match(/(?:^|\n)\s*num_ctx\s+(\d+)/);
+  if (paramMatch) return positiveInt(Number(paramMatch[1]));
+  const modelInfo = json.model_info;
+  if (modelInfo && typeof modelInfo === "object" && !Array.isArray(modelInfo)) {
+    for (const [key, value] of Object.entries(modelInfo as Record<string, unknown>)) {
+      if (key.endsWith(".context_length")) {
+        const parsed = positiveInt(value);
+        if (parsed) return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function parseLlamaContext(json: Record<string, unknown> | undefined): number | undefined {
+  const settings = json?.default_generation_settings;
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return undefined;
+  return positiveInt((settings as Record<string, unknown>).n_ctx);
+}
+
+/** Probe native local-backend endpoints and return only safe health metadata. */
+export async function probeLlmCapabilities(
+  config: LLMProbeConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<LLMCapabilityStatus> {
+  const status = baseStatus(config);
+  const enabled = config.startupProbe?.enabled ?? status.backend !== "openai-compatible";
+  if (!enabled) return status;
+
+  const timeoutMs = positiveInt(config.startupProbe?.timeoutMs) ?? 5_000;
+  try {
+    let effectiveContextWindow: number | undefined;
+    if (status.backend === "ollama") {
+      const result = await fetchJson(`${nativeRoot(config.baseUrl)}/api/show`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: config.model }),
+      }, timeoutMs, fetchImpl);
+      if (!result.response.ok) {
+        throw new Error(`Ollama /api/show returned HTTP ${result.response.status}`);
+      }
+      effectiveContextWindow = parseOllamaContext(result.json);
+    } else if (status.backend === "llama.cpp") {
+      const health = await fetchJson(`${nativeRoot(config.baseUrl)}/health`, {}, timeoutMs, fetchImpl);
+      if (!health.response.ok) {
+        throw new Error(`llama.cpp /health returned HTTP ${health.response.status}`);
+      }
+      const props = await fetchJson(`${nativeRoot(config.baseUrl)}/props`, {}, timeoutMs, fetchImpl);
+      if (!props.response.ok) {
+        throw new Error(`llama.cpp /props returned HTTP ${props.response.status}`);
+      }
+      effectiveContextWindow = parseLlamaContext(props.json);
+      if (!effectiveContextWindow) {
+        throw new Error("llama.cpp /props did not report default_generation_settings.n_ctx");
+      }
+      const caps = props.json?.chat_template_caps;
+      if (config.reasoning?.enabled !== undefined
+        && (!caps || typeof caps !== "object" || Array.isArray(caps))) {
+        throw new Error("llama.cpp /props did not report chat_template_caps required for reasoning control");
+      }
+    } else {
+      const models = await fetchJson(`${config.baseUrl.replace(/\/+$/, "")}/models`, {
+        headers: config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {},
+      }, timeoutMs, fetchImpl);
+      if (!models.response.ok) {
+        throw new Error(`OpenAI-compatible /models returned HTTP ${models.response.status}`);
+      }
+    }
+
+    status.state = "ready";
+    status.effectiveContextWindow = effectiveContextWindow ?? status.configuredContextWindow;
+    status.effectiveInputBudgetTokens = effectiveBudget(config, status.effectiveContextWindow);
+    const contextError = contextConfigurationError(config, status.effectiveContextWindow);
+    if (contextError) {
+      status.state = "degraded";
+      status.detail = `model ready but context configuration is incompatible: ${contextError}`;
+      return status;
+    }
+    status.detail = status.effectiveContextWindow
+      ? `model ready; effective context window ${status.effectiveContextWindow} tokens`
+      : "model endpoint ready; backend did not report a context window";
+    return status;
+  } catch (error) {
+    status.state = "degraded";
+    const message = error instanceof Error ? error.message : String(error);
+    const contextError = contextConfigurationError(config);
+    status.detail = `model/backend compatibility probe failed: ${boundedDiagnostic(message)}`
+      + (contextError ? `; context configuration is incompatible: ${contextError}` : "");
+    return status;
+  }
+}
+
+export class PromptContextLimitError extends Error {
+  readonly inputTokens: number;
+  readonly inputBudgetTokens: number;
+  readonly configuredContextWindow?: number;
+  readonly effectiveContextWindow?: number;
+
+  constructor(args: {
+    inputTokens: number;
+    inputBudgetTokens: number;
+    configuredContextWindow?: number;
+    effectiveContextWindow?: number;
+  }) {
+    super(
+      `LLM prompt requires ${args.inputTokens} tokens but effective input budget is `
+      + `${args.inputBudgetTokens} (configured context=${args.configuredContextWindow ?? "unknown"}, `
+      + `effective context=${args.effectiveContextWindow ?? "unknown"}); refusing silent truncation`,
+    );
+    this.name = "PromptContextLimitError";
+    this.inputTokens = args.inputTokens;
+    this.inputBudgetTokens = args.inputBudgetTokens;
+    this.configuredContextWindow = args.configuredContextWindow;
+    this.effectiveContextWindow = args.effectiveContextWindow;
+  }
+}
+
+/** Refuse requests which a configured/probed backend would silently truncate. */
+export function assertPromptWithinContext(
+  systemPrompt: string | undefined,
+  prompt: string,
+  config: StandaloneLLMCapabilityConfig,
+  maxOutputTokens: number,
+): number {
+  const context = positiveInt(config.effectiveContextWindow) ?? positiveInt(config.contextWindow);
+  const budget = positiveInt(config.inputBudgetTokens)
+    ?? (context ? Math.max(1, context - maxOutputTokens) : undefined);
+  const inputTokens = tiktokenCount(`${systemPrompt ?? ""}\n${prompt}`) + 8;
+  if (budget && inputTokens > budget) {
+    throw new PromptContextLimitError({
+      inputTokens,
+      inputBudgetTokens: budget,
+      configuredContextWindow: positiveInt(config.contextWindow),
+      effectiveContextWindow: context,
+    });
+  }
+  return inputTokens;
+}

--- a/MemoryCore/src/adapters/standalone/llm-capabilities.ts
+++ b/MemoryCore/src/adapters/standalone/llm-capabilities.ts
@@ -65,6 +65,16 @@ function positiveInt(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
+function boundedEffectiveContext(
+  config: LLMProbeConfig,
+  probedContextWindow?: number,
+): number | undefined {
+  const configured = positiveInt(config.contextWindow);
+  const probed = positiveInt(probedContextWindow);
+  if (configured && probed) return Math.min(configured, probed);
+  return configured ?? probed;
+}
+
 function nativeRoot(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "").replace(/\/v1$/i, "");
 }
@@ -275,7 +285,11 @@ export async function probeLlmCapabilities(
     }
 
     status.state = "ready";
-    status.effectiveContextWindow = effectiveContextWindow ?? status.configuredContextWindow;
+    // Native model metadata may advertise the training maximum rather than
+    // the operator/runtime cap (for example Ollama's model_info context
+    // length while OLLAMA_CONTEXT_LENGTH is lower). Never let a probe widen
+    // the configured safety boundary.
+    status.effectiveContextWindow = boundedEffectiveContext(config, effectiveContextWindow);
     status.effectiveInputBudgetTokens = effectiveBudget(config, status.effectiveContextWindow);
     const contextError = contextConfigurationError(config, status.effectiveContextWindow);
     if (contextError) {

--- a/MemoryCore/src/adapters/standalone/llm-runner.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.ts
@@ -29,6 +29,11 @@ import type {
   Logger,
 } from "../../core/types.js";
 import type { LLMUsage } from "../../core/report/metric-tracking-runner.js";
+import {
+  assertPromptWithinContext,
+  createLlmFetch,
+  type StandaloneLLMCapabilityConfig,
+} from "./llm-capabilities.js";
 
 const TAG = "[memory-tdai] [standalone-runner]";
 
@@ -77,7 +82,7 @@ function buildTelemetryMetadata(params: LLMRunParams): Record<string, unknown> {
 // Configuration
 // ============================
 
-export interface StandaloneLLMConfig {
+export interface StandaloneLLMConfig extends StandaloneLLMCapabilityConfig {
   /** OpenAI-compatible API base URL (e.g. "https://api.openai.com/v1"). */
   baseUrl: string;
   /** API key for authentication. */
@@ -298,6 +303,20 @@ export class StandaloneLLMRunner implements LLMRunner {
       `tools=${effectiveEnableTools}${callerProvidedTools ? "(caller)" : ""}, timeout=${timeoutMs}ms`,
     );
 
+    const inputTokens = assertPromptWithinContext(
+      params.systemPrompt,
+      params.prompt,
+      this.config,
+      maxTokens,
+    );
+    if (this.config.inputBudgetTokens || this.config.contextWindow || this.config.effectiveContextWindow) {
+      this.logger?.debug?.(
+        `${TAG} prompt context: input=${inputTokens}, configured=${this.config.contextWindow ?? "unknown"}, `
+        + `effective=${this.config.effectiveContextWindow ?? this.config.contextWindow ?? "unknown"}, `
+        + `budget=${this.config.inputBudgetTokens ?? "derived"}`,
+      );
+    }
+
     // Create OpenAI-compatible provider via AI SDK
     // Use "compatible" mode to call /chat/completions (not Responses API),
     // which works with all OpenAI-compatible backends (DeepSeek, Qwen, etc.)
@@ -305,6 +324,7 @@ export class StandaloneLLMRunner implements LLMRunner {
       baseURL: this.config.baseUrl,
       apiKey: this.config.apiKey,
       compatibility: "compatible",
+      fetch: createLlmFetch(this.config),
     });
 
     // Select tools based on mode + storage

--- a/MemoryCore/src/config.ts
+++ b/MemoryCore/src/config.ts
@@ -7,6 +7,8 @@
  * Minimal config (zero config): {} — all fields have sensible defaults.
  */
 
+import type { StandaloneLLMCapabilityConfig } from "./adapters/standalone/llm-capabilities.js";
+
 // ============================
 // Type definitions
 // ============================
@@ -199,7 +201,7 @@ export interface ReportConfig {
  *
  * Leave undefined (default) to use the host's native LLM mechanism.
  */
-export interface StandaloneLLMOverrideConfig {
+export interface StandaloneLLMOverrideConfig extends StandaloneLLMCapabilityConfig {
   /** Enable standalone LLM mode (default: false). When false, uses host LLM. */
   enabled: boolean;
   /** OpenAI-compatible API base URL (e.g. "https://api.openai.com/v1"). */
@@ -637,6 +639,8 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
     },
     llm: (() => {
       const llmGroup = obj(c, "llm");
+      const reasoningGroup = obj(llmGroup, "reasoning");
+      const startupProbeGroup = obj(llmGroup, "startupProbe");
       const rawProvider = str(llmGroup, "provider");
       const provider: "openai" | "proxy" =
         rawProvider === "proxy" ? "proxy" : "openai";
@@ -648,6 +652,23 @@ export function parseConfig(raw: Record<string, unknown> | undefined): MemoryTda
         model: str(llmGroup, "model") ?? "gpt-4o",
         maxTokens: num(llmGroup, "maxTokens") ?? 4096,
         timeoutMs: num(llmGroup, "timeoutMs") ?? 120_000,
+        backend: (() => {
+          const value = str(llmGroup, "backend");
+          return value === "ollama" || value === "llama.cpp" ? value : "openai-compatible";
+        })(),
+        contextWindow: num(llmGroup, "contextWindow"),
+        inputBudgetTokens: num(llmGroup, "inputBudgetTokens"),
+        extraBody: obj(llmGroup, "extraBody"),
+        reasoning: {
+          enabled: bool(reasoningGroup, "enabled"),
+          effort: str(reasoningGroup, "effort"),
+          format: str(reasoningGroup, "format"),
+        },
+        startupProbe: {
+          enabled: bool(startupProbeGroup, "enabled"),
+          strict: bool(startupProbeGroup, "strict") ?? false,
+          timeoutMs: num(startupProbeGroup, "timeoutMs") ?? 5_000,
+        },
         provider,
         stream: bool(llmGroup, "stream") ?? false,
         proxy: {

--- a/MemoryCore/src/gateway/config.llm-capabilities.test.ts
+++ b/MemoryCore/src/gateway/config.llm-capabilities.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadGatewayConfig } from "./config.js";
+
+const originalConfigPath = process.env.TDAI_GATEWAY_CONFIG;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  if (originalConfigPath === undefined) delete process.env.TDAI_GATEWAY_CONFIG;
+  else process.env.TDAI_GATEWAY_CONFIG = originalConfigPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("gateway local LLM configuration", () => {
+  it("loads and passes capability controls to memory runners", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "tdai-llm-config-"));
+    tempDirs.push(dir);
+    const configPath = path.join(dir, "gateway.yaml");
+    await fs.writeFile(configPath, `
+llm:
+  backend: llama.cpp
+  baseUrl: http://127.0.0.1:8080/v1
+  apiKey: local
+  model: qwen3.5-27b
+  maxTokens: 2048
+  contextWindow: 8192
+  inputBudgetTokens: 6000
+  reasoning:
+    enabled: false
+    format: none
+  startupProbe:
+    enabled: true
+    strict: true
+    timeoutMs: 3000
+  extraBody:
+    cache_prompt: true
+`, "utf8");
+    process.env.TDAI_GATEWAY_CONFIG = configPath;
+
+    const config = loadGatewayConfig();
+    expect(config.llm).toMatchObject({
+      backend: "llama.cpp",
+      contextWindow: 8192,
+      inputBudgetTokens: 6000,
+      reasoning: { enabled: false, format: "none" },
+      startupProbe: { enabled: true, strict: true, timeoutMs: 3000 },
+      extraBody: { cache_prompt: true },
+    });
+    expect(config.memory.llm).toMatchObject({
+      enabled: true,
+      backend: "llama.cpp",
+      contextWindow: 8192,
+      reasoning: { enabled: false, format: "none" },
+    });
+  });
+});

--- a/MemoryCore/src/gateway/config.ts
+++ b/MemoryCore/src/gateway/config.ts
@@ -444,15 +444,37 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
   //             见 src/gateway/llm-resolver.ts 的 resolveEffectiveLlmConfig。
   const llmConfig = obj(fileConfig, "llm");
   const llmProxyConfig = obj(llmConfig, "proxy");
+  const llmReasoningConfig = obj(llmConfig, "reasoning");
+  const llmStartupProbeConfig = obj(llmConfig, "startupProbe");
   const rawLlmProvider = env("TDAI_LLM_PROVIDER") ?? str(llmConfig, "provider");
   const llmProvider: "openai" | "proxy" =
     rawLlmProvider === "proxy" ? "proxy" : "openai";
+  const rawLlmBackend = env("TDAI_LLM_BACKEND") ?? str(llmConfig, "backend");
+  const backend = rawLlmBackend === "ollama" || rawLlmBackend === "llama.cpp"
+    ? rawLlmBackend
+    : "openai-compatible";
   const llm: StandaloneLLMConfig = {
     baseUrl: env("TDAI_LLM_BASE_URL") ?? str(llmConfig, "baseUrl") ?? "https://api.openai.com/v1",
     apiKey: env("TDAI_LLM_API_KEY") ?? str(llmConfig, "apiKey") ?? "",
     model: env("TDAI_LLM_MODEL") ?? str(llmConfig, "model") ?? "gpt-4o",
     maxTokens: envInt("TDAI_LLM_MAX_TOKENS") ?? num(llmConfig, "maxTokens") ?? 4096,
     timeoutMs: envInt("TDAI_LLM_TIMEOUT_MS") ?? num(llmConfig, "timeoutMs") ?? 120_000,
+    backend,
+    contextWindow: envInt("TDAI_LLM_CONTEXT_WINDOW") ?? num(llmConfig, "contextWindow"),
+    inputBudgetTokens: envInt("TDAI_LLM_INPUT_BUDGET_TOKENS") ?? num(llmConfig, "inputBudgetTokens"),
+    extraBody: obj(llmConfig, "extraBody"),
+    reasoning: {
+      enabled: envBool("TDAI_LLM_REASONING_ENABLED") ?? bool(llmReasoningConfig, "enabled"),
+      effort: env("TDAI_LLM_REASONING_EFFORT") ?? str(llmReasoningConfig, "effort"),
+      format: env("TDAI_LLM_REASONING_FORMAT") ?? str(llmReasoningConfig, "format"),
+    },
+    startupProbe: {
+      enabled: envBool("TDAI_LLM_STARTUP_PROBE") ?? bool(llmStartupProbeConfig, "enabled"),
+      strict: envBool("TDAI_LLM_STARTUP_PROBE_STRICT") ?? bool(llmStartupProbeConfig, "strict") ?? false,
+      timeoutMs: envInt("TDAI_LLM_STARTUP_PROBE_TIMEOUT_MS")
+        ?? num(llmStartupProbeConfig, "timeoutMs")
+        ?? 5_000,
+    },
     provider: llmProvider,
     proxy: {
       useMemorySystemUserKey: bool(llmProxyConfig, "useMemorySystemUserKey") ?? true,
@@ -488,16 +510,10 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
     !memory.llm.enabled && llm.baseUrl && (llm.apiKey || llm.provider === "proxy");
   if (shouldSpliceLlm) {
     memory.llm = {
+      ...llm,
       enabled: true,
-      baseUrl: llm.baseUrl,
-      apiKey: llm.apiKey,
-      model: llm.model,
       maxTokens: llm.maxTokens ?? 4096,
       timeoutMs: llm.timeoutMs ?? 120_000,
-      provider: llm.provider,
-      proxy: {
-        useMemorySystemUserKey: llm.proxy?.useMemorySystemUserKey ?? true,
-      },
     };
   }
 
@@ -829,6 +845,13 @@ function envInt(key: string): number | undefined {
   if (!v) return undefined;
   const n = parseInt(v, 10);
   return Number.isFinite(n) ? n : undefined;
+}
+
+function envBool(key: string): boolean | undefined {
+  const v = env(key)?.toLowerCase();
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  return undefined;
 }
 
 function obj(c: Record<string, unknown>, key: string): Record<string, unknown> {

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -78,6 +78,12 @@ import type { MemorySystemUserConfig } from "../metadata/system-user.js";
 import { validateLlmProviderConfig, LlmResolveError } from "./llm-resolver.js";
 import type { StandaloneLLMConfig } from "../adapters/standalone/llm-runner.js";
 import { resolveStandaloneLlmForRuntime } from "../adapters/standalone/llm-provider-resolver.js";
+import {
+  applyLlmRequestOptions,
+  assertPromptWithinContext,
+  probeLlmCapabilities,
+  type LLMCapabilityStatus,
+} from "../adapters/standalone/llm-capabilities.js";
 import { resolveReportedCredit } from "./quota-credit-policy.js";
 import {
   initApiTraceConfig,
@@ -284,6 +290,14 @@ export class TdaiGateway {
   private startTime = Date.now();
   /** Guards against concurrent / repeated stop() invocations (e.g. multiple SIGINT). */
   private stopPromise: Promise<void> | null = null;
+  private llmCapabilityStatus: LLMCapabilityStatus = {
+    state: "unchecked",
+    backend: "openai-compatible",
+    model: "unknown",
+    reasoning: {},
+    extraBodyKeys: [],
+    detail: "gateway has not started",
+  };
 
   // ── Integrated services (Scanner + Worker) ──
   private stateBackend: IStateBackend | null = null;
@@ -505,6 +519,21 @@ export class TdaiGateway {
         throw new Error(`[LLM] provider 配置校验失败: ${err.message}`);
       }
       throw err;
+    }
+
+    this.llmCapabilityStatus = await probeLlmCapabilities(this.config.llm);
+    if (this.llmCapabilityStatus.effectiveContextWindow) {
+      this.config.llm.effectiveContextWindow = this.llmCapabilityStatus.effectiveContextWindow;
+      this.config.memory.llm.effectiveContextWindow = this.llmCapabilityStatus.effectiveContextWindow;
+    }
+    const llmSummary = `${this.llmCapabilityStatus.state}: ${this.llmCapabilityStatus.detail}`;
+    if (this.llmCapabilityStatus.state === "degraded") {
+      this.logger.warn(`[LLM] ${llmSummary}`);
+      if (this.config.llm.startupProbe?.strict) {
+        throw new Error(`[LLM] strict startup capability probe failed: ${this.llmCapabilityStatus.detail}`);
+      }
+    } else {
+      this.logger.info(`[LLM] ${llmSummary}`);
     }
 
     const metadataStoreCfg = validateMetadataStartupConfig(
@@ -1373,14 +1402,16 @@ export class TdaiGateway {
   }
 
   private handleHealth(res: http.ServerResponse): void {
+    const vectorReady = !!this.core.getVectorStore();
     const response: HealthResponse = {
-      status: this.core.getVectorStore() ? "ok" : "degraded",
+      status: vectorReady && this.llmCapabilityStatus.state !== "degraded" ? "ok" : "degraded",
       version: VERSION,
       uptime: Math.floor((Date.now() - this.startTime) / 1000),
       stores: {
-        vectorStore: !!this.core.getVectorStore(),
+        vectorStore: vectorReady,
         embeddingService: !!this.core.getEmbeddingService(),
       },
+      llm: this.llmCapabilityStatus,
       // Integrated services status
       services: {
         timerScanner: this.timerScanner?.getMetrics() ?? null,
@@ -1992,13 +2023,7 @@ export class TdaiGateway {
     );
 
     const llmRunner = new StandaloneLLMRunner({
-      config: {
-        baseUrl: effective.baseUrl,
-        apiKey: effective.apiKey,
-        model: effective.model ?? "default",
-        timeoutMs: effective.timeoutMs ?? 120_000,
-        stream: effective.stream ?? false,
-      },
+      config: { ...effective },
     });
     const cfg = this.core.getResolvedSkillConfig();
     return new SkillExtractorClass({
@@ -2979,18 +3004,28 @@ export class TdaiGateway {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), params.timeoutMs ?? 30000);
         try {
+          const systemPrompt = params.messages
+            .filter((message) => message.role === "system")
+            .map((message) => message.content)
+            .join("\n");
+          const prompt = params.messages
+            .filter((message) => message.role === "user")
+            .map((message) => message.content)
+            .join("\n");
+          assertPromptWithinContext(systemPrompt, prompt, effective, params.max_tokens);
+          const requestBody = applyLlmRequestOptions({
+            model: effective.model || params.model,
+            messages: params.messages,
+            temperature: params.temperature,
+            max_tokens: params.max_tokens,
+          }, effective);
           const response = await fetch(`${effective.baseUrl}/chat/completions`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
               Authorization: `Bearer ${effective.apiKey}`,
             },
-            body: JSON.stringify({
-              model: effective.model || params.model,
-              messages: params.messages,
-              temperature: params.temperature,
-              max_tokens: params.max_tokens,
-            }),
+            body: JSON.stringify(requestBody),
             signal: controller.signal,
           });
           clearTimeout(timer);

--- a/MemoryCore/src/gateway/types.ts
+++ b/MemoryCore/src/gateway/types.ts
@@ -2,6 +2,8 @@
  * TDAI Gateway — Request/Response types for the HTTP API.
  */
 
+import type { LLMCapabilityStatus } from "../adapters/standalone/llm-capabilities.js";
+
 // ============================
 // Common
 // ============================
@@ -23,6 +25,8 @@ export interface HealthResponse {
     vectorStore: boolean;
     embeddingService: boolean;
   };
+  /** Safe LLM/model compatibility state; never includes credentials or option values. */
+  llm: LLMCapabilityStatus;
   /** Integrated services status (only present when state_backend is configured) */
   services?: {
     timerScanner: unknown;

--- a/MemoryCore/tdai-gateway.standalone.yaml
+++ b/MemoryCore/tdai-gateway.standalone.yaml
@@ -17,11 +17,22 @@ data:
 
 # ── LLM (必填) ──
 llm:
+  # For local servers, set backend to "ollama" or "llama.cpp" to enable
+  # native startup/model probes and effective context reporting in /health.
+  backend: "openai-compatible"
   baseUrl: "https://api.openai.com/v1"
   apiKey: "${TDAI_LLM_API_KEY}"    # 通过环境变量注入
   model: "gpt-4o"
   maxTokens: 4096
   timeoutMs: 120000
+  # contextWindow: 8192
+  # inputBudgetTokens: 6144
+  # reasoning:
+  #   enabled: false
+  # startupProbe:
+  #   enabled: true
+  #   strict: true
+  #   timeoutMs: 5000
 
 # ── Memory 引擎配置 ──
 memory:


### PR DESCRIPTION
## Summary
- add explicit `ollama` and `llama.cpp` standalone backend profiles with native startup probes
- expose safe configured/effective context limits and model readiness in `/health`
- refuse oversized prompts before a compatible backend can silently truncate them
- support explicit reasoning/Jinja and provider-specific request body controls without runner edits
- preserve all new controls across gateway, memory, skill-extractor, and offload call paths

## Verification
- `npm test` (5 tests: Ollama and llama.cpp HTTP integrations, failed-model redaction, prompt budget, YAML pass-through)
- `npm run build:plugin`
- `git diff --check`

Tracks downstream CDB issue gavinlouuu-kpt/codex-discord-bridge#248.