### PR TITLE
fix(l1): don't advance cursor when L1 extraction fails

### DIFF
--- a/MemoryCore/src/utils/pipeline-factory.ts
+++ b/MemoryCore/src/utils/pipeline-factory.ts
@@ -587,6 +587,7 @@ export function createL1Runner(opts: {
 
       let totalExtracted = 0;
       let totalStored = 0;
+      let anyExtractionFailed = false;
       let lastSceneName: string | undefined;
       const profileScopes = new Set<string>();
       const l1PromptTargets = groups.map((group) => ({
@@ -633,6 +634,11 @@ export function createL1Runner(opts: {
           storage,
         });
 
+        // Track extraction failures (e.g. LLM 429/error). extractL1Memories returns
+        // success:false on failure (it does not throw), so without this the batch's
+        // cursor would still advance below and silently skip the un-extracted L0.
+        if (!l1Result.success) anyExtractionFailed = true;
+
         totalExtracted += l1Result.extractedCount;
         totalStored += l1Result.storedCount;
         if (l1Result.storedCount > 0) {
@@ -650,6 +656,19 @@ export function createL1Runner(opts: {
         if (l1Result.lastSceneName) {
           lastSceneName = l1Result.lastSceneName;
         }
+      }
+
+      // If any group's L1 extraction failed (e.g. LLM 429/error), do NOT advance
+      // the cursor: doing so would move it past L0 rows that were never distilled,
+      // permanently skipping them. Instead leave the cursor untouched and signal
+      // retry (hasMore), so the batch is reprocessed once the LLM recovers. Dedup
+      // (enableDedup) makes reprocessing idempotent for any records already stored.
+      if (anyExtractionFailed) {
+        logger.warn(
+          `${TAG} [l1] extraction failed for ≥1 group; cursor NOT advanced (will retry). ` +
+          `session=${sessionKey}, stored=${totalStored}`,
+        );
+        return { processedCount: totalMessages, storedCount: totalStored, hasMore: true, hasFullBacklog: false, profileScopes: Array.from(profileScopes) };
       }
 
       // Use maxRecordedAtMs (write time) of the **processed** slice as cursor —


### PR DESCRIPTION
## Problem
`createL1Runner` (pipeline-factory) advances the per-session L1 cursor via `markL1ExtractionComplete(sessionKey, totalStored, maxRecordedAtMs, ...)` **unconditionally** after the group loop.

`extractL1Memories` returns `{ success: false }` on LLM failure (e.g. HTTP 429 / timeout) rather than throwing. So when extraction fails, the cursor still advances to `maxRecordedAtMs` of the fetched slice — moving past L0 rows that were never distilled. Those rows sit below the cursor and are never re-fetched, so they are **silently and permanently skipped**.

This is easy to hit during backfill / high-throughput distillation when the LLM endpoint rate-limits: a burst of failed batches quietly drops large spans of L0 from ever being distilled into L1/L2/L3.

## Fix
Track `anyExtractionFailed` across the group loop. If any group failed, skip `markL1ExtractionComplete` (leave the cursor untouched) and return `hasMore: true` so the batch is retried once the LLM recovers. `enableDedup` keeps reprocessing idempotent for records already stored in a partially-successful batch.

## Impact
- No behavior change on the success path.
- On failure: cursor no longer advances past un-distilled rows; the batch is retried instead of skipped.

## Testing (runtime-verified)
1. **Bug reproduced** (unpatched): under sustained LLM 429s, batches complete with `extracted=0` while the cursor still advances, and the underlying L0 is never distilled — a large fraction of sessions were skipped this way during a backfill.
2. **Fix verified live** (patched build deployed): forced sustained 429s from the LLM endpoint, then triggered L1 on a fresh session whose two L0 rows have an old `recorded_at`. With the fix:
   - the session cursor stayed at `0` (did **not** advance to the rows' `recorded_at`);
   - log: `L1] extraction failed for ≥1 group; cursor NOT advanced (will retry). session=…, stored=0`;
   - concurrently, other in-flight sessions hit by the same 429 were likewise held (no skip). Restoring the LLM lets the held batches distill on the next retry.

Reviewers: please flag if you would prefer per-record partial-advance over whole-batch retry.