### PR TITLE
fix(tsconfig): add rootDir to fix TS5.5+ output layout warning

### DIFF
--- a/MemoryProxy/tsconfig.json
+++ b/MemoryProxy/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "rootDir": "src",
     "outDir": "dist",
     "resolveJsonModule": true,
     "paths": {


### PR DESCRIPTION
## Description | 描述

TypeScript 5.5+ 在 `include` 为 `src/**/*` 且 `outDir` 为 `dist` 时，要求显式设置 `rootDir`，否则会报 `TS6` 警告并将产物输出到 `dist/src/...` 而非 `dist/...`。

- `MemoryProxy/tsconfig.json`：新增 `"rootDir": "src"`

## Related Issue | 关联 Issue

无，base `c387ea4` 预存问题。

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [x] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- `npx tsc --noEmit`：tsconfig 警告消除，无新增类型错误（base 已有 29 个错误不变）
- 仅改动 1 行，不影响运行时行为
