### PR TITLE
feat(proxy): 支持 Chat/Responses ↔ Anthropic 协议转换

### DIFF
--- a/MemoryProxy/README.md
+++ b/MemoryProxy/README.md
@@ -2,7 +2,7 @@
 
 MemoryProxy is a **transparent LLM request proxy**: instead of having a coding agent (Claude Code / CodeBuddy / ...) talk to the LLM directly, requests are routed through the proxy first. Around each forward it automatically runs session initialization, memory injection, conversation write-back and more, so an agent can tap into the team memory, Skills and Knowledge provided by [MemoryCore](../MemoryCore/README.md) **without changing a single line of code**.
 
-It is "transparent" to both the client and the upstream model — it changes no protocol and forwards OpenAI `/v1/chat/completions` and Anthropic `/v1/messages` verbatim. It just does a few extra things on the way in and out: **session initialization, context injection, conversation write-back, authentication and usage reporting**.
+By default it transparently forwards the client's protocol. When an upstream protocol is configured, it can also convert between OpenAI Chat Completions, OpenAI Responses and Anthropic Messages with explicit compatibility boundaries. Each request still runs **session initialization, context injection, conversation write-back, authentication and usage reporting**.
 
 > In one line: MemoryProxy handles "access & forwarding"; MemoryCore handles "storage & processing" of memory. The proxy itself persists no memory data — all Memory / Skill / Knowledge reads and writes go through the MemoryCore Gateway (default `:8420`). For the overall product positioning, see the repo root [README.md](../README.md).
 
@@ -26,6 +26,7 @@ Coding agent (Claude Code / CodeBuddy / ...)
 
 - **Session initialization**: intercepts the first request and guides the user through an interactive form to pick team → agent → task, then injects the agent/task context into the system prompt. Supports auto pre-selection from request headers (`x-team-id` / `x-agent-id` / `x-task-id`).
 - **Context injection**: injects Skills, Knowledge and Memory L2/L3 into the system prompt on demand; L0/L1 are exposed as read-only tools for the model to query proactively, avoiding upstream KV-cache invalidation.
+- **Protocol conversion**: converts Chat Completions ↔ Anthropic Messages and Responses ↔ Anthropic Messages for JSON and SSE, preserving text, images, function tools, stop reasons and token usage. Conversion errors use the client's error schema.
 - **Conversation write-back (extraction)**: at the end of each human turn, sends the conversation slice to MemoryCore `/v3/skill/conversation/add` (Skill archival) and writes L0 short-term memory for background extraction on the core side.
 - **Auth & identity**: calls MemoryCore `POST /v3/meta/auth/verify` to validate `x-tdai-user-key` and resolve `user_id` as the end-to-end user identity; `spaceId` (memory instance id) is auto-extracted from the `/proxy/<spaceId>/...` path.
 - **System-user passthrough**: internal service accounts (e.g. memory / wiki internal calls) short-circuit session init and injection on match, doing pure passthrough + billing only.
@@ -101,6 +102,24 @@ At minimum confirm:
 
 - `upstream.url` / `upstream.apiKey` — upstream LLM address and credentials
 - `auth.url` / `tdai.endpoint` / `skill.endpoint` — point to your MemoryCore Gateway (default `http://127.0.0.1:8420`)
+
+### Protocol conversion
+
+Set `upstream.protocol` to the actual upstream protocol. Omitting it keeps same-protocol forwarding. The same fields can be set under `upstream.agents.<agent>` for a client-specific override:
+
+```yaml
+upstream:
+  url: https://claude.example.com/v1
+  apiKey: sk-ant-example
+  protocol: anthropic
+  maxTokens: 8192
+  agents:
+    codex:
+      url: https://claude.example.com/v1
+      protocol: anthropic
+```
+
+Conversion applies only to primary inference endpoints; auxiliary endpoints such as `responses/compact` remain native passthroughs. Features without a lossless mapping return `400`, including reasoning/thinking, stateful or background Responses calls, server-hosted tools, strict function schemas and Anthropic `cache_control` unless `allowCacheControlDrop: true` explicitly permits dropping cache breakpoints.
 
 > **Run locally without Redis**: the example config defaults to `redis.enabled: true`, which spams `ECONNREFUSED 127.0.0.1:6379` when no Redis is running locally. For pure local development, set `redis.enabled: false` + `storage.enabled: true` (`storage.backend: sqlite`); session/injection/Skill state then goes to local SQLite and the process starts up cleanly.
 

--- a/MemoryProxy/README_CN.md
+++ b/MemoryProxy/README_CN.md
@@ -2,7 +2,7 @@
 
 MemoryProxy 是一个**透明的 LLM 请求代理**：把编码 Agent（Claude Code / CodeBuddy 等）原本直连大模型的请求，改为先经过它中转。它在转发前后自动完成会话初始化、记忆注入、对话回流等动作，让 Agent **无需改动一行代码**就能用上 [MemoryCore](../MemoryCore/README_CN.md) 提供的团队记忆、Skill 和 Knowledge。
 
-对客户端和上游模型来说，它是“透明”的——不改变任何协议，原样转发 OpenAI `/v1/chat/completions` 和 Anthropic `/v1/messages`，只是在中转的这一进一出里，顺手做了这些事：**会话初始化、上下文注入、对话回流、鉴权与用量上报**。
+默认情况下它按客户端协议透明转发；配置上游协议后，也可以在 OpenAI Chat Completions、OpenAI Responses 与 Anthropic Messages 之间做有边界的双向转换。中转过程同时完成：**会话初始化、上下文注入、对话回流、鉴权与用量上报**。
 
 > 一句话分工：MemoryProxy 管“接入与转发”，MemoryCore 管“记忆的存储与处理”。Proxy 自身不落记忆数据，所有 Memory / Skill / Knowledge 读写都经 MemoryCore Gateway（默认 `:8420`）完成。整体产品定位见仓库根 [README_CN.md](../README_CN.md)。
 
@@ -26,6 +26,7 @@ MemoryProxy 是一个**透明的 LLM 请求代理**：把编码 Agent（Claude C
 
 - **会话初始化**：首次对话时拦截请求，通过交互式表单引导用户选择 team → agent → task，完成后把 agent/task 上下文注入 system prompt。支持从请求头（`x-team-id` / `x-agent-id` / `x-task-id`）自动预选。
 - **上下文注入**：把 Skill、Knowledge、Memory L2/L3 等按需注入 system prompt；L0/L1 通过只读工具接口暴露给模型主动查询，避免破坏上游 KV cache。
+- **协议转换**：支持 Chat Completions ↔ Anthropic Messages、Responses ↔ Anthropic Messages 的 JSON 与 SSE 双向转换；保留文本、图片、函数工具、停止原因与 token 用量，转换失败按客户端协议返回明确错误。
 - **对话回流（提取）**：每轮真人对话结束时，把对话切片同步发到 MemoryCore `/v3/skill/conversation/add`（Skill 归档）并写入 L0 短期记忆，供 core 侧后台抽取。
 - **鉴权与身份**：调用 MemoryCore `POST /v3/meta/auth/verify` 校验 `x-tdai-user-key`，解析出 `user_id` 作为全链路用户标识；`spaceId`（memory 实例 id）从 `/proxy/<spaceId>/...` 路径自动提取。
 - **系统用户短路透传**：内部服务账号（如 memory / wiki 内部调用）命中后跳过 session init 和注入，只做透明转发 + 计费。
@@ -101,6 +102,24 @@ cp config.example.yaml config.yaml
 
 - `upstream.url` / `upstream.apiKey` —— 上游 LLM 地址与凭据
 - `auth.url` / `tdai.endpoint` / `skill.endpoint` —— 指向你的 MemoryCore Gateway（默认 `http://127.0.0.1:8420`）
+
+### 协议转换
+
+`upstream.protocol` 声明上游实际协议；省略时继续按客户端协议转发。它也可写在 `upstream.agents.<agent>` 下，覆盖指定客户端：
+
+```yaml
+upstream:
+  url: https://claude.example.com/v1
+  apiKey: sk-ant-example
+  protocol: anthropic
+  maxTokens: 8192
+  agents:
+    codex:
+      url: https://claude.example.com/v1
+      protocol: anthropic
+```
+
+转换只作用于主推理端点，`responses/compact` 等辅助端点仍按原协议透传。不能无损表达的能力会返回 `400`，包括 reasoning/thinking、Responses 的有状态或后台执行、服务端内置工具、严格函数 schema，以及未获允许的 Anthropic `cache_control`。确实接受丢失缓存断点时才设置 `allowCacheControlDrop: true`。
 
 > **本地无 Redis 快速跑通**：示例配置默认 `redis.enabled: true`，本机没起 Redis 时会持续刷 `ECONNREFUSED 127.0.0.1:6379`。纯本地开发建议改为 `redis.enabled: false` + `storage.enabled: true`（`storage.backend: sqlite`），会话/注入/Skill 状态改走本地 SQLite，启动即干净。
 

--- a/MemoryProxy/config.example.yaml
+++ b/MemoryProxy/config.example.yaml
@@ -29,16 +29,20 @@ server:
 
 # ── 上游 LLM 服务（默认兜底） ──────────────────────────────────────────────────
 upstream:
-  # 上游 OpenAI-compatible API 地址（/v1/chat/completions 会由 proxy 自动拼接）
-  # 也支持完整路径如 https://llm-upstream.example.com/v2/
+  # 上游 API 地址；推理端点会由 proxy 按协议自动拼接。
   url: https://tokenhub.example.com/v1
   # 若非空，则替换所有转发请求中的 Authorization: Bearer <apiKey>。
   # 留空则透传客户端原始 API Key。
   apiKey: "<YOUR_TOKENHUB_API_KEY>"
+  # 上游实际使用的协议。省略时保持历史行为：按客户端协议原样转发。
+  # protocol: anthropic       # chat | responses | anthropic
+  # 转为 Anthropic Messages 时，若客户端没给输出上限则使用此值；不猜测或截断。
+  # maxTokens: 8192
+  # Anthropic cache_control 无法无损映射到 OpenAI；默认拒绝，可显式允许丢弃并记录告警。
+  # allowCacheControlDrop: false
 
   # ── Per-Agent 覆盖 ─────────────────────────────────────────────────────────
-  # 按 agent 名（URL 路径前缀 /{agent}/...）覆盖 url + apiKey。
-  # Anthropic 和 OpenAI 协议共用同一张表。
+  # 按 agent 名（URL 路径前缀 /{agent}/...）覆盖 url、apiKey 和协议转换选项。
   #
   # 兜底规则（重要）——只有"没配这个 agent"才会走外层 upstream 兜底：
   #
@@ -65,6 +69,8 @@ upstream:
     #   apiKey: "sk-ant-agent-key"
     # codex:                                              # 客户端 key 透传模式
     #   url: "https://codex-upstream.example.com/v1"
+    #   protocol: anthropic                               # Responses 客户端转 Anthropic 上游
+    #   maxTokens: 8192
     #   # 不写 apiKey → 透传客户端自己带上来的 key，不走外层兜底
     # 注意：workbuddy / codebuddy / claude-code 等客户端不需要单独配 per-agent override，
     # 它们的请求会自然落到外层 upstream.url + 鉴权走的 user_key，proxy 自动按 user_id
@@ -707,8 +713,6 @@ ccRequestRouting:
 
 # ── Per-Agent 上游路由 ─────────────────────────────────────────────────────
 # 见文件顶部 `upstream.agents` 一段。
-
-
 # ── 本地 JSONL Trace 归档 ─────────────────────────────────────────────────────
 # 启用后，每个 trace + span 以 JSONL 行追加写入本地文件（按日期分文件），
 # 文件名格式：<hostname>-<YYYY-MM-DD>.jsonl

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -24,8 +24,11 @@ import {
 } from "./langfuse.js";
 import { countHumanTurns } from "./turnSeq.js";
 import type { ProxyConfig } from "./types.js";
+import { fetchProtocolAttempt, protocolErrorResponse, upstreamAccounting, type ForwardProtocolContext } from "./protocol/forward.js";
+import { ProtocolError } from "./protocol/common.js";
 import {
   resolveForwardTarget,
+  joinUrl,
   resolveSessionKey,
   resolveLatestUserQuery,
   reportAnalyzerTrace,
@@ -386,6 +389,7 @@ async function forwardWithRetry(
   forwardTimeoutMs: number,
   sessionKeyForDebug?: string,
   rateLimitContext?: { config: ProxyConfig; instanceId?: string },
+  protocolContext?: ForwardProtocolContext,
 ): Promise<{ resp: Response; retried: boolean }> {
   let upstreamResp: Response | undefined;
   let forwardFailed = false;
@@ -451,13 +455,14 @@ async function forwardWithRetry(
     });
   }
   try {
-    upstreamResp = await fetch(target.url, {
+    upstreamResp = await fetchProtocolAttempt(target, {
       method: "POST",
       headers: upstreamHeaders,
       body: JSON.stringify(upstreamBody),
-      signal: AbortSignal.timeout(forwardTimeoutMs),
-    });
+      ...(forwardTimeoutMs > 0 ? { signal: AbortSignal.timeout(forwardTimeoutMs) } : {}),
+    }, protocolContext);
   } catch (err: unknown) {
+    if (err instanceof ProtocolError) throw err;
     if (err instanceof DOMException && err.name === "TimeoutError") {
       pipe.error("FORWARD", `Timeout after ${forwardTimeoutMs / 1000}s`);
     } else {
@@ -474,6 +479,7 @@ async function forwardWithRetry(
     (forwardFailed || (upstreamResp && upstreamResp.status >= 400 && upstreamResp.status < 500));
 
   if (shouldRetry && target.retryTarget) {
+    await upstreamResp?.body?.cancel();
     const reason = forwardFailed ? "timeout/error" : `${upstreamResp!.status}`;
     pipe.info("RETRY", `Routed model failed (${reason}), retrying with ${target.retryTarget.model}`);
 
@@ -492,12 +498,12 @@ async function forwardWithRetry(
           protocol: "anthropic",
         });
       }
-      upstreamResp = await fetch(target.retryTarget.url, {
+      upstreamResp = await fetchProtocolAttempt(target.retryTarget, {
         method: "POST",
         headers: retryHeaders,
-        body: JSON.stringify(originalBody),
-        signal: AbortSignal.timeout(forwardTimeoutMs),
-      });
+        body: JSON.stringify({ ...originalBody, model: target.retryTarget.model }),
+        ...(forwardTimeoutMs > 0 ? { signal: AbortSignal.timeout(forwardTimeoutMs) } : {}),
+      }, protocolContext);
       if (upstreamResp.ok) {
         pipe.info("RETRY_SUCCESS", `Retry returned ${upstreamResp.status}`);
       } else {
@@ -505,6 +511,7 @@ async function forwardWithRetry(
       }
       return { resp: upstreamResp, retried: true };
     } catch (retryErr: unknown) {
+      if (retryErr instanceof ProtocolError) throw retryErr;
       if (isRateLimitExceededError(retryErr)) throw retryErr;
       if (retryErr instanceof DOMException && retryErr.name === "TimeoutError") {
         pipe.error("RETRY_FORWARD", `Timeout after ${forwardTimeoutMs / 1000}s`);
@@ -1448,6 +1455,11 @@ export async function handleAnthropicMessages(
   pipe.forwardStart();
   let upstreamResp: Response;
   let retried = false;
+  const protocolContext: ForwardProtocolContext = {
+    source: "anthropic", settings: { ...config.upstream, ...agentUpstreamEntry },
+    defaultUrl: joinUrl(defaultUpstreamUrl, forwardEndpoint),
+    request: body, signal: c.req.raw.signal, warn: message => pipe.info("PROTOCOL", message),
+  };
 
   try {
     const result = await forwardWithRetry(
@@ -1456,10 +1468,12 @@ export async function handleAnthropicMessages(
       pipe, forwardTimeoutMs,
       sessionKey,
       { config, instanceId: spaceId || undefined },
+      protocolContext,
     );
     upstreamResp = result.resp;
     retried = result.retried;
   } catch (err: unknown) {
+    if (err instanceof ProtocolError) return protocolErrorResponse(err, "anthropic", err.status);
     if (isRateLimitExceededError(err)) {
       pipe.info("RATE_LIMIT", "TPM/QPM exceeded");
       return err.response;
@@ -1510,7 +1524,7 @@ export async function handleAnthropicMessages(
     }
 
     // Log error body for 4xx
-    if (!retried && upstreamResp.status >= 400 && upstreamResp.status < 500) {
+    if (upstreamResp.status >= 400) {
       const [errStream, clientStream] = upstreamResp.body.tee();
       const errText = await new Response(errStream).text();
       pipe.error("UPSTREAM_4xx", `status=${upstreamResp.status} body=${errText.slice(0, 1000)}`);
@@ -1548,6 +1562,7 @@ export async function handleAnthropicMessages(
 
     // Background: consume tap stream for Anthropic SSE → extract usage
     consumeAnthropicStream(tapStream, {
+      protocolContext,
       config,
       modelId: effectiveModel,
       keyId,
@@ -1809,17 +1824,21 @@ export async function handleAnthropicMessages(
     console.log(`[cc-routing] skip L0 write for kind=${requestKind} session=${sessionKey}`);
   }
 
-  // Credit usage reporting (non-streaming).
+  // Credit usage reporting (non-streaming). Failures are surfaced to the client
+  // via the `x-credit-report-error` response header but never replace the
+  // upstream LLM response body — the user-facing answer is preserved.
+  const accounting = upstreamAccounting(protocolContext, usage, effectiveModel, target.url, "anthropic");
   const creditOutcome = skipCreditReport
     ? { attempted: false, ok: false }
     : await tryReportCreditFromPath(
     config.creditReport,
     c.req.path,
-    usage,
+    accounting.usage,
     config.creditPricing,
-    effectiveModel,
-    target.url,
+    accounting.model,
+    accounting.url,
     "usage",
+    accounting.protocol,
   );
   if (creditOutcome.attempted && !creditOutcome.ok) {
     pipe.error("CREDIT_REPORT", creditOutcome.errorMessage ?? "unknown");
@@ -1951,6 +1970,7 @@ function createSseThinkingFixStream(
 // ── Stream processing helpers ────────────────────────────────────────────────
 
 interface AnthropicTapContext {
+  protocolContext?: ForwardProtocolContext;
   config: ProxyConfig;
   modelId: string;
   keyId: string;
@@ -2212,17 +2232,21 @@ function consumeAnthropicStream(stream: ReadableStream<Uint8Array>, ctx: Anthrop
         console.log(`[cc-routing] skip skill buffer (stream) for kind=${ctx.requestKind} session=${ctx.sessionKeyForSkill}`);
       }
 
-      // Credit usage reporting for streaming responses.
+      // Credit usage reporting for streaming responses. The stream has already
+      // been forwarded to the client; failures here are best-effort and can
+      // only be observed via server logs (no way to retro-add response headers).
+      const accounting = upstreamAccounting(ctx.protocolContext, usage, ctx.modelId, ctx.upstreamUrl, "anthropic");
       (ctx.skipCreditReport
-        ? Promise.resolve({ attempted: false, ok: false })
+        ? Promise.resolve({ attempted: false, ok: false, errorMessage: undefined })
         : tryReportCreditFromPath(
             ctx.config.creditReport,
             ctx.requestPath,
-            usage,
+            accounting.usage,
             ctx.config.creditPricing,
-            ctx.modelId,
-            ctx.upstreamUrl,
+            accounting.model,
+            accounting.url,
             "usage",
+            accounting.protocol,
           ))
         .then((outcome) => {
           if (outcome.attempted && !outcome.ok) {

--- a/MemoryProxy/src/codexHandler.ts
+++ b/MemoryProxy/src/codexHandler.ts
@@ -30,6 +30,8 @@ import type { ProxyConfig } from "./types.js";
 import { apiKeyToKeyId, extractBearerToken, uuidv7 } from "./opik.js";
 import { createPipeline, writeLog } from "./logger.js";
 import { extractSpaceIdFromPath } from "./credit-reporter.js";
+import { fetchProtocolAttempt, protocolErrorResponse, type ForwardProtocolContext } from "./protocol/forward.js";
+import { ProtocolError } from "./protocol/common.js";
 import { joinUrl } from "./guard-adapter.js";
 import { verifyUserKey } from "./auth.js";
 import { resolveModelId } from "./pricing.js";
@@ -1133,13 +1135,23 @@ async function forwardToUpstream(
   pipe.forwardStart(upstreamUrl);
 
   let upstreamResp: Response;
+  const isInference = /\/responses\/?$/.test(c.req.path);
+  const protocolContext: ForwardProtocolContext | undefined = isInference ? {
+    source: "responses",
+    settings: { ...config.upstream, ...agentUpstreamEntry },
+    defaultUrl: upstreamUrl,
+    request: body,
+    signal: c.req.raw.signal,
+    warn: message => pipe.info("PROTOCOL", message),
+  } : undefined;
   try {
-    upstreamResp = await fetch(upstreamUrl, {
+    upstreamResp = await fetchProtocolAttempt({ url: upstreamUrl, model: modelId }, {
       method: "POST",
       headers: upstreamHeaders,
       body: JSON.stringify(body),
-    });
+    }, protocolContext);
   } catch (err: unknown) {
+    if (err instanceof ProtocolError) return protocolErrorResponse(err, "responses", err.status);
     pipe.error("CODEX_FORWARD", err instanceof Error ? err : new Error(String(err)));
     // 上报 langfuse 失败（转发异常 —— 上游未回响应体，只有本地 fetch 抛错）
     if (lf) {

--- a/MemoryProxy/src/config.ts
+++ b/MemoryProxy/src/config.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { load as yamlLoad } from "js-yaml";
-import type { CostGuardConfig, ProxyConfig, RawYamlConfig } from "./types.js";
+import type { AgentUpstreamEntry, CostGuardConfig, ProxyConfig, RawYamlConfig, UpstreamProtocolOptions } from "./types.js";
 
 const DEFAULT_UPSTREAM = "https://llm-upstream.example.com/v2/chat/completions";
 
@@ -244,19 +244,29 @@ function parseCostGuard(yaml: RawYamlConfig): CostGuardConfig {
  * noise (and would make "did I configure this right?" harder to answer at
  * a glance).
  */
+function parseUpstreamProtocol(raw: UpstreamProtocolOptions | undefined): UpstreamProtocolOptions {
+  if (!raw) return {};
+  if (raw.protocol !== undefined && !["chat", "anthropic", "responses"].includes(raw.protocol)) throw new Error("upstream.protocol must be chat, anthropic, or responses");
+  if (raw.maxTokens !== undefined && (!Number.isSafeInteger(raw.maxTokens) || raw.maxTokens < 1)) throw new Error("upstream.maxTokens must be a positive integer");
+  if (raw.allowCacheControlDrop !== undefined && typeof raw.allowCacheControlDrop !== "boolean") throw new Error("upstream.allowCacheControlDrop must be boolean");
+  return {
+    ...(raw.protocol !== undefined ? { protocol: raw.protocol } : {}),
+    ...(raw.maxTokens !== undefined ? { maxTokens: raw.maxTokens } : {}),
+    ...(raw.allowCacheControlDrop !== undefined ? { allowCacheControlDrop: raw.allowCacheControlDrop } : {}),
+  };
+}
+
 function parseUpstreamAgents(
-  raw: Record<string, { url?: string; apiKey?: string } | null | undefined> | undefined,
-): Record<string, { url: string; apiKey?: string }> {
+  raw: NonNullable<RawYamlConfig["upstream"]>["agents"],
+): Record<string, AgentUpstreamEntry> {
   if (!raw || typeof raw !== "object") return {};
-  const out: Record<string, { url: string; apiKey?: string }> = {};
+  const out: Record<string, AgentUpstreamEntry> = {};
   for (const [name, entry] of Object.entries(raw)) {
     if (!entry || typeof entry !== "object") continue;
     const url = (entry as { url?: unknown }).url;
     if (typeof url !== "string" || url.length === 0) continue;
     const apiKey = (entry as { apiKey?: unknown }).apiKey;
-    out[name] = typeof apiKey === "string" && apiKey.length > 0
-      ? { url, apiKey }
-      : { url };
+    out[name] = { url, ...(typeof apiKey === "string" && apiKey.length > 0 ? { apiKey } : {}), ...parseUpstreamProtocol(entry) };
   }
   return out;
 }
@@ -278,6 +288,7 @@ export function buildConfig(overrides: CliOverrides = {}): ProxyConfig {
         DEFAULT_CONFIG.server.forwardTimeoutMs,
     },
     upstream: {
+      ...parseUpstreamProtocol(yaml.upstream),
       url:
         overrides.upstreamUrl ??
         yaml.upstream?.url ??

--- a/MemoryProxy/src/credit-reporter.ts
+++ b/MemoryProxy/src/credit-reporter.ts
@@ -117,6 +117,7 @@ export function computeCreditDelta(
   pricingConfig: CreditPricingConfig | null | undefined,
   modelId?: string,
   upstreamUrl?: string,
+  wireProtocol?: import("./protocol/common.js").WireProtocol,
 ): number {
   if (!usage) return 0;
 
@@ -124,7 +125,7 @@ export function computeCreditDelta(
   const isTokenHub = upstreamUrl ? /tokenhub/i.test(upstreamUrl) : false;
   if (!isTokenHub) return 0;
 
-  const protocol = detectUsageProtocol(upstreamUrl ?? "");
+  const protocol = wireProtocol ?? detectUsageProtocol(upstreamUrl ?? "");
 
   // 通用字段
   const output = numField(usage.completion_tokens) || numField(usage.output_tokens);
@@ -146,8 +147,8 @@ export function computeCreditDelta(
     cacheWrite1h = Math.max(0, totalCacheWrite - ephemeral5m);
   } else {
     // OpenAI: prompt_tokens 含缓存，需减去 cached_tokens
-    const promptDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined;
-    const promptTokens = numField(usage.prompt_tokens);
+    const promptDetails = (protocol === "responses" ? usage.input_tokens_details : usage.prompt_tokens_details) as Record<string, unknown> | undefined;
+    const promptTokens = numField(protocol === "responses" ? usage.input_tokens : usage.prompt_tokens);
     cacheRead =
       numField(usage.cache_read_tokens) ||
       numField(promptDetails?.cached_tokens);
@@ -302,6 +303,7 @@ export async function tryReportCreditFromPath(
    * Defaults to `"usage"` semantically when omitted (backward compatible).
    */
   event?: "usage" | "analyzer_usage",
+  wireProtocol?: import("./protocol/common.js").WireProtocol,
 ): Promise<CreditReportOutcome> {
   // Defense-in-depth: extension telemetry events must never trigger a credit report.
   // Today the extension telemetry path (writeLog with event="analyzer_usage") does not
@@ -319,7 +321,7 @@ export async function tryReportCreditFromPath(
     SpaceId: spaceId,
     MemoryLevel: PROXY_MEMORY_LEVEL,
     MemoryDelta: 0,
-    CreditDelta: computeCreditDelta(usage, pricingConfig, modelId, upstreamUrl),
+    CreditDelta: computeCreditDelta(usage, pricingConfig, modelId, upstreamUrl, wireProtocol),
   });
   if (result.ok) {
     return { attempted: true, ok: true, result };

--- a/MemoryProxy/src/guard-adapter.ts
+++ b/MemoryProxy/src/guard-adapter.ts
@@ -49,6 +49,7 @@ interface RetryTarget {
   url: string;
   model: string;
   authHeaders: Record<string, string> | null;
+  wireProtocol?: import("./protocol/common.js").WireProtocol;
 }
 
 /** Analyzer trace returned by cost-guard for host observability. */
@@ -73,6 +74,7 @@ export interface ForwardTarget {
   authHeaders: Record<string, string> | null;
   bodyOverrides: Record<string, unknown> | null;
   retryTarget: RetryTarget | null;
+  wireProtocol?: import("./protocol/common.js").WireProtocol;
   logLine: string;
   logLineExtra: string;
   tags: string[];
@@ -330,6 +332,7 @@ export function joinUrl(base: string, requestPath: string): string {
   // agentUpstreams 或完整 endpoint base 已含路径时勿再拼接。
   if (
     baseWithoutQuery.endsWith("/messages") ||
+    baseWithoutQuery.endsWith("/responses") ||
     baseWithoutQuery.endsWith("/chat/completions")
   ) {
     return normalizedBase;
@@ -468,6 +471,7 @@ export async function resolveForwardTarget(
     authHeaders: Record<string, string> | null;
     bodyOverrides: Record<string, unknown> | null;
     retryTarget: RetryTarget | null;
+    wireProtocol?: import("./protocol/common.js").WireProtocol;
     logLine?: string;
     logLineExtra?: string;
     tags?: unknown[];
@@ -486,6 +490,7 @@ export async function resolveForwardTarget(
     authHeaders: raw.authHeaders ?? null,
     bodyOverrides: raw.bodyOverrides ?? null,
     retryTarget: raw.retryTarget ?? null,
+    wireProtocol: raw.wireProtocol,
     logLine: typeof raw.logLine === "string" ? raw.logLine : "",
     logLineExtra: typeof raw.logLineExtra === "string" ? raw.logLineExtra : "",
     tags: Array.isArray(raw.tags)

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -23,8 +23,11 @@ import {
 } from "./common/langfuse-debug.js";
 import { countHumanTurns } from "./turnSeq.js";
 import type { ProxyConfig } from "./types.js";
+import { fetchProtocolAttempt, protocolErrorResponse, upstreamAccounting, type ForwardProtocolContext } from "./protocol/forward.js";
+import { ProtocolError } from "./protocol/common.js";
 import {
   resolveForwardTarget,
+  joinUrl,
   resolveSessionKey,
   resolveLatestUserQuery,
   reportAnalyzerTrace,
@@ -308,6 +311,7 @@ async function forwardWithRetry(
   forwardTimeoutMs: number,
   sessionKeyForDebug?: string,
   rateLimitContext?: { config: ProxyConfig; instanceId?: string },
+  protocolContext?: ForwardProtocolContext,
 ): Promise<{ resp: Response; retried: boolean }> {
   let upstreamResp: Response | undefined;
   let forwardFailed = false;
@@ -369,8 +373,9 @@ async function forwardWithRetry(
     });
   }
   try {
-    upstreamResp = await fetch(target.url, fetchOpts);
+    upstreamResp = await fetchProtocolAttempt(target, fetchOpts, protocolContext);
   } catch (err: unknown) {
+    if (err instanceof ProtocolError) throw err;
     if (err instanceof DOMException && err.name === "TimeoutError") {
       pipe.error("FORWARD", `Timeout after ${forwardTimeoutMs / 1000}s`);
     } else {
@@ -387,6 +392,7 @@ async function forwardWithRetry(
     (forwardFailed || (upstreamResp && upstreamResp.status >= 400 && upstreamResp.status < 500));
 
   if (shouldRetry && target.retryTarget) {
+    await upstreamResp?.body?.cancel();
     const reason = forwardFailed ? "timeout/error" : `${upstreamResp!.status}`;
     pipe.info("RETRY", `Routed model failed (${reason}), retryUrl=${target.retryTarget.url} model=${target.retryTarget.model}`);
 
@@ -414,7 +420,7 @@ async function forwardWithRetry(
       if (forwardTimeoutMs > 0) {
         retryFetchOpts.signal = AbortSignal.timeout(forwardTimeoutMs);
       }
-      upstreamResp = await fetch(target.retryTarget.url, retryFetchOpts);
+      upstreamResp = await fetchProtocolAttempt(target.retryTarget, retryFetchOpts, protocolContext);
       if (upstreamResp.ok) {
         pipe.info("RETRY_SUCCESS", `Retry returned ${upstreamResp.status}`);
       } else {
@@ -422,6 +428,7 @@ async function forwardWithRetry(
       }
       return { resp: upstreamResp, retried: true };
     } catch (retryErr: unknown) {
+      if (retryErr instanceof ProtocolError) throw retryErr;
       if (isRateLimitExceededError(retryErr)) throw retryErr;
       if (retryErr instanceof DOMException && retryErr.name === "TimeoutError") {
         pipe.error("RETRY_FORWARD", `Timeout after ${forwardTimeoutMs / 1000}s`);
@@ -1540,6 +1547,11 @@ export async function handleChatCompletions(
   pipe.forwardStart(target.url);
   let upstreamResp: Response;
   let retried = false;
+  const protocolContext: ForwardProtocolContext = {
+    source: "chat", settings: { ...config.upstream, ...agentUpstreamEntry },
+    defaultUrl: joinUrl(agentUpstreamEntry?.url ?? config.upstream.url, forwardEndpoint),
+    request: body, signal: c.req.raw.signal, warn: message => pipe.info("PROTOCOL", message),
+  };
 
   try {
     const result = await forwardWithRetry(
@@ -1548,10 +1560,12 @@ export async function handleChatCompletions(
       pipe, forwardTimeoutMs,
       sessionKey,
       { config, instanceId: spaceId || undefined },
+      protocolContext,
     );
     upstreamResp = result.resp;
     retried = result.retried;
   } catch (err: unknown) {
+    if (err instanceof ProtocolError) return protocolErrorResponse(err, "chat", err.status);
     if (isRateLimitExceededError(err)) {
       pipe.info("RATE_LIMIT", "TPM/QPM exceeded");
       return err.response;
@@ -1605,7 +1619,7 @@ export async function handleChatCompletions(
     }
 
     // Log upstream error body for 4xx responses
-    if (!retried && upstreamResp.status >= 400 && upstreamResp.status < 500) {
+    if (upstreamResp.status >= 400) {
       const [errBodyStream, clientPassStream] = upstreamResp.body.tee();
       const errText = await new Response(errBodyStream).text();
       pipe.error("UPSTREAM_4xx", `status=${upstreamResp.status} body=${errText.slice(0, 1000)}`);
@@ -1641,6 +1655,7 @@ export async function handleChatCompletions(
     pipe.streamStart();
 
     const tapCtx: TapContext = {
+      protocolContext,
       config,
       modelId: effectiveModel,
       keyId,
@@ -1892,16 +1907,18 @@ export async function handleChatCompletions(
   // via the `x-credit-report-error` response header but never replace the
   // upstream LLM response body — the user-facing answer is preserved.
   // skipCreditReport: instance config custom model → user's expense, skip credit.
+  const accounting = upstreamAccounting(protocolContext, usage, effectiveModel, target.url, "chat");
   const creditOutcome = skipCreditReport
     ? { attempted: false, ok: false }
     : await tryReportCreditFromPath(
     config.creditReport,
     c.req.path,
-    usage,
+    accounting.usage,
     config.creditPricing,
-    effectiveModel,
-    target.url,
+    accounting.model,
+    accounting.url,
     "usage",
+    accounting.protocol,
   );
   if (creditOutcome.attempted && !creditOutcome.ok) {
     pipe.error("CREDIT_REPORT", creditOutcome.errorMessage ?? "unknown");
@@ -1953,6 +1970,7 @@ function outputMessageContent(message: Record<string, unknown> | null): string |
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 interface TapContext {
+  protocolContext?: ForwardProtocolContext;
   config: ProxyConfig;
   modelId: string;
   keyId: string;
@@ -2319,16 +2337,18 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
     // been forwarded to the client; failures here are best-effort and can
     // only be observed via server logs (no way to retro-add response headers).
     // skipCreditReport: instance config custom model → user's expense, skip credit.
+    const accounting = upstreamAccounting(ctx.protocolContext, lastUsage, ctx.modelId, ctx.upstreamUrl, "chat");
     (ctx.skipCreditReport
-      ? Promise.resolve({ attempted: false, ok: false })
+      ? Promise.resolve({ attempted: false, ok: false, errorMessage: undefined })
       : tryReportCreditFromPath(
           ctx.config.creditReport,
           ctx.requestPath,
-          lastUsage,
+          accounting.usage,
           ctx.config.creditPricing,
-          ctx.modelId,
-          ctx.upstreamUrl,
+          accounting.model,
+          accounting.url,
           "usage",
+          accounting.protocol,
         ))
       .then((outcome) => {
         if (outcome.attempted && !outcome.ok) {

--- a/MemoryProxy/src/injection/adapters/__tests__/preservation.test.ts
+++ b/MemoryProxy/src/injection/adapters/__tests__/preservation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { AnthropicAdapter } from "../anthropic.js";
+import { OpenAIAdapter } from "../openai.js";
+import { InjectionPipeline } from "../../pipeline.js";
+import { HookRegistryImpl } from "../../registry.js";
+import type { AgentContextMetadata } from "../../types.js";
+import { anthropicToResponses } from "../../../protocol/responses-anthropic.js";
+
+const meta: AgentContextMetadata = { protocol: "anthropic", traceId: "fixture", keyId: "fixture", modelId: "m", stream: false, agentSource: "fixture" };
+const image = { type: "image", source: { type: "url", url: "https://example.invalid/image.png" } };
+describe("native injection preserves content that is not being injected", () => {
+  const adapter = new AnthropicAdapter();
+  it("preserves nested tool output images, explicit false, and URL image sources", () => {
+    const body = { messages: [{ role: "user", content: [image, { type: "tool_result", tool_use_id: "call_a", is_error: false, content: [image, { type: "text", text: "caption" }] }] }] };
+    expect(adapter.serialize(adapter.parse(body, meta))).toEqual(body);
+  });
+  it("keeps single system cache metadata and opaque content", () => {
+    const body = { system: [{ type: "text", text: "prefix", cache_control: { type: "ephemeral" } }], messages: [{ role: "assistant", content: [{ type: "thinking", thinking: "reason", signature: "signed" }, { type: "redacted_thinking", data: "opaque" }] }] };
+    expect(adapter.serialize(adapter.parse(body, meta))).toEqual(body);
+  });
+  it("preserves native server tools without inventing input_schema or description", () => {
+    const body = { messages: [], tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3 }] };
+    expect(adapter.serialize(adapter.parse(body, meta))).toEqual(body);
+  });
+  it("applies real injection while preserving original tool history and cache fields", async () => {
+    const registry = new HookRegistryImpl();
+    registry.register({ id: "memory-fixture", point: "system.suffix", priority: 100, description: "test memory", execute: () => [{ type: "text", content: "remember fixture" }] });
+    const pipeline = new InjectionPipeline(registry, new Map([["anthropic", adapter]]));
+    const body = { model: "m", max_tokens: 100, system: [{ type: "text", text: "prefix", cache_control: { type: "ephemeral" } }], messages: [{ role: "user", content: [{ type: "tool_result", tool_use_id: "a", content: [image] }] }] };
+    const result = await pipeline.process(body, meta);
+    expect(result.messages).toEqual(body.messages);
+    expect(JSON.stringify(result.system)).toContain("remember fixture");
+    expect(JSON.stringify(result.system)).toContain('"cache_control":{"type":"ephemeral"}');
+    expect(body.system[0].text).toBe("prefix");
+    const outbound = anthropicToResponses(result, { onWarning: () => {} });
+    expect(JSON.stringify(outbound.input)).toContain("remember fixture");
+    expect(JSON.stringify(outbound.input)).toContain("https://example.invalid/image.png");
+  });
+  it("keeps a modified text block rather than restoring stale native content", () => {
+    const ctx = adapter.parse({ messages: [{ role: "user", content: [{ type: "text", text: "before", citations: [] }] }] }, meta);
+    ctx.messages[0].blocks[0].content = "after";
+    expect(adapter.serialize(ctx).messages).toEqual([{ role: "user", content: [{ type: "text", text: "after", citations: [] }] }]);
+  });
+  it("keeps an explicit empty tool array", () => {
+    expect(adapter.serialize(adapter.parse({ messages: [], tools: [] }, meta)).tools).toEqual([]);
+  });
+});
+
+describe("OpenAI native fields survive injection adapters", () => {
+  const adapter = new OpenAIAdapter();
+  const metadata = { ...meta, protocol: "openai" as const };
+  it("preserves custom user/assistant content, message extras, and strict tool definitions", () => {
+    const body = { messages: [
+      { role: "user", name: "alice", content: [{ type: "input_audio", input_audio: { data: "AA==", format: "wav" } }] },
+      { role: "assistant", content: [{ type: "refusal", refusal: "no" }], reasoning_content: "opaque", provider_state: { a: 1 } },
+    ], tools: [{ type: "function", function: { name: "lookup", parameters: { type: "object" }, strict: true }, provider_field: true }] };
+    expect(adapter.serialize(adapter.parse(body, metadata))).toEqual(body);
+  });
+  it("preserves text array metadata and observes changed text", () => {
+    const body = { messages: [{ role: "user", content: [{ type: "text", text: "before", cache_control: { type: "ephemeral" } }] }] };
+    const ctx = adapter.parse(body, metadata);
+    ctx.messages[0].blocks[0].content = "after";
+    expect(adapter.serialize(ctx).messages).toEqual([{ role: "user", content: [{ ...body.messages[0].content[0], text: "after" }] }]);
+  });
+});

--- a/MemoryProxy/src/injection/adapters/anthropic.ts
+++ b/MemoryProxy/src/injection/adapters/anthropic.ts
@@ -26,7 +26,7 @@ export class AnthropicAdapter implements ProtocolAdapter {
     // Anthropic has a top-level "system" field
     if (body.system != null) {
       const systemBlocks = this.parseSystemField(body.system);
-      messages.push({ role: "system", blocks: systemBlocks });
+      messages.push({ role: "system", blocks: systemBlocks, metadata: { arrayContent: Array.isArray(body.system) } });
     }
 
     // Parse conversation messages
@@ -69,7 +69,7 @@ export class AnthropicAdapter implements ProtocolAdapter {
     body.messages = conversationMsgs.map((m) => this.serializeMessage(m));
 
     // Serialize tools
-    if (ctx.tools && ctx.tools.length > 0) {
+    if (ctx.tools) {
       body.tools = ctx.tools.map((t) => this.serializeTool(t));
     }
 
@@ -101,12 +101,13 @@ export class AnthropicAdapter implements ProtocolAdapter {
       }
     }
 
-    return { role, blocks };
+    return { role, blocks, native: structuredClone(m) };
   }
 
   private parseContentBlock(block: Record<string, unknown>): ContextBlock {
     const type = block.type as string;
     const parsed = this.parseContentBlockInner(block, type);
+    parsed.native = structuredClone(block);
     // Preserve prompt-cache breakpoint marker across the round-trip.
     if (block.cache_control !== undefined && parsed.type !== "custom") {
       parsed.metadata = { ...parsed.metadata, cache_control: block.cache_control };
@@ -149,6 +150,7 @@ export class AnthropicAdapter implements ProtocolAdapter {
           metadata: {
             tool_use_id: block.tool_use_id as string,
             is_error: block.is_error as boolean | undefined,
+            originalText: contentStr,
           },
         };
       }
@@ -164,7 +166,7 @@ export class AnthropicAdapter implements ProtocolAdapter {
         const source = block.source as Record<string, unknown> | undefined;
         return {
           type: "image",
-          content: (source?.data as string) ?? "",
+          content: (source?.type === "url" ? source.url as string : source?.data as string) ?? "",
           metadata: {
             media_type: source?.media_type,
             source_type: source?.type,
@@ -186,6 +188,7 @@ export class AnthropicAdapter implements ProtocolAdapter {
       name: (raw.name as string) ?? "unknown",
       description: (raw.description as string) ?? "",
       parameters: (raw.input_schema as Record<string, unknown>) ?? {},
+      native: structuredClone(raw),
     };
     if (raw.cache_control !== undefined) {
       tool.cacheControl = raw.cache_control;
@@ -197,7 +200,7 @@ export class AnthropicAdapter implements ProtocolAdapter {
 
   private serializeSystemMessage(msg: ContextMessage): unknown {
     const textBlocks = msg.blocks.filter((b) => b.type === "text");
-    if (textBlocks.length === 1) {
+    if (msg.blocks.length === 1 && textBlocks.length === 1 && !msg.metadata?.arrayContent && textBlocks[0].metadata?.cache_control === undefined && !textBlocks[0].native) {
       return textBlocks[0].content;
     }
     // Multiple blocks → use array format
@@ -206,11 +209,12 @@ export class AnthropicAdapter implements ProtocolAdapter {
 
   private serializeMessage(msg: ContextMessage): Record<string, unknown> {
     const content = msg.blocks.map((b) => this.serializeContentBlock(b));
-    return { role: msg.role, content };
+    const plainText = typeof msg.native?.content === "string" && msg.blocks.every(b => b.type === "text" && !b.native && !b.metadata?.cache_control);
+    return { ...msg.native, role: msg.role, content: plainText ? msg.blocks.map(b => b.content).join("\n") : content };
   }
 
   private serializeContentBlock(block: ContextBlock): Record<string, unknown> {
-    const out = this.serializeContentBlockInner(block);
+    const out = { ...block.native, ...this.serializeContentBlockInner(block) };
     // Restore prompt-cache breakpoint marker (skip custom: already fully rebuilt from JSON).
     if (block.type !== "custom" && block.metadata?.cache_control !== undefined) {
       out.cache_control = block.metadata.cache_control;
@@ -237,13 +241,29 @@ export class AnthropicAdapter implements ProtocolAdapter {
       }
 
       case "tool_result": {
+        const nativeContent = block.native?.content;
+        let content: unknown = block.content;
+        if (Array.isArray(nativeContent)) {
+          if (block.content === block.metadata?.originalText) content = nativeContent;
+          else {
+            // Keep non-text results even when a hook replaces the textual projection.
+            let replaced = false;
+            content = nativeContent.flatMap((part: Record<string, unknown>) => {
+              if (part.type !== "text") return [part];
+              if (replaced) return [];
+              replaced = true;
+              return [{ ...part, text: block.content }];
+            });
+            if (!replaced) (content as unknown[]).push({ type: "text", text: block.content });
+          }
+        }
         const result: Record<string, unknown> = {
           type: "tool_result",
           tool_use_id: block.metadata?.tool_use_id ?? "",
-          content: block.content,
+          content,
         };
-        if (block.metadata?.is_error) {
-          result.is_error = true;
+        if (block.metadata?.is_error !== undefined) {
+          result.is_error = block.metadata.is_error;
         }
         return result;
       }
@@ -258,7 +278,10 @@ export class AnthropicAdapter implements ProtocolAdapter {
       case "image":
         return {
           type: "image",
-          source: {
+          source: block.metadata?.source_type === "url" ? {
+            ...(block.native?.source as Record<string, unknown>), type: "url", url: block.content,
+          } : {
+            ...(block.native?.source as Record<string, unknown>),
             type: block.metadata?.source_type ?? "base64",
             media_type: block.metadata?.media_type ?? "image/png",
             data: block.content,
@@ -277,10 +300,11 @@ export class AnthropicAdapter implements ProtocolAdapter {
 
   private serializeTool(tool: AgentTool): Record<string, unknown> {
     const out: Record<string, unknown> = {
+      ...tool.native,
       name: tool.name,
-      description: tool.description,
-      input_schema: tool.parameters,
     };
+    if (!tool.native || "description" in tool.native || tool.description !== "") out.description = tool.description;
+    if (!tool.native || "input_schema" in tool.native || Object.keys(tool.parameters).length) out.input_schema = tool.parameters;
     if (tool.cacheControl !== undefined) {
       out.cache_control = tool.cacheControl;
     }

--- a/MemoryProxy/src/injection/adapters/openai.ts
+++ b/MemoryProxy/src/injection/adapters/openai.ts
@@ -51,7 +51,7 @@ export class OpenAIAdapter implements ProtocolAdapter {
     };
 
     // Add tools if present
-    if (ctx.tools && ctx.tools.length > 0) {
+    if (ctx.tools) {
       body.tools = ctx.tools.map((t) => this.serializeTool(t));
     }
 
@@ -61,6 +61,12 @@ export class OpenAIAdapter implements ProtocolAdapter {
   // ── Private: parse helpers ──────────────────────────────────────────────────
 
   private parseMessage(raw: unknown): ContextMessage {
+    const result = this.parseMessageInner(raw);
+    result.native = structuredClone(raw as Record<string, unknown>);
+    return result;
+  }
+
+  private parseMessageInner(raw: unknown): ContextMessage {
     const m = raw as Record<string, unknown>;
     const role = m.role as MessageRole;
     const blocks: ContextBlock[] = [];
@@ -97,7 +103,7 @@ export class OpenAIAdapter implements ProtocolAdapter {
               name: fn?.name ?? "unknown",
               arguments: fn?.arguments ?? "{}",
             }),
-            metadata: { tool_id: tc.id as string },
+            metadata: { tool_id: tc.id as string }, native: structuredClone(tc),
           });
         }
       }
@@ -126,6 +132,12 @@ export class OpenAIAdapter implements ProtocolAdapter {
   }
 
   private parseContentPart(part: Record<string, unknown>): ContextBlock {
+    const result = this.parseContentPartInner(part);
+    result.native = structuredClone(part);
+    return result;
+  }
+
+  private parseContentPartInner(part: Record<string, unknown>): ContextBlock {
     const type = part.type as string;
     switch (type) {
       case "text":
@@ -153,12 +165,21 @@ export class OpenAIAdapter implements ProtocolAdapter {
       name: (fn?.name as string) ?? (raw.name as string) ?? "unknown",
       description: (fn?.description as string) ?? (raw.description as string) ?? "",
       parameters: (fn?.parameters as Record<string, unknown>) ?? (raw.parameters as Record<string, unknown>) ?? {},
+      native: structuredClone(raw),
     };
   }
 
   // ── Private: serialize helpers ──────────────────────────────────────────────
 
   private serializeMessage(msg: ContextMessage): Record<string, unknown> {
+    const result = this.serializeMessageInner(msg);
+    const native = { ...msg.native };
+    delete native.content;
+    delete native.tool_calls;
+    return { ...native, ...result };
+  }
+
+  private serializeMessageInner(msg: ContextMessage): Record<string, unknown> {
     if (msg.role === "tool") {
       // Serialize tool role message
       const toolResult = msg.blocks.find((b) => b.type === "tool_result");
@@ -171,14 +192,16 @@ export class OpenAIAdapter implements ProtocolAdapter {
 
     if (msg.role === "assistant") {
       // Assistant can have text + tool_calls
-      const textBlocks = msg.blocks.filter((b) => b.type === "text");
+      const contentBlocks = msg.blocks.filter((b) => b.type !== "tool_use");
       const toolUseBlocks = msg.blocks.filter((b) => b.type === "tool_use");
 
       const result: Record<string, unknown> = { role: "assistant" };
 
       // Content
-      if (textBlocks.length > 0) {
-        result.content = textBlocks.map((b) => b.content).join("");
+      if (Array.isArray(msg.native?.content) || contentBlocks.some(b => b.type !== "text")) {
+        result.content = contentBlocks.map(b => this.serializeContentPart(b));
+      } else if (contentBlocks.length > 0) {
+        result.content = contentBlocks.map((b) => b.content).join("");
       } else {
         result.content = null;
       }
@@ -188,9 +211,11 @@ export class OpenAIAdapter implements ProtocolAdapter {
         result.tool_calls = toolUseBlocks.map((b) => {
           const parsed = JSON.parse(b.content) as { name: string; arguments: string };
           return {
+            ...b.native,
             id: b.metadata?.tool_id ?? "",
             type: "function",
             function: {
+              ...(b.native?.function as Record<string, unknown>),
               name: parsed.name,
               arguments: typeof parsed.arguments === "string"
                 ? parsed.arguments
@@ -213,7 +238,7 @@ export class OpenAIAdapter implements ProtocolAdapter {
     const textBlocks = msg.blocks.filter((b) => b.type === "text");
     const otherBlocks = msg.blocks.filter((b) => b.type !== "text");
 
-    if (otherBlocks.length === 0) {
+    if (otherBlocks.length === 0 && !Array.isArray(msg.native?.content) && !textBlocks.some(b => b.native)) {
       // Simple text-only message
       return {
         role: msg.role,
@@ -222,33 +247,31 @@ export class OpenAIAdapter implements ProtocolAdapter {
     }
 
     // Mixed content: serialize as array
-    const parts: Record<string, unknown>[] = [];
-    for (const block of msg.blocks) {
-      switch (block.type) {
-        case "text":
-          parts.push({ type: "text", text: block.content });
-          break;
-        case "image":
-          parts.push({
-            type: "image_url",
-            image_url: { url: block.content, detail: block.metadata?.detail },
-          });
-          break;
-        default:
-          parts.push({ type: block.type, content: block.content, ...block.metadata });
-          break;
-      }
-    }
+    const parts = msg.blocks.map(block => this.serializeContentPart(block));
 
     return { role: msg.role, content: parts };
   }
 
+  private serializeContentPart(block: ContextBlock): Record<string, unknown> {
+    if (block.type === "text") return { ...block.native, type: "text", text: block.content };
+    if (block.type === "image") return {
+      ...block.native, type: "image_url",
+      image_url: { ...(block.native?.image_url as Record<string, unknown>), url: block.content, ...(block.metadata?.detail !== undefined ? { detail: block.metadata.detail } : {}) },
+    };
+    if (block.type === "custom") return JSON.parse(block.content) as Record<string, unknown>;
+    throw new Error(`Unsupported OpenAI injection content block: ${block.type}`);
+  }
+
   private serializeTool(tool: AgentTool): Record<string, unknown> {
+    if (tool.native && tool.native.type !== "function") return { ...tool.native };
+    const nativeFunction = tool.native?.function as Record<string, unknown> | undefined;
     return {
+      ...tool.native,
       type: "function",
       function: {
+        ...nativeFunction,
         name: tool.name,
-        description: tool.description,
+        ...(!nativeFunction || "description" in nativeFunction || tool.description !== "" ? { description: tool.description } : {}),
         parameters: tool.parameters,
       },
     };

--- a/MemoryProxy/src/injection/types.ts
+++ b/MemoryProxy/src/injection/types.ts
@@ -30,6 +30,8 @@ export interface ContextBlock {
   type: ContextBlockType;
   content: string;
   metadata?: Record<string, unknown>;
+  /** Native fields retained by same-protocol adapters; never an interchange format. */
+  native?: Record<string, unknown>;
 }
 
 // ── Messages ──────────────────────────────────────────────────────────────────
@@ -46,6 +48,7 @@ export interface ContextMessage {
   role: MessageRole;
   blocks: ContextBlock[];
   metadata?: Record<string, unknown>;
+  native?: Record<string, unknown>;
 }
 
 // ── Tools ─────────────────────────────────────────────────────────────────────
@@ -63,6 +66,8 @@ export interface AgentTool {
    * Sits at the same level as `input_schema` in the wire format.
    */
   cacheControl?: unknown;
+  /** Original provider fields (server-tool type, strict, etc.) for native forwarding. */
+  native?: Record<string, unknown>;
 }
 
 // ── Context Metadata ──────────────────────────────────────────────────────────

--- a/MemoryProxy/src/protocol/__tests__/accounting.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/accounting.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { computeCreditDelta } from "../../credit-reporter.js";
+import { upstreamAccounting, type ForwardProtocolContext } from "../forward.js";
+
+const pricing = { models: [{ name: "m", input: 1, output: 1, cacheRead: 0.1, cacheWrite5m: 2, cacheWrite1h: 3 }] };
+describe("account against the actual upstream schema", () => {
+  it("prices Responses total input and nested cached tokens using its declared protocol", () => {
+    expect(computeCreditDelta({ input_tokens: 130, output_tokens: 5, input_tokens_details: { cached_tokens: 100 } }, pricing, "m", "https://tokenhub.invalid/custom", "responses")).toBeCloseTo(0.045);
+  });
+  it("keeps Anthropic cache-write categories even when the client receives Chat usage", () => {
+    const usage = { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 20, cache_creation: { ephemeral_5m_input_tokens: 15, ephemeral_1h_input_tokens: 5 } };
+    const context: ForwardProtocolContext = { source: "chat", settings: {}, defaultUrl: "", request: {}, warn() {}, actual: { url: "https://tokenhub.invalid/custom", model: "m", protocol: "anthropic", converted: true, usage } };
+    const record = upstreamAccounting(context, { prompt_tokens: 130, completion_tokens: 5 }, "m", "wrong-url", "chat");
+    expect(record.usage).toEqual(usage);
+    expect(computeCreditDelta(record.usage, pricing, record.model, record.url, record.protocol)).toBeCloseTo(0.07);
+  });
+  it("never substitutes fabricated client counters when a converted upstream omitted usage", () => {
+    const context: ForwardProtocolContext = { source: "anthropic", settings: {}, defaultUrl: "", request: {}, warn() {}, actual: { url: "https://example.invalid", model: "m", protocol: "chat", converted: true } };
+    expect(upstreamAccounting(context, { input_tokens: 0, output_tokens: 0 }, "m", "", "anthropic").usage).toBeNull();
+  });
+});

--- a/MemoryProxy/src/protocol/__tests__/chat-anthropic.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/chat-anthropic.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { anthropicToChat, chatToAnthropic, anthropicJsonToChat, chatJsonToAnthropic } from "../chat-anthropic.js";
+
+const tool = { type: "function", function: { name: "lookup", description: "Lookup", parameters: { type: "object", properties: {} } } };
+const messages = [{ role: "user", content: "hello" }];
+describe("Chat ↔ Anthropic requests", () => {
+  it("maps text, instructions, defaults and explicit output limit without clamping", () => {
+    const body = { model: "model", max_completion_tokens: 64000, messages: [{ role: "system", content: "first" }, { role: "developer", content: "second" }, ...messages] };
+    const copy = structuredClone(body);
+    expect(chatToAnthropic(body)).toEqual({ model: "model", max_tokens: 64000, stream: false, system: [{ type: "text", text: "first" }, { type: "text", text: "second" }], messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }] });
+    expect(body).toEqual(copy);
+  });
+  it("requires a documented fallback when the source has no output limit", () => {
+    expect(() => chatToAnthropic({ model: "m", messages })).toThrow(/max_tokens/);
+    expect(chatToAnthropic({ model: "m", messages }, { maxTokens: 8192 }).max_tokens).toBe(8192);
+  });
+  it.each([["required", { type: "any" }], ["auto", { type: "auto" }], ["none", { type: "none" }]] as const)("preserves tool selection %s", (source, target) => {
+    const converted = chatToAnthropic({ model: "m", messages, max_tokens: 100, tools: [tool], tool_choice: source });
+    expect(converted.tool_choice).toEqual(target);
+    expect(anthropicToChat(converted).tool_choice).toBe(source);
+  });
+  it("preserves parallel tool IDs and tool result associations across a complete history", () => {
+    const body = { model: "m", max_tokens: 100, tools: [tool], messages: [
+      ...messages,
+      { role: "assistant", content: "checking", tool_calls: [
+        { id: "a", type: "function", function: { name: "lookup", arguments: '{"a":1}' } },
+        { id: "b", type: "function", function: { name: "lookup", arguments: '{"b":2}' } },
+      ] },
+      { role: "tool", tool_call_id: "b", content: "second" },
+      { role: "tool", tool_call_id: "a", content: "first" },
+    ] };
+    const result = anthropicToChat(chatToAnthropic(body));
+    expect(result.messages).toEqual(body.messages);
+    expect(result.tools).toEqual([tool]);
+  });
+  it("retains text/image/text order and converts data URLs without fetching", () => {
+    const content = [{ type: "text", text: "before" }, { type: "image_url", image_url: { url: "data:image/png;base64,AA==" } }, { type: "text", text: "after" }];
+    const converted = chatToAnthropic({ model: "m", max_tokens: 100, messages: [{ role: "user", content }] });
+    expect(anthropicToChat(converted).messages).toEqual([{ role: "user", content }]);
+  });
+  it("rejects image tool results when the Chat tool message cannot represent them", () => {
+    expect(() => anthropicToChat({ model: "m", messages: [{ role: "user", content: [{ type: "tool_result", tool_use_id: "a", content: [{ type: "image", source: { type: "url", url: "https://example.invalid/a.png" } }] }] }] })).toThrow(/tool_result/);
+  });
+  it("does not silently discard opaque thinking, malformed tool arguments, or strict constraints", () => {
+    expect(() => anthropicToChat({ messages: [{ role: "assistant", content: [{ type: "thinking", thinking: "x", signature: "opaque" }] }] })).toThrow(/thinking/);
+    expect(() => chatToAnthropic({ model: "m", max_tokens: 10, messages: [{ role: "assistant", tool_calls: [{ id: "a", type: "function", function: { name: "lookup", arguments: "{" } }] }] })).toThrow(/arguments/);
+    expect(() => chatToAnthropic({ model: "m", max_tokens: 10, messages, tools: [{ ...tool, function: { ...tool.function, strict: true } }] })).toThrow(/strict/);
+  });
+  it("requires explicit acknowledgement before dropping nonportable cache control", () => {
+    const input = { model: "m", system: [{ type: "text", text: "prefix", cache_control: { type: "ephemeral" } }], messages };
+    expect(() => anthropicToChat(input)).toThrow(/cache_control/);
+    const warnings: string[] = [];
+    expect(anthropicToChat(input, { onWarning: warning => warnings.push(warning) }).messages).toEqual([{ role: "system", content: "prefix" }, ...messages]);
+    expect(warnings.join(" ")).toMatch(/cache_control/);
+  });
+});
+
+describe("Chat ↔ Anthropic JSON responses", () => {
+  it("preserves max-token termination, tool arguments and cache accounting", () => {
+    const response = { id: "msg_a", model: "m", type: "message", role: "assistant", stop_reason: "max_tokens", content: [{ type: "text", text: "partial" }], usage: { input_tokens: 10, cache_read_input_tokens: 100, cache_creation_input_tokens: 20, output_tokens: 5 } };
+    const chat = anthropicJsonToChat(response);
+    expect((chat.choices as any[])[0].finish_reason).toBe("length");
+    expect(chat.usage).toMatchObject({ prompt_tokens: 130, total_tokens: 135 });
+    expect(chatJsonToAnthropic(chat)).toMatchObject({ stop_reason: "max_tokens", content: response.content, usage: { input_tokens: 30, cache_read_input_tokens: 100 } });
+  });
+  it("maps tool finish independently of whether text was generated", () => {
+    const source = { id: "c", model: "m", choices: [{ index: 0, message: { role: "assistant", content: null, tool_calls: [{ type: "function", id: "call_a", function: { name: "lookup", arguments: '{"q":"x"}' } }] }, finish_reason: "tool_calls" }] };
+    const target = chatJsonToAnthropic(source);
+    expect(target).toMatchObject({ stop_reason: "tool_use", content: [{ type: "tool_use", id: "call_a", name: "lookup", input: { q: "x" } }] });
+    expect((anthropicJsonToChat(target).choices as any[])[0].message.tool_calls).toEqual(source.choices[0].message.tool_calls);
+  });
+  it("rejects multi-choice responses rather than silently keeping choice zero", () => {
+    expect(() => chatJsonToAnthropic({ choices: [{ message: { content: "a" }, finish_reason: "stop" }, { message: { content: "b" }, finish_reason: "stop" }] })).toThrow(/choices/);
+  });
+});

--- a/MemoryProxy/src/protocol/__tests__/common.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/common.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { convertUsage, createSseDecoder, type SseFrame } from "../common.js";
+
+describe("upstream usage conversion", () => {
+  const anthropic = {
+    input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100,
+    cache_creation_input_tokens: 20,
+    cache_creation: { ephemeral_5m_input_tokens: 15, ephemeral_1h_input_tokens: 5 },
+  };
+  it("includes cache reads and writes once in OpenAI input totals", () => {
+    expect(convertUsage(anthropic, "anthropic", "chat")).toEqual({
+      prompt_tokens: 130, completion_tokens: 5, total_tokens: 135,
+      prompt_tokens_details: { cached_tokens: 100 },
+    });
+    expect(convertUsage(anthropic, "anthropic", "responses")).toEqual({
+      input_tokens: 130, output_tokens: 5, total_tokens: 135,
+      input_tokens_details: { cached_tokens: 100 },
+    });
+  });
+  it.each(["chat", "responses"] as const)("subtracts cache reads from %s totals", source => {
+    const usage = source === "chat"
+      ? { prompt_tokens: 130, completion_tokens: 5, prompt_tokens_details: { cached_tokens: 100 } }
+      : { input_tokens: 130, output_tokens: 5, input_tokens_details: { cached_tokens: 100 } };
+    expect(convertUsage(usage, source, "anthropic")).toEqual({
+      input_tokens: 30, output_tokens: 5, cache_read_input_tokens: 100,
+    });
+  });
+  it("does not turn absent usage or absent input into a measured zero", () => {
+    expect(convertUsage(undefined, "chat", "anthropic")).toBeUndefined();
+    expect(convertUsage({ completion_tokens: 0 }, "chat", "anthropic")).toEqual({ output_tokens: 0 });
+  });
+  it("retains native provider usage without modifying the source", () => {
+    const before = structuredClone(anthropic);
+    expect(convertUsage(anthropic, "anthropic", "anthropic")).toEqual(before);
+    convertUsage(anthropic, "anthropic", "chat");
+    expect(anthropic).toEqual(before);
+  });
+  it.each([
+    { prompt_tokens: 1, prompt_tokens_details: { cached_tokens: 2 } },
+    { prompt_tokens: -1 }, { completion_tokens: Number.NaN },
+  ])("rejects inconsistent upstream counters: %j", usage => {
+    expect(() => convertUsage(usage, "chat", "anthropic")).toThrow();
+  });
+});
+
+async function decode(chunks: Uint8Array[], limit?: number): Promise<SseFrame[]> {
+  const input = new ReadableStream<Uint8Array>({ start(controller) {
+    chunks.forEach(chunk => controller.enqueue(chunk)); controller.close();
+  } });
+  const reader = input.pipeThrough(createSseDecoder(limit)).getReader();
+  const frames: SseFrame[] = [];
+  for (;;) { const next = await reader.read(); if (next.done) return frames; frames.push(next.value); }
+}
+
+describe("SSE framing at arbitrary transport boundaries", () => {
+  const encoder = new TextEncoder();
+  it("keeps UTF-8, CRLF, multiline data and significant spaces at every byte split", async () => {
+    const bytes = encoder.encode(': ping\r\nevent: delta\r\nid: 12\r\ndata:  中文\r\ndata: next\r\n\r\ndata: [DONE]\n\n');
+    const expected = [{ event: "delta", data: " 中文\nnext", id: "12" }, { event: "message", data: "[DONE]", id: "12" }];
+    for (let cut = 0; cut <= bytes.length; cut++) {
+      expect(await decode([bytes.slice(0, cut), bytes.slice(cut)])).toEqual(expected);
+    }
+  });
+  it("supports lone CR separators including a final blank line", async () => {
+    expect(await decode([encoder.encode("data: hello\r\r")])).toEqual([{ event: "message", data: "hello" }]);
+  });
+  it("rejects truncated data frames instead of treating EOF as a completed event", async () => {
+    await expect(decode([encoder.encode("data: partial\n")])).rejects.toThrow(/truncated/i);
+  });
+  it("bounds a frame across both one long line and many short data lines", async () => {
+    await expect(decode([encoder.encode("data: " + "x".repeat(40))], 32)).rejects.toThrow(/limit/i);
+    await expect(decode([encoder.encode("data: x\n".repeat(8))], 32)).rejects.toThrow(/limit/i);
+  });
+  it("propagates downstream cancellation to the upstream stream", async () => {
+    let cancelled = false;
+    const source = new ReadableStream<Uint8Array>({
+      pull(c) { c.enqueue(encoder.encode("data: hello\n\n")); },
+      cancel() { cancelled = true; },
+    });
+    const reader = source.pipeThrough(createSseDecoder()).getReader();
+    await reader.read();
+    await reader.cancel("client disconnected");
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(cancelled).toBe(true);
+  });
+});

--- a/MemoryProxy/src/protocol/__tests__/forward.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/forward.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildConfig } from "../../config.js";
+import { prepareProtocolRequest, convertProtocolResponse, fetchProtocolAttempt, type ForwardProtocolContext } from "../forward.js";
+import { vi } from "vitest";
+
+const directories: string[] = [];
+afterEach(() => { for (const path of directories.splice(0)) { unlinkSync(join(path, "config.json")); rmdirSync(path); } });
+afterEach(() => vi.unstubAllGlobals());
+function configFile(upstream: unknown) {
+  const dir = mkdtempSync(join(tmpdir(), "protocol-config-")); directories.push(dir);
+  const path = join(dir, "config.json"); writeFileSync(path, JSON.stringify({ upstream })); return path;
+}
+describe("explicit upstream protocol configuration", () => {
+  it("retains one target protocol and model output fallback with per-agent credentials", () => {
+    const config = buildConfig({ configFile: configFile({ url: "https://example.invalid/v1", apiKey: "global-fixture", protocol: "chat", agents: { codex: { url: "https://example.invalid/v1/messages", protocol: "anthropic", maxTokens: 8192, allowCacheControlDrop: true } } }) });
+    expect(config.upstream).toMatchObject({ protocol: "chat", agents: { codex: { protocol: "anthropic", maxTokens: 8192, allowCacheControlDrop: true } } });
+    expect(config.upstream.agents.codex.apiKey).toBeUndefined();
+  });
+  it("rejects unknown protocols and invalid token fallbacks at configuration load", () => {
+    expect(() => buildConfig({ configFile: configFile({ protocol: "guess" }) })).toThrow(/protocol/);
+    expect(() => buildConfig({ configFile: configFile({ protocol: "anthropic", maxTokens: -1 }) })).toThrow(/maxTokens/);
+  });
+});
+
+describe("request conversion at the actual forwarding boundary", () => {
+  const body = { model: "m", max_tokens: 100, messages: [{ role: "user", content: "hello" }] };
+  it("rewrites only a known inference endpoint and rebuilds target authentication", () => {
+    const result = prepareProtocolRequest({ body, from: "chat", to: "anthropic", url: "https://example.invalid/v1/chat/completions?route=a", headers: { authorization: "Bearer fixture", "x-api-key": "stale", "content-length": "10", "openai-beta": "responses=v1" } });
+    expect(result.url).toBe("https://example.invalid/v1/messages?route=a");
+    expect(result.headers.get("x-api-key")).toBe("fixture");
+    expect(result.headers.get("authorization")).toBeNull();
+    expect(result.headers.get("content-length")).toBeNull();
+    expect(result.headers.get("openai-beta")).toBeNull();
+    expect(result.body.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }]);
+  });
+  it("uses actual route credentials over client headers", () => {
+    const result = prepareProtocolRequest({ body, from: "chat", to: "anthropic", url: "https://example.invalid/v1/messages", headers: { authorization: "Bearer client" }, authHeaders: { "x-api-key": "route-key" } });
+    expect(result.headers.get("x-api-key")).toBe("route-key");
+    expect(result.url).toBe("https://example.invalid/v1/messages");
+  });
+  it("refuses compact/count_tokens rather than converting them into text generation", () => {
+    for (const path of ["/v1/responses/compact", "/v1/messages/count_tokens"]) {
+      expect(() => prepareProtocolRequest({ body, from: "responses", to: "anthropic", url: `https://example.invalid${path}`, headers: {} })).toThrow(/endpoint/);
+    }
+  });
+  it("leaves unconverted native bodies and endpoint URLs untouched", () => {
+    const result = prepareProtocolRequest({ body, from: "chat", to: "chat", url: "https://example.invalid/custom", headers: {} });
+    expect(result.body).toBe(body);
+    expect(result.url).toBe("https://example.invalid/custom");
+  });
+});
+
+describe("upstream response conversion", () => {
+  it("captures raw usage before projecting JSON to the client schema", async () => {
+    const raw = { input_tokens: 10, cache_read_input_tokens: 100, cache_creation_input_tokens: 20, output_tokens: 5 };
+    const upstream = Response.json({ id: "msg_a", model: "m", stop_reason: "end_turn", content: [{ type: "text", text: "hello" }], usage: raw }, { headers: { "content-length": "999", "content-encoding": "gzip", "x-request-id": "request-a" } });
+    let captured: unknown;
+    const result = await convertProtocolResponse(upstream, "anthropic", "chat", { stream: false }, { onUsage: value => { captured = value; } });
+    expect(captured).toEqual(raw);
+    expect((await result.json()).usage.prompt_tokens).toBe(130);
+    expect(result.headers.get("content-length")).toBeNull();
+    expect(result.headers.get("content-encoding")).toBeNull();
+    expect(result.headers.get("x-request-id")).toBe("request-a");
+  });
+  it("converts an HTTP failure independently of the requested streaming mode", async () => {
+    const upstream = Response.json({ error: { message: "rate limited" } }, { status: 429, headers: { "retry-after": "3" } });
+    const result = await convertProtocolResponse(upstream, "chat", "anthropic", { stream: true });
+    expect(result.status).toBe(429);
+    expect(result.headers.get("retry-after")).toBe("3");
+    expect(await result.json()).toEqual({ type: "error", error: { type: "rate_limit_error", message: "rate limited" } });
+  });
+  it("rejects a successful but mismatched response format rather than passing wrong wire data", async () => {
+    const response = await convertProtocolResponse(Response.json({ choices: [] }), "chat", "anthropic", { stream: true });
+    expect(response.status).toBe(502);
+    expect((await response.json()).error.message).toMatch(/stream/i);
+  });
+});
+
+describe("each route attempt is encoded from the native injected request", () => {
+  it("re-encodes a Chat request independently for an Anthropic first attempt and Chat retry", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown>; headers: Headers }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init.body)), headers: new Headers(init.headers) });
+      return calls.length === 1 ? Response.json({ error: { message: "try fallback" } }, { status: 400 }) : Response.json({ id: "chat", model: "fallback", choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }] });
+    }));
+    const native = { model: "requested", messages: [{ role: "user", content: "hello" }], max_tokens: 100, stream: false };
+    const context: ForwardProtocolContext = { source: "chat", settings: { protocol: "anthropic" }, defaultUrl: "https://example.invalid/v1/chat/completions", request: native, warn() {} };
+    await fetchProtocolAttempt({ url: context.defaultUrl, model: "routed" }, { method: "POST", headers: { authorization: "Bearer client" }, body: JSON.stringify(native) }, context);
+    const response = await fetchProtocolAttempt({ url: "https://example.invalid/v1/chat/completions", model: "fallback", wireProtocol: "chat", authHeaders: { authorization: "Bearer retry" } }, { method: "POST", headers: { authorization: "Bearer client" }, body: JSON.stringify(native) }, context);
+    expect(calls[0]).toMatchObject({ url: "https://example.invalid/v1/messages", body: { model: "routed", messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }] } });
+    expect(calls[1].body).toEqual(native);
+    expect(calls[1].headers.get("authorization")).toBe("Bearer retry");
+    expect((await response.json()).choices[0].message.content).toBe("ok");
+    expect(context.actual).toMatchObject({ protocol: "chat", model: "fallback", converted: false });
+  });
+  it("requires a dynamic route to declare its wire protocol when conversion is enabled", async () => {
+    const context: ForwardProtocolContext = { source: "chat", settings: { protocol: "anthropic" }, defaultUrl: "https://default.invalid/v1/chat/completions", request: { model: "m", messages: [], max_tokens: 1 }, warn() {} };
+    await expect(fetchProtocolAttempt({ url: "https://router.invalid/v1/messages", model: "m" }, { method: "POST" }, context)).rejects.toThrow(/wireProtocol/);
+  });
+  it("passes client cancellation through the combined upstream signal", async () => {
+    const client = new AbortController();
+    let upstreamSignal: AbortSignal | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init: RequestInit) => {
+      upstreamSignal = init.signal ?? undefined;
+      return Response.json({ id: "msg", model: "m", stop_reason: "end_turn", content: [], usage: { input_tokens: 1, output_tokens: 0 } });
+    }));
+    const native = { model: "m", messages: [{ role: "user", content: "hello" }], max_tokens: 100, stream: false };
+    await fetchProtocolAttempt(
+      { url: "https://example.invalid/v1/messages", model: "m" },
+      { method: "POST", headers: { authorization: "Bearer fixture" } },
+      { source: "chat", settings: { protocol: "anthropic" }, defaultUrl: "https://example.invalid/v1/messages", request: native, signal: client.signal, warn() {} },
+    );
+    expect(upstreamSignal?.aborted).toBe(false);
+    client.abort();
+    expect(upstreamSignal?.aborted).toBe(true);
+  });
+});

--- a/MemoryProxy/src/protocol/__tests__/handler-integration.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/handler-integration.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { DEFAULT_CONFIG } from "../../config.js";
+import { handleChatCompletions } from "../../handler.js";
+import { handleAnthropicMessages } from "../../anthropicHandler.js";
+import { handleCodexEndpoint } from "../../codexHandler.js";
+import { handleWorkbuddyEndpoint } from "../../workbuddyHandler.js";
+import { clearCache as clearInstanceUpstreamCache } from "../../instance-upstream-cache.js";
+import type { ProxyConfig } from "../../types.js";
+
+afterEach(() => {
+  clearInstanceUpstreamCache();
+  vi.unstubAllGlobals();
+});
+const isInstanceUpstreamRequest = (url: string) => url.endsWith("/v3/internal/meta/instance-upstream/list");
+function config(protocol: "chat" | "anthropic" | "responses"): ProxyConfig {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.upstream = { url: "https://upstream.invalid/v1", apiKey: "fixture-server-key", protocol, maxTokens: 1024, agents: {} };
+  config.extraction.enabled = false;
+  config.creditPricing.models = [{ name: "m", modelName: "m", input: 1, output: 1, cacheRead: 1, cacheWrite5m: 1, cacheWrite1h: 1 }];
+  return config;
+}
+const anth = { id: "msg_a", type: "message", role: "assistant", model: "m", content: [{ type: "text", text: "hello" }], stop_reason: "end_turn", usage: { input_tokens: 10, output_tokens: 5 } };
+const chat = { id: "chat_a", object: "chat.completion", model: "m", choices: [{ index: 0, message: { role: "assistant", content: "hello" }, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5 } };
+const responses = { id: "resp_a", object: "response", status: "completed", model: "m", output: [{ type: "message", id: "item_a", role: "assistant", content: [{ type: "output_text", text: "hello", annotations: [] }], status: "completed" }], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15, input_tokens_details: { cached_tokens: 0 } } };
+const event = (name: string, data: unknown) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+const anthropicStream = event("message_start", { type: "message_start", message: { id: "msg_a", model: "m", content: [], usage: { input_tokens: 10, output_tokens: 0 } } })
+  + event("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })
+  + event("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hello" } })
+  + event("content_block_stop", { type: "content_block_stop", index: 0 })
+  + event("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })
+  + event("message_stop", { type: "message_stop" });
+const chatStream = (data: unknown) => `data: ${JSON.stringify(data)}\n\n`;
+
+describe("actual inference handlers cross the configured protocol boundary", () => {
+  it("Messages handler sends Responses upstream and returns a Messages response", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => { calls.push(String(url)); return Response.json(responses); }));
+    const app = new Hono(); app.post("/v1/messages", c => handleAnthropicMessages(c, config("responses")));
+    const response = await app.request("/v1/messages", { method: "POST", headers: { "content-type": "application/json", "x-api-key": "fixture" }, body: JSON.stringify({ model: "m", max_tokens: 100, messages: [{ role: "user", content: "hello" }] }) });
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["https://upstream.invalid/v1/responses"]);
+    expect(await response.json()).toMatchObject({ type: "message", stop_reason: "end_turn", content: [{ type: "text", text: "hello" }] });
+  });
+
+  it("Chat handler converts an upstream Messages SSE through the real stream path", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(anthropicStream, { headers: { "content-type": "text/event-stream" } })));
+    const app = new Hono(); app.post("/v1/chat/completions", c => handleChatCompletions(c, config("anthropic")));
+    const response = await app.request("/v1/chat/completions", { method: "POST", headers: { "content-type": "application/json", authorization: "Bearer fixture" }, body: JSON.stringify({ model: "m", messages: [{ role: "user", content: "hello" }], stream: true }) });
+    const text = await response.text();
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(text).toContain('"content":"hello"');
+    expect(text).toContain('"finish_reason":"stop"');
+    expect(text.match(/data: \[DONE\]/g)).toHaveLength(1);
+  });
+
+  it("Messages handler converts an upstream Chat SSE through the real stream path", async () => {
+    const stream = chatStream({ id: "chat_a", model: "m", choices: [{ index: 0, delta: { role: "assistant", content: "hello" }, finish_reason: null }] })
+      + chatStream({ id: "chat_a", model: "m", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 5 } }) + "data: [DONE]\n\n";
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(stream, { headers: { "content-type": "text/event-stream" } })));
+    const app = new Hono(); app.post("/v1/messages", c => handleAnthropicMessages(c, config("chat")));
+    const response = await app.request("/v1/messages", { method: "POST", headers: { "content-type": "application/json", "x-api-key": "fixture" }, body: JSON.stringify({ model: "m", max_tokens: 100, messages: [{ role: "user", content: "hello" }], stream: true }) });
+    const text = await response.text();
+    expect(text).toContain('"text":"hello"');
+    expect(text).toContain('"stop_reason":"end_turn"');
+    expect(text).toContain('"type":"message_stop"');
+  });
+  it.each([
+    ["codex", handleCodexEndpoint],
+    ["workbuddy", handleWorkbuddyEndpoint],
+  ] as const)("%s Responses handler sends Messages upstream and returns Responses JSON", async (agent, handler) => {
+    const settings = config("anthropic");
+    settings.upstream.agents[agent] = { url: "https://upstream.invalid/v1", protocol: "anthropic", maxTokens: 2048 };
+    const calls: { url: string; body: Record<string, unknown> }[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      if (isInstanceUpstreamRequest(String(url))) return Response.json({ code: 0, data: { items: [] } });
+      calls.push({ url: String(url), body: JSON.parse(String(init.body)) });
+      return Response.json(anth);
+    }));
+    const app = new Hono(); app.post(`/${agent}/fixture/v1/responses`, c => handler(c, settings));
+    const response = await app.request(`/${agent}/fixture/v1/responses`, { method: "POST", headers: { "content-type": "application/json", authorization: "Bearer fixture" }, body: JSON.stringify({ model: "m", input: "hello", max_output_tokens: 100, stream: false }) });
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://upstream.invalid/v1/messages");
+    expect(calls[0].body.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }]);
+    expect(await response.json()).toMatchObject({ object: "response", status: "completed", output: [{ type: "message", content: [{ type: "output_text", text: "hello" }] }] });
+  });
+
+  it("Codex Responses handler converts an upstream Messages SSE through the real stream path", async () => {
+    const settings = config("anthropic");
+    settings.upstream.agents.codex = { url: "https://upstream.invalid/v1", protocol: "anthropic", maxTokens: 2048 };
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => isInstanceUpstreamRequest(String(url))
+      ? Response.json({ code: 0, data: { items: [] } })
+      : new Response(anthropicStream, { headers: { "content-type": "text/event-stream" } })));
+    const app = new Hono(); app.post("/codex/fixture/v1/responses", c => handleCodexEndpoint(c, settings));
+    const response = await app.request("/codex/fixture/v1/responses", { method: "POST", headers: { "content-type": "application/json", authorization: "Bearer fixture" }, body: JSON.stringify({ model: "m", input: "hello", max_output_tokens: 100, stream: true }) });
+    const text = await response.text();
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(text).toContain("event: response.output_text.delta");
+    expect(text).toContain('"delta":"hello"');
+    expect(text).toContain("event: response.completed");
+    expect(text).toContain('"input_tokens":10');
+  });
+
+  it.each([
+    ["codex", handleCodexEndpoint],
+    ["workbuddy", handleWorkbuddyEndpoint],
+  ] as const)("%s auxiliary Responses endpoint remains a native passthrough", async (agent, handler) => {
+    const settings = config("anthropic");
+    settings.upstream.agents[agent] = { url: "https://upstream.invalid/v1", protocol: "anthropic", maxTokens: 2048 };
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (isInstanceUpstreamRequest(String(url))) return Response.json({ code: 0, data: { items: [] } });
+      calls.push(String(url));
+      return Response.json({ compacted: true });
+    }));
+    const app = new Hono(); app.post(`/${agent}/fixture/v1/responses/compact`, c => handler(c, settings));
+    const response = await app.request(`/${agent}/fixture/v1/responses/compact`, { method: "POST", headers: { "content-type": "application/json", authorization: "Bearer fixture" }, body: JSON.stringify({ model: "m", input: [] }) });
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["https://upstream.invalid/v1/responses/compact"]);
+    expect(await response.json()).toEqual({ compacted: true });
+  });
+  it("reports credit from raw upstream cache categories through the actual Chat handler", async () => {
+    const settings = config("anthropic");
+    settings.upstream.url = "https://tokenhub.invalid/v1";
+    settings.creditReport.url = "https://credits.invalid/report";
+    Object.assign(settings.creditPricing.models[0], { cacheRead: 0.1, cacheWrite5m: 2, cacheWrite1h: 3 });
+    let credited: Record<string, unknown> | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      if (String(url).startsWith("https://credits.invalid")) { credited = JSON.parse(String(init.body)); return Response.json({ code: 0 }); }
+      if (isInstanceUpstreamRequest(String(url))) return Response.json({ code: 0, data: { items: [] } });
+      if (!String(url).startsWith("https://tokenhub.invalid")) throw new Error(`Unexpected fixture request ${url}`);
+      return Response.json({ ...anth, usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 20, cache_creation: { ephemeral_5m_input_tokens: 15, ephemeral_1h_input_tokens: 5 } } });
+    }));
+    const app = new Hono(); app.post("/claude-code/fixture-space/v1/chat/completions", c => handleChatCompletions(c, settings));
+    const response = await app.request("/claude-code/fixture-space/v1/chat/completions", { method: "POST", headers: { "content-type": "application/json", authorization: "Bearer fixture" }, body: JSON.stringify({ model: "m", messages: [{ role: "user", content: "hello" }] }) });
+    expect(response.status).toBe(200);
+    expect((await response.json()).usage.prompt_tokens).toBe(130);
+    expect(credited?.CreditDelta).toBeCloseTo(0.07);
+  });
+  it("Chat handler sends Messages upstream and returns a Chat response", async () => {
+    const calls: { url: string; body: Record<string, unknown>; headers: Headers }[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init.body)), headers: new Headers(init.headers) });
+      return Response.json(anth);
+    }));
+    const app = new Hono(); app.post("/v1/chat/completions", c => handleChatCompletions(c, config("anthropic")));
+    const response = await app.request("/v1/chat/completions", { method: "POST", headers: { "content-type": "application/json", authorization: "Bearer fixture-client-key" }, body: JSON.stringify({ model: "m", messages: [{ role: "user", content: "hello" }] }) });
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://upstream.invalid/v1/messages");
+    expect(calls[0].headers.get("x-api-key")).toBe("fixture-server-key");
+    expect(calls[0].body).toMatchObject({ max_tokens: 1024, messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }] });
+    expect((await response.json()).choices[0].message.content).toBe("hello");
+  });
+  it("Messages handler sends Chat upstream and returns a Messages response", async () => {
+    const calls: { url: string; body: Record<string, unknown>; headers: Headers }[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init.body)), headers: new Headers(init.headers) });
+      return Response.json(chat);
+    }));
+    const app = new Hono(); app.post("/v1/messages", c => handleAnthropicMessages(c, config("chat")));
+    const response = await app.request("/v1/messages", { method: "POST", headers: { "content-type": "application/json", "x-api-key": "fixture-client-key" }, body: JSON.stringify({ model: "m", max_tokens: 100, messages: [{ role: "user", content: "hello" }] }) });
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://upstream.invalid/v1/chat/completions");
+    expect(calls[0].headers.get("authorization")).toBe("Bearer fixture-server-key");
+    expect(calls[0].body.messages).toEqual([{ role: "user", content: "hello" }]);
+    expect(await response.json()).toMatchObject({ type: "message", content: [{ type: "text", text: "hello" }] });
+  });
+});

--- a/MemoryProxy/src/protocol/__tests__/responses-anthropic.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/responses-anthropic.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { responsesToAnthropic, anthropicToResponses, anthropicJsonToResponses, responsesJsonToAnthropic } from "../responses-anthropic.js";
+
+describe("Responses ↔ Anthropic direct requests", () => {
+  it.each(["hello", [{ role: "user", content: "hello" }], [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }]])("accepts standard input form %j", input => {
+    expect(responsesToAnthropic({ model: "m", input, max_output_tokens: 64000 })).toEqual({ model: "m", max_tokens: 64000, stream: false, messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }] });
+  });
+  it("preserves ordered multimodal tool results without a Chat intermediate", () => {
+    const output = [{ type: "input_text", text: "before" }, { type: "input_image", image_url: "data:image/png;base64,AA==" }, { type: "input_text", text: "after" }];
+    const body = { model: "m", max_output_tokens: 100, input: [
+      { type: "function_call", call_id: "call_a", name: "lookup", arguments: '{"x":1}' },
+      { type: "function_call_output", call_id: "call_a", output },
+    ] };
+    const anth = responsesToAnthropic(body);
+    expect(anth.messages).toEqual([
+      { role: "assistant", content: [{ type: "tool_use", id: "call_a", name: "lookup", input: { x: 1 } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call_a", content: [{ type: "text", text: "before" }, { type: "image", source: { type: "base64", media_type: "image/png", data: "AA==" } }, { type: "text", text: "after" }] }] },
+    ]);
+    expect((anthropicToResponses(anth).input as Record<string, unknown>[])[1]).toMatchObject({ type: "function_call_output", call_id: "call_a", output });
+  });
+  it("preserves assistant text / tool / text item order", () => {
+    const body = { model: "m", messages: [{ role: "assistant", content: [{ type: "text", text: "first" }, { type: "tool_use", id: "a", name: "lookup", input: {} }, { type: "text", text: "last" }] }] };
+    const input = anthropicToResponses(body).input as Record<string, unknown>[];
+    expect(input.map(item => item.type)).toEqual(["message", "function_call", "message"]);
+    expect(responsesToAnthropic({ ...anthropicToResponses(body), max_output_tokens: 100 }).messages).toEqual(body.messages);
+  });
+  it("retains tools, tool choice, instructions and disabled parallel calls", () => {
+    const result = responsesToAnthropic({ model: "m", input: "hello", max_output_tokens: 100, instructions: "be precise", tools: [{ type: "function", name: "lookup", parameters: { type: "object" } }], tool_choice: "required", parallel_tool_calls: false });
+    expect(result).toMatchObject({ system: [{ type: "text", text: "be precise" }], tools: [{ name: "lookup", input_schema: { type: "object" } }], tool_choice: { type: "any", disable_parallel_tool_use: true } });
+  });
+  it.each([
+    { previous_response_id: "resp_old" }, { conversation: "conv_a" }, { background: true },
+    { input: [{ type: "reasoning", encrypted_content: "opaque" }] },
+    { input: [{ role: "user", content: [{ type: "input_image", file_id: "file_a" }] }] },
+  ])("explicitly rejects unsupported state or nonportable content %j", extra => {
+    expect(() => responsesToAnthropic({ model: "m", input: "hello", max_output_tokens: 100, ...extra })).toThrow();
+  });
+});
+
+describe("Responses ↔ Anthropic complete JSON responses", () => {
+  const anth = { id: "msg_a", model: "m", role: "assistant", type: "message", stop_reason: "max_tokens", content: [{ type: "text", text: "partial" }], usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 20 } };
+  it("keeps incomplete status and standard nested cache usage", () => {
+    expect(anthropicJsonToResponses(anth)).toMatchObject({ object: "response", status: "incomplete", incomplete_details: { reason: "max_output_tokens" }, usage: { input_tokens: 130, output_tokens: 5, input_tokens_details: { cached_tokens: 100 } } });
+  });
+  it("keeps incomplete termination in the reverse direction", () => {
+    const result = responsesJsonToAnthropic({ id: "resp_a", model: "m", status: "incomplete", incomplete_details: { reason: "max_output_tokens" }, output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "partial", annotations: [] }] }] });
+    expect(result).toMatchObject({ stop_reason: "max_tokens", content: [{ type: "text", text: "partial" }] });
+  });
+  it("does not change failed or in_progress results into successful messages", () => {
+    expect(() => responsesJsonToAnthropic({ status: "failed", error: { message: "fixture failure" }, output: [] })).toThrow(/fixture failure/);
+    expect(() => responsesJsonToAnthropic({ status: "in_progress", output: [] })).toThrow(/in_progress/);
+  });
+  it("preserves function calls as distinct ordered output items", () => {
+    const result = anthropicJsonToResponses({ ...anth, stop_reason: "tool_use", content: [{ type: "text", text: "first" }, { type: "tool_use", id: "call_a", name: "lookup", input: { x: 1 } }] });
+    expect((result.output as Record<string, unknown>[]).map(item => item.type)).toEqual(["message", "function_call"]);
+    expect(responsesJsonToAnthropic(result)).toMatchObject({ stop_reason: "tool_use", content: [{ type: "text", text: "first" }, { type: "tool_use", id: "call_a", name: "lookup", input: { x: 1 } }] });
+  });
+});

--- a/MemoryProxy/src/protocol/__tests__/stream.test.ts
+++ b/MemoryProxy/src/protocol/__tests__/stream.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { convertSse } from "../stream.js";
+import type { WireProtocol } from "../common.js";
+
+const encoder = new TextEncoder();
+const frame = (type: string | undefined, data: unknown) => `${type ? `event: ${type}\n` : ""}data: ${JSON.stringify(data)}\n\n`;
+async function run(text: string, from: WireProtocol, to: WireProtocol, cut = 0) {
+  const bytes = encoder.encode(text);
+  const source = new ReadableStream<Uint8Array>({ start(c) { c.enqueue(bytes.slice(0, cut)); c.enqueue(bytes.slice(cut)); c.close(); } });
+  const output = await new Response(convertSse(source, from, to)).text();
+  return output.split("\n\n").filter(Boolean).map(block => {
+    const data = block.split("\n").find(line => line.startsWith("data: "))!.slice(6);
+    return data === "[DONE]" ? data : JSON.parse(data);
+  });
+}
+const anth = (reason = "end_turn") => [
+  frame("message_start", { type: "message_start", message: { id: "msg_a", model: "m", content: [], usage: { input_tokens: 10, output_tokens: 0, cache_read_input_tokens: 100, cache_creation_input_tokens: 20 } } }),
+  frame("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+  frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "中文" } }),
+  frame("content_block_stop", { type: "content_block_stop", index: 0 }),
+  frame("message_delta", { type: "message_delta", delta: { stop_reason: reason }, usage: { output_tokens: 5 } }),
+  frame("message_stop", { type: "message_stop" }),
+].join("");
+
+describe("stream conversion uses semantic terminal events", () => {
+  it("Anthropic → Chat emits text, correct cache totals and one terminal marker", async () => {
+    const events = await run(anth(), "anthropic", "chat");
+    expect(events.filter(event => event === "[DONE]")).toHaveLength(1);
+    expect(events.some(event => event.choices?.[0]?.delta?.content === "中文")).toBe(true);
+    expect(events.find(event => event.usage)?.usage).toMatchObject({ prompt_tokens: 130, completion_tokens: 5, total_tokens: 135 });
+    expect(events.some(event => event.choices?.[0]?.finish_reason === "stop")).toBe(true);
+  });
+  it("Anthropic → Responses preserves incomplete and nested standard usage", async () => {
+    const events = await run(anth("max_tokens"), "anthropic", "responses");
+    expect(events.some(event => event.type === "response.completed")).toBe(false);
+    const final = events.at(-1);
+    expect(final).toMatchObject({ type: "response.incomplete", response: { status: "incomplete", incomplete_details: { reason: "max_output_tokens" }, usage: { input_tokens: 130, input_tokens_details: { cached_tokens: 100 } } } });
+    expect(final.response.output[0].content[0].text).toBe("中文");
+    expect(events.every(event => Number.isInteger(event.sequence_number))).toBe(true);
+  });
+  it("Chat → Anthropic handles interleaved parallel tool-argument fragments", async () => {
+    const chunk = (delta: unknown, finish_reason: unknown = null, usage?: unknown) => frame(undefined, { id: "chat_a", model: "m", choices: [{ index: 0, delta, finish_reason }], ...(usage ? { usage } : {}) });
+    const input = chunk({ role: "assistant", tool_calls: [
+      { index: 0, id: "a", type: "function", function: { name: "lookup", arguments: '{"q":' } },
+      { index: 1, id: "b", type: "function", function: { name: "calc", arguments: '{"x":' } },
+    ] }) + chunk({ tool_calls: [{ index: 1, function: { arguments: "2}" } }, { index: 0, function: { arguments: '"中文"}' } }] }) + chunk({}, "tool_calls", { prompt_tokens: 130, completion_tokens: 5, prompt_tokens_details: { cached_tokens: 100 } }) + "data: [DONE]\n\n";
+    const events = await run(input, "chat", "anthropic");
+    expect(events.filter(event => event.type === "content_block_start").map(event => event.content_block.id)).toEqual(["a", "b"]);
+    for (const [index, expected] of [[0, '{"q":"中文"}'], [1, '{"x":2}']] as const) {
+      expect(events.filter(event => event.type === "content_block_delta" && event.index === index).map(event => event.delta.partial_json).join("")).toBe(expected);
+    }
+    expect(events.find(event => event.type === "message_delta")).toMatchObject({ delta: { stop_reason: "tool_use" }, usage: { input_tokens: 30, output_tokens: 5, cache_read_input_tokens: 100 } });
+    expect(events.at(-1).type).toBe("message_stop");
+  });
+  it("Responses → Anthropic maps output text and incomplete completion", async () => {
+    const input = frame("response.created", { type: "response.created", sequence_number: 0, response: { id: "resp_a", model: "m", status: "in_progress" } })
+      + frame("response.output_item.added", { type: "response.output_item.added", sequence_number: 1, output_index: 0, item: { type: "message", id: "msg_a", role: "assistant", content: [] } })
+      + frame("response.content_part.added", { type: "response.content_part.added", sequence_number: 2, output_index: 0, content_index: 0, part: { type: "output_text", text: "" } })
+      + frame("response.output_text.delta", { type: "response.output_text.delta", sequence_number: 3, output_index: 0, content_index: 0, delta: "partial" })
+      + frame("response.incomplete", { type: "response.incomplete", sequence_number: 4, response: { id: "resp_a", model: "m", status: "incomplete", incomplete_details: { reason: "max_output_tokens" }, usage: { input_tokens: 10, output_tokens: 5 } } });
+    const events = await run(input, "responses", "anthropic");
+    expect(events.some(event => event.delta?.text === "partial")).toBe(true);
+    expect(events.find(event => event.type === "message_delta").delta.stop_reason).toBe("max_tokens");
+  });
+  it("passes the actual nested Responses failure instead of synthesizing success", async () => {
+    const input = frame("response.failed", { type: "response.failed", sequence_number: 0, response: { status: "failed", error: { code: "server_error", message: "fixture failure" } } });
+    const events = await run(input, "responses", "anthropic");
+    expect(events).toEqual([{ type: "error", error: { type: "api_error", message: "fixture failure" } }]);
+  });
+  it("does not treat partial output or a naked DONE marker as model completion", async () => {
+    for (const input of [frame(undefined, { id: "a", model: "m", choices: [{ index: 0, delta: { content: "partial" }, finish_reason: null }] }), "data: [DONE]\n\n"]) {
+      const events = await run(input, "chat", "anthropic");
+      expect(events.some(event => event.type === "message_stop")).toBe(false);
+      expect(events.at(-1).type).toBe("error");
+    }
+  });
+  it("produces the same semantic result at every UTF-8 byte split", async () => {
+    const input = anth();
+    for (let cut = 0; cut < encoder.encode(input).length; cut += 7) {
+      const events = await run(input, "anthropic", "responses", cut);
+      expect(events.at(-1).response.output[0].content[0].text).toBe("中文");
+      expect(events.at(-1).type).toBe("response.completed");
+    }
+  });
+});

--- a/MemoryProxy/src/protocol/chat-anthropic.ts
+++ b/MemoryProxy/src/protocol/chat-anthropic.ts
@@ -1,0 +1,175 @@
+import { acknowledgeCache, checkFields, convertUsage, list, object, outputLimit, parseArguments, ProtocolError, string, unsupported, type ConversionOptions, type JsonObject } from "./common.js";
+
+function chatContent(raw: unknown): JsonObject[] {
+  if (raw == null) return [];
+  if (typeof raw === "string") return [{ type: "text", text: raw }];
+  return list(raw, "content").map(value => {
+    const part = object(value, "content[]");
+    if (part.type === "text") return { type: "text", text: string(part.text, "text") };
+    if (part.type === "image_url") {
+      const image = object(part.image_url, "image_url");
+      if (image.detail && image.detail !== "auto") unsupported("image_url.detail");
+      const url = string(image.url, "image_url.url");
+      const data = /^data:(image\/[\w.+-]+);base64,([A-Za-z0-9+/=]+)$/.exec(url);
+      if (url.startsWith("data:") && !data) throw new ProtocolError("Invalid image data URL", "image_url");
+      return { type: "image", source: data ? { type: "base64", media_type: data[1], data: data[2] } : { type: "url", url } };
+    }
+    return unsupported(`content.${part.type}`);
+  });
+}
+
+function anthropicParts(raw: unknown, options: ConversionOptions): JsonObject[] {
+  if (typeof raw === "string") return [{ type: "text", text: raw }];
+  return list(raw, "content").map(value => {
+    const block = object(value, "content[]");
+    acknowledgeCache(block, options);
+    if (block.type === "text") return { type: "text", text: string(block.text, "text") };
+    if (block.type === "image") {
+      const source = object(block.source, "image.source");
+      const url = source.type === "url" ? string(source.url, "image.url")
+        : source.type === "base64" ? `data:${string(source.media_type, "image.media_type")};base64,${string(source.data, "image.data")}`
+        : unsupported("image.source.type");
+      return { type: "image_url", image_url: { url } };
+    }
+    return unsupported(`content.${block.type}`);
+  });
+}
+
+function collapse(parts: JsonObject[]): unknown {
+  return parts.every(part => part.type === "text") ? parts.map(part => part.text).join("") : parts;
+}
+
+function chatAssistant(message: JsonObject): JsonObject[] {
+  if (message.refusal) unsupported("assistant.refusal");
+  if (message.reasoning_content || message.reasoning) unsupported("assistant.reasoning");
+  const content = chatContent(message.content);
+  if (content.some(part => part.type !== "text")) unsupported("assistant.image");
+  for (const value of list(message.tool_calls ?? [], "tool_calls")) {
+    const call = object(value, "tool_calls[]");
+    if (call.type !== "function") unsupported("tool_calls.type");
+    const fn = object(call.function, "tool_calls.function");
+    content.push({ type: "tool_use", id: string(call.id, "tool_calls.id"), name: string(fn.name, "function.name"), input: parseArguments(fn.arguments) });
+  }
+  return content;
+}
+
+function anthropicAssistant(raw: unknown, options: ConversionOptions): JsonObject {
+  const parts = typeof raw === "string" ? [{ type: "text", text: raw }] : list(raw, "content").map(value => object(value, "content[]"));
+  const texts: JsonObject[] = [];
+  const calls: JsonObject[] = [];
+  for (const part of parts) {
+    acknowledgeCache(part, options);
+    if (part.type === "tool_use") {
+      calls.push({ id: string(part.id, "tool_use.id"), type: "function", function: { name: string(part.name, "tool_use.name"), arguments: JSON.stringify(object(part.input, "tool_use.input")) } });
+    } else if (part.type === "text") {
+      // Chat has a separate text field, so later text cannot retain its position after a tool call.
+      if (calls.length) unsupported("assistant.content order after tool_use");
+      texts.push({ type: "text", text: string(part.text, "text") });
+    } else unsupported(`content.${part.type}`);
+  }
+  return { role: "assistant", content: texts.length ? collapse(texts) : null, ...(calls.length ? { tool_calls: calls } : {}) };
+}
+
+export function chatToAnthropic(body: JsonObject, options: ConversionOptions = {}): JsonObject {
+  checkFields(body, ["model", "messages", "max_tokens", "max_completion_tokens", "stream", "stream_options", "temperature", "top_p", "stop", "tools", "tool_choice", "parallel_tool_calls", "n"]);
+  if (body.n != null && body.n !== 1) unsupported("n");
+  if (body.max_tokens != null && body.max_completion_tokens != null && body.max_tokens !== body.max_completion_tokens) unsupported("conflicting token limits");
+  const messages: JsonObject[] = [];
+  const system: JsonObject[] = [];
+  for (const value of list(body.messages, "messages")) {
+    const message = object(value, "messages[]");
+    if (message.role === "system" || message.role === "developer") {
+      if (messages.length) unsupported("system/developer after conversation messages");
+      const parts = chatContent(message.content);
+      if (parts.some(part => part.type !== "text")) unsupported("system.image");
+      system.push(...parts);
+    } else if (message.role === "tool") {
+      if (typeof message.content !== "string") unsupported("tool.content");
+      const result = { type: "tool_result", tool_use_id: string(message.tool_call_id, "tool_call_id"), content: message.content };
+      const previous = messages.at(-1);
+      if (previous?.role === "user" && Array.isArray(previous.content) && previous.content.every(part => object(part).type === "tool_result")) previous.content.push(result);
+      else messages.push({ role: "user", content: [result] });
+    } else if (message.role === "assistant") messages.push({ role: "assistant", content: chatAssistant(message) });
+    else if (message.role === "user") messages.push({ role: "user", content: chatContent(message.content) });
+    else unsupported(`messages.role.${message.role}`);
+  }
+  const result: JsonObject = { model: string(body.model, "model"), max_tokens: outputLimit(body.max_completion_tokens ?? body.max_tokens ?? options.maxTokens), stream: body.stream === true, ...(system.length ? { system } : {}), messages };
+  for (const key of ["temperature", "top_p"]) if (body[key] != null) result[key] = body[key];
+  if (body.stop != null) result.stop_sequences = typeof body.stop === "string" ? [body.stop] : list(body.stop, "stop").map(value => string(value, "stop[]"));
+  if (body.tools != null) result.tools = list(body.tools, "tools").map(value => {
+    const tool = object(value, "tools[]");
+    if (tool.type !== "function") unsupported("tools.type");
+    const fn = object(tool.function, "tools.function");
+    if (fn.strict === true) unsupported("tools.function.strict");
+    checkFields(fn, ["name", "description", "parameters", "strict"], "tools.function");
+    return { name: string(fn.name, "tools.name"), ...(fn.description != null ? { description: string(fn.description, "tools.description") } : {}), input_schema: object(fn.parameters ?? { type: "object", properties: {} }, "tools.parameters") };
+  });
+  if (body.tool_choice != null || body.parallel_tool_calls === false) {
+    const choice = body.tool_choice ?? "auto";
+    const mapped = typeof choice === "string"
+      ? { type: choice === "required" ? "any" : ["auto", "none"].includes(choice) ? choice : unsupported("tool_choice") }
+      : { type: "tool", name: string(object(object(choice).function, "tool_choice.function").name, "tool_choice.name") };
+    result.tool_choice = { ...mapped, ...(body.parallel_tool_calls === false && mapped.type !== "none" ? { disable_parallel_tool_use: true } : {}) };
+  }
+  return result;
+}
+
+export function anthropicToChat(body: JsonObject, options: ConversionOptions = {}): JsonObject {
+  checkFields(body, ["model", "messages", "system", "max_tokens", "stream", "temperature", "top_p", "stop_sequences", "tools", "tool_choice"]);
+  const messages: JsonObject[] = [];
+  if (body.system != null) {
+    const system = anthropicParts(body.system, options);
+    if (system.some(part => part.type !== "text")) unsupported("system.image");
+    messages.push({ role: "system", content: collapse(system) });
+  }
+  for (const value of list(body.messages, "messages")) {
+    const message = object(value, "messages[]");
+    if (message.role === "assistant") { messages.push(anthropicAssistant(message.content, options)); continue; }
+    if (message.role !== "user") unsupported(`messages.role.${message.role}`);
+    const content = typeof message.content === "string" ? [{ type: "text", text: message.content }] : list(message.content, "content");
+    let pending: unknown[] = [];
+    const flush = () => { if (pending.length) { messages.push({ role: "user", content: collapse(anthropicParts(pending, options)) }); pending = []; } };
+    for (const raw of content) {
+      const part = object(raw, "content[]");
+      if (part.type !== "tool_result") { pending.push(part); continue; }
+      flush(); acknowledgeCache(part, options);
+      if (part.is_error === true) unsupported("tool_result.is_error");
+      const result = typeof part.content === "string" ? part.content : collapse(anthropicParts(part.content ?? [], options));
+      if (typeof result !== "string") unsupported("tool_result.image");
+      messages.push({ role: "tool", tool_call_id: string(part.tool_use_id, "tool_result.tool_use_id"), content: result });
+    }
+    flush();
+  }
+  const result: JsonObject = { model: string(body.model, "model"), messages, stream: body.stream === true };
+  if (body.max_tokens != null) result.max_tokens = outputLimit(body.max_tokens);
+  for (const key of ["temperature", "top_p"]) if (body[key] != null) result[key] = body[key];
+  if (body.stop_sequences != null) result.stop = body.stop_sequences;
+  if (body.tools != null) result.tools = list(body.tools, "tools").map(value => {
+    const tool = object(value, "tools[]");
+    acknowledgeCache(tool, options);
+    checkFields(tool, ["name", "description", "input_schema", "cache_control"], "tools");
+    return { type: "function", function: { name: string(tool.name, "tools.name"), ...(tool.description != null ? { description: tool.description } : {}), parameters: object(tool.input_schema, "tools.input_schema") } };
+  });
+  if (body.tool_choice != null) {
+    const choice = object(body.tool_choice, "tool_choice");
+    result.tool_choice = choice.type === "any" ? "required" : choice.type === "tool" ? { type: "function", function: { name: string(choice.name, "tool_choice.name") } }
+      : choice.type === "auto" || choice.type === "none" ? choice.type : unsupported("tool_choice.type");
+    if (choice.disable_parallel_tool_use === true) result.parallel_tool_calls = false;
+  }
+  return result;
+}
+
+export function chatJsonToAnthropic(body: JsonObject): JsonObject {
+  const choices = list(body.choices, "choices");
+  if (choices.length !== 1) unsupported("choices (exactly one required)");
+  const choice = object(choices[0], "choices[0]");
+  const reason = choice.finish_reason === "stop" ? "end_turn" : choice.finish_reason === "length" ? "max_tokens" : choice.finish_reason === "tool_calls" ? "tool_use" : unsupported(`finish_reason.${choice.finish_reason}`);
+  const usage = convertUsage(body.usage, "chat", "anthropic");
+  return { id: string(body.id, "id"), type: "message", role: "assistant", model: string(body.model, "model"), content: chatAssistant(object(choice.message, "message")), stop_reason: reason, stop_sequence: null, ...(usage ? { usage } : {}) };
+}
+
+export function anthropicJsonToChat(body: JsonObject): JsonObject {
+  const reason = body.stop_reason === "end_turn" || body.stop_reason === "stop_sequence" ? "stop" : body.stop_reason === "max_tokens" || body.stop_reason === "model_context_window_exceeded" ? "length" : body.stop_reason === "tool_use" ? "tool_calls" : unsupported(`stop_reason.${body.stop_reason}`);
+  const usage = convertUsage(body.usage, "anthropic", "chat");
+  return { id: string(body.id, "id"), object: "chat.completion", created: Math.floor(Date.now() / 1000), model: string(body.model, "model"), choices: [{ index: 0, message: anthropicAssistant(body.content, {}), finish_reason: reason }], ...(usage ? { usage } : {}) };
+}

--- a/MemoryProxy/src/protocol/common.ts
+++ b/MemoryProxy/src/protocol/common.ts
@@ -1,0 +1,161 @@
+/** Shared wire-level helpers. Archival/injection formats are intentionally separate. */
+export type WireProtocol = "chat" | "anthropic" | "responses";
+export type JsonObject = Record<string, unknown>;
+export interface ConversionOptions {
+  /** Required fallback for a target Messages request when the source omits its limit. */
+  maxTokens?: number;
+  /** Providing this callback explicitly acknowledges nonportable cache controls. */
+  onWarning?: (message: string) => void;
+}
+
+export class ProtocolError extends Error {
+  constructor(message: string, readonly param?: string, readonly status = 400) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}
+
+export function object(value: unknown, param = "body"): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ProtocolError(`Expected an object at ${param}`, param);
+  }
+  return value as JsonObject;
+}
+
+export function list(value: unknown, param: string): unknown[] {
+  if (!Array.isArray(value)) throw new ProtocolError(`Expected an array at ${param}`, param);
+  return value;
+}
+
+export function string(value: unknown, param: string): string {
+  if (typeof value !== "string") throw new ProtocolError(`Expected text at ${param}`, param);
+  return value;
+}
+
+export function unsupported(param: string): never {
+  throw new ProtocolError(`Cannot preserve ${param} in the target protocol`, param);
+}
+
+export function checkFields(body: JsonObject, allowed: string[], param = "body") {
+  for (const [key, value] of Object.entries(body)) {
+    if (value != null && !allowed.includes(key)) unsupported(`${param}.${key}`);
+  }
+}
+
+export function acknowledgeCache(block: JsonObject, options: ConversionOptions) {
+  if (block.cache_control == null) return;
+  if (!options.onWarning) unsupported("cache_control");
+  options.onWarning("cache_control has no portable equivalent; upstream cache policy applies");
+}
+
+export function outputLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    throw new ProtocolError("A positive max_tokens limit or configured maxTokens fallback is required", "max_tokens");
+  }
+  return value;
+}
+
+export function parseArguments(value: unknown, param = "arguments"): JsonObject {
+  try { return object(JSON.parse(string(value, param)), param); }
+  catch { throw new ProtocolError(`Invalid JSON object in ${param}`, param); }
+}
+
+function counter(value: unknown, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new ProtocolError(`Invalid upstream usage counter: ${name}`, "usage", 502);
+  }
+  return value;
+}
+
+/** Counts remain measurements from the upstream tokenizer, not a retokenization. */
+export function convertUsage(raw: unknown, from: WireProtocol, to: WireProtocol): JsonObject | undefined {
+  if (raw == null) return undefined;
+  const usage = object(raw, "usage");
+  if (from === to) return { ...usage };
+  const inputKey = from === "chat" ? "prompt_tokens" : "input_tokens";
+  const outputKey = from === "chat" ? "completion_tokens" : "output_tokens";
+  const input = counter(usage[inputKey], inputKey);
+  const output = counter(usage[outputKey], outputKey);
+  const details = usage[from === "chat" ? "prompt_tokens_details" : "input_tokens_details"];
+  const read = counter(from === "anthropic"
+    ? usage.cache_read_input_tokens
+    : details == null ? undefined : object(details, "usage.details").cached_tokens, "cached_tokens");
+  const created = from === "anthropic" ? counter(usage.cache_creation_input_tokens, "cache_creation_input_tokens") : undefined;
+  if (from !== "anthropic" && input !== undefined && read !== undefined && read > input) {
+    throw new ProtocolError("Upstream cached tokens exceed total input tokens", "usage", 502);
+  }
+  const totalInput = input === undefined ? undefined : from === "anthropic" ? input + (read ?? 0) + (created ?? 0) : input;
+  const result: JsonObject = {};
+  if (to === "anthropic") {
+    if (totalInput !== undefined) result.input_tokens = totalInput - (read ?? 0);
+    if (output !== undefined) result.output_tokens = output;
+    if (read !== undefined) result.cache_read_input_tokens = read;
+    // OpenAI does not report Anthropic cache-write TTL categories. Do not invent them.
+  } else {
+    if (totalInput !== undefined) result[to === "chat" ? "prompt_tokens" : "input_tokens"] = totalInput;
+    if (output !== undefined) result[to === "chat" ? "completion_tokens" : "output_tokens"] = output;
+    if (totalInput !== undefined && output !== undefined) result.total_tokens = totalInput + output;
+    if (read !== undefined) result[to === "chat" ? "prompt_tokens_details" : "input_tokens_details"] = { cached_tokens: read };
+    if (from !== "anthropic") {
+      const outputDetails = usage[from === "chat" ? "completion_tokens_details" : "output_tokens_details"];
+      if (outputDetails !== undefined) result[to === "chat" ? "completion_tokens_details" : "output_tokens_details"] = { ...object(outputDetails, "usage.output_details") };
+    }
+  }
+  return result;
+}
+
+export interface SseFrame { event: string; data: string; id?: string }
+
+/** Incremental SSE framing; decoding alone never establishes model completion. */
+export function createSseDecoder(maxFrameChars = 2 * 1024 * 1024): TransformStream<Uint8Array, SseFrame> {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let buffer = "";
+  let event = "message";
+  let id: string | undefined;
+  let data: string[] = [];
+  let frameChars = 0;
+  const limit = () => { if (frameChars + buffer.length > maxFrameChars) throw new ProtocolError("Upstream SSE frame exceeds limit", undefined, 502); };
+  function line(value: string, controller: TransformStreamDefaultController<SseFrame>) {
+    if (!value) {
+      if (data.length) controller.enqueue({ event, data: data.join("\n"), ...(id !== undefined ? { id } : {}) });
+      event = "message"; data = []; frameChars = 0;
+      return;
+    }
+    frameChars += value.length + 1;
+    if (frameChars > maxFrameChars) throw new ProtocolError("Upstream SSE frame exceeds limit", undefined, 502);
+    if (value.startsWith(":")) return;
+    const colon = value.indexOf(":");
+    const field = colon < 0 ? value : value.slice(0, colon);
+    let content = colon < 0 ? "" : value.slice(colon + 1);
+    if (content.startsWith(" ")) content = content.slice(1);
+    if (field === "data") data.push(content);
+    else if (field === "event") event = content || "message";
+    else if (field === "id" && !content.includes("\0")) id = content;
+  }
+  function drain(controller: TransformStreamDefaultController<SseFrame>, eof = false) {
+    let start = 0;
+    for (let i = 0; i < buffer.length; i++) {
+      if (buffer[i] !== "\n" && buffer[i] !== "\r") continue;
+      if (buffer[i] === "\r" && i + 1 === buffer.length && !eof) break;
+      line(buffer.slice(start, i), controller);
+      if (buffer[i] === "\r" && buffer[i + 1] === "\n") i++;
+      start = i + 1;
+    }
+    buffer = buffer.slice(start);
+    limit();
+  }
+  return new TransformStream({
+    transform(chunk, controller) { buffer += decoder.decode(chunk, { stream: true }); drain(controller); },
+    flush(controller) {
+      buffer += decoder.decode(); drain(controller, true);
+      if (data.length || (buffer && !buffer.startsWith(":"))) {
+        throw new ProtocolError("Truncated upstream SSE frame", undefined, 502);
+      }
+    },
+  });
+}
+
+export function sseFrame(event: string | undefined, data: unknown): Uint8Array {
+  return new TextEncoder().encode(`${event ? `event: ${event}\n` : ""}data: ${typeof data === "string" ? data : JSON.stringify(data)}\n\n`);
+}

--- a/MemoryProxy/src/protocol/forward.ts
+++ b/MemoryProxy/src/protocol/forward.ts
@@ -1,0 +1,156 @@
+import { anthropicToChat, chatToAnthropic, anthropicJsonToChat, chatJsonToAnthropic } from "./chat-anthropic.js";
+import { anthropicToResponses, responsesToAnthropic, anthropicJsonToResponses, responsesJsonToAnthropic } from "./responses-anthropic.js";
+import { convertSse, type StreamOptions } from "./stream.js";
+import { object, ProtocolError, unsupported, type ConversionOptions, type JsonObject, type WireProtocol } from "./common.js";
+import type { UpstreamProtocolOptions } from "../types.js";
+
+export interface ForwardProtocolContext {
+  source: WireProtocol;
+  settings: UpstreamProtocolOptions;
+  defaultUrl: string;
+  request: JsonObject;
+  signal?: AbortSignal;
+  warn: (message: string) => void;
+  actual?: { protocol: WireProtocol; url: string; model: string; converted: boolean; usage?: JsonObject };
+}
+
+export function upstreamAccounting(context: ForwardProtocolContext | undefined, clientUsage: JsonObject | null | undefined, model: string, url: string, protocol: WireProtocol) {
+  const actual = context?.actual;
+  return { usage: actual?.converted ? actual.usage ?? null : clientUsage ?? null,
+    model: actual?.model ?? model, url: actual?.url ?? url, protocol: actual?.protocol ?? protocol };
+}
+
+/** One actual attempt. Retry callers use the same unconverted request with a new target. */
+export async function fetchProtocolAttempt(
+  target: { url: string; model: string; wireProtocol?: WireProtocol; authHeaders?: Record<string, string> | null; bodyOverrides?: JsonObject | null },
+  init: RequestInit,
+  context?: ForwardProtocolContext,
+): Promise<Response> {
+  if (!context) return fetch(target.url, init);
+  if (context.settings.protocol && !target.wireProtocol && target.url !== context.defaultUrl) {
+    throw new ProtocolError("A dynamically selected route must declare wireProtocol when protocol conversion is configured", "upstream.protocol");
+  }
+  const protocol = target.wireProtocol ?? context.settings.protocol ?? context.source;
+  if (!["chat", "anthropic", "responses"].includes(protocol)) throw new ProtocolError("Unknown route wireProtocol", "wireProtocol");
+  const converted = protocol !== context.source;
+  let url = target.url;
+  let headers = new Headers(init.headers);
+  let body = init.body;
+  if (converted) {
+    const prepared = prepareProtocolRequest({
+      from: context.source, to: protocol, url, headers,
+      body: { ...context.request, model: target.model }, authHeaders: target.authHeaders,
+      options: { maxTokens: context.settings.maxTokens, ...(context.settings.allowCacheControlDrop ? { onWarning: context.warn } : {}) },
+    });
+    const overrides = target.bodyOverrides ?? {};
+    for (const key of ["messages", "input", "system", "tools", "tool_choice", "stream"]) {
+      if (key in overrides) throw new ProtocolError(`Cross-protocol route cannot override structural field ${key}`, `bodyOverrides.${key}`);
+    }
+    const outbound: JsonObject = { ...prepared.body, ...overrides, model: target.model };
+    if (protocol === "chat" && outbound.stream === true) outbound.stream_options = { include_usage: true };
+    url = prepared.url; headers = prepared.headers; body = JSON.stringify(outbound);
+  } else if (target.authHeaders) {
+    const auth = new Headers(target.authHeaders);
+    if (auth.has("authorization") || auth.has("x-api-key")) { headers.delete("authorization"); headers.delete("x-api-key"); }
+    auth.forEach((value, key) => headers.set(key, value));
+  }
+  const actual: NonNullable<ForwardProtocolContext["actual"]> = { protocol, url, model: target.model, converted };
+  context.actual = actual;
+  const signals = [context.signal, init.signal].filter((value): value is AbortSignal => value != null);
+  const response = await fetch(url, { ...init, headers, body, ...(signals.length ? { signal: AbortSignal.any(signals) } : {}) });
+  return convertProtocolResponse(response, protocol, context.source, context.request, { onUsage: value => { actual.usage = value; } });
+}
+
+export interface ProtocolRequest {
+  body: JsonObject;
+  url: string;
+  headers: HeadersInit;
+  from: WireProtocol;
+  to: WireProtocol;
+  /** Explicit destination credentials from the selected route, when present. */
+  authHeaders?: Record<string, string> | null;
+  options?: ConversionOptions;
+}
+
+export function prepareProtocolRequest(request: ProtocolRequest): { url: string; headers: Headers; body: JsonObject } {
+  const { from, to, body, options } = request;
+  const headers = new Headers(request.headers);
+  if (from === to) return { url: request.url, headers, body };
+  const endpoint = { chat: "/chat/completions", anthropic: "/messages", responses: "/responses" };
+  const url = new URL(request.url);
+  const suffix = /\/(chat\/completions|messages|responses)$/.exec(url.pathname);
+  if (!suffix) throw new ProtocolError("This endpoint does not support inference protocol conversion", "endpoint");
+  url.pathname = url.pathname.slice(0, -suffix[0].length) + endpoint[to];
+  const converted = from === "chat" && to === "anthropic" ? chatToAnthropic(body, options)
+    : from === "anthropic" && to === "chat" ? anthropicToChat(body, options)
+    : from === "responses" && to === "anthropic" ? responsesToAnthropic(body, options)
+    : from === "anthropic" && to === "responses" ? anthropicToResponses(body, options)
+    : unsupported(`${from} → ${to}`);
+  const bearer = headers.get("authorization");
+  const key = from === "anthropic" ? headers.get("x-api-key") ?? bearer?.replace(/^Bearer\s+/i, "")
+    : bearer?.replace(/^Bearer\s+/i, "") ?? headers.get("x-api-key");
+  for (const name of ["authorization", "x-api-key", "anthropic-version", "anthropic-beta", "openai-beta", "content-length", "content-encoding", "host"]) headers.delete(name);
+  if (key) headers.set(to === "anthropic" ? "x-api-key" : "authorization", to === "anthropic" ? key : `Bearer ${key}`);
+  if (request.authHeaders) {
+    const explicit = new Headers(request.authHeaders);
+    if (explicit.has("authorization") || explicit.has("x-api-key")) {
+      headers.delete("authorization"); headers.delete("x-api-key");
+    }
+    explicit.forEach((value, name) => headers.set(name, value));
+  }
+  if (to === "anthropic" && !headers.has("anthropic-version")) headers.set("anthropic-version", "2023-06-01");
+  headers.set("content-type", "application/json");
+  return { url: url.toString(), headers, body: converted };
+}
+
+function responseHeaders(source: Headers): Headers {
+  const headers = new Headers(source);
+  for (const name of ["content-length", "content-encoding", "transfer-encoding", "connection", "etag", "digest", "content-md5"]) headers.delete(name);
+  return headers;
+}
+
+export function protocolErrorResponse(error: unknown, protocol: WireProtocol, status = 400, originalHeaders?: Headers): Response {
+  const message = error instanceof Error ? error.message : String(error);
+  const headers = responseHeaders(originalHeaders ?? new Headers());
+  headers.set("content-type", "application/json");
+  const type = status === 429 ? "rate_limit_error" : status === 401 ? "authentication_error" : status >= 500 ? "api_error" : "invalid_request_error";
+  const body = protocol === "anthropic" ? { type: "error", error: { type, message } }
+    : { error: { message, type: status >= 500 ? "server_error" : type, code: "protocol_conversion_error", param: error instanceof ProtocolError ? error.param ?? null : null } };
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+/** Convert only after routing/retry has selected the actual upstream response. */
+export async function convertProtocolResponse(response: Response, from: WireProtocol, to: WireProtocol, request: JsonObject, options: StreamOptions = {}): Promise<Response> {
+  if (from === to) return response;
+  if (!response.ok) {
+    let message = `Upstream HTTP ${response.status}`;
+    try {
+      const raw = object(await response.json());
+      const error = raw.error;
+      message = typeof error === "string" ? error : error && typeof error === "object" ? String(object(error).message ?? message) : typeof raw.message === "string" ? raw.message : message;
+    } catch { /* Preserve HTTP status even when the upstream error body is not JSON. */ }
+    return protocolErrorResponse(message, to, response.status, response.headers);
+  }
+  try {
+    const stream = response.headers.get("content-type")?.includes("text/event-stream") === true;
+    if (stream !== (request.stream === true)) {
+      await response.body?.cancel();
+      throw new ProtocolError("Upstream response does not match the requested streaming mode", undefined, 502);
+    }
+    const headers = responseHeaders(response.headers);
+    if (stream) {
+      if (!response.body) throw new ProtocolError("Empty upstream stream", undefined, 502);
+      headers.set("content-type", "text/event-stream");
+      return new Response(convertSse(response.body, from, to, { ...options, request }), { status: response.status, headers });
+    }
+    const raw = object(await response.json());
+    if (raw.usage != null) options.onUsage?.(structuredClone(object(raw.usage, "usage")));
+    const converted = from === "anthropic" && to === "chat" ? anthropicJsonToChat(raw)
+      : from === "chat" && to === "anthropic" ? chatJsonToAnthropic(raw)
+      : from === "anthropic" && to === "responses" ? anthropicJsonToResponses(raw, request)
+      : from === "responses" && to === "anthropic" ? responsesJsonToAnthropic(raw)
+      : unsupported(`${from} → ${to}`);
+    headers.set("content-type", "application/json");
+    return new Response(JSON.stringify(converted), { status: response.status, headers });
+  } catch (error) { return protocolErrorResponse(error, to, 502, response.headers); }
+}

--- a/MemoryProxy/src/protocol/responses-anthropic.ts
+++ b/MemoryProxy/src/protocol/responses-anthropic.ts
@@ -1,0 +1,168 @@
+import { acknowledgeCache, checkFields, convertUsage, list, object, outputLimit, parseArguments, ProtocolError, string, unsupported, type ConversionOptions, type JsonObject } from "./common.js";
+
+function toAnthropicContent(raw: unknown): JsonObject[] {
+  if (typeof raw === "string") return [{ type: "text", text: raw }];
+  return list(raw, "content").map(value => {
+    const part = object(value, "content[]");
+    if (part.type === "input_text" || part.type === "output_text") {
+      if (Array.isArray(part.annotations) && part.annotations.length) unsupported("content.annotations");
+      return { type: "text", text: string(part.text, "content.text") };
+    }
+    if (part.type === "input_image") {
+      if (part.file_id != null) unsupported("input_image.file_id");
+      if (part.detail && part.detail !== "auto") unsupported("input_image.detail");
+      const url = string(part.image_url, "input_image.image_url");
+      const data = /^data:(image\/[\w.+-]+);base64,([A-Za-z0-9+/=]+)$/.exec(url);
+      if (url.startsWith("data:") && !data) throw new ProtocolError("Invalid image data URL", "input_image");
+      return { type: "image", source: data ? { type: "base64", media_type: data[1], data: data[2] } : { type: "url", url } };
+    }
+    return unsupported(`content.${part.type}`);
+  });
+}
+
+function toResponsesContent(raw: unknown, assistant: boolean, options: ConversionOptions): JsonObject[] {
+  const content = typeof raw === "string" ? [{ type: "text", text: raw }] : list(raw, "content");
+  return content.map(value => {
+    const block = object(value, "content[]");
+    acknowledgeCache(block, options);
+    if (block.type === "text") {
+      if (Array.isArray(block.citations) && block.citations.length) unsupported("content.citations");
+      return { type: assistant ? "output_text" : "input_text", text: string(block.text, "text"), ...(assistant ? { annotations: [] } : {}) };
+    }
+    if (block.type === "image" && !assistant) {
+      const source = object(block.source, "image.source");
+      const url = source.type === "url" ? string(source.url, "image.url")
+        : source.type === "base64" ? `data:${string(source.media_type, "image.media_type")};base64,${string(source.data, "image.data")}` : unsupported("image.source");
+      return { type: "input_image", image_url: url };
+    }
+    return unsupported(`content.${block.type}`);
+  });
+}
+
+export function responsesToAnthropic(body: JsonObject, options: ConversionOptions = {}): JsonObject {
+  checkFields(body, ["model", "input", "instructions", "max_output_tokens", "stream", "temperature", "top_p", "tools", "tool_choice", "parallel_tool_calls", "store", "background"]);
+  if (body.background === true) unsupported("background");
+  if (body.store === true) unsupported("store");
+  const system: JsonObject[] = body.instructions == null ? [] : [{ type: "text", text: string(body.instructions, "instructions") }];
+  const messages: JsonObject[] = [];
+  function append(role: string, content: JsonObject[]) {
+    const last = messages.at(-1);
+    if (last?.role === role) (last.content as JsonObject[]).push(...content);
+    else messages.push({ role, content });
+  }
+  const input = typeof body.input === "string" ? [{ role: "user", content: body.input }] : list(body.input, "input");
+  for (const value of input) {
+    const item = object(value, "input[]");
+    if (item.type === "function_call") {
+      append("assistant", [{ type: "tool_use", id: string(item.call_id, "call_id"), name: string(item.name, "name"), input: parseArguments(item.arguments) }]);
+    } else if (item.type === "function_call_output") {
+      append("user", [{ type: "tool_result", tool_use_id: string(item.call_id, "call_id"), content: typeof item.output === "string" ? item.output : toAnthropicContent(item.output) }]);
+    } else if (item.type === "message" || item.type === undefined) {
+      const content = toAnthropicContent(item.content);
+      if (item.role === "system" || item.role === "developer") {
+        if (messages.length) unsupported("system/developer after conversation messages");
+        if (content.some(block => block.type !== "text")) unsupported("system.image");
+        system.push(...content);
+      } else if (item.role === "user" || item.role === "assistant") {
+        if (item.role === "assistant" && content.some(block => block.type !== "text")) unsupported("assistant.image");
+        append(item.role, content);
+      } else unsupported(`input.role.${item.role}`);
+    } else unsupported(`input.${item.type}`);
+  }
+  const result: JsonObject = { model: string(body.model, "model"), max_tokens: outputLimit(body.max_output_tokens ?? options.maxTokens), stream: body.stream === true, ...(system.length ? { system } : {}), messages };
+  for (const key of ["temperature", "top_p"]) if (body[key] != null) result[key] = body[key];
+  if (body.tools != null) result.tools = list(body.tools, "tools").map(value => {
+    const tool = object(value, "tools[]");
+    if (tool.type !== "function") unsupported(`tools.${tool.type}`);
+    if (tool.strict === true) unsupported("tools.strict");
+    checkFields(tool, ["type", "name", "description", "parameters", "strict"], "tools");
+    return { name: string(tool.name, "tools.name"), ...(tool.description != null ? { description: tool.description } : {}), input_schema: object(tool.parameters ?? { type: "object", properties: {} }, "tools.parameters") };
+  });
+  if (body.tool_choice != null || body.parallel_tool_calls === false) {
+    const choice = body.tool_choice ?? "auto";
+    const mapped = typeof choice === "string" ? { type: choice === "required" ? "any" : ["auto", "none"].includes(choice) ? choice : unsupported("tool_choice") }
+      : object(choice).type === "function" ? { type: "tool", name: string(object(choice).name, "tool_choice.name") } : unsupported("tool_choice.type");
+    result.tool_choice = { ...mapped, ...(body.parallel_tool_calls === false && mapped.type !== "none" ? { disable_parallel_tool_use: true } : {}) };
+  }
+  return result;
+}
+
+/** Direct ordered item conversion: no Chat tool-message/text projection. */
+export function anthropicToResponses(body: JsonObject, options: ConversionOptions = {}): JsonObject {
+  checkFields(body, ["model", "messages", "system", "max_tokens", "stream", "temperature", "top_p", "tools", "tool_choice"]);
+  const input: JsonObject[] = [];
+  if (body.system != null) input.push({ type: "message", role: "system", content: toResponsesContent(body.system, false, options) });
+  for (const value of list(body.messages, "messages")) {
+    const message = object(value, "messages[]");
+    if (message.role !== "user" && message.role !== "assistant") unsupported(`messages.role.${message.role}`);
+    const content = typeof message.content === "string" ? [{ type: "text", text: message.content }] : list(message.content, "content");
+    let pending: unknown[] = [];
+    const flush = () => { if (pending.length) { input.push({ type: "message", role: message.role, content: toResponsesContent(pending, message.role === "assistant", options) }); pending = []; } };
+    for (const raw of content) {
+      const block = object(raw, "content[]");
+      if (block.type !== "tool_use" && block.type !== "tool_result") { pending.push(block); continue; }
+      flush(); acknowledgeCache(block, options);
+      if (block.type === "tool_use") {
+        if (message.role !== "assistant") unsupported("user.tool_use");
+        input.push({ type: "function_call", call_id: string(block.id, "tool_use.id"), name: string(block.name, "tool_use.name"), arguments: JSON.stringify(object(block.input, "tool_use.input")) });
+      } else {
+        if (message.role !== "user") unsupported("assistant.tool_result");
+        if (block.is_error === true) unsupported("tool_result.is_error");
+        input.push({ type: "function_call_output", call_id: string(block.tool_use_id, "tool_result.tool_use_id"), output: typeof block.content === "string" ? block.content : toResponsesContent(block.content ?? [], false, options) });
+      }
+    }
+    flush();
+  }
+  const result: JsonObject = { model: string(body.model, "model"), input, stream: body.stream === true, store: false };
+  if (body.max_tokens != null) result.max_output_tokens = outputLimit(body.max_tokens);
+  for (const key of ["temperature", "top_p"]) if (body[key] != null) result[key] = body[key];
+  if (body.tools != null) result.tools = list(body.tools, "tools").map(value => {
+    const tool = object(value, "tools[]");
+    acknowledgeCache(tool, options);
+    checkFields(tool, ["name", "description", "input_schema", "cache_control"], "tools");
+    return { type: "function", name: string(tool.name, "tools.name"), ...(tool.description != null ? { description: tool.description } : {}), parameters: object(tool.input_schema, "tools.input_schema") };
+  });
+  if (body.tool_choice != null) {
+    const choice = object(body.tool_choice, "tool_choice");
+    result.tool_choice = choice.type === "any" ? "required" : choice.type === "tool" ? { type: "function", name: string(choice.name, "tool_choice.name") } : choice.type === "auto" || choice.type === "none" ? choice.type : unsupported("tool_choice.type");
+    if (choice.disable_parallel_tool_use === true) result.parallel_tool_calls = false;
+  }
+  return result;
+}
+
+export function anthropicJsonToResponses(body: JsonObject, request: JsonObject = {}): JsonObject {
+  const truncated = body.stop_reason === "max_tokens" || body.stop_reason === "model_context_window_exceeded";
+  if (!truncated && !["end_turn", "stop_sequence", "tool_use"].includes(String(body.stop_reason))) unsupported(`stop_reason.${body.stop_reason}`);
+  const id = string(body.id, "id");
+  const output: JsonObject[] = list(body.content, "content").map((value, index) => {
+    const block = object(value, "content[]");
+    if (block.type === "tool_use") return { type: "function_call", id: `fc_${id}_${index}`, call_id: string(block.id, "tool_use.id"), name: string(block.name, "tool_use.name"), arguments: JSON.stringify(object(block.input, "tool_use.input")), status: truncated ? "incomplete" : "completed" };
+    return { type: "message", id: `msg_${id}_${index}`, role: "assistant", content: toResponsesContent([block], true, {}), status: truncated ? "incomplete" : "completed" };
+  });
+  const usage = convertUsage(body.usage, "anthropic", "responses");
+  return { id, object: "response", created_at: Math.floor(Date.now() / 1000), status: truncated ? "incomplete" : "completed", error: null, incomplete_details: truncated ? { reason: "max_output_tokens" } : null, model: string(body.model, "model"), output,
+    instructions: request.instructions ?? null, max_output_tokens: request.max_output_tokens ?? null,
+    parallel_tool_calls: request.parallel_tool_calls ?? true, tool_choice: request.tool_choice ?? "auto", tools: request.tools ?? [],
+    temperature: request.temperature ?? null, top_p: request.top_p ?? null,
+    previous_response_id: null, store: false, metadata: {}, ...(usage ? { usage } : {}),
+  };
+}
+
+export function responsesJsonToAnthropic(body: JsonObject): JsonObject {
+  if (body.status === "failed") throw new ProtocolError(String(object(body.error ?? {}).message ?? "Upstream response failed"), undefined, 502);
+  if (body.status !== "completed" && body.status !== "incomplete") unsupported(`status.${body.status}`);
+  const content: JsonObject[] = [];
+  for (const value of list(body.output, "output")) {
+    const item = object(value, "output[]");
+    if (item.type === "function_call") content.push({ type: "tool_use", id: string(item.call_id, "call_id"), name: string(item.name, "name"), input: parseArguments(item.arguments) });
+    else if (item.type === "message") {
+      if (item.role !== "assistant") unsupported(`output.role.${item.role}`);
+      content.push(...toAnthropicContent(item.content));
+    } else unsupported(`output.${item.type}`);
+  }
+  const incomplete = body.status === "incomplete";
+  const reason = incomplete ? object(body.incomplete_details, "incomplete_details").reason : undefined;
+  if (incomplete && reason !== "max_output_tokens") unsupported(`incomplete_details.${reason}`);
+  const usage = convertUsage(body.usage, "responses", "anthropic");
+  return { id: string(body.id, "id"), type: "message", role: "assistant", model: string(body.model, "model"), content, stop_reason: incomplete ? "max_tokens" : content.some(part => part.type === "tool_use") ? "tool_use" : "end_turn", stop_sequence: null, ...(usage ? { usage } : {}) };
+}

--- a/MemoryProxy/src/protocol/stream.ts
+++ b/MemoryProxy/src/protocol/stream.ts
@@ -1,0 +1,272 @@
+import { convertUsage, createSseDecoder, list, object, parseArguments, ProtocolError, sseFrame, string, unsupported, type JsonObject, type SseFrame, type WireProtocol } from "./common.js";
+
+interface Item {
+  kind: "text" | "tool";
+  index: number;
+  toolIndex: number;
+  id: string;
+  name: string;
+  text: string;
+  closed: boolean;
+}
+export interface StreamOptions {
+  request?: JsonObject;
+  /** Cumulative, raw upstream usage. Never account against the converted schema. */
+  onUsage?: (usage: JsonObject) => void;
+  maxOutputChars?: number;
+}
+
+/** Ordered content events are mapped directly, without a Chat-message intermediate. */
+export function convertSse(source: ReadableStream<Uint8Array>, from: WireProtocol, to: WireProtocol, options: StreamOptions = {}): ReadableStream<Uint8Array> {
+  if (from === to) return source;
+  let id = "";
+  let model = "";
+  let started = false;
+  let ended = false;
+  let reason: string | undefined;
+  let rawUsage: JsonObject | undefined;
+  let sequence = 0;
+  let totalChars = 0;
+  const created = Math.floor(Date.now() / 1000);
+  const items: Item[] = [];
+  const bySource = new Map<string, Item>();
+  const responseMessageIds = new Map<number, string>();
+  let controller: TransformStreamDefaultController<Uint8Array>;
+
+  function emit(event: string | undefined, value: JsonObject | string) {
+    const data = to === "responses" && typeof value !== "string" ? { ...value, sequence_number: sequence++ } : value;
+    controller.enqueue(sseFrame(event, data));
+  }
+  function chat(delta: JsonObject, finish: string | null = null) {
+    emit(undefined, { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta, finish_reason: finish }] });
+  }
+  function snapshot(status: string, error: JsonObject | null = null): JsonObject {
+    const output = items.map(item => item.kind === "text"
+      ? { type: "message", id: item.id, role: "assistant", content: [{ type: "output_text", text: item.text, annotations: [] }], status: status === "incomplete" ? "incomplete" : item.closed ? "completed" : "in_progress" }
+      : { type: "function_call", id: `fc_${item.index}_${id}`, call_id: item.id, name: item.name, arguments: item.text, status: status === "incomplete" ? "incomplete" : item.closed ? "completed" : "in_progress" });
+    return { id, object: "response", created_at: created, model, status, output, error,
+      incomplete_details: status === "incomplete" ? { reason: "max_output_tokens" } : null,
+      usage: convertUsage(rawUsage, from, "responses") ?? null,
+      instructions: options.request?.instructions ?? null, tools: options.request?.tools ?? [],
+      tool_choice: options.request?.tool_choice ?? "auto", parallel_tool_calls: options.request?.parallel_tool_calls ?? true,
+      max_output_tokens: options.request?.max_output_tokens ?? null, store: false, previous_response_id: null, metadata: {},
+    };
+  }
+  function fail(message: string) {
+    if (ended) return;
+    if (to === "anthropic") emit("error", { type: "error", error: { type: "api_error", message } });
+    else if (to === "chat") emit(undefined, { error: { message, type: "server_error", code: "protocol_conversion_error" } });
+    else emit("response.failed", { type: "response.failed", response: snapshot("failed", { code: "server_error", message }) });
+    ended = true;
+    controller.terminate();
+  }
+  function usage(value: unknown) {
+    if (value == null) return;
+    rawUsage = { ...rawUsage, ...object(value, "usage") };
+    // Validate even when the caller does not request usage in client-facing events.
+    convertUsage(rawUsage, from, to);
+    options.onUsage?.(structuredClone(rawUsage));
+  }
+  function start(sourceId: unknown, sourceModel: unknown) {
+    if (started) return;
+    id = string(sourceId, "stream.id"); model = string(sourceModel, "stream.model"); started = true;
+    if (to === "anthropic") emit("message_start", { type: "message_start", message: { id, type: "message", role: "assistant", model, content: [], stop_reason: null, stop_sequence: null,
+      // Messages requires initial counters; later cumulative snapshots replace these.
+      usage: { input_tokens: 0, output_tokens: 0, ...convertUsage(rawUsage, from, "anthropic") },
+    } });
+    else if (to === "chat") chat({ role: "assistant", content: "" });
+    else emit("response.created", { type: "response.created", response: snapshot("in_progress") });
+  }
+  function get(key: string): Item {
+    const item = bySource.get(key);
+    if (!item) throw new ProtocolError(`Delta for unknown content item ${key}`, undefined, 502);
+    return item;
+  }
+  function add(key: string, kind: Item["kind"], callId = "", name = ""): Item {
+    if (!started || bySource.has(key)) throw new ProtocolError("Invalid stream content start", undefined, 502);
+    const item: Item = { kind, index: items.length, toolIndex: items.filter(item => item.kind === "tool").length, id: kind === "tool" ? callId : `msg_${id}_${items.length}`, name, text: "", closed: false };
+    if (kind === "tool" && (!callId || !name)) throw new ProtocolError("Tool stream requires a complete call ID and name before arguments", undefined, 502);
+    bySource.set(key, item); items.push(item);
+    if (to === "anthropic") emit("content_block_start", { type: "content_block_start", index: item.index, content_block: kind === "text" ? { type: "text", text: "" } : { type: "tool_use", id: item.id, name, input: {} } });
+    else if (to === "chat" && kind === "tool") chat({ tool_calls: [{ index: item.toolIndex, id: item.id, type: "function", function: { name, arguments: "" } }] });
+    else if (to === "responses") {
+      const output = (snapshot("in_progress").output as JsonObject[])[item.index];
+      emit("response.output_item.added", { type: "response.output_item.added", output_index: item.index, item: kind === "text" ? { ...output, content: [] } : output });
+      if (kind === "text") emit("response.content_part.added", { type: "response.content_part.added", item_id: item.id, output_index: item.index, content_index: 0, part: { type: "output_text", text: "", annotations: [] } });
+    }
+    return item;
+  }
+  function delta(item: Item, value: unknown) {
+    const text = string(value, "stream.delta");
+    if (item.closed) throw new ProtocolError("Delta received after content end", undefined, 502);
+    totalChars += text.length;
+    // Responses terminal events contain full output: retain it with an explicit ceiling.
+    if (totalChars > (options.maxOutputChars ?? 16 * 1024 * 1024)) throw new ProtocolError("Converted stream output exceeds limit", undefined, 502);
+    item.text += text;
+    if (to === "anthropic") emit("content_block_delta", { type: "content_block_delta", index: item.index, delta: item.kind === "text" ? { type: "text_delta", text } : { type: "input_json_delta", partial_json: text } });
+    else if (to === "chat") chat(item.kind === "text" ? { content: text } : { tool_calls: [{ index: item.toolIndex, function: { arguments: text } }] });
+    else {
+      const type = item.kind === "text" ? "response.output_text.delta" : "response.function_call_arguments.delta";
+      emit(type, { type, item_id: item.kind === "text" ? item.id : `fc_${item.index}_${id}`, output_index: item.index, ...(item.kind === "text" ? { content_index: 0, logprobs: [] } : {}), delta: text });
+    }
+  }
+  function close(item: Item) {
+    if (item.closed) return;
+    item.closed = true;
+    if (to === "anthropic") emit("content_block_stop", { type: "content_block_stop", index: item.index });
+    else if (to === "responses") {
+      if (item.kind === "text") {
+        emit("response.output_text.done", { type: "response.output_text.done", item_id: item.id, output_index: item.index, content_index: 0, text: item.text, logprobs: [] });
+        emit("response.content_part.done", { type: "response.content_part.done", item_id: item.id, output_index: item.index, content_index: 0, part: { type: "output_text", text: item.text, annotations: [] } });
+      } else emit("response.function_call_arguments.done", { type: "response.function_call_arguments.done", item_id: `fc_${item.index}_${id}`, output_index: item.index, name: item.name, arguments: item.text });
+    }
+  }
+  function finish() {
+    if (ended) return;
+    if (!started || !reason) throw new ProtocolError("Upstream stream ended without a model terminal event", undefined, 502);
+    if (!["end_turn", "stop_sequence", "tool_use", "max_tokens", "model_context_window_exceeded"].includes(reason)) unsupported(`stream.stop_reason.${reason}`);
+    const incomplete = reason === "max_tokens" || reason === "model_context_window_exceeded";
+    for (const item of items) {
+      if (item.kind === "tool" && !incomplete) parseArguments(item.text || "{}");
+      close(item);
+    }
+    const converted = convertUsage(rawUsage, from, to);
+    if (to === "anthropic") {
+      emit("message_delta", { type: "message_delta", delta: { stop_reason: incomplete ? "max_tokens" : reason, stop_sequence: null }, usage: { output_tokens: 0, ...converted } });
+      emit("message_stop", { type: "message_stop" });
+    } else if (to === "chat") {
+      chat({}, incomplete ? "length" : reason === "tool_use" ? "tool_calls" : "stop");
+      if (converted) emit(undefined, { id, object: "chat.completion.chunk", created, model, choices: [], usage: converted });
+      emit(undefined, "[DONE]");
+    } else {
+      const response = snapshot(incomplete ? "incomplete" : "completed");
+      for (const item of items) emit("response.output_item.done", { type: "response.output_item.done", output_index: item.index, item: (response.output as JsonObject[])[item.index] });
+      const type = incomplete ? "response.incomplete" : "response.completed";
+      emit(type, { type, response });
+    }
+    ended = true;
+  }
+  function readChat(data: JsonObject) {
+    if (data.error) { fail(String(object(data.error).message ?? "Upstream error")); return; }
+    usage(data.usage);
+    start(data.id, data.model);
+    const choices = list(data.choices, "choices");
+    if (choices.length > 1) unsupported("stream.choices");
+    for (const value of choices) {
+      const choice = object(value, "choice");
+      if (choice.index !== 0) unsupported("stream.choice.index");
+      const part = object(choice.delta ?? {}, "delta");
+      if (part.refusal || part.reasoning_content) unsupported("stream.reasoning/refusal");
+      if (part.content != null && part.content !== "") {
+        const key = `text:${items.filter(item => item.kind === "tool").length}`;
+        delta(bySource.get(key) ?? add(key, "text"), part.content);
+      }
+      for (const value of list(part.tool_calls ?? [], "delta.tool_calls")) {
+        const call = object(value, "tool_call");
+        if (!Number.isInteger(call.index)) unsupported("tool_call.index");
+        const key = `tool:${call.index}`;
+        const fn = object(call.function ?? {}, "tool_call.function");
+        let item = bySource.get(key);
+        if (!item) item = add(key, "tool", string(call.id, "tool_call.id"), string(fn.name, "function.name"));
+        else if ((call.id != null && call.id !== item.id) || (fn.name != null && fn.name !== item.name)) unsupported("fragmented tool name/id after start");
+        if (fn.arguments != null && fn.arguments !== "") delta(item, fn.arguments);
+      }
+      if (choice.finish_reason != null) reason = choice.finish_reason === "stop" ? "end_turn" : choice.finish_reason === "length" ? "max_tokens" : choice.finish_reason === "tool_calls" ? "tool_use" : String(choice.finish_reason);
+    }
+  }
+  function readAnthropic(data: JsonObject) {
+    const type = data.type;
+    if (type === "ping") return;
+    if (type === "error") { fail(String(object(data.error).message ?? "Upstream error")); return; }
+    if (type === "message_start") {
+      const message = object(data.message, "message"); usage(message.usage); start(message.id, message.model); return;
+    }
+    if (type === "content_block_start") {
+      const block = object(data.content_block, "content_block");
+      if (block.type !== "text" && block.type !== "tool_use") unsupported(`stream.${block.type}`);
+      const item = add(String(data.index), block.type === "text" ? "text" : "tool", block.type === "tool_use" ? string(block.id, "tool_use.id") : "", block.type === "tool_use" ? string(block.name, "tool_use.name") : "");
+      if (block.type === "text" && block.text) delta(item, block.text);
+      if (block.type === "tool_use" && Object.keys(object(block.input ?? {}, "tool_use.input")).length) delta(item, JSON.stringify(block.input));
+      return;
+    }
+    if (type === "content_block_delta") {
+      const part = object(data.delta, "delta");
+      if (part.type !== "text_delta" && part.type !== "input_json_delta") unsupported(`stream.${part.type}`);
+      const item = get(String(data.index));
+      if ((item.kind === "text") !== (part.type === "text_delta")) throw new ProtocolError("Mismatched content delta type", undefined, 502);
+      delta(item, part.type === "text_delta" ? part.text : part.partial_json); return;
+    }
+    if (type === "content_block_stop") { close(get(String(data.index))); return; }
+    if (type === "message_delta") { usage(data.usage); reason = string(object(data.delta).stop_reason, "stop_reason"); return; }
+    if (type === "message_stop") { finish(); return; }
+    unsupported(`stream.event.${type}`);
+  }
+  function readResponses(data: JsonObject) {
+    const type = String(data.type);
+    if (type === "response.failed" || type === "error") {
+      const error = type === "response.failed" ? object(object(data.response, "response").error, "response.error") : data;
+      fail(String(error.message ?? "Upstream response failed")); return;
+    }
+    if (type === "response.created") { const response = object(data.response); start(response.id, response.model); usage(response.usage); return; }
+    if (type === "response.in_progress") return;
+    const index = data.output_index;
+    if (type === "response.output_item.added") {
+      const item = object(data.item, "item");
+      if (item.type === "message" && item.role === "assistant") responseMessageIds.set(Number(index), string(item.id, "item.id"));
+      else if (item.type === "function_call") {
+        const added = add(`tool:${index}`, "tool", string(item.call_id, "call_id"), string(item.name, "name"));
+        if (item.arguments) delta(added, item.arguments);
+      } else unsupported(`stream.output.${item.type}`);
+      return;
+    }
+    if (type === "response.content_part.added") {
+      if (!responseMessageIds.has(Number(index))) throw new ProtocolError("Content part without output message", undefined, 502);
+      const part = object(data.part, "part");
+      if (part.type !== "output_text") unsupported(`stream.part.${part.type}`);
+      const item = add(`text:${index}:${data.content_index}`, "text");
+      if (part.text) delta(item, part.text); return;
+    }
+    if (type === "response.output_text.delta") { delta(get(`text:${index}:${data.content_index}`), data.delta); return; }
+    if (type === "response.function_call_arguments.delta") { delta(get(`tool:${index}`), data.delta); return; }
+    if (type === "response.output_text.done" || type === "response.function_call_arguments.done") {
+      const item = get(type === "response.output_text.done" ? `text:${index}:${data.content_index}` : `tool:${index}`);
+      if (item.text !== (type === "response.output_text.done" ? data.text : data.arguments)) throw new ProtocolError("Terminal content differs from streamed deltas", undefined, 502);
+      close(item); return;
+    }
+    if (type === "response.content_part.done" || type === "response.output_item.done") return;
+    if (type === "response.completed" || type === "response.incomplete") {
+      const response = object(data.response, "response"); usage(response.usage);
+      if (type === "response.incomplete") {
+        if (object(response.incomplete_details).reason !== "max_output_tokens") unsupported("response.incomplete reason");
+        reason = "max_tokens";
+      } else reason = items.some(item => item.kind === "tool") ? "tool_use" : "end_turn";
+      finish(); return;
+    }
+    unsupported(`stream.event.${type}`);
+  }
+  const mapper = new TransformStream<SseFrame, Uint8Array>({
+    transform(frame, target) {
+      controller = target;
+      if (ended) return;
+      try {
+        if (frame.data === "[DONE]") {
+          if (from !== "chat") throw new ProtocolError("Unexpected DONE marker", undefined, 502);
+          finish(); return;
+        }
+        const data = object(JSON.parse(frame.data), "SSE data");
+        if (from === "chat") readChat(data);
+        else if (from === "anthropic") readAnthropic(data);
+        else readResponses(data);
+      } catch (error) { fail(error instanceof Error ? error.message : "Invalid upstream stream"); }
+    },
+    flush(target) {
+      controller = target;
+      if (ended) return;
+      try {
+        if (from === "chat" && reason) finish();
+        else fail("Upstream stream ended without a model terminal event");
+      } catch (error) { fail(error instanceof Error ? error.message : "Invalid upstream stream"); }
+    },
+  });
+  return source.pipeThrough(createSseDecoder()).pipeThrough(mapper);
+}

--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -1,4 +1,14 @@
 /** Shared type definitions for context-proxy. */
+import type { WireProtocol } from "./protocol/common.js";
+
+export interface UpstreamProtocolOptions {
+  /** Omitted preserves the existing same-protocol forwarding behavior. */
+  protocol?: WireProtocol;
+  /** Fallback output budget when converting a request without a limit to Messages. */
+  maxTokens?: number;
+  /** Explicitly allow dropping provider-specific cache breakpoints, with a warning. */
+  allowCacheControlDrop?: boolean;
+}
 
 /**
  * Optional private forwarding extension config.
@@ -405,7 +415,7 @@ export interface SkillRuntimeConfig {
  * alone determines routing, matching how {@link ProxyConfig#upstream.url}
  * itself is protocol-agnostic.
  */
-export interface AgentUpstreamEntry {
+export interface AgentUpstreamEntry extends UpstreamProtocolOptions {
   /** Target upstream base URL. Required. */
   url: string;
   /**
@@ -427,7 +437,7 @@ export interface ProxyConfig {
     /** Upstream forward timeout in ms. 0 = no timeout. Default: 600_000 (10 min). */
     forwardTimeoutMs?: number;
   };
-  upstream: {
+  upstream: UpstreamProtocolOptions & {
     url: string; // OpenAI-compatible upstream URL
     apiKey: string; // 若非空则替换请求中的 API Key
     /**
@@ -771,11 +781,11 @@ export interface RawYamlConfig {
     port?: number;
     forwardTimeoutMs?: number;
   };
-  upstream?: {
+  upstream?: UpstreamProtocolOptions & {
     url?: string;
     apiKey?: string;
     /** Per-agent override map. See `AgentUpstreamEntry`. */
-    agents?: Record<string, { url?: string; apiKey?: string } | null | undefined>;
+    agents?: Record<string, (UpstreamProtocolOptions & { url?: string; apiKey?: string }) | null | undefined>;
   };
   log?: {
     file?: string;

--- a/MemoryProxy/src/workbuddyHandler.ts
+++ b/MemoryProxy/src/workbuddyHandler.ts
@@ -19,6 +19,8 @@
 
 import type { Context } from "hono";
 import type { ProxyConfig } from "./types.js";
+import { fetchProtocolAttempt, protocolErrorResponse, type ForwardProtocolContext } from "./protocol/forward.js";
+import { ProtocolError } from "./protocol/common.js";
 import { apiKeyToKeyId, extractBearerToken, uuidv7 } from "./opik.js";
 import { createPipeline, writeLog } from "./logger.js";
 import { extractSpaceIdFromPath } from "./credit-reporter.js";
@@ -545,13 +547,23 @@ async function forwardToUpstream(
   }
 
   let upstreamResp: Response;
+  const isInference = /\/responses\/?$/.test(c.req.path);
+  const protocolContext: ForwardProtocolContext | undefined = isInference ? {
+    source: "responses",
+    settings: { ...config.upstream, ...perAgent },
+    defaultUrl: upstreamUrl,
+    request: body,
+    signal: c.req.raw.signal,
+    warn: message => pipe.info("PROTOCOL", message),
+  } : undefined;
   try {
-    upstreamResp = await fetch(upstreamUrl, {
+    upstreamResp = await fetchProtocolAttempt({ url: upstreamUrl, model: modelId }, {
       method: "POST",
       headers,
       body: bodyStr,
-    });
+    }, protocolContext);
   } catch (err) {
+    if (err instanceof ProtocolError) return protocolErrorResponse(err, "responses", err.status);
     const msg = err instanceof Error ? err.message : String(err);
     pipe.info("WORKBUDDY_FORWARD_ERR", msg);
     // 网络层失败 → langfuse failure 上报，让线上可视化能看到


### PR DESCRIPTION
## 背景

MemoryProxy 原先要求客户端和上游使用相同的推理协议。本 PR 支持 OpenAI Chat Completions、OpenAI Responses 与 Anthropic Messages 之间的双向转换；未配置目标协议时，继续保持原有的同协议转发行为。

## 实现内容

- 在原生 Memory 注入完成后转换请求，并将上游 JSON 或 SSE 响应转换回客户端协议。
- 支持有序文本与图片、函数调用及结果、`tool_choice`、并行工具参数分片、停止状态、错误以及 token/cache usage 映射。
- 重试时从已注入但未转换的原始请求重新编码，并按目标协议重建接口地址、认证头和模型。
- 计费使用真实上游协议、模型、URL 和原始 usage，避免使用转换后的客户端计数。
- 通过全局或 per-agent 的 `upstream.protocol` 选择 `chat`、`responses` 或 `anthropic`；`maxTokens` 可在源请求未指定时补充 Messages 输出上限。
- Anthropic cache breakpoint 默认拒绝跨协议丢弃；仅在显式配置 `allowCacheControlDrop: true` 时丢弃并记录警告。

## 范围边界

协议转换仅用于主推理端点，Responses 辅助端点保持原生透传。对于无法可靠保真的签名 thinking/reasoning、有状态或后台 Responses 调用、服务端工具和 strict function schema，返回客户端协议格式的明确 `400` 错误，避免静默丢失数据。

## 验证

- `npm.cmd test`：8 个测试文件，82 项测试全部通过。
- Handler 与 Pipeline 测试覆盖 Chat、Messages、Codex Responses、WorkBuddy Responses、JSON、SSE、认证、辅助端点透传、重试重新编码、Memory 注入后转换、客户端取消和原始 cache token 计费。
- SSE 测试覆盖 UTF-8 跨分片、CR/LF、多行 data、帧大小限制、取消、并行工具参数、失败/截断终态和异常 EOF。
- `git diff --check` 通过。
- 使用同一依赖树执行 `npm.cmd run typecheck`：`feat/server_team@220af62` 有 60 项既有诊断，本提交有 56 项；本 PR 未新增诊断，并修复了变基时涉及的 4 项计费结果类型诊断。

测试使用确定性的 mock upstream，未调用真实模型 API。
