### PR TITLE
fix(hermes): clarify memory provider activation

### DIFF
--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -548,7 +548,8 @@ class MemoryTencentdbProvider(MemoryProvider):
 
         logger.info(
             "TDBMEM001 memory-tencentdb selected by Hermes: "
-            "memory.provider=memory_tencentdb; state=initializing; gateway_policy=%s. "
+            "memory.provider=memory_tencentdb; state=initializing; gateway_policy=%s; "
+            "runtime=watchdog,gateway,recall,capture,l0-l3. "
             "Hermes memory_enabled/user_profile_enabled flags are not lifecycle "
             "switches for this external provider. To disable it, unset or change "
             "memory.provider.",

--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py
@@ -546,6 +546,15 @@ class MemoryTencentdbProvider(MemoryProvider):
         gateway_cmd = os.environ.get("MEMORY_TENCENTDB_GATEWAY_CMD") or _discover_gateway_cmd()
         api_key = _resolve_gateway_api_key()
 
+        logger.info(
+            "TDBMEM001 memory-tencentdb selected by Hermes: "
+            "memory.provider=memory_tencentdb; state=initializing; gateway_policy=%s. "
+            "Hermes memory_enabled/user_profile_enabled flags are not lifecycle "
+            "switches for this external provider. To disable it, unset or change "
+            "memory.provider.",
+            "managed" if gateway_cmd else "external",
+        )
+
         self._supervisor = GatewaySupervisor(
             host=host,
             port=port,

--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/tests/test_startup_observability.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/tests/test_startup_observability.py
@@ -1,0 +1,90 @@
+"""Regression tests for Hermes provider startup observability."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+_HERMES_PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_HERMES_PLUGIN_ROOT))
+
+if "agent.memory_provider" not in sys.modules:
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+
+    class MemoryProvider:
+        pass
+
+    memory_provider_module.MemoryProvider = MemoryProvider
+    sys.modules.setdefault("agent", agent_module)
+    sys.modules["agent.memory_provider"] = memory_provider_module
+
+from memory import memory_tencentdb as provider_module
+
+
+class StartupObservabilityTest(unittest.TestCase):
+    def test_startup_observability(self):
+        for gateway_cmd, policy in (("start-gateway", "managed"), ("", "external")):
+            with self.subTest(policy=policy):
+                supervisor = mock.Mock()
+                supervisor.is_running.return_value = True
+                supervisor.client = mock.sentinel.client
+                env = {
+                    "MEMORY_TENCENTDB_GATEWAY_CMD": gateway_cmd,
+                    "MEMORY_TENCENTDB_GATEWAY_API_KEY": "super-secret",
+                }
+                with mock.patch.dict(os.environ, env), \
+                        mock.patch.object(
+                            provider_module, "_discover_gateway_cmd", return_value=None
+                        ), \
+                        mock.patch.object(
+                            provider_module, "GatewaySupervisor"
+                        ) as supervisor_class, \
+                        mock.patch.object(
+                            provider_module.MemoryTencentdbProvider,
+                            "_start_watchdog",
+                        ), \
+                        self.assertLogs(
+                            provider_module.logger.name, level="INFO"
+                        ) as logs:
+                    supervisor_class.side_effect = lambda **kwargs: (
+                        self.assertTrue(any(
+                            "TDBMEM001" in record.getMessage()
+                            for record in logs.records
+                        )) or supervisor
+                    )
+                    provider = provider_module.MemoryTencentdbProvider()
+                    provider.initialize(
+                        session_id="private-session",
+                        team_id="private-team",
+                        agent_id="private-agent",
+                        user_id="private-user",
+                        memory_enabled=False,
+                    )
+
+                text = "\n".join(logs.output)
+                for expected in (
+                    "TDBMEM001 memory-tencentdb selected by Hermes",
+                    "memory.provider=memory_tencentdb",
+                    "state=initializing",
+                    f"gateway_policy={policy}",
+                    "memory_enabled/user_profile_enabled",
+                    "not lifecycle switches",
+                    "unset or change memory.provider",
+                ):
+                    self.assertIn(expected, text)
+                for secret_or_false_state in (
+                    "private-session", "private-team", "private-agent",
+                    "private-user", "super-secret", "state=ready",
+                    "state=active", "state=healthy",
+                ):
+                    self.assertNotIn(secret_or_false_state, text)
+                supervisor_class.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/MemoryCore/hermes-plugin/memory/memory_tencentdb/tests/test_startup_observability.py
+++ b/MemoryCore/hermes-plugin/memory/memory_tencentdb/tests/test_startup_observability.py
@@ -72,6 +72,7 @@ class StartupObservabilityTest(unittest.TestCase):
                     "memory.provider=memory_tencentdb",
                     "state=initializing",
                     f"gateway_policy={policy}",
+                    "runtime=watchdog,gateway,recall,capture,l0-l3",
                     "memory_enabled/user_profile_enabled",
                     "not lifecycle switches",
                     "unset or change memory.provider",


### PR DESCRIPTION
Fixes #95

## Summary

- Emit `TDBMEM001` before `GatewaySupervisor` creation to explain that Hermes selected `memory_tencentdb`.
- Report `state=initializing`, the resolved `managed` or `external` Gateway policy, and the continuing `watchdog`, `gateway`, `recall`, `capture`, and L0-L3 runtime effects without claiming readiness.
- Clarify that `memory_enabled` and `user_profile_enabled` are not lifecycle switches for this external provider, while preserving the existing lifecycle unchanged.
- Add regression coverage for both Gateway policies, log ordering, lifecycle continuity, runtime effects, and sensitive-value redaction.

## Changed files

- `MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py`
- `MemoryCore/hermes-plugin/memory/memory_tencentdb/tests/test_startup_observability.py`

## Validation

- `python3 -m unittest discover -s MemoryCore/hermes-plugin/memory/memory_tencentdb/tests -p 'test_startup_observability.py' -v`
- `python3 -m py_compile MemoryCore/hermes-plugin/memory/memory_tencentdb/__init__.py MemoryCore/hermes-plugin/memory/memory_tencentdb/tests/test_startup_observability.py`
- `pnpm build:plugin`
- `git diff --check`

## Repository baseline checks

- `pnpm test` currently exits because the checked-out baseline contains no files matching its configured TypeScript test patterns.
- `pnpm build` completes the plugin and three script builds, then exits because the baseline references the absent `scripts/seed-v2/tsconfig.json`.

## Related PR context

#259 was closed as a duplicate of #185. #185 was the prior canonical fix but targeted the old branch and directory structure. This implementation is rebuilt on `feat/server_team` and intentionally omits unreachable host-flag parsing.

## AI assistance

Codex assisted with implementation and verification. The user approved development, reviewed the prepared branch and PR text, and separately approved pull-request creation. Maintainers should review the complete diff before merge.
