### PR TITLE
feat(proxy): add structured skill access telemetry

### DIFF
--- a/MemoryProxy/docs/skill-access-telemetry.md
+++ b/MemoryProxy/docs/skill-access-telemetry.md
@@ -1,0 +1,72 @@
+# Structured Skill access telemetry
+
+`tool_call_logs` records attempts, not task outcomes. For `bridge_source =
+'skill-bridge'` and `executed_endpoint IN ('get', 'get-by-name')`, the proxy
+additionally records `skill_id` and `skill_version` from the Core response when:
+
+- HTTP status is 2xx and the JSON envelope has numeric `code: 0`;
+- `data.skill_id` is a nonblank string;
+- `data.version` is a positive safe integer;
+- `data.content` is a string (metadata-only reads are excluded).
+
+An empty content string is allowed: this records the returned content, not its
+quality. The version comes from the response, since session pinning may override
+the requested version. Search/listing results and file reads are not Skill opens.
+Missing or malformed information leaves both fields absent (`''` / `NULL` in
+ClickHouse). Absence means insufficient evidence, not proof of a failed load.
+`upstream_status` remains the HTTP status, including when a 200 envelope reports
+a business error. Network failures retain status 0 in telemetry and return 502.
+
+This is **proxy-observed loaded evidence**: Core returned Skill content to the
+bridge. It cannot prove that the client received or read the response, adopted
+the instructions, executed them, or succeeded because of them. Retries can
+produce multiple rows. Telemetry is buffered and best effort, not a durable audit
+ledger; disabled logging, overflow or sink failures can leave gaps.
+
+## Schema and deployment
+
+New tables include `skill_id String DEFAULT ''` and
+`skill_version Nullable(UInt64) DEFAULT NULL`. The existing `migrateSchema`
+path issues these idempotent upgrades for existing tables:
+
+```sql
+ALTER TABLE tool_call_logs ADD COLUMN IF NOT EXISTS skill_id String DEFAULT '';
+ALTER TABLE tool_call_logs ADD COLUMN IF NOT EXISTS skill_version Nullable(UInt64) DEFAULT NULL;
+```
+
+Existing rows get empty/NULL defaults; old writers can omit the columns. Other
+bridge calls and model-intent rows retain existing fields with empty/NULL access
+fields. New writers require the columns: apply and verify these ALTERs before
+rolling out new writers, especially with multiple pods. The existing startup
+migration is best effort and asynchronous; missing ALTER permissions or a startup
+race can cause telemetry inserts to fail. Defaults alone do not fix a missing
+column. Check migration warnings and `DESCRIBE TABLE tool_call_logs` before rollout.
+No ClickHouse engine validation is claimed by the unit tests (they check generated
+commands and row shapes).
+
+```sql
+SELECT space_id, user_id, team_id, agent_id, agent_source, session_key,
+       executed_endpoint, skill_id, skill_version, upstream_status, elapsed_ms
+FROM tool_call_logs
+WHERE kind = 'bridge_call' AND bridge_source = 'skill-bridge'
+  AND executed_endpoint IN ('get', 'get-by-name')
+  AND skill_id != '' AND skill_version IS NOT NULL;
+```
+
+`elapsed_ms` covers the upstream fetch and body read; it is not Skill execution
+time. Bridge callers do not currently supply `turnSeq`, so `turn_seq` remains 0.
+Do not derive a real round trace from that default. Cross-pod round correlation
+requires a separate design accounting for concurrent requests and retries.
+
+## Privacy and failure isolation
+
+The extractor retains only the resolved ID and version, never Skill content,
+manifest, storage paths or authorization headers. These identifiers still have
+tenant context and should remain under the existing telemetry access controls.
+Existing truncated request-body logging is unchanged; truncation is not
+redaction and caller-provided bodies can already contain sensitive text.
+
+Parsing failures degrade to absent access fields. The existing synchronous
+telemetry helper swallows sink exceptions; the default ClickHouse writer buffers
+and handles asynchronous flushing separately. Neither extraction nor sink
+failures change the successful Skill response.

--- a/MemoryProxy/src/clickhouse.ts
+++ b/MemoryProxy/src/clickhouse.ts
@@ -399,6 +399,11 @@ export async function migrateSchema(
     );
   }
 
+  // Add resolved Skill fields to existing tool-call tables; old rows remain unknown.
+  migrations.push(
+    { table: TOOL_CALL_TABLE, column: "skill_id", type: "String DEFAULT ''" },
+    { table: TOOL_CALL_TABLE, column: "skill_version", type: "Nullable(UInt64) DEFAULT NULL" },
+  );
   // tool_call_logs：补 reject_reason 列 (存量表由本次上线时通过 ALTER 加齐)
   migrations.push({
     table: TOOL_CALL_TABLE,
@@ -983,6 +988,9 @@ export interface SessionInitLogRow {
 
 /** 埋点点位传入的 tool_call 行输入。 */
 export interface ToolCallLogInput {
+  /** Resolved Skill content access; absent for other calls or insufficient evidence. */
+  skillId?: string;
+  skillVersion?: number;
   timestamp: string;
   sessionKey: string;
   turnSeq?: number;
@@ -1018,6 +1026,8 @@ export interface ToolCallLogInput {
 
 /** ClickHouse `tool_call_logs` 表一行的最终形态。 */
 export interface ToolCallLogRow {
+  skill_id: string;
+  skill_version: number | null;
   timestamp: string;
   session_key: string;
   turn_seq: number;
@@ -1070,6 +1080,8 @@ export function buildSessionInitLogRow(input: SessionInitLogInput): SessionInitL
 export function buildToolCallLogRow(input: ToolCallLogInput): ToolCallLogRow {
   const body = (input.requestBody ?? "").slice(0, TOOL_CALL_BODY_MAX_BYTES);
   return {
+    skill_id: input.skillId ?? "",
+    skill_version: input.skillVersion ?? null,
     timestamp: toChTimestamp(input.timestamp),
     session_key: input.sessionKey ?? "",
     turn_seq: input.turnSeq ?? 0,
@@ -1329,6 +1341,8 @@ export function toolCallTableDdl(): string {
     "  elapsed_ms UInt32 DEFAULT 0,",
     // proxy 前置校验失败原因; 上游已响应/异常时为空串; 与 session_init.bypass_reason 对称。
     "  reject_reason LowCardinality(String) DEFAULT '',",
+    "  skill_id String DEFAULT '',",
+    "  skill_version Nullable(UInt64) DEFAULT NULL,",
     "  source_tag LowCardinality(String) DEFAULT 'proxy',",
     "  host LowCardinality(String)",
     ") ENGINE = MergeTree()",

--- a/MemoryProxy/src/memory/bridge-telemetry.ts
+++ b/MemoryProxy/src/memory/bridge-telemetry.ts
@@ -35,6 +35,9 @@ export interface BridgeCallTelemetryInput {
    * 非空 = proxy 前置早退，没到 fetcher。见 clickhouse.ts ToolCallLogInput 注释。
    */
   rejectReason?: string;
+  /** Only populated for a resolved Skill content read. */
+  skillId?: string;
+  skillVersion?: number;
 }
 
 /**
@@ -63,6 +66,8 @@ export function emitBridgeToolCallTelemetry(
       upstreamStatus: input.upstreamStatus,
       elapsedMs: input.elapsedMs,
       rejectReason: input.rejectReason,
+      skillId: input.skillId,
+      skillVersion: input.skillVersion,
     };
     try {
       sink(row);

--- a/MemoryProxy/src/skill/__tests__/skill-access-telemetry.test.ts
+++ b/MemoryProxy/src/skill/__tests__/skill-access-telemetry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { extractResolvedSkillAccess } from "../skill-access-telemetry.js";
+import { emitBridgeToolCallTelemetry } from "../../memory/bridge-telemetry.js";
+import { buildToolCallLogRow, migrateSchema, toolCallTableDdl } from "../../clickhouse.js";
+
+const detail = { skill_id: "skl-resolved", version: 3, content: "# Skill" };
+const response = (data: unknown = detail, code = 0) => JSON.stringify({ code, data });
+
+describe("resolved Skill access", () => {
+  it.each(["get", "get-by-name"])("extracts Core identity and version for %s", (endpoint) => {
+    expect(extractResolvedSkillAccess(endpoint, 200, response())).toEqual({ skillId: "skl-resolved", skillVersion: 3 });
+  });
+  it.each([
+    ["get", 404, response()],
+    ["get", 200, response(detail, 40401)],
+    ["get", 200, "not JSON"],
+    ["get", 200, "null"],
+    ["get", 200, response({ skill_id: "skl-a", content: "body" })],
+    ["get", 200, response({ ...detail, version: "3" })],
+    ["get", 200, response({ ...detail, version: 0 })],
+    ["get", 200, response({ ...detail, version: -1 })],
+    ["get", 200, response({ ...detail, version: 1.5 })],
+    ["get", 200, response({ ...detail, version: Number.MAX_SAFE_INTEGER + 1 })],
+    ["get", 200, response({ ...detail, skill_id: " " })],
+    ["get", 200, response({ ...detail, content: undefined })],
+    ["search", 200, response()],
+    ["files/read", 200, response()],
+    ["get", 0, response()],
+  ])("does not infer loaded from insufficient evidence (%s, %s, %s)", (endpoint, status, text) => {
+    expect(extractResolvedSkillAccess(endpoint, status, text)).toBeUndefined();
+  });
+});
+
+const input = {
+  sessionKey: "claude-code:session", agentSource: "claude-code",
+  bridgeSource: "skill-bridge", executedEndpoint: "get",
+  requestBody: "x".repeat(600), upstreamStatus: 200, elapsedMs: 17,
+};
+
+describe("telemetry compatibility", () => {
+  it("preserves resolved fields independently of truncated request and default turn", () => {
+    const sink = vi.fn();
+    emitBridgeToolCallTelemetry({ ...input, ...extractResolvedSkillAccess("get", 200, response()) }, sink);
+    const row = buildToolCallLogRow(sink.mock.calls[0][0]);
+    expect(row).toMatchObject({ skill_id: "skl-resolved", skill_version: 3, turn_seq: 0, elapsed_ms: 17, upstream_status: 200 });
+    expect(row.request_body).toHaveLength(512);
+    expect(JSON.stringify(row)).not.toContain("# Skill");
+  });
+  it("leaves Memory Bridge and model intent rows compatible", () => {
+    for (const kind of ["bridge_call", "model_intent"]) {
+      expect(buildToolCallLogRow({ ...input, timestamp: new Date().toISOString(), kind, bridgeSource: "memory-bridge" }))
+        .toMatchObject({ kind, bridge_source: "memory-bridge", skill_id: "", skill_version: null, upstream_status: 200 });
+    }
+  });
+  it("swallows synchronous sink exceptions", () => {
+    expect(() => emitBridgeToolCallTelemetry(input, () => { throw new Error("sink down"); })).not.toThrow();
+  });
+  it("adds defaulted columns idempotently to existing tables", async () => {
+    const command = vi.fn().mockResolvedValue({});
+    const client = { command } as unknown as Parameters<typeof migrateSchema>[0];
+    const cfg = { table: "usage_logs" } as Parameters<typeof migrateSchema>[1];
+    await migrateSchema(client, cfg);
+    await migrateSchema(client, cfg);
+    const queries = command.mock.calls.map(([arg]) => arg.query);
+    for (const definition of ["skill_id String DEFAULT ''", "skill_version Nullable(UInt64) DEFAULT NULL"]) {
+      expect(queries.filter(q => q === `ALTER TABLE tool_call_logs ADD COLUMN IF NOT EXISTS ${definition}`)).toHaveLength(2);
+      expect(toolCallTableDdl()).toContain(definition);
+    }
+  });
+});

--- a/MemoryProxy/src/skill/__tests__/skill-bridge-access.test.ts
+++ b/MemoryProxy/src/skill/__tests__/skill-bridge-access.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { ProxyConfig } from "../../types.js";
+
+const mocks = vi.hoisted(() => ({ sink: vi.fn(), pin: vi.fn(), pinMany: vi.fn() }));
+vi.mock("../../clickhouse.js", () => ({ writeToolCallRow: mocks.sink }));
+vi.mock("../../session/store.js", () => ({
+  getSessionStore: () => ({
+    getBindingRepo: () => null,
+    get: (key: string) => key === "claude-code:session" ? {
+      status: "initialized", sessionInfo: { user_id: "user", team_id: "team", agent_id: "agent", space_id: "space" },
+    } : undefined,
+  }),
+}));
+vi.mock("../../storage/factory.js", () => ({ getProxyStorage: () => ({}) }));
+vi.mock("../kv-version-pin-repo.js", () => ({
+  KvVersionPinRepo: class { getVersion = mocks.pin; pinMany = mocks.pinMany; },
+}));
+import { createSkillBridgeHandler } from "../skill-bridge.js";
+
+const config = {
+  coreSkill: { endpoint: "http://core", serviceToken: "secret", serviceId: "fallback", timeoutMs: 1000 },
+  storage: { enabled: true }, redis: { enabled: false },
+} as ProxyConfig;
+const detail = JSON.stringify({ code: 0, data: { skill_id: "skl-resolved", version: 2, content: "# private body" } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.sink.mockReset();
+  mocks.pin.mockResolvedValue(null);
+  mocks.pinMany.mockResolvedValue(undefined);
+});
+
+async function call(endpoint: string, text: string, status = 200, body: Record<string, unknown> = {}, failFetch = false) {
+  const fetcher = vi.fn<typeof fetch>();
+  if (failFetch) fetcher.mockRejectedValue(new Error("network unavailable"));
+  else fetcher.mockResolvedValue(new Response(text, { status, headers: { "content-type": "application/json" } }));
+  const app = new Hono();
+  app.all("/skill-bridge/*", createSkillBridgeHandler(config, { fetcher }));
+  const result = await app.request(`/skill-bridge/v3/skill/${endpoint}`, {
+    method: "POST", headers: { "content-type": "application/json", "x-conversation-id": "session", "x-tdai-service-id": "space" },
+    body: JSON.stringify(body),
+  });
+  return { result, fetcher };
+}
+
+it("records the returned historical version and trusted session identities", async () => {
+  const { result, fetcher } = await call("get", detail, 200, { skill_id: "skl-resolved", version: 2, user_id: "forged" });
+  expect(await result.text()).toBe(detail);
+  expect(JSON.parse(fetcher.mock.calls[0][1]!.body as string)).toMatchObject({ version: 2, user_id: "user", team_id: "team", agent_id: "agent" });
+  expect(mocks.sink).toHaveBeenCalledWith(expect.objectContaining({ skillId: "skl-resolved", skillVersion: 2, sessionKey: "claude-code:session", spaceId: "space", agentId: "agent" }));
+  expect(JSON.stringify(mocks.sink.mock.calls)).not.toContain("# private body");
+});
+
+it("records response version when a session pin overrides the requested version", async () => {
+  mocks.pin.mockResolvedValue(2);
+  const { fetcher } = await call("get", detail, 200, { skill_id: "skl-resolved", version: 9 });
+  expect(JSON.parse(fetcher.mock.calls[0][1]!.body as string).version).toBe(2);
+  expect(mocks.sink.mock.calls[0][0].skillVersion).toBe(2);
+});
+
+it("records resolved ID for get-by-name without changing pin behavior", async () => {
+  const { result } = await call("get-by-name", detail, 200, { skill_name: "example" });
+  expect(result.status).toBe(200);
+  expect(mocks.sink.mock.calls[0][0]).toMatchObject({ executedEndpoint: "get-by-name", skillId: "skl-resolved", skillVersion: 2 });
+  expect(mocks.pin).not.toHaveBeenCalled();
+  expect(mocks.pinMany).not.toHaveBeenCalled();
+});
+
+it.each([
+  [404, detail], [200, '{"code":42}'], [200, "bad JSON"],
+  [200, '{"code":0,"data":{"skill_id":"skl-a","content":"body"}}'],
+])("preserves failure/insufficient response (%s, %s) without loaded fields", async (status, text) => {
+  const { result } = await call("get", text, status);
+  expect(result.status).toBe(status);
+  expect(await result.text()).toBe(text);
+  expect(mocks.sink.mock.calls[0][0].skillId).toBeUndefined();
+  expect(mocks.sink.mock.calls[0][0].skillVersion).toBeUndefined();
+});
+
+it("returns the successful Skill response even if the telemetry sink throws", async () => {
+  mocks.sink.mockImplementation(() => { throw new Error("sink unavailable"); });
+  const { result } = await call("get", detail);
+  expect(result.status).toBe(200);
+  expect(await result.text()).toBe(detail);
+});
+
+it("records network failure as an attempted call only", async () => {
+  const { result } = await call("get", "", 200, {}, true);
+  expect(result.status).toBe(502);
+  expect(mocks.sink.mock.calls[0][0]).toMatchObject({ upstreamStatus: 0 });
+  expect(mocks.sink.mock.calls[0][0].skillVersion).toBeUndefined();
+});

--- a/MemoryProxy/src/skill/skill-access-telemetry.ts
+++ b/MemoryProxy/src/skill/skill-access-telemetry.ts
@@ -1,0 +1,27 @@
+/** Resolved content access, never evidence of adoption or task success. */
+export interface ResolvedSkillAccess {
+  skillId: string;
+  skillVersion: number;
+}
+
+/** Read only the Core response; request versions may have been overridden by a pin. */
+export function extractResolvedSkillAccess(
+  endpoint: string,
+  status: number,
+  responseText: string,
+): ResolvedSkillAccess | undefined {
+  if ((endpoint !== "get" && endpoint !== "get-by-name") || status < 200 || status >= 300) return;
+  try {
+    const env = JSON.parse(responseText);
+    if (!env || env.code !== 0) return;
+    const data = env.data;
+    if (!data || typeof data.skill_id !== "string" || !data.skill_id.trim()) return;
+    if (!Number.isSafeInteger(data.version) || data.version <= 0) return;
+    // Metadata-only reads do not establish that the Skill body was opened.
+    if (typeof data.content !== "string") return;
+    return { skillId: data.skill_id, skillVersion: data.version };
+  } catch {
+    // Malformed upstream responses must still pass through the bridge unchanged.
+    return;
+  }
+}

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -34,6 +34,7 @@ import { getMetadataClient } from "../meta/client.js";
 import type { ProxyConfig } from "../types.js";
 import { emitBridgeToolCallTelemetry, emitBridgeRejectTelemetry, agentSourceFromSessionKey } from "../memory/bridge-telemetry.js";
 import { getCoreSkillClient, type CoreSkillClient } from "./core-client.js";
+import { extractResolvedSkillAccess } from "./skill-access-telemetry.js";
 
 /**
  * 二选一的 pin repo（KvVersionPinRepo 或 VersionPinRepo）——
@@ -920,6 +921,7 @@ export function createSkillBridgeHandler(
       requestBody: outboundBody.slice(0, 512),
       upstreamStatus: resp.status,
       elapsedMs: (deps.now ?? Date.now)() - callStart,
+      ...extractResolvedSkillAccess(sub, resp.status, respText),
     });
 
     // 曾经这里会在写操作 / extract 成功时清零 proxy 侧 buffer 计数器,


### PR DESCRIPTION
# feat(proxy): add structured skill access telemetry

## Description | 描述

Skill Bridge currently records HTTP attempts without the resolved Skill ID and
version. A request version may be overridden by a session pin, and name lookups
resolve the ID in Core. Add response-derived `skill_id` / `skill_version` to
existing tool-call telemetry for successful get/get-by-name content responses.
Invalid JSON, nonzero business codes, missing versions and metadata-only reads
leave these fields empty/NULL. Responses remain unchanged when telemetry fails.

A pure extractor isolates parsing and evidence semantics. ClickHouse DDL and
idempotent migrations supply compatible defaults for older rows/writers.
This records proxy-observed loaded evidence only, not Skill adoption or success.

## Related Issue | 关联 Issue

Closes #1304.

Related to #1189 and #1216 (Core aggregate usage counters); this PR does not
implement those counters.

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过（30 unit/handler tests, mocked dependencies）
- [ ] No existing features affected | 无影响现有功能（targeted compatibility verified; full integration pending）

## Additional Notes | 其他说明

- Base: feat/server_team at c387ea4534d08f3204d50a137ef55206d7c50301.
- `npm ci --no-audit --no-fund` succeeded without disabling scripts.
- Baseline `npm test` found no files. Added tests match existing Vitest include;
  full target-module run now passes 30 tests in 2 files.
- `npm run typecheck`: 60 pre-existing diagnostics, output unchanged before/after.
- No Proxy build script exists. Tests also pass under temporary Node 22.23.2:
  2 files / 30 tests. The system default remains Node 24.14.1.
- ClickHouse 25.8.33.6 integration: migrated a legacy table twice, confirmed
  pre/post-migration legacy writes default to empty/NULL, and queried a new row
  with skill_id/version/status/latency. No real Core/Redis/COS or Agent E2E claimed.
- Apply the two documented ALTERs before rolling out new writers. Startup
  migration is best effort; permission failures/races can still lose telemetry.
- No Skill body or credentials added to logs; existing request-body logging unchanged.
- No turnSeq inference, Core changes, usage counters or maturity changes.
- Before submission exclude week1-notes (learning artifacts) from commits.

Two DCO-signed commits are included. The branch is pushed from the contributor's Fork.
