### PR TITLE
fix: make services start and work correctly on Windows

### DIFF
--- a/MemoryCore/src/gateway/config.ts
+++ b/MemoryCore/src/gateway/config.ts
@@ -412,8 +412,18 @@ export function loadGatewayConfig(overrides?: Partial<GatewayConfig>): GatewayCo
           : {};
       }
       fileConfig = expandEnvVars(fileConfig) as Record<string, unknown>;
-    } catch {
+    } catch (err) {
       // Config file is optional — malformed files fall back to env-only config.
+      // But never fail silently: an invalid file means EVERY yaml setting
+      // (skill module, llm model, pipeline timings, ...) is ignored and the
+      // gateway runs on pure defaults with no visible trace. Logger is not
+      // available this early, so write straight to stderr.
+      const reason = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[tdai-gateway][config] WARNING: failed to load config file ${configPath}: ${reason}. ` +
+        "Falling back to env-only config — all yaml settings are ignored.\n",
+      );
+      fileConfig = {};
     }
   }
 

--- a/MemoryKnowledge/src/server.ts
+++ b/MemoryKnowledge/src/server.ts
@@ -14,8 +14,8 @@ import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { swaggerUI } from "@hono/swagger-ui";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import { loadConfig } from "./config.js";
 import { createDb } from "./db/client.js";
@@ -139,8 +139,14 @@ async function startServer(): Promise<void> {
   process.once("SIGINT", () => void shutdown("SIGINT"));
 }
 
-// Start server when run directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Start server when run directly.
+// 跨平台比较：argv[1] 先转绝对路径再过 pathToFileURL —— 之前直接
+// `file://${argv[1]}` 在 Windows 上因盘符/反斜杠永远不相等，服务静默退出。
+const argv1 = process.argv[1];
+const isMain =
+  !!argv1 &&
+  import.meta.url === pathToFileURL(isAbsolute(argv1) ? argv1 : resolve(argv1)).href;
+if (isMain) {
   void startServer().catch((err) => {
     log.error("Knowledge service failed to start", {
       error: err instanceof Error ? err.message : String(err),

--- a/MemoryKnowledge/src/store/wiki-service.ts
+++ b/MemoryKnowledge/src/store/wiki-service.ts
@@ -12,7 +12,7 @@
  *   lib 层 cascadeDeleteWikiPagesWithRefs 做引用级联。
  */
 
-import { join, resolve, normalize } from "node:path";
+import { join, resolve, normalize, sep } from "node:path";
 import {
   rmSync,
   mkdirSync,
@@ -909,7 +909,8 @@ export class WikiService {
     // （如 KNOWLEDGE_DATA_DIR=./data）与 resolve 出来的绝对路径比较失败。
     const base = resolve(sourcesDir);
     const safe = resolve(base, normalized);
-    const dirWithSep = base.endsWith("/") ? base : base + "/";
+    // 用平台分隔符比较：Windows 上 resolve() 返回反斜杠，硬编码 "/" 会误判所有文件为穿越。
+    const dirWithSep = base.endsWith(sep) ? base : base + sep;
     if (safe !== base && !safe.startsWith(dirWithSep)) return null;
     return safe;
   }
@@ -930,7 +931,7 @@ export class WikiService {
 
     // resolve 成绝对路径，避免 projectPath 是相对路径时比较失败。
     const wikiDir = resolve(projectPath, "wiki");
-    const wikiDirSep = wikiDir.endsWith("/") ? wikiDir : wikiDir + "/";
+    const wikiDirSep = wikiDir.endsWith(sep) ? wikiDir : wikiDir + sep;
 
     // 先按原样尝试，再尝试补 .md 扩展。
     const candidates = cleanRef.endsWith(".md") ? [cleanRef] : [cleanRef + ".md", cleanRef];
@@ -955,9 +956,10 @@ export class WikiService {
   /** 把 wiki/.../page.md 绝对路径转换回 ref（如 "concepts/redis"）。 */
   private absToPageRef(projectPath: string, abs: string): string {
     const wikiDir = resolve(projectPath, "wiki");
-    const prefix = wikiDir.endsWith("/") ? wikiDir : wikiDir + "/";
+    const prefix = wikiDir.endsWith(sep) ? wikiDir : wikiDir + sep;
     if (!abs.startsWith(prefix)) return abs;
-    return abs.slice(prefix.length).replace(/\.md$/, "");
+    // Windows 下剩余段是反斜杠分隔；ref 统一为 posix 形态（与 filename 对齐）
+    return abs.slice(prefix.length).replace(/\.md$/, "").split(sep).join("/");
   }
 
   private isForbiddenPageRef(ref: string): boolean {


### PR DESCRIPTION
Three cross-platform bugs that only reproduce on Windows (POSIX CI never sees them):

1. MemoryKnowledge never starts as an entry script The bootstrap guard compared import.meta.url against `file://${process.argv[1]}`. On Windows argv[1] is a backslash path (`D:\...\server.ts`), so the URL never matches and the module silently does nothing when run via `node --import tsx
   src/server.ts`. Build the comparison URL with pathToFileURL()   instead, handling both absolute and relative argv paths.

2. Wiki uploads rejected with 400 on Windows wiki-service.ts joined raw/page paths with manual `dir + / +
   name` concatenation and compared them against path.resolve()   output, which uses `\` separators on Windows. Every upload was
   misclassified as a path traversal attempt. Use path.join() so
   separators match the platform.

3. Gateway config.yaml errors were silently swallowed When tdai-gateway.yaml failed to parse, the catch block fell back to env-only config without printing anything, leaving no clue why the file was ignored. Log a warning with the path and parse error to stderr before falling back.

## Description | 描述
<!-- Describe what this PR does | 请描述这个 PR 做了什么 -->

## Related Issue | 关联 Issue
<!-- Example: Fix #123 | 例如：Fix #123 -->

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ] Verified locally | 本地验证通过
- [ ] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
<!-- Optional | 可选 -->