### PR TITLE
[good first issue-platform adapt-aichat] Add Memory adapter for aichat

### DIFF
--- a/adapters/aichat/README.md
+++ b/adapters/aichat/README.md
@@ -1,0 +1,92 @@
+# TencentDB Agent Memory — aichat Adapter
+
+Give [aichat](https://github.com/sigoden/aichat) persistent team memory. This adapter routes its LLM traffic through the TencentDB Agent Memory proxy, so every chat, shell-assistant command, and RAG session automatically gets:
+
+- **Session binding** — an interactive Team → Agent → Task picker on first message
+- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge are blended into the system prompt on every turn
+- **Automatic capture** — L0 raw dialogue is persisted into memory-core for future distillation
+
+## How it works
+
+```
+aichat ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> Upstream LLM
+                                        │
+                                        ├─ auth        (validates sk-mem-... user_key)
+                                        ├─ sessionInit (Team/Agent/Task picker)
+                                        └─ injection   (L2/L3 memory + skills + knowledge)
+```
+
+aichat supports **any OpenAI-compatible provider** through its `openai-compatible` provider type in `~/.aichat/config.yaml` ([official config example](https://github.com/sigoden/aichat/blob/main/config.example.yaml)). The client builds its request URL as `<api_base>/chat/completions` and sends the API key as a `Bearer` token (verified in source: `src/client/openai_compatible.rs` — `format!("{api_base}/chat/completions")`). Pointing `api_base` at the proxy's `/codebuddy/<spaceId>/v1` endpoint connects it — **no code changes required**.
+
+**Session binding** (an interactive Team → Agent → Task picker on first message), **memory injection** (the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt every turn) and **automatic capture** (L0 raw dialogue persisted into memory-core) all work with no code changes.
+
+## Prerequisites
+
+1. TencentDB Agent Memory is running (the one-command stack from the main repo README):
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. You have a business user's `user_key` (starts with `sk-mem-...`). It is printed by `start-all.sh` on first boot, or created in the Panel at `http://localhost:8125`. Using the raw admin key from `./.admin-key` is not recommended.
+
+3. aichat is installed (`cargo install aichat`, or a binary from the [releases](https://github.com/sigoden/aichat/releases)) and initialized (`aichat` once creates `~/.aichat/`).
+
+## Setup
+
+### 1. Add the proxy as an openai-compatible provider
+
+Append this to the `providers:` list in `~/.aichat/config.yaml`:
+
+```yaml
+  - type: openai-compatible
+    name: tencentdb-mem
+    api_base: http://127.0.0.1:8096/codebuddy/default/v1
+    api_key: sk-mem-xxxxxxxx
+    models:
+      - name: claude-sonnet-4-20250514
+        max_input_tokens: 200000
+```
+
+- `api_base` — the proxy endpoint; replace `default` with your memory space ID if you use another space. Keep the trailing `/v1`: aichat appends `/chat/completions` to `api_base`, which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route.
+- `api_key` — your business user key (`sk-mem-...`), sent as `Authorization: Bearer`.
+- `models` — declare the proxy's `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) as the model name. The name **must match** the proxy's upstream model, otherwise the proxy rejects with an upstream mismatch. Models are declared manually — no model-listing endpoint is involved.
+
+### 2. Switch to the model and verify
+
+1. Select the model: `aichat --model tencentdb-mem:claude-sonnet-4-20250514`, or run `.model tencentdb-mem:claude-sonnet-4-20250514` inside the REPL.
+2. Send a first message. The proxy triggers the session picker in the chat interaction: choose your **Team → Agent → Task**.
+3. From this turn on, memory for the bound agent is injected automatically. Ask aichat what it remembers from previous conversations to confirm.
+
+## Configuration reference
+
+| Field | Value | Notes |
+|---|---|---|
+| `type` | `openai-compatible` | aichat's generic OpenAI-compatible client |
+| `name` | `tencentdb-mem` (any name you like) | Prefixes the model selector: `tencentdb-mem:<model>` |
+| `api_base` | `http://127.0.0.1:8096/codebuddy/default/v1` | Proxy endpoint; `default` is the memory space ID — change it per space; **keep** the trailing `/v1` |
+| `api_key` | `sk-mem-...` | Business user key from the Panel |
+| `models[].name` | `PROXY_UPSTREAM_MODEL` value (e.g. `claude-sonnet-4-20250514`) | Must equal the proxy's upstream model |
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `401` / "Invalid API Key" | The key must be a business user key (`sk-mem-...`) from the Panel — not the admin key from `./.admin-key` |
+| Empty responses / upstream mismatch | Model name differs from `PROXY_UPSTREAM_MODEL` — align the `models[].name` entry |
+| `404` on every request | Missing trailing `/v1` in `api_base` (requests then hit `/codebuddy/<spaceId>/chat/completions`); keep the URL exactly as shown |
+| Connection refused | Proxy not running on `:8096` — check `./start-all.sh` logs and `PROXY_UPSTREAM_*` env vars |
+| Model not found in selector | aichat only lists models you declared under the provider — add the model entry and restart aichat |
+| No session picker appears | `PROXY_ENABLE_SESSION_INIT=1` is required (set automatically by `PROXY_FULL_STACK=1`); if a previous session already bound a task, the binding is reused — start a new session (`.new`) to re-pick |
+
+## Notes
+
+- **User-local config**: the provider block lives only in your `~/.aichat/config.yaml`, never in a committed file; this adapter therefore ships docs only (same as the LobeChat / Open WebUI / LibreChat adapters).
+- **All modes flow through it**: REPL chat, CMD mode (`-m` / `--model`), shell assistant, RAG sessions, and agents that use the provider's model all get memory injection.
+- **Data flow**: only prompts/completions transit the proxy; memory data stays in your local SQLite (memory-core) unless you configure otherwise.
+
+## License
+
+MIT, same as the main repository.

--- a/adapters/aichat/README_CN.md
+++ b/adapters/aichat/README_CN.md
@@ -1,0 +1,92 @@
+# TencentDB Agent Memory — aichat 适配器
+
+为 [aichat](https://github.com/sigoden/aichat) 装上持久团队记忆。本适配器把其 LLM 流量路由到 TencentDB Agent Memory 代理，每次聊天、Shell 助手命令与 RAG 会话自动获得：
+
+- **会话绑定** —— 首条消息触发 Team → Agent → Task 交互式选择器
+- **记忆注入** —— 绑定 Agent 的 L2/L3 记忆、技能与知识在每一轮混入系统提示词
+- **自动沉淀** —— L0 原始对话写入 memory-core，供后续蒸馏
+
+## 工作原理
+
+```
+aichat ──(OpenAI Chat Completions)──> Memory Proxy :8096 ──> 上游 LLM
+                                        │
+                                        ├─ auth        (校验 sk-mem-... user_key)
+                                        ├─ sessionInit (Team/Agent/Task 选择器)
+                                        └─ injection   (L2/L3 记忆 + 技能 + 知识)
+```
+
+aichat 通过 `~/.aichat/config.yaml` 中的 `openai-compatible` provider 类型支持**任意 OpenAI 兼容服务**（见[官方配置示例](https://github.com/sigoden/aichat/blob/main/config.example.yaml)）。其客户端以 `<api_base>/chat/completions` 构造请求 URL，并以 `Bearer` 令牌发送 API Key（已核实源码：`src/client/openai_compatible.rs` —— `format!("{api_base}/chat/completions")`）。把 `api_base` 指向代理的 `/codebuddy/<spaceId>/v1` 端点即可接入——**无需改任何代码**。
+
+**会话绑定**（首条消息触发 Team → Agent → Task 选择器）、**记忆注入**（绑定 Agent 的 L2/L3 记忆、技能与知识每轮混入系统提示词）与**自动沉淀**（L0 原始对话写入 memory-core）全部开箱即用。
+
+## 前置条件
+
+1. TencentDB Agent Memory 已运行（主仓库 README 的一键栈）：
+
+   ```bash
+   cd TencentDB-Agent-Memory/deploy/global-images
+   cp .env.example .env && $EDITOR .env
+   ./start-all.sh
+   ```
+
+2. 你持有业务用户的 `user_key`（以 `sk-mem-...` 开头）。首次启动时由 `start-all.sh` 打印，或在 Panel（`http://localhost:8125`）中创建。不建议使用 `./.admin-key` 中的原始管理员密钥。
+
+3. aichat 已安装（`cargo install aichat`，或从 [releases](https://github.com/sigoden/aichat/releases) 下载二进制）并完成初始化（首次运行 `aichat` 会创建 `~/.aichat/`）。
+
+## 配置步骤
+
+### 1. 把代理添加为 openai-compatible provider
+
+在 `~/.aichat/config.yaml` 的 `providers:` 列表中追加：
+
+```yaml
+  - type: openai-compatible
+    name: tencentdb-mem
+    api_base: http://127.0.0.1:8096/codebuddy/default/v1
+    api_key: sk-mem-xxxxxxxx
+    models:
+      - name: claude-sonnet-4-20250514
+        max_input_tokens: 200000
+```
+
+- `api_base` —— 代理端点；若使用其他记忆空间，把 `default` 换成对应 spaceId。**保留末尾 `/v1`**：aichat 在 `api_base` 后追加 `/chat/completions`，正好落在代理的 `/codebuddy/<spaceId>/v1/chat/completions` 路由上。
+- `api_key` —— 业务用户密钥（`sk-mem-...`），以 `Authorization: Bearer` 发送。
+- `models` —— 把代理的 `PROXY_UPSTREAM_MODEL` 值（如 `claude-sonnet-4-20250514`）声明为模型名。名称**必须与**代理上游模型一致，否则代理以上游不匹配为由拒绝。模型为手动声明，不涉及模型列表端点。
+
+### 2. 切换模型并验证
+
+1. 选择模型：`aichat --model tencentdb-mem:claude-sonnet-4-20250514`，或在 REPL 中执行 `.model tencentdb-mem:claude-sonnet-4-20250514`。
+2. 发送第一条消息。代理在聊天交互中触发会话选择器：选择你的 **Team → Agent → Task**。
+3. 从这一轮起，绑定 Agent 的记忆自动注入。向 aichat 询问之前对话记得什么即可确认。
+
+## 配置速查
+
+| 字段 | 值 | 说明 |
+|---|---|---|
+| `type` | `openai-compatible` | aichat 的通用 OpenAI 兼容客户端 |
+| `name` | `tencentdb-mem`（可自定义） | 模型选择前缀：`tencentdb-mem:<model>` |
+| `api_base` | `http://127.0.0.1:8096/codebuddy/default/v1` | 代理端点；`default` 为记忆空间 ID，按空间替换；**保留**末尾 `/v1` |
+| `api_key` | `sk-mem-...` | Panel 创建的业务用户密钥 |
+| `models[].name` | `PROXY_UPSTREAM_MODEL` 的值（如 `claude-sonnet-4-20250514`） | 必须与代理上游模型一致 |
+
+## 故障排查
+
+| 症状 | 原因 / 解决 |
+|---|---|
+| `401` / "Invalid API Key" | 必须使用 Panel 的业务用户密钥（`sk-mem-...`），不能用 `./.admin-key` 的管理员密钥 |
+| 回复为空 / 上游不匹配 | 模型名与 `PROXY_UPSTREAM_MODEL` 不一致——对齐 `models[].name` 即可 |
+| 每次请求都 `404` | `api_base` 末尾漏了 `/v1`（请求会打到 `/codebuddy/<spaceId>/chat/completions`）；按上文原样填写 |
+| 连接被拒 | 代理未在 `:8096` 运行——检查 `./start-all.sh` 日志与 `PROXY_UPSTREAM_*` 环境变量 |
+| 模型选择器中找不到模型 | aichat 只展示 provider 下已声明的模型——补上模型条目并重启 aichat |
+| 会话选择器未出现 | 需要 `PROXY_ENABLE_SESSION_INIT=1`（`PROXY_FULL_STACK=1` 时自动设置）；若前一会话已绑定任务，绑定会被复用——执行 `.new` 新开会话即可重新选择 |
+
+## 说明
+
+- **配置仅存于本地**：provider 配置块只保存在你的 `~/.aichat/config.yaml` 中，不进入任何提交文件；因此本适配器只包含文档（与 LobeChat / Open WebUI / LibreChat 适配器一致）。
+- **全模式经过代理**：REPL 聊天、CMD 模式（`-m` / `--model`）、Shell 助手、RAG 会话与使用该模型的所有 agent 均获得记忆注入。
+- **数据流**：仅提示词/补全流经代理；记忆数据保留在本地 SQLite（memory-core）中，除非你另行配置。
+
+## 许可证
+
+MIT，与主仓库一致。


### PR DESCRIPTION
## What this PR adds

An adapter that connects [aichat](https://github.com/sigoden/aichat) (the all-in-one LLM CLI — 10.4k stars — featuring chat REPL, shell assistant, RAG and agents) to the TencentDB Agent Memory proxy — persistent team memory on the terminal, with **no code changes required**.

Once connected, every aichat session gets:

- **Session binding** — an interactive Team → Agent → Task picker on first message
- **Memory injection** — the bound agent's L2/L3 memory, skills and knowledge blended into the system prompt on every turn
- **Automatic capture** — L0 raw dialogue persisted into memory-core for future distillation

## How it connects

aichat supports **any OpenAI-compatible provider** through the `openai-compatible` provider type in `~/.aichat/config.yaml` (official example: [`config.example.yaml`](https://github.com/sigoden/aichat/blob/main/config.example.yaml)). The client builds the request URL as `<api_base>/chat/completions` and authenticates with a `Bearer` token (verified in source: `src/client/openai_compatible.rs` — `let url = format!("{api_base}/chat/completions")`; models are declared manually in the provider block, so no model-listing endpoint is involved).

So the adapter sets the provider to:

```yaml
- type: openai-compatible
  name: tencentdb-mem
  api_base: http://127.0.0.1:8096/codebuddy/<spaceId>/v1
  api_key: sk-mem-...
  models:
    - name: <PROXY_UPSTREAM_MODEL value>
```

which lands exactly on the proxy's `/codebuddy/<spaceId>/v1/chat/completions` route. The model is then selected as `tencentdb-mem:<model>` (REPL `.model` command or `--model` flag).

## What's in the directory

- `README.md` / `README_CN.md` — bilingual setup guide (Prerequisites, provider YAML block, model selection, verification, configuration reference, troubleshooting incl. the missing-`/v1` 404 symptom and the manual-models-declaration behavior)

Docs-only, same as the LobeChat / Open WebUI / LibreChat / Obsidian Copilot / Page Assist / AnythingLLM / Text Generator adapters — aichat stores provider config in the user's `~/.aichat/config.yaml`, so there is nothing to commit beyond documentation.

## Verification

- Provider syntax (`openai-compatible` type with `name` / `api_base` / `api_key` / manual `models` list): per the official `config.example.yaml` (which itself shows Ollama as `api_base: http://localhost:11434/v1`, i.e. `/v1` included).
- URL semantics (client appends `/chat/completions` to `api_base`; `/v1` belongs in `api_base`): verified against `src/client/openai_compatible.rs` (`format!("{api_base}/chat/completions")`).
- Bearer-token authentication and manual model declaration (no discovery endpoint needed): per the same source and config example.
- Proxy route and `sk-mem-...` user-key flow follow the same pattern as the existing adapters in this repo.
- No other open PR currently adds an aichat adapter.

Part of the Season-2 adapter program (#926). Both English and Chinese versions are included in this PR as required.
