### PR TITLE
fix(proxy): correct skill resource download behavior and recipes

### DIFF
--- a/MemoryProxy/src/injection/injectors/skill-tools-injector.ts
+++ b/MemoryProxy/src/injection/injectors/skill-tools-injector.ts
@@ -14,7 +14,7 @@
  *
  * Tools injected:
  *   Always (read-only): skill_search, skill_view, skill_files_read,
- *                       skill_extract
+ *                       skill_extract, skill_files_download
  *   Only when allowLlmWrite=true: skill_create, skill_update, skill_patch,
  *                                skill_delete, skill_files_write, skill_files_remove
  *
@@ -113,7 +113,13 @@ export function renderSkillToolsBlock(
     `  <tool name="skill_files_read">`,
     `    path: ${bridge}/files/read`,
     `    body: {"skill_id": "skl-xxx", "path": "scripts/run.sh", "encoding": "utf-8|base64"}`,
-    `    use:  读取单个资源文件内容。**必须先调 skill_view 拿 manifest**，从里面挑出 skill_id + path，本工具才能定位。默认返回 JSON 信封（含 base64/utf-8 编码的字节）。\n    若需下载到本地：在 curl 末尾加 -o <本地路径>，proxy 会返回原始字节直接写入文件，不进上下文。下载的脚本需 chmod +x 后再执行。`,
+    `    use:  读取单个资源文件内容，返回 JSON 信封（含 base64/utf-8 编码的字节）。**必须先调 skill_view 拿 manifest**，从里面挑出 skill_id + path，本工具才能定位。\n    要把文件存到本地、不进上下文，用下面的 skill_files_download —— 本接口无论加不加 curl 的 -o 都返回 JSON 信封。`,
+    `  </tool>`,
+    "",
+    `  <tool name="skill_files_download">`,
+    `    path: ${bridge}/files/download`,
+    `    body: {"skill_id": "skl-xxx", "path": "scripts/run.sh"}`,
+    `    use:  下载单个资源文件的原始字节（不是 JSON 信封），适合直接存盘：在 curl 末尾加 -o <本地路径>。同样要先调 skill_view 拿 manifest 定位。下载的脚本需 chmod +x 后再执行。`,
     `  </tool>`,
     "",
     `  <tool name="skill_extract">`,

--- a/MemoryProxy/src/skill/__tests__/skill-bridge-download-behavior.test.ts
+++ b/MemoryProxy/src/skill/__tests__/skill-bridge-download-behavior.test.ts
@@ -1,0 +1,117 @@
+/**
+ * 下载分支的两件事。
+ *
+ * ① 合法的空文件被当成异常。判断是 `if (parsed.code !== 0 || !parsed.data?.content)`,
+ *    而 `""` 是 falsy —— 于是一个真实存在、内容为空的资源,返回的不是 0 字节文件,
+ *    而是整个 JSON 信封。Core 侧两种编码都接受零字节资源。
+ *
+ * ② 注入给模型的说明说:对 `files/read` 的 curl 加 `-o` 就能拿到原始字节。
+ *    服务端看不见 `-o`(那是 curl 客户端参数),它按**子路径**分流;真正返回字节的是
+ *    独立的 `files/download`,而说明里从没提过这条路。
+ *
+ * 这些用例把两件事都钉住,并保留原有的错误透传行为。
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../memory/bridge-telemetry.js", () => ({
+  emitBridgeToolCallTelemetry: () => {},
+  emitBridgeRejectTelemetry: () => {},
+  agentSourceFromSessionKey: (k: string) => String(k).split(":")[0] || "claude-code",
+}));
+
+const { createSkillBridgeHandler } = await import("../skill-bridge.js");
+const { getSessionStore } = await import("../../session/store.js");
+const { renderSkillToolsBlock } = await import("../../injection/injectors/skill-tools-injector.js");
+
+const SESSION = "codebuddy:dl-behavior";
+const config = {
+  coreSkill: { endpoint: "http://core.invalid", serviceToken: "t", timeoutMs: 1000, serviceId: "sp-1" },
+  skillRuntime: { allowLlmWrite: false },
+} as never;
+
+const ctx = (sub: string) => {
+  const req = new Request(`http://proxy/skill-bridge/v3/skill/${sub}`, {
+    method: "POST",
+    headers: { "x-conversation-id": "dl-behavior", "content-type": "application/json" },
+    body: JSON.stringify({ skill_id: "skl-abc", path: "scripts/empty.sh" }),
+  });
+  return { req: { url: req.url, method: "POST", raw: req,
+                  header: (n: string) => req.headers.get(n) ?? undefined,
+                  text: () => req.text(), json: () => req.json() } } as never;
+};
+
+const core = (data: unknown, code = 0) => new Response(JSON.stringify({ code, message: "ok", data }),
+  { status: 200, headers: { "content-type": "application/json" } });
+
+const run = async (data: unknown, sub = "files/download") => {
+  const h = createSkillBridgeHandler(config, { fetcher: (async () => core(data)) as never });
+  const res = await h(ctx(sub));
+  const body = await res.arrayBuffer();
+  return { res, bytes: body.byteLength, text: new TextDecoder().decode(body) };
+};
+
+beforeEach(async () => {
+  await getSessionStore().set(SESSION, {
+    status: "initialized",
+    sessionInfo: { user_id: "usr-1", team_id: "team-1", agent_id: "agt-1", space_id: "sp-1" },
+  } as never);
+});
+
+describe("① 合法的空文件下载后应当是空文件", () => {
+  test("utf-8 的零字节资源:返回 0 字节,不是 JSON 信封", async () => {
+    const { res, bytes, text } = await run({ content: "", encoding: "utf-8", mime_type: "text/x-sh", size_bytes: 0 });
+    expect(res.status).toBe(200);
+    expect(text).not.toMatch(/"code"/);          // 不是信封
+    expect(bytes).toBe(0);
+    expect(res.headers.get("content-type")).toBe("text/x-sh");
+  });
+
+  test("base64 的零字节资源:同样是 0 字节", async () => {
+    const { bytes, text } = await run({ content: "", encoding: "base64", mime_type: "application/octet-stream" });
+    expect(text).not.toMatch(/"code"/);
+    expect(bytes).toBe(0);
+  });
+
+  test("content 字段缺失:仍按原样透传信封(这才是真的异常)", async () => {
+    const { text } = await run({ encoding: "utf-8" });
+    expect(text).toMatch(/"code"/);
+  });
+
+  test("content 类型不对:也按原样透传信封", async () => {
+    const { text } = await run({ content: 123, encoding: "utf-8" });
+    expect(text).toMatch(/"code"/);
+  });
+
+  test("非空文件不受影响", async () => {
+    const body = "#!/bin/sh\necho hi\n";
+    const { bytes, text } = await run({ content: body, encoding: "utf-8", mime_type: "text/x-sh" });
+    expect(text).toBe(body);
+    expect(bytes).toBe(Buffer.byteLength(body));
+  });
+
+  test("对照:同一个空资源走 files/read,拿到的是信封(这条路本来就该返回 JSON)", async () => {
+    const { text } = await run({ content: "", encoding: "utf-8" }, "files/read");
+    expect(text).toMatch(/"code"/);
+  });
+});
+
+describe("② 注入给模型的下载配方要指向真正返回字节的那条路", () => {
+  const block = () => renderSkillToolsBlock("http://proxy", false);
+
+  test("说明里出现 files/download", () => {
+    expect(block()).toMatch(/files\/download/);
+  });
+
+  test("不再声称给 files/read 加 -o 就会拿到原始字节", () => {
+    const s = block();
+    const readRecipe = s.slice(s.indexOf("skill_files_read"), s.indexOf("skill_files_read") + 900);
+    expect(readRecipe).not.toMatch(/加 -o[^\n]*原始字节|proxy 会返回原始字节/);
+  });
+
+  test("读与下载是两个配方,各自写明返回什么", () => {
+    const s = block();
+    expect(s).toMatch(/files\/read/);
+    expect(s).toMatch(/JSON 信封/);
+    expect(s).toMatch(/原始字节|raw bytes/);
+  });
+});

--- a/MemoryProxy/src/skill/skill-bridge.ts
+++ b/MemoryProxy/src/skill/skill-bridge.ts
@@ -637,7 +637,11 @@ export function createSkillBridgeHandler(
       } catch {
         return envelope(50001, `${TAG} files/download: failed to parse core response`, 502);
       }
-      if (parsed.code !== 0 || !parsed.data?.content) {
+      // `content: ""` 是合法的:Core 两种编码都接受零字节资源。原来用 `!content`
+      // 判失败,于是一个真实存在的空文件返回的不是 0 字节,而是整个信封 —— 调用方
+      // 按说明 `curl -o` 存下来,得到一个装着 JSON 的"脚本"。这里只把「字段缺失 /
+      // 类型不对」当异常,空字符串照常走解码。
+      if (parsed.code !== 0 || typeof parsed.data?.content !== "string") {
         return new Response(coreText, {
           status: coreResp.status,
           headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Description | 描述

Two defects in the `files/download` path, both measured against the handler with a stubbed
core rather than argued from reading it.

**An empty file does not come back empty.** The branch decides failure with

```ts
if (parsed.code !== 0 || !parsed.data?.content)
```

and `""` is falsy, so a resource that genuinely exists and is zero bytes takes the error
exit and the caller receives the whole JSON envelope. Core accepts zero-byte resources in both
encodings — `skillResourcePayloadSchema` in `MemoryCore/src/gateway/skill-schemas.ts`, which
both `create.resources` and `files/write.files` use, declares `content: z.string()` with no
`.min(1)` — so this is an ordinary shape, not a contrived one. Measured:

| request | before | after |
|---|---|---|
| empty resource → `files/download` | **90 bytes of `{"code":0,…}`**, `content-type: application/json` | **0 bytes**, the resource's own content-type |
| 18-byte script → `files/download` | 18 bytes | 18 bytes (unchanged) |
| `content` field missing | envelope passthrough | envelope passthrough (unchanged) |

The guard now separates a missing or non-string `content` — still an envelope passthrough,
exactly as before — from a legitimately empty one, which decodes like any other content. A
`content` of the wrong type used to slip into the decode path as well; it no longer does.

**The injected recipe points the model at the endpoint that cannot do what it promises.**
The `skill_files_read` description told the model that adding `-o <local path>` to its
curl would make proxy return raw bytes. `-o` is a client-side curl flag the server never
sees; the bridge dispatches on the subpath, and the subpath that returns bytes is
`files/download` — which the tools block never mentioned at all. Measured on the same
18-byte script: `files/read` returns a 110-byte JSON envelope, `files/download` returns
the 18 bytes. A model that follows the recipe writes the envelope to disk and then tries
to run it as a script.

`files/read` keeps its description and its JSON contract — now stated plainly — plus one
sentence saying the flag makes no difference there. `skill_files_download` is added beside
it as its own recipe. `files/download` was already in `ALLOWED_SUBPATHS`, so this only
tells the model about a route the bridge already serves.

## Related Issue | 关联 Issue

None filed for either. Both found while exercising the skill bridge end to end.

## Change Type | 修改类型

- [x] Bug fix | Bug 修复
- [ ] New feature | 新功能
- [ ] Documentation update | 文档更新
- [ ] Code optimization | 代码优化

## Self-test Checklist | 自测清单

- [x] Verified locally | 本地验证通过

  New `MemoryProxy/src/skill/__tests__/skill-bridge-download-behavior.test.ts` — 9 tests,
  written before the fix; 6 failed for the reasons above and pass now, 3 passed from the
  start because they pin behaviour that was already correct.

  - zero-byte resource, utf-8 → 0 bytes and the resource's content-type, not an envelope;
  - zero-byte resource, base64 → 0 bytes;
  - `content` missing → envelope passthrough (unchanged);
  - `content` of the wrong type → envelope passthrough (this one used to reach the decode);
  - non-empty file → byte-for-byte unchanged;
  - control: the same empty resource through `files/read` still returns JSON, because that
    is that route's contract;
  - the tools block names `files/download`; no longer claims `-o` on `files/read` yields
    raw bytes; and read and download are two recipes each stating what it returns.

  ```
  cd MemoryProxy && npx vitest run src/skill/__tests__/skill-bridge-download-behavior.test.ts
  Test Files  1 passed (1)
       Tests  9 passed (9)
  ```

- [x] No existing features affected | 无影响现有功能

  The error paths keep their existing shape, non-empty downloads are untouched, and
  `files/read` still returns what it always returned. `npx tsc --noEmit` reports the same
  **60** pre-existing errors on `feat/server_team` before and after.
  `BASE_REF=origin/feat/server_team bash MemoryCore/scripts/ci/check-skill-queue-isolation.sh`
  → PASS.

## Additional Notes | 其他说明

### The recipe wording is yours

The second half of this changes text the model reads, which is prompt surface and so your
call, not mine. Treat the new sentences as a placeholder: what matters is that the recipe
names `files/download` for downloading and stops promising that a curl flag changes the
server's response format. Rephrase or restructure them however you like — including
dropping the separate `skill_files_download` entry and simply correcting the `files/read`
sentence, if you would rather not grow the tools block.

### Overlap with other open PRs

Two open PRs touch `skill-tools-injector.ts`:

- **#974** (`fix(proxy): stop injecting offline skill_extract tool`) **will conflict**. It
  rewrites the header comment that lists the read-only tools — the same line this PR edits
  to add `skill_files_download` — and removes the `skill_extract` tool block immediately
  above the recipe this PR edits. Whichever lands second needs a small manual merge: keep
  #974's rewritten comment and add `skill_files_download` to it, and keep this PR's
  `skill_files_download` block where #974 left the surrounding list.
- **#1347** (`fix(injection): curl 配方补 Windows 说明`) does **not** overlap. Its hunk is in
  `writeErrors`, roughly sixty lines below the recipe this PR changes.

If the header-comment edit is what makes this awkward, I am happy to drop it — it only
keeps the tool list in that comment accurate, and the recipe change stands without it.

### Scope

- **Not** a change to `files/read`'s contract. It returned a JSON envelope before and
  returns one now; the description just says so instead of implying otherwise.
- **Not** a new route. `files/download` already existed and was already allowed.
- **Not** a change to what counts as an upstream error — only to whether an empty string
  counts as one.
- The two halves are separable; happy to split them into two PRs if you prefer to take one
  without the other.

`.github/workflows/pr-ci.yml` triggers on `pull_request: branches: [main]`, so it does not
run for a PR targeting `feat/server_team`; the checks above were run locally instead.

Size: `+5/−1` in `skill-bridge.ts` (one line of logic, the rest the comment explaining it),
`+8/−2` in `skill-tools-injector.ts` (the new recipe and the corrected sentence), and
`+117` of test.
