### PR TITLE
fix(sdk-py): reject malformed falsey response data

### DIFF
--- a/sdk/memory-core/python/tencentdb_agent_memory/_v3_http.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/_v3_http.py
@@ -62,7 +62,9 @@ def _decode_response(resp: httpx.Response) -> dict:
             details=details,
         )
 
-    result = envelope.get("data") or {}
+    result = envelope.get("data")
+    if result is None:
+        result = {}
     if not isinstance(result, dict):
         raise TDAMError(-1, "API response data must be a JSON object", header_request_id)
     trace_id = resp.headers.get("x-trace-id")

--- a/sdk/memory-core/python/tests/test_v3_http.py
+++ b/sdk/memory-core/python/tests/test_v3_http.py
@@ -1,0 +1,60 @@
+import asyncio
+import unittest
+
+import httpx
+
+from tencentdb_agent_memory._v3_http import AsyncHttpStub, HttpStub
+from tencentdb_agent_memory.errors import TDAMError
+
+
+class ResponseDataTest(unittest.TestCase):
+    def request(self, envelope, asynchronous=False):
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(
+                200, json=envelope, headers={"x-trace-id": "test-trace"}
+            )
+        )
+        if asynchronous:
+            async def run():
+                async with httpx.AsyncClient(transport=transport) as client:
+                    stub = AsyncHttpStub(
+                        "https://example.test", "test-key", "default", client=client
+                    )
+                    return await stub.post("/v3/test", {})
+            return asyncio.run(run())
+        with httpx.Client(transport=transport) as client:
+            stub = HttpStub(
+                "https://example.test", "test-key", "default", client=client
+            )
+            return stub.post("/v3/test", {})
+
+    def test_rejects_non_object_data_in_sync_and_async_responses(self):
+        for asynchronous in (False, True):
+            for data in ([], False, 0, "", [1], True, 1, "text"):
+                with self.subTest(asynchronous=asynchronous, data=data):
+                    with self.assertRaises(TDAMError) as caught:
+                        self.request({"code": 0, "data": data}, asynchronous)
+                    self.assertEqual(caught.exception.code, -1)
+                    self.assertEqual(
+                        caught.exception.message,
+                        "API response data must be a JSON object",
+                    )
+                    self.assertEqual(caught.exception.request_id, "test-trace")
+
+    def test_preserves_objects_and_optional_data(self):
+        for asynchronous in (False, True):
+            for envelope, expected in (
+                ({"code": 0}, {}),
+                ({"code": 0, "data": None}, {}),
+                ({"code": 0, "data": {}}, {}),
+                ({"code": 0, "data": {"items": []}}, {"items": []}),
+            ):
+                with self.subTest(asynchronous=asynchronous, envelope=envelope):
+                    self.assertEqual(
+                        self.request(envelope, asynchronous),
+                        {**expected, "trace_id": "test-trace"},
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Python v3 transport promises object-valued response data, but `envelope.get("data") or {}` converts `[]`, `false`, `0`, and `""` into a successful empty result before checking their types. This hides malformed server responses from both synchronous and asynchronous SDK callers.

Only missing or null data now defaults to an empty object. Other non-object values raise the existing `TDAMError` with the response trace ID. Object payloads and optional data retain their existing behavior.

## Verification

From `sdk/memory-core/python/`, using Python 3.12.13 and httpx 0.28.1:

- `python -m unittest discover -s tests -v` — 2 tests passed, covering 24 synchronous/asynchronous subcases. Before the fix, the 8 falsey-data cases failed because no exception was raised.
- `python -m build` — source distribution and wheel built successfully.
- `git diff --check` — passed.

Tests use `httpx.MockTransport` and make no external requests. This change is confined to v3 response decoding; v2 behavior is unchanged.
