### PR TITLE
chore(proxy): 修复 feat/server_team 基线类型错误（MemoryProxy tsc 0）

### DIFF
--- a/.github/workflows/memory-proxy-ci.yml
+++ b/.github/workflows/memory-proxy-ci.yml
@@ -1,0 +1,41 @@
+name: MemoryProxy CI
+
+on:
+  pull_request:
+    paths:
+      - "MemoryProxy/**"
+      - ".github/workflows/memory-proxy-ci.yml"
+  push:
+    paths:
+      - "MemoryProxy/**"
+      - ".github/workflows/memory-proxy-ci.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: mp-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-and-test:
+    name: Typecheck + Vitest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: MemoryProxy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: MemoryProxy/package-lock.json
+
+      - name: Install dependencies (skip native builds)
+        run: npm ci --ignore-scripts
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test

--- a/MemoryProxy/package.json
+++ b/MemoryProxy/package.json
@@ -8,7 +8,7 @@
     "start:config": "node --import tsx/esm src/index.ts --config config.yaml",
     "dev": "node --import tsx/esm --watch src/index.ts",
     "dev:config": "node --import tsx/esm --watch src/index.ts --config config.yaml",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/MemoryProxy/src/anthropicHandler.ts
+++ b/MemoryProxy/src/anthropicHandler.ts
@@ -35,6 +35,7 @@ import { hasCostGuardMarker, matchWhitelistEndpoint } from "./routes/whitelist.j
 import { writeRequestLog } from "./requestLog.js";
 import { prepareUpstreamRequest, notifyUpstreamResponse } from "./request-prepare-adapter.js";
 import { tryReportCreditFromPath, extractSpaceIdFromPath } from "./credit-reporter.js";
+import type { CreditReportOutcome } from "./credit-reporter.js";
 import {
   getInstanceUpstreamConfigs,
   resolveUpstreamConfig,
@@ -570,7 +571,7 @@ export async function handleAnthropicMessages(
     ? _pathPartsEarly[0] : undefined;
   const agentAdapter = resolveAgentAdapter(_agentFromPathEarly ?? "claude-code");
   const ccRoutingEnabled = config.ccRequestRouting?.enabled === true;
-  const requestKind: CcRequestKind = ccRoutingEnabled ? agentAdapter.classifyRequest(body) : "main";
+  const requestKind: CcRequestKind = ccRoutingEnabled ? (agentAdapter.classifyRequest(body) as CcRequestKind) : "main";
 
   // ── Model gate: reject requests whose `model` is not a registered display name ──
   // 价目表已配置时，客户端 `model` 必须匹配某条 entry 的 `modelName`（展示名，
@@ -708,7 +709,7 @@ export async function handleAnthropicMessages(
         // ── 强制归档旧 agent 的 skill buffer（best-effort）──
         const oldState = store.get(compositeKey);
         if (oldState?.status === "initialized" && oldState.sessionInfo && config.coreSkill?.endpoint) {
-          const si = oldState.sessionInfo as Record<string, string>;
+          const si = oldState.sessionInfo as unknown as Record<string, string>;
           if (si.space_id && si.user_id && si.team_id && si.agent_id) {
             import("./skill/core-client.js").then(({ getCoreSkillClient }) => {
               const client = getCoreSkillClient(config.coreSkill!);
@@ -981,12 +982,12 @@ export async function handleAnthropicMessages(
           agentName: initResult.agentDetail?.name ?? "未知",
           // agentIdShort 字段名沿用历史，但此处**存完整 agent_id**（如 agt-1celthr7yn）。
           // 之前 slice(-8) 会截断成 "elthr7yn" 用户看不懂，与 team 截断问题对称。
-          agentIdShort: (initResult.sessionInfo as Record<string, unknown>)?.agent_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).agent_id) : "",
+          agentIdShort: (initResult.sessionInfo as unknown as Record<string, unknown>)?.agent_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).agent_id) : "",
           // teamName + 完整 teamId：见 handler.ts 对称注释。
           teamName: initResult.teamName ?? undefined,
-          teamId: (initResult.sessionInfo as Record<string, unknown>)?.team_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).team_id) : "",
+          teamId: (initResult.sessionInfo as unknown as Record<string, unknown>)?.team_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).team_id) : "",
           taskName: initResult.taskDetail?.name,
         };
       }
@@ -2214,7 +2215,7 @@ function consumeAnthropicStream(stream: ReadableStream<Uint8Array>, ctx: Anthrop
 
       // Credit usage reporting for streaming responses.
       (ctx.skipCreditReport
-        ? Promise.resolve({ attempted: false, ok: false })
+        ? Promise.resolve<CreditReportOutcome>({ attempted: false, ok: false })
         : tryReportCreditFromPath(
             ctx.config.creditReport,
             ctx.requestPath,

--- a/MemoryProxy/src/codexHandler.ts
+++ b/MemoryProxy/src/codexHandler.ts
@@ -414,7 +414,7 @@ export async function handleCodexEndpoint(
         // ── 强制归档旧 agent 的 skill buffer（best-effort）──
         const oldState = store.get(compositeKey);
         if (oldState?.status === "initialized" && oldState.sessionInfo && config.coreSkill?.endpoint) {
-          const si = oldState.sessionInfo as Record<string, string>;
+          const si = oldState.sessionInfo as unknown as Record<string, string>;
           if (si.space_id && si.user_id && si.team_id && si.agent_id) {
             import("./skill/core-client.js").then(({ getCoreSkillClient }) => {
               const client = getCoreSkillClient(config.coreSkill!);
@@ -685,12 +685,12 @@ export async function handleCodexEndpoint(
           agentName: initResult.agentDetail?.name ?? "未知",
           // agentIdShort 字段名沿用历史，但此处**存完整 agent_id**（如 agt-1celthr7yn）。
           // 之前 slice(-8) 会截断成 "elthr7yn" 用户看不懂，与 team 截断问题对称。
-          agentIdShort: (initResult.sessionInfo as Record<string, unknown>)?.agent_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).agent_id) : "",
+          agentIdShort: (initResult.sessionInfo as unknown as Record<string, unknown>)?.agent_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).agent_id) : "",
           // teamName + 完整 teamId：见 handler.ts 对称注释。
           teamName: initResult.teamName ?? undefined,
-          teamId: (initResult.sessionInfo as Record<string, unknown>)?.team_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).team_id) : "",
+          teamId: (initResult.sessionInfo as unknown as Record<string, unknown>)?.team_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).team_id) : "",
           taskName: initResult.taskDetail?.name,
         };
       }

--- a/MemoryProxy/src/cost-guard.d.ts
+++ b/MemoryProxy/src/cost-guard.d.ts
@@ -1,0 +1,2 @@
+/** 可选子模块：cost-guard（COS kernel-sts / 计费守卫）。缺失时走降级链，见 storage/factory.ts。 */
+declare module "@context-proxy/cost-guard";

--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -34,6 +34,7 @@ import { hasCostGuardMarker, matchWhitelistEndpoint } from "./routes/whitelist.j
 import { writeRequestLog } from "./requestLog.js";
 import { prepareUpstreamRequest, notifyUpstreamResponse } from "./request-prepare-adapter.js";
 import { tryReportCreditFromPath, extractSpaceIdFromPath } from "./credit-reporter.js";
+import type { CreditReportOutcome } from "./credit-reporter.js";
 import {
   getInstanceUpstreamConfigs,
   resolveUpstreamConfig,
@@ -813,7 +814,7 @@ export async function handleChatCompletions(
         // reset 前旧 agent 累积的对话片段可能还没达到阈值，不 flush 会永久丢失。
         const oldState = store.get(compositeKey);
         if (oldState?.status === "initialized" && oldState.sessionInfo && config.coreSkill?.endpoint) {
-          const si = oldState.sessionInfo as Record<string, string>;
+          const si = oldState.sessionInfo as unknown as Record<string, string>;
           if (si.space_id && si.user_id && si.team_id && si.agent_id) {
             import("./skill/core-client.js").then(({ getCoreSkillClient }) => {
               const client = getCoreSkillClient(config.coreSkill!);
@@ -1102,14 +1103,14 @@ export async function handleChatCompletions(
           // agentIdShort 字段名沿用历史，但此处**存完整 agent_id**（如 agt-1celthr7yn）。
           // 之前 slice(-8) 只留后 8 位会显示成 "elthr7yn" 这种截断串，用户完全看不懂，
           // 与 team 截断问题同源。agent id 本身就短，全量展示无害且更可读。
-          agentIdShort: (initResult.sessionInfo as Record<string, unknown>)?.agent_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).agent_id) : "",
+          agentIdShort: (initResult.sessionInfo as unknown as Record<string, unknown>)?.agent_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).agent_id) : "",
           // teamName 来自 session-init（cachedTeams[selected].team_name）；
           // teamId 存**完整** team_id（如 team-wyuyb7sion）—— 之前 slice(-8)
           // 会显示成 "uyb7sion" 用户看不懂，且 teamName 为空时兜底更差。
           teamName: initResult.teamName ?? undefined,
-          teamId: (initResult.sessionInfo as Record<string, unknown>)?.team_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).team_id) : "",
+          teamId: (initResult.sessionInfo as unknown as Record<string, unknown>)?.team_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).team_id) : "",
           taskName: initResult.taskDetail?.name,
         };
       }
@@ -2320,7 +2321,7 @@ function createUsageTapTransform(ctx: TapContext): TransformStream<Uint8Array, U
     // only be observed via server logs (no way to retro-add response headers).
     // skipCreditReport: instance config custom model → user's expense, skip credit.
     (ctx.skipCreditReport
-      ? Promise.resolve({ attempted: false, ok: false })
+      ? Promise.resolve<CreditReportOutcome>({ attempted: false, ok: false })
       : tryReportCreditFromPath(
           ctx.config.creditReport,
           ctx.requestPath,

--- a/MemoryProxy/src/memory/memory-bridge.ts
+++ b/MemoryProxy/src/memory/memory-bridge.ts
@@ -56,6 +56,8 @@ interface SessionIdFields {
   user_id: string;
   team_id: string;
   agent_id: string;
+  /** 客户端来源（claude-code / codex / workbuddy 等），供遥测使用。 */
+  agent_source?: string;
   session_id: string;
   task_id?: string;
   user_key?: string;

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -120,6 +120,8 @@ export interface SessionInitResult {
    * 常量供跨 handler 判定即可。
    */
   bypassReason?: "default-gate";
+  /** mem:session-reset 触发时标记本次 init 是 reset 流程（跨 handler 判定用）。 */
+  resetFlow?: boolean;
   /**
    * Anthropic-only: pre-built `<session_context>` string the caller must
    * append to `body.system` (the ClaudeCode init module populates this;

--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -879,6 +879,7 @@ export interface RawYamlConfig {
     injectAgentContext?: boolean;
     injectTaskContext?: boolean;
     defaultTaskId?: string;
+    skipAssetConfirm?: boolean;
     debugForceIdentity?: {
       team_id?: string;
       agent_id?: string;
@@ -950,6 +951,7 @@ export interface RequestLogEntry {
   sessionKey?: string; // conversationId || keyId — per-conversation isolation key
   upstreamUrl: string;
   stream: boolean;
+  traceId?: string;
   temperature?: number;
   maxTokens?: number;
   routedFrom?: string;     // original model if routing was applied

--- a/MemoryProxy/src/workbuddyHandler.ts
+++ b/MemoryProxy/src/workbuddyHandler.ts
@@ -954,7 +954,7 @@ export async function handleWorkbuddyEndpoint(
         // ── 强制归档旧 agent 的 skill buffer（best-effort）──
         const oldState = store.get(compositeKey);
         if (oldState?.status === "initialized" && oldState.sessionInfo && config.coreSkill?.endpoint) {
-          const si = oldState.sessionInfo as Record<string, string>;
+          const si = oldState.sessionInfo as unknown as Record<string, string>;
           if (si.space_id && si.user_id && si.team_id && si.agent_id) {
             import("./skill/core-client.js").then(({ getCoreSkillClient }) => {
               const client = getCoreSkillClient(config.coreSkill!);
@@ -1213,15 +1213,15 @@ export async function handleWorkbuddyEndpoint(
           agentName: initResult.agentDetail?.name ?? "未知",
           // agentIdShort 字段名沿用历史，但此处**存完整 agent_id**（如 agt-1celthr7yn）。
           // 之前 slice(-8) 会截断成 "elthr7yn" 用户看不懂，与 team 截断问题对称。
-          agentIdShort: (initResult.sessionInfo as Record<string, unknown>)?.agent_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).agent_id) : "",
+          agentIdShort: (initResult.sessionInfo as unknown as Record<string, unknown>)?.agent_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).agent_id) : "",
           // teamName 来自 session-init 返回值（从 cachedTeams 里查得）；
           // teamIdShort 字段名沿用历史，但此处**存完整 team_id**（如 team-wyuyb7sion）。
           // 之前 slice(-8) 只留后 8 位会让用户看到 "uyb7sion" 这种截断串，配合
           // teamName 常为空导致的兜底路径显示极不完整。团队 id 本身就短，全量展示无害。
           teamName: initResult.teamName ?? undefined,
-          teamIdShort: (initResult.sessionInfo as Record<string, unknown>)?.team_id
-            ? String((initResult.sessionInfo as Record<string, unknown>).team_id) : "",
+          teamIdShort: (initResult.sessionInfo as unknown as Record<string, unknown>)?.team_id
+            ? String((initResult.sessionInfo as unknown as Record<string, unknown>).team_id) : "",
           taskName: initResult.taskDetail?.name,
         };
       }

--- a/MemoryProxy/tsconfig.json
+++ b/MemoryProxy/tsconfig.json
@@ -7,10 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "resolveJsonModule": true,
-    "paths": {
-      "@context-proxy/cost-guard": ["./packages/cost-guard/src/index.ts"]
-    }
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
**共享前置：修复 `feat/server_team` 基线的 MemoryProxy 类型错误，并接入 Typecheck + Vitest 门禁。**

基线该目录有 60 个 TypeScript 错误、0 个测试文件、CI 不覆盖，因此"改动有没有把东西改坏"没有参照基准。本支先把基准建起来，其余 12 支都依赖它。

## 改动

| 位置 | 内容 |
|---|---|
| `src/anthropicHandler.ts`、`codexHandler.ts`、`workbuddyHandler.ts`、`handler.ts` | 基线类型错误修复（联合类型收窄、`Record` 断言、缺失字段） |
| `src/memory/memory-bridge.ts`、`session/codebuddy/init.ts`、`types.ts`、`cost-guard.d.ts` | 同上，补类型声明与字段 |
| `package.json` / `tsconfig.json` | `test` 脚本加 `--passWithNoTests`；收敛编译范围 |
| `.github/workflows/memory-proxy-ci.yml` | 新增门禁：`npm run typecheck` + `npm test`（`pull_request` / `push`，`paths: MemoryProxy/**`），支持 `workflow_dispatch` |

- **本 PR 净增量**：+77 / −29（11 个文件）——本支本身就是基线修复与门禁，没有前序层。

## 验证

- `npx tsc --noEmit`：基线 **60 个错误 → 0**
- `npm test`：基线 0 个测试文件，靠 `--passWithNoTests` 通过
- 本支相对基线：11 文件，+77 / −29，不涉及运行逻辑改动

## 边界

- 只做类型与门禁，不改任何业务行为；不引入测试用例（各课题的用例随各自 PR 提交）

---

## 合入顺序（本批 13 支）

`#1326`（基线类型修复 + CI 门禁，最先）→ 协议 `#1226 → #1253` → 接入 `#1334 → #1325` → Opik `#1270 → #1307 → #1309 → #1310 → #1328`；`#1251`、`#1346`、`#1347` 与其它支无文件交集，任意时间合。

- **本支位置**：第 1 步，最先合（其余 12 支的前置）
- 全批合入态实测：`tsc --noEmit` 0 错误、37 文件 / 408 用例通过
- 冲突只出现在共享文件：`package.json` 取并集（= #1226 侧带 json reporter + posttest 的那一行）；`docs/protocol-conversion-matrix.md` 与 `src/__tests__/chat-anthropic-role-rules.test.ts`（add/add）取 **#1226 一侧**；`scripts/qa/check-doc-claims.mjs` 已在 #1226 / #1253 / #1328 三支逐字节同步（blob `f4aa8815`），**不再产生冲突**；`src/agent-adapters/{index,types}.ts` 已随 #1334 合并。核心逻辑文件零冲突（2026-09-12 用当前 head 实合复核：冲突面共 **3 个文件**）
- **评审提示**：本批分支都在 fork（`cjl-ux`），而 PR 的 base 只能是目标仓库的分支，所以**做不到**把堆叠 PR 的 base 指向前一层——页面 diff 只能是相对公共祖先的累计值。要看本层改动请用 `git diff <上一层 head> <本支 head>`。
- 默认行为：`sessionInit.enabled` / `threadIsolation` / `upstream.autoDetect` / `opik` / `sessionInit.autoConversationId.enabled` 默认**全部为 `false`**，合入不改变现有部署行为；需要"服务端为无会话头的客户端签发 `auto-*` 会话"时显式打开该开关