### PR TITLE
fix(proxy): 将 Codex 资产注入 Responses instructions

### DIFF
--- a/MemoryProxy/src/__tests__/codex-handler.test.ts
+++ b/MemoryProxy/src/__tests__/codex-handler.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { injectCodexAssets } from "../codexHandler.js";
+
+const assets = { raw: "<knowledge_tools>wiki fixture</knowledge_tools>" };
+
+describe("injectCodexAssets", () => {
+  it("writes assets to Responses instructions", () => {
+    const input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }];
+
+    const result = injectCodexAssets({ input }, assets);
+
+    expect(result.instructions).toContain("<tdai_injections>");
+    expect(result.instructions).toContain("<knowledge_tools>wiki fixture</knowledge_tools>");
+    expect(result.input).toEqual(input);
+  });
+
+  it("appends assets after existing instructions", () => {
+    const result = injectCodexAssets({ instructions: "Keep existing guidance." }, assets);
+
+    expect(result.instructions).toBe(
+      "Keep existing guidance.\n\n<tdai_injections>\n<knowledge_tools>wiki fixture</knowledge_tools>\n</tdai_injections>",
+    );
+  });
+
+  it("does not depend on the first input item being a message", () => {
+    const input = [{ type: "function_call_output", call_id: "call_1", output: "done" }];
+
+    const result = injectCodexAssets({ input }, assets);
+
+    expect(result.instructions).toContain("<knowledge_tools>wiki fixture</knowledge_tools>");
+    expect(result.input).toEqual(input);
+  });
+});

--- a/MemoryProxy/src/codexHandler.ts
+++ b/MemoryProxy/src/codexHandler.ts
@@ -205,11 +205,7 @@ export function detectDefaultModeGate(input: unknown): boolean {
 // ── Asset injection (exported for unit tests) ────────────────────────────────
 
 /**
- * Inject `<tdai_injections>` wrapper into codex body.input[0].content[].
- *
- * Appends the injection block to the developer message (input[0]) content.
- * Defensive: if input[0] is not a message with an array content, returns
- * the body unchanged.
+ * Inject `<tdai_injections>` into Responses `body.instructions`.
  *
  * Returns a shallow copy — original body is not mutated.
  */
@@ -217,23 +213,9 @@ export function injectCodexAssets(
   body: Record<string, unknown>,
   assets: CodexInjectionInput,
 ): Record<string, unknown> {
-  const input = body.input;
-  if (!Array.isArray(input) || input.length === 0) return body;
-
-  const devMsg = input[0] as Record<string, unknown> | null;
-  if (!devMsg || typeof devMsg !== "object") return body;
-  if (devMsg.type !== "message") return body;
-
-  const content = devMsg.content;
-  if (!Array.isArray(content)) return body;
-
-  const injectionBlock = buildCodexInjectionBlock(assets);
-
-  // Shallow-copy chain: body → input → input[0] → content
-  const newContent = [...content, injectionBlock];
-  const newDevMsg = { ...devMsg, content: newContent };
-  const newInput = [newDevMsg, ...input.slice(1)];
-  return { ...body, input: newInput };
+  const injectionText = buildCodexInjectionBlock(assets).text;
+  const existing = typeof body.instructions === "string" ? body.instructions : "";
+  return { ...body, instructions: existing ? `${existing}\n\n${injectionText}` : injectionText };
 }
 
 // ── Upstream request helpers ─────────────────────────────────────────────────


### PR DESCRIPTION
## 问题

Codex 资产 Hook 能够成功生成 `<tdai_injections>`，但最终 Responses 请求可能没有携带这些内容。原因是 `injectCodexAssets()` 将资产追加到 `input[0].content`，当第一个 input item 不是 message 时会直接返回原请求；而项目的 Codex 接入约定使用顶层 `instructions` 作为系统提示字段。

## 修复

- 将生成的资产注入文本追加到 `body.instructions`。
- 保留请求原有的 instructions。
- 保持 `body.input` 不变。
- 同时支持普通消息请求和首项为 `function_call_output` 的工具续轮请求。

## 验证

- 3 项回归测试在修复前全部失败，修复后全部通过。
- `npm.cmd test`：1 个测试文件，3 项测试全部通过。
- `git diff --check` 通过。
- `npm.cmd run typecheck` 与 `feat/server_team@220af62` 均为相同的 60 项既有诊断，本 PR 未新增类型诊断。

Fixes #1231
