### PR TITLE
fix(deploy): make global-images scripts work under Git Bash on Windows

### DIFF
--- a/deploy/global-images/_lib.sh
+++ b/deploy/global-images/_lib.sh
@@ -4,6 +4,12 @@
 
 set -euo pipefail
 
+# Git Bash / MSYS on Windows rewrites arguments that look like POSIX paths, so
+# `docker run -v /data/...` turns into `-v C:/Program Files/Git/data/...` and the
+# mount silently points at the wrong place. Opt out for every script that sources
+# this library. No-op on Linux/macOS.
+export MSYS_NO_PATHCONV=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/.env}"
 

--- a/deploy/global-images/start-memory-core.sh
+++ b/deploy/global-images/start-memory-core.sh
@@ -244,11 +244,11 @@ generate_user_key() {
 verify_user_key() {
   local key="$1"
   local code
-  code=$(/usr/bin/curl -sS -o /dev/null -w "%{http_code}" --max-time 5 \
+  code=$("$CURL" -sS -o /dev/null -w "%{http_code}" --max-time 5 \
     -X POST -H "Content-Type: application/json" \
     -H "x-tdai-service-id: default" \
     ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
-    "http://localhost:${MEMORY_CORE_PORT}/v3/meta/auth/verify" \
+    "http://127.0.0.1:${MEMORY_CORE_PORT}/v3/meta/auth/verify" \
     -d "$(printf '{"user_key":"%s"}' "$key")" 2>/dev/null || echo "000")
   [[ "$code" == "200" ]]
 }
@@ -265,11 +265,11 @@ fi
 
 init_body=$(printf '{"username":"%s","user_key":"%s"}' \
   "$MEMORY_CORE_ADMIN_USERNAME" "$ADMIN_KEY")
-init_resp=$(/usr/bin/curl -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
+init_resp=$("$CURL" -sS -o /tmp/init-admin.$$ -w "%{http_code}" \
   -X POST -H "Content-Type: application/json" \
   ${MEMORY_CORE_GATEWAY_API_KEY:+-H "Authorization: Bearer ${MEMORY_CORE_GATEWAY_API_KEY}"} \
   -H "x-tdai-service-id: default" \
-  "http://localhost:${MEMORY_CORE_PORT}/v3/internal/meta/user/init-admin" \
+  "http://127.0.0.1:${MEMORY_CORE_PORT}/v3/internal/meta/user/init-admin" \
   -d "$init_body" 2>/dev/null || echo "000")
 
 case "$init_resp" in

--- a/deploy/global-images/verify.sh
+++ b/deploy/global-images/verify.sh
@@ -37,7 +37,8 @@ done
 
 ERRORS=0
 WARNS=0
-CURL=/usr/bin/curl
+# CURL is resolved by _lib.sh, which falls back to `command -v curl` when
+# /usr/bin/curl is absent (Git Bash ships it at /mingw64/bin/curl).
 
 # ─── LLM 通路检查函数 ───────────────────────────────────────────────
 # check_llm_openai <label> <base_url> <api_key> <model>


### PR DESCRIPTION
## Description | 描述

Running `deploy/global-images/start-all.sh` from Git Bash on Windows fails in three
places. Each also affects `start-memory-core.sh` and `verify.sh` when run directly.

**1. MSYS path conversion mangles docker mounts**

Git Bash rewrites arguments that look like POSIX paths, so `docker run -v /data/...`
becomes `-v C:/Program Files/Git/data/...` and the mount silently points at the wrong
place. `_lib.sh` now exports `MSYS_NO_PATHCONV=1`, which covers every script that
sources it. No-op on Linux/macOS.

**2. Hardcoded `/usr/bin/curl`**

`_lib.sh` already resolves `$CURL` with a `command -v curl` fallback — precisely
because `/usr/bin/curl` does not exist under Git Bash, which ships curl at
`/mingw64/bin/curl`. Two callers bypass that work:

- `start-memory-core.sh` invokes `/usr/bin/curl` directly (2 call sites)
- `verify.sh` reassigns `CURL=/usr/bin/curl` *after* sourcing `_lib.sh`, clobbering
  the fallback it just computed

Both now use the resolved `$CURL`. This is the smallest change consistent with the
existing design rather than a new fallback of its own.

**3. `localhost` resolves to `::1` on Windows**

Docker publishes ports on IPv4 only, so the `init-admin` and `auth/verify` calls fail
with connection refused even though the container is healthy. Those two loopback calls
now address `127.0.0.1` explicitly. User-facing URLs printed to the console are left as
`localhost` on purpose.

## Related Issue | 关联 Issue

None — found while bringing the stack up on Windows.

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Verified on macOS:

- `bash -n` clean on all three scripts
- `$CURL` resolves correctly after sourcing `_lib.sh`
- the `_lib.sh` fallback still engages when the configured curl is not executable
  (simulated with `CURL=/nonexistent`)
- `MSYS_NO_PATHCONV` is exported to sourcing scripts

On Linux/macOS the changes are inert: `MSYS_NO_PATHCONV` is ignored, `$CURL` resolves
to `/usr/bin/curl` as before, and `127.0.0.1` is what `localhost` already resolved to.

## Additional Notes | 其他说明

I do not have a Windows machine available to run the full stack end to end, so the Git
Bash behaviour is reasoned from documented MSYS semantics rather than executed. Happy to
adjust if a maintainer with a Windows box sees something different.

`CONTRIBUTING.md` says to target `develop_server_team` or `master`, but neither branch
exists on the remote — I targeted `feat/server_team`, which is where these scripts live.
Glad to retarget if that is wrong.
