### PR TITLE
fix(memory-core): stop compact truncation loops spinning on oversized tool results

### DIFF
--- a/MemoryCore/src/offload_server/compact/compressor-truncate.test.ts
+++ b/MemoryCore/src/offload_server/compact/compressor-truncate.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  TOOL_RESULT_TRUNCATE_CHARS,
+  truncateTailToolResults,
+  truncateToolResultText,
+} from "./compressor.js";
+import type { Message } from "./helpers.js";
+
+function toolResult(content: string): Message {
+  return { role: "tool", content };
+}
+
+function countingEstimator(maxCalls: number) {
+  let calls = 0;
+  return (text: string) => {
+    if (++calls > maxCalls) {
+      throw new Error(`estimateTokens called ${calls} times — truncation is not converging`);
+    }
+    return Math.max(1, Math.ceil(text.length / 4));
+  };
+}
+
+describe("truncateToolResultText", () => {
+  it("keeps short content unchanged", () => {
+    expect(truncateToolResultText("hello", 2000)).toBe("hello");
+  });
+
+  it("fits notice-inclusive output within truncateChars", () => {
+    const content = "x".repeat(TOOL_RESULT_TRUNCATE_CHARS + 500);
+    const truncated = truncateToolResultText(content, TOOL_RESULT_TRUNCATE_CHARS);
+    expect(truncated.length).toBeLessThanOrEqual(TOOL_RESULT_TRUNCATE_CHARS);
+    expect(truncated).toContain("content truncated");
+  });
+});
+
+describe("truncateTailToolResults", () => {
+  it("terminates when a single tool_result cannot free the requested budget", () => {
+    const truncateChars = TOOL_RESULT_TRUNCATE_CHARS;
+    const messages = [toolResult("x".repeat(truncateChars + 500))];
+    const tokenArray = [Math.ceil((truncateChars + 500) / 4)];
+
+    const freed = truncateTailToolResults(
+      messages,
+      tokenArray,
+      0,
+      100_000,
+      countingEstimator(20),
+      truncateChars,
+    );
+
+    expect(freed).toBeGreaterThan(0);
+    const content = messages[0].content as string;
+    expect(content.length).toBeLessThanOrEqual(truncateChars);
+    expect(content).toContain("content truncated");
+  });
+
+  it("does not re-select an already truncated message", () => {
+    const truncateChars = 80;
+    const messages = [toolResult("a".repeat(200)), toolResult("b".repeat(180))];
+    const tokenArray = [
+      Math.ceil(200 / 4),
+      Math.ceil(180 / 4),
+    ];
+
+    truncateTailToolResults(
+      messages,
+      tokenArray,
+      0,
+      100_000,
+      countingEstimator(20),
+      truncateChars,
+    );
+
+    expect((messages[0].content as string).length).toBeLessThanOrEqual(truncateChars);
+    expect((messages[1].content as string).length).toBeLessThanOrEqual(truncateChars);
+  });
+});

--- a/MemoryCore/src/offload_server/compact/compressor.ts
+++ b/MemoryCore/src/offload_server/compact/compressor.ts
@@ -200,6 +200,27 @@ function isSystemReminder(msg: Message): boolean {
 /** Max characters to keep when truncating a large tool_result. */
 export const TOOL_RESULT_TRUNCATE_CHARS = 2000;
 
+/** Suffix appended when a tool_result is truncated. Reserved inside the char budget. */
+export function toolResultTruncationNotice(truncateChars: number): string {
+  return `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+}
+
+/**
+ * Truncate tool_result text so the result (notice included) fits in `truncateChars`.
+ *
+ * Slicing to `truncateChars` and then appending a notice produces a string still
+ * longer than the skip threshold (`content.length <= truncateChars`), so the
+ * truncation loops re-select the same message forever (#832).
+ */
+export function truncateToolResultText(content: string, truncateChars: number): string {
+  if (content.length <= truncateChars) return content;
+  const notice = toolResultTruncationNotice(truncateChars);
+  if (notice.length >= truncateChars) {
+    return content.slice(0, truncateChars);
+  }
+  return content.slice(0, truncateChars - notice.length) + notice;
+}
+
 /**
  * Find index of the last user message (excluding MMD injections).
  * Returns -1 if no user message found.
@@ -227,6 +248,7 @@ export function truncateTailToolResults(
   truncateChars: number = TOOL_RESULT_TRUNCATE_CHARS,
 ): number {
   let totalFreed = 0;
+  const seen = new Set<number>();
 
   while (tokensToFree > 0) {
     // Find the largest tool_result in protected zone
@@ -234,6 +256,7 @@ export function truncateTailToolResults(
     let maxLen = 0;
 
     for (let i = protectedTailIdx; i < messages.length; i++) {
+      if (seen.has(i)) continue;
       if (!isToolResultMessage(messages[i])) continue;
       const content = getTextContent(messages[i]);
       if (content.length <= truncateChars) continue; // already small enough
@@ -244,17 +267,20 @@ export function truncateTailToolResults(
     }
 
     if (maxIdx === -1) break; // nothing left to truncate
+    seen.add(maxIdx);
 
-    // Truncate
+    // Truncate — result (notice included) must stay within truncateChars
     const msg = messages[maxIdx];
     const oldContent = getTextContent(msg);
-    const truncated = oldContent.slice(0, truncateChars) + `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+    const truncated = truncateToolResultText(oldContent, truncateChars);
+    if (truncated.length >= oldContent.length) continue;
     setTextContent(msg, truncated);
 
     // Recalculate token for this message
     const newTokens = estimateTokensFn(truncated);
     const freed = tokenArray[maxIdx] - newTokens;
     tokenArray[maxIdx] = newTokens;
+    if (freed <= 0) continue;
     tokensToFree -= freed;
     totalFreed += freed;
   }
@@ -277,6 +303,7 @@ function truncateRemainingToolResults(
   truncateChars: number = TOOL_RESULT_TRUNCATE_CHARS,
 ): number {
   let totalFreed = 0;
+  const seen = new Set<number>();
 
   while (tokensToFree > 0) {
     // Find the largest tool_result content among non-deleted messages
@@ -284,7 +311,7 @@ function truncateRemainingToolResults(
     let maxLen = 0;
 
     for (let i = 0; i < messages.length; i++) {
-      if (deleteIndices.has(i)) continue;
+      if (seen.has(i) || deleteIndices.has(i)) continue;
       if (!isToolResultMessage(messages[i])) continue;
       const content = getTextContent(messages[i]);
       if (content.length <= truncateChars) continue;
@@ -295,11 +322,12 @@ function truncateRemainingToolResults(
     }
 
     if (maxIdx === -1) break;
+    seen.add(maxIdx);
 
-    // Truncate
+    // Truncate — result (notice included) must stay within truncateChars
     const oldContent = getTextContent(messages[maxIdx]);
-    const truncated = oldContent.slice(0, truncateChars) +
-      `\n\n[... content truncated, only first ${truncateChars} characters retained ...]`;
+    const truncated = truncateToolResultText(oldContent, truncateChars);
+    if (truncated.length >= oldContent.length) continue;
     setTextContent(messages[maxIdx], truncated);
 
     // Recalculate token
@@ -309,6 +337,7 @@ function truncateRemainingToolResults(
       : Math.max(1, Math.ceil(truncated.length / 4));
     tokenArray[maxIdx] = newTokens;
     const freed = oldTokens - newTokens;
+    if (freed <= 0) continue;
     tokensToFree -= freed;
     totalFreed += freed;
   }
@@ -754,8 +783,7 @@ export function aggressiveCompress(
 
     const oldTokens = tokenArray[maxIdx];
     const oldContent = getTextContent(messages[maxIdx]);
-    const truncated = oldContent.slice(0, TOOL_RESULT_TRUNCATE_CHARS) +
-      `\n\n[... content truncated, only first ${TOOL_RESULT_TRUNCATE_CHARS} characters retained ...]`;
+    const truncated = truncateToolResultText(oldContent, TOOL_RESULT_TRUNCATE_CHARS);
     setTextContent(messages[maxIdx], truncated);
     const newTokens = preciseMessageTokens(messages[maxIdx]);
     tokenArray[maxIdx] = newTokens;
@@ -1079,8 +1107,7 @@ export function emergencyCompress(
 
     const oldTokens = tokenArray[maxIdx];
     const oldContent = getTextContent(messages[maxIdx]);
-    const truncated = oldContent.slice(0, TOOL_RESULT_TRUNCATE_CHARS) +
-      `\n\n[... content truncated, only first ${TOOL_RESULT_TRUNCATE_CHARS} characters retained ...]`;
+    const truncated = truncateToolResultText(oldContent, TOOL_RESULT_TRUNCATE_CHARS);
     setTextContent(messages[maxIdx], truncated);
     const newTokens = preciseMessageTokens(messages[maxIdx]);
     tokenArray[maxIdx] = newTokens;


### PR DESCRIPTION
## Description | 描述
Compact used to slice a large `tool_result` to 2000 characters and then append a truncation notice. The combined string stayed above the 2000-character skip threshold, so `while (tokensToFree > 0)` re-selected the same message forever and pinned CPU.

The notice is now counted inside the character budget, already-truncated messages are skipped, and a regression test covers the issue #832 fixture.

## Related Issue | 关联 Issue
Fixes #832

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

```
cd MemoryCore
npx vitest run src/offload_server/compact/compressor-truncate.test.ts
# Test Files  1 passed (1)
# Tests  4 passed (4)
```

## Additional Notes | 其他说明
`aggressiveCompress` / `emergencyCompress` used the same slice-then-append pattern; they now share `truncateToolResultText` so the length gate keeps working there too.


Made with [Cursor](https://cursor.com)