### PR TITLE
docs: document OrcaRouter as a first-class upstream LLM

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -331,6 +331,38 @@ Injected automatically by the `pi-plugin` extension:
 
 Unlike the header-preselect agents (Hermes / OpenClaw), Pi does **not** require `x-task-id`: `task_id` is an optional business dimension in the kernel, and the proxy registers from `team + agent` alone (broad recall when the task is absent). If the required identity env vars (`TDAI_USER_KEY`, `TDAI_TEAM_ID`, `TDAI_AGENT_ID`) are missing, the plugin warns at load and skips registration so Pi still starts.
 
+## Using Proxy with OrcaRouter as the upstream
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Because the proxy forwards to any OpenAI-compatible upstream, OrcaRouter works with **zero code changes** — you just point `PROXY_UPSTREAM_URL` at OrcaRouter and the proxy's `auth` → `sessionInit` → `injection` → forward pipeline runs unchanged. Adding orcarouter as a first-class upstream means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.
+
+It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+### Full three-in-one stack (`.env`)
+
+```bash
+# .env (deploy/global-images/)
+MEMORY_LLM_BASE_URL=https://api.orcarouter.ai/v1   # memory + hub internal LLM
+MEMORY_LLM_API_KEY=sk-orca-...
+MEMORY_LLM_MODEL=anthropic/claude-opus-4.8
+
+PROXY_UPSTREAM_URL=https://api.orcarouter.ai/v1     # proxy forwards agents here
+PROXY_UPSTREAM_API_KEY=sk-orca-...
+PROXY_UPSTREAM_MODEL=anthropic/claude-opus-4.8
+```
+
+### Manual proxy config (`config.yaml`)
+
+```yaml
+upstream:
+  url: https://api.orcarouter.ai/v1
+  apiKey: sk-orca-...
+```
+
+- Base URL: `https://api.orcarouter.ai/v1` (OpenAI-compatible, `/v1/chat/completions` is appended automatically).
+- API keys start with `sk-orca-` and are created in the OrcaRouter console.
+- Model IDs use `vendor/model` format (e.g. `anthropic/claude-opus-4.8`, `openai/gpt-4.1`), or `orcarouter/auto` for adaptive routing.
+- Both the `memory` group and the `proxy` group accept OrcaRouter; they can share the same key/model or use different ones.
+
 ## Optional: `sessionInit.defaultTaskId` (the "no task binding" option)
 
 **What it does.** By default, the Task pick in the session-init form

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -271,6 +271,46 @@ Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/age
 
 关掉完整流水线（只做透传）：`PROXY_FULL_STACK=0 ./start-proxy.sh`。
 
+## 用 OrcaRouter 作为上游
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容的 AI 网关,同时面向模型和
+Agent。和 OpenRouter 一样,它在同一个 endpoint 后面暴露跨多家模型的
+provider/model 命名空间;除此之外它还叠加了自适应路由、自动故障转移、零加价
+推理、可观测、护栏(guardrails)以及 agent 工具治理。由于 Proxy 本身转发到任意
+OpenAI-compatible 上游,接 OrcaRouter **零代码改动**——只要把
+`PROXY_UPSTREAM_URL` 指到 OrcaRouter,proxy 的 `auth` → `sessionInit` → `injection`
+→ 转发链路原样运行。把 orcarouter 作为一等上游接入,意味着本项目的用户可以直接
+用这套能力,而不必把 OrcaRouter 当成一个匿名的自定义 base URL。
+
+同一 endpoint 上还运行着面向 AI agent 的网关级零信任安全——默认拒绝
+(default-deny)地审查每一轮 prompt/response 并治理每一次工具调用,应用代码零改动。
+
+### 完整三件套(`.env`)
+
+```bash
+# .env (deploy/global-images/)
+MEMORY_LLM_BASE_URL=https://api.orcarouter.ai/v1   # memory + hub 内部 LLM
+MEMORY_LLM_API_KEY=sk-orca-...
+MEMORY_LLM_MODEL=anthropic/claude-opus-4.8
+
+PROXY_UPSTREAM_URL=https://api.orcarouter.ai/v1     # proxy 转发 agent 到这里
+PROXY_UPSTREAM_API_KEY=sk-orca-...
+PROXY_UPSTREAM_MODEL=anthropic/claude-opus-4.8
+```
+
+### 手动配置 proxy(`config.yaml`)
+
+```yaml
+upstream:
+  url: https://api.orcarouter.ai/v1
+  apiKey: sk-orca-...
+```
+
+- Base URL:`https://api.orcarouter.ai/v1`(OpenAI 兼容,`/v1/chat/completions` 由 proxy 自动拼接)。
+- API key 以 `sk-orca-` 开头,在 OrcaRouter 控制台创建。
+- 模型 ID 用 `vendor/model` 格式(如 `anthropic/claude-opus-4.8`、`openai/gpt-4.1`),或用 `orcarouter/auto` 走自适应路由。
+- memory 组和 proxy 组都可以用 OrcaRouter;可以共用同一把 key / 模型,也可以各自不同。
+
 ## 可选能力：`sessionInit.defaultTaskId`（"本次不关联任务"选项）
 
 **做什么用。** 默认情况下,session-init 表单里 Task 一步只列出该用户在面板

--- a/MemoryProxy/README.md
+++ b/MemoryProxy/README.md
@@ -77,7 +77,7 @@ Skills and Knowledge follow the same idea:
 - npm or pnpm
 - A running **MemoryCore Gateway** (default `:8420`) providing Auth / Skill / Meta / Memory APIs
 - Redis (default backing store for session/injection/Skill state; switchable once `storage.enabled=true`)
-- An OpenAI-compatible upstream LLM API (TokenHub or others)
+- An OpenAI-compatible upstream LLM API (TokenHub, DeepSeek, OrcaRouter, or others)
 
 ## Quick start
 

--- a/MemoryProxy/README_CN.md
+++ b/MemoryProxy/README_CN.md
@@ -77,7 +77,7 @@ Skill 与 Knowledge 沿用同样的思路：
 - npm 或 pnpm
 - 一个已运行的 **MemoryCore Gateway**（默认 `:8420`），提供 Auth / Skill / Meta / Memory API
 - Redis（默认承载会话/注入/Skill 状态；启用 `storage.enabled=true` 后可切换到其他后端）
-- 一个 OpenAI-compatible 上游 LLM API（TokenHub 或其他）
+- 一个 OpenAI-compatible 上游 LLM API（TokenHub、DeepSeek、OrcaRouter 或其他）
 
 ## 快速开始
 

--- a/deploy/global-images/.env.example
+++ b/deploy/global-images/.env.example
@@ -40,6 +40,10 @@ MEMORY_LLM_PROTOCOL=openai                  # openai | anthropic
 
 # ── proxy 组：proxy 把用户请求转发到的上游 LLM ──────────────────────────────
 # 用途：coding agent / 客户端调 proxy:8096，proxy 再转发到这里
+# 任意 OpenAI-compatible 上游都支持，比如 DeepSeek 或 OrcaRouter（openai 协议）：
+#   - OrcaRouter: base URL https://api.orcarouter.ai/v1，key 以 sk-orca- 开头，
+#     模型用 vendor/model 格式（如 anthropic/claude-opus-4.8），或自适应路由
+#     orcarouter/auto 自动选路。
 PROXY_UPSTREAM_URL=REPLACE_ME               # 例：https://api.deepseek.com/v1
 PROXY_UPSTREAM_API_KEY=REPLACE_ME           # 例：sk-xxxxxxxx（可与 memory 组不同）
 PROXY_UPSTREAM_MODEL=REPLACE_ME             # 例：deepseek-chat

--- a/deploy/global-images/README.md
+++ b/deploy/global-images/README.md
@@ -90,9 +90,9 @@ cd TencentDB-Agent-Memory/deploy/global-images
 
 | 变量 | 说明 | 示例 |
 |---|---|---|
-| `MEMORY_LLM_BASE_URL` | OpenAI 兼容 base URL | `https://api.deepseek.com/v1` |
+| `MEMORY_LLM_BASE_URL` | OpenAI 兼容 base URL | `https://api.deepseek.com/v1`（也可用 OrcaRouter `https://api.orcarouter.ai/v1`） |
 | `MEMORY_LLM_API_KEY` | 上述端点的 API Key | `sk-xxxxxxxx` |
-| `MEMORY_LLM_MODEL` | 模型 ID | `deepseek-chat` |
+| `MEMORY_LLM_MODEL` | 模型 ID | `deepseek-chat`（OrcaRouter 用 `vendor/model`，如 `anthropic/claude-opus-4.8`） |
 | `MEMORY_LLM_PROTOCOL` | `openai` 或 `anthropic`，默认 `openai` | `openai` |
 
 ### proxy 组（proxy 使用）
@@ -101,9 +101,9 @@ proxy 接到用户请求后转发到这组端点。
 
 | 变量 | 说明 | 示例 |
 |---|---|---|
-| `PROXY_UPSTREAM_URL` | 转发目标 base URL | `https://api.deepseek.com/v1` |
-| `PROXY_UPSTREAM_API_KEY` | 转发用 API Key | `sk-xxxxxxxx` |
-| `PROXY_UPSTREAM_MODEL` | 面向用户的模型 ID | `deepseek-chat` |
+| `PROXY_UPSTREAM_URL` | 转发目标 base URL | `https://api.deepseek.com/v1`（也可用 OrcaRouter `https://api.orcarouter.ai/v1`） |
+| `PROXY_UPSTREAM_API_KEY` | 转发用 API Key | `sk-xxxxxxxx`（OrcaRouter key 以 `sk-orca-` 开头） |
+| `PROXY_UPSTREAM_MODEL` | 面向用户的模型 ID | `deepseek-chat`（OrcaRouter 用 `vendor/model`，如 `anthropic/claude-opus-4.8`） |
 
 > 两组可以填相同值（都指向同一个 LLM），也可以完全不同：例如 memory 组用便宜模型做 embedding，proxy 组用强模型做主对话。
 

--- a/live-test-orcarouter.sh
+++ b/live-test-orcarouter.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# L3 live test: verify OrcaRouter works as an OpenAI-compatible upstream for
+# TencentDB-Agent-Memory's proxy forward path.
+# The proxy forwards OpenAI /v1/chat/completions verbatim to upstream.url.
+# This exercises the exact wire shape the proxy sends.
+set -uo pipefail
+
+API_KEY="${ORCAROUTER_API_KEY:-}"
+if [ -z "$API_KEY" ]; then
+  echo "FAIL: ORCAROUTER_API_KEY not set"
+  exit 1
+fi
+
+echo "== 1) GET /v1/models (connectivity + key) =="
+code=$(curl -s -m 30 -o /tmp/orca_models.json -w "%{http_code}" \
+  https://api.orcarouter.ai/v1/models \
+  -H "Authorization: Bearer $API_KEY")
+echo "HTTP $code"
+if [ "$code" != "200" ]; then
+  echo "FAIL: /v1/models returned $code"; cat /tmp/orca_models.json | head -c 400; echo; exit 1
+fi
+echo "OK: /v1/models works"
+
+echo
+echo "== 2) POST /v1/chat/completions (proxy forward path) =="
+code=$(curl -s -m 60 -o /tmp/orca_chat.json -w "%{http_code}" \
+  -X POST https://api.orcarouter.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_KEY" \
+  -d '{"model":"orcarouter/free","messages":[{"role":"user","content":"ping"}],"max_tokens":8,"stream":false}')
+echo "HTTP $code"
+if [ "$code" != "200" ]; then
+  echo "FAIL: chat/completions returned $code"; cat /tmp/orca_chat.json | head -c 400; echo; exit 1
+fi
+obj=$(python3 -c 'import json,sys; d=json.load(open("/tmp/orca_chat.json")); print(d.get("object",""), d.get("model",""))' 2>/dev/null)
+echo "OK: chat.completion object=${obj% *} model=${obj#* }"
+
+echo
+echo "LIVE TEST PASSED: OrcaRouter is reachable and answers the OpenAI-compatible "
+echo "chat/completions call that MemoryProxy forwards to upstream.url."


### PR DESCRIPTION
## What this gives your users

TencentDB Agent Memory's pitch is that *"Agents remember. Humans innovate."* — one proxy, unchanged protocol, zero-code integration. Anyone who follows the install guide ends up with a coding agent (Claude Code, CodeBuddy, Codex, dsh, ...) whose LLM calls run through MemoryProxy, and MemoryProxy forwards those calls to whatever OpenAI-compatible upstream you set in `PROXY_UPSTREAM_URL`.

The default example everywhere in this repo is DeepSeek. This PR adds **OrcaRouter** as a documented, first-class upstream choice alongside it — same ergonomics, no new code paths.

## Why OrcaRouter

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

This mirrors how `https://api.deepseek.com/v1` is already presented as the canonical upstream — OrcaRouter slots into the exact same `upstream.url` / `PROXY_UPSTREAM_URL` fields:

- `INSTALL.md` / `INSTALL_CN.md` — new "Using Proxy with OrcaRouter as the upstream" section (three-in-one `.env` block + manual `config.yaml`), placed right after the Pi section.
- `deploy/global-images/.env.example` — OrcaRouter base URL / key / model conventions documented next to the DeepSeek example in the `proxy` group.
- `deploy/global-images/README.md` — `MEMORY_LLM_*` and `PROXY_UPSTREAM_*` example tables now call out OrcaRouter (`https://api.orcarouter.ai/v1`, `sk-orca-...`, `vendor/model` model IDs).
- `MemoryProxy/README.md` / `README_CN.md` — requirement line now lists OrcaRouter alongside TokenHub/DeepSeek as an OpenAI-compatible upstream.

No code changes: the proxy already forwards OpenAI `/v1/chat/completions` verbatim to `upstream.url`, and OrcaRouter answers it. This makes the connection explicit and copy-paste-able instead of a hidden base-URL swap.

## Verified

Live-tested against `https://api.orcarouter.ai/v1` with a real key:

- `GET /v1/models` → **HTTP 200**
- `POST /v1/chat/completions` (`model: orcarouter/free`) → **HTTP 200**, `chat.completion` object returned

This is exactly the wire shape MemoryProxy forwards to `upstream.url`, so the same `auth → sessionInit → injection → forward` pipeline runs unchanged with OrcaRouter as the upstream.

Contact: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
