### PR TITLE
[good first issue-platform adapt-Pi] Add native Memory extension for Pi (no proxy), beside pi-plugin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -287,6 +287,7 @@ The Proxy supports 9 agent clients. **Full setup instructions, adaptation detail
 | **Hermes** | `~/.hermes/config.yaml` + header preselect | [`agents/hermes/`](./agents/hermes/) |
 | **OpenClaw** | `~/.openclaw/openclaw.json` + header preselect | [`agents/openclaw/`](./agents/openclaw/) |
 | **Pi** | `pi-plugin` extension (env vars) | [`MemoryCore/pi-plugin/`](./MemoryCore/pi-plugin/) |
+| **Pi (native, no proxy)** | `pi-native-plugin` extension (env vars); Pi keeps its own model provider | [`MemoryCore/pi-native-plugin/`](./MemoryCore/pi-native-plugin/) |
 | **Other platforms** | Header preselect (generic) | [`agents/README.md`](./agents/README.md) |
 
 The proxy pipeline in order: `auth` (validates user_key) → `sessionInit`

--- a/INSTALL_CN.md
+++ b/INSTALL_CN.md
@@ -263,6 +263,8 @@ Proxy 目前支持 8 类 AI Agent 客户端。每个 agent 的**完整接入配�
 | **OpenCode** | `~/.config/opencode/opencode.json` | [`agents/opencode/`](./agents/opencode/) |
 | **Hermes** | `~/.hermes/config.yaml` + Header 预选 | [`agents/hermes/`](./agents/hermes/) |
 | **OpenClaw** | `~/.openclaw/openclaw.json` + Header 预选 | [`agents/openclaw/`](./agents/openclaw/) |
+| **Pi** | `pi-plugin` 扩展（环境变量） | [`MemoryCore/pi-plugin/`](./MemoryCore/pi-plugin/) |
+| **Pi（原生，不经代理）** | `pi-native-plugin` 扩展（环境变量）；Pi 保留自己的模型提供方 | [`MemoryCore/pi-native-plugin/`](./MemoryCore/pi-native-plugin/) |
 | **其他平台** | Header 预选（通用） | [`agents/README.md`](./agents/README.md) |
 
 Proxy 会依次做：`auth`（校验 user_key）→ `sessionInit`（选 team/agent/task

--- a/MemoryCore/pi-native-plugin/.gitignore
+++ b/MemoryCore/pi-native-plugin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.tgz
+package-lock.json

--- a/MemoryCore/pi-native-plugin/README.md
+++ b/MemoryCore/pi-native-plugin/README.md
@@ -1,0 +1,92 @@
+# Pi Adapter for TencentDB Agent Memory (v3, native)
+
+[简体中文](./README_CN.md) · English
+
+This directory is the **native Pi extension** for Memory Gateway **`/v3/*`** and the Knowledge Service. It is the no-proxy counterpart of [`pi-plugin`](../pi-plugin/): where `pi-plugin` routes Pi's model traffic through the Memory Proxy and lets the proxy inject and capture, this extension keeps Pi on **its own model provider** and does recall, injection and capture itself through Pi's extension API. Choose it when you want memory without moving Pi's LLM traffic, key or billing to the proxy.
+
+| Item | Value |
+|------|-------|
+| Host | [Pi](https://github.com/earendil-works/pi) ≥ 0.84 |
+| Data plane | Gateway `/v3/atomic/*`, `/v3/conversation/add`, `/v3/core/read`, `/v3/scenario/ls`; Knowledge Service `/v3/wiki/*` |
+| Tools | 8 (`tdai_search`, `tdai_memory_list`, `tdai_capture`, `tdai_wiki_list`, `tdai_wiki_search`, `tdai_wiki_pages`, `tdai_wiki_read`, `tdai_wiki_write`) |
+| Injection | visible transcript message: L2/L3 once per session, L1 every turn (deduped), optional knowledge-map page |
+| Capture | full L0 transcript delta at `session_shutdown` |
+| Not included | proxy routing, Offload |
+
+The same code is published for `pi install` as [`@plainwuatlig/pi-tencentdb-agent-memory`](https://www.npmjs.com/package/@plainwuatlig/pi-tencentdb-agent-memory) (community package, source of truth at [plainwuatlig/pi-tencentdb-agent-memory](https://github.com/plainwuatlig/pi-tencentdb-agent-memory)); this directory tracks its releases.
+
+## What it does
+
+- **8 on-demand tools** — L1 recall (`tdai_search` / `tdai_memory_list`), manual capture (`tdai_capture`), and knowledge/wiki access (`tdai_wiki_list` / `search` / `pages` / `read` / `write`). Wiki ids are always parameters, discovered with `tdai_wiki_list`.
+- **Automatic L0 capture** — on `session_shutdown`, the conversation is written back as L0 messages: only the delta since the last capture, chunked to ≤ 8192 chars, batched to ≤ 100 messages per post. Thinking is dropped; tool calls and results become prefixed text. Kill switch: `TDAI_CAPTURE=off`.
+- **L2/L3 injection, once per session** — on the session's first `before_agent_start`, the L3 persona and the L2 scenario summaries are injected within a char budget (default 16,000 ≈ 4K tokens). Re-armed after `/compact` and retried after an outage. Kill switch: `TDAI_INJECT=off`.
+- **L1 injection, every turn** — the turn's own prompt is searched against L1 (top 3), deduped against the previous turn's hits.
+- **Knowledge-map injection (optional)** — `TDAI_INJECT_MAP="<wiki_id>:<page ref>"` injects a team-maintained wiki page first, so the agent knows what the knowledge base *contains*, not merely that it exists. Team content stays in the wiki; the extension carries none.
+- **Visible delivery** — every injection lands as an ordinary session message (`customType: "tdai-memory-inject"`, `display: true`), never a hidden splice, so it can be reviewed in the transcript.
+- **Query-first routing guidance** — tool descriptions tell the model to search memory and the wiki before hunting the filesystem for a repo, host, config or deploy recipe.
+
+Everything is fail-open: an outage, timeout or unset key degrades to "no injection / no capture" and never blocks Pi.
+
+## Tools
+
+| Tool | Endpoint | What it does |
+|---|---|---|
+| `tdai_search` | `POST /v3/atomic/search` | Semantic search over L1 memory notes |
+| `tdai_memory_list` | `POST /v3/atomic/query` | List L1 notes, newest first, with pagination |
+| `tdai_capture` | `POST /v3/conversation/add` | Store a note as an L0 message (L1 extraction happens async) |
+| `tdai_wiki_list` | `POST /v3/wiki/list` | List wikis in the Knowledge Service |
+| `tdai_wiki_search` | `POST /v3/wiki/search` | Full-text search inside one wiki |
+| `tdai_wiki_pages` | `POST /v3/wiki/page/ls` | List page refs in a wiki |
+| `tdai_wiki_read` | `POST /v3/wiki/page/read` | Read up to 20 pages by ref |
+| `tdai_wiki_write` | `POST /v3/wiki/page/write` | Write or update up to 20 markdown pages |
+
+## Install
+
+From npm (recommended, the published community package):
+
+```bash
+pi install npm:@plainwuatlig/pi-tencentdb-agent-memory
+```
+
+From this directory (development):
+
+```bash
+cd MemoryCore/pi-native-plugin
+npm install
+npm test
+pi -e .            # load once, or: pi install /absolute/path/to/MemoryCore/pi-native-plugin
+```
+
+## Configuration
+
+All configuration is by environment variables. **Fail-fast, no defaults:** the seven "yes" variables are required; if any is unset the extension refuses to load (Pi reports `Failed to load extension … missing …` and continues without it).
+
+| Variable | Required | Description |
+|---|---|---|
+| `TDAI_API_KEY` | yes | Per-user key (`sk-mem-…`), sent as Bearer to the Gateway |
+| `TDAI_GATEWAY_URL` | yes | Memory Gateway base URL |
+| `TDAI_KNOWLEDGE_URL` | yes | Knowledge Service base URL |
+| `TDAI_SERVICE_ID` | yes | Memory instance id (`x-tdai-service-id`), e.g. `default` |
+| `TDAI_TEAM_ID` / `TDAI_USER_ID` / `TDAI_AGENT_ID` | yes | v3 isolation triple, sent with every request |
+| `TDAI_INJECT` | no | `on` (default) / `off` — L2/L3 and L1 injection |
+| `TDAI_CAPTURE` | no | `on` (default) / `off` — automatic L0 capture at shutdown |
+| `TDAI_INJECT_MAX_CHARS` | no | Injection char budget (default `16000`) |
+| `TDAI_SCENARIO_MAP` | no | JSON `{ "cwd-prefix": ["path", …] }` selecting L2 files per project; unset = all |
+| `TDAI_INJECT_MAP` | no | `<wiki_id>:<page ref>` of a knowledge-map page to inject once per session |
+
+## Notes
+
+- **L0 → L1 is async.** A capture lands as an L0 message; the pipeline extracts it into L1 notes on its own schedule.
+- **Capture is a session-close act.** Mid-session capture would contaminate recall for the running session and memorialise drafts; the extension captures the consolidated transcript at shutdown, and `tdai_capture` exists for milestones the agent wants recorded in its own words.
+- **Relation to `pi-plugin`.** Both can coexist in a Pi install; use one. `pi-plugin` gives server-side injection through the proxy with zero client code; this extension gives client-side, visible injection and wiki write without touching Pi's model route.
+
+## Files
+
+```text
+pi-native-plugin/
+├── extensions/tdai-memory/
+│   ├── index.ts     tools, hooks, injection, capture
+│   └── lib.ts       pure helpers: normalisation, batching, budgets, env validation
+├── __tests__/       vitest
+└── README.md / README_CN.md
+```

--- a/MemoryCore/pi-native-plugin/README_CN.md
+++ b/MemoryCore/pi-native-plugin/README_CN.md
@@ -1,0 +1,92 @@
+# Pi 适配器（v3，原生接入）
+
+简体中文 · [English](./README.md)
+
+本目录是 Memory Gateway **`/v3/*`** 与 Knowledge Service 的 **原生 Pi 扩展**，是 [`pi-plugin`](../pi-plugin/) 的不经代理版本：`pi-plugin` 把 Pi 的模型流量转到 Memory Proxy，由代理注入与捕获；本扩展让 Pi 保留**自己的模型提供方**，通过 Pi 扩展 API 自行完成召回、注入与捕获。当你希望获得记忆、又不想把 Pi 的 LLM 流量、密钥和计费转到代理时，选它。
+
+| 项目 | 值 |
+|------|----|
+| 宿主 | [Pi](https://github.com/earendil-works/pi) ≥ 0.84 |
+| 数据面 | Gateway `/v3/atomic/*`、`/v3/conversation/add`、`/v3/core/read`、`/v3/scenario/ls`；Knowledge Service `/v3/wiki/*` |
+| 工具 | 8 个（`tdai_search`、`tdai_memory_list`、`tdai_capture`、`tdai_wiki_list`、`tdai_wiki_search`、`tdai_wiki_pages`、`tdai_wiki_read`、`tdai_wiki_write`） |
+| 注入 | 可见的会话消息：L2/L3 每会话一次，L1 每回合一次（去重），可选知识地图页面 |
+| 捕获 | `session_shutdown` 时发送完整 L0 转录增量 |
+| 不包含 | 代理路由、Offload |
+
+同一份代码以 [`@plainwuatlig/pi-tencentdb-agent-memory`](https://www.npmjs.com/package/@plainwuatlig/pi-tencentdb-agent-memory) 发布供 `pi install` 使用（社区包，源码仓库 [plainwuatlig/pi-tencentdb-agent-memory](https://github.com/plainwuatlig/pi-tencentdb-agent-memory)）；本目录跟随其发布版本更新。
+
+## 功能
+
+- **8 个按需工具** — L1 召回（`tdai_search` / `tdai_memory_list`）、手动捕获（`tdai_capture`）、知识库访问（`tdai_wiki_list` / `search` / `pages` / `read` / `write`）。wiki id 始终是参数，用 `tdai_wiki_list` 查询。
+- **自动 L0 捕获** — 在 `session_shutdown` 时把对话写回为 L0 消息：只发自上次捕获以来的增量，按 ≤ 8192 字符分块，每次最多 100 条。thinking 丢弃，工具调用与结果转为带前缀的文本。开关：`TDAI_CAPTURE=off`。
+- **L2/L3 注入，每会话一次** — 在会话首个 `before_agent_start` 注入 L3 人格与 L2 场景摘要，受字符预算约束（默认 16,000 ≈ 4K token）。`/compact` 后重新武装，出错后下一回合重试。开关：`TDAI_INJECT=off`。
+- **L1 注入，每回合一次** — 用本回合 prompt 搜索 L1（前 3 条），与上一回合命中去重。
+- **知识地图注入（可选）** — `TDAI_INJECT_MAP="<wiki_id>:<page ref>"` 首先注入一页团队维护的 wiki 页面，让 agent 知道知识库*有什么*，而不只是知道它存在。团队内容留在 wiki 中，扩展本身不含任何团队内容。
+- **可见投递** — 所有注入都作为普通会话消息落地（`customType: "tdai-memory-inject"`、`display: true`），绝不隐式拼接，可在转录中审阅。
+- **查询优先的路由指引** — 工具描述要求模型在文件系统里翻找仓库、主机、配置或部署流程之前，先查记忆与 wiki。
+
+全部 fail-open：中断、超时或未设置密钥只会退化为"不注入 / 不捕获"，绝不阻塞 Pi。
+
+## 工具
+
+| 工具 | 端点 | 作用 |
+|---|---|---|
+| `tdai_search` | `POST /v3/atomic/search` | L1 记忆语义搜索 |
+| `tdai_memory_list` | `POST /v3/atomic/query` | 按时间倒序分页列出 L1 记忆 |
+| `tdai_capture` | `POST /v3/conversation/add` | 把一段说明写入 L0（L1 抽取异步进行） |
+| `tdai_wiki_list` | `POST /v3/wiki/list` | 列出 Knowledge Service 中的 wiki |
+| `tdai_wiki_search` | `POST /v3/wiki/search` | 单个 wiki 内全文搜索 |
+| `tdai_wiki_pages` | `POST /v3/wiki/page/ls` | 列出 wiki 页面 ref |
+| `tdai_wiki_read` | `POST /v3/wiki/page/read` | 按 ref 读取最多 20 页 |
+| `tdai_wiki_write` | `POST /v3/wiki/page/write` | 写入或更新最多 20 个 markdown 页面 |
+
+## 安装
+
+从 npm（推荐，已发布的社区包）：
+
+```bash
+pi install npm:@plainwuatlig/pi-tencentdb-agent-memory
+```
+
+从本目录（开发）：
+
+```bash
+cd MemoryCore/pi-native-plugin
+npm install
+npm test
+pi -e .            # 临时加载；或 pi install /absolute/path/to/MemoryCore/pi-native-plugin
+```
+
+## 配置
+
+全部通过环境变量配置。**Fail-fast，无默认值：**下表标"是"的七个变量必填，缺任一项扩展拒绝加载（Pi 提示 `Failed to load extension … missing …` 并继续运行）。
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `TDAI_API_KEY` | 是 | 用户级密钥（`sk-mem-…`），以 Bearer 发送给 Gateway |
+| `TDAI_GATEWAY_URL` | 是 | Memory Gateway 地址 |
+| `TDAI_KNOWLEDGE_URL` | 是 | Knowledge Service 地址 |
+| `TDAI_SERVICE_ID` | 是 | 记忆实例 id（`x-tdai-service-id`），如 `default` |
+| `TDAI_TEAM_ID` / `TDAI_USER_ID` / `TDAI_AGENT_ID` | 是 | v3 隔离三元组，随每个请求发送 |
+| `TDAI_INJECT` | 否 | `on`（默认）/ `off` — L2/L3 与 L1 注入 |
+| `TDAI_CAPTURE` | 否 | `on`（默认）/ `off` — 关闭时的自动 L0 捕获 |
+| `TDAI_INJECT_MAX_CHARS` | 否 | 注入字符预算（默认 `16000`） |
+| `TDAI_SCENARIO_MAP` | 否 | JSON `{ "cwd-prefix": ["path", …] }`，按项目选择 L2 文件；未设置则全部注入 |
+| `TDAI_INJECT_MAP` | 否 | 每会话注入一次的知识地图页面 `<wiki_id>:<page ref>` |
+
+## 说明
+
+- **L0 → L1 是异步的。** 捕获先落为 L0 消息，流水线再按自己的节奏抽取为 L1。
+- **捕获是会话结束时的动作。** 会话中途捕获会污染当前会话的召回并记下草稿；本扩展在关闭时捕获整合后的转录，`tdai_capture` 用于 agent 想以自己的话记下的里程碑。
+- **与 `pi-plugin` 的关系。** 两者可同时安装，但只用其一。`pi-plugin` 通过代理提供服务端注入、零客户端代码；本扩展提供客户端可见注入与 wiki 写入，且不改动 Pi 的模型路由。
+
+## 文件
+
+```text
+pi-native-plugin/
+├── extensions/tdai-memory/
+│   ├── index.ts     工具、hook、注入、捕获
+│   └── lib.ts       纯函数：规范化、分批、预算、环境变量校验
+├── __tests__/       vitest
+└── README.md / README_CN.md
+```

--- a/MemoryCore/pi-native-plugin/__tests__/index.test.ts
+++ b/MemoryCore/pi-native-plugin/__tests__/index.test.ts
@@ -1,0 +1,642 @@
+import { test, expect } from "vitest";
+
+// Configure the extension BEFORE importing it (it reads config at module load).
+process.env.TDAI_GATEWAY_URL = "http://tdai.test";
+// Trailing slash on purpose: exercises base-URL trailing-slash normalization (#7).
+process.env.TDAI_KNOWLEDGE_URL = "http://tdai-knowledge.test/";
+process.env.TDAI_API_KEY = "fake-key";
+process.env.TDAI_SERVICE_ID = "default";
+process.env.TDAI_TEAM_ID = "team-test";
+process.env.TDAI_USER_ID = "usr-test";
+process.env.TDAI_AGENT_ID = "agt-test";
+process.env.TDAI_INJECT = "1";
+process.env.TDAI_CAPTURE = "1";
+
+// Mock fetch — route by URL suffix, capture request bodies.
+const calls: { url: string; body: Record<string, unknown> }[] = [];
+const json = (status: number, obj: unknown) =>
+  new Response(JSON.stringify(obj), { status });
+globalThis.fetch = (async (url: string, init?: RequestInit) => {
+  const body = init?.body
+    ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+    : {};
+  calls.push({ url: String(url), body });
+  const u = String(url);
+  if (u.endsWith("/v3/core/read"))
+    return json(200, { code: 0, data: { content: "TEST CORE PERSONA" } });
+  if (u.endsWith("/v3/scenario/ls"))
+    return json(200, {
+      code: 0,
+      data: {
+        entries: [{ path: "proj.md", summary: "proj summary" }],
+        total: 1,
+      },
+    });
+  if (u.endsWith("/v3/conversation/add"))
+    return json(200, { code: 0, data: { ok: true } });
+  return json(404, { code: 1, message: "not found" });
+}) as typeof fetch;
+
+const { default: extension } = await import(
+  "../extensions/tdai-memory/index.js"
+);
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+};
+
+function makePi() {
+  const handlers: Record<string, Array<(...a: unknown[]) => unknown>> = {};
+  const tools = new Map<string, ToolDef>();
+  const appended: Array<{ type: string; data?: unknown }> = [];
+  const pi = {
+    on: (name: string, fn: (...a: unknown[]) => unknown) => {
+      (handlers[name] ||= []).push(fn);
+    },
+    registerTool: (def: ToolDef) => {
+      tools.set(def.name, def);
+    },
+    appendEntry: (type: string, data?: unknown) => {
+      appended.push({ type, data });
+    },
+  };
+  return { pi, handlers, appended, tools };
+}
+
+// Swap in a fetch mock that records requests; returns restore() to undo.
+function mockFetch(status: number, body: unknown) {
+  const seen: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const prev = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    seen.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? "{}")),
+    });
+    return new Response(
+      typeof body === "string" ? body : JSON.stringify(body),
+      { status },
+    );
+  }) as typeof fetch;
+  return { seen, restore: () => (globalThis.fetch = prev) };
+}
+
+// ── tool-level guards (issues #2, #3, #5, #6, #7, #8, #9, #11, #12, #15) ───
+
+function getTool(name: string): ToolDef {
+  const { pi, tools } = makePi();
+  extension(pi);
+  const tool = tools.get(name);
+  if (!tool) throw new Error(`tool ${name} not registered`);
+  return tool;
+}
+
+test("#2 tdai_wiki_write rejects more than 20 pages", async () => {
+  const pages = Array.from({ length: 21 }, (_, i) => ({
+    ref: `p${i}.md`,
+    content: "x",
+  }));
+  await expect(
+    getTool("tdai_wiki_write").execute("1", { wiki_id: "w", pages }),
+  ).rejects.toThrow(/21 pages given, max is 20/);
+});
+
+test("#3 tdai_wiki_read rejects more than 20 refs", async () => {
+  const refs = Array.from({ length: 21 }, (_, i) => `p${i}.md`);
+  await expect(
+    getTool("tdai_wiki_read").execute("1", { wiki_id: "w", refs }),
+  ).rejects.toThrow(/21 refs given, max is 20/);
+});
+
+test("#5 non-JSON 200 body -> friendly tdai error, not a raw SyntaxError", async () => {
+  const { restore } = mockFetch(200, "<html>bad gateway</html>");
+  try {
+    await expect(
+      getTool("tdai_search").execute("1", { query: "q" }),
+    ).rejects.toThrow(/^tdai \/v3\/atomic\/search: response is not valid JSON/);
+  } finally {
+    restore();
+  }
+});
+
+test("#5 literal null body does not throw a TypeError", async () => {
+  const { restore } = mockFetch(200, "null");
+  try {
+    const res = await getTool("tdai_search").execute("1", { query: "q" });
+    expect(res.content[0].text).toBe("{}");
+  } finally {
+    restore();
+  }
+});
+
+test("#6 explicit data:null returns the null payload, not the envelope", async () => {
+  const { restore } = mockFetch(200, {
+    code: 0,
+    message: "ok",
+    request_id: "req-1",
+    data: null,
+  });
+  try {
+    const res = await getTool("tdai_search").execute("1", { query: "q" });
+    expect(res.content[0].text).toBe("null");
+    expect(res.content[0].text).not.toContain("request_id");
+  } finally {
+    restore();
+  }
+});
+
+test("#6 missing data key still falls back to the envelope", async () => {
+  const { restore } = mockFetch(200, { code: 0, message: "ok" });
+  try {
+    const res = await getTool("tdai_search").execute("1", { query: "q" });
+    expect(res.content[0].text).toContain("message");
+  } finally {
+    restore();
+  }
+});
+
+test("#7 trailing-slash base URL does not produce a double slash", async () => {
+  const { seen, restore } = mockFetch(200, { code: 0, data: [] });
+  try {
+    await getTool("tdai_wiki_list").execute("1", {});
+    expect(seen[0].url).toBe("http://tdai-knowledge.test/v3/wiki/list");
+  } finally {
+    restore();
+  }
+});
+
+test("#8 tdai_wiki_pages sends a limit (default 20, clamped max 100)", async () => {
+  const { seen, restore } = mockFetch(200, { code: 0, data: [] });
+  try {
+    await getTool("tdai_wiki_pages").execute("1", { wiki_id: "w" });
+    expect(seen[0].body.limit).toBe(20);
+    await getTool("tdai_wiki_pages").execute("1", { wiki_id: "w", limit: 5 });
+    expect(seen[1].body.limit).toBe(5);
+    await getTool("tdai_wiki_pages").execute("1", { wiki_id: "w", limit: 999 });
+    expect(seen[2].body.limit).toBe(100);
+  } finally {
+    restore();
+  }
+});
+
+test("#9 limit/offset are clamped to documented bounds", async () => {
+  const { seen, restore } = mockFetch(200, { code: 0, data: [] });
+  try {
+    await getTool("tdai_search").execute("1", { query: "q", limit: 5000 });
+    expect(seen[0].body.limit).toBe(100);
+    await getTool("tdai_search").execute("1", { query: "q", limit: -5 });
+    expect(seen[1].body.limit).toBe(1);
+    await getTool("tdai_search").execute("1", { query: "q", limit: 2.5 });
+    expect(seen[2].body.limit).toBe(2);
+    await getTool("tdai_memory_list").execute("1", { offset: -3 });
+    expect(seen[3].body.offset).toBe(0);
+  } finally {
+    restore();
+  }
+});
+
+test("#11 timeout gets a distinct retry hint, not the reachability message", async () => {
+  const prev = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    const err = new Error("The operation was aborted due to timeout");
+    err.name = "TimeoutError";
+    throw err;
+  }) as typeof fetch;
+  try {
+    await expect(
+      getTool("tdai_search").execute("1", { query: "q" }),
+    ).rejects.toThrow(/timed out after 60s.*retry/s);
+  } finally {
+    globalThis.fetch = prev;
+  }
+});
+
+test("#11 plain network errors still get the reachability message", async () => {
+  const prev = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new TypeError("fetch failed");
+  }) as typeof fetch;
+  try {
+    await expect(
+      getTool("tdai_search").execute("1", { query: "q" }),
+    ).rejects.toThrow(/is the memory gateway reachable\?/);
+  } finally {
+    globalThis.fetch = prev;
+  }
+});
+
+test("#12 tdai_capture: empty-string session falls back to local-date default", async () => {
+  const { seen, restore } = mockFetch(200, { code: 0, data: { ok: true } });
+  try {
+    await getTool("tdai_capture").execute("1", { text: "note", session: "" });
+    expect(seen[0].body.session_id).toMatch(/^pi-\d{4}-\d{2}-\d{2}$/);
+    await getTool("tdai_capture").execute("1", {
+      text: "note",
+      session: "my-sess",
+    });
+    expect(seen[1].body.session_id).toBe("my-sess");
+  } finally {
+    restore();
+  }
+});
+
+test("#15 lock-conflict responses get an actionable retry hint", async () => {
+  const { restore } = mockFetch(409, {
+    code: 40901,
+    message: "page is locked by another writer",
+  });
+  try {
+    await expect(
+      getTool("tdai_wiki_write").execute("1", {
+        wiki_id: "w",
+        pages: [{ ref: "a.md", content: "x" }],
+      }),
+    ).rejects.toThrow(/locked by another writer.*retry/s);
+  } finally {
+    restore();
+  }
+});
+
+test("#15 non-lock errors are unchanged", async () => {
+  const { restore } = mockFetch(500, { code: 50000, message: "internal boom" });
+  try {
+    await expect(
+      getTool("tdai_wiki_write").execute("1", {
+        wiki_id: "w",
+        pages: [{ ref: "a.md", content: "x" }],
+      }),
+    ).rejects.toThrow(
+      /^tdai \/v3\/wiki\/page\/write HTTP 500: \{"code":50000,"message":"internal boom"\}$/,
+    );
+  } finally {
+    restore();
+  }
+});
+
+// ── before_agent_start: visible injection, once-per-session L2/L3 + per-turn L1 ──
+// Module state (sessionOpened, lastAtomicFingerprint) persists across tests in this
+// file — every test below starts by firing session_start to get a clean slate,
+// exactly the reset a real /new or /resume would trigger.
+function freshSession(handlers: ReturnType<typeof makePi>["handlers"]) {
+  handlers.session_start[0]({}, {
+    ui: { setStatus: () => {}, theme: { fg: (_: string, s: string) => s } },
+  });
+}
+
+test("first turn of a session injects core + scenario as a VISIBLE message, not the system prompt", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const h = handlers.before_agent_start[0];
+  const res = (await h(
+    { systemPrompt: "BASE PROMPT", systemPromptOptions: { cwd: "/test/cwd" } },
+    {},
+  )) as { systemPrompt?: string; message?: { customType: string; content: string; display: boolean } };
+  expect(res.systemPrompt).toBeUndefined();
+  expect(res.message?.display).toBe(true);
+  expect(res.message?.customType).toBe("tdai-memory-inject");
+  expect(res.message?.content).toContain("TEST CORE PERSONA");
+  expect(res.message?.content).toContain("proj.md");
+  expect(res.message?.content).toContain("proj summary");
+});
+
+test("the SECOND turn of the same session does not repeat the full L2/L3 push", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const h = handlers.before_agent_start[0];
+  await h({ systemPrompt: "P", systemPromptOptions: { cwd: "/x" } }, {}); // first turn
+  const res = (await h(
+    { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "" },
+    {},
+  )) as { message?: { content: string } };
+  // second turn: no query text either, so nothing at all to inject
+  expect(res).toBeUndefined();
+});
+
+test("a NEW session (session_start again) gets the full push again", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const h = handlers.before_agent_start[0];
+  await h({ systemPrompt: "P", systemPromptOptions: { cwd: "/x" } }, {}); // first session's first turn
+  freshSession(handlers); // /new or /resume
+  const res = (await h(
+    { systemPrompt: "P", systemPromptOptions: { cwd: "/x" } },
+    {},
+  )) as { message?: { content: string } };
+  expect(res.message?.content).toContain("TEST CORE PERSONA");
+});
+
+test("every turn searches L1 atoms with THIS turn's own incoming prompt text", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const { seen, restore } = mockFetch(200, {
+    code: 0,
+    data: { results: [{ content: "vouchers ship in farm2" }] },
+  });
+  try {
+    const h = handlers.before_agent_start[0];
+    const res = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "what about vouchers?" },
+      {},
+    )) as { message?: { content: string } };
+    // this is the FIRST turn of a fresh session, so core/scenario calls fire first —
+    // find the atomic search call by URL rather than assume its index.
+    const atomicCall = seen.find((c) => c.url.endsWith("/v3/atomic/search"));
+    expect(atomicCall?.body.query).toBe("what about vouchers?");
+    expect(atomicCall?.body.limit).toBe(3);
+    expect(res.message?.content).toContain("vouchers ship in farm2");
+  } finally {
+    restore();
+  }
+});
+
+test("identical atomic hits across consecutive turns are not repeated", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const { restore } = mockFetch(200, {
+    code: 0,
+    data: { results: [{ content: "same fact every time" }] },
+  });
+  try {
+    const h = handlers.before_agent_start[0];
+    const first = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q1" },
+      {},
+    )) as { message?: { content: string } };
+    expect(first.message?.content).toContain("same fact every time");
+
+    const second = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q2" },
+      {},
+    )) as { message?: { content: string } | undefined } | undefined;
+    // full L2/L3 already sent on turn one, and the atoms are identical -> nothing left to send
+    expect(second).toBeUndefined();
+  } finally {
+    restore();
+  }
+});
+
+test("changed atomic hits are NOT suppressed on the next turn", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const h = handlers.before_agent_start[0];
+
+  // try/finally throughout — found by review: a bare `m.restore()` call after the
+  // assertion left the mock leaked into every LATER test in the file if that
+  // assertion ever threw, since bun does not isolate globalThis.fetch per test.
+  let m = mockFetch(200, { code: 0, data: { results: [{ content: "fact one" }] } });
+  try {
+    const first = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q1" },
+      {},
+    )) as { message?: { content: string } };
+    expect(first.message?.content).toContain("fact one");
+  } finally {
+    m.restore();
+  }
+
+  m = mockFetch(200, { code: 0, data: { results: [{ content: "fact two" }] } });
+  try {
+    const second = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q2" },
+      {},
+    )) as { message?: { content: string } };
+    expect(second.message?.content).toContain("fact two");
+  } finally {
+    m.restore();
+  }
+});
+
+test("an atomic-search outage is a VISIBLE marker, not silently swallowed", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const prev = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new TypeError("fetch failed");
+  }) as typeof fetch;
+  try {
+    const h = handlers.before_agent_start[0];
+    const res = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "anything" },
+      {},
+    )) as { message?: { content: string } };
+    expect(res.message?.content).toContain("tdai-memory-unavailable");
+    expect(res.message?.content).toContain("reachable");
+  } finally {
+    globalThis.fetch = prev;
+  }
+});
+
+test("a repeated outage marks EVERY turn it actually fails, never deduped against itself", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const prev = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new TypeError("fetch failed");
+  }) as typeof fetch;
+  try {
+    const h = handlers.before_agent_start[0];
+    const first = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q1" },
+      {},
+    )) as { message?: { content: string } };
+    const second = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q2" },
+      {},
+    )) as { message?: { content: string } };
+    expect(first.message?.content).toContain("tdai-memory-unavailable");
+    expect(second.message?.content).toContain("tdai-memory-unavailable");
+  } finally {
+    globalThis.fetch = prev;
+  }
+});
+
+test("no hits and no query text -> no message at all, not an empty one", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const prev = globalThis.fetch;
+  // Everything empty: no core, no scenarios, no atoms — this is still the FIRST
+  // turn of the session (freshSession reset sessionOpened), so the full push is
+  // attempted; it must yield nothing rather than an empty <tdai-memory></tdai-memory>.
+  globalThis.fetch = (async (url: string) => {
+    const u = String(url);
+    if (u.endsWith("/v3/core/read")) return new Response(JSON.stringify({ code: 0, data: { content: null } }), { status: 200 });
+    if (u.endsWith("/v3/scenario/ls")) return new Response(JSON.stringify({ code: 0, data: { entries: [] } }), { status: 200 });
+    if (u.endsWith("/v3/atomic/search")) return new Response(JSON.stringify({ code: 0, data: { results: [] } }), { status: 200 });
+    return new Response(JSON.stringify({ code: 1, message: "not found" }), { status: 404 });
+  }) as typeof fetch;
+  try {
+    const h = handlers.before_agent_start[0];
+    const res = await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: "q" },
+      {},
+    );
+    expect(res).toBeUndefined();
+  } finally {
+    globalThis.fetch = prev;
+  }
+});
+
+test("a first-turn outage does NOT permanently lose the full push — the next turn retries and succeeds", async () => {
+  // Found by review: buildMemoryBlock is internally fail-open (its own core/
+  // scenario try/catches never rethrow), so the OLD code latched sessionOpened
+  // BEFORE the fetch — a single transient hiccup at the exact moment of the
+  // session's first prompt meant no persona for the session's entire life,
+  // silently. The fix only latches when at least one call actually reached tdai.
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const h = handlers.before_agent_start[0];
+  const prev = globalThis.fetch;
+  try {
+    // Turn 1: total outage — both core/read and scenario/ls throw.
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+    const first = await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" } }, // no prompt -> no atomic call
+      {},
+    );
+    expect(first).toBeUndefined(); // both calls failed silently, nothing to inject yet
+
+    // Turn 2: tdai recovers — this must be treated as STILL the first successful turn.
+    globalThis.fetch = (async (url: string) => {
+      const u = String(url);
+      if (u.endsWith("/v3/core/read"))
+        return new Response(JSON.stringify({ code: 0, data: { content: "RECOVERED PERSONA" } }), { status: 200 });
+      if (u.endsWith("/v3/scenario/ls"))
+        return new Response(JSON.stringify({ code: 0, data: { entries: [] } }), { status: 200 });
+      return new Response(JSON.stringify({ code: 1, message: "not found" }), { status: 404 });
+    }) as typeof fetch;
+    const second = (await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" } },
+      {},
+    )) as { message?: { content: string } };
+    expect(second.message?.content).toContain("RECOVERED PERSONA");
+  } finally {
+    globalThis.fetch = prev;
+  }
+});
+
+test("session_compact re-arms the full push so persona survives compaction", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const h = handlers.before_agent_start[0];
+  await h({ systemPrompt: "P", systemPromptOptions: { cwd: "/x" } }, {}); // consumes the first-turn push
+
+  const second = (await h({ systemPrompt: "P", systemPromptOptions: { cwd: "/x" } }, {})) as
+    | { message?: { content: string } }
+    | undefined;
+  expect(second).toBeUndefined(); // second turn, same session: no repeat, as designed
+
+  handlers.session_compact[0]({}, {}); // the framework summarized the injected message away
+  const third = (await h(
+    { systemPrompt: "P", systemPromptOptions: { cwd: "/x" } },
+    {},
+  )) as { message?: { content: string } };
+  expect(third.message?.content).toContain("TEST CORE PERSONA");
+});
+
+test("the per-turn query sent to atomic search is capped, not the raw prompt verbatim", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+  const { seen, restore } = mockFetch(200, { code: 0, data: { results: [] } });
+  try {
+    const h = handlers.before_agent_start[0];
+    const hugePrompt = "q".repeat(200_000);
+    await h(
+      { systemPrompt: "P", systemPromptOptions: { cwd: "/x" }, prompt: hugePrompt },
+      {},
+    );
+    const atomicCall = seen.find((c) => c.url.endsWith("/v3/atomic/search"));
+    const sentQuery = atomicCall?.body.query as string;
+    expect(sentQuery.length).toBeLessThan(hugePrompt.length);
+    expect(sentQuery.length).toBeLessThanOrEqual(2000);
+  } finally {
+    restore();
+  }
+});
+
+test("session_shutdown captures the session (normalized) and records the marker", async () => {
+  const { pi, handlers, appended } = makePi();
+  extension(pi);
+  const entries = [
+    {
+      type: "message",
+      id: "e1",
+      message: { role: "user", content: [{ type: "text", text: "hello" }] },
+    },
+    {
+      type: "message",
+      id: "e2",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hi there" },
+          { type: "thinking", thinking: "secret" },
+        ],
+      },
+    },
+  ];
+  const ctx = {
+    sessionManager: { getEntries: () => entries, getSessionId: () => "sess-1" },
+  };
+  await handlers.session_shutdown[0]({}, ctx);
+
+  const add = calls.find((c) => c.url.endsWith("/v3/conversation/add"));
+  expect(add).toBeTruthy();
+  expect(add.body.messages).toEqual([
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "hi there" },
+  ]);
+  expect(add.body.session_id).toBe("sess-1");
+  expect(appended[0].type).toBe("tdai-capture");
+  expect((appended[0].data as { lastEntryId: string }).lastEntryId).toBe("e2");
+});
+
+test("session_shutdown is a no-op when nothing new since the last capture", async () => {
+  const { pi, handlers } = makePi();
+  extension(pi);
+  const before = calls.filter((c) =>
+    c.url.endsWith("/v3/conversation/add"),
+  ).length;
+  const entries = [
+    {
+      type: "custom",
+      id: "m1",
+      customType: "tdai-capture",
+      data: { lastEntryId: "e2" },
+    },
+    {
+      type: "message",
+      id: "e1",
+      message: { role: "user", content: [{ type: "text", text: "hello" }] },
+    },
+    {
+      type: "message",
+      id: "e2",
+      message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    },
+  ];
+  const ctx = {
+    sessionManager: { getEntries: () => entries, getSessionId: () => "sess-1" },
+  };
+  await handlers.session_shutdown[0]({}, ctx);
+  const after = calls.filter((c) =>
+    c.url.endsWith("/v3/conversation/add"),
+  ).length;
+  expect(after).toBe(before); // dedupe: no re-send
+});

--- a/MemoryCore/pi-native-plugin/__tests__/inject-map.test.ts
+++ b/MemoryCore/pi-native-plugin/__tests__/inject-map.test.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "vitest";
+
+// TDAI_INJECT_MAP is read once at module load, so this file configures the
+// environment and then imports its own module instance (the `?inject-map`
+// query keeps it separate from the instance index.test.ts loads without a map).
+process.env.TDAI_GATEWAY_URL = "http://tdai.test";
+process.env.TDAI_KNOWLEDGE_URL = "http://tdai-knowledge.test";
+process.env.TDAI_API_KEY = "fake-key";
+process.env.TDAI_SERVICE_ID = "default";
+process.env.TDAI_TEAM_ID = "team-test";
+process.env.TDAI_USER_ID = "usr-test";
+process.env.TDAI_AGENT_ID = "agt-test";
+process.env.TDAI_INJECT = "1";
+process.env.TDAI_CAPTURE = "1";
+process.env.TDAI_INJECT_MAP = "wiki-test:wiki/index/knowledge-map.md";
+
+const MAP_PAGE =
+  "---\ntype: orientation\nlocked: true\n---\n# Knowledge Map\n\nQuery the wiki BEFORE any filesystem discovery.";
+
+const calls: { url: string; body: Record<string, unknown> }[] = [];
+let knowledgeDown = false;
+const json = (status: number, obj: unknown) => new Response(JSON.stringify(obj), { status });
+globalThis.fetch = (async (url: string, init?: RequestInit) => {
+  const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+  calls.push({ url: String(url), body });
+  const u = String(url);
+  if (u.endsWith("/v3/wiki/page/read")) {
+    if (knowledgeDown) return json(503, { code: 1, message: "knowledge unavailable" });
+    return json(200, { code: 0, data: { items: [{ ref: "wiki/index/knowledge-map.md", content: MAP_PAGE }] } });
+  }
+  if (u.endsWith("/v3/core/read")) return json(200, { code: 0, data: { content: "TEST CORE PERSONA" } });
+  if (u.endsWith("/v3/scenario/ls")) return json(200, { code: 0, data: { entries: [], total: 0 } });
+  if (u.endsWith("/v3/atomic/search")) return json(200, { code: 0, data: { results: [] } });
+  return json(404, { code: 1, message: "not found" });
+}) as typeof fetch;
+
+const { default: extension } = await import("../extensions/tdai-memory/index.js?inject-map");
+
+type Handler = (...a: unknown[]) => unknown;
+type InjectResult = { message?: { customType: string; content: string; display: boolean } } | undefined;
+
+function makePi() {
+  const handlers: Record<string, Handler[]> = {};
+  const pi = {
+    on: (name: string, fn: Handler) => {
+      (handlers[name] ||= []).push(fn);
+    },
+    registerTool: () => {},
+    appendEntry: () => {},
+  };
+  return { pi, handlers };
+}
+
+const uiCtx = { ui: { setStatus: () => {}, theme: { fg: (_: string, s: string) => s } } };
+function freshSession(handlers: Record<string, Handler[]>) {
+  for (const h of handlers.session_start ?? []) h({}, uiCtx);
+}
+const turn = (handlers: Record<string, Handler[]>) =>
+  handlers.before_agent_start[0]({ systemPrompt: "P", systemPromptOptions: { cwd: "/x" } }, {}) as Promise<InjectResult>;
+const mapReads = () => calls.filter((c) => c.url.endsWith("/v3/wiki/page/read"));
+
+test("first turn injects the knowledge-map page named by TDAI_INJECT_MAP, frontmatter stripped", async () => {
+  calls.length = 0;
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+
+  const res = await turn(handlers);
+
+  expect(res?.message?.display).toBe(true);
+  expect(res?.message?.customType).toBe("tdai-memory-inject");
+  expect(res?.message?.content).toContain("<tdai-knowledge-map>");
+  expect(res?.message?.content).toContain("Query the wiki BEFORE any filesystem discovery.");
+  expect(res?.message?.content).not.toContain("locked: true");
+  // The map is read from the wiki and page named in the env var, with tenant identity.
+  expect(mapReads()).toHaveLength(1);
+  expect(mapReads()[0].body).toMatchObject({
+    wiki_id: "wiki-test",
+    refs: ["wiki/index/knowledge-map.md"],
+    team_id: "team-test",
+  });
+  // The map block comes before the persona block: orientation first.
+  const content = res?.message?.content ?? "";
+  expect(content.indexOf("<tdai-knowledge-map>")).toBeLessThan(content.indexOf("TEST CORE PERSONA"));
+});
+
+test("the map is pushed once per session and again after session_compact", async () => {
+  calls.length = 0;
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+
+  await turn(handlers);
+  const second = await turn(handlers);
+  expect(second?.message?.content ?? "").not.toContain("<tdai-knowledge-map>");
+  expect(mapReads()).toHaveLength(1);
+
+  handlers.session_compact[0]({}, {});
+  const third = await turn(handlers);
+  expect(third?.message?.content).toContain("<tdai-knowledge-map>");
+  expect(mapReads()).toHaveLength(2);
+});
+
+test("a knowledge-service outage on the first turn does not latch: the next turn retries the map", async () => {
+  calls.length = 0;
+  const { pi, handlers } = makePi();
+  extension(pi);
+  freshSession(handlers);
+
+  knowledgeDown = true;
+  try {
+    const first = await turn(handlers);
+    // Persona still lands (fail-open per block); the map does not.
+    expect(first?.message?.content).toContain("TEST CORE PERSONA");
+    expect(first?.message?.content ?? "").not.toContain("<tdai-knowledge-map>");
+  } finally {
+    knowledgeDown = false;
+  }
+
+  const second = await turn(handlers);
+  expect(second?.message?.content).toContain("<tdai-knowledge-map>");
+  expect(mapReads()).toHaveLength(2);
+});
+
+test("an unparseable TDAI_INJECT_MAP (no wiki_id:ref separator) never calls the knowledge service", async () => {
+  process.env.TDAI_INJECT_MAP = "no-separator-here";
+  const { default: badMapExtension } = await import("../extensions/tdai-memory/index.js?inject-map-bad");
+  process.env.TDAI_INJECT_MAP = "wiki-test:wiki/index/knowledge-map.md";
+
+  calls.length = 0;
+  const { pi, handlers } = makePi();
+  badMapExtension(pi);
+  freshSession(handlers);
+
+  const res = await turn(handlers);
+  expect(res?.message?.content).toContain("TEST CORE PERSONA");
+  expect(res?.message?.content ?? "").not.toContain("<tdai-knowledge-map>");
+  expect(mapReads()).toHaveLength(0);
+});

--- a/MemoryCore/pi-native-plugin/__tests__/lib.test.ts
+++ b/MemoryCore/pi-native-plugin/__tests__/lib.test.ts
@@ -1,0 +1,350 @@
+import { test, expect } from "vitest";
+import {
+  chunkContent,
+  splitBatches,
+  selectScenarioPaths,
+  assembleMemoryBlock,
+  normalizeEntries,
+  missingRequiredEnv,
+  isKillSwitchOff,
+  atomicHitsFrom,
+  atomicFingerprint,
+  sameFingerprint,
+  REQUIRED_ENV,
+  MAX_MSG_CHARS,
+  MAX_MSGS_PER_POST,
+  ATOMIC_SUMMARY_MAX,
+  type L0Message,
+  type SessionEntryLike,
+} from "../extensions/tdai-memory/lib.js";
+
+// ── chunkContent ─────────────────────────────────────────────────────────────
+test("chunkContent: short string -> single unchanged chunk", () => {
+  expect(chunkContent("hello")).toEqual(["hello"]);
+});
+
+test("chunkContent: each chunk within max, order + no data loss", () => {
+  const s = "a".repeat(25) + "b".repeat(25); // 50 chars, max 30
+  const chunks = chunkContent(s, 30);
+  for (const c of chunks) expect(c.length).toBeGreaterThanOrEqual(1);
+  for (const c of chunks) expect(c.length).toBeLessThanOrEqual(30);
+  expect(chunks.join("")).toBe(s);
+});
+
+test("chunkContent: default max is 8192", () => {
+  expect(MAX_MSG_CHARS).toBe(8192);
+  const s = "x".repeat(8192 * 2 + 5);
+  const chunks = chunkContent(s);
+  for (const c of chunks) expect(c.length).toBeLessThanOrEqual(8192);
+  expect(chunks.join("")).toBe(s);
+});
+
+test("chunkContent: empty string -> no chunks", () => {
+  expect(chunkContent("")).toEqual([]);
+});
+
+// ── splitBatches ─────────────────────────────────────────────────────────────
+test("splitBatches: <= maxPerBatch per batch, order + no loss", () => {
+  const msgs: L0Message[] = Array.from({ length: 101 }, (_, i) => ({
+    role: i % 2 ? "assistant" : "user",
+    content: String(i),
+  }));
+  const batches = splitBatches(msgs, 100);
+  expect(batches).toHaveLength(2);
+  for (const b of batches) expect(b.length).toBeLessThanOrEqual(100);
+  expect(batches.flat()).toEqual(msgs);
+});
+
+test("splitBatches: default max is 100", () => {
+  expect(MAX_MSGS_PER_POST).toBe(100);
+});
+
+test("splitBatches: empty -> no batches", () => {
+  expect(splitBatches([])).toEqual([]);
+});
+
+// ── selectScenarioPaths ──────────────────────────────────────────────────────
+const ENTRIES = [
+  { path: "工作/", summary: "dir" },
+  { path: "工作/pi.md" },
+  { path: "工作/交付物.md" },
+  { path: "misc.md" },
+];
+
+test("selectScenarioPaths: no map -> inject all non-directory entries", () => {
+  expect(selectScenarioPaths(ENTRIES, "/anywhere")).toEqual([
+    "工作/pi.md",
+    "工作/交付物.md",
+    "misc.md",
+  ]);
+});
+
+test("selectScenarioPaths: map prefix match -> mapped paths", () => {
+  const map = { "/Users/plainwu/Working/ai/plain": ["工作/pi.md"] };
+  expect(selectScenarioPaths(ENTRIES, "/Users/plainwu/Working/ai/plain/x", map)).toEqual(["工作/pi.md"]);
+});
+
+test("selectScenarioPaths: longest cwd prefix wins", () => {
+  const map = {
+    "/Users/plainwu/Working": ["a.md"],
+    "/Users/plainwu/Working/ai/plain": ["b.md"],
+  };
+  expect(selectScenarioPaths(ENTRIES, "/Users/plainwu/Working/ai/plain", map)).toEqual(["b.md"]);
+});
+
+test("selectScenarioPaths: map present but no prefix match -> inject all", () => {
+  const map = { "/elsewhere": ["nope.md"] };
+  expect(selectScenarioPaths(ENTRIES, "/here", map)).toEqual(["工作/pi.md", "工作/交付物.md", "misc.md"]);
+});
+
+// ── assembleMemoryBlock ──────────────────────────────────────────────────────
+test("assembleMemoryBlock: nothing to inject -> empty string", () => {
+  expect(assembleMemoryBlock({ core: null, scenarios: [] })).toBe("");
+  expect(assembleMemoryBlock({ core: "", scenarios: [] })).toBe("");
+});
+
+test("assembleMemoryBlock: core + scenario, within budget, correct shape", () => {
+  const block = assembleMemoryBlock({
+    core: "I am the core persona.",
+    scenarios: [{ path: "工作/pi.md", summary: "project facts" }],
+  });
+  expect(block).toContain("I am the core persona.");
+  expect(block).toContain("project facts");
+  expect(block).toContain("工作/pi.md");
+  expect(block.length).toBeLessThanOrEqual(16000);
+  expect(block.trimStart().startsWith("<tdai-memory>")).toBe(true);
+});
+
+test("assembleMemoryBlock: core before scenarios in output order", () => {
+  const block = assembleMemoryBlock({
+    core: "CORE_MARKER",
+    scenarios: [{ path: "s.md", summary: "SCENE_MARKER" }],
+  });
+  expect(block.indexOf("CORE_MARKER")).toBeLessThan(block.indexOf("SCENE_MARKER"));
+});
+
+test("assembleMemoryBlock: strips a trailing '## 🗺️' scene-nav block from core", () => {
+  const block = assembleMemoryBlock({ core: "persona line\n## 🗺️\n- nav item", scenarios: [] });
+  expect(block).toContain("persona line");
+  expect(block).not.toContain("nav item");
+});
+
+test("assembleMemoryBlock: drops scenarios that exceed the budget", () => {
+  const scenarios = Array.from({ length: 8 }, (_, i) => ({ path: `s${i}.md`, summary: "x".repeat(60) }));
+  const block = assembleMemoryBlock({ core: "core", scenarios, budgetChars: 400 });
+  expect(block.length).toBeLessThanOrEqual(400);
+  expect(block).toContain("core");
+  expect(block).toContain("s0.md");
+  expect(block).not.toContain("s7.md"); // later ones dropped
+});
+
+test("assembleMemoryBlock: truncates L2 summaries to 200 chars", () => {
+  const block = assembleMemoryBlock({ core: null, scenarios: [{ path: "p.md", summary: "y".repeat(500) }] });
+  expect(block).toContain("y".repeat(200));
+  expect(block).not.toContain("y".repeat(201));
+});
+
+test("assembleMemoryBlock: atomic hits alone -> a Recent Memories section", () => {
+  const block = assembleMemoryBlock({
+    core: null,
+    scenarios: [],
+    atomicHits: [{ content: "vouchers ship in farm2" }],
+  });
+  expect(block).toContain("### Recent Memories");
+  expect(block).toContain("vouchers ship in farm2");
+});
+
+test("assembleMemoryBlock: section order is Core, Scenarios, then Recent Memories", () => {
+  const block = assembleMemoryBlock({
+    core: "CORE_MARKER",
+    scenarios: [{ path: "s.md", summary: "SCENE_MARKER" }],
+    atomicHits: [{ content: "ATOM_MARKER" }],
+  });
+  expect(block.indexOf("CORE_MARKER")).toBeLessThan(block.indexOf("SCENE_MARKER"));
+  expect(block.indexOf("SCENE_MARKER")).toBeLessThan(block.indexOf("ATOM_MARKER"));
+});
+
+test("assembleMemoryBlock: atomic hits fall back to the text key", () => {
+  const block = assembleMemoryBlock({ core: null, scenarios: [], atomicHits: [{ text: "fallback fact" }] });
+  expect(block).toContain("fallback fact");
+});
+
+test("assembleMemoryBlock: an atom with neither content nor text contributes no empty bullet", () => {
+  const block = assembleMemoryBlock({ core: null, scenarios: [], atomicHits: [{}] });
+  expect(block).toBe(""); // nothing anywhere else either -> nothing at all
+});
+
+test("assembleMemoryBlock: atomic hit content truncated to ATOMIC_SUMMARY_MAX chars", () => {
+  expect(ATOMIC_SUMMARY_MAX).toBe(200);
+  const block = assembleMemoryBlock({ core: null, scenarios: [], atomicHits: [{ content: "y".repeat(500) }] });
+  expect(block).toContain("y".repeat(200));
+  expect(block).not.toContain("y".repeat(201));
+});
+
+test("assembleMemoryBlock: drops atomic hits that exceed the budget", () => {
+  const atomicHits = Array.from({ length: 8 }, (_, i) => ({ content: `atom${i}-` + "x".repeat(60) }));
+  const block = assembleMemoryBlock({ core: "core", scenarios: [], atomicHits, budgetChars: 400 });
+  expect(block.length).toBeLessThanOrEqual(400);
+  expect(block).toContain("atom0-");
+  expect(block).not.toContain("atom7-"); // later ones dropped, same discipline as scenarios
+});
+
+test("assembleMemoryBlock: omitting atomicHits entirely behaves exactly as before (no regression)", () => {
+  const block = assembleMemoryBlock({ core: "persona", scenarios: [{ path: "s.md" }] });
+  expect(block).not.toContain("Recent Memories");
+});
+
+// ── atomicHitsFrom ───────────────────────────────────────────────────────────
+test("atomicHitsFrom: reads the observed key and the defended ones", () => {
+  const hits = [{ content: "a fact" }];
+  expect(atomicHitsFrom({ results: hits })).toEqual(hits);
+  expect(atomicHitsFrom({ memories: hits })).toEqual(hits);
+  expect(atomicHitsFrom({ list: hits })).toEqual(hits);
+  expect(atomicHitsFrom({ entries: hits })).toEqual(hits);
+  expect(atomicHitsFrom(hits)).toEqual(hits); // a bare array
+});
+
+test("atomicHitsFrom: anything unrecognizable is no hits, never a throw", () => {
+  expect(atomicHitsFrom(null)).toEqual([]);
+  expect(atomicHitsFrom(undefined)).toEqual([]);
+  expect(atomicHitsFrom({ unrelated: 1 })).toEqual([]);
+  expect(atomicHitsFrom(["not", "objects"])).toEqual([]);
+  expect(atomicHitsFrom("a string")).toEqual([]);
+});
+
+// ── atomicFingerprint / sameFingerprint ──────────────────────────────────────
+test("atomicFingerprint: sorted content strings, blanks dropped", () => {
+  expect(atomicFingerprint([{ content: "b" }, { content: "a" }, { content: "  " }])).toEqual(["a", "b"]);
+});
+
+test("atomicFingerprint: order of the input hits does not change the fingerprint", () => {
+  const fp1 = atomicFingerprint([{ content: "x" }, { content: "y" }]);
+  const fp2 = atomicFingerprint([{ content: "y" }, { content: "x" }]);
+  expect(fp1).toEqual(fp2);
+});
+
+test("sameFingerprint: null previous never matches, even an empty current", () => {
+  expect(sameFingerprint(null, [])).toBe(false);
+});
+
+test("sameFingerprint: equal arrays match, different ones don't", () => {
+  expect(sameFingerprint(["a", "b"], ["a", "b"])).toBe(true);
+  expect(sameFingerprint(["a", "b"], ["a", "c"])).toBe(false);
+  expect(sameFingerprint(["a"], ["a", "b"])).toBe(false);
+});
+
+test("atomicFingerprint: matches what actually renders — hits differing only past ATOMIC_SUMMARY_MAX fingerprint identically", () => {
+  // Found by review: fingerprinting the FULL text while rendering a TRUNCATED line
+  // meant two hits differing only past char 200 got DIFFERENT fingerprints but
+  // byte-identical rendered output, defeating the dedup on exactly the case it
+  // exists to catch.
+  const hitA = { content: "x".repeat(200) + "AAAA" };
+  const hitB = { content: "x".repeat(200) + "BBBB" };
+  const fpA = atomicFingerprint([hitA]);
+  const fpB = atomicFingerprint([hitB]);
+  expect(fpA).toEqual(fpB);
+  // and the rendered block really is identical, proving the fingerprints were
+  // right to treat them as the same turn's hits
+  const blockA = assembleMemoryBlock({ core: null, scenarios: [], atomicHits: [hitA] });
+  const blockB = assembleMemoryBlock({ core: null, scenarios: [], atomicHits: [hitB] });
+  expect(blockA).toBe(blockB);
+});
+
+// ── isKillSwitchOff ──────────────────────────────────────────────────────────
+test("isKillSwitchOff: both documented and legacy spellings disable", () => {
+  expect(isKillSwitchOff("off")).toBe(true);
+  expect(isKillSwitchOff("OFF")).toBe(true);
+  expect(isKillSwitchOff("0")).toBe(true);
+});
+
+test("isKillSwitchOff: unset, on, or anything else means enabled", () => {
+  expect(isKillSwitchOff(undefined)).toBe(false);
+  expect(isKillSwitchOff("")).toBe(false);
+  expect(isKillSwitchOff("on")).toBe(false);
+  expect(isKillSwitchOff("1")).toBe(false);
+});
+
+// ── normalizeEntries ─────────────────────────────────────────────────────────
+const msg = (role: string, content: unknown, extra: Record<string, unknown> = {}): SessionEntryLike => ({
+  type: "message",
+  id: Math.random().toString(36).slice(2),
+  message: { role, content, ...extra },
+});
+
+test("normalizeEntries: user text -> one user message", () => {
+  const out = normalizeEntries([msg("user", [{ type: "text", text: "hi" }])]);
+  expect(out).toEqual([{ role: "user", content: "hi" }]);
+});
+
+test("normalizeEntries: assistant text + thinking dropped + toolCall -> assistant text", () => {
+  const out = normalizeEntries([
+    msg("assistant", [
+      { type: "text", text: "let me check" },
+      { type: "thinking", thinking: "hidden reasoning" },
+      { type: "toolCall", id: "c1", name: "bash", arguments: { command: "ls" } },
+    ]),
+  ]);
+  expect(out).toHaveLength(1);
+  expect(out[0].role).toBe("assistant");
+  expect(out[0].content).toContain("let me check");
+  expect(out[0].content).toContain("bash");
+  expect(out[0].content).not.toContain("hidden reasoning");
+});
+
+test("normalizeEntries: toolResult -> user message with name + text", () => {
+  const out = normalizeEntries([
+    msg("toolResult", [{ type: "text", text: "file listing" }], { toolName: "read" }),
+  ]);
+  expect(out).toEqual([{ role: "user", content: "[tool_result name=read] file listing" }]);
+});
+
+test("normalizeEntries: ignores non-message entries", () => {
+  const out = normalizeEntries([
+    { type: "compaction", id: "x" },
+    { type: "custom_message", id: "y" },
+    msg("user", [{ type: "text", text: "kept" }]),
+  ]);
+  expect(out).toEqual([{ role: "user", content: "kept" }]);
+});
+
+test("normalizeEntries: long content is chunked to <= 8192 chars, no loss", () => {
+  const big = "q".repeat(20000);
+  const out = normalizeEntries([msg("assistant", [{ type: "text", text: big }])]);
+  expect(out.length).toBeGreaterThan(1);
+  for (const m of out) expect(m.content.length).toBeLessThanOrEqual(MAX_MSG_CHARS);
+  expect(out.map((m) => m.content).join("")).toBe(big);
+});
+
+test("normalizeEntries: empty content is dropped", () => {
+  const out = normalizeEntries([msg("assistant", [{ type: "thinking", thinking: "only thinking" }])]);
+  expect(out).toEqual([]);
+});
+
+// ── missingRequiredEnv (fail-fast) ──────────────────────────────────────────
+const fullEnv: Record<string, string> = {
+  TDAI_API_KEY: "k",
+  TDAI_GATEWAY_URL: "http://gw",
+  TDAI_KNOWLEDGE_URL: "http://kn",
+  TDAI_SERVICE_ID: "default",
+  TDAI_TEAM_ID: "team",
+  TDAI_USER_ID: "usr",
+  TDAI_AGENT_ID: "agt",
+};
+
+test("missingRequiredEnv: all set -> []", () => {
+  expect(missingRequiredEnv(fullEnv)).toEqual([]);
+});
+
+test("missingRequiredEnv: none set -> the full REQUIRED_ENV list", () => {
+  expect(missingRequiredEnv({})).toEqual([...REQUIRED_ENV]);
+});
+
+test("missingRequiredEnv: reports exactly the unset ones", () => {
+  const rest: Record<string, string> = { ...fullEnv };
+  delete rest.TDAI_GATEWAY_URL;
+  expect(missingRequiredEnv(rest)).toEqual(["TDAI_GATEWAY_URL"]);
+});
+
+test("missingRequiredEnv: empty string counts as missing", () => {
+  expect(missingRequiredEnv({ ...fullEnv, TDAI_API_KEY: "" })).toEqual(["TDAI_API_KEY"]);
+});

--- a/MemoryCore/pi-native-plugin/extensions/tdai-memory/index.ts
+++ b/MemoryCore/pi-native-plugin/extensions/tdai-memory/index.ts
@@ -1,0 +1,835 @@
+/**
+ * TencentDB Agent Memory (tdai-memory) — pi extension
+ * Upstream: https://github.com/TencentCloud/TencentDB-Agent-Memory
+ *
+ * Exposes the memory gateway and knowledge (wiki) service as
+ * native pi tools.
+ *
+ * Env (all required — the extension fails to load if any are missing; no defaults):
+ *   TDAI_GATEWAY_URL    memory gateway base URL
+ *   TDAI_KNOWLEDGE_URL  knowledge (wiki) service base URL
+ *   TDAI_API_KEY        sk-mem-… (per-user key, Bearer for gateway)
+ *   TDAI_SERVICE_ID     service id (x-tdai-service-id header), e.g. "default"
+ *   TDAI_TEAM_ID        team-… (tenant identity, sent with every request)
+ *   TDAI_USER_ID        usr-…
+ *   TDAI_AGENT_ID       agt-…
+ */
+
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+  assembleMemoryBlock,
+  selectScenarioPaths,
+  normalizeEntries,
+  splitBatches,
+  missingRequiredEnv,
+  isKillSwitchOff,
+  atomicHitsFrom,
+  atomicFingerprint,
+  sameFingerprint,
+  DEFAULT_BUDGET_CHARS,
+  type ScenarioEntry,
+  type AtomicHit,
+} from "./lib.js";
+
+// ── Config (fail-fast: every external var is required, no silent defaults) ──
+// Missing required var -> throw at load -> pi reports "Failed to load extension:
+// <msg>" and continues without this extension.
+const missing = missingRequiredEnv(process.env);
+if (missing.length > 0) {
+  throw new Error(
+    `tdai-memory: missing required env var(s): ${missing.join(", ")}. ` +
+      "Set them (see README) and restart pi.",
+  );
+}
+const API_KEY = process.env.TDAI_API_KEY as string;
+const GATEWAY_URL = process.env.TDAI_GATEWAY_URL as string;
+const KNOWLEDGE_URL = process.env.TDAI_KNOWLEDGE_URL as string;
+const SERVICE_ID = process.env.TDAI_SERVICE_ID as string;
+const TEAM_ID = process.env.TDAI_TEAM_ID as string;
+const USER_ID = process.env.TDAI_USER_ID as string;
+const AGENT_ID = process.env.TDAI_AGENT_ID as string;
+const TIMEOUT_MS = 60_000; // first request per serviceId can cold-start a store
+// The per-turn atomic push (below) is AUTOMATIC — the model never asked for it —
+// unlike every other call in this file, which a tool call or an explicit turn start
+// triggers. Reusing TIMEOUT_MS here would mean a hung (not merely refused) gateway
+// adds up to 60s to EVERY ordinary turn. Tight on purpose: one vector lookup has no
+// business taking longer than this, and a slow answer is worse than a skipped one.
+const AUTO_ATOMIC_TIMEOUT_MS = 5_000;
+
+// ── Behavior (L2/L3 + L1 injection + L0 capture) — all on by default; kill switches below
+const INJECT_ENABLED = !isKillSwitchOff(process.env.TDAI_INJECT);
+const CAPTURE_ENABLED = !isKillSwitchOff(process.env.TDAI_CAPTURE);
+const INJECT_BUDGET_CHARS = Number(
+  process.env.TDAI_INJECT_MAX_CHARS ?? DEFAULT_BUDGET_CHARS,
+);
+// Top-N atoms searched with the incoming prompt on EVERY turn — same number ADLC's
+// own per-turn recall settled on (spec 18), for the same reason: fewer than a
+// once-per-session push needs, since this repeats every turn rather than once per
+// kernel/session life.
+const ATOMIC_LIMIT = 3;
+
+// ── Knowledge-map injection (advertise CONTENTS, not existence) ─────────────
+// Added 2026-08-30 after a deploy session: the agent ran `find ~` sweeps to locate
+// a repo TWICE — once even AFTER being corrected — because the tool list said the
+// KB exists but nothing said WHAT it holds. Routing is expected-value: an agent
+// that cannot predict a KB hit pattern-matches "locate X" to the filesystem.
+// The map's CONTENT is deliberately NOT in this file — this extension is
+// team-agnostic; the map is an ordinary wiki page the team maintains, named here:
+//   TDAI_INJECT_MAP="<wiki_id>:<page ref>"     (unset -> no map injection)
+const INJECT_MAP = process.env.TDAI_INJECT_MAP ?? "";
+
+function scenarioMap(): Record<string, string[]> | undefined {
+  const raw = process.env.TDAI_SCENARIO_MAP;
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as Record<string, string[]>;
+  } catch {
+    return undefined; // invalid JSON -> fall back to inject-all
+  }
+}
+
+// ── HTTP helper ─────────────────────────────────────────────────────────────
+async function call(
+  baseUrl: string,
+  urlEnvVar: string,
+  path: string,
+  body: Record<string, unknown>,
+  withAuth: boolean,
+  timeoutMs: number = TIMEOUT_MS,
+): Promise<unknown> {
+  if (!baseUrl) {
+    throw new Error(`tdai ${path}: base URL not set (set ${urlEnvVar})`);
+  }
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-tdai-service-id": SERVICE_ID,
+    ...(withAuth && API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
+  };
+
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl.replace(/\/+$/, "")}${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    const e = err as Error & { name?: string };
+    if (e?.name === "TimeoutError" || e?.name === "AbortError") {
+      throw new Error(
+        `tdai ${path}: timed out after ${timeoutMs / 1000}s — the first request per service id can cold-start a store; retry.`,
+      );
+    }
+    throw new Error(
+      `tdai ${path}: request failed — ${e?.message} (is the memory gateway reachable?)`,
+    );
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      lockHint(`tdai ${path} HTTP ${res.status}: ${text.slice(0, 500)}`),
+    );
+  }
+
+  let env: {
+    code?: number;
+    message?: string;
+    request_id?: string;
+    data?: unknown;
+  };
+  try {
+    env = (await res.json()) as typeof env;
+  } catch (err) {
+    throw new Error(
+      `tdai ${path}: response is not valid JSON: ${(err as Error).message}`,
+    );
+  }
+  if (env === null || typeof env !== "object") env = {}; // literal null / scalar body
+  if (env.code !== undefined && env.code !== 0) {
+    throw new Error(
+      lockHint(
+        `tdai ${path} error ${env.code}: ${env.message} (${env.request_id})`,
+      ),
+    );
+  }
+  // "data" in env distinguishes a missing key from an explicit data:null —
+  // the latter is a legitimate empty result, not the envelope.
+  return "data" in env ? env.data : env;
+}
+
+// ponytail: naive "lock" substring heuristic — the knowledge API has no dedicated
+// lock error code today. Replace with a code-based check if one is introduced.
+function lockHint(msg: string): string {
+  if (/lock/i.test(msg))
+    return `${msg} — page may be locked by a concurrent write; retry`;
+  return msg;
+}
+
+const idFields = () => ({
+  team_id: TEAM_ID,
+  user_id: USER_ID,
+  agent_id: AGENT_ID,
+});
+
+// pi does not validate tool params at runtime, so enforce the documented
+// bounds here too — the schema constraints alone are advisory to the model.
+const clampLimit = (v: number | undefined, def: number, max = 100) =>
+  Math.min(max, Math.max(1, Math.trunc(v ?? def)));
+const clampOffset = (v: number | undefined) => Math.max(0, Math.trunc(v ?? 0));
+
+function format(data: unknown): string {
+  const s = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  return s;
+}
+
+const result = (data: unknown) => ({
+  content: [{ type: "text" as const, text: format(data) }],
+  details: {},
+});
+
+// Bounds the two once-per-session calls below — automatic (the model never asked
+// for them), same reasoning as AUTO_ATOMIC_TIMEOUT_MS. A hung gateway must not stall
+// the FIRST reply of a session by up to 120s (2 sequential calls at the old 60s
+// default) — worse still now that a genuine outage retries every turn (see `ok`
+// below), which without a tight bound would mean repeatedly stalling every turn.
+const AUTO_SESSION_TIMEOUT_MS = 8_000;
+
+// ── L2/L3 injection (before_agent_start, once per session) ──────────────────
+/**
+ * `ok` distinguishes "genuinely nothing to inject" from "could not reach tdai" —
+ * found by review: `buildMemoryBlock` used to swallow both cases identically
+ * (empty core, empty scenarios), so the caller had no way to tell a real outage
+ * from an empty-but-healthy memory, and latched `sessionOpened = true` either way.
+ * One transient hiccup at the exact moment of a session's FIRST prompt meant no
+ * persona for the rest of that session's life, silently. `ok` is true unless BOTH
+ * calls threw — mirrors ADLC's own spec-15 recall push ("not (persona.ok or
+ * scenarios.ok)" — a total outage, not a partial one, is what actually blocks).
+ */
+async function buildMemoryBlock(cwd: string): Promise<{ block: string; ok: boolean }> {
+  // L3 core persona (fail-open: absence -> null).
+  let core: string | null = null;
+  let coreOk = false;
+  try {
+    const r = (await call(
+      GATEWAY_URL,
+      "TDAI_GATEWAY_URL",
+      "/v3/core/read",
+      idFields(),
+      true,
+      AUTO_SESSION_TIMEOUT_MS,
+    )) as { content?: unknown };
+    if (typeof r?.content === "string") core = r.content;
+    coreOk = true;
+  } catch {
+    /* no L3 */
+  }
+
+  // L2 scenario list -> select paths for this cwd -> read each.
+  let entries: ScenarioEntry[] = [];
+  let scenariosOk = false;
+  try {
+    const r = (await call(
+      GATEWAY_URL,
+      "TDAI_GATEWAY_URL",
+      "/v3/scenario/ls",
+      { ...idFields(), path_prefix: "" },
+      true,
+      AUTO_SESSION_TIMEOUT_MS,
+    )) as {
+      entries?: ScenarioEntry[];
+    };
+    entries = (r?.entries ?? [])
+      .filter((e): e is ScenarioEntry => typeof e?.path === "string")
+      .map((e) => ({ path: e.path, summary: e.summary }));
+    scenariosOk = true;
+  } catch {
+    /* no L2 */
+  }
+
+  const selected = selectScenarioPaths(entries, cwd, scenarioMap());
+  const scenarios = selected.map((p) => ({
+    path: p,
+    summary: entries.find((e) => e.path === p)?.summary,
+  }));
+
+  return {
+    block: assembleMemoryBlock({ core, scenarios, budgetChars: INJECT_BUDGET_CHARS }),
+    ok: coreOk || scenariosOk,
+  };
+}
+
+/** Strip one leading YAML frontmatter block — page/read serves page STATE there
+ * (e.g. the `locked: true` the write path injects), which is not knowledge. */
+function stripFrontmatter(s: string): string {
+  const m = s.match(/^---\n[\s\S]*?\n---\n?/);
+  return m ? s.slice(m[0].length) : s;
+}
+
+/** The knowledge-map push: read the team-maintained map page named by
+ * TDAI_INJECT_MAP and wrap it for injection. "" when unset, unparseable, or the
+ * page is empty — the caller latches on a successful call either way (healthy but
+ * empty is not an outage), and only a throw leaves the latch open for retry. */
+async function buildMapBlock(): Promise<string> {
+  const sep = INJECT_MAP.indexOf(":");
+  if (sep <= 0) return "";
+  const data = (await call(
+    KNOWLEDGE_URL,
+    "TDAI_KNOWLEDGE_URL",
+    "/v3/wiki/page/read",
+    { ...idFields(), wiki_id: INJECT_MAP.slice(0, sep), refs: [INJECT_MAP.slice(sep + 1)] },
+    false,
+    AUTO_SESSION_TIMEOUT_MS,
+  )) as { items?: { content?: string }[] };
+  const content = stripFrontmatter((data?.items?.[0]?.content ?? "").trim()).trim();
+  if (!content) return "";
+  return `<tdai-knowledge-map>\n${content.slice(0, INJECT_BUDGET_CHARS)}\n</tdai-knowledge-map>`;
+}
+
+// ── L1 per-turn injection (before_agent_start, every turn) ──────────────────
+// Module-level, on purpose: one Node process = one pi session's worth of "kernel
+// life" (same distinction ADLC's own coordinators.py draws) — a fresh process
+// naturally starts with no fingerprint to dedupe against and no full-block sent yet,
+// no explicit reset needed. `session_start` below resets both anyway for the
+// mid-process case (/resume, /fork, /new): a different conversation must not be
+// judged against the PREVIOUS one's last atoms, and deserves its own full push.
+let sessionOpened = false;
+let lastAtomicFingerprint: string[] | null = null;
+// Latched separately from `sessionOpened`: the two pushes hit different services
+// (gateway vs knowledge) and must retry independently — one outage must not force
+// the OTHER block to be re-pushed on every retry turn.
+let mapPushed = false;
+
+// Caps the query sent to /v3/atomic/search — found by review: `event.prompt` handed
+// straight through was UNBOUNDED, so a 200,000-char prompt posted 200,000 chars every
+// turn. Every other boundary in this file is capped (MAX_MSG_CHARS 8192, refs/pages
+// limits); a search query needs far less than that to be useful, and a very long
+// query is not obviously BETTER for a vector/BM25 backend than a capped one.
+const ATOMIC_QUERY_MAX_CHARS = 2000;
+
+/**
+ * The proxy-mimic per-turn push (mirrors ADLC spec 18): search THIS TURN's own
+ * incoming prompt text against L1 atoms, top `ATOMIC_LIMIT`, rendered via the same
+ * `assembleMemoryBlock` the full L2/L3 push uses. Landing in a visible session
+ * MESSAGE (see the `before_agent_start` handler below), not spliced into the system
+ * prompt — the whole point of this refactor: every injection is a reviewable row in
+ * the transcript, not invisible context the model silently receives.
+ *
+ * Skipped (returns "") when this turn's hits are IDENTICAL to the previous turn's —
+ * a topic that persists across turns must not silt the transcript with the same
+ * three atoms every single time. An outage is NEVER deduped against a prior outage
+ * (`lastAtomicFingerprint` is reset to null on failure) — unlike ADLC's own harness,
+ * this returns the failure VISIBLY inline rather than a separate marker constant,
+ * since this file has no equivalent of `tdai.unavailable_marker` to reuse.
+ */
+async function buildTurnAtomicBlock(query: string): Promise<string> {
+  const trimmed = query.trim().slice(0, ATOMIC_QUERY_MAX_CHARS);
+  if (!trimmed) return "";
+  let hits: AtomicHit[];
+  try {
+    const data = await call(
+      GATEWAY_URL,
+      "TDAI_GATEWAY_URL",
+      "/v3/atomic/search",
+      { ...idFields(), query: trimmed, limit: ATOMIC_LIMIT },
+      true,
+      AUTO_ATOMIC_TIMEOUT_MS,
+    );
+    hits = atomicHitsFrom(data);
+  } catch (err) {
+    lastAtomicFingerprint = null; // an outage is never "the same as last turn"
+    return `<tdai-memory-unavailable>\n${(err as Error).message}\n</tdai-memory-unavailable>`;
+  }
+  const fp = atomicFingerprint(hits);
+  if (sameFingerprint(lastAtomicFingerprint, fp)) return "";
+  lastAtomicFingerprint = fp;
+  if (fp.length === 0) return "";
+  // budgetChars explicit: found by review — omitting it here silently fell back to
+  // lib.ts's own DEFAULT_BUDGET_CHARS (16000) instead of honoring TDAI_INJECT_MAX_CHARS,
+  // harmless only by coincidence (3 hits × 200 chars is nowhere near either budget).
+  return assembleMemoryBlock({
+    core: null,
+    scenarios: [],
+    atomicHits: hits,
+    budgetChars: INJECT_BUDGET_CHARS,
+  });
+}
+
+// ── L0 capture (session_shutdown) ───────────────────────────────────────────
+const CAPTURE_TYPE = "tdai-capture";
+
+function lastCapturedEntryId(ctx: ExtensionContext): string | null {
+  const entries = ctx.sessionManager.getEntries();
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i] as {
+      type: string;
+      customType?: string;
+      data?: { lastEntryId?: string };
+    };
+    if (e.type === "custom" && e.customType === CAPTURE_TYPE)
+      return e.data?.lastEntryId ?? null;
+  }
+  return null;
+}
+
+async function captureSession(
+  ctx: ExtensionContext,
+  pi: ExtensionAPI,
+): Promise<void>
+{
+  const entries = ctx.sessionManager.getEntries();
+  const lastId = lastCapturedEntryId(ctx);
+  const lastIdx = lastId ? entries.findIndex((e) => e.id === lastId) : -1;
+  const fresh = lastIdx === -1 ? entries : entries.slice(lastIdx + 1);
+  if (fresh.length === 0) return;
+
+  const messages = normalizeEntries(
+    fresh as Parameters<typeof normalizeEntries>[0],
+  );
+  const batches = splitBatches(messages).filter((b) => b.length > 0);
+  if (batches.length === 0) {
+    // Record how far we've captured so a later shutdown doesn't blindly re-send.
+    pi.appendEntry(CAPTURE_TYPE, {
+      lastEntryId: fresh[fresh.length - 1].id,
+      ts: Date.now(),
+    });
+    return;
+  }
+
+  // Send all batches in parallel — fail-open: if any fail, the marker prevents
+  // re-sending the same entries, and individual failures don't block shutdown.
+  await Promise.all(
+    batches.map((batch) =>
+      call(
+        GATEWAY_URL,
+        "TDAI_GATEWAY_URL",
+        "/v3/conversation/add",
+        {
+          ...idFields(),
+          session_id: ctx.sessionManager.getSessionId(),
+          messages: batch,
+        },
+        true,
+      ).catch(() => undefined), // individual failure is non-blocking
+    ),
+  );
+
+  // Record how far we've captured so a later shutdown doesn't blindly re-send.
+  // The marker must be a SESSION ENTRY id (what lastCapturedEntryId looks up),
+  // not anything from the batches: L0Message rows are chunked copies with no id.
+  // Found 2026-09-06: the previous version read `.id` off the last batch row,
+  // which is always undefined, so every shutdown re-sent the whole session.
+  pi.appendEntry(CAPTURE_TYPE, {
+    lastEntryId: fresh[fresh.length - 1].id,
+    ts: Date.now(),
+  });
+}
+
+// ── Extension ───────────────────────────────────────────────────────────────
+export default function tdaiMemoryExtension(pi: ExtensionAPI) {
+  // ── tdai_search — L1 memory semantic search ───────────────────────────────
+  pi.registerTool({
+    name: "tdai_search",
+    label: "TDai Memory Search",
+    description:
+      "Semantic search over TencentDB (tdai-memory) L1 memory notes. Returns scored notes (content, type, background, timestamps).",
+    promptSnippet:
+      "Search team memory: recent decisions, events, lessons learned",
+    // 2026-08-30, a deploy session: a vague "use when relevant" guideline lost to
+    // the harness's own "Use bash for ls, rg, find" — the agent swept the
+    // filesystem twice to locate a repo the KB maps. A rule survives routing only
+    // when it names the TRIGGER (the task shapes) and the forbidden alternative,
+    // so both halves are stated here.
+    promptGuidelines: [
+      "Use tdai_search to recall memories, decisions, and context stored in TencentDB (tdai-memory).",
+      "L1 note types: episodic / persona / instruction — filter with `type` if needed.",
+      "To locate a repo, host, config, deploy recipe, or team decision: query tdai (tdai_search + tdai_wiki_search) FIRST. A find/ls sweep over the home directory or unrelated projects before a tdai miss is an error; targeted reads of files already in play are fine.",
+    ],
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 100,
+          description: "Max results (default 5, max 100)",
+        }),
+      ),
+      type: Type.Optional(
+        Type.String({
+          description: "Filter by type: episodic | persona | instruction",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const data = await call(
+        GATEWAY_URL,
+        "TDAI_GATEWAY_URL",
+        "/v3/atomic/search",
+        {
+          ...idFields(),
+          query: params.query,
+          limit: clampLimit(params.limit, 5),
+          ...(params.type ? { type: params.type } : {}),
+        },
+        true,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_memory_list — list L1 notes ──────────────────────────────────────
+  pi.registerTool({
+    name: "tdai_memory_list",
+    label: "TDai Memory List",
+    description:
+      "List TencentDB (tdai-memory) L1 memory notes (newest first) with pagination.",
+    promptSnippet: "List TencentDB memory notes",
+    parameters: Type.Object({
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 100,
+          description: "Max results (default 20, max 100)",
+        }),
+      ),
+      offset: Type.Optional(
+        Type.Integer({ minimum: 0, description: "Offset (default 0)" }),
+      ),
+      type: Type.Optional(
+        Type.String({
+          description: "Filter by type: episodic | persona | instruction",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const data = await call(
+        GATEWAY_URL,
+        "TDAI_GATEWAY_URL",
+        "/v3/atomic/query",
+        {
+          ...idFields(),
+          limit: clampLimit(params.limit, 20),
+          offset: clampOffset(params.offset),
+          ...(params.type ? { type: params.type } : {}),
+        },
+        true,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_capture — store a note as a conversation message ─────────────────
+  pi.registerTool({
+    name: "tdai_capture",
+    label: "TDai Capture",
+    description:
+      "Capture a note/thought into TencentDB (tdai-memory) as an L0 conversation message. The memory pipeline may extract it into L1 notes asynchronously.",
+    promptSnippet: "Capture a note into TencentDB memory",
+    promptGuidelines: [
+      "Use tdai_capture to store decisions, findings, or context that should survive this session.",
+    ],
+    parameters: Type.Object({
+      text: Type.String({ description: "The note to capture" }),
+      session: Type.Optional(
+        Type.String({ description: "Session id (default: pi-<date>)" }),
+      ),
+    }),
+    async execute(_id, params) {
+      const data = await call(
+        GATEWAY_URL,
+        "TDAI_GATEWAY_URL",
+        "/v3/conversation/add",
+        {
+          ...idFields(),
+          // || (not ??): an explicit empty session also falls back to the default.
+          // toLocaleDateString("en-CA") = YYYY-MM-DD in the caller's local time.
+          session_id:
+            params.session || `pi-${new Date().toLocaleDateString("en-CA")}`,
+          messages: [{ role: "user", content: params.text }],
+        },
+        true,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_wiki_list — list wikis in the knowledge service ──────────────────
+  pi.registerTool({
+    name: "tdai_wiki_list",
+    label: "TDai Wiki List",
+    description:
+      "List knowledge-base wikis on the tdai-memory knowledge service. Returns wiki_id + name — needed before search/read/write.",
+    promptSnippet: "List TencentDB knowledge-base wikis",
+    parameters: Type.Object({
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 100,
+          description: "Max results (default 20, max 100)",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const data = await call(
+        KNOWLEDGE_URL,
+        "TDAI_KNOWLEDGE_URL",
+        "/v3/wiki/list",
+        { ...idFields(), limit: clampLimit(params.limit, 20) },
+        false,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_wiki_search — BM25 full-text search in a wiki ────────────────────
+  pi.registerTool({
+    name: "tdai_wiki_search",
+    label: "TDai Wiki Search",
+    description:
+      "Full-text (BM25) search inside one TencentDB wiki. Requires wiki_id (from tdai_wiki_list). " +
+      "Wikis hold the team's settled knowledge: product docs, architecture, contracts, decisions.",
+    promptSnippet:
+      "Search the team knowledge-base wiki (product docs, architecture, decisions)",
+    promptGuidelines: [
+      "The team KB wiki is where settled docs live — tdai_wiki_search it for product, architecture, and deploy knowledge before hunting the filesystem.",
+    ],
+    parameters: Type.Object({
+      wiki_id: Type.String({ description: "Wiki id (from tdai_wiki_list)" }),
+      query: Type.String({ description: "Search query" }),
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 100,
+          description: "Max results (default 20, max 100)",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const data = await call(
+        KNOWLEDGE_URL,
+        "TDAI_KNOWLEDGE_URL",
+        "/v3/wiki/search",
+        {
+          ...idFields(),
+          wiki_id: params.wiki_id,
+          query: params.query,
+          limit: clampLimit(params.limit, 20),
+        },
+        false,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_wiki_pages — list pages in a wiki ────────────────────────────────
+  pi.registerTool({
+    name: "tdai_wiki_pages",
+    label: "TDai Wiki Pages",
+    description: "List processed pages (refs) in one TencentDB wiki.",
+    promptSnippet: "List pages in a TencentDB wiki",
+    parameters: Type.Object({
+      wiki_id: Type.String({ description: "Wiki id (from tdai_wiki_list)" }),
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 100,
+          description: "Max results (default 20, max 100)",
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const data = await call(
+        KNOWLEDGE_URL,
+        "TDAI_KNOWLEDGE_URL",
+        "/v3/wiki/page/ls",
+        {
+          ...idFields(),
+          wiki_id: params.wiki_id,
+          limit: clampLimit(params.limit, 20),
+        },
+        false,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_wiki_read — read wiki pages ──────────────────────────────────────
+  pi.registerTool({
+    name: "tdai_wiki_read",
+    label: "TDai Wiki Read",
+    description:
+      "Read page contents from one TencentDB wiki. refs from tdai_wiki_pages or tdai_wiki_search (max 20).",
+    promptSnippet: "Read pages from a TencentDB wiki",
+    parameters: Type.Object({
+      wiki_id: Type.String({ description: "Wiki id (from tdai_wiki_list)" }),
+      refs: Type.Array(Type.String(), {
+        description: "Page refs to read (max 20)",
+      }),
+    }),
+    async execute(_id, params) {
+      if (params.refs.length > 20) {
+        throw new Error(
+          `tdai_wiki_read: ${params.refs.length} refs given, max is 20 — split into multiple calls`,
+        );
+      }
+      const data = await call(
+        KNOWLEDGE_URL,
+        "TDAI_KNOWLEDGE_URL",
+        "/v3/wiki/page/read",
+        { ...idFields(), wiki_id: params.wiki_id, refs: params.refs },
+        false,
+      );
+      return result(data);
+    },
+  });
+
+  // ── tdai_wiki_write — write wiki pages ────────────────────────────────────
+  pi.registerTool({
+    name: "tdai_wiki_write",
+    label: "TDai Wiki Write",
+    description:
+      "Write or update markdown pages in one TencentDB wiki. Pages are locked during concurrent writes; a locked page fails with a lock error — retry.",
+    promptSnippet: "Write pages to a TencentDB wiki",
+    parameters: Type.Object({
+      wiki_id: Type.String({ description: "Wiki id (from tdai_wiki_list)" }),
+      pages: Type.Array(
+        Type.Object({
+          ref: Type.String({ description: "Page ref/path" }),
+          content: Type.String({ description: "Markdown content" }),
+        }),
+        { description: "Pages to write (max 20)" },
+      ),
+    }),
+    async execute(_id, params) {
+      if (params.pages.length > 20) {
+        throw new Error(
+          `tdai_wiki_write: ${params.pages.length} pages given, max is 20 — split into multiple calls`,
+        );
+      }
+      const data = await call(
+        KNOWLEDGE_URL,
+        "TDAI_KNOWLEDGE_URL",
+        "/v3/wiki/page/write",
+        {
+          ...idFields(),
+          wiki_id: params.wiki_id,
+          pages: params.pages,
+        },
+        false,
+      );
+      return result(data);
+    },
+  });
+
+  // ── Behavior: L2/L3 (once per session) + L1 (every turn) injection, visible ─
+  if (INJECT_ENABLED) {
+    // A fresh session — /new, /resume, /fork, or a brand-new process — starts its
+    // own full push and must not be judged against the PREVIOUS session's last
+    // atoms. `before_agent_start` always fires after this on the first turn (see
+    // the framework's own lifecycle: session_start precedes every prompt), so
+    // resetting here is enough; no ordering race with the read below.
+    pi.on("session_start", () => {
+      sessionOpened = false;
+      lastAtomicFingerprint = null;
+      mapPushed = false;
+    });
+
+    // Compaction can summarize away the injected message just like any other
+    // conversation entry (session_compact treats custom messages as an ordinary cut
+    // point) — found by review: the OLD design (spliced into systemPrompt, rebuilt
+    // fresh every turn) was structurally immune to this; moving delivery to a
+    // visible message reopened it. Re-arming here means the NEXT turn after a
+    // compaction gets the full persona back, rather than it being gone for the rest
+    // of the process life.
+    pi.on("session_compact", () => {
+      sessionOpened = false;
+      mapPushed = false;
+    });
+
+    pi.on("before_agent_start", async (event) => {
+      const parts: string[] = [];
+
+      // Knowledge map first — orientation before content. Once per session, like
+      // the L2/L3 push, and re-armed after compaction for the same reason.
+      // Latched only on a successful call, so a knowledge-service outage retries
+      // next turn (mirrors `sessionOpened`).
+      if (INJECT_MAP && !mapPushed) {
+        try {
+          const mapBlock = await buildMapBlock();
+          if (mapBlock) parts.push(mapBlock);
+          mapPushed = true;
+        } catch {
+          /* fail-open: retry next turn */
+        }
+      }
+
+      // The full L2/L3 push, ONCE per session — not every turn. Found in this
+      // refactor, not merely inherited: once injection becomes a VISIBLE message
+      // (below) rather than an invisible system-prompt splice, repeating a mostly-
+      // static persona+scenario block on every single turn would be transcript
+      // clutter, not context. Each half stays independently fail-open, same as
+      // buildMemoryBlock's own internal per-call try/catch.
+      //
+      // The latch (`sessionOpened = true`) is set ONLY when `ok` — found by review:
+      // setting it unconditionally meant a single transient hiccup at the exact
+      // moment of a session's FIRST prompt silently lost the persona for that
+      // session's entire life, because `buildMemoryBlock` is internally fail-open
+      // and never actually throws, so the outer catch never had a chance to leave
+      // `sessionOpened` false for a retry. Left false, the very next turn retries.
+      if (!sessionOpened) {
+        try {
+          const cwd = event.systemPromptOptions?.cwd ?? process.cwd();
+          const { block, ok } = await buildMemoryBlock(cwd);
+          if (block) parts.push(block);
+          if (ok) sessionOpened = true;
+        } catch {
+          /* fail-open: a memory outage must never block the agent; sessionOpened
+             stays false so the next turn retries */
+        }
+      }
+
+      // The per-turn L1 push — every turn, this turn's own incoming text.
+      try {
+        const turnBlock = await buildTurnAtomicBlock(event.prompt ?? "");
+        if (turnBlock) parts.push(turnBlock);
+      } catch {
+        /* fail-open: buildTurnAtomicBlock itself is fail-open internally, but
+           nothing outside this file guarantees it always will be */
+      }
+
+      if (parts.length === 0) return;
+      return {
+        message: {
+          customType: "tdai-memory-inject",
+          content: parts.join("\n\n"),
+          display: true,
+        },
+      };
+    });
+  }
+
+  if (CAPTURE_ENABLED) {
+    pi.on("session_shutdown", async (_event, ctx) => {
+      try {
+        await captureSession(ctx, pi);
+      } catch {
+        // fail-open: capture must never block quit/replacement
+      }
+    });
+  }
+
+  // ── Status on start ───────────────────────────────────────────────────────
+  // All required env vars are guaranteed at load (fail-fast above), so success
+  // here is accurate — there is no partially-configured state to report.
+  pi.on("session_start", (_event, ctx) => {
+    ctx.ui.setStatus(
+      "tdai-memory",
+      ctx.ui.theme.fg("success", `tdai: ${GATEWAY_URL} (sid=${SERVICE_ID})`),
+    );
+  });
+}

--- a/MemoryCore/pi-native-plugin/extensions/tdai-memory/lib.ts
+++ b/MemoryCore/pi-native-plugin/extensions/tdai-memory/lib.ts
@@ -1,0 +1,314 @@
+// extensions/tdai-memory/lib.ts
+// Pure, dependency-free logic for the tdai-memory pi extension:
+//   - L0 capture: normalize a pi session into user/assistant messages
+//   - L2/L3 injection: select scenarios + assemble the budgeted prompt block
+// No pi imports, no network — unit-testable in isolation.
+
+export const MAX_MSG_CHARS = 8192; // tdai conversation/add: content 1..8192 JS chars
+export const MAX_MSGS_PER_POST = 100; // tdai conversation/add: 1..100 messages per POST
+export const DEFAULT_BUDGET_CHARS = 16000; // ~4K tokens of injected memory
+export const SUMMARY_MAX = 200; // L2 summary length cap (proxy renders path + ≤200-char summary, no body)
+
+export interface ScenarioEntry {
+  path: string;
+  summary?: string;
+}
+/** One L1 atomic-search hit. Shape is opaque server-side (never asserted elsewhere in
+ * this file); `content` is the field the ADLC harness's own tdai client (same backend,
+ * same endpoint) found the notes under. */
+export interface AtomicHit {
+  content?: string;
+  text?: string;
+}
+export interface MemoryBlockInput {
+  core?: string | null;
+  /** L2 scenarios to inject: path + optional summary (proxy-faithful: path + ≤200-char summary, no full body). */
+  scenarios: ScenarioEntry[];
+  /** L1 atoms found by searching THIS TURN's own incoming prompt text — the per-turn
+   * proxy-mimic push. Optional: omitted (or empty) turns render no "Recent Memories"
+   * section at all, distinct from a turn whose hits are present but deduped away by
+   * the caller before this is even called. */
+  atomicHits?: AtomicHit[];
+  budgetChars?: number;
+}
+export interface L0Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/** Minimal view of a pi session entry — only the fields the normalizer reads. */
+export interface SessionEntryLike {
+  type: string;
+  id: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+    toolName?: string;
+    toolCallId?: string;
+  };
+}
+
+/** A content part of a pi message (text / toolCall / ...). Only fields we read. */
+interface ContentPart {
+  type?: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  arguments?: unknown;
+}
+
+/** Split a string into pieces of 1..max chars (UTF-16 units), order preserved, no loss. Empty -> []. */
+export function chunkContent(s: string, max: number = MAX_MSG_CHARS): string[] {
+  if (s.length === 0) return [];
+  const out: string[] = [];
+  for (let i = 0; i < s.length; i += max) {
+    let end = i + max;
+    // Don't split a UTF-16 surrogate pair at the boundary (e.g. emoji).
+    if (end < s.length && s.charCodeAt(end) >= 0xdc00 && s.charCodeAt(end) <= 0xdfff) end -= 1;
+    out.push(s.slice(i, end));
+  }
+  return out;
+}
+
+/** Split a flat message list into batches of at most maxPerBatch, order preserved. Empty -> []. */
+export function splitBatches(messages: L0Message[], maxPerBatch: number = MAX_MSGS_PER_POST): L0Message[][] {
+  if (messages.length === 0) return [];
+  const out: L0Message[][] = [];
+  for (let i = 0; i < messages.length; i += maxPerBatch) out.push(messages.slice(i, i + maxPerBatch));
+  return out;
+}
+
+/**
+ * Choose which L2 scenario paths to inject for a cwd.
+ * If `map` has a key that is a prefix of `cwd`, return the longest match's paths.
+ * Otherwise return every non-directory entry (inject-all).
+ */
+export function selectScenarioPaths(
+  entries: ScenarioEntry[],
+  cwd: string,
+  map?: Record<string, string[]>,
+): string[] {
+  if (map) {
+    let bestKey: string | null = null;
+    for (const key of Object.keys(map)) {
+      if (cwd.startsWith(key) && (bestKey === null || key.length > bestKey.length)) bestKey = key;
+    }
+    if (bestKey !== null) return map[bestKey];
+  }
+  return entries.filter((e) => !e.path.endsWith("/")).map((e) => e.path);
+}
+
+/** Join the text parts of a message's content (string or array-of-parts). */
+function partText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p) => (p && typeof p === "object" && typeof (p as ContentPart).text === "string" ? (p as ContentPart).text : ""))
+      .join("\n");
+  }
+  return "";
+}
+
+/** Drop a trailing scene-navigation block (a line starting with "## 🗺️"). */
+function stripSceneNav(s: string): string {
+  const lines = s.split("\n");
+  const cut = lines.findIndex((l) => l.trimStart().startsWith("## 🗺️"));
+  return cut === -1 ? s : lines.slice(0, cut).join("\n").trimEnd();
+}
+
+function safeJson(v: unknown): string {
+  try {
+    return JSON.stringify(v) ?? "";
+  } catch {
+    return String(v);
+  }
+}
+
+/** One L2 scenario line: path + optional ≤SUMMARY_MAX-char summary (proxy-faithful). */
+function scenarioLine(s: ScenarioEntry): string {
+  const summary = (s.summary ?? "").trim().slice(0, SUMMARY_MAX);
+  return summary ? `- ${s.path}: ${summary}` : `- ${s.path}`;
+}
+
+/** L1 atomic-hit summary cap — same 200-char ceiling as an L2 summary line; atoms are
+ * the memory's own already-distilled notes, not full pages, so a shorter cap than a
+ * wiki page would need is the right size here too. */
+export const ATOMIC_SUMMARY_MAX = 200;
+
+function atomicLine(hit: AtomicHit): string {
+  const text = (hit.content ?? hit.text ?? "").trim().slice(0, ATOMIC_SUMMARY_MAX);
+  return text ? `- ${text}` : "";
+}
+
+/**
+ * Assemble the <tdai-memory> prompt block: L3 core (full, truncated to fit) first,
+ * then selected L2 scenarios, then L1 atomic hits (the spec-18-style per-turn push),
+ * as "- text" lines, everything within budgetChars.
+ * Returns "" when there is nothing to inject.
+ */
+export function assembleMemoryBlock(input: MemoryBlockInput): string {
+  const budget = input.budgetChars ?? DEFAULT_BUDGET_CHARS;
+  const header = "<tdai-memory>\n";
+  const footer = "\n</tdai-memory>";
+
+  const coreText = stripSceneNav((input.core ?? "").trim());
+  const scenes = input.scenarios.filter((s) => s.path);
+  const atoms = (input.atomicHits ?? []).map(atomicLine).filter(Boolean);
+  if (!coreText && scenes.length === 0 && atoms.length === 0) return "";
+
+  // L3 core first, truncated to fit on its own.
+  let coreBlock = "";
+  if (coreText) {
+    const coreLine = "### Core\n";
+    const allow = Math.max(0, budget - header.length - footer.length - coreLine.length);
+    coreBlock = `### Core\n${allow >= coreText.length ? coreText : coreText.slice(0, allow)}`;
+  }
+
+  const render = (sceneLines: string[], atomicLines: string[]) => {
+    const blocks = [
+      ...(coreBlock ? [coreBlock] : []),
+      ...(sceneLines.length ? [`### Scenarios\n${sceneLines.join("\n")}`] : []),
+      ...(atomicLines.length ? [`### Recent Memories\n${atomicLines.join("\n")}`] : []),
+    ];
+    return header + blocks.join("\n\n") + footer;
+  };
+
+  // L2 lines, added in order while within budget. NOTE (found by review): this loop
+  // checks against `render([...sceneLines, line], [])` — as if no atomic section
+  // existed — so scenes always get first claim on the budget and can starve atoms
+  // entirely in a caller that passes BOTH scenarios and atomicHits in one call.
+  // Not reachable today: index.ts's two call sites never combine them (the
+  // once-per-session push sends scenarios only, the per-turn push sends atoms
+  // only) — but this function is shared, and a future caller combining both should
+  // budget them together rather than assume this ordering is fair.
+  const sceneLines: string[] = [];
+  for (const s of scenes) {
+    const line = scenarioLine(s);
+    if (render([...sceneLines, line], []).length <= budget) sceneLines.push(line);
+  }
+
+  // L1 lines, added in order while within budget — scenes already settled above.
+  const atomicLines: string[] = [];
+  for (const a of atoms) {
+    if (render(sceneLines, [...atomicLines, a]).length <= budget) atomicLines.push(a);
+  }
+
+  return render(sceneLines, atomicLines);
+}
+
+/**
+ * Pull the hit list out of an atomic-search response — pure, defensive. The response
+ * shape is opaque here (no schema asserted anywhere in this codebase, since
+ * `tdai_search` the TOOL just forwards raw data to the model); this defends the SAME
+ * keys the ADLC harness's own tdai client found against the identical backend
+ * endpoint (`results` observed live; `memories`/`list` defended the same way;
+ * `entries` added defensively since this extension's OWN `/v3/scenario/ls` uses that
+ * key and the two endpoints could plausibly share a response convention). A bare
+ * array is accepted too. Anything unrecognizable is no hits, never a throw.
+ */
+export function atomicHitsFrom(data: unknown): AtomicHit[] {
+  const isHit = (h: unknown): h is AtomicHit => !!h && typeof h === "object";
+  if (Array.isArray(data)) return data.filter(isHit);
+  if (data && typeof data === "object") {
+    for (const key of ["results", "memories", "list", "entries"] as const) {
+      const v = (data as Record<string, unknown>)[key];
+      if (Array.isArray(v)) return v.filter(isHit);
+    }
+  }
+  return [];
+}
+
+/** The dedup key for this turn's atomic hits — sorted, so a ranking-order change
+ * alone (plausible noise from the search backend) does not defeat the dedup.
+ * Truncated to ATOMIC_SUMMARY_MAX, same as `atomicLine`'s own render cap — found by
+ * review: fingerprinting the FULL text while rendering a TRUNCATED line meant two
+ * hits differing only past char 200 got different fingerprints but byte-identical
+ * rendered output, defeating the dedup on exactly the case it exists to catch. */
+export function atomicFingerprint(hits: AtomicHit[]): string[] {
+  return hits
+    .map((h) => (h.content ?? h.text ?? "").trim().slice(0, ATOMIC_SUMMARY_MAX))
+    .filter(Boolean)
+    .sort();
+}
+
+/** Fingerprint equality — `null` (no previous turn, or the previous turn was an
+ * outage) never matches anything, so the very next turn after either always renders
+ * fresh rather than being spuriously suppressed. */
+export function sameFingerprint(a: string[] | null, b: string[]): boolean {
+  if (a === null) return false;
+  if (a.length !== b.length) return false;
+  return a.every((v, i) => v === b[i]);
+}
+
+/**
+ * Normalize pi session entries into tdai L0 messages (user/assistant only).
+ * thinking dropped; toolCall -> assistant text; toolResult -> user text;
+ * long content chunked to <= MAX_MSG_CHARS; empty messages dropped; order preserved.
+ */
+export function normalizeEntries(entries: SessionEntryLike[]): L0Message[] {
+  const out: L0Message[] = [];
+  const push = (role: "user" | "assistant", text: string) => {
+    for (const piece of chunkContent(text)) out.push({ role, content: piece });
+  };
+
+  for (const e of entries) {
+    if (e.type !== "message" || !e.message) continue;
+    const m = e.message;
+
+    if (m.role === "user") {
+      const t = partText(m.content).trim();
+      if (t) push("user", t);
+    } else if (m.role === "assistant") {
+      const parts: string[] = [];
+      if (Array.isArray(m.content)) {
+        for (const raw of m.content as ContentPart[]) {
+          if (!raw || typeof raw !== "object") continue;
+          if (raw.type === "text" && typeof raw.text === "string") {
+            parts.push(raw.text);
+          } else if (raw.type === "toolCall") {
+            parts.push(`[tool_call id=${raw.id ?? ""} name=${raw.name ?? ""} ${safeJson(raw.arguments ?? {})}]`);
+          }
+          // "thinking" and anything else: intentionally dropped
+        }
+      } else if (typeof m.content === "string") {
+        parts.push(m.content);
+      }
+      const t = parts.filter((x) => x.trim()).join("\n").trim();
+      if (t) push("assistant", t);
+    } else if (m.role === "toolResult") {
+      const t = partText(m.content).trim();
+      if (t) push("user", `[tool_result name=${m.toolName ?? ""}] ${t}`);
+    }
+  }
+
+  return out;
+}
+
+// ── Config validation (fail-fast: no silent defaults) ───────────────────────
+/** Env vars the extension requires. If any is unset, the extension refuses to load. */
+export const REQUIRED_ENV = [
+  "TDAI_API_KEY",
+  "TDAI_GATEWAY_URL",
+  "TDAI_KNOWLEDGE_URL",
+  "TDAI_SERVICE_ID",
+  "TDAI_TEAM_ID",
+  "TDAI_USER_ID",
+  "TDAI_AGENT_ID",
+] as const;
+
+/** Return the required env vars that are unset/empty in `env`. Empty array = all present. */
+export function missingRequiredEnv(env: Record<string, string | undefined>): string[] {
+  return REQUIRED_ENV.filter((k) => !env[k]);
+}
+
+/** Whether a TDAI_INJECT / TDAI_CAPTURE kill-switch value means "disabled" — found by
+ * review: the code used to check ONLY `=== "0"`, while README.md documents `off` as
+ * the value to set. A user following the README's own instructions had the switch
+ * silently do nothing — pre-existing, but this refactor raised the stakes: injection
+ * now costs a visible message plus an extra HTTP call every turn, not an invisible
+ * splice, so a kill switch that does not kill anything matters more than it used to.
+ * Both spellings accepted going forward; case-insensitive. */
+export function isKillSwitchOff(value: string | undefined): boolean {
+  const v = (value ?? "").trim().toLowerCase();
+  return v === "0" || v === "off";
+}

--- a/MemoryCore/pi-native-plugin/package.json
+++ b/MemoryCore/pi-native-plugin/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@tencentdb-agent-memory/pi-native-plugin",
+  "version": "0.4.0",
+  "description": "Native Pi extension for TencentDB Agent Memory v3 — 8 memory/knowledge tools, automatic L0 capture at session shutdown, visible L2/L3 (once per session) and L1 (every turn) injection. No LLM-traffic proxy: Pi keeps its own model provider.",
+  "type": "module",
+  "license": "MIT",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "tencentdb",
+    "agent-memory",
+    "tdai"
+  ],
+  "pi": {
+    "extensions": [
+      "./extensions"
+    ]
+  },
+  "files": [
+    "extensions",
+    "README.md",
+    "README_CN.md"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.84.2",
+    "@types/node": "^22.0.0",
+    "typebox": "^1.3.7",
+    "typescript": "^5.5.0",
+    "vitest": "^3.2.2"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/MemoryCore/pi-native-plugin/tsconfig.json
+++ b/MemoryCore/pi-native-plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["extensions/**/*.ts"]
+}

--- a/MemoryCore/pi-native-plugin/vitest.config.ts
+++ b/MemoryCore/pi-native-plugin/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Description | 描述

Adds `MemoryCore/pi-native-plugin/`: the **no-proxy** counterpart of `MemoryCore/pi-plugin/` (#1126). Where `pi-plugin` routes Pi's model traffic through the Memory Proxy and lets the proxy inject and capture, this extension keeps Pi on **its own model provider** and does recall, injection and capture itself through Pi's extension API, against Gateway `/v3/*` and the Knowledge Service `/v3/wiki/*`. It is the Pi analogue of the OpenClaw client adapter, for teams that want memory without moving Pi's LLM traffic, key or billing to the proxy. The two can coexist in a Pi install; a user picks one.

新增 `MemoryCore/pi-native-plugin/`：`MemoryCore/pi-plugin/`（#1126）的**不经代理**版本。`pi-plugin` 把 Pi 的模型流量转到 Memory Proxy、由代理注入与捕获；本扩展让 Pi 保留**自己的模型提供方**，通过 Pi 扩展 API 自行完成召回、注入与捕获，直接访问 Gateway `/v3/*` 与 Knowledge Service `/v3/wiki/*`。它相当于 OpenClaw 客户端适配器的 Pi 版本，供不希望把 Pi 的 LLM 流量、密钥与计费转到代理的团队选用。两者可同时安装，按需选其一。

- **8 tools**: `tdai_search`, `tdai_memory_list`, `tdai_capture`, `tdai_wiki_list`, `tdai_wiki_search`, `tdai_wiki_pages`, `tdai_wiki_read`, `tdai_wiki_write`. Wiki ids are always tool parameters; the extension carries no team-specific content.
- **Injection as a visible transcript message** (`customType: "tdai-memory-inject"`, `display: true`), never a hidden splice: L3 persona + L2 scenario summaries once per session (re-armed after `/compact`, retried after an outage), L1 hits for the turn's own prompt every turn (deduped), plus an optional team-maintained knowledge-map wiki page (`TDAI_INJECT_MAP="<wiki_id>:<page ref>"`) so the agent knows what the knowledge base contains.
- **Automatic L0 capture** of the transcript delta at `session_shutdown`, chunked to ≤ 8192 chars and batched to ≤ 100 messages; thinking dropped, tool calls/results as prefixed text. Capture at session close, not mid-flight, matching `docs/tdai-v2-technical-ops.md` §12.
- **Fail-fast** on missing `TDAI_*` env at load (Pi reports and continues without the extension); **fail-open** on every call.
- Query-first routing guidance in the tool descriptions: search memory and the wiki before hunting the filesystem for repos, hosts, configs or deploy recipes.

The same code is published for `pi install` as the community package [`@plainwuatlig/pi-tencentdb-agent-memory`](https://www.npmjs.com/package/@plainwuatlig/pi-tencentdb-agent-memory) (v0.4.0); this directory tracks its releases. Bilingual `README.md` / `README_CN.md`; one row added to the agent tables in `INSTALL.md` / `INSTALL_CN.md`.

## Related Issue | 关联 Issue

#926 (Adapters Wanted, Pi). Complements #1126 rather than replacing it. Sibling PR for Claude Code: #1268.

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 — `npm run typecheck`; `npm test` (75 vitest tests: tool guards, injection once per session and re-arm after compaction, per-turn L1 dedupe, knowledge-map injection, capture delta and marker, env validation). The published package is in daily use against a running Gateway + Knowledge Service; a headless `pi -p` run shows one injected memory message containing the knowledge map and one capture marker with a real entry id.
- [x] No existing features affected | 无影响现有功能 — new directory only; two table rows in the install guides.

## Additional Notes | 其他说明

Commit is DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkVfNqVBnTAHnc62NUieKj