### PR TITLE
fix(memory-bridge): populate agent_source in SessionIdFields

### DIFF
--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -72,6 +72,12 @@ interface SessionIdFields {
    * session_key —— 埋点不能猜前缀，必须用真实命中的 key。
    */
   composite_key?: string;
+  /**
+   * Agent source prefix (e.g. `codebuddy`, `claude-code`, `hermes`).
+   * Extracted from `composite_key` or `binding.agentSource` so that
+   * `emitBridgeRejectTelemetry` receives a non-undefined `agentSource`.
+   */
+  agent_source?: string;
 }
 
 /**
@@ -108,6 +114,7 @@ function toIdFields(
     user_key: s.user_key,
     space_id: s.space_id,
     composite_key: compositeKey,
+    agent_source: compositeKey.includes(":") ? compositeKey.split(":")[0] : undefined,
   };
 }
 
@@ -128,6 +135,7 @@ function bindingToIdFields(
     user_key: binding.userKey,
     space_id: spaceId,
     composite_key: `${agentSource}:${sessionId}`,
+    agent_source: agentSource,
   };
 }
 


### PR DESCRIPTION
## Description | 描述

`SessionIdFields` 接口缺少 `agent_source` 字段，`toIdFields` 和 `bindingToIdFields` 均未填充该字段。但 `memory-bridge.ts` 第 338/349 行读取 `ids.agent_source` 作为 `emitBridgeRejectTelemetry` 的 `agentSource` 参数，运行时永远为 `undefined`，导致埋点数据丢失 agent 来源。

- `SessionIdFields` 新增 `agent_source?: string` 字段
- `toIdFields`：从 `compositeKey` 前缀提取（`${agentSource}:${sessionId}`）
- `bindingToIdFields`：使用已有的 `binding.agentSource` 值

## Related Issue | 关联 Issue

无，base `c387ea4` 预存问题。

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- `npx tsc --noEmit`：`agent_source` 相关 2 个 TS2339 错误消除，无新增错误
- 仅改动 1 个文件，8 行新增，不影响运行时已有逻辑
