### PR TITLE
[good first issue-platform adapt-Obsidian Copilot] Add Memory adapter for Obsidian Copilot

### DIFF
--- a/adapters/obsidian-copilot/README.md
+++ b/adapters/obsidian-copilot/README.md
@@ -1,0 +1,86 @@
+# TencentDB Agent Memory — Obsidian Copilot Adapter
+
+Give [Obsidian Copilot](https://github.com/logancyang/obsidian-copilot) persistent team memory. This adapter routes the plugin's LLM traffic through the TencentDB Agent Memory proxy, so every conversation automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Obsidian Copilot ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                                 │
+                                                 ├─ auth        (validates sk-mem-... user_key)
+                                                 ├─ sessionInit (Team/Agent/Task picker)
+                                                 └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Obsidian Copilot's **BYOK** (bring your own key) settings support adding a **custom provider** backed by any OpenAI-compatible endpoint — the plugin drives it with a generic OpenAI chat client that appends `/chat/completions` to the configured Base URL ([official LLM providers docs](https://github.com/logancyang/obsidian-copilot/blob/master/docs/llm-providers.md)). Pointing that Base URL at the proxy's `/codebuddy/<spaceId>/v1` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. The [Obsidian Copilot](https://github.com/logancyang/obsidian-copilot) plugin is installed in your vault (Community Plugins → Browse → "Copilot").
+
+## Setup
+
+### 1. Add the proxy as a custom provider
+
+1. Open Obsidian → **Settings → Copilot → BYOK**.
+2. Click **Add a provider** and choose **Add a custom provider**.
+3. Fill in:
+   - **Base URL**: `http://127.0.0.1:8096/codebuddy/default/v1` — replace `default` with your memory space ID if you use another space. Keep the trailing `/v1`: the plugin's OpenAI client appends `/chat/completions` to the Base URL, which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route.
+   - **API key**: your business user key (`sk-mem-...`).
+4. For the model, enter your proxy's `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) as an exact model ID. Model discovery queries `<Base URL>/models`; if your proxy deployment does not serve the model-list endpoint, type the model ID directly instead of relying on discovery.
+5. Click **Test**, then **Save**.
+
+### 2. Enable the model for chat
+
+New models are enabled for Quick Chat by default; verify under **Settings → Copilot → Basic → Agents → Quick Chat** that the proxy model appears and, if you use it often, set it as the **Default model**.
+
+### 3. Verify
+
+1. Open the Copilot chat pane, pick the proxy model, and send a first message.
+2. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask Copilot what it remembers from previous conversations to confirm.
+
+## Configuration reference
+
+| Field | Value | Notes |
+|---|---|---|
+| Base URL | `http://127.0.0.1:8096/codebuddy/default/v1` | Proxy endpoint; `default` is the memory space ID — change it per space; **keep** the trailing `/v1` |
+| API key | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| Model ID | `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) | Must equal the proxy's upstream model, otherwise the proxy rejects with an upstream mismatch |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| Test succeeds but Quick Chat cannot send a message | Obsidian's renderer applies browser CORS rules — edit the provider and turn on **Enable CORS** (responses then arrive after completion instead of streaming) |
+| Model discovery finds nothing | Enter the exact model ID manually — discovery needs the `/models` listing endpoint, which the proxy does not require |
+| Empty AI responses / upstream mismatch | Model name differs from `PROXY_UPSTREAM_MODEL` — align them |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new chat to re-pick |
+
+## Notes
+
+- **Vault-local config**: the provider and key live only in your Obsidian plugin settings (`data.json` of the vault), never in a committed file; this adapter therefore ships docs only (same as the LobeChat / Open WebUI / LibreChat adapters).
+- **All chats flow through it**: every chat (and agent feature) that uses the configured model gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/obsidian-copilot/README_CN.md
+++ b/adapters/obsidian-copilot/README_CN.md
@@ -1,0 +1,86 @@
+# TencentDB Agent Memory — Obsidian Copilot 适配器
+
+为 [Obsidian Copilot](https://github.com/logancyang/obsidian-copilot) 装上持久团队记忆。本适配器把插件的 LLM 流量路由到 TencentDB Agent Memory 代理，每段对话自动获得：
+
+- **会话绑定** —— 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** —— 绑定 Agent 的 L2/L3 记忆、技能与知识在每一轮混入系统提示词
+- **自动沉淀** —— L0 原始对话写入 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Obsidian Copilot ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游 LLM
+                                                 │
+                                                 ├─ auth        (校验 sk-mem-... user_key)
+                                                 ├─ sessionInit (Team/Agent/Task 选择器)
+                                                 └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+Obsidian Copilot 的 **BYOK**（自带密钥）设置支持添加**自定义 provider**，可对接任意 OpenAI 兼容端点——插件使用通用 OpenAI 聊天客户端，会在所配置的 Base URL 后拼接 `/chat/completions`（见[官方 LLM Providers 文档](https://github.com/logancyang/obsidian-copilot/blob/master/docs/llm-providers.md)）。把 Base URL 指向代理的 `/codebuddy/<spaceId>/v1` 端点即可接入——**无需改任何代码**。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 选择器）、**记忆注入**（绑定 Agent 的 L2/L3 记忆、技能与知识每轮混入系统提示词）与**自动沉淀**（L0 原始对话写入 memory-core）全部开箱即用。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 你持有业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）中创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. Vault 中已安装 [Obsidian Copilot](https://github.com/logancyang/obsidian-copilot) 插件（第三方插件 → 浏览 → "Copilot"）。
+
+## 配置步骤
+
+### 1. 把代理添加为自定义 provider
+
+1. 打开 Obsidian → **Settings → Copilot → BYOK**。
+2. 点击 **Add a provider**，选择 **Add a custom provider**。
+3. 填写：
+   - **Base URL**：`http://127.0.0.1:8096/codebuddy/default/v1` —— 若使用其他记忆空间，把 `default` 换成对应 spaceId。**保留末尾 `/v1`**：插件的 OpenAI 客户端会在 Base URL 后追加 `/chat/completions`，正好落在代理的 `/codebuddy/<spaceId>/v1/chat/completions` 路由上。
+   - **API key**：业务用户密钥（`sk-mem-...`）。
+4. 模型处直接输入代理的 `PROXY_UPSTREAM_MODEL` 值（如 `claude-sonnet-4-20250514`)作为确切 model ID。模型发现会请求 `<Base URL>/models`；若你的代理部署未提供模型列表端点，请直接手填 model ID，不要依赖发现列表。
+5. 点击 **Test**，再点 **Save**。
+
+### 2. 为聊天启用该模型
+
+新模型默认对 Quick Chat 启用；在 **Settings → Copilot → Basic → Agents → Quick Chat** 中确认代理模型已出现，常用的话可设为 **Default model**。
+
+### 3. 验证
+
+1. 打开 Copilot 聊天面板，选择代理模型，发送第一条消息。
+2. 代理在聊天交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从这一轮起，绑定 Agent 的记忆自动注入。向 Copilot 询问之前对话记得什么即可确认。
+
+## 配置速查
+
+| 字段 | 值 | 说明 |
+|---|---|---|
+| Base URL | `http://127.0.0.1:8096/codebuddy/default/v1` | 代理端点；`default` 为记忆空间 ID，按空间替换；**保留**末尾 `/v1` |
+| API key | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+| Model ID | `PROXY_UPSTREAM_MODEL` 的值（如 `claude-sonnet-4-20250514`） | 必须与代理上游模型一致，否则代理以上游不匹配为由拒绝 |
+
+## 故障排查
+
+| 症状 | 原因 / 解决 |
+|---|---|
+| `401` / "Invalid API Key" | 必须使用 Panel 的业务用户密钥（`sk-mem-...`），不能用 `./.admin-key` 的管理员密钥 |
+| Test 成功但 Quick Chat 发不出消息 | Obsidian 渲染进程遵循浏览器 CORS 规则——编辑该 provider 并开启 **Enable CORS**（响应将整体返回而非逐 token 流式） |
+| 模型发现为空 | 手动输入确切 model ID——发现依赖 `/models` 列表端点，而代理并不要求实现它 |
+| AI 回复为空 / 上游不匹配 | 模型名与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行——检查 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 会话选择器未出现 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动设置）；若前一会话已绑定任务，绑定会被复用——新开聊天即可重新选择 |
+
+## 说明
+
+- **配置仅存于本地**：provider 与密钥只保存在你 Obsidian 插件设置（vault 的 `data.json`）中，不进入任何提交文件；因此本适配器只包含文档（与 LobeChat / Open WebUI / LibreChat 适配器一致）。
+- **全部聊天经过代理**：所有使用该配置模型的聊天（含 agent 功能）都会获得记忆注入。
+- **数据流**：仅提示词/补全流经代理；记忆数据保留在本地 SQLite（memory-core）中，除非你另行配置。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What this PR adds

An adapter that connects [Obsidian Copilot](https://github.com/logancyang/obsidian-copilot) (the AI assistant plugin for Obsidian) to the TencentDB Agent Memory proxy — persistent team memory for note-driven workflows, with **no code changes required**.

Once connected, every Copilot chat gets:

- **Session binding** — an interactive Team → Agent → Task picker on first message
- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt on every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core for future distillation

## How it connects

Obsidian Copilot's **BYOK** settings support adding a **custom provider** backed by any OpenAI-compatible endpoint (official docs: [`docs/llm-providers.md`](https://github.com/logancyang/obsidian-copilot/blob/master/docs/llm-providers.md)). The plugin drives custom providers with a generic OpenAI chat client that appends `/chat/completions` to the configured Base URL (verified in source: `src/modelManagement/chatModel/configuredModelToCustomModel.ts` routes arbitrary custom proxies through `OPENAI_FORMAT` — a `ChatOpenAI` client built from the provider's `baseUrl`; the built-in Ollama/LM Studio templates also carry `/v1` in their base URLs).

So the adapter points the custom provider at:

```
Base URL:  http://127.0.0.1:8096/codebuddy/<spaceId>/v1
API key:   sk-mem-...   (business user key from the Panel)
Model ID:  the proxy's PROXY_UPSTREAM_MODEL value
```

which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route.

## What's in the directory

- `README.md` / `README_CN.md` — bilingual setup guide (Prerequisites, BYOK provider steps, model alignment, verification, configuration reference, troubleshooting incl. the Obsidian-specific CORS toggle and manual model-ID entry when discovery can't list the proxy's models)

Docs-only, same as the LobeChat / Open WebUI / LibreChat adapters — the plugin stores provider config in vault-local settings, so there is nothing to commit beyond documentation.

## Verification

- Settings path (**Settings → Copilot → BYOK → Add a provider → Add a custom provider**), optional API key, and `/v1/models`-based model discovery with manual model-ID fallback: all per the official `docs/llm-providers.md`.
- Base-URL semantics (client appends `/chat/completions`; `/v1` belongs in the Base URL): verified against `src/modelManagement/chatModel/configuredModelToCustomModel.ts` (`OPENAI_FORMAT` / `ChatOpenAI` routing for custom providers) and the Ollama (`http://localhost:11434/v1`) / LM Studio (`http://localhost:1234/v1`) templates in the official docs.
- CORS behavior ("Test succeeds but Quick Chat cannot send → enable **Enable CORS**") per the official docs.
- Proxy route and `sk-mem-...` user-key flow follow the same pattern as the existing adapters in this repo.
- No other open PR currently adds an Obsidian Copilot adapter.

Part of the Season-2 adapter program (#926). Both English and Chinese versions are included in this PR as required.
