### PR TITLE
fix(proxy): record completed skill download calls in telemetry

### DIFF
--- a/MemoryProxy/src/skill/__tests__/skill-bridge-download-telemetry.test.ts
+++ b/MemoryProxy/src/skill/__tests__/skill-bridge-download-telemetry.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `bridge-telemetry.ts` 的契约是每次上游请求完成都发一条 `bridge_call`,主路径照做:
+ * 拿到响应发一条(含 4xx/5xx),upstream 不响应也发一条。files/download 分支只补了后者
+ * ——那处 catch 的注释还写着"之前这个 catch 分支静默 return, 导致 curl 视角『打了 N 次』
+ * CH 少一条",也就是说同一类洞已经为失败路径补过,成功路径被落下了。
+ *
+ * 下游是真有人读的:Core Analytics 用这些行算调用次数与会话调用率。成功下载缺行会把
+ * 这些指标算低。
+ *
+ * 这些用例钉住"每条路径恰好一条",并且不改响应本身。
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const emitted: Array<Record<string, unknown>> = [];
+vi.mock("../../memory/bridge-telemetry.js", () => ({
+  emitBridgeToolCallTelemetry: (row: Record<string, unknown>) => { emitted.push(row); },
+  emitBridgeRejectTelemetry: (row: Record<string, unknown>) => { emitted.push({ ...row, _reject: true }); },
+  agentSourceFromSessionKey: (k: string) => String(k).split(":")[0] || "claude-code",
+}));
+
+const { createSkillBridgeHandler } = await import("../skill-bridge.js");
+const { getSessionStore } = await import("../../session/store.js");
+
+const SESSION = "codebuddy:dl-test";
+const config = {
+  coreSkill: { endpoint: "http://core.invalid", serviceToken: "t", timeoutMs: 1000, serviceId: "sp-1" },
+  skillRuntime: { allowLlmWrite: false },
+} as never;
+
+const ctx = (sub = "files/download") => {
+  const req = new Request(`http://proxy/skill-bridge/v3/skill/${sub}`, {
+    method: "POST",
+    headers: { "x-conversation-id": "dl-test", "content-type": "application/json" },
+    body: JSON.stringify({ skill_id: "skl-abc", path: "scripts/run.sh" }),
+  });
+  return { req: { url: req.url, method: "POST", raw: req,
+                  header: (n: string) => req.headers.get(n) ?? undefined,
+                  text: () => req.text(), json: () => req.json() } } as never;
+};
+
+const envelope = (data: unknown) => new Response(JSON.stringify({ code: 0, message: "ok", data }),
+  { status: 200, headers: { "content-type": "application/json" } });
+
+beforeEach(async () => {
+  emitted.length = 0;
+  await getSessionStore().set(SESSION, {
+    status: "initialized",
+    sessionInfo: { user_id: "usr-1", team_id: "team-1", agent_id: "agt-1", space_id: "sp-1" },
+  } as never);
+});
+
+const calls = () => emitted.filter((r) => !r._reject);
+
+describe("files/download emits exactly one bridge_call per upstream request", () => {
+  test("成功下载:恰好一条,带真实状态码", async () => {
+    const h = createSkillBridgeHandler(config, {
+      fetcher: (async () => envelope({ content: "#!/bin/sh\necho hi\n", encoding: "utf-8", mime_type: "text/x-sh" })) as never,
+      now: () => 1_000,
+    });
+    const res = await h(ctx());
+    expect(res.status).toBe(200);
+    expect(calls()).toHaveLength(1);
+    expect(calls()[0]).toMatchObject({ executedEndpoint: "files/download", upstreamStatus: 200, bridgeSource: "skill-bridge" });
+  });
+
+  test("上游 4xx:也恰好一条,记真实状态码", async () => {
+    const h = createSkillBridgeHandler(config, {
+      fetcher: (async () => new Response(JSON.stringify({ code: 40401, message: "not found" }),
+        { status: 404, headers: { "content-type": "application/json" } })) as never,
+    });
+    await h(ctx());
+    expect(calls()).toHaveLength(1);
+    expect(calls()[0]).toMatchObject({ executedEndpoint: "files/download", upstreamStatus: 404 });
+  });
+
+  test("上游回了但内容不可用:仍是一条,不是零条也不是两条", async () => {
+    const h = createSkillBridgeHandler(config, {
+      fetcher: (async () => envelope({ encoding: "utf-8" })) as never,   // 没有 content
+    });
+    await h(ctx());
+    expect(calls()).toHaveLength(1);
+    expect(calls()[0]).toMatchObject({ upstreamStatus: 200 });
+  });
+
+  test("网络异常:原有的那一条还在,upstreamStatus=0", async () => {
+    const h = createSkillBridgeHandler(config, {
+      fetcher: (async () => { throw new Error("ECONNREFUSED"); }) as never,
+    });
+    await h(ctx());
+    expect(calls()).toHaveLength(1);
+    expect(calls()[0]).toMatchObject({ executedEndpoint: "files/download", upstreamStatus: 0 });
+  });
+
+  test("对照:同样成功的 files/read 本来就发一条 —— 缺的只是 download", async () => {
+    // 这行数字在 PR 正文的对照表里,所以要测出来,不能靠读主路径代码推断。
+    const h = createSkillBridgeHandler(config, {
+      fetcher: (async () => envelope({ content: "x", encoding: "utf-8" })) as never,
+    });
+    await h(ctx("files/read"));
+    expect(calls()).toHaveLength(1);
+    expect(calls()[0]).toMatchObject({ executedEndpoint: "files/read", upstreamStatus: 200 });
+  });
+
+  test("响应本身不受埋点影响:成功时仍返回原始字节", async () => {
+    const body = "#!/bin/sh\necho hi\n";
+    const h = createSkillBridgeHandler(config, {
+      fetcher: (async () => envelope({ content: body, encoding: "utf-8", mime_type: "text/x-sh" })) as never,
+    });
+    const res = await h(ctx());
+    expect(await res.text()).toBe(body);
+    expect(res.headers.get("content-type")).toBe("text/x-sh");
+  });
+});

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -622,6 +622,26 @@ export function createSkillBridgeHandler(
       const elapsed = (deps.now ?? Date.now)() - t0;
       console.log(`${TAG} sub=files/download status=${coreResp.status} elapsed=${elapsed}ms`);
 
+      // 埋点: upstream 已响应(含 4xx/5xx), 与主路径末尾那条"已响应"的 emit 对称
+      // (故意不写行号 —— 上面那条注释里的 `:822` 就是这么烂掉的)。
+      // 上面那个 catch 分支早就补过"未响应也算一次调用", 唯独成功/已响应这条落下了 ——
+      // 于是 curl 视角每下载一次, CH 就少一条。这里发, 是因为下面三个 return
+      // (状态非 2xx 原样透传 / 信封不可解析 / 解出字节) 都算"这次调用完成了"。
+      const dlDoneKey = ids.composite_key ?? sessionKey;
+      emitBridgeToolCallTelemetry({
+        sessionKey: dlDoneKey,
+        spaceId: ids.space_id,
+        userId: ids.user_id,
+        teamId: ids.team_id,
+        agentId: ids.agent_id,
+        agentSource: ids.agent_source || agentSourceFromSessionKey(dlDoneKey),
+        bridgeSource: "skill-bridge",
+        executedEndpoint: "files/download",
+        requestBody: dlOutboundBody.slice(0, 512),
+        upstreamStatus: coreResp.status,
+        elapsedMs: (deps.now ?? Date.now)() - dlCallStart,
+      });
+
       // Core error → pass through as JSON envelope
       if (coreResp.status < 200 || coreResp.status >= 300) {
         return new Response(coreText, {


### PR DESCRIPTION
## Description | 描述

`bridge-telemetry.ts` states the contract as one `bridge_call` per completed upstream
request, and the main path keeps both halves of it: one emit once a response is in hand
(4xx and 5xx included), one emit when upstream never answers.

The `files/download` branch only has the second. Its own comment records why that one was
added:

```
埋点补齐: 与主路径 :822 对称, upstream 未响应也算一次调用。
之前这个 catch 分支静默 return, 导致 curl 视角"打了 N 次" CH 少一条。
```

The same hole was closed for the failure path and left open for the success path. So a
download that works produces no row at all, and the branch is silent exactly when it
succeeds.

Measured against the handler with a stubbed sink:

| path | `bridge_call` rows |
|---|---:|
| `files/read`, success | 1 |
| `files/download`, success | **0** |
| `files/download`, network error | 1 |

This emits once the response is in hand, mirroring the main path field for field, placed
before the three returns that follow it — status passthrough, unparseable envelope,
decoded bytes — so each of those counts as exactly one completed call and no path can
produce two. Response bodies, status codes and headers are untouched.

## Related Issue | 关联 Issue

None filed. Found while reading the bridge's telemetry paths against the contract in
`bridge-telemetry.ts`.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过

  New `MemoryProxy/src/skill/__tests__/skill-bridge-download-telemetry.test.ts` — 6 tests,
  written before the fix. Three of them passed immediately (they pin behaviour that was
  already correct), three failed for the reason above and pass now:

  - success → exactly one row, `executedEndpoint: "files/download"`, `upstreamStatus: 200`;
  - upstream 4xx → exactly one row, real status recorded;
  - upstream responded but the envelope carries no usable content → still exactly one,
    neither zero nor two;
  - network error → the row that already existed is still there, `upstreamStatus: 0`;
  - the response itself is unchanged — the success path still returns the raw bytes and
    the skill's own content-type;
  - and a control: a `files/read` success on the main path emits exactly one row, which is
    the first line of the table above — measured, not inferred from reading that path.

  ```
  cd MemoryProxy && npx vitest run src/skill/__tests__/skill-bridge-download-telemetry.test.ts
  Test Files  1 passed (1)
       Tests  6 passed (6)
  ```

  The tests drive the real `createSkillBridgeHandler` with an injected fetcher and a
  seeded session, and capture emissions through a mocked telemetry module — no network,
  no ClickHouse.

- [x] No existing features affected | 无影响现有功能

  Emission only; no response body, status code or header changes, and no new failure mode
  — `emitBridgeToolCallTelemetry` already swallows sink errors so telemetry never blocks
  the request. `npx tsc --noEmit` reports the same **60** pre-existing errors on
  `feat/server_team` before and after. `BASE_REF=origin/feat/server_team bash
  MemoryCore/scripts/ci/check-skill-queue-isolation.sh` → PASS.

## Additional Notes | 其他说明

### Who reads these rows

Not a field nobody consumes: `MemoryCore/src/gateway/analytics/analytics-sql.ts` builds
its `bridge_calls` and `prev_bridge_calls` CTEs from `tool_call_logs` where
`kind = 'bridge_call'`, and uses them for call counts and per-session call rates. A
missing row on the path that succeeds biases exactly the metric that is supposed to show
the bridge being used. This reaches persisted statistics only where the ClickHouse
collection is configured; where it is not, the fix simply makes the two paths consistent.

### Scope

- **Not** a change to what the download branch returns, or when it returns it.
- **Not** a change to the schema of a `bridge_call` row — the same fields the main path
  already sends, with `executedEndpoint: "files/download"`.
- **Not** a change to the reject-telemetry path, which was already emitting on every
  early return.

### One thing I did not touch

The sibling comment above the catch-branch emit says `与主路径 :822 对称`, and that line
number no longer points at anything related — the main path's emits sit much further down.
My own comment deliberately refers to the main path by behaviour instead of by line, so it
cannot rot the same way. I left the existing `:822` alone to keep this diff to the bug;
say the word and I will fix it here or in a one-line follow-up.

### Overlap with #1305

[#1305](https://github.com/TencentCloud/TencentDB-Agent-Memory/pull/1305) also edits
`skill-bridge.ts`, but in a different region — an import near the top and one line inside
the *main* path's emit, adding `...extractResolvedSkillAccess(sub, resp.status, respText)`.
There is no hunk overlap with this change, which is ~300 lines earlier in the download
branch, and the two do not conflict. Worth noting for whoever reviews both: if #1305 lands,
the same spread would presumably belong on this new emit too, and I am happy to add it in
a follow-up or fold it in here — say which you prefer.

`.github/workflows/pr-ci.yml` triggers on `pull_request: branches: [main]`, so it does not
run for a PR targeting `feat/server_team`; the checks above were run locally instead.

Size: +19 in `skill-bridge.ts` (the emit plus the comment saying why it sits where it
does), plus 116 lines of test.
