### PR TITLE
fix(deploy): honor PROXY_UPSTREAM_PROTOCOL in LLM connectivity checks

### DIFF
--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -368,17 +368,20 @@ interactive_llm_setup() {
     PROXY_UPSTREAM_URL="$MEMORY_LLM_BASE_URL"
     PROXY_UPSTREAM_API_KEY="$MEMORY_LLM_API_KEY"
     PROXY_UPSTREAM_MODEL="$MEMORY_LLM_MODEL"
+    PROXY_UPSTREAM_PROTOCOL="$MEMORY_LLM_PROTOCOL"
     ok "proxy 组复用 memory 组配置，跳过重复检查"
   else
     while true; do
       base=$(prompt_with_default "proxy 组 UPSTREAM_URL" "${PROXY_UPSTREAM_URL:-}")
       key=$(prompt_with_default "proxy 组 UPSTREAM_API_KEY" "${PROXY_UPSTREAM_API_KEY:-}")
       model=$(prompt_with_default "proxy 组 UPSTREAM_MODEL" "${PROXY_UPSTREAM_MODEL:-}")
+      proto=$(prompt_protocol "${PROXY_UPSTREAM_PROTOCOL:-openai}")
 
-      if check_llm_group "proxy 组" "$base" "$key" "$model" openai; then
+      if check_llm_group "proxy 组" "$base" "$key" "$model" "$proto"; then
         PROXY_UPSTREAM_URL="$base"
         PROXY_UPSTREAM_API_KEY="$key"
         PROXY_UPSTREAM_MODEL="$model"
+        PROXY_UPSTREAM_PROTOCOL="$proto"
         break
       fi
       warn "proxy 组 LLM 通路检查未通过。"
@@ -395,6 +398,7 @@ interactive_llm_setup() {
   set_env_value PROXY_UPSTREAM_URL "$PROXY_UPSTREAM_URL" "$ENV_FILE"
   set_env_value PROXY_UPSTREAM_API_KEY "$PROXY_UPSTREAM_API_KEY" "$ENV_FILE"
   set_env_value PROXY_UPSTREAM_MODEL "$PROXY_UPSTREAM_MODEL" "$ENV_FILE"
+  set_env_value PROXY_UPSTREAM_PROTOCOL "$PROXY_UPSTREAM_PROTOCOL" "$ENV_FILE"
   ok "LLM 配置已保存到 $ENV_FILE"
 }
 

--- a/deploy/global-images/verify.sh
+++ b/deploy/global-images/verify.sh
@@ -150,8 +150,14 @@ check_llm_from_container() {
   local url code
   case "$proto" in
     anthropic)
-      base="${base%/}"; [[ "$base" == */messages ]] || base="${base}/v1/messages"
-      url="$base"
+      base="${base%/}"
+      if [[ "$base" == */messages ]]; then
+        url="$base"
+      elif [[ "$base" == */v1 ]]; then
+        url="${base}/messages"
+      else
+        url="${base}/v1/messages"
+      fi
       code=$($DOCKER exec "$container" curl -sS -o /dev/null --max-time 15 \
          -w "%{http_code}" -X POST -H "Content-Type: application/json" \
          -H "x-api-key: $key" -H "anthropic-version: 2023-06-01" \
@@ -259,13 +265,13 @@ else
           "$PROXY_UPSTREAM_MODEL" == "$MEMORY_LLM_MODEL" ]]; then
       ok "proxy 组 与 memory 组完全相同，跳过重复检查"
     else
-      # proxy 组默认按 openai 协议（与 config.yaml 一致）
       if ! check_llm_group "proxy 组" "$PROXY_UPSTREAM_URL" "$PROXY_UPSTREAM_API_KEY" \
-           "$PROXY_UPSTREAM_MODEL" openai; then
+           "$PROXY_UPSTREAM_MODEL" "${PROXY_UPSTREAM_PROTOCOL:-openai}"; then
         ERRORS=$((ERRORS+1))
       fi
       check_llm_from_container tdai-proxy "proxy 组 (from container)" \
-        "$PROXY_UPSTREAM_URL" "$PROXY_UPSTREAM_API_KEY" "$PROXY_UPSTREAM_MODEL" openai
+        "$PROXY_UPSTREAM_URL" "$PROXY_UPSTREAM_API_KEY" "$PROXY_UPSTREAM_MODEL" \
+        "${PROXY_UPSTREAM_PROTOCOL:-openai}"
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- `verify.sh` and `_lib.sh`'s `interactive_llm_setup` both hardcoded `openai` as the protocol for the proxy group's upstream precheck, ignoring `PROXY_UPSTREAM_PROTOCOL` from `.env` — this produced a spurious `GET /models 404` warning on every start for anthropic-protocol upstreams (e.g. `PROXY_UPSTREAM_URL=https://api.anthropic.com`).
- `interactive_llm_setup` also never persisted `PROXY_UPSTREAM_PROTOCOL` back to `.env`, so it silently reverted to the `openai` default on every interactive run.
- `check_llm_from_container`'s anthropic branch unconditionally appended `/v1/messages`, even when the base URL already ended in `/v1`, producing a double `/v1/v1` 404 during the container-reachability check.

## Test plan
- [x] `./verify.sh` with `PROXY_UPSTREAM_PROTOCOL=anthropic` and `PROXY_UPSTREAM_URL=https://api.anthropic.com/v1` now reports `协议=anthropic` for the proxy group and passes with no warnings, both from the host and from-container checks.
- [x] `./start-all.sh`'s interactive flow now correctly prompts/reuses the anthropic protocol for the proxy group and writes `PROXY_UPSTREAM_PROTOCOL` back to `.env`.
- [x] End-to-end: a real `/v1/messages` call through the running `tdai-proxy` container against an Anthropic upstream returns `200` with a valid completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)