### PR TITLE
fix(types): declare skipAssetConfirm in RawYamlConfig.sessionInit

### DIFF
--- a/MemoryProxy/src/types.ts
+++ b/MemoryProxy/src/types.ts
@@ -879,6 +879,12 @@ export interface RawYamlConfig {
     injectAgentContext?: boolean;
     injectTaskContext?: boolean;
     defaultTaskId?: string;
+    /**
+     * 跳过 asset_confirm 前置对话框，默认视为用户选了"是，关联团队资产"。
+     * 开启后首轮直接进入 team → agent → task 选择流程（或 auto-select 级联）。
+     * 默认 false（保持原有行为，弹 asset_confirm 对话框）。
+     */
+    skipAssetConfirm?: boolean;
     debugForceIdentity?: {
       team_id?: string;
       agent_id?: string;


### PR DESCRIPTION
## Description | 描述

`loadYamlConfig` reads `yaml.sessionInit?.skipAssetConfirm` (`MemoryProxy/src/config.ts`), and the
consumer type `SessionInitConfig` declares the field — but the **raw YAML shape**
(`RawYamlConfig.sessionInit`) does not, so `tsc --noEmit` reports:

```
src/config.ts(425,41): error TS2339: Property 'skipAssetConfirm' does not exist on type
'{ enabled?: boolean | undefined; maxRetries?: number | undefined; injectAgentContext?: ... }'
```

`loadYamlConfig` is a cast (`return parsed as RawYamlConfig`), so this is a **type-only gap with no
runtime impact**. Declaring the field on the raw shape aligns it with the consumer type and clears
the diagnostic.

`RawYamlConfig.sessionInit` 缺 `skipAssetConfirm?: boolean`：`SessionInitConfig` 已有该字段、读取处
（`config.ts`）也在用，只有 **raw YAML 形状**漏了。补齐声明；注释照抄 `SessionInitConfig` 上同名字段
的说明。**零行为改动**（`loadYamlConfig` 本就是 cast，运行时不缺该字段）。

## Related Issue | 关联 Issue

<!-- None filed — a one-line type-declaration gap. | 未开 issue：1 行类型声明缺口。 -->

## Change Type | 修改类型
- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单
- [x] Verified locally | 本地验证通过
- [x] No existing features affected | 无影响现有功能

## Additional Notes | 其他说明

- Verified with `npx tsc --noEmit` inside `MemoryProxy/`: **60 → 59** errors on this branch
  (measured on the branch and on its base commit; the only changed diagnostic is the
  `skipAssetConfirm` TS2339 quoted above).
- No behavior change: the field is only *declared*; `loadYamlConfig` already reads it through a cast.
- Single file, `+6 −0` (`MemoryProxy/src/types.ts`): the declaration + a doc-comment mirroring
  `SessionInitConfig.skipAssetConfirm`.
