### PR TITLE
fix(proxy): honor read-only mode in skill listing instructions

### DIFF
--- a/MemoryProxy/src/injection/index.ts
+++ b/MemoryProxy/src/injection/index.ts
@@ -300,14 +300,14 @@ function buildPipelineBundle(config: ProxyConfig): PipelineBundle {
     // RAG-driven `<cloud_skills>` block. Calls /v3/skill/search at prewarm time.
     // When coreSkill is unconfigured (no serviceToken), the searchSkills call
     // will fail and the injector silently degrades to no <cloud_skills> block.
+    const allowLlmWrite = config.skillRuntime?.allowLlmWrite ?? false;
     registry.register(
-      new SkillInjector({ coreSkill: config.coreSkill }),
+      new SkillInjector({ coreSkill: config.coreSkill, allowLlmWrite }),
     );
 
     // Always inject the curl-recipe `<skill_tools>` block alongside the
     // dynamic `<cloud_skills>` block. Even when there are no skills to
     // recommend, the LLM still needs to know how to create / search them.
-    const allowLlmWrite = config.skillRuntime?.allowLlmWrite ?? false;
     registry.register(new SkillToolsInjector({ proxyBaseUrl: proxyBaseUrl!, allowLlmWrite }));
   }
 

--- a/MemoryProxy/src/injection/injectors/__tests__/skill-injector-readonly.test.ts
+++ b/MemoryProxy/src/injection/injectors/__tests__/skill-injector-readonly.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `skillRuntime.allowLlmWrite` is false by default (`config.ts` DEFAULT_CONFIG,
+ * and `config.example.yaml` says so). Under it the bridge rejects every write
+ * subpath with 40302/403, and `SkillToolsInjector` correctly omits skill_patch /
+ * skill_create from the tool list it shows the model.
+ *
+ * The `<available_skills>` block is the one place that did not get the memo: its
+ * header told the model to patch a skill that has issues and to update a skill
+ * before finishing, no matter what the switch said. A model that complied called
+ * a tool it had never been given and got a 403 back.
+ *
+ * These tests pin both directions: read-only says report, write-enabled keeps the
+ * existing instructions verbatim.
+ */
+import { describe, test, expect } from "vitest";
+import { wrapAvailableSkillsBlock, SkillInjector } from "../skill-injector.js";
+
+const LISTING = "<available_skills>\n  - skl-abc: demo skill\n</available_skills>";
+
+describe("available-skills block honours the write switch", () => {
+  test("read-only: no instruction to edit a skill", () => {
+    const out = wrapAvailableSkillsBlock(LISTING, false);
+    expect(out).not.toMatch(/skill_patch/);
+    expect(out).not.toMatch(/skill_create/);
+    expect(out).not.toMatch(/update it before finishing/i);
+    expect(out).not.toMatch(/fix it with/i);
+  });
+
+  test("read-only: the model is told what to do instead — report it", () => {
+    const out = wrapAvailableSkillsBlock(LISTING, false);
+    expect(out).toMatch(/read-only/i);
+    expect(out).toMatch(/report/i);
+  });
+
+  test("read-only: everything else about the block is unchanged", () => {
+    const ro = wrapAvailableSkillsBlock(LISTING, false);
+    // the load directive, the curl reminder, the listing and the footer all stay
+    expect(ro).toMatch(/## Skills \(mandatory\)/);
+    expect(ro).toMatch(/skill_view/);
+    expect(ro).toContain(LISTING);
+    expect(ro).toMatch(/Only proceed without loading a skill/);
+  });
+
+  test("write enabled: the existing instructions are kept word for word", () => {
+    const rw = wrapAvailableSkillsBlock(LISTING, true);
+    expect(rw).toContain("If a skill has issues, fix it with the `skill_patch` skill-bridge tool.");
+    expect(rw).toContain("offer to save the approach as a new skill");
+    expect(rw).toContain("update it before finishing");
+  });
+
+  test("the flag is what decides — the two renderings differ only in that clause", () => {
+    const ro = wrapAvailableSkillsBlock(LISTING, false);
+    const rw = wrapAvailableSkillsBlock(LISTING, true);
+    expect(ro).not.toEqual(rw);
+    // Same opening directive and same tail: only the middle clause is swapped.
+    expect(ro.slice(0, 200)).toEqual(rw.slice(0, 200));
+    expect(ro.endsWith("Only proceed without loading a skill if genuinely none are relevant to the task."))
+      .toBe(true);
+    expect(rw.endsWith("Only proceed without loading a skill if genuinely none are relevant to the task."))
+      .toBe(true);
+  });
+
+  test("omitting the flag falls back to read-only — the product default", () => {
+    // Callers that predate the flag must not keep emitting write instructions.
+    expect((wrapAvailableSkillsBlock as (l: string, a?: boolean) => string)(LISTING)).not.toMatch(/skill_patch/);
+  });
+});
+
+/**
+ * The flag has to survive the trip from config to the rendered block, not just
+ * work when the pure function is called directly. These drive the real injector
+ * through `prewarm()` with a stubbed core client.
+ */
+describe("the switch reaches the injected block", () => {
+  const stubClient = {
+    listListing: async () => ({ mode: "full", listing: LISTING, hits: [{ skill_id: "skl-abc" }] }),
+  };
+  const prewarmInput = {
+    sessionInfo: { team_id: "team-1", agent_id: "agt-1", space_id: "sp-1" },
+  };
+  const make = (allowLlmWrite?: boolean) =>
+    new SkillInjector(
+      { coreSkill: { endpoint: "http://core.invalid", serviceToken: "t", timeoutMs: 1000 } as never, allowLlmWrite },
+      stubClient as never,
+    );
+
+  test("prewarm with writes off: the block carries no edit instruction", async () => {
+    const [block] = await make(false).prewarm(prewarmInput as never);
+    expect(block.content).not.toMatch(/skill_patch/);
+    expect(block.content).toMatch(/read-only/i);
+    expect(block.content).toContain(LISTING);
+  });
+
+  test("prewarm with writes on: the edit instruction is there", async () => {
+    const [block] = await make(true).prewarm(prewarmInput as never);
+    expect(block.content).toContain("fix it with the `skill_patch` skill-bridge tool");
+  });
+
+  test("prewarm with the flag unset: read-only, matching the product default", async () => {
+    const [block] = await make().prewarm(prewarmInput as never);
+    expect(block.content).not.toMatch(/skill_patch/);
+  });
+});

--- a/MemoryProxy/src/injection/injectors/skill-injector.ts
+++ b/MemoryProxy/src/injection/injectors/skill-injector.ts
@@ -42,6 +42,12 @@ const TAG = "[skill-injector]";
 export interface SkillInjectorConfig {
   /** Core skill client config; passed to `getCoreSkillClient(config)`. */
   coreSkill: CoreSkillConfig;
+  /**
+   * `skillRuntime.allowLlmWrite`. Off by default, and when off the header must
+   * not ask the model to patch or create a skill — skill-bridge rejects those
+   * subpaths with 40302 and `SkillToolsInjector` never showed the tools.
+   */
+  allowLlmWrite?: boolean;
 }
 
 /**
@@ -56,7 +62,12 @@ export interface SkillInjectorConfig {
  * block above `<available_skills>` for the exact curl recipes.
  *
  * When updating either copy, update the other so the LLM sees consistent
- * guidance regardless of which host renders the block.
+ * guidance regardless of which host renders the block — with one deliberate
+ * divergence: the write clause below is gated on `skillRuntime.allowLlmWrite`,
+ * which is a proxy-side switch Core knows nothing about. Core's
+ * `SKILL_LISTING_HEADER` is exported but not referenced by Core itself (the
+ * `/v3/skill/listing` response carries only the `<available_skills>` lines), so
+ * on this path the header the model sees is this one.
  */
 const SKILL_LISTING_HEADER =
   "## Skills (mandatory)\n"
@@ -70,11 +81,35 @@ const SKILL_LISTING_HEADER =
   + "even if you think you could handle the task with basic tools like web_search or terminal. "
   + "Skills also encode the user's preferred approach, conventions, and quality standards "
   + "for tasks like code review, planning, and testing — load them even for tasks you "
-  + "already know how to do, because the skill defines how it should be done here.\n"
-  + "If a skill has issues, fix it with the `skill_patch` skill-bridge tool.\n"
+  + "already know how to do, because the skill defines how it should be done here.\n";
+
+/**
+ * The part of the header that asks the model to WRITE. Only rendered when
+ * `skillRuntime.allowLlmWrite` is on, because that is the same switch
+ * `SkillToolsInjector` uses to decide whether skill_patch / skill_create are in
+ * the tool list at all, and the same one skill-bridge checks before answering a
+ * write subpath with 40302.
+ */
+const SKILL_LISTING_WRITE_CLAUSE =
+  "If a skill has issues, fix it with the `skill_patch` skill-bridge tool.\n"
   + "After difficult/iterative tasks, offer to save the approach as a new skill "
   + "(`skill_create`). If a skill you loaded was missing steps, had wrong commands, "
   + "or needed pitfalls you discovered, update it before finishing.\n";
+
+/**
+ * What to say instead when writes are off (the product default — see
+ * `DEFAULT_CONFIG.skillRuntime.allowLlmWrite` in `src/config.ts`). The model
+ * still has something useful to do with a broken skill; it just cannot be the
+ * one to fix it. No write tool is named, so nothing here invites a call that
+ * would come back 403.
+ */
+const SKILL_LISTING_READONLY_CLAUSE =
+  "Skills are read-only in this session. If one has issues — missing steps, wrong "
+  + "commands, or pitfalls you discovered — report them in your reply so a human can "
+  + "act on it; do not try to edit or create a skill.\n";
+
+const skillListingHeader = (allowLlmWrite: boolean): string =>
+  SKILL_LISTING_HEADER + (allowLlmWrite ? SKILL_LISTING_WRITE_CLAUSE : SKILL_LISTING_READONLY_CLAUSE);
 
 const SKILL_LISTING_FOOTER =
   "\nOnly proceed without loading a skill if genuinely none are relevant to the task.";
@@ -90,9 +125,9 @@ const SKILL_LISTING_FOOTER =
  *   3. `<available_skills>` listing (verbatim from core).
  *   4. SKILL_LISTING_FOOTER — "only skip if genuinely nothing matches".
  */
-export function wrapAvailableSkillsBlock(listing: string): string {
+export function wrapAvailableSkillsBlock(listing: string, allowLlmWrite = false): string {
   return [
-    SKILL_LISTING_HEADER,
+    skillListingHeader(allowLlmWrite),
     "以下是你（当前 agent）自带的云端 skill 列表。这些 skill 存储在你的 agent 名下，",
     "优先使用它们完成任务。如果你觉得自带的 skill 不够，可以用 skill_search 工具",
     "在团队的 skill 库中检索更多（跨 agent 共享）。",
@@ -285,7 +320,7 @@ export class SkillInjector implements InjectionHook {
     const listing = result.listing;
     if (!listing || listing.includes("(none)")) return [];
 
-    const content = wrapAvailableSkillsBlock(listing);
+    const content = wrapAvailableSkillsBlock(listing, this.config.allowLlmWrite ?? false);
     return [{
       type: "text",
       content,


### PR DESCRIPTION
## Description | 描述

`skillRuntime.allowLlmWrite` is **false by default** — `DEFAULT_CONFIG` in
`MemoryProxy/src/config.ts`, and `config.example.yaml` documents it as such. Under that
default `skill-bridge` answers every write subpath with `40302` / HTTP 403, and
`SkillToolsInjector` correctly leaves `skill_patch` / `skill_create` out of the tool list
it renders for the model.

The `<available_skills>` header did not get the memo. `skill-injector.ts` rendered these
two sentences unconditionally:

```
If a skill has issues, fix it with the `skill_patch` skill-bridge tool.
After difficult/iterative tasks, offer to save the approach as a new skill
(`skill_create`). If a skill you loaded was missing steps, had wrong commands, or
needed pitfalls you discovered, update it before finishing.
```

So on a default deployment the model is told to use a tool it was never given, and the
call comes back 403. That costs a tool round-trip, and leaves the model holding an
instruction it cannot carry out. `allowLlmWrite` is not consulted anywhere in that file.

This splits the write sentences out of the header and renders them only when the switch
is on. With writes off the model is told what it can still do — report the problem in its
reply — and **no write tool is named**, so nothing in the read-only text invites a call
that would be rejected. Everything else in the block is untouched: the mandatory-load
directive, the curl reminder, the listing itself, and the footer.

The flag already existed one line away: `injection/index.ts` computed it for
`SkillToolsInjector`; it now passes the same value to `SkillInjector` as well.

**MemoryCore's copy of this header is deliberately not changed.** The file comment asks
that the two copies be kept in sync, so to be explicit about the divergence: the switch
is proxy-side and Core knows nothing about it, and Core's `SKILL_LISTING_HEADER` is
exported but never referenced by Core itself — `/v3/skill/listing` returns only the
`<available_skills>` lines — so on this path the header the model sees is the proxy's.
The comment now records this.

## Related Issue | 关联 Issue

None filed for this. Found while running the product end to end with the default
configuration.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过

  New `MemoryProxy/src/injection/injectors/__tests__/skill-injector-readonly.test.ts` —
  9 tests, written before the fix (4 of them failing for the reason above), all passing
  after:

  - read-only renders no `skill_patch` / `skill_create` / "update it before finishing" /
    "fix it with";
  - read-only says what to do instead (report it), and says the session is read-only;
  - read-only keeps the rest of the block — the mandatory-load directive, `skill_view`,
    the listing verbatim, the footer;
  - write-enabled keeps both original sentences word for word;
  - the two renderings share the same opening and the same tail, so only that clause
    swaps;
  - omitting the flag falls back to read-only, matching the product default;
  - and three that drive the real injector through `prewarm()` with a stubbed core
    client, so the value is shown to travel config → injector → rendered block, off, on,
    and unset.

  ```
  cd MemoryProxy && npx vitest run src/injection/injectors/__tests__/skill-injector-readonly.test.ts
  Test Files  1 passed (1)
       Tests  9 passed (9)
  ```

- [x] No existing features affected | 无影响现有功能

  With `allowLlmWrite: true` the header is byte-for-byte what it was. The only other
  change is one argument at the registration site. `npx tsc --noEmit` reports the same
  **60** pre-existing errors on `feat/server_team` before and after. `BASE_REF=origin/feat/server_team
  bash MemoryCore/scripts/ci/check-skill-queue-isolation.sh` → PASS.

## Additional Notes | 其他说明

Scope, stated plainly:

- **Not** a change to what the bridge accepts or rejects. `WRITE_SUBPATHS` and the 40302
  branch are untouched; this only stops the prompt from asking for something that branch
  will refuse.
- **Not** a change to `SkillToolsInjector`, which was already correct.
- **Not** a claim about hosts that render the block themselves. The proxy path is what
  this fixes.
- An agent whose listing is empty never received these sentences to begin with — the
  injector returns no block when the listing is `(none)` — so this changes nothing for
  those sessions.

### The replacement wording is yours, not mine

One part of this is a product decision I had to make to open the PR, and it should be
yours: the sentence the read-only branch renders. What the model is told is prompt
surface, so treat that text as a placeholder — happy to take whatever phrasing you
prefer, or to drop the clause entirely and simply omit the write instructions with no
replacement. The gating is the part this PR is actually about.

The one thing I would keep for a non-taste reason: whatever replaces it, better not to
name a write tool. Something like "you cannot use `skill_patch` here" puts the tool name
back in front of the model, which is what invites the 403 in the first place.

### Overlap with #1281

[#1281](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/1281)
(`feat(proxy): add dynamic skill queue strategies`) touches the same two files, and one
of its hunks rewrites the exact line this PR rewrites — the `new SkillInjector({...})`
call in `injection/index.ts`. So whichever lands second will conflict there. The
resolution is to keep both fields:

```ts
new SkillInjector({
  coreSkill: config.coreSkill,
  queueStrategy: config.injection.skillQueueStrategy,   // #1281
  allowLlmWrite,                                        // this PR
}),
```

The two are otherwise independent: #1281 changes *where and when* the listing is
injected (`point` / `anchor` / `cacheStrategy` via a queue strategy) and its diff contains
no occurrence of `allowLlmWrite`, `skill_patch`, `SKILL_LISTING_HEADER`, or the write
sentences — it does not address this bug. Both PRs also add tests under
`injectors/__tests__/`, with different filenames, so there is no collision there.

`.github/workflows/pr-ci.yml` triggers on `pull_request: branches: [main]`, so it does not
run for a PR targeting `feat/server_team`; the checks above were run locally instead.

Size: +43/−8 in the two source files (most of it comments explaining the switch), plus
103 lines of test.
