### PR TITLE
feat(hermes): minimal interactive session-init via clarify tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ MemoryCore/scripts/bench-l0-mongo/reports/
 # Local-only: parity snapshots & runtime configs (never commit)
 MemoryProxy/.archive-tmp/
 z_config/
+
+# Local scratch dirs (Devin session artifacts)
+docs/
+try-reports/

--- a/MemoryProxy/src/__tests__/hermes-adapter.test.ts
+++ b/MemoryProxy/src/__tests__/hermes-adapter.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { hermesAdapter } from "../agent-adapters/hermes.js";
+
+describe("hermesAdapter", () => {
+  it("classifyRequest always returns main", () => {
+    expect(hermesAdapter.classifyRequest({}, "/hermes/default/v1/chat/completions", {})).toBe("main");
+  });
+
+  it("extractUserText returns string content directly", () => {
+    expect(hermesAdapter.extractUserText("hello")).toBe("hello");
+  });
+
+  it("extractUserText returns null for empty string", () => {
+    expect(hermesAdapter.extractUserText("")).toBeNull();
+  });
+
+  it("extractUserText falls back to default for non-string", () => {
+    expect(hermesAdapter.extractUserText(null)).toBeNull();
+  });
+});

--- a/MemoryProxy/src/agent-adapters/hermes.ts
+++ b/MemoryProxy/src/agent-adapters/hermes.ts
@@ -1,0 +1,37 @@
+/**
+ * Hermes 客户端适配器。
+ *
+ * hermes（github.com/NousResearch/hermes-agent，PyPI `hermes-agent`）是
+ * Nous Research 的开源 AI Agent 框架，CLI 名为 `hermes`，内置 70+ 工具
+ * （web_search / terminal / browser_* / delegate_task / clarify 等）。
+ *
+ *   - LLM 出站走 OpenAI SDK。`model.provider: custom` + `model.base_url` 时
+ *     api_mode 恒为 `chat_completions`（agent/agent_init.py 的 provider 判定链），
+ *     请求 POST `{base_url}/chat/completions`，即**标准 OpenAI Chat
+ *     Completions**，与 codebuddy / dsh / openclaw 同族。
+ *   - 交互式工具：`clarify`（tools/clarify_tool.py）是标准 OpenAI
+ *     function-calling 工具，由 Hermes 本地执行 CLI/平台交互、把用户回答
+ *     作为 tool result 回填——对 Proxy 而言就是一次普通 tool-call 往返，
+ *     无需协议特化，只需保证 SSE tool_calls 增量与 role=tool 消息不被破坏。
+ *
+ * 两个适配点：
+ *   - `classifyRequest`: 恒 `"main"` —— Hermes 的 context compaction /
+ *     title 等 aux 请求同样经 OpenAI SDK 走同一 base_url，目前未发现
+ *     独立 header 或稳定 body 指纹。保守走 main，代价只是这些低频请求
+ *     多一次注入，不破坏链路。
+ *   - `extractUserText`: content 是 string 直接返回（OpenAI SDK 默认形态）；
+ *     若未来版本改发 content-block 数组，走 default 兜底拼接。
+ */
+import { defaultAdapter } from "./default.js";
+import type { AgentAdapter } from "./types.js";
+
+export const hermesAdapter: AgentAdapter = {
+  agentKind: "hermes",
+  classifyRequest() {
+    return "main";
+  },
+  extractUserText(content) {
+    if (typeof content === "string") return content.length > 0 ? content : null;
+    return defaultAdapter.extractUserText(content);
+  },
+};

--- a/MemoryProxy/src/agent-adapters/index.ts
+++ b/MemoryProxy/src/agent-adapters/index.ts
@@ -19,6 +19,7 @@ import { workbuddyAdapter } from "./workbuddy.js";
 import { dshAdapter } from "./dsh.js";
 import { opencodeAdapter } from "./opencode.js";
 import { piAdapter } from "./pi.js";
+import { hermesAdapter } from "./hermes.js";
 import { defaultAdapter } from "./default.js";
 
 export type { AgentAdapter, AgentKind, RequestKind } from "./types.js";
@@ -39,6 +40,8 @@ export function resolveAgentAdapter(agentSource: string): AgentAdapter {
       return opencodeAdapter;
     case "pi":
       return piAdapter;
+    case "hermes":
+      return hermesAdapter;
     default:
       return defaultAdapter;
   }

--- a/MemoryProxy/src/agent-adapters/types.ts
+++ b/MemoryProxy/src/agent-adapters/types.ts
@@ -20,7 +20,7 @@
  * 只是**取用户输入的规则**和**分类规则**按 agent 适配。
  */
 
-export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "opencode" | "pi" | "unknown";
+export type AgentKind = "claude-code" | "codebuddy" | "codex" | "workbuddy" | "dsh" | "opencode" | "hermes" | "pi" | "unknown";
 
 export type RequestKind = "main" | "fork" | "sidequery" | "auxiliary";
 

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -729,31 +729,31 @@ export async function handleChatCompletions(
     console.log(`[request-classify] session=${sessionKey} agent=${agentSource} → auxiliary (skip session-init/mem/injection/L0/skill)`);
   }
 
-  // ── dsh (deepseek-harness) CLI headless / no-preset bypass ──────────────
-  // dsh 客户端在 headless bundle 或未挂 ask-user preset 时,body.tools 里
-  // 不含 `ask_user_question` 工具。proxy 塞 fake `ask_user_question` tool_call
-  // 会被 dsh agent-loop 校验为 unknown tool 直接抛错。此时直接 bypass
-  // session-init 而非弹 form —— 没 UI 场景强弹表单没意义。
+  // ── dsh / hermes headless bypass ────────────────────────────────────────
+  // dsh 在 headless bundle 时 body.tools 不含 `ask_user_question`；
+  // hermes 在 api-server/acp（无交互 UI）时 body.tools 不含 `clarify`。
+  // proxy 塞 fake tool_call 会被 agent-loop 校验为 unknown tool 直接抛错。
+  // 此时直接 bypass session-init 而非弹 form —— 没 UI 场景强弹表单没意义。
   //
-  // 判定:agentSource=dsh 且 body.tools 非空且不含 ask_user_question。
-  // (tools 空数组表示纯对话/aux,不用兜底;tools 里就有 ask_user_question 说明
-  // 有 preset 挂 UI 工具,正常走 form。)
-  //
-  // NOTE(opencode): opencode CLI 同样不支持虚拟 ask_followup_question tool,
-  // 但走独立的 header-driven session-init 分支(见下方 opencode 特化块),
-  // 因此不需要走这里的 headless bypass —— opencode 能吃 mem 命令纯文本响应,
-  // 也需要 injection / L0 / skill 提取,只是不能弹 form。
-  const _dshHeadless = agentSource === "dsh" && (() => {
+  // 判定方式：内联查 tools 里有没有对应交互工具名。
+  // NOTE(opencode): opencode 走独立的 header-driven session-init 分支，
+  // 不需要走这里的 headless bypass。
+  const _hasTool = (name: string) => {
     const tools = (body as { tools?: unknown }).tools;
     if (!Array.isArray(tools) || tools.length === 0) return false;
-    return !tools.some((t) => {
+    return tools.some((t) => {
       const fn = (t as { function?: { name?: string }; name?: string })?.function;
       const n = fn?.name ?? (t as { name?: string })?.name;
-      return n === "ask_user_question";
+      return n === name;
     });
-  })();
+  };
+  const _dshHeadless = agentSource === "dsh" && !_hasTool("ask_user_question");
   if (_dshHeadless) {
     console.log(`[request-classify] session=${sessionKey} agent=dsh headless/no-preset (no ask_user_question tool) → bypass session-init, direct passthrough`);
+  }
+  const _hermesHeadless = agentSource === "hermes" && !_hasTool("clarify");
+  if (_hermesHeadless) {
+    console.log(`[request-classify] session=${sessionKey} agent=hermes headless/no-clarify (no clarify tool) → bypass session-init, direct passthrough`);
   }
 
   // ── Client capabilities detection ─────────────────────────────────────────
@@ -774,23 +774,28 @@ export async function handleChatCompletions(
   }
 
   // ── mem:session-reset pre-hook ──
-  // hermes / openclaw 走 header 预选身份, dsh headless 无 ask_user_question tool —
-  // 三者都没有交互式 form UI 可以弹,reset 后 session 会永远卡在 pending_asset_confirm。
-  // 直接返回"不支持"文案。
-  const _headerOnlyAgents = new Set(["hermes", "openclaw"]);
-  const _noFormAgent = _headerOnlyAgents.has(agentSource) || _dshHeadless;
+  // openclaw 走 header 预选身份且无交互式 form UI；dsh/hermes headless（请求里
+  // 没有交互工具）同样没有表单入口 —— reset 后 session 会永远卡在
+  // pending_asset_confirm。直接返回"不支持"文案。
+  // hermes 带 clarify 时（CLI/gateway 交互形态）已支持表单，不列入 no-form 集合。
+  const _headerOnlyAgents = new Set(["openclaw"]);
+  const _noFormAgent = _headerOnlyAgents.has(agentSource) || _dshHeadless || _hermesHeadless;
   if (!isAuxiliary && _noFormAgent) {
     const { isSessionResetCommand } = await import("./mem-command/pre-intercept.js");
     if (isSessionResetCommand(body as Record<string, unknown>, agentSource)) {
       const { buildMemResponse } = await import("./mem-command/response-builder.js");
-      console.log(`[mem-command:pre] session-reset unsupported for agent=${agentSource} dshHeadless=${_dshHeadless}`);
+      console.log(`[mem-command:pre] session-reset unsupported for agent=${agentSource} dshHeadless=${_dshHeadless} hermesHeadless=${_hermesHeadless}`);
       const msg = _headerOnlyAgents.has(agentSource)
         ? `⚠️ mem:session-reset 不支持 ${agentSource} 客户端。\n\n`
           + `${agentSource} 通过 x-team-id / x-agent-id / x-task-id 请求头预选身份，没有交互式表单入口。\n`
           + `请在客户端配置中直接更改这些请求头来切换 Team / Agent / Task。`
-        : "⚠️ mem:session-reset 不支持 dsh headless 模式。\n\n"
-          + "dsh 客户端在 headless / no-preset 场景下不挂 ask_user_question tool，无法弹出资产选择表单。\n"
-          + "请在带 ask_user_question preset 的 dsh 环境下使用。";
+        : agentSource === "hermes"
+          ? "⚠️ mem:session-reset 不支持 hermes headless 模式。\n\n"
+            + "hermes 在 api-server / acp 等无交互 UI 形态下不挂 clarify tool，无法弹出资产选择表单。\n"
+            + "请在带 clarify 工具的 hermes CLI / gateway 环境下使用。"
+          : "⚠️ mem:session-reset 不支持 dsh headless 模式。\n\n"
+            + "dsh 客户端在 headless / no-preset 场景下不挂 ask_user_question tool，无法弹出资产选择表单。\n"
+            + "请在带 ask_user_question preset 的 dsh 环境下使用。";
       return buildMemResponse(msg, {
         protocol: "openai",
         stream: isStream,
@@ -798,7 +803,7 @@ export async function handleChatCompletions(
       });
     }
   }
-  if (!isAuxiliary && !_dshHeadless && !_headerOnlyAgents.has(agentSource)) {
+  if (!isAuxiliary && !_dshHeadless && !_hermesHeadless && !_headerOnlyAgents.has(agentSource)) {
     const { isSessionResetCommand } = await import("./mem-command/pre-intercept.js");
     if (isSessionResetCommand(body as Record<string, unknown>, agentSource)) {
       const { parseMemCommand } = await import("./mem-command/index.js");
@@ -849,11 +854,11 @@ export async function handleChatCompletions(
   // ── Session Init (before injection pipeline) ─────────────────────────────
   let sessionInfo: Record<string, unknown> | null | undefined;
   let assetCapabilities: import("./injection/types.js").AssetCapabilityFlags | undefined;
-  let injectedSkipped = !conversationId || isAuxiliary || _dshHeadless;
+  let injectedSkipped = !conversationId || isAuxiliary || _dshHeadless || _hermesHeadless;
   let sessionJustRegistered = false;
   let _resetFlowResult: { agentName: string; agentIdShort: string; teamName?: string; teamId: string; taskName?: string | null; bypassed?: boolean } | null = null;
-  console.log(`[injection-debug] conversationId=${conversationId} sessionKey=${sessionKey} userId=${userId} agentSource=${agentSource} kind=${_requestKind} dshHeadless=${_dshHeadless} sessionInitEnabled=${config.sessionInit?.enabled} injectionEnabled=${config.injection?.enabled} injectors=${JSON.stringify(config.injection?.injectors)} injectedSkipped=${injectedSkipped} spaceId=${spaceId}`);
-  if (config.sessionInit?.enabled && conversationId && !isAuxiliary && !_dshHeadless) {
+  console.log(`[injection-debug] conversationId=${conversationId} sessionKey=${sessionKey} userId=${userId} agentSource=${agentSource} kind=${_requestKind} dshHeadless=${_dshHeadless} hermesHeadless=${_hermesHeadless} sessionInitEnabled=${config.sessionInit?.enabled} injectionEnabled=${config.injection?.enabled} injectors=${JSON.stringify(config.injection?.injectors)} injectedSkipped=${injectedSkipped} spaceId=${spaceId}`);
+  if (config.sessionInit?.enabled && conversationId && !isAuxiliary && !_dshHeadless && !_hermesHeadless) {
     try {
       const { getSessionStore, handleSessionInit, parsePresetIdentity } = await import("./session/index.js");
       const { getMetadataClient } = await import("./meta/client.js");
@@ -1026,7 +1031,7 @@ export async function handleChatCompletions(
       // fallback 语义：sessionJustRegistered 在此已定型（见上文 L786），
       // checkFirst 场景可安全复用。
       let memCommandPending = false;
-      if (!isAuxiliary && !_dshHeadless) {
+      if (!isAuxiliary && !_dshHeadless && !_hermesHeadless) {
         try {
           const { parseMemCommand } = await import("./mem-command/index.js");
           let peek = parseMemCommand(body as Record<string, unknown>, agentSource);
@@ -1165,7 +1170,7 @@ export async function handleChatCompletions(
   //
   // 请求分类：OpenAI 协议不做 CC 的 fork/sidequery 分流（handler.ts 没接 CC
   // routing），所有请求都视为 main —— 与 codebuddy adapter classifyRequest 一致。
-  if (!isAuxiliary && !_dshHeadless) {
+  if (!isAuxiliary && !_dshHeadless && !_hermesHeadless) {
     const { parseMemCommand, executeMemCommand, buildMemResponse, extractSimpleMessages, truncateArgs } = await import("./mem-command/index.js");
     // 常规检测：最后一条 user message
     let memCmd = parseMemCommand(body as Record<string, unknown>, agentSource);
@@ -1284,8 +1289,8 @@ export async function handleChatCompletions(
     }
   }
 
-  // aux 请求(compaction/title)/ dsh headless(无 UI 无 preset)不写 L0 —— 直接透传
-  const tdaiClient = isAuxiliary || _dshHeadless || assetCapabilities?.chat_memory === false ? null : createTdaiClient(config, spaceId);
+  // aux 请求(compaction/title)/ dsh·hermes headless(无 UI 无表单工具)不写 L0 —— 直接透传
+  const tdaiClient = isAuxiliary || _dshHeadless || _hermesHeadless || assetCapabilities?.chat_memory === false ? null : createTdaiClient(config, spaceId);
   const tdaiIdentity = injectedSkipped
     ? null
     : deriveTdaiIdentity({
@@ -1663,6 +1668,7 @@ export async function handleChatCompletions(
       agentSource,
       isAuxiliary,
       isDshHeadless: _dshHeadless,
+      isHermesHeadless: _hermesHeadless,
       sessionInfo,
       lf,
       spaceId,
@@ -1872,8 +1878,8 @@ export async function handleChatCompletions(
 
   // Skill extract trigger — count tool calls + buffer conversation.
   // 同步 await：直到 store 落盘再继续，保证下一轮跨节点读到最新数据。
-  // aux 请求(compaction/title)/dsh headless 不触发 skill 提取 —— 保持归档 buffer 语义纯净
-  if (!isAuxiliary && !_dshHeadless && isExtractionAllowed(config, "skill")) {
+  // aux 请求(compaction/title)/dsh·hermes headless 不触发 skill 提取 —— 保持归档 buffer 语义纯净
+  if (!isAuxiliary && !_dshHeadless && !_hermesHeadless && isExtractionAllowed(config, "skill")) {
     await triggerSkillExtractIfReady({
       config,
       sessionKey,
@@ -1884,7 +1890,7 @@ export async function handleChatCompletions(
       protocol: "openai",
       assetCapabilities,
     });
-  } else if (!isAuxiliary && !_dshHeadless) {
+  } else if (!isAuxiliary && !_dshHeadless && !_hermesHeadless) {
     logExtractionSkipped(config, "skill", sessionKey);
   }
 
@@ -1982,6 +1988,9 @@ interface TapContext {
   /** True when this dsh request came from CLI headless / no-preset (no ask_user_question
    * in tools) — behaves like aux for downstream side-effects. */
   isDshHeadless: boolean;
+  /** True when this hermes request came from api-server/acp (no `clarify` in
+   * tools) — behaves like aux for downstream side-effects. */
+  isHermesHeadless: boolean;
   sessionInfo: Record<string, unknown> | null | undefined;
   /** Langfuse turn-trace context (trace = one turn). */
   lf: LangfuseTurnContext;

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -747,7 +747,8 @@ export async function handleChatCompletions(
       return n === name;
     });
   };
-  const _dshHeadless = agentSource === "dsh" && !_hasTool("ask_user_question");
+  const _dshTools = (body as { tools?: unknown }).tools;
+  const _dshHeadless = agentSource === "dsh" && Array.isArray(_dshTools) && _dshTools.length > 0 && !_hasTool("ask_user_question");
   if (_dshHeadless) {
     console.log(`[request-classify] session=${sessionKey} agent=dsh headless/no-preset (no ask_user_question tool) → bypass session-init, direct passthrough`);
   }
@@ -854,11 +855,11 @@ export async function handleChatCompletions(
   // ── Session Init (before injection pipeline) ─────────────────────────────
   let sessionInfo: Record<string, unknown> | null | undefined;
   let assetCapabilities: import("./injection/types.js").AssetCapabilityFlags | undefined;
-  let injectedSkipped = !conversationId || isAuxiliary || _dshHeadless || _hermesHeadless;
+  let injectedSkipped = !conversationId || isAuxiliary || _dshHeadless;
   let sessionJustRegistered = false;
   let _resetFlowResult: { agentName: string; agentIdShort: string; teamName?: string; teamId: string; taskName?: string | null; bypassed?: boolean } | null = null;
   console.log(`[injection-debug] conversationId=${conversationId} sessionKey=${sessionKey} userId=${userId} agentSource=${agentSource} kind=${_requestKind} dshHeadless=${_dshHeadless} hermesHeadless=${_hermesHeadless} sessionInitEnabled=${config.sessionInit?.enabled} injectionEnabled=${config.injection?.enabled} injectors=${JSON.stringify(config.injection?.injectors)} injectedSkipped=${injectedSkipped} spaceId=${spaceId}`);
-  if (config.sessionInit?.enabled && conversationId && !isAuxiliary && !_dshHeadless && !_hermesHeadless) {
+  if (config.sessionInit?.enabled && conversationId && !isAuxiliary && !_dshHeadless) {
     try {
       const { getSessionStore, handleSessionInit, parsePresetIdentity } = await import("./session/index.js");
       const { getMetadataClient } = await import("./meta/client.js");
@@ -940,6 +941,9 @@ export async function handleChatCompletions(
           bypassed: recovered.bypassed,
           justRegistered: needsPrewarm, // 只在 L2b / history-scan recovery 时触发 prewarm
         };
+      } else if (_hermesHeadless) {
+        initResult = { intercepted: false };
+        injectedSkipped = true;
       } else {
         // opencode 走跟 codebuddy 完全同构的通用 else 分支（复用 handleSessionInit +
         // ask_followup_question form）。验证 opencode 客户端对未知 tool_call 的真实反应。
@@ -1031,7 +1035,7 @@ export async function handleChatCompletions(
       // fallback 语义：sessionJustRegistered 在此已定型（见上文 L786），
       // checkFirst 场景可安全复用。
       let memCommandPending = false;
-      if (!isAuxiliary && !_dshHeadless && !_hermesHeadless) {
+      if (!isAuxiliary && !_dshHeadless) {
         try {
           const { parseMemCommand } = await import("./mem-command/index.js");
           let peek = parseMemCommand(body as Record<string, unknown>, agentSource);
@@ -1170,7 +1174,7 @@ export async function handleChatCompletions(
   //
   // 请求分类：OpenAI 协议不做 CC 的 fork/sidequery 分流（handler.ts 没接 CC
   // routing），所有请求都视为 main —— 与 codebuddy adapter classifyRequest 一致。
-  if (!isAuxiliary && !_dshHeadless && !_hermesHeadless) {
+  if (!isAuxiliary && !_dshHeadless) {
     const { parseMemCommand, executeMemCommand, buildMemResponse, extractSimpleMessages, truncateArgs } = await import("./mem-command/index.js");
     // 常规检测：最后一条 user message
     let memCmd = parseMemCommand(body as Record<string, unknown>, agentSource);
@@ -1290,7 +1294,7 @@ export async function handleChatCompletions(
   }
 
   // aux 请求(compaction/title)/ dsh·hermes headless(无 UI 无表单工具)不写 L0 —— 直接透传
-  const tdaiClient = isAuxiliary || _dshHeadless || _hermesHeadless || assetCapabilities?.chat_memory === false ? null : createTdaiClient(config, spaceId);
+  const tdaiClient = isAuxiliary || _dshHeadless || injectedSkipped || assetCapabilities?.chat_memory === false ? null : createTdaiClient(config, spaceId);
   const tdaiIdentity = injectedSkipped
     ? null
     : deriveTdaiIdentity({
@@ -1668,7 +1672,7 @@ export async function handleChatCompletions(
       agentSource,
       isAuxiliary,
       isDshHeadless: _dshHeadless,
-      isHermesHeadless: _hermesHeadless,
+      isHermesHeadless: _hermesHeadless && !sessionInfo,
       sessionInfo,
       lf,
       spaceId,
@@ -1879,7 +1883,7 @@ export async function handleChatCompletions(
   // Skill extract trigger — count tool calls + buffer conversation.
   // 同步 await：直到 store 落盘再继续，保证下一轮跨节点读到最新数据。
   // aux 请求(compaction/title)/dsh·hermes headless 不触发 skill 提取 —— 保持归档 buffer 语义纯净
-  if (!isAuxiliary && !_dshHeadless && !_hermesHeadless && isExtractionAllowed(config, "skill")) {
+  if (!isAuxiliary && !_dshHeadless && !(_hermesHeadless && !sessionInfo) && isExtractionAllowed(config, "skill")) {
     await triggerSkillExtractIfReady({
       config,
       sessionKey,
@@ -1890,7 +1894,7 @@ export async function handleChatCompletions(
       protocol: "openai",
       assetCapabilities,
     });
-  } else if (!isAuxiliary && !_dshHeadless && !_hermesHeadless) {
+  } else if (!isAuxiliary && !_dshHeadless && !(_hermesHeadless && !sessionInfo)) {
     logExtractionSkipped(config, "skill", sessionKey);
   }
 
@@ -2308,7 +2312,7 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
     // Skill extract trigger — after stream finalization.
     // 同步 await：直到 store 落盘再继续，保证下一轮跨节点读到最新数据。
     // aux 请求(compaction/title)/dsh headless 跳过 skill 触发,保持归档 buffer 语义纯净。
-    if (!ctx.isAuxiliary && !ctx.isDshHeadless && isExtractionAllowed(ctx.config, "skill")) {
+    if (!ctx.isAuxiliary && !ctx.isDshHeadless && !ctx.isHermesHeadless && isExtractionAllowed(ctx.config, "skill")) {
       await triggerSkillExtractIfReady({
         config: ctx.config,
         sessionKey: ctx.sessionKeyForSkill,
@@ -2320,7 +2324,7 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
         assetCapabilities: ctx.assetCapabilities,
         toolCallCountOverride: toolCallAccumulators.size,
       });
-    } else if (!ctx.isAuxiliary && !ctx.isDshHeadless) {
+    } else if (!ctx.isAuxiliary && !ctx.isDshHeadless && !ctx.isHermesHeadless) {
       logExtractionSkipped(ctx.config, "skill", ctx.sessionKeyForSkill);
     }
 

--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -140,7 +140,7 @@ function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   // 通常是 bare sessionId。按候选前缀顺序探,命中即返回。
   const candidates = sessionId.includes(":")
     ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
+    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`, `hermes:${sessionId}`];
   for (const k of candidates) {
     const state = getSessionStore().get(k);
     if (state) {

--- a/MemoryProxy/src/routes/whitelist.ts
+++ b/MemoryProxy/src/routes/whitelist.ts
@@ -172,7 +172,7 @@ const PROXY_PREFIX_RE = /^\/proxy\/[^/]+/;
  * 白名单入口 `/v1/messages`、`/responses` 自身不会被误剥（因为它们不匹配 agent
  * 段——agent 段限定为已知名字）。
  */
-const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|anthropic|openai|pi)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
+const AGENT_PREFIX_RE = /^\/(claude-code|codebuddy|codex|cursor|anthropic|openai|hermes|pi)(?:\/[^/]+)?(?=\/v1\/|\/responses(?:\/|$)|\/memories\/|\/realtime\/)/i;
 
 /**
  * `/cost-guard` marker 正则：位于 `/{agent}/{spaceId}` 之后的独立 segment。

--- a/MemoryProxy/src/session/codebuddy/cleaner.ts
+++ b/MemoryProxy/src/session/codebuddy/cleaner.ts
@@ -76,7 +76,7 @@ export function getLastUserMessageText(messages: RawMessage[]): string {
     // dsh 的 `call_dsh_session_init_`（dsh/form.ts TOOLCALL_PREFIX）、
     // opencode 的 `call_oc_session_init_`（opencode/form.ts TOOLCALL_PREFIX）。
     const tcid = (messages[i] as any).tool_call_id as string | undefined;
-    if (role === "tool" && tcid && /call_(wb_|dsh_|oc_)?session_init_/.test(tcid)) {
+    if (role === "tool" && tcid && /call_(wb_|dsh_|oc_|hermes_)?session_init_/.test(tcid)) {
       return text;
     }
 

--- a/MemoryProxy/src/session/codebuddy/extractor.ts
+++ b/MemoryProxy/src/session/codebuddy/extractor.ts
@@ -15,6 +15,7 @@
  */
 
 import type { SessionInitData, TeamOption } from "../types.js";
+import { extractHermesAnswers } from "../hermes/extractor.js";
 import { SKIP_LABEL, PATH_SEP, ASSET_CONFIRM_YES, ASSET_CONFIRM_NO } from "./form.js";
 
 // ── Markers ────────────────────────────────────────────────────────────────────
@@ -60,6 +61,7 @@ function extractOpencodeAnswers(content: string): string | null {
  * 返回 true=是（关联资产），false=否（bypass），null=未识别。
  */
 export function extractAssetConfirm(content: string): boolean | null {
+  content = extractHermesAnswers(content) ?? content;
   // XML parsing
   const xml = parseQuestionAnswerXml(content);
   const answer = xml?.teamAnswer ?? xml?.agentAnswer ?? xml?.taskAnswer ?? content;
@@ -144,6 +146,7 @@ export function extractTeamFromOptionText(
 ): string | null {
   if (cachedTeams.length === 0) return null;
 
+  content = extractHermesAnswers(content) ?? content;
   // opencode: 剥壳 tool-result 包裹，避免问题描述里的"跳过"字样触发误 SKIP。
   // 见 extractOpencodeAnswers 头部注释。
   const opencodeAnswer = extractOpencodeAnswers(content);
@@ -267,6 +270,7 @@ export function extractFromOptionText(
       : null;
   if (!team) return null;
 
+  content = extractHermesAnswers(content) ?? content;
   // opencode: 剥壳 tool-result 包裹（见 extractOpencodeAnswers 头部）。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;
@@ -336,6 +340,7 @@ export function extractAgentOnly(
       ? cachedTeams[0]
       : null;
   if (!team) return null;
+  content = extractHermesAnswers(content) ?? content;
   // opencode: 剥壳 tool-result 包裹（见 extractOpencodeAnswers 头部）。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;
@@ -372,6 +377,7 @@ export function extractTaskOnly(
       ? cachedTeams[0]
       : null;
   if (!team) return null;
+  content = extractHermesAnswers(content) ?? content;
   // opencode: 剥壳 tool-result 包裹（见 extractOpencodeAnswers 头部）。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -41,6 +41,7 @@ import {
 import { getLastUserMessageText } from "./cleaner.js";
 import { emitSessionInitTelemetryIfCompleted } from "../init-telemetry.js";
 import { isDshRuntimeContextSnapshot } from "../../common/user-query-extractor.js";
+import { extractHermesAnswers } from "../hermes/extractor.js";
 import {
   CODEX_MORE_LABEL,
   DEFAULT_GATE_PREFIX,
@@ -105,6 +106,7 @@ export interface SessionInitResult {
   teamName?: string | null;
   /** 用户选"否"不关联团队资产 → bypass 路径，所有注入钩子应跳过。 */
   bypassed?: boolean;
+  resetFlow?: boolean;
   /**
    * bypass 触发原因（仅 `bypassed === true` 时有意义）。codexHandler 用它决定
    * 首次 gate 命中是否要返 "Plan 模式提示" 而非直接透传。
@@ -242,6 +244,10 @@ function withCodexPageIndex(
  * @param total       当前 stage 候选总数（agents.length / tasks.length / teams.length）
  * @returns null=非 MORE；number=翻页后的 pageIndex（越界回绕 0）
  */
+function paginationAnswerText(answerText: string, agentSource: string): string {
+  return agentSource === "hermes" ? extractHermesAnswers(answerText) ?? answerText : answerText;
+}
+
 function detectWorkbuddyMorePage(
   answerText: string,
   currentPage: number,
@@ -601,6 +607,7 @@ async function handleSessionInitInner(
   // gate/MORE 识别；空 input 首帧不需要，但依然按 codex 语义走后续 stage 拆分。
   const codexInput = reqCtx.codexAnswerInput;
   const isCodexClient = agentSource === "codex";
+  const usesSplitAssetStages = isCodexClient || ["workbuddy", "dsh", "opencode", "hermes"].includes(agentSource);
   const isCodexSource = isCodexClient && Array.isArray(codexInput);
 
   // A. Default 模式 gate —— codex 客户端拦截了 request_user_input 并回填了
@@ -877,8 +884,8 @@ async function handleSessionInitInner(
         //
         // opencode 说明：opencode 客户端原生 `question` tool 每次只能弹一个题，
         // 无法承载"同时问 agent+task"的语义，必须拆 stage（同 codex/wb/dsh）。
-        const nextStatus = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "pending_agent_select" : "pending_agent_task";
-        const nextStage: FormData["stage"] = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "agent_select" : "agent_task";
+        const nextStatus = usesSplitAssetStages ? "pending_agent_select" : "pending_agent_task";
+        const nextStage: FormData["stage"] = usesSplitAssetStages ? "agent_select" : "agent_task";
         await store.set(compositeKey, {
           status: nextStatus,
           keyId: sessionKey,
@@ -956,7 +963,7 @@ async function handleSessionInitInner(
           return { intercepted: true, response: buildFormResponse(fd), formData: fd };
         }
         // ≥2 agents
-        const useSplitStage = isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode";
+        const useSplitStage = usesSplitAssetStages;
         const nextStatus = useSplitStage ? "pending_agent_select" : "pending_agent_task";
         const nextStage: FormData["stage"] = useSplitStage ? "agent_select" : "agent_task";
         await store.set(compositeKey, {
@@ -1198,7 +1205,7 @@ async function handleSessionInitInner(
         // codex 分支，避免落到 legacy agent_task stage 后 form 里只问 agent
         // 却按老语义处理的语义歧义。opencode 原生 `question` tool 每次只能弹
         // 一个题，也必须走 split stage。
-        const useSplitStage = isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode";
+        const useSplitStage = usesSplitAssetStages;
         const nextStatus = useSplitStage ? "pending_agent_select" : "pending_agent_task";
         const nextStage: FormData["stage"] = useSplitStage ? "agent_select" : "agent_task";
         await store.set(compositeKey, {
@@ -1283,9 +1290,9 @@ async function handleSessionInitInner(
     // 重渲染分支按 stage 从 codexPageIndex.teamPage 挑出，传给 WB/OC form 的
     // pageIndex）。dsh 客户端无 options 上限，team 不分页，即使误触也无害。
     // 2026-09-03 新增，对齐 agent_select / task_select 分支的姿势。
-    if (agentSource === "workbuddy" || agentSource === "opencode" || agentSource === "dsh") {
+    if (agentSource === "workbuddy" || agentSource === "opencode" || agentSource === "dsh" || agentSource === "hermes") {
       const curTeamPage = state.codexPageIndex?.teamPage ?? 0;
-      const nextTeamPage = detectWorkbuddyMorePage(lastUserText, curTeamPage, cachedTeamsForMore.length);
+      const nextTeamPage = detectWorkbuddyMorePage(paginationAnswerText(lastUserText, agentSource), curTeamPage, cachedTeamsForMore.length);
       if (nextTeamPage !== null) {
         const nextPx = {
           teamPage: nextTeamPage,
@@ -1333,8 +1340,8 @@ async function handleSessionInitInner(
 
     if (teamId && teamId !== BYPASS_MARKER) {
       // codex/WB/dsh/opencode 拆 stage：先 agent_select → task_select；CB 老路径继续 agent_task 一发同时问。
-      const nextStatus = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "pending_agent_select" : "pending_agent_task";
-      const nextStage: FormData["stage"] = (isCodexClient || agentSource === "workbuddy" || agentSource === "dsh" || agentSource === "opencode") ? "agent_select" : "agent_task";
+      const nextStatus = usesSplitAssetStages ? "pending_agent_select" : "pending_agent_task";
+      const nextStage: FormData["stage"] = usesSplitAssetStages ? "agent_select" : "agent_task";
       const next: SessionInitState = {
         ...state,
         status: nextStatus,
@@ -1401,9 +1408,9 @@ async function handleSessionInitInner(
     // 无限重发第 1 页。命中则 bump agentPage 并重发 agent_select form（页码经
     // session/index.ts 的 workbuddy/opencode 重渲染分支按 stage 从 codexPageIndex.agentPage 挑出）。
     // opencode 与 workbuddy 共用 `更多 →` MORE_LABEL 与分页语义，一并拦截。
-    if (agentSource === "workbuddy" || agentSource === "opencode") {
+    if (agentSource === "workbuddy" || agentSource === "opencode" || agentSource === "hermes") {
       const curAgentPage = state.codexPageIndex?.agentPage ?? 0;
-      const nextAgentPage = detectWorkbuddyMorePage(lastUserText, curAgentPage, team.agents.length);
+      const nextAgentPage = detectWorkbuddyMorePage(paginationAnswerText(lastUserText, agentSource), curAgentPage, team.agents.length);
       if (nextAgentPage !== null) {
         const nextPx = {
           teamPage: state.codexPageIndex?.teamPage ?? 0,
@@ -1551,9 +1558,9 @@ async function handleSessionInitInner(
     // 同 pending_agent_select：extractTaskOnly 不识别 "更多 →"，必须先拦截。命中则
     // bump taskPage 并重发 task_select form（页码经 session/index.ts 的 workbuddy/opencode
     // 重渲染分支按 stage 从 codexPageIndex.taskPage 挑出）。
-    if (agentSource === "workbuddy" || agentSource === "opencode") {
+    if (agentSource === "workbuddy" || agentSource === "opencode" || agentSource === "hermes") {
       const curTaskPage = state.codexPageIndex?.taskPage ?? 0;
-      const nextTaskPage = detectWorkbuddyMorePage(lastUserText, curTaskPage, team.tasks.length);
+      const nextTaskPage = detectWorkbuddyMorePage(paginationAnswerText(lastUserText, agentSource), curTaskPage, team.tasks.length);
       if (nextTaskPage !== null) {
         const nextPx = {
           teamPage: state.codexPageIndex?.teamPage ?? 0,

--- a/MemoryProxy/src/session/hermes/__tests__/extractor.test.ts
+++ b/MemoryProxy/src/session/hermes/__tests__/extractor.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { extractHermesAnswers, HERMES_BYPASS_TEXT } from "../extractor.js";
+import {
+  extractAgentOnly,
+  extractAssetConfirm,
+  extractTaskOnly,
+  extractTeamFromOptionText,
+} from "../../codebuddy/extractor.js";
+import { getLastUserMessageText } from "../../codebuddy/cleaner.js";
+import type { TeamOption } from "../../types.js";
 
 describe("extractHermesAnswers", () => {
   it("returns null for non-JSON content", () => {
@@ -69,5 +77,50 @@ describe("extractHermesAnswers", () => {
       user_response: ["opt1", "opt2"],
     });
     expect(extractHermesAnswers(content)).toBe("opt1 | opt2");
+  });
+});
+
+const teams: TeamOption[] = [{
+  team_id: "team-alpha-11112222",
+  team_name: "Alpha",
+  agents: [
+    { agent_id: "agent-one-33334444", agent_name: "One" },
+    { agent_id: "agent-two-55556666", agent_name: "Two" },
+  ],
+  tasks: [
+    { task_id: "task-one-77778888", task_name: "First" },
+    { task_id: "task-two-99990000", task_name: "Second" },
+  ],
+}, {
+  team_id: "team-beta-22223333",
+  team_name: "Beta",
+  agents: [],
+  tasks: [],
+}];
+
+function clarifyResult(userResponse: string, choices: string[]): string {
+  return JSON.stringify({ question: "pick one or 跳过", choices_offered: choices, user_response: userResponse });
+}
+
+describe("Hermes answers in the CodeBuddy state machine", () => {
+  it("recognizes Hermes session-init tool results", () => {
+    const content = clarifyResult("Beta (22223333)", ["Alpha (11112222)", "Beta (22223333)"]);
+    expect(getLastUserMessageText([{ role: "tool", tool_call_id: "call_hermes_session_init_1", content }])).toBe(content);
+  });
+
+  it("extracts only the selected team from the clarify envelope", () => {
+    const content = clarifyResult("Beta (22223333)", ["Alpha (11112222)", "Beta (22223333)"]);
+    expect(extractTeamFromOptionText(content, teams)).toBe("team-beta-22223333");
+  });
+
+  it("extracts selected agent and task without matching echoed choices", () => {
+    const agent = clarifyResult("Two (55556666)", ["One (33334444)", "Two (55556666)"]);
+    const task = clarifyResult("Second (99990000)", ["First (77778888)", "Second (99990000)"]);
+    expect(extractAgentOnly(agent, teams, teams[0].team_id)).toBe("agent-two-55556666");
+    expect(extractTaskOnly(task, teams, teams[0].team_id)).toBe("task-two-99990000");
+  });
+
+  it("does not confuse echoed yes/no choices", () => {
+    expect(extractAssetConfirm(clarifyResult("否，本次不关联", ["是，关联团队资产", "否，本次不关联"]))).toBe(false);
   });
 });

--- a/MemoryProxy/src/session/hermes/__tests__/extractor.test.ts
+++ b/MemoryProxy/src/session/hermes/__tests__/extractor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { extractHermesAnswers, HERMES_BYPASS_TEXT } from "../extractor.js";
+
+describe("extractHermesAnswers", () => {
+  it("returns null for non-JSON content", () => {
+    expect(extractHermesAnswers("plain text answer")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractHermesAnswers("")).toBeNull();
+  });
+
+  it("extracts single question user_response", () => {
+    const content = JSON.stringify({
+      question: "请选择 Team",
+      choices_offered: ["Alpha (11112222)", "Beta (33334444)"],
+      user_response: "Alpha (11112222)",
+    });
+    expect(extractHermesAnswers(content)).toBe("Alpha (11112222)");
+  });
+
+  it("returns bypass for headless error envelope", () => {
+    const content = JSON.stringify({ error: "Clarify tool is not available in this execution context." });
+    expect(extractHermesAnswers(content)).toBe(HERMES_BYPASS_TEXT);
+  });
+
+  it("returns bypass for timeout", () => {
+    const content = JSON.stringify({
+      question: "test",
+      user_response: "The user did not provide a response within the time limit. Use your best judgement.",
+    });
+    expect(extractHermesAnswers(content)).toBe(HERMES_BYPASS_TEXT);
+  });
+
+  it("returns bypass for oneshot auto-answer", () => {
+    const content = JSON.stringify({
+      question: "test",
+      user_response: "[oneshot mode: no user available. auto-answering.]",
+    });
+    expect(extractHermesAnswers(content)).toBe(HERMES_BYPASS_TEXT);
+  });
+
+  it("returns bypass for timed_out batch", () => {
+    const content = JSON.stringify({
+      responses: [{ question: "q1", user_response: "a1" }],
+      timed_out: true,
+    });
+    expect(extractHermesAnswers(content)).toBe(HERMES_BYPASS_TEXT);
+  });
+
+  it("extracts batch responses joined with |", () => {
+    const content = JSON.stringify({
+      responses: [
+        { question: "q1", user_response: "a1" },
+        { question: "q2", user_response: "a2" },
+      ],
+    });
+    expect(extractHermesAnswers(content)).toBe("a1 | a2");
+  });
+
+  it("returns empty string for valid envelope but no user_response", () => {
+    const content = JSON.stringify({ question: "test", user_response: "" });
+    expect(extractHermesAnswers(content)).toBe("");
+  });
+
+  it("handles multi_select user_response array", () => {
+    const content = JSON.stringify({
+      question: "test",
+      user_response: ["opt1", "opt2"],
+    });
+    expect(extractHermesAnswers(content)).toBe("opt1 | opt2");
+  });
+});

--- a/MemoryProxy/src/session/hermes/__tests__/form.test.ts
+++ b/MemoryProxy/src/session/hermes/__tests__/form.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { buildFormResponse, buildClarifyArgs, FormData, TOOL_NAME, TOOLCALL_PREFIX, containsFormTitle, isSessionInitToolCallId } from "../form.js";
+import type { TeamOption } from "../../types.js";
+
+const mockTeams: TeamOption[] = [
+  {
+    team_id: "team-aaa-11112222",
+    team_name: "Alpha",
+    agents: [
+      { agent_id: "agent-aaa-33334444", agent_name: "AgentA" },
+      { agent_id: "agent-bbb-55556666", agent_name: "AgentB" },
+    ],
+    tasks: [
+      { task_id: "task-default", task_name: "本次不关联任务", isDefault: true },
+      { task_id: "task-aaa-77778888", task_name: "TaskX" },
+    ],
+  },
+  {
+    team_id: "team-bbb-99990000",
+    team_name: "Beta",
+    agents: [
+      { agent_id: "agent-ccc-11112222", agent_name: "AgentC" },
+    ],
+    tasks: [
+      { task_id: "task-default", task_name: "本次不关联任务", isDefault: true },
+    ],
+  },
+];
+
+describe("hermes form", () => {
+  it("buildClarifyArgs team stage produces choices with team names", () => {
+    const data: FormData = { teams: mockTeams, stage: "team" };
+    const result = buildClarifyArgs(data);
+    expect(result.questions).toHaveLength(1);
+    expect(result.questions[0].multi_select).toBe(false);
+    expect(result.questions[0].choices.length).toBeGreaterThanOrEqual(1);
+    expect(result.questions[0].choices[0]).toContain("Alpha");
+  });
+
+  it("buildClarifyArgs asset_confirm stage has 2 choices", () => {
+    const data: FormData = { teams: mockTeams, stage: "asset_confirm" };
+    const result = buildClarifyArgs(data);
+    expect(result.questions[0].choices).toHaveLength(2);
+  });
+
+  it("buildFormResponse non-stream returns valid JSON response", async () => {
+    const data: FormData = { teams: mockTeams, stage: "team", stream: false, modelId: "test-model" };
+    const resp = buildFormResponse(data);
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.choices[0].message.tool_calls[0].function.name).toBe(TOOL_NAME);
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("buildFormResponse stream returns text/event-stream", () => {
+    const data: FormData = { teams: mockTeams, stage: "team", stream: true, modelId: "test-model" };
+    const resp = buildFormResponse(data);
+    expect(resp.headers.get("Content-Type")).toBe("text/event-stream");
+  });
+
+  it("containsFormTitle detects known titles", () => {
+    expect(containsFormTitle("会话初始化 — 选择 Team")).toBe(true);
+    expect(containsFormTitle("random text")).toBe(false);
+  });
+
+  it("isSessionInitToolCallId matches prefix", () => {
+    expect(isSessionInitToolCallId(TOOLCALL_PREFIX + "123")).toBe(true);
+    expect(isSessionInitToolCallId("call_other_123")).toBe(false);
+  });
+
+  it("truncates to MAX_CHOICES when too many teams", () => {
+    const manyTeams: TeamOption[] = Array.from({ length: 10 }, (_, i) => ({
+      team_id: `team-${i}`,
+      team_name: `Team${i}`,
+      agents: [],
+      tasks: [],
+    }));
+    const data: FormData = { teams: manyTeams, stage: "team" };
+    const result = buildClarifyArgs(data);
+    expect(result.questions[0].choices.length).toBe(4);
+  });
+});

--- a/MemoryProxy/src/session/hermes/__tests__/form.test.ts
+++ b/MemoryProxy/src/session/hermes/__tests__/form.test.ts
@@ -68,15 +68,26 @@ describe("hermes form", () => {
     expect(isSessionInitToolCallId("call_other_123")).toBe(false);
   });
 
-  it("truncates to MAX_CHOICES when too many teams", () => {
+  it("paginates choices without making later teams unreachable", () => {
     const manyTeams: TeamOption[] = Array.from({ length: 10 }, (_, i) => ({
       team_id: `team-${i}`,
       team_name: `Team${i}`,
       agents: [],
       tasks: [],
     }));
-    const data: FormData = { teams: manyTeams, stage: "team" };
-    const result = buildClarifyArgs(data);
-    expect(result.questions[0].choices.length).toBe(4);
+    const first = buildClarifyArgs({ teams: manyTeams, stage: "team" });
+    const last = buildClarifyArgs({ teams: manyTeams, stage: "team", pageIndex: 2 });
+    expect(first.questions[0].choices).toEqual([
+      "Team0 (team-0)",
+      "Team1 (team-1)",
+      "Team2 (team-2)",
+      "更多 →",
+    ]);
+    expect(last.questions[0].choices).toEqual([
+      "Team6 (team-6)",
+      "Team7 (team-7)",
+      "Team8 (team-8)",
+      "Team9 (team-9)",
+    ]);
   });
 });

--- a/MemoryProxy/src/session/hermes/extractor.ts
+++ b/MemoryProxy/src/session/hermes/extractor.ts
@@ -1,0 +1,98 @@
+/**
+ * Hermes Session Init — Extractor（clarify 结果解包）。
+ *
+ * hermes 的 `clarify` 工具执行后，把用户回答以 JSON 字符串作为 role=tool 消息
+ * 回填（tools/clarify_tool.py clarify_tool 的返回值）：
+ *
+ *   单题：{"question":"...","choices_offered":["A","B"],"user_response":"A"}
+ *   批量：{"responses":[{"question":"...","user_response":"A"},...]}
+ *         （timed_out=true 表示用户中途走人，剩余问题被 hermes 主动放弃）
+ *   multi_select：user_response 是 string[]
+ *   headless：{"error":"Clarify tool is not available in this execution context."}
+ *             （callback=None，oneshot/api-server 场景）
+ *   超时：user_response = TIMEOUT_RESPONSE
+ *
+ * # 为什么必须解包（不能把原始 JSON 直接喂 CB extractor）
+ *
+ * clarify 结果 JSON 会**原样回显 question 与 choices_offered**：
+ *   - question 里含 SKIP_HINT（"跳过"字样）→ SKIP_RE 误判 bypass；
+ *   - choices_offered 里含所有选项标签 → 误判。
+ * 解包后的文本喂给 CB extractor 的 substring 匹配。
+ */
+
+import { ASSET_CONFIRM_NO } from "./form.js";
+
+// ── Markers ────────────────────────────────────────────────────────────────────
+
+const TIMEOUT_PREFIX = "The user did not provide a response within the time limit";
+const ONESHOT_MARKER = "[oneshot mode:";
+
+/**
+ * bypass 信号载体文本。
+ * 含 ASSET_CONFIRM_NO（"否，本次不关联"）→ extractAssetConfirm 返回 false → bypass；
+ * 含 "不关联" → SKIP_RE 命中 → BYPASS_MARKER。
+ */
+export const HERMES_BYPASS_TEXT = `${ASSET_CONFIRM_NO}（用户未响应会话初始化表单，自动跳过）`;
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * 从 hermes clarify 的 role=tool 结果文本里解包出纯答案文本。
+ *
+ * 返回：
+ *   - null            ：不是 hermes 结果包裹层 → 调用方继续走原始 content 老路径。
+ *   - HERMES_BYPASS_TEXT：headless error / 超时 / oneshot / 批量中途弃答 → bypass。
+ *   - ""              ：是包裹层但没有可用的 user_response → 当"未识别"处理。
+ *   - 非空字符串       ：解包后的答案，直接喂 CB extractor。
+ */
+export function extractHermesAnswers(content: string): string | null {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{")) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+
+  // headless（callback=None）error 信封 → bypass。
+  if (typeof obj.error === "string" && obj.error.length > 0) {
+    return HERMES_BYPASS_TEXT;
+  }
+
+  // 批量形态：{responses: [...], timed_out?: true}
+  if (Array.isArray(obj.responses)) {
+    const answers: string[] = [];
+    for (const r of obj.responses) {
+      if (r && typeof r === "object") {
+        const ur = (r as Record<string, unknown>).user_response;
+        if (typeof ur === "string" && ur.trim().length > 0) answers.push(ur.trim());
+      }
+    }
+    if (obj.timed_out === true) return HERMES_BYPASS_TEXT;
+    return answers.join(" | ");
+  }
+
+  // 单题形态：{question, choices_offered, user_response}
+  if ("user_response" in obj || "question" in obj) {
+    const raw = obj.user_response;
+    let text: string;
+    if (Array.isArray(raw)) {
+      text = raw.map((x) => (typeof x === "string" ? x.trim() : "")).filter(Boolean).join(" | ");
+    } else if (typeof raw === "string") {
+      text = raw.trim();
+    } else {
+      text = "";
+    }
+    if (!text) return "";
+    if (text.includes(TIMEOUT_PREFIX) || text.startsWith(ONESHOT_MARKER)) {
+      return HERMES_BYPASS_TEXT;
+    }
+    return text;
+  }
+
+  return null;
+}

--- a/MemoryProxy/src/session/hermes/form.ts
+++ b/MemoryProxy/src/session/hermes/form.ts
@@ -1,0 +1,261 @@
+/**
+ * Hermes Session Init Form — `clarify` tool_call 载体。
+ *
+ * hermes（github.com/NousResearch/hermes-agent）内置交互式提问工具 `clarify`
+ * （tools/clarify_tool.py，CLARIFY_SCHEMA），是 hermes 原生的交互载体。
+ *
+ * proxy 侧的 session-init form 复用这个 hermes 原生 tool 名，fake 一个
+ * assistant tool_call SSE 让 hermes 的 agent-loop 执行 clarify → 弹原生 UI →
+ * 把用户回答以 role=tool JSON 结果回填，与 dsh/workbuddy 同模式。
+ *
+ * # 简化版说明
+ *   首版不做分页（MORE 翻页）。hermes MAX_CHOICES=4 硬限制，超过 4 个选项
+ *   直接截断。后续如需分页可在此基础上加回 pageIndex + computePagination。
+ *
+ * # 传输
+ *   协议 = OpenAI /v1/chat/completions（stream 或 non-stream）
+ *   3-chunk 骨架照抄 opencode/dsh
+ *
+ * # 状态机
+ *   完全复用 CB 状态机（session/codebuddy/init.ts），同 workbuddy/dsh/opencode
+ *   模式；stage 值与 CB 完全一致，直接透传。
+ *
+ * # tool_call id 前缀
+ *   `call_hermes_session_init_`
+ */
+
+import type { TeamOption } from "../types.js";
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+/** hermes 原生 tool 名。不要改成 `AskUserQuestion` / `ask_followup_question`。 */
+export const TOOL_NAME = "clarify";
+export const TOOLCALL_PREFIX = "call_hermes_session_init_";
+
+export const TEAM_FORM_TITLE = "会话初始化 — 选择 Team";
+export const AGENT_TASK_FORM_TITLE = "会话初始化 — 选择 Agent 与任务";
+export const RETRY_FORM_TITLE = "未能识别选择，请重新选择";
+
+export const SKIP_LABEL = "本次不关联（跳过注入，直接放行）";
+
+export const ASSET_CONFIRM_YES = "是，关联团队资产";
+export const ASSET_CONFIRM_NO = "否，本次不关联";
+export const ASSET_CONFIRM_FORM_TITLE = "会话初始化 — 是否关联团队资产";
+
+/** hermes MAX_CHOICES=4 硬限制。 */
+const MAX_CHOICES = 4;
+
+const SKIP_HINT = '（如选择"跳过"选项，本次 session init 将跳过，不注入任何团队资产）';
+
+/** Returns true if the given string contains any hermes form title marker. */
+export function containsFormTitle(s: string): boolean {
+  return (
+    s.includes(TEAM_FORM_TITLE) ||
+    s.includes(AGENT_TASK_FORM_TITLE) ||
+    s.includes(RETRY_FORM_TITLE) ||
+    s.includes(ASSET_CONFIRM_FORM_TITLE)
+  );
+}
+
+/** Returns true if a tool_call id belongs to a hermes session-init form. */
+export function isSessionInitToolCallId(id: string): boolean {
+  return id.startsWith(TOOLCALL_PREFIX);
+}
+
+// ── Form Data ──────────────────────────────────────────────────────────────────
+
+export type FormStage = "asset_confirm" | "team" | "agent_select" | "agent_task" | "task_select";
+
+export interface FormData {
+  teams: TeamOption[];
+  stage: FormStage;
+  selectedTeamId?: string;
+  selectedAgentId?: string;
+  retry?: boolean;
+  stream?: boolean;
+  modelId?: string;
+}
+
+// ── clarify input schema（hermes CLARIFY_SCHEMA 的 questions[] 形态）──────────
+
+interface HermesClarifyQuestion {
+  question: string;
+  choices: string[];
+  multi_select: boolean;
+}
+
+export function buildClarifyArgs(data: FormData): { questions: HermesClarifyQuestion[] } {
+  const { teams, stage, selectedTeamId, retry } = data;
+  const titlePrefix = retry ? "⚠️ " : "";
+  const questions: HermesClarifyQuestion[] = [];
+
+  if (stage === "asset_confirm") {
+    questions.push({
+      question: titlePrefix + "本次对话是否要关联团队资产？" + SKIP_HINT,
+      choices: [ASSET_CONFIRM_YES, ASSET_CONFIRM_NO],
+      multi_select: false,
+    });
+    return { questions };
+  }
+
+  if (stage === "team") {
+    const teamOpts = teams.slice(0, MAX_CHOICES).map((t) =>
+      `${t.team_name} (${t.team_id.slice(-8)})`,
+    );
+    if (teamOpts.length < 2) {
+      throw new Error(
+        `[hermes form] team stage requires ≥2 teams. Caller must auto-select when teams.length === 1.`,
+      );
+    }
+    questions.push({
+      question: titlePrefix + "请选择本次会话所属的 Team：" + SKIP_HINT,
+      choices: teamOpts,
+      multi_select: false,
+    });
+    return { questions };
+  }
+
+  const team = teams.find((t) => t.team_id === selectedTeamId) ?? teams[0];
+  if (!team) return { questions };
+
+  if (stage === "agent_select" || stage === "agent_task") {
+    const agentOpts = team.agents.slice(0, MAX_CHOICES).map((a) =>
+      `${a.agent_name} (${a.agent_id.slice(-8)})`,
+    );
+    if (agentOpts.length < 2) {
+      throw new Error(`[hermes form] agent stage requires ≥2 options.`);
+    }
+    questions.push({
+      question: titlePrefix + `请选择「${team.team_name}」下要使用的 Agent：` + SKIP_HINT,
+      choices: agentOpts,
+      multi_select: false,
+    });
+    return { questions };
+  }
+
+  if (stage === "task_select") {
+    const taskOpts = team.tasks.slice(0, MAX_CHOICES).map((t) =>
+      t.isDefault ? t.task_name : `${t.task_name} (${t.task_id.slice(-8)})`,
+    );
+    if (taskOpts.length < 2) {
+      throw new Error(`[hermes form] task stage requires ≥2 options.`);
+    }
+    questions.push({
+      question: titlePrefix + `请选择「${team.team_name}」下要关联的任务：` + SKIP_HINT,
+      choices: taskOpts,
+      multi_select: false,
+    });
+    return { questions };
+  }
+
+  return { questions };
+}
+
+// ── Form Builder ───────────────────────────────────────────────────────────────
+
+export function buildFormResponse(data: FormData): Response {
+  const model = data.modelId ?? "unknown";
+  const created = Math.floor(Date.now() / 1000);
+  const id = "hermes-session-init-" + Date.now();
+  const toolCallId = TOOLCALL_PREFIX + Date.now();
+  const input = buildClarifyArgs(data);
+  const argsStr = JSON.stringify(input);
+
+  if (data.stream) {
+    return buildOpenAIStreamingResponse(id, created, model, toolCallId, argsStr);
+  }
+  return buildOpenAINonStreamingResponse(id, created, model, toolCallId, argsStr);
+}
+
+// ── OpenAI Non-streaming ───────────────────────────────────────────────────────
+
+function buildOpenAINonStreamingResponse(
+  id: string,
+  created: number,
+  model: string,
+  toolCallId: string,
+  argsStr: string,
+): Response {
+  return new Response(JSON.stringify({
+    id,
+    object: "chat.completion",
+    created,
+    model,
+    choices: [{
+      index: 0,
+      message: {
+        role: "assistant",
+        content: null,
+        tool_calls: [{
+          id: toolCallId,
+          type: "function",
+          function: { name: TOOL_NAME, arguments: argsStr },
+        }],
+      },
+      finish_reason: "tool_calls",
+    }],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  }), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+// ── OpenAI Streaming ───────────────────────────────────────────────────────────
+
+function buildOpenAIStreamingResponse(
+  id: string,
+  created: number,
+  model: string,
+  toolCallId: string,
+  argsStr: string,
+): Response {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // Chunk 1: role + tool_call declaration
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+        id, object: "chat.completion.chunk", created, model,
+        choices: [{
+          index: 0,
+          delta: {
+            role: "assistant",
+            content: null,
+            tool_calls: [{
+              index: 0,
+              id: toolCallId,
+              type: "function",
+              function: { name: TOOL_NAME, arguments: "" },
+            }],
+          },
+          finish_reason: null,
+        }],
+      })}\n\n`));
+
+      // Chunk 2: arguments delta
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+        id, object: "chat.completion.chunk", created, model,
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: argsStr } }],
+          },
+          finish_reason: null,
+        }],
+      })}\n\n`));
+
+      // Chunk 3: finish
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({
+        id, object: "chat.completion.chunk", created, model,
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      })}\n\n`));
+
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "Connection": "keep-alive" },
+  });
+}

--- a/MemoryProxy/src/session/hermes/form.ts
+++ b/MemoryProxy/src/session/hermes/form.ts
@@ -25,6 +25,7 @@
  */
 
 import type { TeamOption } from "../types.js";
+import { computePagination } from "../claude-code/pagination.js";
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -37,6 +38,7 @@ export const AGENT_TASK_FORM_TITLE = "会话初始化 — 选择 Agent 与任务
 export const RETRY_FORM_TITLE = "未能识别选择，请重新选择";
 
 export const SKIP_LABEL = "本次不关联（跳过注入，直接放行）";
+export const MORE_LABEL = "更多 →";
 
 export const ASSET_CONFIRM_YES = "是，关联团队资产";
 export const ASSET_CONFIRM_NO = "否，本次不关联";
@@ -71,6 +73,7 @@ export interface FormData {
   stage: FormStage;
   selectedTeamId?: string;
   selectedAgentId?: string;
+  pageIndex?: number;
   retry?: boolean;
   stream?: boolean;
   modelId?: string;
@@ -85,7 +88,7 @@ interface HermesClarifyQuestion {
 }
 
 export function buildClarifyArgs(data: FormData): { questions: HermesClarifyQuestion[] } {
-  const { teams, stage, selectedTeamId, retry } = data;
+  const { teams, stage, selectedTeamId, retry, pageIndex = 0 } = data;
   const titlePrefix = retry ? "⚠️ " : "";
   const questions: HermesClarifyQuestion[] = [];
 
@@ -99,9 +102,11 @@ export function buildClarifyArgs(data: FormData): { questions: HermesClarifyQues
   }
 
   if (stage === "team") {
-    const teamOpts = teams.slice(0, MAX_CHOICES).map((t) =>
+    const page = computePagination(teams.length, pageIndex);
+    const teamOpts = teams.slice(page.start, page.end).map((t) =>
       `${t.team_name} (${t.team_id.slice(-8)})`,
     );
+    if (!page.isLastPage) teamOpts.push(MORE_LABEL);
     if (teamOpts.length < 2) {
       throw new Error(
         `[hermes form] team stage requires ≥2 teams. Caller must auto-select when teams.length === 1.`,
@@ -119,9 +124,11 @@ export function buildClarifyArgs(data: FormData): { questions: HermesClarifyQues
   if (!team) return { questions };
 
   if (stage === "agent_select" || stage === "agent_task") {
-    const agentOpts = team.agents.slice(0, MAX_CHOICES).map((a) =>
+    const page = computePagination(team.agents.length, pageIndex);
+    const agentOpts = team.agents.slice(page.start, page.end).map((a) =>
       `${a.agent_name} (${a.agent_id.slice(-8)})`,
     );
+    if (!page.isLastPage) agentOpts.push(MORE_LABEL);
     if (agentOpts.length < 2) {
       throw new Error(`[hermes form] agent stage requires ≥2 options.`);
     }
@@ -134,9 +141,11 @@ export function buildClarifyArgs(data: FormData): { questions: HermesClarifyQues
   }
 
   if (stage === "task_select") {
-    const taskOpts = team.tasks.slice(0, MAX_CHOICES).map((t) =>
+    const page = computePagination(team.tasks.length, pageIndex);
+    const taskOpts = team.tasks.slice(page.start, page.end).map((t) =>
       t.isDefault ? t.task_name : `${t.task_name} (${t.task_id.slice(-8)})`,
     );
+    if (!page.isLastPage) taskOpts.push(MORE_LABEL);
     if (taskOpts.length < 2) {
       throw new Error(`[hermes form] task stage requires ≥2 options.`);
     }

--- a/MemoryProxy/src/session/index.ts
+++ b/MemoryProxy/src/session/index.ts
@@ -91,6 +91,11 @@ import {
   FormData as OCFormData,
   FormStage as OCFormStage,
 } from "./opencode/form.js";
+import {
+  buildFormResponse as buildHermesFormResponse,
+  FormData as HermesFormData,
+  FormStage as HermesFormStage,
+} from "./hermes/form.js";
 
 // Re-export the types under their old names for backward compat
 export type SessionRequestContext = CBSessionRequestContext & Partial<CCSessionRequestContext>;
@@ -248,6 +253,22 @@ export async function handleSessionInit(
       modelId: reqCtx.modelId,
     };
     result.response = buildOpencodeFormResponse(ocFd);
+  }
+
+  // hermes 客户端复用 CB 状态机 + 自己的 `clarify` 载体。
+  // 与 workbuddy/dsh/opencode 完全对称：CB 状态机产出 formData 后外层重渲染 response。
+  if (agentSource === "hermes" && result.intercepted && result.formData) {
+    const cbFd = result.formData;
+    const hFd: HermesFormData = {
+      teams: cbFd.teams,
+      stage: cbFd.stage as HermesFormStage,
+      selectedTeamId: cbFd.selectedTeamId,
+      selectedAgentId: cbFd.selectedAgentId,
+      retry: cbFd.retry,
+      stream: reqCtx.stream,
+      modelId: reqCtx.modelId,
+    };
+    result.response = buildHermesFormResponse(hFd);
   }
 
   return result;

--- a/MemoryProxy/src/session/index.ts
+++ b/MemoryProxy/src/session/index.ts
@@ -264,6 +264,11 @@ export async function handleSessionInit(
       stage: cbFd.stage as HermesFormStage,
       selectedTeamId: cbFd.selectedTeamId,
       selectedAgentId: cbFd.selectedAgentId,
+      pageIndex:
+        cbFd.stage === "team" ? cbFd.teamPage
+        : cbFd.stage === "agent_select" ? cbFd.agentPage
+        : cbFd.stage === "task_select" ? cbFd.taskPage
+        : 0,
       retry: cbFd.retry,
       stream: reqCtx.stream,
       modelId: reqCtx.modelId,

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -294,7 +294,7 @@ function bindingToIdFields(
 function loadSessionIdsL1(sessionId: string): SessionIdFields | null {
   const candidates = sessionId.includes(":")
     ? [sessionId]
-    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`];
+    : [sessionId, `codebuddy:${sessionId}`, `claude-code:${sessionId}`, `hermes:${sessionId}`];
   for (const k of candidates) {
     const s = getSessionStore().get(k);
     if (s) {

--- a/agents/hermes/tdaimemory-provider-plugin/__init__.py
+++ b/agents/hermes/tdaimemory-provider-plugin/__init__.py
@@ -1,0 +1,99 @@
+r"""TencentDB Agent Memory provider profile for hermes-agent.
+
+为每个 hermes 会话动态注入 ``x-conversation-id`` header，配合
+TencentDB Agent Memory Proxy 完成 session-init 表单的跨轮续跑与 session 状态保持。
+
+机制与 OpenRouter 内置插件的 ``x-grok-conv-id`` 完全一致：
+transport 在每次请求前调用 ``build_api_kwargs_extras(session_id=...)``，
+profile 把 header 放进 top-level ``extra_headers``，随 OpenAI SDK 发出。
+
+为什么 subclass ``CustomProfile`` 并注册为 ``custom``：
+  hermes 0.20.x 运行时会把 named custom provider 的 ``agent.provider`` 统一
+  重写为 ``"custom"``。因此按原名注册的 profile 永远不会被运行时查到。
+  provider 插件的发现顺序是 last-writer-wins，这里用同名子类覆盖内置
+  CustomProfile：Ollama num_ctx / reasoning_effort 等 quirk 全部经
+  ``super()`` 保留，仅对 base_url 含 ``/hermes/`` 的请求追加会话 header。
+
+安装（二选一）：
+  1. 用户插件目录（推荐）：
+       mkdir -p ~/.hermes/plugins/model-providers
+       cp -r tdaimemory ~/.hermes/plugins/model-providers/tdaimemory
+  2. hermes-agent 仓库内置目录
+
+配置（~/.hermes/config.yaml）：
+  model:
+    default: <模型名>
+    provider: tdaimemory      # 名字任意；运行时被重写为 custom
+  providers:
+    tdaimemory:
+      base_url: http://<proxy-host>:8096/hermes/<spaceId>/v1
+      api_key: <sk-mem-... user_key>
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from plugins.model_providers.custom import CustomProfile
+from providers import register_provider
+
+
+@dataclass
+class TdaiProxyProfile(CustomProfile):
+    """Custom/Ollama profile + TencentDB Agent Memory 会话 header 注入。
+
+    仅当 base_url 含 ``/hermes/``（本 Proxy 的路由特征）且 session_id
+    非空时追加 ``x-conversation-id: ses_<session_id>``。oneshot（``-z``）
+    无持久 session_id → 不注入 → Proxy 跳过 session-init 直接透传。
+    """
+
+    @staticmethod
+    def _is_tdai_proxy(base_url: str | None) -> bool:
+        return bool(base_url) and "/hermes/" in base_url
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        if self._is_tdai_proxy(base_url):
+            return None
+        return super().fetch_models(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        session_id: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body, top_level = super().build_api_kwargs_extras(
+            session_id=session_id, **context
+        )
+        if session_id and self._is_tdai_proxy(context.get("base_url")):
+            headers = dict(top_level.get("extra_headers") or {})
+            headers.setdefault("x-conversation-id", f"ses_{session_id}")
+            top_level["extra_headers"] = headers
+        return extra_body, top_level
+
+
+register_provider(
+    TdaiProxyProfile(
+        name="custom",
+        aliases=(
+            "ollama",
+            "local",
+            "vllm",
+            "llamacpp",
+            "llama.cpp",
+            "llama-cpp",
+        ),
+        env_vars=(),
+        base_url="",
+        default_max_tokens=65536,
+    )
+)

--- a/agents/hermes/tdaimemory-provider-plugin/plugin.yaml
+++ b/agents/hermes/tdaimemory-provider-plugin/plugin.yaml
@@ -1,0 +1,5 @@
+name: tdaimemory-provider
+kind: model-provider
+version: 1.0.0
+description: TencentDB Agent Memory Proxy provider profile (per-session x-conversation-id)
+author: TencentCloud

--- a/agents/hermes/tdaimemory-provider-plugin/selftest.py
+++ b/agents/hermes/tdaimemory-provider-plugin/selftest.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""tdaimemory-provider-plugin 自测脚本（不依赖 pytest）。
+
+模拟 hermes `_discover_providers()` 的加载顺序（bundled → user），
+验证插件覆盖内置 `custom` profile 后的关键行为。
+
+用法（需已安装 hermes-agent，或用 HERMES_AGENT_DIR 指向其 checkout）：
+    python selftest.py
+    HERMES_AGENT_DIR=/path/to/hermes-agent python selftest.py
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+
+
+def _find_hermes_agent() -> Path:
+    env = os.environ.get("HERMES_AGENT_DIR")
+    if env:
+        p = Path(env)
+        if p.is_dir():
+            return p
+    candidates = [
+        Path.home() / "hermes-agent",
+        Path.home() / "Desktop" / "Projects" / "hermes-agent",
+        Path("/opt/hermes-agent"),
+    ]
+    for p in candidates:
+        if (p / "providers" / "__init__.py").is_file():
+            return p
+    raise SystemExit(
+        "ERROR: cannot locate hermes-agent checkout. "
+        "Set HERMES_AGENT_DIR=/path/to/hermes-agent and retry."
+    )
+
+
+def _load_bundled_plugin(repo: Path, name: str) -> None:
+    d = repo / "plugins" / "model-providers" / name
+    spec = importlib.util.spec_from_file_location(
+        f"plugins.model_providers.{name.replace('-', '_')}",
+        d / "__init__.py",
+        submodule_search_locations=[str(d)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+
+def _load_user_plugin() -> None:
+    spec = importlib.util.spec_from_file_location(
+        "_hermes_user_provider_tdaimemory",
+        PLUGIN_DIR / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+
+def main() -> int:
+    repo = _find_hermes_agent()
+    sys.path.insert(0, str(repo))
+
+    _load_bundled_plugin(repo, "custom")
+    _load_user_plugin()
+
+    from providers import get_provider_profile
+
+    failures = []
+
+    def check(name: str, cond: bool, detail: str = "") -> None:
+        print(f"  [{'PASS' if cond else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+        if not cond:
+            failures.append(name)
+
+    p = get_provider_profile("custom")
+    check("custom profile is overridden by TdaiProxyProfile", type(p).__name__ == "TdaiProxyProfile")
+
+    proxy_url = "http://localhost:8096/hermes/default/v1"
+    sid = "20260830_150940_ce0835"
+
+    eb, tl = p.build_api_kwargs_extras(session_id=sid, base_url=proxy_url)
+    hdr = (tl or {}).get("extra_headers") or {}
+    check("proxy base_url → injects x-conversation-id", hdr.get("x-conversation-id") == f"ses_{sid}")
+
+    eb2, tl2 = p.build_api_kwargs_extras(session_id=sid, base_url="http://127.0.0.1:11434/v1", ollama_num_ctx=8192)
+    check("ollama base_url → no header injected", not ((tl2 or {}).get("extra_headers")))
+    check("ollama num_ctx quirk preserved", "options" in (eb2 or {}))
+
+    eb3, tl3 = p.build_api_kwargs_extras(session_id=None, base_url=proxy_url)
+    check("no session_id (oneshot) → no header", not (tl3 or {}).get("extra_headers"))
+
+    check("proxy base_url skips model listing", p.fetch_models(api_key="unused", base_url=proxy_url) is None)
+
+    print()
+    if failures:
+        print(f"SELFTEST FAILED: {len(failures)} check(s): {failures}")
+        return 1
+    print("SELFTEST PASSED (all checks green).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description | 描述

为 Hermes Agent 接入交互式 session-init：复用现有 CodeBuddy session-init 状态机，但把表单渲染成 hermes 原生的 `clarify` tool_call。

本 PR 是 PR #1215 的**最小修改替代版本**

- 新增 Hermes adapter（`classifyRequest=main`，string content 透传）
- 新增 `session/hermes/form.ts`：`clarify` tool_call SSE 渲染（stream + non-stream），MAX_CHOICES=4 截断（首版不做分页）
- 新增 `session/hermes/extractor.ts`：解包 `clarify` JSON 结果（单题/批量/headless/超时/oneshot）喂给 CB extractor
- `session/index.ts`：第 4 个 form-render 分支（hermes 复用 CB 状态机，与 workbuddy/dsh/opencode 同模式）
- `handler.ts`：内联 `_hermesHeadless` 判定（`body.tools` 无 `clarify` → bypass，与 `_dshHeadless` 同模式）；从 `_headerOnlyAgents` 移除 hermes，交互式 hermes 支持表单
- `memory-bridge.ts` / `skill-bridge.ts`：L1 候选前缀各加 1 行 `hermes:`（不做全局 registry 重设计）
- `routes/whitelist.ts`：`AGENT_PREFIX_RE` 加 `hermes`
- `agents/hermes/tdaimemory-provider-plugin/`：per-session `x-conversation-id` header 注入（subclass `CustomProfile`，last-writer-wins）
- 测试：adapter(4) + form(7) + extractor(10) = 21 tests，全绿

### 相对旧 PR #1215 刻意排除的内容

- 不含全局 bridge L1 registry 重设计（`fe66af7`）
- 不含 Windows deploy 兼容修复（`842880c`）
- 不含 CodeBuddy 翻页修复
- 不含通用化 capability 框架（`init-capability.ts`）
- 不含表单分页（MAX_CHOICES=4 截断）
- 不含 broad provider 行为变更

## Related Issue | 关联 Issue

替代 PR #1215（最小修改版本）

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [x] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- `npx vitest run`：21/21 tests pass（3 个新测试文件）
- `npx tsc --noEmit`：本 PR 未引入新类型错误（基座已有错误不变）
- 待人工验证：hermes CLI 带 `clarify` tool → 表单渲染 → 用户回答喂入 CB 状态机；hermes api-server 无 `clarify` tool → bypass 直接透传
- 待人工验证：`python agents/hermes/tdaimemory-provider-plugin/selftest.py`（需 hermes-agent checkout）
