### PR TITLE
fix(injection): curl 配方补 Windows 说明（PowerShell 别名导致调用失效）

### DIFF
--- a/MemoryProxy/src/__tests__/injection-shell-recipe.test.ts
+++ b/MemoryProxy/src/__tests__/injection-shell-recipe.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { renderSkillToolsBlock } from "../injection/injectors/skill-tools-injector.js";
+import { renderTdaiMemoryToolsBlock } from "../injection/injectors/tdai-tools-injector.js";
+
+/**
+ * 注入块里的 curl 配方必须是"跨 shell 可抄"的。
+ *
+ * 真机背景：Codex CLI 在 Windows 上把模型生成的 shell 命令交给 PowerShell 执行，
+ * 而 `curl` 在 PowerShell 里是 `Invoke-WebRequest` 的别名 —— 它不接受 `-H 'k: v'`
+ * 这种写法（报「无法绑定参数 Headers」/「Cannot bind parameter 'Headers'」，类型
+ * System.String → System.Collections.IDictionary），也不认 `-d`。
+ * 结果是模型照抄配方、连试两次后放弃，整段 skill / 记忆调用失效。
+ * 所以两个配方块都必须写明 Windows 下用 `curl.exe`。
+ */
+describe("注入块的 curl 配方跨 shell 可用", () => {
+  const blocks: Array<[string, string]> = [
+    ["skill_tools", renderSkillToolsBlock("http://127.0.0.1:8096", true, "sid-x", "default")],
+    ["tdai_memory_tools", renderTdaiMemoryToolsBlock("http://127.0.0.1:8096", "sid-x", "default")],
+  ];
+
+  it.each(blocks)("%s 块点明 Windows 下必须写 curl.exe", (_name, text) => {
+    expect(text).toContain("curl.exe");
+    expect(text).toMatch(/PowerShell/);
+  });
+
+  it.each(blocks)("%s 块给出别名报错的特征串，便于模型自行纠正", (_name, text) => {
+    expect(text).toMatch(/无法绑定参数 Headers/);
+  });
+
+  it("基础配方本身保持不变（仍是 curl + -H 'k: v'）", () => {
+    const text = renderSkillToolsBlock("http://127.0.0.1:8096", true, "sid-x", "default");
+    expect(text).toContain("curl -sSk -X POST");
+    expect(text).toContain("-H 'x-conversation-id: sid-x'");
+  });
+});

--- a/MemoryProxy/src/injection/injectors/skill-tools-injector.ts
+++ b/MemoryProxy/src/injection/injectors/skill-tools-injector.ts
@@ -180,12 +180,18 @@ export function renderSkillToolsBlock(
 
   return [
     "<skill_tools>",
-    "以下是云端 skill 操作工具。**这些不是本地工具**，需要用 Bash 调用 curl 命中 proxy 的 skill-bridge 路径来执行。",
+    "以下是云端 skill 操作工具。**这些不是本地工具**，需要用 shell 调用 curl 命中 proxy 的 skill-bridge 路径来执行。",
     "proxy 会自动注入身份与鉴权（user_id / team_id / agent_id 由 session 决定），body 里你只需要传业务字段。",
     "",
     "调用模板：",
     `  curl -sSk -X POST <bridge>/<action> -H 'content-type: application/json'${authHeader} -d '{...业务字段...}'`,
     `  其中 <bridge> = ${bridge}`,
+    // Windows 上 `curl` 是 PowerShell `Invoke-WebRequest` 的别名：它不接受 `-H 'k: v'`
+    // 这种写法（报「无法绑定参数 Headers」/「Cannot bind parameter 'Headers'」，类型
+    // System.String → System.Collections.IDictionary），也不认 `-d`。实测 Codex CLI
+    // （Windows）照抄上面的模板会连试两次后放弃，整段 skill 调用失效。
+    "  shell 写法：Linux / macOS 用 `curl`；Windows PowerShell 下 `curl` 是 `Invoke-WebRequest` 的别名，必须写 `curl.exe`（其余参数照抄）。",
+    "  若报错为 `无法绑定参数 Headers` / `Cannot bind parameter 'Headers'` / `System.Collections.IDictionary`，即踩到这个别名，改成 `curl.exe` 重试。",
     "",
     "可用工具：",
     "",

--- a/MemoryProxy/src/injection/injectors/tdai-tools-injector.ts
+++ b/MemoryProxy/src/injection/injectors/tdai-tools-injector.ts
@@ -68,12 +68,16 @@ export function renderTdaiMemoryToolsBlock(
 
   const lines: string[] = [
     "<tdai_memory_tools>",
-    "**这些是你可以主动调用的记忆能力**（不是文档），通过 Bash + curl 使用。",
+    "**这些是你可以主动调用的记忆能力**（不是文档），通过 shell + curl 使用。",
     "这组 TDAI 记忆能力与 Claude Code 原生 Memory/MEMORY.md 具有同等优先级；涉及记忆时不要只查本地 MEMORY.md。",
     "遇到用户问身份/历史/偏好/过往结论/项目约定时，必须先使用下面的 TDAI 记忆工具查询，再基于查询结果回答。",
     "禁止说\"我没有这个工具 / 需要 MCP / 只能查本地记忆\" —— 你有 TDAI 记忆工具，就用下面的 curl 命令。",
     "",
-    "调用方式：Bash 里执行 curl 命中 proxy 的 memory-bridge 路径。proxy 会自动注入身份鉴权（team_id/user_id/agent_id），body 只需业务字段。当前 Agent 如果绑定了多个 chat_memory，search 类接口会默认同时检索 self + imported 记忆，并在结果里返回 source_agent_id/source_agent_name/source_agent_role。",
+    "调用方式：在 shell 里执行 curl 命中 proxy 的 memory-bridge 路径。proxy 会自动注入身份鉴权（team_id/user_id/agent_id），body 只需业务字段。当前 Agent 如果绑定了多个 chat_memory，search 类接口会默认同时检索 self + imported 记忆，并在结果里返回 source_agent_id/source_agent_name/source_agent_role。",
+    // Windows 上 `curl` 是 PowerShell `Invoke-WebRequest` 的别名，`-H 'k: v'` / `-d` 都不可用
+    // （报「无法绑定参数 Headers」/「Cannot bind parameter 'Headers'」），必须写 `curl.exe`。
+    "shell 写法：Linux / macOS 用 `curl`；Windows PowerShell 下 `curl` 是 `Invoke-WebRequest` 的别名，必须写 `curl.exe`。",
+    "若报错 `无法绑定参数 Headers` / `Cannot bind parameter 'Headers'`，即踩到这个别名，改用 `curl.exe` 重试。",
     "",
     "覆盖范围：",
     "- L3（persona 长期画像）与 L2 场景索引（`<l2_scene_index>`）已直接注入 system，无需查询；",


### PR DESCRIPTION
**修复注入块里的 curl 配方在 Windows PowerShell 下不可用的问题。**

PowerShell 5.1 内置 `curl` 是 `Invoke-WebRequest` 的别名，配方里的 `-H 'k: v'` 与 `-d` 会被拒绝，模型照抄后调用失败、表现为"记忆工具不可用"。

**问题来源**：基线自身缺陷，不是本批改动引入。该配方由上游 `4144434 feat: release v2.0.0-beta.1`（2026-07-22，作者 chrishuan）写入，基线文本里没有任何 Windows / PowerShell / `curl.exe` 字样；本批 13 支中只有本 PR 改过这两个注入文件。
## 改动

| 位置 | 内容 |
|---|---|
| `src/injection/injectors/skill-tools-injector.ts` | 在同一位置补 Windows 说明：Linux / macOS 用 `curl`，Windows PowerShell 下写 `curl.exe`；并给出报错特征串（`无法绑定参数 Headers` / `Cannot bind parameter 'Headers'`） |
| `src/injection/injectors/tdai-tools-injector.ts` | 同上 |

选择"改提示文本"而不是"按平台下发不同模板"：Proxy 拿不到统一的平台信号（Stainless SDK 系客户端带 `x-stainless-os`，Codex CLI 不带），而命令由模型生成，把差异与报错特征写进提示即可让它自愈。基础 POSIX 配方保持不变，避免"修一处、坏一处"。

- **本 PR 净增量**：+48 / −3（3 个文件）——独立缺陷修复，无前序层。

## 验证

- `npx tsc --noEmit` → 0 错误（**合并态**，前提是先合 #1326）。本支从 `906b582` 切出、不含 #1326 的类型修复，单独 `git checkout <本支 head>` 后 `tsc` 仍报基线遗留的 **60 个类型错误**，也不含 #1326 新增的 `.github/workflows/memory-proxy-ci.yml` 门禁。
- `npm test` → **1 文件 / 5 用例**全过（两个注入块各含跨 shell 说明；基础配方保持不变）
- 真机：Windows PowerShell 5.1 下 `curl` 解析为 `Invoke-WebRequest`，改 `curl.exe` 后同一命令返回 200

## 边界

- 只是提示文本层面的适配；若客户端在没有 shell 的环境调用（例如纯 HTTP 工具），仍以它自身的调用方式为准。

---

## 合入顺序
`#1326`（基线类型修复 + CI 门禁，最先）→ 协议 `#1226 → #1253` → 接入 `#1334 → #1325` → Opik `#1270 → #1307 → #1309 → #1310 → #1328`；`#1251`、`#1346`、`#1347` 与其它支无文件交集，任意时间合。

- **本支位置**：独立（真机暴露的缺陷修复），任意时间合
- 全批合入态实测：`tsc --noEmit` 0 错误、37 文件 / 408 用例通过
- 冲突只出现在共享文件：`package.json` 取并集（= #1226 侧带 json reporter + posttest 的那一行）；`docs/protocol-conversion-matrix.md` 与 `src/__tests__/chat-anthropic-role-rules.test.ts`（add/add）取 **#1226 一侧**；`scripts/qa/check-doc-claims.mjs` 已在 #1226 / #1253 / #1328 三支逐字节同步（blob `f4aa8815`），**不再产生冲突**；`src/agent-adapters/{index,types}.ts` 已随 #1334 合并。核心逻辑文件零冲突
- **评审提示**：本批分支都在 fork（`cjl-ux`），而 PR 的 base 只能是目标仓库的分支，所以**做不到**把堆叠 PR 的 base 指向前一层——页面 diff 只能是相对公共祖先的累计值。要看本层改动请用 `git diff <上一层 head> <本支 head>`。
- 默认行为：`sessionInit.enabled` / `threadIsolation` / `upstream.autoDetect` / `opik` / `sessionInit.autoConversationId.enabled` 默认**全部为 `false`**，合入不改变现有部署行为；需要"服务端为无会话头的客户端签发 `auto-*` 会话"时显式打开该开关