### PR TITLE
fix(memory-core): preserve source fields in conversation search

### DIFF
--- a/MemoryCore/src/core/tools/conversation-search.test.ts
+++ b/MemoryCore/src/core/tools/conversation-search.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddingService } from "../store/embedding.js";
+import type { IMemoryStore, L0SearchResult } from "../store/types.js";
+import { executeConversationSearch } from "./conversation-search.js";
+
+function conversation(id: string): L0SearchResult {
+  return {
+    record_id: id,
+    session_key: `key-${id}`,
+    session_id: `session-${id}`,
+    team_id: "team-1",
+    task_id: "task-1",
+    user_id: `user-${id}`,
+    agent_id: `agent-${id}`,
+    role: "user",
+    message_text: `Remember the deployment decision from ${id}`,
+    score: 0.9,
+    recorded_at: "2026-09-11T00:00:00.000Z",
+    timestamp: 1789084800000,
+  };
+}
+
+function expectSource(result: object, row: L0SearchResult): void {
+  expect(result).toMatchObject({
+    id: row.record_id,
+    session_key: row.session_key,
+    session_id: row.session_id,
+    user_id: row.user_id,
+    agent_id: row.agent_id,
+    role: row.role,
+    content: row.message_text,
+    recorded_at: row.recorded_at,
+  });
+}
+
+describe("executeConversationSearch source fields", () => {
+  it.each(["fts", "embedding", "hybrid", "native-hybrid"] as const)(
+    "preserves each message's source through %s search",
+    async (mode) => {
+      const rows = [conversation("first"), conversation("second")];
+      const searchL0Fts = vi.fn().mockResolvedValue(rows);
+      const searchL0Vector = vi.fn().mockResolvedValue(rows);
+      const searchL0Hybrid = vi.fn().mockResolvedValue(rows);
+      const store = {
+        isFtsAvailable: () => mode !== "embedding",
+        getCapabilities: () => ({ nativeHybridSearch: mode === "native-hybrid" }),
+        searchL0Fts,
+        searchL0Vector,
+        searchL0Hybrid,
+      } as unknown as IMemoryStore;
+      const embed = vi.fn().mockResolvedValue(new Float32Array([1, 0]));
+      const embeddingService = { embed } as unknown as EmbeddingService;
+
+      const result = await executeConversationSearch({
+        query: "deployment decision",
+        limit: 2,
+        vectorStore: store,
+        embeddingService: mode === "embedding" || mode === "hybrid" ? embeddingService : undefined,
+      });
+
+      expect(result.strategy).toBe(mode === "native-hybrid" ? "hybrid" : mode);
+      expect(result.total).toBe(2);
+      expect(result.results).toHaveLength(2);
+      rows.forEach((row, index) => expectSource(result.results[index], row));
+      if (mode === "hybrid") {
+        expect(searchL0Fts).toHaveBeenCalledOnce();
+        expect(searchL0Vector).toHaveBeenCalledOnce();
+        // Both paths return the same records; RRF must merge them without losing their source.
+        expect(result.results[0].score).toBeCloseTo(2 / 61);
+        expect(result.results[1].score).toBeCloseTo(2 / 62);
+      } else {
+        expect(result.results[0].score).toBe(rows[0].score);
+      }
+    },
+  );
+
+  it("preserves source fields when embedding fails and search falls back to FTS", async () => {
+    const row = conversation("fallback");
+    const store = {
+      isFtsAvailable: () => true,
+      getCapabilities: () => ({ nativeHybridSearch: false }),
+      searchL0Fts: vi.fn().mockResolvedValue([row]),
+    } as unknown as IMemoryStore;
+    const embed = vi.fn().mockRejectedValue(new Error("Embedding provider unavailable"));
+
+    const result = await executeConversationSearch({
+      query: "deployment decision",
+      limit: 1,
+      vectorStore: store,
+      embeddingService: { embed } as unknown as EmbeddingService,
+    });
+
+    expect(embed).toHaveBeenCalledOnce();
+    expect(result.strategy).toBe("fts");
+    expect(result.total).toBe(1);
+    expectSource(result.results[0], row);
+  });
+});

--- a/MemoryCore/src/core/tools/conversation-search.ts
+++ b/MemoryCore/src/core/tools/conversation-search.ts
@@ -191,6 +191,9 @@ export async function executeConversationSearch(params: {
         return ftsResults.map((r) => ({
           id: r.record_id,
           session_key: r.session_key,
+          session_id: r.session_id,
+          user_id: r.user_id,
+          agent_id: r.agent_id,
           role: r.role,
           content: r.message_text,
           score: r.score,


### PR DESCRIPTION
# fix(memory-core): preserve source fields in conversation search

FTS conversation search drops `session_id`, `user_id`, and `agent_id` while
mapping L0 store results to `ConversationSearchResultItem`. The store returns
these fields and the result interface requires them, but callers lose the
source metadata when searching historical conversations.

This also affects client-side hybrid search: RRF visits FTS hits first and
retains that copy when the vector path returns the same record. Even a complete
vector hit therefore loses its source fields after merging.

Copy the three fields in the FTS result mapping, matching the existing vector
and native-hybrid mappings. No public API, ranking, or filtering changes are
required.

## Validation

- Added five tests covering FTS, vector, client-side hybrid, native hybrid,
  and fallback to FTS after an embedding failure.
- Before the fix: three failures (FTS, hybrid, fallback) and two passes.
- After the fix: all five tests pass, including RRF deduplication and scores.
- Plugin bundle builds successfully with `tsdown`.
- Skill queue isolation guard and `git diff --check` pass.

Commands from `MemoryCore` with Node.js 24.19.0:

```sh
npm test -- --reporter=verbose
npm run build:plugin
BASE_REF=origin/feat/server_team bash scripts/ci/check-skill-queue-isolation.sh
git diff --check
```

The tests mock store and embedding responses and exercise the real conversation
search implementation. The checked-out module's test configuration discovers
only this new test file. Live database integration and migration-script builds
were not run.
