### PR TITLE
fix(global-images): quote model variable in LLM check

### DIFF
--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -178,7 +178,7 @@ check_llm_openai() {
     if grep -q "\"$model\"" "$body_file" 2>/dev/null; then
       ok "$label OpenAI 协议通路 OK（$model 在 /models 列表内）"
     else
-      ok "$label OpenAI 协议通路 OK（未在 /models 里显式列出 $model，业务侧仍可能可用）"
+      ok "$label OpenAI 协议通路 OK（未在 /models 里显式列出 ${model}，业务侧仍可能可用）"
     fi
   elif [[ "$code" == "401" || "$code" == "403" ]]; then
     warn "$label API key 无效（HTTP ${code}）：$url"


### PR DESCRIPTION
## Summary

Fixes the interactive `start-all.sh` LLM connectivity check under UTF-8 locales by using `${model}` before full-width Chinese punctuation.

Without braces, Bash with `set -u` can parse the punctuation as part of the variable name when the configured model is absent from the OpenAI `/models` response, terminating the startup flow with an unbound-variable error.

## Validation

- Reproduced the original failure using a mocked HTTP 200 `/models` response without the configured model.
- Re-ran the same reproduction after the change; it completes successfully.
- Ran `bash -n deploy/global-images/_lib.sh deploy/global-images/start-all.sh`.

Closes #1191.