### PR TITLE
feat: add expected-version CAS for atomic memory updates

### DIFF
--- a/MemoryCore/src/core/store/sqlite-cas.test.ts
+++ b/MemoryCore/src/core/store/sqlite-cas.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { MemoryRecord } from "../record/l1-writer.js";
+import { VectorStore } from "./sqlite.js";
+
+const opened: VectorStore[] = [];
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const store of opened.splice(0)) store.close();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeRecord(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id: "memory-1",
+    content: "original",
+    type: "persona",
+    priority: 50,
+    scene_name: "default",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [],
+    createdAt: "2026-09-01T00:00:00.000Z",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    version: 2,
+    sessionKey: "session-key",
+    sessionId: "session-id",
+    teamId: "team-1",
+    userId: "user-1",
+    agentId: "agent-1",
+    ...overrides,
+  };
+}
+
+function makeStore(): VectorStore {
+  const dir = mkdtempSync(path.join(tmpdir(), "tdai-cas-"));
+  dirs.push(dir);
+  const store = new VectorStore(path.join(dir, "memory.sqlite"), 0);
+  const init = store.init();
+  expect(store.isDegraded(), init.reason).toBe(false);
+  opened.push(store);
+  return store;
+}
+
+describe("VectorStore.compareAndSwapL1", () => {
+  it("updates exactly once and rejects a stale writer without overwriting content", async () => {
+    const store = makeStore();
+    expect(await store.upsertL1(makeRecord(), undefined)).toBe(true);
+
+    const first = await store.compareAndSwapL1(
+      makeRecord({ content: "first edit", version: 3 }),
+      2,
+      undefined,
+    );
+    expect(first).toEqual({ status: "updated" });
+
+    const stale = await store.compareAndSwapL1(
+      makeRecord({ content: "stale edit", version: 3 }),
+      2,
+      undefined,
+    );
+    expect(stale).toEqual({ status: "conflict", currentVersion: 3 });
+
+    const [persisted] = await store.queryL1Records({ recordIds: ["memory-1"] });
+    expect(persisted.content).toBe("first edit");
+    expect(persisted.version).toBe(3);
+  });
+
+  it("distinguishes a deleted record from a version conflict", async () => {
+    const store = makeStore();
+    const result = await store.compareAndSwapL1(makeRecord({ id: "missing" }), 2, undefined);
+    expect(result).toEqual({ status: "not_found" });
+  });
+});

--- a/MemoryCore/src/core/store/sqlite.ts
+++ b/MemoryCore/src/core/store/sqlite.ts
@@ -57,6 +57,7 @@ import type {
   MemoryContentClearResult,
   AuditEntry,
   AuditQueryFilter,
+  L1CompareAndSwapResult,
 } from "./types.js";
 import { DEFAULT_ISOLATION_ID, rowMatchesIsolation } from "./types.js";
 import { SKILLS_DDL, SKILL_FTS_DDL } from "../skill/skill-store-ddl.js";
@@ -391,6 +392,8 @@ export class VectorStore implements IMemoryStore {
 
   // Prepared statements — L1 (initialized in init())
   private stmtUpsertMeta!: StatementSync;
+  private stmtCompareAndSwapMeta!: StatementSync;
+  private stmtGetL1Version!: StatementSync;
   private stmtDeleteVec?: StatementSync;   // optional — only set when vecTablesReady
   private stmtInsertVec?: StatementSync;   // optional — only set when vecTablesReady
   private stmtDeleteMeta!: StatementSync;
@@ -716,6 +719,33 @@ export class VectorStore implements IMemoryStore {
         user_id=excluded.user_id,
         agent_id=excluded.agent_id
     `);
+
+    this.stmtCompareAndSwapMeta = this.db.prepare(`
+      UPDATE l1_records SET
+        content = ?,
+        type = ?,
+        priority = ?,
+        scene_name = ?,
+        team_id = ?,
+        task_id = ?,
+        version = ?,
+        timestamp_str = ?,
+        timestamp_start = ?,
+        timestamp_end = ?,
+        updated_time = ?,
+        metadata_json = ?,
+        user_id = ?,
+        agent_id = ?
+      WHERE record_id = ?
+        AND version = ?
+        AND team_id = ?
+        AND user_id = ?
+        AND agent_id = ?
+        AND task_id = ?
+    `);
+    this.stmtGetL1Version = this.db.prepare(
+      "SELECT version FROM l1_records WHERE record_id = ?",
+    );
 
     if (this.dimensions > 0) {
       this.stmtDeleteVec = this.db.prepare("DELETE FROM l1_vec WHERE record_id = ?");
@@ -1457,6 +1487,117 @@ export class VectorStore implements IMemoryStore {
         `${TAG} [L1-upsert] FAILED (non-fatal) id=${record.id}: ${err instanceof Error ? err.message : String(err)}`,
       );
       return false;
+    }
+  }
+
+  /**
+   * Atomically replace an existing L1 row when its version matches.
+   * BEGIN IMMEDIATE serializes writers before the conditional UPDATE; vector
+   * and FTS side tables are committed in the same transaction.
+   */
+  compareAndSwapL1(
+    record: MemoryRecord,
+    expectedVersion: number,
+    embedding: Float32Array | undefined,
+  ): L1CompareAndSwapResult {
+    if (this.degraded) return { status: "failed" };
+
+    const { id: recordId, timestamps } = record;
+    const tsStr = timestamps[0] ?? "";
+    const tsStart = timestamps.length > 0
+      ? timestamps.reduce((a, b) => (a < b ? a : b))
+      : tsStr;
+    const tsEnd = timestamps.length > 0
+      ? timestamps.reduce((a, b) => (a > b ? a : b))
+      : tsStr;
+    const nextVersion = expectedVersion + 1;
+    const skipVec = !embedding || embedding.every((v) => v === 0) || !this.vecTablesReady;
+
+    try {
+      this.db.exec("BEGIN IMMEDIATE");
+      try {
+        const result = this.stmtCompareAndSwapMeta.run(
+          record.content,
+          record.type,
+          record.priority,
+          record.scene_name,
+          record.teamId || DEFAULT_ISOLATION_ID,
+          record.taskId || "",
+          nextVersion,
+          tsStr,
+          tsStart,
+          tsEnd,
+          record.updatedAt,
+          JSON.stringify(record.metadata),
+          record.userId || DEFAULT_ISOLATION_ID,
+          record.agentId || DEFAULT_ISOLATION_ID,
+          recordId,
+          expectedVersion,
+          record.teamId || DEFAULT_ISOLATION_ID,
+          record.userId || DEFAULT_ISOLATION_ID,
+          record.agentId || DEFAULT_ISOLATION_ID,
+          record.taskId || "",
+        );
+
+        if (Number(result.changes) === 0) {
+          const current = this.stmtGetL1Version.get(recordId) as
+            | { version: number }
+            | undefined;
+          this.db.exec("ROLLBACK");
+          return current
+            ? { status: "conflict", currentVersion: Number(current.version) }
+            : { status: "not_found" };
+        }
+
+        if (!skipVec) {
+          this.stmtDeleteVec!.run(recordId);
+          this.stmtInsertVec!.run(
+            recordId,
+            Buffer.from(embedding!.buffer),
+            record.updatedAt,
+          );
+        }
+
+        if (this.ftsAvailable) {
+          try {
+            this.stmtL1FtsDelete.run(recordId);
+            this.stmtL1FtsInsert.run(
+              tokenizeForFts(record.content),
+              record.content,
+              recordId,
+              record.type,
+              record.priority,
+              record.scene_name,
+              record.sessionKey,
+              record.sessionId || DEFAULT_ISOLATION_ID,
+              record.teamId || DEFAULT_ISOLATION_ID,
+              record.taskId || "",
+              record.userId || DEFAULT_ISOLATION_ID,
+              record.agentId || DEFAULT_ISOLATION_ID,
+              nextVersion,
+              tsStr,
+              tsStart,
+              tsEnd,
+              JSON.stringify(record.metadata),
+            );
+          } catch (ftsErr) {
+            this.logger?.warn(
+              `${TAG} [L1-CAS] FTS write failed (non-fatal) id=${recordId}: ${ftsErr instanceof Error ? ftsErr.message : String(ftsErr)}`,
+            );
+          }
+        }
+
+        this.db.exec("COMMIT");
+        return { status: "updated" };
+      } catch (err) {
+        try { this.db.exec("ROLLBACK"); } catch { /* ignore rollback errors */ }
+        throw err;
+      }
+    } catch (err) {
+      this.logger?.warn(
+        `${TAG} [L1-CAS] FAILED id=${recordId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { status: "failed" };
     }
   }
 

--- a/MemoryCore/src/core/store/tcvdb-cas.test.ts
+++ b/MemoryCore/src/core/store/tcvdb-cas.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MemoryRecord } from "../record/l1-writer.js";
+import { TcvdbMemoryStore } from "./tcvdb.js";
+
+function makeRecord(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id: "memory-1",
+    content: "edited content",
+    type: "persona",
+    priority: 50,
+    scene_name: "default",
+    source_message_ids: [],
+    metadata: {},
+    timestamps: [],
+    createdAt: "2026-09-01T00:00:00.000Z",
+    updatedAt: "2026-09-01T00:01:00.000Z",
+    version: 3,
+    sessionKey: "session-key",
+    sessionId: "session-id",
+    teamId: "team-1",
+    userId: "user-1",
+    agentId: "agent-1",
+    taskId: "task-1",
+    ...overrides,
+  };
+}
+
+function makeStore() {
+  const store = new TcvdbMemoryStore({
+    url: "https://example.invalid",
+    username: "user",
+    apiKey: "key",
+    database: "test",
+    embeddingEnabled: false,
+    embeddingModel: "none",
+    timeout: 1000,
+  });
+  const client = {
+    update: vi.fn(),
+    query: vi.fn(),
+  };
+  // Bypass remote collection initialization and replace the REST client with a deterministic fake.
+  Object.assign(store as any, { client, _initPromise: Promise.resolve(), degraded: false });
+  return { store, client };
+}
+
+describe("TcvdbMemoryStore.compareAndSwapL1", () => {
+  it("uses one server-side version-filtered update", async () => {
+    const { store, client } = makeStore();
+    client.update.mockResolvedValue(1);
+
+    const result = await store.compareAndSwapL1(makeRecord(), 2, undefined);
+
+    expect(result).toEqual({ status: "updated" });
+    expect(client.update).toHaveBeenCalledTimes(1);
+    expect(client.update).toHaveBeenCalledWith(
+      "test_l1_memories",
+      {
+        documentIds: ["memory-1"],
+        filter:
+          'version = 2 and team_id = "team-1" and user_id = "user-1" and agent_id = "agent-1" and task_id = "task-1"',
+      },
+      expect.objectContaining({ text: "edited content", version: 3 }),
+    );
+  });
+
+  it("reports the current version after a rejected stale update", async () => {
+    const { store, client } = makeStore();
+    client.update.mockResolvedValue(0);
+    client.query.mockResolvedValue({ documents: [{ id: "memory-1", version: 4 }] });
+
+    const result = await store.compareAndSwapL1(makeRecord(), 2, undefined);
+
+    expect(result).toEqual({ status: "conflict", currentVersion: 4 });
+    expect(client.query).toHaveBeenCalledWith("test_l1_memories", {
+      documentIds: ["memory-1"],
+      retrieveVector: false,
+      outputFields: ["version"],
+      limit: 1,
+    });
+  });
+
+  it("distinguishes a missing document", async () => {
+    const { store, client } = makeStore();
+    client.update.mockResolvedValue(0);
+    client.query.mockResolvedValue({ documents: [] });
+
+    const result = await store.compareAndSwapL1(makeRecord(), 2, undefined);
+
+    expect(result).toEqual({ status: "not_found" });
+  });
+});

--- a/MemoryCore/src/core/store/tcvdb-client-update.test.ts
+++ b/MemoryCore/src/core/store/tcvdb-client-update.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { TcvdbClient } from "./tcvdb-client.js";
+
+describe("TcvdbClient.update", () => {
+  it("disables transport retries for non-idempotent conditional updates", async () => {
+    const client = new TcvdbClient({
+      url: "https://example.invalid",
+      username: "user",
+      apiKey: "key",
+      database: "test",
+      timeout: 1000,
+    });
+    const request = vi
+      .spyOn(client, "request")
+      .mockResolvedValue({ affectedCount: 1 });
+
+    const affected = await client.update(
+      "test_l1_memories",
+      { documentIds: ["memory-1"], filter: "version = 2" },
+      { text: "edited content", version: 3 },
+    );
+
+    expect(affected).toBe(1);
+    expect(request).toHaveBeenCalledWith(
+      "/document/update",
+      {
+        database: "test",
+        collection: "test_l1_memories",
+        query: { documentIds: ["memory-1"], filter: "version = 2" },
+        update: { text: "edited content", version: 3 },
+      },
+      { maxRetries: 0 },
+    );
+  });
+});

--- a/MemoryCore/src/core/store/tcvdb-client.ts
+++ b/MemoryCore/src/core/store/tcvdb-client.ts
@@ -125,11 +125,16 @@ export class TcvdbClient {
    * Send a POST request to VectorDB API.
    * Handles auth, timeout, retries (5xx/timeout), and error unwrapping.
    */
-  async request<T = ApiResponse>(path: string, body: Record<string, unknown>): Promise<T> {
+  async request<T = ApiResponse>(
+    path: string,
+    body: Record<string, unknown>,
+    options: { maxRetries?: number } = {},
+  ): Promise<T> {
     let lastError: Error | undefined;
     const t0 = performance.now();
+    const maxRetries = options.maxRetries ?? MAX_RETRIES;
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       const tAttempt = performance.now();
       try {
         this.logger?.debug?.(`${TAG} → ${path} attempt=${attempt} body=${JSON.stringify(body).slice(0, 500)}`);
@@ -165,16 +170,16 @@ export class TcvdbClient {
         const attemptMs = Math.round(performance.now() - tAttempt);
         if (err instanceof TcvdbApiError && err.apiCode !== 0) throw err;
         lastError = err instanceof Error ? err : new Error(String(err));
-        if (attempt < MAX_RETRIES) {
+        if (attempt < maxRetries) {
           const delay = 500 * (attempt + 1);
-          this.logger?.debug?.(`${TAG} ${path} retry ${attempt + 1}/${MAX_RETRIES} in ${delay}ms (lastAttemptMs=${attemptMs}, error=${lastError.message})`);
+          this.logger?.debug?.(`${TAG} ${path} retry ${attempt + 1}/${maxRetries} in ${delay}ms (lastAttemptMs=${attemptMs}, error=${lastError.message})`);
           await new Promise((r) => setTimeout(r, delay));
         }
       }
     }
 
     const totalMs = Math.round(performance.now() - t0);
-    this.logger?.debug?.(`${TAG} ✗ ${path} totalMs=${totalMs} attempts=${MAX_RETRIES + 1} error=${lastError?.message}`);
+    this.logger?.debug?.(`${TAG} ✗ ${path} totalMs=${totalMs} attempts=${maxRetries + 1} error=${lastError?.message}`);
     throw lastError ?? new Error(`${TAG} ${path} failed after retries`);
   }
 
@@ -249,6 +254,27 @@ export class TcvdbClient {
       buildIndex: true,
       documents,
     });
+  }
+
+  async update(
+    collection: string,
+    query: Record<string, unknown>,
+    update: Record<string, unknown>,
+  ): Promise<number> {
+    // A conditional update is not safely retryable: the first attempt may have
+    // committed even when its response is lost. A blind retry would then return
+    // affectedCount=0 and turn a successful CAS into a false conflict.
+    const resp = await this.request<{ affectedCount: number }>(
+      "/document/update",
+      {
+        database: this.database,
+        collection,
+        query,
+        update,
+      },
+      { maxRetries: 0 },
+    );
+    return resp.affectedCount ?? 0;
   }
 
   async search(collection: string, searchParams: Record<string, unknown>): Promise<SearchResponse> {

--- a/MemoryCore/src/core/store/tcvdb.ts
+++ b/MemoryCore/src/core/store/tcvdb.ts
@@ -45,6 +45,7 @@ import type {
   BatchDeleteResult,
   MemoryContentClearFilter,
   MemoryContentClearResult,
+  L1CompareAndSwapResult,
 } from "./types.js";
 import { DEFAULT_ISOLATION_ID } from "./types.js";
 import { TcvdbClient, TcvdbApiError } from "./tcvdb-client.js";
@@ -654,6 +655,86 @@ export class TcvdbMemoryStore implements IMemoryStore {
     } catch (err) {
       this.logger?.warn(`${TAG} [L1-upsert] FAILED id=${record.id}: ${err instanceof Error ? err.message : String(err)}`);
       return false;
+    }
+  }
+
+  async compareAndSwapL1(
+    record: MemoryRecord,
+    expectedVersion: number,
+    _embedding?: Float32Array,
+  ): Promise<L1CompareAndSwapResult> {
+    try {
+      await this._ensureInit();
+      if (this.degraded) return { status: "failed" };
+
+      const tsStr = record.timestamps[0] ?? "";
+      const tsStart = record.timestamps.length > 0
+        ? record.timestamps.reduce((a, b) => (a < b ? a : b))
+        : tsStr;
+      const tsEnd = record.timestamps.length > 0
+        ? record.timestamps.reduce((a, b) => (a > b ? a : b))
+        : tsStr;
+      const nextVersion = expectedVersion + 1;
+      const update: Record<string, unknown> = {
+        text: record.content,
+        type: record.type,
+        priority: record.priority,
+        scene_name: record.scene_name,
+        team_id: record.teamId ?? "",
+        user_id: record.userId ?? "",
+        agent_id: record.agentId ?? "",
+        version: nextVersion,
+        session_key: record.sessionKey,
+        session_id: record.sessionId,
+        task_id: record.taskId ?? "",
+        timestamp_str: tsStr,
+        timestamp_start: tsStart,
+        timestamp_end: tsEnd,
+        updated_time_ms: isoToEpochMs(record.updatedAt),
+        metadata_json: JSON.stringify(record.metadata),
+        memory_type: DEFAULT_MEMORY_TYPE,
+      };
+      if (!this.embeddingEnabled) update.vector = [1];
+      if (this.bm25Encoder) {
+        const sparse = this.bm25Encoder.encodeTexts([record.content]);
+        if (sparse.length > 0 && sparse[0].length > 0) {
+          update.sparse_vector = sparse[0];
+        }
+      }
+
+      const affected = await this.client.update(
+        this.l1Collection,
+        {
+          documentIds: [record.id],
+          filter: joinFilter([
+            `version = ${expectedVersion}`,
+            ...buildIsolationConditions({
+              teamId: record.teamId ?? "",
+              userId: record.userId ?? "",
+              agentId: record.agentId ?? "",
+              taskId: record.taskId ?? "",
+            }),
+          ]),
+        },
+        update,
+      );
+      if (affected > 0) return { status: "updated" };
+
+      const current = await this.client.query(this.l1Collection, {
+        documentIds: [record.id],
+        retrieveVector: false,
+        outputFields: ["version"],
+        limit: 1,
+      });
+      const doc = current.documents?.[0];
+      return doc
+        ? { status: "conflict", currentVersion: Number(doc.version ?? 0) }
+        : { status: "not_found" };
+    } catch (err) {
+      this.logger?.warn(
+        `${TAG} [L1-CAS] FAILED id=${record.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { status: "failed" };
     }
   }
 

--- a/MemoryCore/src/core/store/types.ts
+++ b/MemoryCore/src/core/store/types.ts
@@ -548,6 +548,13 @@ export interface AuditQueryFilter {
   offset?: number;
 }
 
+/** Result of an L1 compare-and-swap update. */
+export type L1CompareAndSwapResult =
+  | { status: "updated" }
+  | { status: "conflict"; currentVersion: number }
+  | { status: "not_found" }
+  | { status: "failed" };
+
 export interface IMemoryStore extends MemoryPromptStore, MemoryGenerationRefStore {
   // ── Capabilities ───────────────────────────────────────────
 
@@ -570,6 +577,16 @@ export interface IMemoryStore extends MemoryPromptStore, MemoryGenerationRefStor
   // ── L1 Write ─────────────────────────────────────────────
 
   upsertL1(record: MemoryRecord, embedding?: Float32Array): MaybePromise<boolean>;
+  /**
+   * Atomically replace an existing L1 record only when its persisted version
+   * equals `expectedVersion`. Implementations must not fall back to a
+   * read-then-write check.
+   */
+  compareAndSwapL1?(
+    record: MemoryRecord,
+    expectedVersion: number,
+    embedding?: Float32Array,
+  ): MaybePromise<L1CompareAndSwapResult>;
   deleteL1(recordId: string, filter?: IsolationFilter): MaybePromise<boolean>;
   deleteL1Batch(recordIds: string[], filter?: IsolationFilter): MaybePromise<boolean>;
   deleteL1Expired(cutoffIso: string): MaybePromise<number>;

--- a/MemoryCore/src/gateway/v2-atomic-cas.test.ts
+++ b/MemoryCore/src/gateway/v2-atomic-cas.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IMemoryStore, L1RecordRow } from "../core/store/types.js";
+import { handleV2Route, type V2RouterDeps } from "./v2-router.js";
+
+const requestBody = {
+  team_id: "team-1",
+  agent_id: "agent-1",
+  user_id: "user-1",
+  session_id: "session-1",
+  id: "memory-1",
+  content: "edited content",
+};
+
+function record(version: number): L1RecordRow {
+  return {
+    record_id: "memory-1",
+    content: "original content",
+    type: "persona",
+    priority: 50,
+    scene_name: "default",
+    metadata_json: "{}",
+    timestamp_str: "",
+    timestamp_start: "",
+    timestamp_end: "",
+    created_time: "2026-09-01T00:00:00.000Z",
+    updated_time: "2026-09-01T00:00:00.000Z",
+    version,
+    session_key: "session-key",
+    session_id: "session-1",
+    team_id: "team-1",
+    task_id: "",
+    user_id: "user-1",
+    agent_id: "agent-1",
+  };
+}
+
+function makeStore(version: number) {
+  return {
+    queryL1Records: vi.fn().mockResolvedValue([record(version)]),
+    upsertL1: vi.fn().mockResolvedValue(true),
+    compareAndSwapL1: vi.fn(),
+  };
+}
+
+async function dispatch(
+  body: Record<string, unknown>,
+  store: ReturnType<typeof makeStore>,
+): Promise<{ status: number; body: any }> {
+  let response: { status: number; body: any } | undefined;
+  const req = {
+    headers: {
+      authorization: "Bearer test-key",
+      "x-tdai-service-id": "service-1",
+    },
+    url: "/v3/atomic/update",
+  } as any;
+  const res = {} as any;
+  const deps: V2RouterDeps = {
+    getStore: () => store as unknown as IMemoryStore,
+    getEmbedding: () => undefined,
+    getStorage: () => undefined,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any,
+    deployMode: "standalone",
+  };
+
+  const handled = await handleV2Route(
+    req,
+    res,
+    "/v3/atomic/update",
+    "POST",
+    async <T,>() => body as T,
+    (_res, status, envelope) => {
+      response = { status, body: envelope };
+    },
+    deps,
+  );
+
+  expect(handled).toBe(true);
+  expect(response).toBeDefined();
+  return response!;
+}
+
+describe("POST /v3/atomic/update expected_version", () => {
+  it("returns 409 with a stable error code and current version for a stale edit", async () => {
+    const store = makeStore(4);
+    store.compareAndSwapL1.mockResolvedValue({ status: "conflict", currentVersion: 4 });
+
+    const response = await dispatch({ ...requestBody, expected_version: 3 }, store);
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      code: 409,
+      message: "ATOMIC_VERSION_CONFLICT",
+      data: {
+        error_code: "ATOMIC_VERSION_CONFLICT",
+        expected_version: 3,
+        current_version: 4,
+      },
+    });
+    expect(store.upsertL1).not.toHaveBeenCalled();
+    expect(store.compareAndSwapL1).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses CAS for a fresh edit and returns the incremented version", async () => {
+    const store = makeStore(3);
+    store.compareAndSwapL1.mockResolvedValue({ status: "updated" });
+
+    const response = await dispatch({ ...requestBody, expected_version: 3 }, store);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      code: 0,
+      data: { id: "memory-1", version: "v4" },
+    });
+    const [written, expectedVersion] = store.compareAndSwapL1.mock.calls[0];
+    expect(expectedVersion).toBe(3);
+    expect(written).toMatchObject({ content: "edited content", version: 4 });
+  });
+
+  it("preserves legacy last-write-wins behavior when expected_version is omitted", async () => {
+    const store = makeStore(7);
+
+    const response = await dispatch(requestBody, store);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.version).toBe("v8");
+    expect(store.upsertL1).toHaveBeenCalledTimes(1);
+    expect(store.compareAndSwapL1).not.toHaveBeenCalled();
+  });
+
+  it("rejects a version whose increment would exceed the safe-integer range", async () => {
+    const store = makeStore(3);
+
+    const response = await dispatch(
+      { ...requestBody, expected_version: Number.MAX_SAFE_INTEGER },
+      store,
+    );
+
+    expect(response.status).toBe(400);
+    expect(store.upsertL1).not.toHaveBeenCalled();
+    expect(store.compareAndSwapL1).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the record disappears during the guarded update", async () => {
+    const store = makeStore(3);
+    store.compareAndSwapL1.mockResolvedValue({ status: "not_found" });
+
+    const response = await dispatch({ ...requestBody, expected_version: 3 }, store);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Atomic note not found: memory-1");
+  });
+
+  it("returns 503 when guarded updates are unsupported by the store", async () => {
+    const store = makeStore(3);
+    (store as { compareAndSwapL1?: unknown }).compareAndSwapL1 = undefined;
+
+    const response = await dispatch({ ...requestBody, expected_version: 3 }, store);
+
+    expect(response.status).toBe(503);
+    expect(response.body.message).toBe("ATOMIC_CAS_UNSUPPORTED");
+    expect(store.upsertL1).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when a guarded persistence operation fails", async () => {
+    const store = makeStore(3);
+    store.compareAndSwapL1.mockResolvedValue({ status: "failed" });
+
+    const response = await dispatch({ ...requestBody, expected_version: 3 }, store);
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe("ATOMIC_UPDATE_FAILED");
+    expect(store.upsertL1).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryCore/src/gateway/v2-router.ts
+++ b/MemoryCore/src/gateway/v2-router.ts
@@ -1044,7 +1044,7 @@ async function handleConversationDelete(body: unknown, auth: V2AuthContext, requ
 async function handleAtomicUpdate(body: unknown, _auth: V2AuthContext, requestId: string, deps: V2RouterDeps): Promise<ApiResponseEnvelope> {
   const parsed = atomicUpdateRequestSchema.safeParse(body);
   if (!parsed.success) return errorEnvelope(400, formatZodError(parsed.error), requestId);
-  const { id, content, background } = parsed.data;
+  const { id, content, background, expected_version: expectedVersion } = parsed.data;
 
   const store = deps.getStore();
   if (!store) return errorEnvelope(503, "Store not available", requestId);
@@ -1060,16 +1060,22 @@ async function handleAtomicUpdate(body: unknown, _auth: V2AuthContext, requestId
 
   // Build update: content is always overwritten; background (scene_name) only if provided.
   // user_id / agent_id are preserved from the existing row — updates don't
-  // re-derive them. If the caller supplied an isolation triple that does NOT
+  // re-derive them. If the caller supplied an isolation field that does NOT
   // match the existing row, we treat it as a permission denial.
   const iso = deps.requestIsolation;
+  if (iso?.teamId && record.team_id && record.team_id !== iso.teamId) {
+    return errorEnvelope(403, `Atomic note ${id} belongs to a different team`, requestId);
+  }
   if (iso?.userId && record.user_id && record.user_id !== iso.userId) {
     return errorEnvelope(403, `Atomic note ${id} belongs to a different user`, requestId);
   }
   if (iso?.agentId && record.agent_id && record.agent_id !== iso.agentId) {
     return errorEnvelope(403, `Atomic note ${id} belongs to a different agent`, requestId);
   }
-  const updatedVersion = (record.version ?? 0) + 1;
+  if (iso?.taskId && record.task_id && record.task_id !== iso.taskId) {
+    return errorEnvelope(403, `Atomic note ${id} belongs to a different task`, requestId);
+  }
+  const updatedVersion = (expectedVersion ?? record.version ?? 0) + 1;
   const updated: MemoryRecord = {
     id,
     content,
@@ -1094,7 +1100,28 @@ async function handleAtomicUpdate(body: unknown, _auth: V2AuthContext, requestId
   let emb: Float32Array | undefined;
   if (embedding) { try { emb = await embedding.embed(content); } catch (e) { console.warn(`[v2-router] L1 embedding failed:`, e); } }
 
-  await store.upsertL1(updated, emb);
+  if (expectedVersion === undefined) {
+    const stored = await store.upsertL1(updated, emb);
+    if (!stored) return errorEnvelope(500, "ATOMIC_UPDATE_FAILED", requestId);
+  } else {
+    if (!store.compareAndSwapL1) {
+      return errorEnvelope(503, "ATOMIC_CAS_UNSUPPORTED", requestId);
+    }
+    const result = await store.compareAndSwapL1(updated, expectedVersion, emb);
+    if (result.status === "conflict") {
+      return errorEnvelope(409, "ATOMIC_VERSION_CONFLICT", requestId, {
+        error_code: "ATOMIC_VERSION_CONFLICT",
+        expected_version: expectedVersion,
+        current_version: result.currentVersion,
+      });
+    }
+    if (result.status === "not_found") {
+      return errorEnvelope(404, `Atomic note not found: ${id}`, requestId);
+    }
+    if (result.status === "failed") {
+      return errorEnvelope(500, "ATOMIC_UPDATE_FAILED", requestId);
+    }
+  }
 
   // 审计：L1 update — 用外部请求的 IdFields 而非 record 原值（per user 决策）
   await recordAudit(store, {

--- a/MemoryCore/src/gateway/v2-schemas.ts
+++ b/MemoryCore/src/gateway/v2-schemas.ts
@@ -27,7 +27,6 @@ export {
   conversationQueryDataSchema,
   conversationDeleteDataSchema,
   atomicDetailSchema,
-  atomicUpdateRequestSchema,
   atomicUpdateDataSchema,
   atomicDeleteDataSchema,
   atomicQueryRequestSchema,
@@ -58,7 +57,6 @@ export type {
   ConversationQueryRequest,
   ConversationQueryData,
   ConversationDeleteData,
-  AtomicUpdateRequest,
   AtomicUpdateData,
   AtomicDeleteData,
   AtomicQueryRequest,
@@ -97,6 +95,7 @@ export interface ConversationItem extends GeneratedConversationItem {
 export type ConversationSearchHit = ConversationItem & { score: number };
 import {
   conversationItemSchema as _conversationItemSchema,
+  idFieldsSchema as _idFieldsSchema,
   scenarioReadRequestSchema as _scenarioReadRequestSchema,
   scenarioWriteRequestSchema as _scenarioWriteRequestSchema,
   scenarioRmRequestSchema as _scenarioRmRequestSchema,
@@ -143,11 +142,23 @@ export type ScenarioCountRequest = z.infer<typeof scenarioCountRequestSchema>;
 export const coreCountRequestSchema = z.object({});
 export type CoreCountRequest = z.infer<typeof coreCountRequestSchema>;
 
+/**
+ * Optional compare-and-swap guard for human-authored atomic updates.
+ * Omitting expected_version preserves the existing last-write-wins contract.
+ */
+export const atomicUpdateRequestSchema = _idFieldsSchema.and(z.object({
+  id: z.string(),
+  content: z.string().max(8192),
+  background: z.string().optional(),
+  expected_version: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER - 1).optional(),
+}));
+export type AtomicUpdateRequest = z.infer<typeof atomicUpdateRequestSchema>;
+
 // ============================
 // Override: atomic response version exposure
 // ============================
 
-export interface AtomicDetail extends GeneratedAtomicDetail {
+export interface AtomicDetail extends Omit<GeneratedAtomicDetail, "version"> {
   /** Monotonic L1 memory version, starts from 0 and increments on update/merge. */
   version: number;
   team_id?: string;

--- a/MemoryPanel/src/panel/http/routes/chat-memory.ts
+++ b/MemoryPanel/src/panel/http/routes/chat-memory.ts
@@ -1241,6 +1241,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
               id: r.record_id ?? r.id,
               title: (r.type ?? "atomic") as string,
               body: r.content ?? "",
+              version: typeof r.version === "number" ? r.version : undefined,
               tags: r.tags ?? [],
               refs: [],
               // L1 时间来源（v3 内核实际返回）：
@@ -1577,7 +1578,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
 
   // ==========================================================================
   // POST /chat-memory/layer-update
-  //   body: { block_id, layer: 'L1'|'L2'|'L3', id?, content, summary? }
+  //   body: { block_id, layer: 'L1'|'L2'|'L3', id?, content, summary?, expected_version? }
   //
   // 编辑单层记忆内容（Owner-only —— 与 layer-delete / clear 同口径：读可以借入，
   // 但修改内容只允许资产 Owner，避免借入方改掉别人的记忆）：
@@ -1599,12 +1600,27 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
       const itemId = typeof body?.id === "string" ? body.id.trim() : "";
       const summary =
         typeof body?.summary === "string" ? body.summary : undefined;
+      const expectedVersionValue = body?.expected_version;
+      const expectedVersion =
+        typeof expectedVersionValue === "number" ? expectedVersionValue : undefined;
 
       if (!blockId) return respondControlError(c, 400, "MISSING_BLOCK_ID");
       if (layerRaw !== "L1" && layerRaw !== "L2" && layerRaw !== "L3")
         return respondControlError(c, 400, "INVALID_LAYER");
       const layer = layerRaw as "L1" | "L2" | "L3";
       if (content === null) return respondControlError(c, 400, "MISSING_CONTENT");
+      if (
+        expectedVersionValue !== undefined &&
+        (expectedVersion === undefined ||
+          !Number.isSafeInteger(expectedVersion) ||
+          expectedVersion < 0 ||
+          expectedVersion >= Number.MAX_SAFE_INTEGER)
+      ) {
+        return respondControlError(c, 400, "INVALID_EXPECTED_VERSION");
+      }
+      if (expectedVersion !== undefined && layer !== "L1") {
+        return respondControlError(c, 400, "EXPECTED_VERSION_REQUIRES_L1");
+      }
       // L1（记录主键）/ L2（文件路径）都需要定位单条；L3 是整份 persona，无需 id。
       if ((layer === "L1" || layer === "L2") && !itemId)
         return respondControlError(c, 400, "MISSING_ITEM_ID");
@@ -1644,7 +1660,14 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
         if (layer === "L1") {
           const env = await deps.kernelHttp.postEnvelope<unknown>(
             "/v3/atomic/update",
-            { ...idFields, id: itemId, content },
+            {
+              ...idFields,
+              id: itemId,
+              content,
+              ...(expectedVersion !== undefined
+                ? { expected_version: expectedVersion }
+                : {}),
+            },
             cred,
           );
           return respondEnvelope(c, env);
@@ -1797,6 +1820,7 @@ export function registerChatMemoryRoutes(api: Hono, deps: PanelDeps): void {
         id: (r.id ?? r.record_id ?? "") as string,
         title: (r.type ?? "atomic") as string,
         body: (r.content ?? "") as string,
+        version: typeof r.version === "number" ? r.version : undefined,
         tags: Array.isArray(r.tags) ? (r.tags as string[]) : [],
         refs: [] as string[],
         score: typeof r.score === "number" ? r.score : undefined,

--- a/MemoryPanel/tests/chat-memory-layer-update-cas.test.ts
+++ b/MemoryPanel/tests/chat-memory-layer-update-cas.test.ts
@@ -1,0 +1,142 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { PanelDeps } from "../src/panel/panel-deps.js";
+import { registerChatMemoryRoutes } from "../src/panel/http/routes/chat-memory.js";
+
+const endpoint = "/chat-memory/layer-update";
+const headers = {
+  "Content-Type": "application/json",
+  "X-Tdai-Service-Id": "instance-1",
+  "X-Tdai-User-Key": "user-key-1",
+};
+const baseBody = {
+  block_id: "chat_memory-team-1-agt1",
+  layer: "L1",
+  id: "memory-1",
+  content: "edited content",
+};
+
+function makeApp(kernelEnvelope: Record<string, unknown> = {
+  code: 0,
+  message: "ok",
+  request_id: "kernel-request-1",
+  data: { id: "memory-1", version: "v4" },
+}) {
+  const postEnvelope = vi.fn().mockResolvedValue(kernelEnvelope);
+  const invoke = vi.fn(async (action: string) => {
+    if (action === "auth/verify") {
+      return {
+        code: 0,
+        message: "ok",
+        request_id: "meta-request-1",
+        data: { valid: true, user: { user_id: "user-1" } },
+      };
+    }
+    if (action === "asset/get") {
+      return {
+        code: 0,
+        message: "ok",
+        request_id: "meta-request-2",
+        data: {
+          asset_id: baseBody.block_id,
+          asset_type: "chat_memory",
+          owner_user_id: "user-1",
+        },
+      };
+    }
+    throw new Error(`unexpected meta action: ${action}`);
+  });
+  const deps = {
+    instanceRegistry: {
+      resolve: vi.fn().mockReturnValue({
+        instance_id: "instance-1",
+        gateway_endpoint: "http://memory.test",
+        api_key: "gateway-key",
+      }),
+    },
+    metaKernel: { invoke },
+    kernelHttp: { postEnvelope },
+  } as unknown as PanelDeps;
+  const app = new Hono();
+  registerChatMemoryRoutes(app, deps);
+  return { app, invoke, postEnvelope };
+}
+
+async function post(app: Hono, body: Record<string, unknown>) {
+  const response = await app.request(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() as any };
+}
+
+describe("chat-memory layer-update expected_version", () => {
+  it("forwards a valid L1 compare-and-swap guard to MemoryCore", async () => {
+    const { app, postEnvelope } = makeApp();
+
+    const response = await post(app, { ...baseBody, expected_version: 3 });
+
+    expect(response.status).toBe(200);
+    expect(postEnvelope).toHaveBeenCalledWith(
+      "/v3/atomic/update",
+      expect.objectContaining({
+        id: "memory-1",
+        content: "edited content",
+        expected_version: 3,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("preserves a MemoryCore 409 conflict envelope and status", async () => {
+    const { app } = makeApp({
+      code: 409,
+      message: "ATOMIC_VERSION_CONFLICT",
+      request_id: "kernel-request-2",
+      data: {
+        error_code: "ATOMIC_VERSION_CONFLICT",
+        expected_version: 3,
+        current_version: 4,
+      },
+    });
+
+    const response = await post(app, { ...baseBody, expected_version: 3 });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      code: 409,
+      message: "ATOMIC_VERSION_CONFLICT",
+      data: { expected_version: 3, current_version: 4 },
+    });
+  });
+
+  it("rejects unsafe versions before authorization or kernel calls", async () => {
+    const { app, invoke, postEnvelope } = makeApp();
+
+    const response = await post(app, {
+      ...baseBody,
+      expected_version: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("INVALID_EXPECTED_VERSION");
+    expect(invoke).not.toHaveBeenCalled();
+    expect(postEnvelope).not.toHaveBeenCalled();
+  });
+
+  it("rejects expected_version on non-L1 edits", async () => {
+    const { app, invoke, postEnvelope } = makeApp();
+
+    const response = await post(app, {
+      ...baseBody,
+      layer: "L2",
+      expected_version: 3,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("EXPECTED_VERSION_REQUIRES_L1");
+    expect(invoke).not.toHaveBeenCalled();
+    expect(postEnvelope).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryPanel/web/src/i18n/zh-CN.ts
+++ b/MemoryPanel/web/src/i18n/zh-CN.ts
@@ -641,6 +641,7 @@ export const zhCN = {
   'memory.notify.l2Failed': '加载 L2 原文失败',
   'memory.notify.editSuccess': '已保存',
   'memory.notify.editFailed': '保存失败',
+  'memory.notify.versionConflict': '内容已被其他编辑更新。草稿已保留，请刷新后合并再保存。',
   'memory.notify.copied': '已复制',
   'memory.notify.copyFailed': '复制失败',
   'memory.notify.searchFailed': '搜索失败',

--- a/MemoryPanel/web/src/lib/api/chat-memory.ts
+++ b/MemoryPanel/web/src/lib/api/chat-memory.ts
@@ -27,6 +27,8 @@ export interface ChatMemoryLayerItem {
   role?: string;
   title: string;
   body: string;
+  /** L1 optimistic-concurrency version. */
+  version?: number;
   tags?: string[];
   refs?: string[];
   /** 条目创建/记录时间（ISO8601），backend 从 recorded_at_ms / created_time_ms / updated_at 转换 */
@@ -168,7 +170,7 @@ export const chatMemoryApi = {
   updateLayer: (
     blockId: string,
     layer: 'L1' | 'L2' | 'L3',
-    params: { id?: string; content: string; summary?: string },
+    params: { id?: string; content: string; summary?: string; expectedVersion?: number },
   ) =>
     chatMemoryCall<{
       id?: string;
@@ -181,6 +183,9 @@ export const chatMemoryApi = {
       ...(params.id ? { id: params.id } : {}),
       content: params.content,
       ...(params.summary !== undefined ? { summary: params.summary } : {}),
+      ...(params.expectedVersion !== undefined
+        ? { expected_version: params.expectedVersion }
+        : {}),
     }),
 
   /** 分层语义 / 关键字搜索（agent 维度跨 session 召回，命中项带 score）：

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/components/BlockDetail.tsx
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/components/BlockDetail.tsx
@@ -8,6 +8,7 @@ import { getLayerCount, stripAtMention, extractRole, formatDisplayTime } from '.
 import { stripScenarioMeta, copyToClipboard } from '../utils/memory-utils';
 import { useUserDisplayName } from '@/services/user-profile-store';
 import { tea } from '@/lib/tea-bridge';
+import { ApiError } from '@/lib/api/base';
 import { MarkdownView } from '@/components/MarkdownView';
 import type { ChatMemorySearchHit } from '@/lib/teamApi';
 import {
@@ -446,7 +447,8 @@ export function BlockDetail({
     l: 'L1' | 'L2' | 'L3',
     id: string,
     content: string,
-  ) => Promise<void>;
+    expectedVersion?: number,
+  ) => Promise<number | undefined>;
   /** 分层语义搜索（L0 = 对话消息，L1 = 原子记忆）；未传则不显示搜索框 */
   onSearchLayer?: (l: 'L0' | 'L1', query: string) => Promise<ChatMemorySearchHit[]>;
 }) {
@@ -474,6 +476,7 @@ export function BlockDetail({
     layer: 'L1' | 'L2' | 'L3';
     id: string;
     title: string;
+    version?: number;
   } | null>(null);
   const [editContent, setEditContent] = useState('');
   const [saving, setSaving] = useState(false);
@@ -482,26 +485,52 @@ export function BlockDetail({
     if (layer === 'L0') return;
     // L2 正文带 META 头，编辑框只展示纯正文（写回时后端会用现有 META 重建）。
     const draft = layer === 'L2' ? stripScenarioMeta(item.body) : item.body;
-    setEditing({ layer: layer as 'L1' | 'L2' | 'L3', id: item.id, title: item.title });
+    setEditing({
+      layer: layer as 'L1' | 'L2' | 'L3',
+      id: item.id,
+      title: item.title,
+      version: item.version,
+    });
     setEditContent(draft);
   }
   async function saveEdit() {
     if (!editing || !onSaveLayerItem) return;
     setSaving(true);
     try {
-      await onSaveLayerItem(editing.layer, editing.id, editContent);
+      const returnedVersion = await onSaveLayerItem(
+        editing.layer,
+        editing.id,
+        editContent,
+        editing.version,
+      );
       // 搜索结果态：hook 的乐观更新只作用于分页列表，这里同步更新搜索结果条目，
       // 否则搜索视图里刚编辑的那条正文不会刷新。
       setSearchResults((prev) =>
         prev
           ? prev.map((it) =>
-              it.id === editing.id ? { ...it, body: editContent } : it,
+              it.id === editing.id
+                ? {
+                    ...it,
+                    body: editContent,
+                    ...(returnedVersion !== undefined ? { version: returnedVersion } : {}),
+                  }
+                : it,
             )
           : prev,
       );
       setEditing(null);
     } catch (e) {
-      tea.notify.error(e instanceof Error ? e.message : t('memory.notify.editFailed'));
+      if (
+        e instanceof ApiError &&
+        e.status === 409 &&
+        e.rawMessage === 'ATOMIC_VERSION_CONFLICT'
+      ) {
+        // Keep both the draft and stale version in place. A blind retry must
+        // conflict again until the user reloads and reconciles the newer text.
+        tea.notify.error(t('memory.notify.versionConflict'));
+      } else {
+        tea.notify.error(e instanceof Error ? e.message : t('memory.notify.editFailed'));
+      }
     } finally {
       setSaving(false);
     }

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/constants/types.ts
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/constants/types.ts
@@ -17,6 +17,8 @@ export interface AtomicItem {
   id: string;
   title: string;
   body: string;
+  /** L1 optimistic-concurrency version. */
+  version?: number;
   refs?: string[];
   tags?: string[];
   /** 条目创建/记录时间（ISO8601），仅展示，不参与排序 */

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/hooks/useChatMemory.ts
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/hooks/useChatMemory.ts
@@ -426,12 +426,24 @@ export function useChatMemory(props: { activeTeamId?: string | null } = {}) {
   // L1 = content 覆盖；L2 = 整份 scenario 正文覆盖（BFF 会剥 META 后写、内核重建 META）；
   // L3 = 整份 core persona 覆盖。失败时抛出，交由调用方（编辑弹窗）保留输入并提示。
   const handleSaveLayerItem = useCallback(
-    async (targetLayer: 'L1' | 'L2' | 'L3', itemId: string, content: string) => {
+    async (
+      targetLayer: 'L1' | 'L2' | 'L3',
+      itemId: string,
+      content: string,
+      expectedVersion?: number,
+    ): Promise<number | undefined> => {
       if (!selected?.id) return;
-      await chatMemoryApi.updateLayer(selected.id, targetLayer, {
+      const result = await chatMemoryApi.updateLayer(selected.id, targetLayer, {
         id: itemId,
         content,
+        ...(targetLayer === 'L1' && expectedVersion !== undefined
+          ? { expectedVersion }
+          : {}),
       });
+      const returnedVersion =
+        typeof result.version === 'string' && /^v\d+$/.test(result.version)
+          ? Number(result.version.slice(1))
+          : undefined;
       setBlocks((prev) =>
         prev.map((b) => {
           if (b.id !== selected.id) return b;
@@ -440,13 +452,20 @@ export function useChatMemory(props: { activeTeamId?: string | null } = {}) {
             layers: {
               ...b.layers,
               [targetLayer]: b.layers[targetLayer].map((item) =>
-                item.id === itemId ? { ...item, body: content } : item,
+                item.id === itemId
+                  ? {
+                      ...item,
+                      body: content,
+                      ...(returnedVersion !== undefined ? { version: returnedVersion } : {}),
+                    }
+                  : item,
               ),
             },
           };
         }),
       );
       tea.notify.success(t('memory.notify.editSuccess'));
+      return returnedVersion;
     },
     [selected?.id, t],
   );

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/utils/memory-utils.ts
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/utils/memory-utils.ts
@@ -33,6 +33,7 @@ export function mapLayerItem(i: ChatMemoryLayerItem) {
     id: i.id,
     title: i.title,
     body: i.body,
+    version: i.version,
     refs: i.refs,
     tags: i.tags,
     created_at: i.created_at,

--- a/sdk/memory-core/typescript/src/types.ts
+++ b/sdk/memory-core/typescript/src/types.ts
@@ -107,6 +107,8 @@ export interface AtomicDetail {
   type: string;
   content: string;
   background?: string;
+  /** Monotonic L1 version used for compare-and-swap updates. */
+  version?: number;
   created_at: string;
   updated_at: string;
 }
@@ -115,9 +117,13 @@ export interface AtomicUpdateRequest extends IdFields {
   id: string;
   content: string;
   background?: string;
+  /** Reject the update with HTTP 409 when the stored version no longer matches. */
+  expected_version?: number;
 }
 export interface AtomicUpdateData {
   id: string;
+  /** New monotonic version after a successful update (serialized by the API). */
+  version?: string;
   updated_at: string;
 }
 

--- a/sdk/memory-core/typescript/src/v3/client.ts
+++ b/sdk/memory-core/typescript/src/v3/client.ts
@@ -273,6 +273,7 @@ export class MemoryClient {
       id: params.id,
       content: params.content,
       background: params.background,
+      expected_version: params.expected_version,
     }));
   }
 

--- a/sdk/memory-core/typescript/src/v3/types.ts
+++ b/sdk/memory-core/typescript/src/v3/types.ts
@@ -104,6 +104,8 @@ export interface V3AtomicUpdateRequest {
   id: string;
   content: string;
   background?: string;
+  /** Reject the update when the stored version no longer matches. */
+  expected_version?: number;
   session_id?: string;
 }
 export type V3AtomicUpdateData = AtomicUpdateData;

--- a/sdk/memory-core/typescript/tests/v3-client-cas.test.ts
+++ b/sdk/memory-core/typescript/tests/v3-client-cas.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Transport } from "../src/client.js";
+import { MemoryClient } from "../src/v3/client.js";
+
+function makeClient() {
+  const post = vi.fn().mockResolvedValue({
+    id: "memory-1",
+    version: "v4",
+    updated_at: "2026-09-02T00:00:00.000Z",
+  });
+  const transport = { post } as unknown as Transport;
+  const client = new MemoryClient(transport, {
+    team_id: "team-1",
+    agent_id: "agent-1",
+    user_id: "user-1",
+    session_id: "session-1",
+  });
+  return { client, post };
+}
+
+describe("v3 MemoryClient.updateAtomic expected_version", () => {
+  it("forwards the compare-and-swap guard", async () => {
+    const { client, post } = makeClient();
+
+    const result = await client.updateAtomic({
+      id: "memory-1",
+      content: "edited content",
+      expected_version: 3,
+    });
+
+    expect(post).toHaveBeenCalledWith("/v3/atomic/update", {
+      team_id: "team-1",
+      agent_id: "agent-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      id: "memory-1",
+      content: "edited content",
+      expected_version: 3,
+    });
+    expect(result.version).toBe("v4");
+  });
+
+  it("omits the guard for backward-compatible last-write-wins calls", async () => {
+    const { client, post } = makeClient();
+
+    await client.updateAtomic({ id: "memory-1", content: "legacy edit" });
+
+    expect(post.mock.calls[0][1]).not.toHaveProperty("expected_version");
+  });
+});


### PR DESCRIPTION
## Description | 描述

> Draft implementation for maintainer review following the internal-review acknowledgement in #1236. This does not assume the proposal has been accepted.

Add an optional `expected_version` guard to `/v3/atomic/update` so human-authored L1 edits can reject stale writes instead of silently overwriting a newer revision.

- Preserve the existing last-write-wins behavior when `expected_version` is omitted.
- Perform atomic compare-and-swap updates in both SQLite (`UPDATE ... WHERE version = ?` inside `BEGIN IMMEDIATE`) and Tencent VectorDB (one server-side version-filtered document update).
- Disable transport retries for the conditional Tencent VectorDB update so a lost success response cannot become a false conflict on retry.
- Return `409 ATOMIC_VERSION_CONFLICT` with `expected_version` and `current_version` when the stored version has advanced.
- Keep L1 isolation fields in the atomic predicate and reject cross-team/user/agent/task update attempts.
- Expose L1 versions through query/search paths and pass them from MemoryPanel editors into subsequent updates.
- Add `expected_version` to both TypeScript SDK update APIs while retaining compatibility with older callers and servers.

## Related Issue | 关联 Issue

Closes #1236

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verification performed with Node.js v22.22.2:

- [x] MemoryCore CAS regression suite: 4 files, 13 tests passed
  - SQLite winner/stale-writer and not-found behavior
  - Tencent VectorDB version-filtered update, conflict, and not-found behavior
  - Tencent VectorDB conditional-update no-retry policy
  - Gateway success, legacy no-guard behavior, 409/404/500/503 mapping, and unsafe-version validation
- [x] MemoryCore plugin build: `npm run build:plugin`
- [x] MemoryPanel route suite: 4 tests passed (forwarding, 409 propagation, unsafe/non-L1 rejection)
- [x] MemoryPanel server typecheck: `npm run typecheck`
- [x] MemoryPanel web lint: 0 errors (32 pre-existing warnings)
- [x] MemoryPanel web production build: `npm run build`
- [x] TypeScript SDK suite: 2 tests passed (guard included/omitted)
- [x] TypeScript SDK build: `npm run build`

## Additional Notes | 其他说明

- This is opt-in concurrency control: clients that do not send `expected_version` retain the current behavior.
- Durable `operation_id` replay receipts are intentionally out of scope for this patch. That broader retry contract should be designed separately and aligned with the idempotency work in #1087 / #1142.
- The gateway uses a local request-schema override because the generated schema source is not present in this branch; generated files are intentionally left untouched.
- The update response still serializes the new version using the existing `vN` wire format. Query/search items expose the persisted numeric version used as the next `expected_version`.
- MemoryPanel preserves a stale edit draft on 409 and requires the user to reload/reconcile before retrying; it does not silently advance the editor to the server version.
- Please review the Tencent VectorDB `/document/update` predicate shape in `TcvdbMemoryStore.compareAndSwapL1`; it uses a single document ID plus version and isolation filters, not a read-then-upsert sequence.
