### PR TITLE
fix(store-pool): forward sendDimensions to the sqlite embedding service

### DIFF
--- a/MemoryCore/src/core/store/store-pool.test.ts
+++ b/MemoryCore/src/core/store/store-pool.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { MemoryTdaiConfig } from "../../config.js";
+
+const mocks = vi.hoisted(() => ({
+  createEmbeddingService: vi.fn(() => ({})),
+}));
+
+vi.mock("./embedding.js", () => ({
+  createEmbeddingService: mocks.createEmbeddingService,
+  NoopEmbeddingService: class {},
+}));
+vi.mock("./bm25-local.js", () => ({ createBM25Encoder: () => undefined }));
+vi.mock("./sqlite/memory-store.js", () => ({
+  VectorStore: class {
+    async close(): Promise<void> {}
+  },
+}));
+vi.mock("../report/kafka-metric-producer.js", () => ({
+  metricProducer: { initialize: async () => undefined },
+}));
+
+import { StorePool } from "./store-pool.js";
+
+const logger = { info() {}, warn() {}, error() {}, debug() {} };
+
+function memoryCfg(sendDimensions: boolean): MemoryTdaiConfig {
+  return {
+    bm25: { enabled: false, language: "en" },
+    embedding: {
+      enabled: true,
+      provider: "openai",
+      baseUrl: "https://embeddings.example/v1",
+      apiKey: "test-key",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+      sendDimensions,
+      maxInputChars: 8000,
+    },
+  } as unknown as MemoryTdaiConfig;
+}
+
+describe("StorePool sqlite embedding service", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    mocks.createEmbeddingService.mockClear();
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("forwards sendDimensions from the embedding config (#1343)", async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), "store-pool-"));
+    dirs.push(dataDir);
+    const pool = new StorePool({ mode: "sqlite", memoryCfg: memoryCfg(false), dataDir, logger });
+
+    await pool.getStore("tenant-a", null);
+
+    expect(mocks.createEmbeddingService).toHaveBeenCalledTimes(1);
+    expect(mocks.createEmbeddingService.mock.calls[0]?.[0]).toMatchObject({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+      sendDimensions: false,
+    });
+  });
+
+  it("keeps sendDimensions enabled when the config says so", async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), "store-pool-"));
+    dirs.push(dataDir);
+    const pool = new StorePool({ mode: "sqlite", memoryCfg: memoryCfg(true), dataDir, logger });
+
+    await pool.getStore("tenant-b", null);
+
+    expect(mocks.createEmbeddingService.mock.calls[0]?.[0]).toMatchObject({ sendDimensions: true });
+  });
+});

--- a/MemoryCore/src/core/store/store-pool.ts
+++ b/MemoryCore/src/core/store/store-pool.ts
@@ -463,6 +463,7 @@ export class StorePool {
         apiKey: embCfg.apiKey,
         model: embCfg.model,
         dimensions: embCfg.dimensions,
+        sendDimensions: embCfg.sendDimensions,
         maxInputChars: embCfg.maxInputChars,
       }, this.logger as StoreLogger);
     }


### PR DESCRIPTION
## Description | 描述

`StorePool.createSqliteStore()` in `MemoryCore/src/core/store/store-pool.ts` built the embedding service without `sendDimensions`, so `OpenAIEmbeddingService` fell back to `true` on the store-pool (v3 multi-tenant) path even when the config disabled it. Against an endpoint that rejects an explicit `dimensions` parameter every embed call failed, and because embedding failures are non-fatal the deployment silently degraded to keyword-only retrieval. `factory.ts` already forwards the option; the pool now passes `sendDimensions: embCfg.sendDimensions` as well.

`MemoryCore/src/core/store/store-pool.test.ts` (new) builds a `StorePool` in sqlite mode with the embedding service, BM25 encoder, SQLite store and Kafka producer mocked, calls `getStore()` and asserts that `createEmbeddingService` receives `sendDimensions: false` from the config (and `true` when configured so). The first case fails on the current branch because the key is missing.

## Related Issue | 关联 Issue

Fix #1343

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过 (`vitest run src/core/store/store-pool.test.ts`: 2 passed)
- [x] No existing features affected | 无影响现有功能 (one added key on the sqlite path; tcvdb and mongodb paths untouched)

## Additional Notes | 其他说明

The repository had no vitest files under `MemoryCore/src` yet; the new test follows the `include` pattern in `vitest.config.ts`.
