### PR TITLE
fix(proxy): preserve WorkBuddy memory routing

### DIFF
--- a/MemoryProxy/src/session/codebuddy/__tests__/workbuddy-extractor.test.ts
+++ b/MemoryProxy/src/session/codebuddy/__tests__/workbuddy-extractor.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { TeamOption } from "../../types.js";
+import {
+  BYPASS_MARKER,
+  extractAgentOnly,
+  extractAssetConfirm,
+  extractTaskOnly,
+  extractTeamFromOptionText,
+} from "../extractor.js";
+
+const team: TeamOption = {
+  team_id: "team-12345678",
+  team_name: "home",
+  agents: [
+    { agent_id: "agent-workbuddy-0001", agent_name: "workbuddy" },
+    { agent_id: "agent-coder-0000002", agent_name: "coder" },
+  ],
+  tasks: [{ task_id: "task-12345678", task_name: "general" }],
+};
+
+const skipHint =
+  '（如选择"跳过"选项，本次 session init 将跳过，不注入任何团队资产）';
+
+describe("WorkBuddy AskUserQuestion answer extraction", () => {
+  it("keeps the selected asset-confirm answer instead of the skip hint", () => {
+    const content = ` · 本次对话是否要关联团队资产？${skipHint} → 是，关联团队资产`;
+    expect(extractAssetConfirm(content)).toBe(true);
+  });
+
+  it("extracts a Team selection from the rendered question and answer line", () => {
+    const content =
+      ` · 请选择本次会话所属的 Team：${skipHint} → ` +
+      `${team.team_name} (${team.team_id.slice(-8)})`;
+    expect(extractTeamFromOptionText(content, [team])).toBe(team.team_id);
+  });
+
+  it("reproduces and fixes the production Agent selection", () => {
+    const content =
+      ` · 请选择「home」下要使用的 Agent：${skipHint} → workbuddy (ddy-0001)`;
+    expect(extractAgentOnly(content, [team], team.team_id)).toBe("agent-workbuddy-0001");
+  });
+
+  it("extracts a Task selection without treating the question hint as bypass", () => {
+    const content =
+      ` · 请选择「home」下要关联的任务：${skipHint} → general (12345678)`;
+    expect(extractTaskOnly(content, [team], team.team_id)).toBe("task-12345678");
+  });
+
+  it("preserves an explicit skip answer", () => {
+    const content =
+      ` · 请选择「home」下要使用的 Agent：${skipHint} → 跳过`;
+    expect(extractAgentOnly(content, [team], team.team_id)).toBe(BYPASS_MARKER);
+  });
+
+  it("does not turn the pagination label into an Agent selection", () => {
+    const content =
+      ` · 请选择「home」下要使用的 Agent：${skipHint} → 更多 →`;
+    expect(extractAgentOnly(content, [team], team.team_id)).toBeNull();
+  });
+});

--- a/MemoryProxy/src/session/codebuddy/extractor.ts
+++ b/MemoryProxy/src/session/codebuddy/extractor.ts
@@ -56,13 +56,29 @@ function extractOpencodeAnswers(content: string): string | null {
 }
 
 /**
+ * WorkBuddy renders AskUserQuestion tool results as one display line:
+ *   · <question including the skip hint> → <selected option>
+ *
+ * Keep only the answer after the spaced delimiter. Otherwise the question's
+ * own "跳过 / 不关联" hint is mistaken for an explicit bypass. A selected
+ * "更多 →" stays intact because its trailing arrow has no answer after it.
+ */
+function extractWorkbuddyAnswer(content: string): string | null {
+  const match = content.match(/(?:^|\s)→\s+([\s\S]+)$/);
+  const answer = match?.[1]?.trim();
+  return answer ? answer : null;
+}
+
+/**
  * 从用户答复中提取 asset_confirm 选择。
  * 返回 true=是（关联资产），false=否（bypass），null=未识别。
  */
 export function extractAssetConfirm(content: string): boolean | null {
   // XML parsing
   const xml = parseQuestionAnswerXml(content);
-  const answer = xml?.teamAnswer ?? xml?.agentAnswer ?? xml?.taskAnswer ?? content;
+  let answer = xml?.teamAnswer ?? xml?.agentAnswer ?? xml?.taskAnswer ?? content;
+  const workbuddyAnswer = extractWorkbuddyAnswer(answer);
+  if (workbuddyAnswer !== null) answer = workbuddyAnswer;
 
   if (answer.includes(ASSET_CONFIRM_YES) || /是.*关联|关联.*是|确认.*关联/i.test(answer)) {
     return true;
@@ -148,6 +164,8 @@ export function extractTeamFromOptionText(
   // 见 extractOpencodeAnswers 头部注释。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;
+  const workbuddyAnswer = extractWorkbuddyAnswer(content);
+  if (workbuddyAnswer !== null) content = workbuddyAnswer;
 
   let teamText: string | null = null;
 
@@ -270,6 +288,8 @@ export function extractFromOptionText(
   // opencode: 剥壳 tool-result 包裹（见 extractOpencodeAnswers 头部）。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;
+  const workbuddyAnswer = extractWorkbuddyAnswer(content);
+  if (workbuddyAnswer !== null) content = workbuddyAnswer;
 
   let agentText: string | null = null;
   let taskText: string | null = null;
@@ -339,6 +359,8 @@ export function extractAgentOnly(
   // opencode: 剥壳 tool-result 包裹（见 extractOpencodeAnswers 头部）。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;
+  const workbuddyAnswer = extractWorkbuddyAnswer(content);
+  if (workbuddyAnswer !== null) content = workbuddyAnswer;
   const trimmed = content.trim();
   if (!trimmed) return null;
   // 先尝试匹配 agent 候选：CB codebuddy form 里 SKIP_HINT_LATER_STAGE 描述文本
@@ -375,6 +397,8 @@ export function extractTaskOnly(
   // opencode: 剥壳 tool-result 包裹（见 extractOpencodeAnswers 头部）。
   const opencodeAnswer = extractOpencodeAnswers(content);
   if (opencodeAnswer !== null) content = opencodeAnswer;
+  const workbuddyAnswer = extractWorkbuddyAnswer(content);
+  if (workbuddyAnswer !== null) content = workbuddyAnswer;
   const trimmed = content.trim();
   if (!trimmed) return null;
   // 先尝试匹配真实/虚拟 task 条目（虚拟条目由 fetchTeamsAndAgents 头部注入,

--- a/MemoryProxy/src/session/codebuddy/init.ts
+++ b/MemoryProxy/src/session/codebuddy/init.ts
@@ -928,15 +928,14 @@ async function handleSessionInitInner(
             `[session-init:cb] session=${compositeKey} skipAssetConfirm only-team=${onlyTeam.team_id} only-agent=${soloAgent.agent_id} auto-select`,
           );
           if (onlyTeam.tasks.length === 0) {
-            await store.set(compositeKey, {
-              ...nextState,
-              status: "initialized",
-              sessionInfo: null,
-              agentDetail: null,
-              taskDetail: null,
-              bypassed: true,
-            } as SessionInitState);
-            return { intercepted: false, bypassed: true, justRegistered: true, resetFlow: state?.resetFlow ?? false };
+            console.log(
+              `[session-init:cb] session=${compositeKey} team has 0 tasks → register without task`,
+            );
+            return await completeRegistration(
+              { agent_id: soloAgent.agent_id },
+              nextState, teams, compositeKey, sessionKey, userId,
+              config, store, messages, metadataClient, userKey, spaceId,
+            );
           }
           if (onlyTeam.tasks.length === 1) {
             return await completeRegistration(
@@ -1146,20 +1145,17 @@ async function handleSessionInitInner(
           console.log(
             `[session-init:cb] session=${compositeKey} only-team=${onlyTeam.team_id} only-agent=${soloAgent.agent_id} auto-select`,
           );
-          // 0 tasks → bypass；1 task → 直接 completeRegistration；≥2 → 出 task form。
+          // task_id 是可选的记忆维度。0 tasks 仍注册 Agent；
+          // 1 task 直接 completeRegistration；≥2 出 task form。
           if (onlyTeam.tasks.length === 0) {
-            await store.set(compositeKey, {
-              ...nextState,
-              status: "initialized",
-              sessionInfo: null,
-              agentDetail: null,
-              taskDetail: null,
-              bypassed: true,
-            } as SessionInitState);
             console.log(
-              `[session-init:cb] session=${compositeKey} team has 0 tasks → bypass`,
+              `[session-init:cb] session=${compositeKey} team has 0 tasks → register without task`,
             );
-            return { intercepted: false, bypassed: true, justRegistered: true, resetFlow: state?.resetFlow ?? false };
+            return await completeRegistration(
+              { agent_id: soloAgent.agent_id },
+              nextState, teams, compositeKey, sessionKey, userId,
+              config, store, messages, metadataClient, userKey, spaceId,
+            );
           }
           if (onlyTeam.tasks.length === 1) {
             const soleTaskId = onlyTeam.tasks[0].task_id;
@@ -1449,26 +1445,17 @@ async function handleSessionInitInner(
 
     if (picked) {
       const resolvedAgentId = resolveAgent(picked, cachedTeams, selectedTeamId);
-      // 0 tasks → bypass；1 task → auto-select 直接 complete。
+      // task_id is an optional recall dimension. A Team with no tasks still
+      // registers the selected Agent so injection and L0 write-back work.
       if (team.tasks.length === 0) {
         console.log(
-          `[session-init:cb] session=${compositeKey} agent=${resolvedAgentId} team has 0 tasks → bypass`,
+          `[session-init:cb] session=${compositeKey} agent=${resolvedAgentId} team has 0 tasks → register without task`,
         );
-        await store.set(compositeKey, {
-          status: "initialized",
-          keyId: sessionKey,
-          startedAt: state.startedAt,
-          attemptCount: 0,
-          userId: state.userId,
-          cachedTeams,
-          selectedTeamId,
-          selectedAgentId: resolvedAgentId,
-          sessionInfo: null,
-          agentDetail: null,
-          taskDetail: null,
-          bypassed: true,
-        } as SessionInitState);
-        return { intercepted: false, bypassed: true, justRegistered: true, resetFlow: state?.resetFlow ?? false };
+        return await completeRegistration(
+          { agent_id: resolvedAgentId },
+          state, cachedTeams, compositeKey, sessionKey, userId,
+          config, store, messages, metadataClient, userKey, spaceId,
+        );
       }
       if (team.tasks.length === 1) {
         const soleTaskId = team.tasks[0].task_id;


### PR DESCRIPTION
## Description | 描述

WorkBuddy renders an `AskUserQuestion` result as a single line containing the question, its skip hint, and the selected option. The CodeBuddy extractor previously scanned the whole line, so the hint's `跳过 / 不关联` text could win over an affirmative Team or Agent selection. The session was then persisted as bypassed, which disabled memory injection and L0 write-back.

This change:

- extracts the selected option after WorkBuddy's spaced `→` delimiter before applying bypass detection;
- preserves explicit skip selections and the `更多 →` pagination option;
- registers the selected Agent when a Team has no Task, because `task_id` is an optional memory isolation dimension;
- adds regression coverage for asset, Team, Agent and Task answers, explicit bypass, and pagination.

## Related Issue | 关联 Issue

None.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

Validation:

- `cd MemoryProxy && npm test` — 6 tests passed.
- End-to-end WorkBuddy form flow — selected Agent initialized, memory context available, and L0 messages read back successfully.
- `npm run typecheck` still reports errors already present on the base branch, including `SessionInitResult.resetFlow`, SessionInfo casts, the `skipAssetConfirm` config type, and the optional `@context-proxy/cost-guard` module. No new error category originates from this patch.

## Additional Notes | 其他说明

The parser only strips a delimiter when `→` is surrounded by the WorkBuddy display spacing and has a non-empty answer after it. This keeps the trailing arrow in the `更多 →` option intact.
