### PR TITLE
fix(l3): enqueue L3 when L2 is skipped so persona can (re)generate

### DIFF
--- a/MemoryCore/src/services/pipeline-worker.ts
+++ b/MemoryCore/src/services/pipeline-worker.ts
@@ -1034,7 +1034,29 @@ export class PipelineWorker {
     if (task.type === "L2") {
       // If L2 was skipped (no new L1 records), don't cascade to L3 or arm timer
       if ((task as any)._l2Skipped) {
-        this.logger?.debug?.(`${TAG} [${task.instanceId}/${task.sessionId}] L2 skipped (no new data), not arming timer or enqueuing L3`);
+        // L2 made no scene change — common once the scene set is at maxScenes,
+        // so CREATE is blocked and no existing scene is updated. Don't arm the
+        // L2 timer or advance L2 state, but DO still enqueue L3. Otherwise,
+        // once every session's L1 is fully drained, no L2 ever produces a
+        // change, so L3 is never reached and the persona can never
+        // (re)generate — even with request_persona_update set — and the dead
+        // end recurs after every restart (l2LastRunTime is in-memory, so the
+        // first post-restart L2 for each session is a cold-start skip).
+        // PersonaTrigger.shouldGenerate() (checkpoint-only, no LLM) stays the
+        // sole gate, so this is cheap and idempotent: it returns should=false
+        // in the steady state and only generates on request/threshold/recovery.
+        this.logger?.debug?.(`${TAG} [${task.instanceId}/${task.sessionId}] L2 skipped (no new data); enqueuing L3 anyway (PersonaTrigger gates actual generation)`);
+        await this.backend.enqueueTask({
+          id: `L3-${task.id}`,
+          type: "L3",
+          instanceId: task.instanceId,
+          sessionId: task.sessionId,
+          teamId: tid,
+          agentId: aid,
+          priority: 2,
+          data: task.data ? { ...task.data, ...serializeTraceContext() } : { teamId: tid, agentId: aid, ...serializeTraceContext() },
+          createdAt: now,
+        });
         return;
       }
 


### PR DESCRIPTION
## Problem

In service/worker mode, `cascadeSchedule` enqueues an L3 task only after a **non-skipped** L2. But an L2 is marked `_l2Skipped` whenever it produces no scene change — which is the steady state once a scope's scene set reaches `persona.maxScenes` (SceneExtractor blocks CREATE) or once every session's L1 is fully drained (no new records to turn into scenes).

Consequence: after the scene set fills up or the backlog drains, **every L2 skips, so L3 is never enqueued and the persona can never (re)generate** — even when `request_persona_update` is set. It also recurs after every restart: `l2LastRunTime` is in-memory, so the first post-restart L2 for each session is a cold-start skip. A persona that was wiped or lost then has no path back.

## Fix

On an L2 skip, still enqueue L3 (without arming the L2 timer or advancing L2 state). `PersonaTrigger.shouldGenerate()` is checkpoint-only (no LLM) and is already the single source of truth for whether to generate — it returns `should=false` in the steady state and only fires on explicit request / threshold / recovery (persona body missing). So this is cheap and idempotent; the L3 task id stays `L3-${task.id}` for replay-stable dedup.

## Testing

Verified live (standalone + worker, CF Workers AI backend): with a fully-drained L1 backlog and scenes at cap, forcing `request_persona_update` previously never regenerated the persona; after this change the next L2 skip enqueues L3, `shouldGenerate` P1 fires, and the persona regenerates exactly once, after which subsequent L2 skips log "Persona generation not needed" (no loop).