### PR TITLE
[good first issue-platform adapt-Claude Code] Add native Memory plugin for Claude Code (hooks + MCP, no proxy)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -287,6 +287,7 @@ The Proxy supports 9 agent clients. **Full setup instructions, adaptation detail
 | **Hermes** | `~/.hermes/config.yaml` + header preselect | [`agents/hermes/`](./agents/hermes/) |
 | **OpenClaw** | `~/.openclaw/openclaw.json` + header preselect | [`agents/openclaw/`](./agents/openclaw/) |
 | **Pi** | `pi-plugin` extension (env vars) | [`MemoryCore/pi-plugin/`](./MemoryCore/pi-plugin/) |
+| **Claude Code (native, no proxy)** | lifecycle hooks + stdio MCP server (env vars); model traffic stays with Anthropic | [`MemoryCore/claude-code-plugin/`](./MemoryCore/claude-code-plugin/) |
 | **Other platforms** | Header preselect (generic) | [`agents/README.md`](./agents/README.md) |
 
 The proxy pipeline in order: `auth` (validates user_key) → `sessionInit`

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -263,6 +263,8 @@ Proxy 目前支持 8 类 AI Agent 客户端。每个 agent 的**完整接入配�
 | **OpenCode** | `~/.config/opencode/opencode.json` | [`agents/opencode/`](./agents/opencode/) |
 | **Hermes** | `~/.hermes/config.yaml` + Header 预选 | [`agents/hermes/`](./agents/hermes/) |
 | **OpenClaw** | `~/.openclaw/openclaw.json` + Header 预选 | [`agents/openclaw/`](./agents/openclaw/) |
+| **Pi** | `pi-plugin` 扩展（环境变量） | [`MemoryCore/pi-plugin/`](./MemoryCore/pi-plugin/) |
+| **Claude Code（原生，不经代理）** | 生命周期 Hook + stdio MCP server（环境变量）；模型流量仍直连 Anthropic | [`MemoryCore/claude-code-plugin/`](./MemoryCore/claude-code-plugin/) |
 | **其他平台** | Header 预选（通用） | [`agents/README.md`](./agents/README.md) |
 
 Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/agent/task

--- a/MemoryCore/claude-code-plugin/.gitignore
+++ b/MemoryCore/claude-code-plugin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tgz
+package-lock.json

--- a/MemoryCore/claude-code-plugin/README.md
+++ b/MemoryCore/claude-code-plugin/README.md
@@ -1,0 +1,132 @@
+# Claude Code Adapter for TencentDB Agent Memory (v3, native)
+
+[简体中文](./README_CN.md) · English
+
+This directory is the **Claude Code client adapter** for Memory Gateway **`/v3/*`**. Like the [OpenClaw client adapter](../openclaw-plugin/), it is a pure client: it runs no extraction, indexing, scene or persona generation, and it does **not** route Claude Code's model traffic through a proxy. Claude Code keeps talking to Anthropic directly; memory is added through Claude Code's own lifecycle hooks and a stdio MCP server, both backed by the npm TypeScript SDK.
+
+| Item | Value |
+|------|-------|
+| Host | Claude Code `v2.1.196+` (supplies `prompt_id` and `transcript_path` in hook payloads) |
+| SDK | [`@tencentdb-agent-memory/memory-sdk-ts-v2`](https://www.npmjs.com/package/@tencentdb-agent-memory/memory-sdk-ts-v2) (`V3MemoryClient` → `/v3/*` with `teamId` / `agentId` / `userId` isolation) |
+| Hooks | `UserPromptSubmit` recall · `Stop` per-turn capture · `SessionEnd` remainder capture |
+| MCP tools | `tdai_memory_search`, `tdai_conversation_search`, `tdai_scenario_read`, `tdai_memory_capture`, and `tdai_wiki_*` when a Knowledge Service is configured |
+| Not included | Proxy routing, Offload, COS file read |
+
+When to choose this over the [proxy route](../../agents/claude-code/): you want memory without moving Claude Code's model traffic, key, or billing to the proxy. When to choose the proxy: you want zero-code setup and server-side injection, and routing through the proxy is acceptable.
+
+## Architecture
+
+```text
+Claude Code
+  ├─ hooks (one process per event; ~/.claude/settings.json)
+  │    UserPromptSubmit → dist/hooks/cli.js → searchAtomic (+ readCore, listScenarios once per session)
+  │                        → additionalContext: <user-persona>, <scene-navigation>, <relevant-memories>, tool guide
+  │    Stop             → dist/hooks/cli.js → transcript delta of the finished turn → addConversation (L0)
+  │    SessionEnd       → dist/hooks/cli.js → whatever transcript remains → addConversation (L0)
+  └─ MCP server (stdio; ~/.claude.json or .mcp.json)
+       dist/mcp/stdio.js → tdai_memory_search / tdai_conversation_search / tdai_scenario_read / tdai_memory_capture
+                          → tdai_wiki_list / search / pages / read / write   (Knowledge Service, optional)
+            │
+            ▼
+       TencentDB Agent Memory Gateway (:8420)   +   Knowledge Service (:8421, optional)
+```
+
+## What gets captured
+
+`Stop` reads the session transcript named by `transcript_path` in the hook payload (fallback: `<config dir>/projects/<cwd with non-alphanumerics as "-">/<session_id>.jsonl`) and sends the finished turn as one `addConversation` call: the prompt, every tool call, every tool result, intermediate and final assistant text. `SessionEnd` sends whatever is still unsent, for example a turn whose Stop was skipped because background tasks were running.
+
+- Thinking blocks and images are dropped. A tool call becomes assistant text `[tool_use id=… name=… input=…]` (input quoted up to 2000 characters); a tool result becomes user text `[tool_result tool_use_id=…] …` (up to 4000 characters). Messages longer than 8192 characters are chunked; batches hold at most 100 messages.
+- Credential-shaped substrings (private keys, bearer tokens, `sk-…` keys, GitHub / GitLab / Slack / AWS / Google / npm tokens, `password=…` values) are replaced by `[redacted:<kind>]` before anything leaves the machine. Tool traffic routinely carries env dumps and config files.
+- A per-session marker in the state directory records the last transcript entry sent. A batch that fails leaves the marker where it was and the turn unclaimed, so `SessionEnd` sends the rest. A resumed session that ends again sends only what is new.
+- When no transcript can be read, `Stop` falls back to the prompt and final assistant message. A turn captured that way contributes only its tool traffic later, so nothing lands twice.
+- Capture is skipped while `background_tasks` or `session_crons` are present, so a pause with work in flight is not treated as a final response.
+
+Why per turn rather than at session end: a 100-message batch costs the Gateway a few seconds, and a session's `SessionEnd` fires once, so an end-only capture loses the tail of a long session.
+
+## What gets recalled
+
+On every prompt the L1 hits for that prompt are injected as `<relevant-memories>`. On the session's first prompt the stable block is added once: the L3 persona (`<user-persona>`), the L2 scene index (`<scene-navigation>`, readable with `tdai_scenario_read`), and a short guide to the MCP tools. If every recall request fails, nothing is injected and the stable block is retried on the next prompt.
+
+## Quick Start
+
+### 1. Build
+
+```bash
+cd MemoryCore/claude-code-plugin
+npm install
+npm run build          # → dist/hooks/cli.js, dist/mcp/stdio.js
+npm test
+```
+
+### 2. Environment
+
+Set these in the shell that launches `claude` (or in the `env` block of `~/.claude/settings.json`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TDAI_GATEWAY_URL` | `http://127.0.0.1:8420` | Memory Gateway base URL. |
+| `TDAI_GATEWAY_API_KEY` (or `TDAI_API_KEY`) | `local` | Bearer token for the Gateway. |
+| `TDAI_SERVICE_ID` | `default` | Memory instance id (`x-tdai-service-id`). |
+| `TDAI_TEAM_ID` / `TDAI_AGENT_ID` / `TDAI_USER_ID` | `default` | v3 isolation triple, from the panel. |
+| `TDAI_KNOWLEDGE_URL` | unset | Knowledge Service base URL; enables the `tdai_wiki_*` tools. |
+| `TDAI_KNOWLEDGE_API_KEY` | falls back to the Gateway key | Bearer token for the Knowledge Service. |
+| `TDAI_CLAUDE_CODE_STATE_DIR` | `~/.memory-tencentdb/claude-code-plugin` | Prompt cache, capture markers, transcript position. |
+| `TDAI_RECALL_MAX_RESULTS` | `5` | L1 hits per prompt. |
+| `TDAI_RECALL_PERSONA` / `TDAI_RECALL_SCENE_NAV` | `on` | Set `off` to leave persona / scene index out of the first-prompt block. |
+| `TDAI_CAPTURE` | `on` | Set `off` to disable capture at Stop and SessionEnd. |
+| `TDAI_STOP_BUDGET_MS` / `TDAI_SESSION_END_BUDGET_MS` | `3500` / `25000` | Wall-clock budgets for transcript batches. A budget only stops new batches from starting. |
+| `TDAI_RECALL_TIMEOUT_MS` / `TDAI_CAPTURE_TIMEOUT_MS` | `3000` / `15000` | Gateway timeouts for recall and for one capture batch. |
+
+### 3. Hooks
+
+Merge [`integrations/hooks.json`](./integrations/hooks.json) into `~/.claude/settings.json` (every project) or `.claude/settings.json` (one project), replacing the absolute path. The hook timeouts (5 s, 15 s, 30 s) must cover a batch in flight, or the Gateway records a batch whose marker is never written. Check with `/hooks` inside Claude Code.
+
+### 4. MCP server
+
+Copy [`integrations/mcp.json.example`](./integrations/mcp.json.example) to the project root as `.mcp.json`, or register for every project:
+
+```bash
+claude mcp add --transport stdio --scope user tdai -- \
+  node /absolute/path/to/TencentDB-Agent-Memory/MemoryCore/claude-code-plugin/dist/mcp/stdio.js
+```
+
+Check with `/mcp`. Tell the model which wiki id to use in your `CLAUDE.md`; the adapter never assumes one.
+
+### 5. Test a hook by hand
+
+```bash
+printf '%s' '{"hook_event_name":"UserPromptSubmit","session_id":"demo","prompt_id":"p1","cwd":"/tmp","prompt":"what is our release flow?"}' \
+  | node dist/hooks/cli.js
+```
+
+Expect `{}` when nothing matches, or `hookSpecificOutput.additionalContext` when recall succeeds.
+
+## Adapter responsibilities
+
+- Hook processes share state only through files under the state directory (hashed names, 0600). Prompt cache and capture markers expire after 24 hours; session markers after 30 days.
+- Every path fails open. Recall errors return `{}`; capture errors are logged to stderr and retried by a later hook; the MCP server surfaces Gateway errors as tool errors.
+- The plugin holds no organisation-specific content: wiki ids are tool parameters, identity comes from the environment.
+
+## Files
+
+```text
+claude-code-plugin/
+├── src/
+│   ├── config.ts            env → config
+│   ├── client.ts            V3MemoryClient + Knowledge client factories
+│   ├── format.ts            recall context formatting
+│   ├── knowledge.ts         Knowledge Service client + wiki tools
+│   ├── hooks/
+│   │   ├── cli.ts           hook entry (stdin → stdout)
+│   │   ├── handler.ts       UserPromptSubmit / Stop / SessionEnd
+│   │   ├── recall.ts        searchAtomic + readCore + listScenarios
+│   │   ├── capture.ts       transcript delta → addConversation
+│   │   ├── transcript.ts    JSONL parsing, normalisation, redaction, chunking
+│   │   └── state.ts         prompt cache, capture markers, session markers
+│   └── mcp/
+│       ├── server.ts        tool definitions
+│       └── stdio.ts         MCP entry
+├── __tests__/               vitest
+├── integrations/            hooks.json, mcp.json.example
+└── README.md / README_CN.md
+```

--- a/MemoryCore/claude-code-plugin/README_CN.md
+++ b/MemoryCore/claude-code-plugin/README_CN.md
@@ -1,0 +1,132 @@
+# Claude Code 适配器（v3，原生接入）
+
+简体中文 · [English](./README.md)
+
+本目录是 Memory Gateway **`/v3/*`** 的 **Claude Code 客户端适配器**。与 [OpenClaw 客户端适配器](../openclaw-plugin/) 一样，它是纯客户端：不做抽取、索引、场景或人格生成，也**不**把 Claude Code 的模型流量转到代理。Claude Code 仍然直接访问 Anthropic；记忆能力通过 Claude Code 自身的生命周期 Hook 和一个 stdio MCP server 接入，两者都基于 npm TypeScript SDK。
+
+| 项目 | 值 |
+|------|----|
+| 宿主 | Claude Code `v2.1.196+`（hook 载荷提供 `prompt_id` 与 `transcript_path`） |
+| SDK | [`@tencentdb-agent-memory/memory-sdk-ts-v2`](https://www.npmjs.com/package/@tencentdb-agent-memory/memory-sdk-ts-v2)（`V3MemoryClient` → `/v3/*`，`teamId` / `agentId` / `userId` 隔离） |
+| Hook | `UserPromptSubmit` 召回 · `Stop` 逐回合捕获 · `SessionEnd` 补发剩余 |
+| MCP 工具 | `tdai_memory_search`、`tdai_conversation_search`、`tdai_scenario_read`、`tdai_memory_capture`；配置 Knowledge Service 后另有 `tdai_wiki_*` |
+| 不包含 | 代理路由、Offload、COS 文件读取 |
+
+何时选它而不是[代理方式](../../agents/claude-code/)：你希望获得记忆，但不想把 Claude Code 的模型流量、密钥和计费转到代理上。何时选代理：你希望零代码接入和服务端注入，且可以接受流量经过代理。
+
+## 架构
+
+```text
+Claude Code
+  ├─ hooks（每个事件一个进程；~/.claude/settings.json）
+  │    UserPromptSubmit → dist/hooks/cli.js → searchAtomic（每会话首次另加 readCore、listScenarios）
+  │                        → additionalContext：<user-persona>、<scene-navigation>、<relevant-memories>、工具指引
+  │    Stop             → dist/hooks/cli.js → 本回合转录增量 → addConversation（L0）
+  │    SessionEnd       → dist/hooks/cli.js → 尚未发送的转录 → addConversation（L0）
+  └─ MCP server（stdio；~/.claude.json 或 .mcp.json）
+       dist/mcp/stdio.js → tdai_memory_search / tdai_conversation_search / tdai_scenario_read / tdai_memory_capture
+                          → tdai_wiki_list / search / pages / read / write（Knowledge Service，可选）
+            │
+            ▼
+       TencentDB Agent Memory Gateway（:8420）  +  Knowledge Service（:8421，可选）
+```
+
+## 捕获什么
+
+`Stop` 读取 hook 载荷中 `transcript_path` 指向的会话转录（缺省时按 `<config dir>/projects/<cwd 中非字母数字替换为 "-">/<session_id>.jsonl` 定位），把刚结束的回合作为一次 `addConversation` 发送：prompt、每一次工具调用、每一个工具结果、中间与最终回复。`SessionEnd` 发送尚未发送的部分，例如因后台任务运行而跳过了 Stop 的回合。
+
+- thinking 与图片丢弃。tool_use 转为 assistant 文本 `[tool_use id=… name=… input=…]`（input 最多引用 2000 字符）；tool_result 转为 user 文本 `[tool_result tool_use_id=…] …`（最多 4000 字符）。超过 8192 字符的消息分块；每批最多 100 条。
+- 凭证形状的片段（私钥、Bearer token、`sk-…` 密钥、GitHub / GitLab / Slack / AWS / Google / npm token、`password=…` 之类的值）在离开本机前替换为 `[redacted:<kind>]`。工具流量经常带有 env 输出与配置文件。
+- 状态目录中的会话 marker 记录最后发送的转录条目。失败的批次不推进 marker，回合也不标记为已捕获，由 `SessionEnd` 补发。resume 后再次结束的会话只发送新增部分。
+- 读不到转录时，`Stop` 退回到只发送 prompt 与最终回复；这种回合之后只补发工具流量，不会重复落库。
+- 存在 `background_tasks` 或 `session_crons` 时跳过捕获，避免把等待后台工作的停顿当作最终回复。
+
+为何按回合而不是在会话结束时发送：100 条消息的批次要占 Gateway 数秒，而一个会话的 `SessionEnd` 只触发一次，全部留到最后会丢失长会话的尾部。
+
+## 召回什么
+
+每个 prompt 注入该 prompt 的 L1 命中（`<relevant-memories>`）。会话首个 prompt 另加一次稳定内容：L3 人格（`<user-persona>`）、L2 场景索引（`<scene-navigation>`，可用 `tdai_scenario_read` 读取）以及 MCP 工具指引。若所有召回请求都失败，则不注入任何内容，稳定内容在下一个 prompt 重试。
+
+## 快速开始
+
+### 1. 构建
+
+```bash
+cd MemoryCore/claude-code-plugin
+npm install
+npm run build          # → dist/hooks/cli.js, dist/mcp/stdio.js
+npm test
+```
+
+### 2. 环境变量
+
+在启动 `claude` 的 shell 中设置（或写入 `~/.claude/settings.json` 的 `env` 字段）：
+
+| 变量 | 默认值 | 用途 |
+|---|---|---|
+| `TDAI_GATEWAY_URL` | `http://127.0.0.1:8420` | Memory Gateway 地址。 |
+| `TDAI_GATEWAY_API_KEY`（或 `TDAI_API_KEY`） | `local` | Gateway 的 Bearer token。 |
+| `TDAI_SERVICE_ID` | `default` | 记忆实例 id（`x-tdai-service-id`）。 |
+| `TDAI_TEAM_ID` / `TDAI_AGENT_ID` / `TDAI_USER_ID` | `default` | v3 隔离三元组，来自面板。 |
+| `TDAI_KNOWLEDGE_URL` | 未设置 | Knowledge Service 地址；设置后启用 `tdai_wiki_*` 工具。 |
+| `TDAI_KNOWLEDGE_API_KEY` | 回退到 Gateway key | Knowledge Service 的 Bearer token。 |
+| `TDAI_CLAUDE_CODE_STATE_DIR` | `~/.memory-tencentdb/claude-code-plugin` | prompt 缓存、捕获标记、转录位置。 |
+| `TDAI_RECALL_MAX_RESULTS` | `5` | 每个 prompt 的 L1 命中数。 |
+| `TDAI_RECALL_PERSONA` / `TDAI_RECALL_SCENE_NAV` | `on` | 设为 `off` 时首个 prompt 不注入人格 / 场景索引。 |
+| `TDAI_CAPTURE` | `on` | 设为 `off` 关闭 Stop 与 SessionEnd 的捕获。 |
+| `TDAI_STOP_BUDGET_MS` / `TDAI_SESSION_END_BUDGET_MS` | `3500` / `25000` | 转录批次的时间预算；预算只阻止新批次开始。 |
+| `TDAI_RECALL_TIMEOUT_MS` / `TDAI_CAPTURE_TIMEOUT_MS` | `3000` / `15000` | 召回与单个捕获批次的 Gateway 超时。 |
+
+### 3. Hook
+
+把 [`integrations/hooks.json`](./integrations/hooks.json) 合并到 `~/.claude/settings.json`（全局）或 `.claude/settings.json`（单项目），替换绝对路径。hook 的 timeout（5 秒、15 秒、30 秒）必须覆盖进行中的批次，否则 Gateway 已记录的批次不会写下 marker。在 Claude Code 中用 `/hooks` 检查。
+
+### 4. MCP server
+
+把 [`integrations/mcp.json.example`](./integrations/mcp.json.example) 复制到项目根目录作为 `.mcp.json`，或全局注册：
+
+```bash
+claude mcp add --transport stdio --scope user tdai -- \
+  node /absolute/path/to/TencentDB-Agent-Memory/MemoryCore/claude-code-plugin/dist/mcp/stdio.js
+```
+
+用 `/mcp` 检查。请在 `CLAUDE.md` 中告诉模型应使用哪个 wiki id；适配器不会预设任何 wiki。
+
+### 5. 手动测试 Hook
+
+```bash
+printf '%s' '{"hook_event_name":"UserPromptSubmit","session_id":"demo","prompt_id":"p1","cwd":"/tmp","prompt":"what is our release flow?"}' \
+  | node dist/hooks/cli.js
+```
+
+无匹配时输出 `{}`，召回成功时输出带 `hookSpecificOutput.additionalContext` 的 JSON。
+
+## 适配器职责
+
+- Hook 进程只通过状态目录下的文件共享状态（文件名为哈希，权限 0600）。prompt 缓存与捕获标记 24 小时过期；会话 marker 30 天过期。
+- 所有路径 fail-open。召回失败返回 `{}`；捕获失败写 stderr 并由后续 hook 重试；MCP server 把 Gateway 错误作为工具错误返回。
+- 插件不含任何组织专有内容：wiki id 始终是工具参数，身份来自环境变量。
+
+## 文件
+
+```text
+claude-code-plugin/
+├── src/
+│   ├── config.ts            环境变量 → 配置
+│   ├── client.ts            V3MemoryClient 与 Knowledge 客户端工厂
+│   ├── format.ts            召回上下文格式化
+│   ├── knowledge.ts         Knowledge Service 客户端 + wiki 工具
+│   ├── hooks/
+│   │   ├── cli.ts           hook 入口（stdin → stdout）
+│   │   ├── handler.ts       UserPromptSubmit / Stop / SessionEnd
+│   │   ├── recall.ts        searchAtomic + readCore + listScenarios
+│   │   ├── capture.ts       转录增量 → addConversation
+│   │   ├── transcript.ts    JSONL 解析、规范化、脱敏、分块
+│   │   └── state.ts         prompt 缓存、捕获标记、会话 marker
+│   └── mcp/
+│       ├── server.ts        工具定义
+│       └── stdio.ts         MCP 入口
+├── __tests__/               vitest
+├── integrations/            hooks.json、mcp.json.example
+└── README.md / README_CN.md
+```

--- a/MemoryCore/claude-code-plugin/__tests__/hooks.test.ts
+++ b/MemoryCore/claude-code-plugin/__tests__/hooks.test.ts
@@ -1,0 +1,179 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import { loadConfig } from "../src/config.js";
+import { handleHook, type HookDeps } from "../src/hooks/handler.js";
+import { PluginState } from "../src/hooks/state.js";
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-cc-hooks-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function fakeClient(overrides: Partial<Record<keyof V3MemoryClient, unknown>> = {}): V3MemoryClient {
+  return {
+    searchAtomic: vi.fn().mockResolvedValue({ items: [{ id: "m1", type: "instruction", content: "Ask tdai first.", score: 0.9 }] }),
+    readCore: vi.fn().mockResolvedValue({ content: "PERSONA TEXT", created_at: null, updated_at: null }),
+    listScenarios: vi.fn().mockResolvedValue({ entries: [{ path: "scene/a.md", summary: "about a", created_at: "", updated_at: "" }], total: 1 }),
+    searchConversation: vi.fn().mockResolvedValue({ messages: [] }),
+    addConversation: vi.fn().mockResolvedValue({ accepted_ids: ["x"], total_count: 1 }),
+    readScenario: vi.fn(),
+    ...overrides,
+  } as unknown as V3MemoryClient;
+}
+
+async function deps(overrides: Partial<HookDeps> = {}): Promise<HookDeps & { client: V3MemoryClient; log: ReturnType<typeof vi.fn> }> {
+  const stateDir = await tempDir();
+  const config = loadConfig({ TDAI_CLAUDE_CODE_STATE_DIR: stateDir } as NodeJS.ProcessEnv);
+  const client = fakeClient();
+  const log = vi.fn();
+  return {
+    config,
+    state: new PluginState(stateDir),
+    recallClient: client,
+    captureClient: client,
+    log,
+    claudeConfigDir: await tempDir(),
+    ...overrides,
+    client,
+  } as HookDeps & { client: V3MemoryClient; log: ReturnType<typeof vi.fn> };
+}
+
+const TURN = [
+  { type: "user", uuid: "u1", promptId: "p1", timestamp: "2026-09-06T01:00:00.000Z", message: { role: "user", content: "fix the build" } },
+  { type: "assistant", uuid: "a1", message: { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "npm test" } }] } },
+  { type: "user", uuid: "u2", promptId: "p1", message: { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "1 failing" }] } },
+  { type: "assistant", uuid: "a2", message: { role: "assistant", content: [{ type: "text", text: "Fixed it." }] } },
+];
+
+async function writeTranscript(entries: Record<string, unknown>[]): Promise<string> {
+  const file = path.join(await tempDir(), "session.jsonl");
+  await writeFile(file, `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`);
+  return file;
+}
+
+describe("UserPromptSubmit", () => {
+  it("injects persona, scenes, guide and L1 hits on the first prompt, L1 hits only afterwards", async () => {
+    const d = await deps();
+    const first = await handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p1", cwd: "/proj", prompt: "where is the deploy recipe?" }, d);
+    const ctx = (first as { hookSpecificOutput: { additionalContext: string } }).hookSpecificOutput.additionalContext;
+    expect(ctx).toContain("<user-persona>\nPERSONA TEXT");
+    expect(ctx).toContain("<scene-navigation>");
+    expect(ctx).toContain("scene/a.md — about a");
+    expect(ctx).toContain("<memory-tools-guide>");
+    expect(ctx).toContain("[instruction] Ask tdai first.");
+    expect(d.client.searchAtomic).toHaveBeenCalledWith({ query: "where is the deploy recipe?", limit: 5 });
+
+    const second = await handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p2", cwd: "/proj", prompt: "and the host?" }, d);
+    const ctx2 = (second as { hookSpecificOutput: { additionalContext: string } }).hookSpecificOutput.additionalContext;
+    expect(ctx2).not.toContain("<user-persona>");
+    expect(ctx2).toContain("<relevant-memories>");
+    expect(d.client.readCore).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open when the Gateway is down and retries the session block next prompt", async () => {
+    const d = await deps();
+    for (const key of ["searchAtomic", "readCore", "listScenarios"] as const) {
+      (d.client[key] as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("down"));
+    }
+    await expect(handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p1", cwd: "/proj", prompt: "hi" }, d)).resolves.toEqual({});
+    expect(await d.state.hasSessionFlag("s1", "session-context-sent")).toBe(false);
+  });
+});
+
+describe("Stop", () => {
+  it("sends the whole turn from the transcript as one conversation add and marks the turn captured", async () => {
+    const d = await deps();
+    const transcriptPath = await writeTranscript(TURN);
+    await handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p1", cwd: "/proj", prompt: "fix the build" }, d);
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: false, last_assistant_message: "Fixed it.", transcript_path: transcriptPath }, d);
+
+    expect(d.client.addConversation).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(d.client.addConversation).mock.calls[0][0];
+    expect(request.session_id).toBe("s1");
+    expect(request.messages).toEqual([
+      { id: "claude-code:s1:u1", role: "user", content: "fix the build", timestamp: "2026-09-06T01:00:00.000Z" },
+      { id: "claude-code:s1:a1", role: "assistant", content: '[tool_use id=t1 name=Bash input={"command":"npm test"}]' },
+      { id: "claude-code:s1:u2", role: "user", content: "[tool_result tool_use_id=t1] 1 failing" },
+      { id: "claude-code:s1:a2", role: "assistant", content: "Fixed it." },
+    ]);
+    expect(await d.state.isCaptured("s1", "p1")).toBe(true);
+
+    // Repeated Stop and SessionEnd send nothing more.
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: false, last_assistant_message: "Fixed it.", transcript_path: transcriptPath }, d);
+    await handleHook({ hook_event_name: "SessionEnd", session_id: "s1", cwd: "/proj", reason: "exit", transcript_path: transcriptPath }, d);
+    expect(d.client.addConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to prompt + reply when no transcript can be read", async () => {
+    const d = await deps();
+    await handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p1", cwd: "/nowhere", prompt: "fix the build" }, d);
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/nowhere", stop_hook_active: false, last_assistant_message: "Fixed it.", transcript_path: "/does/not/exist.jsonl" }, d);
+    expect(vi.mocked(d.client.addConversation).mock.calls[0][0].messages).toEqual([
+      { id: "claude-code:s1:p1:user", role: "user", content: "fix the build" },
+      { id: "claude-code:s1:p1:assistant", role: "assistant", content: "Fixed it." },
+    ]);
+    expect(await d.state.isCaptured("s1", "p1")).toBe(true);
+  });
+
+  it("skips capture while background tasks run, with no final message, or when capture is off", async () => {
+    const d = await deps();
+    await handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p1", cwd: "/proj", prompt: "x" }, d);
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: false, last_assistant_message: "y", background_tasks: [{}] }, d);
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: false, last_assistant_message: "" }, d);
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: true, last_assistant_message: "y" }, d);
+    expect(d.client.addConversation).not.toHaveBeenCalled();
+
+    const off = await deps({ config: loadConfig({ TDAI_CAPTURE: "off", TDAI_CLAUDE_CODE_STATE_DIR: d.config.stateDir } as NodeJS.ProcessEnv) });
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: false, last_assistant_message: "y" }, off);
+    expect(off.client.addConversation).not.toHaveBeenCalled();
+  });
+
+  it("leaves a turn unclaimed when its send fails, so SessionEnd sends it", async () => {
+    const d = await deps();
+    const transcriptPath = await writeTranscript(TURN);
+    vi.mocked(d.client.addConversation).mockRejectedValueOnce(new Error("gateway down"));
+    await handleHook({ hook_event_name: "UserPromptSubmit", session_id: "s1", prompt_id: "p1", cwd: "/proj", prompt: "fix the build" }, d);
+    await handleHook({ hook_event_name: "Stop", session_id: "s1", prompt_id: "p1", cwd: "/proj", stop_hook_active: false, last_assistant_message: "Fixed it.", transcript_path: transcriptPath }, d);
+    expect(d.log).toHaveBeenCalledWith(expect.stringContaining("failed open"));
+    expect(await d.state.isCaptured("s1", "p1")).toBe(false);
+
+    await handleHook({ hook_event_name: "SessionEnd", session_id: "s1", cwd: "/proj", reason: "exit", transcript_path: transcriptPath }, d);
+    expect(d.client.addConversation).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(d.client.addConversation).mock.calls[1][0].messages).toHaveLength(4);
+  });
+});
+
+describe("SessionEnd", () => {
+  it("keeps the marker at the last batch that landed and resumes from there", async () => {
+    const d = await deps();
+    const entries = Array.from({ length: 150 }, (_, i) => (
+      i % 2 === 0
+        ? { type: "user", uuid: `u${i}`, promptId: `p${i}`, message: { role: "user", content: `prompt ${i}` } }
+        : { type: "assistant", uuid: `a${i}`, message: { role: "assistant", content: [{ type: "text", text: `answer ${i}` }] } }
+    ));
+    const transcriptPath = await writeTranscript(entries);
+    vi.mocked(d.client.addConversation)
+      .mockResolvedValueOnce({ accepted_ids: [], total_count: 100 })
+      .mockRejectedValueOnce(new Error("gateway down"))
+      .mockResolvedValue({ accepted_ids: [], total_count: 150 });
+    const end = { hook_event_name: "SessionEnd" as const, session_id: "s1", cwd: "/proj", reason: "exit", transcript_path: transcriptPath };
+
+    await handleHook(end, d);
+    expect(d.client.addConversation).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(d.client.addConversation).mock.calls[0][0].messages).toHaveLength(100);
+
+    await handleHook(end, d);
+    expect(d.client.addConversation).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(d.client.addConversation).mock.calls[2][0].messages).toHaveLength(50);
+    expect(vi.mocked(d.client.addConversation).mock.calls[2][0].messages[0].content).toBe("prompt 100");
+  });
+});

--- a/MemoryCore/claude-code-plugin/__tests__/mcp.test.ts
+++ b/MemoryCore/claude-code-plugin/__tests__/mcp.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import { createClaudeCodeMcpServer } from "../src/mcp/server.js";
+import { createKnowledgeTools, KnowledgeServiceClient } from "../src/knowledge.js";
+
+function fakeMemory(): V3MemoryClient {
+  return {
+    searchAtomic: vi.fn().mockResolvedValue({ items: [{ id: "m1", type: "episodic", content: "Deployed v1.9", score: 0.8 }] }),
+    searchConversation: vi.fn().mockResolvedValue({ messages: [{ role: "assistant", content: "[tool_use …]", timestamp: "2026-09-06T00:00:00Z", score: 0.7 }] }),
+    readScenario: vi.fn().mockResolvedValue({ path: "scene/a.md", content: "# A", created_at: null, updated_at: null }),
+    addConversation: vi.fn().mockResolvedValue({ accepted_ids: ["c1"], total_count: 9 }),
+  } as unknown as V3MemoryClient;
+}
+
+async function connect(server: ReturnType<typeof createClaudeCodeMcpServer>) {
+  const client = new Client({ name: "test", version: "0.0.0" });
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await server.connect(b);
+  await client.connect(a);
+  return { client, close: async () => { await client.close(); await server.close(); } };
+}
+
+describe("createClaudeCodeMcpServer", () => {
+  it("exposes memory tools, and wiki tools only when a Knowledge Service is configured", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({ code: 0, data: { items: [{ wiki_id: "w1", name: "team" }] } })));
+    const knowledge = createKnowledgeTools({ baseUrl: "http://knowledge.test", serviceId: "default", teamId: "t1", fetch: fetchMock });
+    const withWiki = await connect(createClaudeCodeMcpServer({ memory: fakeMemory(), knowledge }));
+    expect((await withWiki.client.listTools()).tools.map((t) => t.name)).toEqual([
+      "tdai_memory_search", "tdai_conversation_search", "tdai_scenario_read", "tdai_memory_capture",
+      "tdai_wiki_list", "tdai_wiki_search", "tdai_wiki_pages", "tdai_wiki_read", "tdai_wiki_write",
+    ]);
+    await expect(withWiki.client.callTool({ name: "tdai_wiki_list", arguments: {} })).resolves.toMatchObject({
+      structuredContent: { items: [{ wiki_id: "w1", name: "team" }] },
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("http://knowledge.test/v3/wiki/list");
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({ team_id: "t1", limit: 20 });
+    await withWiki.close();
+
+    const without = await connect(createClaudeCodeMcpServer({ memory: fakeMemory() }));
+    expect((await without.client.listTools()).tools.map((t) => t.name)).toHaveLength(4);
+    await without.close();
+  });
+
+  it("formats search results, reads scenes, and captures milestones through the v3 client", async () => {
+    const memory = fakeMemory();
+    const { client, close } = await connect(createClaudeCodeMcpServer({ memory, defaultSessionId: "claude-code:s1" }));
+
+    const search = await client.callTool({ name: "tdai_memory_search", arguments: { query: "deploy", limit: 3, type: "episodic" } });
+    expect(memory.searchAtomic).toHaveBeenCalledWith({ query: "deploy", limit: 3, type: "episodic" });
+    expect((search.content as { text: string }[])[0].text).toContain("**[episodic]** (score: 0.800)");
+
+    const conv = await client.callTool({ name: "tdai_conversation_search", arguments: { query: "tool_use", session_id: "s9" } });
+    expect(memory.searchConversation).toHaveBeenCalledWith({ query: "tool_use", limit: 5, session_id: "s9" });
+    expect((conv.content as { text: string }[])[0].text).toContain("[tool_use …]");
+
+    await expect(client.callTool({ name: "tdai_scenario_read", arguments: { path: "scene/a.md" } })).resolves.toMatchObject({
+      content: [{ type: "text", text: "# A" }],
+    });
+
+    await client.callTool({ name: "tdai_memory_capture", arguments: { note: "Ruling: tdai is an option." } });
+    expect(memory.addConversation).toHaveBeenCalledWith({ session_id: "claude-code:s1", messages: [{ role: "assistant", content: "Ruling: tdai is an option." }] });
+    await close();
+  });
+
+  it("knowledge client unwraps envelopes and surfaces non-zero codes", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 0, data: { results: [1] } })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ code: 40401, message: "wiki not found", request_id: "r1" })))
+      .mockResolvedValueOnce(new Response("down", { status: 503 }));
+    const client = new KnowledgeServiceClient({ baseUrl: "http://k/", serviceId: "svc", apiKey: "key", teamId: "t", userId: "u", agentId: "a", fetch: fetchMock });
+    await expect(client.post("/v3/wiki/search", { query: "x" })).resolves.toEqual({ results: [1] });
+    expect(fetchMock.mock.calls[0][1]?.headers).toEqual({ "Content-Type": "application/json", "x-tdai-service-id": "svc", Authorization: "Bearer key" });
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({ team_id: "t", user_id: "u", agent_id: "a", query: "x" });
+    await expect(client.post("/v3/wiki/search", {})).rejects.toThrow("Knowledge /v3/wiki/search error 40401: wiki not found (r1)");
+    await expect(client.post("/v3/wiki/list", {})).rejects.toThrow("returned HTTP 503");
+  });
+});

--- a/MemoryCore/claude-code-plugin/__tests__/transcript.test.ts
+++ b/MemoryCore/claude-code-plugin/__tests__/transcript.test.ts
@@ -1,0 +1,146 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  normalizeTranscript,
+  promptIdsIn,
+  readTranscriptEntries,
+  redactSecrets,
+  resolveTranscriptPath,
+  sliceAfter,
+  splitBatches,
+  type TranscriptEntry,
+} from "../src/hooks/transcript.js";
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tdai-cc-transcript-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const user = (uuid: string, content: TranscriptEntry["message"]["content"], extra: Partial<TranscriptEntry> = {}): TranscriptEntry =>
+  ({ uuid, type: "user", message: { role: "user", content }, ...extra });
+const assistant = (uuid: string, content: TranscriptEntry["message"]["content"], extra: Partial<TranscriptEntry> = {}): TranscriptEntry =>
+  ({ uuid, type: "assistant", message: { role: "assistant", content }, ...extra });
+
+const TWO_TURNS: TranscriptEntry[] = [
+  user("u1", "fix the build", { promptId: "p1", timestamp: "2026-09-06T01:00:00.000Z" }),
+  assistant("a1", [
+    { type: "thinking", text: "secret reasoning" },
+    { type: "text", text: "Looking at the build." },
+    { type: "tool_use", id: "t1", name: "Bash", input: { command: "npm test" } },
+  ], { timestamp: "2026-09-06T01:00:01.000Z" }),
+  user("u2", [{ type: "tool_result", tool_use_id: "t1", content: [{ type: "text", text: "1 failing" }] }], { promptId: "p1" }),
+  assistant("a2", [{ type: "text", text: "Fixed the failing test." }]),
+  user("u3", "now deploy", { promptId: "p2" }),
+  assistant("a3", [{ type: "tool_use", id: "t2", name: "Bash", input: { command: "make deploy" } }]),
+  user("u4", [{ type: "tool_result", tool_use_id: "t2", content: "deployed" }], { promptId: "p2" }),
+  assistant("a4", [{ type: "text", text: "Deployed." }]),
+];
+
+describe("normalizeTranscript", () => {
+  it("turns prompts, tool calls, tool results and assistant text into ordered messages, dropping thinking", () => {
+    const messages = normalizeTranscript(TWO_TURNS, { sessionId: "s1" });
+    expect(messages.map((m) => [m.role, m.content])).toEqual([
+      ["user", "fix the build"],
+      ["assistant", 'Looking at the build.\n[tool_use id=t1 name=Bash input={"command":"npm test"}]'],
+      ["user", "[tool_result tool_use_id=t1] 1 failing"],
+      ["assistant", "Fixed the failing test."],
+      ["user", "now deploy"],
+      ["assistant", '[tool_use id=t2 name=Bash input={"command":"make deploy"}]'],
+      ["user", "[tool_result tool_use_id=t2] deployed"],
+      ["assistant", "Deployed."],
+    ]);
+    expect(messages[0]).toMatchObject({ id: "claude-code:s1:u1", sourceUuid: "u1", timestamp: "2026-09-06T01:00:00.000Z" });
+    expect(messages[2].timestamp).toBeUndefined();
+    expect(messages.some((m) => m.content.includes("secret reasoning"))).toBe(false);
+  });
+
+  it("leaves out the prompt and final prose of turns already captured, keeping their tool traffic", () => {
+    const messages = normalizeTranscript(TWO_TURNS, { sessionId: "s1", capturedPromptIds: new Set(["p2"]) });
+    expect(messages.map((m) => m.content)).toEqual([
+      "fix the build",
+      'Looking at the build.\n[tool_use id=t1 name=Bash input={"command":"npm test"}]',
+      "[tool_result tool_use_id=t1] 1 failing",
+      "Fixed the failing test.",
+      '[tool_use id=t2 name=Bash input={"command":"make deploy"}]',
+      "[tool_result tool_use_id=t2] deployed",
+    ]);
+  });
+
+  it("clips long tool inputs and results and chunks long messages with numbered ids", () => {
+    const entries: TranscriptEntry[] = [
+      assistant("a1", [{ type: "tool_use", id: "t1", name: "Write", input: { content: "x".repeat(50) } }]),
+      user("u1", [{ type: "tool_result", tool_use_id: "t1", content: "y".repeat(50) }]),
+      assistant("a2", [{ type: "text", text: "z".repeat(25) }]),
+    ];
+    const messages = normalizeTranscript(entries, { sessionId: "s1", toolInputMaxChars: 20, toolResultMaxChars: 10, chunkChars: 10 });
+    const joined = (uuid: string) => messages.filter((m) => m.sourceUuid === uuid).map((m) => m.content).join("");
+    expect(joined("a1")).toContain("… [");
+    expect(joined("u1")).toBe(`[tool_result tool_use_id=t1] ${"y".repeat(10)}… [40 more chars]`);
+    expect(messages.filter((m) => m.sourceUuid === "a2").map((m) => m.id)).toEqual(["claude-code:s1:a2", "claude-code:s1:a2#1", "claude-code:s1:a2#2"]);
+  });
+
+  it("redacts credential-shaped substrings", () => {
+    const entries: TranscriptEntry[] = [
+      user("u1", "env: TDAI_API_KEY=sk-mem-MiOjHig4avPfKZ6bXRaaVNLKTk8zqdfD OTHER=fine", { promptId: "p1" }),
+      assistant("a1", [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "curl -H 'authorization: Bearer gbrain_172b5369fce1b3c48edf059bf6e4b3833f5087849b23682f6713c6d98d6d9f21' http://x" } }]),
+      user("u2", [{ type: "tool_result", tool_use_id: "t1", content: "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----\npassword: hunter2secret\nghp_abcdefghijklmnopqrstuvwxyz0123456789" }]),
+    ];
+    const contents = normalizeTranscript(entries, { sessionId: "s1" }).map((m) => m.content);
+    expect(contents[0]).toBe("env: TDAI_API_KEY=[redacted:secret-key] OTHER=fine");
+    expect(contents[1]).toContain("authorization: [redacted:authorization]");
+    expect(contents[2]).toContain("[redacted:private-key]");
+    expect(contents[2]).toContain("password: [redacted:value]");
+    expect(contents[2]).toContain("[redacted:github-token]");
+    expect(redactSecrets("plain text stays")).toBe("plain text stays");
+  });
+
+  it("drops images and entries that produce no text", () => {
+    expect(normalizeTranscript([
+      user("u1", [{ type: "image" }]),
+      assistant("a1", [{ type: "thinking", text: "only thinking" }]),
+      user("u2", "   "),
+    ], { sessionId: "s1" })).toEqual([]);
+  });
+});
+
+describe("transcript files", () => {
+  it("reads user and assistant entries only, skipping sidechain, meta, and malformed lines", async () => {
+    const file = path.join(await tempDir(), "t.jsonl");
+    await writeFile(file, [
+      JSON.stringify({ type: "user", uuid: "u1", promptId: "p1", message: { role: "user", content: "hi" } }),
+      "not json",
+      JSON.stringify({ type: "system", uuid: "s1", content: "hook output" }),
+      JSON.stringify({ type: "user", uuid: "u2", isMeta: true, message: { role: "user", content: "injected" } }),
+      JSON.stringify({ type: "assistant", uuid: "a1", isSidechain: true, message: { role: "assistant", content: [{ type: "text", text: "subagent" }] } }),
+      JSON.stringify({ type: "assistant", uuid: "a2", message: { role: "assistant", content: [{ type: "text", text: "hello" }] } }),
+    ].join("\n"));
+    const entries = await readTranscriptEntries(file);
+    expect(entries.map((e) => e.uuid)).toEqual(["u1", "a2"]);
+    expect(promptIdsIn(entries)).toEqual(["p1"]);
+  });
+
+  it("slices after a known marker, batches by 100, and resolves the transcript path with a fallback", async () => {
+    expect(sliceAfter(TWO_TURNS, "a2").map((e) => e.uuid)).toEqual(["u3", "a3", "u4", "a4"]);
+    expect(sliceAfter(TWO_TURNS, "missing")).toHaveLength(TWO_TURNS.length);
+    expect(splitBatches(Array.from({ length: 250 }, (_, i) => i)).map((b) => b.length)).toEqual([100, 100, 50]);
+
+    const dir = await tempDir();
+    const given = path.join(dir, "given.jsonl");
+    await writeFile(given, "");
+    await expect(resolveTranscriptPath({ transcriptPath: given, sessionId: "s1" })).resolves.toBe(given);
+    const configDir = path.join(dir, "claude");
+    const projectDir = path.join(configDir, "projects", "-Users-me-proj-x");
+    await mkdir(projectDir, { recursive: true });
+    const fallback = path.join(projectDir, "s1.jsonl");
+    await writeFile(fallback, "");
+    await expect(resolveTranscriptPath({ transcriptPath: path.join(dir, "gone.jsonl"), cwd: "/Users/me/proj.x", sessionId: "s1", claudeConfigDir: configDir })).resolves.toBe(fallback);
+    await expect(resolveTranscriptPath({ cwd: "/nowhere", sessionId: "s2", claudeConfigDir: configDir })).resolves.toBeUndefined();
+  });
+});

--- a/MemoryCore/claude-code-plugin/integrations/hooks.json
+++ b/MemoryCore/claude-code-plugin/integrations/hooks.json
@@ -1,0 +1,43 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["/absolute/path/to/TencentDB-Agent-Memory/MemoryCore/claude-code-plugin/dist/hooks/cli.js"],
+            "timeout": 5,
+            "statusMessage": "Recalling TencentDB Agent Memory"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["/absolute/path/to/TencentDB-Agent-Memory/MemoryCore/claude-code-plugin/dist/hooks/cli.js"],
+            "timeout": 15,
+            "statusMessage": "Capturing TencentDB Agent Memory"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["/absolute/path/to/TencentDB-Agent-Memory/MemoryCore/claude-code-plugin/dist/hooks/cli.js"],
+            "timeout": 30,
+            "statusMessage": "Capturing TencentDB Agent Memory"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/MemoryCore/claude-code-plugin/integrations/mcp.json.example
+++ b/MemoryCore/claude-code-plugin/integrations/mcp.json.example
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "tdai": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/absolute/path/to/TencentDB-Agent-Memory/MemoryCore/claude-code-plugin/dist/mcp/stdio.js"],
+      "env": {
+        "TDAI_GATEWAY_URL": "http://127.0.0.1:8420",
+        "TDAI_SERVICE_ID": "default",
+        "TDAI_TEAM_ID": "default",
+        "TDAI_AGENT_ID": "default",
+        "TDAI_USER_ID": "default",
+        "TDAI_KNOWLEDGE_URL": "http://127.0.0.1:8421"
+      }
+    }
+  }
+}

--- a/MemoryCore/claude-code-plugin/package.json
+++ b/MemoryCore/claude-code-plugin/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@tencentdb-agent-memory/claude-code-plugin",
+  "version": "0.1.0",
+  "description": "Claude Code client for TencentDB Agent Memory v3 — lifecycle hooks (recall, per-turn transcript capture) and a stdio MCP server (memory + wiki tools). Native, no LLM-traffic proxy.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "tdai-claude-code-hook": "./dist/hooks/cli.js",
+    "tdai-claude-code-mcp": "./dist/mcp/stdio.js"
+  },
+  "scripts": {
+    "clean": "rm -rf dist *.tgz",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "prepack": "npm run clean && npm install --no-save --no-audit --no-fund && npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@tencentdb-agent-memory/memory-sdk-ts-v2": "1.0.0-beta.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^3.2.2"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "files": [
+    "dist/",
+    "src/",
+    "integrations/",
+    "README.md",
+    "README_CN.md"
+  ]
+}

--- a/MemoryCore/claude-code-plugin/src/client.ts
+++ b/MemoryCore/claude-code-plugin/src/client.ts
@@ -1,0 +1,29 @@
+import { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import type { PluginConfig } from "./config.js";
+import { createKnowledgeTools, type KnowledgeTools } from "./knowledge.js";
+
+export function createMemoryClient(config: PluginConfig, timeoutMs: number): V3MemoryClient {
+  return new V3MemoryClient({
+    endpoint: config.gatewayUrl,
+    apiKey: config.gatewayApiKey,
+    serviceId: config.serviceId,
+    teamId: config.teamId,
+    agentId: config.agentId,
+    userId: config.userId,
+    timeout: timeoutMs,
+  });
+}
+
+/** Wiki tools exist only when a Knowledge Service URL is configured. */
+export function createKnowledge(config: PluginConfig, timeoutMs = 15_000): KnowledgeTools | undefined {
+  if (!config.knowledgeUrl) return undefined;
+  return createKnowledgeTools({
+    baseUrl: config.knowledgeUrl,
+    apiKey: config.knowledgeApiKey,
+    serviceId: config.serviceId,
+    teamId: config.teamId,
+    userId: config.userId,
+    agentId: config.agentId,
+    timeoutMs,
+  });
+}

--- a/MemoryCore/claude-code-plugin/src/config.ts
+++ b/MemoryCore/claude-code-plugin/src/config.ts
@@ -1,0 +1,80 @@
+/**
+ * Plugin configuration, read from environment variables.
+ *
+ * Claude Code runs every hook as a fresh process and starts the MCP server
+ * once per session, so the environment is the only configuration channel
+ * both share. Defaults match the OpenClaw client adapter: a local standalone
+ * Gateway with the `default` isolation triple.
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+export interface PluginConfig {
+  /** Memory Gateway base URL. */
+  gatewayUrl: string;
+  /** Bearer token for the Gateway (`x-tdai-user-key`). */
+  gatewayApiKey: string;
+  /** Memory instance id (`x-tdai-service-id`). */
+  serviceId: string;
+  /** v3 isolation triple. */
+  teamId: string;
+  agentId: string;
+  userId: string;
+  /** Knowledge Service (wiki) base URL; wiki tools are registered when set. */
+  knowledgeUrl?: string;
+  knowledgeApiKey?: string;
+  /** Where hook processes share prompt cache and capture markers. */
+  stateDir: string;
+  /** Recall: L1 hits per prompt; persona and scene navigation once per session. */
+  recallMaxResults: number;
+  recallIncludePersona: boolean;
+  recallIncludeSceneNav: boolean;
+  /** Capture: on by default; `TDAI_CAPTURE=off` disables. */
+  captureEnabled: boolean;
+  /** Wall-clock budgets for the transcript batches at Stop and SessionEnd. */
+  stopBudgetMs: number;
+  sessionEndBudgetMs: number;
+  /** Gateway timeout for one capture batch. */
+  captureTimeoutMs: number;
+  /** Gateway timeout for recall calls (must fit the UserPromptSubmit hook timeout). */
+  recallTimeoutMs: number;
+}
+
+function off(value: string | undefined): boolean {
+  const v = (value ?? "").trim().toLowerCase();
+  return v === "off" || v === "0" || v === "false";
+}
+
+function integer(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
+}
+
+export function defaultStateDir(env: NodeJS.ProcessEnv = process.env): string {
+  const root = env.MEMORY_TENCENTDB_ROOT
+    ?? path.join(env.HOME ?? env.USERPROFILE ?? os.tmpdir(), ".memory-tencentdb");
+  return env.TDAI_CLAUDE_CODE_STATE_DIR ?? path.join(root, "claude-code-plugin");
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): PluginConfig {
+  return {
+    gatewayUrl: (env.TDAI_GATEWAY_URL ?? "http://127.0.0.1:8420").replace(/\/+$/, ""),
+    gatewayApiKey: env.TDAI_GATEWAY_API_KEY ?? env.TDAI_API_KEY ?? "local",
+    serviceId: env.TDAI_SERVICE_ID ?? env.TDAI_INSTANCE_ID ?? "default",
+    teamId: env.TDAI_TEAM_ID ?? "default",
+    agentId: env.TDAI_AGENT_ID ?? "default",
+    userId: env.TDAI_USER_ID ?? "default",
+    knowledgeUrl: env.TDAI_KNOWLEDGE_URL ? env.TDAI_KNOWLEDGE_URL.replace(/\/+$/, "") : undefined,
+    knowledgeApiKey: env.TDAI_KNOWLEDGE_API_KEY ?? env.TDAI_GATEWAY_API_KEY ?? env.TDAI_API_KEY,
+    stateDir: defaultStateDir(env),
+    recallMaxResults: integer(env.TDAI_RECALL_MAX_RESULTS, 5),
+    recallIncludePersona: !off(env.TDAI_RECALL_PERSONA),
+    recallIncludeSceneNav: !off(env.TDAI_RECALL_SCENE_NAV),
+    captureEnabled: !off(env.TDAI_CAPTURE),
+    stopBudgetMs: integer(env.TDAI_STOP_BUDGET_MS, 3_500),
+    sessionEndBudgetMs: integer(env.TDAI_SESSION_END_BUDGET_MS, 25_000),
+    captureTimeoutMs: integer(env.TDAI_CAPTURE_TIMEOUT_MS, 15_000),
+    recallTimeoutMs: integer(env.TDAI_RECALL_TIMEOUT_MS, 3_000),
+  };
+}

--- a/MemoryCore/claude-code-plugin/src/format.ts
+++ b/MemoryCore/claude-code-plugin/src/format.ts
@@ -1,0 +1,71 @@
+/**
+ * Recall results → the `additionalContext` block Claude Code injects before a turn.
+ *
+ * Layout follows the OpenClaw client adapter: stable material (persona, scene
+ * navigation, tool guide) is sent once per session; the per-prompt L1 hits are
+ * sent on every prompt.
+ */
+
+export interface L1Item {
+  id: string;
+  content: string;
+  type: string;
+  score?: number;
+}
+
+export interface SceneEntry {
+  path: string;
+  summary?: string;
+  updated_at?: string;
+}
+
+export const MEMORY_TOOLS_GUIDE = `<memory-tools-guide>
+When the injected memory does not answer the question, use the memory tools before searching the filesystem:
+- tdai_memory_search: structured memories (L1) — preferences, past events, decisions, rules.
+- tdai_conversation_search: raw conversation messages (L0) — exact wording, timelines, tool traffic.
+- tdai_scenario_read: a scene block from Scene Navigation, by its path.
+- tdai_wiki_search / tdai_wiki_read: the team wiki, when a Knowledge Service is configured.
+Keep it to three memory searches per turn; if nothing turns up, answer from what you have.
+</memory-tools-guide>`;
+
+export function formatL1Memories(items: L1Item[]): string | undefined {
+  if (items.length === 0) return undefined;
+  const lines = ["<relevant-memories>"];
+  for (const item of items) {
+    const tag = item.type ? `[${item.type}]` : "";
+    lines.push(`- ${tag} ${item.content}`.trim());
+  }
+  lines.push("</relevant-memories>");
+  return lines.join("\n");
+}
+
+export function formatSessionContext(persona: string | null, scenes: SceneEntry[], includeGuide = true): string | undefined {
+  const parts: string[] = [];
+  if (persona && persona.trim()) {
+    parts.push("<user-persona>", persona.trim(), "</user-persona>");
+  }
+  if (scenes.length > 0 && !(persona && persona.includes("Scene Navigation"))) {
+    parts.push("<scene-navigation>");
+    parts.push("Scene memory index. Read a block with tdai_scenario_read and its path.");
+    for (const scene of scenes) {
+      parts.push(scene.summary ? `- ${scene.path} — ${scene.summary}` : `- ${scene.path}`);
+    }
+    parts.push("</scene-navigation>");
+  }
+  if (includeGuide) parts.push(MEMORY_TOOLS_GUIDE);
+  const text = parts.join("\n").trim();
+  return text || undefined;
+}
+
+export function formatRecallContext(input: {
+  l1Items: L1Item[];
+  persona: string | null;
+  scenes: SceneEntry[];
+  includeSessionContext: boolean;
+}): string | undefined {
+  const blocks = [
+    input.includeSessionContext ? formatSessionContext(input.persona, input.scenes) : undefined,
+    formatL1Memories(input.l1Items),
+  ].filter((block): block is string => Boolean(block));
+  return blocks.length > 0 ? blocks.join("\n\n") : undefined;
+}

--- a/MemoryCore/claude-code-plugin/src/hooks/capture.ts
+++ b/MemoryCore/claude-code-plugin/src/hooks/capture.ts
@@ -1,0 +1,105 @@
+/**
+ * Capture: send the transcript delta since the marker to L0 via `/v3/conversation/add`.
+ *
+ * At Stop the delta is the finished turn, sent as batches of at most 100
+ * messages; at SessionEnd it is whatever is still unsent. A batch that does
+ * not land leaves the marker at the last batch that did, so the next hook
+ * retries from there. Turns captured by the plain prompt+reply path (no
+ * transcript available at the time) contribute only their tool traffic later.
+ */
+
+import type { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import type { PluginState } from "./state.js";
+import {
+  normalizeTranscript,
+  promptIdsIn,
+  readTranscriptEntries,
+  resolveTranscriptPath,
+  sliceAfter,
+  splitBatches,
+} from "./transcript.js";
+
+export type TranscriptDeltaOutcome = "no-transcript" | "nothing-new" | "partial" | "complete";
+
+export interface TranscriptDeltaInput {
+  sessionId: string;
+  cwd?: string;
+  transcriptPath?: string;
+  /** Wall-clock budget; batches beyond it wait for the next Stop or SessionEnd. */
+  budgetMs: number;
+  claudeConfigDir?: string;
+}
+
+export interface CaptureDeps {
+  client: V3MemoryClient;
+  state: PluginState;
+  log: (message: string) => void;
+}
+
+export async function sendTranscriptDelta(deps: CaptureDeps, delta: TranscriptDeltaInput): Promise<TranscriptDeltaOutcome> {
+  const transcriptPath = await resolveTranscriptPath({
+    transcriptPath: delta.transcriptPath,
+    cwd: delta.cwd,
+    sessionId: delta.sessionId,
+    claudeConfigDir: delta.claudeConfigDir,
+  });
+  if (!transcriptPath) return "no-transcript";
+
+  const entries = sliceAfter(await readTranscriptEntries(transcriptPath), await deps.state.getTranscriptMarker(delta.sessionId));
+  if (entries.length === 0) return "nothing-new";
+
+  const capturedPromptIds = new Set<string>();
+  for (const promptId of promptIdsIn(entries)) {
+    if (await deps.state.isCaptured(delta.sessionId, promptId)) capturedPromptIds.add(promptId);
+  }
+
+  const messages = normalizeTranscript(entries, { sessionId: delta.sessionId, capturedPromptIds });
+  const lastEntryUuid = entries[entries.length - 1].uuid;
+  if (messages.length === 0) {
+    await deps.state.setTranscriptMarker(delta.sessionId, lastEntryUuid);
+    return "nothing-new";
+  }
+
+  const deadline = Date.now() + delta.budgetMs;
+  const batches = splitBatches(messages);
+  for (const [index, batch] of batches.entries()) {
+    if (Date.now() > deadline) {
+      deps.log(`transcript capture stopped at budget: ${batches.length - index} batch(es) left for session ${delta.sessionId}`);
+      return "partial";
+    }
+    try {
+      await deps.client.addConversation({
+        session_id: delta.sessionId,
+        messages: batch.map(({ sourceUuid: _sourceUuid, ...message }) => message),
+      });
+    } catch (error) {
+      deps.log(`transcript capture failed open: ${error instanceof Error ? error.message : String(error)}`);
+      return "partial";
+    }
+    const last = batch[batch.length - 1];
+    await deps.state.setTranscriptMarker(delta.sessionId, index === batches.length - 1 ? lastEntryUuid : last.sourceUuid);
+  }
+  return "complete";
+}
+
+/** The plain path when no transcript can be read: prompt and final reply only. */
+export async function sendPlainTurn(deps: CaptureDeps, input: {
+  sessionId: string;
+  promptId: string;
+  prompt: string;
+  reply: string;
+}): Promise<boolean> {
+  try {
+    await deps.client.addConversation({
+      session_id: input.sessionId,
+      messages: [
+        { id: `claude-code:${input.sessionId}:${input.promptId}:user`, role: "user", content: input.prompt },
+        { id: `claude-code:${input.sessionId}:${input.promptId}:assistant`, role: "assistant", content: input.reply },
+      ],
+    });
+    return true;
+  } catch (error) {
+    deps.log(`capture failed open: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}

--- a/MemoryCore/claude-code-plugin/src/hooks/cli.ts
+++ b/MemoryCore/claude-code-plugin/src/hooks/cli.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Hook entry: Claude Code pipes the hook payload on stdin and reads one JSON
+ * object from stdout. Any failure prints `{}` so the session continues.
+ */
+
+import { loadConfig } from "../config.js";
+import { createMemoryClient } from "../client.js";
+import { handleHook, type HookInput } from "./handler.js";
+import { PluginState } from "./state.js";
+
+async function main(): Promise<void> {
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const input = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as HookInput;
+    const config = loadConfig();
+    const output = await handleHook(input, {
+      config,
+      state: new PluginState(config.stateDir),
+      recallClient: createMemoryClient(config, config.recallTimeoutMs),
+      captureClient: createMemoryClient(config, config.captureTimeoutMs),
+      log: (message) => process.stderr.write(`[tdai][claude-code] ${message}\n`),
+    });
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  } catch (error) {
+    process.stderr.write(`[tdai][claude-code] hook failed open: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.stdout.write("{}\n");
+  }
+}
+
+void main();

--- a/MemoryCore/claude-code-plugin/src/hooks/handler.ts
+++ b/MemoryCore/claude-code-plugin/src/hooks/handler.ts
@@ -1,0 +1,174 @@
+/**
+ * Claude Code lifecycle hooks → Memory Gateway v3.
+ *
+ * | Event            | Action                                                                  |
+ * |------------------|-------------------------------------------------------------------------|
+ * | UserPromptSubmit | cache the prompt; recall L1 (and persona + scenes on the first prompt); |
+ * |                  | return `additionalContext`                                              |
+ * | Stop             | capture the finished turn from the transcript (fallback: prompt+reply)  |
+ * | SessionEnd       | capture whatever transcript remains unsent                              |
+ *
+ * Every path fails open: a Gateway problem never blocks Claude Code.
+ */
+
+import type { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import type { PluginConfig } from "../config.js";
+import { sendPlainTurn, sendTranscriptDelta } from "./capture.js";
+import { performRecall } from "./recall.js";
+import type { PluginState } from "./state.js";
+
+export interface UserPromptSubmitInput {
+  hook_event_name: "UserPromptSubmit";
+  session_id: string;
+  prompt_id?: string;
+  cwd?: string;
+  prompt: string;
+  transcript_path?: string;
+}
+
+export interface StopInput {
+  hook_event_name: "Stop";
+  session_id: string;
+  prompt_id?: string;
+  cwd?: string;
+  stop_hook_active?: boolean;
+  last_assistant_message?: string | null;
+  background_tasks?: unknown[];
+  session_crons?: unknown[];
+  transcript_path?: string;
+}
+
+export interface SessionEndInput {
+  hook_event_name: "SessionEnd";
+  session_id: string;
+  cwd?: string;
+  reason?: string;
+  transcript_path?: string;
+}
+
+export type HookInput = UserPromptSubmitInput | StopInput | SessionEndInput;
+export type HookOutput = Record<string, unknown>;
+
+export interface HookDeps {
+  config: PluginConfig;
+  state: PluginState;
+  /** Client with the short recall timeout. */
+  recallClient: V3MemoryClient;
+  /** Client with the longer capture timeout. */
+  captureClient: V3MemoryClient;
+  log: (message: string) => void;
+  claudeConfigDir?: string;
+}
+
+const SESSION_CONTEXT_FLAG = "session-context-sent";
+
+export async function handleHook(input: HookInput, deps: HookDeps): Promise<HookOutput> {
+  switch (input.hook_event_name) {
+    case "UserPromptSubmit":
+      return onUserPromptSubmit(input, deps);
+    case "Stop":
+      return onStop(input, deps);
+    case "SessionEnd":
+      return onSessionEnd(input, deps);
+    default:
+      return {};
+  }
+}
+
+async function onUserPromptSubmit(input: UserPromptSubmitInput, deps: HookDeps): Promise<HookOutput> {
+  const { config, state } = deps;
+  if (input.prompt_id) await state.savePrompt(input.session_id, input.prompt_id, input.prompt);
+  else await state.saveLatestPrompt(input.session_id, input.prompt);
+
+  const includeSessionContext = !(await state.hasSessionFlag(input.session_id, SESSION_CONTEXT_FLAG));
+  let result;
+  try {
+    result = await performRecall(deps.recallClient, {
+      query: input.prompt,
+      maxResults: config.recallMaxResults,
+      includePersona: config.recallIncludePersona,
+      includeSceneNav: config.recallIncludeSceneNav,
+      includeSessionContext,
+    });
+  } catch (error) {
+    deps.log(`recall failed open: ${error instanceof Error ? error.message : String(error)}`);
+    return {};
+  }
+  if (includeSessionContext && !result.allFailed) await state.setSessionFlag(input.session_id, SESSION_CONTEXT_FLAG);
+  if (!result.context) return {};
+  return {
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: result.context,
+    },
+  };
+}
+
+async function onStop(input: StopInput, deps: HookDeps): Promise<HookOutput> {
+  const { config, state } = deps;
+  if (!config.captureEnabled) return {};
+  if (
+    input.stop_hook_active
+    || !input.last_assistant_message?.trim()
+    || (input.background_tasks?.length ?? 0) > 0
+    || (input.session_crons?.length ?? 0) > 0
+  ) return {};
+
+  const promptRecord = input.prompt_id
+    ? await state.getPromptRecord(input.session_id, input.prompt_id)
+    : await state.getLatestPromptRecord(input.session_id);
+  if (!promptRecord) return {};
+  const promptId = promptRecord.promptId;
+  if (!await state.beginCapture(input.session_id, promptId)) return {};
+
+  const captureDeps = { client: deps.captureClient, state, log: deps.log };
+  let outcome: Awaited<ReturnType<typeof sendTranscriptDelta>> = "no-transcript";
+  try {
+    outcome = await sendTranscriptDelta(captureDeps, {
+      sessionId: input.session_id,
+      cwd: input.cwd,
+      transcriptPath: input.transcript_path,
+      budgetMs: config.stopBudgetMs,
+      claudeConfigDir: deps.claudeConfigDir,
+    });
+  } catch (error) {
+    deps.log(`transcript capture failed open: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (outcome === "complete" || outcome === "nothing-new") {
+    await state.markCaptured(input.session_id, promptId);
+    return {};
+  }
+  if (outcome === "partial") {
+    // Unclaimed on purpose: SessionEnd sends the rest of this turn.
+    await state.releaseCapture(input.session_id, promptId);
+    return {};
+  }
+
+  const sent = await sendPlainTurn(captureDeps, {
+    sessionId: input.session_id,
+    promptId,
+    prompt: promptRecord.prompt,
+    reply: input.last_assistant_message,
+  });
+  if (sent) await state.markCaptured(input.session_id, promptId);
+  else await state.releaseCapture(input.session_id, promptId);
+  return {};
+}
+
+async function onSessionEnd(input: SessionEndInput, deps: HookDeps): Promise<HookOutput> {
+  const { config, state } = deps;
+  if (!config.captureEnabled) return {};
+  try {
+    await sendTranscriptDelta({ client: deps.captureClient, state, log: deps.log }, {
+      sessionId: input.session_id,
+      cwd: input.cwd,
+      transcriptPath: input.transcript_path,
+      budgetMs: config.sessionEndBudgetMs,
+      claudeConfigDir: deps.claudeConfigDir,
+    });
+  } catch (error) {
+    deps.log(`transcript capture failed open: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return {};
+}

--- a/MemoryCore/claude-code-plugin/src/hooks/recall.ts
+++ b/MemoryCore/claude-code-plugin/src/hooks/recall.ts
@@ -1,0 +1,52 @@
+/**
+ * Recall at UserPromptSubmit: L1 search for this prompt, plus persona and
+ * scene navigation on the session's first prompt. All three calls run in
+ * parallel and each fails open on its own.
+ */
+
+import type { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import { formatRecallContext, type L1Item, type SceneEntry } from "../format.js";
+
+export interface RecallOptions {
+  query: string;
+  maxResults: number;
+  includePersona: boolean;
+  includeSceneNav: boolean;
+  /** Whether the stable session block (persona, scenes, guide) is part of this recall. */
+  includeSessionContext: boolean;
+}
+
+export interface RecallResult {
+  context?: string;
+  l1Count: number;
+  personaIncluded: boolean;
+  sceneCount: number;
+  /** True when every request failed; the caller keeps its "session context sent" flag unset. */
+  allFailed: boolean;
+}
+
+export async function performRecall(client: V3MemoryClient, opts: RecallOptions): Promise<RecallResult> {
+  const wantPersona = opts.includeSessionContext && opts.includePersona;
+  const wantScenes = opts.includeSessionContext && opts.includeSceneNav;
+  const [search, persona, scenarios] = await Promise.allSettled([
+    opts.query.trim() ? client.searchAtomic({ query: opts.query, limit: opts.maxResults }) : Promise.resolve({ items: [] }),
+    wantPersona ? client.readCore() : Promise.resolve(null),
+    wantScenes ? client.listScenarios({}) : Promise.resolve(null),
+  ]);
+
+  const l1Items: L1Item[] = search.status === "fulfilled" ? (search.value?.items ?? []) : [];
+  const personaContent = persona.status === "fulfilled" && persona.value ? persona.value.content : null;
+  const scenes: SceneEntry[] = scenarios.status === "fulfilled" && scenarios.value ? (scenarios.value.entries ?? []) : [];
+  const allFailed = [search, persona, scenarios].every((result) => result.status === "rejected");
+
+  return {
+    // A total outage injects nothing: the tool guide alone would advertise tools that just failed.
+    context: allFailed
+      ? undefined
+      : formatRecallContext({ l1Items, persona: personaContent, scenes, includeSessionContext: opts.includeSessionContext }),
+    l1Count: l1Items.length,
+    personaIncluded: Boolean(personaContent),
+    sceneCount: scenes.length,
+    allFailed,
+  };
+}

--- a/MemoryCore/claude-code-plugin/src/hooks/state.ts
+++ b/MemoryCore/claude-code-plugin/src/hooks/state.ts
@@ -1,0 +1,250 @@
+/**
+ * State shared between hook processes.
+ *
+ * Every Claude Code hook is a separate process, so the prompt cached at
+ * UserPromptSubmit, the capture markers and the transcript position live in
+ * small files under one directory. Names are hashes of the session id (and
+ * prompt id), so nothing sensitive appears in file names.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, open, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface PromptRecord {
+  sessionId: string;
+  promptId: string;
+  prompt: string;
+}
+
+export interface PluginStateOptions {
+  /** Prompt cache and capture markers expire after this. */
+  stateTtlMs?: number;
+  /** A capture claim left by a killed hook is reclaimable after this. */
+  claimTtlMs?: number;
+  /** Session-level markers (transcript position, persona sent) expire after this. */
+  sessionTtlMs?: number;
+}
+
+const DEFAULT_STATE_TTL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_CLAIM_TTL_MS = 60_000;
+const DEFAULT_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+
+export class PluginState {
+  private readonly stateTtlMs: number;
+  private readonly claimTtlMs: number;
+  private readonly sessionTtlMs: number;
+
+  constructor(private readonly stateDir: string, options: PluginStateOptions = {}) {
+    this.stateTtlMs = options.stateTtlMs ?? DEFAULT_STATE_TTL_MS;
+    this.claimTtlMs = options.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS;
+    this.sessionTtlMs = options.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
+  }
+
+  // ── prompt cache ──────────────────────────────────────────────────────
+
+  async savePrompt(sessionId: string, promptId: string, prompt: string): Promise<void> {
+    await this.cleanupExpiredState();
+    await this.writeAtomic(this.promptPath(sessionId, promptId), JSON.stringify({ sessionId, promptId, prompt } satisfies PromptRecord));
+  }
+
+  /** For hosts that do not supply `prompt_id`: remember the newest prompt of the session. */
+  async saveLatestPrompt(sessionId: string, prompt: string): Promise<string> {
+    const promptId = `fallback:${randomUUID()}`;
+    await this.savePrompt(sessionId, promptId, prompt);
+    await this.writeAtomic(this.sessionPath(sessionId, "latest-prompt.json"), JSON.stringify({ promptId }));
+    return promptId;
+  }
+
+  async getPromptRecord(sessionId: string, promptId: string): Promise<PromptRecord | undefined> {
+    const raw = await readOptional(this.promptPath(sessionId, promptId));
+    if (!raw) return undefined;
+    const record = JSON.parse(raw) as Partial<PromptRecord>;
+    return typeof record.prompt === "string" ? { sessionId, promptId, prompt: record.prompt } : undefined;
+  }
+
+  async getLatestPromptRecord(sessionId: string): Promise<PromptRecord | undefined> {
+    const raw = await readOptional(this.sessionPath(sessionId, "latest-prompt.json"));
+    if (!raw) return undefined;
+    const record = JSON.parse(raw) as { promptId?: unknown };
+    return typeof record.promptId === "string" ? this.getPromptRecord(sessionId, record.promptId) : undefined;
+  }
+
+  // ── per-turn capture markers ──────────────────────────────────────────
+
+  async isCaptured(sessionId: string, promptId: string): Promise<boolean> {
+    return exists(this.capturedPath(sessionId, promptId));
+  }
+
+  /** Claim a turn so two Stop processes never capture it twice. */
+  async beginCapture(sessionId: string, promptId: string): Promise<boolean> {
+    await mkdir(this.stateDir, { recursive: true });
+    await this.cleanupExpiredState();
+    if (await this.isCaptured(sessionId, promptId)) return false;
+    const claimPath = this.claimPath(sessionId, promptId);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const handle = await open(claimPath, "wx", 0o600);
+        await handle.writeFile(JSON.stringify({ pid: process.pid, claimedAt: Date.now() }));
+        await handle.close();
+        return true;
+      } catch (error) {
+        if (!isExistingFile(error)) throw error;
+        if (attempt > 0 || !await this.isClaimStale(claimPath)) return false;
+        await rm(claimPath, { force: true });
+      }
+    }
+    return false;
+  }
+
+  async releaseCapture(sessionId: string, promptId: string): Promise<void> {
+    await rm(this.claimPath(sessionId, promptId), { force: true });
+  }
+
+  async markCaptured(sessionId: string, promptId: string): Promise<void> {
+    await mkdir(this.stateDir, { recursive: true });
+    await writeFile(this.capturedPath(sessionId, promptId), "captured\n", { encoding: "utf-8", mode: 0o600 });
+    await Promise.all([
+      rm(this.promptPath(sessionId, promptId), { force: true }),
+      rm(this.claimPath(sessionId, promptId), { force: true }),
+    ]);
+  }
+
+  // ── session-level markers ─────────────────────────────────────────────
+
+  /** Last transcript entry uuid sent to the Gateway. */
+  async getTranscriptMarker(sessionId: string): Promise<string | undefined> {
+    const raw = await readOptional(this.sessionPath(sessionId, "transcript-marker.json"));
+    if (!raw) return undefined;
+    const marker = JSON.parse(raw) as { lastUuid?: unknown };
+    return typeof marker.lastUuid === "string" && marker.lastUuid ? marker.lastUuid : undefined;
+  }
+
+  async setTranscriptMarker(sessionId: string, lastUuid: string): Promise<void> {
+    await this.writeAtomic(this.sessionPath(sessionId, "transcript-marker.json"), JSON.stringify({ lastUuid, updatedAt: Date.now() }));
+  }
+
+  /** A named once-per-session flag, for example "persona-sent". */
+  async hasSessionFlag(sessionId: string, name: string): Promise<boolean> {
+    return exists(this.sessionPath(sessionId, `${name}.flag`));
+  }
+
+  async setSessionFlag(sessionId: string, name: string): Promise<void> {
+    await this.writeAtomic(this.sessionPath(sessionId, `${name}.flag`), JSON.stringify({ setAt: Date.now() }));
+  }
+
+  // ── housekeeping ──────────────────────────────────────────────────────
+
+  async cleanupExpiredState(): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(this.stateDir, { withFileTypes: true });
+    } catch (error) {
+      if (isMissingFile(error)) return;
+      throw error;
+    }
+    const now = Date.now();
+    await Promise.all(entries
+      .filter((entry) => entry.isFile() && isStateFile(entry.name))
+      .map(async (entry) => {
+        const file = path.join(this.stateDir, entry.name);
+        let metadata;
+        try {
+          metadata = await stat(file);
+        } catch (error) {
+          if (isMissingFile(error)) return;
+          throw error;
+        }
+        if (entry.name.endsWith(".capture.claim")) {
+          if (metadata.mtimeMs < now - this.claimTtlMs && await this.isClaimStale(file)) await rm(file, { force: true });
+        } else if (entry.name.endsWith(".transcript-marker.json") || entry.name.endsWith(".flag")) {
+          if (metadata.mtimeMs < now - this.sessionTtlMs) await rm(file, { force: true });
+        } else if (metadata.mtimeMs < now - this.stateTtlMs) {
+          await rm(file, { force: true });
+        }
+      }));
+  }
+
+  private async writeAtomic(target: string, content: string): Promise<void> {
+    await mkdir(this.stateDir, { recursive: true });
+    const temp = `${target}.${randomUUID()}.tmp`;
+    await writeFile(temp, content, { encoding: "utf-8", mode: 0o600 });
+    try {
+      await rename(temp, target);
+    } catch (error) {
+      await rm(temp, { force: true });
+      throw error;
+    }
+  }
+
+  private promptPath(sessionId: string, promptId: string): string {
+    return path.join(this.stateDir, `${hash(`${sessionId}\0${promptId}`)}.prompt.json`);
+  }
+
+  private claimPath(sessionId: string, promptId: string): string {
+    return path.join(this.stateDir, `${hash(`${sessionId}\0${promptId}`)}.capture.claim`);
+  }
+
+  private capturedPath(sessionId: string, promptId: string): string {
+    return path.join(this.stateDir, `${hash(`${sessionId}\0${promptId}`)}.captured`);
+  }
+
+  private sessionPath(sessionId: string, suffix: string): string {
+    return path.join(this.stateDir, `${hash(sessionId)}.${suffix}`);
+  }
+
+  private async isClaimStale(claimPath: string): Promise<boolean> {
+    try {
+      const metadata = await stat(claimPath);
+      const claim = JSON.parse(await readFile(claimPath, "utf-8")) as { pid?: unknown };
+      if (typeof claim.pid === "number" && isProcessRunning(claim.pid)) return false;
+      return metadata.mtimeMs < Date.now() - this.claimTtlMs;
+    } catch (error) {
+      return isMissingFile(error);
+    }
+  }
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function readOptional(file: string): Promise<string | undefined> {
+  try {
+    return await readFile(file, "utf-8");
+  } catch (error) {
+    if (isMissingFile(error)) return undefined;
+    throw error;
+  }
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await stat(file);
+    return true;
+  } catch (error) {
+    if (isMissingFile(error)) return false;
+    throw error;
+  }
+}
+
+function isStateFile(name: string): boolean {
+  return /^[a-f0-9]{64}\.(?:prompt\.json|latest-prompt\.json|capture\.claim|captured|transcript-marker\.json|[a-z-]+\.flag)(?:\.[0-9a-f-]{36}\.tmp)?$/.test(name);
+}
+
+function isMissingFile(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isExistingFile(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "EEXIST";
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && "code" in error && error.code === "EPERM";
+  }
+}

--- a/MemoryCore/claude-code-plugin/src/hooks/transcript.ts
+++ b/MemoryCore/claude-code-plugin/src/hooks/transcript.ts
@@ -1,0 +1,315 @@
+/**
+ * Claude Code transcript → L0 messages.
+ *
+ * Claude Code writes every session as JSONL under its projects directory and
+ * names the file in each hook payload (`transcript_path`). This module turns
+ * the entries after a marker into v3 conversation items: prompts, tool calls,
+ * tool results, intermediate and final assistant text. The Gateway records
+ * what it is sent, so exclusion of already-captured turns and redaction of
+ * credential-shaped text both happen here.
+ */
+
+import { access, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface TranscriptContentBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+}
+
+export interface TranscriptEntry {
+  uuid: string;
+  type: "user" | "assistant";
+  promptId?: string;
+  timestamp?: string;
+  isMeta?: boolean;
+  isSidechain?: boolean;
+  message: {
+    role?: string;
+    content?: string | TranscriptContentBlock[];
+  };
+}
+
+export interface TranscriptMessage {
+  /** Stable id: `claude-code:<session>:<entry uuid>[#chunk]`. */
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  /** ISO timestamp of the transcript entry, when it carries one. */
+  timestamp?: string;
+  /** Transcript entry the message came from; the capture marker records the last one sent. */
+  sourceUuid: string;
+}
+
+export interface NormalizeTranscriptOptions {
+  sessionId: string;
+  /** Prompt ids whose prompt + final assistant text were already captured by the plain path. */
+  capturedPromptIds?: Set<string>;
+  chunkChars?: number;
+  toolInputMaxChars?: number;
+  toolResultMaxChars?: number;
+}
+
+export const DEFAULT_CHUNK_CHARS = 8_192;
+export const DEFAULT_TOOL_INPUT_MAX_CHARS = 2_000;
+export const DEFAULT_TOOL_RESULT_MAX_CHARS = 4_000;
+export const DEFAULT_BATCH_SIZE = 100;
+
+/**
+ * Credential shapes that tool traffic routinely carries (env dumps, config
+ * files, curl commands). Each match becomes `[redacted:<kind>]`; surrounding
+ * text stays so the event is still legible.
+ */
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "private-key"],
+  [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{16,}/g, "authorization"],
+  [/\bsk-[A-Za-z0-9_-]{16,}/g, "secret-key"],
+  [/\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}/g, "github-token"],
+  [/\bglpat-[A-Za-z0-9_-]{16,}/g, "gitlab-token"],
+  [/\bxox[abprs]-[A-Za-z0-9-]{10,}/g, "slack-token"],
+  [/\bAKIA[0-9A-Z]{16}\b/g, "aws-access-key"],
+  [/\bAIza[0-9A-Za-z_-]{30,}\b/g, "google-api-key"],
+  [/\bnpm_[A-Za-z0-9]{30,}\b/g, "npm-token"],
+  [/\b[a-z]+_[0-9a-f]{40,}\b/g, "token"],
+  [/\b((?:api[_-]?key|api[_-]?token|access[_-]?token|secret|password|passwd|pwd)\s*[=:]\s*["']?)([^\s"'&]{8,})/gi, "value"],
+];
+
+export function redactSecrets(text: string): string {
+  let out = text;
+  for (const [pattern, kind] of SECRET_PATTERNS) {
+    out = kind === "value"
+      ? out.replace(pattern, (_match, key: string) => `${key}[redacted:${kind}]`)
+      : out.replace(pattern, `[redacted:${kind}]`);
+  }
+  return out;
+}
+
+export async function readTranscriptEntries(transcriptPath: string): Promise<TranscriptEntry[]> {
+  const raw = await readFile(transcriptPath, "utf-8");
+  const entries: TranscriptEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const entry = parsed as Partial<TranscriptEntry>;
+    if (entry.type !== "user" && entry.type !== "assistant") continue;
+    if (typeof entry.uuid !== "string" || !entry.message || typeof entry.message !== "object") continue;
+    if (entry.isSidechain === true || entry.isMeta === true) continue;
+    entries.push(entry as TranscriptEntry);
+  }
+  return entries;
+}
+
+export function sliceAfter(entries: TranscriptEntry[], afterUuid: string | undefined): TranscriptEntry[] {
+  if (!afterUuid) return entries;
+  const index = entries.findIndex((entry) => entry.uuid === afterUuid);
+  return index === -1 ? entries : entries.slice(index + 1);
+}
+
+export function promptIdsIn(entries: TranscriptEntry[]): string[] {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (entry.type === "user" && entry.promptId && isPromptEntry(entry) && !seen.has(entry.promptId)) {
+      seen.add(entry.promptId);
+    }
+  }
+  return [...seen];
+}
+
+interface Part {
+  text: string;
+  prose: boolean;
+}
+
+/**
+ * Policy: thinking and images dropped; a tool call becomes assistant text
+ * `[tool_use …]`; a tool result becomes user text `[tool_result …]`; long
+ * content chunked. For a turn in `capturedPromptIds` the prompt and the final
+ * assistant prose are left out; its tool traffic stays.
+ */
+export function normalizeTranscript(entries: TranscriptEntry[], options: NormalizeTranscriptOptions): TranscriptMessage[] {
+  const chunkChars = options.chunkChars ?? DEFAULT_CHUNK_CHARS;
+  const toolInputMax = options.toolInputMaxChars ?? DEFAULT_TOOL_INPUT_MAX_CHARS;
+  const toolResultMax = options.toolResultMaxChars ?? DEFAULT_TOOL_RESULT_MAX_CHARS;
+  const captured = options.capturedPromptIds ?? new Set<string>();
+
+  interface Draft {
+    entry: TranscriptEntry;
+    role: "user" | "assistant";
+    parts: Part[];
+    prompt: boolean;
+    promptId?: string;
+  }
+
+  const drafts: Draft[] = [];
+  let currentPromptId: string | undefined;
+
+  for (const entry of entries) {
+    const content = entry.message.content;
+    if (entry.type === "user") {
+      const parts: Part[] = [];
+      if (typeof content === "string") {
+        parts.push({ text: content, prose: true });
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== "object") continue;
+          if (block.type === "text" && typeof block.text === "string") {
+            parts.push({ text: block.text, prose: true });
+          } else if (block.type === "tool_result") {
+            const body = clip(blockText(block.content), toolResultMax);
+            parts.push({ text: `[tool_result tool_use_id=${block.tool_use_id ?? ""}] ${body}`.trim(), prose: false });
+          }
+        }
+      }
+      const prompt = isPromptEntry(entry);
+      if (prompt) currentPromptId = entry.promptId;
+      drafts.push({ entry, role: "user", parts, prompt, promptId: prompt ? entry.promptId : currentPromptId });
+    } else {
+      const parts: Part[] = [];
+      if (typeof content === "string") {
+        parts.push({ text: content, prose: true });
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== "object") continue;
+          if (block.type === "text" && typeof block.text === "string") {
+            parts.push({ text: block.text, prose: true });
+          } else if (block.type === "tool_use") {
+            const input = clip(safeJson(block.input ?? {}), toolInputMax);
+            parts.push({ text: `[tool_use id=${block.id ?? ""} name=${block.name ?? ""} input=${input}]`, prose: false });
+          }
+        }
+      }
+      drafts.push({ entry, role: "assistant", parts, prompt: false, promptId: currentPromptId });
+    }
+  }
+
+  const finalProseIndex = new Set<number>();
+  for (let i = 0; i < drafts.length; i += 1) {
+    const draft = drafts[i];
+    if (!draft.promptId || !captured.has(draft.promptId)) continue;
+    if (draft.role !== "assistant" || !draft.parts.some((part) => part.prose && part.text.trim())) continue;
+    let last = true;
+    for (let j = i + 1; j < drafts.length; j += 1) {
+      if (drafts[j].prompt) break;
+      if (drafts[j].role === "assistant" && drafts[j].parts.some((part) => part.prose && part.text.trim())) {
+        last = false;
+        break;
+      }
+    }
+    if (last) finalProseIndex.add(i);
+  }
+
+  const messages: TranscriptMessage[] = [];
+  drafts.forEach((draft, index) => {
+    let parts = draft.parts;
+    if (draft.promptId && captured.has(draft.promptId)) {
+      if (draft.prompt) return;
+      if (finalProseIndex.has(index)) parts = parts.filter((part) => !part.prose);
+    }
+    const text = redactSecrets(parts.map((part) => part.text).filter((part) => part.trim()).join("\n").trim());
+    if (!text) return;
+    const base = `claude-code:${options.sessionId}:${draft.entry.uuid}`;
+    const timestamp = typeof draft.entry.timestamp === "string" ? draft.entry.timestamp : undefined;
+    chunk(text, chunkChars).forEach((piece, chunkIndex) => {
+      messages.push({
+        id: chunkIndex === 0 ? base : `${base}#${chunkIndex}`,
+        role: draft.role,
+        content: piece,
+        ...(timestamp ? { timestamp } : {}),
+        sourceUuid: draft.entry.uuid,
+      });
+    });
+  });
+  return messages;
+}
+
+export function splitBatches<T>(messages: T[], size = DEFAULT_BATCH_SIZE): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < messages.length; i += size) batches.push(messages.slice(i, i + size));
+  return batches;
+}
+
+/**
+ * Claude Code passes `transcript_path` in every hook payload. When absent, the
+ * file is looked up under the projects directory, whose per-project folder is
+ * the cwd with every non-alphanumeric character replaced by `-`.
+ */
+export async function resolveTranscriptPath(input: {
+  transcriptPath?: string;
+  cwd?: string;
+  sessionId: string;
+  claudeConfigDir?: string;
+}): Promise<string | undefined> {
+  if (input.transcriptPath && await exists(input.transcriptPath)) return input.transcriptPath;
+  if (!input.cwd) return undefined;
+  const configDir = input.claudeConfigDir ?? process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+  const candidate = path.join(configDir, "projects", input.cwd.replace(/[^A-Za-z0-9]/g, "-"), `${input.sessionId}.jsonl`);
+  return await exists(candidate) ? candidate : undefined;
+}
+
+export function isPromptEntry(entry: TranscriptEntry): boolean {
+  if (entry.type !== "user") return false;
+  const content = entry.message.content;
+  if (typeof content === "string") return content.trim().length > 0;
+  if (!Array.isArray(content)) return false;
+  const hasText = content.some((block) => block?.type === "text" && typeof block.text === "string" && block.text.trim());
+  const hasToolResult = content.some((block) => block?.type === "tool_result");
+  return hasText && !hasToolResult;
+}
+
+function blockText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (!block || typeof block !== "object") return "";
+        const b = block as TranscriptContentBlock;
+        if (b.type === "text" && typeof b.text === "string") return b.text;
+        if (b.type === "image") return "";
+        return safeJson(block);
+      })
+      .filter((text) => text.trim())
+      .join("\n");
+  }
+  if (content === undefined || content === null) return "";
+  return safeJson(content);
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function clip(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}… [${text.length - max} more chars]`;
+}
+
+function chunk(text: string, size: number): string[] {
+  if (text.length <= size) return [text];
+  const pieces: string[] = [];
+  for (let i = 0; i < text.length; i += size) pieces.push(text.slice(i, i + size));
+  return pieces;
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/MemoryCore/claude-code-plugin/src/index.ts
+++ b/MemoryCore/claude-code-plugin/src/index.ts
@@ -1,0 +1,19 @@
+export { loadConfig, defaultStateDir, type PluginConfig } from "./config.js";
+export { createMemoryClient, createKnowledge } from "./client.js";
+export { handleHook, type HookInput, type HookOutput, type HookDeps } from "./hooks/handler.js";
+export { PluginState } from "./hooks/state.js";
+export { performRecall } from "./hooks/recall.js";
+export { sendTranscriptDelta, sendPlainTurn } from "./hooks/capture.js";
+export {
+  normalizeTranscript,
+  readTranscriptEntries,
+  redactSecrets,
+  resolveTranscriptPath,
+  sliceAfter,
+  splitBatches,
+  type TranscriptEntry,
+  type TranscriptMessage,
+} from "./hooks/transcript.js";
+export { formatRecallContext, formatL1Memories, formatSessionContext, MEMORY_TOOLS_GUIDE } from "./format.js";
+export { KnowledgeServiceClient, createKnowledgeTools, WIKI_PAGE_BATCH_LIMIT, type KnowledgeTools } from "./knowledge.js";
+export { createClaudeCodeMcpServer } from "./mcp/server.js";

--- a/MemoryCore/claude-code-plugin/src/knowledge.ts
+++ b/MemoryCore/claude-code-plugin/src/knowledge.ts
@@ -1,0 +1,125 @@
+/**
+ * HTTP client for the Knowledge Service (team wikis).
+ *
+ * The Knowledge Service is a separate HTTP service from the memory Gateway.
+ * Every request is a JSON POST carrying the tenant identity in the body and
+ * the instance id in the `x-tdai-service-id` header; every response is an
+ * envelope `{ code, message, request_id?, data }` where `code === 0` is success.
+ * Wiki ids are always parameters, never defaults.
+ */
+
+export interface KnowledgeServiceOptions {
+  baseUrl: string;
+  apiKey?: string;
+  serviceId: string;
+  teamId?: string;
+  userId?: string;
+  agentId?: string;
+  timeoutMs?: number;
+  fetch?: typeof globalThis.fetch;
+}
+
+interface KnowledgeEnvelope<T> {
+  code?: number;
+  message?: string;
+  request_id?: string;
+  data?: T;
+}
+
+export class KnowledgeServiceClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly serviceId: string;
+  private readonly identity: Record<string, string>;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(options: KnowledgeServiceOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.serviceId = options.serviceId;
+    this.identity = {};
+    if (options.teamId) this.identity.team_id = options.teamId;
+    if (options.userId) this.identity.user_id = options.userId;
+    if (options.agentId) this.identity.agent_id = options.agentId;
+    this.timeoutMs = options.timeoutMs ?? 15_000;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  async post<T>(pathname: string, body: Record<string, unknown>): Promise<T> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${pathname}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-tdai-service-id": this.serviceId,
+          ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
+        },
+        body: JSON.stringify({ ...this.identity, ...body }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Knowledge ${pathname} returned HTTP ${response.status}`);
+      }
+      const envelope = await response.json() as KnowledgeEnvelope<T> | null;
+      if (envelope === null || typeof envelope !== "object") return envelope as T;
+      if (envelope.code !== undefined && envelope.code !== 0) {
+        const requestId = envelope.request_id ? ` (${envelope.request_id})` : "";
+        throw new Error(`Knowledge ${pathname} error ${envelope.code}: ${envelope.message ?? "unknown error"}${requestId}`);
+      }
+      return ("data" in envelope ? envelope.data : envelope) as T;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export interface WikiPageWrite {
+  ref: string;
+  content: string;
+}
+
+export const WIKI_PAGE_BATCH_LIMIT = 20;
+
+export interface KnowledgeTools {
+  listWikis(input?: { limit?: number }): Promise<unknown>;
+  searchWiki(input: { wikiId: string; query: string; limit?: number }): Promise<unknown>;
+  listWikiPages(input: { wikiId: string; limit?: number }): Promise<unknown>;
+  readWikiPages(input: { wikiId: string; refs: string[] }): Promise<unknown>;
+  writeWikiPages(input: { wikiId: string; pages: WikiPageWrite[] }): Promise<unknown>;
+}
+
+function clampLimit(value: number | undefined, fallback: number, max = 100): number {
+  return Math.min(max, Math.max(1, Math.trunc(value ?? fallback)));
+}
+
+function assertBatch(kind: string, count: number): void {
+  if (count > WIKI_PAGE_BATCH_LIMIT) {
+    throw new Error(`${kind}: ${count} given, max is ${WIKI_PAGE_BATCH_LIMIT}; split into multiple calls`);
+  }
+}
+
+export function createKnowledgeTools(options: KnowledgeServiceOptions): KnowledgeTools {
+  const knowledge = new KnowledgeServiceClient(options);
+  return {
+    listWikis(input = {}) {
+      return knowledge.post("/v3/wiki/list", { limit: clampLimit(input.limit, 20) });
+    },
+    searchWiki(input) {
+      return knowledge.post("/v3/wiki/search", { wiki_id: input.wikiId, query: input.query, limit: clampLimit(input.limit, 20) });
+    },
+    listWikiPages(input) {
+      return knowledge.post("/v3/wiki/page/ls", { wiki_id: input.wikiId, limit: clampLimit(input.limit, 20) });
+    },
+    async readWikiPages(input) {
+      assertBatch("wiki page read", input.refs.length);
+      return knowledge.post("/v3/wiki/page/read", { wiki_id: input.wikiId, refs: input.refs });
+    },
+    async writeWikiPages(input) {
+      assertBatch("wiki page write", input.pages.length);
+      return knowledge.post("/v3/wiki/page/write", { wiki_id: input.wikiId, pages: input.pages });
+    },
+  };
+}

--- a/MemoryCore/claude-code-plugin/src/mcp/server.ts
+++ b/MemoryCore/claude-code-plugin/src/mcp/server.ts
@@ -1,0 +1,155 @@
+/**
+ * stdio MCP server: memory tools on the Gateway v3 API, wiki tools on the
+ * Knowledge Service. Lifecycle hooks do the automatic recall and capture;
+ * these tools are for on-demand detail and for explicit milestone captures.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import type { V3MemoryClient } from "@tencentdb-agent-memory/memory-sdk-ts-v2";
+import { WIKI_PAGE_BATCH_LIMIT, type KnowledgeTools } from "../knowledge.js";
+
+export interface McpServerOptions {
+  memory: V3MemoryClient;
+  knowledge?: KnowledgeTools;
+  /** Session id used by tdai_memory_capture when the caller gives none. */
+  defaultSessionId?: string;
+}
+
+const INSTRUCTIONS =
+  "TencentDB Agent Memory tools for Claude Code. Lifecycle hooks already recall memory before each prompt and " +
+  "capture each turn. Use the search tools when the injected memory does not answer the question, " +
+  "tdai_memory_capture to record a milestone (a decision, a deploy, a lesson) in its own words, and the " +
+  "wiki tools for settled team knowledge before exploring the filesystem.";
+
+function textResult(text: string, structured?: Record<string, unknown>) {
+  return { content: [{ type: "text" as const, text }], ...(structured ? { structuredContent: structured } : {}) };
+}
+
+function dataResult(data: unknown) {
+  const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  return textResult(text, data !== null && typeof data === "object" && !Array.isArray(data) ? data as Record<string, unknown> : undefined);
+}
+
+export function createClaudeCodeMcpServer(options: McpServerOptions): McpServer {
+  const { memory, knowledge } = options;
+  const server = new McpServer({ name: "tdai-claude-code", version: "0.1.0" }, { instructions: INSTRUCTIONS });
+
+  server.registerTool("tdai_memory_search", {
+    title: "Search structured memory",
+    description: "Search L1 structured memories: preferences, past events, decisions, rules.",
+    inputSchema: {
+      query: z.string().min(1),
+      limit: z.number().int().min(1).max(20).optional(),
+      type: z.enum(["persona", "episodic", "instruction"]).optional(),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ query, limit, type }) => {
+    const result = await memory.searchAtomic({ query, limit: limit ?? 5, type });
+    const items = result.items ?? [];
+    if (items.length === 0) return textResult("No matching memories found.", { items: [] });
+    const lines = [`Found ${items.length} matching memories:`, ""];
+    for (const item of items) {
+      const score = item.score != null ? ` (score: ${item.score.toFixed(3)})` : "";
+      lines.push(`- **[${item.type}]**${score}`, `  ${item.content}`, "");
+    }
+    return textResult(lines.join("\n"), { items });
+  });
+
+  server.registerTool("tdai_conversation_search", {
+    title: "Search conversation history",
+    description: "Search L0 raw conversation messages, including captured tool calls and results.",
+    inputSchema: {
+      query: z.string().min(1),
+      limit: z.number().int().min(1).max(20).optional(),
+      session_id: z.string().optional(),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ query, limit, session_id }) => {
+    const result = await memory.searchConversation({ query, limit: limit ?? 5, session_id });
+    const messages = result.messages ?? [];
+    if (messages.length === 0) return textResult("No matching conversation messages found.", { messages: [] });
+    const lines = [`Found ${messages.length} matching message(s):`, ""];
+    for (const message of messages) {
+      const score = message.score != null ? ` (score: ${message.score.toFixed(3)})` : "";
+      const when = message.timestamp ? ` [${message.timestamp}]` : "";
+      lines.push("---", `**[${message.role}]**${when}${score}`, "", message.content, "");
+    }
+    return textResult(lines.join("\n"), { messages });
+  });
+
+  server.registerTool("tdai_scenario_read", {
+    title: "Read a scene block",
+    description: "Read one L2 scene block by the path shown in Scene Navigation.",
+    inputSchema: { path: z.string().min(1) },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ path }) => {
+    const file = await memory.readScenario({ path });
+    return textResult(file.content ?? `(no scene block at ${path})`, { path: file.path, content: file.content });
+  });
+
+  server.registerTool("tdai_memory_capture", {
+    title: "Capture a milestone",
+    description:
+      "Record a milestone in L0 in your own words: a ruling from the user, a merged change, a deploy, a lesson that cost time. " +
+      "Hooks capture the transcript; this is for the summary other agents should find first.",
+    inputSchema: {
+      note: z.string().min(1).describe("What happened and why it matters, written for a reader with no context."),
+      session_id: z.string().optional(),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+  }, async ({ note, session_id }) => {
+    const sessionId = session_id ?? options.defaultSessionId ?? `claude-code:${new Date().toISOString().slice(0, 10)}`;
+    const result = await memory.addConversation({
+      session_id: sessionId,
+      messages: [{ role: "assistant", content: note }],
+    });
+    return textResult(`Captured (${result.accepted_ids?.length ?? 0} message).`, { session_id: sessionId, accepted_ids: result.accepted_ids });
+  });
+
+  if (knowledge) registerWikiTools(server, knowledge);
+  return server;
+}
+
+const WIKI_ID = z.string().min(1).describe("Wiki id, from tdai_wiki_list.");
+const WIKI_LIMIT = z.number().int().min(1).max(100).optional().describe("Max results (default 20, max 100).");
+
+function registerWikiTools(server: McpServer, wiki: KnowledgeTools): void {
+  server.registerTool("tdai_wiki_list", {
+    title: "List wikis",
+    description: "List the team wikis on the Knowledge Service. Returns wiki ids and names needed by every other wiki tool.",
+    inputSchema: { limit: WIKI_LIMIT },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ limit }) => dataResult(await wiki.listWikis({ limit })));
+
+  server.registerTool("tdai_wiki_search", {
+    title: "Search a wiki",
+    description: "Full-text search inside one team wiki: product docs, architecture, contracts, deploy recipes, decisions. Search here before hunting the filesystem.",
+    inputSchema: { wiki_id: WIKI_ID, query: z.string().min(1), limit: WIKI_LIMIT },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ wiki_id, query, limit }) => dataResult(await wiki.searchWiki({ wikiId: wiki_id, query, limit })));
+
+  server.registerTool("tdai_wiki_pages", {
+    title: "List wiki pages",
+    description: "List page refs in one team wiki.",
+    inputSchema: { wiki_id: WIKI_ID, limit: WIKI_LIMIT },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ wiki_id, limit }) => dataResult(await wiki.listWikiPages({ wikiId: wiki_id, limit })));
+
+  server.registerTool("tdai_wiki_read", {
+    title: "Read wiki pages",
+    description: `Read page contents from one team wiki (max ${WIKI_PAGE_BATCH_LIMIT} refs per call).`,
+    inputSchema: { wiki_id: WIKI_ID, refs: z.array(z.string().min(1)).min(1).max(WIKI_PAGE_BATCH_LIMIT) },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  }, async ({ wiki_id, refs }) => dataResult(await wiki.readWikiPages({ wikiId: wiki_id, refs })));
+
+  server.registerTool("tdai_wiki_write", {
+    title: "Write wiki pages",
+    description: `Create or update markdown pages in one team wiki (max ${WIKI_PAGE_BATCH_LIMIT} per call). Read the existing page first and amend it; a locked page fails with a lock error, so retry.`,
+    inputSchema: {
+      wiki_id: WIKI_ID,
+      pages: z.array(z.object({ ref: z.string().min(1), content: z.string() })).min(1).max(WIKI_PAGE_BATCH_LIMIT),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+  }, async ({ wiki_id, pages }) => dataResult(await wiki.writeWikiPages({ wikiId: wiki_id, pages })));
+}

--- a/MemoryCore/claude-code-plugin/src/mcp/stdio.ts
+++ b/MemoryCore/claude-code-plugin/src/mcp/stdio.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { loadConfig } from "../config.js";
+import { createKnowledge, createMemoryClient } from "../client.js";
+import { createClaudeCodeMcpServer } from "./server.js";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const server = createClaudeCodeMcpServer({
+    memory: createMemoryClient(config, config.captureTimeoutMs),
+    knowledge: createKnowledge(config),
+  });
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((error) => {
+  process.stderr.write(`[tdai][claude-code][mcp] ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/MemoryCore/claude-code-plugin/tsconfig.json
+++ b/MemoryCore/claude-code-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/MemoryCore/claude-code-plugin/vitest.config.ts
+++ b/MemoryCore/claude-code-plugin/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Description | 描述

Adds `MemoryCore/claude-code-plugin/`: a **native** Claude Code client for Memory Gateway **`/v3/*`**, in the same shape as the OpenClaw client adapter (`MemoryCore/openclaw-plugin/`): a pure client over `@tencentdb-agent-memory/memory-sdk-ts-v2`, no extraction or storage, and **no LLM-traffic proxy**. Claude Code keeps talking to Anthropic directly; memory arrives through Claude Code's own lifecycle hooks and a stdio MCP server. It sits beside the existing proxy route (`agents/claude-code/`) as the choice for teams that do not want to move model traffic, keys, or billing to the proxy.

新增 `MemoryCore/claude-code-plugin/`：Memory Gateway `/v3/*` 的 **原生** Claude Code 客户端，形态与 OpenClaw 客户端适配器一致——基于 `@tencentdb-agent-memory/memory-sdk-ts-v2` 的纯客户端，不做抽取和存储，**不经过 LLM 流量代理**。Claude Code 仍直连 Anthropic；记忆通过 Claude Code 自身的生命周期 Hook 与一个 stdio MCP server 接入。与现有代理路线（`agents/claude-code/`）并列，供不希望把模型流量、密钥与计费转到代理的团队选用。

**Hooks** (one process per event; state shared via hashed files in a state dir)
- `UserPromptSubmit`: `searchAtomic` for the prompt on every turn; `readCore` + `listScenarios` once per session; injected as `additionalContext` (`<user-persona>`, `<scene-navigation>`, `<relevant-memories>`, tool guide). A total Gateway outage injects nothing.
- `Stop`: the finished turn is read from the transcript named by `transcript_path` (fallback: the Claude Code projects directory) and sent as one `addConversation`: prompt, tool calls, tool results, intermediate and final text. Thinking/images dropped; tool traffic quoted with size caps; 8192-char chunks; 100 messages per batch. **Credential-shaped substrings are redacted** before sending (tool traffic carries env dumps and config files). Falls back to prompt + reply when no transcript can be read. Skipped while `background_tasks` / `session_crons` are present.
- `SessionEnd`: whatever transcript remains unsent. A failed batch leaves the marker at the last batch that landed and the turn unclaimed, so a later hook sends the rest.

**MCP server** (stdio): `tdai_memory_search`, `tdai_conversation_search`, `tdai_scenario_read`, `tdai_memory_capture` (a milestone in the agent's own words), and, when `TDAI_KNOWLEDGE_URL` is set, `tdai_wiki_list / search / pages / read / write` against the Knowledge Service `/v3/wiki` API. Wiki ids are always tool parameters; identity comes from `TDAI_*` env; the plugin carries no organisation-specific content.

Docs: bilingual `README.md` / `README_CN.md`, `integrations/hooks.json`, `integrations/mcp.json.example`; one row added to the agent tables in `INSTALL.md` / `INSTALL_CN.md`.

## Related Issue | 关联 Issue

#926 (Adapters Wanted, Claude Code native route). Complements #1126's proxy route for Pi and `agents/claude-code/` for Claude Code rather than replacing them.

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 — `npm run typecheck`, `npm run build`, `npm test` (17 vitest tests: transcript normalisation and redaction, hook flows incl. partial failure and retry, MCP round-trips, Knowledge client envelopes). Live against a running Gateway + Knowledge Service: first-prompt recall 178 ms with persona/guide/L1, second prompt L1 only; `Stop` sent the turn in 346 ms with the secret redacted; `queryConversation` read back all four messages; MCP server lists 9 tools and returns real wiki and memory hits.
- [x] No existing features affected | 无影响现有功能 — new directory only; two table rows in the install guides.

## Additional Notes | 其他说明

Design choices worth a reviewer's eye: (1) per-turn capture at `Stop` rather than only at `SessionEnd`, because a 100-message batch costs the Gateway a few seconds and a session's `SessionEnd` fires once, so end-only capture loses the tail of long sessions; (2) redaction on the client, because the Gateway records what it is sent; (3) the MCP wiki tools include `wiki_write`, which `MemoryKnowledge`'s own MCP server does not yet expose — happy to move that there instead if preferred.

Commit is DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkVfNqVBnTAHnc62NUieKj