### PR TITLE
fix(proxy): bridge session resolution + make Pi a first-class client

### DIFF
--- a/MemoryCore/pi-plugin/README.md
+++ b/MemoryCore/pi-plugin/README.md
@@ -5,11 +5,22 @@ through the [TencentDB Agent Memory v2](https://github.com/TencentCloud/TencentD
 proxy for team memory: L3 persona, L2 scene index, L0 conversation capture, and
 on-demand L0/L1/L2 search.
 
-The plugin carries **only routing + a dynamic per-session `x-conversation-id`
-header**. All memory capability is delivered server-side by the proxy
-(injected into the system prompt and captured from the response). This keeps
-the extension minimal and keeps memory logic in one place. (Scope: routing +
-header; no client-side recall/capture.)
+The plugin carries **routing + a dynamic per-session `x-conversation-id` header + an interactive Team/Agent/Task picker**. All memory capability is delivered server-side by the proxy (injected into the system prompt and captured from the response). This keeps the extension minimal and keeps memory logic in one place. (Scope: routing + header + picker; no client-side recall/capture.)
+
+## Interactive session init (default)
+
+On the **first turn of each new Pi session**, if no preset identity is set (see
+below), the proxy sends a Team → Agent → Task form and this plugin renders it as
+a Pi-native TUI menu: `↑↓` to navigate, `Enter` to select, `Esc` to cancel. Pick
+once and the session is bound for its lifetime — the chosen team's memory (L3
+persona, L2 scene index) is injected and the conversation is captured (L0).
+
+This matches the Claude Code / CodeBuddy UX. The picking is **manual**, by
+design — which team/agent a piece of work belongs to is a human-intent decision,
+not auto-inferred from your prompt.
+
+Requires interactive mode (the default `pi` TUI). In `pi -p` / RPC / non-TUI
+modes the picker cannot render; set the preset env vars instead (below).
 
 ## Prerequisites
 
@@ -26,17 +37,49 @@ header; no client-side recall/capture.)
 | `TDAI_PROXY_URL` | no | `http://127.0.0.1:8096` | proxy host:port |
 | `TDAI_SPACE_ID` | no | `default` | memory instance id |
 | `TDAI_AGENT_SOURCE` | no | `pi` | first-class path; set `codebuddy` to fall back to the CodeBuddy profile for debugging |
-| `TDAI_TEAM_ID` | **yes** | — | from the panel (Team) |
-| `TDAI_AGENT_ID` | **yes** | — | from the panel (Agent) |
+| `TDAI_TEAM_ID` | no | — | **preset fallback** — set to skip the interactive picker (CI, scripts, fixed-context users). From the panel (Team) |
+| `TDAI_AGENT_ID` | no | — | **preset fallback** — same as team. From the panel (Agent) |
 | `TDAI_TASK_ID` | no | — | optional; from the panel (Task linked to the agent). When set, recall narrows to that task; when absent, recall is broad across the agent's memories |
 | `TDAI_USER_KEY` | **yes** | — | the **user's** API key (panel → API Key), NOT the admin/gateway key |
-| `TDAI_MODEL` | no | `glm-5.2-vision` | must match a model the proxy forwards to |
+| `TDAI_MODEL` | no | `glm-5.2-vision` | **fallback model** — used before the first refresh, offline, and against proxies without the `/models` route |
 
 Set these in your shell or Pi's env block; the plugin reads them at load.
 
+**Dynamic model catalog:** on refresh the provider fetches
+`GET {TDAI_PROXY_URL}/{TDAI_AGENT_SOURCE}/{TDAI_SPACE_ID}/v1/models` (user-key
+authenticated) and replaces the model list with the upstream gateway catalog,
+persisted across sessions. The static `TDAI_MODEL` entry is the fallback when
+that endpoint is unreachable or the proxy predates the route. Requires proxy
+build with `handleModelsCatalog` (`GET /:agent/:spaceId/v1/models`).
+
+**Default usage is interactive:** set only `TDAI_USER_KEY` (and optionally
+`TDAI_MODEL`), leave the identity vars unset, and pick Team/Agent/Task on the
+first turn of each session. Set `TDAI_TEAM_ID`/`TDAI_AGENT_ID`/`TDAI_TASK_ID`
+only when you want to skip the picker (CI, scripts, a fixed context).
+
 ## Install / load
 
-Quick test (throwaway load):
+**From npm** (also listed in the [Pi package gallery](https://pi.dev/packages)):
+
+```bash
+pi install npm:@tencentdb-agent-memory/pi-tdai-client
+```
+
+Then run (interactive mode — no identity env vars, the picker fires on turn 1):
+
+```bash
+export TDAI_USER_KEY=<your-user-key>
+pi --provider tdai --model glm-5.2-vision
+```
+
+**Quick test** (throwaway load, from a checkout of this repo):
+
+```bash
+TDAI_USER_KEY=<your-user-key> \
+  pi -e ./MemoryCore/pi-plugin --provider tdai --model glm-5.2-vision
+```
+
+**Fixed identity** (skips the picker — for CI / scripts / a fixed context):
 
 ```bash
 TDAI_USER_KEY=<your-user-key> TDAI_TEAM_ID=<...> TDAI_AGENT_ID=<...> \
@@ -46,7 +89,7 @@ TDAI_USER_KEY=<your-user-key> TDAI_TEAM_ID=<...> TDAI_AGENT_ID=<...> \
 (Add `TDAI_TASK_ID=<...>` only if you want task-scoped recall.)
 
 Auto-discover (global): symlink or copy into `~/.pi/agent/extensions/` and Pi
-loads it on startup.
+loads it on startup. Or use `pi install` (above) for npm-managed install.
 
 ## Verify (integration gate)
 
@@ -65,6 +108,7 @@ identity headers are wrong.
 
 ## Troubleshooting
 
+- **Interactive mode is the default.** With no `TDAI_TEAM_ID`/`TDAI_AGENT_ID`/`TDAI_TASK_ID` set, the first turn of a new session shows a Team → Agent → Task picker (↑↓ + Enter). The session binds to your pick for its lifetime. Requires interactive (TUI) mode.
 - **Use the user's API key, not the admin key.** The proxy validates the
   `Authorization: Bearer` against the user's API key (panel → API Key). The
   admin/gateway key is for internal endpoints, not client routing.
@@ -72,7 +116,9 @@ identity headers are wrong.
   recall). Set `TDAI_TASK_ID` only to narrow recall to a specific Task. A
   stale/unknown task id is dropped with a warning and recall broadens — it
   does not block memory.
-- **Missing env vars don't block Pi.** If a required env var is unset, the
+- **Non-interactive mode needs the preset env vars.** `pi -p` / RPC / non-TUI
+  modes cannot render the picker. Set `TDAI_TEAM_ID`/`TDAI_AGENT_ID` to skip it.
+- **Missing required env vars don't block Pi.** If `TDAI_USER_KEY` is unset, the
   extension logs a warning at load and skips registering the `tdai` provider —
   Pi starts normally, just without the TDAI provider available. Set the vars
   and restart Pi to enable it.

--- a/MemoryCore/pi-plugin/__tests__/discovery.test.ts
+++ b/MemoryCore/pi-plugin/__tests__/discovery.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for discovery.ts — catalog mapping, stored-model shape, and the
+ * refreshModels fallback chain (offline → stored → static; 404/network
+ * failure → stored/static; success → mapped catalog + persist).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapCatalogEntry,
+  toStoredModel,
+  createRefreshModels,
+  type GatewayModelObject,
+} from "../discovery.js";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { RefreshModelsContext } from "@earendil-works/pi-ai";
+
+const fallback: ProviderModelConfig = {
+  id: "glm-5.2-vision",
+  name: "glm-5.2-vision",
+  reasoning: true,
+  input: ["text", "image"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 524288,
+  maxTokens: 16384,
+};
+
+function makeContext(overrides: Partial<RefreshModelsContext> = {}): RefreshModelsContext {
+  return {
+    allowNetwork: true,
+    signal: new AbortController().signal,
+    publish: async () => true,
+    ...overrides,
+  } as RefreshModelsContext;
+}
+
+describe("mapCatalogEntry", () => {
+  it("maps a non-reasoning model without a pi block", () => {
+    const entry: GatewayModelObject = { id: "flux2-klein" };
+    const result = mapCatalogEntry(entry);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.id).toBe("flux2-klein");
+      expect(result.model.reasoning).toBe(false);
+      expect(result.model.input).toEqual(["text"]);
+    }
+  });
+
+  it("rejects a reasoning model without a pi block", () => {
+    const entry: GatewayModelObject = {
+      id: "some-reasoner",
+      capabilities: { reasoning: true },
+    };
+    const result = mapCatalogEntry(entry);
+    expect(result).toEqual({ ok: false, reason: "reasoning_missing_pi_block", id: "some-reasoner" });
+  });
+
+  it("maps a reasoning model with client_compat.pi (thinkingLevelMap + vision)", () => {
+    const entry: GatewayModelObject = {
+      id: "glm-5.2-vision",
+      display_name: "GLM 5.2 Vision",
+      context_window: 524288,
+      max_output_tokens: 16384,
+      capabilities: { reasoning: true, vision: true },
+      client_compat: {
+        pi: { thinkingLevelMap: { off: "none", high: "high" } },
+      },
+    };
+    const result = mapCatalogEntry(entry);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.reasoning).toBe(true);
+      expect(result.model.input).toEqual(["text", "image"]);
+      expect(result.model.thinkingLevelMap).toEqual({ off: "none", high: "high" });
+      expect(result.model.contextWindow).toBe(524288);
+    }
+  });
+
+  it("maps a reasoning model with a top-level pi block", () => {
+    const entry: GatewayModelObject = {
+      id: "glm-5.3-flash",
+      capabilities: { reasoning: true },
+      pi: { thinkingLevelMap: { off: "none", max: "max" } },
+    };
+    const result = mapCatalogEntry(entry);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.thinkingLevelMap).toEqual({ off: "none", max: "max" });
+    }
+  });
+});
+
+describe("toStoredModel", () => {
+  it("fills api/provider/baseUrl so the entry round-trips the ModelsStore", () => {
+    const stored = toStoredModel(fallback, "http://127.0.0.1:8096/pi/default/v1");
+    expect(stored.api).toBe("openai-completions");
+    expect(stored.provider).toBe("tdai");
+    expect(stored.baseUrl).toBe("http://127.0.0.1:8096/pi/default/v1");
+    expect(stored.id).toBe("glm-5.2-vision");
+  });
+});
+
+describe("createRefreshModels", () => {
+  const deps = {
+    baseUrl: "http://127.0.0.1:8096/pi/default/v1",
+    userKey: "sk-mem-test",
+    fallback,
+  };
+
+  it("offline (allowNetwork=false) restores the stored catalog", async () => {
+    const refresh = createRefreshModels(deps);
+    const ctx = makeContext({
+      allowNetwork: false,
+      stored: { models: [toStoredModel(fallback, deps.baseUrl)], checkedAt: 1 },
+    });
+    const models = await refresh(ctx);
+    expect(models).toHaveLength(1);
+    expect(models[0].id).toBe("glm-5.2-vision");
+  });
+
+  it("offline with nothing stored falls back to the static entry", async () => {
+    const refresh = createRefreshModels(deps);
+    const models = await refresh(makeContext({ allowNetwork: false }));
+    expect(models).toEqual([fallback]);
+  });
+
+  it("fetches the catalog, maps entries, and persists", async () => {
+    const fetchCalls: string[] = [];
+    const fakeFetch = (async (url: string, init?: RequestInit) => {
+      fetchCalls.push(`${url} ${init?.headers ? (init.headers as Record<string, string>).authorization : ""}`);
+      return new Response(
+        JSON.stringify({
+          data: [
+            { id: "glm-5.2-vision", capabilities: { reasoning: true, vision: true }, client_compat: { pi: { thinkingLevelMap: { high: "high" } } } },
+            { id: "flux2-klein" },
+            { id: "broken-reasoner", capabilities: { reasoning: true } }, // skipped
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const published: unknown[] = [];
+    const refresh = createRefreshModels({ ...deps, fetch: fakeFetch });
+    const models = await refresh(
+      makeContext({
+        publish: async (pub) => {
+          published.push(pub);
+          return true;
+        },
+      }),
+    );
+
+    expect(models.map((m) => m.id)).toEqual(["glm-5.2-vision", "flux2-klein"]);
+    expect(published).toHaveLength(1);
+    expect(fetchCalls).toEqual([`${deps.baseUrl}/models Bearer sk-mem-test`]);
+  });
+
+  it("404 from an old proxy falls back to stored, then static", async () => {
+    const fakeFetch = (async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
+    const refresh = createRefreshModels({ ...deps, fetch: fakeFetch });
+
+    // Nothing stored → static fallback.
+    expect(await refresh(makeContext())).toEqual([fallback]);
+
+    // Something stored → stored wins over static.
+    const ctx = makeContext({
+      stored: { models: [toStoredModel({ ...fallback, id: "glm-5.3" }, deps.baseUrl)], checkedAt: 1 },
+    });
+    const models = await refresh(ctx);
+    expect(models[0].id).toBe("glm-5.3");
+  });
+
+  it("network failure falls back without throwing", async () => {
+    const fakeFetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const refresh = createRefreshModels({ ...deps, fetch: fakeFetch });
+    const models = await refresh(makeContext());
+    expect(models).toEqual([fallback]);
+  });
+
+  it("empty catalog mapping falls back (no empty-list replacement)", async () => {
+    const fakeFetch = (async () =>
+      new Response(JSON.stringify({ data: [{ id: "broken-reasoner", capabilities: { reasoning: true } }] }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+    const refresh = createRefreshModels({ ...deps, fetch: fakeFetch });
+    const models = await refresh(makeContext());
+    expect(models).toEqual([fallback]);
+  });
+});

--- a/MemoryCore/pi-plugin/__tests__/form.test.ts
+++ b/MemoryCore/pi-plugin/__tests__/form.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { parseFormArgs, formatAnswerXml } from "../form.js";
+
+const teamFormArgs = JSON.stringify({
+  title: "会话初始化 — 选择 Team",
+  questions: JSON.stringify([{ id: "team", question: "请选择 Team：", options: ["Team A (a1b2c3d4)", "Team B (e5f6g7h8)"], multiSelect: false }]),
+});
+
+const agentTaskArgs = JSON.stringify({
+  title: "会话初始化 — 选择 Agent 与任务",
+  questions: JSON.stringify([
+    { id: "agent", question: "请选择 Agent：", options: ["Lucius Fox (0b0wybln)", "default-agent (ao5f94a7)"], multiSelect: false },
+    { id: "task", question: "请选择 任务：", options: ["Pi adapter development (hnrorewx)"], multiSelect: false },
+  ]),
+});
+
+describe("parseFormArgs", () => {
+  it("double-decodes a single-question (team) form", () => {
+    const f = parseFormArgs(teamFormArgs)!;
+    expect(f.title).toBe("会话初始化 — 选择 Team");
+    expect(f.questions).toHaveLength(1);
+    expect(f.questions[0]).toEqual({ id: "team", question: "请选择 Team：", options: ["Team A (a1b2c3d4)", "Team B (e5f6g7h8)"], multiSelect: false });
+  });
+  it("double-decodes a two-question (agent+task) form", () => {
+    const f = parseFormArgs(agentTaskArgs)!;
+    expect(f.questions).toHaveLength(2);
+    expect(f.questions[0].id).toBe("agent");
+    expect(f.questions[1].id).toBe("task");
+  });
+  it("returns null for non-JSON string args", () => {
+    expect(parseFormArgs("not json")).toBeNull();
+  });
+  it("returns null when questions field is missing", () => {
+    expect(parseFormArgs(JSON.stringify({ title: "x" }))).toBeNull();
+  });
+  it("accepts the already-parsed object (Pi passes params parsed)", () => {
+    const parsed = { title: "会话初始化 — 选择 Team", questions: JSON.stringify([{ id: "team", question: "Q?", options: ["A"], multiSelect: false }]) };
+    const f = parseFormArgs(parsed)!;
+    expect(f.questions[0].id).toBe("team");
+  });
+});
+
+describe("formatAnswerXml", () => {
+  it("wraps a single answer in question_answer XML", () => {
+    const xml = formatAnswerXml([{ id: "team", answer: "Team A (a1b2c3d4)" }]);
+    expect(xml).toContain('<question_item id="team">');
+    expect(xml).toContain("<answers>Team A (a1b2c3d4)</answers>");
+    expect(xml).toContain("<question_answer>");
+    expect(xml).toContain("</question_answer>");
+  });
+  it("emits one question_item per answer (agent+task)", () => {
+    const xml = formatAnswerXml([
+      { id: "agent", answer: "Lucius Fox (0b0wybln)" },
+      { id: "task", answer: "Pi adapter development (hnrorewx)" },
+    ]);
+    expect(xml.match(/<question_item id="agent">/)).toBeTruthy();
+    expect(xml.match(/<question_item id="task">/)).toBeTruthy();
+    expect(xml.match(/<question_item/g)?.length).toBe(2);
+  });
+});

--- a/MemoryCore/pi-plugin/__tests__/index.test.ts
+++ b/MemoryCore/pi-plugin/__tests__/index.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Stub the env before importing the factory.
+const setters: Record<string, string> = {
+  TDAI_PROXY_URL: "http://127.0.0.1:8096",
+  TDAI_SPACE_ID: "default",
+  TDAI_AGENT_SOURCE: "pi",
+  TDAI_TEAM_ID: "team-azqo3jvm25",
+  TDAI_AGENT_ID: "agt-ea0b0wybln",
+  TDAI_TASK_ID: "task-enjvravg2l",
+  TDAI_USER_KEY: "sk-mem-test",
+  TDAI_MODEL: "glm-5.2-vision",
+};
+
+describe("pi-plugin", () => {
+  let registerProviderCalls: { name: string; cfg: any }[];
+  let onCalls: { evt: string; h: any }[];
+  let factory: any;
+  let originalEnv: Record<string, string | undefined> | undefined;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    for (const [k, v] of Object.entries(setters)) process.env[k] = v;
+    registerProviderCalls = [];
+    onCalls = [];
+    vi.resetModules();
+    factory = (await import("../index.js")).default;
+  });
+
+  afterEach(() => {
+    // Restore env so stubbed TDAI_* values never leak to later files in the
+    // test process (vitest worker isolation limits but does not prevent it).
+    if (originalEnv) {
+      for (const k of Object.keys(setters)) {
+        if (k in originalEnv) process.env[k] = originalEnv[k] as string;
+        else delete process.env[k];
+      }
+    }
+  });
+
+  it("registers a 'tdai' provider with /v1 baseUrl and static identity headers", () => {
+    const api: any = {
+      registerProvider: (name: string, cfg: any) => registerProviderCalls.push({ name, cfg }),
+      registerTool: () => {},
+      on: (evt: string, h: any) => onCalls.push({ evt, h }),
+    };
+    factory(api);
+    expect(registerProviderCalls).toHaveLength(1);
+    const { name, cfg } = registerProviderCalls[0];
+    expect(name).toBe("tdai");
+    expect(cfg.baseUrl).toBe("http://127.0.0.1:8096/pi/default/v1");
+    expect(cfg.api).toBe("openai-completions");
+    expect(cfg.apiKey).toBe("sk-mem-test");
+    expect(cfg.headers["x-team-id"]).toBe("team-azqo3jvm25");
+    expect(cfg.headers["x-agent-id"]).toBe("agt-ea0b0wybln");
+    expect(cfg.headers["x-task-id"]).toBe("task-enjvravg2l");
+    expect(cfg.models[0].id).toBe("glm-5.2-vision");
+  });
+
+  it("registers a before_provider_headers hook", () => {
+    const api: any = {
+      registerProvider: () => {},
+      registerTool: () => {},
+      on: (evt: string, h: any) => onCalls.push({ evt, h }),
+    };
+    factory(api);
+    const hook = onCalls.find((c) => c.evt === "before_provider_headers");
+    expect(hook).toBeDefined();
+  });
+
+  it("sets x-conversation-id = pi-<sid> only for the tdai provider", () => {
+    const localOnCalls: { evt: string; h: any }[] = [];
+    const api: any = {
+      registerProvider: () => {},
+      registerTool: () => {},
+      on: (evt: string, h: any) => localOnCalls.push({ evt, h }),
+    };
+    factory(api);
+    const hook = localOnCalls.find((c) => c.evt === "before_provider_headers")!.h;
+
+    const event: any = { headers: {} };
+    // Non-tdai provider: must NOT mutate
+    hook(event, { model: { provider: "lunaroute" }, sessionManager: { getSessionId: () => "abc" } });
+    expect(event.headers["x-conversation-id"]).toBeUndefined();
+
+    // tdai provider: must set
+    hook(event, { model: { provider: "tdai" }, sessionManager: { getSessionId: () => "sess-123" } });
+    expect(event.headers["x-conversation-id"]).toBe("pi-sess-123");
+  });
+
+  it("warns and skips registration when TDAI_USER_KEY is missing (Pi still starts)", async () => {
+    delete process.env.TDAI_USER_KEY;
+    vi.resetModules();
+    const failingFactory = (await import("../index.js")).default;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const registerProvider = vi.fn();
+    const registerTool = vi.fn();
+    const on = vi.fn();
+    const api: any = { registerProvider, registerTool, on };
+    // Must NOT throw — a startup extension must never block Pi from loading.
+    expect(() => failingFactory(api)).not.toThrow();
+    // Must NOT register the provider, tool, or hook when USER_KEY is missing.
+    expect(registerProvider).not.toHaveBeenCalled();
+    expect(registerTool).not.toHaveBeenCalled();
+    expect(on).not.toHaveBeenCalled();
+    // Must warn naming the missing var.
+    expect(warn.mock.calls[0]?.[0]).toMatch(/TDAI_USER_KEY/);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/tdai-client/);
+    warn.mockRestore();
+  });
+
+  it("registers WITHOUT identity headers in interactive mode (team/agent unset)", async () => {
+    delete process.env.TDAI_TEAM_ID;
+    delete process.env.TDAI_AGENT_ID;
+    delete process.env.TDAI_TASK_ID;
+    vi.resetModules();
+    const interactiveFactory = (await import("../index.js")).default;
+    const registerProviderCalls: { name: string; cfg: any }[] = [];
+    const api: any = {
+      registerProvider: (name: string, cfg: any) => registerProviderCalls.push({ name, cfg }),
+      registerTool: () => {},
+      on: () => {},
+    };
+    // Must NOT throw and MUST still register (interactive mode — no preset).
+    expect(() => interactiveFactory(api)).not.toThrow();
+    expect(registerProviderCalls).toHaveLength(1);
+    const { cfg } = registerProviderCalls[0];
+    // No identity headers sent → proxy falls back to the interactive picker.
+    expect(cfg.headers["x-team-id"]).toBeUndefined();
+    expect(cfg.headers["x-agent-id"]).toBeUndefined();
+    expect(cfg.headers["x-task-id"]).toBeUndefined();
+  });
+
+  it("registers WITHOUT x-task-id when TDAI_TASK_ID is absent (task-optional)", async () => {
+    delete process.env.TDAI_TASK_ID;
+    vi.resetModules();
+    const tasklessFactory = (await import("../index.js")).default;
+    const registerProviderCalls: { name: string; cfg: any }[] = [];
+    const onCalls: { evt: string; h: any }[] = [];
+    const api: any = {
+      registerProvider: (name: string, cfg: any) => registerProviderCalls.push({ name, cfg }),
+      registerTool: () => {},
+      on: (evt: string, h: any) => onCalls.push({ evt, h }),
+    };
+    // Must NOT throw and MUST still register (task is optional).
+    expect(() => tasklessFactory(api)).not.toThrow();
+    expect(registerProviderCalls).toHaveLength(1);
+    const { cfg } = registerProviderCalls[0];
+    expect(cfg.headers["x-team-id"]).toBe("team-azqo3jvm25");
+    expect(cfg.headers["x-agent-id"]).toBe("agt-ea0b0wybln");
+    // No x-task-id header when task is absent → proxy registers with broad recall.
+    expect(cfg.headers["x-task-id"]).toBeUndefined();
+  });
+
+  it("registers an ask_followup_question tool that picks and returns XML", async () => {
+    const registerTool = vi.fn();
+    const api: any = { registerProvider: () => {}, registerTool, on: () => {} };
+    factory(api);
+    expect(registerTool).toHaveBeenCalled();
+    const tool = registerTool.mock.calls[0][0];
+    expect(tool.name).toBe("ask_followup_question");
+
+    // The proxy's args (double-encoded questions string). Pi parses
+    // function.arguments against the tool's parameters schema before calling
+    // execute, so params arrives as { title: string, questions: string }.
+    const params = {
+      title: "会话初始化 — 选择 Team",
+      questions: JSON.stringify([{ id: "team", question: "Team?", options: ["Team A (a1b2c3d4)"], multiSelect: false }]),
+    };
+    const ctx: any = {
+      mode: "tui", hasUI: true,
+      ui: { custom: async (factory: any) => {
+        const comp = factory({ requestRender() {} }, { fg: (_c: string, s: string) => s }, {}, (d: any) => d);
+        comp.handleInput("\r"); // Enter → first option
+        return { id: "team", answer: "Team A (a1b2c3d4)" };
+      } },
+    };
+    const res = await tool.execute("call_session_init_123", params, undefined, undefined, ctx);
+    expect(res.content[0].type).toBe("text");
+    expect(res.content[0].text).toContain("Team A (a1b2c3d4)");
+    expect(res.content[0].text).toContain("<question_answer>");
+  });
+
+  it("the ask_followup_question tool no-ops for non-session-init ids", async () => {
+    const registerTool = vi.fn();
+    const api: any = { registerProvider: () => {}, registerTool, on: () => {} };
+    factory(api);
+    const tool = registerTool.mock.calls[0][0];
+    const res = await tool.execute("call_some_other_id", { title: "x", questions: "[]" }, undefined, undefined, { mode: "tui", hasUI: true, ui: { custom: async () => null } });
+    // Non-matching id → must NOT render a picker and must return a benign skip.
+    expect(res.content[0].text).toMatch(/session-init|skip/i);
+  });
+});

--- a/MemoryCore/pi-plugin/__tests__/picker.test.ts
+++ b/MemoryCore/pi-plugin/__tests__/picker.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderSessionInitPicker } from "../picker.js";
+import type { SessionInitForm } from "../form.js";
+import { Key } from "@earendil-works/pi-tui";
+
+// The real matchesKey compares against legacy byte sequences. We feed those
+// same bytes so the test exercises the real input-handling path:
+//   Enter = "\r", Up = "\x1b[A", Down = "\x1b[B", Esc = "\x1b".
+const ENTER = "\r";
+const DOWN = "\x1b[B";
+
+// A stub ctx.ui.custom that drives the factory's component with canned keys.
+// Each question's menu is a separate custom() call; keySeqs is consumed
+// across calls in order.
+function makeCtx(keySeqsPerQuestion: string[][]) {
+  let qIdx = 0;
+  const ctx: any = {
+    mode: "tui",
+    hasUI: true,
+    ui: {
+      custom<T>(factory: any): Promise<T | null> {
+        return new Promise((resolve) => {
+          const comp = factory(
+            { requestRender: () => {} }, // tui
+            { fg: (_c: string, s: string) => s, bold: (s: string) => s }, // theme
+            {}, // keybindings
+            (result: T | null) => resolve(result),
+          );
+          for (const k of keySeqsPerQuestion[qIdx] ?? []) comp.handleInput(k);
+          qIdx++;
+        });
+      },
+    },
+  };
+  return ctx;
+}
+
+const twoQ: SessionInitForm = {
+  title: "Pick",
+  questions: [
+    { id: "agent", question: "Agent?", options: ["Lucius Fox (0b0wybln)", "Other (ao5f94a7)"], multiSelect: false },
+    { id: "task", question: "Task?", options: ["Pi adapter development (hnrorewx)"], multiSelect: false },
+  ],
+};
+
+describe("renderSessionInitPicker", () => {
+  it("picks the first option of each question with Enter", async () => {
+    const ctx = makeCtx([[ENTER], [ENTER]]);
+    const ans = await renderSessionInitPicker(ctx, twoQ);
+    expect(ans).toEqual([
+      { id: "agent", answer: "Lucius Fox (0b0wybln)" },
+      { id: "task", answer: "Pi adapter development (hnrorewx)" },
+    ]);
+  });
+  it("picks the second option with Down then Enter", async () => {
+    const ctx = makeCtx([[DOWN, ENTER], [ENTER]]);
+    const ans = await renderSessionInitPicker(ctx, twoQ);
+    expect(ans?.[0]).toEqual({ id: "agent", answer: "Other (ao5f94a7)" });
+  });
+  it("returns null on Esc (cancel whole picker)", async () => {
+    const ctx = makeCtx([["\x1b"]]);
+    const ans = await renderSessionInitPicker(ctx, twoQ);
+    expect(ans).toBeNull();
+  });
+  it("returns null in non-TUI mode", async () => {
+    const ctx: any = { mode: "print", hasUI: false, ui: { custom: vi.fn() } };
+    const ans = await renderSessionInitPicker(ctx, twoQ);
+    expect(ans).toBeNull();
+    expect(ctx.ui.custom).not.toHaveBeenCalled();
+  });
+});

--- a/MemoryCore/pi-plugin/discovery.ts
+++ b/MemoryCore/pi-plugin/discovery.ts
@@ -1,0 +1,167 @@
+/**
+ * Dynamic model discovery for the tdai provider.
+ *
+ * The proxy exposes `GET {baseUrl}/models` (handleModelsCatalog) — a
+ * passthrough of the upstream gateway's OpenAI-style catalog
+ * (`{ data: [...] }`). The mapping follows the same rules as
+ * @lunaroute/pi-extension's discovery (same gateway shape, since the proxy
+ * forwards gw.lunaroute.com/v1/models verbatim): reasoning models without a
+ * client_compat.pi block are skipped, everything else maps 1:1. The static
+ * TDAI_MODEL entry stays registered as the fallback so /model is non-empty
+ * before the first refresh, offline, and against proxies not yet redeployed
+ * with the /models route (they 404 the GET — the catch-all only covers POST).
+ */
+import type { Api, Model, RefreshModelsContext } from "@earendil-works/pi-ai";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+
+export const TDAI_PROVIDER = "tdai";
+// Every model behind the proxy is served over OpenAI-completions; also set on
+// the provider config, so toStoredModel mirrors provider-composer output and
+// the catalog round-trips Pi's ModelsStore.
+export const TDAI_API = "openai-completions" as const;
+
+// ── Gateway catalog shape (client_compat.pi block) ──────────────────────────
+
+export type GatewayPiBlock = {
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+  compat?: Model<Api>["compat"];
+} & Partial<Model<Api>["compat"]>;
+
+export type GatewayModelObject = {
+  id: string;
+  display_name?: string;
+  context_window?: number;
+  max_output_tokens?: number;
+  capabilities?: Record<string, boolean>;
+  client_compat?: { pi?: GatewayPiBlock } | null;
+  pi?: GatewayPiBlock;
+};
+
+export type CatalogMappingResult =
+  | { ok: true; model: ProviderModelConfig }
+  | { ok: false; reason: "reasoning_missing_pi_block"; id: string };
+
+function normalizeGatewayPiBlock(pi: GatewayPiBlock): {
+  thinkingLevelMap?: Model<Api>["thinkingLevelMap"];
+  compat?: Model<Api>["compat"];
+} {
+  const { thinkingLevelMap, compat: nestedCompat, ...flatCompat } = pi;
+  return {
+    thinkingLevelMap,
+    compat: nestedCompat ?? (Object.keys(flatCompat).length > 0 ? flatCompat : undefined),
+  };
+}
+
+export function mapCatalogEntry(entry: GatewayModelObject): CatalogMappingResult {
+  const reasoning = entry.capabilities?.reasoning === true;
+  const input: ("text" | "image")[] = entry.capabilities?.vision === true ? ["text", "image"] : ["text"];
+  const gatewayPi = entry.client_compat?.pi ?? entry.pi;
+
+  if (reasoning && !gatewayPi) {
+    return { ok: false, reason: "reasoning_missing_pi_block", id: entry.id };
+  }
+
+  const model: ProviderModelConfig = {
+    id: entry.id,
+    name: entry.display_name ?? entry.id,
+    reasoning,
+    input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: entry.context_window ?? 0,
+    maxTokens: entry.max_output_tokens ?? 0,
+  };
+  if (reasoning && gatewayPi) {
+    const { thinkingLevelMap, compat } = normalizeGatewayPiBlock(gatewayPi);
+    if (thinkingLevelMap) model.thinkingLevelMap = thinkingLevelMap;
+    if (compat) model.compat = compat;
+  }
+  return { ok: true, model };
+}
+
+/** Persisted Model object for a mapped entry. Mirrors provider-composer's
+ * applyExtension output (api/provider/baseUrl filled from the provider
+ * config) so the entry survives a structuredClone through the ModelsStore
+ * and re-applies cleanly on the next launch. */
+export function toStoredModel(model: ProviderModelConfig, baseUrl: string): Model<Api> {
+  return {
+    id: model.id,
+    name: model.name,
+    api: model.api ?? TDAI_API,
+    provider: TDAI_PROVIDER,
+    baseUrl: model.baseUrl ?? baseUrl,
+    reasoning: model.reasoning,
+    thinkingLevelMap: model.thinkingLevelMap,
+    input: model.input,
+    cost: model.cost,
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+    compat: model.compat,
+  } as Model<Api>;
+}
+
+// ── refreshModels ───────────────────────────────────────────────────────────
+
+export type RefreshModelsDeps = {
+  /** Provider baseUrl (already includes /v1): fetch `${baseUrl}/models`. */
+  baseUrl: string;
+  /** TDAI user key — the proxy authenticates it before forwarding upstream. */
+  userKey: string;
+  /** Static TDAI_MODEL entry: last-resort fallback. */
+  fallback: ProviderModelConfig;
+  fetch?: typeof fetch;
+};
+
+/** Restored catalog from a prior session (stored entries are Model<Api>
+ * objects — a structural superset of ProviderModelConfig). Falls back to the
+ * static entry when nothing was persisted yet. */
+function restore(
+  stored: RefreshModelsContext["stored"],
+  fallback: ProviderModelConfig,
+): ProviderModelConfig[] {
+  const models = stored?.models;
+  return models && models.length > 0 ? ([...models] as ProviderModelConfig[]) : [fallback];
+}
+
+export function createRefreshModels(
+  deps: RefreshModelsDeps,
+): (context: RefreshModelsContext) => Promise<ProviderModelConfig[]> {
+  const doFetch = deps.fetch ?? fetch;
+  return async (context) => {
+    // Phase 1 (offline / restore): surface the persisted catalog so getModels()
+    // is non-empty at startup — before any network refresh. The static
+    // fallback covers the very first launch (nothing persisted yet).
+    if (!context.allowNetwork) return restore(context.stored, deps.fallback);
+
+    try {
+      const res = await doFetch(`${deps.baseUrl}/models`, {
+        signal: context.signal,
+        headers: { authorization: `Bearer ${deps.userKey}` },
+      });
+      // Old proxy without the /models route → 404 → keep what we have.
+      if (!res.ok) return restore(context.stored, deps.fallback);
+
+      const body = (await res.json()) as { data?: GatewayModelObject[] };
+      const models: ProviderModelConfig[] = [];
+      for (const entry of body.data ?? []) {
+        const result = mapCatalogEntry(entry);
+        if (result.ok) models.push(result.model);
+      }
+      if (!models.length) return restore(context.stored, deps.fallback);
+
+      // Persist for next startup; the returned list replaces the in-memory
+      // registry via the provider-composer wrapper. A store-write failure
+      // must not discard the fresh catalog — the next refresh retries persist.
+      await context
+        .publish({
+          persist: {
+            models: models.map((m) => toStoredModel(m, deps.baseUrl)),
+            checkedAt: Date.now(),
+          },
+        })
+        .catch(() => {});
+      return models;
+    } catch {
+      return restore(context.stored, deps.fallback);
+    }
+  };
+}

--- a/MemoryCore/pi-plugin/form.ts
+++ b/MemoryCore/pi-plugin/form.ts
@@ -1,0 +1,91 @@
+/**
+ * Proxy session-init form protocol helpers.
+ *
+ * The TDAI proxy's CodeBuddy state machine emits its Team/Agent/Task picker as
+ * an `ask_followup_question` tool_call whose `function.arguments` is a JSON
+ * string of shape `{ title: string, questions: string }` — and `questions` is
+ * ITSELF a JSON string (double-encoded) of `SessionInitQuestion[]`.
+ *
+ * The answer is returned as `<question_answer>` XML so the proxy's
+ * `extractFromOptionText` → `parseQuestionAnswerXml` can split a combined
+ * agent+task form into per-question answers (see RFC §3).
+ */
+
+export interface SessionInitQuestion {
+  id: string;
+  question: string;
+  options: string[];
+  multiSelect: boolean;
+}
+export interface SessionInitForm {
+  title: string;
+  questions: SessionInitQuestion[];
+}
+
+/**
+ * Parse the proxy's `ask_followup_question` arguments. Accepts either:
+ *  - the raw `function.arguments` JSON string (double-decodes), or
+ *  - the already-parsed object `{ title, questions: string }` (Pi parses
+ *    `function.arguments` against the tool's `parameters` schema before
+ *    calling `execute`, so `params` arrives parsed — `questions` is still the
+ *    inner JSON string).
+ * Returns `null` when `input` is not a valid session-init form, so the tool
+ * can no-op for unrelated calls.
+ */
+export function parseFormArgs(input: string | object): SessionInitForm | null {
+  let outer: unknown;
+  if (typeof input === "string") {
+    try {
+      outer = JSON.parse(input);
+    } catch {
+      return null;
+    }
+  } else if (input && typeof input === "object") {
+    outer = input;
+  } else {
+    return null;
+  }
+  if (!outer || typeof outer !== "object") return null;
+  const o = outer as { title?: unknown; questions?: unknown };
+  if (typeof o.title !== "string") return null;
+  // `questions` is a JSON string (the proxy double-encodes); decode it.
+  if (typeof o.questions !== "string") return null;
+  let qs: unknown;
+  try {
+    qs = JSON.parse(o.questions);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(qs)) return null;
+  const questions: SessionInitQuestion[] = qs
+    .map((q): SessionInitQuestion | null => {
+      if (!q || typeof q !== "object") return null;
+      const r = q as Record<string, unknown>;
+      if (typeof r.id !== "string" || typeof r.question !== "string" || !Array.isArray(r.options) || typeof r.multiSelect !== "boolean") return null;
+      return {
+        id: r.id,
+        question: r.question,
+        options: (r.options as unknown[]).filter((x): x is string => typeof x === "string"),
+        multiSelect: r.multiSelect,
+      };
+    })
+    .filter((q): q is SessionInitQuestion => q !== null);
+  if (questions.length === 0) return null;
+  return { title: o.title, questions };
+}
+
+/**
+ * Build the `<question_answer>` XML the proxy's extractor expects. One
+ * `<question_item id="…">` per answer, each wrapping the EXACT option label
+ * the proxy sent (the extractor matches by full label first).
+ */
+export function formatAnswerXml(answers: { id: string; answer: string }[]): string {
+  const items = answers
+    .map((a) => `<question_item id="${a.id}"><answers>${escapeXml(a.answer)}</answers></question_item>`)
+    .join("");
+  return `<question_answer><questions>${items}</questions></question_answer>`;
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/MemoryCore/pi-plugin/index.ts
+++ b/MemoryCore/pi-plugin/index.ts
@@ -7,7 +7,11 @@
  * capability (L3/L2 injection, L0 capture, L0/L1/L2 search via curl
  * recipes) arrives server-side from the proxy. (Scope C.)
  */
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { parseFormArgs, formatAnswerXml } from "./form.js";
+import { renderSessionInitPicker } from "./picker.js";
+import { createRefreshModels, TDAI_API } from "./discovery.js";
 
 export default function (pi: ExtensionAPI) {
   const proxyBase = process.env.TDAI_PROXY_URL ?? "http://127.0.0.1:8096";
@@ -19,71 +23,110 @@ export default function (pi: ExtensionAPI) {
   const agentId = process.env.TDAI_AGENT_ID ?? "";
   const taskId = process.env.TDAI_TASK_ID ?? "";
 
-  // Graceful degradation: if required identity env vars are missing, warn and
-  // skip registration so Pi still starts. The user sees the warning at load
-  // and can fix the env. (A startup extension must not throw and block Pi.)
-  // NOTE: TDAI_TASK_ID is OPTIONAL — task_id is an optional business dimension
-  // in the TDAI kernel (MemoryCore/src/core/store/isolation.ts), and the proxy
-  // registers from team+agent alone (broad recall when task is absent).
-  const required: Record<string, string> = {
-    TDAI_USER_KEY: userKey,
-    TDAI_TEAM_ID: teamId,
-    TDAI_AGENT_ID: agentId,
-  };
-  const missing = Object.keys(required).filter((k) => !required[k]);
-  if (missing.length > 0) {
+  // Graceful degradation: if TDAI_USER_KEY is missing, warn and skip
+  // registration so Pi still starts. (A startup extension must not throw and
+  // block Pi.) TDAI_TEAM_ID / TDAI_AGENT_ID / TDAI_TASK_ID are OPTIONAL in
+  // interactive mode: when unset, the proxy sends a Team→Agent→Task form on
+  // turn 1 and the registered `ask_followup_question` tool renders a TUI
+  // picker. Set them only to skip the picker (CI, scripts, fixed context).
+  // TDAI_TASK_ID additionally narrows recall to a specific task when set.
+  if (!userKey) {
     console.warn(
-      `[pi-tdai-client] Not registering the TDAI provider: missing required env var(s): ` +
-        `${missing.join(", ")}. Set TDAI_USER_KEY, TDAI_TEAM_ID, ` +
-        `TDAI_AGENT_ID (see MemoryCore/pi-plugin/README.md). ` +
-        `TDAI_TASK_ID is optional. ` +
-        `Pi will start without the TDAI provider.`,
+      `[tdai-client] Not registering the TDAI provider: missing required env var ` +
+        `TDAI_USER_KEY (the user's API key, panel → API Key — NOT the admin/gateway key). ` +
+        `Pi will start without the TDAI provider. See MemoryCore/pi-plugin/README.md.`,
     );
     return;
   }
 
-  // Only send x-task-id when explicitly set; an absent/stale task makes the
-  // proxy register with broad recall (no task filter) instead of failing.
-  const headers: Record<string, string> = {
-    "x-team-id": teamId,
-    "x-agent-id": agentId,
-  };
+  // Static identity headers — only the ones that are set. When team/agent are
+  // absent, no preset is sent and the proxy falls back to the interactive
+  // picker. x-task-id is sent only when set (broad recall when absent).
+  const headers: Record<string, string> = {};
+  if (teamId) headers["x-team-id"] = teamId;
+  if (agentId) headers["x-agent-id"] = agentId;
   if (taskId) headers["x-task-id"] = taskId;
 
   // baseUrl MUST include /v1: the OpenAI-completions provider appends
   // /chat/completions but does NOT insert /v1. Including /v1 hits the
   // proxy's explicit /:agent/:spaceId/v1/chat/completions route.
+  const baseUrl = `${proxyBase}/${agentSource}/${spaceId}/v1`;
+
+  // Static fallback entry (TDAI_MODEL): registered immediately so /model is
+  // non-empty before the first refresh, offline, and against proxies without
+  // the /models route. refreshModels replaces it with the live catalog.
+  const staticModel: ProviderModelConfig = {
+    id: model,
+    name: model,
+    api: TDAI_API,
+    input: ["text", "image"],
+    reasoning: true,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 524288,
+    maxTokens: 16384,
+    thinkingLevelMap: {
+      off: "none",
+      minimal: "minimal",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "xhigh",
+      max: "max",
+    },
+  };
+
   pi.registerProvider("tdai", {
     name: "TDAI Memory Proxy",
-    baseUrl: `${proxyBase}/${agentSource}/${spaceId}/v1`,
+    baseUrl,
     api: "openai-completions",
     apiKey: userKey,
     headers,
-    models: [
-      {
-        id: model,
-        name: model,
-        input: ["text", "image"],
-        reasoning: true,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 524288,
-        maxTokens: 16384,
-        thinkingLevelMap: {
-          off: "none",
-          minimal: "minimal",
-          low: "low",
-          medium: "medium",
-          high: "high",
-          xhigh: "xhigh",
-          max: "max",
-        },
-      },
-    ],
+    models: [staticModel],
+    refreshModels: createRefreshModels({ baseUrl, userKey, fallback: staticModel }),
   });
 
   pi.on("before_provider_headers", (event: any, ctx: any) => {
     if (ctx.model?.provider !== "tdai") return;
     const sid = ctx.sessionManager.getSessionId();
     event.headers["x-conversation-id"] = `pi-${sid}`;
+  });
+
+  // Register the session-init picker tool. The proxy returns its form as an
+  // ask_followup_question tool_call with id `call_session_init_<ts>`; Pi
+  // executes this tool, we render a TUI picker, and return the answer as
+  // <question_answer> XML text. Pi sends that back as a role:"tool" message
+  // whose tool_call_id the proxy's getLastUserMessageText matches
+  // (/call_(wb_|dsh_)?session_init_/) → the answer is extracted. Zero proxy
+  // changes — reuses the existing CodeBuddy state machine for agentSource=pi.
+  pi.registerTool({
+    name: "ask_followup_question",
+    label: "TDAI Session Init",
+    description: "Renders the TDAI proxy's Team/Agent/Task picker. Invoked automatically on the first turn of a session when no preset identity (TDAI_TEAM_ID/TDAI_AGENT_ID/TDAI_TASK_ID) is set.",
+    parameters: Type.Object({
+      title: Type.String(),
+      questions: Type.String(),
+    }),
+    executionMode: "sequential",
+    async execute(toolCallId, params, _signal, _onUpdate, ctx) {
+      // Guard: only handle the proxy's session-init tool calls.
+      if (!/^call_session_init_/.test(toolCallId)) {
+        return { content: [{ type: "text" as const, text: "ask_followup_question: not a session-init call (skipped)" }], details: { skipped: true } };
+      }
+      // params is the parsed function.arguments object (Pi parses against
+      // the parameters schema before calling execute). params.questions is
+      // the inner JSON string the proxy double-encoded; parseFormArgs decodes it.
+      const form = parseFormArgs(params);
+      if (!form) {
+        return { content: [{ type: "text" as const, text: "ask_followup_question: could not parse session-init form" }], details: { error: true } };
+      }
+      if (ctx.mode !== "tui") {
+        return { content: [{ type: "text" as const, text: "TDAI session-init requires interactive mode. Set TDAI_TEAM_ID/TDAI_AGENT_ID env vars for non-interactive use." }], details: { error: true } };
+      }
+      const answers = await renderSessionInitPicker(ctx, form);
+      if (!answers) {
+        return { content: [{ type: "text" as const, text: "User cancelled session init" }], details: { cancelled: true } };
+      }
+      return { content: [{ type: "text" as const, text: formatAnswerXml(answers) }], details: { answers } };
+    },
   });
 }

--- a/MemoryCore/pi-plugin/package.json
+++ b/MemoryCore/pi-plugin/package.json
@@ -1,24 +1,64 @@
 {
   "name": "@tencentdb-agent-memory/pi-tdai-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pi client for TencentDB Agent Memory v2 — routes Pi through the TDAI Memory Proxy for team memory (L3 persona, L2 scene index, L0 capture, on-demand L0/L1/L2 search).",
   "type": "module",
   "main": "index.ts",
-  "keywords": ["pi-package"],
+  "keywords": [
+    "pi-package"
+  ],
   "pi": {
-    "extensions": ["index.ts"]
+    "extensions": [
+      "index.ts"
+    ]
   },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
     "clean": "rm -rf dist *.tgz"
   },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/TencentCloud/TencentDB-Agent-Memory#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TencentCloud/TencentDB-Agent-Memory.git",
+    "directory": "MemoryCore/pi-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/TencentCloud/TencentDB-Agent-Memory/issues"
+  },
+  "files": [
+    "index.ts",
+    "form.ts",
+    "picker.ts",
+    "discovery.ts",
+    "README.md",
+    "package.json",
+    "tsconfig.json",
+    "vitest.config.ts",
+    "__tests__/"
+  ],
   "devDependencies": {
-    "typescript": "^5.5.0",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-tui": "^0.84.2",
     "@types/node": "^22.0.0",
+    "typebox": "^1.3.18",
+    "typescript": "^5.5.0",
     "vitest": "^3.2.2"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-ai": { "optional": false },
+    "@earendil-works/pi-coding-agent": { "optional": false },
+    "@earendil-works/pi-tui": { "optional": false },
+    "typebox": { "optional": false }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/MemoryCore/pi-plugin/picker.ts
+++ b/MemoryCore/pi-plugin/picker.ts
@@ -1,0 +1,70 @@
+/**
+ * TUI session-init picker.
+ *
+ * Renders the proxy's `ask_followup_question` form as a Pi-native menu (one
+ * menu per question, in order) via `ctx.ui.custom`. Pure UI — no proxy
+ * knowledge. Modeled on pi's `examples/extensions/question.ts`.
+ */
+import { Key, matchesKey } from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { SessionInitForm } from "./form.js";
+
+/**
+ * Render one menu per question in `form`, in order. Returns the user's
+ * selections, or `null` if the user cancelled (Esc) or running non-TUI.
+ */
+export async function renderSessionInitPicker(
+  ctx: ExtensionContext,
+  form: SessionInitForm,
+): Promise<{ id: string; answer: string }[] | null> {
+  if (ctx.mode !== "tui") return null;
+  const answers: { id: string; answer: string }[] = [];
+  for (const q of form.questions) {
+    if (q.options.length === 0) return null;
+    const picked = await ctx.ui.custom<{ id: string; answer: string } | null>(
+      (tui, theme, _kb, done) => {
+        let idx = 0;
+        const refresh = () => tui.requestRender();
+        function handleInput(data: string) {
+          if (matchesKey(data, Key.up)) {
+            idx = Math.max(0, idx - 1);
+            refresh();
+            return;
+          }
+          if (matchesKey(data, Key.down)) {
+            idx = Math.min(q.options.length - 1, idx + 1);
+            refresh();
+            return;
+          }
+          if (matchesKey(data, Key.enter)) {
+            done({ id: q.id, answer: q.options[idx] });
+            return;
+          }
+          if (matchesKey(data, Key.escape)) {
+            done(null);
+            return;
+          }
+        }
+        function render(width: number): string[] {
+          const lines: string[] = [];
+          const w = Math.max(1, width);
+          lines.push(theme.fg("accent", "─".repeat(w)));
+          lines.push(theme.fg("text", q.question));
+          lines.push("");
+          for (let i = 0; i < q.options.length; i++) {
+            const sel = i === idx;
+            const prefix = sel ? theme.fg("accent", "> ") : "  ";
+            lines.push(`${prefix}${i + 1}. ${q.options[i]}`);
+          }
+          lines.push("");
+          lines.push(theme.fg("dim", "↑↓ navigate • Enter to select • Esc to cancel"));
+          return lines;
+        }
+        return { render, invalidate: () => {}, handleInput };
+      },
+    );
+    if (picked === null) return null;
+    answers.push(picked);
+  }
+  return answers;
+}

--- a/MemoryProxy/src/__tests__/bridge-session-resolution.test.ts
+++ b/MemoryProxy/src/__tests__/bridge-session-resolution.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it, beforeEach } from "vitest";
+import { Hono } from "hono";
 import { SessionStore, getSessionStore, __resetSessionStoreForTests } from "../session/store.js";
+import { createMemoryBridgeHandler } from "../memory/memory-bridge.js";
 import type { SessionInitState } from "../session/types.js";
+import type { ProxyConfig } from "../types.js";
 
-function makeInitializedState(agentId: string, teamId: string): SessionInitState {
+function makeInitializedState(
+  agentId: string,
+  teamId: string,
+  sessionId: string,
+): SessionInitState {
   return {
     status: "initialized",
     keyId: "",
     startedAt: Date.now(),
     attemptCount: 0,
     sessionInfo: {
-      session_id: "",
+      session_id: sessionId,
       team_id: teamId,
       agent_id: agentId,
       user_id: "usr-test",
@@ -22,6 +29,19 @@ function makeInitializedState(agentId: string, teamId: string): SessionInitState
   };
 }
 
+/** Minimal config — memory-bridge only needs coreSkill.endpoint (+ optional tdai). */
+function makeBridgeConfig(): ProxyConfig {
+  return {
+    coreSkill: {
+      endpoint: "http://upstream.test",
+      serviceToken: "tok",
+      serviceId: "default",
+      timeoutMs: 5_000,
+    },
+    tdai: { enabled: false, apiKey: "", serviceId: "default" },
+  } as unknown as ProxyConfig;
+}
+
 describe("SessionStore.keysWithSuffix", () => {
   let store: SessionStore;
 
@@ -30,58 +50,101 @@ describe("SessionStore.keysWithSuffix", () => {
   });
 
   it("finds a key by bare sessionId match", () => {
-    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1"));
+    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1", "abc-123"));
     expect(store.keysWithSuffix("abc-123")).toEqual(["pi:abc-123"]);
   });
 
   it("finds keys by `:${sessionId}` suffix across multiple agent sources", () => {
-    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1"));
-    store.set("dsh:abc-123", makeInitializedState("agt-2", "team-2"));
-    store.set("claude-code:abc-123", makeInitializedState("agt-3", "team-3"));
-    store.set("codex:def-456", makeInitializedState("agt-4", "team-4"));
+    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1", "abc-123"));
+    store.set("dsh:abc-123", makeInitializedState("agt-2", "team-2", "abc-123"));
+    store.set("claude-code:abc-123", makeInitializedState("agt-3", "team-3", "abc-123"));
+    store.set("codex:def-456", makeInitializedState("agt-4", "team-4", "def-456"));
     const found = store.keysWithSuffix("abc-123");
     expect(found.sort()).toEqual(["claude-code:abc-123", "dsh:abc-123", "pi:abc-123"]);
   });
 
   it("returns empty array when no key matches", () => {
-    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1"));
+    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1", "abc-123"));
     expect(store.keysWithSuffix("zzz-000")).toEqual([]);
   });
 
   it("does not match a sessionId that is a substring but not a suffix", () => {
-    store.set("pi:abc-123-extra", makeInitializedState("agt-1", "team-1"));
+    store.set("pi:abc-123-extra", makeInitializedState("agt-1", "team-1", "abc-123-extra"));
     expect(store.keysWithSuffix("abc-123")).toEqual([]);
   });
 });
 
-describe("bridge L1 resolution via keysWithSuffix (integration)", () => {
+describe("memory-bridge L1 resolution via keysWithSuffix", () => {
   beforeEach(() => {
     __resetSessionStoreForTests();
   });
 
-  it("memory-bridge loadSessionIdsL1 finds a pi-prefixed session with a bare sessionId", async () => {
+  async function postBridge(
+    conversationId: string,
+    fetcher: typeof fetch,
+  ): Promise<Response> {
+    const app = new Hono();
+    const handler = createMemoryBridgeHandler(makeBridgeConfig(), { fetcher });
+    app.post("/memory-bridge/*", (c) => handler(c));
+    return app.request("http://localhost/memory-bridge/v3/atomic/search", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-conversation-id": conversationId,
+        "x-tdai-service-id": "default",
+      },
+      body: "{}",
+    });
+  }
+
+  it("resolves a pi-prefixed L1 session from a bare x-conversation-id", async () => {
     const store = getSessionStore();
-    store.set("pi:pi-01abc", makeInitializedState("agt-ea0b0wybln", "team-azqo3jvm25"));
+    store.set("pi:pi-01abc", makeInitializedState("agt-ea0b0wybln", "team-azqo3jvm25", "pi-01abc"));
 
-    // The bridge receives a bare sessionId from x-conversation-id.
-    // The old code tried [bare, "codebuddy:bare", "claude-code:bare"] — all miss.
-    // The new code uses keysWithSuffix to find "pi:pi-01abc".
-    const candidates = store.keysWithSuffix("pi-01abc");
-    expect(candidates).toEqual(["pi:pi-01abc"]);
+    let upstreamBody: unknown;
+    const fetcher = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      upstreamBody = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
 
-    const state = store.get(candidates[0]);
-    expect(state?.status).toBe("initialized");
-    expect(state?.sessionInfo?.agent_id).toBe("agt-ea0b0wybln");
+    const res = await postBridge("pi-01abc", fetcher);
+    expect(res.status).toBe(200);
+    // session_id is only forwarded when the caller sets it; identity inject is team/user/agent.
+    expect(upstreamBody).toMatchObject({
+      agent_id: "agt-ea0b0wybln",
+      team_id: "team-azqo3jvm25",
+      user_id: "usr-test",
+    });
   });
 
-  it("memory-bridge loadSessionIdsL1 finds a dsh-prefixed session with a bare sessionId", async () => {
+  it("resolves a dsh-prefixed L1 session from a bare x-conversation-id", async () => {
     const store = getSessionStore();
-    store.set("dsh:dsh-02def", makeInitializedState("agt-dsh", "team-dsh"));
+    store.set("dsh:dsh-02def", makeInitializedState("agt-dsh", "team-dsh", "dsh-02def"));
 
-    const candidates = store.keysWithSuffix("dsh-02def");
-    expect(candidates).toEqual(["dsh:dsh-02def"]);
+    const fetcher = (async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
 
-    const state = store.get(candidates[0]);
-    expect(state?.sessionInfo?.agent_id).toBe("agt-dsh");
+    const res = await postBridge("dsh-02def", fetcher);
+    expect(res.status).toBe(200);
+  });
+
+  it("still returns 40101 when no L1 key matches the bare conversation id", async () => {
+    const store = getSessionStore();
+    store.set("pi:other-session", makeInitializedState("agt-1", "team-1", "other-session"));
+
+    const fetcher = (async () => {
+      throw new Error("upstream must not be called on L1 miss");
+    }) as typeof fetch;
+
+    const res = await postBridge("missing-session", fetcher);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toMatchObject({ code: 40101 });
   });
 });

--- a/MemoryProxy/src/__tests__/bridge-session-resolution.test.ts
+++ b/MemoryProxy/src/__tests__/bridge-session-resolution.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { SessionStore, getSessionStore, __resetSessionStoreForTests } from "../session/store.js";
+import type { SessionInitState } from "../session/types.js";
+
+function makeInitializedState(agentId: string, teamId: string): SessionInitState {
+  return {
+    status: "initialized",
+    keyId: "",
+    startedAt: Date.now(),
+    attemptCount: 0,
+    sessionInfo: {
+      session_id: "",
+      team_id: teamId,
+      agent_id: agentId,
+      user_id: "usr-test",
+      user_key: "key-test",
+      space_id: "default",
+    },
+    userId: "usr-test",
+    agentDetail: null,
+    taskDetail: null,
+  };
+}
+
+describe("SessionStore.keysWithSuffix", () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(30 * 60 * 1000);
+  });
+
+  it("finds a key by bare sessionId match", () => {
+    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1"));
+    expect(store.keysWithSuffix("abc-123")).toEqual(["pi:abc-123"]);
+  });
+
+  it("finds keys by `:${sessionId}` suffix across multiple agent sources", () => {
+    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1"));
+    store.set("dsh:abc-123", makeInitializedState("agt-2", "team-2"));
+    store.set("claude-code:abc-123", makeInitializedState("agt-3", "team-3"));
+    store.set("codex:def-456", makeInitializedState("agt-4", "team-4"));
+    const found = store.keysWithSuffix("abc-123");
+    expect(found.sort()).toEqual(["claude-code:abc-123", "dsh:abc-123", "pi:abc-123"]);
+  });
+
+  it("returns empty array when no key matches", () => {
+    store.set("pi:abc-123", makeInitializedState("agt-1", "team-1"));
+    expect(store.keysWithSuffix("zzz-000")).toEqual([]);
+  });
+
+  it("does not match a sessionId that is a substring but not a suffix", () => {
+    store.set("pi:abc-123-extra", makeInitializedState("agt-1", "team-1"));
+    expect(store.keysWithSuffix("abc-123")).toEqual([]);
+  });
+});
+
+describe("bridge L1 resolution via keysWithSuffix (integration)", () => {
+  beforeEach(() => {
+    __resetSessionStoreForTests();
+  });
+
+  it("memory-bridge loadSessionIdsL1 finds a pi-prefixed session with a bare sessionId", async () => {
+    const store = getSessionStore();
+    store.set("pi:pi-01abc", makeInitializedState("agt-ea0b0wybln", "team-azqo3jvm25"));
+
+    // The bridge receives a bare sessionId from x-conversation-id.
+    // The old code tried [bare, "codebuddy:bare", "claude-code:bare"] — all miss.
+    // The new code uses keysWithSuffix to find "pi:pi-01abc".
+    const candidates = store.keysWithSuffix("pi-01abc");
+    expect(candidates).toEqual(["pi:pi-01abc"]);
+
+    const state = store.get(candidates[0]);
+    expect(state?.status).toBe("initialized");
+    expect(state?.sessionInfo?.agent_id).toBe("agt-ea0b0wybln");
+  });
+
+  it("memory-bridge loadSessionIdsL1 finds a dsh-prefixed session with a bare sessionId", async () => {
+    const store = getSessionStore();
+    store.set("dsh:dsh-02def", makeInitializedState("agt-dsh", "team-dsh"));
+
+    const candidates = store.keysWithSuffix("dsh-02def");
+    expect(candidates).toEqual(["dsh:dsh-02def"]);
+
+    const state = store.get(candidates[0]);
+    expect(state?.sessionInfo?.agent_id).toBe("agt-dsh");
+  });
+});

--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -137,15 +137,22 @@ function bindingToIdFields(
  */
 function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   // handler 层存的 L1 key 形如 `${agentSource}:${sessionId}`; curl 拿到的
-  // 通常是 bare sessionId。按候选前缀顺序探,命中即返回。
-  const candidates = sessionId.includes(":")
-    ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
-  for (const k of candidates) {
-    const state = getSessionStore().get(k);
-    if (state) {
-      const fields = toIdFields(state, k);
-      if (fields) return fields;
+  // 通常是 bare sessionId。先试 bare，再枚举所有以 `:${sessionId}` 结尾的 key，
+  // 这样无论 agentSource 是 pi / dsh / codex / workbuddy 还是任何新增值
+  // 都能命中——不再维护硬编码前缀列表。
+  const store = getSessionStore();
+  const bare = store.get(sessionId);
+  if (bare) {
+    const fields = toIdFields(bare, sessionId);
+    if (fields) return fields;
+  }
+  if (!sessionId.includes(":")) {
+    for (const k of store.keysWithSuffix(sessionId)) {
+      const state = store.get(k);
+      if (state) {
+        const fields = toIdFields(state, k);
+        if (fields) return fields;
+      }
     }
   }
   return null;

--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -140,6 +140,10 @@ function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   // 通常是 bare sessionId。先试 bare，再枚举所有以 `:${sessionId}` 结尾的 key，
   // 这样无论 agentSource 是 pi / dsh / codex / workbuddy 还是任何新增值
   // 都能命中——不再维护硬编码前缀列表。
+  // 注：若同时存在多个前缀 key（如 pi:abc 与 dsh:abc），Map 迭代先命中者胜——
+  // 真实流量中一个会话只有一个 agentSource，故可接受。
+  // Note: if multiple prefixed keys match, first Map hit wins — acceptable
+  // since one conversation has exactly one agentSource in practice.
   const store = getSessionStore();
   const bare = store.get(sessionId);
   if (bare) {

--- a/MemoryProxy/src/server.ts
+++ b/MemoryProxy/src/server.ts
@@ -12,7 +12,7 @@ import { createMemoryBridgeHandler } from "./memory/memory-bridge.js";
 import { createInstanceDestroyHandler } from "./routes/instance-destroy.js";
 import { createRateLimitHandlers } from "./routes/rate-limits.js";
 import { hasAnalyseMarker, hasCostGuardMarker } from "./routes/whitelist.js";
-import { tryActivateStorage, tryActivateRedis } from "./injection/index.js";
+import { tryActivateStorage, tryActivateRedis, ensureBindingRepoPersistent } from "./injection/index.js";
 import { getEffectiveBackend } from "./storage/factory.js";
 import type { ProxyConfig } from "./types.js";
 
@@ -26,6 +26,12 @@ export function createApp(config: ProxyConfig): Hono {
   if (!tryActivateStorage(config)) {
     tryActivateRedis(config);
   }
+  // Fs fallback for deployments with neither storage.enabled nor redis.enabled
+  // (the default 3-container install). Without this, the BindingRepo is null
+  // when the first session-init completes, so completeRegistration's L2b
+  // binding write is silently skipped — bridge L2 lookups then always miss.
+  // Idempotent: skips if storage/redis already set a BindingRepo.
+  ensureBindingRepoPersistent(config);
 
   // `/cost-guard` marker 门控 (P0 前置)：
   // markerOptIn=false 时 marker 完全作废——任何路径里带 `/cost-guard/` 段的请求

--- a/MemoryProxy/src/session/store.ts
+++ b/MemoryProxy/src/session/store.ts
@@ -133,6 +133,21 @@ export class SessionStore {
   }
 
   /**
+   * Return all L1 keys whose suffix matches `:${sessionId}` (or the bare
+   * sessionId). Used by the memory/skill bridge L1 fast path to find a
+   * session without knowing the agentSource prefix — the bridge curl only
+   * carries `x-conversation-id`, not the agent source that handler.ts used
+   * to build the composite key (`${agentSource}:${sessionKey}`).
+   */
+  keysWithSuffix(sessionId: string): string[] {
+    const result: string[] = [];
+    for (const k of this.states.keys()) {
+      if (k === sessionId || k.endsWith(`:${sessionId}`)) result.push(k);
+    }
+    return result;
+  }
+
+  /**
    * 把 recovery source 挂到 state 的**非可枚举**字段上——handler 侧读取
    * `state.__recoverySource` 语义不变，但 `deepEqual` / `JSON.stringify` /
    * `Object.keys` 都不会看到这一枚 transient marker，避免测试断言"恢复后

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -284,22 +284,26 @@ function bindingToIdFields(
 
 /**
  * L1: 先按 bare sessionId 试(handler.ts 存的 keyId 是 `${agentSource}:${sessionId}`,
- * bridge curl 拿不到 agentSource,所以按候选前缀顺序探)。
+ * bridge curl 拿不到 agentSource,所以枚举所有以 `:${sessionId}` 结尾的 key)。
  *
- * ⚠️ 候选轮询是过渡期兼容:同 pod 内主对话链路建过 session, L1 Map 里的 key 带
- * agentSource 前缀,bare sessionId 命中不到。方案 B 拍平后 L2b binding 直接命中
- * 2 段 key,不再需要前缀轮询;这里 L1 保留是为了 L2b 出问题时,仍能从内存 L1
- * 恢复而不 401。
+ * 不再维护硬编码前缀列表——无论 agentSource 是 pi / dsh / codex / workbuddy
+ * 还是任何新增值都能命中。L2b binding 拍平后可直接命中 2 段 key;
+ * L1 保留是为了 L2b 出问题时仍能从内存 L1 恢复而不 401。
  */
 function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
-  const candidates = sessionId.includes(":")
-    ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
-  for (const k of candidates) {
-    const s = getSessionStore().get(k);
-    if (s) {
-      const fields = stateToIdFields(s, k);
-      if (fields) return fields;
+  const store = getSessionStore();
+  const bare = store.get(sessionId);
+  if (bare) {
+    const fields = stateToIdFields(bare, sessionId);
+    if (fields) return fields;
+  }
+  if (!sessionId.includes(":")) {
+    for (const k of store.keysWithSuffix(sessionId)) {
+      const s = store.get(k);
+      if (s) {
+        const fields = stateToIdFields(s, k);
+        if (fields) return fields;
+      }
     }
   }
   return null;

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -298,6 +298,8 @@ function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
     if (fields) return fields;
   }
   if (!sessionId.includes(":")) {
+    // If multiple prefixed keys match (e.g. pi:abc + dsh:abc), the first Map
+    // hit wins — acceptable since one conversation has one agentSource.
     for (const k of store.keysWithSuffix(sessionId)) {
       const s = store.get(k);
       if (s) {

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-Memory Proxy 目前适配了 7 类 AI Agent 客户端，各自协议、会话初始化方式、注入逻辑差异显著。
+Memory Proxy 目前适配了 8 类 AI Agent 客户端，各自协议、会话初始化方式、注入逻辑差异显著。
 
 ## 快速开始
 
@@ -83,6 +83,7 @@ cp -r agents ~/agents
 | [dsh (DeepSeek Harness)](./dsh/) | OpenAI Chat Completions | 交互式 Form + Headless Bypass | `ask_user_question` | ❌ (无上限) | ❌ | ✅ (无 tool 时) |
 | [Hermes](./hermes/) | OpenAI Chat Completions | Header 预选（无 Form） | N/A | N/A | N/A | ✅ (header 缺失时) |
 | [OpenClaw](./openclaw/) | OpenAI Chat Completions | Header 预选（无 Form） | N/A | N/A | N/A | ✅ (header 缺失时) |
+| [Pi](./pi/) | OpenAI Chat Completions | 交互式 Form（TUI 菜单） | TUI picker (`↑↓`+`Enter`) | ❌ (无上限) | ❌ | ❌ |
 
 ---
 
@@ -108,6 +109,7 @@ tsx agents/asset-import.ts --source claude-code --agent-id <id> --team-id <tid> 
 | dsh | [asset-import.md](./dsh/asset-import.md) |
 | Hermes | [asset-import.md](./hermes/asset-import.md) |
 | OpenClaw | [asset-import.md](./openclaw/asset-import.md) |
+| Pi | [asset-import.md](./pi/asset-import.md) |
 
 ---
 

--- a/agents/asset-import.ts
+++ b/agents/asset-import.ts
@@ -400,7 +400,7 @@ export function parseJsonlLines(text: string): ImportMessage[] {
     try {
       const obj = JSON.parse(t) as Record<string, unknown>;
       let rec: Record<string, unknown> = obj;
-      if (obj.type === 'event_msg' || obj.type === 'session_meta' || obj.type === 'turn_context' || obj.type === 'world_state') {
+      if (obj.type === 'event_msg' || obj.type === 'session_meta' || obj.type === 'session' || obj.type === 'turn_context' || obj.type === 'world_state') {
         continue;
       }
       if (obj.type === 'response_item' && obj.payload && typeof obj.payload === 'object') {
@@ -2635,8 +2635,78 @@ function scanSessionsOverride(kind: AgentKind, sessionsDir: string): ScannedSess
   return { kind: KIND, scanSkills, scanSessions, scanSessionsOverride, detect };
 }
 
+function make_piAdapter(): IdeAdapter {
+const KIND = 'pi' as const;
+
+function piHome(): string {
+  const env = process.env.PI_HOME?.trim();
+  return env ? resolve(env) : join(home(), '.pi', 'agent');
+}
+
+function detect(): boolean {
+  return existsSync(join(home(), '.pi', 'agent'));
+}
+
+function scanSkills(opts?: ScanOptions): ScannedSkill[] {
+  const cwd = projectCwd(opts);
+  const h = home();
+  // Pi global skills: ~/.pi/agent/skills/*/SKILL.md
+  // Pi project skills: <cwd>/.pi/skills/*/SKILL.md
+  return collectSkillDirs(KIND, [
+    join(h, '.pi', 'agent', 'skills'),
+    join(cwd, '.pi', 'skills'),
+  ]);
+}
+
+function scanSessions(sessionsDir?: string, _opts?: ScanOptions): ScannedSession[] {
+  if (sessionsDir) return scanSessionsOverride(KIND, sessionsDir);
+  const out: ScannedSession[] = [];
+  // Pi sessions: ~/.pi/agent/sessions/<workspace-slug>/*.jsonl
+  // Each file is JSONL; first line is a {"type":"session"} header, rest are messages.
+  const root = join(piHome(), 'sessions');
+  if (existsSync(root)) {
+    for (const ws of readdirSync(root)) {
+      const dir = join(root, ws);
+      if (!statSync(dir).isDirectory()) continue;
+      for (const f of listJsonlRecursive(dir)) {
+        const msgs = parseJsonlLines(readFileSync(f, 'utf-8'))
+          .map((m) => ({ role: m.role, content: m.content, ts: m.ts, hasToolUse: m.hasToolUse }));
+        if (msgs.length) {
+          out.push({
+            sessionId: `${ws}/${basename(f, '.jsonl')}`,
+            messages: msgs,
+            sourceKey: `session:${KIND}:${f}`,
+            origin: f,
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function scanSessionsOverride(kind: AgentKind, sessionsDir: string): ScannedSession[] {
+  const out: ScannedSession[] = [];
+  for (const f of listJsonlRecursive(sessionsDir)) {
+    const msgs = parseJsonlLines(readFileSync(f, 'utf-8'))
+      .map((m) => ({ role: m.role, content: m.content, ts: m.ts, hasToolUse: m.hasToolUse }));
+    if (msgs.length) {
+      out.push({
+        sessionId: basename(f, '.jsonl'),
+        messages: msgs,
+        sourceKey: `session:${kind}:${f}`,
+        origin: f,
+      });
+    }
+  }
+  return out;
+}
+
+return { kind: KIND, scanSkills, scanSessions, scanSessionsOverride, detect };
+}
+
 export const ADAPTERS: Record<string, IdeAdapter> = {
-  openclaw: make_openclawAdapter(), codebuddy: make_codebuddyAdapter(), codex: make_codexAdapter(), 'claude-code': make_claude_codeAdapter(), dsh: make_dshAdapter(), hermes: make_hermesAdapter(), workbuddy: make_workbuddyAdapter(),
+  openclaw: make_openclawAdapter(), codebuddy: make_codebuddyAdapter(), codex: make_codexAdapter(), 'claude-code': make_claude_codeAdapter(), dsh: make_dshAdapter(), hermes: make_hermesAdapter(), workbuddy: make_workbuddyAdapter(), pi: make_piAdapter(),
 };
 
 /** 各 adapter 在项目目录（cwd）下的专属 marker 目录（用于「项目本地优先」判定）。 */
@@ -2648,6 +2718,7 @@ const CWD_MARKER_DIRS: Record<string, string[]> = {
   dsh: ['.dsh'],
   hermes: ['.hermes'],
   workbuddy: ['.workbuddy', 'workbuddy'],
+  pi: ['.pi'],
 };
 
 /** 第一优先：当前项目目录（cwd，或 --workspace 指定目录）里是否存在某个 adapter 的专属 marker 目录（不看 home）。 */

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -1,0 +1,154 @@
+# Pi (earendil-works)
+
+> agentSource: `pi` | 协议: OpenAI Chat Completions | Handler: `handler.ts` (与 CB / dsh / opencode 共享)
+>
+> 本地历史导入 Memory Hub：见 [资产导入手册](./asset-import.md)。
+
+---
+
+## 1. 客户端接入配置
+
+[Pi](https://github.com/earendil-works/pi-coding-agent) is a terminal coding agent with an extension system. Unlike the other agents (which point their base URL at the proxy via a config file), Pi uses a **Pi extension** (`@tencentdb-agent-memory/pi-tdai-client`) that registers a `tdai` provider, injects a per-session `x-conversation-id` header, and renders the interactive Team/Agent/Task picker as a Pi-native TUI menu.
+
+### 方式一：安装扩展 + 环境变量（推荐）
+
+```bash
+# Install the extension (one time)
+pi install npm:@tencentdb-agent-memory/pi-tdai-client
+
+# Set your user key (from the TDAI panel → API Key page)
+export TDAI_USER_KEY="<your-user-key>"
+
+# Run Pi with the tdai provider
+pi --provider tdai --model <model-id>
+```
+
+On the **first turn of each new session**, if no preset identity is set, the proxy sends a Team → Agent → Task form and the extension renders it as a TUI menu (`↑↓` navigate, `Enter` select, `Esc` cancel). Pick once and the session is bound for its lifetime — the chosen team's memory (L3 persona, L2 scene index) is injected and the conversation is captured (L0).
+
+### 方式二：固定身份（跳过 picker — CI / 脚本 / 固定上下文）
+
+```bash
+export TDAI_USER_KEY="<your-user-key>"
+export TDAI_TEAM_ID="<team-id>"
+export TDAI_AGENT_ID="<agent-id>"
+# TDAI_TASK_ID is optional — set only for task-scoped recall
+pi --provider tdai --model <model-id>
+```
+
+### 方式三：从仓库 checkout 快速加载（开发/测试）
+
+```bash
+export TDAI_USER_KEY="<your-user-key>"
+pi -e ./MemoryCore/pi-plugin --provider tdai --model <model-id>
+```
+
+### 环境变量
+
+| 变量 | 必填 | 默认值 | 说明 |
+|------|------|--------|------|
+| `TDAI_USER_KEY` | yes | — | 业务用户的 user_key（面板 → API Key 页） |
+| `TDAI_PROXY_URL` | no | `http://127.0.0.1:8096` | proxy 地址 |
+| `TDAI_SPACE_ID` | no | `default` | memory 实例 ID（本地部署固定 `default`） |
+| `TDAI_AGENT_SOURCE` | no | `pi` | agent source；设 `codebuddy` 可回退到 CodeBuddy profile 调试 |
+| `TDAI_TEAM_ID` | no | — | preset — 设后跳过 picker |
+| `TDAI_AGENT_ID` | no | — | preset — 设后跳过 picker |
+| `TDAI_TASK_ID` | no | — | preset — 设后缩小 recall 到特定 task |
+| `TDAI_MODEL` | no | — | 静态模型 ID（无动态模型目录时的兜底） |
+
+> `TDAI_TEAM_ID` + `TDAI_AGENT_ID` 同时设则跳过交互 picker。`TDAI_TASK_ID` 可选。
+> 缺少 `TDAI_USER_KEY` 不会阻塞 Pi 启动 — 扩展只 warn 并跳过注册 `tdai` provider。
+
+Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/agent/task）→ `injection`（把 L2/L3 记忆、skill、knowledge 注入 system prompt）→ 转发到上游 LLM。
+
+客户端发出的请求命中 `POST /pi/:spaceId/v1/chat/completions`。
+
+---
+
+## 2. Session ID
+
+| 优先级 | Header |
+|--------|--------|
+| 1 | `x-conversation-id` |
+
+Pi 扩展为每个 session 自动生成 `x-conversation-id`（格式 `pi-<uuid>`），无需手动配置。
+
+---
+
+## 3. Session Init（会话初始化 / Form）
+
+### 3.1 机制
+
+Pi 使用 **TUI 原生菜单** 发起交互式 Form：
+
+- 扩展拦截 proxy 返回的 session-init form，渲染为终端菜单
+- 按键：`↑↓` 导航，`Enter` 选择，`Esc` 取消
+- 要求交互式模式（默认的 `pi` TUI）；`pi -p` / RPC / 非 TUI 模式无法渲染，需用 preset 环境变量
+
+### 3.2 状态机
+
+```
+asset_confirm → team_select → agent_task_select → initialized
+```
+
+4 步流程：
+1. **asset_confirm** — 是否关联团队资产
+2. **team_select** — 选择团队
+3. **agent_task_select** — 选择 Agent（+ Task，Task 可跳过）
+4. **initialized** — 注入资产，进入正常对话
+
+### 3.3 预选身份（Header Auto-Select）
+
+设 `TDAI_TEAM_ID` + `TDAI_AGENT_ID` 后，proxy 跳过交互表单直接注册（`headerAutoSelect.enabled=true`）。
+
+---
+
+## 4. 模型目录（动态发现）
+
+扩展启动时调用 `GET {TDAI_PROXY_URL}/{TDAI_AGENT_SOURCE}/{TDAI_SPACE_ID}/v1/models`（user-key 鉴权），拉取上游网关模型列表并持久化。静态 `TDAI_MODEL` 是该端点不可达时的兜底。需 proxy 构建含 `handleModelsCatalog`（`GET /:agent/:spaceId/v1/models`）。
+
+---
+
+## 5. 注入
+
+Pi 的 system prompt 使用 `Label:` 行（非 markdown heading，也非 XML tag）。`PiProfile`（`MemoryProxy/src/injection/agents/pi/profile.ts`）按 label 行拆分并映射语义槽位：
+
+| 槽位 | Pi Label / 锚点 | 说明 |
+|------|-----------------|------|
+| tools | `Available tools` | skill tools 注入在 tools 之前 |
+| skills | `Guidelines` | 无独立 skills 段，锚定 Guidelines |
+| memory | `system.suffix` | 无 memory 段，注入到末尾 |
+| task_context | `<project_context>` | project context XML 块 |
+
+Lossless parse→rebuild（`join "\n"`，无 trim），保证 Pi prompt drift 不破坏注入——只移动锚位。
+
+---
+
+## 6. 验证（集成闸门）
+
+确认 proxy 识别 `pi` agent-source 且记忆已联通：
+
+```bash
+TDAI_USER_KEY=<your-user-key> TDAI_TEAM_ID=<...> TDAI_AGENT_ID=<...> \
+  pi -e ./MemoryCore/pi-plugin --provider tdai --model <model-id> -p "say OK"
+# 检查 proxy 日志：
+docker logs tdai-proxy --tail 30 2>&1 | grep -E "agentSource|write-l0|register"
+```
+
+预期看到 `agentSource=pi`、`register directly`、和 `write-l0` 行。若看到 `agentSource=codebuddy`（或默认值）或无 `write-l0`，说明 base URL 或身份 header 有误。
+
+---
+
+## 7. 故障排查
+
+- **交互模式是默认。** 未设 `TDAI_TEAM_ID`/`TDAI_AGENT_ID`/`TDAI_TASK_ID` 时，新 session 首轮显示 Team → Agent → Task picker（↑↓ + Enter）。需交互式（TUI）模式。
+- **使用用户 API key，不是 admin key。** Proxy 校验 `Authorization: Bearer` 对应用户的 API key（面板 → API Key）。admin/gateway key 是内部端点用的。
+- **`x-task-id` 可选。** 只需 team + agent 即可有记忆（宽 recall）。设 `TDAI_TASK_ID` 仅缩小 recall 到特定 Task。过期/未知 task id 会被 warn 并丢弃，不阻塞记忆。
+- **非交互模式需 preset 环境变量。** `pi -p` / RPC / 非 TUI 模式无法渲染 picker，需设 `TDAI_TEAM_ID`/`TDAI_AGENT_ID` 跳过。
+- **缺少必填环境变量不阻塞 Pi。** 若 `TDAI_USER_KEY` 未设，扩展在加载时 warn 并跳过注册 `tdai` provider — Pi 正常启动，只是没有 TDAI provider。设好变量重启 Pi 即可。
+- **回退到 CodeBuddy profile 调试。** 设 `TDAI_AGENT_SOURCE=codebuddy` 走已有验证的 CodeBuddy profile（注入仍工作；锚位更粗）。用于隔离问题是 Pi 特有还是 proxy/config 问题。
+
+---
+
+## 8. 扩展源码
+
+Pi 扩展源码在 `MemoryCore/pi-plugin/`。详见 [pi-plugin README](../../MemoryCore/pi-plugin/README.md)。

--- a/agents/pi/asset-import.md
+++ b/agents/pi/asset-import.md
@@ -1,0 +1,52 @@
+# Pi 资产导入
+
+把本机 Pi 的 **skill / session** 导入 Memory Hub。这一份手册即可完成。
+
+
+## 扫什么
+
+| 类型 | 路径 |
+|------|------|
+| Skill | `~/.pi/agent/skills/*/SKILL.md`；项目 `<cwd>/.pi/skills/*/SKILL.md` |
+| Session | `~/.pi/agent/sessions/<workspace-slug>/*.jsonl` |
+
+`--workspace` 把项目侧路径改成该目录（不排除 `~/.pi/agent` 全局）。
+
+Pi session 文件格式为 JSONL（每行一个 JSON 对象），首行是 `{"type":"session","id":"...","cwd":"..."}` 头，后续行为对话消息。
+
+## 前置
+
+在仓库根执行。需要 Node >= 22，以及：
+
+```bash
+export PANEL_URL=http://127.0.0.1:8123
+export TDAI_SERVICE_ID=<spaceId>
+export TDAI_USER_KEY=<该 agent owner 的 sk-mem-...>
+```
+
+`--agent-id` / `--team-id` 必填；owner 必须等于 `TDAI_USER_KEY` 反查用户。
+
+## 用法
+
+统一入口为仓库根 `agents/asset-import.ts`。用 `--source pi` 指定本手册对应的 IDE；省略时默认 `auto` 自动识别当前工作区所用 IDE。
+
+```bash
+# 交互式导入：先列举待导入项 —— skill（编号/名称/描述/来源/关联脚本数）、session（id/时间范围/项目路径），再选择「全导入 / 不导入 / 部分导入」（部分导入可填编号或 ID，逗号/空格分隔，可多个）
+tsx agents/asset-import.ts --source pi --agent-id <id> --team-id <tid>
+
+# 非交互（脚本/CI，直接全量导入，不询问）
+tsx agents/asset-import.ts --source pi --agent-id <id> --team-id <tid> -y
+
+# 指定项目目录
+tsx agents/asset-import.ts --source pi --workspace /path/to/repo --agent-id <id> --team-id <tid>
+
+# 重新导入（忽略断点续传，重导已导入项）
+tsx agents/asset-import.ts --source pi --agent-id <id> --team-id <tid> --force
+
+```
+
+## 注意
+
+- Pi 的 `--sessions` 覆盖可直接指向 `~/.pi/agent/sessions/` 下的某个 workspace 子目录（如 `--sessions ~/.pi/agent/sessions/--home-nick-myproject--`）。
+- Skill 路径同时扫描全局（`~/.pi/agent/skills/`）和项目本地（`<cwd>/.pi/skills/`），`--workspace` 只影响项目侧。
+- Session JSONL 的首行 `type: "session"` 头会被跳过，只导入后续消息行。

--- a/agents/setup-proxy.sh
+++ b/agents/setup-proxy.sh
@@ -2,7 +2,7 @@
 # ──────────────────────────────────────────────────────────────────────────────
 # agents/setup-proxy.sh — One-shot interactive proxy configuration for AI agents
 #
-# Supports: Claude Code | CodeBuddy | Codex | WorkBuddy | dsh | Hermes | OpenClaw
+# Supports: Claude Code | CodeBuddy | Codex | WorkBuddy | dsh | Hermes | OpenClaw | Pi
 #
 # Usage:
 #   bash agents/setup-proxy.sh            # interactive
@@ -88,7 +88,7 @@ check_jq() {
 }
 
 # ─── Constants ────────────────────────────────────────────────────────────────
-AGENTS=("claude-code" "codebuddy" "codex" "workbuddy" "dsh" "hermes" "openclaw")
+AGENTS=("claude-code" "codebuddy" "codex" "workbuddy" "dsh" "hermes" "openclaw" "pi")
 AGENT_LABELS=(
   "Claude Code       — Anthropic Messages, ~/.claude/settings.json"
   "CodeBuddy         — OpenAI Chat, ~/.codebuddy/models.json"
@@ -97,6 +97,7 @@ AGENT_LABELS=(
   "dsh (DeepSeek)    — OpenAI Chat, ~/.dsh/settings.yaml + .credentials.yaml"
   "Hermes            — OpenAI Chat + Header预选, ~/.hermes/config.yaml"
   "OpenClaw          — OpenAI Chat + Header预选, ~/.openclaw/openclaw.json"
+  "Pi               — OpenAI Chat + Pi extension, env vars (no config file)"
 )
 
 DEFAULT_CONFIG_PATHS=(
@@ -107,6 +108,7 @@ DEFAULT_CONFIG_PATHS=(
   "~/.dsh/settings.yaml"
   "~/.hermes/config.yaml"
   "~/.openclaw/openclaw.json"
+  "~/.pi/agent/settings.json"
 )
 
 # Expand ~ to $HOME for actual file operations
@@ -156,7 +158,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --task-id ID       Task ID (or 'no-task')"
       echo "  --conv-id ID       Conversation ID"
       echo ""
-      echo "Agents: claude-code|codebuddy|codex|workbuddy|dsh|hermes|openclaw"
+      echo "Agents: claude-code|codebuddy|codex|workbuddy|dsh|hermes|openclaw|pi"
       exit 0 ;;
     *) error "Unknown arg: $1"; exit 1 ;;
   esac
@@ -335,6 +337,24 @@ if ! $SCAN_FOUND; then
       SCAN_KEY=$(jq -r '.models.providers[]? | select(.baseUrl and (.baseUrl | contains("/openclaw/"))) | .apiKey' "$_oc_path" 2>/dev/null | head -1)
       SCAN_MODEL=$(jq -r '.models.providers[]? | select(.baseUrl and (.baseUrl | contains("/openclaw/"))) | .models[0].id' "$_oc_path" 2>/dev/null | head -1)
       [[ -n "$SCAN_PROXY" ]] && SCAN_FOUND=true && SCAN_SOURCES+=("openclaw → $_oc_path")
+    fi
+  fi
+fi
+
+# --- Scan Pi (~/.pi/agent/settings.json) ---
+if ! $SCAN_FOUND; then
+  _pi_path="$(expand_path "~/.pi/agent/settings.json")"
+  if [[ -f "$_pi_path" && -s "$_pi_path" ]]; then
+    # Pi stores defaultProvider="tdai" and defaultModel; the proxy URL is in env
+    # (TDAI_PROXY_URL), not in settings.json. We detect by checking if the
+    # @tencentdb-agent-memory/pi-tdai-client package is listed.
+    _pi_pkg=$(jq -r '.packages[]? | select(. | tostring | contains("pi-tdai-client")) | tostring' "$_pi_path" 2>/dev/null | head -1)
+    if [[ -n "$_pi_pkg" ]]; then
+      # Proxy URL comes from env, not the config file — use the default
+      SCAN_PROXY="http://127.0.0.1:8096"
+      SCAN_INSTANCE="default"
+      SCAN_MODEL=$(jq -r '.defaultModel // empty' "$_pi_path" 2>/dev/null)
+      [[ -n "$SCAN_PROXY" ]] && SCAN_FOUND=true && SCAN_SOURCES+=("pi → $_pi_path (package detected)")
     fi
   fi
 fi
@@ -1064,6 +1084,62 @@ write_openclaw() {
   echo -e "  • 在 OpenClaw 中选择 provider 为 ${BOLD}memory-proxy${RESET}，模型选 ${BOLD}${MODEL_ID}${RESET}"
 }
 
+write_pi() {
+  # Pi doesn't use a config file — it uses a Pi extension + env vars.
+  # This function guides the user through the env-var setup and optionally
+  # installs the extension, rather than writing a config file.
+  local _unused="$1"
+
+  echo -e "${BOLD}Pi 通过 Pi 扩展 + 环境变量接入 Proxy（不写配置文件）${RESET}"
+  echo ""
+  echo -e "  ${DIM}扩展注册 tdai provider，自动注入 x-conversation-id，${RESET}"
+  echo -e "  ${DIM}并在首轮渲染 Team/Agent/Task 交互选择器。${RESET}"
+  echo ""
+
+  # Step 1: Install the extension
+  header "Step 1: 安装 Pi 扩展"
+  if command -v pi &>/dev/null; then
+    if confirm "执行 pi install npm:@tencentdb-agent-memory/pi-tdai-client?" "y"; then
+      pi install npm:@tencentdb-agent-memory/pi-tdai-client
+      success "扩展已安装"
+    else
+      warn "跳过安装。手动执行: pi install npm:@tencentdb-agent-memory/pi-tdai-client"
+    fi
+  else
+    warn "pi 未找到，跳过自动安装。请手动执行:"
+    echo -e "  ${BOLD}pi install npm:@tencentdb-agent-memory/pi-tdai-client${RESET}"
+  fi
+
+  # Step 2: Show env vars to set
+  header "Step 2: 环境变量"
+  echo -e "  将以下变量加入 shell 配置（~/.bashrc / ~/.zshrc）或项目 .env："
+  echo ""
+  echo -e "  ${BOLD}export TDAI_USER_KEY=${USER_KEY}${RESET}"
+  echo -e "  export TDAI_PROXY_URL=${PROXY_HOST}"
+  echo -e "  export TDAI_SPACE_ID=${INSTANCE_ID}"
+  if [[ -n "$TEAM_ID" ]]; then
+    echo -e "  export TDAI_TEAM_ID=${TEAM_ID}"
+    echo -e "  export TDAI_AGENT_ID=${AGENT_ID}"
+    if [[ -n "$TASK_ID" && "$TASK_ID" != "no-task" ]]; then
+      echo -e "  export TDAI_TASK_ID=${TASK_ID}"
+    fi
+  else
+    echo -e "  ${DIM}# 不设 TDAI_TEAM_ID / TDAI_AGENT_ID 则首轮弹交互选择器${RESET}"
+  fi
+  echo ""
+
+  # Step 3: How to run
+  header "Step 3: 启动"
+  echo -e "  ${BOLD}pi --provider tdai --model ${MODEL_ID}${RESET}"
+  echo -e "  ${DIM}首轮会弹 Team/Agent/Task 选择器（↑↓ + Enter）${RESET}"
+  echo ""
+  if [[ -n "$TEAM_ID" ]]; then
+    success "已配置固定身份，跳过交互选择器"
+  else
+    warn "交互模式：首轮选择 Team/Agent/Task 后，session 绑定该身份"
+  fi
+}
+
 # ─── Execute Write ────────────────────────────────────────────────────────────
 case "$CHOSEN_AGENT" in
   claude-code) write_claude_code "$CONFIG_PATH" ;;
@@ -1073,6 +1149,7 @@ case "$CHOSEN_AGENT" in
   dsh)         write_dsh "$CONFIG_PATH" ;;
   hermes)      write_hermes "$CONFIG_PATH" ;;
   openclaw)    write_openclaw "$CONFIG_PATH" ;;
+  pi)          write_pi "$CONFIG_PATH" ;;
 esac
 
 # ━━━ Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -1113,6 +1190,9 @@ case "$CHOSEN_AGENT" in
     ;;
   hermes|openclaw)
     warn "使用时确保客户端选择的模型/provider 指向 Proxy 配置（${MODEL_ID}）"
+    ;;
+  pi)
+    warn "使用时运行: ${BOLD}pi --provider tdai --model ${MODEL_ID}${RESET}"
     ;;
 esac
 echo ""


### PR DESCRIPTION
## Problem

The memory-bridge and skill-bridge read path is broken for any agent source other than `codebuddy` and `claude-code`. When an agent (pi, dsh, codex, workbuddy, opencode) tries to search its L1/L0 memory or load skills via the bridge, it receives `40101 "session not initialized"` — even though the session was successfully initialized and the agent has persona/skills injected.

This affects **every default-install user** (the 3-container `start-all.sh` deploy with no Redis and no `storage:` section), not just custom deployments.

## Root Causes

### Bug 1: BindingRepo never activated in default install

The default install generates `redis: enabled: false` and no `storage:` section. The eager activation block in `server.ts` only calls `tryActivateStorage` and `tryActivateRedis` — both silently no-op when their config flags are false.

`ensureBindingRepoPersistent` (the fs fallback) is only called inside `buildPipelineBundle`, which runs **lazily on the first main request** — after `completeRegistration` → `store.set()` already skipped the L2b binding write because `this.bindingRepo` was still `null`.

Result: the L2b binding (designed as the bridge's L2 backstop, keyed by `(spaceId, sessionId)`) is never written. The bridge L2 lookup always misses.

### Bug 2: Bridge L1 lookup uses a hardcoded agent-source prefix list

`loadSessionIdsL1` in both `memory-bridge.ts` and `skill-bridge.ts` tries these candidate keys:
```typescript
const candidates = sessionId.includes(":")
  ? [sessionId]
  : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
```

The `pi:` prefix (and `dsh:`, `codex:`, `workbuddy:`, `opencode:`) is missing. The L1 state IS in the `states` Map under `pi:sessionId`, but the bridge never looks there.

## Fixes

### Fix 1: Eagerly activate BindingRepo at startup

Add `ensureBindingRepoPersistent(config)` to the `server.ts` eager block, right after `tryActivateStorage`/`tryActivateRedis`. It is idempotent (no-ops if a BindingRepo was already set by storage/redis).

This ensures the BindingRepo is ready before any request can trigger `completeRegistration`, so the L2b binding write actually happens.

### Fix 2: Enumerate L1 keys by suffix instead of hardcoded prefixes

Add `SessionStore.keysWithSuffix(sessionId)` — returns all L1 keys matching `:${sessionId}` (or the bare sessionId). Both bridges use it in `loadSessionIdsL1`:

```typescript
function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
  const store = getSessionStore();
  const bare = store.get(sessionId);
  if (bare) { /* ... */ }
  if (!sessionId.includes(":")) {
    for (const k of store.keysWithSuffix(sessionId)) {
      const state = store.get(k);
      if (state) { /* ... */ }
    }
  }
  return null;
}
```

This works for **any** current or future agentSource without maintaining a hardcoded list.

## Impact

- **No breaking changes.** The L2b binding write and L1 lookup are additive — existing codebuddy/claude-code sessions continue to work exactly as before.
- **No new dependencies.** Uses the existing `SessionStore.states` Map.
- **Default install now functional.** The 3-container deploy (no Redis, no storage) now has a working bridge read path.

## Testing

6 new tests in `src/__tests__/bridge-session-resolution.test.ts`:
- `keysWithSuffix`: bare match, multi-agent-source, no-match, substring-vs-suffix
- Integration: pi-prefixed and dsh-prefixed sessions found with bare sessionId

All 14 tests pass (8 existing + 6 new).

## Files Changed

| File | Change |
|------|--------|
| `src/server.ts` | Add `ensureBindingRepoPersistent(config)` to eager activation |
| `src/session/store.ts` | Add `keysWithSuffix(sessionId)` method |
| `src/memory/memory-bridge.ts` | Use `keysWithSuffix` in `loadSessionIdsL1` |
| `src/skill/skill-bridge.ts` | Use `keysWithSuffix` in `loadSessionIdsL1` |
| `src/__tests__/bridge-session-resolution.test.ts` | New test file