### PR TITLE
fix(memory-core): publish L3 persona after successful generation

### DIFF
--- a/MemoryCore/src/adapters/standalone/llm-runner.test.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.test.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveSandboxedPath } from "./llm-runner.js";
+
+describe("standalone LLM file-tool sandbox", () => {
+  it("rejects parent traversal into a sibling with the same path prefix", () => {
+    const workspace = path.resolve("persona-draft-root");
+    expect(resolveSandboxedPath(workspace, "persona.md"))
+      .toBe(path.join(workspace, "persona.md"));
+    expect(resolveSandboxedPath(workspace, "../persona-draft-root-escape/persona.md"))
+      .toBeNull();
+    expect(resolveSandboxedPath(workspace, "../persona-draft-root/persona.md"))
+      .toBe(path.join(workspace, "persona.md"));
+  });
+});

--- a/MemoryCore/src/adapters/standalone/llm-runner.ts
+++ b/MemoryCore/src/adapters/standalone/llm-runner.ts
@@ -115,11 +115,11 @@ export interface StandaloneLLMConfig {
 // Sandboxed tool execution helpers
 // ============================
 
-function resolveSandboxedPath(workspaceDir: string, relativePath: string): string | null {
-  const resolved = path.resolve(workspaceDir, relativePath);
-  if (!resolved.startsWith(path.resolve(workspaceDir))) {
-    return null;
-  }
+export function resolveSandboxedPath(workspaceDir: string, relativePath: string): string | null {
+  const root = path.resolve(workspaceDir);
+  const resolved = path.resolve(root, relativePath);
+  const relative = path.relative(root, resolved);
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null;
   return resolved;
 }
 

--- a/MemoryCore/src/core/persona/persona-generator.test.ts
+++ b/MemoryCore/src/core/persona/persona-generator.test.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocalStorageBackend } from "../storage/local-backend.js";
+import { StorageAdapter } from "../storage/adapter.js";
+import type { LLMRunner } from "../types.js";
+import { PersonaGenerator } from "./persona-generator.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "persona-generator-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("PersonaGenerator atomic publication", () => {
+  it("keeps the live storage persona unchanged when the runner writes a draft and then fails", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    const previousPersona = "# Stable persona\n\nKeep this published version.";
+    await storage.writeFile("persona.md", previousPersona);
+    await storage.writeFile("scene_blocks/work.md", "# Work\n\nNew operating preference.");
+    await storage.writeFile(".metadata/scene_index.json", JSON.stringify([{
+      filename: "work.md",
+      summary: "Work preference",
+      heat: 1,
+      created: "2026-09-09T10:00:00.000Z",
+      updated: "2026-09-09T10:00:00.000Z",
+    }]));
+
+    let draftDir = "";
+    const runner: LLMRunner = {
+      async run(params) {
+        draftDir = params.workspaceDir ?? "";
+        expect(draftDir).not.toBe(dataDir);
+        expect(params.storage).toBeUndefined();
+        await fs.writeFile(path.join(draftDir, "persona.md"), "# Partial, must never be published", "utf-8");
+        throw new Error("upstream rate limit after tool call");
+      },
+    };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("test failure")).rejects.toThrow("upstream rate limit after tool call");
+    await expect(storage.readFile("persona.md")).resolves.toBe(previousPersona);
+    await expect(fs.stat(draftDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not create a live filesystem persona when a first-generation draft fails", async () => {
+    const dataDir = await makeTempDir();
+    const runner: LLMRunner = {
+      async run(params) {
+        await fs.writeFile(path.join(params.workspaceDir!, "persona.md"), "# Partial", "utf-8");
+        throw new Error("model failed");
+      },
+    };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, llmRunner: runner });
+    await expect(generator.generateLocalPersona("test failure")).rejects.toThrow("model failed");
+    await expect(fs.stat(path.join(dataDir, "persona.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("publishes a validated draft only after the runner completes", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    const runner: LLMRunner = {
+      async run(params) {
+        await fs.writeFile(
+          path.join(params.workspaceDir!, "persona.md"),
+          "# Complete persona\n\nNever emit </user-persona> literally.",
+          "utf-8",
+        );
+        return "done";
+      },
+    };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("test success")).resolves.toBe(true);
+    await expect(storage.readFile("persona.md")).resolves.toBe(
+      "# Complete persona\n\nNever emit &lt;/user-persona&gt; literally.",
+    );
+  });
+
+  it("returns false only for a successful no-change decision", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    await storage.writeFile("persona.md", "# Stable persona");
+    await storage.writeFile(".metadata/scene_index.json", "[]");
+    const runner: LLMRunner = {
+      async run() {
+        throw new Error("runner must not be called");
+      },
+    };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("no changes")).resolves.toBe(false);
+    await expect(storage.readFile("persona.md")).resolves.toBe("# Stable persona");
+  });
+
+  it("rejects a live persona read failure instead of treating it as a cold start", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    const originalRead = storage.readFile.bind(storage);
+    vi.spyOn(storage, "readFile").mockImplementation(async (key) => {
+      if (key === "persona.md") throw new Error("storage unavailable");
+      return originalRead(key);
+    });
+    const runner: LLMRunner = { async run() { throw new Error("runner must not be called"); } };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("read failure")).rejects.toThrow("Could not read existing persona.md");
+  });
+
+  it("rejects a scene-index read failure instead of treating it as no changes", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    await storage.writeFile("persona.md", "# Stable persona");
+    const originalRead = storage.readFile.bind(storage);
+    vi.spyOn(storage, "readFile").mockImplementation(async (key) => {
+      if (key === ".metadata/scene_index.json") throw new Error("storage unavailable");
+      return originalRead(key);
+    });
+    const runner: LLMRunner = { async run() { throw new Error("runner must not be called"); } };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("index failure")).rejects.toThrow("Could not read scene index");
+    await expect(storage.readFile("persona.md")).resolves.toBe("# Stable persona");
+  });
+
+  it("rejects a missing changed scene instead of advancing past incomplete evidence", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    await storage.writeFile("persona.md", "# Stable persona");
+    await storage.writeFile(".metadata/scene_index.json", JSON.stringify([{
+      filename: "missing.md",
+      summary: "Missing evidence",
+      heat: 1,
+      created: "2026-09-09T10:00:00.000Z",
+      updated: "2026-09-09T10:00:00.000Z",
+    }]));
+    const runner: LLMRunner = { async run() { throw new Error("runner must not be called"); } };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("missing scene"))
+      .rejects.toThrow("Could not read changed scene block: missing.md");
+    await expect(storage.readFile("persona.md")).resolves.toBe("# Stable persona");
+  });
+
+  it("rejects a scene-index filename that escapes the scene directory", async () => {
+    const dataDir = await makeTempDir();
+    const storage = new StorageAdapter(new LocalStorageBackend(dataDir));
+    await storage.writeFile("persona.md", "# Stable persona");
+    await storage.writeFile(".metadata/scene_index.json", JSON.stringify([{
+      filename: "../../persona.md",
+      summary: "Unsafe evidence",
+      heat: 1,
+      created: "2026-09-09T10:00:00.000Z",
+      updated: "2026-09-09T10:00:00.000Z",
+    }]));
+    const runner: LLMRunner = { async run() { throw new Error("runner must not be called"); } };
+
+    const generator = new PersonaGenerator({ dataDir, config: {}, storage, llmRunner: runner });
+    await expect(generator.generateLocalPersona("unsafe index")).rejects.toThrow("Could not read scene index");
+    await expect(storage.readFile("persona.md")).resolves.toBe("# Stable persona");
+  });
+});

--- a/MemoryCore/src/core/persona/persona-generator.ts
+++ b/MemoryCore/src/core/persona/persona-generator.ts
@@ -4,6 +4,10 @@
  */
 
 import type { MemoryPromptMode } from "../../config.js";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { CleanContextRunner } from "../../utils/clean-context-runner.js";
 import { CheckpointManager } from "../../utils/checkpoint.js";
 import { readSceneIndex } from "../scene/scene-index.js";
@@ -21,6 +25,20 @@ import type { ResolvedMemoryPrompt } from "../memory-prompt/types.js";
 import { composeMemorySystemPrompt } from "../memory-prompt/composer.js";
 
 const TAG = "[memory-tdai] [persona]";
+
+async function publishLocalFileAtomically(filePath: string, content: string): Promise<void> {
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    await fs.writeFile(tempPath, content, "utf-8");
+    await fs.rename(tempPath, filePath);
+  } finally {
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+  }
+}
 
 export class PersonaGenerator {
   private dataDir: string;
@@ -76,6 +94,9 @@ export class PersonaGenerator {
 
   /**
    * Execute local persona generation without advancing checkpoint.
+   * Returns `false` only when the published persona already covers every
+   * scene. Generation, validation, and publication failures reject so the
+   * caller cannot mistake them for a successful no-op and advance checkpoint.
    */
   async generateLocalPersona(triggerReason?: string): Promise<boolean> {
     const startMs = Date.now();
@@ -90,25 +111,32 @@ export class PersonaGenerator {
 
     // 1. Read existing L3 document (strip navigation)
     let existingPersona: string | undefined;
+    let existingPersonaFile: string | undefined;
     try {
       let raw: string | null;
       if (this.storage) {
         raw = await this.storage.readFile(targetFile);
       } else {
-        const fs = await import("node:fs/promises");
-        const path = await import("node:path");
-        raw = await fs.default.readFile(path.default.join(this.dataDir, targetFile), "utf-8");
+        raw = await fs.readFile(path.join(this.dataDir, targetFile), "utf-8");
       }
       if (raw) {
+        existingPersonaFile = raw;
         existingPersona = stripSceneNavigation(raw).trim() || undefined;
       }
       this.logger?.debug?.(`${TAG} Existing ${targetLabel}: ${existingPersona ? `${existingPersona.length} chars` : "empty"}`);
-    } catch {
-      this.logger?.debug?.(`${TAG} No existing ${targetFile} file`);
+    } catch (err) {
+      if (!this.storage && isNotFound(err)) {
+        this.logger?.debug?.(`${TAG} No existing ${targetFile} file`);
+      } else {
+        throw new Error(`Could not read existing ${targetFile}`, { cause: err });
+      }
     }
 
     // 2. Load scene index + identify changed scenes
-    const index = await readSceneIndex(this.dataDir, this.storage);
+    const index = await readSceneIndex(this.dataDir, this.storage, { strict: true })
+      .catch((err: unknown) => {
+        throw new Error("Could not read scene index", { cause: err });
+      });
     const changedScenes = index.filter((e) => {
       if (!cp.last_persona_time) return true;
       const updatedMs = new Date(e.updated).getTime();
@@ -127,16 +155,15 @@ export class PersonaGenerator {
         if (this.storage) {
           raw = await this.storage.readFile(`${StoragePaths.sceneBlocksDir}${entry.filename}`);
         } else {
-          const fs = await import("node:fs/promises");
-          const path = await import("node:path");
-          raw = await fs.default.readFile(path.default.join(this.dataDir, "scene_blocks", entry.filename), "utf-8");
+          raw = await fs.readFile(path.join(this.dataDir, "scene_blocks", entry.filename), "utf-8");
         }
-        if (!raw) continue;
+        if (raw === null) throw new Error(`Scene block is missing: ${entry.filename}`);
         changedSceneContents.push(
           `### [${changedSceneContents.length + 1}] ${entry.filename}\n\n\`\`\`markdown\n${raw}\n\`\`\``,
         );
-      } catch {
+      } catch (err) {
         this.logger?.warn(`${TAG} Could not read scene block: ${entry.filename}`);
+        throw new Error(`Could not read changed scene block: ${entry.filename}`, { cause: err });
       }
     }
 
@@ -163,12 +190,10 @@ export class PersonaGenerator {
     }
 
     // 6. Build prompt
-    const personaFilePath = this.storage
-      ? targetFile
-      : await (async () => { const path = await import("node:path"); return path.default.join(this.dataDir, targetFile); })();
+    const personaFilePath = path.join(this.dataDir, targetFile);
     const checkpointPath = this.storage
       ? StoragePaths.checkpoint
-      : await (async () => { const path = await import("node:path"); return path.default.join(this.dataDir, ".metadata", "recall_checkpoint.json"); })();
+      : path.join(this.dataDir, ".metadata", "recall_checkpoint.json");
 
     const { systemPrompt: baseSystemPrompt, userPrompt } = buildPersonaPrompt({
       mode,
@@ -185,19 +210,19 @@ export class PersonaGenerator {
     });
     const systemPrompt = composeMemorySystemPrompt(baseSystemPrompt, this.memoryPrompt);
 
-    // 7. Backup before LLM run (LLM writes persona.md via tools)
-    const bm = new BackupManager(this.storage
-      ? undefined  // COS mode: BackupManager not used (TODO: adapt BackupManager for StorageAdapter)
-      : await (async () => { const path = await import("node:path"); return path.default.join(this.dataDir, ".backup"); })()
-    );
-    if (!this.storage) {
-      const path = await import("node:path");
-      await bm.backupFile(path.default.join(this.dataDir, targetFile), "persona", `offset${cp.total_processed}`, this.backupCount);
+    // 7. Run the LLM against an isolated draft workspace. Tool calls must not
+    // publish directly to the live profile: a later model/API failure can occur
+    // after one or more successful write/edit calls. Only a fully completed,
+    // validated run is committed below.
+    const draftDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-tdai-persona-"));
+    const draftPath = path.join(draftDir, targetFile);
+    if (existingPersonaFile !== undefined) {
+      await fs.writeFile(draftPath, existingPersonaFile, "utf-8");
     }
 
-    // 8. Run LLM agent (sandboxed to dataDir, tools enabled — LLM writes target L3 file directly)
+    let personaText: string;
     try {
-      this.logger?.debug?.(`${TAG} Calling LLM for ${targetFile} generation (timeout=180s, tools=enabled, workspaceDir=${this.dataDir})...`);
+      this.logger?.debug?.(`${TAG} Calling LLM for ${targetFile} generation (timeout=180s, tools=enabled, workspaceDir=${draftDir})...`);
       // langfuse trace 语义：L3 persona 生成有独立 name / 顶级 user/session 列 / 可筛选 tags。
       const traceParams = buildTraceParams("memory.persona-generate", this.traceContext);
       await this.runner.run({
@@ -206,53 +231,42 @@ export class PersonaGenerator {
         taskId: "persona-generation",
         timeoutMs: 180_000,
         // maxTokens omitted → core uses the resolved model's maxTokens from catalog
-        workspaceDir: this.dataDir,
-        // Service mode: LLM tools read/write via StorageAdapter (COS) instead of local FS
-        storage: this.storage,
-        storagePrefix: this.storage ? "" : undefined,
+        workspaceDir: draftDir,
+        // Deliberately omit storage: both standalone and OpenClaw runners then
+        // expose file tools rooted in the isolated draft directory.
         ...traceParams,
       });
       this.logger?.debug?.(`${TAG} LLM runner completed`);
+
+      const raw = await fs.readFile(draftPath, "utf-8");
+      personaText = raw;
     } catch (err) {
       const elapsedMs = Date.now() - startMs;
       this.logger?.error(`${TAG} Persona generation failed after ${elapsedMs}ms: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
-      return false;
+      throw err;
+    } finally {
+      await fs.rm(draftDir, { recursive: true, force: true }).catch(() => {});
     }
 
-    // 9. Read LLM-written persona.md and apply post-processing
-    let personaText: string;
-    try {
-      let raw: string | null;
-      if (this.storage) {
-        raw = await this.storage.readFile(targetFile);
-      } else {
-        const fs = await import("node:fs/promises");
-        raw = await fs.default.readFile(personaFilePath, "utf-8");
-      }
-      if (!raw) throw new Error(`${targetFile} not found`);
-      personaText = raw;
-    } catch {
-      // LLM failed to write persona.md — treat as failure
-      this.logger?.error(`${TAG} LLM did not write ${targetFile} — file not found after runner completed`);
-      return false;
-    }
-
-    // 10. Strip any navigation the LLM might have added + sanitize for safe injection
+    // 8. Strip any navigation the LLM might have added + sanitize for safe injection
     personaText = escapeXmlTags(stripSceneNavigation(personaText).trim());
 
     if (!personaText) {
       this.logger?.error(`${TAG} LLM wrote empty ${targetFile} — skipping`);
-      return false;
+      throw new Error(`LLM wrote empty ${targetFile}`);
     }
 
-    // 11. Append fresh scene navigation and write final content
+    // 9. Append fresh scene navigation and publish once. Storage backends expose
+    // whole-object replacement; the fs fallback uses tmp+rename so readers see
+    // either the previous persona or the complete new one.
     const nav = generateSceneNavigation(index, undefined, false);
     const finalContent = nav ? `${personaText}\n\n${nav}\n` : personaText;
     if (this.storage) {
       await this.storage.writeFile(targetFile, finalContent);
     } else {
-      const fs = await import("node:fs/promises");
-      await fs.default.writeFile(personaFilePath, finalContent, "utf-8");
+      const bm = new BackupManager(path.join(this.dataDir, ".backup"));
+      await bm.backupFile(personaFilePath, "persona", `offset${cp.total_processed}`, this.backupCount);
+      await publishLocalFileAtomically(personaFilePath, finalContent);
     }
 
     const elapsedMs = Date.now() - startMs;
@@ -301,4 +315,8 @@ export class PersonaGenerator {
     await cpManager.markPersonaGenerated(cp.total_processed);
     return true;
   }
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
 }

--- a/MemoryCore/src/core/scene/scene-index.ts
+++ b/MemoryCore/src/core/scene/scene-index.ts
@@ -58,7 +58,11 @@ async function fsReaddir(absDir: string, suffix: string): Promise<string[]> {
  * The index is written exclusively by syncSceneIndex() (engineering side).
  * The LLM is sandboxed to scene_blocks/ and cannot access this file.
  */
-export async function readSceneIndex(dataDir: string, storage?: StorageAdapter): Promise<SceneIndexEntry[]> {
+export async function readSceneIndex(
+  dataDir: string,
+  storage?: StorageAdapter,
+  options: { strict?: boolean } = {},
+): Promise<SceneIndexEntry[]> {
   // P2-D2: rowfs 模式索引实时派生自 L2 行，不读 sidecar 文件。
   const derivable = asSceneIndexDerivable(storage);
   if (derivable) return derivable.deriveSceneIndex();
@@ -68,19 +72,43 @@ export async function readSceneIndex(dataDir: string, storage?: StorageAdapter):
       raw = await storage.readFile(StoragePaths.sceneIndex);
     } else {
       const path = await import("node:path");
-      raw = await fsReadFile(path.default.join(dataDir, ".metadata", "scene_index.json"));
+      const indexPath = path.default.join(dataDir, ".metadata", "scene_index.json");
+      if (options.strict) {
+        const fs = await import("node:fs/promises");
+        try {
+          raw = await fs.default.readFile(indexPath, "utf-8");
+        } catch (error) {
+          if (isNotFound(error)) raw = null;
+          else throw error;
+        }
+      } else {
+        raw = await fsReadFile(indexPath);
+      }
     }
-    if (!raw) return [];
+    if (raw === null) return [];
+    if (raw.length === 0 && !options.strict) return [];
 
     const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      if (options.strict) throw new Error("Scene index must be a JSON array");
+      return [];
+    }
 
     const entries: SceneIndexEntry[] = [];
     for (const item of parsed) {
-      if (!item || typeof item !== "object") continue;
+      if (!item || typeof item !== "object") {
+        if (options.strict) throw new Error("Scene index contains a malformed entry");
+        continue;
+      }
 
       const filename = typeof item.filename === "string" ? item.filename : "";
-      if (!filename) continue;
+      if (!filename) {
+        if (options.strict) throw new Error("Scene index contains an entry without a filename");
+        continue;
+      }
+      if (options.strict && (filename === "." || filename === ".." || filename.includes("/") || filename.includes("\\"))) {
+        throw new Error("Scene index contains an unsafe filename");
+      }
 
       entries.push({
         filename,
@@ -91,9 +119,14 @@ export async function readSceneIndex(dataDir: string, storage?: StorageAdapter):
       });
     }
     return entries;
-  } catch {
+  } catch (error) {
+    if (options.strict) throw error;
     return [];
   }
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
 /**

--- a/MemoryCore/src/utils/pipeline-factory.ts
+++ b/MemoryCore/src/utils/pipeline-factory.ts
@@ -1001,7 +1001,7 @@ export function createL3Runner(opts: {
       // Guard: no scene files → nothing to generate from. Skip without marking
       // checkpoint so cold-start trigger remains available for the next attempt.
       const { readSceneIndex } = await import("../core/scene/scene-index.js");
-      const sceneIndex = await readSceneIndex(scopedDir, scopedStore);
+      const sceneIndex = await readSceneIndex(scopedDir, scopedStore, { strict: true });
       if (sceneIndex.length === 0) {
         logger.info(`${TAG} [L3] No scene files available for scope=${scope}, skipping (checkpoint unchanged)`);
         continue;


### PR DESCRIPTION
## Summary

- run L3 file tools in an isolated draft workspace and publish `persona.md` only after the complete runner succeeds
- reject generation, profile/index reads, and missing changed-scene evidence instead of advancing the L3 checkpoint
- make filesystem publication atomic and harden sandbox path containment against same-prefix sibling traversal

## Verification

- `npm test` — 2 files, 9 tests passed
- `npm run build:plugin` — passed
- deterministic local OpenAI-compatible AI-SDK smoke — first response wrote the draft, three continuation attempts returned HTTP 429, generation rejected, and the live persona remained byte-for-byte unchanged
- `git diff --check` — passed

## Known baseline issue

The aggregate `npm run build` reaches and passes the plugin, migration, export, and read-local-memory builds, then fails because the checked-out branch's `package.json` references the absent `scripts/seed-v2/tsconfig.json`. This PR does not touch that script.
