### PR TITLE
feat(proxy): session-init autoDefault 静默默认 + 超时收敛

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -399,6 +399,70 @@ this ID marking sessions that opted out of Task binding.
 > template to include `defaultTaskId`, or point `PROXY_CONFIG_DIR` at
 > a directory holding your own hand-edited `config.yaml`.
 
+## Optional: `sessionInit.autoDefault` (silent defaults) + `initTimeoutMs` (timeout convergence)
+
+**Why.** Every fresh session — the main agent and sub-agents alike (a
+sub-agent is also a brand-new session) — asks the user to pick
+team/agent/task, and the interactive form leaves the session hanging
+while it waits for the answer. If you want the session to initialise
+with a configured identity **silently** whenever the user has no explicit
+choice intent (no form, no waiting), use this pair.
+
+**`sessionInit.autoDefault` — silent defaults.**
+
+```yaml
+sessionInit:
+  enabled: true
+  maxRetries: 3
+  injectAgentContext: true
+  injectTaskContext: true
+  defaultTaskId: "no-task"
+  headerAutoSelect:
+    enabled: true
+    teamHeader: "x-team-id"
+    agentHeader: "x-agent-id"
+    taskHeader: "x-task-id"
+    onMismatch: "form"
+  autoDefault:
+    enabled: true        # false (default) = keep the interactive form, zero behaviour change
+    teamId: ""           # default team_id; empty = first team the user can see
+    agentId: ""          # default agent_id; empty = first agent of the chosen team
+    taskId: ""           # default task_id; empty = no task (recorded as the defaultTaskId virtual item)
+    onUnresolved: "skip" # when defaults can't resolve: skip=skip init (default) | form=fall back to the form
+```
+
+**Behaviour & precedence.**
+
+- When enabled, the state machine (before showing the `asset_confirm` form)
+  resolves `(team, agent)` from `autoDefault`; if it can, it **calls the
+  existing `completeRegistration` and injects memory — no interactive form
+  is shown**. Main agent and sub-agent are treated identically: a sub-agent
+  is also a fresh session key, so this path needs **no parent/child session
+  detection and no DSH-side parent-session header**.
+- Precedence: `headerAutoSelect` (explicit identity in headers) wins;
+  `autoDefault` backs up "no header, no explicit intent" on a new session.
+  To re-bind later, use `mem:session-reset`.
+- `taskId` left empty → recorded as the `defaultTaskId` virtual item
+  ("no task binding": kernel skips `getTask`, no `[Task]` block is
+  injected); a real task_id → injected as a real task.
+
+**`sessionInit.initTimeoutMs` — timeout convergence (milliseconds, default
+`900000` = 15 minutes).**
+
+The state machine is **request-driven**: while the user sits on a pending
+form without replying, no new request reaches the proxy (the hang is on
+the DSH side; this feature does **not** touch the DSH core, so it cannot
+actively unblock a hung turn). Its value is: when the **next** request
+arrives after the timeout (user comes back / a sub-agent pushes on), the
+state machine sees that `startedAt` is more than `initTimeoutMs` old and,
+instead of re-showing the form / parsing the reply, **registers with the
+`autoDefault` identity** and injects memory — so that real message is
+processed normally without the session-init hanging in `pending` forever.
+
+> Note: `initTimeoutMs` only applies when `autoDefault.enabled=true`; when
+> disabled, the existing store `DEFAULT_TTL_MS` (30 min) just drops stale
+> pending state — it does not converge to a default identity.
+
 ## Optional: `/analyse` URL marker (asset injection effectiveness review)
 
 **What it does.** The Proxy ships a debug/evaluation feature called

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -322,6 +322,60 @@ sessionInit:
 会跟着 session-init 请求写到日志 / 埋点里,后续追 trace 时能看到它标记
 着"这条会话主动跳过了 Task 绑定"。
 
+## 可选能力：`sessionInit.autoDefault`（静默默认）+ `initTimeoutMs`（超时收敛）
+
+**问题背景。** 每次开新会话,main agent 与 sub-agent(子代理 = 也是一个全新
+session)都要手选 team/agent/task;而且交互式表单在等待用户答复时会挂着会话。
+如果你希望用户**无明确选择意图时直接以默认值完成初始化**(不再弹表单、
+不再等回复),用下面这一对配置。
+
+**`sessionInit.autoDefault` —— 静默默认。**
+
+```yaml
+sessionInit:
+  enabled: true
+  maxRetries: 3
+  injectAgentContext: true
+  injectTaskContext: true
+  defaultTaskId: "no-task"
+  headerAutoSelect:
+    enabled: true
+    teamHeader: "x-team-id"
+    agentHeader: "x-agent-id"
+    taskHeader: "x-task-id"
+    onMismatch: "form"
+  autoDefault:
+    enabled: true        # false（默认）= 维持原交互表单流程，零行为变化
+    teamId: ""           # 默认 team_id；留空 = 取用户可见列表第一个 team
+    agentId: ""          # 默认 agent_id；留空 = 取所选 team 第一个 agent
+    taskId: ""           # 默认 task_id；留空 = 不关联任务（记为 defaultTaskId 虚拟项）
+    onUnresolved: "skip" # 默认值无法解析时：skip=跳过初始化直接放行（默认）| form=退化为交互表单
+```
+
+**行为与优先级。**
+
+- 开启后,状态机在"要弹 asset_confirm 之前"判断:若 `autoDefault.enabled`
+  且能解析出 `(team, agent)` → **直接调用既有 `completeRegistration` 注册并
+  注入记忆,不再弹任何交互表单**。main agent 与 sub-agent 一视同仁——
+  sub-agent 也是一个全新 session key,天然走同一路径,因此**无需识别父/子会话、
+  也不需要 DSH 侧携带 parent session header**。
+- 优先级:`headerAutoSelect`(header 显式身份)优先;`autoDefault` 兜底
+  "无 header、无明确意图"的开新会话场景。想换绑定 → 用 `mem:session-reset`。
+- `taskId` 不填 → 记作 `defaultTaskId` 虚拟项("本次不关联任务",kernel 不
+  `getTask`、不注入 `[Task]` 块);填真实 task_id → 按真实任务注入。
+
+**`sessionInit.initTimeoutMs` —— 超时收敛(毫秒,默认 `900000` = 15 分钟)。**
+
+状态机是**请求驱动**的:用户挂在 pending 表单上迟迟不答复时,proxy 侧不会有
+新请求进来(turn 挂起发生在 DSH 侧;本次**不改 DSH 核心**,因此无法主动解除
+挂起的 turn)。它的价值在于:超时后**下一次**请求(用户回来 / sub-agent 继续
+推进)到达时,状态机发现距 `startedAt` 已超过 `initTimeoutMs`,则**不再弹表单
+/ 解析答复**,直接以 `autoDefault` 默认值完成注册并注入记忆,让这条真实消息被
+正常处理——避免反复弹表单、避免会话初始化长期悬在 pending。
+
+> 注意:`initTimeoutMs` 仅在 `autoDefault.enabled=true` 时生效;关闭时维持既有
+> store `DEFAULT_TTL_MS`(30min)只负责丢弃过期 pending、不负责"收敛到默认值"。
+
 > 💡 覆写提醒(同 `/analyse` marker):走 `deploy/global-images/start-proxy.sh`
 > 的话,生成的 `config.yaml` 每次启动都会被覆盖——要么改脚本里 YAML 模板
 > 加上 `defaultTaskId`,要么用 `PROXY_CONFIG_DIR` 指到你自己维护的

--- a/MemoryProxy/config.example.yaml
+++ b/MemoryProxy/config.example.yaml
@@ -569,6 +569,28 @@ sessionInit:
     taskHeader: "x-task-id"  # 携带 task_id 的请求头名（可选）
     onMismatch: "form"       # header 值查不到时：form=回退交互表单（默认）| bypass=跳过 session init
 
+  # ── 静默默认（autoDefault）────────────────────────────────────────────────
+  # main agent 与 sub-agent（子代理 = 也是全新会话）每次开新会话都要手选
+  # team/agent/task，且 ask 表单等待用户回复会把会话初始化挂起。开启后：
+  #   用户无明确选择意图时，直接以默认值完成注册并**注入记忆**，不再弹交互表单。
+  #   主会话与 sub-agent 一视同仁——sub-agent 也是一个全新 session key，天然走同路径，
+  #   因此无需单独判别父/子会话，也不需要 DSH 侧携带 parent session header。
+  # 优先级：headerAutoSelect（header 显式身份）优先；autoDefault 兜底"无 header、
+  # 无明确意图"的开新会话场景。想换绑定 → 用 mem:session-reset。
+  autoDefault:
+    enabled: false           # false（默认）= 维持原交互表单流程，零行为变化
+    teamId: ""               # 默认 team_id；留空 = 取用户可见列表第一个 team
+    agentId: ""              # 默认 agent_id；留空 = 取所选 team 第一个 agent
+    taskId: ""               # 默认 task_id；留空 = 不关联任务（记为 defaultTaskId 虚拟项）
+    onUnresolved: "skip"     # 默认值无法解析时：skip=跳过初始化直接放行（默认）| form=退化为交互表单
+
+  # 交互式初始化表单的超时收敛时长（毫秒）。默认 900000（15 分钟）。
+  # 用户挂在 pending 表单上迟迟不答复时，proxy 侧不会有新请求进来（turn 挂起发生在
+  # DSH 侧，本次不动 DSH 核心），因此这里无法主动解除挂起，而是：超时后**下一次**
+  # 请求（用户回来 / sub-agent 继续推进）到达时，直接以 autoDefault 默认值完成注册，
+  # 不再反复弹表单。仅 autoDefault.enabled=true 时生效。
+  initTimeoutMs: 900000
+
   # ── DEBUG：本地开发/e2e 短路 ────────────────────────────────────────────────
   # 打开 debugForceIdentity 后，agentSource=workbuddy 和 agentSource=codebuddy
   # 的会话会**直接**注册为固定三元组，绕过所有表单/header 匹配逻辑；

--- a/MemoryProxy/src/config.ts
+++ b/MemoryProxy/src/config.ts
@@ -101,6 +101,11 @@ export const DEFAULT_CONFIG: ProxyConfig = {
       taskHeader: "x-task-id",
       onMismatch: "form",
     },
+    autoDefault: {
+      enabled: false,
+      onUnresolved: "skip",
+    },
+    initTimeoutMs: 15 * 60 * 1000,
     // debugForceIdentity intentionally omitted — must be explicitly set in yaml
     // to activate the bypass path.
   },
@@ -415,6 +420,22 @@ export function buildConfig(overrides: CliOverrides = {}): ProxyConfig {
       taskHeader: (yaml.sessionInit?.headerAutoSelect?.taskHeader ?? DEFAULT_CONFIG.sessionInit.headerAutoSelect!.taskHeader).toLowerCase(),
       onMismatch: yaml.sessionInit?.headerAutoSelect?.onMismatch ?? DEFAULT_CONFIG.sessionInit.headerAutoSelect!.onMismatch,
     },
+    autoDefault: {
+      enabled: yaml.sessionInit?.autoDefault?.enabled ?? DEFAULT_CONFIG.sessionInit.autoDefault!.enabled,
+      teamId: typeof yaml.sessionInit?.autoDefault?.teamId === "string" && yaml.sessionInit.autoDefault.teamId.trim()
+        ? yaml.sessionInit.autoDefault.teamId.trim()
+        : undefined,
+      agentId: typeof yaml.sessionInit?.autoDefault?.agentId === "string" && yaml.sessionInit.autoDefault.agentId.trim()
+        ? yaml.sessionInit.autoDefault.agentId.trim()
+        : undefined,
+      taskId: typeof yaml.sessionInit?.autoDefault?.taskId === "string" && yaml.sessionInit.autoDefault.taskId.trim()
+        ? yaml.sessionInit.autoDefault.taskId.trim()
+        : undefined,
+      onUnresolved: yaml.sessionInit?.autoDefault?.onUnresolved ?? DEFAULT_CONFIG.sessionInit.autoDefault!.onUnresolved,
+    },
+    initTimeoutMs: typeof yaml.sessionInit?.initTimeoutMs === "number" && yaml.sessionInit.initTimeoutMs > 0
+      ? yaml.sessionInit.initTimeoutMs
+      : DEFAULT_CONFIG.sessionInit.initTimeoutMs,
     debugForceIdentity: yaml.sessionInit?.debugForceIdentity
       && typeof yaml.sessionInit.debugForceIdentity === "object"
       && typeof (yaml.sessionInit.debugForceIdentity as Record<string, unknown>).team_id === "string"

--- a/MemoryProxy/src/session/__tests__/session-init-auto-default.test.ts
+++ b/MemoryProxy/src/session/__tests__/session-init-auto-default.test.ts
@@ -1,0 +1,206 @@
+/**
+ * session-init autoDefault（静默默认）+ initTimeoutMs（超时收敛）单元测试。
+ *
+ * 背景：main agent 与 sub-agent（子代理 = 也是全新 session）每次开新会话都要手选
+ * team/agent/task，且 ask 表单等待用户回复会把会话初始化挂起。本测试覆盖：
+ *   1. resolveAutoDefaultIdentity —— 默认值解析纯函数（team/agent/task 匹配与回退语义）。
+ *   2. handleSessionInit —— uninitialized 会话在 autoDefault 开启时直接静默注册（不弹表单）。
+ *   3. handleSessionInit —— pending 会话超时（超过 initTimeoutMs）后收敛到默认值。
+ */
+import { describe, it, expect } from "vitest";
+import { SessionStore } from "../store.js";
+import { resolveAutoDefaultIdentity, handleSessionInit } from "../codebuddy/init.js";
+import type { SessionInitConfig } from "../../types.js";
+import type { TeamOption } from "../types.js";
+import type { MetadataClient } from "../../meta/client.js";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const teamA: TeamOption = {
+  team_id: "team-abc12345",
+  team_name: "Team A",
+  agents: [{ agent_id: "agt-aaa11111", agent_name: "Agent A" }],
+  tasks: [{ task_id: "task-x", task_name: "Task X" }],
+};
+const teamB: TeamOption = {
+  team_id: "team-def67890",
+  team_name: "Team B",
+  agents: [{ agent_id: "agt-bbb22222", agent_name: "Agent B" }],
+  tasks: [],
+};
+
+function baseConfig(overrides: Partial<SessionInitConfig> = {}): SessionInitConfig {
+  return {
+    enabled: true,
+    maxRetries: 3,
+    injectAgentContext: true,
+    injectTaskContext: true,
+    defaultTaskId: "default",
+    headerAutoSelect: {
+      enabled: true,
+      teamHeader: "x-team-id",
+      agentHeader: "x-agent-id",
+      taskHeader: "x-task-id",
+      onMismatch: "form",
+    },
+    autoDefault: { enabled: false, onUnresolved: "skip" },
+    initTimeoutMs: 15 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+const metadataClient = {
+  listTeams: async () => [{ team_id: teamA.team_id, name: teamA.team_name }],
+  listAgents: async () => [{ agent_id: "agt-aaa11111", name: "Agent A" }],
+  listTasks: async () => [{ task_id: "task-x", title: "Task X" }],
+  getAgent: async (id: string) => ({ agent_id: id, name: "Agent A" }),
+  getTask: async (id: string) => ({ task_id: id, title: "Task X" }),
+  appendParticipationLog: async () => {},
+} as unknown as MetadataClient;
+
+const reqCtx = { stream: false, modelId: "test-model" } as Parameters<typeof handleSessionInit>[5];
+
+function userMessages(): Record<string, unknown>[] {
+  return [{ role: "user", content: "hi" }];
+}
+
+// ── resolveAutoDefaultIdentity ────────────────────────────────────────────────
+
+describe("resolveAutoDefaultIdentity", () => {
+  it("returns null when autoDefault is disabled", () => {
+    const cfg = baseConfig({ autoDefault: { enabled: false, onUnresolved: "skip" } });
+    expect(resolveAutoDefaultIdentity([teamA, teamB], cfg)).toBeNull();
+  });
+
+  it("resolves default team/agent/task when no ids configured", () => {
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip" } });
+    // 取第一个 team / 第一个 agent；task 缺省用 defaultTaskId（虚拟"不关联任务"）。
+    expect(resolveAutoDefaultIdentity([teamA, teamB], cfg)).toEqual({
+      agent_id: "agt-aaa11111",
+      task_id: "default",
+    });
+  });
+
+  it("honours explicit teamId + agentId + taskId", () => {
+    const cfg = baseConfig({
+      autoDefault: { enabled: true, onUnresolved: "skip", teamId: teamB.team_id, agentId: "agt-bbb22222", taskId: "task-real" },
+    });
+    expect(resolveAutoDefaultIdentity([teamA, teamB], cfg)).toEqual({
+      agent_id: "agt-bbb22222",
+      task_id: "task-real",
+    });
+  });
+
+  it("falls back to defaultTaskId when taskId omitted", () => {
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip", teamId: teamB.team_id } });
+    expect(resolveAutoDefaultIdentity([teamA, teamB], cfg)).toEqual({
+      agent_id: "agt-bbb22222",
+      task_id: "default",
+    });
+  });
+
+  it("returns 'skip' when configured agent not in the team (onUnresolved=skip)", () => {
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip", agentId: "agt-bbb22222" } });
+    // teamA 没有 agt-bbb22222 → 无法解析。
+    expect(resolveAutoDefaultIdentity([teamA], cfg)).toBe("skip");
+  });
+
+  it("returns null when onUnresolved=form and agent missing", () => {
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "form", agentId: "agt-bbb22222" } });
+    expect(resolveAutoDefaultIdentity([teamA], cfg)).toBeNull();
+  });
+
+  it("returns 'skip' when the team list is empty", () => {
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip" } });
+    expect(resolveAutoDefaultIdentity([], cfg)).toBe("skip");
+  });
+
+  it("returns 'skip' when a team has no agents", () => {
+    const emptyTeam: TeamOption = { team_id: "team-00000000", team_name: "Empty", agents: [], tasks: [] };
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip" } });
+    expect(resolveAutoDefaultIdentity([emptyTeam], cfg)).toBe("skip");
+  });
+});
+
+// ── handleSessionInit: autoDefault silent registration ───────────────────────
+
+describe("handleSessionInit with autoDefault", () => {
+  it("registers directly (no form) on a fresh session when autoDefault enabled", async () => {
+    const store = new SessionStore();
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip" } });
+    const result = await handleSessionInit(
+      "session-1", "user-1", userMessages(), cfg, store, reqCtx,
+      metadataClient, "user-key", "space-1", undefined, "dsh",
+    );
+    expect(result.intercepted).toBe(false);
+    expect(result.justRegistered).toBe(true);
+    expect(result.sessionInfo?.user_id).toBe("user-1");
+    const state = store.get("dsh:session-1");
+    expect(state?.status).toBe("initialized");
+    expect(state?.agentDetail?.id).toBe("agt-aaa11111");
+    // 默认未配 taskId → 记 defaultTaskId 虚拟项，task 段为空。
+    expect(state?.taskDetail).toBeNull();
+  });
+
+  it("keeps the interactive form when autoDefault is disabled", async () => {
+    const store = new SessionStore();
+    const cfg = baseConfig({ autoDefault: { enabled: false, onUnresolved: "skip" } });
+    const result = await handleSessionInit(
+      "session-2", "user-1", userMessages(), cfg, store, reqCtx,
+      metadataClient, "user-key", "space-1", undefined, "dsh",
+    );
+    expect(result.intercepted).toBe(true);
+    expect(result.formData).toBeDefined();
+    const state = store.get("dsh:session-2");
+    expect(state?.status).toBe("pending_asset_confirm");
+  });
+});
+
+// ── handleSessionInit: pending timeout convergence ───────────────────────────
+
+describe("handleSessionInit pending timeout", () => {
+  it("converges a stale pending session to autoDefault when past initTimeoutMs", async () => {
+    const store = new SessionStore();
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip" }, initTimeoutMs: 15 * 60 * 1000 });
+    // 种子：一个 20 分钟前开始的 pending_asset_confirm（< 30min 的 store TTL，
+    // 但 > 15min 的 initTimeoutMs），用户一直没有答复。
+    await store.set("dsh:session-3", {
+      status: "pending_asset_confirm",
+      keyId: "session-3",
+      startedAt: Date.now() - 20 * 60 * 1000,
+      attemptCount: 0,
+      userId: "user-1",
+      cachedTeams: [teamA],
+    } as never);
+
+    const result = await handleSessionInit(
+      "session-3", "user-1", userMessages(), cfg, store, reqCtx,
+      metadataClient, "user-key", "space-1", undefined, "dsh",
+    );
+    expect(result.intercepted).toBe(false);
+    expect(result.justRegistered).toBe(true);
+    const state = store.get("dsh:session-3");
+    expect(state?.status).toBe("initialized");
+    expect(state?.agentDetail?.id).toBe("agt-aaa11111");
+  });
+
+  it("does NOT converge when not yet past initTimeoutMs", async () => {
+    const store = new SessionStore();
+    const cfg = baseConfig({ autoDefault: { enabled: true, onUnresolved: "skip" }, initTimeoutMs: 15 * 60 * 1000 });
+    await store.set("dsh:session-4", {
+      status: "pending_asset_confirm",
+      keyId: "session-4",
+      startedAt: Date.now() - 5 * 60 * 1000, // 5 分钟前，未超时
+      attemptCount: 0,
+      userId: "user-1",
+      cachedTeams: [teamA],
+    } as never);
+
+    const result = await handleSessionInit(
+      "session-4", "user-1", userMessages(), cfg, store, reqCtx,
+      metadataClient, "user-key", "space-1", undefined, "dsh",
+    );
+    // 未超时 → 走原状态机（pending_asset_confirm 分支尝试解析答复，未识别 → 重发表单）。
+    expect(result.intercepted).toBe(true);
+  });
+});

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -323,6 +323,59 @@ function findTeamIdForAgent(teams: TeamOption[], agentId: string): string | unde
   return undefined;
 }
 
+// ── [autoDefault] 默认值解析 ──────────────────────────────────────────────────
+
+/**
+ * autoDefault 解析结果：
+ * - `{ agent_id, task_id? }` → 成功，可直接调 completeRegistration 静默注册。
+ * - `"skip"`                 → 已启用但无法解析，按 onUnresolved="skip" 直接放行（不注入）。
+ * - `null`                   → 未启用，或 onUnresolved="form" 需要退化为交互表单。
+ */
+type AutoDefaultResolution = { agent_id: string; task_id?: string } | "skip" | null;
+
+/**
+ * 把 `sessionInit.autoDefault` 解析成可注册的 (agent, task) 组合。
+ *
+ * 见 types.ts SessionInitConfig.autoDefault 的语义。要点：
+ * - team：配了 `teamId` 按 id 匹配，缺省取用户可见列表第一个 team。
+ * - agent：配了 `agentId` 需在该 team 内存在，缺省取该 team 第一个 agent。
+ * - task：配了 `taskId` 用真实任务；缺省/空 → 记为 `config.defaultTaskId` 虚拟项
+ *   （"本次不关联任务"——kernel 不 getTask、注入 task 段为空、记忆走 broad recall）。
+ * - 任一环节无法解析 → 依 `onUnresolved` 返回 "skip"（放行）或 null（回退表单）。
+ *
+ * 导出仅为单元测试；业务调用点在 init.ts 内部。
+ */
+export function resolveAutoDefaultIdentity(
+  teams: TeamOption[],
+  config: SessionInitConfig,
+): AutoDefaultResolution {
+  const ad = config.autoDefault;
+  if (!ad?.enabled) return null;
+  const fallback: AutoDefaultResolution = ad.onUnresolved === "form" ? null : "skip";
+
+  // team：显式 teamId 优先，否则用第一个可见 team（对齐 headerAutoSelect 的"单 team 自动选"直觉）。
+  let team: TeamOption | undefined;
+  if (ad.teamId) team = teams.find((t) => t.team_id === ad.teamId);
+  else team = teams[0];
+  if (!team) return fallback;
+
+  // agent：显式 agentId 需在该 team 内存在，否则取第一个。
+  let agentId = ad.agentId;
+  if (agentId) {
+    if (!team.agents.some((a) => a.agent_id === agentId)) return fallback;
+  } else {
+    if (team.agents.length === 0) return fallback;
+    agentId = team.agents[0].agent_id;
+  }
+
+  // task：显式 taskId 用真实任务；否则记为 defaultTaskId 虚拟项（"本次不关联任务"）。
+  let taskId: string | undefined;
+  if (ad.taskId) taskId = ad.taskId;
+  else if (config.defaultTaskId) taskId = config.defaultTaskId;
+
+  return { agent_id: agentId, task_id: taskId };
+}
+
 /**
  * Assemble the registration payload for a resolved (agent, task). Returns
  * `null` when the agent cannot be matched to any team in the cached list —
@@ -558,6 +611,51 @@ async function handleSessionInitInner(
   if (sessionKey === "unknown" || !sessionKey) return { intercepted: false };
 
   const state = store.get(compositeKey);
+
+  // ── [autoDefault] pending 表单超时 → 直接以默认值收敛 ────────────────────
+  //
+  // 状态机是**请求驱动**的：用户挂在一个 pending 表单上迟迟不答复时，proxy 侧不会
+  // 有新的请求进来，因此这里无法"主动解除 DSH 已挂起的 turn"（那需要 DSH 侧给
+  // ask_user_question 加超时——本次不动 DSH 核心）。它的价值在于：超时后**下一次**
+  // 请求（用户终于回来 / sub-agent 继续推进）到达时，不再反复弹表单 / 解析答复，
+  // 直接以 autoDefault 默认值完成注册并注入记忆，让这条真实消息被正常处理。
+  //
+  // 触发条件：autoDefault.enabled 且当前为 pending 状态且距 startedAt 超过
+  // initTimeoutMs。未启用或未超时 → 完全维持现状（含 store 既有的 TTL 丢弃语义）。
+  if (
+    state &&
+    state.status !== "initialized" &&
+    state.status !== "uninitialized" &&
+    state.startedAt &&
+    config.autoDefault?.enabled
+  ) {
+    const timeout = config.initTimeoutMs ?? 15 * 60 * 1000;
+    if (Date.now() - state.startedAt > timeout) {
+      const cachedTeams = state.cachedTeams ?? [];
+      const autoResolved = resolveAutoDefaultIdentity(cachedTeams, config);
+      if (autoResolved && autoResolved !== "skip") {
+        console.log(
+          `[session-init:cb] session=${compositeKey} pending=${state.status} timed out ` +
+            `(${Math.round((Date.now() - state.startedAt) / 1000)}s > ${Math.round(timeout / 1000)}s) → autoDefault register`,
+        );
+        return await completeRegistration(
+          { agent_id: autoResolved.agent_id, task_id: autoResolved.task_id },
+          state, cachedTeams, compositeKey, sessionKey, userId,
+          config, store, messages, metadataClient, userKey, spaceId,
+        );
+      }
+      // autoDefault 无法解析（onUnresolved=skip）→ 显式按 bypass 收敛，避免下一条
+      // 消息又弹表单。onUnresolved=form → resolveAutoDefaultIdentity 返回 null → 不
+      // 拦截，fall through 走原状态机（保持既有 retry/TTL 语义）。
+      if (autoResolved === "skip") {
+        console.warn(
+          `[session-init:cb] session=${compositeKey} pending=${state.status} timed out but autoDefault unresolved → bypass`,
+        );
+        await store.set(compositeKey, { status: "initialized", bypassed: true } as SessionInitState);
+        return { intercepted: false, bypassed: true, justRegistered: true, resetFlow: state?.resetFlow ?? false };
+      }
+    }
+  }
 
   // ── codex-only pre-checks: Default gate + MORE 分页 ───────────────────────
   //
@@ -874,6 +972,57 @@ async function handleSessionInitInner(
         };
         return { intercepted: true, response: buildFormResponse(fd), formData: fd };
       }
+    }
+
+    // ── [autoDefault] 用户无明确选择意图 → 直接以默认值静默注册 ─────────────
+    //
+    // 在"要弹 asset_confirm 之前"收敛：autoDefault 开启且能解析出 (team, agent) 时，
+    // 不再弹任何交互表单，直接 completeRegistration（注入记忆）。sub-agent 也是一个
+    // 全新 session key，天然走同一路径——因此不需单独判别父/子会话，也不需要 DSH 侧
+    // 携带 parent session header。
+    //
+    // 优先级：headerAutoSelect（header 显式身份）已在**上方**先判，这里只兜底
+    // "无 header、无明确意图"的开新会话场景。host 或客户端想换绑定 → 用 mem:session-reset。
+    {
+      const autoResolved = resolveAutoDefaultIdentity(teams, config);
+      if (autoResolved && autoResolved !== "skip") {
+        console.log(
+          `[session-init:cb] session=${compositeKey} autoDefault team=${findTeamIdForAgent(teams, autoResolved.agent_id) ?? "-"} ` +
+            `agent=${autoResolved.agent_id} task=${autoResolved.task_id ?? "-"} → register directly`,
+        );
+        const seedState: SessionInitState = {
+          status: "uninitialized",
+          keyId: sessionKey,
+          startedAt: Date.now(),
+          attemptCount: 0,
+          userId,
+          cachedTeams: teams,
+        };
+        return await completeRegistration(
+          { agent_id: autoResolved.agent_id, task_id: autoResolved.task_id },
+          seedState, teams, compositeKey, sessionKey, userId,
+          config, store, messages, metadataClient, userKey, spaceId,
+        );
+      }
+      if (autoResolved === "skip") {
+        console.warn(
+          `[session-init:cb] session=${compositeKey} autoDefault enabled but unresolved → bypass (onUnresolved=skip)`,
+        );
+        await store.set(compositeKey, {
+          status: "initialized",
+          keyId: sessionKey,
+          startedAt: Date.now(),
+          attemptCount: 0,
+          userId,
+          cachedTeams: teams,
+          sessionInfo: null,
+          agentDetail: null,
+          taskDetail: null,
+          bypassed: true,
+        } as SessionInitState);
+        return { intercepted: false, bypassed: true, justRegistered: true, resetFlow: state?.resetFlow ?? false };
+      }
+      // null（未启用，或 onUnresolved=form）→ fall through 到原弹表单流程。
     }
 
     // 先弹 asset_confirm 对话框

--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -288,6 +288,51 @@ export interface SessionInitConfig {
     /** header 值在用户可见列表中查不到时：'form' 回退交互表单（默认）| 'bypass' 直接跳过 session init。 */
     onMismatch: "form" | "bypass";
   };
+  /**
+   * 交互式初始化表单的「静默默认」机制（自 2026-08 引入，解决 main agent / sub-agent
+   * 每次开新会话都要手选 team/agent/task 的摩擦，以及 ask 表单等待用户回复导致的
+   * 会话初始化挂起）。
+   *
+   * 核心语义：**用户没有明确选择意图时，直接以默认值完成注册，不弹交互表单**。
+   *
+   * 行为（对齐 slot 已确认的产品方向）：
+   * - `enabled=true` 且能解析出 `(team, agent)` → 状态机在"要弹 asset_confirm 之前"
+   *   直接调 `completeRegistration`，注入记忆、不透传表单。主会话与 sub-agent（新会话）
+   *   一视同仁——sub-agent 也是一个全新 session key，同样走默认值静默注册。
+   * - `enabled=false` / 解析失败（onUnresolved="form"）→ 完全维持原交互表单流程。
+   *
+   * 与 `headerAutoSelect`（header 显式身份）的优先级：header 优先（客户端已明确指定），
+   * autoDefault 作为「无 header、无明确意图」时的兜底。
+   */
+  autoDefault?: {
+    /** 是否启用静默默认。默认 false（保持现状，走表单）。 */
+    enabled: boolean;
+    /** 默认 team_id。缺省时取用户可见列表的第一个 team。 */
+    teamId?: string;
+    /** 默认 agent_id。缺省时取所选 team 的第一个 agent。 */
+    agentId?: string;
+    /**
+     * 默认 task_id。缺省/空字符串 = 不关联任务（记作 config.defaultTaskId 虚拟项，
+     * kernel 不 getTask，注入时 task 段为空、记忆走 broad recall）。
+     * 指定真实 task_id 时按真实任务注入。
+     */
+    taskId?: string;
+    /** 默认值无法解析（如 team/agent 不存在、无可用 agent）时：'skip'=跳过初始化直接放行 | 'form'=退化为交互表单。默认 'skip'。 */
+    onUnresolved?: "skip" | "form";
+  };
+  /**
+   * 交互式初始化表单的「超时收敛」时长（毫秒）。默认 15 分钟。
+   *
+   * 状态机是**请求驱动**的：用户挂在一个 pending 表单上迟迟不答复时，proxy 侧不会有
+   * 新请求进来，因此这里无法"主动解除 DSH 已挂起的 turn"。它的生效方式是：超时后
+   * **下一次**请求（用户终于回来、或 sub-agent 继续推进）到达时，状态机发现距
+   * `startedAt` 已超过本时长，则**不再弹表单 / 解析答复**，直接以 `autoDefault`
+   * 的默认值完成注册并注入记忆，让这条真实消息被正常处理。
+   *
+   * 仅当 `autoDefault.enabled` 为 true 时生效；否则维持现状（store 里既有的
+   * `DEFAULT_TTL_MS` 只负责丢弃过期 pending，不负责"收敛到默认值"）。
+   */
+  initTimeoutMs?: number;
 }
 
 export interface TdaiConfig {
@@ -848,6 +893,14 @@ export interface RawYamlConfig {
       taskHeader?: string;
       onMismatch?: "form" | "bypass";
     };
+    autoDefault?: {
+      enabled?: boolean;
+      teamId?: string;
+      agentId?: string;
+      taskId?: string;
+      onUnresolved?: "skip" | "form";
+    };
+    initTimeoutMs?: number;
   };
   tdai?: {
     enabled?: boolean;

--- a/agents/dsh/README.md
+++ b/agents/dsh/README.md
@@ -100,6 +100,29 @@ proxy 生成 form 响应时需要填入非空 `reasoning_content` 占位。
 2. 用户输入 "跳过" / "skip"
 3. 在 asset_confirm 选"否"
 
+### 3.6.1 静默默认（autoDefault）与超时收敛（initTimeoutMs）
+
+dsh 主会话与 sub-agent（子代理 = 也是全新 session）每次开新会话都会走这套
+初始化表单。如果希望用户**无明确选择意图时直接以默认值完成注册**（不弹表单、
+不等回复），在 proxy `config.yaml` 的 `sessionInit` 段开启：
+
+```yaml
+sessionInit:
+  autoDefault:
+    enabled: true        # 开：不弹表单，直接以默认 (team, agent) 注册并注入记忆
+    teamId: ""           # 默认 team_id；留空 = 取第一个可见 team
+    agentId: ""          # 默认 agent_id；留空 = 取所选 team 第一个 agent
+    taskId: ""           # 留空 = 不关联任务（记 defaultTaskId 虚拟项）
+    onUnresolved: "skip" # 默认值无法解析时：skip=放行 | form=回退表单
+  initTimeoutMs: 900000  # 默认 15 分钟；pending 超时后下一次交互直接收敛到默认值
+```
+
+- **sub-agent 无需 DSH 侧改动**：sub-agent 也是一个全新 session key，天然走
+  `autoDefault` 静默注册路径——不需要识别父/子会话，也不需要 DSH 携带
+  parent session header。
+- 想换绑定 → 用 `mem:session-reset`。详见 [`INSTALL_CN.md`](../../INSTALL_CN.md)
+  的 `sessionInit.autoDefault` 一节。
+
 ### 3.7 首次会话 —— 选 Team → Agent → Task
 
 启动 Web UI：


### PR DESCRIPTION
## 背景与问题

DSH 接入的 TencentDB Agent Memory 会话初始化目前存在两个体验问题：

1. **无默认值**：每次开新会话（main agent 与 sub-agent 都是全新 session）都要手选 team/agent/task；且交互式表单在等待用户答复时会让会话初始化挂起。
2. **子代理被当新会话**：sub-agent 也是全新 session key，同样走这套表单流程，用户往往不在屏幕前。

## 方案

在 **Context Proxy（tdai-memory）** 侧引入「静默默认」，**零改动官方 DSH**（符合"不改宿主"原则）：

- **`sessionInit.autoDefault`**：开启且能解析 `(team, agent)` 时，在弹 `asset_confirm` 之前直接调既有 `completeRegistration` 完成注册并**注入记忆**，不再弹交互表单。main agent 与 sub-agent 一视同仁——sub-agent 也是全新 session key，天然走同一路径，**无需识别父/子会话、无需 DSH 携带 parent session header**。
- **`sessionInit.initTimeoutMs`**（默认 15 分钟）：`pending` 状态超时后，下一次请求（用户回来 / sub-agent 继续推进）直接以 `autoDefault` 收敛注册，不再反复弹表单。

优先级：`headerAutoSelect`（header 显式身份）优先；`autoDefault` 兜底"无 header、无明确意图"的开新会话场景。想换绑定 → `mem:session-reset`。

## 主要改动

- `MemoryProxy/src/types.ts` — `SessionInitConfig` 新增 `autoDefault` + `initTimeoutMs`（含根级 yaml 配置类型）
- `MemoryProxy/src/config.ts` — 默认值 + yaml 解析映射
- `MemoryProxy/src/session/codebuddy/init.ts` — 新增 `resolveAutoDefaultIdentity`；Uninitialized 分支静默注册；pending 超时收敛（状态机被 dsh/codebuddy/codex/workbuddy/opencode 共享）
- `MemoryProxy/src/session/__tests__/session-init-auto-default.test.ts` — 新增 12 个单测
- `MemoryProxy/config.example.yaml` / `INSTALL.md` / `INSTALL_CN.md` / `agents/dsh/README.md` — 配置与文档

## 验证

- vitest 全量 **20/20 通过**（含新增 12 个；另 8 个项目既有）
- 改动文件 `tsc --noEmit` 无新增类型错误（仅项目既有 `resetFlow` 等 56 处红，非本次引入）

## 边界

- 超时是"下一次交互收敛"，不是"主动解除 DSH 已挂起的 turn"（proxy 请求驱动 + 按约定不改 DSH 核心；如需彻底解除需 DSH 侧给 `ask_user_question` 加超时）。
- `autoDefault` 覆盖复用 CB 状态机的客户端（dsh/codebuddy/codex/workbuddy/opencode）；`claude-code` 是独立 init 文件，本次未覆盖（不影响 dsh）。