### PR TITLE
fix(panel): allow agent deletion without SkillCore

### DIFF
--- a/MemoryPanel/panel-api-doc.md
+++ b/MemoryPanel/panel-api-doc.md
@@ -765,7 +765,7 @@ L0/L1 列表批量删除。**仅资产 Owner**。
 | deleted_skill_count | number | 已删 skill 数 |
 | deleted_skill_ids | string[] | 已删 skill ID 列表 |
 
-**错误**：`MISSING_AGENT_ID`、`INVALID_USER_KEY`、`AGENT_NOT_FOUND`、`NOT_YOUR_AGENT`；任一 skill 删除失败返回 `500 SKILL_DELETE_FAILED`（含 `failed_skill_id`、`deleted_skill_ids`），此时 agent 不会 archive。
+**错误**：`MISSING_AGENT_ID`、`INVALID_USER_KEY`、`AGENT_NOT_FOUND`、`NOT_YOUR_AGENT`；任一 skill 删除失败返回 `500 SKILL_DELETE_FAILED`（含 `failed_skill_id`、`deleted_skill_ids`），此时 agent 不会 archive。若内核明确返回 `404 Skill module not enabled`，Control 会将其视为没有可级联的 skill 并继续归档 Agent；其它 `skill/list` 错误仍原样阻断归档。
 
 **示例**
 

--- a/MemoryPanel/src/panel/http/routes/agent-lifecycle.ts
+++ b/MemoryPanel/src/panel/http/routes/agent-lifecycle.ts
@@ -10,7 +10,8 @@
  * 本路由的做法（业务级联收口在 control 层，不改内核）：
  *   1. auth/verify 反查 caller
  *   2. agent/get 拿到 agent，强校验 owner_user_id === caller（本期不允许 admin 代删）
- *   3. skill/list 按 owner_agent_id + active 分页拉全
+ *   3. skill/list 按 owner_agent_id + active 分页拉全；只有内核明确返回
+ *      404 "Skill module not enabled" 时，才把 capability 缺失视为没有 skill
  *   4. 逐条 skill/delete —— 任一失败立即中断，返回 500 + 已删列表 + 失败 skill_id
  *      + 内核错误 message；此时 agent/archive 不会被调用，caller 需要修复后重试
  *   5. 全部 skill 成功归档后调 meta/agent/archive
@@ -39,6 +40,7 @@ import {
 
 /** skill/list 一页 100 条 —— 与 knowledge fetchAllMetaListItems 分页步长对齐。 */
 const SKILL_LIST_PAGE = 100;
+const SKILL_MODULE_DISABLED_MESSAGE = 'Skill module not enabled';
 
 interface AgentRaw {
   agent_id: string;
@@ -52,6 +54,11 @@ interface SkillRow {
   skill_id: string;
   version: number;
   owner_agent_id?: string;
+}
+
+/** Only MemoryCore's explicit capability-absence response is safe to treat as no Skills. */
+function isSkillModuleDisabled(env: MetaEnvelope<unknown>): boolean {
+  return env.code === 404 && env.message === SKILL_MODULE_DISABLED_MESSAGE;
 }
 
 /** skill/list 分页拉取该 agent 名下所有 active skill。 */
@@ -76,7 +83,10 @@ async function listAgentSkills(
       },
       ctx,
     );
-    if (env.code !== 0) return { ok: false, envelope: env };
+    if (env.code !== 0) {
+      if (isSkillModuleDisabled(env)) return { ok: true, items: [] };
+      return { ok: false, envelope: env };
+    }
     const batch = extractListItems<SkillRow>(env);
     all.push(...batch);
     const total = (env.data as { total?: number } | null)?.total ?? all.length;

--- a/MemoryPanel/tests/agent-lifecycle.test.ts
+++ b/MemoryPanel/tests/agent-lifecycle.test.ts
@@ -1,0 +1,187 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { InstanceRegistry } from '../src/panel/config/instance-registry.js';
+import { registerAgentLifecycleRoutes } from '../src/panel/http/routes/agent-lifecycle.js';
+import type { MetaEnvelope } from '../src/panel/kernel/envelope.js';
+import type { MetaKernelPort } from '../src/panel/kernel/ports/meta-kernel-port.js';
+import type { SkillKernelPort } from '../src/panel/kernel/ports/skill-kernel-port.js';
+import type { PanelDeps } from '../src/panel/panel-deps.js';
+
+const CALLER_ID = 'user-1';
+const TEAM_ID = 'team-1';
+const AGENT_ID = 'agent-1';
+
+function envelope<T>(code: number, message: string, data: T): MetaEnvelope<T> {
+  return { code, message, request_id: 'request-1', data };
+}
+
+function createHarness(skillInvoke: SkillKernelPort['invoke']) {
+  const metaActions: string[] = [];
+  const skillActions: string[] = [];
+  const lifecycleActions: string[] = [];
+
+  const metaKernel: MetaKernelPort = {
+    async invoke(action) {
+      metaActions.push(action);
+      lifecycleActions.push(`meta:${action}`);
+      if (action === 'auth/verify') {
+        return envelope(0, 'ok', { valid: true, user: { user_id: CALLER_ID } });
+      }
+      if (action === 'agent/get') {
+        return envelope(0, 'ok', {
+          agent_id: AGENT_ID,
+          team_id: TEAM_ID,
+          owner_user_id: CALLER_ID,
+          status: 'active',
+        });
+      }
+      if (action === 'agent/archive') {
+        return envelope(0, 'ok', { archived: true });
+      }
+      throw new Error(`unexpected meta action: ${action}`);
+    },
+  };
+
+  const skillKernel: SkillKernelPort = {
+    async invoke(action, body, ctx) {
+      skillActions.push(action);
+      lifecycleActions.push(`skill:${action}`);
+      return skillInvoke(action, body, ctx);
+    },
+  };
+
+  const deps = {
+    instanceRegistry: new InstanceRegistry([
+      {
+        instance_id: 'instance-1',
+        name: 'test',
+        gateway_endpoint: 'http://127.0.0.1:8420',
+        api_key: 'test-api-key',
+      },
+    ]),
+    metaKernel,
+    skillKernel,
+  } as unknown as PanelDeps;
+
+  const app = new Hono();
+  registerAgentLifecycleRoutes(app, deps);
+
+  return { app, metaActions, skillActions, lifecycleActions };
+}
+
+async function deleteAgent(app: Hono) {
+  return app.request('/agent/delete-cascade', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-tdai-service-id': 'instance-1',
+      'x-tdai-user-key': 'user-key',
+    },
+    body: JSON.stringify({ agent_id: AGENT_ID }),
+  });
+}
+
+describe('POST /agent/delete-cascade', () => {
+  it('archives an empty Agent when SkillCore is explicitly disabled', async () => {
+    const { app, metaActions, skillActions } = createHarness(async () =>
+      envelope(404, 'Skill module not enabled', null),
+    );
+
+    const response = await deleteAgent(app);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      code: 0,
+      data: {
+        archived: true,
+        agent_id: AGENT_ID,
+        deleted_skill_count: 0,
+        deleted_skill_ids: [],
+      },
+    });
+    expect(skillActions).toEqual(['list']);
+    expect(metaActions).toEqual(['auth/verify', 'agent/get', 'agent/archive']);
+  });
+
+  it('keeps unrelated Skill list errors fail-closed', async () => {
+    const { app, metaActions, skillActions } = createHarness(async () =>
+      envelope(404, 'Skill not found', null),
+    );
+
+    const response = await deleteAgent(app);
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toMatchObject({ code: 404, message: 'Skill not found' });
+    expect(skillActions).toEqual(['list']);
+    expect(metaActions).toEqual(['auth/verify', 'agent/get']);
+  });
+
+  it('deletes existing Skills before archiving the Agent', async () => {
+    const { app, lifecycleActions } = createHarness(async (action) => {
+      if (action === 'list') {
+        return envelope(0, 'ok', {
+          items: [{ skill_id: 'skill-1', version: 3, owner_agent_id: AGENT_ID }],
+          total: 1,
+        });
+      }
+      if (action === 'delete') return envelope(0, 'ok', { deleted: true });
+      throw new Error(`unexpected skill action: ${action}`);
+    });
+
+    const response = await deleteAgent(app);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      code: 0,
+      data: {
+        archived: true,
+        deleted_skill_count: 1,
+        deleted_skill_ids: ['skill-1'],
+      },
+    });
+    expect(lifecycleActions).toEqual([
+      'meta:auth/verify',
+      'meta:agent/get',
+      'skill:list',
+      'skill:delete',
+      'meta:agent/archive',
+    ]);
+  });
+
+  it('does not archive the Agent when deleting a Skill fails', async () => {
+    const { app, lifecycleActions } = createHarness(async (action) => {
+      if (action === 'list') {
+        return envelope(0, 'ok', {
+          items: [{ skill_id: 'skill-1', version: 3, owner_agent_id: AGENT_ID }],
+          total: 1,
+        });
+      }
+      if (action === 'delete') return envelope(409, 'VERSION_CONFLICT', null);
+      throw new Error(`unexpected skill action: ${action}`);
+    });
+
+    const response = await deleteAgent(app);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toMatchObject({
+      code: 500,
+      message: 'SKILL_DELETE_FAILED',
+      data: {
+        failed_skill_id: 'skill-1',
+        kernel_code: 409,
+        kernel_message: 'VERSION_CONFLICT',
+        deleted_skill_ids: [],
+      },
+    });
+    expect(lifecycleActions).toEqual([
+      'meta:auth/verify',
+      'meta:agent/get',
+      'skill:list',
+      'skill:delete',
+    ]);
+  });
+});


### PR DESCRIPTION
## Description | 描述

Fixes #1218.

### Root cause

`POST /api/v1/agent/delete-cascade` unconditionally calls `skill/list`. A deployment without SkillCore returns the explicit capability-absence envelope `404 Skill module not enabled`, which MemoryPanel previously forwarded before reaching `meta/agent/archive`. This blocked deletion even when the Agent had no Skills.

### Behavior change

- Treat only the exact `code=404` plus `message=Skill module not enabled` response as an empty Skill collection, then continue to archive the Agent.
- Preserve fail-closed behavior for every other `skill/list` error.
- Preserve the existing ordering when SkillCore is available: list Skills, delete every Skill, then archive the Agent.
- Preserve the existing failure behavior: if any `skill/delete` fails, do not archive the Agent.

### Non-goals

- Do not enable or deploy SkillCore.
- Do not change MemoryCore, persistence, authorization, or Agent ownership.
- Do not treat generic 404 or upstream failures as an empty Skill collection.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [x] Documentation update | 文档更新
- [ ] New feature | 新功能
- [ ] Code optimization | 代码优化

## Verification | 验证

- [x] Regression test first reproduced the old `404` behavior.
- [x] `pnpm test` — 4/4 route-level tests passed.
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Standalone strict TypeScript check for the new test.
- [x] Scoped strict secret scan for all changed files.
- [ ] Full `bash scripts/secret-scan.sh --strict` is currently blocked by three pre-existing placeholder hits in `MemoryPanel/web/src/pages/GuidePage/index.tsx` at lines 88, 106, and 141; this PR does not change that file.
- [ ] Live E2E was not run; the regression is covered at the public Hono route with the MemoryCore boundaries stubbed.

Covered cases:

1. SkillCore explicitly disabled: empty Agent is archived.
2. Unrelated Skill list errors still block archive.
3. Existing Skills are deleted before archive.
4. Skill deletion failure prevents archive.

## Compatibility and rollback | 兼容与回滚

No request/response schema or durable state changes. SkillCore-enabled deployments retain their current behavior. Rollback is a single commit revert; that restores the prior failure for SkillCore-disabled deployments without requiring data migration.

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能