### PR TITLE
fix(mem-command): session-reset 在真实客户端报文下的识别缺陷

### DIFF
--- a/MemoryProxy/src/__tests__/mem-session-reset-intercept.test.ts
+++ b/MemoryProxy/src/__tests__/mem-session-reset-intercept.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import { isSessionResetCommand } from "../mem-command/pre-intercept.js";
+import { parseCommandFromText, parseMemCommand } from "../mem-command/parser.js";
+
+/**
+ * `mem:session-reset` 的前置拦截判定。
+ *
+ * 真机背景：Claude Code 2.x 会在用户消息后面追加自己的内容（`<system-reminder>…`），
+ * 可能是同一个 content 数组里的第二个 text 块，也可能在同一块里换行追加。此时按"整段文本
+ * 解析命令"会得到 `command="session-reset\n<system-reminder>…"`，与 `session-reset` 不等，
+ * reset 永远不会触发——用户发了命令，会话仍停在 bypassed，模型把它当普通提问回答。
+ */
+describe("mem:session-reset 前置拦截", () => {
+  const ccBody = (text: string) => ({
+    messages: [{ role: "user", content: [{ type: "text", text }] }],
+  });
+  const ccBodyMulti = (texts: string[]) => ({
+    messages: [{ role: "user", content: texts.map((t) => ({ type: "text", text: t })) }],
+  });
+
+  it("干净的命令命中", () => {
+    expect(isSessionResetCommand(ccBody("mem:session-reset"), "claude-code")).toBe(true);
+  });
+
+  it("命令后换行追加 system-reminder（同一块）也命中", () => {
+    expect(
+      isSessionResetCommand(
+        ccBody("mem:session-reset\n<system-reminder>\nbe concise\n</system-reminder>"),
+        "claude-code",
+      ),
+    ).toBe(true);
+  });
+
+  it("命令是第一个 text 块、reminder 是第二个块也命中", () => {
+    expect(
+      isSessionResetCommand(
+        ccBodyMulti(["mem:session-reset", "<system-reminder>\nbe concise\n</system-reminder>"]),
+        "claude-code",
+      ),
+    ).toBe(true);
+  });
+
+  it("命令后的同一行还有别的内容 → 不命中（避免把正常提问拦掉）", () => {
+    expect(
+      isSessionResetCommand(ccBody("mem:session-reset 是什么意思"), "claude-code"),
+    ).toBe(false);
+  });
+
+  it("普通提问不命中", () => {
+    expect(isSessionResetCommand(ccBody("你好，帮我看看这段代码"), "claude-code")).toBe(false);
+  });
+
+  it("Responses 形态（body.input[]）同样适用", () => {
+    expect(
+      isSessionResetCommand(
+        {
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "mem:session-reset" }],
+            },
+          ],
+        },
+        "codex",
+      ),
+    ).toBe(true);
+  });
+
+  // 真机抓到的形态：CC 在用户输入后面再挂一条 role:"system" 的 token 提示，
+  // 于是"最后一条就是用户消息"的前提不成立——命令会被整条漏掉。
+  const ccRealShape = {
+    messages: [
+      { role: "user", content: "上一轮的问题" },
+      { role: "assistant", content: [{ type: "text", text: "上一轮的回答" }] },
+      { role: "user", content: "mem:session-reset" },
+      {
+        role: "system",
+        content: [{ type: "text", text: "<total_tokens>15000000 tokens left</total_tokens>" }],
+      },
+    ],
+  };
+
+  it("尾随一条 role:system 提示时仍命中（真机形态）", () => {
+    expect(isSessionResetCommand(ccRealShape, "claude-code")).toBe(true);
+  });
+
+  it("历史里的旧命令不会被重放触发（只看最近一条带文本的 user 消息）", () => {
+    expect(
+      isSessionResetCommand(
+        {
+          messages: [
+            { role: "user", content: "mem:session-reset" },
+            { role: "assistant", content: [{ type: "text", text: "好的" }] },
+            { role: "user", content: "现在问个别的问题" },
+            {
+              role: "system",
+              content: [{ type: "text", text: "<total_tokens>…</total_tokens>" }],
+            },
+          ],
+        },
+        "claude-code",
+      ),
+    ).toBe(false);
+  });
+
+  // 真机第二个形态：CC 把 AskUserQuestion 的选择以 `role:"user"` + `tool_result` 回执发回来。
+  // 回执里没有用户键入的文本，若"往回跳过没有文本的 user 消息"这条规则生效，回看就会越过
+  // 回执、命中会话更早那条 mem:session-reset，把已执行过的命令重放一遍 —— 状态被打回
+  // uninitialized，同一张表单弹两次（第一次的选择被覆盖）。
+  const ccFormReply = (extra?: Record<string, unknown>) => ({
+    messages: [
+      { role: "user", content: [{ type: "text", text: "mem:session-reset" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_cc_session_init_1",
+            name: "AskUserQuestion",
+            input: { questions: [] },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_cc_session_init_1",
+            content: '{"answers":{"本次对话是否要关联团队资产？":"否，本次不关联"}}',
+          },
+        ],
+      },
+      ...(extra ? [extra] : []),
+    ],
+  });
+
+  it("表单回执（tool_result）不算新命令 → 不命中，表单不会被重弹", () => {
+    expect(isSessionResetCommand(ccFormReply(), "claude-code")).toBe(false);
+  });
+
+  it("表单回执后还挂着 role:system 提示 → 同样不命中", () => {
+    expect(
+      isSessionResetCommand(
+        ccFormReply({
+          role: "system",
+          content: [{ type: "text", text: "<total_tokens>15000000 tokens left</total_tokens>" }],
+        }),
+        "claude-code",
+      ),
+    ).toBe(false);
+  });
+
+  it("同一条消息里既有工具回执又有用户键入的文本 → 按文本判定", () => {
+    expect(
+      isSessionResetCommand(
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "上一轮" }] },
+            { role: "assistant", content: [{ type: "text", text: "好的" }] },
+            {
+              role: "user",
+              content: [
+                { type: "tool_result", tool_use_id: "tu1", content: "ok" },
+                { type: "text", text: "mem:session-reset" },
+              ],
+            },
+          ],
+        },
+        "claude-code",
+      ),
+    ).toBe(true);
+  });
+
+  // 真机第三个形态（Hermes / workbuddy 这类 OpenAI Chat 客户端）：表单回执不是
+  // role:"user" + tool_result，而是**独立角色** `role:"tool"`。
+  // 旧逻辑只跳过"没有文本的 user 消息"，于是回看越过 tool 回执、命中更早那条
+  // mem:session-reset → 重置被打回 uninitialized → 同一张资产确认表单连问三次。
+  const chatFormReply = (tail?: Record<string, unknown>) => ({
+    messages: [
+      { role: "user", content: "mem:session-reset" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_hermes_session_init_1",
+            type: "function",
+            function: { name: "clarify", arguments: '{"question":"是否关联资产"}' },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call_hermes_session_init_1",
+        content: '{"answer":"否，本次不关联"}',
+      },
+      ...(tail ? [tail] : []),
+    ],
+  });
+
+  it("OpenAI 形态的表单回执（role:tool）不算新命令 → 不命中", () => {
+    expect(isSessionResetCommand(chatFormReply(), "hermes")).toBe(false);
+  });
+
+  it("OpenAI 形态的表单回执后还有一条 assistant 消息 → 同样不命中", () => {
+    expect(
+      isSessionResetCommand(
+        chatFormReply({ role: "assistant", content: "已记录" }),
+        "hermes",
+      ),
+    ).toBe(false);
+  });
+
+  it("历史里的 role:function 回执同样算工具续接", () => {
+    expect(
+      isSessionResetCommand(
+        {
+          messages: [
+            { role: "user", content: "mem:session-reset" },
+            { role: "assistant", content: null },
+            { role: "function", name: "clarify", content: '{"answer":"否"}' },
+          ],
+        },
+        "hermes",
+      ),
+    ).toBe(false);
+  });
+});
+
+/**
+ * 同一个边界还有第二处：handler 在前置拦截里拿到 `isSessionResetCommand=true` 之后，
+ * 还会再用 `parseMemCommand` 解析一次；只修前者会出现"判定通过但解析为 null"的半修状态。
+ */
+describe("mem 命令解析对首行的容错", () => {
+  it("命令 + 换行追加的 reminder → 仍解析出 session-reset", () => {
+    expect(
+      parseCommandFromText("mem:session-reset\n<system-reminder>\nbe concise\n</system-reminder>"),
+    ).toMatchObject({ command: "session-reset", args: "" });
+  });
+
+  it("命令与其它内容在同一行 → 仍按普通对话（不解析）", () => {
+    expect(parseCommandFromText("mem:session-reset 是什么意思")).toBeNull();
+  });
+
+  it("普通多行文本不受影响", () => {
+    expect(parseCommandFromText("你好\n第二行")).toBeNull();
+  });
+
+  it("尾随 role:system 提示时 parseMemCommand 仍能解析出命令（真机形态）", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "mem:session-reset" },
+        {
+          role: "system",
+          content: [{ type: "text", text: "<total_tokens>15000000 tokens left</total_tokens>" }],
+        },
+      ],
+    };
+    expect(parseMemCommand(body as Record<string, unknown>, "claude-code")).toMatchObject({
+      command: "session-reset",
+      args: "",
+    });
+  });
+
+  it("OpenAI 形态的工具回执在场时 parseMemCommand 不再回放历史命令", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "mem:session-reset" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_hermes_session_init_1",
+              type: "function",
+              function: { name: "clarify", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_hermes_session_init_1", content: '{"answer":"否"}' },
+      ],
+    };
+    expect(parseMemCommand(body as Record<string, unknown>, "hermes")).toBeNull();
+  });
+});

--- a/MemoryProxy/src/__tests__/mem-session-reset-intercept.test.ts
+++ b/MemoryProxy/src/__tests__/mem-session-reset-intercept.test.ts
@@ -264,8 +264,9 @@ describe("mem 命令解析对首行的容错", () => {
     });
   });
 
-  it("OpenAI 形态的工具回执在场时 parseMemCommand 不再回放历史命令", () => {
-    const body = {
+  it("工具回执在场时 parseMemCommand 不再回放历史命令（OpenAI / Anthropic 两种形态）", () => {
+    // OpenAI Chat 形态：独立角色 `role:"tool"`
+    const openaiBody = {
       messages: [
         { role: "user", content: "mem:session-reset" },
         {
@@ -282,6 +283,47 @@ describe("mem 命令解析对首行的容错", () => {
         { role: "tool", tool_call_id: "call_hermes_session_init_1", content: '{"answer":"否"}' },
       ],
     };
-    expect(parseMemCommand(body as Record<string, unknown>, "hermes")).toBeNull();
+    expect(parseMemCommand(openaiBody as Record<string, unknown>, "hermes")).toBeNull();
+
+    // Anthropic 形态（Claude Code）：`role:"user"` + content[{type:"tool_result"}]，
+    // 真机上后面还会再挂一条 `role:"system"` 的 token 提示。
+    const anthropicBody = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "mem:session-reset" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_session_init_1", name: "clarify", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_session_init_1", content: "否" }],
+        },
+        {
+          role: "system",
+          content: [{ type: "text", text: "<total_tokens>15000000 tokens left</total_tokens>" }],
+        },
+      ],
+    };
+    expect(parseMemCommand(anthropicBody as Record<string, unknown>, "claude-code")).toBeNull();
+
+    // 工具回执与用户键入的文本在同一条消息里 → 仍按文本判定（先看文本，再看回执），
+    // 否则会把"用户自己回答了表单又敲了命令"这种情况误判否。
+    const mixedBody = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "你好" }] },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_session_init_1", content: "否" },
+            { type: "text", text: "mem:session-reset" },
+          ],
+        },
+      ],
+    };
+    expect(parseMemCommand(mixedBody as Record<string, unknown>, "claude-code")).toMatchObject({
+      command: "session-reset",
+    });
   });
 });

--- a/MemoryProxy/src/mem-command/parser.ts
+++ b/MemoryProxy/src/mem-command/parser.ts
@@ -71,7 +71,23 @@ export function parseMemCommand(
   if (options?.checkFirst) {
     targetMsg = messages.find((m: any) => m && m.role === "user");
   } else {
-    targetMsg = messages[messages.length - 1];
+    // 真机上 CC 会在用户输入后面再挂一条 `role:"system"` 的提示（形如
+    // `<total_tokens>… tokens left</total_tokens>`），取"最后一条"就会漏掉命令。
+    // 这里从尾部往回找最近一条**带文本的 user 消息**（最多回看 6 条，
+    // 避免把历史里很久以前的命令当成当前输入重放）。
+    const adapterForPick = resolveAgentAdapter(agentSource);
+    for (let i = messages.length - 1; i >= 0 && i >= messages.length - 6; i--) {
+      const m = messages[i];
+      if (!m) continue;
+      // OpenAI Chat 形态的工具回执（`role:"tool"` / 历史 `role:"function"`）表示本 turn 是
+      // 工具或 Session Init 表单的续接，不是新的用户输入。继续回看会把历史里那条命令重放
+      // 一次 —— 真机 Hermes：答复资产确认后 mem:session-reset 被连着重放，同一张表单连问三次。
+      if (m.role === "tool" || m.role === "function") return null;
+      if (m.role !== "user") continue;
+      const probe = adapterForPick.extractUserText(m.content);
+      if (typeof probe === "string" && probe.trim().length > 0) { targetMsg = m; break; }
+    }
+    if (!targetMsg) targetMsg = messages[messages.length - 1];
   }
   if (!targetMsg || targetMsg.role !== "user") return null;
   const lastMsg = targetMsg;
@@ -81,7 +97,22 @@ export function parseMemCommand(
   const text = adapter.extractUserText(lastMsg.content);
   if (text === null) return null;
 
-  return parseCommandFromText(text);
+  const direct = parseCommandFromText(text);
+  if (direct) return direct;
+
+  // 兜底：客户端会把用户输入与自己的元数据拆成多个 text 块，而 adapter 只取**最后一块**
+  // （Claude Code 2.x 常把 `<system-reminder>` 追加在用户输入之后，于是最后一块反而是 reminder）。
+  // 这种情况下逐块再试一次——只要某一块是合法 mem 命令就认，避免命令被静默当成普通提问。
+  if (Array.isArray((lastMsg as { content?: unknown }).content)) {
+    for (const block of (lastMsg as { content: unknown[] }).content) {
+      const b = block as Record<string, unknown> | null | undefined;
+      if (!b || typeof b !== "object") continue;
+      if ((b.type !== "text" && b.type !== "input_text") || typeof b.text !== "string") continue;
+      const parsed = parseCommandFromText(b.text);
+      if (parsed) return parsed;
+    }
+  }
+  return null;
 }
 
 /**
@@ -99,6 +130,19 @@ export function parseMemCommand(
 export function parseCommandFromText(text: string): ParsedMemCommand | null {
   // trim 后判断
   const trimmed = text.trim();
+
+  // 客户端会把用户输入和自己的内容拼在一条消息里（Claude Code 2.x 追加
+  // `<system-reminder>…`：可能是同一 content 数组的第二个 text 块，也可能在同一块里换行追加）。
+  // 这种拼接会让下面"按整段文本取命令名"得到 `session-reset\n<system-reminder>…`，
+  // 与 `session-reset` 不等，命令于是永远认不出来——真机表现是用户发了 mem:session-reset，
+  // 会话仍停在 bypassed/pending，模型把它当普通提问回答。
+  // 因此先按**首行**再判一次：命令写在第一行就认（同一行后面还有别的内容仍按原规则当普通对话，
+  // 例如 `mem:help 你好` 不受影响）。
+  const firstLine = trimmed.split(/\r?\n/, 1)[0].trim();
+  if (firstLine !== trimmed) {
+    const byFirstLine = parseCommandFromText(firstLine);
+    if (byFirstLine) return byFirstLine;
+  }
 
   // 必须以 mem: 开头（大小写不敏感）
   if (!trimmed.toLowerCase().startsWith("mem:")) return null;

--- a/MemoryProxy/src/mem-command/parser.ts
+++ b/MemoryProxy/src/mem-command/parser.ts
@@ -14,6 +14,23 @@
 
 import { resolveAgentAdapter } from "../agent-adapters/index.js";
 
+/**
+ * content 里是否含工具回执块：Anthropic 的 `tool_result`（`role:"user"` + content 数组）
+ * 与 Responses 的 `function_call_output`。这类消息没有用户键入的文本，
+ * 与 pre-intercept.ts::hasToolResult 同一口径。
+ */
+function hasToolResultBlock(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some((block) => {
+    const b = block as Record<string, unknown> | null | undefined;
+    return (
+      !!b &&
+      typeof b === "object" &&
+      (b.type === "tool_result" || b.type === "function_call_output")
+    );
+  });
+}
+
 export interface ParsedMemCommand {
   /** 命令名（小写），如 "sync"、"create-skill"、"help" */
   command: string;
@@ -86,6 +103,11 @@ export function parseMemCommand(
       if (m.role !== "user") continue;
       const probe = adapterForPick.extractUserText(m.content);
       if (typeof probe === "string" && probe.trim().length > 0) { targetMsg = m; break; }
+      // Anthropic 形态的工具回执（`role:"user"` + content[{type:"tool_result"}]）同样表示
+      // 本 turn 是工具 / Session Init 表单的续接：它没有 text block，extractUserText 返回
+      // null，若继续回看就会命中历史里那条已经执行过的 `mem:` 命令并重放。
+      // 真机：Claude Code 提交表单后 mem:session-reset 被重放，同一张表单反复弹出。
+      if (hasToolResultBlock(m.content)) return null;
     }
     if (!targetMsg) targetMsg = messages[messages.length - 1];
   }

--- a/MemoryProxy/src/mem-command/pre-intercept.ts
+++ b/MemoryProxy/src/mem-command/pre-intercept.ts
@@ -42,6 +42,8 @@ export function isSessionResetCommand(
   try {
     const adapter = resolveAgentAdapter(agentSource);
     let text: string | null = null;
+    // 同一轮用户消息里的所有文本块（顺序不固定，命令可能不在最后一块）
+    const allTexts: string[] = [];
 
     // Codex / WorkBuddy 用 body.input[] (Responses API)
     if (Array.isArray((body as any).input)) {
@@ -62,6 +64,7 @@ export function isSessionResetCommand(
         const b = block as Record<string, unknown> | null | undefined;
         if (b && typeof b === "object" && b.type === "input_text" && typeof b.text === "string") {
           texts.push(b.text);
+          allTexts.push(b.text);
         }
       }
       text = texts.length > 0 ? texts.join("\n") : null;
@@ -69,15 +72,78 @@ export function isSessionResetCommand(
       // CC/CB/dsh 用 body.messages[]
       const messages = (body as any).messages as any[];
       if (messages.length === 0) return false;
-      // 最后一条 user
-      const last = messages[messages.length - 1];
-      if (!last || last.role !== "user") return false;
+      // 真机上 CC 会在用户输入后面再挂一条 `role:"system"` 的提示
+      // （实测形如 `<total_tokens>15000000 tokens left</total_tokens>`），
+      // 于是"最后一条就是用户消息"的前提不成立、命令被整条漏掉。
+      //
+      // 于是从尾部往回找"本 turn 的用户输入"，一路跳过非 user 消息（上面那条 system 提示）
+      // 与没有文本的占位消息，最多回看 6 条，避免历史里的旧命令被重放触发。
+      //
+      // 但"往回跳过没有文本的消息"这条规则会误伤表单续接：客户端把表单选择以**工具回执**
+      // 发回来，回执里没有用户键入的文本，于是回看会越过它、命中会话更早那条
+      // `mem:session-reset`，把一条已经执行过的命令当成新命令重放 —— 状态被打回
+      // uninitialized，同一张表单被反复弹（真机现象：CC 上资产关联问句连弹两遍、
+      // 第一次的选择被第二次重置覆盖；Hermes 上更明显，连问三次）。
+      // 工具回执有两种形态，都要挡住：
+      //   - OpenAI Chat：独立角色 `{role:"tool", tool_call_id, content}`（Hermes / workbuddy …）
+      //   - Anthropic：`{role:"user", content:[{type:"tool_result", …}]}`
+      // 遇到任一种都判否：本 turn 是工具/表单的续接，不是用户新输入。
+      const hasText = (m: any): boolean => {
+        if (!m || m.role !== "user") return false;
+        if (typeof m.content === "string") return m.content.trim().length > 0;
+        if (!Array.isArray(m.content)) return false;
+        return m.content.some(
+          (b: any) => b && (b.type === "text" || b.type === "input_text") && typeof b.text === "string" && b.text.trim().length > 0,
+        );
+      };
+      const isToolReply = (m: any): boolean =>
+        !!m && typeof m === "object" && (m.role === "tool" || m.role === "function");
+      const hasToolResult = (m: any): boolean => {
+        if (!m || m.role !== "user" || !Array.isArray(m.content)) return false;
+        return m.content.some(
+          (b: any) => b && typeof b === "object" && (b.type === "tool_result" || b.type === "function_call_output"),
+        );
+      };
+      let last: any = undefined;
+      for (let i = messages.length - 1; i >= 0 && i >= messages.length - 6; i--) {
+        const m = messages[i];
+        if (isToolReply(m)) return false;
+        if (!m || m.role !== "user") continue;
+        if (hasText(m)) { last = m; break; }
+        if (hasToolResult(m)) return false;
+      }
+      if (!last) return false;
       text = adapter.extractUserText(last.content);
+      if (Array.isArray(last.content)) {
+        for (const block of last.content as unknown[]) {
+          const b = block as Record<string, unknown> | null | undefined;
+          if (b && typeof b === "object" && (b.type === "text" || b.type === "input_text") && typeof b.text === "string") {
+            allTexts.push(b.text);
+          }
+        }
+      }
     } else {
       return false;
     }
 
     if (!text) return false;
+
+    // 客户端会往用户消息里掺自己的内容：Claude Code 2.x 把 `<system-reminder>…` 与用户输入
+    // 分成多个 text 块（顺序不固定），也可能在同一块里换行追加。这两种情况下，
+    // "按整段文本解析命令"会得到 command="session-reset\n<system-reminder>…"（或干脆取到
+    // reminder 那一块），与 "session-reset" 不相等，reset 永远不会触发——真机表现是用户发了
+    // mem:session-reset，会话仍停在 bypassed/pending，模型把它当普通提问回答。
+    //
+    // 因此：先看**首行**是否恰好是命令（不放松成"包含"，免得把"mem:session-reset 是什么意思"
+    // 这类正常提问也拦掉），并允许命令出现在任意一个 text 块里。
+    const isResetLine = (value: string | null | undefined): boolean =>
+      typeof value === "string" &&
+      value.trim().split(/\r?\n/, 1)[0].trim().toLowerCase() === "mem:session-reset";
+
+    if (isResetLine(text)) return true;
+    for (const candidate of allTexts) if (isResetLine(candidate)) return true;
+
+    // 兜底：保持原有严格解析（含参数校验）不变。
     const parsed = parseCommandFromText(text);
     return parsed?.command === "session-reset";
   } catch {


### PR DESCRIPTION
**修复 `mem:session-reset` 在真实客户端报文下识别不到、以及表单回执触发历史命令重放的问题。**

上游自 v2.0.1 起提供 `mem:session-reset`，但在真机报文上会失效：用户发命令后会话仍停在 `bypassed` / `pending`，模型把它当普通提问回答。

## 症状与根因

| 症状 | 根因 |
|---|---|
| 命令识别不到 | Claude Code 2.x 会把 `<system-reminder>` 与用户输入拆成多个 text 块（或同块换行追加），adapter 只取最后一块 → 取到的是 reminder 而不是命令 |
| 同上 | CC 会在用户输入后追加一条 `role:"system"` 的 token 提示，"最后一条就是用户消息"的前提不成立 |
| 同一张表单连续弹出 | 表单回执（Anthropic `tool_result` / OpenAI `role:"tool"`）没有用户键入的文本，回看时会越过它命中更早那条已执行过的命令，把上一轮的重放成新命令 |

**问题来源**：把本 PR 的 19 例回归移植到基线 `906b582` 上运行，结果是 **5 例失败 / 14 例通过**——命令识别在真实报文下失效在上游基线里已经存在。
## 改动

| 位置 | 内容 |
|---|---|
| `src/mem-command/parser.ts` | 从"只看最后一条"改为"按首行判定 + 从尾部回看最近一条带文本的 user 消息"（最多回看 6 条）；遇到工具回执一律判否；多条 text 块时逐块再试一次 |
| `src/mem-command/pre-intercept.ts` | `isSessionResetCommand` 同步同样的规则：跳过非 user 消息、封住两类工具回执 |

- **本 PR 净增量**：+466 / −5（3 个文件）——独立缺陷修复，无前序层。

## 验证

- `npx tsc --noEmit` → 0 错误（**合并态**，前提是先合 #1326）。本支从 `906b582` 切出、不含 #1326 的类型修复，单独 `git checkout <本支 head>` 后 `tsc` 仍报基线遗留的 **60 个类型错误**，也不含 #1326 新增的 `.github/workflows/memory-proxy-ci.yml` 门禁。
- `npm test` → **1 文件 / 19 用例**全过
- 对照实验：把同一套 19 例移植到基线 → **5 例失败 / 14 例通过**，证明缺陷真实存在；修复后全过
- 真机：reset 前置拦截对同一会话的命中次数由 2–3 次收敛为 1 次

## 边界

- 回看上限为 6 条，更早的历史命令不会被误判，但超过 6 条且当前轮没有文本输入时也不会触发 reset（保守取舍）。

## 本轮修复

- `src/mem-command/parser.ts`：回看循环补齐 Anthropic 形态的工具回执判定（`role:"user"` + `content[{type:"tool_result"}]`，以及 Responses 的 `function_call_output`），与 `pre-intercept.ts` 同序（先看文本、再看回执，避免把「用户自己答了表单又敲了命令」误判否）。此前 parser 只挡 OpenAI 的 `role:"tool"/"function"`：Anthropic 工具回执没有 text block，`extractUserText` 返回 null，于是继续回看并命中历史里的 `mem:` 命令。session-reset 这条路有两道兜底（pre-hook + 两处 `command === "session-reset"` 置空），所以不会重放 reset；但其它 mem 命令在「纯工具续接轮次」下仍可能被回放。
- 测试：把原本只覆盖 OpenAI 形态的那条用例扩成两种形态，并补一条「同一条消息里既有回执又有用户文本 → 仍按文本判定」的断言；用例数保持 19。
- 反证：把扩展后的用例拿到未修版本上跑 = **1 例失败 / 18 例通过**；修完 19/19 通过。
- 本支回归：`npm test` 1 文件 / 19 用例通过；净增量 +402 / −5 → **+466 / −5**（3 个文件）。本支不含 #1326 的类型修复，单独 checkout 仍是基线遗留的 60 个 `tsc` 错误（合并态为 0）。

---

## 合入顺序（本批 13 支）

`#1326`（基线类型修复 + CI 门禁，最先）→ 协议 `#1226 → #1253` → 接入 `#1334 → #1325` → Opik `#1270 → #1307 → #1309 → #1310 → #1328`；`#1251`、`#1346`、`#1347` 与其它支无文件交集，任意时间合。

- **本支位置**：独立（真机暴露的缺陷修复），任意时间合
- 全批合入态实测：`tsc --noEmit` 0 错误、37 文件 / 408 用例通过
- 冲突只出现在共享文件：`package.json` 取并集（= #1226 侧带 json reporter + posttest 的那一行）；`docs/protocol-conversion-matrix.md` 与 `src/__tests__/chat-anthropic-role-rules.test.ts`（add/add）取 **#1226 一侧**；`scripts/qa/check-doc-claims.mjs` 已在 #1226 / #1253 / #1328 三支逐字节同步（blob `f4aa8815`），**不再产生冲突**；`src/agent-adapters/{index,types}.ts` 已随 #1334 合并。核心逻辑文件零冲突（2026-09-12 用当前 head 实合复核：冲突面共 **3 个文件**）
- **评审提示**：本批分支都在 fork（`cjl-ux`），而 PR 的 base 只能是目标仓库的分支，所以**做不到**把堆叠 PR 的 base 指向前一层——页面 diff 只能是相对公共祖先的累计值。要看本层改动请用 `git diff <上一层 head> <本支 head>`。
- 默认行为：`sessionInit.enabled` / `threadIsolation` / `upstream.autoDetect` / `opik` / `sessionInit.autoConversationId.enabled` 默认**全部为 `false`**，合入不改变现有部署行为；需要"服务端为无会话头的客户端签发 `auto-*` 会话"时显式打开该开关