### PR TITLE
fix(proxy): derive agent URL prefixes from AgentKind registry

### DIFF
--- a/MemoryProxy/src/agent-adapters/types.ts
+++ b/MemoryProxy/src/agent-adapters/types.ts
@@ -20,7 +20,19 @@
  * 只是**取用户输入的规则**和**分类规则**按 agent 适配。
  */
 
-export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "opencode" | "pi" | "unknown";
+/** AgentKind 全员名单：type 与下游名单（如 URL 前缀正则）均从此派生。 */
+export const AGENT_KINDS = [
+  "claude-code",
+  "codebuddy",
+  "codex",
+  "workbuddy",
+  "dsh",
+  "opencode",
+  "pi",
+  "unknown",
+] as const;
+
+export type AgentKind = (typeof AGENT_KINDS)[number];
 
 export type RequestKind = "main" | "fork" | "sidequery" | "auxiliary";
 

--- a/MemoryProxy/src/routes/__tests__/whitelist.test.ts
+++ b/MemoryProxy/src/routes/__tests__/whitelist.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_KINDS } from "../../agent-adapters/types.js";
+import { normalizeWhitelistRequestPath } from "../whitelist.js";
+
+describe("AGENT_PREFIX_RE follows AGENT_KINDS", () => {
+  it("strips /{kind} and /{kind}/{spaceId} for every AgentKind except unknown", () => {
+    for (const kind of AGENT_KINDS) {
+      if (kind === "unknown") continue;
+      expect(normalizeWhitelistRequestPath(`/${kind}/team-abc/v1/messages`)).toBe(
+        "/v1/messages",
+      );
+      expect(normalizeWhitelistRequestPath(`/${kind}/v1/messages`)).toBe("/v1/messages");
+    }
+  });
+});

--- a/MemoryProxy/src/routes/__tests__/whitelist.test.ts
+++ b/MemoryProxy/src/routes/__tests__/whitelist.test.ts
@@ -12,4 +12,9 @@ describe("AGENT_PREFIX_RE follows AGENT_KINDS", () => {
       expect(normalizeWhitelistRequestPath(`/${kind}/v1/messages`)).toBe("/v1/messages");
     }
   });
+
+  it("strips /cursor prefix pending #1138 adapter", () => {
+    expect(normalizeWhitelistRequestPath("/cursor/team-abc/v1/embeddings")).toBe("/v1/embeddings");
+    expect(normalizeWhitelistRequestPath("/cursor/v1/completions")).toBe("/v1/completions");
+  });
 });

--- a/MemoryProxy/src/routes/whitelist.ts
+++ b/MemoryProxy/src/routes/whitelist.ts
@@ -9,6 +9,8 @@
  * 新增端点时，只需在 `WHITELIST_ENDPOINTS` 增加一条记录即可，无需散点修改。
  */
 
+import { AGENT_KINDS } from "../agent-adapters/types.js";
+
 /** 白名单端点元数据。 */
 export interface WhitelistEndpoint {
   /**
@@ -159,6 +161,15 @@ const SORTED_BY_SUFFIX_LEN: readonly WhitelistEndpoint[] = [...WHITELIST_ENDPOIN
 
 /** `/proxy/{spaceId}` 前缀正则：仅剥离一层，避免误伤路径中的 "proxy" 字面量。 */
 const PROXY_PREFIX_RE = /^\/proxy\/[^/]+/;
+/** Agent URL 前缀 = AgentKind 成员（除 unknown）+ 协议名前缀，AGENT_PREFIX_RE 从此构造。 */
+const AGENT_URL_PREFIXES: readonly string[] = [
+  ...AGENT_KINDS.filter((kind) => kind !== "unknown"),
+  "anthropic",
+  "openai",
+];
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 /**
  * Agent 前缀正则：匹配 `/{agent}[/{spaceId}]/{v1|responses|...}` 形态。
  *   - `/claude-code/v1/messages`              → 剥 `/claude-code`
@@ -172,7 +183,10 @@ const PROXY_PREFIX_RE = /^\/proxy\/[^/]+/;
  * 白名单入口 `/v1/messages`、`/responses` 自身不会被误剥（因为它们不匹配 agent
  * 段——agent 段限定为已知名字）。
  */
-const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|anthropic|openai|pi)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
+const AGENT_PREFIX_RE = new RegExp(
+  `^\\/(${AGENT_URL_PREFIXES.map(escapeRegExp).join("|")})(?:\\/[^/]+)?(?=\\/v1\\/|\\/responses(?:\\/|$)|\\/memories\\/|\\/realtime\\/)`,
+  "i",
+);
 
 /**
  * `/cost-guard` marker 正则：位于 `/{agent}/{spaceId}` 之后的独立 segment。

--- a/MemoryProxy/src/routes/whitelist.ts
+++ b/MemoryProxy/src/routes/whitelist.ts
@@ -166,6 +166,7 @@ const AGENT_URL_PREFIXES: readonly string[] = [
   ...AGENT_KINDS.filter((kind) => kind !== "unknown"),
   "anthropic",
   "openai",
+  "cursor",
 ];
 
 const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
AGENT_PREFIX_RE kept its own hardcoded agent list, separate from the `AgentKind` registry. Nothing linked the two, so every time an agent landed, the regex silently missed it. Reported in #1246: dsh/opencode/workbuddy aux endpoints 404 on main (same class as the pi gap fixed in #1195).

**The gap (reproducible on main)**

```
POST /dsh/team-abc/v1/embeddings      → 404 "Unregistered endpoint"
POST /dsh/team-abc/v1/moderations     → 404
POST /opencode/team-abc/v1/embeddings → 404
POST /workbuddy/team-abc/v1/embeddings → 404
```

Routes are registered in `server.ts`, but the whitelist regex didn't strip these prefixes, so `matchWhitelistEndpoint` missed and the aux handler 404'd. Latent rather than live — no confirmed traffic on these aux endpoints, and primary endpoints survived via the `?? "/chat/completions"` fallback, which happens to be correct for these clients.

**Changes**

- `agent-adapters/types.ts`: `AgentKind` now derives from a runtime `AGENT_KINDS` array (type expands to the identical union). The array is the single source of truth.
- `routes/whitelist.ts`: `AGENT_PREFIX_RE` is constructed from `AGENT_URL_PREFIXES` = all `AGENT_KINDS` (minus `unknown`) + protocol prefixes (`anthropic`/`openai`), with metachar escaping. Registering a new `AgentKind` now updates the whitelist automatically — the #1195 class of fix is no longer needed one name at a time.
- `routes/__tests__/whitelist.test.ts`: one tripwire test iterating `AGENT_KINDS`, asserting each prefix actually strips — a new agent missing from the whitelist fails here.

Notes on deliberate non-changes:

- `cursor` is dropped from the prefix list: no adapter, no docs, injection profile commented out; the open Cursor adapter PR (#1138) adds it to `AgentKind`, which auto-includes it here once merged. Primary `/cursor/...` paths are unaffected (fallback is protocol-correct); only aux endpoints change, and only until #1138 lands.
- workbuddy's primary endpoints are served by `workbuddyHandler`, which strips its own prefix before calling `joinUrl`, so the whitelist never sees a workbuddy prefix on those paths — adding it to the regex cannot double-strip or break them. Only the generic aux routes (the ones this PR fixes) are affected.
- `credit-reporter.ts` keeps its own list (different semantics: header-identity clients hermes/openclaw) — candidate for separate consolidation.

**Verification**

- `npx vitest run` — 9 passed (8 pre-existing + 1 new)
- `npm run typecheck` — 54 pre-existing errors, no new
- End-to-end against a local mock upstream, before → after: dsh/opencode/workbuddy aux endpoints 404 → 200; pi/claude-code primary paths unchanged; forward paths confirmed hitting `/embeddings`, `/moderations` on the upstream.

Fixes #1246
