### PR TITLE
 fix(memory): cascade-delete agents on member/user removal and allow admin deletion (#1321)

### DIFF
--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -1876,16 +1876,21 @@ export class MetadataService {
     return this.updateAgent(agentId, patch);
   }
 
-  // team admin 可代删/代归档成员的 Agent（与 createAgentForCaller 允许 admin 代建对称）
+  // team admin 可代删/代归档成员的 Agent（与 createAgentForCaller 允许 admin 代建对称）；
+  // system_admin 是实例级管理员，无需加入目标 team 即可操作（对齐 Panel delete-cascade 的权限面）
   async deleteAgentsForCaller(agentIds: string[], ctx: V3AuthContext): Promise<BatchDeleteResult> {
     for (const agentId of agentIds) {
-      await this.assertCallerIsAgentOwnerOrTeamAdmin(ctx, agentId);
+      if (!ctx.isSystemAdmin) {
+        await this.assertCallerIsAgentOwnerOrTeamAdmin(ctx, agentId);
+      }
     }
     return this.deleteAgents(agentIds);
   }
 
   async archiveAgentForCaller(agentId: string, ctx: V3AuthContext): Promise<AgentEntity> {
-    await this.assertCallerIsAgentOwnerOrTeamAdmin(ctx, agentId);
+    if (!ctx.isSystemAdmin) {
+      await this.assertCallerIsAgentOwnerOrTeamAdmin(ctx, agentId);
+    }
     return this.archiveAgent(agentId);
   }
 

--- a/MemoryCore/src/metadata/service/metadata-service.ts
+++ b/MemoryCore/src/metadata/service/metadata-service.ts
@@ -608,6 +608,13 @@ export class MetadataService {
     if (totalAdmins > 0 && totalAdmins - deletingSystemAdmins < 1) {
       throw new MetadataError("last_system_admin", "cannot delete the last system_admin user");
     }
+    // 删除用户前级联硬删除其所有 Agent（owner 即将不存在，归档无意义）
+    const allAgentIds: string[] = [];
+    for (const userId of userIds) {
+      const ids = await this.collectAgentIdsByOwner(userId);
+      allAgentIds.push(...ids);
+    }
+    if (allAgentIds.length > 0) await this.deleteAgents(allAgentIds);
     return this.deleteUsers(userIds);
   }
 
@@ -1820,6 +1827,9 @@ export class MetadataService {
     if (userId === team.owner_user_id) {
       throw new MetadataError("permission_denied", "cannot remove team owner");
     }
+    // 移除成员前级联硬删除其在此 team 的所有 Agent（owner 即将不可达，归档无意义）
+    const agentIds = await this.collectAgentIdsByOwnerInTeam(teamId, userId);
+    if (agentIds.length > 0) await this.deleteAgents(agentIds);
     return this.removeTeamMember(teamId, userId);
   }
 
@@ -1866,15 +1876,16 @@ export class MetadataService {
     return this.updateAgent(agentId, patch);
   }
 
+  // team admin 可代删/代归档成员的 Agent（与 createAgentForCaller 允许 admin 代建对称）
   async deleteAgentsForCaller(agentIds: string[], ctx: V3AuthContext): Promise<BatchDeleteResult> {
     for (const agentId of agentIds) {
-      await this.assertCallerIsAgentOwner(ctx, agentId);
+      await this.assertCallerIsAgentOwnerOrTeamAdmin(ctx, agentId);
     }
     return this.deleteAgents(agentIds);
   }
 
   async archiveAgentForCaller(agentId: string, ctx: V3AuthContext): Promise<AgentEntity> {
-    await this.assertCallerIsAgentOwner(ctx, agentId);
+    await this.assertCallerIsAgentOwnerOrTeamAdmin(ctx, agentId);
     return this.archiveAgent(agentId);
   }
 
@@ -2034,6 +2045,42 @@ export class MetadataService {
     const ids: string[] = [];
     for (let offset = 0; offset < MAX_AGENTS; offset += PAGE) {
       const page = await this.store.listAgentsByTeam(teamId, { limit: PAGE, offset });
+      for (const agent of page.items) ids.push(agent.agent_id);
+      if (page.items.length < PAGE) break;
+    }
+    return ids;
+  }
+
+  /**
+   * 收集指定用户在指定 team 下拥有的全部 agent_id（分页遍历）。
+   * 用于成员移除时级联删除其 Agent。
+   */
+  private async collectAgentIdsByOwnerInTeam(teamId: string, userId: string): Promise<string[]> {
+    const PAGE = 100;
+    const MAX_AGENTS = 10_000;
+    const ids: string[] = [];
+    for (let offset = 0; offset < MAX_AGENTS; offset += PAGE) {
+      const page = await this.store.listAgentsByTeam(
+        teamId,
+        { limit: PAGE, offset },
+        { owner_user_id: userId },
+      );
+      for (const agent of page.items) ids.push(agent.agent_id);
+      if (page.items.length < PAGE) break;
+    }
+    return ids;
+  }
+
+  /**
+   * 收集指定用户在所有 team 下拥有的全部 agent_id（分页遍历）。
+   * 用于用户删除时级联删除其所有 Agent。
+   */
+  private async collectAgentIdsByOwner(userId: string): Promise<string[]> {
+    const PAGE = 100;
+    const MAX_AGENTS = 10_000;
+    const ids: string[] = [];
+    for (let offset = 0; offset < MAX_AGENTS; offset += PAGE) {
+      const page = await this.store.listAgentsByOwner(userId, { limit: PAGE, offset });
       for (const agent of page.items) ids.push(agent.agent_id);
       if (page.items.length < PAGE) break;
     }

--- a/MemoryCore/src/metadata/store/metadata-store.contract.ts
+++ b/MemoryCore/src/metadata/store/metadata-store.contract.ts
@@ -672,6 +672,57 @@ export function runMetadataStoreContract(
         await store.deleteTasks([task.task_id]);
         expect((await store.listTaskAgents(task.task_id, P)).items).toHaveLength(0);
       });
+
+      it("deleteTeams 级联清理 agents 的 task_agents + fixed_assets + chat_memory", async () => {
+        const owner = await store.createUser(uniqueUserInput());
+        const team = await store.createTeam(teamInput(owner.user_id));
+        const agent = await store.createAgent({ team_id: team.team_id, owner_user_id: owner.user_id, name: "A" });
+        const task = await store.createTask({ team_id: team.team_id, creator_user_id: owner.user_id, title: "T" });
+        await store.linkTaskAgent(task.task_id, agent.agent_id);
+
+        const skillAsset = await store.createAsset({ asset_id: newAssetId(), team_id: team.team_id, asset_type: "skill", name: "S", owner_user_id: owner.user_id, source_type: "manual" });
+        await store.setAgentFixedAssets(agent.agent_id, [{ asset_id: skillAsset.asset_id, asset_type: "skill", created_by: owner.user_id }]);
+
+        const chatMemoryId = buildChatMemoryAssetId(team.team_id, agent.agent_id);
+        await store.createAsset({ asset_id: chatMemoryId, team_id: team.team_id, asset_type: "chat_memory", name: "Memory", owner_user_id: owner.user_id, source_type: "auto", visibility: "private", status: "active" });
+        await store.setAgentFixedAssets(agent.agent_id, [
+          { asset_id: skillAsset.asset_id, asset_type: "skill", created_by: owner.user_id },
+          { asset_id: chatMemoryId, asset_type: "chat_memory", created_by: owner.user_id },
+        ]);
+
+        await store.deleteTeams([team.team_id]);
+
+        // task_agents 应被清理
+        expect((await store.listTaskAgents(task.task_id, P)).items).toHaveLength(0);
+        // agent_fixed_assets 应被清理
+        expect((await store.listAgentFixedAssets(agent.agent_id, P)).items).toHaveLength(0);
+        // chat_memory asset 应被删除
+        expect(await store.getAssetById(chatMemoryId)).toBeNull();
+        // agent 本身应不存在
+        expect(await store.getAgentById(agent.agent_id)).toBeNull();
+      });
+
+      it("removeTeamMember 不级联删除 agents（由 service 层负责）", async () => {
+        const owner = await store.createUser(uniqueUserInput());
+        const member = await store.createUser(uniqueUserInput());
+        const team = await store.createTeam(teamInput(owner.user_id));
+        await store.addTeamMember({ team_id: team.team_id, user_id: member.user_id, role: "member" });
+        const agent = await store.createAgent({ team_id: team.team_id, owner_user_id: member.user_id, name: "A" });
+
+        await store.removeTeamMember(team.team_id, member.user_id);
+        // store 层不级联，agent 仍存在（service 层 removeTeamMemberForCaller 负责级联）
+        expect(await store.getAgentById(agent.agent_id)).not.toBeNull();
+      });
+
+      it("deleteUsers 不级联删除 agents（由 service 层负责）", async () => {
+        const owner = await store.createUser(uniqueUserInput());
+        const team = await store.createTeam(teamInput(owner.user_id));
+        const agent = await store.createAgent({ team_id: team.team_id, owner_user_id: owner.user_id, name: "A" });
+
+        await store.deleteUsers([owner.user_id]);
+        // store 层不级联，agent 仍存在（service 层 deleteUsersForCaller 负责级联）
+        expect(await store.getAgentById(agent.agent_id)).not.toBeNull();
+      });
     });
 
     // ── v3.1：username / external_id 无唯一约束 ──

--- a/MemoryCore/src/metadata/store/mongodb-adapter.ts
+++ b/MemoryCore/src/metadata/store/mongodb-adapter.ts
@@ -663,10 +663,17 @@ export class MongoMetadataStore implements IMetadataStore {
   }
 
   async deleteTeams(teamIds: string[]): Promise<BatchDeleteResult> {
+    // 级联删除 agents（走 deleteAgents 获得完整级联：task_agents, fixed_assets, chat_memory）
+    const agents = await this.col("meta_agents")
+      .find({ team_id: { $in: teamIds } } as Document, { projection: { agent_id: 1 } })
+      .toArray();
+    const agentIds = agents.map((a) => a.agent_id as string);
+    if (agentIds.length > 0) await this.deleteAgents(agentIds);
+
     const result = await this.batchDelete("meta_teams", "team_id", teamIds);
     if (result.deleted_ids.length > 0) {
       await this.col("meta_team_members").deleteMany({ team_id: { $in: result.deleted_ids } } as Document);
-      await this.col("meta_agents").deleteMany({ team_id: { $in: result.deleted_ids } } as Document);
+      // meta_agents 已由 deleteAgents 处理
       await this.col("meta_tasks").deleteMany({ team_id: { $in: result.deleted_ids } } as Document);
       await this.col("meta_assets").deleteMany({ team_id: { $in: result.deleted_ids } } as Document);
     }

--- a/MemoryCore/src/metadata/store/sqlite-adapter.ts
+++ b/MemoryCore/src/metadata/store/sqlite-adapter.ts
@@ -809,13 +809,22 @@ export class SqliteMetadataStore implements IMetadataStore {
   }
 
   deleteTeams(teamIds: string[]): BatchDeleteResult {
+    // 级联删除 agents（走 deleteAgents 获得完整级联：task_agents, fixed_assets, chat_memory）
+    const ph = teamIds.map(() => "?").join(",");
+    const agentRows = this.all<{ agent_id: string }>(
+      `SELECT agent_id FROM meta_agents WHERE team_id IN (${ph})`,
+      ...teamIds,
+    );
+    const agentIds = agentRows.map((r) => r.agent_id);
+    if (agentIds.length > 0) this.deleteAgents(agentIds);
+
     const result = this.batchDelete("meta_teams", "team_id", teamIds);
     if (result.deleted_ids.length > 0) {
-      const ph = result.deleted_ids.map(() => "?").join(",");
-      this.run(`DELETE FROM meta_team_members WHERE team_id IN (${ph})`, ...result.deleted_ids);
-      this.run(`DELETE FROM meta_agents WHERE team_id IN (${ph})`, ...result.deleted_ids);
-      this.run(`DELETE FROM meta_tasks WHERE team_id IN (${ph})`, ...result.deleted_ids);
-      this.run(`DELETE FROM meta_assets WHERE team_id IN (${ph})`, ...result.deleted_ids);
+      const ph2 = result.deleted_ids.map(() => "?").join(",");
+      this.run(`DELETE FROM meta_team_members WHERE team_id IN (${ph2})`, ...result.deleted_ids);
+      // meta_agents 已由 deleteAgents 处理
+      this.run(`DELETE FROM meta_tasks WHERE team_id IN (${ph2})`, ...result.deleted_ids);
+      this.run(`DELETE FROM meta_assets WHERE team_id IN (${ph2})`, ...result.deleted_ids);
     }
     return result;
   }

--- a/MemoryPanel/panel-api-doc.md
+++ b/MemoryPanel/panel-api-doc.md
@@ -765,6 +765,8 @@ L0/L1 列表批量删除。**仅资产 Owner**。
 | deleted_skill_count | number | 已删 skill 数 |
 | deleted_skill_ids | string[] | 已删 skill ID 列表 |
 
+**权限**：Agent owner、Team Admin、System Admin 均可调用。Owner 走 archive 路径（软删除 + skill 逐条清理）；Admin 走 delete 路径（硬删除，跳过 skill 逐条删除，由内核级联处理）。
+
 **错误**：`MISSING_AGENT_ID`、`INVALID_USER_KEY`、`AGENT_NOT_FOUND`、`NOT_YOUR_AGENT`；任一 skill 删除失败返回 `500 SKILL_DELETE_FAILED`（含 `failed_skill_id`、`deleted_skill_ids`），此时 agent 不会 archive。
 
 **示例**

--- a/MemoryPanel/src/panel/http/routes/agent-lifecycle.ts
+++ b/MemoryPanel/src/panel/http/routes/agent-lifecycle.ts
@@ -9,18 +9,18 @@
  *
  * 本路由的做法（业务级联收口在 control 层，不改内核）：
  *   1. auth/verify 反查 caller
- *   2. agent/get 拿到 agent，强校验 owner_user_id === caller（本期不允许 admin 代删）
- *   3. skill/list 按 owner_agent_id + active 分页拉全
- *   4. 逐条 skill/delete —— 任一失败立即中断，返回 500 + 已删列表 + 失败 skill_id
- *      + 内核错误 message；此时 agent/archive 不会被调用，caller 需要修复后重试
- *   5. 全部 skill 成功归档后调 meta/agent/archive
- *      —— 内核在同一次 archive 里顺手清 chat_memory（这部分保持原样）
+ *   2. agent/get 拿到 agent，校验 caller 是 owner / team admin / system admin
+ *   3a. Owner 路径：skill/list 按 owner_agent_id + active 分页拉全 → 逐条 skill/delete
+ *       → 全部成功后调 meta/agent/archive（内核顺手清 chat_memory）
+ *   3b. Admin 路径：跳过 skill 逐条删除（skill/delete 要求 owner），
+ *       改调 meta/agent/delete 硬删除（内核已放行 admin，完整级联由 deleteAgents 处理）
  *
- * 为什么不做 admin 代删：内核 skill/delete 要求 caller 是 owner_agent 的 owner；
- * admin 代删需要 impersonation 或 control 层拿到 owner 的 user_key，本期先不做。
- *
- * 前端配套：agentsApi.delete 需从 meta/agent/archive 切到本路由；如果要跳过级联走
- * 老逻辑（例如迁移工具），可继续直接调 /api/v1/meta/agent/archive（保留逃生舱）。
+ * Admin 代删说明：
+ *   - Owner 路径走 archive（软删除，与原有行为一致）
+ *   - Admin（team admin / system admin）路径走硬删除（owner 不可恢复时归档无意义，
+ *     且 skill/delete 要求 caller 是 owner，admin 无法逐条清理 skill）
+ *   - 内核 deleteAgentsForCaller 已扩展为 owner-or-team-admin，与 createAgentForCaller
+ *     允许 admin 代建对称
  */
 import type { Hono } from 'hono';
 import type { PanelDeps } from '../../panel-deps.js';
@@ -35,6 +35,8 @@ import {
   readJson,
   resolveCallerUserId,
   str,
+  isCallerSystemAdmin,
+  isTeamAdmin,
 } from './knowledge/common.js';
 
 /** skill/list 一页 100 条 —— 与 knowledge fetchAllMetaListItems 分页步长对齐。 */
@@ -99,63 +101,86 @@ export function registerAgentLifecycleRoutes(api: Hono, deps: PanelDeps): void {
     const callerId = await resolveCallerUserId(deps, ctx);
     if (!callerId) return respondControlError(c, 401, 'INVALID_USER_KEY');
 
-    // 2. agent + owner 强校验
+    // 2. agent + 权限校验：owner / team admin / system admin
     const agentEnv = await deps.metaKernel.invoke('agent/get', { agent_id: agentId }, ctx);
     if (agentEnv.code === 404 || (agentEnv.code === 0 && !agentEnv.data)) {
       return respondControlError(c, 404, 'AGENT_NOT_FOUND');
     }
     if (agentEnv.code !== 0) return respondEnvelope(c, agentEnv);
     const agent = agentEnv.data as AgentRaw;
-    if (agent.owner_user_id !== callerId) {
-      return respondControlError(c, 403, 'NOT_YOUR_AGENT');
-    }
 
-    // 3. skill list
-    const listRes = await listAgentSkills(deps, ctx, callerId, agent.team_id, agent.agent_id);
-    if (!listRes.ok) return respondEnvelope(c, listRes.envelope);
-    const skills = listRes.items;
+    const isOwner = agent.owner_user_id === callerId;
+    let canDelete = isOwner;
+    if (!canDelete) canDelete = await isCallerSystemAdmin(deps, ctx);
+    if (!canDelete) canDelete = await isTeamAdmin(deps, ctx, agent.team_id, callerId);
+    if (!canDelete) return respondControlError(c, 403, 'NOT_YOUR_AGENT');
 
-    // 4. 逐条 skill/delete —— 任一失败立即中断，agent 不 archive
-    const deletedIds: string[] = [];
-    for (const s of skills) {
-      const delEnv = await deps.skillKernel.invoke(
-        'delete',
-        {
-          user_id: callerId,
-          team_id: agent.team_id,
-          agent_id: agent.agent_id,
-          skill_id: s.skill_id,
-          expected_version: s.version,
-        },
-        ctx,
-      );
-      if (delEnv.code !== 0) {
-        return respondEnvelope(c, {
-          code: 500,
-          message: 'SKILL_DELETE_FAILED',
-          request_id: c.get('reqId') ?? '',
-          data: {
-            failed_skill_id: s.skill_id,
-            kernel_code: delEnv.code,
-            kernel_message: delEnv.message,
-            deleted_skill_ids: deletedIds,
+    // ── Owner 路径：skill 逐条删除 → agent/archive（软删除，保留原有行为） ──
+    if (isOwner) {
+      // 3. skill list
+      const listRes = await listAgentSkills(deps, ctx, callerId, agent.team_id, agent.agent_id);
+      if (!listRes.ok) return respondEnvelope(c, listRes.envelope);
+      const skills = listRes.items;
+
+      // 4. 逐条 skill/delete —— 任一失败立即中断，agent 不 archive
+      const deletedIds: string[] = [];
+      for (const s of skills) {
+        const delEnv = await deps.skillKernel.invoke(
+          'delete',
+          {
+            user_id: callerId,
+            team_id: agent.team_id,
+            agent_id: agent.agent_id,
+            skill_id: s.skill_id,
+            expected_version: s.version,
           },
-        });
+          ctx,
+        );
+        if (delEnv.code !== 0) {
+          return respondEnvelope(c, {
+            code: 500,
+            message: 'SKILL_DELETE_FAILED',
+            request_id: c.get('reqId') ?? '',
+            data: {
+              failed_skill_id: s.skill_id,
+              kernel_code: delEnv.code,
+              kernel_message: delEnv.message,
+              deleted_skill_ids: deletedIds,
+            },
+          });
+        }
+        deletedIds.push(s.skill_id);
       }
-      deletedIds.push(s.skill_id);
+
+      // 5. agent/archive —— 内核仍然会顺手清 chat_memory
+      const archiveEnv = await deps.metaKernel.invoke('agent/archive', { agent_id: agentId }, ctx);
+      if (archiveEnv.code !== 0) return respondEnvelope(c, archiveEnv);
+
+      return respondEnvelope(
+        c,
+        okEnvelope(c, {
+          archived: true,
+          agent_id: agentId,
+          deleted_skill_count: deletedIds.length,
+          deleted_skill_ids: deletedIds,
+        }),
+      );
     }
 
-    // 5. agent/archive —— 内核仍然会顺手清 chat_memory
-    const archiveEnv = await deps.metaKernel.invoke('agent/archive', { agent_id: agentId }, ctx);
-    if (archiveEnv.code !== 0) return respondEnvelope(c, archiveEnv);
+    // ── Admin 路径：跳过 skill 逐条删除，走 agent/delete 硬删除 ──
+    // skill/delete 要求 caller 是 owner，admin 无法代删；agent/delete 内核已放行 admin，
+    // 完整级联（task_agents, fixed_assets, chat_memory）由 store 层 deleteAgents 处理
+    const deleteEnv = await deps.metaKernel.invoke('agent/delete', { agent_ids: [agentId] }, ctx);
+    if (deleteEnv.code !== 0) return respondEnvelope(c, deleteEnv);
 
     return respondEnvelope(
       c,
       okEnvelope(c, {
         archived: true,
         agent_id: agentId,
-        deleted_skill_count: deletedIds.length,
-        deleted_skill_ids: deletedIds,
+        deleted_skill_count: 0,
+        deleted_skill_ids: [],
+        admin_initiated: true,
       }),
     );
   });

--- a/MemoryPanel/src/panel/http/routes/knowledge/common.ts
+++ b/MemoryPanel/src/panel/http/routes/knowledge/common.ts
@@ -94,6 +94,24 @@ export async function isTeamMember(
   }
 }
 
+/** 校验 user 是否是 team admin（team-member/get 且 role === 'admin'）。异常保守返 false。 */
+export async function isTeamAdmin(
+  deps: PanelDeps,
+  ctx: MetaCallContext,
+  teamId: string,
+  userId: string,
+): Promise<boolean> {
+  if (!teamId || !userId) return false;
+  try {
+    const env = await deps.metaKernel.invoke('team-member/get', { team_id: teamId, user_id: userId }, ctx);
+    if (env.code !== 0 || !env.data) return false;
+    const member = env.data as { role?: string };
+    return member.role === 'admin';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * team 门控：要求 caller 是有效用户且为 team 成员。
  * 通过返回 { userId }；不通过返回 { error: Response }（路由直接 return）。


### PR DESCRIPTION
 ## Description | 描述

  移除团队成员或删除用户后，其 Agent 成为孤儿（`owner_user_id` 悬空），且 Agent 删除严格
  owner-only，任何角色（含 admin）均无法清理。本 PR 消除所有产生孤儿 Agent 的路径，并将 Agent
  删除/归档权限对齐到 owner / team admin / system admin 三层。详见 #1321 的根因分析（三条缺陷链）。

  **MemoryCore（内核）**

  - `removeTeamMemberForCaller`：移除成员前级联硬删除其在该 team 的所有 Agent（与 `team-member/add`
  自动为新成员建默认 Agent 形成对称）
  - `deleteUsersForCaller`：删除用户前级联硬删除其所有 Agent
  - 新增 `collectAgentIdsByOwnerInTeam` / `collectAgentIdsByOwner` 分页收集 helper（10,000 安全上限，与既有
  `listAllAgentIdsByTeam` 模式一致）
  - `deleteAgentsForCaller` / `archiveAgentForCaller`：权限从 owner-only 扩展为 owner-or-team-admin（复用既有
  `assertCallerIsAgentOwnerOrTeamAdmin`），且 `ctx.isSystemAdmin` 时跳过校验 —— 与 Panel 控制层权限面对齐
  - store 层 `deleteTeams`（sqlite 与 mongodb 两个 adapter 同步）：改为先收集 agent_ids 再走 `deleteAgents()` 
  完整级联，修复原先 raw SQL 直删 `meta_agents` 导致 `meta_task_agents` / `meta_agent_fixed_assets` / 
  chat_memory 资产记录残留

  **MemoryPanel（控制层）**

  - `agent/delete-cascade` 权限从 owner-only 放宽为 owner / team admin / system admin：
    - Owner 路径：保持原有行为（skill 逐条清理 → `agent/archive` 软删除）
    - Admin 路径：跳过 skill 逐条删除（`skill/delete` 仍要求 owner），改走 `agent/delete` 硬删除，响应带
  `admin_initiated: true`
  - 新增 `isTeamAdmin` helper（与既有 `isTeamMember` 平行）；更新路由头部注释（原"本期不允许 admin 代删"）与
  `panel-api-doc.md`

  **测试**
  
  - `metadata-store.contract.ts` 新增 3 个契约测试：`deleteTeams` 完整级联、`removeTeamMember` / `deleteUsers`
  的 store 层不级联（由 service 层负责）

  ## Related Issue | 关联 Issue

  Fix #1321

  ## Change Type | 修改类型
  
  - [x] Bug fix | Bug 修复

  ## Self-test Checklist | 自测清单

  - [x] Verified locally | 本地验证通过
    - store 层 `deleteTeams` 级联已在真实 SQLite 冒烟验证：task_agents / agent_fixed_assets / chat_memory 资产 /
  agent 本体 / team 本体全部清理干净
    - 端到端（容器部署）：admin 通过 Panel 对已移除成员的 Agent 调 `delete-cascade` 成功（硬删除路径）；owner
  自删行为不变（archive 路径）
    - `deleteTeams([])` 的 `IN ()` 风险不可达：v3 `idList` 与 v2 `teamBatchDeleteRequestSchema` 均为 `.min(1)`
  - [x] No existing features affected | 无影响现有功能
    - 向后兼容：owner 与 team admin 的原有调用路径行为不变，仅新增 admin 能力
    - v2 废弃路由使用独立的 v2 entity store（软删除），不受本次 metadata store 改动影响

  ## Additional Notes | 其他说明

  **已知限制**（不阻塞本修复）：

  - 级联删除为多步非事务操作（mongo 未用 `withTx`，sqlite 未包
  tx），中途失败可能留下部分状态，与改动前风险性质相同
  - Panel 路由对 `auth/verify` 存在重复调用（既有模式，可后续优化）
  - SkillCore 未启用时 owner 路径的 `skill/list` 404 会阻断归档 —— 属 #1218 的独立问题，不在本 PR 范围

  **相关 issue**：

  - #1237 —— 同类权限不对称（`deleteTeamsForCaller` 未考虑 `ctx.isSystemAdmin`），本 PR 在 Agent
  维度部分对齐，Team 维度可参考同样思路单独处理
  - #1250 —— "删除仍有归属资源的用户会留下资产归属问题"同根源
