### PR TITLE
docs: refresh contribution workflow and L1 backlog comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,8 @@ it standalone (usually `cd <module> && npm install && npm run dev`).
 ## Submitting changes
 
 1. Fork the repo
-2. Cut a feature branch off `master` or the latest `develop_*` branch
+2. Cut a feature branch from the repository's current default development
+   branch
    ```bash
    git checkout -b fix/xxx-issue
    ```
@@ -69,8 +70,9 @@ it standalone (usually `cd <module> && npm install && npm run dev`).
    npm test          # or pnpm test
    ```
 4. Commit using Conventional Commits + DCO sign-off (see below)
-5. Push and open a PR against `develop_server_team` or `master` (follow the
-   maintainer's latest guidance)
+5. Push to your fork and open a PR against the same upstream development
+   branch you based your work on, unless maintainers ask you to target a
+   different branch
 6. Get through CI + review, then merge
 
 ## Commit conventions

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -46,7 +46,7 @@ tdai-memory-openclaw-plugin/
 最简单的开发闭环是先用 Docker 起一套完整三件套，再本地开发目标模块：
 
 ```bash
-git clone https://github.com/Tencent/TencentDB-Agent-Memory.git
+git clone https://github.com/TencentCloud/TencentDB-Agent-Memory.git
 cd TencentDB-Agent-Memory/deploy/global-images
 cp .env.example .env && $EDITOR .env
 ./start-all.sh
@@ -58,7 +58,7 @@ cp .env.example .env && $EDITOR .env
 ## 提交流程
 
 1. Fork 仓库
-2. 从 `master` 或最新的 `develop_*` 分支切出 feature 分支
+2. 从仓库当前默认的开发分支切出 feature 分支
    ```bash
    git checkout -b fix/xxx-issue
    ```
@@ -68,8 +68,8 @@ cp .env.example .env && $EDITOR .env
    npm test          # 或 pnpm test
    ```
 4. 提交（Conventional Commits + DCO 签名，见下文）
-5. 推到 fork，发起 PR 到 `develop_server_team` 或 `master`（按维护者最新
-   指示）
+5. 推到 fork，向本次开发所基于的同一上游开发分支发起 PR；若维护者有明确
+   指示，则按其要求选择目标分支
 6. 通过 CI + Review 后合并
 
 ## Commit 规范

--- a/MemoryCore/src/utils/stateful-pipeline-manager.ts
+++ b/MemoryCore/src/utils/stateful-pipeline-manager.ts
@@ -59,9 +59,8 @@ export interface L1RunnerResult {
   /**
    * True iff there are still L0 rows past the cursor that this run did not
    * consume. See pipeline-manager.ts L1RunnerResult for the full semantics.
-   * Currently only consumed by the standalone MemoryPipelineManager; the
-   * service-mode worker pipeline (this class) does not yet honor this flag.
-   * TODO: extend pipeline-worker to drain backlog via task re-enqueue.
+   * In service mode, a full backlog is drained immediately, while a small
+   * tail re-arms the L1 idle timer for a later drain.
    */
   hasMore?: boolean;
   /** True iff the over-fetch returned exactly 2N rows — drain via direct enqueue. */


### PR DESCRIPTION
## Description | 描述

- Refresh the stale `L1RunnerResult.hasMore` comment to match current service-mode backlog handling.
- Update English/Chinese contribution guidance to follow the current upstream development branch instead of stale hard-coded branch names.
- Fix the Chinese clone URL to `TencentCloud/TencentDB-Agent-Memory`.

## Related Issue | 关联 Issue

N/A

## Change Type | 修改类型
- [ ] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [ ] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

Documentation/comment-only change; no runtime behavior is modified. Runtime tests were not run. The final diff was verified to contain only the three intended files, and the commit includes DCO sign-off.
