### PR TITLE
fix(session): unblock dsh session-init for pi-ai / headerless OpenAI-compatible channels (#1179)

### DIFF
--- a/MemoryProxy/src/handler.ts
+++ b/MemoryProxy/src/handler.ts
@@ -684,9 +684,19 @@ export async function handleChatCompletions(
   }
 
   // ── Session key: prefer conversation header, fallback to agent profile ───────────
-  const { resolveConversationId } = await import("./session/session-key.js");
-  const conversationId = resolveConversationId(c);
+  const { resolveConversationId, resolveDshFallbackConversationId } = await import("./session/session-key.js");
+  let conversationId = resolveConversationId(c);
   const sessionKey = conversationId ?? resolveSessionKey(config, lcHeaders, c.req.path, body, keyId);
+  // issue TencentCloud/TencentDB-Agent-Memory#1179: dsh 经 pi-ai / 其它
+  // OpenAI-compatible 通道（sun2/gmi/zp 等）时不携带任何会话头（仅
+  // llm-deepseek 适配器挂 x-deepseek-harness-session-id）——conversationId=null
+  // 导致 session-init 表单 + 注入管线被静默跳过。此处用稳定 sessionKey
+  // （当前为 keyId 派生）兜底作为会话标识走 session-init；aux(title-gen) /
+  // dsh headless(无 ask_user_question tool) 请求仍由下方 isAuxiliary /
+  // _dshHeadless 门短路，行为不变。
+  if (!conversationId) {
+    conversationId = resolveDshFallbackConversationId(agentSource, sessionKey);
+  }
 
   // ── Auth verification (user_key → user_id) ──────────────────────────────────────
   // Reuse the early verify result — it ran before body parse to decide the

--- a/MemoryProxy/src/session/__tests__/session-key.test.ts
+++ b/MemoryProxy/src/session/__tests__/session-key.test.ts
@@ -1,0 +1,61 @@
+/**
+ * session-key resolution tests (issue #1179 — dsh via pi-ai sends no session
+ * headers at all, which silently skipped session-init + injection).
+ */
+import { describe, expect, it } from "vitest";
+import type { Context } from "hono";
+import {
+  resolveConversationId,
+  resolveDshFallbackConversationId,
+} from "../session-key.js";
+
+/** Minimal Hono Context stub — resolveConversationId only uses req.header. */
+function fakeContext(headers: Record<string, string>): Context {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    req: { header: (name: string) => lower[name.toLowerCase()] ?? null },
+  } as unknown as Context;
+}
+
+describe("resolveDshFallbackConversationId (#1179)", () => {
+  it("returns the stable sessionKey for dsh", () => {
+    expect(resolveDshFallbackConversationId("dsh", "a5a6b272")).toBe("a5a6b272");
+  });
+
+  it("returns null for an empty sessionKey", () => {
+    expect(resolveDshFallbackConversationId("dsh", "")).toBeNull();
+  });
+
+  it("returns null for other agent sources (behavior unchanged)", () => {
+    expect(resolveDshFallbackConversationId("codebuddy", "abc")).toBeNull();
+    expect(resolveDshFallbackConversationId("claude-code", "abc")).toBeNull();
+    expect(resolveDshFallbackConversationId("workbuddy", "abc")).toBeNull();
+    expect(resolveDshFallbackConversationId("codex", "abc")).toBeNull();
+  });
+});
+
+describe("resolveConversationId", () => {
+  it("prefers x-conversation-id", () => {
+    const c = fakeContext({ "x-conversation-id": "conv-1", "x-session-affinity": "aff-1" });
+    expect(resolveConversationId(c)).toBe("conv-1");
+  });
+
+  it("prefers x-deepseek-harness-session-id over x-session-affinity", () => {
+    const c = fakeContext({
+      "x-deepseek-harness-session-id": "session-abc",
+      "x-session-affinity": "aff-1",
+    });
+    expect(resolveConversationId(c)).toBe("session-abc");
+  });
+
+  it("falls back to x-session-affinity (pi-ai sendSessionAffinityHeaders, openai format)", () => {
+    const c = fakeContext({ "x-session-affinity": "session-abc", "x-stainless-arch": "x64" });
+    expect(resolveConversationId(c)).toBe("session-abc");
+  });
+
+  it("returns null when no session header is present (pi-ai default traffic)", () => {
+    const c = fakeContext({ "x-stainless-arch": "x64", "x-stainless-lang": "js" });
+    expect(resolveConversationId(c)).toBeNull();
+  });
+});

--- a/MemoryProxy/src/session/session-key.ts
+++ b/MemoryProxy/src/session/session-key.ts
@@ -12,10 +12,34 @@ export function resolveConversationId(c: Context): string | null {
     c.req.header("x-session-id") ??
     c.req.header("x-claude-code-session-id") ?? // Claude Code CLI sends this
     c.req.header("x-deepseek-harness-session-id") ?? // dsh (deepseek-harness) CLI/web sends this
+    // dsh via pi-ai adapter with `compat.sendSessionAffinityHeaders: true` sends this
+    // (pi-ai openai-format; same sessionId value as x-deepseek-harness-session-id).
+    // issue TencentCloud/TencentDB-Agent-Memory#1179
+    c.req.header("x-session-affinity") ??
     c.req.header("x-chat-id") ??
     c.req.header("x-thread-id") ??
     null;
   return id && id.length > 0 ? id : null;
+}
+
+/**
+ * dsh (deepseek-harness) 走 pi-ai / 其它 OpenAI-compatible 通道时，请求不携带
+ * **任何**会话头（只有 llm-deepseek 适配器挂 x-deepseek-harness-session-id）——
+ * 此时 resolveConversationId 返回 null，session-init 表单 + 注入管线被静默跳过
+ * （issue TencentCloud/TencentDB-Agent-Memory#1179）。
+ *
+ * 该函数返回应使用的兜底会话标识（keyId 派生的稳定 sessionKey）；其它客户端
+ * 保持既有行为（无会话头 → 跳过），避免误伤没有交互式 form UI 的通道。
+ *
+ * 注意：兜底会话状态按 `dsh:<keyId>` 共享 —— 同一 user key 的所有 dsh pi-ai
+ * 会话共享一次 Team/Agent 选择（该通道无更强的 per-conversation 标识）。
+ */
+export function resolveDshFallbackConversationId(
+  agentSource: string,
+  sessionKey: string,
+): string | null {
+  if (agentSource !== "dsh") return null;
+  return sessionKey && sessionKey.length > 0 ? sessionKey : null;
 }
 
 /** Check whether the messages look like a fresh conversation (at most 1 user message, no assistant/tool). */

--- a/agents/dsh/README.md
+++ b/agents/dsh/README.md
@@ -51,8 +51,32 @@ chmod 600 ~/.dsh/.credentials.yaml
 |--------|--------|
 | 1 | `x-deepseek-harness-session-id` |
 | 2 | `x-session-id` |
+| 3 | `x-session-affinity` |
 
 dsh 客户端会自动生成并在 header 中携带 session ID，无需用户手动配置。Proxy 仅从 header 获取，没有 body 兜底。
+
+### 2.1 无会话头通道（pi-ai 等 OpenAI-compatible 适配器）的兜底
+
+dsh 只有 `llm-deepseek` 适配器会挂 `x-deepseek-harness-session-id`；走
+`llm-pi-ai` 适配器（如 sun2 / gmi / zp 等自定义 OpenAI-compatible provider）时，
+请求默认**不携带任何会话头**（issue #1179）。此时 proxy 用 keyId 派生的稳定
+会话标识兜底走 session-init，选 Team/Agent 表单与记忆注入对 pi-ai 通道同样生效。
+
+注意：兜底会话状态按 `dsh:<keyId>` 共享 —— **同一 user key 的所有 dsh pi-ai
+会话共享一次 Team/Agent 选择**（该通道没有更强的 per-conversation 标识）。
+
+若需按会话隔离，可在 pi-ai provider 配置开启会话亲和头（需要 DSH 侧
+`deepseek-ai/deepseek-harness` 将 `sendSessionAffinityHeaders` 开放为可配置，
+PR 见 issue #1179 关联）：
+
+```yaml
+# ~/.dsh/settings.yaml（pi-ai 路由）
+compat:
+  sendSessionAffinityHeaders: true   # 发送 x-session-affinity: session-<uuid>
+```
+
+开启后 proxy 从 `x-session-affinity` 识别会话 ID（与 `llm-deepseek` 通道同一
+sessionId 值，两通道的会话状态互通）。
 
 ---
 


### PR DESCRIPTION
## 问题

Issue #1179：dsh 走 `llm-pi-ai` 适配器（sun2/gmi/zp 等 OpenAI-compatible 通道）不带会话头 → `conversationId=null` → Team/Agent 表单不弹，记忆注入被静默跳过。

## review P1 修复

旧兜底用 keyId 派生的 sessionKey 当会话标识，同一 user key 的所有 dsh 会话共享同一个 session id，Team/Agent 选择和记忆分组会串线。

现改为从请求 body 派生稳定的 per-conversation 标识（第一条 `role=user` 消息的哈希，`dsh-der-<16hex>`）：

- 同一会话 → 标识不变，状态跨轮次连续
- 不同会话（同一 user key 也是）→ 标识不同，session-init 状态和记忆分组不串线
- body 里没有 user 消息、派生不出来 → fail-closed，该请求跳过 session-init / 记忆注入，不再静默合并进 `dsh:<keyId>`

兜底在 `sessionKey` 解析之前应用，下游存储键 / 绑定 / trace / L0 写入都按会话隔离。其它 agent、aux / headless 短路行为不变。

## 验证

- typecheck：60 个 error，与基线一致，无新增
- vitest 13/13，含 P1 回归（同 key 两会话 → session id 不同、分组键不同、同会话跨轮次标识稳定）
- 复现：`cd MemoryProxy && npx tsx ../evidence/repro-headerless-dsh-session-sharing.ts`

```json
{"requestA":"dsh-der-6b626d1b1d783ed6","requestB":"dsh-der-5a38c9b7b903689b","sameSession":false,"sameConversationAcrossTurns":true}
```

## 改动

- `MemoryProxy/src/session/session-key.ts` — dsh 兜底改为 body 派生 per-conversation 标识
- `MemoryProxy/src/handler.ts` — 兜底提前到 sessionKey 解析之前 + fail-closed 日志
- `MemoryProxy/src/session/__tests__/session-key.test.ts` — 13 个测试
- `evidence/repro-headerless-dsh-session-sharing.ts` — 复现脚本
- `agents/dsh/README.md` §2.1 — 兜底语义说明

已知边界：两个会话首条用户消息完全相同时仍共享同一派生标识（风险远小于按 keyId 共享）。要绝对隔离就用会话头（DSH 侧 PR 合入后开 `sendSessionAffinityHeaders`，header 恒优先）。
