### PR TITLE
Wt feat/server team

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,9 +135,9 @@ After logging in as admin:
    **exactly once** — **copy and save it right away**; the panel won't show the
    full value again.
 
-> You can also do this via the API (equivalent to panel steps 2–3). Note it takes
-> **two calls**: `user/create` only creates the user account and does **not** add it
-> to any Team; to "create a user and add to the team", you must then call
+> In addition to the panel, this flow can also be completed via the API. Note that it
+> requires **two steps**: `user/create` only creates the user account and does **not**
+> add it to any Team; to "create a user and add them to a team", you must also call
 > `team-member/add`. Both endpoints require **admin / team-admin** privilege —
 > calling them with an ordinary business user's key returns `permission_denied`:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,21 +135,37 @@ After logging in as admin:
    **exactly once** — **copy and save it right away**; the panel won't show the
    full value again.
 
-> You can also create a user via the API (the panel equivalent is steps 2–3 above).
-> Note that `user/create` requires **global admin** privilege — calling it with an
-> ordinary business user's key returns `permission_denied`:
+> You can also do this via the API (equivalent to panel steps 2–3). Note it takes
+> **two calls**: `user/create` only creates the user account and does **not** add it
+> to any Team; to "create a user and add to the team", you must then call
+> `team-member/add`. Both endpoints require **admin / team-admin** privilege —
+> calling them with an ordinary business user's key returns `permission_denied`:
 
 ```bash
-# Call with the admin key; panel equivalent: enter a Team → "Members" → "Add Member" → "Create New User & Add to Team"
 ADMIN_KEY=$(cat ./.admin-key)
+
+# Step 1: create the user (account only, NOT added to any team). Note the returned data.user_id and data.default_user_key
 curl -sS -X POST http://localhost:8420/v3/meta/user/create \
   -H "x-tdai-user-key: $ADMIN_KEY" \
   -H "x-tdai-service-id: default" \
   -H "Content-Type: application/json" \
   -d '{"username":"you"}' | jq
+
+# Step 2: add that user_id to an existing Team (replace TEAM_ID; role is usually member)
+curl -sS -X POST http://localhost:8420/v3/meta/team-member/add \
+  -H "x-tdai-user-key: $ADMIN_KEY" \
+  -H "x-tdai-service-id: default" \
+  -H "Content-Type: application/json" \
+  -d '{"team_id":"<TEAM_ID>","user_id":"<user_id from step 1>","role":"member"}' | jq
 ```
 
-The response body's `data.default_user_key` (`sk-mem-...`) is the login
+> ⚠️ Running only step 1 (`user/create`) **creates a user that belongs to no team** —
+> it can't manage anything in the panel and won't appear in the session picker. You
+> must also run step 2 `team-member/add` to match the panel's "Create New User & Add
+> to Team". `team-member/add` requires the `team_id` Team to already exist, and you
+> cannot add yourself.
+
+The `data.default_user_key` (`sk-mem-...`) returned by step 1 is the login
 key for the new user — **save it now**; the panel won't show the full
 value again after creation.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -196,6 +196,7 @@ Every memory entry attaches to a `team / agent / task` triple:
 
      ```bash
      # Call with the business user's OWN user_key created in Step 1.5
+     # "name" is the team name — change it to whatever you want (the example uses repro-own-team)
      curl -sS -X POST http://localhost:8420/v3/meta/team/create \
        -H "x-tdai-user-key: <that business user's user_key>" \
        -H "x-tdai-service-id: default" \
@@ -203,10 +204,11 @@ Every memory entry attaches to a `team / agent / task` triple:
        -d '{"name":"repro-own-team","owner_user_id":"<that business user's user_id>"}' | jq
      ```
 
-     > `team/create` requires `owner_user_id` in the body to **equal the user_id of the
-     > calling key** (i.e. you can only create Teams you own), otherwise it returns
-     > `permission_denied`. Once created you are the owner and admin, and can manage
-     > assets / run sessions inside this Team right away.
+     > `name` is the team's display name and is up to you (avoid duplicates under the
+     > same user, or it returns `409`). `team/create` requires `owner_user_id` in the
+     > body to **equal the user_id of the calling key** (i.e. you can only create Teams
+     > you own), otherwise it returns `permission_denied`. Once created you are the
+     > owner and admin, and can manage assets / run sessions inside this Team right away.
 2. **Agent**: enter a Team → left sidebar **"Agents"** → New
    - Fill a clear `description` + `system prompt` (the agent's role)
    - e.g. `bug-fix engineer`, `frontend reviewer`, `SQL tuner`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,9 +173,12 @@ Then log out of the panel and log back in with this new key — you're now
 a `normal` business user, and you can manage assets (Agent / Task / Skill /
 Wiki / memory) **inside the Team the admin already added you to**.
 
-> **Only admin can create a Team.** After logging in, a business user **won't see
-> the "New Team" entry** — this is by design, not a bug. When a business user needs
-> a new Team, ask an admin to create it in the panel and add you to it.
+> **Creating a Team in the panel is admin-only.** After logging in, a business user
+> **won't see the "New Team" entry** — this is the panel's permission design, not a
+> bug. When a business user needs a new Team, there are two ways: ① ask an admin to
+> create it in the panel and add you; ② create it yourself via the `team/create` API
+> with your own key (set `owner_user_id` to yourself — you automatically become that
+> Team's admin). See the next step.
 
 ### Step 2: Create Team / Agent / Task in the panel
 
@@ -184,8 +187,26 @@ Every memory entry attaches to a `team / agent / task` triple:
 1. **Team**: the **Team switcher in the top-left** (the header dropdown showing the
    current team name) → **"+ New Team"** at the bottom
    - A Team owns everything: memory, skill, knowledge
-   - ⚠️ **Only admin can create a Team**; it's normal that a business user doesn't
-     see this entry — ask an admin to create it and add you
+   - ⚠️ **Only admin can create a Team in the panel**; it's normal that a business
+     user doesn't see this entry — ask an admin to create it and add you
+   - 💡 **Want a business user to self-serve a Team?** There's no panel entry, but you
+     can call the API with **your own key** and set `owner_user_id` to your own user_id —
+     the core creates the Team and **automatically makes you its admin** (no separate
+     add-member step needed):
+
+     ```bash
+     # Call with the business user's OWN user_key created in Step 1.5
+     curl -sS -X POST http://localhost:8420/v3/meta/team/create \
+       -H "x-tdai-user-key: <that business user's user_key>" \
+       -H "x-tdai-service-id: default" \
+       -H "Content-Type: application/json" \
+       -d '{"name":"repro-own-team","owner_user_id":"<that business user's user_id>"}' | jq
+     ```
+
+     > `team/create` requires `owner_user_id` in the body to **equal the user_id of the
+     > calling key** (i.e. you can only create Teams you own), otherwise it returns
+     > `permission_denied`. Once created you are the owner and admin, and can manage
+     > assets / run sessions inside this Team right away.
 2. **Agent**: enter a Team → left sidebar **"Agents"** → New
    - Fill a clear `description` + `system prompt` (the agent's role)
    - e.g. `bug-fix engineer`, `frontend reviewer`, `SQL tuner`
@@ -196,8 +217,8 @@ Every memory entry attaches to a `team / agent / task` triple:
    - To give the first session a "skip Task" shortcut, configure `defaultTaskId`
      on the proxy (see below)
 
-Have an admin create **at least 1 Team**, then **at least 1 Agent** inside it;
-Task is optional.
+Get **at least 1 Team** ready (admin-created in the panel, or self-served by a
+business user via the API above), **at least 1 Agent** inside it; Task is optional.
 
 ### Step 3: Point Claude Code at the Proxy
 
@@ -281,11 +302,11 @@ assets; if using a business user, check that you've created Agents under
 the corresponding team.
 
 **Q: I logged in as a business user but there's no "New Team" button?**
-This is by design, not a bug: **only admin can create a Team**. Business users
-work inside the Teams an admin added them to. When you need a new Team, ask an
-admin to log in → top-left Team switcher → "+ New Team" to create it, then add
-you under that Team's "Members" — after you log back in, the Team shows up in
-the picker.
+This is the panel's permission design, not a bug: **creating a Team in the panel is
+admin-only**. You have two options: ① ask an admin to log in → top-left Team switcher →
+"+ New Team", then add you under that Team's "Members"; ② create it yourself via the
+`team/create` API (set `owner_user_id` to your own user_id — you become that Team's
+admin; see Step 2). Either way, after you log back in the Team shows up in the picker.
 
 **Q: Panel shows "Panel API 8125 not started"?**
 `docker ps` and check `tdai-memory-hub` is healthy. If not, look at

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,21 +98,49 @@ Open **<http://localhost:8125>** in your browser (Panel UI).
   `normal` business user → copy that user's `user_key` → log out → log
   back in as the new user.
 
-> In short: admin is the "ops account" for managing users; business users
-> are the "app accounts" for managing assets. Even in a single-machine
-> local playground, keeping this split is recommended — don't use the
-> admin key to drive CC.
-> Note: in 2.0.0-beta.1, admin could not own business assets; starting
-> from 2.0.0 stable, admin can directly operate on assets.
+> **Permission model (understand this first, or the later steps won't add up)**:
+> - **admin is the "ops account"**: responsible for organization-level actions —
+>   **creating Teams, creating users, and adding users into Teams**. The
+>   "New Team" and "New User" entries in the panel are **visible only to admin**.
+> - **Business users are the "app accounts"**: they manage assets (Agent / Task /
+>   Skill / Wiki / CodeGraph / memory) **inside the Teams the admin added them to**,
+>   and use their own `user_key` to drive coding agents like Claude Code.
+> - Even in a single-machine local playground, keeping this split is recommended —
+>   don't use the admin key to drive CC.
+> - Note: in 2.0.0-beta.1, admin could not own business assets; starting
+>   from 2.0.0 stable, admin can directly operate on assets.
 
 Knowledge Service Swagger (optional, for API poking):
 <http://localhost:8424/docs>
 
-### Step 1.5: Admin creates a business user (optional, recommended for ops/business separation)
+### Step 1.5: Admin creates a business user (recommended for ops/business separation)
 
-Panel: top-left "Users" → "New" (or use the API directly):
+> **Important (entry-point convention in the current version)**: the panel has
+> **no standalone "Users" menu**. Creating a business user lives inside a
+> **Team's member management**, so the order is: **admin creates a Team first,
+> then creates the business user inside that Team**. Only admin can do this step.
+
+After logging in as admin:
+
+1. **Create a Team first**: click the **Team switcher in the top-left** (the
+   dropdown in the header showing the current team name) → **"+ New Team"** at
+   the bottom of the panel → enter a name → create. (This entry is admin-only.)
+2. **Open that Team's member management**: left sidebar → **"Members"** →
+   **"Add Member"** in the top-right.
+3. In the dialog, switch the mode to **"Create New User & Add to Team"** → enter a
+   username (letters / digits / underscore only) → click **"Create & Add"**.
+   - To assign an initial key yourself, toggle "Custom User_Key"; otherwise the
+     core generates one automatically.
+4. On success, the dialog shows the new user's `user_key` (`sk-mem-...`)
+   **exactly once** — **copy and save it right away**; the panel won't show the
+   full value again.
+
+> You can also create a user via the API (the panel equivalent is steps 2–3 above).
+> Note that `user/create` requires **global admin** privilege — calling it with an
+> ordinary business user's key returns `permission_denied`:
 
 ```bash
+# Call with the admin key; panel equivalent: enter a Team → "Members" → "Add Member" → "Create New User & Add to Team"
 ADMIN_KEY=$(cat ./.admin-key)
 curl -sS -X POST http://localhost:8420/v3/meta/user/create \
   -H "x-tdai-user-key: $ADMIN_KEY" \
@@ -126,24 +154,34 @@ key for the new user — **save it now**; the panel won't show the full
 value again after creation.
 
 Then log out of the panel and log back in with this new key — you're now
-a `normal` user and can create Team / Agent / Task under your own name.
-Of course, admin can also operate directly; this is just a recommended separation.
+a `normal` business user, and you can manage assets (Agent / Task / Skill /
+Wiki / memory) **inside the Team the admin already added you to**.
+
+> **Only admin can create a Team.** After logging in, a business user **won't see
+> the "New Team" entry** — this is by design, not a bug. When a business user needs
+> a new Team, ask an admin to create it in the panel and add you to it.
 
 ### Step 2: Create Team / Agent / Task in the panel
 
 Every memory entry attaches to a `team / agent / task` triple:
 
-1. **Team**: sidebar → "Team" → New
+1. **Team**: the **Team switcher in the top-left** (the header dropdown showing the
+   current team name) → **"+ New Team"** at the bottom
    - A Team owns everything: memory, skill, knowledge
-2. **Agent**: enter a Team → "Agent" → New
+   - ⚠️ **Only admin can create a Team**; it's normal that a business user doesn't
+     see this entry — ask an admin to create it and add you
+2. **Agent**: enter a Team → left sidebar **"Agents"** → New
    - Fill a clear `description` + `system prompt` (the agent's role)
    - e.g. `bug-fix engineer`, `frontend reviewer`, `SQL tuner`
-3. **Task** (optional): Team → "Task" → New
+3. **Task** (optional): left sidebar **"Task Board"** → **"New Task"**
    - A Task is the concrete piece of work: "fix login XSS", "ship v1.4"
    - Memories link to Tasks; skipping Task still works but L2/L3 lose the
      Task dimension
+   - To give the first session a "skip Task" shortcut, configure `defaultTaskId`
+     on the proxy (see below)
 
-You'll want **at least 1 Team + 1 Agent** before you start; Task is optional.
+Have an admin create **at least 1 Team**, then **at least 1 Agent** inside it;
+Task is optional.
 
 ### Step 3: Point Claude Code at the Proxy
 
@@ -225,6 +263,13 @@ Make sure the current account has created at least one Team and Agent in
 the panel. If using the admin account, ensure you've created the relevant
 assets; if using a business user, check that you've created Agents under
 the corresponding team.
+
+**Q: I logged in as a business user but there's no "New Team" button?**
+This is by design, not a bug: **only admin can create a Team**. Business users
+work inside the Teams an admin added them to. When you need a new Team, ask an
+admin to log in → top-left Team switcher → "+ New Team" to create it, then add
+you under that Team's "Members" — after you log back in, the Team shows up in
+the picker.
 
 **Q: Panel shows "Panel API 8125 not started"?**
 `docker ps` and check `tdai-memory-hub` is healthy. If not, look at

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -116,9 +116,9 @@ Knowledge Service Swagger（可选，看接口调试用）：
 4. 创建成功后弹窗会**一次性**显示该用户的 `user_key`（`sk-mem-...`），
    **务必当场复制保存**——面板之后不会再展示完整值。
 
-> 也可以用 API 完成（等价于面板第 2～3 步）。注意这需要**两步**：`user/create` 只
-> 创建用户账号、**不会**把它加进任何 Team；要"新建用户并加入团队"，还得再调一次
-> `team-member/add`。两个接口都需要 **admin / 团队 admin** 权限，用普通业务用户的 key 调用会返回 `permission_denied`：
+> 除面板操作外，上述流程也可通过 API 完成。请注意这需要**两个步骤**：`user/create` 仅
+> 创建用户账号，**不会**将其加入任何 Team；如需实现"新建用户并加入团队"，还须再调用
+> `team-member/add`。两个接口均需要 **admin / 团队 admin** 权限，使用普通业务用户的 key 调用将返回 `permission_denied`：
 
 ```bash
 ADMIN_KEY=$(cat ./.admin-key)

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -167,6 +167,7 @@ Coding agent 用记忆必须落到具体 `team / agent / task` 三元组上：
 
      ```bash
      # 用第 1.5 步创建的那个业务用户自己的 user_key 调用
+     # 其中 name 就是团队名，改成你想要的即可（示例用的是 repro-own-team）
      curl -sS -X POST http://localhost:8420/v3/meta/team/create \
        -H "x-tdai-user-key: <该业务用户的 user_key>" \
        -H "x-tdai-service-id: default" \
@@ -174,6 +175,7 @@ Coding agent 用记忆必须落到具体 `team / agent / task` 三元组上：
        -d '{"name":"repro-own-team","owner_user_id":"<该业务用户的 user_id>"}' | jq
      ```
 
+     > `name` 是团队显示名，可自定义（同一用户名下不要重名，否则返回 `409`）。
      > `team/create` 要求 body 里的 `owner_user_id` **必须等于调用 key 对应的 user_id**
      > （即"只能建自己 own 的 Team"），否则返回 `permission_denied`。建成后你就是 owner
      > 兼 admin，可直接在这个 Team 内管资产、跑会话。

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -88,19 +88,39 @@ cd TencentDB-Agent-Memory/deploy/global-images
 - admin 登录后可以直接使用 Wiki、CodeGraph、Skill 等资产管理功能，创建 Team / Agent / Task 等业务资产
 - 如果希望隔离运维与业务（推荐），可创建 `normal` 业务用户 → 复制新用户的 `user_key` → 退出 admin 换新用户登录
 
-> 换句话说：admin 是"运维口"用来管人，业务用户是"应用口"用来管资产。
-> 单机本地体验也推荐遵循这个分层，不要用 admin key 直接跑 CC。
-> 注：2.0.0-beta.1 中 admin 不能拥有业务资产；2.0.0 正式版起 admin 也可以直接操作资产。
+> **权限模型（先理解这一点，后面步骤才不会走错）**：
+> - **admin 是"运维口"**：负责**创建 Team、创建用户、把用户拉进 Team** 这类组织管理操作。
+>   面板上「新建团队」「新建用户」的入口**只有 admin 能看到**。
+> - **业务用户是"应用口"**：在**被 admin 加入的 Team 内**管理资产（Agent / Task / Skill /
+>   Wiki / CodeGraph / 记忆），并用自己的 `user_key` 去跑 Claude Code 等 coding agent。
+> - 单机本地体验也推荐遵循这个分层，不要用 admin key 直接跑 CC。
+> - 注：2.0.0-beta.1 中 admin 不能拥有业务资产；2.0.0 正式版起 admin 也可以直接操作资产。
 
 Knowledge Service Swagger（可选，看接口调试用）：
 <http://localhost:8424/docs>
 
-### 第 1.5 步：admin 建业务用户（可选，推荐隔离运维与业务）
+### 第 1.5 步：admin 建业务用户（推荐隔离运维与业务）
 
-面板左上角「用户管理」（或用 admin 直接调 API）新建一个用户：
+> **重要（当前版本的入口约定）**：面板上**没有独立的「用户管理」菜单**。创建业务用户
+> 的入口挂在**某个 Team 的成员管理**里，因此顺序是**先由 admin 建好一个 Team，再在这个
+> Team 里创建业务用户**。这一步只能由 admin 完成。
+
+用 admin 登录面板后：
+
+1. **先建一个 Team**：点击**左上角的 Team 切换器**（顶栏那个显示当前团队名的下拉）→
+   面板底部「**+ 新建团队**」→ 填团队名 → 创建。（此入口仅 admin 可见。）
+2. **进入该 Team 的成员管理**：左侧「**成员管理**」→ 右上角「**添加成员**」。
+3. 在弹窗里把「方式」切到「**新建用户并加入团队**」→ 填用户名（仅英文字母 / 数字 /
+   下划线）→ 点「**新建并添加**」。
+   - 需要指定初始 key 时，可打开「自定义 User_Key」开关；否则由内核自动生成。
+4. 创建成功后弹窗会**一次性**显示该用户的 `user_key`（`sk-mem-...`），
+   **务必当场复制保存**——面板之后不会再展示完整值。
+
+> 也可以用 API 创建用户（面板等价操作即上面第 2～3 步）。注意 `user/create` 需要
+> **全局 admin** 权限，用普通业务用户的 key 调用会返回 `permission_denied`：
 
 ```bash
-# API 方式，更明确（面板里等价操作在「用户」→「新建」）
+# 用 admin key 调用；面板等价操作：进入某个 Team →「成员管理」→「添加成员」→「新建用户并加入团队」
 ADMIN_KEY=$(cat ./.admin-key)
 curl -sS -X POST http://localhost:8420/v3/meta/user/create \
   -H "x-tdai-user-key: $ADMIN_KEY" \
@@ -112,23 +132,28 @@ curl -sS -X POST http://localhost:8420/v3/meta/user/create \
 返回体里 `data.default_user_key`（`sk-mem-...`）就是新用户的登录 key，
 **保存好**（面板无处再看到全值，只有创建时返回一次）。
 
-之后**面板退出登录**，用这把新 key 重新登录 —— 你现在是 `normal` 用户，
-可以在自己名下建 Team / Agent / Task 了。当然，admin 也可以直接操作，这里只是推荐隔离。
+之后**面板退出登录**，用这把新 key 重新登录 —— 你现在是 `normal` 业务用户，
+可以在 **admin 已经把你加入的 Team 内**管理 Agent / Task / Skill / Wiki / 记忆等资产了。
+
+> **建 Team 只能由 admin 做。** 业务用户登录后**看不到「新建团队」入口**，这是权限设计
+> （不是 bug）。业务用户需要新的 Team 时，请让 admin 在面板里建好并把你加入。
 
 ### 第 2 步：在面板里建 Team / Agent / Task
 
 Coding agent 用记忆必须落到具体 `team / agent / task` 三元组上：
 
-1. **Team**（团队）：面板左侧「团队」→ 新建
+1. **Team**（团队）：**左上角的 Team 切换器**（顶栏显示当前团队名的下拉）→ 底部「**+ 新建团队**」
    - 一个 Team 是一组资产的归属容器（memory、skill、knowledge 都归 Team）
-2. **Agent**（智能体）：进入 Team → 「Agent」→ 新建
+   - ⚠️ **仅 admin 能建 Team**；业务用户看不到这个入口属正常，请让 admin 建好并把你加入
+2. **Agent**（智能体）：进入 Team → 左侧「**Agents 管理**」→ 新建
    - 给它填一段清晰的 `description` + `system prompt`（就是这个 agent 的角色说明）
    - 例：`bug-fix 工程师`、`前端评审 agent`、`SQL 优化师`
-3. **Task**（任务，可选）：Team → 「任务」→ 新建
+3. **Task**（任务，可选）：左侧「**任务看板**」→「**新建 Task**」
    - Task 是**这一次工作的抓手**，比如「修复登录页 XSS」「上线 v1.4 灰度」
    - 记忆会关联到 Task；不建 Task 也能用，但 L2/L3 会缺 Task 维度
+   - 若想让首次会话有"一键跳过 Task"入口，可给 proxy 配 `defaultTaskId`（见后文）
 
-先建**至少 1 个 Team + 1 个 Agent**，可选建 Task。
+先由 admin 建**至少 1 个 Team**，Team 内建**至少 1 个 Agent**，可选建 Task。
 
 ### 第 3 步：把 Claude Code 指向 Proxy
 
@@ -204,6 +229,12 @@ curl -s http://localhost:8420/health | jq .services.pipelineWorker
 
 **Q: 表单选择项里空空的，或者只有别人的 team？**
 请确认当前使用的账号已在面板中创建过 Team 和 Agent。如果用的是 admin 账号，确保已创建了相关资产；如果用的是业务用户账号，检查是否已在对应 team 下建过 Agent。
+
+**Q: 用业务用户登录后，找不到「新建团队」按钮？**
+这是权限设计，不是 bug：**建 Team 只能由 admin 完成**。业务用户只能在被 admin 加入的
+Team 内工作。需要新 Team 时，请让 admin 用 admin 账号登录 → 左上角 Team 切换器 →
+「+ 新建团队」建好，再到该 Team 的「成员管理」里把你加入；你重新登录后就能在表单里
+看到这个 Team 了。
 
 
 **Q: 面板显示"Panel API 8125 未启动"？**

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -149,8 +149,10 @@ curl -sS -X POST http://localhost:8420/v3/meta/team-member/add \
 之后**面板退出登录**，用这把新 key 重新登录 —— 你现在是 `normal` 业务用户，
 可以在 **admin 已经把你加入的 Team 内**管理 Agent / Task / Skill / Wiki / 记忆等资产了。
 
-> **建 Team 只能由 admin 做。** 业务用户登录后**看不到「新建团队」入口**，这是权限设计
-> （不是 bug）。业务用户需要新的 Team 时，请让 admin 在面板里建好并把你加入。
+> **面板上建 Team 只对 admin 开放。** 业务用户登录后**看不到「新建团队」入口**，这是
+> 面板的权限设计（不是 bug）。业务用户需要新 Team 时有两条路：① 让 admin 在面板里建好
+> 并把你加入；② 用自己的 key 调 `team/create` API 自助建（把 `owner_user_id` 填成自己，
+> 建成后自动成为该 Team admin）—— 详见下一步。
 
 ### 第 2 步：在面板里建 Team / Agent / Task
 
@@ -158,7 +160,23 @@ Coding agent 用记忆必须落到具体 `team / agent / task` 三元组上：
 
 1. **Team**（团队）：**左上角的 Team 切换器**（顶栏显示当前团队名的下拉）→ 底部「**+ 新建团队**」
    - 一个 Team 是一组资产的归属容器（memory、skill、knowledge 都归 Team）
-   - ⚠️ **仅 admin 能建 Team**；业务用户看不到这个入口属正常，请让 admin 建好并把你加入
+   - ⚠️ **面板上只有 admin 能建 Team**；业务用户看不到这个入口属正常，请让 admin 建好并把你加入
+   - 💡 **业务用户想自助建 Team？** 面板没有入口，但可以用**自己的 key** 调 API，把
+     `owner_user_id` 填成自己的 user_id —— 内核会建出 Team 并**自动把你设为该 Team 的
+     admin**（无需再手动加成员）：
+
+     ```bash
+     # 用第 1.5 步创建的那个业务用户自己的 user_key 调用
+     curl -sS -X POST http://localhost:8420/v3/meta/team/create \
+       -H "x-tdai-user-key: <该业务用户的 user_key>" \
+       -H "x-tdai-service-id: default" \
+       -H "Content-Type: application/json" \
+       -d '{"name":"repro-own-team","owner_user_id":"<该业务用户的 user_id>"}' | jq
+     ```
+
+     > `team/create` 要求 body 里的 `owner_user_id` **必须等于调用 key 对应的 user_id**
+     > （即"只能建自己 own 的 Team"），否则返回 `permission_denied`。建成后你就是 owner
+     > 兼 admin，可直接在这个 Team 内管资产、跑会话。
 2. **Agent**（智能体）：进入 Team → 左侧「**Agents 管理**」→ 新建
    - 给它填一段清晰的 `description` + `system prompt`（就是这个 agent 的角色说明）
    - 例：`bug-fix 工程师`、`前端评审 agent`、`SQL 优化师`
@@ -167,7 +185,7 @@ Coding agent 用记忆必须落到具体 `team / agent / task` 三元组上：
    - 记忆会关联到 Task；不建 Task 也能用，但 L2/L3 会缺 Task 维度
    - 若想让首次会话有"一键跳过 Task"入口，可给 proxy 配 `defaultTaskId`（见后文）
 
-先由 admin 建**至少 1 个 Team**，Team 内建**至少 1 个 Agent**，可选建 Task。
+先准备好**至少 1 个 Team**（admin 面板建、或业务用户用上面的 API 自助建），Team 内建**至少 1 个 Agent**，可选建 Task。
 
 ### 第 3 步：把 Claude Code 指向 Proxy
 
@@ -245,10 +263,10 @@ curl -s http://localhost:8420/health | jq .services.pipelineWorker
 请确认当前使用的账号已在面板中创建过 Team 和 Agent。如果用的是 admin 账号，确保已创建了相关资产；如果用的是业务用户账号，检查是否已在对应 team 下建过 Agent。
 
 **Q: 用业务用户登录后，找不到「新建团队」按钮？**
-这是权限设计，不是 bug：**建 Team 只能由 admin 完成**。业务用户只能在被 admin 加入的
-Team 内工作。需要新 Team 时，请让 admin 用 admin 账号登录 → 左上角 Team 切换器 →
-「+ 新建团队」建好，再到该 Team 的「成员管理」里把你加入；你重新登录后就能在表单里
-看到这个 Team 了。
+这是面板的权限设计，不是 bug：**面板上建 Team 只对 admin 开放**。你有两种办法：
+① 让 admin 登录 → 左上角 Team 切换器 →「+ 新建团队」建好，再到该 Team 的「成员管理」把你加入；
+② 自己用 `team/create` API 建（`owner_user_id` 填自己的 user_id，建成后你就是该 Team 的 admin，
+见第 2 步的说明）。两种方式建好后，重新登录就能在会话表单里看到这个 Team。
 
 
 **Q: 面板显示"Panel API 8125 未启动"？**

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -116,20 +116,34 @@ Knowledge Service Swagger（可选，看接口调试用）：
 4. 创建成功后弹窗会**一次性**显示该用户的 `user_key`（`sk-mem-...`），
    **务必当场复制保存**——面板之后不会再展示完整值。
 
-> 也可以用 API 创建用户（面板等价操作即上面第 2～3 步）。注意 `user/create` 需要
-> **全局 admin** 权限，用普通业务用户的 key 调用会返回 `permission_denied`：
+> 也可以用 API 完成（等价于面板第 2～3 步）。注意这需要**两步**：`user/create` 只
+> 创建用户账号、**不会**把它加进任何 Team；要"新建用户并加入团队"，还得再调一次
+> `team-member/add`。两个接口都需要 **admin / 团队 admin** 权限，用普通业务用户的 key 调用会返回 `permission_denied`：
 
 ```bash
-# 用 admin key 调用；面板等价操作：进入某个 Team →「成员管理」→「添加成员」→「新建用户并加入团队」
 ADMIN_KEY=$(cat ./.admin-key)
+
+# 第 1 步：创建用户（仅建账号，不加入任何团队）。记下返回的 data.user_id 与 data.default_user_key
 curl -sS -X POST http://localhost:8420/v3/meta/user/create \
   -H "x-tdai-user-key: $ADMIN_KEY" \
   -H "x-tdai-service-id: default" \
   -H "Content-Type: application/json" \
   -d '{"username":"you"}' | jq
+
+# 第 2 步：把上一步的 user_id 加入某个已存在的 Team（TEAM_ID 换成目标团队，role 一般填 member）
+curl -sS -X POST http://localhost:8420/v3/meta/team-member/add \
+  -H "x-tdai-user-key: $ADMIN_KEY" \
+  -H "x-tdai-service-id: default" \
+  -H "Content-Type: application/json" \
+  -d '{"team_id":"<TEAM_ID>","user_id":"<上一步返回的 user_id>","role":"member"}' | jq
 ```
 
-返回体里 `data.default_user_key`（`sk-mem-...`）就是新用户的登录 key，
+> ⚠️ 只跑第 1 步（`user/create`）**只会建出一个不属于任何团队的用户**——它无法在面板里
+> 被自己管理，也进不了会话表单。务必接着跑第 2 步 `team-member/add` 才等于面板的
+> 「新建用户并加入团队」。`team-member/add` 要求 `team_id` 对应的 Team 已存在，且不能把
+> 自己 add 进去。
+
+第 1 步返回体里的 `data.default_user_key`（`sk-mem-...`）就是新用户的登录 key，
 **保存好**（面板无处再看到全值，只有创建时返回一次）。
 
 之后**面板退出登录**，用这把新 key 重新登录 —— 你现在是 `normal` 业务用户，


### PR DESCRIPTION
## Description | 描述

纯文档修改：修复 `INSTALL_CN.md` / `INSTALL.md` 纯 Panel 初始化流程与实现不一致、照做跑不通的问题（中英文同步）。
Docs-only: fix the pure-Panel init flow in `INSTALL_CN.md` / `INSTALL.md` so it matches the real UI and can be followed end-to-end.

- 修正过时的菜单/按钮名，对齐真实 UI（Team 切换器 / 成员管理 / Agents 管理 / 任务看板）
- 澄清权限模型：建 Team / 建用户仅 admin，业务用户在被加入的 Team 内管资产
- 修正创建用户真实路径（Team → 成员管理 → 添加成员 → 新建用户并加入团队），删除"新用户可自建 Team"的错误引导
- 修正 API 示例：`user/create` 不含加团队，需配 `team-member/add`；补充业务用户用自身 key 调 `team/create` 自助建团

> 仅覆盖 #1250 待办中的文档项（#13、#16）

## Related Issue | 关联 Issue

Related to #1250（docs-only）

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过（逐条对照源码核对）
- [x] No existing features affected | 无影响现有功能（无代码变更）

## Additional Notes | 其他说明

目的为 unblock 安装流程；建议保留 #1250 open，其余项由后续代码 PR 闭环。
