### PR TITLE
fix(knowledge): enforce auto-sync build concurrency

### DIFF
--- a/MemoryKnowledge/src/store/auto-sync-scheduler.test.ts
+++ b/MemoryKnowledge/src/store/auto-sync-scheduler.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoSyncScheduler } from "./auto-sync-scheduler.js";
+import { CodeGraphService } from "./code-graph-service.js";
+import type { CodeGraphRow, IKnowledgeStore } from "./types.js";
+
+describe("AutoSyncScheduler build concurrency", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each([1, 2, 3])("holds each of %i slots until the actual build finishes", async (limit) => {
+    const rows = Array.from({ length: 6 }, (_, i) => ({
+      service_id: "test-service", team_id: "test-team", code_graph_id: `graph-${i}`,
+      repo_url: `https://example.invalid/repo-${i}.git`, branch: "main",
+      status: "ready", internal_status: null, version: 1,
+    } as CodeGraphRow));
+    const byId = new Map(rows.map((row) => [row.code_graph_id, row]));
+    const store = {
+      listSyncedCodeGraphs: () => rows.filter((row) => row.status === "ready"),
+      getCodeGraph: (_service: string, _team: string, id: string) => byId.get(id) ?? null,
+      getCodeGraphById: (_service: string, id: string) => byId.get(id) ?? null,
+      updateCodeGraphStatus: (_service: string, id: string, patch: Partial<CodeGraphRow>) => {
+        Object.assign(byId.get(id)!, patch);
+      },
+      appendCodeGraphAudit: () => {},
+    } as unknown as IKnowledgeStore;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let active = 0;
+    let peak = 0;
+    let started = 0;
+    const service = new CodeGraphService({
+      store, dataRoot: "/unused-test-root",
+      worker: async () => {
+        started++;
+        active++;
+        peak = Math.max(peak, active);
+        await gate;
+        active--;
+        return {};
+      },
+    });
+    const scheduler = new AutoSyncScheduler({
+      store, cgService: service,
+      config: { enabled: true, scanIntervalMs: 600_000, maxConcurrentSyncs: limit },
+    });
+    scheduler.start();
+    scheduler.triggerScan();
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      expect(started).toBe(limit);
+      expect(active).toBe(limit);
+      expect(scheduler.getStatus()).toMatchObject({ activeSyncs: limit, queueLength: rows.length - limit });
+      release();
+      await vi.advanceTimersByTimeAsync(100);
+      await service.onIdle();
+      expect(started).toBe(rows.length);
+      expect(peak).toBeLessThanOrEqual(limit);
+      expect(scheduler.getStatus()).toMatchObject({ activeSyncs: 0, queueLength: 0 });
+      expect(rows.every((row) => row.status === "ready")).toBe(true);
+    } finally {
+      release();
+      scheduler.stop();
+      await service.onIdle();
+    }
+  });
+});

--- a/MemoryKnowledge/src/store/auto-sync-scheduler.ts
+++ b/MemoryKnowledge/src/store/auto-sync-scheduler.ts
@@ -290,6 +290,9 @@ export class AutoSyncScheduler {
       switch (result.kind) {
         case "ok":
           log.info(`[auto-sync] sync enqueued for ${row.code_graph_id} (took ${durationMs}ms)`);
+          // sync() only enqueues a per-asset build. Hold this worker slot until
+          // that build completes; enqueue acceptance is not sync completion.
+          await this.cgService.onIdle(row.code_graph_id);
           break;
         case "busy":
           log.debug(`[auto-sync] skip ${row.code_graph_id}: already ${result.status} (step: ${result.step})`);


### PR DESCRIPTION
## Description | 描述

`AutoSyncScheduler.maxConcurrentSyncs` currently limits scheduler workers, but `CodeGraphService.sync()` returns immediately after enqueueing a per-asset `BuildQueue` job. The scheduler therefore releases its slot before the actual clone/index build finishes, and multiple real builds can exceed the configured limit.

This change waits for `CodeGraphService.onIdle(code_graph_id)` after a successful enqueue, so a scheduler slot remains occupied until that asset's build completes. It also adds a fake-timer regression test for configured limits 1, 2, and 3.

## Related Issue | 关联 Issue

N/A — no exact existing issue was found for this enqueue-vs-completion concurrency gap. Existing #737 concerns waking stopped auto-sync workers and is a different failure mode.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Verification

- Baseline regression: with six ready repositories, configured limits 1/2/3 all started six builds.
- Patched regression: peak build concurrency never exceeded the configured limit; 3/3 tests passed.
- `MemoryKnowledge`: `pnpm run build` passed.
- `git diff --cached --check` passed.
- Commit includes DCO sign-off.
