### PR TITLE
feat(recall): deepen RRF candidate pool for L1 hybrid search

### DIFF
--- a/MemoryCore/src/core/hooks/auto-recall.ts
+++ b/MemoryCore/src/core/hooks/auto-recall.ts
@@ -653,7 +653,12 @@ async function searchHybrid(
   embeddingCallOpts?: EmbeddingCallOptions,
 ): Promise<SearchResult> {
   // Run keyword and embedding searches in parallel
-  const candidateK = maxResults * 3; // retrieve more for merging
+  // Over-fetch a deeper candidate pool before RRF merge. With only maxResults*3
+  // (=15 at the default), a specific/rare match (e.g. one memory naming a
+  // particular entity) can fall outside both the FTS and vector candidate lists
+  // for a broad multi-term query and never enter the fusion. A larger pool keeps
+  // such matches eligible without materially changing the top-N output.
+  const candidateK = Math.max(50, maxResults * 10);
 
   const [keywordResult, embeddingResult] = await Promise.all([
     // Keyword search: FTS5 only (no in-memory fallback)

--- a/MemoryCore/src/core/tools/memory-search.ts
+++ b/MemoryCore/src/core/tools/memory-search.ts
@@ -131,7 +131,10 @@ export async function executeMemorySearch(params: {
     };
   }
 
-  const candidateK = limit * 3;
+  // Over-fetch a deeper candidate pool before RRF merge (see rationale in
+  // auto-recall.ts): a small pool can drop specific/rare matches for broad
+  // multi-term queries before fusion. Keep both call sites aligned.
+  const candidateK = Math.max(50, limit * 10);
   const recalled = await recallL1Candidates({
     query,
     topK: candidateK,


### PR DESCRIPTION
## Problem
Both L1 hybrid-search paths — `searchHybrid` in auto-recall and the `tdai_memory_search` tool — retrieve only `N * 3` candidates from FTS and from vector search before RRF fusion (= 15 at the default `maxResults`/`limit` of 5).

For a broad multi-term query, a specific or rare match (e.g. the single L1 memory that names a particular entity) can fall outside **both** the FTS top-15 and the vector top-15, so it never enters the RRF merge and never surfaces — even though it exists and clearly matches. Increasing `maxResults` alone does not help, because the candidate pool is the limiting factor.

## Fix
Deepen the candidate pool to `max(50, N * 10)` at both call sites. This keeps specific/rare matches eligible for fusion while leaving the top-N output essentially unchanged for common queries. The two sites are kept aligned.

## Notes
- Low risk: only widens the pre-fusion candidate set; ranking/threshold logic unchanged.
- Could instead be exposed as a config option (e.g. `recall.candidatePoolSize`) if the maintainers prefer that over a constant — happy to follow up.