### PR TITLE
[good first issue-platform adapt-Text Generator] Add Memory adapter for Text Generator

### DIFF
--- a/adapters/text-generator/README.md
+++ b/adapters/text-generator/README.md
@@ -1,0 +1,82 @@
+# TencentDB Agent Memory — Text Generator Adapter
+
+Give [Text Generator](https://github.com/nhaouari/obsidian-textgenerator-plugin) (the Obsidian AI text-generation plugin) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every generation automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+Text Generator ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                                 │
+                                                 ├─ auth        (validates sk-mem-... user_key)
+                                                 ├─ sessionInit (Team/Agent/Task picker)
+                                                 └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+Text Generator has a **Custom** LLM provider whose defaults are already an OpenAI chat-completions request: the endpoint is a full URL (default `https://api.openai.com/v1/chat/completions`), the API key is injected as `Authorization: Bearer`, and the request body carries the model name (verified in source: `src/LLMProviders/custom/base.tsx` + `custom.tsx` — endpoint, header template, and body template are all editable fields). Pointing the endpoint at the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. The [Text Generator](https://github.com/nhaouari/obsidian-textgenerator-plugin) plugin is installed in your vault (Community Plugins → Browse → "Text Generator").
+
+## Setup
+
+### 1. Configure the Custom provider
+
+In Obsidian, open **Text Generator → Settings → Providers** and add (or edit) a provider of type **Custom**, then set:
+
+- **Endpoint**: `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` — replace `default` with your memory space ID if you use another space. This is the **full** request URL: Text Generator's custom provider takes a complete chat-completions endpoint, exactly like its OpenAI default.
+- **API Key**: your business user key (`sk-mem-...`) — it is injected into the default header template as `Authorization: Bearer {{api_key}}`.
+- **Model**: your proxy's `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`). It **must match** the proxy's upstream model, otherwise the proxy rejects with an upstream mismatch.
+
+Leave the default header/body templates as they are — they already produce a standard OpenAI chat-completions request.
+
+### 2. Verify
+
+1. Open a note, run a Text Generator command (e.g. *Generate & Insert*) with the Custom provider active.
+2. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Generate something that leans on earlier conversations to confirm.
+
+## Configuration reference
+
+| Field | Value | Notes |
+|---|---|---|
+| Endpoint | `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` | **Full** request URL; `default` is the memory space ID — change it per space |
+| API Key | `sk-mem-...` | Business user key from the Panel; injected as `Authorization: Bearer` via the header template |
+| Model | `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) | Must equal the proxy's upstream model; free-text field, no model listing required |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| "Network request failed — this is usually a CORS error" | Obsidian's renderer follows browser CORS rules — enable the **CORS Bypass** option in the provider settings (the plugin ships its own bypass proxy for this) |
+| Empty AI responses / upstream mismatch | Model differs from `PROXY_UPSTREAM_MODEL` — align them |
+| `404` on every request | The endpoint must be the **full** URL including `/v1/chat/completions`; a bare host or base URL will 404 |
+| Connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new chat to re-pick |
+
+## Notes
+
+- **Vault-local config**: the endpoint and key live only in your plugin settings, never in a committed file; this adapter therefore ships docs only (same as the LobeChat / Open WebUI / Obsidian Copilot adapters).
+- **All generations flow through it**: every Text Generator template and command that uses the Custom provider gets memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/text-generator/README_CN.md
+++ b/adapters/text-generator/README_CN.md
@@ -1,0 +1,82 @@
+# TencentDB Agent Memory — Text Generator 适配器
+
+为 [Text Generator](https://github.com/nhaouari/obsidian-textgenerator-plugin)（Obsidian AI 文本生成插件）装上持久团队记忆。本适配器把其 LLM 流量路由到 TencentDB Agent Memory 代理，每次生成自动获得：
+
+- **会话绑定** —— 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** —— 绑定 Agent 的 L2/L3 记忆、技能与知识在每一轮混入系统提示词
+- **自动沉淀** —— L0 原始对话写入 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+Text Generator ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游 LLM
+                                                 │
+                                                 ├─ auth        (校验 sk-mem-... user_key)
+                                                 ├─ sessionInit (Team/Agent/Task 选择器)
+                                                 └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+Text Generator 的 **Custom** LLM provider 默认即是一个 OpenAI chat-completions 请求：endpoint 为完整 URL（默认 `https://api.openai.com/v1/chat/completions`），API Key 以 `Authorization: Bearer` 注入，请求体携带模型名（已核实源码：`src/LLMProviders/custom/base.tsx` + `custom.tsx`——endpoint、header 模板与 body 模板均为可编辑字段）。把 endpoint 指向代理的 `/codebuddy/<spaceId>/v1/chat/completions` 路由即可接入——**无需改任何代码**。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 选择器）、**记忆注入**（绑定 Agent 的 L2/L3 记忆、技能与知识每轮混入系统提示词）与**自动沉淀**（L0 原始对话写入 memory-core）全部开箱即用。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 你持有业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）中创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. Vault 中已安装 [Text Generator](https://github.com/nhaouari/obsidian-textgenerator-plugin) 插件（第三方插件 → 浏览 → "Text Generator"）。
+
+## 配置步骤
+
+### 1. 配置 Custom provider
+
+在 Obsidian 中打开 **Text Generator → Settings → Providers**，添加（或编辑）一个 **Custom** 类型 provider，设置：
+
+- **Endpoint**：`http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` —— 若使用其他记忆空间，把 `default` 换成对应 spaceId。这是**完整**请求 URL：Text Generator 的 custom provider 接收的就是完整的 chat-completions 端点，与其 OpenAI 默认值形式一致。
+- **API Key**：业务用户密钥（`sk-mem-...`）——经默认 header 模板以 `Authorization: Bearer {{api_key}}` 注入。
+- **Model**：代理的 `PROXY_UPSTREAM_MODEL` 值（如 `claude-sonnet-4-20250514`）。**必须与**代理上游模型一致，否则代理以上游不匹配为由拒绝。
+
+默认 header/body 模板无需改动——它们产出的就是标准 OpenAI chat-completions 请求。
+
+### 2. 验证
+
+1. 打开一篇笔记，在 Custom provider 生效下执行任一 Text Generator 命令（如 *Generate & Insert*）。
+2. 代理在聊天交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从这一轮起，绑定 Agent 的记忆自动注入。生成一段依赖此前对话内容的结果即可确认。
+
+## 配置速查
+
+| 字段 | 值 | 说明 |
+|---|---|---|
+| Endpoint | `http://127.0.0.1:8096/codebuddy/default/v1/chat/completions` | **完整**请求 URL；`default` 为记忆空间 ID，按空间替换 |
+| API Key | `sk-mem-...` | Panel 创建的业务用户密钥；经 header 模板以 `Authorization: Bearer` 注入 |
+| Model | `PROXY_UPSTREAM_MODEL` 的值（如 `claude-sonnet-4-20250514`） | 必须与代理上游模型一致；纯文本字段，无需模型列表端点 |
+
+## 故障排查
+
+| 症状 | 原因 / 解决 |
+|---|---|
+| `401` / "Invalid API Key" | 必须使用 Panel 的业务用户密钥（`sk-mem-...`），不能用 `./.admin-key` 的管理员密钥 |
+| "Network request failed — this is usually a CORS error" | Obsidian 渲染进程遵循浏览器 CORS 规则——在 provider 设置中开启 **CORS Bypass** 选项（插件自带旁路代理） |
+| AI 回复为空 / 上游不匹配 | Model 与 `PROXY_UPSTREAM_MODEL` 不一致——对齐即可 |
+| 每次请求都 `404` | endpoint 必须是含 `/v1/chat/completions` 的**完整** URL；只填主机或 base URL 会 404 |
+| 连接被拒 | 代理未在 `:8096` 运行——检查 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 会话选择器未出现 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动设置）；若前一会话已绑定任务，绑定会被复用——新开聊天即可重新选择 |
+
+## 说明
+
+- **配置仅存于本地**：endpoint 与密钥只保存在插件设置中，不进入任何提交文件；因此本适配器只包含文档（与 LobeChat / Open WebUI / Obsidian Copilot 适配器一致）。
+- **全部生成经过代理**：所有使用 Custom provider 的 Text Generator 模板与命令都会获得记忆注入。
+- **数据流**：仅提示词/补全流经代理；记忆数据保留在本地 SQLite（memory-core）中，除非你另行配置。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What this PR adds

An adapter that connects [Text Generator](https://github.com/nhaouari/obsidian-textgenerator-plugin) (the Obsidian AI text-generation plugin, 1.9k stars) to the TencentDB Agent Memory proxy — persistent team memory for note-driven generation workflows, with **no code changes required**.

Once connected, every Text Generator command gets:

- **Session binding** — an interactive Team → Agent → Task picker on first message
- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt on every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core for future distillation

## How it connects

Text Generator ships a **Custom** LLM provider whose defaults are already an OpenAI chat-completions request: the endpoint is a full URL (default `https://api.openai.com/v1/chat/completions`), the API key is injected via an editable header template (`Authorization: Bearer {{api_key}}`), and the body template carries the model name (verified in source: `src/LLMProviders/custom/base.tsx` and `custom.tsx`).

So the adapter sets the provider to:

```
Endpoint:  http://127.0.0.1:8096/codebuddy/<spaceId>/v1/chat/completions   (full request URL)
API Key:   sk-mem-...   (business user key from the Panel)
Model:     the proxy's PROXY_UPSTREAM_MODEL value   (free-text field — no model-listing endpoint needed)
```

No model-discovery step is involved, so this adapter works with the proxy as-is.

## What's in the directory

- `README.md` / `README_CN.md` — bilingual setup guide (Prerequisites, Custom provider fields, template notes, verification, configuration reference, troubleshooting incl. the plugin's **CORS Bypass** option and the full-URL requirement)

Docs-only, same as the LobeChat / Open WebUI / LibreChat / Obsidian Copilot / Page Assist / AnythingLLM adapters — the plugin stores provider config in vault-local settings, so there is nothing to commit beyond documentation.

## Verification

- Provider semantics (full-endpoint URL, `Bearer` header template, `model` body field, editable header/body templates): verified against `src/LLMProviders/custom/base.tsx` (`default_values.endpoint = "https://api.openai.com/v1/chat/completions"`, `custom_header` with `Bearer {{api_key}}`, `custom_body` with `model: "{{model}}"`) and `src/LLMProviders/custom/custom.tsx` (endpoint / API key / model input fields).
- CORS failure path ("Network request failed — this is usually a CORS error … Try enabling the CORS Bypass option"): per the error handling in `src/LLMProviders/custom/base.tsx`.
- Proxy route and `sk-mem-...` user-key flow follow the same pattern as the existing adapters in this repo.
- No other open PR currently adds a Text Generator adapter.

Part of the Season-2 adapter program (#926). Both English and Chinese versions are included in this PR as required.
