### PR TITLE
fix(memory-core): route standalone Skill assets by request instance

### DIFF
--- a/MemoryCore/src/core/skill/conversation-add/wire.ts
+++ b/MemoryCore/src/core/skill/conversation-add/wire.ts
@@ -36,7 +36,7 @@ export interface WireConversationAddDeps {
   /**
    * sink 兜底登记 skill asset 需要的 metadata service（幂等）。
    * 不传时 sink 是 no-op —— skill 已由 extractor 的 tool-call 落库，
-   * 只是前端管控页可能看不到（standalone 模式下无 onSkillCreated 钩子）。
+   * 只是前端管控页可能看不到（例如 host 未提供 metadataService/hook wiring）。
    */
   metadataService?: MetadataServiceLike;
 

--- a/MemoryCore/src/gateway/server.ts
+++ b/MemoryCore/src/gateway/server.ts
@@ -87,6 +87,7 @@ import {
 import { readApiTraceEnabled } from "../utils/env-config.js";
 import { makeSkillRouteTable } from "./skill-handlers.js";
 import type { SkillRouterDeps as SkillRouterDeps } from "./skill-handlers.js";
+import { resolveSkillInstance } from "./skill-instance-context.js";
 import {
   wireConversationAddHandler,
   RedisSkillAgentTaskQueue,
@@ -348,12 +349,12 @@ export class TdaiGateway {
     // （每个 SkillCore 只调它自己被挂上的钩子），ensureSkillAsset / deleteAssets
     // 幂等，即使叠加触发也无副作用。详见 SkillAssetHooks doc。
     //
-    // standalone 模式下 instanceId 固定为 "default"（见 start() 里的
-    // `this.config.instanceId ?? "default"`），闭包这里直接拿 default 即可；
-    // service 模式下这份 SkillCore 事实上不会被 v3/skill/* 走到，闭包的 default
-    // 只是占位（不 fire 就没影响）。
+    // HTTP skill routes resolve the instance lazily from their request context so a
+    // standalone gateway can honor each x-tdai-service-id. Calls that bypass those
+    // routes keep the configured/default instance; the service-mode singleton remains
+    // a placeholder because requests use per-instance SkillCore objects instead.
     const gatewayRef = this;
-    const skillAssetInstanceId = this.config.instanceId
+    const fallbackSkillAssetInstanceId = this.config.instanceId
       ?? (this.config.deployMode === "service" ? "__unset__" : "default");
     // Shared permit pool — memory PipelineWorker 用。skill 侧走
     // wireConversationAdd 内的 SkillConversationExtractWorker (agent 级串行 lock),
@@ -370,14 +371,16 @@ export class TdaiGateway {
         // handleCreate 兜底之外就是这里 —— 无论谁调 SkillCore.create 都能触发。
         onSkillCreated: async ({ skill_id, team_id, agent_id, name }) => {
           if (!team_id || !agent_id) return; // 无租户上下文 → 跳过（OpenClaw local scope 等）
-          const metaSvc = await gatewayRef.ensureMetadataService(skillAssetInstanceId);
+          const metaSvc = await gatewayRef.ensureMetadataService(
+            resolveSkillInstance(fallbackSkillAssetInstanceId),
+          );
           await metaSvc.ensureSkillAsset({ skill_id, team_id, agent_id, name });
         },
         // 读时自愈：fire-and-forget，异常吞掉。补历史 / 迁移 / 误删产生的孤儿 skill。
         onSkillAccessed: (skill) => {
           if (!skill.team_id || !skill.owner_agent_id) return;
           gatewayRef
-            .ensureMetadataService(skillAssetInstanceId)
+            .ensureMetadataService(resolveSkillInstance(fallbackSkillAssetInstanceId))
             .then((svc) => svc.ensureSkillAsset({
               skill_id: skill.skill_id,
               team_id: skill.team_id!,
@@ -394,7 +397,7 @@ export class TdaiGateway {
         // 归档级联：fire-and-forget，异常吞掉。二次 delete 会重触发钩子，最终收敛。
         onSkillArchived: ({ skill_id, team_id }) => {
           gatewayRef
-            .ensureMetadataService(skillAssetInstanceId)
+            .ensureMetadataService(resolveSkillInstance(fallbackSkillAssetInstanceId))
             .then((svc) => svc.deleteAssets([skill_id]))
             .catch((err: unknown) => {
               gatewayRef.logger.warn(
@@ -932,10 +935,8 @@ export class TdaiGateway {
         getResolvedSkillConfig: () => this.core.getResolvedSkillConfig(),
         quotaManager: this.quotaManager ?? undefined,
         logger: this.logger,
-        // Standalone 模式下 SkillCore 由 TdaiCore 全局构造（不带 onSkillCreated 钩子），
-        // handleCreate 用这个 dep 在 skill 创建成功后调 metaSvc.ensureSkillAsset()
-        // 完成 asset 登记 + agent fixed-asset 绑定。service 模式下 buildSkillCore 里
-        // 的 onSkillCreated 钩子做同样的事，两条路径都覆盖，ensureSkillAsset 本身幂等。
+        // Lifecycle hooks and handler fallbacks both resolve this request's instance.
+        // Registration is intentionally duplicated because ensureSkillAsset is idempotent.
         getMetadataService: (instanceId) => this.ensureMetadataService(instanceId),
       };
 

--- a/MemoryCore/src/gateway/skill-handlers.ts
+++ b/MemoryCore/src/gateway/skill-handlers.ts
@@ -56,6 +56,7 @@ import type { CompressibleMessage } from "../core/skill/conversation-add/message
 import { trace } from "../core/report/trace.js";
 import { metricProducer } from "../core/report/kafka-metric-producer.js";
 import { obsLogger } from "../core/report/obs-logger.js";
+import { runWithSkillInstance } from "./skill-instance-context.js";
 
 const TAG = "[skill-handlers]";
 
@@ -101,9 +102,9 @@ export interface SkillRouterDeps {
    * 拿到 (per instance) 的 MetadataService。用于 handleCreate 成功后自动登记
    * skill 资产（asset_id === skill_id）并绑定到 owner agent 的 fixed-asset。
    *
-   * standalone 模式下 SkillCore 是 TdaiCore 全局构造的（不带钩子），所以由 handler
-   * 层做这个登记；service 模式下 buildSkillCore 里的 onSkillCreated 钩子会做同样的
-   * 事（幂等，重复调用无副作用）。两条路径都覆盖，保证前端管控页永远能看到 skill。
+   * Standalone routes establish a request-scoped instance for TdaiCore's lifecycle
+   * hooks, and this handler repeats the registration as an idempotent fallback.
+   * Service mode uses the per-instance SkillCore hook and the same fallback.
    *
    * 语义与 v2-router 里 handleConversationAdd 用同一 dep 自动登记 chat_memory 资产
    * 一致（详见 v2-router.ts:648 及 metadata-service.ts:ensureSkillAsset）。
@@ -295,8 +296,8 @@ export async function handleCreate(body: unknown, auth: V2AuthContext, requestId
     // ── 自动登记 skill 资产（asset_id === skill_id）+ 绑定到 owner agent 的 fixed-asset ──
     //
     // 为什么要在这里做：
-    //   - standalone 模式下 SkillCore 由 TdaiCore 全局构造（无 onSkillCreated 钩子）；
-    //   - 若不在这里补登记，asset/list-accessible / acl/* 等元数据层接口就查不到这个 skill，
+    //   - standalone 的全局 SkillCore hook 使用请求级 instance；这里仍做幂等兜底；
+    //   - 若不在这里补登记，asset/list-accessible / acl/* 等元数据层接口就可能查不到这个 skill，
     //     前端管控页的"团队资产 / 授权"链路完全断开。
     //
     // 与 service 模式的关系：
@@ -392,8 +393,8 @@ export async function handleDelete(body: unknown, _auth: V2AuthContext, requestI
     // 为什么在这里再做一次：
     //   - service 模式：buildSkillCore 里的 onSkillArchived 钩子已经调过一次；这里再
     //     调是幂等收敛（deleteAssets 对已不存在的 asset 视为成功，无副作用）。
-    //   - standalone 模式：SkillCore 由 TdaiCore 全局构造，未注入钩子（避免耦合
-    //     MetadataService 拉起时序）。handler 层这一次调用是唯一联动入口。
+    //   - standalone 模式：TdaiCore hook 与 handler 都使用请求级 instance；这里的
+    //     handler 调用是幂等兜底，保证删除路径最终收敛。
     //
     // 失败策略：fire-and-forget，warn 不回退 delete。二次 delete 会重触发 core 钩子
     // 与本次兜底，最终收敛。参考 handleCreate 里 ensureSkillAsset 的对称做法
@@ -1136,7 +1137,7 @@ export type SkillHandler = (
 ) => Promise<ApiResponseEnvelope>;
 
 export function makeSkillRouteTable(): Record<string, SkillHandler> {
-  return {
+  const routes: Record<string, SkillHandler> = {
     "/v3/skill/create": handleCreate,
     "/v3/skill/update": handleUpdate,
     "/v3/skill/patch": handlePatch,
@@ -1155,4 +1156,12 @@ export function makeSkillRouteTable(): Record<string, SkillHandler> {
     "/v3/skill/conversation/add": handleConversationAdd,
     "/v3/skill/conversation/force-archive": handleForceArchive,
   };
+
+  return Object.fromEntries(
+    Object.entries(routes).map(([path, handler]) => [
+      path,
+      (body: unknown, auth: V2AuthContext, requestId: string, deps: SkillRouterDeps) =>
+        runWithSkillInstance(auth.serviceId, () => handler(body, auth, requestId, deps)),
+    ]),
+  );
 }

--- a/MemoryCore/src/gateway/skill-instance-context.test.ts
+++ b/MemoryCore/src/gateway/skill-instance-context.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { SkillCore } from "../core/skill/skill-core.js";
+import type { Skill } from "../core/skill/types.js";
+import type { Logger } from "../core/types.js";
+import { makeSkillRouteTable, type SkillRouterDeps } from "./skill-handlers.js";
+import { resolveSkillInstance, runWithSkillInstance } from "./skill-instance-context.js";
+
+const logger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function skill(name: string): Skill {
+  return {
+    row_id: `row-${name}`,
+    skill_id: `skl-${name}`,
+    version: 1,
+    is_head: true,
+    user_id: "user-1",
+    owner_agent_id: "agent-1",
+    team_id: "team-1",
+    task_id: "",
+    name,
+    description: "test",
+    content: `# ${name}`,
+    content_hash: "hash",
+    manifest: [],
+    storage_dir: "",
+    status: "active",
+    metadata_json: "{}",
+    created_at_ms: 1,
+    updated_at_ms: 1,
+  };
+}
+
+describe("Skill request instance context", () => {
+  it("falls back outside a routed request", () => {
+    expect(resolveSkillInstance("default")).toBe("default");
+  });
+
+  it("restores the fallback after a request completes", async () => {
+    await runWithSkillInstance("dev-1", async () => {
+      expect(resolveSkillInstance("default")).toBe("dev-1");
+    });
+    expect(resolveSkillInstance("default")).toBe("default");
+  });
+
+  it("keeps concurrent routed requests isolated by service id", async () => {
+    const observed = new Map<string, string>();
+    const core = {
+      create: async (input: { name: string }) => {
+        await new Promise((resolve) => setTimeout(resolve, input.name === "slow" ? 10 : 0));
+        observed.set(input.name, resolveSkillInstance("default"));
+        return skill(input.name);
+      },
+    } as unknown as SkillCore;
+    const deps: SkillRouterDeps = {
+      getSkillCore: () => core,
+      logger,
+    };
+    const create = makeSkillRouteTable()["/v3/skill/create"];
+
+    const invoke = (name: string, serviceId: string) => create(
+      { name, content: `# ${name}` },
+      { apiKey: "key", serviceId },
+      `req-${name}`,
+      deps,
+    );
+
+    const [slow, fast] = await Promise.all([
+      invoke("slow", "dev-1"),
+      invoke("fast", "dev-2"),
+    ]);
+
+    expect(slow.code).toBe(0);
+    expect(fast.code).toBe(0);
+    expect(observed).toEqual(new Map([
+      ["fast", "dev-2"],
+      ["slow", "dev-1"],
+    ]));
+    expect(resolveSkillInstance("default")).toBe("default");
+  });
+});

--- a/MemoryCore/src/gateway/skill-instance-context.ts
+++ b/MemoryCore/src/gateway/skill-instance-context.ts
@@ -1,0 +1,13 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const skillInstanceStorage = new AsyncLocalStorage<string>();
+
+/** Run one Skill request with the service instance selected by its auth header. */
+export function runWithSkillInstance<T>(instanceId: string, fn: () => T): T {
+  return skillInstanceStorage.run(instanceId, fn);
+}
+
+/** Resolve the active request instance, preserving the legacy non-HTTP fallback. */
+export function resolveSkillInstance(fallbackInstanceId: string): string {
+  return skillInstanceStorage.getStore() ?? fallbackInstanceId;
+}


### PR DESCRIPTION
Fixes #1212.

## Root cause

The standalone `TdaiCore` owns lifecycle hooks for Skill asset registration and cleanup. Those hooks previously captured one `skillAssetInstanceId` when `TdaiGateway` was constructed. With no configured instance, that value was permanently `default`, even when a `/v3/skill/*` request authenticated with another `x-tdai-service-id`.

As a result, `SkillCore.create()` could write the Skill for the request but ask the `default` MetadataService to validate/register its Agent. The hook runs before the handler's existing idempotent fallback, so a non-default standalone request failed with `agent_not_found` before the correctly scoped fallback was reached.

## What changed

- Add a request-scoped Skill instance context backed by Node's `AsyncLocalStorage`.
- Wrap every `/v3/skill/*` handler with the authenticated `serviceId`.
- Resolve the standalone lifecycle-hook instance lazily when create/access/archive fires.
- Preserve the configured/default instance for internal calls that bypass HTTP routing.
- Keep service mode unchanged: requests there continue to use per-instance `SkillCore` objects.
- Update stale comments that incorrectly described the standalone core as having no hooks.

`AsyncLocalStorage` is used instead of a mutable current-instance field so concurrent requests cannot route each other's asset operations.

## Verification

- `vitest run`: 3/3 focused tests passed.
- Concurrent `dev-1` and `dev-2` creates retain their own request instance even when completion order is reversed.
- Request context is removed after completion; non-routed calls retain the `default` fallback.
- `tsdown`: MemoryCore plugin production build passed.
- `git diff --check`: passed.

## Scope and compatibility

- No request or response schema changes.
- No MetadataStore, SkillStore, authorization, or service-mode changes.
- The existing handler-level `ensureSkillAsset`/`deleteAssets` calls remain as idempotent fallbacks.
- No global mutable tenant state is introduced.
