### PR TITLE
[good first issue-platform adapt-Page Assist] Add Memory adapter for Page Assist

### DIFF
--- a/adapters/page-assist/README.md
+++ b/adapters/page-assist/README.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Page Assist Adapter
+
+Give [Page Assist](https://github.com/n4ze3m/page-assist) persistent team memory. This adapter routes the extension's LLM traffic through the TencentDB Agent Memory proxy, so every sidebar or web-UI chat automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Page Assist ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                             │
+                                             ├─ auth        (validates sk-mem-... user_key)
+                                             ├─ sessionInit (Team/Agent/Task picker)
+                                             └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Page Assist supports **OpenAI Compatible API** endpoints: in Settings → **OpenAI Compatible API** you can add a **Custom** provider with your own API URL and API key ([official provider docs](https://github.com/n4ze3m/page-assist/blob/main/docs/providers/openai.md)). The extension drives custom providers with an OpenAI chat client that appends `/chat/completions` to the configured API URL (verified in source: `src/models/CustomChatOpenAI.ts` builds the client from the provider's `baseUrl`). Pointing that URL at the proxy's `/codebuddy/<spaceId>/v1` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. The [Page Assist](https://github.com/n4ze3m/page-assist) extension is installed in your browser (Chrome / Edge / Brave / Firefox).
+
+## Setup
+
+### 1. Add the proxy as a custom provider
+
+1. Click the Page Assist icon in the browser toolbar, then the **Settings** icon.
+2. Go to the **OpenAI Compatible API** tab.
+3. Click **Add Provider** and select **Custom** from the dropdown.
+4. Enter:
+   - **API URL**: `http://127.0.0.1:8096/codebuddy/default/v1` — replace `default` with your memory space ID if you use another space. Keep the trailing `/v1`: the extension's OpenAI client appends `/chat/completions` to the API URL, which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route.
+   - **API Key**: your business user key (`sk-mem-...`).
+5. Click **Save**.
+
+### 2. Add the model
+
+Custom providers don't auto-discover models (only the Ollama / LM Studio / Llamafile presets do), so add the model manually in the same tab:
+
+- **Model ID**: your proxy's `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`). It **must match** the proxy's upstream model, otherwise the proxy rejects with an upstream mismatch.
+
+### 3. Verify
+
+1. Open the Page Assist sidebar (or web UI) and pick the proxy model.
+2. Send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask Page Assist what it remembers from previous conversations to confirm.
+
+## Configuration reference
+
+| Field | Value | Notes |
+|---|---|---|
+| API URL | `http://127.0.0.1:8096/codebuddy/default/v1` | Proxy endpoint; `default` is the memory space ID — change it per space; **keep** the trailing `/v1` |
+| API Key | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| Model ID | `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) | Must equal the proxy's upstream model |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| Requests blocked by the browser | The provider settings include a **Fix CORS** option (the extension otherwise follows browser CORS rules); toggle it if the sidebar can't reach `127.0.0.1:8096` |
+| Empty AI responses / upstream mismatch | Model ID differs from `PROXY_UPSTREAM_MODEL` — align them |
+| Model list empty | Expected for Custom providers — add the model ID manually (only Ollama / LM Studio / Llamafile presets auto-fetch) |
+| `404` / connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new chat to re-pick |
+
+## Notes
+
+- **Browser-local config**: the provider and key live only in the extension's local storage, never in a committed file; this adapter therefore ships docs only (same as the LobeChat / Open WebUI / LibreChat adapters).
+- **All chats flow through it**: every sidebar chat and web-UI conversation that uses the configured model gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/page-assist/README_CN.md
+++ b/adapters/page-assist/README_CN.md
@@ -1,0 +1,88 @@
+# TencentDB Agent Memory — Page Assist 适配器
+
+为 [Page Assist](https://github.com/n4ze3m/page-assist) 装上持久团队记忆。本适配器把扩展的 LLM 流量路由到 TencentDB Agent Memory 代理，每段侧边栏 / Web UI 对话自动获得：
+
+- **会话绑定** —— 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** —— 绑定 Agent 的 L2/L3 记忆、技能与知识在每一轮混入系统提示词
+- **自动沉淀** —— L0 原始对话写入 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Page Assist ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游 LLM
+                                             │
+                                             ├─ auth        (校验 sk-mem-... user_key)
+                                             ├─ sessionInit (Team/Agent/Task 选择器)
+                                             └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+Page Assist 支持 **OpenAI Compatible API** 端点：在 Settings → **OpenAI Compatible API** 中可添加 **Custom** 自定义 provider，填入自己的 API URL 与 API Key（见[官方 provider 文档](https://github.com/n4ze3m/page-assist/blob/main/docs/providers/openai.md)）。扩展使用 OpenAI 聊天客户端驱动自定义 provider，会在 API URL 后拼接 `/chat/completions`（已核实源码：`src/models/CustomChatOpenAI.ts` 以 provider 的 `baseUrl` 构建客户端）。把该 URL 指向代理的 `/codebuddy/<spaceId>/v1` 端点即可接入——**无需改任何代码**。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 选择器）、**记忆注入**（绑定 Agent 的 L2/L3 记忆、技能与知识每轮混入系统提示词）与**自动沉淀**（L0 原始对话写入 memory-core）全部开箱即用。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 你持有业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）中创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. 浏览器已安装 [Page Assist](https://github.com/n4ze3m/page-assist) 扩展（Chrome / Edge / Brave / Firefox）。
+
+## 配置步骤
+
+### 1. 把代理添加为自定义 provider
+
+1. 点击浏览器工具栏的 Page Assist 图标，再点击 **Settings** 图标。
+2. 进入 **OpenAI Compatible API** 标签页。
+3. 点击 **Add Provider**，在下拉框中选择 **Custom**。
+4. 填写：
+   - **API URL**：`http://127.0.0.1:8096/codebuddy/default/v1` —— 若使用其他记忆空间，把 `default` 换成对应 spaceId。**保留末尾 `/v1`**：扩展的 OpenAI 客户端会在 API URL 后追加 `/chat/completions`，正好落在代理的 `/codebuddy/<spaceId>/v1/chat/completions` 路由上。
+   - **API Key**：业务用户密钥（`sk-mem-...`）。
+5. 点击 **Save**。
+
+### 2. 添加模型
+
+Custom provider 不会自动发现模型（仅 Ollama / LM Studio / Llamafile 预置项会自动拉取），需在同一标签页手动添加：
+
+- **Model ID**：代理的 `PROXY_UPSTREAM_MODEL` 值（如 `claude-sonnet-4-20250514`）。**必须与**代理上游模型一致，否则代理以上游不匹配为由拒绝。
+
+### 3. 验证
+
+1. 打开 Page Assist 侧边栏（或 Web UI），选择代理模型。
+2. 发送第一条消息。代理在聊天交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从这一轮起，绑定 Agent 的记忆自动注入。向 Page Assist 询问之前对话记得什么即可确认。
+
+## 配置速查
+
+| 字段 | 值 | 说明 |
+|---|---|---|
+| API URL | `http://127.0.0.1:8096/codebuddy/default/v1` | 代理端点；`default` 为记忆空间 ID，按空间替换；**保留**末尾 `/v1` |
+| API Key | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+| Model ID | `PROXY_UPSTREAM_MODEL` 的值（如 `claude-sonnet-4-20250514`） | 必须与代理上游模型一致 |
+
+## 故障排查
+
+| 症状 | 原因 / 解决 |
+|---|---|
+| `401` / "Invalid API Key" | 必须使用 Panel 的业务用户密钥（`sk-mem-...`），不能用 `./.admin-key` 的管理员密钥 |
+| 请求被浏览器拦截 | provider 设置中有 **Fix CORS** 选项（扩展默认遵循浏览器 CORS 规则）；侧边栏无法访问 `127.0.0.1:8096` 时开启它 |
+| AI 回复为空 / 上游不匹配 | Model ID 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 模型列表为空 | Custom provider 的预期行为——手动添加 model ID（仅 Ollama / LM Studio / Llamafile 预置项自动拉取） |
+| `404` / 连接被拒 | 代理未在 `:8096` 运行——检查 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 会话选择器未出现 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动设置）；若前一会话已绑定任务，绑定会被复用——新开聊天即可重新选择 |
+
+## 说明
+
+- **配置仅存于本地**：provider 与密钥只保存在扩展本地存储中，不进入任何提交文件；因此本适配器只包含文档（与 LobeChat / Open WebUI / LibreChat 适配器一致）。
+- **全部聊天经过代理**：所有使用该配置模型的侧边栏聊天与 Web UI 对话都会获得记忆注入。
+- **数据流**：仅提示词/补全流经代理；记忆数据保留在本地 SQLite（memory-core）中，除非你另行配置。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What this PR adds

An adapter that connects [Page Assist](https://github.com/n4ze3m/page-assist) (the open-source browser-extension sidebar / web UI for AI models) to the TencentDB Agent Memory proxy — persistent team memory on every webpage, with **no code changes required**.

Once connected, every Page Assist chat gets:

- **Session binding** — an interactive Team → Agent → Task picker on first message
- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt on every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core for future distillation

## How it connects

Page Assist supports **OpenAI Compatible API** endpoints: Settings → **OpenAI Compatible API** → **Add Provider** → **Custom** with a user-supplied API URL and API key (official docs: [`docs/providers/openai.md`](https://github.com/n4ze3m/page-assist/blob/main/docs/providers/openai.md)). The extension drives custom providers with an OpenAI chat client built from the provider's `baseUrl` that appends `/chat/completions` (verified in source: `src/models/CustomChatOpenAI.ts` sets `baseURL` from the provider config; `src/db/dexie/openai.ts` persists the provider `baseUrl`).

So the adapter points the custom provider at:

```
API URL:   http://127.0.0.1:8096/codebuddy/<spaceId>/v1
API Key:   sk-mem-...   (business user key from the Panel)
Model ID:  the proxy's PROXY_UPSTREAM_MODEL value (added manually — Custom providers don't auto-discover models)
```

which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route.

## What's in the directory

- `README.md` / `README_CN.md` — bilingual setup guide (Prerequisites, custom-provider steps, manual model add, verification, configuration reference, troubleshooting incl. the extension's **Fix CORS** toggle and the expected-empty model list for Custom providers)

Docs-only, same as the LobeChat / Open WebUI / LibreChat / Obsidian Copilot adapters — the extension stores provider config in browser-local storage, so there is nothing to commit beyond documentation.

## Verification

- Settings path (**Settings → OpenAI Compatible API → Add Provider → Custom → API URL + API Key → Save**) and the "custom providers need manual model add" behavior (only Ollama / LM Studio / Llamafile presets auto-fetch): per the official `docs/providers/openai.md`.
- API-URL semantics (client appends `/chat/completions`; `/v1` belongs in the URL): verified against `src/models/CustomChatOpenAI.ts` (client built from the provider `baseUrl` as `baseURL`) and `src/db/dexie/openai.ts` (provider schema with `baseUrl`).
- The provider schema's `fix_cors` option and custom-headers support: verified in `src/db/dexie/openai.ts` (`addOpenAICofig`).
- Proxy route and `sk-mem-...` user-key flow follow the same pattern as the existing adapters in this repo.
- No other open PR currently adds a Page Assist adapter.

Part of the Season-2 adapter program (#926). Both English and Chinese versions are included in this PR as required.
