### PR TITLE
fix(proxy): 允许 Claude Code 初始化在目录请求失败后重试

### DIFF
--- a/MemoryProxy/src/session/__tests__/metadata-retry.test.ts
+++ b/MemoryProxy/src/session/__tests__/metadata-retry.test.ts
@@ -1,0 +1,124 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MetadataClient } from "../../meta/client.js";
+import { handleSessionInit } from "../claude-code/init.js";
+import { SessionStore } from "../store.js";
+import { KvSessionRepo } from "../../db/kv-session-repo.js";
+import { FsStorage } from "../../storage/fs-storage.js";
+import type { SessionInitConfig } from "../../types.js";
+
+const config = { enabled: true, headerAutoSelect: { enabled: true, onMismatch: "form" } } as SessionInitConfig;
+const preset = { teamId: "team", agentId: "agent", taskId: "task" };
+const key = "claude-code:session";
+const messages = [{ role: "user", content: "hello" }];
+let server: Server;
+let client: MetadataClient;
+let failing: boolean;
+let requests: string[];
+let directory: string;
+
+beforeEach(async () => {
+  failing = true;
+  requests = [];
+  directory = await mkdtemp(join(tmpdir(), "session-retry-"));
+  server = createServer((req, res) => {
+    const path = req.url!;
+    requests.push(path);
+    req.resume();
+    // Leave the socket open: the real MetadataClient must hit its HTTP timeout.
+    if (failing && path === "/v3/meta/agent/list") return;
+    const items = path.includes("/team/") ? [{ team_id: "team", name: "Team" }]
+      : path.includes("/agent/") ? [{ agent_id: "agent", team_id: "team", name: "Agent" }]
+      : [{ task_id: "task", team_id: "team", title: "Task" }];
+    const data = path.endsWith("/list") ? { items, total: 1, limit: 100, offset: 0 }
+      : path.endsWith("/get") ? items[0] : {};
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ code: 0, data }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as { port: number };
+  client = new MetadataClient({ endpoint: `http://127.0.0.1:${address.port}`, serviceToken: "test", timeoutMs: 100 }, "space", "test");
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(directory, { recursive: true, force: true });
+});
+
+function run(store: SessionStore, selected: typeof preset | null = preset, input = messages) {
+  return handleSessionInit("session", "user", input, config, store,
+    { stream: false, modelId: "test", protocol: "anthropic" }, client, "test", "space", selected ?? undefined);
+}
+
+describe("Claude Code metadata timeout recovery", () => {
+  it("retries the same session after the directory recovers, then registers only once", async () => {
+    const store = new SessionStore();
+    const now = Date.now();
+    expect((await run(store)).bypassed).toBe(true);
+    failing = false;
+    vi.spyOn(Date, "now").mockReturnValue(now + 31_000);
+    const result = await run(store);
+    expect(result.sessionInfo?.agent_id).toBe("agent");
+    expect(result.sessionInfo?.task_id).toBe("task");
+    expect(result.systemAppend).toContain("agent");
+    expect(requests.filter((p) => p === "/v3/meta/agent/list")).toHaveLength(2);
+    await expect.poll(() => requests.filter((p) => p.endsWith("/participation-log/append")).length).toBe(1);
+    const count = requests.length;
+    await run(store);
+    expect(requests).toHaveLength(count);
+    expect(store.get(key)?.bypassed).not.toBe(true);
+  });
+
+  it("preserves the cooldown through disk recovery and does not persist an opt-out", async () => {
+    const identity = { spaceId: "space", userId: "user", agentSource: "claude-code", sessionId: "session" };
+    const repo = new KvSessionRepo(new FsStorage(directory));
+    const store = new SessionStore(60_000, repo);
+    store.bind(key, identity);
+    await run(store);
+    const restarted = new SessionStore(60_000, new KvSessionRepo(new FsStorage(directory)));
+    await restarted.getOrRecover(key, identity, {});
+    expect(restarted.get(key)?.status).toBe("uninitialized");
+    expect(restarted.get(key)?.bypassed).not.toBe(true);
+    const retryAt = restarted.get(key)!.metadataRetryAt!;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(retryAt - 1);
+    const count = requests.length;
+    failing = false;
+    expect((await run(restarted, null)).bypassed).toBe(true);
+    expect(requests).toHaveLength(count);
+    clock.mockReturnValue(retryAt);
+    expect((await run(restarted, null)).intercepted).toBe(true);
+    expect(restarted.get(key)?.status).toBe("pending_asset_confirm");
+    expect(restarted.get(key)?.metadataRetryAt).toBeUndefined();
+  });
+
+  it("spaces repeated failures rather than retrying on every request", async () => {
+    const store = new SessionStore();
+    await run(store);
+    const retryAt = store.get(key)!.metadataRetryAt!;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(retryAt);
+    expect((await run(store)).bypassed).toBe(true);
+    expect(store.get(key)?.status).toBe("uninitialized");
+    expect(store.get(key)?.metadataRetryAt).toBe(retryAt + 30_000);
+    clock.mockReturnValue(retryAt + 1);
+    const count = requests.length;
+    await run(store);
+    expect(requests).toHaveLength(count);
+  });
+
+  it("keeps an explicit no-assets answer terminal", async () => {
+    failing = false;
+    const store = new SessionStore();
+    expect((await run(store, null)).intercepted).toBe(true);
+    expect((await run(store, null, [{ role: "user", content: "否，本次不关联" }])).bypassed).toBe(true);
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
+    const count = requests.length;
+    expect((await run(store, null)).bypassed).toBe(true);
+    expect(store.get(key)?.status).toBe("initialized");
+    expect(requests).toHaveLength(count);
+  });
+});

--- a/MemoryProxy/src/session/__tests__/metadata-retry.test.ts
+++ b/MemoryProxy/src/session/__tests__/metadata-retry.test.ts
@@ -50,7 +50,7 @@ afterEach(async () => {
   await rm(directory, { recursive: true, force: true });
 });
 
-function run(store: SessionStore, selected: typeof preset | null = preset, input = messages) {
+function run(store: SessionStore, selected: Partial<typeof preset> | null = preset, input = messages) {
   return handleSessionInit("session", "user", input, config, store,
     { stream: false, modelId: "test", protocol: "anthropic" }, client, "test", "space", selected ?? undefined);
 }
@@ -96,32 +96,20 @@ describe("Claude Code metadata timeout recovery", () => {
     expect(restarted.get(key)?.metadataRetryAt).toBeUndefined();
   });
 
-  it("preserves a session reset through a metadata timeout and retry", async () => {
+  it.each([null, preset, { teamId: "team" }])("preserves reset state without reporting a completed opt-out (preset=%j)", async (selected) => {
     const store = new SessionStore();
     await store.set(key, { status: "uninitialized", keyId: "session", startedAt: Date.now(),
       attemptCount: 0, resetFlow: true, resetEpoch: 7 });
-    expect((await run(store, null)).resetFlow).toBe(true);
+    expect((await run(store, selected)).resetFlow).not.toBe(true);
     expect(store.get(key)?.resetEpoch).toBe(7);
-    expect((await run(store, null)).resetFlow).toBe(true);
+    expect((await run(store, selected)).resetFlow).not.toBe(true);
     failing = false;
     vi.spyOn(Date, "now").mockReturnValue(store.get(key)!.metadataRetryAt!);
-    expect((await run(store, null)).intercepted).toBe(true);
+    const result = await run(store, selected);
+    expect(result.intercepted).toBe(selected === null);
+    if (selected) expect(result.resetFlow).toBe(true);
     expect(store.get(key)?.resetFlow).toBe(true);
     expect(store.get(key)?.resetEpoch).toBe(7);
-  });
-
-  it("spaces repeated failures rather than retrying on every request", async () => {
-    const store = new SessionStore();
-    await run(store);
-    const retryAt = store.get(key)!.metadataRetryAt!;
-    const clock = vi.spyOn(Date, "now").mockReturnValue(retryAt);
-    expect((await run(store)).bypassed).toBe(true);
-    expect(store.get(key)?.status).toBe("uninitialized");
-    expect(store.get(key)?.metadataRetryAt).toBe(retryAt + 30_000);
-    clock.mockReturnValue(retryAt + 1);
-    const count = requests.length;
-    await run(store);
-    expect(requests).toHaveLength(count);
   });
 
   it("keeps an explicit no-assets answer terminal", async () => {

--- a/MemoryProxy/src/session/claude-code/init.ts
+++ b/MemoryProxy/src/session/claude-code/init.ts
@@ -686,7 +686,7 @@ async function handleSessionInitInner(
   if (!state || state.status === "uninitialized") {
     // Keep temporary failures retryable without fetching the directory every turn.
     if (state?.metadataRetryAt && Date.now() < state.metadataRetryAt) {
-      return { intercepted: false, bypassed: true, resetFlow: state.resetFlow ?? false };
+      return { intercepted: false, bypassed: true };
     }
     console.log(`[session-init:cc] session=${compositeKey} state=${state?.status ?? "none"} → uninitialized`);
     if (!userId) {
@@ -743,7 +743,8 @@ async function handleSessionInitInner(
         agentDetail: null,
         taskDetail: null,
       } as SessionInitState);
-      return { intercepted: false, bypassed: true, resetFlow: state?.resetFlow ?? false };
+      // A temporary failure is not a completed reset / explicit opt-out.
+      return { intercepted: false, bypassed: true };
     }
 
     const totalAgents = teams.reduce((acc, t) => acc + t.agents.length, 0);
@@ -810,6 +811,8 @@ async function handleSessionInitInner(
           userId,
           cachedTeams: teams,
           selectedTeamId: pr.teamId,
+          resetFlow: state?.resetFlow,
+          resetEpoch: state?.resetEpoch,
         };
         return completeRegistration(
           { agent_id: pr.agentId!, task_id: pr.taskId },
@@ -833,6 +836,8 @@ async function handleSessionInitInner(
             userId,
             cachedTeams: teams,
             selectedTeamId: pr.teamId,
+            resetFlow: state?.resetFlow,
+            resetEpoch: state?.resetEpoch,
           };
           return advanceFromTeamPicked(
             presetTeam, teams, compositeKey, sessionKey, userId,

--- a/MemoryProxy/src/session/claude-code/init.ts
+++ b/MemoryProxy/src/session/claude-code/init.ts
@@ -684,6 +684,10 @@ async function handleSessionInitInner(
 
   // ── Case 1: Uninitialized → 先弹 asset_confirm 对话框 ───────────────────
   if (!state || state.status === "uninitialized") {
+    // Keep temporary failures retryable without fetching the directory every turn.
+    if (state?.metadataRetryAt && Date.now() < state.metadataRetryAt) {
+      return { intercepted: false, bypassed: true, resetFlow: state.resetFlow ?? false };
+    }
     console.log(`[session-init:cc] session=${compositeKey} state=${state?.status ?? "none"} → uninitialized`);
     if (!userId) {
       console.warn(
@@ -724,18 +728,18 @@ async function handleSessionInitInner(
       teams = cfg.teams;
     } catch (err) {
       console.warn(
-        `[session-init:cc] session=${compositeKey} kernel unavailable for user=${userId}, bypassing: ${err instanceof Error ? err.message : String(err)}`,
+        `[session-init:cc] session=${compositeKey} kernel unavailable for user=${userId}, bypassing this request; retry eligible in 30s: ${err instanceof Error ? err.message : String(err)}`,
       );
       await store.set(compositeKey, {
-        status: "initialized",
+        status: "uninitialized",
         keyId: sessionKey,
         startedAt: Date.now(),
         attemptCount: 0,
+        metadataRetryAt: Date.now() + 30_000,
         userId,
         sessionInfo: null,
         agentDetail: null,
         taskDetail: null,
-        bypassed: true,
       } as SessionInitState);
       return { intercepted: false, bypassed: true, resetFlow: state?.resetFlow ?? false };
     }

--- a/MemoryProxy/src/session/types.ts
+++ b/MemoryProxy/src/session/types.ts
@@ -39,6 +39,8 @@ export interface SessionInitState {
   keyId: string;
   startedAt: number;
   attemptCount: number;
+  /** Earliest retry after a Claude Code metadata load failure; never a user opt-out. */
+  metadataRetryAt?: number;
   sessionInfo?: SessionInfo | null;
   /** User ID from auth/verify (not from header). */
   userId?: string;


### PR DESCRIPTION
## Description | 描述

Claude Code 初始化的元数据目录请求临时失败时，原实现会保存终态 `initialized + bypassed`，即使接口恢复，同一会话也持续跳过资产注入。

修复后仅当前请求跳过注入，将会话保留为 `uninitialized` 并持久化 30 秒重试冷却时间；到期后由下一次请求重试。用户主动选择“不关联”仍保持终态。会话重置期间发生超时时，同时保留 `resetFlow` / `resetEpoch`，避免重试丢失重置语义；完整 Header 预选和仅 Team 预选的自动注册均传递该标记。临时故障/冷却返回不再携带完成重置信号，避免 HTTP 层误报用户已跳过关联。

复用现有 SessionStore 持久化机制，不增加后台定时器；Header 预选和交互式表单继续使用原注册流程。

## Related Issue | 关联 Issue

Refs #1285：部分修复 Claude Code 路径中临时目录异常造成持续 bypass 的问题；不解决“已指定 Team 仍加载全部团队目录”，因此不使用自动关闭 Issue 的关键字。

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过（下述回归测试范围）
- [x] No existing features affected | 已回归预选注册、交互表单、主动不关联及会话重置，未发现回归；不代表全量 E2E 验证

验证基线为 `feat/server_team` 的 `906b582`，当前提交 `dd3b71e`。使用 Node.js 24.19.0 和本地已有依赖；未执行全新依赖安装或 Node 22 复测。

在 `MemoryProxy` 目录执行：

```bash
node node_modules/vitest/vitest.mjs run
node node_modules/typescript/bin/tsc --noEmit
```

1 个测试文件、6 个用例通过，覆盖超时后恢复并仅注册一次、真实文件持久层重启恢复冷却、主动不关联的终态，以及无预选、完整预选、仅 Team 预选三条路径的重置标记保留；确认临时故障不返回已完成跳过的信号。

类型检查在目标基线和当前代码上均有 60 条既有诊断，忽略行号后相同，未新增诊断；类型检查仍未通过。

相对目标基线执行 `git diff origin/feat/server_team --check` 通过。

## Additional Notes | 其他说明

已精简重复或低收益测试，保留核心回归；本次 amend 仅调整测试，业务代码不变。

测试使用实际 MetadataClient、本地 HTTP 服务及 FsStorage/KvSessionRepo；HTTP 超时真实触发，冷却时间通过替换 `Date.now` 推进，不是完整 MemoryCore/Claude Code/模型 E2E。未迁移无法区分用户主动跳过与旧故障的历史终态 bypass。

原始故障的历史前后对照见[脱敏实测记录](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/1300#issuecomment-5590111874)，对应旧提交；当前验证以上述 6 个用例为准。

PR 自有提交符合 Conventional Commits，并均带 DCO `Signed-off-by`。当前目标分支为 `feat/server_team`；贡献指南中的 `develop_server_team` / `master` 名称在当前仓库已不存在，沿用现有 PR 目标分支。

仓库 `.github/workflows/pr-ci.yml` 仅对目标 `main` 的 PR 触发，因此当前没有该工作流的 CI 结果；本地回归通过不代表 CI 或维护者 Review 已通过。
