### PR TITLE
fix(deploy): wrap UTF-8-adjacent variables in braces for bash 3.2

### DIFF
--- a/deploy/dockerhub/publish.sh
+++ b/deploy/dockerhub/publish.sh
@@ -57,7 +57,7 @@ TARGET="${1:-}"
 case "$TARGET" in
   memory-core|memory-proxy|memory-hub|all) ;;
   -h|--help|"") usage ;;
-  *) die "未知组件: $TARGET（可选 memory-core | memory-proxy | memory-hub | all）" ;;
+  *) die "未知组件: ${TARGET}（可选 memory-core | memory-proxy | memory-hub | all）" ;;
 esac
 
 [[ -n "${VERSION:-}" ]] || die "请显式指定 VERSION，例：VERSION=1.0.0 ./publish.sh $TARGET"
@@ -200,7 +200,7 @@ JSON
   scan "$ctx" src package.json packages
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    ok "DRY_RUN=1 → context 就绪在 $ctx，跳过 build/push"
+    ok "DRY_RUN=1 → context 就绪在 ${ctx}，跳过 build/push"
     return 0
   fi
   build_image "$image" "$ctx"
@@ -261,7 +261,7 @@ build_memory_hub() {
   scan "$ctx" panel knowledge Dockerfile start-combined.sh
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    ok "DRY_RUN=1 → context 就绪在 $ctx，跳过 build/push"
+    ok "DRY_RUN=1 → context 就绪在 ${ctx}，跳过 build/push"
     return 0
   fi
   build_image "$image" "$ctx"

--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -178,7 +178,7 @@ check_llm_openai() {
     if grep -q "\"$model\"" "$body_file" 2>/dev/null; then
       ok "$label OpenAI 协议通路 OK（$model 在 /models 列表内）"
     else
-      ok "$label OpenAI 协议通路 OK（未在 /models 里显式列出 $model，业务侧仍可能可用）"
+      ok "$label OpenAI 协议通路 OK（未在 /models 里显式列出 ${model}，业务侧仍可能可用）"
     fi
   elif [[ "$code" == "401" || "$code" == "403" ]]; then
     warn "$label API key 无效（HTTP ${code}）：$url"

--- a/deploy/global-images/start-all-mongo.sh
+++ b/deploy/global-images/start-all-mongo.sh
@@ -35,10 +35,10 @@ fi
 env_mode=$(grep -E '^[[:space:]]*MEMORY_CORE_STORE_MODE=' "$ENV_FILE" \
   | tail -n1 | cut -d= -f2- | tr -d '[:space:]"' || true)
 if [[ -n "$env_mode" && "$env_mode" != "mongodb" ]]; then
-  echo "[error] .env 里显式设置了 MEMORY_CORE_STORE_MODE=$env_mode，与本脚本冲突。" >&2
+  echo "[error] .env 里显式设置了 MEMORY_CORE_STORE_MODE=${env_mode}，与本脚本冲突。" >&2
   echo "        二选一：" >&2
   echo "          ① 想用 mongo：注释掉 .env 里该行，重跑本脚本；" >&2
-  echo "          ② 想用 $env_mode：直接 ./start-all.sh。" >&2
+  echo "          ② 想用 ${env_mode}：直接 ./start-all.sh。" >&2
   exit 1
 fi
 

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -71,7 +71,7 @@ fi
 
 if [[ "$MEMORY_CORE_STORE_MODE" == "mongodb" || "$MEMORY_CORE_METADATA_BACKEND" == "mongodb" ]]; then
   if [[ -z "${MONGODB_ENDPOINT:-}" ]]; then
-    info "未设 MONGODB_ENDPOINT → 启动本地 atlas-local（$MONGO_LOCAL_IMAGE）"
+    info "未设 MONGODB_ENDPOINT → 启动本地 atlas-local（${MONGO_LOCAL_IMAGE}）"
     if ! $DOCKER ps --format '{{.Names}}' 2>/dev/null | grep -qx "$MONGO_LOCAL_CONTAINER"; then
       rm_container_if_exists "$MONGO_LOCAL_CONTAINER"
       # --hostname 必须固定：atlas-local 用容器主机名初始化单节点 RS 成员。
@@ -98,14 +98,14 @@ if [[ "$MEMORY_CORE_STORE_MODE" == "mongodb" || "$MEMORY_CORE_METADATA_BACKEND" 
       sleep 2
     done
     [[ "$mongo_ready" == "1" ]] || die "mongo 容器 60s 内未就绪，docker logs $MONGO_LOCAL_CONTAINER 排查"
-    ok "mongo 就绪（容器 $MONGO_LOCAL_CONTAINER，网络内别名 mongo-search）"
+    ok "mongo 就绪（容器 ${MONGO_LOCAL_CONTAINER}，网络内别名 mongo-search）"
     MONGODB_ENDPOINT="mongodb://mongo-search:27017/?directConnection=true"
   fi
 fi
 
 if [[ "$MEMORY_CORE_STORE_MODE" == "mongodb" ]]; then
   MONGO_ENV_ARGS+=( -e "MONGODB_ENDPOINT=$MONGODB_ENDPOINT" -e "MONGODB_DATABASE=$MONGODB_DATABASE" )
-  info "memory-core 数据面后端 = mongodb（endpoint=$MONGODB_ENDPOINT, db=$MONGODB_DATABASE）"
+  info "memory-core 数据面后端 = mongodb（endpoint=$MONGODB_ENDPOINT, db=${MONGODB_DATABASE}）"
 fi
 
 if [[ "$MEMORY_CORE_METADATA_BACKEND" == "mongodb" ]]; then

--- a/deploy/panel-knowledge-combined/build.sh
+++ b/deploy/panel-knowledge-combined/build.sh
@@ -36,9 +36,9 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 err() { echo "[build-combined] error: $*" >&2; exit 1; }
 
 [[ -d "$TMC_DIR/package.json" || -f "$TMC_DIR/package.json" ]] \
-  || err "MemoryPanel 不在 $TMC_DIR（设 TMC_DIR=<path> 指定）"
+  || err "MemoryPanel 不在 ${TMC_DIR}（设 TMC_DIR=<path> 指定）"
 [[ -f "$KNOWLEDGE_DIR/package.json" ]] \
-  || err "MemoryKnowledge 不在 $KNOWLEDGE_DIR（设 KNOWLEDGE_DIR=<path> 指定）"
+  || err "MemoryKnowledge 不在 ${KNOWLEDGE_DIR}（设 KNOWLEDGE_DIR=<path> 指定）"
 [[ -f "$SCRIPT_DIR/Dockerfile" ]] || err "Dockerfile 不在 $SCRIPT_DIR"
 [[ -f "$SCRIPT_DIR/start-combined.sh" ]] || err "start-combined.sh 不在 $SCRIPT_DIR"
 
@@ -129,4 +129,4 @@ docker build --platform "$PLATFORM" -t "$IMAGE_NAME:$IMAGE_TAG" "$CTX_DIR"
 
 echo ""
 echo "[build-combined] ✅ done: $IMAGE_NAME:$IMAGE_TAG"
-echo "[build-combined] context 保留在 $CTX_DIR（KEEP_CTX=0 时下次会清掉）"
+echo "[build-combined] context 保留在 ${CTX_DIR}（KEEP_CTX=0 时下次会清掉）"


### PR DESCRIPTION
## Description | 描述

Fixes #1306, extending the earlier #1052.

macOS 自带的 bash 3.2 有个解析 quirk：变量引用后紧跟 UTF-8 全角字符时,会把该字符的首字节误吞进变量名,在 `set -u` 下报 `unbound variable`。

#1052 修了 `start-memory-core.sh:175` 一处。本 PR 把同类问题一次修全——deploy/ 下 5 个脚本共 12 处（含 #1306 报的 `_lib.sh:181` 的 `$model，`）:

- `deploy/global-images/_lib.sh`
- `deploy/global-images/start-all-mongo.sh`
- `deploy/global-images/start-memory-core.sh`
- `deploy/dockerhub/publish.sh`
- `deploy/panel-knowledge-combined/build.sh`

每处把 `$VAR` 改为 `${VAR}` 消除歧义。bash ≥ 4 下无行为变化。

## Related Issue | 关联 Issue

Fixes #1306

## Change Type | 修改类型

- [x] Bug fix | Bug 修复

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- 逐处核对：12 处均为双引号字符串内、变量名后紧跟全角括号/逗号（与 #1052 的根因一致）；`bash -n` 全部通过；`set -u` 下修复后形式（`${VAR}，`）变量正确展开。
- 未改后跟 ASCII 字符的变量（如 `endpoint=$MONGODB_ENDPOINT,` 中的 ASCII 逗号不受影响）。
- 行尾保持 LF。

---

> 本 PR 在 AI 编码助手辅助下完成;逐处核验、语法与行为验证均由本人本地执行。
