### PR TITLE
fix: preserve accurate agent memory layer counts

### DIFF
--- a/MemoryCore/src/gateway/query-isolation.test.ts
+++ b/MemoryCore/src/gateway/query-isolation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { optionalQueryUserId } from './query-isolation.js';
+
+describe('optionalQueryUserId', () => {
+  it('does not turn a missing user_id into the default isolation bucket filter', () => {
+    expect(optionalQueryUserId({}, 'default')).toBeUndefined();
+  });
+
+  it('preserves an explicitly requested user_id filter', () => {
+    expect(optionalQueryUserId({ user_id: 'openclaw' }, 'openclaw')).toBe('openclaw');
+  });
+});

--- a/MemoryCore/src/gateway/query-isolation.ts
+++ b/MemoryCore/src/gateway/query-isolation.ts
@@ -1,0 +1,12 @@
+/**
+ * Query endpoints use a resolved isolation context, where omitted fields are
+ * represented by the legacy default bucket. That default is valid for writes,
+ * but must not silently narrow an aggregate read.
+ */
+export function optionalQueryUserId(
+  body: Record<string, unknown> | undefined,
+  resolvedUserId: string | undefined,
+): string | undefined {
+  const requested = body?.user_id;
+  return typeof requested === 'string' && requested.trim() ? resolvedUserId : undefined;
+}

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -28,6 +28,7 @@ import { executeMemorySearch } from "../core/tools/memory-search.js";
 import { executeConversationSearch } from "../core/tools/conversation-search.js";
 import type { MemoryRecord } from "../core/record/l1-writer.js";
 import { reportRecallMetrics } from "../core/report/metric-tracking-recall.js";
+import { optionalQueryUserId } from "./query-isolation.js";
 
 // ── Zod schemas (validated types + defaults) ──
 import {
@@ -823,13 +824,16 @@ async function handleConversationQuery(body: unknown, _auth: V2AuthContext, requ
   // agent_id (via body or headers). session_id, if present, comes from the
   // request body and is already in `session_id`.
   const iso = deps.requestIsolation;
+  // Missing user_id resolves to the legacy default bucket for writes, but an
+  // aggregate read must not silently filter to that placeholder.
+  const userId = optionalQueryUserId(body as Record<string, unknown> | undefined, iso?.userId);
 
   // Use paginated query if available (AR-3), else fallback
   if (store.queryL0Paginated) {
     const result = await store.queryL0Paginated({
       sessionId: session_id,
       teamId: iso?.teamId,
-      userId: iso?.userId,
+      userId,
       agentId: iso?.agentId,
       taskId: iso?.taskId,
       timeStartMs: time_start ? new Date(time_start).getTime() : undefined,
@@ -858,7 +862,7 @@ async function handleConversationQuery(body: unknown, _auth: V2AuthContext, requ
   let filtered = session_id ? allRows.filter((r) => r.session_key === session_id || r.session_id === session_id) : allRows;
   // Tenancy isolation post-filter for the legacy path.
   if (iso?.teamId) filtered = filtered.filter((r) => r.team_id === iso.teamId);
-  if (iso?.userId) filtered = filtered.filter((r) => r.user_id === iso.userId);
+  if (userId) filtered = filtered.filter((r) => r.user_id === userId);
   if (iso?.agentId) filtered = filtered.filter((r) => r.agent_id === iso.agentId);
   if (iso?.taskId) filtered = filtered.filter((r) => r.task_id === iso.taskId);
   if (time_start) { const ms = new Date(time_start).getTime(); filtered = filtered.filter((r) => r.timestamp >= ms); }
@@ -888,11 +892,12 @@ async function handleConversationCount(body: unknown, _auth: V2AuthContext, requ
   const store = deps.getStore();
   if (!store) return errorEnvelope(503, "Store not available", requestId);
   const iso = deps.requestIsolation;
+  const userId = optionalQueryUserId(body as Record<string, unknown> | undefined, iso?.userId);
 
   const countFilter = {
     sessionId: session_id,
     teamId: iso?.teamId,
-    userId: iso?.userId,
+    userId: userId,
     agentId: iso?.agentId,
     taskId: iso?.taskId,
     timeStartMs: time_start ? new Date(time_start).getTime() : undefined,
@@ -1120,14 +1125,16 @@ async function handleAtomicQuery(body: unknown, _auth: V2AuthContext, requestId:
   const store = deps.getStore();
   if (!store) return errorEnvelope(503, "Store not available", requestId);
 
-  // Tenancy isolation — narrow the query by user_id / agent_id when supplied.
+  // L0/L1 Agent aggregate views omit user_id intentionally. Do not let the
+  // default write-isolation bucket become an accidental read filter.
   const iso = deps.requestIsolation;
+  const userId = optionalQueryUserId(body as Record<string, unknown> | undefined, iso?.userId);
 
   // Use paginated query if available
   if (store.queryL1Paginated) {
     const result = await store.queryL1Paginated({
       type, timeStart: time_start, timeEnd: time_end, limit, offset,
-      teamId: iso?.teamId, userId: iso?.userId, agentId: iso?.agentId, taskId: iso?.taskId,
+      teamId: iso?.teamId, userId, agentId: iso?.agentId, taskId: iso?.taskId,
     });
     const items: AtomicDetail[] = result.rows.map((r) => ({
       id: r.record_id, type: r.type, content: r.content,
@@ -1147,7 +1154,7 @@ async function handleAtomicQuery(body: unknown, _auth: V2AuthContext, requestId:
   let filtered = allRecords;
   if (type) filtered = filtered.filter((r) => r.type === type);
   if (iso?.teamId) filtered = filtered.filter((r) => r.team_id === iso.teamId);
-  if (iso?.userId) filtered = filtered.filter((r) => r.user_id === iso.userId);
+  if (userId) filtered = filtered.filter((r) => r.user_id === userId);
   if (iso?.agentId) filtered = filtered.filter((r) => r.agent_id === iso.agentId);
   if (iso?.taskId) filtered = filtered.filter((r) => r.task_id === iso.taskId);
   if (time_start) filtered = filtered.filter((r) => r.updated_time >= time_start);
@@ -1176,13 +1183,14 @@ async function handleAtomicCount(body: unknown, _auth: V2AuthContext, requestId:
   const store = deps.getStore();
   if (!store) return errorEnvelope(503, "Store not available", requestId);
   const iso = deps.requestIsolation;
+  const userId = optionalQueryUserId(body as Record<string, unknown> | undefined, iso?.userId);
 
   const total = await store.countL1({
     type,
     timeStart: time_start,
     timeEnd: time_end,
     teamId: iso?.teamId,
-    userId: iso?.userId,
+    userId: userId,
     agentId: iso?.agentId,
     taskId: iso?.taskId,
   });

--- a/MemoryPanel/src/panel/http/routes/chat-memory.ts
+++ b/MemoryPanel/src/panel/http/routes/chat-memory.ts
@@ -110,10 +110,11 @@ interface ListEnvelopeData<T> {
 interface MemoryBlockOut {
   id: string;
   title: string;
-  summary: string;
+  /** 列表端不提供分层统计；前端选中记忆块后按层实时读取。 */
+  summary?: string;
   uploaded_by_user_id: string;
   updated_at_ms: number;
-  layer_counts: { L0_messages: number; L1: number; L2: number; L3: number };
+  layer_counts?: { L0_messages: number; L1: number; L2: number; L3: number };
   scope?: "team" | "private";
   bound_agent_count?: number;
   agent_id?: string;
@@ -156,10 +157,8 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
       const out: MemoryBlockOut[] = items.map((a) => ({
         id: a.asset_id,
         title: a.name,
-        summary: buildSummary(),
         uploaded_by_user_id: a.owner_user_id,
         updated_at_ms: toMs(a.updated_at),
-        layer_counts: emptyLayers(),
       }));
       return respondEnvelope(
         c,
@@ -290,13 +289,10 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
           return {
             id: it.asset_id,
             title: it.name,
-            summary: buildSummary(),
             uploaded_by_user_id: ownerUserId,
             updated_at_ms: toMs(updatedAt),
             // 透传给前端做灰化：team 正常显示，private 灰化 + 打"已被 owner 设为私密"标签
             scope: it.visibility === "private" ? "private" : "team",
-            // TEMP：本地测试展示用；生产应改为懒加载
-            layer_counts: emptyLayers(),
             agent_id: agentId,
           };
         }),
@@ -368,10 +364,8 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
           return {
             id: assetId,
             title: a.name, // ← 用 agent name 作为块标题，符合"一 agent 一块记忆"
-            summary: buildSummary(),
             uploaded_by_user_id: meUserId,
             updated_at_ms,
-            layer_counts: emptyLayers(),
             scope: visibility,
             agent_id: a.agent_id,
           };
@@ -414,11 +408,8 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
       items.map(async (a) => ({
         id: a.asset_id,
         title: a.name,
-        summary: buildSummary(),
         uploaded_by_user_id: a.owner_user_id,
         updated_at_ms: toMs(a.updated_at),
-        // TEMP：本地测试展示用；生产应改为懒加载或前端点击时按需拉
-        layer_counts: emptyLayers(),
         scope: (a.visibility === "private" ? "private" : "team") as
           | "team"
           | "private",
@@ -472,10 +463,8 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
       okEnvelope(c, {
         id: asset.asset_id,
         title: asset.name,
-        summary: buildSummary(),
         uploaded_by_user_id: asset.owner_user_id,
         updated_at_ms: toMs(asset.updated_at),
-        layer_counts: emptyLayers(),
         scope: asset.visibility === "private" ? "private" : "team",
       } satisfies MemoryBlockOut),
     );
@@ -1124,32 +1113,27 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
     );
     if (!canRead) return respondControlError(c, 403, "ASSET_NOT_ACCESSIBLE");
 
-    // chat_memory 数据是 asset owner 写入（用其 user_id 隔离），caller 未必是 owner
-    // （借入场景）。用 asset.owner_user_id 作为数据面 user_id。
-    const ownerUserId = asset.owner_user_id;
-
     const cred = toKernelCredentials(ctx, { timeoutMs: 15_000 });
 
-    // v3 严格 isolation：session_id 必填。管理面聚合场景传 'default'
-    const idFields = {
+    // 面板按一个 Agent 的记忆块展示数据，统计范围必须是 team + agent。
+    // asset owner 是控制面授权主体，而 L0/L1 的 user_id 是各客户端写入身份；
+    // 二者不同是常态。把 owner user_id 传到数据面会把绝大部分记录错误滤掉。
+    // L2/L3 本来也是 team + agent 聚合，不带 user/session 维度。
+    const memoryScope = {
       team_id: parsed.teamId,
       agent_id: parsed.agentId,
-      user_id: ownerUserId,
-      session_id: "default",
     };
 
     try {
       if (layer === "L0") {
-        // 关键：不传 session_id，tdai 会跨 session 聚合返 (team,user,agent) 全部消息
+        // 不传 user_id / session_id，tdai 会跨写入身份、跨 session 聚合该 Agent 全部消息。
         // tdai 返 { messages: [...], total } 而不是 { items: [...] }
-        const { session_id: _drop, ...noSid } = idFields;
-        void _drop;
 
         // 游标分页：before_ts → time_end（-1ms 排他）。
         // 内核 /v3/conversation/query 的 time_end 是 recorded_at_ms <= timeEndMs（含等），
         // 游标语义需要排他（< beforeTs），否则最后一条会被重复返回。
         // 减 1ms 把含等转为不含等。毫秒精度足够（同一 ms 的重复极少且前端有 id 去重兜底）。
-        const l0Query: Record<string, unknown> = { ...noSid };
+        const l0Query: Record<string, unknown> = { ...memoryScope };
         if (timeStart) l0Query.time_start = timeStart;
         // 游标上界（before_ts）与筛选上界（time_end）取更早者（交集）：翻页不能越出用户选定的时间范围。
         let l0TimeEnd = timeEnd;
@@ -1170,7 +1154,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
         const env = await deps.kernelHttp.postEnvelope<{
           messages?: unknown[];
           total?: number;
-        }>("/v3/conversation/query", l0Query, cred);
+        }>("/v2/conversation/query", l0Query, cred);
         if (env.code !== 0) return respondEnvelope(c, env);
         const data = (env.data as {
           messages?: Array<Record<string, unknown>>;
@@ -1215,13 +1199,13 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
       }
 
       if (layer === "L1") {
-        const l1Query: Record<string, unknown> = { ...idFields, limit, offset };
+        const l1Query: Record<string, unknown> = { ...memoryScope, limit, offset };
         if (timeStart) l1Query.time_start = timeStart;
         if (timeEnd) l1Query.time_end = timeEnd;
         const env = await deps.kernelHttp.postEnvelope<{
           items?: unknown[];
           total?: number;
-        }>("/v3/atomic/query", l1Query, cred);
+        }>("/v2/atomic/query", l1Query, cred);
         if (env.code !== 0) return respondEnvelope(c, env);
         const data = (env.data as {
           items?: Array<Record<string, unknown>>;
@@ -1266,7 +1250,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
         if (requestedPath) {
           const readEnv = await deps.kernelHttp.postEnvelope<{
             content?: string | null;
-          }>("/v3/scenario/read", { ...idFields, path: requestedPath }, cred);
+          }>("/v3/scenario/read", { ...memoryScope, path: requestedPath }, cred);
           if (readEnv.code !== 0) return respondEnvelope(c, readEnv);
           const readData = readEnv.data as { content?: string | null } | null;
           const content =
@@ -1312,7 +1296,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
         const env = await deps.kernelHttp.postEnvelope<{
           entries?: unknown[];
           total?: number;
-        }>("/v3/scenario/ls", idFields, cred);
+        }>("/v3/scenario/ls", memoryScope, cred);
         if (env.code !== 0) return respondEnvelope(c, env);
         const data = (env.data as {
           entries?: Array<Record<string, unknown>>;
@@ -1353,7 +1337,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
         content?: string;
         version?: string;
         updated_at?: string;
-      }>("/v3/core/read", idFields, cred);
+      }>("/v3/core/read", memoryScope, cred);
       if (env.code !== 0) return respondEnvelope(c, env);
       const data =
         (env.data as {
@@ -1820,21 +1804,25 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
 }
 
 /**
- * 从 chat_memory-{team_id}-{agent_id} 解出 team_id / agent_id
- * 依赖 agent id 以 `agt` 开头这一稳定前缀。
- */ function parseChatMemoryAssetId(
+ * 从 chat_memory-{team_id}-{agent_id} 解出 team_id / agent_id。
+ * 支持元数据中的两类 Agent 标识：远程记录 ID（agt-*）及本地字符串 ID
+ * （例如 openclaw、hermes）。不支持的格式必须返回 null，避免误读其它资产。
+ */
+function parseChatMemoryAssetId(
   assetId: string,
 ): { teamId: string; agentId: string } | null {
   if (!assetId.startsWith("chat_memory-")) return null;
-  const idx = assetId.lastIndexOf("-agt");
-  if (idx < 0) return null;
   const inner = assetId.slice("chat_memory-".length);
   const dashAgt = inner.lastIndexOf("-agt");
-  if (dashAgt < 0) return null;
-  return {
-    teamId: inner.slice(0, dashAgt),
-    agentId: inner.slice(dashAgt + 1),
-  };
+  if (dashAgt >= 0) {
+    return {
+      teamId: inner.slice(0, dashAgt),
+      agentId: inner.slice(dashAgt + 1),
+    };
+  }
+  const localAgentMatch = inner.match(/^(team-[^-]+)-(.+)$/);
+  if (!localAgentMatch?.[1] || !localAgentMatch[2]) return null;
+  return { teamId: localAgentMatch[1], agentId: localAgentMatch[2] };
 }
 
 // ============================================================================
@@ -1921,13 +1909,6 @@ function isActive(a: AssetRaw): boolean {
   );
 }
 
-function emptyLayers(): MemoryBlockOut["layer_counts"] {
-  return { L0_messages: 0, L1: 0, L2: 0, L3: 0 };
-}
-
-function buildSummary(): string {
-  return "0 条 L1 · 0 条 L2 · 0 条 L3";
-}
 
 /**
  * 去掉 scenario markdown 的 META 头。

--- a/MemoryPanel/tests/chat-memory-regression.test.ts
+++ b/MemoryPanel/tests/chat-memory-regression.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { registerChatMemoryRoutes } from '../src/panel/http/routes/chat-memory.js';
+import type { PanelDeps } from '../src/panel/panel-deps.js';
+import type { MetaEnvelope } from '../src/panel/kernel/envelope.js';
+
+const TEAM_ID = 'team-t9ihoml202';
+const AGENT_ID = 'openclaw';
+const OWNER_ID = 'usr-t9oh1rmkpc';
+const ASSET_ID = `chat_memory-${TEAM_ID}-${AGENT_ID}`;
+
+function ok<T>(data: T): MetaEnvelope<T> {
+  return { code: 0, message: 'ok', request_id: 'test', data };
+}
+
+function buildApp() {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const deps = {
+    instanceRegistry: {
+      resolve: () => ({
+        instance_id: 'default',
+        gateway_endpoint: 'http://kernel.test',
+        api_key: 'test-key',
+      }),
+    },
+    metaKernel: {
+      invoke: async (action: string) => {
+        if (action === 'auth/verify') return ok({ valid: true, user: { user_id: OWNER_ID } });
+        if (action === 'asset/get') {
+          return ok({
+            asset_id: ASSET_ID,
+            team_id: TEAM_ID,
+            asset_type: 'chat_memory',
+            name: 'Memory of OpenClaw',
+            owner_user_id: OWNER_ID,
+            visibility: 'team',
+            status: 'active',
+            updated_at: '2026-08-30T00:00:00.000Z',
+          });
+        }
+        if (action === 'asset/list') {
+          return ok({
+            items: [{
+              asset_id: ASSET_ID,
+              team_id: TEAM_ID,
+              asset_type: 'chat_memory',
+              name: 'Memory of OpenClaw',
+              owner_user_id: OWNER_ID,
+              visibility: 'team',
+              status: 'active',
+              updated_at: '2026-08-30T00:00:00.000Z',
+            }],
+            total: 1,
+          });
+        }
+        throw new Error(`Unexpected meta action: ${action}`);
+      },
+    },
+    kernelHttp: {
+      postEnvelope: async (path: string, body: unknown) => {
+        calls.push({ path, body });
+        if (path === '/v2/conversation/query') {
+          return ok({ messages: [{ id: 'l0-1', role: 'user', content: 'record' }], total: 7218 });
+        }
+        if (path === '/v2/atomic/query') {
+          return ok({ items: [{ record_id: 'l1-1', type: 'episodic', content: 'memory' }], total: 589 });
+        }
+        if (path === '/v3/scenario/ls') return ok({ entries: [{ path: 'OpenClaw.md' }], total: 1 });
+        if (path === '/v3/core/read') return ok({ content: 'OpenClaw core memory' });
+        throw new Error(`Unexpected kernel path: ${path}`);
+      },
+    },
+  } as unknown as PanelDeps;
+
+  const app = new Hono();
+  registerChatMemoryRoutes(app, deps);
+  return { app, calls };
+}
+
+function request(app: Hono, path: string, body: unknown) {
+  return app.request(path, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-tdai-service-id': 'default',
+      'x-tdai-user-key': 'test-user-key',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Chat Memory count regression', () => {
+  it('does not publish fabricated zero layer counts in team asset lists', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app, '/chat-memory/team-assets', { team_id: TEAM_ID });
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { data: { items: Array<Record<string, unknown>> } };
+
+    expect(payload.data.items).toHaveLength(1);
+    expect(payload.data.items[0]).not.toHaveProperty('layer_counts');
+    expect(payload.data.items[0]).not.toHaveProperty('summary');
+  });
+
+  it.each([
+    ['L0', '/v2/conversation/query', 7218],
+    ['L1', '/v2/atomic/query', 589],
+    ['L2', '/v3/scenario/ls', 1],
+    ['L3', '/v3/core/read', 1],
+  ] as const)('queries %s by team and agent without the asset-owner user filter', async (layer, endpoint, total) => {
+    const { app, calls } = buildApp();
+
+    const response = await request(app, '/chat-memory/layer', {
+      block_id: ASSET_ID,
+      layer,
+      limit: 1,
+      offset: 0,
+    });
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { data: { total: number } };
+    expect(payload.data.total).toBe(total);
+
+    const call = calls.find((entry) => entry.path === endpoint);
+    expect(call).toBeDefined();
+    expect(call?.body).toMatchObject({ team_id: TEAM_ID, agent_id: AGENT_ID });
+    expect(call?.body).not.toHaveProperty('user_id');
+    expect(call?.body).not.toHaveProperty('session_id');
+  });
+});

--- a/MemoryPanel/web/src/lib/api/chat-memory.ts
+++ b/MemoryPanel/web/src/lib/api/chat-memory.ts
@@ -12,7 +12,8 @@ export interface ChatMemoryBlock {
   summary?: string;
   uploaded_by_user_id: string;
   updated_at_ms: number;
-  layer_counts: { L0_messages: number; L1: number; L2: number; L3: number };
+  /** 列表不预加载分层统计；选中后通过 layer 接口读取真实数量。 */
+  layer_counts?: { L0_messages: number; L1: number; L2: number; L3: number };
   /** 仅 team-assets */
   bound_agent_count?: number;
   /** 仅 agent-fixed */

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/components/ChatMemoryPanel.tsx
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/components/ChatMemoryPanel.tsx
@@ -176,7 +176,8 @@ export default function ChatMemoryPanel(
                 const isOwner = b.uploaded_by_user_id === currentUserId;
                 const canToggleScope = scopeTab === 'fixed' && isOwner && !!b.scope;
                 const canUnbind = scopeTab === 'fixed' && !isSelfChatMemory(b);
-                const l0Count = b.layer_counts?.L0_messages ?? 0;
+                // 列表不预置 0；只有选中后已读取到的真实计数才显示徽章。
+                const l0Count = b.layerCounts.L0;
                 return (
                   <div className="_memory-card">
                     {/* 第 1 行：标题（左） + 蓝色计数徽章（右） */}
@@ -189,7 +190,9 @@ export default function ChatMemoryPanel(
                           </span>
                         )}
                       </span>
-                      {l0Count > 0 && <span className="_memory-card-count">{l0Count}</span>}
+                      {typeof l0Count === 'number' && l0Count > 0 && (
+                        <span className="_memory-card-count">{l0Count}</span>
+                      )}
                     </div>
 
                     {/* 第 2 行：资产真实 id，等宽灰色 */}

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/constants/types.ts
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/constants/types.ts
@@ -32,7 +32,8 @@ export interface MemoryBlock {
   agent_id?: string;
   uploaded_by_user_id: string;
   scope?: 'team' | 'private';
-  layer_counts: { L0_messages: number; L1: number; L2: number; L3: number };
+  /** 列表不预加载分层统计；选中后通过 layer 接口读取真实数量。 */
+  layer_counts?: { L0_messages: number; L1: number; L2: number; L3: number };
   bound_agent_count?: number;
   layers: {
     L0: ChatMemoryLayerItem[];

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/utils/memory-utils.ts
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/utils/memory-utils.ts
@@ -53,13 +53,14 @@ export function stripScenarioMeta(content: string): string {
 // 由列表接口的 layer_counts 构造初始 layerCounts：只保留 >0 的真实计数，
 // 其余留 undefined＝「未知」。徽章据此显示占位，避免把「未加载」误显示成「0」，
 // 也不再为拿计数而预请求。后端 layer_counts 落地真实值后此处会自动直接采用。
-export function buildInitialLayerCounts(lc: {
+export function buildInitialLayerCounts(lc?: {
   L0_messages: number;
   L1: number;
   L2: number;
   L3: number;
 }): MemoryBlock['layerCounts'] {
   const out: MemoryBlock['layerCounts'] = {};
+  if (!lc) return out;
   if (lc.L0_messages > 0) out.L0 = lc.L0_messages;
   if (lc.L1 > 0) out.L1 = lc.L1;
   if (lc.L2 > 0) out.L2 = lc.L2;


### PR DESCRIPTION
## Summary
- preserve real L0–L3 counts in MemoryPanel instead of returning fabricated zero placeholders
- query agent aggregate L0/L1 data by team + agent scope without incorrectly filtering by control-plane asset-owner user ID
- retain explicit user filtering when a user ID is supplied

## Validation
- MemoryCore query-isolation regression tests passed
- MemoryPanel typecheck passed
- MemoryPanel chat-memory regression tests passed

## Scope
No configuration, credentials, or data migration changes.