### PR TITLE
fix(panel): 修复分配记忆弹窗空 Agent 提示竖排

### DIFF
--- a/MemoryPanel/web/src/pages/ChatMemoryPage/components/AllocateMemoryDialog.tsx
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/components/AllocateMemoryDialog.tsx
@@ -50,25 +50,25 @@ export function AllocateMemoryDialog({
       <Modal.Body>
         <Form>
           <Form.Item label={t('allocMemory.descLabel')}><Form.Text>{description}</Form.Text></Form.Item>
-          {agents.length === 0 ? (
-            <div className="_alloc-memory-alert">
-              <Alert type="warning">
-                {t('allocMemory.noAgents')}
-                <br />
-                {t('allocMemory.noAgents.reason1')}
-                <br />
-                {t('allocMemory.noAgents.reason2')}
-                <br />
-                {t('allocMemory.noAgents.reason3')}
-              </Alert>
-            </div>
-          ) : (
+          {agents.length > 0 && (
             <Form.Item label={t('allocMemory.agent')} required>
               <Select size="full" value={agentId} onChange={setAgentId} placeholder={t('allocMemory.agent.placeholder')}
                 options={agents.map((a) => ({ value: a.agent_id, text: a.name }))} />
             </Form.Item>
           )}
         </Form>
+        {/* Keep the full-width warning outside Form's table layout and label column. */}
+        {agents.length === 0 && (
+          <Alert type="warning" className="_alloc-memory-alert">
+            {t('allocMemory.noAgents')}
+            <br />
+            {t('allocMemory.noAgents.reason1')}
+            <br />
+            {t('allocMemory.noAgents.reason2')}
+            <br />
+            {t('allocMemory.noAgents.reason3')}
+          </Alert>
+        )}
       </Modal.Body>
       <Modal.Footer>
         <Button type="primary" onClick={() => void submit()} disabled={!agentId || submitting} loading={submitting}>{t('allocMemory.submit')}</Button>

--- a/MemoryPanel/web/src/pages/ChatMemoryPage/styles/allocate-memory-dialog.css
+++ b/MemoryPanel/web/src/pages/ChatMemoryPage/styles/allocate-memory-dialog.css
@@ -1,28 +1,3 @@
-/**
- * 分配记忆块到 Agent 弹窗样式。
- *
- * 修复：无可分配 Agent 时的警告文案被压成「每行一个字」的竖排。
- * 根因是 Alert 作为 Form 的非 Form.Item 子级时未拿到父级宽度，
- * 内容容器宽度塌陷为 0，长文本被迫逐字换行。
- * 这里给 Alert 包裹层与内部文本容器显式声明块级+ 100% 宽度，恢复正常横排。
- */
-
 ._alloc-memory-alert {
-  width: 100%;
-}
-
-._alloc-memory-alert .tea-alert {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-/* Tea Alert 采用 flex（图标 __decoration + 内容 __info），
-   内容列需 min-width:0 + flex:1 才不会塌陷成逐字竖排 */
-._alloc-memory-alert .tea-alert__info {
-  flex: 1;
-  min-width: 0;
-  width: auto;
-  white-space: normal;
-  word-break: break-word;
-  line-height: 1.6;
+  margin-top: 16px;
 }


### PR DESCRIPTION
## Description | 描述

修复 Chat_Memory「分配记忆块到 Agent」弹窗在没有可分配 Agent 时，警告文案逐字竖排、弹窗超出屏幕且底部按钮不可见的问题。

Tea Form 使用 CSS table 布局。原先将警告 div 直接作为 Form 子节点，会让它落入匿名表格单元格并被限制在标签列；对子元素设置 `width: 100%` 无法解除这个限制。将 Alert 移为 Form 的同级节点，使其使用弹窗正文完整宽度，并以 16px 间距分隔说明与警告。移除失效的宽度及内部文本样式补丁。

在 1440 × 900 的本地复现中，中文警告由 106 × 2524px 恢复为 370 × 174px，正常换行，底部按钮完整可见。

## Screenshots | 修复前后截图

以下为真实 AllocateMemoryDialog 组件在相同 **1280 × 720** 视口、相同示例数据（`agents=[]`）下的截图，加载项目实际主题及全局样式。

### Before | 修复前

警告被挤入窄列，文字逐字换行；弹窗超出视口，底部操作按钮不可见。

![修复前：警告逐字竖排，底部按钮超出视口](https://github.com/user-attachments/assets/b08ea233-448f-406b-be40-22723c4e89a8)

### After | 修复后

警告使用正文完整宽度并正常换行；弹窗恢复正常高度，禁用的「分配」及可点击的「取消」完整可见。

![修复后：警告正常换行，底部按钮完整可见](https://github.com/user-attachments/assets/3469d6fd-cc39-4ce7-a4f3-2b1241304039)

## Related Issue | 关联 Issue

用户提供的弹窗截图，无关联 Issue。

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能（下述组件范围内验证）

验证结果：
- `MemoryPanel/web`: `npm run build` 通过（TypeScript + Vite）。
- 修改组件 ESLint、CSS Prettier 和 `git diff --check` 通过。
- 临时浏览器验证页面渲染真实 AllocateMemoryDialog，并加载项目实际主题及全局样式；修复前确认警告宽度塌陷和高度超限，修复后相同检查通过。
- 12 个空状态组合通过：中文/英文 × 团队/个人记忆 × 1440/768/480px 视口。验证警告占满正文宽度、文本不横向溢出、按钮在视口内、分配禁用且取消回调正常。
- 4 个非空状态组合通过：中文/英文 × 团队/个人记忆。验证 Agent 正常显示，点击分配传入正确 Agent ID。

## Additional Notes | 其他说明

本次仅调整弹窗结构及局部间距，未修改 Agent 筛选或后端分配逻辑。浏览器验证使用临时组件页面，未连接后端；验证页面未包含在提交中。构建仍提示现有的混合静态/动态导入和 bundle 体积警告。
