### PR TITLE
docs(knowledge): replace dead data-flow.md link with Auto-Sync section

### DIFF
--- a/MemoryKnowledge/README.md
+++ b/MemoryKnowledge/README.md
@@ -11,7 +11,7 @@
 | --- | --- |
 | **LLM-Wiki** | 上传/拉取文档 → LLM 抽取结构化页面 → FTS5 全文检索 + 知识图谱 |
 | **Code-Graph** | `git clone` 仓库 → CodeGraph 索引（符号、调用、文件树）→ 探索查询 |
-| **Auto-Sync**（可选） | 定时扫描 code-graph，FIFO 队列 + worker pool 自动拉取 git 更新并重建索引。默认关闭，见 `docs/data-flow.md` §9。 |
+| **Auto-Sync**（可选） | 定时扫描 code-graph，FIFO 队列 + worker pool 自动拉取 git 更新并重建索引。默认关闭，见下方「可选：Auto-Sync」。 |
 | **Tools** | `POST /v3/tools/list`、`/v3/tools/call`，供 Agent / Kernel 自发现调用 |
 | **状态回调** | ingest/sync 完成后回调 Panel（`TMC_CALLBACK_URL`），再写远端 meta / knowledge |
 
@@ -115,3 +115,15 @@ KNOWLEDGE_CLICKHOUSE_PASSWORD=              # 仅从环境注入，不写入代�
 
 配置 `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`（及可选 `LANGFUSE_BASE_URL`）即可上报 Wiki LLM 调用。  
 未配置时关闭 Trace，不影响业务。
+
+## 可选：Auto-Sync
+
+默认关闭。设置 `KNOWLEDGE_AUTO_SYNC_ENABLED=true` 后，Knowledge Service 会定时扫描 code-graph，以 FIFO 队列 + worker pool 自动拉取 git 更新并重建索引。
+
+```dotenv
+KNOWLEDGE_AUTO_SYNC_ENABLED=true
+KNOWLEDGE_AUTO_SYNC_SCAN_INTERVAL_MIN=10   # 扫描间隔（分钟），范围 1–60
+KNOWLEDGE_AUTO_SYNC_MAX_CONCURRENT=3       # 最大并发 sync worker 数，范围 1–20
+```
+
+启动后延迟 30 秒执行首次扫描；禁用期间调用 `POST /v3/auto-sync/trigger` 为空操作（返回 `triggered: false`）。


### PR DESCRIPTION
## Description | 描述

Fixes #1263.

`MemoryKnowledge/README.md` pointed Auto-Sync readers at `docs/data-flow.md` §9, but that file has **never existed** in the repository (verified via commit history on both `feat/server_team` and `main`), so the relative link was dead and the Auto-Sync configuration was undiscoverable.

Change (option 2 from the issue — replace the dead link with valid documentation):

- The capability-table entry now points to a new **「可选：Auto-Sync」** README section (same style as the existing ClickHouse / Langfuse optional sections).
- The new section documents, all verified against `src/store/auto-sync-scheduler.ts` and `src/routes/auto-sync.ts`:
  - `KNOWLEDGE_AUTO_SYNC_ENABLED` (default `false`)
  - `KNOWLEDGE_AUTO_SYNC_SCAN_INTERVAL_MIN` (default `10`, clamped to 1–60)
  - `KNOWLEDGE_AUTO_SYNC_MAX_CONCURRENT` (default `3`, clamped to 1–20)
  - first scan delayed 30 s after start
  - manual `POST /v3/auto-sync/trigger` is a no-op while disabled (returns `triggered: false`)

## Related Issue | 关联 Issue

Fixes #1263

## Change Type | 修改类型

- [x] Documentation update | 文档更新

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- Acceptance criteria from the issue: no broken relative link remains (the `data-flow.md` reference is gone); the README now explains the enable switch, interval, concurrency, startup delay, and manual-trigger behaviour.
- Checked the other relative Markdown links in this README (`../MemoryPanel/`, `../deploy/panel-knowledge-combined/README.md`) — both resolve.

---

> This PR was prepared with AI coding assistance; the verification (dead-link reproduction, source-of-truth values, link check) was run locally by me. 本 PR 在 AI 编码助手辅助下完成，验证均由本人本地执行。
