### PR TITLE
fix(memory-core): expose extraction configuration in skill archive responses

### DIFF
--- a/MemoryCore/src/gateway/skill-archive-extraction-flag.test.ts
+++ b/MemoryCore/src/gateway/skill-archive-extraction-flag.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The three archive entry points answer a success with `ok`/`status` and a `task_id`.
+ * That answer is accurate — `SkillTriggerService.archive()` writes the archive, appends
+ * the task and enqueues it — but it says nothing about whether extraction is configured
+ * to run at all. With `skill.extraction.enabled=false` the task is accepted and then
+ * cannot be executed, and until now no field in the response said so.
+ *
+ * These tests pin the field that says it, and pin what it must NOT say:
+ *   - it reports the configuration switch, never worker readiness or task completion;
+ *   - it is `null` — not `false` — when the resolved config cannot be reached;
+ *   - it does not change the archive contract, and it is not injected into errors.
+ */
+import { describe, test, expect, vi } from "vitest";
+import { handleExtract, handleConversationAdd, handleForceArchive } from "./skill-handlers.js";
+import type { SkillRouterDeps } from "./skill-handlers.js";
+import type { V2AuthContext } from "./v2-schemas.js";
+
+const auth: V2AuthContext = { apiKey: "k", serviceId: "inst-1" };
+const RID = "req-test";
+
+const logger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as unknown as SkillRouterDeps["logger"];
+
+/** Only the two fields these handlers read off the resolved config. */
+const cfgWith = (enabled: boolean) => () => ({
+  extraction: { enabled, chunkMaxBytes: 1_000_000, headKeepBytes: 400_000, tailKeepBytes: 400_000 },
+  compress: { toolContentThresholdBytes: 4096, headBytes: 1024, tailBytes: 1024 },
+}) as unknown as ReturnType<NonNullable<SkillRouterDeps["getResolvedSkillConfig"]>>;
+
+const archiveOk = () => vi.fn(async () => ({ taskId: "task-1", archivedAtMs: 1_700_000_000_000, archiveKey: "k/1" }));
+
+function deps(over: Partial<SkillRouterDeps> & { archive?: ReturnType<typeof archiveOk>; handle?: unknown; buffer?: unknown } = {}): SkillRouterDeps {
+  const archive = over.archive ?? archiveOk();
+  return {
+    getSkillCore: () => undefined,
+    logger,
+    getResolvedSkillConfig: over.getResolvedSkillConfig,
+    resolveConversationAdd: async () => ({
+      trigger: { archive },
+      handler: { handle: over.handle ?? (async () => ({ status: "ok" })) },
+      buffer: over.buffer ?? {
+        readCurrent: async () => ({ messages: [{ role: "user", content: "hi" }] }),
+        readMeta: async () => ({}),
+        writeCurrent: async () => {},
+        writeMeta: async () => {},
+      },
+    }) as never,
+    ...over,
+  } as SkillRouterDeps;
+}
+
+const extractBody = {
+  user_id: "u1", team_id: "t1", agent_id: "a1",
+  messages: [{ role: "user", content: "how do I fix the exit line" }],
+};
+const addBody = { ...extractBody, session_id: "s1" };
+const forceBody = { space_id: "inst-1", user_id: "u1", team_id: "t1", agent_id: "a1", session_id: "s1" };
+
+describe("extraction switch in the archive responses", () => {
+  test("extraction off: the slice is still archived and the task still registered — and the response says the switch is off", async () => {
+    const archive = archiveOk();
+    const res = await handleExtract(extractBody, auth, RID, deps({ archive, getResolvedSkillConfig: cfgWith(false) }));
+    const data = res.data as Record<string, unknown>;
+    // the existing contract is untouched
+    expect(res.code).toBe(0);
+    expect(data.ok).toBe(true);
+    expect(data.task_id).toBe("task-1");
+    expect(data.archive_key).toBe("k/1");
+    // the task really was registered — this is not a "rejected before archiving" change
+    expect(archive).toHaveBeenCalledTimes(1);
+    // …and the caller can now see why nothing will come of it
+    expect(data.extraction_enabled).toBe(false);
+  });
+
+  test("extraction on: behaviour unchanged, and `true` is not a claim that extraction finished", async () => {
+    const res = await handleExtract(extractBody, auth, RID, deps({ getResolvedSkillConfig: cfgWith(true) }));
+    const data = res.data as Record<string, unknown>;
+    expect(data.extraction_enabled).toBe(true);
+    expect(Object.keys(data).sort()).toEqual(["archive_key", "archived_at_ms", "extraction_enabled", "ok", "task_id"]);
+    // nothing in the response speaks about the outcome of extraction
+    for (const k of ["skill_id", "candidates", "extracted", "candidate_count"]) expect(data[k]).toBeUndefined();
+  });
+
+  test("config unreachable: unknown, never a fabricated `false`", async () => {
+    // the dep is optional and may be absent entirely
+    const noDep = await handleExtract(extractBody, auth, RID, deps());
+    expect((noDep.data as Record<string, unknown>).extraction_enabled).toBeNull();
+    // present but the skill config is not resolved yet (skill not constructed)
+    const undef = await handleExtract(extractBody, auth, RID, deps({ getResolvedSkillConfig: () => undefined }));
+    expect((undef.data as Record<string, unknown>).extraction_enabled).toBeNull();
+  });
+
+  test("conversation/add reports the switch below the threshold and at it", async () => {
+    const below = await handleConversationAdd(addBody, auth, RID, deps({ getResolvedSkillConfig: cfgWith(false), handle: async () => ({ status: "ok" }) }));
+    expect(below.data).toMatchObject({ status: "ok", extraction_enabled: false });
+
+    const at = await handleConversationAdd(addBody, auth, RID, deps({
+      getResolvedSkillConfig: cfgWith(false),
+      handle: async () => ({ status: "archived", archived: { task_id: "task-9", archived_at_ms: 1, reason: "tool_call_threshold" } }),
+    }));
+    expect(at.data).toMatchObject({
+      status: "archived",
+      archived: { task_id: "task-9", reason: "tool_call_threshold" },
+      extraction_enabled: false,
+    });
+  });
+
+  test("force-archive reports the switch on both the empty and the archived answer", async () => {
+    const empty = await handleForceArchive(forceBody, auth, RID, deps({
+      getResolvedSkillConfig: cfgWith(false),
+      buffer: { readCurrent: async () => ({ messages: [] }), readMeta: async () => ({}), writeCurrent: async () => {}, writeMeta: async () => {} },
+    }));
+    expect(empty.data).toMatchObject({ status: "empty", extraction_enabled: false });
+
+    const archived = await handleForceArchive(forceBody, auth, RID, deps({ getResolvedSkillConfig: cfgWith(false) }));
+    expect(archived.data).toMatchObject({ status: "archived", task_id: "task-1", extraction_enabled: false });
+  });
+
+  test("a failed archive keeps its original error — the new field does not soften it", async () => {
+    const archive = vi.fn(async () => { throw new Error("cos put failed"); }) as unknown as ReturnType<typeof archiveOk>;
+    const res = await handleExtract(extractBody, auth, RID, deps({ archive, getResolvedSkillConfig: cfgWith(false) }));
+    expect(res.code).toBe(50001);
+    expect(res.message).toBe("cos put failed");
+    expect((res.data as Record<string, unknown> | undefined)?.extraction_enabled).toBeUndefined();
+  });
+});

--- a/MemoryCore/src/gateway/skill-handlers.ts
+++ b/MemoryCore/src/gateway/skill-handlers.ts
@@ -756,6 +756,28 @@ export async function handleListing(body: unknown, _auth: V2AuthContext, request
 }
 
 /**
+ * 归档类接口的响应里回报「提取开关」。
+ *
+ * 归档成功的响应本来就是准确的:`SkillTriggerService.archive()` 写归档、追加
+ * SkillTaskEntry、入队,三件事都做了。它从来不代表「已经产出 Skill」——
+ * `skill.extraction.enabled=false` 时任务照样被接收,随后在当前配置下无法执行,
+ * 而响应里没有任何字段提示这一点,调用方只能等。
+ *
+ * 该字段只表示**配置开关**,不表示 worker 就绪,也不表示任务一定完成:
+ *   - extractor 按存储模式分别构造(service 每实例一个、standalone 用进程单例),
+ *     所以这里不声称各部署模式都遵守这个开关;
+ *   - `true` 只是「开关开着」,不是「抽取已完成」。
+ *
+ * 配置不可得时(该 dep 可选,skill 未构造时 `getResolvedSkillConfig()` 返回
+ * undefined)值为 `null` —— 「看不出来」和「关着」是两个不同的答案,不能默认成
+ * false。
+ */
+function extractionFlag(deps: SkillRouterDeps): { extraction_enabled: boolean | null } {
+  const cfg = deps.getResolvedSkillConfig?.();
+  return { extraction_enabled: cfg ? cfg.extraction.enabled : null };
+}
+
+/**
  * `POST /v3/skill/extract` — direct-trigger 归档一次会话切片。
  *
  * 改造前是"入 Redis job 队列 + 轮询 /result"; 改造后走跟 conversation/add
@@ -911,6 +933,7 @@ export async function handleExtract(body: unknown, auth: V2AuthContext, requestI
       task_id: res.taskId,
       archived_at_ms: res.archivedAtMs,
       archive_key: res.archiveKey,
+      ...extractionFlag(deps),
     }, requestId);
   } catch (e) {
     deps.logger.warn(`${TAG} /v3/skill/extract archive failed: ${(e as Error).message} req_id=${requestId}`);
@@ -1025,7 +1048,7 @@ export async function handleConversationAdd(
       reason: out.archived?.reason,
       task_id: out.archived?.task_id,
       msg_count: input.messages.length, });
-    return successEnvelope(out, requestId);
+    return successEnvelope({ ...out, ...extractionFlag(deps) }, requestId);
   } catch (err) {
     // HandlerValidationError → 400；其他 → 500
     const isValidation = err instanceof Error && err.name === "HandlerValidationError";
@@ -1093,7 +1116,7 @@ export async function handleForceArchive(
     // Buffer 为空：无需归档
     if (!current.messages || current.messages.length === 0) {
       obsLogger.info("skill.handleForceArchive.done", { req_id: requestId, code: 0, dur_ms: Date.now() - t0, status: "empty" });
-      return successEnvelope({ status: "empty", message: "No messages in buffer to archive" }, requestId);
+      return successEnvelope({ status: "empty", message: "No messages in buffer to archive", ...extractionFlag(deps) }, requestId);
     }
 
     // 无条件调 trigger.archive（跳过阈值判断）
@@ -1131,6 +1154,7 @@ export async function handleForceArchive(
       task_id: archiveRes.taskId,
       archived_at_ms: archiveRes.archivedAtMs,
       archive_key: archiveRes.archiveKey,
+      ...extractionFlag(deps),
     }, requestId);
   } catch (err) {
     deps.logger.warn(`${TAG} /v3/skill/conversation/force-archive failed: ${(err as Error).message} req_id=${requestId}`);

--- a/MemoryCore/v3-api-memorycore-doc.md
+++ b/MemoryCore/v3-api-memorycore-doc.md
@@ -499,7 +499,7 @@ direct-trigger 手动归档一次会话切片（等价一次独立 skill 抽取�
 | space_id | string | 否 | 缺省回落 auth.serviceId |
 | task_id / reason / options | — | 否 | `options.max_iterations`(1–64) |
 
-**响应** `data`：`{ ok: true, task_id, archived_at_ms, archive_key }`。
+**响应** `data`：`{ ok: true, task_id, archived_at_ms, archive_key, extraction_enabled }`。
 
 ### POST /v3/skill/conversation/add
 
@@ -513,7 +513,7 @@ direct-trigger 手动归档一次会话切片（等价一次独立 skill 抽取�
 | messages | object[] | 是 | 1–500 条（role 同 extract，`tool_call`/`tool_result` 必须带 tool_name+tool_call_id） |
 | space_id / task_id | string | 否 | — |
 
-**响应** `data`：`{ status: "ok"\|"archived", archived?: { task_id, archived_at_ms, archive_key, reason } }`，`archived.reason ∈ tool_calls\|bytes\|compressed\|oversize`。
+**响应** `data`：`{ status: "ok"\|"archived", archived?: { task_id, archived_at_ms, archive_key, reason }, extraction_enabled }`，`archived.reason ∈ tool_calls\|bytes\|compressed\|oversize`。
 
 **错误**：`40001`(schema/校验)、`404`(模块未启用)、`50001`。
 
@@ -523,7 +523,20 @@ direct-trigger 手动归档一次会话切片（等价一次独立 skill 抽取�
 
 **请求体**：`space_id`、`user_id`、`team_id`、`agent_id`、`session_id`（均必填）、`reason?`(≤2000)、`task_id?`。
 
-**响应** `data`：`{ status: "empty" \| "archived", task_id?, archived_at_ms?, archive_key?, message? }`。
+**响应** `data`：`{ status: "empty" \| "archived", task_id?, archived_at_ms?, archive_key?, message?, extraction_enabled }`。
+
+**`extraction_enabled`（以上三个归档入口共有）**：服务端解析出的 `skill.extraction.enabled`。
+
+归档成功本身表示「切片已归档、任务已登记并入队」（`SkillTriggerService.archive()` 在
+tasks mutex 内依次写归档、追加 `SkillTaskEntry`、`enqueueAgent`），它从来不表示「已产出
+Skill」。该字段只回报**配置开关**：
+
+- `true` 只是开关开着,不代表 worker 就绪,也不代表抽取已完成;
+- `false` 表示当前配置下抽取不会执行 —— 任务仍然被接收和登记,调用方据此不必再等;
+- `null` 表示服务端读不到已解析的 skill 配置 —— 是「未知」,不是「关闭」。
+
+extractor 按存储模式分别构造（service 每实例一个、standalone 用进程单例）,所以该字段不声称
+各部署模式都遵守这个开关;它也不改变已入队任务的重试行为。
 
 ---
 

--- a/sdk/memory-core/python/tencentdb_agent_memory/v3/skill_client.py
+++ b/sdk/memory-core/python/tencentdb_agent_memory/v3/skill_client.py
@@ -554,6 +554,13 @@ class SkillClient:
         header (``auth.serviceId``). Set only when explicitly overriding
         the instance the transport is scoped to; body value wins over
         header, and a mismatch is logged server-side.
+
+        The response also carries ``extraction_enabled`` — ``skill.extraction
+        .enabled`` as the server resolved it — so an accepted task that will be
+        extracted is distinguishable from one that cannot be in this
+        configuration. It reports the configuration switch only, not worker
+        readiness and not completion; ``None`` means the server could not read
+        its resolved skill config ("unknown", not "off").
         """
         body = _strip_none({
             **self._defaults.merge(team_id, agent_id, user_id, task_id),
@@ -596,6 +603,13 @@ class SkillClient:
         ``{tool_calls, bytes, compressed, oversize}``. See
         ``docs/design/2026-07-15-skill-trigger-in-core-design.md`` §11.1
         for the trigger semantics.
+
+        The response also carries ``extraction_enabled`` — ``skill.extraction
+        .enabled`` as the server resolved it — so an accepted task that will be
+        extracted is distinguishable from one that cannot be in this
+        configuration. It reports the configuration switch only, not worker
+        readiness and not completion; ``None`` means the server could not read
+        its resolved skill config ("unknown", not "off").
         """
         body = _strip_none({
             "session_id": session_id,
@@ -642,6 +656,13 @@ class SkillClient:
           ..., "archive_key": "..."}`` — archive was written. Note the
           coordinates are at the top level (not nested under
           ``archived``), unlike :meth:`conversation_add`.
+
+        The response also carries ``extraction_enabled`` — ``skill.extraction
+        .enabled`` as the server resolved it — so an accepted task that will be
+        extracted is distinguishable from one that cannot be in this
+        configuration. It reports the configuration switch only, not worker
+        readiness and not completion; ``None`` means the server could not read
+        its resolved skill config ("unknown", not "off").
         """
         body = _strip_none({
             "session_id": session_id,

--- a/sdk/memory-core/typescript/src/v3/skill-types.ts
+++ b/sdk/memory-core/typescript/src/v3/skill-types.ts
@@ -312,6 +312,14 @@ export interface SkillExtractData {
   task_id: string;
   archived_at_ms: number;
   archive_key: string;
+  /**
+   * `skill.extraction.enabled` as the server resolved it, so a caller can tell
+   * an accepted task that will be extracted from one that cannot be in this
+   * configuration. It reports the configuration switch ONLY — not worker
+   * readiness, and not that extraction finished. `null` means the server could
+   * not read its resolved skill config; that is "unknown", not "off".
+   */
+  extraction_enabled?: boolean | null;
 }
 
 // ── /v3/skill/conversation/add ──
@@ -390,6 +398,14 @@ export interface SkillConversationArchivedInfo {
 export interface SkillConversationAddData {
   status: "ok" | "archived";
   archived?: SkillConversationArchivedInfo;
+  /**
+   * `skill.extraction.enabled` as the server resolved it, so a caller can tell
+   * an accepted task that will be extracted from one that cannot be in this
+   * configuration. It reports the configuration switch ONLY — not worker
+   * readiness, and not that extraction finished. `null` means the server could
+   * not read its resolved skill config; that is "unknown", not "off".
+   */
+  extraction_enabled?: boolean | null;
 }
 
 // ── /v3/skill/conversation/force-archive ──
@@ -436,6 +452,14 @@ export interface SkillConversationForceArchiveData {
   task_id?: string;
   archived_at_ms?: number;
   archive_key?: string;
+  /**
+   * `skill.extraction.enabled` as the server resolved it, so a caller can tell
+   * an accepted task that will be extracted from one that cannot be in this
+   * configuration. It reports the configuration switch ONLY — not worker
+   * readiness, and not that extraction finished. `null` means the server could
+   * not read its resolved skill config; that is "unknown", not "off".
+   */
+  extraction_enabled?: boolean | null;
 }
 
 // ── SDK-only convenience ──


### PR DESCRIPTION
## Description | 描述

`POST /v3/skill/extract`, `POST /v3/skill/conversation/add` and
`POST /v3/skill/conversation/force-archive` answer a success with `ok`/`status` and a
`task_id`. That answer is accurate: `SkillTriggerService.archive()` writes the archive,
appends the `SkillTaskEntry` and calls `enqueueAgent`, all three inside the tasks mutex.
It has never meant that a Skill was produced — and with `skill.extraction.enabled=false`
the accepted task cannot be executed in that configuration, while no field in the
response says so.

The caller therefore cannot distinguish "accepted, extraction under way" from "accepted,
extraction cannot run here": both are `code: 0` with a `task_id`. A client that waits for
a skill to appear waits forever, and a client polling `/v3/skill/list` cannot tell an
empty result caused by the switch from one caused by a session with nothing worth
keeping.

One of those callers is the product's own agent-facing tool. MemoryProxy injects
`skill_extract` into the read-only tool set of every session
(`MemoryProxy/src/injection/injectors/skill-tools-injector.ts`), described to the model as
"立即归档当前对话触发一次 skill 抽取（异步任务，由后台 agent 分析对话内容生成 skill）".
When the model calls it, the bridge forwards it to Core's
`/v3/skill/conversation/force-archive` (`skill-bridge.ts`, the `sub === "extract"` branch)
and returns Core's envelope to the model verbatim — the response body is passed through
unchanged except for team-search filtering. So with extraction off, the model is told it
triggered extraction, is handed a `task_id`, and has nothing in the answer to tell it
otherwise. With this field it does.

This adds one field, `extraction_enabled`, to the success responses of those three entry
points. It reports the configuration switch and nothing more:

- **not** worker readiness and **not** task completion — `true` only means the switch is on;
- `null`, never `false`, when the resolved skill config cannot be reached, so
  "cannot tell" stays distinguishable from "it is off".

The archive contract is unchanged: the slice is still archived, the task is still
registered and enqueued, and error responses keep their existing shape. Rejecting the
call instead would be worse — the archive and the task entry are already written by the
time the handler returns, so a failure response would invite a retry that duplicates
them.

## Related Issue | 关联 Issue

Related: #972 — `skill_extract` is injected unconditionally while the call cannot do what
its description promises. The 40003 "trigger path retired" half of that report no longer
applies (the bridge now forwards `extract` to `conversation/force-archive`), but the other
half does: the tool is still advertised to every session, and when extraction is off the
call now *succeeds* and still produces nothing. **This PR does not fix #972** — it does not
change what is injected into the tool set, which is what that issue asks for. It makes the
failure visible in the response instead of silent.

Also related but not overlapping: #1117 (see Additional Notes). No issue was filed for this
specific gap — it was found while running the product end to end and hitting it.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [x] Documentation update | 文档更新 — API doc and both SDKs declare the new field
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过

  `npx vitest run src/gateway/skill-archive-extraction-flag.test.ts` — 6 tests, all passing:

  1. extraction off — the slice is still archived, `archive` is still called once,
     `ok`/`task_id`/`archive_key` unchanged, and `extraction_enabled: false`;
  2. extraction on — response keys are exactly the previous four plus the new one, and
     nothing in it speaks about the outcome of extraction;
  3. config unreachable — `null` in both cases: the optional dep absent, and the dep
     present but returning `undefined` (skill not yet constructed). Never a fabricated
     `false`;
  4. `conversation/add` — reported both below the threshold (`status: "ok"`) and at it
     (`status: "archived"`, `archived` preserved);
  5. `force-archive` — reported on both the `empty` and the `archived` answer;
  6. a failed archive keeps its original error (`50001`, original message) and the new
     field is **not** injected into the error envelope.

  Also reproduced live against a running Core — evidence under Additional Notes.

- [x] No existing features affected | 无影响现有功能

  The field is additive on success envelopes only; no request schema, no status code and
  no existing field changes. `bash scripts/ci/check-skill-queue-isolation.sh` with
  `BASE_REF=origin/feat/server_team` → PASS. `tsc` on the touched file reports the same
  18 pre-existing diagnostics before and after (none added). `npm pack --dry-run` does
  not include the new test file (`!src/**/*.test.ts` in `files`), so the published
  package is unchanged in shape. MemoryProxy and MemoryPanel pass the response through
  and ignore unknown fields, so they keep working untouched.

## Additional Notes | 其他说明

### Reproduction

Live, on standalone + sqlite, with `skill.extraction.enabled: false`:

```bash
curl -sS -H "authorization: Bearer $KEY" -H "x-tdai-user-key: $KEY" \
  -H 'content-type: application/json' -H 'x-tdai-service-id: default' \
  -X POST http://localhost:8420/v3/skill/extract -d '{
    "user_id":"usr-…","team_id":"team-…","agent_id":"agt-repro-extraction-flag",
    "session_id":"repro-1",
    "messages":[{"role":"user","content":"…"},{"role":"assistant","content":"…"}]}'
```

① the response — no mention of the switch:

```json
{"code":0,"message":"ok","request_id":"req-6f8365f3512d416d",
 "data":{"ok":true,"task_id":"skill-extract-task-fe84b9ed",
         "archived_at_ms":1789235870833,"archive_key":"skill_buffer/…/data-….jsonl"}}
```

② the task really is registered and enqueued —
`…/agt-repro-extraction-flag/_tasks.json` after the call:

```json
{"tasks":[{"task_id":"skill-extract-task-fe84b9ed","enqueued_at_ms":1789235870833,
           "archive_key":"skill_buffer/…/data-1789235870833.jsonl", "…":"…"}]}
```

③ the worker pool starts and then cannot execute it — `docker logs`:

```
INFO  [skill-worker-pool] start pool_id=skill-pool-default-7 concurrency=60 …
ERROR [skill-worker-pool] skill-pool-default-7#0 consumeAgent error:
      [skill-worker-pool] standalone SkillExtractor unavailable (instance=default)
ERROR [skill-worker-pool] skill-pool-default-7#1 consumeAgent error: … (repeats)
```

An empty candidate pool is deliberately **not** offered as evidence: a real extraction
may also produce no candidates, so on its own it proves nothing.

### Scope — stated explicitly

- **Not** a claim that the task is never queued. It is queued; ① – ③ above show the task
  entry and the worker attempts.
- **Not** a claim that every storage mode honours the switch. The extractor is built per
  storage mode — service mode builds one per instance
  (`buildSkillExtractorForInstance`), standalone uses the process singleton
  (`TdaiCore.getSkillExtractor`) — and this reproduction covers the standalone path only.
  The field reports the process-level resolved configuration, which is what
  `getResolvedSkillConfig()` returns.
- **Not** a change to the retry policy for tasks already in the queue. The repeated
  `consumeAgent error` above is left exactly as it is.
- **Not** a readiness probe. With `extraction.enabled=true` but no LLMRunner the resolver
  records a degradation and keeps `enabled: true`; this field still reports `true`, and
  the doc says so. Surfacing degradations would be a different, larger change.

### Relationship to #1117

[#1117](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/1117)
(`fix(skill): expose extraction action outcomes`) reports what extraction *did* —
aggregate candidate outcomes in the worker's logs and task-completion metadata — and
touches `candidate-outcome.ts` and `extract-worker.ts`. That is the worker side, after
extraction runs. This PR is the synchronous HTTP response, before anything runs, and
touches `skill-handlers.ts`. No file and no field overlaps. The two are complementary:
#1117 tells you what came of a task that executed, this tells you whether one can
execute at all.

A search of this repository's full pull-request history (not only recent PRs) for
`extraction_enabled`, `skill.extraction.enabled`, the three route paths, `force-archive`,
and `skill-handlers` / `extract-worker` / `trigger-service` found no other PR touching
these response fields. #1216 also edits `skill-handlers.ts`, but only `handleGet` — no
hunk overlap.

### Size

26 lines in the implementation (`skill-handlers.ts`: one helper plus four call sites),
125 lines of test, and 61 lines of API-doc and SDK-type declaration —
`v3-api-memorycore-doc.md`, the three TypeScript response interfaces, and the three
Python client docstrings — because a response field nobody has documented is not
finished.

### CI

`.github/workflows/pr-ci.yml` triggers on `pull_request: branches: [main]`, so it does
not run for a PR targeting `feat/server_team`. The checks above were run locally instead;
happy to re-run anything you would like to see.
