### PR TITLE
[good first issue-platform adapt-AnythingLLM] Add Memory adapter for AnythingLLM

### DIFF
--- a/adapters/anythingllm/README.md
+++ b/adapters/anythingllm/README.md
@@ -1,0 +1,89 @@
+# TencentDB Agent Memory — AnythingLLM Adapter
+
+Give [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every workspace chat automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+AnythingLLM ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                             │
+                                             ├─ auth        (validates sk-mem-... user_key)
+                                             ├─ sessionInit (Team/Agent/Task picker)
+                                             └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+AnythingLLM's **Generic OpenAI** LLM provider accepts any OpenAI-compatible endpoint — a Base URL and API key you configure in the UI or via environment variables. The provider is implemented with the OpenAI SDK, passing your Base URL through unchanged and appending `/chat/completions` to it (verified in source: `server/utils/AiProviders/genericOpenAi/index.js` builds the client with `baseURL: GENERIC_OPEN_AI_BASE_PATH`; the settings layer only URL-validates, it never rewrites the path). Pointing the Base URL at the proxy's `/codebuddy/<spaceId>/v1` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. AnythingLLM is running (Desktop app or Docker — see the [official docs](https://docs.anythingllm.com/)).
+
+## Setup
+
+### 1. Point AnythingLLM's Generic OpenAI provider at the proxy
+
+In the AnythingLLM UI: open **Settings → AI Providers → LLM**, select **Generic OpenAI**, and fill in:
+
+- **Base URL**: `http://127.0.0.1:8096/codebuddy/default/v1` — replace `default` with your memory space ID if you use another space. Keep the trailing `/v1`: AnythingLLM passes the Base URL to the OpenAI SDK unchanged, which appends `/chat/completions` and lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route.
+- **API Key**: your business user key (`sk-mem-...`).
+- **Chat Model**: your proxy's `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`). It **must match** the proxy's upstream model, otherwise the proxy rejects with an upstream mismatch.
+
+Save the settings.
+
+For Docker deployments you can configure the same provider via environment variables instead:
+
+```bash
+GENERIC_OPEN_AI_BASE_PATH=http://127.0.0.1:8096/codebuddy/default/v1
+GENERIC_OPEN_AI_API_KEY=sk-mem-xxxxxxxx
+GENERIC_OPEN_AI_MODEL_PREF=claude-sonnet-4-20250514
+```
+
+### 2. Verify
+
+1. Open an AnythingLLM workspace chat and make sure the Generic OpenAI model is the active one.
+2. Send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask AnythingLLM what it remembers from previous conversations to confirm.
+
+## Configuration reference
+
+| Field / Variable | Value | Notes |
+|---|---|---|
+| Base URL / `GENERIC_OPEN_AI_BASE_PATH` | `http://127.0.0.1:8096/codebuddy/default/v1` | Proxy endpoint; `default` is the memory space ID — change it per space; **keep** the trailing `/v1` |
+| API Key / `GENERIC_OPEN_AI_API_KEY` | `sk-mem-...` | Business user key from the Panel; sent as `Authorization: Bearer` |
+| Chat Model / `GENERIC_OPEN_AI_MODEL_PREF` | `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) | Must equal the proxy's upstream model |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| Empty AI responses / upstream mismatch | Chat Model differs from `PROXY_UPSTREAM_MODEL` — align them |
+| `404` on every request | Missing trailing `/v1` in the Base URL (requests then hit `/codebuddy/<spaceId>/chat/completions`); enter the Base URL exactly as shown above |
+| Connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars; for Docker, `127.0.0.1` must resolve to the host running the proxy (use `host.docker.internal` if the proxy is on the Docker host) |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new chat to re-pick |
+
+## Notes
+
+- **App-local config**: the Base URL and key live only in AnythingLLM's settings / environment, never in a committed file; this adapter therefore ships docs only (same as the LobeChat / Open WebUI / LibreChat adapters).
+- **All workspace chats flow through it**: every chat using the Generic OpenAI model gets memory injection — agents included.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/anythingllm/README_CN.md
+++ b/adapters/anythingllm/README_CN.md
@@ -1,0 +1,89 @@
+# TencentDB Agent Memory — AnythingLLM 适配器
+
+为 [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) 装上持久团队记忆。本适配器把其 LLM 流量路由到 TencentDB Agent Memory 代理，每个工作区对话自动获得：
+
+- **会话绑定** —— 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** —— 绑定 Agent 的 L2/L3 记忆、技能与知识在每一轮混入系统提示词
+- **自动沉淀** —— L0 原始对话写入 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+AnythingLLM ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游 LLM
+                                             │
+                                             ├─ auth        (校验 sk-mem-... user_key)
+                                             ├─ sessionInit (Team/Agent/Task 选择器)
+                                             └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+AnythingLLM 的 **Generic OpenAI** LLM provider 可对接任意 OpenAI 兼容端点——Base URL 与 API Key 既可在 UI 配置也可用环境变量。该 provider 基于 OpenAI SDK 实现，Base URL 原样透传并在其后追加 `/chat/completions`（已核实源码：`server/utils/AiProviders/genericOpenAi/index.js` 以 `baseURL: GENERIC_OPEN_AI_BASE_PATH` 构建客户端；设置层仅做 URL 合法性校验，不会改写路径）。把 Base URL 指向代理的 `/codebuddy/<spaceId>/v1` 端点即可接入——**无需改任何代码**。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 选择器）、**记忆注入**（绑定 Agent 的 L2/L3 记忆、技能与知识每轮混入系统提示词）与**自动沉淀**（L0 原始对话写入 memory-core）全部开箱即用。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 你持有业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）中创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. AnythingLLM 已运行（桌面版或 Docker，见[官方文档](https://docs.anythingllm.com/)）。
+
+## 配置步骤
+
+### 1. 把 AnythingLLM 的 Generic OpenAI provider 指向代理
+
+在 AnythingLLM UI 中：打开 **Settings → AI Providers → LLM**，选择 **Generic OpenAI**，填写：
+
+- **Base URL**：`http://127.0.0.1:8096/codebuddy/default/v1` —— 若使用其他记忆空间，把 `default` 换成对应 spaceId。**保留末尾 `/v1`**：AnythingLLM 将 Base URL 原样传给 OpenAI SDK，后者追加 `/chat/completions`，正好落在代理的 `/codebuddy/<spaceId>/v1/chat/completions` 路由上。
+- **API Key**：业务用户密钥（`sk-mem-...`）。
+- **Chat Model**：代理的 `PROXY_UPSTREAM_MODEL` 值（如 `claude-sonnet-4-20250514`）。**必须与**代理上游模型一致，否则代理以上游不匹配为由拒绝。
+
+保存设置。
+
+Docker 部署也可改用环境变量完成同样配置：
+
+```bash
+GENERIC_OPEN_AI_BASE_PATH=http://127.0.0.1:8096/codebuddy/default/v1
+GENERIC_OPEN_AI_API_KEY=sk-mem-xxxxxxxx
+GENERIC_OPEN_AI_MODEL_PREF=claude-sonnet-4-20250514
+```
+
+### 2. 验证
+
+1. 打开 AnythingLLM 工作区对话，确认当前模型为 Generic OpenAI 所配模型。
+2. 发送第一条消息。代理在聊天交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从这一轮起，绑定 Agent 的记忆自动注入。向 AnythingLLM 询问之前对话记得什么即可确认。
+
+## 配置速查
+
+| 字段 / 变量 | 值 | 说明 |
+|---|---|---|
+| Base URL / `GENERIC_OPEN_AI_BASE_PATH` | `http://127.0.0.1:8096/codebuddy/default/v1` | 代理端点；`default` 为记忆空间 ID，按空间替换；**保留**末尾 `/v1` |
+| API Key / `GENERIC_OPEN_AI_API_KEY` | `sk-mem-...` | Panel 创建的业务用户密钥；以 `Authorization: Bearer` 发送 |
+| Chat Model / `GENERIC_OPEN_AI_MODEL_PREF` | `PROXY_UPSTREAM_MODEL` 的值（如 `claude-sonnet-4-20250514`） | 必须与代理上游模型一致 |
+
+## 故障排查
+
+| 症状 | 原因 / 解决 |
+|---|---|
+| `401` / "Invalid API Key" | 必须使用 Panel 的业务用户密钥（`sk-mem-...`），不能用 `./.admin-key` 的管理员密钥 |
+| AI 回复为空 / 上游不匹配 | Chat Model 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 每次请求都 `404` | Base URL 末尾漏了 `/v1`（请求会打到 `/codebuddy/<spaceId>/chat/completions`）；按上文原样填写 Base URL |
+| 连接被拒 | 代理未在 `:8096` 运行——检查 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量；Docker 部署中 `127.0.0.1` 需解析到代理所在主机（代理在 Docker 宿主机上时改用 `host.docker.internal`） |
+| 会话选择器未出现 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动设置）；若前一会话已绑定任务，绑定会被复用——新开对话即可重新选择 |
+
+## 说明
+
+- **配置仅存于应用本地**：Base URL 与密钥只保存在 AnythingLLM 设置/环境变量中，不进入任何提交文件；因此本适配器只包含文档（与 LobeChat / Open WebUI / LibreChat 适配器一致）。
+- **全部工作区对话经过代理**：所有使用 Generic OpenAI 模型的对话（含 agent）都会获得记忆注入。
+- **数据流**：仅提示词/补全流经代理；记忆数据保留在本地 SQLite（memory-core）中，除非你另行配置。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What this PR adds

An adapter that connects [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) (the all-in-one desktop/Docker AI app for RAG and chat) to the TencentDB Agent Memory proxy — persistent team memory for every workspace chat, with **no code changes required**.

Once connected, every AnythingLLM chat gets:

- **Session binding** — an interactive Team → Agent → Task picker on first message
- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt on every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core for future distillation

## How it connects

AnythingLLM's **Generic OpenAI** LLM provider accepts any OpenAI-compatible endpoint via a Base URL + API key (configurable in the UI at Settings → AI Providers → LLM, or via `GENERIC_OPEN_AI_*` environment variables for Docker). The provider passes the Base URL to the OpenAI SDK unchanged and appends `/chat/completions` (verified in source: `server/utils/AiProviders/genericOpenAi/index.js` builds the client with `baseURL: GENERIC_OPEN_AI_BASE_PATH`; `server/utils/helpers/updateENV.js` only URL-validates the value, never rewrites the path).

So the adapter points the provider at:

```
Base URL:   http://127.0.0.1:8096/codebuddy/<spaceId>/v1
API Key:    sk-mem-...   (business user key from the Panel)
Chat Model: the proxy's PROXY_UPSTREAM_MODEL value
```

which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route. Docker deployments get the same result via `GENERIC_OPEN_AI_BASE_PATH` / `GENERIC_OPEN_AI_API_KEY` / `GENERIC_OPEN_AI_MODEL_PREF`.

## What's in the directory

- `README.md` / `README_CN.md` — bilingual setup guide (Prerequisites, UI + env-var configuration paths, model alignment, verification, configuration reference, troubleshooting incl. the missing-`/v1` 404 symptom and the Docker `host.docker.internal` note)

Docs-only, same as the LobeChat / Open WebUI / LibreChat / Obsidian Copilot / Page Assist adapters — AnythingLLM stores provider config in its own settings, so there is nothing to commit beyond documentation.

## Verification

- Provider choice (**Settings → AI Providers → LLM → Generic OpenAI**) with Base URL / API key / Chat Model fields: per the frontend `GenericOpenAiOptions` component.
- Base-URL semantics (value passed unchanged to the OpenAI SDK, which appends `/chat/completions`; `/v1` belongs in the Base URL): verified against `server/utils/AiProviders/genericOpenAi/index.js` (`baseURL: this.basePath` from `GENERIC_OPEN_AI_BASE_PATH`) and `server/utils/helpers/updateENV.js` (validation-only, no path rewriting).
- Environment-variable configuration for Docker deployments: `GENERIC_OPEN_AI_BASE_PATH` / `GENERIC_OPEN_AI_API_KEY` / `GENERIC_OPEN_AI_MODEL_PREF` per the same sources.
- Proxy route and `sk-mem-...` user-key flow follow the same pattern as the existing adapters in this repo.
- No other open PR currently adds an AnythingLLM adapter.

Part of the Season-2 adapter program (#926). Both English and Chinese versions are included in this PR as required.
