### PR TITLE
fix(proxy): 修复未关联任务时虚拟 Task 的持久化与恢复

### DIFF
--- a/MemoryProxy/src/db/__tests__/binding-repo.test.ts
+++ b/MemoryProxy/src/db/__tests__/binding-repo.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "vitest";
+import type { Redis } from "ioredis";
+import { RedisBindingRepo } from "../binding-repo.js";
+
+it("replacing a binding without a task removes a previously stored Redis task", async () => {
+  const fields: Record<string, string> = {};
+  const redis = {
+    hgetall: async () => ({ ...fields }),
+    multi() {
+      const operations: Array<() => void> = [];
+      const tx = {
+        hset(_key: string, values: Record<string, string>) { operations.push(() => Object.assign(fields, values)); return tx; },
+        hdel(_key: string, name: string) { operations.push(() => { delete fields[name]; }); return tx; },
+        expire() { return tx; },
+        async exec() { operations.forEach((op) => op()); return []; },
+      };
+      return tx;
+    },
+  };
+  const repo = new RedisBindingRepo(redis as unknown as Redis);
+  const base = { outcome: "initialized" as const, userId: "user", teamId: "team", agentId: "agent" };
+  await repo.putBinding("space", "session", { ...base, taskId: "default" });
+  expect((await repo.getBinding("space", "session"))?.taskId).toBe("default");
+  await repo.putBinding("space", "session", base);
+  expect((await repo.getBinding("space", "session"))?.taskId).toBeUndefined();
+  expect((await repo.getBinding("space", "session"))?.agentId).toBe("agent");
+  await repo.putBinding("space", "session", { ...base, taskId: "real" });
+  expect((await repo.getBinding("space", "session"))?.taskId).toBe("real");
+});

--- a/MemoryProxy/src/db/binding-repo.ts
+++ b/MemoryProxy/src/db/binding-repo.ts
@@ -96,8 +96,10 @@ export class RedisBindingRepo implements BindingRepo {
       if (binding.userKey) fields.user_key = binding.userKey;
 
       const key = redisKey(spaceId, sessionId);
-      await this.redis.hset(key, fields);
-      await this.redis.expire(key, ttlSeconds(this.bindingTtlDays));
+      // HSET does not remove omitted fields; clear a dropped task atomically.
+      const update = this.redis.multi().hset(key, fields);
+      if (!binding.taskId) update.hdel(key, "task_id");
+      await update.expire(key, ttlSeconds(this.bindingTtlDays)).exec();
     } catch {
       /* ignore */
     }

--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -20,6 +20,7 @@
  *   - v3 strict isolation: 强制注入 session_id，满足 L0/L1 必填要求
  */
 
+import { normalizeTaskId } from "../session/task.js";
 import type { Context } from "hono";
 import { getSessionStore } from "../session/store.js";
 import type { BindingRepo } from "../db/binding-repo.js";
@@ -164,11 +165,19 @@ async function loadSessionIdsL2(
   bindingRepo: BindingRepo | null,
   spaceId: string,
   sessionId: string,
+  defaultTaskId: string | undefined,
 ): Promise<SessionIdFields | null> {
   if (!bindingRepo) return null;
   try {
-    const binding = await bindingRepo.getBinding(spaceId, sessionId);
+    let binding = await bindingRepo.getBinding(spaceId, sessionId);
     if (!binding) return null;
+    const taskId = normalizeTaskId(binding.taskId, defaultTaskId);
+    if (taskId !== binding.taskId) {
+      binding = { ...binding, taskId };
+      await bindingRepo.putBinding(spaceId, sessionId, binding).catch((err: unknown) => {
+        console.warn(`${TAG} virtual task migration failed: ${String(err)}`);
+      });
+    }
     return bindingToIdFields(binding, spaceId, sessionId);
   } catch (err) {
     console.warn(`${TAG} L2 getBinding error space=${spaceId} sid=${sessionId}: ${(err as Error).message}`);
@@ -311,7 +320,7 @@ export function createMemoryBridgeHandler(
     let ids = loadSessionIdsL1(sessionKey);
     if (!ids && bindingRepo && spaceId) {
       console.log(`${TAG} session=${sessionKey} L1 miss → L2 binding lookup (space=${spaceId})`);
-      ids = await loadSessionIdsL2(bindingRepo, spaceId, sessionKey);
+      ids = await loadSessionIdsL2(bindingRepo, spaceId, sessionKey, config.sessionInit.defaultTaskId);
     }
     if (!ids) {
       emitBridgeRejectTelemetry({

--- a/MemoryProxy/src/server.ts
+++ b/MemoryProxy/src/server.ts
@@ -1,5 +1,6 @@
 /** Hono app factory — registers all routes. */
 
+import { getSessionStore } from "./session/store.js";
 import { Hono } from "hono";
 import { handleChatCompletions } from "./handler.js";
 import { handleAnthropicMessages } from "./anthropicHandler.js";
@@ -27,6 +28,7 @@ export function createApp(config: ProxyConfig): Hono {
   if (!tryActivateStorage(config)) {
     tryActivateRedis(config);
   }
+  getSessionStore().setDefaultTaskId(config.sessionInit.defaultTaskId);
 
   // `/cost-guard` marker 门控 (P0 前置)：
   // markerOptIn=false 时 marker 完全作废——任何路径里带 `/cost-guard/` 段的请求

--- a/MemoryProxy/src/session/__tests__/virtual-task.test.ts
+++ b/MemoryProxy/src/session/__tests__/virtual-task.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSessionInit } from "../index.js";
+import { SessionStore } from "../store.js";
+import { normalizeSessionTask } from "../task.js";
+import type { SessionInitConfig } from "../../types.js";
+import type { SessionInitState } from "../types.js";
+import type { MetadataClient } from "../../meta/client.js";
+import type { SessionRepo } from "../../db/sessionRepo.js";
+import type { BindingRepo, SessionBinding } from "../../db/binding-repo.js";
+
+const config = { enabled: true, defaultTaskId: "no-task", headerAutoSelect: { enabled: true, onMismatch: "form" } } as SessionInitConfig;
+const identity = { spaceId: "space", userId: "user", agentSource: "claude-code", sessionId: "session" };
+const key = "claude-code:session";
+function metadata() {
+  return {
+    listTeams: vi.fn(async () => [{ team_id: "team", name: "Team" }]),
+    listAgents: vi.fn(async () => [{ agent_id: "agent", name: "Agent" }]),
+    listTasks: vi.fn(async () => [{ task_id: "real", title: "Real" }]),
+    getAgent: vi.fn(async () => ({ agent_id: "agent", name: "Agent" })),
+    getTask: vi.fn(async (id: string) => ({ task_id: id, title: "Real" })),
+    appendParticipationLog: vi.fn(async () => ({})),
+  };
+}
+function legacy(taskId = "no-task"): SessionInitState {
+  return { status: "initialized", keyId: "session", startedAt: Date.now(), attemptCount: 0,
+    sessionInfo: { session_id: "session", team_id: "team", agent_id: "agent", user_id: "user", task_id: taskId, created_at: "date" },
+    agentDetail: { id: "agent", name: "Agent" }, taskDetail: { id: taskId, name: "old task" },
+  };
+}
+function repos(state: SessionInitState | null, binding: SessionBinding | null = null) {
+  const repo: SessionRepo = { upsert: vi.fn(async (_sp, _u, _src, _sid, next) => { state = structuredClone(next); }),
+    getBySessionId: vi.fn(async () => state && structuredClone(state)), deleteBySessionId: vi.fn(),
+    loadAllInitialized: vi.fn(async () => state ? [{ ...identity, state: structuredClone(state) }] : []),
+  };
+  const bindingRepo: BindingRepo = { getBinding: vi.fn(async () => binding), putBinding: vi.fn(async (_sp, _sid, next) => { binding = { ...next }; }),
+    deleteBinding: vi.fn(async () => {}), touchLastSeen: vi.fn(async () => {}),
+  };
+  return { repo, bindingRepo };
+}
+
+describe("registration with optional tasks", () => {
+  for (const source of ["claude-code", "codebuddy", "codex", "workbuddy", "dsh", "opencode"]) {
+    it.each([undefined, "expired", "no-task", "real"])(`${source}: header task %s`, async (taskId) => {
+      const client = metadata();
+      const result = await handleSessionInit("session", "user", [{ role: "user", content: "hello" }], config,
+        new SessionStore(60000, undefined, undefined, "no-task"), { stream: false, modelId: "test" }, source,
+        client as unknown as MetadataClient, "test-key", "space", { teamId: "team", agentId: "agent", taskId });
+      expect(result.sessionInfo?.agent_id).toBe("agent");
+      expect(result.sessionInfo?.task_id).toBe(taskId === "real" ? "real" : undefined);
+      expect(client.getTask).toHaveBeenCalledTimes(taskId === "real" ? 1 : 0);
+      expect(client.appendParticipationLog).toHaveBeenCalledTimes(taskId === "real" ? 1 : 0);
+    });
+  }
+  it("handles the actual CC no-task form selection, including a virtual marker from older configuration", async () => {
+    const client = metadata();
+    const store = new SessionStore(60000, undefined, undefined, "no-task");
+    await store.set(key, { ...legacy(), status: "pending_task_select", sessionInfo: null,
+      selectedTeamId: "team", selectedAgentId: "agent", cachedTeams: [{ team_id: "team", team_name: "Team",
+        agents: [{ agent_id: "agent", agent_name: "Agent" }],
+        tasks: [{ task_id: "old-placeholder", task_name: "本次不关联任务", isDefault: true }] }] });
+    const result = await handleSessionInit("session", "user", [{ role: "user", content: JSON.stringify({ answers: { Task: "本次不关联任务" } }) }],
+      config, store, { stream: false, modelId: "test", protocol: "anthropic" }, "claude-code", client as unknown as MetadataClient);
+    expect(result.sessionInfo?.task_id).toBeUndefined();
+    expect(store.get(key)?.sessionInfo?.task_id).toBeUndefined();
+    expect(client.getTask).not.toHaveBeenCalled();
+    expect(client.appendParticipationLog).not.toHaveBeenCalled();
+  });
+});
+
+describe("legacy session recovery", () => {
+  it.each(["no-task", "real"])("migrates L2a task %s and survives another store restart", async (taskId) => {
+    const { repo, bindingRepo } = repos(legacy(taskId));
+    const store = new SessionStore(60000, repo, bindingRepo, "no-task");
+    const recovered = await store.getOrRecover(key, identity, {});
+    expect(recovered?.sessionInfo?.task_id).toBe(taskId === "real" ? "real" : undefined);
+    expect(recovered?.sessionInfo?.agent_id).toBe("agent");
+    if (taskId !== "real") {
+      expect(recovered?.taskDetail).toBeNull();
+      expect(repo.upsert).toHaveBeenCalled();
+      expect(bindingRepo.putBinding).toHaveBeenCalledWith("space", "session", expect.objectContaining({ taskId: undefined, agentId: "agent" }));
+    }
+    const restarted = new SessionStore(60000, repo, bindingRepo, "no-task");
+    expect((await restarted.getOrRecover(key, identity, {}))?.sessionInfo?.task_id).toBe(taskId === "real" ? "real" : undefined);
+  });
+  it("cleans startup-hydrated state before a bridge can read it", async () => {
+    const { repo } = repos(legacy());
+    const store = new SessionStore(60000, repo, undefined, "no-task");
+    await store.hydrateFromDb();
+    expect(store.get(key)?.sessionInfo?.task_id).toBeUndefined();
+    expect(repo.upsert).not.toHaveBeenCalled();
+    await store.getOrRecover(key, identity, {});
+    expect(repo.upsert).toHaveBeenCalled();
+  });
+  it("does not overwrite a newer persistent session while cleaning stale L1", async () => {
+    const { repo } = repos(legacy());
+    const store = new SessionStore(60000, repo, undefined, "no-task");
+    await store.hydrateFromDb();
+    await repo.upsert("space", "user", "claude-code", "session", legacy("real"));
+    vi.mocked(repo.upsert).mockClear();
+    expect(store.get(key)?.sessionInfo?.task_id).toBeUndefined();
+    expect(repo.upsert).not.toHaveBeenCalled();
+    expect((await store.getOrRecover(key, identity, {}))?.sessionInfo?.task_id).toBe("real");
+  });
+  it("recovers an old binding without fetching the virtual task", async () => {
+    const { bindingRepo } = repos(null, { outcome: "initialized", userId: "user", teamId: "team", agentId: "agent", taskId: "no-task" });
+    const client = metadata();
+    const store = new SessionStore(60000, undefined, bindingRepo, "no-task");
+    const recovered = await store.getOrRecover(key, identity, { metadataClient: client as unknown as MetadataClient });
+    expect(recovered?.sessionInfo?.task_id).toBeUndefined();
+    expect(recovered?.sessionInfo?.agent_id).toBe("agent");
+    expect(client.getTask).not.toHaveBeenCalled();
+  });
+  it("preserves real IDs and bypass state, and honors old virtual markers", () => {
+    const real = legacy("default");
+    expect(normalizeSessionTask(real, "no-task")).toBe(real);
+    const bypassed = { ...legacy(), bypassed: true, sessionInfo: null };
+    expect(normalizeSessionTask(bypassed, "no-task")).toBe(bypassed);
+    const old = { ...legacy("previous"), cachedTeams: [{ team_id: "team", team_name: "Team", agents: [], tasks: [{ task_id: "previous", task_name: "None", isDefault: true }] }] };
+    expect(normalizeSessionTask(old, "no-task").sessionInfo?.task_id).toBeUndefined();
+  });
+});

--- a/MemoryProxy/src/session/claude-code/init.ts
+++ b/MemoryProxy/src/session/claude-code/init.ts
@@ -9,6 +9,7 @@
  *   5. initialized → 每次请求 strip + inject
  */
 
+import { normalizeTaskId } from "../task.js";
 import type { SessionInitConfig } from "../../types.js";
 import type {
   AgentDetail,
@@ -373,6 +374,7 @@ function buildRegistrationData(
   cachedTeams: TeamOption[],
   sessionId: string,
   userId: string,
+  defaultTaskId: string | undefined,
 ): SessionRegistrationData | null {
   const teamId = findTeamIdForAgent(cachedTeams, extracted.agent_id);
   if (!teamId) return null;
@@ -380,7 +382,9 @@ function buildRegistrationData(
     team_id: teamId,
     user_id: userId,
     agent_id: extracted.agent_id,
-    task_id: extracted.task_id,
+    task_id: normalizeTaskId(
+      extracted.task_id, defaultTaskId, cachedTeams.find((t) => t.team_id === teamId)?.tasks,
+    ),
     session_id: sessionId,
   };
 }
@@ -464,7 +468,7 @@ async function completeRegistration(
   // narrowing to a task. The interactive "暂时跳过" / defaultTaskId path
   // also lands here with task_id = defaultTaskId (a virtual value). Do NOT
   // bypass when task_id is missing/undefined.
-  const regData = buildRegistrationData(resolved, cachedTeams, sessionKey, regUserId);
+  const regData = buildRegistrationData(resolved, cachedTeams, sessionKey, regUserId, config.defaultTaskId);
   if (!regData) {
     console.warn(
       `[session-init:cc] session=${compositeKey} agent=${resolved.agent_id} not bound to any team → bypass`,

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -8,6 +8,7 @@
  *   4. initialized → 每次请求 strip + inject
  */
 
+import { normalizeTaskId } from "../task.js";
 import type { SessionInitConfig } from "../../types.js";
 import type {
   AgentDetail,
@@ -351,6 +352,7 @@ function buildRegistrationData(
   cachedTeams: TeamOption[],
   sessionId: string,
   userId: string,
+  defaultTaskId: string | undefined,
 ): SessionRegistrationData | null {
   const teamId = findTeamIdForAgent(cachedTeams, extracted.agent_id);
   if (!teamId) return null;
@@ -358,7 +360,9 @@ function buildRegistrationData(
     team_id: teamId,
     user_id: userId,
     agent_id: extracted.agent_id,
-    task_id: extracted.task_id,
+    task_id: normalizeTaskId(
+      extracted.task_id, defaultTaskId, cachedTeams.find((t) => t.team_id === teamId)?.tasks,
+    ),
     session_id: sessionId,
   };
 }
@@ -416,7 +420,7 @@ export async function completeRegistration(
   // narrowing to a task. The interactive "暂时跳过" / defaultTaskId path
   // also lands here with task_id = defaultTaskId (a virtual value). Do NOT
   // bypass when task_id is missing/undefined.
-  const regData = buildRegistrationData(resolved, cachedTeams, sessionKey, regUserId);
+  const regData = buildRegistrationData(resolved, cachedTeams, sessionKey, regUserId, config.defaultTaskId);
   if (!regData) {
     console.warn(
       `[session-init:cb] session=${compositeKey} agent=${resolved.agent_id} not bound to any team → bypass`,

--- a/MemoryProxy/src/session/store.ts
+++ b/MemoryProxy/src/session/store.ts
@@ -23,6 +23,7 @@
  * entry point on every turn, so binding-through-that-path is guaranteed.
  */
 
+import { normalizeTaskId, normalizeSessionTask } from "./task.js";
 import type { SessionInitState, SessionInitStatus, SessionInfo, AgentDetail, TaskDetail } from "./types.js";
 import { getSessionRepo, type SessionRepo } from "../db/sessionRepo.js";
 import type { BindingRepo, SessionBinding } from "../db/binding-repo.js";
@@ -78,10 +79,16 @@ export class SessionStore {
     ttlMs: number = DEFAULT_TTL_MS,
     repo?: SessionRepo,
     bindingRepo?: BindingRepo,
+    private defaultTaskId: string | undefined = "default",
   ) {
     this.ttlMs = ttlMs;
     this.repo = repo;
     this.bindingRepo = bindingRepo;
+  }
+
+  /** Use the configured virtual ID for legacy session recovery, including bridge reads. */
+  setDefaultTaskId(taskId: string | undefined): void {
+    this.defaultTaskId = taskId;
   }
 
   /** Attach BindingRepo late (called after Redis / storage activation). */
@@ -129,7 +136,10 @@ export class SessionStore {
       return undefined;
     }
 
-    return state;
+    const normalized = normalizeSessionTask(state, this.defaultTaskId);
+    // L1 can be stale on another node: never write it over an authoritative L2 row.
+    if (normalized !== state) this.states.set(keyId, normalized);
+    return normalized;
   }
 
   /**
@@ -164,6 +174,7 @@ export class SessionStore {
    * "小纸条"型持久化，用于长睡对话唤醒；写延迟不影响 pending 状态跨节点恢复。
    */
   async set(keyId: string, state: SessionInitState): Promise<void> {
+    state = normalizeSessionTask(state, this.defaultTaskId);
     // `__recoverySource` is a transient hint produced by getOrRecover() only,
     // and must not leak into L1/L2a/L2b persistence. Strip it defensively here
     // so future callers who forward a getOrRecover() result into set() don't
@@ -506,8 +517,14 @@ export class SessionStore {
       return undefined;
     }
 
-    // Promote back to L1 so subsequent turns don't hit the repo at all.
-    this.states.set(keyId, row);
+    // Migrate legacy virtual tasks before exposing recovered state to callers.
+    const normalized = normalizeSessionTask(row, this.defaultTaskId);
+    if (normalized !== row) {
+      row = normalized;
+      await this.set(keyId, row);
+    } else {
+      this.states.set(keyId, row);
+    }
     console.log(
       `[session-recover] ${keyId} L2a hit status=${row.status} (agent=${row.sessionInfo?.agent_id ?? "-"}, task=${row.sessionInfo?.task_id ?? "-"})`,
     );
@@ -550,6 +567,15 @@ export class SessionStore {
         attemptCount: 0, bypassed: true,
         sessionInfo: null, agentDetail: null, taskDetail: null,
       };
+    }
+
+    // Old bindings can outlive the full session snapshot. Never query a virtual task.
+    const taskId = normalizeTaskId(binding.taskId, this.defaultTaskId);
+    if (taskId !== binding.taskId) {
+      binding = { ...binding, taskId };
+      await this.bindingRepo?.putBinding(spaceOf(identity), identity.sessionId, binding).catch((err: unknown) => {
+        console.warn(`[session-recover] ${keyId} virtual task migration failed: ${String(err)}`);
+      });
     }
 
     // Step 4.2: fetch details in parallel

--- a/MemoryProxy/src/session/task.ts
+++ b/MemoryProxy/src/session/task.ts
@@ -1,0 +1,29 @@
+import type { SessionInitState, TaskInTeam } from "./types.js";
+
+/** Convert the UI's no-task option to an absent business dimension. */
+export function normalizeTaskId(
+  taskId: string | undefined,
+  defaultTaskId: string | undefined,
+  tasks: TaskInTeam[] = [],
+): string | undefined {
+  if (!taskId || taskId === defaultTaskId || tasks.some((t) => t.task_id === taskId && t.isDefault)) {
+    return undefined;
+  }
+  return taskId;
+}
+
+/** Clean legacy completed sessions without changing pending form selections. */
+export function normalizeSessionTask(
+  state: SessionInitState,
+  defaultTaskId: string | undefined,
+): SessionInitState {
+  const session = state.sessionInfo;
+  if (!session?.task_id) return state;
+  const tasks = state.cachedTeams?.find((t) => t.team_id === session.team_id)?.tasks;
+  if (normalizeTaskId(session.task_id, defaultTaskId, tasks) !== undefined) return state;
+  return {
+    ...state,
+    sessionInfo: { ...session, task_id: undefined },
+    taskDetail: null,
+  };
+}


### PR DESCRIPTION
## Description | 描述

用户选择“本次不关联任务”（“暂时跳过”）时，原实现可能将配置的虚拟 Task ID（例如 `default`）作为真实任务持久化并调用参与日志接口，导致不存在任务的 404。

修复后保留 Team/Agent 绑定，不携带虚拟 Task 维度，也不查询虚拟任务或写其参与日志。共享归一化规则应用于 Claude Code / CodeBuddy 注册、会话读取和恢复、Memory Bridge 旧 binding；Redis 在事务中删除已取消的 `task_id`。进程内旧缓存清理不回写持久层，避免覆盖其他节点的新状态。

选择真实任务时保持关联与参与日志行为。

## Related Issue | 关联 Issue

暂无直接关联 Issue。本 PR 处理虚拟 Task 的传递与恢复，不包含目录超时重试或团队无任务时的其他初始化问题。

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过（下述回归测试范围）
- [x] No existing features affected | 已回归真实任务、无任务、旧会话及 binding 转换，未发现回归；不代表全量 E2E 验证

验证基线为 `feat/server_team` 的 `906b582`，当前提交 `5b0f4be`。使用 Node.js 24.19.0 和本地已有依赖；未执行全新依赖安装或 Node 22 复测。

在 `MemoryProxy` 目录执行：

```bash
node node_modules/vitest/vitest.mjs run
node node_modules/typescript/bin/tsc --noEmit
```

2 个测试文件、30 个用例通过，覆盖各客户端入口的 Header 预选、真实无任务表单、旧会话恢复、缓存清理和 Redis 字段删除。

类型检查在目标基线和当前代码上均有 60 条既有诊断，忽略行号后相同，未新增诊断；类型检查仍未通过。

相对目标基线执行 `git diff origin/feat/server_team --check` 通过。

## Additional Notes | 其他说明

已精简重复或低收益测试，保留核心回归；本次 amend 仅调整测试，业务代码不变。

历史真实服务及 Redis 验证见[脱敏实测记录](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/1299#issuecomment-5590111525)。该记录对应旧提交；当前版本重跑的是上述自动化用例，未重跑完整真实服务/Redis E2E，不将历史结果当作当前 HEAD 全链路验收。

PR 自有提交符合 Conventional Commits，并均带 DCO `Signed-off-by`。当前目标分支为 `feat/server_team`；贡献指南中的 `develop_server_team` / `master` 名称在当前仓库已不存在，沿用现有 PR 目标分支。

仓库 `.github/workflows/pr-ci.yml` 仅对目标 `main` 的 PR 触发，因此当前没有该工作流的 CI 结果；本地回归通过不代表 CI 或维护者 Review 已通过。
