### PR TITLE
fix(knowledge): emit local-time ISO 8601 timestamps from logger

### DIFF
--- a/MemoryKnowledge/src/logger.test.ts
+++ b/MemoryKnowledge/src/logger.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for https://github.com/TencentCloud/TencentDB-Agent-Memory/issues/1264 (gap 1)
+ *
+ * The Knowledge logger previously emitted UTC via `toISOString()` with no
+ * timezone marker, while MemoryCore's gateway logger uses local time with an
+ * explicit offset (nowLocalIso). Cross-service incident correlation required
+ * mental +offset conversion with no in-band hint.
+ *
+ * The Knowledge logger now uses the same local-time ISO 8601 format.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createLogger } from "./logger.js";
+
+describe("createLogger timestamp", () => {
+  it("emits local time with an explicit UTC offset, not bare UTC", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      createLogger("test-tag").info("hello");
+      expect(spy).toHaveBeenCalledOnce();
+      const line = spy.mock.calls[0][0] as string;
+
+      // ISO 8601 local time with offset, e.g. 2026-09-06T18:03:04.123+08:00
+      // Bare UTC output (the old behavior) has no offset and a space separator.
+      expect(line).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2} /);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/MemoryKnowledge/src/logger.ts
+++ b/MemoryKnowledge/src/logger.ts
@@ -2,13 +2,20 @@
  * Logger — simple leveled logging module
  */
 
+import dayjs from "dayjs";
+
 type Level = "debug" | "info" | "warn" | "error";
 
 const LEVEL_PRIORITY: Record<Level, number> = { debug: 0, info: 1, warn: 2, error: 3 };
 const LOG_LEVEL = (process.env.LOG_LEVEL || "debug") as Level;
 
 function ts() {
-  return new Date().toISOString().replace("T", " ").slice(0, 23);
+  // Local time with explicit UTC offset, consistent with MemoryCore's
+  // nowLocalIso() (see MemoryCore/src/gateway/server.ts): the wall-clock
+  // matches what the operator sees in tmux / tail -f while the line stays
+  // ISO 8601 compliant and round-trippable. Previously this was UTC with no
+  // timezone marker, which made cross-service incident correlation error-prone.
+  return dayjs().format("YYYY-MM-DDTHH:mm:ss.SSSZ");
 }
 
 function shouldLog(level: Level) {


### PR DESCRIPTION
## Description | 描述

Addresses the **first item** of #1264 (Knowledge logger timezone).

`MemoryKnowledge/src/logger.ts` produced UTC timestamps via `toISOString()` with no timezone marker (`2026-09-05 08:16:21.677`), while MemoryCore's gateway logger uses local time with an explicit offset (`nowLocalIso`, `2026-09-05T16:16:21.677+08:00`). Correlating an incident across the two services required mental offset conversion with no in-band hint.

Timezone-configurable output was already accepted for the core service in #75 / #87 via #129, but that change predates the MemoryKnowledge module — its 15 changed files contain nothing under `MemoryKnowledge/`, and `logger.ts` still used `toISOString()` on HEAD.

Change: `ts()` now uses the same local-time ISO 8601 format as MemoryCore (`dayjs().format("YYYY-MM-DDTHH:mm:ss.SSSZ")`), which stays ISO 8601 compliant and round-trippable while matching what an operator sees in `tmux` / `tail -f`. `dayjs` is already a MemoryKnowledge dependency.

Scope note: this PR intentionally covers only the timezone item. The other two observations in #1264 (the `LOG_PATH` default deactivating file rotation off-container, and the console logger having no level filter) involve deployment-shape and configuration-surface decisions and are left for a separate change.

## Related Issue | 关联 Issue

Addresses #1264 (item 1)

## Change Type | 修改类型

- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- New `src/logger.test.ts` asserts the emitted line matches local-time ISO 8601 with an explicit offset; it fails against the old bare-UTC format and passes after the change.
- `npm run build` (tsdown) passes.
- `MemoryKnowledge` 依赖安装在本机用 `--ignore-scripts`（无 Visual Studio C++ workload，原生模块跳过）；logger 路径不依赖原生模块。

---

> This PR was prepared with AI coding assistance; the verification (fact-checking #129's file list, red→green test, build) was run locally by me. 本 PR 在 AI 编码助手辅助下完成，核验与验证均由本人本地执行。
