### PR TITLE
fix(proxy): send a configurable bearer on the auth verify call

### DIFF
--- a/MemoryProxy/config.example.yaml
+++ b/MemoryProxy/config.example.yaml
@@ -376,6 +376,8 @@ auth:
   enabled: true            # 是否启用鉴权
   url: "http://kernel.example.com:8420"   # 内核鉴权服务 base URL（自动拼接 /v3/meta/auth/verify）
   timeoutMs: 5000          # 鉴权请求超时（毫秒）
+  apiKey: ""               # 可选：内核 gateway 开启 API Key（server.apiKey / TDAI_GATEWAY_API_KEY）时
+                           #   作为 Authorization: Bearer 发送；留空则不带该头（与 tdai.apiKey 含义相同）
 
 
 # ── Admin / Ops 端点鉴权（服务级 shared secret） ─────────────────────────────

--- a/MemoryProxy/src/__tests__/auth.test.ts
+++ b/MemoryProxy/src/__tests__/auth.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../report/log.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { initAuth, verifyUserKey } from "../auth.js";
+
+const VALID = { code: 0, data: { valid: true, user: { user_id: "usr-1" } } };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("verifyUserKey against a gateway-protected MemoryCore (#1341)", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    initAuth({ enabled: false, url: "", timeoutMs: 0, apiKey: "" });
+  });
+
+  it("sends the configured bearer on the verify call", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, VALID));
+    initAuth({ enabled: true, url: "http://kernel:8420/", timeoutMs: 0, apiKey: "gw-secret" });
+
+    const result = await verifyUserKey("sk-mem-1", "default");
+
+    expect(result).toEqual({ userId: "usr-1", rejected: false });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://kernel:8420/v3/meta/auth/verify");
+    expect(init?.headers).toEqual({
+      "content-type": "application/json",
+      "x-tdai-service-id": "default",
+      "authorization": "Bearer gw-secret",
+    });
+    // The user key stays in the body, where the verify endpoint reads it.
+    expect(JSON.parse(String(init?.body))).toEqual({ user_key: "sk-mem-1" });
+  });
+
+  it("sends no Authorization header when apiKey is empty (unchanged behaviour)", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, VALID));
+    initAuth({ enabled: true, url: "http://kernel:8420", timeoutMs: 0, apiKey: "" });
+
+    await verifyUserKey("sk-mem-1", "default");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.headers).toEqual({
+      "content-type": "application/json",
+      "x-tdai-service-id": "default",
+    });
+  });
+
+  it("still rejects when the gateway answers 401", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, { code: 401 }));
+    initAuth({ enabled: true, url: "http://kernel:8420", timeoutMs: 0, apiKey: "wrong" });
+
+    const result = await verifyUserKey("sk-mem-1", "default");
+
+    expect(result.rejected).toBe(true);
+    expect(result.rejectReason).toBe("auth service returned HTTP 401");
+  });
+});

--- a/MemoryProxy/src/auth.ts
+++ b/MemoryProxy/src/auth.ts
@@ -42,7 +42,7 @@ export function initAuth(cfg: AuthConfig): void {
     return;
   }
   config = cfg;
-  log.info("auth.init", { url: cfg.url });
+  log.info("auth.init", { url: cfg.url, bearer: Boolean(cfg.apiKey) });
 }
 
 /** Check if auth verification is enabled. */
@@ -73,11 +73,15 @@ export async function verifyUserKey(userKey: string, serviceId: string): Promise
   if (!userKey) return { userId: "", rejected: true, rejectReason: "missing user_key" };
 
   try {
+    // A gateway-protected kernel (server.apiKey / TDAI_GATEWAY_API_KEY) answers 401 to
+    // an unauthenticated verify call, so send the configured bearer like the sibling
+    // tdai / skill clients do. Without one the request is unchanged.
     const fetchOpts: RequestInit = {
       method: "POST",
       headers: {
         "content-type": "application/json",
         "x-tdai-service-id": serviceId,
+        ...(config.apiKey ? { "authorization": `Bearer ${config.apiKey}` } : {}),
       },
       body: JSON.stringify({ user_key: userKey }),
     };

--- a/MemoryProxy/src/config.ts
+++ b/MemoryProxy/src/config.ts
@@ -141,6 +141,7 @@ export const DEFAULT_CONFIG: ProxyConfig = {
     enabled: false,
     url: "",
     timeoutMs: 5000,
+    apiKey: "",
   },
   systemUsers: [],
   admin: { apiKey: "" },
@@ -489,6 +490,7 @@ export function buildConfig(overrides: CliOverrides = {}): ProxyConfig {
       enabled: yaml.auth?.enabled ?? DEFAULT_CONFIG.auth.enabled,
       url: yaml.auth?.url ?? DEFAULT_CONFIG.auth.url,
       timeoutMs: yaml.auth?.timeoutMs ?? DEFAULT_CONFIG.auth.timeoutMs,
+      apiKey: yaml.auth?.apiKey ?? DEFAULT_CONFIG.auth.apiKey,
     },
     // Entries without a non-empty userId are silently dropped — matching is
     // by userId now, and an empty userId would otherwise collide with

--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -663,6 +663,13 @@ export interface AuthConfig {
   url: string;
   /** Request timeout in ms. Default: 5000. */
   timeoutMs: number;
+  /**
+   * Bearer token sent as `Authorization` on the verify call, for a MemoryCore
+   * whose gateway is protected by an API key (`server.apiKey` /
+   * `TDAI_GATEWAY_API_KEY`). Empty (default) sends no `Authorization` header.
+   * Mirrors `tdai.apiKey` / `skill.serviceToken` for the sibling kernel clients.
+   */
+  apiKey: string;
 }
 
 /**
@@ -917,6 +924,7 @@ export interface RawYamlConfig {
     enabled?: boolean;
     url?: string;
     timeoutMs?: number;
+    apiKey?: string;
   };
   systemUsers?: Partial<SystemUserEntry>[];
   admin?: {


### PR DESCRIPTION
## Description | 描述

`MemoryProxy/src/auth.ts` `verifyUserKey()` called `POST /v3/meta/auth/verify` with only `content-type` and `x-tdai-service-id`, and `AuthConfig` had no field for a token. Against a MemoryCore whose gateway is protected (`server.apiKey` / `TDAI_GATEWAY_API_KEY`) every verify call answered 401, so every proxied request failed with `authentication_error`, exactly as measured in #1341 (bearer + `user_key` in the body is what the endpoint accepts; the proxy already had the body right and was only missing the header).

This adds `auth.apiKey`:

- `AuthConfig.apiKey` (`src/types.ts`, plus the raw yaml type) with `""` as the default in `src/config.ts`, so the existing `${VAR}` expansion can reference a secret.
- `verifyUserKey()` sends `authorization: Bearer <apiKey>` when it is set and is byte-for-byte unchanged when it is empty. `auth.init` logs whether a bearer is configured (never the value).
- `config.example.yaml` documents the new key next to `timeoutMs`, mirroring `tdai.apiKey` / `skill.serviceToken` for the sibling kernel clients.

Not covered here: the follow-up in the issue that `auth.enabled: false` silently disables the memory pipeline. That is a separate problem in how the empty `userId` is handled downstream and deserves its own change.

## Related Issue | 关联 Issue

Fix #1341

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

New `MemoryProxy/src/__tests__/auth.test.ts` (the first file under the vitest `src/__tests__` include) stubs `fetch` and asserts: the bearer and body shape sent to `/v3/meta/auth/verify`, the exact header set when `apiKey` is empty, and that a 401 from the gateway is still a rejection.

```
cd MemoryProxy && npx vitest run src/__tests__/auth.test.ts
Test Files  1 passed (1)
     Tests  3 passed (3)
npx tsc --noEmit   # 60 pre-existing errors on feat/server_team, unchanged by this PR
```