### PR TITLE
fix(sdk-ts): validate v3 response envelopes before accessing fields

### DIFF
--- a/sdk/memory-core/typescript/src/v3/http.ts
+++ b/sdk/memory-core/typescript/src/v3/http.ts
@@ -94,6 +94,14 @@ export class V3HttpTransport {
         );
       }
 
+      if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+        throw new TDAMError(
+          response.ok ? -1 : response.status,
+          "API response must be a JSON object",
+          headerRequestId,
+        );
+      }
+
       const businessCode = typeof envelope.code === "number" ? envelope.code : undefined;
       if (!response.ok || businessCode !== 0) {
         const code = businessCode && businessCode !== 0 ? businessCode : response.status;

--- a/sdk/memory-core/typescript/tests/v3-http.test.ts
+++ b/sdk/memory-core/typescript/tests/v3-http.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { V3HttpTransport } from "../src/v3/http.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe.each(["get", "post"] as const)("V3HttpTransport.%s", (method) => {
+  const transport = new V3HttpTransport({
+    endpoint: "https://memory.example.com",
+    apiKey: "test-api-key",
+    serviceId: "test-service-id",
+  });
+
+  function mockResponse(body: string, status = 200, headers: Record<string, string> = {}) {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(body, { status, headers })));
+  }
+
+  it.each(["null", "[]", '"unexpected"', "42", "true"])(
+    "rejects a non-object JSON envelope: %s",
+    async (body) => {
+      mockResponse(body, 200, { "x-trace-id": "trace-invalid-envelope" });
+
+      await expect(transport[method]("/v3/test")).rejects.toMatchObject({
+        name: "TDAMError",
+        code: -1,
+        message: expect.stringContaining("API response must be a JSON object"),
+        requestId: "trace-invalid-envelope",
+      });
+    },
+  );
+
+  it("preserves the HTTP status and transaction ID for an invalid error envelope", async () => {
+    mockResponse("null", 502, {
+      "x-qcloud-transaction-id": "transaction-error",
+      "x-trace-id": "trace-error",
+    });
+
+    await expect(transport[method]("/v3/test")).rejects.toMatchObject({
+      name: "TDAMError",
+      code: 502,
+      requestId: "transaction-error",
+    });
+  });
+
+  it("returns valid data with its trace ID", async () => {
+    mockResponse(JSON.stringify({ code: 0, data: { items: [] } }), 200, {
+      "x-trace-id": "trace-success",
+    });
+
+    await expect(transport[method]("/v3/test")).resolves.toEqual({
+      items: [],
+      trace_id: "trace-success",
+    });
+  });
+
+  it("continues to accept successful envelopes without data", async () => {
+    mockResponse(JSON.stringify({ code: 0 }));
+
+    await expect(transport[method]("/v3/test")).resolves.toEqual({});
+  });
+
+  it("preserves business error details and the envelope request ID", async () => {
+    mockResponse(JSON.stringify({
+      code: 40901,
+      message: "Skill version is stale",
+      request_id: "request-conflict",
+      data: { current_version: 2 },
+    }));
+
+    await expect(transport[method]("/v3/test")).rejects.toMatchObject({
+      name: "TDAMError",
+      code: 40901,
+      message: expect.stringContaining("Skill version is stale"),
+      requestId: "request-conflict",
+      details: { current_version: 2 },
+    });
+  });
+});


### PR DESCRIPTION
[PR-description.md](https://github.com/user-attachments/files/32092866/PR-description.md)
# fix(sdk-ts): validate v3 response envelopes before accessing fields

When a v3 endpoint or intermediary returns JSON `null`, the TypeScript SDK
throws `TypeError: Cannot read properties of null (reading 'code')` instead
of `TDAMError`. This loses the HTTP status and request ID, including when
the response is an HTTP error. Other non-object JSON responses produce
misleading errors such as `[200] HTTP 200`.

Validate that the parsed envelope is a non-null, non-array object before
accessing its fields. Invalid envelopes now raise `TDAMError` with a clear
message, the request ID from response headers, and either the failing HTTP
status or `-1` for successful HTTP responses with an invalid envelope.

The change is limited to the shared v3 GET/POST transport. Valid success
envelopes, trace propagation, and business error details retain their
existing behavior.

## Validation

From `sdk/memory-core/typescript`:

```sh
npm test -- --reporter=verbose
npm run build
```

- Added 18 tests using mocked fetch responses; no live service is required.
- Without the fix: 12 tests fail and 6 pass.
- With the fix: all 18 tests pass.
- TypeScript build passes.
- `git diff --check` passes.

Verified on Windows with Node.js 20.17.0 and npm 10.8.2. This SDK declares
Node.js >=18 support. Full-stack Docker integration and the repository's
GitHub Actions workflow were not run.
