### PR TITLE
fix(memory-core): compute L1 dedup timestamps in code instead of trusting the model

### DIFF
--- a/MemoryCore/src/core/prompts/l1-dedup.ts
+++ b/MemoryCore/src/core/prompts/l1-dedup.ts
@@ -43,8 +43,8 @@ export const CONFLICT_DETECTION_SYSTEM_PROMPT = `你是记忆冲突检测器。�
    - 跨类型示例：一条 episodic "用户在 2018 年开始做播客" + 一条 persona "用户有播客制作经验" → 可 merge 为一条 persona 或 episodic（取决于信息侧重）
 
 5. **timestamp 处理**：
-   - merge / update 时，merged_timestamps 应包含**所有相关记忆的时间戳并集**（去重排序）
-   - 这样可以保留事件发生的完整时间线
+   - 每条新记忆和候选记忆都已带 \`timestamps\`（来源消息时间，ISO 8601）。
+   - merge / update 时系统会用「新记忆 timestamps + 你选中的 target_ids 对应候选 timestamps」做并集，**不要编造时间戳**。\`merged_timestamps\` 可省略，填写也会被忽略。
 
 ## 输出格式
 
@@ -57,17 +57,15 @@ export const CONFLICT_DETECTION_SYSTEM_PROMPT = `你是记忆冲突检测器。�
     "target_ids": ["要删除的候选记忆 record_id 1", "record_id 2"],
     "merged_content": "合并/更新后的记忆内容（merge/update 时必填）",
     "merged_type": "合并后的最佳 type：persona|episodic|instruction|work_fact|work_task|work_method|work_artifact（merge/update 时必填）",
-    "merged_priority": 85,
-    "merged_timestamps": ["合并后的时间戳数组，包含所有新旧记忆时间戳的并集（merge/update 时必填）"]
+    "merged_priority": 85
   }
 ]
 
 字段说明：
-- target_ids：要删除替换的旧记忆 ID **数组**（可以 1 条或多条）。store/skip 时省略或为空。
+- target_ids：要删除替换的旧记忆 ID **数组**（可以 1 条或多条）。必须来自统一候选记忆池。store/skip 时省略或为空。
 - merged_content：merge/update 时的最终记忆文本。store/skip 时省略。
 - merged_type：merge/update 后记忆应归属的 type。根据合并后内容本质判断。
-- merged_priority：merge/update 后的新优先级（0-100 整数，merge/update 时必填）。合并后信息更完整、更确定，通常应**酌情提升** priority（例如两条 priority 70 的记忆合并后可提升到 80）。参考标准：80-100（核心特质/重要事件），60-79（一般偏好/普通活动），<60（次要信息）。
-- merged_timestamps：合并后的时间戳数组。收集新记忆 + 所有被合并旧记忆的时间戳，去重排序。`;
+- merged_priority：merge/update 后的新优先级（0-100 整数，merge/update 时必填）。合并后信息更完整、更确定，通常应**酌情提升** priority（例如两条 priority 70 的记忆合并后可提升到 80）。参考标准：80-100（核心特质/重要事件），60-79（一般偏好/普通活动），<60（次要信息）。`;
 
 export const WORK_CONFLICT_DETECTION_SYSTEM_PROMPT = `你是团队工作记忆冲突检测器。批量比较多条【新记忆】与【统一候选记忆池】中的已有记忆，逐条决定如何处理。
 
@@ -107,8 +105,8 @@ export const WORK_CONFLICT_DETECTION_SYSTEM_PROMPT = `你是团队工作记忆�
    - 跨类型示例：一条 work_fact "团队决定 L1 type 保持少量高层分类" + 一条 work_method "L1 type 不宜过细，否则影响 L2/L3 聚合" → 可 merge 为 work_method。
 
 5. **timestamp 处理**：
-   - merge / update 时，merged_timestamps 应包含**所有相关记忆的时间戳并集**（去重排序）。
-   - 这样可以保留工作事实、任务或方法演化的完整时间线。
+   - 每条新记忆和候选记忆都已带 \`timestamps\`（来源消息时间，ISO 8601）。
+   - merge / update 时系统会用「新记忆 timestamps + 你选中的 target_ids 对应候选 timestamps」做并集，**不要编造时间戳**。\`merged_timestamps\` 可省略，填写也会被忽略。
 
 ## 输出格式
 
@@ -121,17 +119,15 @@ export const WORK_CONFLICT_DETECTION_SYSTEM_PROMPT = `你是团队工作记忆�
     "target_ids": ["要删除的候选记忆 record_id 1", "record_id 2"],
     "merged_content": "合并/更新后的记忆内容（merge/update 时必填）",
     "merged_type": "合并后的最佳 type：work_fact|work_task|work_method|work_artifact（merge/update 时必填）",
-    "merged_priority": 85,
-    "merged_timestamps": ["合并后的时间戳数组，包含所有新旧记忆时间戳的并集（merge/update 时必填）"]
+    "merged_priority": 85
   }
 ]
 
 字段说明：
-- target_ids：要删除替换的旧记忆 ID **数组**（可以 1 条或多条）。store/skip 时省略或为空。
+- target_ids：要删除替换的旧记忆 ID **数组**（可以 1 条或多条）。必须来自统一候选记忆池。store/skip 时省略或为空。
 - merged_content：merge/update 时的最终记忆文本。store/skip 时省略。
 - merged_type：merge/update 后记忆应归属的 type。根据合并后内容本质判断。
-- merged_priority：merge/update 后的新优先级（0-100 整数，merge/update 时必填）。合并后信息更完整、更确定，通常应**酌情提升** priority。参考标准：80-100（关键事实/重要任务/核心方法/重要资产），60-79（一般工作信息），<60（次要信息）。
-- merged_timestamps：合并后的时间戳数组。收集新记忆 + 所有被合并旧记忆的时间戳，去重排序。`;
+- merged_priority：merge/update 后的新优先级（0-100 整数，merge/update 时必填）。合并后信息更完整、更确定，通常应**酌情提升** priority。参考标准：80-100（关键事实/重要任务/核心方法/重要资产），60-79（一般工作信息），<60（次要信息）。`;
 
 export function getConflictDetectionSystemPrompt(mode: MemoryPromptMode = "chat"): string {
   return mode === "code" ? WORK_CONFLICT_DETECTION_SYSTEM_PROMPT : CONFLICT_DETECTION_SYSTEM_PROMPT;
@@ -209,6 +205,7 @@ export function formatBatchConflictPrompt(matches: CandidateMatch[]): string {
         type: m.newMemory.type,
         priority: m.newMemory.priority,
         scene_name: m.newMemory.scene_name,
+        timestamps: m.newMemory.timestamps ?? [],
       },
       null,
       2,

--- a/MemoryCore/src/core/record/l1-dedup-timestamps.test.ts
+++ b/MemoryCore/src/core/record/l1-dedup-timestamps.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { formatBatchConflictPrompt, type CandidateMatch } from "../prompts/l1-dedup.js";
+import { applyDedupProvenance } from "./l1-dedup.js";
+import { resolveSourceTimestamps, timestampsForWrite } from "./l1-timestamps.js";
+import type { DedupDecision, ExtractedMemory, MemoryRecord } from "./l1-writer.js";
+
+const oldTime = "2026-09-08T04:00:00.000Z";
+const newTime = "2026-09-09T04:00:00.000Z";
+const inventedTime = "2099-01-01T00:00:00.000Z";
+
+function newMemory(overrides: Partial<ExtractedMemory> & { record_id: string }): ExtractedMemory & { record_id: string } {
+  return {
+    content: "Use UTC for reports.",
+    type: "instruction",
+    priority: 70,
+    source_message_ids: ["msg-1"],
+    metadata: {},
+    scene_name: "Reporting",
+    timestamps: [newTime],
+    ...overrides,
+  };
+}
+
+function candidate(id: string, timestamps: string[]): MemoryRecord {
+  return {
+    id,
+    content: "Use local time for reports.",
+    type: "instruction",
+    priority: 70,
+    source_message_ids: [],
+    metadata: {},
+    scene_name: "Reporting",
+    timestamps,
+    createdAt: oldTime,
+    updatedAt: oldTime,
+    sessionKey: "example",
+    sessionId: "example",
+  };
+}
+
+describe("formatBatchConflictPrompt — new-memory timestamps", () => {
+  it("includes new-memory source timestamps alongside candidate timestamps", () => {
+    const matches: CandidateMatch[] = [{
+      newMemory: newMemory({ record_id: "new-1" }),
+      candidates: [candidate("old-1", [oldTime])],
+    }];
+
+    const prompt = formatBatchConflictPrompt(matches);
+    expect(prompt.includes(oldTime)).toBe(true);
+    expect(prompt.includes(newTime)).toBe(true);
+  });
+
+  it("does not invent timestamps that are not on the new memory or candidates", () => {
+    const matches: CandidateMatch[] = [{
+      newMemory: newMemory({ record_id: "new-1" }),
+      candidates: [candidate("old-1", [oldTime])],
+    }];
+
+    const prompt = formatBatchConflictPrompt(matches);
+    expect(prompt.includes(inventedTime)).toBe(false);
+  });
+});
+
+describe("resolveSourceTimestamps", () => {
+  it("converts matching source_message_ids from epoch ms to ISO", () => {
+    const iso = resolveSourceTimestamps(
+      ["msg-1"],
+      [{ id: "msg-1", timestamp: Date.parse(newTime) }],
+    );
+    expect(iso).toEqual([newTime]);
+  });
+
+  it("skips unresolved ids instead of falling back to every scene message", () => {
+    const iso = resolveSourceTimestamps(
+      ["missing"],
+      [
+        { id: "msg-1", timestamp: Date.parse(oldTime) },
+        { id: "msg-2", timestamp: Date.parse(newTime) },
+      ],
+    );
+    expect(iso).toEqual([]);
+  });
+
+  it("keeps only the resolved subset when some source ids are missing", () => {
+    const iso = resolveSourceTimestamps(
+      ["msg-1", "missing"],
+      [{ id: "msg-1", timestamp: Date.parse(newTime) }],
+    );
+    expect(iso).toEqual([newTime]);
+  });
+});
+
+describe("applyDedupProvenance — timestamp union", () => {
+  it("unions new-memory timestamps with selected candidate timestamps", () => {
+    const matches: CandidateMatch[] = [{
+      newMemory: newMemory({ record_id: "new-1" }),
+      candidates: [candidate("old-1", [oldTime])],
+    }];
+    const decisions: DedupDecision[] = [{
+      record_id: "new-1",
+      action: "update",
+      target_ids: ["old-1"],
+      merged_timestamps: [inventedTime],
+    }];
+
+    const [out] = applyDedupProvenance(decisions, matches);
+    expect(out.merged_timestamps).toEqual([oldTime, newTime]);
+    expect(out.merged_timestamps).not.toContain(inventedTime);
+  });
+
+  it("drops hallucinated target_ids outside the unified candidate pool", () => {
+    const matches: CandidateMatch[] = [{
+      newMemory: newMemory({ record_id: "new-1" }),
+      candidates: [candidate("old-1", [oldTime])],
+    }];
+    const decisions: DedupDecision[] = [{
+      record_id: "new-1",
+      action: "merge",
+      target_ids: ["old-1", "not-in-pool"],
+    }];
+
+    const [out] = applyDedupProvenance(decisions, matches);
+    expect(out.target_ids).toEqual(["old-1"]);
+    expect(out.merged_timestamps).toEqual([oldTime, newTime]);
+  });
+});
+
+describe("timestampsForWrite", () => {
+  const nowIso = "2026-09-10T00:00:00.000Z";
+
+  it("uses the code-computed union for merge/update", () => {
+    expect(timestampsForWrite({
+      action: "update",
+      memoryTimestamps: [newTime],
+      mergedTimestamps: [oldTime, newTime],
+      nowIso,
+    })).toEqual([oldTime, newTime]);
+  });
+
+  it("drops unparseable merged timestamps and falls back to source timestamps", () => {
+    expect(timestampsForWrite({
+      action: "merge",
+      memoryTimestamps: [newTime],
+      mergedTimestamps: ["not-a-date", ""],
+      nowIso,
+    })).toEqual([newTime]);
+  });
+
+  it("falls back to processing time for store when no source timestamps resolved", () => {
+    expect(timestampsForWrite({
+      action: "store",
+      memoryTimestamps: [],
+      nowIso,
+    })).toEqual([nowIso]);
+  });
+
+  it("persists source timestamps on store when they resolved", () => {
+    expect(timestampsForWrite({
+      action: "store",
+      memoryTimestamps: [newTime],
+      nowIso,
+    })).toEqual([newTime]);
+  });
+});

--- a/MemoryCore/src/core/record/l1-dedup.ts
+++ b/MemoryCore/src/core/record/l1-dedup.ts
@@ -18,6 +18,7 @@ import type { MemoryPromptMode } from "../../config.js";
 import type { ExtractedMemory, MemoryRecord, DedupDecision, MemoryType } from "./l1-writer.js";
 import { formatBatchConflictPrompt, getConflictDetectionSystemPrompt } from "../prompts/l1-dedup.js";
 import type { CandidateMatch } from "../prompts/l1-dedup.js";
+import { uniqueSortedTimestamps } from "./l1-timestamps.js";
 import { CleanContextRunner } from "../../utils/clean-context-runner.js";
 import { sanitizeJsonForParse } from "../../utils/sanitize.js";
 import type { IMemoryStore, IsolationFilter, L1SearchResult } from "../store/types.js";
@@ -186,7 +187,7 @@ async function runLlmJudgment(
     }
 
     const decisions = parseBatchResult(result, memories, logger);
-    return decisions;
+    return applyDedupProvenance(decisions, matches);
   } catch (err) {
     logger?.warn?.(
       `${TAG} Batch conflict detection failed, defaulting all to store: ${err instanceof Error ? err.message : String(err)}`,
@@ -305,7 +306,8 @@ const VALID_TYPES: MemoryType[] = ["persona", "episodic", "instruction", "work_f
 /**
  * Parse the LLM's batch conflict detection JSON response.
  *
- * Expected format: [{record_id, action, target_ids, merged_content, merged_type, merged_priority, merged_timestamps}]
+ * Expected format: [{record_id, action, target_ids, merged_content, merged_type, merged_priority}]
+ * `merged_timestamps` from the model is ignored; applyDedupProvenance fills it.
  */
 function parseBatchResult(
   raw: string,
@@ -387,7 +389,7 @@ function parseBatchResult(
         merged_content: typeof d.merged_content === "string" ? d.merged_content : undefined,
         merged_type: VALID_TYPES.includes(d.merged_type as MemoryType) ? (d.merged_type as MemoryType) : undefined,
         merged_priority: typeof d.merged_priority === "number" ? d.merged_priority : undefined,
-        merged_timestamps: Array.isArray(d.merged_timestamps) ? d.merged_timestamps.map(String) : undefined,
+        // merged_timestamps is computed in applyDedupProvenance — ignore model output.
       });
     }
 
@@ -409,6 +411,42 @@ function parseBatchResult(
     logger?.warn?.(`${TAG} Failed to parse conflict detection result: ${err instanceof Error ? err.message : String(err)}`);
     return fallbackStoreAll(memories);
   }
+}
+
+/**
+ * Restrict target_ids to the unified candidate pool of this batch, then set
+ * `merged_timestamps` to the sorted union of the new memory's source timestamps
+ * and the selected candidates' timestamps.
+ *
+ * Allowed targets = the unified pool shown to the model (not every L1 record).
+ * Hallucinated IDs and model-invented timestamps are dropped, not thrown.
+ */
+export function applyDedupProvenance(
+  decisions: DedupDecision[],
+  matches: CandidateMatch[],
+): DedupDecision[] {
+  const pool = new Map<string, MemoryRecord>();
+  const memoryById = new Map<string, ExtractedMemory & { record_id: string }>();
+  for (const m of matches) {
+    memoryById.set(m.newMemory.record_id, m.newMemory);
+    for (const candidate of m.candidates) {
+      if (!pool.has(candidate.id)) pool.set(candidate.id, candidate);
+    }
+  }
+
+  return decisions.map((decision) => {
+    const allowedTargets = decision.target_ids.filter((id) => pool.has(id));
+    const mem = memoryById.get(decision.record_id);
+    const union = uniqueSortedTimestamps([
+      ...(mem?.timestamps ?? []),
+      ...allowedTargets.flatMap((id) => pool.get(id)?.timestamps ?? []),
+    ]);
+    return {
+      ...decision,
+      target_ids: allowedTargets,
+      merged_timestamps: union.length > 0 ? union : undefined,
+    };
+  });
 }
 
 /**

--- a/MemoryCore/src/core/record/l1-extractor.ts
+++ b/MemoryCore/src/core/record/l1-extractor.ts
@@ -17,6 +17,7 @@ import { formatExtractionPrompt, getExtractMemoriesSystemPrompt, type MemoryProm
 import { batchDedup } from "./l1-dedup.js";
 import { writeMemory, generateMemoryId } from "./l1-writer.js";
 import type { ExtractedMemory, MemoryRecord, MemoryType, DedupDecision } from "./l1-writer.js";
+import { resolveSourceTimestamps } from "./l1-timestamps.js";
 import { CleanContextRunner } from "../../utils/clean-context-runner.js";
 import { sanitizeJsonForParse, shouldExtractL1 } from "../../utils/sanitize.js";
 import type { IMemoryStore } from "../store/types.js";
@@ -235,6 +236,10 @@ export async function extractL1Memories(params: {
         source_message_ids: Array.isArray(mem.source_message_ids) ? mem.source_message_ids : [],
         metadata: mem.metadata ?? {},
         scene_name: scene.scene_name,
+        timestamps: resolveSourceTimestamps(
+          Array.isArray(mem.source_message_ids) ? mem.source_message_ids : [],
+          messages,
+        ),
       });
     }
   }

--- a/MemoryCore/src/core/record/l1-timestamps.ts
+++ b/MemoryCore/src/core/record/l1-timestamps.ts
@@ -1,0 +1,89 @@
+/**
+ * L1 timestamp provenance helpers.
+ *
+ * Source-message time is distinct from event time (`metadata.activity_*`) and
+ * from `createdAt`/`updatedAt`. Conflict detection and merge/update writes
+ * must use timestamps that can be traced to L0 messages or already-stored
+ * candidate records — never model-invented values.
+ */
+
+export interface TimestampedMessage {
+  id: string;
+  timestamp: number;
+}
+
+/**
+ * Keep strings that parse as real dates, de-duplicate, and sort lexicographically
+ * (ISO-8601 UTC strings compare in chronological order).
+ *
+ * Invalid / empty values are dropped rather than throwing: a bad timestamp on
+ * one memory must not abort the rest of the extraction batch.
+ */
+export function uniqueSortedTimestamps(values: Iterable<string | undefined>): string[] {
+  const seen = new Set<string>();
+  for (const raw of values) {
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (Number.isNaN(Date.parse(trimmed))) continue;
+    seen.add(trimmed);
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Resolve ISO timestamps for an extracted memory from its `source_message_ids`.
+ *
+ * Policy (missing / partial sources):
+ * - Only IDs that exist in `messages` with a finite epoch timestamp contribute.
+ * - Unresolved IDs are skipped (no throw, no fallback to every scene message).
+ * - If nothing resolves, return `[]` and let the writer fall back to processing time.
+ */
+export function resolveSourceTimestamps(
+  sourceMessageIds: string[] | undefined,
+  messages: TimestampedMessage[],
+): string[] {
+  if (!Array.isArray(sourceMessageIds) || sourceMessageIds.length === 0) return [];
+
+  const byId = new Map<string, number>();
+  for (const msg of messages) {
+    if (!msg?.id) continue;
+    if (typeof msg.timestamp !== "number" || !Number.isFinite(msg.timestamp)) continue;
+    byId.set(msg.id, msg.timestamp);
+  }
+
+  const iso: string[] = [];
+  for (const id of sourceMessageIds) {
+    const epochMs = byId.get(id);
+    if (epochMs === undefined) continue;
+    iso.push(new Date(epochMs).toISOString());
+  }
+  return uniqueSortedTimestamps(iso);
+}
+
+/**
+ * Timestamps that will be persisted on an L1 record.
+ *
+ * - merge/update: use the code-computed union (`mergedTimestamps`); if empty,
+ *   fall back to the new memory's source timestamps, then processing time.
+ * - store: prefer source timestamps when present, else processing time.
+ * - skip: unused (writer returns null before writing).
+ */
+export function timestampsForWrite(params: {
+  action: "store" | "update" | "merge" | "skip";
+  memoryTimestamps?: string[];
+  mergedTimestamps?: string[];
+  nowIso: string;
+}): string[] {
+  const fromMemory = uniqueSortedTimestamps(params.memoryTimestamps ?? []);
+  if (params.action === "merge" || params.action === "update") {
+    const union = uniqueSortedTimestamps(params.mergedTimestamps ?? []);
+    if (union.length > 0) return union;
+    if (fromMemory.length > 0) return fromMemory;
+    return [params.nowIso];
+  }
+  if (params.action === "store") {
+    return fromMemory.length > 0 ? fromMemory : [params.nowIso];
+  }
+  return [];
+}

--- a/MemoryCore/src/core/record/l1-writer.ts
+++ b/MemoryCore/src/core/record/l1-writer.ts
@@ -22,6 +22,7 @@ import type { EmbeddingService } from "../store/embedding.js";
 import type { StorageAdapter } from "../storage/adapter.js";
 import { StoragePaths } from "../storage/types.js";
 import type { Logger } from "../types.js";
+import { timestampsForWrite } from "./l1-timestamps.js";
 
 // ============================
 // Types
@@ -109,6 +110,12 @@ export interface ExtractedMemory {
   metadata: EpisodicMetadata | Record<string, never>;
   /** Scene name this memory was extracted in */
   scene_name: string;
+  /**
+   * ISO timestamps of the source L0 messages (`source_message_ids`).
+   * Empty when none of the source IDs could be resolved. Distinct from
+   * event time in `metadata` and from `createdAt`/`updatedAt`.
+   */
+  timestamps?: string[];
 }
 
 export type DedupAction = "store" | "update" | "merge" | "skip";
@@ -132,7 +139,10 @@ export interface DedupDecision {
   merged_type?: MemoryType;
   /** Priority after merge (for update/merge) */
   merged_priority?: number;
-  /** Union of all related timestamps (for update/merge) */
+  /**
+   * Union of new-memory source timestamps and selected candidate timestamps.
+   * Filled in code after conflict detection — not taken from the model.
+   */
   merged_timestamps?: string[];
 }
 
@@ -209,14 +219,19 @@ export async function writeMemory(params: {
     finalContent = decision.merged_content ?? memory.content;
     finalType = decision.merged_type ?? memory.type;
     finalPriority = decision.merged_priority ?? memory.priority;
-    finalTimestamps = decision.merged_timestamps ?? [now];
   } else {
     // store
     finalContent = memory.content;
     finalType = memory.type;
     finalPriority = memory.priority;
-    finalTimestamps = [now];
   }
+
+  finalTimestamps = timestampsForWrite({
+    action: decision.action,
+    memoryTimestamps: memory.timestamps,
+    mergedTimestamps: decision.merged_timestamps,
+    nowIso: now,
+  });
 
   const record: MemoryRecord = {
     id: decision.record_id || generateMemoryId(),


### PR DESCRIPTION
## Description | 描述
L1 conflict detection omitted new-memory source timestamps and wrote model-supplied `merged_timestamps`. Merge/update now unions source-message times with selected candidate timestamps in code, and ignores invented model values.

Unsafe merge/update decisions fall back to `store` (original extracted content, no target deletes): missing source timestamps, empty targets, all-invalid IDs, and mixed valid/invalid IDs. `writeMemory` applies the same guard so a raw decision cannot delete existing records without timestamps or targets.

## Related Issue | 关联 Issue
Fixes #1318

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明
- `cd MemoryCore && npx vitest run src/core/record/l1-dedup-timestamps.test.ts` → 34 passed
- Missing `source_message_ids` and out-of-range epoch values are skipped (no throw, no fallback to every scene message)
- Invalid / mixed / empty `target_ids` on merge/update fall back to `store`; blank ids are ignored, not treated as mixed
- Search hits contribute `timestamp_str` / `timestamp_start` / `timestamp_end` to the union
- Merge/update never stamps processing time; `writeMemory` also coerces empty-timestamp or empty-target replace actions to `store`