### PR TITLE
fix(memory-core): update skill usage_count/last_used_at on read (#1189)

### DIFF
--- a/MemoryCore/src/gateway/__tests__/skill-handlers.test.ts
+++ b/MemoryCore/src/gateway/__tests__/skill-handlers.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression test for #1189: `usage_count` / `last_used_at` on `meta_assets`
+ * were never updated when a skill was read via `handleGet`, because the read
+ * path never called `MetadataService.touchAssetUsage()` — unlike the create
+ * path, which registers the asset via `ensureSkillAsset()`.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import { handleGet } from "../skill-handlers.js";
+import type { SkillRouterDeps } from "../skill-handlers.js";
+import type { V2AuthContext } from "../v2-schemas.js";
+import type { Skill } from "../../core/skill/types.js";
+import type { SkillCore } from "../../core/skill/skill-core.js";
+
+const AUTH: V2AuthContext = { apiKey: "test", serviceId: "dev-1" };
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    skill_id: "skl-test1",
+    name: "code-review",
+    description: "test skill",
+    version: 1,
+    is_head: true,
+    status: "active",
+    user_id: "usr-1",
+    owner_agent_id: "agt-1",
+    team_id: "team-1",
+    task_id: "default",
+    created_at_ms: 0,
+    updated_at_ms: 0,
+    metadata_json: "{}",
+    content: "# hi",
+    content_hash: undefined,
+    storage_dir: undefined,
+    manifest: undefined,
+    ...overrides,
+  } as unknown as Skill;
+}
+
+function makeDeps(opts: {
+  skill?: Skill;
+  touchAssetUsage?: ReturnType<typeof vi.fn>;
+  withMetadataService?: boolean;
+}): SkillRouterDeps {
+  const skill = opts.skill ?? makeSkill();
+  const core = {
+    get: vi.fn().mockResolvedValue(skill),
+  } as unknown as SkillCore;
+
+  const deps: SkillRouterDeps = {
+    getSkillCore: () => core,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+
+  if (opts.withMetadataService !== false) {
+    const touchAssetUsage = opts.touchAssetUsage ?? vi.fn().mockResolvedValue(undefined);
+    deps.getMetadataService = vi.fn().mockResolvedValue({ touchAssetUsage });
+  }
+
+  return deps;
+}
+
+describe("handleGet — usage tracking (#1189)", () => {
+  it("calls touchAssetUsage with the skill_id after a successful read", async () => {
+    const touchAssetUsage = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({ touchAssetUsage });
+
+    const res = await handleGet({ skill_id: "skl-test1" }, AUTH, "req-1", deps);
+
+    expect(res.code).toBe(0);
+    expect(touchAssetUsage).toHaveBeenCalledTimes(1);
+    expect(touchAssetUsage).toHaveBeenCalledWith("skl-test1");
+  });
+
+  it("still returns the skill successfully even if touchAssetUsage fails", async () => {
+    const touchAssetUsage = vi.fn().mockRejectedValue(new Error("boom"));
+    const deps = makeDeps({ touchAssetUsage });
+
+    const res = await handleGet({ skill_id: "skl-test1" }, AUTH, "req-2", deps);
+
+    expect(res.code).toBe(0);
+    expect((res as { data?: { skill_id?: string } }).data?.skill_id).toBe("skl-test1");
+    expect(touchAssetUsage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/MemoryCore/src/gateway/skill-handlers.ts
+++ b/MemoryCore/src/gateway/skill-handlers.ts
@@ -507,6 +507,14 @@ export async function handleGet(body: unknown, _auth: V2AuthContext, requestId: 
   if (!pre.ok) { obsLogger.warn("skill.handleGet.done", { req_id: requestId, code: pre.envelope.code, dur_ms: Date.now() - t0, reason: "precheck" }); return pre.envelope; }
   try {
     const row = await pre.core.get(pre.data);
+    if (deps.getMetadataService) {
+      try {
+        const metaSvc = await deps.getMetadataService(_auth.serviceId);
+        await metaSvc.touchAssetUsage(row.skill_id);
+      } catch (err) {
+        deps.logger.error(`touchAssetUsage failed for ${row.skill_id}: ` + (err instanceof Error ? err.message : String(err)));
+      }
+    }
     const includeContent = pre.data.include_content ?? true;
     const includeManifest = pre.data.include_manifest ?? true;
     // Detail view 额外附上 content_hash / storage_dir（summary 没输出这些）。


### PR DESCRIPTION
Fixes #1189

## Description | 描述

`handleGet()` in `skill-handlers.ts` only reads the skill content — it never calls `MetadataService.touchAssetUsage()`. This is inconsistent with `handleCreate()`, which registers the asset via `ensureSkillAsset()`. As a result, `meta_assets.usage_count` and `last_used_at` stay at 0/null no matter how many times a skill is read.

**Fix:** call `metaSvc.touchAssetUsage(row.skill_id)` right after a successful read, wrapped in its own try/catch so a failure here never blocks the skill response — matching the "read-time self-heal path must not block the response" contract already documented on `ensureSkillAsset()`'s failure-strategy comment in `metadata-service.ts`.

## Related Issue | 关联 Issue

Fixes #1189

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

**Tests added** (`MemoryCore/src/gateway/__tests__/skill-handlers.test.ts`):
- asserts `touchAssetUsage` is called once with the correct `skill_id` after a successful read;
- asserts a failure inside `touchAssetUsage` does not affect the response (still returns the skill with `code: 0`).

**Manual end-to-end verification:** created a skill via `/v3/skill/create`, called `/v3/skill/get` 5 times, confirmed `meta_assets.usage_count` went `0 -> 5` and `last_used_at` was populated in the SQLite metadata store.