### PR TITLE
fix(sanitize): repair unescaped ASCII quotes inside JSON string values from LLM output

### DIFF
--- a/MemoryCore/src/utils/sanitize.test.ts
+++ b/MemoryCore/src/utils/sanitize.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeJsonForParse } from "./sanitize.js";
+
+/**
+ * Regression tests for the stray-quote repair pass (phase 3) in
+ * `sanitizeJsonForParse`.
+ *
+ * All three failure fixtures below reproduce the same error class: the LLM
+ * opens a typographic quote (e.g. German „) inside a JSON string value but
+ * closes it with a literal ASCII `"` instead of the matching typographic
+ * glyph or an escaped `\"`. That stray `"` ends the JSON string early, and
+ * `JSON.parse` then throws a few tokens later (typically
+ * `Expecting ',' delimiter` or similar). The fixtures use neutral,
+ * synthetic content — not real production data — but reproduce the exact
+ * quote-mismatch shape observed in the wild.
+ */
+describe("sanitizeJsonForParse — stray ASCII quote inside a JSON string value", () => {
+  it("repairs a stray quote at the end of a sentence, followed by trailing punctuation", () => {
+    const broken =
+      '[{"scene_name":"Chat","message_ids":["m1"],"memories":[{"content":"The reviewer replied: „Looks good to me".","type":"episodic","priority":50,"source_message_ids":["m1"],"metadata":{}}]}]';
+
+    const sanitized = sanitizeJsonForParse(broken);
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+
+    const parsed = JSON.parse(sanitized);
+    // The stray quote must be preserved as a literal character in the
+    // repaired content — no data loss, just correct escaping.
+    expect(parsed[0].memories[0].content).toBe('The reviewer replied: „Looks good to me".');
+  });
+
+  it("repairs a stray quote wrapping a named entity mid-sentence", () => {
+    const broken =
+      '[{"scene_name":"Planning","message_ids":["m2"],"memories":[{"content":"The user renamed the project to „Aurora" during the call.","type":"episodic","priority":50,"source_message_ids":["m2"],"metadata":{}}]}]';
+
+    const sanitized = sanitizeJsonForParse(broken);
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+
+    const parsed = JSON.parse(sanitized);
+    expect(parsed[0].memories[0].content).toBe('The user renamed the project to „Aurora" during the call.');
+  });
+
+  it("repairs a stray quote around a quoted slogan followed by an em dash", () => {
+    const broken =
+      '[{"scene_name":"Retro","message_ids":["m3"],"memories":[{"content":"Their guiding principle is „ship it" – the team repeats it every standup.","type":"episodic","priority":50,"source_message_ids":["m3"],"metadata":{}}]}]';
+
+    const sanitized = sanitizeJsonForParse(broken);
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+
+    const parsed = JSON.parse(sanitized);
+    expect(parsed[0].memories[0].content).toBe(
+      'Their guiding principle is „ship it" – the team repeats it every standup.',
+    );
+  });
+
+  it("is idempotent: already-valid JSON with an escaped quote is left byte-identical", () => {
+    const valid =
+      '[{"scene_name":"Chat","message_ids":["m4"],"memories":[{"content":"She said \\"let\'s go\\" and left.","type":"episodic","priority":50,"source_message_ids":["m4"],"metadata":{}}]}]';
+
+    const sanitized = sanitizeJsonForParse(valid);
+    expect(sanitized).toBe(valid);
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+  });
+
+  it("is idempotent: already-valid JSON with a properly paired typographic quote is left byte-identical", () => {
+    const valid =
+      '[{"scene_name":"Chat","message_ids":["m5"],"memories":[{"content":"The motto is „ship it“ and everyone agrees.","type":"episodic","priority":50,"source_message_ids":["m5"],"metadata":{}}]}]';
+
+    const sanitized = sanitizeJsonForParse(valid);
+    expect(sanitized).toBe(valid);
+    expect(() => JSON.parse(sanitized)).not.toThrow();
+  });
+});

--- a/MemoryCore/src/utils/sanitize.ts
+++ b/MemoryCore/src/utils/sanitize.ts
@@ -305,13 +305,19 @@ export function escapeXmlTags(text: string): string {
  * LLMs sometimes produce unescaped control characters (raw newlines, tabs, etc.)
  * inside string values.
  *
- * Strategy (two-phase):
+ * Strategy (three-phase):
  *  1. **Precise pass** — walk through JSON string literals (delimited by `"`)
  *     and escape any unescaped U+0000–U+001F inside them to `\uXXXX` form,
  *     while leaving structural whitespace (between values) untouched.
  *  2. **Fallback** — if the precise pass still fails `JSON.parse`, fall back to
  *     a simple global strip of rare control chars (\x00–\x08, \x0b, \x0c,
  *     \x0e–\x1f) which are almost never meaningful in natural-language content.
+ *  3. **Stray-quote pass** — if phase 2 still fails `JSON.parse`, walk the JSON
+ *     string literals again and escape unescaped ASCII `"` that are clearly NOT
+ *     a real string terminator (see {@link escapeStrayQuotesInJsonStrings}).
+ *     Observed root cause (2026-08-30): the LLM occasionally opens a German
+ *     quote with „ but closes it with a literal ASCII `"` instead of the
+ *     typographic `"` or an escaped `\"`, prematurely ending the JSON string.
  */
 export function sanitizeJsonForParse(raw: string): string {
   // Phase 1: Escape control characters inside JSON string literals.
@@ -330,7 +336,29 @@ export function sanitizeJsonForParse(raw: string): string {
   // control-character escaping Phase 1 performed is preserved even when the JSON has
   // other issues (e.g. trailing commas) that cause the Phase 1 parse to fail.
   const stripped = escaped.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
-  return stripped;
+  try {
+    JSON.parse(stripped);
+    return stripped;
+  } catch {
+    // Phase 2 still doesn't parse — fall through to phase 3
+  }
+
+  // Phase 3: Escape stray/unescaped ASCII quotes inside string values that are
+  // not real string terminators (see escapeStrayQuotesInJsonStrings for the rule).
+  //
+  // IMPORTANT: this pass runs on `raw` (the original text), not on `escaped`/
+  // `stripped`. Phase 1's control-char escaper toggles its `inString` state on
+  // *every* unescaped `"` with no lookahead — a single stray quote (the exact
+  // bug this phase targets) flips that parity for the rest of the document,
+  // which can turn real structural newlines between fields into literal `\n`
+  // escape sequences further down. Running the smarter, lookahead-based quote
+  // fix first restores correct quote pairing; phases 1+2 are then re-applied
+  // (their logic untouched) to the corrected text so control chars inside the
+  // now-correctly-delimited strings are still handled.
+  const quoteFixed = escapeStrayQuotesInJsonStrings(raw);
+  const reEscaped = escapeControlCharsInJsonStrings(quoteFixed);
+  const reStripped = reEscaped.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
+  return reStripped;
 }
 
 /**
@@ -389,6 +417,85 @@ function escapeControlCharsInJsonStrings(text: string): string {
       i++;
     } else {
       // Outside string literal
+      if (ch === '"') {
+        out.push(ch);
+        inString = true;
+        i++;
+        continue;
+      }
+      // Structural character (including whitespace) — pass through
+      out.push(ch);
+      i++;
+    }
+  }
+
+  return out.join("");
+}
+
+/**
+ * Walk through a JSON text and escape unescaped ASCII `"` (U+0022) characters
+ * that appear *inside* a JSON string literal but are clearly not the string's
+ * real terminator.
+ *
+ * Root cause: the LLM sometimes opens a typographic quote (e.g. a German „,
+ * U+201E) but closes it with a literal ASCII `"` instead of the matching
+ * typographic closing glyph (e.g. U+201C) or an escaped `\"`. Since the
+ * surrounding JSON string is itself delimited by `"`, that stray character
+ * ends the JSON string early and breaks the parse a few tokens later. Same
+ * error class as unescaped-quote/trailing-text JSON failures reported for
+ * other models (see #110).
+ *
+ * Rule: when an unescaped `"` is encountered while inside a string, look at
+ * the next non-whitespace character. If it is a JSON structural continuation
+ * character (`,` `}` `]` `:`) — or end-of-text — the quote is treated as the
+ * real terminator and left untouched. Otherwise it is almost certainly a
+ * stray quote embedded in natural-language content, so it gets escaped to
+ * `\"` and the string is kept open.
+ *
+ * This is deliberately conservative: it only fires on quotes that are NOT
+ * followed by valid JSON continuation syntax, so well-formed strings (the
+ * overwhelming majority) pass through byte-for-byte unchanged.
+ */
+function escapeStrayQuotesInJsonStrings(text: string): string {
+  const STRUCTURAL_AFTER_QUOTE = new Set([",", "}", "]", ":"]);
+
+  const out: string[] = [];
+  let inString = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const ch = text[i]!;
+
+    if (inString) {
+      if (ch === "\\" && i + 1 < text.length) {
+        // Already-escaped sequence — copy both characters verbatim
+        out.push(ch, text[i + 1]!);
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        // Peek ahead past whitespace to decide: real terminator or stray quote?
+        let j = i + 1;
+        while (j < text.length && /\s/.test(text[j]!)) j++;
+        const nextCh = j < text.length ? text[j] : undefined;
+
+        if (nextCh === undefined || STRUCTURAL_AFTER_QUOTE.has(nextCh)) {
+          // Real string terminator — leave as-is, exit string mode.
+          out.push(ch);
+          inString = false;
+          i++;
+          continue;
+        }
+
+        // Stray quote embedded in content — escape it, stay inside the string.
+        out.push('\\"');
+        i++;
+        continue;
+      }
+      // Normal character inside string
+      out.push(ch);
+      i++;
+    } else {
       if (ch === '"') {
         out.push(ch);
         inString = true;


### PR DESCRIPTION
## Description | 描述

Adds a third, conservative repair pass to `sanitizeJsonForParse()` in
`MemoryCore/src/utils/sanitize.ts` that recovers a specific LLM JSON-output
failure mode: the model opens a typographic quote inside a string value
(e.g. a German opening quote, U+201E „) but closes it with a literal ASCII
`"` instead of the matching typographic glyph or an escaped `\"`. Because
the enclosing JSON string is itself delimited by `"`, that stray character
ends the string early and `JSON.parse` fails a few tokens later — a shape
the existing two phases (control-character escaping only) cannot catch,
since neither ever inspects ASCII-quote placement.

The new phase 3 walks the JSON string literals and, on encountering an
unescaped ASCII `"`, peeks at the next non-whitespace character: a JSON
structural continuation character (`,` `}` `]` `:`) or end-of-text means
it's the real terminator and is left untouched; anything else means it's a
stray quote embedded in content, which gets escaped to `\"` while the
string stays open. It deliberately runs on the *original* raw text rather
than the phase-1/2 output, because phase 1's control-char escaper toggles
its string-open/closed state on every unescaped quote with no lookahead —
a single stray quote would desync that state for the rest of the document
(turning real structural newlines into literal `\n` sequences further
down). The lookahead-based fix restores correct quote pairing first;
phases 1 and 2 (unchanged) are then reapplied to the corrected text so
control characters inside the now-correctly-delimited strings are still
handled.

No changes to the exported signature (`sanitizeJsonForParse(raw: string):
string`) or its call site (`l1-extractor.ts:543`). Phase 3 only runs when
phases 1 and 2 both still fail to produce parseable JSON, so well-formed
output is byte-for-byte unaffected.

## Related Issue | 关联 Issue

Same error class as #110 (L1 extraction JSON parse failure) — that report
covers a different model (deepseek-v4-flash) producing unescaped Chinese
characters and trailing text after the JSON object. This PR covers a
quote-mismatch variant of the same underlying problem (non-strict LLM JSON
output breaking a naive `JSON.parse` in the L1 extraction pipeline). Not a
duplicate of #110 — a narrower, additive fix for a specific failure shape
that report doesn't cover and the current sanitizer doesn't handle.

## Reproduction

Observed in production against a locally hosted OpenAI-compatible model
(Qwen3.8-27B) used for L1 memory extraction, with a German-language system
prompt. Across 3 real extraction failures (verified byte-for-byte against
the raw LLM output captured in application logs), all 3 hit the identical
pattern — the model opens a quote with „ (U+201E) and closes it with an
ASCII `"` (U+0022) instead of the typographic closing glyph or `\"`, e.g.
(anonymized, shape-preserving example):

    "content":"The reviewer replied: „Looks good to me"."
                                                        ^ stray ASCII quote ends the string here

`JSON.parse` then fails a few tokens later (`Expecting ',' delimiter` or
similar). `sanitizeJsonForParse()`'s existing phases 1–2 pass this input
through unchanged, since no control character is involved — the extraction
result was silently dropped (`extracted=0`) for every one of these 3
failures before this fix.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

**Unit tests added** (`MemoryCore/src/utils/sanitize.test.ts`, 5 cases, all
passing):

- 3 synthetic fixtures reproducing the exact quote-mismatch shape
  (end-of-sentence, a quoted named entity mid-sentence, a quoted phrase
  followed by an em dash) — all repaired and parse correctly, with the
  stray quote preserved as a literal character in the output (no data
  loss)
- 2 idempotency cases: an already-escaped `\"` and a correctly paired
  typographic quote (`„…“`) both stay byte-identical through
  `sanitizeJsonForParse()`

```
$ npm test

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Offline validation against the real failures that motivated this fix:**
replayed the 3 real production payloads that originally broke L1
extraction (reconstructed byte-for-byte from application logs) directly
through the patched `sanitizeJsonForParse()` — all 3 now parse (0/3 before
this fix). 3 previously-valid extraction outputs re-checked for
idempotency — all 3 stay unchanged and still parse.

**Field validation:** after deploying this fix — together with an
unrelated, complementary prompt-side mitigation that reduces how often the
model produces this quote shape in the first place, and is not part of
this PR — a 67-minute live reimport through the L1 pipeline produced 74
extracted records with 1 residual parse failure (down from 3/3 failures on
comparable content before). The residual case marks this heuristic's
documented limit: a stray quote directly followed by a natural-language
comma is indistinguishable from a real string terminator without language
understanding, so phase 3 correctly leaves it untouched; the pipeline's
existing retry regenerates the output, which resolves such cases in
practice.

## Additional Notes | 其他说明

Scope is intentionally narrow: one new private helper
(`escapeStrayQuotesInJsonStrings`), one new call site inside
`sanitizeJsonForParse()`'s existing phase-3 fallback, one colocated test
file. No dependency, config, or public-API changes.

---

*This PR was researched and written by Ren, an AI agent operated by @karls0r, with his review.*